### PR TITLE
fix(codex): accepted inputs no longer appear twice in session history (#104653)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -419,7 +419,15 @@ def _persist_projected_messages(agent, turn, messages: List[Dict[str, Any]]) -> 
     if not turn.projected_messages:
         return
     from agent.message_metadata import append_message
-    for projected_message in turn.projected_messages:
+    projected_messages = turn.projected_messages
+    # Turn-start persistence owns the accepted input. Codex's leading user item
+    # only echoes its coerced wire text; later/nonmatching events remain real.
+    submitted_user_text = getattr(turn, "submitted_user_text", None)
+    first = projected_messages[0]
+    if (submitted_user_text is not None and first.get("role") == "user"
+            and first.get("content") == submitted_user_text):
+        projected_messages = projected_messages[1:]
+    for projected_message in projected_messages:
         append_message(messages, projected_message)
     if getattr(agent, "_session_db", None) is None:
         return

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -46,6 +46,8 @@ class TurnResult:
     error: Optional[str] = None  # non-recoverable turn error
     turn_id: Optional[str] = None
     thread_id: Optional[str] = None
+    # Exact turn/start text distinguishes the input echo from a new user event.
+    submitted_user_text: Optional[str] = None
     token_usage_last: Optional[dict[str, Any]] = None
     model_context_window: Optional[int] = None
     compacted: bool = False
@@ -341,9 +343,10 @@ class CodexAppServerSession:
             if self._interrupt_event.is_set():
                 result.interrupted = True
             else:
+                result.submitted_user_text = _coerce_turn_input_text(user_input)
                 ts = self._request_for(
                     result, "turn/start",
-                    {"threadId": self._thread_id, "input": [{"type": "text", "text": _coerce_turn_input_text(user_input)}]},
+                    {"threadId": self._thread_id, "input": [{"type": "text", "text": result.submitted_user_text}]},
                     "turn/start",
                 )
                 if ts is not None:

--- a/evals/codex_echo/README.md
+++ b/evals/codex_echo/README.md
@@ -1,0 +1,39 @@
+# Codex input ownership probe
+
+Run in a fresh process from the checkout:
+
+```sh
+PYTHONPATH=. .venv/bin/python evals/codex_echo/probe.py
+```
+
+The executable fixture is an **offline JSON-RPC peer**, not a live Codex service.
+It exercises production subprocess pipes, protocol handling, event projection,
+message splice, real SQLite writes, and conversation replay in isolated homes.
+No actual provider, Telegram account, or recipient is contacted.
+
+## Independently repeated A/B
+
+Base: `d8a07768c5ee59afae62e9fb51d45e1e30aa74da`.
+Fix implementation: `fdaae2635b6df5202e8bb74eb4662159b7735f99`.
+Each case accepts the same input twice. Both plain/platform-ID and rich/keyless
+inputs run through every row of this matrix:
+
+| Projection | Expected user rows | Base | Fix |
+|---|---:|---:|---:|
+| Leading exact echo | 2 | 4 | 2 |
+| Assistant only | 2 | 2 | 2 |
+| Leading different user event | 4 | 4 | 4 |
+| Exact echo, assistant, later identical user event | 4 | 6 | 4 |
+
+Base passes 4/8 cases; fix passes 8/8. This confirms the local ownership mechanism,
+not provider fidelity or the issue's proposed universal gateway double-write
+mechanism. Historical duplicates are not migrated. The probe checks final reply
+text and durable user-row counts; the regression invariant additionally checks
+exact replayed user content. The separate transport invariant checks that the
+recorded submitted text equals the actual `turn/start` payload.
+
+Independent review checked the sole splice caller, turn-start ownership,
+rich-input coercion, no-echo/nonmatching controls, and preservation of later
+identical events and independently repeated accepted inputs. No production
+change was needed after review. Recovery work for #104691 remains separate in
+#104857; its original macOS initiating failure is not established here.

--- a/evals/codex_echo/fixture_server.py
+++ b/evals/codex_echo/fixture_server.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Offline Codex JSON-RPC peer; no provider or authentication calls."""
+import json
+import os
+import sys
+
+
+def send(value):
+    print(json.dumps(value), flush=True)
+
+
+for line in sys.stdin:
+    request = json.loads(line)
+    if "id" not in request:
+        continue
+    method = request["method"]
+    result = {}
+    if method == "thread/start":
+        result = {"thread": {"id": "fixture-thread"}}
+    elif method == "turn/start":
+        result = {"turn": {"id": "fixture-turn"}}
+    send({"jsonrpc": "2.0", "id": request["id"], "result": result})
+    if method != "turn/start":
+        continue
+    text = request["params"]["input"][0]["text"]
+    mode = os.environ.get("ECHO_FIXTURE_MODE", "echo")
+    items = []
+    if mode != "assistant_only":
+        items.append({"type": "userMessage", "id": "input", "content": [
+            {"type": "text", "text": "different" if mode == "different" else text}]})
+    items.append({"type": "agentMessage", "id": "reply", "text": "fixture reply"})
+    if mode == "later_equal":
+        items.append({"type": "userMessage", "id": "steer", "content": [{"type": "text", "text": text}]})
+    for item in items:
+        send({"method": "item/completed", "params": {
+            "threadId": "fixture-thread", "turnId": "fixture-turn", "item": item}})
+    send({"method": "turn/completed", "params": {
+        "threadId": "fixture-thread", "turn": {"id": "fixture-turn", "status": "completed", "error": None}}})

--- a/evals/codex_echo/probe.py
+++ b/evals/codex_echo/probe.py
@@ -1,0 +1,61 @@
+"""Run from the checkout: PYTHONPATH=. python evals/codex_echo/probe.py.
+
+Real subprocess pipes, protocol parser/projector, persistence and SQLite replay.
+The peer is an offline fixture, not a Codex/provider validation.
+"""
+import json
+import os
+from pathlib import Path
+import tempfile
+import threading
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix="hermes-echo-") as tmp:
+        os.environ.update(HOME=tmp, HERMES_HOME=tmp, CODEX_HOME=tmp, HERMES_DISABLE_PLUGINS="1")
+        from agent import codex_runtime
+        from agent.message_metadata import append_message
+        from agent.session_persistence import SessionPersistenceMixin
+        from agent.transports.codex_app_server_session import CodexAppServerSession
+        from hermes_state import SessionDB
+
+        observations = []
+        for mode in ["echo", "assistant_only", "different", "later_equal"]:
+            for rich in [False, True]:
+                os.environ["ECHO_FIXTURE_MODE"] = mode
+                sid = f"{mode}-{rich}"
+                db = SessionDB(Path(tmp) / f"{sid}.db")
+                db.create_session(session_id=sid, source="telegram", model="fixture")
+                agent = SessionPersistenceMixin()
+                agent.session_id = sid
+                agent._session_db = db
+                agent._session_db_created = True
+                agent._last_flushed_db_idx = 0
+                agent._session_persist_lock = threading.RLock()
+                session = CodexAppServerSession(cwd=tmp, codex_home=tmp,
+                    codex_bin=str(Path(__file__).with_name("fixture_server.py").resolve()))
+                messages = []
+                wire_input = [{"type": "text", "text": "caption"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}] if rich else "caption"
+                try:
+                    for accepted in range(2):
+                        append_message(messages, {"role": "user", "content": "caption",
+                            "platform_message_id": str(accepted) if not rich else None})
+                        assert agent._flush_messages_to_session_db(messages)
+                        turn = session.run_turn(wire_input, turn_timeout=10)
+                        assert turn.error is None, turn.error
+                        assert turn.final_text == "fixture reply", turn
+                        codex_runtime._persist_projected_messages(agent, turn, messages)
+                        assert agent._flush_messages_to_session_db(messages)
+                    users = [m["content"] for m in db.get_messages_as_conversation(sid) if m["role"] == "user"]
+                    expected_count = 4 if mode in {"different", "later_equal"} else 2
+                    observations.append({"mode": mode, "rich_keyless": rich, "users": users,
+                        "expected_user_rows": expected_count, "user_rows": len(users), "pass": len(users) == expected_count})
+                finally:
+                    session.close()
+                    db.close()
+        print(json.dumps({"module": codex_runtime.__file__, "cases": observations}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_codex_echo_ownership.py
+++ b/tests/agent/test_codex_echo_ownership.py
@@ -1,0 +1,50 @@
+"""The accepted input owns its row; transport echoes do not own new rows."""
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from agent.codex_runtime import _persist_projected_messages
+from agent.message_metadata import append_message
+from agent.session_persistence import SessionPersistenceMixin
+from agent.transports.codex_event_projector import CodexEventProjector
+from hermes_state import SessionDB
+
+
+@pytest.mark.parametrize("platform_id", ["2146", None])
+@pytest.mark.parametrize("projection", ["echo", "assistant_only", "different", "later_equal"])
+def test_only_submitted_leading_echo_is_excluded(tmp_path, platform_id, projection):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        db.create_session(session_id="echo", source="telegram", model="codex")
+        agent = SessionPersistenceMixin()
+        agent.session_id = "echo"
+        agent._session_db = db
+        agent._session_db_created = True
+        agent._last_flushed_db_idx = 0
+        agent._session_persist_lock = threading.RLock()
+        messages = []
+        # Two independently accepted identical inputs must both survive.
+        for turn_index in range(2):
+            append_message(messages, {"role": "user", "content": "accepted", "platform_message_id": platform_id})
+            assert agent._flush_messages_to_session_db(messages)
+            projector = CodexEventProjector()
+            items = []
+            if projection != "assistant_only":
+                items.append({"type": "userMessage", "id": f"u{turn_index}", "content": [
+                    {"type": "text", "text": "different" if projection == "different" else "wire caption"}]})
+            items.append({"type": "agentMessage", "id": f"a{turn_index}", "text": "reply"})
+            if projection == "later_equal":
+                items.append({"type": "userMessage", "id": f"s{turn_index}", "content": [
+                    {"type": "text", "text": "wire caption"}]})
+            projected = []
+            for item in items:
+                projected.extend(projector.project({"method": "item/completed", "params": {"item": item}}).messages)
+            _persist_projected_messages(agent, SimpleNamespace(
+                projected_messages=projected, submitted_user_text="wire caption"), messages)
+            assert agent._flush_messages_to_session_db(messages)
+        users = [row["content"] for row in db.get_messages_as_conversation("echo") if row["role"] == "user"]
+        extra = {"different": ["different"], "later_equal": ["wire caption"]}.get(projection, [])
+        assert users == (["accepted"] + extra) * 2
+    finally:
+        db.close()

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -211,6 +211,21 @@ class TestRunTurn:
 
 
 
+    def test_result_records_the_exact_submitted_input(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        rich_input = [
+            {"type": "text", "text": "caption"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        ]
+        result = make_session(client).run_turn(rich_input, turn_timeout=2.0)
+        _, params = next(request for request in client.requests if request[0] == "turn/start")
+        assert result.submitted_user_text == params["input"][0]["text"]
+        assert result.submitted_user_text != rich_input
+
     def test_foreign_completion_in_server_request_drain_is_ignored(self):
         """Approval draining must not project a child result into the parent."""
         client = FakeClient()

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -31,6 +31,17 @@ history that appears to revert.
 
 
 
+## Codex app-server input ownership
+
+The agent persists an accepted user input before starting its Codex turn. Codex
+then projects that input as a leading `userMessage` notification. At the runtime
+splice boundary, Hermes excludes only that leading item when it exactly matches
+the text serialized into `turn/start`, including rich-input coercion. Later or
+nonmatching user events remain intact, as do separately accepted identical turns.
+This also applies to synthetic/keyless input; it does not depend on a platform
+message ID. Existing historical duplicates are not rewritten. The gateway skips
+its transcript write when the agent reports that it owns persistence.
+
 ## Architecture Overview
 
 ```


### PR DESCRIPTION
Codex app-server input echoes no longer create a second durable user message after Hermes has accepted the turn.

Refs #104653. Campaign: #104868 (https://github.com/NousResearch/hermes-agent/issues/104868).

- Record the exact coerced text sent in `turn/start`; exclude only its matching leading projected user echo at the runtime splice boundary.
- Preserve nonmatching and later user events, independently accepted identical inputs, and synthetic/keyless turns. No storage-wide content or platform-ID deduplication, and no historical-row migration.
- Add two regression invariants, a real offline subprocess/SQLite probe under `evals/codex_echo/`, and session-storage documentation.

Root cause: the projected echo is a fresh unmarked message after turn-start persistence already owns the accepted input; this is not evidence that all gateway runtimes double-write.

## Validation

**Live repro:** independently repeated real subprocess JSON-RPC peer → production client/session/projector/splice → SQLite persistence and replay: current main `d8a07768c5ee59afae62e9fb51d45e1e30aa74da` passes **4/8**, fixed implementation passes **8/8**.

Each row ran both plain/platform-ID and rich/keyless input, accepting an identical input twice:

| Projection | Expected durable user rows | Before | After |
|---|---:|---:|---:|
| Exact leading echo | 2 | 4 | 2 |
| Assistant only | 2 | 2 | 2 |
| Leading different user event | 4 | 4 | 4 |
| Exact echo followed by later identical event | 4 | 6 | 4 |

- Ownership regression on base: 4 expected failures, 4 passing controls.
- Ruff, Windows-footguns, compatibility-pointer, subprocess-stdin and diff checks passed.
- Independent review found no production defect; review and reproducible commands are recorded in `evals/codex_echo/README.md`.
- The original affected-directory invocation completed: **499 files, 6396 passed, 3 failed, 26 skipped**, using the runner default of 40 workers. Both changed test files passed (ownership: 8; transport session: 35). Three compression timing tests failed outside the changed code; a serial rerun of only those three files is queued on the shared campaign lock. No duplicate directory suite was started, and this is **not a green-suite claim**.

**Fidelity limits:** this is a real local subprocess and database test with an offline protocol fixture, not a live Codex provider or Telegram account validation. The separate transport-metadata invariant was not individually RED-run due to the shared lock; the ownership invariant and subprocess A/B establish the before/after symptom. No claim is made to resolve the original macOS initiating failure in #104691; recovery is separately owned by existing #104857.

## Credit

Focused wire-text correction ported from #93546 by @fancyboi999 (Xinmin Zeng), preserving coauthor credit; original implementation #43127 by VECTOR / @vectorcmd, submitted by @vashkartik; original diagnosis @gitszabolcs (#38254). Considered current-main carry-forward #104698 and the mechanism analysis from @strzhao on #104673. The broad platform-ID deduplication proposal is not adopted.

## Infographic

![Input ownership: exact transport echoes excluded, real inputs preserved](https://v3b.fal.media/files/b/0aa9731e/il4JhPrKFNDwc1VHHz7L8_aBrXWGkE.png)
