### PR TITLE
fix: legacy allowlists recover without per-character approvals

### DIFF
--- a/tests/tools/test_allowlist_legacy_config.py
+++ b/tests/tools/test_allowlist_legacy_config.py
@@ -1,0 +1,21 @@
+import yaml
+from tools import approval
+
+
+def test_legacy_string_allowlist_recovers_only_string_lists(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    description = "script execution via -e/-c flag"
+    for value in ([description], yaml.safe_dump([description])):
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump({"command_allowlist": value}))
+        assert approval.load_permanent_allowlist() == {description}
+        assert approval.is_approved("probe", description)
+    assert "command_allowlist" in caplog.text
+
+
+def test_malformed_allowlist_does_not_grant_approval(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for value in ("plain text", "[bad", {"not": "a list"}, [True, "candidate"], "[true, candidate]", 42):
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump({"command_allowlist": value}))
+        assert approval.load_permanent_allowlist() == set()
+        assert not approval.is_approved("probe", "candidate")
+    assert "command_allowlist" in caplog.text

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -330,7 +330,23 @@ def load_permanent_allowlist() -> set:
     try:
         from hermes_cli.config import load_config_readonly
         config = load_config_readonly()
-        patterns = set(config.get("command_allowlist", []) or [])
+        raw = config.get("command_allowlist")
+        legacy = isinstance(raw, str)
+        if legacy:
+            # Old config-set versions serialized list values as scalar strings.
+            import yaml
+            try:
+                raw = yaml.safe_load(raw)
+            except yaml.YAMLError:
+                raw = False
+        if raw is None and not legacy:
+            raw = []
+        if not isinstance(raw, list) or any(not isinstance(item, str) for item in raw):
+            logger.warning("Ignoring malformed command_allowlist; configure a list of strings.")
+            return set()
+        if legacy:
+            logger.warning("Recovered legacy string command_allowlist; re-save it as a list of strings.")
+        patterns = set(raw)
         if patterns:
             load_permanent(patterns)
         return patterns

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -262,6 +262,12 @@ command_allowlist:
 
 These patterns are loaded at startup and silently approved in all future sessions.
 
+The setting must be a list of strings. Legacy installs that stored a list as a
+quoted YAML/JSON string recover that list at load time and log a warning to
+re-save it with `hermes config edit`. Other malformed values are ignored with
+a warning; they never become per-character approvals. Loading does not rewrite
+your configuration file.
+
 :::tip
 Use `hermes config edit` to review or remove patterns from your permanent allowlist.
 :::


### PR DESCRIPTION
Legacy string allowlists recover without per-character approvals.

Fixes #104779.

Campaign tracker: #104868.

## Changes

Recovers only stringified lists of strings, rejects malformed shapes/nonstring members with a warning, and preserves the normal list path. Read-only loading does not rewrite user config.

## Live A/B

| Case | Base | Fix |
|---|---|---|
| Stringified approval list | Set of individual characters | One intact approval description |
| Normal list | Intact description | Intact description |
| Plain string / mapping / mixed-type list | Characters, mapping keys, or invalid entries | Empty result with warning |

Real YAML written under isolated HOME/HERMES_HOME and read by production load_permanent_allowlist. No user configuration or real command execution. Separate reload-replacement semantics are unchanged.

## Validation

Two real-YAML invariants were red on base. Targeted and mirror-directory suites are queued under the campaign test lock; results will be added before readiness.

Ruff, Windows-footgun scan, compatibility-pointer scan, subprocess-stdin scan, and diff whitespace checks passed. Each issue has two regression invariants. Branches are independent single-fix patches on the same base; no unrelated cluster is included.

**Independent review:** standalone head reviewed; same-surface live controls repeated against current main and this head with asserted module-path provenance. Applied versus staged notifications, intact versus malformed allowlists, and exact refusal-code controls passed in the relevant standalone PR. No source changes were required by this review.

**Draft gate:** the original queued targeted and serialized mirror-directory suites remain required before this is marked ready. Their logs are still empty; this is not a test pass. No merge requested or performed.

## Contributor credit

Slim redo of #104787 by @liuhao1024 with contributor credit. Extends its type guard to malformed mappings and nonstring list members; does not silently grant those entries.

## Infographic

![Legacy string allowlists recover without per-character approvals](https://files.catbox.moe/wpevrh.png)

Locally rendered technical-layout fallback (no paid image inference); image text and layout were vision-checked.
