### PR TITLE
fix(desktop): saved assistant final replies survive history hydration

### DIFF
--- a/apps/desktop/src/lib/chat-messages.codex-json-sidecar.test.ts
+++ b/apps/desktop/src/lib/chat-messages.codex-json-sidecar.test.ts
@@ -1,0 +1,32 @@
+import { expect, it } from 'vitest'
+
+import { chatMessageText, toChatMessages } from './chat-messages'
+
+it('hydrates the SQLite JSON-text sidecar returned by REST like the decoded RPC sidecar', () => {
+  const items = [{
+    type: 'message',
+    role: 'assistant',
+    phase: 'final_answer',
+    content: [{ type: 'output_text', text: 'Durable reply' }]
+  }]
+
+  const row = {
+    id: 1, role: 'assistant' as const, content: '', timestamp: 1, reasoning: 'Thinking before tool',
+    tool_calls: [{ id: 'call-1', type: 'function', function: { name: 'terminal', arguments: '{}' } }]
+  }
+
+  const decoded = toChatMessages([{ ...row, codex_message_items: items }])
+  const stored = toChatMessages([{ ...row, codex_message_items: JSON.stringify(items) }])
+
+  expect(stored).toEqual(decoded)
+  expect(chatMessageText(stored[0])).toBe('Durable reply')
+  const empty = { ...row, reasoning: null, tool_calls: undefined }
+  expect(toChatMessages([{ ...empty, codex_message_items: '{invalid' }])).toEqual([])
+  expect(toChatMessages([{ ...empty, display_kind: 'hidden', codex_message_items: JSON.stringify(items) }])).toEqual([])
+
+  for (const phase of ['analysis', 'commentary']) {
+    expect(toChatMessages([{ ...empty, codex_message_items: JSON.stringify([{ ...items[0], phase }]) }])).toEqual([])
+  }
+
+  expect(chatMessageText(toChatMessages([{ ...row, content: 'Canonical reply', codex_message_items: JSON.stringify(items) }])[0])).toBe('Canonical reply')
+})

--- a/apps/desktop/src/lib/chat-messages/hydration.ts
+++ b/apps/desktop/src/lib/chat-messages/hydration.ts
@@ -26,7 +26,16 @@ const CONTEXT_REF_RE = /@(file|folder|url|image|tool|terminal):(?:"[^"\n]+"|'[^'
  * (codex_responses_adapter `_OutputScan._message`); the remaining phases are the reply.
  */
 function codexMessageItemText(message: SessionMessage): string {
-  const items = message.codex_message_items
+  let items = message.codex_message_items
+
+  // REST carries SQLite JSON text; RPC history carries the decoded list.
+  if (typeof items === 'string') {
+    try {
+      items = JSON.parse(items)
+    } catch {
+      return ''
+    }
+  }
 
   if (!Array.isArray(items)) {
     return ''
@@ -296,21 +305,20 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       )
     }
 
