### PR TITLE
fix(update): slow systemd restarts no longer fail at 15 seconds (#104740, salvage #104745)

### DIFF
--- a/contributors/emails/github@doryani.cloud
+++ b/contributors/emails/github@doryani.cloud
@@ -1,0 +1,2 @@
+doryani-ai
+# Salvaged unit-budget fix from #104745

--- a/evals/update_unit_client_budget.py
+++ b/evals/update_unit_client_budget.py
@@ -7,7 +7,8 @@ import sys
 import tempfile
 import time
 
-repo, tag, output = sys.argv[1:]
+repo, tag, output = sys.argv[1:4]
+catchup = sys.argv[4:] == ["--catchup"]
 if not tag.isalnum():
     raise SystemExit("tag must be alphanumeric")
 home = Path(tempfile.mkdtemp(prefix=f"updater-{tag}-"))
@@ -15,7 +16,18 @@ allowed = {key: os.environ[key] for key in ("PATH", "XDG_RUNTIME_DIR", "DBUS_SES
 os.environ.clear()
 os.environ.update(allowed, HOME=str(home), HERMES_HOME=str(home / "hermes"))
 sys.path.insert(0, repo)
-from hermes_cli.update_cmd_fleet import _systemctl_reset_and_restart
+from hermes_cli import update_cmd_fleet as fleet
+_systemctl_reset_and_restart = fleet._systemctl_reset_and_restart
+actual_systemctl = fleet._systemctl
+def scoped_systemctl(argv, *, timeout):
+    if "list-units" in argv:
+        if "--user" not in argv:
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        argv = [arg for arg in argv if arg not in ("hermes-gateway*", "hermes-serve*")] + [unit + ".service"]
+    return actual_systemctl(argv, timeout=timeout)
+if catchup:
+    # Bound discovery to our transient unit; never enumerate user services.
+    fleet._systemctl = scoped_systemctl
 unit = f"hermes-serve-audit-089c35aa-{tag}"
 cmd = ["systemctl", "--user"]
 def run(args):
@@ -24,13 +36,18 @@ def pid():
     return run(cmd + ["show", unit, "--property=MainPID", "--value"]).stdout.strip()
 record: dict[str, object] = {"repo": repo, "tag": tag, "unit": unit, "home": str(home), "tier": "native disposable systemd service"}
 try:
-    start = run(["systemd-run", "--user", "--unit", unit, "--property=ExecStop=/bin/sleep 16", "--property=TimeoutStopSec=30", "--property=TimeoutStartSec=30", "/bin/sleep", "infinity"])
+    start = run(["systemd-run", "--user", "--unit", unit, f"--property=ExecStop=/bin/sleep {31 if catchup else 16}", "--property=TimeoutStopSec=45", "--property=TimeoutStartSec=30", "/bin/sleep", "infinity"])
     assert start.returncode == 0, start.stderr
     old = pid()
     began = time.monotonic()
     try:
-        result = _systemctl_reset_and_restart(cmd, unit)
-        record.update(returncode=result.returncode, stderr=result.stderr)
+        if catchup:
+            failed = []
+            fleet._restart_systemd_gateway_units_best_effort(failed)
+            record.update(failed_units=failed)
+        else:
+            result = _systemctl_reset_and_restart(cmd, unit)
+            record.update(returncode=result.returncode, stderr=result.stderr)
     except subprocess.TimeoutExpired as exc:
         record.update(timeout=exc.timeout)
     record["elapsed"] = time.monotonic() - began

--- a/evals/update_unit_client_budget.py
+++ b/evals/update_unit_client_budget.py
@@ -43,7 +43,7 @@ try:
     try:
         if catchup:
             failed = []
-            fleet._restart_systemd_gateway_units_best_effort(failed)
+            fleet._restart_systemd_gateway_units_best_effort(failed, list(fleet._systemd_gateway_unit_listings()))
             record.update(failed_units=failed)
         else:
             result = _systemctl_reset_and_restart(cmd, unit)

--- a/evals/update_unit_client_budget.py
+++ b/evals/update_unit_client_budget.py
@@ -1,0 +1,48 @@
+"""Real disposable user-systemd transaction, never a production gateway."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+repo, tag, output = sys.argv[1:]
+if not tag.isalnum():
+    raise SystemExit("tag must be alphanumeric")
+home = Path(tempfile.mkdtemp(prefix=f"updater-{tag}-"))
+allowed = {key: os.environ[key] for key in ("PATH", "XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS") if key in os.environ}
+os.environ.clear()
+os.environ.update(allowed, HOME=str(home), HERMES_HOME=str(home / "hermes"))
+sys.path.insert(0, repo)
+from hermes_cli.update_cmd_fleet import _systemctl_reset_and_restart
+unit = f"hermes-serve-audit-089c35aa-{tag}"
+cmd = ["systemctl", "--user"]
+def run(args):
+    return subprocess.run(args, stdin=subprocess.DEVNULL, capture_output=True, text=True, timeout=65)
+def pid():
+    return run(cmd + ["show", unit, "--property=MainPID", "--value"]).stdout.strip()
+record: dict[str, object] = {"repo": repo, "tag": tag, "unit": unit, "home": str(home), "tier": "native disposable systemd service"}
+try:
+    start = run(["systemd-run", "--user", "--unit", unit, "--property=ExecStop=/bin/sleep 16", "--property=TimeoutStopSec=30", "--property=TimeoutStartSec=30", "/bin/sleep", "infinity"])
+    assert start.returncode == 0, start.stderr
+    old = pid()
+    began = time.monotonic()
+    try:
+        result = _systemctl_reset_and_restart(cmd, unit)
+        record.update(returncode=result.returncode, stderr=result.stderr)
+    except subprocess.TimeoutExpired as exc:
+        record.update(timeout=exc.timeout)
+    record["elapsed"] = time.monotonic() - began
+    deadline = time.monotonic() + 20
+    while (pid() in (old, "0", "")) and time.monotonic() < deadline:
+        time.sleep(.1)
+    record.update(old_pid=old, new_pid=pid(), active=run(cmd + ["is-active", unit]).stdout.strip())
+    missing = _systemctl_reset_and_restart(cmd, unit + "-missing")
+    record["missing_unit_error_preserved"] = missing.returncode != 0 and bool(missing.stderr)
+finally:
+    record["cleanup_stop_rc"] = run(cmd + ["stop", unit]).returncode
+    run(cmd + ["reset-failed", unit])
+    record["inactive_after_cleanup"] = run(cmd + ["is-active", unit]).returncode != 0
+    Path(output).write_text(json.dumps(record, indent=2), encoding="utf-8")
+print(json.dumps(record, indent=2))

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -236,13 +236,16 @@ def _systemd_timeout_stop_us(unit_name: str) -> Optional[int]:
 
 def parse_systemd_duration_to_us(raw: str) -> Optional[int]:
     """Parse 'TimeoutStopUSec=1min 30s' / '90s' style values to microseconds. Covers us, ms, s, min,
-    h; a bare number is seconds. None on anything unexpected; never raises. Public: also consumed by
+    h, d, w, month, y; a bare number is seconds. None on anything unexpected; never raises. Public: also consumed by
     hermes_cli.gateway's restart-wait sizing.
     """
     if not raw:
         return None
     units = {"us": 1, "ms": 1_000, "s": 1_000_000, "sec": 1_000_000,
-             "min": 60_000_000, "h": 3_600_000_000, "hr": 3_600_000_000}
+             "min": 60_000_000, "h": 3_600_000_000, "hr": 3_600_000_000,
+             # Fixed systemd time-util.h constants, not variable calendar months/years.
+             "d": 86_400_000_000, "w": 604_800_000_000,
+             "month": 2_629_800_000_000, "y": 31_557_600_000_000}
     total_us, token, digits = 0, "", ""
 
     def _flush() -> bool:  # fold the pending digits/token pair into total_us
@@ -252,7 +255,7 @@ def parse_systemd_duration_to_us(raw: str) -> Optional[int]:
             return False
         try:
             total_us += int(float(digits) * multiplier)
-        except ValueError:
+        except (ValueError, OverflowError):
             return False
         digits = token = ""
         return True

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -324,11 +324,53 @@ def _systemctl(cmd: list, *, timeout: float):
     return subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=timeout)
 
 
-def _systemctl_reset_and_restart(manage_cmd: list, svc_name: str):
+# poll() takes signed 32-bit milliseconds; keep headroom for rounding in communicate().
+_SYSTEMCTL_RESTART_TIMEOUT_MAX = (2**31 - 1) // 1000 - 1
+
+
+def _systemd_restart_timeout(scope_cmd: list, svc_name: str, *, start_only: bool = False) -> float:
+    """Outwait the unit's stop + start budgets, not just the systemctl client.
+
+    A client timeout does not cancel the manager's queued restart. Unknown or
+    infinite limits use systemd's usual 90s per phase so automation stays bounded.
+    Custom ExecStop chains or EXTEND_TIMEOUT_USEC can still exceed this budget;
+    genuine timeouts must continue through the existing per-unit failure path.
+    """
+    from gateway.shutdown_forensics import parse_systemd_duration_to_us
+
+    budgets = {"TimeoutStartUSec": 90.0}
+    if not start_only:
+        budgets["TimeoutStopUSec"] = 90.0
+    try:
+        show = _systemctl(
+            scope_cmd + ["show", svc_name, "--property=TimeoutStopUSec,TimeoutStartUSec"],
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return sum(budgets.values()) + 15.0
+    if show.returncode == 0:
+        for line in (show.stdout or "").splitlines():
+            key, _, raw = line.partition("=")
+            if key in budgets:
+                # The shared parser returns None for infinity/unrecognized units.
+                try:
+                    raw = raw.strip()
+                    duration = int(raw) if raw.isascii() and raw.isdigit() else parse_systemd_duration_to_us(raw)
+                    if duration is not None and duration > 0:
+                        budgets[key] = duration / 1_000_000
+                except (ValueError, OverflowError):
+                    pass
+    return min(sum(budgets.values()) + 15.0, _SYSTEMCTL_RESTART_TIMEOUT_MAX)
+
+
+def _systemctl_reset_and_restart(manage_cmd: list, svc_name: str, *, scope_cmd: list | None = None):
     """``reset-failed`` then ``restart``: a unit parked in failed state by systemd's own
     auto-restart can wedge a plain ``restart`` against RestartSec backoff and stay dead."""
+    # Property reads need no manage-units privileges: narrow sudoers may permit
+    # restart/reset-failed but deny show. Keep the same user/system manager scope.
+    timeout = _systemd_restart_timeout(scope_cmd if scope_cmd is not None else manage_cmd, svc_name)
     _systemctl(manage_cmd + ["reset-failed", svc_name], timeout=10)
-    return _systemctl(manage_cmd + ["restart", svc_name], timeout=15)
+    return _systemctl(manage_cmd + ["restart", svc_name], timeout=timeout)
 
 
 def _is_hermes_gateway_unit(unit: str) -> bool:
@@ -735,7 +777,10 @@ def _restart_one_systemd_gateway_unit(
         # privileges; without them auto-restart still fires after RestartSec.
         if _manage_cmd is not None:
             _systemctl(_manage_cmd + ["reset-failed", svc_name], timeout=10)
-            _systemctl(_manage_cmd + ["start", svc_name], timeout=15)
+            _systemctl(
+                _manage_cmd + ["start", svc_name],
+                timeout=_systemd_restart_timeout(scope_cmd, svc_name, start_only=True),
+            )
             if _wait_for_service_active(scope_cmd, svc_name, timeout=10.0):
                 restarted_services.append(svc_name)
                 return
@@ -770,7 +815,7 @@ def _restart_one_systemd_gateway_unit(
 
     # Blunt restart — only when the graceful path failed (no SIGUSR1 wiring, drain over
     # budget, restart-policy mismatch). Mirrors `hermes gateway restart` (`systemd_restart()`).
-    restart = _systemctl_reset_and_restart(_manage_cmd, svc_name)
+    restart = _systemctl_reset_and_restart(_manage_cmd, svc_name, scope_cmd=scope_cmd)
     if restart.returncode != 0:
         failed_or_stale_units.append(svc_name)
         print(f"  ⚠ Failed to restart {svc_name}: {restart.stderr.strip()}")
@@ -782,7 +827,7 @@ def _restart_one_systemd_gateway_unit(
     # Retry once — transient startup failures (stale module cache,
     # import race) often clear; reset-failed so the retry isn't blocked.
     print(f"  ⚠ {svc_name} died after restart, retrying...")
-    _systemctl_reset_and_restart(_manage_cmd, svc_name)
+    _systemctl_reset_and_restart(_manage_cmd, svc_name, scope_cmd=scope_cmd)
     if _wait_for_service_active(scope_cmd, svc_name, timeout=10.0):
         restarted_services.append(svc_name)
         print(f"  ✓ {svc_name} recovered on retry")

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -208,7 +208,7 @@ def _restart_systemd_gateway_units_best_effort(failed: list, listings) -> None:
             manage_cmd = list(_cmd) + ["--no-ask-password"]
             if _needs_sudo(_scope):
                 manage_cmd = ["sudo", "-n"] + manage_cmd
-            result = _systemctl_reset_and_restart(manage_cmd, svc_name)
+            result = _systemctl_reset_and_restart(manage_cmd, svc_name, scope_cmd=_cmd)
             if result.returncode != 0 or not _wait_for_service_active(_cmd, svc_name):
                 failed.append(svc_name)
 

--- a/tests/hermes_cli/test_update_unit_client_budget.py
+++ b/tests/hermes_cli/test_update_unit_client_budget.py
@@ -30,7 +30,7 @@ def test_unit_transaction_budget_preserves_scope_and_health(monkeypatch, gracefu
     if catchup:
         monkeypatch.setattr(fleet, "_SYSTEMD_SCOPES", (("user", scope),))
         failed = []
-        fleet._restart_systemd_gateway_units_best_effort(failed)
+        fleet._restart_systemd_gateway_units_best_effort(failed, list(fleet._systemd_gateway_unit_listings()))
         assert not failed
         assert sum("restart" in cmd for cmd, _ in calls) == 1
         return

--- a/tests/hermes_cli/test_update_unit_client_budget.py
+++ b/tests/hermes_cli/test_update_unit_client_budget.py
@@ -1,0 +1,61 @@
+"""Update clients cover unit transactions without hiding manager failures."""
+import subprocess
+
+import pytest
+
+from hermes_cli import update_cmd_fleet as fleet
+
+
+@pytest.mark.parametrize("graceful,retry", [(False, False), (False, True), (True, False)])
+def test_unit_transaction_budget_preserves_scope_and_health(monkeypatch, graceful, retry):
+    scope = ["systemctl", "--no-ask-password"]
+    manage = ["sudo", "-n", *scope]
+    calls = []
+
+    def systemctl(cmd, *, timeout):
+        calls.append((cmd, timeout))
+        if "show" in cmd:
+            assert cmd[:len(scope)] == scope
+            output = "42" if "--property=MainPID" in cmd else "TimeoutStopUSec=70s\nTimeoutStartUSec=90s"
+            return subprocess.CompletedProcess(cmd, 0, output, "")
+        if "restart" in cmd or "start" in cmd:
+            assert cmd[:len(manage)] == manage
+            assert timeout > (90 if graceful else 160)
+        return subprocess.CompletedProcess(cmd, 0, "active", "")
+
+    monkeypatch.setattr(fleet, "_systemctl", systemctl)
+    monkeypatch.setattr(fleet, "_drain_or_signal_gateway_for_update", lambda *a: True)
+    health = iter([False, True] if retry else [True])
+    monkeypatch.setattr(fleet, "_wait_for_service_active", lambda *a, **kw: next(health))
+    name = "hermes-gateway-test" if graceful else "hermes-serve-test"
+    restarted, failed = [], []
+    fleet._restart_one_systemd_gateway_unit(
+        name, scope="system", scope_cmd=scope, drain_budget=45,
+        _manage_cmd_cache={"system": manage}, restarted_services=restarted,
+        failed_or_stale_units=failed,
+    )
+    assert restarted == [name] and not failed
+    assert sum("restart" in cmd or "start" in cmd for cmd, _ in calls) == (2 if retry else 1)
+
+
+@pytest.mark.parametrize("limits", ["", "TimeoutStopUSec=infinity\nTimeoutStartUSec=invalid", "TimeoutStopUSec=70000000\nTimeoutStartUSec=90s"])
+@pytest.mark.parametrize("outcome", [0, 7, "timeout"])
+def test_budget_fallback_keeps_real_errors(monkeypatch, limits, outcome):
+    def systemctl(cmd, *, timeout):
+        if "show" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, limits, "")
+        if "restart" in cmd:
+            assert 160 < timeout < 2**31 / 1000
+            if outcome == "timeout":
+                raise subprocess.TimeoutExpired(cmd, timeout)
+            return subprocess.CompletedProcess(cmd, outcome, "", "manager diagnostic")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(fleet, "_systemctl", systemctl)
+    if outcome == "timeout":
+        with pytest.raises(subprocess.TimeoutExpired):
+            fleet._systemctl_reset_and_restart(["systemctl"], "hermes-serve-test")
+    else:
+        result = fleet._systemctl_reset_and_restart(["systemctl"], "hermes-serve-test")
+        assert result.returncode == outcome
+        assert result.stderr == "manager diagnostic"

--- a/tests/hermes_cli/test_update_unit_client_budget.py
+++ b/tests/hermes_cli/test_update_unit_client_budget.py
@@ -6,14 +6,17 @@ import pytest
 from hermes_cli import update_cmd_fleet as fleet
 
 
-@pytest.mark.parametrize("graceful,retry", [(False, False), (False, True), (True, False)])
+@pytest.mark.parametrize("graceful,retry", [(False, False), (False, True), (True, False), ("catchup", False)])
 def test_unit_transaction_budget_preserves_scope_and_health(monkeypatch, graceful, retry):
-    scope = ["systemctl", "--no-ask-password"]
-    manage = ["sudo", "-n", *scope]
+    catchup = graceful == "catchup"
+    scope = ["systemctl", "--user"] if catchup else ["systemctl", "--no-ask-password"]
+    manage = scope if catchup else ["sudo", "-n", *scope]
     calls = []
 
     def systemctl(cmd, *, timeout):
         calls.append((cmd, timeout))
+        if "list-units" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "hermes-serve-test.service loaded active running", "")
         if "show" in cmd:
             assert cmd[:len(scope)] == scope
             output = "42" if "--property=MainPID" in cmd else "TimeoutStopUSec=70s\nTimeoutStartUSec=90s"
@@ -24,6 +27,13 @@ def test_unit_transaction_budget_preserves_scope_and_health(monkeypatch, gracefu
         return subprocess.CompletedProcess(cmd, 0, "active", "")
 
     monkeypatch.setattr(fleet, "_systemctl", systemctl)
+    if catchup:
+        monkeypatch.setattr(fleet, "_SYSTEMD_SCOPES", (("user", scope),))
+        failed = []
+        fleet._restart_systemd_gateway_units_best_effort(failed)
+        assert not failed
+        assert sum("restart" in cmd for cmd, _ in calls) == 1
+        return
     monkeypatch.setattr(fleet, "_drain_or_signal_gateway_for_update", lambda *a: True)
     health = iter([False, True] if retry else [True])
     monkeypatch.setattr(fleet, "_wait_for_service_active", lambda *a, **kw: next(health))

--- a/website/docs/developer-guide/cli-internals.md
+++ b/website/docs/developer-guide/cli-internals.md
@@ -14,6 +14,22 @@ The stage-by-stage contract (`plan → snapshot → apply → restart-per-kind �
 field failure each stage guards are documented in `hermes_cli/AGENTS.md`; user-facing behaviour
 (receipts, `--plan`, snapshot modes) is in [Updating](../getting-started/updating.md).
 
+The systemd blunt-restart fallback waits for the unit's `TimeoutStopUSec` plus
+`TimeoutStartUSec`, with 15 seconds of client-side slack. It reads the target unit
+in the same manager scope as the restart; both the initial attempt and retry use
+this budget. A start after a graceful drain uses only the start budget plus slack.
+A missing, unparseable, or infinite phase limit falls back to 90 seconds
+for that phase, keeping unattended updates bounded. Timing out the `systemctl`
+client does **not** cancel the manager's transaction. Custom multi-command stop
+chains or `EXTEND_TIMEOUT_USEC` can still outlast this estimate; a real timeout
+remains an incomplete restart, and successful commands still require the existing
+service-health and fleet-version verification. Raw numeric `*USec` values are
+microseconds, while formatted values use systemd's fixed units, including days,
+weeks, months and years. The combined timeout is capped below the native signed
+32-bit millisecond poll limit (with rounding headroom), so exceptionally long
+unit limits cannot overflow subprocess polling. Zero/unknown/infinite phase
+limits use the bounded fallback. This does not change active-turn drain settings.
+
 ## Process identity: never infer it from argv substrings
 
 The bug class behind ~10 fleet-update issues (#90778, #87594, #78089, #76129, #91964, ...):

--- a/website/docs/developer-guide/cli-internals.md
+++ b/website/docs/developer-guide/cli-internals.md
@@ -17,7 +17,8 @@ field failure each stage guards are documented in `hermes_cli/AGENTS.md`; user-f
 The systemd blunt-restart fallback waits for the unit's `TimeoutStopUSec` plus
 `TimeoutStartUSec`, with 15 seconds of client-side slack. It reads the target unit
 in the same manager scope as the restart; both the initial attempt and retry use
-this budget. A start after a graceful drain uses only the start budget plus slack.
+this budget, including the catch-up restart after an interrupted update.
+A start after a graceful drain uses only the start budget plus slack.
 A missing, unparseable, or infinite phase limit falls back to 90 seconds
 for that phase, keeping unattended updates bounded. Timing out the `systemctl`
 client does **not** cancel the manager's transaction. Custom multi-command stop


### PR DESCRIPTION
Systemd-backed updates no longer report failure merely because a legitimate unit stop/start transaction outlasts the old 15-second client timeout.

- Read the target unit's stop/start budgets in the unprivileged manager scope, with finite fallbacks and bounded native polling.
- Apply that budget to initial, retry, and interrupted-update catch-up restarts, and the start-only budget after a graceful drain.
- Preserve real errors, per-unit failure isolation, and service/fleet health verification.
- Salvages #104745 by @doryani-ai with author credit preserved; reduces coverage to two invariant tests and closes its graceful-start sibling gap. Earlier related proposal: #102558.

Fixes #104740.

Campaign tracker: #104868.

Root cause: killing the blocking `systemctl` client at 15 seconds does not cancel the manager's longer restart transaction.

## Validation

**Live repro:** native disposable user-systemd unit, real 16-second `ExecStop`, identical production helper before/after. No production Hermes services restarted.

| Probe | Before | After |
|---|---|---|
| Slow native unit | Client timed out at 15.03s; manager subsequently completed | Client exited 0 at 16.13s; unit active with a fresh PID |
| Missing unit | Real command error retained | Real command error retained |
| Fixture cleanup | Unit inactive | Unit inactive |
| Two invariant tests, original 12 parameter rows | 12 assertion failures | 12 passed |
| Catch-up native unit with 31-second stop | Failed-unit result at 30.05s despite eventual new active PID | No failed units at 31.22s; new active PID |

The catch-up probe narrows production unit discovery at the subprocess boundary to the disposable unit; restart/show calls use real systemd. The serialized directory run verified all 13 invariant parameter rows, including catch-up (13 passed). Independent catch-up sabotage against the old 30-second client remains queued under the shared campaign lock.

Repeatable native harness: `python evals/update_unit_client_budget.py <checkout> <alphanumeric-tag> <receipt.json> [--catchup]`; requires a working user systemd manager. Fresh-process rerun of the committed harness completed in 16.93s with a new active PID and preserved missing-unit errors.

Ruff, Windows-footgun, compat-pointer, subprocess-stdin, and diff checks passed. Full affected `tests/hermes_cli/` and `tests/gateway/` directories completed: **16,816 passed, 10 failed, 173 skipped**, plus one timed-out file and two files that passed on retry. Failures comprise missing `acp`, a local-model quickstart HTTP 400, and updater fixtures reaching the live-system signal guard; baseline classification is queued. **Draft pending failure classification and catch-up regression-test sabotage.** Independent source review found no new timeout-path blocker. No full-suite or CI-green claim.

Limitations: start-only/retry/least-privilege combinations have invariant coverage; the native transaction probe uses the user-manager blunt restart. Multiple `ExecStop` commands and `EXTEND_TIMEOUT_USEC` can still exceed a finite estimate; those remain errors rather than false success.

Independent native repeat on the current-main source and PR head: ordinary client timeout at 15.05s → exit 0 at 16.48s; catch-up failed-unit result at 30.03s → no failed units at 31.76s. Each run reached a fresh active PID, preserved a real missing-unit error, and verified the disposable service inactive after cleanup. The final combined harness CLI was exercised with `--catchup`; no production service was restarted.

## Infographic
![Systemd restart clients wait for the unit budget](https://v3b.fal.media/files/b/0aa972e4/YnZ4J0N6zJ4hl4ieFs-rm_rEqFlF76.png)
