### PR TITLE
fix(cli): resolve key_cmd token before the Ollama capability probe

### DIFF
--- a/hermes_cli/models_local.py
+++ b/hermes_cli/models_local.py
@@ -18,7 +18,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any, NamedTuple, Optional
+from typing import Any, Callable, NamedTuple, Optional
 from hermes_cli.urllib_security import url_origin
 
 # Log-record parity with the origin module.
@@ -576,13 +576,14 @@ def lmstudio_model_reasoning_options(
 def ollama_model_supports_thinking(
     model: str,
     base_url: Optional[str],
-    api_key: Optional[str] = None,
+    api_key: Optional[str | Callable[[], str]] = None,
     timeout: float = 5.0,
 ) -> Optional[bool]:
     """Tri-state: True if an Ollama (Cloud or local) model advertises ``thinking`` in native
     ``/api/show`` ``capabilities`` (authoritative; OpenAI-compat ``/v1/models`` omits it), False
     when the probe succeeded without it, None when it failed (caller treats as "don't emit")."""
     import httpx
+    from agent.azure_identity_adapter import materialize_bearer_for_http
 
     server_url = (base_url or "").strip().rstrip("/")
     if server_url.endswith("/v1"):
@@ -591,8 +592,9 @@ def ollama_model_supports_thinking(
     if not server_url or not bare_model:
         return None
 
-    token = str(api_key or "").strip()
     try:
+        # Manual HTTP requests must mint callable credentials instead of stringifying them.
+        token = materialize_bearer_for_http(api_key).strip() if api_key else ""
         with httpx.Client(timeout=timeout, headers={"Authorization": f"Bearer {token}"} if token else {}) as client:
             resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
             if resp.status_code != 200:

--- a/tests/plugins/model_providers/test_ollama_cloud_profile.py
+++ b/tests/plugins/model_providers/test_ollama_cloud_profile.py
@@ -172,6 +172,56 @@ class TestOllamaCloudCapabilityGating:
 class TestOllamaModelSupportsThinking:
     """The /api/show capability probe used to resolve supports_reasoning."""
 
+    def test_probe_sends_minted_command_token(self, monkeypatch):
+        from functools import partial
+        from subprocess import CompletedProcess
+
+        import httpx
+
+        from agent.command_token_source import CommandTokenSource
+        from hermes_cli.models_local import ollama_model_supports_thinking
+
+        source = CommandTokenSource("mint-test-token", "test-provider")
+        monkeypatch.setattr(
+            "agent.command_token_source.subprocess.run",
+            lambda *a, **k: CompletedProcess(a[0], 0, stdout="minted-test-token\n"),
+        )
+        requests = []
+
+        def respond(request):
+            requests.append(request)
+            return httpx.Response(200, json={"capabilities": ["thinking"]})
+
+        monkeypatch.setattr(
+            httpx, "Client", partial(httpx.Client, transport=httpx.MockTransport(respond))
+        )
+
+        assert ollama_model_supports_thinking("test-model", "https://example.invalid/v1", source) is True
+        assert len(requests) == 1
+        assert requests[0].url.path == "/api/show"
+        assert requests[0].headers["Authorization"] == "Bearer minted-test-token"
+
+    @pytest.mark.parametrize("returncode", [0, 1], ids=["empty-output", "command-failed"])
+    def test_probe_skips_request_when_command_token_fails(self, monkeypatch, returncode):
+        from subprocess import CompletedProcess
+        from unittest.mock import Mock
+
+        import httpx
+
+        from agent.command_token_source import CommandTokenSource
+        from hermes_cli.models_local import ollama_model_supports_thinking
+
+        source = CommandTokenSource("mint-test-token", "test-provider")
+        monkeypatch.setattr(
+            "agent.command_token_source.subprocess.run",
+            lambda *a, **k: CompletedProcess(a[0], returncode, stdout=""),
+        )
+        client = Mock()
+        monkeypatch.setattr(httpx, "Client", client)
+
+        assert ollama_model_supports_thinking("test-model", "https://example.invalid/v1", source) is None
+        client.assert_not_called()
+
     def _patch_show(self, monkeypatch, *, status=200, capabilities=None, raise_exc=None):
         import httpx
 


### PR DESCRIPTION
## What does this PR do?

The Ollama capability probe sends the `CommandTokenSource` object's repr as the bearer when a provider uses `key_cmd` (#104460). Measured by the reporter: `/api/show` goes out with `Bearer <agent.command_token_source.CommandTokenSource object at 0x...>` (len 76 — exactly "Bearer " + repr) while `/chat/completions` on the same provider carries the real minted token. Some endpoints answer 403; non-Ollama endpoints get a wasted request with a leaked object repr in an Authorization header.

The probe now resolves the key through the same token-resolution path the chat client uses before building the request: minted token in, never an object repr. Unresolvable tokens fail the probe gracefully (treated as no-capabilities).

## Related Issue

Fixes #104460

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models_local.py` — probe resolves `api_key` via the shared token resolution before the `/api/show` request
- `tests/model_providers/test_ollama_cloud_profile.py` — regression: outgoing probe Authorization is the resolved token, not a repr

## How to Test

1. Targeted test file green
2. Before the fix, the new test fails: the captured Authorization contains "CommandTokenSource object"
3. Manual shape: configure a custom provider with `key_cmd` pointing at a local server; the `/api/show` probe arrives with the minted token

## Checklist

### Code
- [x] Contributing Guide read; Conventional Commits followed
- [x] Searched for duplicate PRs
- [x] Only changes related to this fix
- [x] Relevant tests pass; tests added
- [x] Tested on Linux (Python 3.11)

### Documentation & Housekeeping
- [x] N/A