-    if (message.role === 'assistant' && Array.isArray(message.tool_calls)) {
-      parts.push(
-        ...message.tool_calls.map((call, callIndex) => toolPartFromStoredCall(call, callIndex, message.timestamp))
-      )
-    }
-
-    // #68321: Responses-API turns can persist with `content` empty while the reply the
-    // user saw lives only in codex_message_items; without this the rehydrated bubble
-    // blanks and reconcileResumeMessages then strips the cached row at that ordinal.
-    if (message.role === 'assistant' && !displayContent && !parts.length) {
+    // Reply text can live only in the sidecar alongside reasoning or tool parts.
+    // Those parts are not a substitute for the answer; canonical content still wins.
+    if (message.role === 'assistant' && message.display_kind !== 'hidden' && !displayContent) {
       const codexText = codexMessageItemText(message)
 
       if (codexText) {
         parts.push(assistantTextPart(codexText, message.timestamp))
       }
+    }
+
+    if (message.role === 'assistant' && Array.isArray(message.tool_calls)) {
+      parts.push(
+        ...message.tool_calls.map((call, callIndex) => toolPartFromStoredCall(call, callIndex, message.timestamp))
+      )
     }
 
     if (!parts.length && !extractedAttachmentRefs?.length) {

--- a/contributors/emails/ahmadalfakeh973@gmail.com
+++ b/contributors/emails/ahmadalfakeh973@gmail.com
@@ -1,0 +1,1 @@
+PLASMA-FR

--- a/evals/desktop_bug_campaign/history_live.py
+++ b/evals/desktop_bug_campaign/history_live.py
@@ -1,0 +1,87 @@
+"""Real serve/HTTP/WS history witness. No provider calls; seeded SQLite data."""
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--repo', required=True)
+parser.add_argument('--output', required=True)
+parser.add_argument('--port', type=int, default=18146)
+args = parser.parse_args()
+repo, tag = str(Path(args.repo).resolve()), 'run'
+sys.path.insert(0, repo)
+out = Path(args.output).resolve()
+out.mkdir(parents=True, exist_ok=False)
+home = Path(tempfile.mkdtemp(prefix='history-'+tag+'-', dir=out))
+os.environ['HOME'] = str(home)
+os.environ['HERMES_HOME'] = str(home)
+from hermes_state import SessionDB
+from websockets.sync.client import connect
+
+items = [{'type': 'message', 'role': 'assistant', 'phase': 'final_answer', 'content': [{'type': 'output_text', 'text': 'HISTORY_SIDECAR_REPLY'}]}]
+with SessionDB(db_path=home/'state.db') as db:
+    db.create_session('history-witness', source='desktop')
+    db.append_message('history-witness', 'user', 'HISTORY_USER_PROMPT')
+    db.append_message('history-witness', 'assistant', '', codex_message_items=items, reasoning='THINKING_BEFORE_TOOL', tool_calls=[{'id':'call-1','type':'function','function':{'name':'terminal','arguments':'{}'}}])
+    db.append_message('history-witness', 'tool', 'TOOL_OUTPUT', tool_call_id='call-1')
+    db.create_session('history-control', source='desktop')
+    db.append_message('history-control', 'user', 'CONTROL_USER')
+    db.append_message('history-control', 'assistant', 'CONTROL_REPLY')
+env = {k: v for k, v in os.environ.items() if k in ['PATH', 'HOME', 'LANG', 'USER', 'VIRTUAL_ENV']}
+env.update(HOME=str(home), HERMES_HOME=str(home), HERMES_DASHBOARD_SESSION_TOKEN='history-fixture-token', PYTHONPATH=repo, HERMES_NONINTERACTIVE='1')
+cmd=[sys.executable, '-m', 'hermes_cli.main', 'serve', '--host', '127.0.0.1', '--port', str(args.port), '--isolated']
+log=open(out/(tag+'-serve.log'),'w',encoding='utf-8')
+p=subprocess.Popen(cmd,cwd=repo,env=env,stdin=subprocess.DEVNULL,stdout=log,stderr=subprocess.STDOUT)
+frames=[]
+try:
+    for _ in range(120):
+        try:
+            req=urllib.request.Request(f'http://127.0.0.1:{args.port}/api/status',headers={'X-Hermes-Token':'history-fixture-token'})
+            status=json.load(urllib.request.urlopen(req,timeout=2));break
+        except Exception:
+            if p.poll() is not None: raise RuntimeError('serve exited')
+            time.sleep(.5)
+    else: raise RuntimeError('serve never healthy')
+    def rpc(ws,method,params):
+        rid=len(frames)+1
+        request={'jsonrpc':'2.0','id':rid,'method':method,'params':params}
+        frames.append({'sent':request});ws.send(json.dumps(request))
+        while True:
+            reply=json.loads(ws.recv(timeout=30));frames.append({'received':reply})
+            if reply.get('id')==rid:
+                if 'error' in reply: raise RuntimeError(reply)
+                return reply['result']
+    results={}
+    for sid in ['history-witness','history-control']:
+        with connect(f'ws://127.0.0.1:{args.port}/api/ws?token=history-fixture-token') as ws:
+            first=rpc(ws,'session.resume',{'session_id':sid,'lazy':True})
+            rid=first['session_id']
+            history=rpc(ws,'session.history',{'session_id':rid})
+        with connect(f'ws://127.0.0.1:{args.port}/api/ws?token=history-fixture-token') as ws:
+            resumed=rpc(ws,'session.resume',{'session_id':sid,'lazy':True})
+            activated=rpc(ws,'session.activate',{'session_id':resumed['session_id']})
+            after=rpc(ws,'session.history',{'session_id':resumed['session_id']})
+        results[sid]={'first':first,'history':history,'resumed':resumed,'activated':activated,'after':after}
+    receipt={'tag':tag,'sha':subprocess.check_output(['git','rev-parse','HEAD'],cwd=repo,stdin=subprocess.DEVNULL,text=True).strip(),'command':cmd,'home':str(home),'results':results}
+    (out/(tag+'-rpc.json')).write_text(json.dumps(receipt,indent=2))
+    (out/(tag+'-frames.json')).write_text(json.dumps(frames,indent=2))
+    for sid, responses in results.items():
+        for method, value in responses.items():
+            messages = value['messages']
+            assert len(messages) == (3 if sid == 'history-witness' else 2), (sid, method)
+            if sid == 'history-witness':
+                assert 'HISTORY_SIDECAR_REPLY' in json.dumps(messages[1]), method
+            else:
+                assert 'CONTROL_REPLY' in json.dumps(messages[1]), method
+    print('10 real RPC history controls passed; receipts saved:', out)
+finally:
+    p.terminate()
+    try:p.wait(timeout=15)
+    except subprocess.TimeoutExpired:p.kill();p.wait()
+    log.close()

--- a/tests/tui_gateway/test_session_history_codex_sidecar.py
+++ b/tests/tui_gateway/test_session_history_codex_sidecar.py
@@ -24,6 +24,8 @@ def test_session_history_preserves_codex_message_items(tmp_path):
         "assistant",
         "",
         codex_message_items=message_items,
+        reasoning="Thinking before the tool",
+        tool_calls=[{"id": "call-1", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}],
     )
     previous_db = server._db
     setattr(server, "_db", db)

--- a/tests/tui_gateway/test_session_history_codex_sidecar.py
+++ b/tests/tui_gateway/test_session_history_codex_sidecar.py
@@ -1,0 +1,54 @@
+"""RPC history must retain visible Responses-API assistant sidecars (#68321)."""
+
+from __future__ import annotations
+
+import threading
+
+from hermes_state import SessionDB
+import tui_gateway.server as server
+
+
+def test_session_history_preserves_codex_message_items(tmp_path):
+    message_items = [
+        {
+            "type": "message",
+            "role": "assistant",
+            "phase": "final_answer",
+            "content": [{"type": "output_text", "text": "Persisted answer"}],
+        }
+    ]
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("stored-session", source="desktop")
+    db.append_message(
+        "stored-session",
+        "assistant",
+        "",
+        codex_message_items=message_items,
+    )
+    previous_db = server._db
+    setattr(server, "_db", db)
+    server._sessions["runtime-session"] = {
+        "session_key": "stored-session",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "running": False,
+        "agent": None,
+    }
+
+    try:
+        response = server.handle_request(
+            {"id": "1", "method": "session.history", "params": {"session_id": "runtime-session"}}
+        )
+    finally:
+        server._sessions.pop("runtime-session", None)
+        setattr(server, "_db", previous_db)
+        db.close()
+
+    assert isinstance(response, dict)
+    assert "error" not in response
+    assert response["result"]["count"] == 1
+    messages = response["result"]["messages"]
+    assert len(messages) == 1
+    assert messages[0]["role"] == "assistant"
+    assert messages[0]["text"] == ""
+    assert messages[0]["codex_message_items"] == message_items

--- a/tui_gateway/session_history.py
+++ b/tui_gateway/session_history.py
@@ -167,7 +167,13 @@ def _legacy_display_kind(role: str, text: str) -> str | None:
     return "auto_continue" if role == "user" and text.lstrip().startswith(_AUTO_CONTINUE_NOTE_PREFIX) else None
 
 
-_HISTORY_REASONING_KEYS = ("reasoning", "reasoning_content", "reasoning_details", "codex_reasoning_items")
+_HISTORY_ASSISTANT_DETAIL_KEYS = (
+    "reasoning",
+    "reasoning_content",
+    "reasoning_details",
+    "codex_reasoning_items",
+    "codex_message_items",
+)
 _HISTORY_ROLES = frozenset({"user", "assistant", "tool", "system"})
 
 
@@ -205,9 +211,9 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
             # `context` is an 80-char preview; ship args so a full-call renderer isn't truncated.
             messages.append({"role": "tool", "name": name, "context": _tool_ctx(name, args), **({"args": args} if args else {})})
             continue
-        # A reasoning-only assistant turn is kept so "Thinking…" still shows after resume/reload.
-        has_reasoning = role == "assistant" and any(m.get(key) for key in _HISTORY_REASONING_KEYS)
-        if not content_text.strip() and not has_reasoning:
+        # Assistant detail sidecars can carry the only visible reply or reasoning after resume/reload.
+        has_assistant_detail = role == "assistant" and any(m.get(key) for key in _HISTORY_ASSISTANT_DETAIL_KEYS)
+        if not content_text.strip() and not has_assistant_detail:
             continue
         msg = {"role": role, "text": content_text}
         # Authoring time (Unix seconds) for display.timestamps; display-only.
@@ -223,7 +229,7 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
         if invocation:
             msg.update(text=invocation, display_kind="skill_invocation")
         if role == "assistant":
-            msg.update((key, m[key]) for key in _HISTORY_REASONING_KEYS if m.get(key) is not None)
+            msg.update((key, m[key]) for key in _HISTORY_ASSISTANT_DETAIL_KEYS if m.get(key) is not None)
         # Display-only timeline metadata (model switches, delegation events).
         display_kind = m.get("display_kind") or _legacy_display_kind(role, content_text)
         if display_kind:

--- a/tui_gateway/session_history.py
+++ b/tui_gateway/session_history.py
@@ -202,8 +202,6 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                     except (json.JSONDecodeError, TypeError):
                         args = {}
                     tool_call_args[tc_id] = (fn["name"], args)
-            if not content_text.strip():
-                continue
         if role == "tool":
             tc_name, tc_args = tool_call_args.get(m.get("tool_call_id") or "", (None, None))
             name = tc_name or m.get("tool_name") or "tool"

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -122,7 +122,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, id);
 Notes:
 - `tool_calls` is stored as a JSON string (serialized list of tool call objects)
 - `reasoning_details`, `codex_reasoning_items`, and `codex_message_items` are stored as JSON strings
