### PR TITLE
fix: owned Anthropic grants win and auxiliary refresh stays source-bound

### DIFF
--- a/agent/anthropic_credentials.py
+++ b/agent/anthropic_credentials.py
@@ -1,8 +1,9 @@
 """Anthropic credential sources, OAuth flows, and token resolution.
 
 ``resolve_anthropic_token()`` order: ``ANTHROPIC_TOKEN`` / ``CLAUDE_CODE_OAUTH_TOKEN``,
-``ANTHROPIC_API_KEY``, ``~/.claude/.credentials.json`` / macOS Keychain, then the
-``auth.json`` credential pool. ``~/.hermes/.anthropic_oauth.json`` (Hermes PKCE) and
+``ANTHROPIC_API_KEY``, Hermes-owned OAuth grants in the ``auth.json`` credential
+pool, then ``~/.claude/.credentials.json`` / macOS Keychain as a borrowed fallback.
+``~/.hermes/.anthropic_oauth.json`` (Hermes PKCE) and
 the Claude Code file are *singletons*: ``credential_pool._seed_from_singletons()``
 re-reads them on every ``load_pool()``, so a failed write here is a failed refresh
 (``CredentialPersistError``), not a cache miss.
@@ -424,7 +425,7 @@ def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[Dict[s
     return None
 
 
-def _resolve_anthropic_pool_token() -> Optional[str]:
+def _resolve_anthropic_pool_token(*, skip_borrowed: bool = False) -> Optional[str]:
     """First available Anthropic OAuth token from credential_pool, read-only: enumerates with ``clear_expired=False,
     refresh=False`` (never ``select()``) so diagnostic call sites (account_usage, ``hermes models``) never mutate
     auth.json or hit the network; refresh-on-expiry belongs to the API call path's pool recovery."""
@@ -435,6 +436,8 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
         logger.debug("Failed to read Anthropic credential_pool", exc_info=True)
         return None
     for entry in entries:
+        if skip_borrowed and entry.source == "claude_code":
+            continue
         # access_token may be an explicit null on a persisted entry; None.strip() would crash the resolver.
         token = (getattr(entry, "access_token", None) or "").strip()
         if getattr(entry, "auth_type", None) != AUTH_TYPE_OAUTH or not token:
@@ -461,7 +464,8 @@ def resolve_anthropic_token() -> Optional[str]:
     api_key = _first_env("ANTHROPIC_API_KEY")  # an explicit API key must not be shadowed by discovered OAuth creds
     if api_key:
         return api_key
-    return _resolve_claude_code_token_from_credentials(_read_creds()) or _resolve_anthropic_pool_token()
+    # The pool's claude_code row mirrors the same externally owned refresh grant.
+    return _resolve_anthropic_pool_token(skip_borrowed=True) or _resolve_claude_code_token_from_credentials(_read_creds())
 
 
 def run_oauth_setup_token() -> Optional[str]:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3425,13 +3425,19 @@ def _refresh_nous_credentials() -> bool:
     ))
 
 
-def _refresh_anthropic_credentials() -> bool:
-    from agent.anthropic_credentials import read_claude_code_credentials, _refresh_oauth_token, resolve_anthropic_token
+def _refresh_anthropic_credentials(failed_api_key: str = "") -> bool:
+    from agent.anthropic_credentials import read_claude_code_credentials, _refresh_oauth_token
+    token = failed_api_key
+    if not token:
+        return False
+    pool = load_pool("anthropic")
+    if pool.entry_id_for_api_key(token):
+        return pool.try_refresh_matching(api_key_hint=token) is not None
     creds = read_claude_code_credentials()
-    token = _refresh_oauth_token(creds) if isinstance(creds, dict) and creds.get("refreshToken") else None
-    if not str(token or "").strip():
-        token = resolve_anthropic_token()
-    return bool(str(token or "").strip())
+    # Never spend an ambient login's refresh rotation for another request's key.
+    if isinstance(creds, dict) and creds.get("accessToken") == token and creds.get("refreshToken"):
+        return bool(_refresh_oauth_token(creds))
+    return False
 
 
 def _refresh_xai_oauth_credentials() -> bool:
