### PR TITLE
fix(cron): silent ticks no longer erase continuity (#104541)

### DIFF
--- a/cron/scheduler_prompt.py
+++ b/cron/scheduler_prompt.py
@@ -91,9 +91,20 @@ def _inject_context_from(job: dict, prompt: str) -> tuple[str, bool]:
                 (output_dir / source_job_id).glob("*.md"), key=lambda f: f.stat().st_mtime,
                 reverse=True,
             )
-            if not output_files:
-                continue  # silent skip — no output yet
-            latest_output = output_files[0].read_text(encoding="utf-8").strip()
+            latest_output = ""
+            for output_file in output_files:
+                candidate = output_file.read_text(encoding="utf-8").strip()
+                # Only the run header describes suppression; script/agent payloads can
+                # quote these markers. Keep error documents useful for recovery context.
+                header = candidate.split("\n---\n", 1)[0].split("\n## Prompt", 1)[0]
+                silent_audit = candidate.startswith("# Cron Job:") and any(
+                    line.startswith(("**Status:** no_change", "**Status:** silent",
+                                     "Script gate returned `wakeAgent=false`"))
+                    for line in header.splitlines()
+                )
+                if candidate and not silent_audit:
+                    latest_output = candidate
+                    break
             if len(latest_output) > _MAX_CONTEXT_CHARS:
                 latest_output = (
                     latest_output[:_MAX_CONTEXT_CHARS] + "\n\n[... output truncated ...]")

--- a/tests/cron/test_continuity_silent_audits.py
+++ b/tests/cron/test_continuity_silent_audits.py
@@ -1,0 +1,38 @@
+"""Silent audit records must not replace useful continuity output (#104541)."""
+import os
+
+from cron import jobs
+from cron.scheduler_prompt import _inject_context_from
+
+
+def test_silent_audits_preserve_latest_payload(tmp_path):
+    with jobs.use_cron_store(tmp_path):
+        directory = jobs.get_cron_output_dir() / "abcdef"
+        directory.mkdir(parents=True)
+        header = "# Cron Job: " + "long name " * 80 + "\n\n**Job ID:** abcdef\n**Run Time:** now\n"
+        payload = header + "**Mode:** no_agent (script)\n\n---\n\n**Status:** silent but useful payload\n"
+        records = [payload, header + "**Mode:** monitor\n**Status:** no_change (agent run suppressed)\n",
+                   header + "**Mode:** no_agent (script)\n**Status:** silent (empty output)\n",
+                   header + "\nScript gate returned `wakeAgent=false` — agent skipped.\n", ""]
+        for index, text in enumerate(records):
+            path = directory / f"{index}.md"
+            path.write_text(text, encoding="utf-8")
+            os.utime(path, (index + 1, index + 1))
+        for source in ("self", "abcdef"):
+            prompt, injected = _inject_context_from({"id": "abcdef", "context_from": [source]}, "next")
+            assert injected and "silent but useful payload" in prompt
+            assert "agent skipped" not in prompt and "agent run suppressed" not in prompt
+        assert len(list(directory.glob("*.md"))) == len(records)
+
+
+def test_audit_only_history_is_empty_but_errors_remain_context(tmp_path):
+    with jobs.use_cron_store(tmp_path):
+        directory = jobs.get_cron_output_dir() / "abcdef"
+        directory.mkdir(parents=True)
+        path = directory / "audit.md"
+        path.write_text("# Cron Job: monitor\n**Status:** no_change (agent run suppressed)\n", encoding="utf-8")
+        job = {"id": "abcdef", "context_from": ["self"]}
+        assert _inject_context_from(job, "next") == ("next", False)
+        path.write_text("# Cron Job: monitor\n**Status:** monitor source failed\n\nConnection refused\n", encoding="utf-8")
+        prompt, injected = _inject_context_from(job, "next")
+        assert injected and "Connection refused" in prompt

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -817,7 +817,7 @@ cronjob(
 )
 ```
 
-The first run has no previous output, so the prompt runs as-is. On later runs the previous output is prepended with continuity framing ("avoid repeating what was already reported"). It combines freely with upstream jobs (`context_from=["<other_job_id>"]` plus `continuity=true`), and `continuity=false` on update turns it off while preserving other `context_from` entries. Internally the flag is stored as the reserved `self` entry in `context_from`.
+The first run has no previous output, so the prompt runs as-is. Silent monitor ticks (`no_change`), empty output, and `wakeAgent=false` audit records are skipped when selecting context, so a quiet period preserves the latest substantive output. Audit files remain on disk. Error documents remain eligible to give the next run recovery context; this is not a success-only history filter. On later runs the previous output is prepended with continuity framing ("avoid repeating what was already reported"). It combines freely with upstream jobs (`context_from=["<other_job_id>"]` plus `continuity=true`), and `continuity=false` on update turns it off while preserving other `context_from` entries. Internally the flag is stored as the reserved `self` entry in `context_from`.
 
 From the CLI: `hermes cron create "every 6h" "Scan for news" --continuity`, and `hermes cron edit <job_id> --continuity` / `--no-continuity` to toggle it on an existing job. The same toggle appears in the dashboard's cron editor and the desktop Bot Mode routine dialog.
 


### PR DESCRIPTION
Quiet monitor and script-gated ticks no longer replace useful cron continuity context.

Campaign: #104868. Fixes #104541. Slim redo of #104546 by @PRATHAMESH75 and #104551 by @kokhlo, credited in the commit.

- Walk output files newest-first, skipping empty and silent audit documents; keep audit files unchanged.
- Match suppression only in the run header, not script/agent payloads; no fixed header-length cutoff.
- Keep error documents eligible for recovery context and document that policy.

Root cause: selection read only the newest file, including nonempty records from suppressed runs.

## Validation

| Check | Before | After |
|---|---|---|
| Real localhost HTTP monitor → production run_job → disk → self/upstream context | New no_change stub replaced previous report | Previous report selected; audit remains on disk |
| New invariant tests | 2 failures on base | Both pass |
| Full cron directory | — | 1220 passed, 0 failed, 2 skipped (95 files) |

Ruff, Windows-footgun checker, compatibility-pointer checker and git diff check passed. Probe artifacts: `/tmp/resolve-089c35aa/cron-evidence/continuity-{before,after}.json`; regression runner logs alongside them. Fidelity: production-function integration with real HTTP/filesystem I/O, not paid inference or external delivery. Independent campaign review pending; opened draft for review. No merge requested.

## Infographic
![Cron continuity across silent ticks](https://v3b.fal.media/files/b/0aa972a4/E0UUNmaEtWp81PsCJnqOA_usrJKSfo.png)