-- Desktop history hydration retains assistant sidecars in both REST and JSON-RPC (`session.resume`, `session.activate`, `session.history`) projections. A Responses reply may live only in `codex_message_items` while `content` is empty; that is not an empty transcript row.
+- Desktop history hydration retains assistant sidecars in both REST and JSON-RPC (`session.resume`, `session.activate`, `session.history`) projections, including rows with reasoning and tool calls. REST may return the SQLite JSON string while RPC returns decoded items; Desktop accepts both. A final Responses reply may live only in `codex_message_items` while `content` is empty. Canonical content still takes precedence, and analysis/commentary items are not promoted to reply text.
 - `reasoning` stores the raw reasoning text for providers that expose it
 - `api_content` is a byte-fidelity sidecar: the exact content string sent to the API for this message when it differs from `content` (ephemeral memory/plugin injections, persist overrides). It preserves the wire bytes for prompt-cache-stable replay — stored as sent, except lone surrogates, which sqlite3 cannot bind and which the conversation loop scrubs from every outgoing payload anyway. `NULL` means `content` was sent verbatim.
 - Timestamps are Unix epoch floats (`time.time()`)

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -122,6 +122,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, id);
 Notes:
 - `tool_calls` is stored as a JSON string (serialized list of tool call objects)
 - `reasoning_details`, `codex_reasoning_items`, and `codex_message_items` are stored as JSON strings
