### PR TITLE
fix(desktop): keep composer hover actions reachable (#104786, salvage #104797)

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -231,6 +231,9 @@ Sizes: `default`, `xs`, `overlay` (titlebar glyph counts).
 - Bordered surfaces in the transcript (tables, fences, callouts, attachments)
   use `--ui-stroke-tertiary`. Not `border-border` — that's the app-wide
   default and reads too hot against the thread.
+- Interactive directive chips in the composer expose their action on hover.
+  The action stays visible for a 500ms grace period while the pointer crosses
+  from the chip to the floating pill; leaving both dismisses it.
 - A tool result may expose an inline action that opens a preview. It must not
   open the rail automatically.
 - Install, onboarding, connecting, boot failure, and reauthentication are


### PR DESCRIPTION
The Desktop composer’s directive action remains reachable while the pointer travels from its chip to the floating action pill.

- Salvages #104797 by @kokhlo, preserving Konstantin Khlopkov’s original commit and authorship.
- Extends the hover grace from 120ms to 500ms; the existing enter/leave handling still keeps the pill visible while hovered and dismisses it after departure.
- Documents the interaction in the Desktop design contract.

Root cause: the 120ms hide timer expired before ordinary chip-to-pill pointer transit finished.

Fixes #104786. Supersedes #104797 on current main; no merge requested.

## Validation

| Gate | Actual result |
| --- | --- |
| **Live repro: native Electron + actual `hermes serve` backend** | Before: 50ms transit survived; 300ms transit lost the action. After: both survived transit and continued hover, then dismissed after leaving. |
| Native action click | After 300ms transit, clicking Open created the real in-app webview for a loopback page. Its title and unique page text rendered successfully. |
| Regression red on main | New slow-transit test failed with `null` instead of the URL; 8 controls passed. |
| Composer directory suite | 50 files, 420 tests passed. |
| Full Desktop typecheck + lint | All three TypeScript projects passed; ESLint 0 errors, 135 warnings. |
| Repository checks | Windows-footguns, compat-pointer check, and `git diff --check` passed. |

Native verification used isolated HOME, HERMES_HOME, Electron user-data directory, Xvfb display, and private CDP/Vite ports. The production paste handler received a synthetic clipboard event to create the URL chip; subsequent pointer motion and click were real Chromium input. No paid inference, external recipient, or live user state was used. Linux native development shell verified; Windows packaging was not exercised.

Local receipts: `/tmp/resolve-089c35aa/desktop-evidence/hover-{before,after}.json`, `hover-click.json`, `hover-click.png`, `hover-tests.log`, and `lint.log`.

## Review status

Independent review of head 7240c4a completed: no blocker in the bounded hover-delay change. Repeated native 50ms/300ms transit, continued hover, renderer-sidebar departure, and actual Open action successfully. The legacy departure coordinate can land in a webview; the corrected negative control uses the renderer sidebar. Prior unit/lint receipts were reviewed, not rerun in this pass. Maintainer review and merge approval remain outstanding.

## Infographic

![Composer hover action remains reachable](https://v3b.fal.media/files/b/0aa972ad/Yjj-MSeX0JAuWlzfFuzaJ_nxk3YJTp.png)


Campaign tracker: #104868.
