### PR TITLE
fix(verify): detect Python test runners from real files

### DIFF
--- a/agent/verify/recipes.py
+++ b/agent/verify/recipes.py
@@ -11,7 +11,9 @@ recipe missed (``hermes_cli.verify_cmd._merge_project_facts_commands``).
 
 from __future__ import annotations
 
+import ast
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -171,6 +173,127 @@ def _detect_node_recipe(root: Path, pkg: dict[str, Any]) -> Recipe:
 
 _PYTHON_INSTALL = {"uv": "uv sync", "poetry": "poetry install", "pipenv": "pipenv install"}
 
+_PYTHON_TEST_MAX_DEPTH = 8
+_PYTHON_TEST_MAX_DIRS = 4096
+_PYTHON_TEST_MAX_FILES = 512
+_PYTHON_TEST_MAX_BYTES = 256 * 1024
+_PYTHON_TEST_IGNORED_DIRS = frozenset({
+    "__pycache__", "build", "dist", "node_modules", "site-packages", "vendor", "venv",
+})
+
+
+def _is_python_test_filename(name: str) -> bool:
+    return name.endswith(".py") and (name.startswith("test_") or name.endswith("_test.py"))
+
+
+def _find_python_test_files(root: Path) -> list[Path]:
+    """Find real Python test-file candidates without walking generated/dependency trees forever."""
+    found: list[Path] = []
+    visited_dirs = 0
+
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        visited_dirs += 1
+        if visited_dirs > _PYTHON_TEST_MAX_DIRS:
+            return found
+        directory = Path(dirpath)
+        try:
+            depth = len(directory.relative_to(root).parts)
+        except ValueError:
+            continue
+
+        dirnames[:] = sorted(
+            name for name in dirnames
+            if depth < _PYTHON_TEST_MAX_DEPTH
+            and not name.startswith(".")
+            and name not in _PYTHON_TEST_IGNORED_DIRS
+        )
+        for name in sorted(filenames):
+            if not _is_python_test_filename(name):
+                continue
+            path = directory / name
+            try:
+                if path.is_symlink() or path.stat().st_size > _PYTHON_TEST_MAX_BYTES:
+                    continue
+            except OSError:
+                continue
+            found.append(path)
+            if len(found) >= _PYTHON_TEST_MAX_FILES:
+                return found
+
+    return found
+
+
+def _dotted_name(node: ast.expr) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        owner = _dotted_name(node.value)
+        return f"{owner}.{node.attr}" if owner else node.attr
+    return ""
+
+
+def _python_test_styles(path: Path) -> tuple[bool, bool]:
+    """Return ``(has_pytest, has_unittest)`` from executable test declarations."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"), filename=str(path))
+    except (OSError, SyntaxError, ValueError):
+        return False, False
+
+    unittest_modules: set[str] = set()
+    unittest_cases: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "unittest":
+                    unittest_modules.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "unittest":
+            unittest_cases.update(alias.asname or alias.name for alias in node.names)
+
+    has_pytest = any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_")
+        for node in tree.body
+    )
+    has_unittest = False
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        has_test_method = any(
+            isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name.startswith("test_")
+            for item in node.body
+        )
+        if not has_test_method:
+            continue
+        bases = {_dotted_name(base) for base in node.bases}
+        is_unittest_case = any(
+            base in unittest_cases
+            or any(
+                base == f"{module}.{case}"
+                for module in unittest_modules
+                for case in ("TestCase", "IsolatedAsyncioTestCase")
+            )
+            for base in bases
+        )
+        has_unittest = has_unittest or is_unittest_case
+        has_pytest = has_pytest or not is_unittest_case
+
+    return has_pytest, has_unittest
+
+
+def _python_test_commands(root: Path) -> list[str]:
+    """Choose a runner from actual bounded test files; pytest wins for mixed suites."""
+    has_pytest = False
+    has_unittest = False
+    for path in _find_python_test_files(root):
+        file_pytest, file_unittest = _python_test_styles(path)
+        has_pytest = has_pytest or file_pytest
+        has_unittest = has_unittest or file_unittest
+
+    if has_pytest:
+        return ["python -m pytest"]
+    if has_unittest:
+        return ["python -m unittest discover"]
+    return []
+
 
 def _detect_python_recipe(root: Path) -> Recipe | None:
     pyproject = _read_text(root, "pyproject.toml")
@@ -183,7 +306,7 @@ def _detect_python_recipe(root: Path) -> Recipe | None:
     install = _PYTHON_INSTALL.get(detect_package_manager(root) or "") or (
         "pip install -e ." if pyproject and not requirements else "pip install -r requirements.txt"
     )
-    pytest_or_empty = ["pytest"] if (root / "tests").exists() else []
+    test_commands = _python_test_commands(root)
 
     # Precedence: Django, then FastAPI/uvicorn, then Flask, then generic.
     if manage_py or "django" in lower:
@@ -196,20 +319,20 @@ def _detect_python_recipe(root: Path) -> Recipe | None:
     if "fastapi" in lower or "uvicorn" in lower:
         app_module = (_first_existing(root, ("main.py", "app.py")) or "main.py").removesuffix(".py") + ":app"
         return Recipe(
-            name="FastAPI app", kind="fastapi", bootstrap=[install], test=pytest_or_empty,
+            name="FastAPI app", kind="fastapi", bootstrap=[install], test=test_commands,
             start=f"uvicorn {app_module} --host 0.0.0.0 --port 8000", port=8000,
             evidence=["Detected Python project", "Detected FastAPI/Uvicorn dependency"],
         )
     if "flask" in lower:
         app_module = _first_existing(root, ("app.py", "main.py")) or "app.py"
         return Recipe(
-            name="Flask app", kind="flask", bootstrap=[install], test=pytest_or_empty,
+            name="Flask app", kind="flask", bootstrap=[install], test=test_commands,
             start=f"flask --app {app_module} run --host 0.0.0.0 --port 5000", port=5000,
             evidence=["Detected Python project", "Detected Flask dependency"],
         )
     return Recipe(
         name="Python project", kind="python", bootstrap=[install],
-        test=pytest_or_empty or ["python -m unittest discover"],
+        test=test_commands,
         evidence=["Detected Python project"],
     )
 

--- a/hermes_cli/verify_cmd.py
+++ b/hermes_cli/verify_cmd.py
@@ -75,6 +75,11 @@ def _merge_project_facts_commands(root: Path, recipe) -> None:
     existing = {c.strip() for c in (*recipe.bootstrap, *recipe.build, *recipe.test) if c}
     for command in facts_commands:
         command = command.strip()
+        # Runtime recipe detection inspects real Python test files. Do not let
+        # the cheap prompt-time pytest-config hint override that verdict or add
+        # a second runner to a pure-unittest project.
+        if recipe.kind in {"python", "fastapi", "flask"} and command == "pytest":
+            continue
         if command and command not in existing:
             recipe.test.append(command)
             existing.add(command)

--- a/tests/verify/test_recipes.py
+++ b/tests/verify/test_recipes.py
@@ -143,13 +143,42 @@ class TestPythonDetection:
         (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
         recipe = detect_recipe(tmp_path)
         assert recipe.bootstrap == ["pip install -e ."]
-        assert recipe.test == ["python -m unittest discover"]
+        assert recipe.test == []
 
-    def test_pytest_when_tests_dir(self, tmp_path):
+    @pytest.mark.parametrize(
+        "files,expected",
+        [
+            ({"tests/.keep": ""}, []),
+            ({"scripts/validator.py": "print('valid')\n"}, []),
+            ({"venv/lib/test_dependency.py": "def test_dependency(): pass\n"}, []),
+            (
+                {"tests/test_sample.py": "import unittest\nclass TestSample(unittest.TestCase):\n    def test_ok(self): pass\n"},
+                ["python -m unittest discover"],
+            ),
+            ({"tests/unit/test_nested.py": "def test_nested():\n    assert True\n"}, ["python -m pytest"]),
+            (
+                {"tests/test_custom_base.py": "class TestCase: pass\nclass TestSample(TestCase):\n    def test_ok(self): pass\n"},
+                ["python -m pytest"],
+            ),
+            (
+                {
+                    "tests/test_unit.py": "from unittest import TestCase\nclass UnitTest(TestCase):\n    def test_ok(self): pass\n",
+                    "tests/integration_test.py": "def test_integration():\n    assert True\n",
+                },
+                ["python -m pytest"],
+            ),
+        ],
+    )
+    def test_python_runner_follows_real_test_declarations(self, tmp_path, files, expected):
         (tmp_path / "requirements.txt").write_text("requests\n", encoding="utf-8")
-        (tmp_path / "tests").mkdir()
+        for relative, content in files.items():
+            path = tmp_path / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
         recipe = detect_recipe(tmp_path)
-        assert recipe.test == ["pytest"]
+        assert recipe.test == expected
+        assert not (tmp_path / ".pytest_cache").exists()
+        assert not list(tmp_path.rglob("__pycache__"))
 
 
 class TestOtherEcosystems:

--- a/tests/verify/test_verify_cmd.py
+++ b/tests/verify/test_verify_cmd.py
@@ -32,6 +32,19 @@ def test_detect_only_json(tmp_path, capsys):
     assert payload["recipe"]["build"] == ["go build ./..."]
 
 
+def test_detect_only_does_not_restore_pytest_hint_without_tests(tmp_path, capsys):
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname='x'\n[tool.pytest.ini_options]\naddopts='-q'\n",
+        encoding="utf-8",
+    )
+
+    code = run_verify_command(make_args(tmp_path, detect_only=True, json=True))
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["recipe"]["test"] == []
+
+
 def test_no_recipe_found(tmp_path, capsys):
     code = run_verify_command(make_args(tmp_path, detect_only=True))
     assert code == 1


### PR DESCRIPTION
## Summary

- detect Python test runners from bounded, real test-file declarations instead of directory shape
- support nested pytest suites, pure unittest suites, and mixed suites without inventing a test phase for empty or validator-only projects
- prevent prompt-time pytest configuration hints from overriding the runtime recipe verdict

## Validation

- `scripts/run_tests.sh tests/verify/ tests/agent/test_coding_context.py tests/hermes_cli/test_verify_console_scripts.py` — 117 passed
- `.venv/bin/ruff check agent/verify/recipes.py hermes_cli/verify_cmd.py tests/verify/test_recipes.py tests/verify/test_verify_cmd.py` — passed
- `git diff origin/main...HEAD --check` — passed
- direct reproduction matrix — pure unittest selects `python -m unittest discover`; nested pytest selects `python -m pytest`; empty tests and validator-only projects select no test phase
- `.venv/bin/ty check agent/verify/recipes.py hermes_cli/verify_cmd.py` — reports one pre-existing diagnostic at the unchanged Makefile-target `map()` expression in `agent/verify/recipes.py`

Fixes #90276