+- Desktop history hydration retains assistant sidecars in both REST and JSON-RPC (`session.resume`, `session.activate`, `session.history`) projections. A Responses reply may live only in `codex_message_items` while `content` is empty; that is not an empty transcript row.
 - `reasoning` stores the raw reasoning text for providers that expose it
 - `api_content` is a byte-fidelity sidecar: the exact content string sent to the API for this message when it differs from `content` (ephemeral memory/plugin injections, persist overrides). It preserves the wire bytes for prompt-cache-stable replay — stored as sent, except lone surrogates, which sqlite3 cannot bind and which the conversation loop scrubs from every outgoing payload anyway. `NULL` means `content` was sent verbatim.
 - Timestamps are Unix epoch floats (`time.time()`)


### PR DESCRIPTION
Saved assistant final replies survive history projection and Desktop hydration when their text lives in a response sidecar.

- Retain sidecar-backed assistant rows even when they also contain reasoning or tool calls.
- Restore final-answer text from object or JSON-string sidecars without replacing nonempty canonical text or exposing hidden analysis/commentary phases.
- Add two focused invariants, documentation, and a standalone isolated real-serve/WebSocket history probe.

Root cause: history projection dropped the empty-content assistant before inspecting its sidecar, while renderer fallback depended on having no existing reasoning/tool parts.