@@ -3455,21 +3461,21 @@ def _refresh_vertex_credentials() -> bool:
 
 
 # Each refresher returns True when a usable credential exists; the caller then evicts cached clients.
-_CREDENTIAL_REFRESHERS: Dict[str, Callable[[], bool]] = {
+_CREDENTIAL_REFRESHERS: Dict[str, Callable[..., bool]] = {
     "copilot": _refresh_copilot_credentials, "openai-codex": _refresh_codex_credentials,
     "nous": _refresh_nous_credentials, "anthropic": _refresh_anthropic_credentials,
     "xai-oauth": _refresh_xai_oauth_credentials, "vertex": _refresh_vertex_credentials,
 }
 
 
-def _refresh_provider_credentials(provider: str) -> bool:
+def _refresh_provider_credentials(provider: str, *, failed_api_key: str = "") -> bool:
     """Refresh short-lived credentials for OAuth-backed auxiliary providers."""
     normalized = _normalize_aux_provider(provider)
     refresher = _CREDENTIAL_REFRESHERS.get(normalized)
     if refresher is None:
         return False
     try:
-        if not refresher():
+        if not (refresher(failed_api_key) if normalized == "anthropic" else refresher()):
             return False
         _evict_cached_clients(normalized)
         return True
@@ -3663,11 +3669,13 @@ def _plan_fallback_auth_retry(
     destination: _FallbackDestination,
     rebuild: Callable[[str, Any, Optional[str]], Tuple[_FallbackDestination, Dict[str, Any]]], *,
     async_mode: bool,
+    failed_api_key: str = "",
 ) -> Tuple[str, Optional[Tuple[Any, Dict[str, Any], _FallbackDestination]]]:
     """After an auth error on a fallback candidate: refresh credentials and rebuild the request.
     Returns ``(refresh_provider, retry)``; ``retry`` = ``(client, kwargs, destination)`` or None."""
     fb_provider = _auth_refresh_provider_for_route(destination.provider, destination.base_url)
-    if fb_provider not in {"auto", "", None} and _refresh_provider_credentials(fb_provider):
+    refresh_kwargs = {"failed_api_key": failed_api_key} if fb_provider == "anthropic" else {}
+    if fb_provider not in {"auto", "", None} and _refresh_provider_credentials(fb_provider, **refresh_kwargs):
         retry_client, retry_model = _get_cached_client(
             fb_provider, destination.model, **({"async_mode": True} if async_mode else {}),
             base_url=destination.base_url or None, api_mode=destination.api_mode,
@@ -3714,7 +3722,8 @@ def _call_fallback_candidate_sync(
     except Exception as fb_err:
         if not _is_auth_error(fb_err):
             raise
-        fb_provider, retry = _plan_fallback_auth_retry(destination, rebuild, async_mode=False)
+        fb_provider, retry = _plan_fallback_auth_retry(
+            destination, rebuild, async_mode=False, failed_api_key=getattr(fb_client, "api_key", ""))
         failed_destination = destination
         if retry is not None:
             failed_destination = retry[2]
@@ -3752,7 +3761,8 @@ async def _call_fallback_candidate_async(
     except Exception as fb_err:
         if not _is_auth_error(fb_err):
             raise
-        fb_provider, retry = _plan_fallback_auth_retry(destination, rebuild, async_mode=True)
+        fb_provider, retry = _plan_fallback_auth_retry(
+            destination, rebuild, async_mode=True, failed_api_key=getattr(fb_client, "api_key", ""))
         failed_destination = destination
         if retry is not None:
             failed_destination = retry[2]
@@ -6767,7 +6777,9 @@ def _ladder_credential_rungs(
     auth_refresh_provider = _auth_refresh_provider_for_route(resolved_provider, route.base_info)
     if (_is_auth_error(first_err) and auth_refresh_provider not in {"auto", "", None}
             and not client_is_nous):
-        if _refresh_provider_credentials(auth_refresh_provider):
+        refresh_kwargs = ({"failed_api_key": getattr(client, "api_key", "")}
+                          if auth_refresh_provider == "anthropic" else {})
+        if _refresh_provider_credentials(auth_refresh_provider, **refresh_kwargs):
             if auth_refresh_provider != _normalize_aux_provider(resolved_provider):
                 # The stale client is cached under the route label (e.g. "auto"), not the
                 # concrete backend we refreshed.

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -12,6 +12,7 @@ from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import build_anthropic_client, build_anthropic_bedrock_client, build_anthropic_kwargs
 from agent.anthropic_credentials import _is_oauth_token, _refresh_oauth_token, _write_claude_code_credentials, is_claude_code_token_valid, read_claude_code_credentials, resolve_anthropic_token, run_oauth_setup_token
 from agent.anthropic_endpoints import _is_azure_anthropic_endpoint
+from agent.credential_pool import PooledCredential
 from agent.anthropic_message_convert import _to_plain_data, convert_messages_to_anthropic, convert_tools_to_anthropic, normalize_model_name
 from agent.transports import get_transport
 
@@ -272,10 +273,9 @@ class TestResolveAnthropicToken:
         # returns nothing, mirroring a Hermes-PKCE-only setup.
         monkeypatch.setattr("agent.anthropic_credentials.read_claude_code_credentials", lambda: None)
 
-        pool_entry = SimpleNamespace(
-            auth_type="oauth",
-            access_token="pool-oauth-token",
-        )
+        pool_entry = PooledCredential.from_dict("anthropic", {
+            "auth_type": "oauth", "access_token": "pool-oauth-token",
+        })
         pool = SimpleNamespace(
             _available_entries=lambda **_kwargs: ([pool_entry], []),
         )
@@ -330,7 +330,9 @@ class TestResolveAnthropicToken:
         monkeypatch.setattr("agent.anthropic_credentials.Path.home", lambda: tmp_path)
         monkeypatch.setattr("agent.anthropic_credentials.read_claude_code_credentials", lambda: None)
 
-        api_key_entry = SimpleNamespace(auth_type="api_key", access_token="sk-pool-apikey")
+        api_key_entry = PooledCredential.from_dict("anthropic", {
+            "auth_type": "api_key", "access_token": "sk-pool-apikey",
+        })
         pool = SimpleNamespace(
             _available_entries=lambda **_kwargs: ([api_key_entry], []),
         )
@@ -351,7 +353,9 @@ class TestResolveAnthropicToken:
         monkeypatch.setattr("agent.anthropic_credentials.read_claude_code_credentials", lambda: None)
 
         captured = {}
-        pool_entry = SimpleNamespace(auth_type="oauth", access_token="pool-oauth-token")
+        pool_entry = PooledCredential.from_dict("anthropic", {
+            "auth_type": "oauth", "access_token": "pool-oauth-token",
+        })
 
         def _available_entries(**kwargs):
             captured.update(kwargs)

--- a/tests/agent/test_anthropic_owned_routing.py
+++ b/tests/agent/test_anthropic_owned_routing.py
@@ -1,0 +1,50 @@
+"""Owned OAuth must win without rotating an unrelated borrowed grant."""
+import json
+import time
+
+import pytest
+
+from agent import anthropic_credentials as ac
+from agent import auxiliary_client as aux
+
+
+def _seed(tmp_path, monkeypatch):
+    monkeypatch.setattr(ac.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(ac, "_first_env", lambda *names: "")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    borrowed = tmp_path / ".claude" / ".credentials.json"
+    borrowed.parent.mkdir()
+    borrowed.write_text(json.dumps({"claudeAiOauth": {
+        "accessToken": "borrowed-token", "refreshToken": "borrowed-refresh", "expiresAt": 1,
+    }}))
+    (tmp_path / "auth.json").write_text(json.dumps({"credential_pool": {"anthropic": [{
+        "id": "owned", "source": "manual:hermes_pkce", "auth_type": "oauth",
+        "access_token": "owned-token", "refresh_token": "owned-refresh",
+        "expires_at": int(time.time()*1000)+3600000, "priority": 0,
+    }]}}))
+    return borrowed
+
+
+def test_owned_pool_precedes_expired_borrowed_login(tmp_path, monkeypatch):
+    borrowed = _seed(tmp_path, monkeypatch)
+    before = borrowed.read_bytes()
+    def forbidden(*args, **kwargs):
+        pytest.fail("Borrowed refresh was consumed despite owned grant")
+    monkeypatch.setattr(ac, "_refresh_oauth_token", forbidden)
+    assert ac.resolve_anthropic_token() == "owned-token"
+    assert borrowed.read_bytes() == before
+
+
+def test_auxiliary_owned_refresh_does_not_spend_borrowed_rotation(tmp_path, monkeypatch):
+    borrowed = _seed(tmp_path, monkeypatch)
+    before = borrowed.read_bytes()
+    def refresh(refresh_token, **kwargs):
+        assert refresh_token == "owned-refresh"
+        return {"access_token": "owned-new-token", "refresh_token": "owned-new-refresh",
+                "expires_at_ms": int(time.time()*1000)+3600000}
+    def forbidden(*args, **kwargs):
+        pytest.fail("Auxiliary refreshed an unrelated borrowed grant")
+    monkeypatch.setattr(ac, "refresh_anthropic_oauth_pure", refresh)
+    monkeypatch.setattr(ac, "_refresh_oauth_token", forbidden)
+    assert aux._refresh_anthropic_credentials("owned-token")
+    assert borrowed.read_bytes() == before

--- a/tests/agent/test_anthropic_owned_routing.py
+++ b/tests/agent/test_anthropic_owned_routing.py
@@ -1,8 +1,11 @@
 """Owned OAuth must win without rotating an unrelated borrowed grant."""
 import json
 import time
+from types import SimpleNamespace
 
+import httpx
 import pytest
+from openai import AuthenticationError
 
 from agent import anthropic_credentials as ac
 from agent import auxiliary_client as aux
@@ -46,5 +49,13 @@ def test_auxiliary_owned_refresh_does_not_spend_borrowed_rotation(tmp_path, monk
         pytest.fail("Auxiliary refreshed an unrelated borrowed grant")
     monkeypatch.setattr(ac, "refresh_anthropic_oauth_pure", refresh)
     monkeypatch.setattr(ac, "_refresh_oauth_token", forbidden)
-    assert aux._refresh_anthropic_credentials("owned-token")
+    error = AuthenticationError("Invalid API key", response=httpx.Response(
+        401, request=httpx.Request("POST", "https://api.anthropic.com/v1/messages")), body={})
+    route = SimpleNamespace(client=SimpleNamespace(api_key="owned-token"), task="compression", tag="",
+        resolved_provider="anthropic", base_info="https://api.anthropic.com", resolved_model="fixture",
+        final_model="fixture", main_runtime=None)
+    retry = aux._ladder_credential_rungs(error, route, {}, False)
+    assert next(retry).kind == "retry_same_provider"
+    retry.close()
     assert borrowed.read_bytes() == before
+    assert aux._refresh_anthropic_credentials("unrelated-api-key") is False

--- a/tests/agent/test_anthropic_spent_rotation_verdict.py
+++ b/tests/agent/test_anthropic_spent_rotation_verdict.py
@@ -226,7 +226,7 @@ def test_auxiliary_refresh_reports_failure_for_a_lost_commit(
     monkeypatch.setattr(AA, "refresh_anthropic_oauth_pure", _rotating_refresh)
     _break_durable_write(monkeypatch)
 
-    assert _refresh_provider_credentials("anthropic") is False
+    assert _refresh_provider_credentials("anthropic", failed_api_key=_STALE_ACCESS) is False
 
 
 def test_independent_pool_credential_stays_eligible(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2772,7 +2772,7 @@ class TestAuxiliaryAuthRefreshRetry:
         ):
             from agent.auxiliary_client import _refresh_provider_credentials
 
-            assert _refresh_provider_credentials("anthropic") is True
+            assert _refresh_provider_credentials("anthropic", failed_api_key="expired-token") is True
 
         mock_refresh_oauth.assert_called_once_with("refresh-token", use_json=False)
         mock_write.assert_called_once_with("fresh-token", "refresh-token-2", 9999999999999)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1724,6 +1724,7 @@ class TestStaleFallbackCandidateSkip:
 
         stale_fb = MagicMock()
         stale_fb.base_url = "https://api.anthropic.com"
+        stale_fb.api_key = "expired-anthropic-token"
         stale_fb.chat.completions.create.side_effect = _AuxAuth401("Invalid bearer token")
 
         fresh_fb = MagicMock()
@@ -1752,7 +1753,7 @@ class TestStaleFallbackCandidateSkip:
             )
 
         assert result.choices[0].message.content == "fresh-fallback"
-        mock_refresh.assert_called_once_with("anthropic")
+        mock_refresh.assert_called_once_with("anthropic", failed_api_key=stale_fb.api_key)
         assert stale_fb.chat.completions.create.call_count == 1
         assert fresh_fb.chat.completions.create.call_count == 1
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -145,6 +145,13 @@ If you'd rather not track per-provider plan semantics at all, [Nous Portal](#nou
 
 Use Claude models directly through the Anthropic API — no OpenRouter proxy needed. Supports three auth methods:
 
+When no explicit environment credential is selected, Hermes-owned OAuth grants
+in the credential pool take precedence over a borrowed Claude Code login. The
+borrowed login remains the fallback when no owned OAuth grant is available.
+Auxiliary authentication recovery refreshes the credential used by the failed
+request, not an unrelated ambient login; rotating a borrowed login can otherwise
+invalidate its owner's refresh token.
+
 :::caution Requires Claude Max "extra usage" credits
 When you authenticate via `hermes model` → Anthropic OAuth (or via `hermes auth add anthropic --type oauth`), Hermes routes as Claude Code against your Anthropic account. **It only works if you're on a Claude Max plan and have purchased extra usage credits.** The base Max plan allowance (the usage included in Claude Code by default) is not consumed by Hermes — only the extra/overage credits you've added on top are. Claude Pro subscribers cannot use this path.
 


### PR DESCRIPTION
Hermes-owned Anthropic OAuth grants take precedence over borrowed logins, and auxiliary refresh targets the credential that supplied the failed request.

Fixes #104622. Slim port of #104624 by @liuhao1024, with root-cause credit to @dwb1991; both are coauthors. #101555 was reviewed as adjacent source-affinity work but its unrelated pool-CLI mutation policy is not included.

## Changes
- Skip the borrowed `claude_code` mirror when resolving owned OAuth grants before the borrowed-login fallback.
- Forward the failed API key through the primary and synchronous/asynchronous fallback auxiliary refresh paths.
- Use the existing pool matching-refresh primitive; refresh a borrowed singleton only when it supplied the failed key. A missing credential identity cannot initiate refresh.
- Keep explicit environment credential precedence and document the owned-grant behavior.

## Live repro
Isolated HOME/HERMES_HOME, fake credentials, real temporary auth stores, and real HTTP exchanges against loopback. No real credentials, macOS Keychain, or vendor inference were accessed.

| Case | Before | After |
|---|---|---|
| Owned + valid borrowed grant | borrowed token selected | owned token selected |
| Owned + expired borrowed grant | borrowed refresh POST; borrowed file rewritten | owned token selected; no borrowed POST/write |
| Auxiliary 401 with owned request credential | borrowed refresh POST and rewrite | owned refresh POST; borrowed file byte-identical |
| Explicit API key | explicit key | explicit key |
| Borrowed-only fallback | borrowed token | borrowed token |

The auxiliary case drives the production recovery ladder using an SDK AuthenticationError and a real local token endpoint. The baseline ladder replay loads the complete two unchanged module sources from `a688e7d5ff9aeaaa9c97d28c316467f89ab8c943` in a fresh isolated process, not patched predicates. This verifies local refresh ownership, not actual vendor single-use enforcement or a macOS logout.

Evidence retained at `/tmp/resolve-089c35aa/auth-routing-evidence/anthropic-{before-ladder,after-ladder}.json` and `anthropic-live.py`.

## Draft validation gates
- The original two owned-routing invariants failed on base at borrowed-refresh assertions. Their low-level fixture and explicit-identity call contract were subsequently updated; final regression/sibling suites remain queued under the campaign test lock.
- Ruff, Windows-footgun scan, compat-pointer scan, subprocess-stdin scan, and diff check passed.
- Independent review, final targeted and affected-directory suites, and exact isolated-head revalidation are still required. **Not merge-ready.**
- Broader main-agent pool-selected source affinity in #101555 is not claimed solved here.

## Infographic
![Refresh the request credential](https://v3b.fal.media/files/b/0aa9733d/xSSft4W1SaObOCTnO7-Em_8ZJNHQ0J.png)


Campaign tracker: #104868.
