### PR TITLE
fix: auxiliary Copilot calls recover after token rejection

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3239,7 +3239,7 @@ _POOL_PROVIDER_BY_HOST = (
     ("githubcopilot.com", "copilot"), ("api.kimi.com", "kimi-coding"), ("api.x.ai", "xai-oauth"),
 )
 _AUTH_REFRESH_PROVIDER_BY_HOST = (
-    ("api.githubcopilot.com", "copilot"), ("chatgpt.com", "openai-codex"),
+    ("githubcopilot.com", "copilot"), ("chatgpt.com", "openai-codex"),
     ("api.anthropic.com", "anthropic"), ("inference-api.nousresearch.com", "nous"),
 )
 
@@ -3387,11 +3387,11 @@ def _creds_have_api_key(creds: Dict[str, Any]) -> bool:
 
 
 def _refresh_copilot_credentials() -> bool:
-    from hermes_cli.copilot_auth import _jwt_cache, _token_fingerprint, exchange_copilot_token, resolve_copilot_token
+    from hermes_cli.copilot_auth import evict_cached_exchanged_token, exchange_copilot_token, resolve_copilot_token
     raw_token, _source = resolve_copilot_token()
     if not str(raw_token or "").strip():
         return False
-    _jwt_cache.pop(_token_fingerprint(raw_token), None)
+    evict_cached_exchanged_token(raw_token)
     exchange_copilot_token(raw_token)
     return True
 

--- a/tests/agent/test_copilot_aux_auth_recovery.py
+++ b/tests/agent/test_copilot_aux_auth_recovery.py
@@ -1,0 +1,32 @@
+"""Copilot auxiliary recovery must recognize account hosts and drop stale caches."""
+
+import pytest
+
+from agent import auxiliary_client as aux
+from hermes_cli import copilot_auth
+
+
+@pytest.mark.parametrize("host,expected", [
+    ("api.githubcopilot.com", "copilot"),
+    ("api.business.githubcopilot.com", "copilot"),
+    ("api.enterprise.githubcopilot.com", "copilot"),
+    ("api.githubcopilot.com.evil.invalid", "auto"),
+    ("githubcopilot.com.attacker.invalid", "auto"),
+])
+def test_auto_auth_recovery_uses_account_host(host, expected):
+    assert aux._auth_refresh_provider_for_route("auto", f"https://{host}") == expected
+    assert aux._auth_refresh_provider_for_route("anthropic", f"https://{host}") == "anthropic"
+
+
+def test_auth_recovery_does_not_reuse_durable_rejected_token(monkeypatch):
+    raw = "gho_fixture_only"
+    monkeypatch.setattr(copilot_auth, "resolve_copilot_token", lambda: (raw, "fixture"))
+    # Exercise actual durable storage and cache eviction, not a mock eviction call.
+    fp = copilot_auth._token_fingerprint(raw)
+    copilot_auth._save_jwt_to_disk(fp, "rejected", 9999999999, None)
+    assert copilot_auth._load_jwt_from_disk(fp)[0] == "rejected"
+    monkeypatch.setattr(copilot_auth, "exchange_copilot_token", lambda token: (
+        pytest.fail("Rejected durable token survived refresh")
+        if copilot_auth._load_jwt_from_disk(fp) else ("fresh", None, None)
+    ))
+    assert aux._refresh_provider_credentials("copilot")

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -200,6 +200,11 @@ hermes chat --provider copilot --model gpt-5.4
 
 If no token is found, `hermes model` offers an **OAuth device code login** — the same flow used by the Copilot CLI and opencode.
 
+Auxiliary tasks (including compression and title generation) recognize personal,
+Business, and Enterprise Copilot API hosts when recovering from authentication
+errors. Recovery discards the rejected exchanged token from memory and disk,
+exchanges a fresh token, and retries before considering fallbacks.
+
 :::warning Token types
 The Copilot API does **not** support classic Personal Access Tokens (`ghp_*`). Supported token types:
 


### PR DESCRIPTION
Auxiliary Copilot calls recover from rejected tokens on personal, Business, and Enterprise hosts instead of skipping refresh or reusing a rejected disk-cached token.

Fixes #104792. Ports the substantive correction from #81131 by @s905060 (Jash Lee, coauthor credit preserved); also covers #104847's host-matching change. Neither contributor PR is merged or closed by this work.

## Changes
- Match parsed `githubcopilot.com` host boundaries, consistent with existing pool routing; lookalike suffixes remain excluded.
- Use the existing canonical eviction function before token exchange, clearing memory, disk, and negative exchange caches together.
- Add two invariant tests and document auxiliary recovery behavior.

Root cause: auth-refresh routing recognized only the personal account host, and refresh invalidated only the in-process JWT cache.

## Validation
**Live repro:** isolated real-import / loopback-wire integration, same production `_ladder_credential_rungs` and real OpenAI SDK before and after; fake credentials only.

| Case | Before | After |
|---|---|---|
| Auto / Business | 401, no exchange | local exchange, retry 200 |
| Auto / Enterprise | 401, no exchange | local exchange, retry 200 |
| Auto / personal; explicit Copilot / Business | disk-cached rejected token reused, retry 401 | local exchange, retry 200 |
| Lookalike suffix host | no refresh | no refresh |

Regression RED: **3 failed, 3 passed** on unchanged source. GREEN: **220 passed, 0 failed** across `test_copilot_aux_auth_recovery.py`, `test_auxiliary_client.py`, and `test_copilot_token_exchange.py`, using `scripts/run_tests.sh` under the campaign lock. Ruff, Windows-footgun scan, compat-pointer scan, and `git diff --check` passed.

The fixture redirects token exchange to loopback and supplies the account host as route metadata; the final retry is driven using the real SDK after the production ladder yields. This proves local routing and cache invalidation, **not** a real GitHub account, token lifetime, vendor inference, or an end-to-end daemon soak. Raw scripts/results are retained in the campaign's `/tmp/resolve-089c35aa/auth-routing-evidence/` workspace (`copilot-live.py`, `copilot-before.json`, `copilot-after.json`).

## Remaining draft gates
- Independent review by the campaign parent.
- Broader affected-directory validation under the shared campaign test lock.
- No merge authorized.

## Infographic
![Auxiliary authentication recovery](https://v3b.fal.media/files/b/0aa97301/anqVap2h1RI7veXesQ02L_XOjwR2Z8.png)


Campaign tracker: #104868.