Addresses the persisted-final-answer mechanism in #68321. Campaign: #104839. This is not a claim that every clarify/reconnect symptom in that report is resolved.

## Live repro

| Actual control | Base | Fixed |
|---|---|---|
| Seeded user + sidecar assistant + tool, five resume/history/activate responses | Two rows; assistant missing | Three rows, assistant and final sidecar retained |
| Ordinary canonical-text control, same five responses | Two correct rows | Same two correct rows |
| Production Desktop renderer, seeded mixed reply | Final text missing in original A/B | Final text visible and retained across socket reconnection |

Parent reran the maintained real serve/SQLite/WebSocket probe on base and the rebased source: expected missing-row assertion fails on base; all ten RPC controls pass after. No model requests are needed.

Parent also repeated the live production-renderer witness against an isolated backend: the final reply appears exactly once before and after reconnect; the hidden-analysis sentinel appears zero times. This is a renderer/real-backend seeded-history control, not native Electron or successful new-generation QA. Its reconnect uses deferred hydration, so it is not presented as a single combined session.history-to-DOM refresh test; the separate wire probe establishes that projection.

## Validation

- Changed Python and renderer invariants pass; parent repeated both after rebase.
- Existing directory-suite receipts are preserved privately; no overlapping suite totals are summed.
- Independent review confirmed both initially identified mixed-tool/reasoning omissions were corrected and found no new blocker in this final-answer path.
- Ruff, Windows-footgun, compatibility-pointer, subprocess-stdin, and diff gates pass.

Native sleep/wake, broader active-tail reconciliation, and the reporter's complete clarification flow remain separate investigations. No issue closure is implied before merge.

## Infographic

![Desktop reliability campaign](https://v3b.fal.media/files/b/0aa970ff/01HBIjxrk8-g59IYVhD6F_GOQaUsZH.png)

## Source credit
The RPC history portion of @PLASMA-FR’s #104754 is preserved with Ahmad Al-Faqih’s authorship (`9d1eec0ce0776583a2b467958276affaf15a5062` on main). Its separate locale-picker work is not superseded and #104754 remains open for that surviving scope.
