### PR TITLE
fix: capability probes use minted credentials rather than callable text

### DIFF
--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -34,6 +34,15 @@ class CommandTokenError(RuntimeError):
     """A ``key_cmd`` failed to produce a usable token."""
 
 
+def materialize_probe_api_key(api_key: object) -> str:
+    """Best-effort probe credential; never send a callable's repr or log mint errors."""
+    try:
+        token = api_key() if callable(api_key) else api_key
+    except Exception:
+        return ""
+    return token.strip() if isinstance(token, str) else ""
+
+
 def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
     """Run *command*, returning ``(token, ttl_seconds_or_None)``."""
     try:

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -104,7 +104,9 @@ def _runtime_main(key: str) -> str:
     try:
         from agent.auxiliary_client import _runtime_main_value
 
-        return _clean_str(_runtime_main_value(key))
+        from agent.command_token_source import materialize_probe_api_key
+        value = _runtime_main_value(key)
+        return materialize_probe_api_key(value) if key == "api_key" else _clean_str(value)
     except Exception:
         return ""
 

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -99,14 +99,13 @@ def _clean_str(raw: Any) -> str:
     return str(raw or "").strip()
 
 
-def _runtime_main(key: str) -> str:
-    """Stripped context-local main-runtime value, or "" when unavailable."""
+def _runtime_main(key: str) -> Any:
+    """Context-local credential source or stripped runtime text; "" when unavailable."""
     try:
         from agent.auxiliary_client import _runtime_main_value
 
-        from agent.command_token_source import materialize_probe_api_key
         value = _runtime_main_value(key)
-        return materialize_probe_api_key(value) if key == "api_key" else _clean_str(value)
+        return value if key == "api_key" else _clean_str(value)
     except Exception:
         return ""
 
@@ -178,6 +177,12 @@ def _resolve_inference_value(
     → ``custom_providers[].<key>``, ``<name>`` covering the provider and
     ``model.provider`` in both bare and ``custom:``-prefixed forms."""
     runtime = _runtime_main(key)
+    # A declared source owns authentication even when its mint fails.
+    if key == "api_key":
+        from agent.command_token_source import materialize_probe_api_key
+        if callable(runtime):
+            return materialize_probe_api_key(runtime)
+        runtime = materialize_probe_api_key(runtime)
     if runtime and runtime_ok(runtime):
         return runtime
     if not isinstance(cfg, dict):

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -416,8 +416,9 @@ def _normalize_base_url(base_url: str) -> str:
     return (base_url or "").strip().rstrip("/")
 
 
-def _auth_headers(api_key: str = "") -> Dict[str, str]:
-    token = str(api_key or "").strip()
+def _auth_headers(api_key: object = "") -> Dict[str, str]:
+    from agent.command_token_source import materialize_probe_api_key
+    token = materialize_probe_api_key(api_key)
     return {"Authorization": f"Bearer {token}"} if token else {}
 
 
@@ -919,7 +920,7 @@ def fetch_endpoint_model_metadata(base_url: str, api_key: str = "", force_refres
         return {}
     alternate = normalized[:-3].rstrip("/") if normalized.endswith("/v1") else normalized + "/v1"
     candidates = [normalized] + ([alternate] if alternate != normalized else [])
-    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    headers = _auth_headers(api_key)
     verify = _resolve_requests_verify(normalized)
     last_error: Optional[Exception] = None
     if local:

--- a/hermes_cli/models_local.py
+++ b/hermes_cli/models_local.py
@@ -152,7 +152,8 @@ def _get_ollama_native_headers(base_url: Optional[str], *, api_key: Optional[str
     *base_url* shares the configured Ollama root; an explicit *api_key* replaces any configured
     Authorization variant rather than inheriting it."""
     configured_base = _configured_ollama_base_url()
-    explicit_key = str(api_key or "").strip()
+    from agent.command_token_source import materialize_probe_api_key
+    explicit_key = materialize_probe_api_key(api_key)
     configured_matches = bool(configured_base and base_url and _same_ollama_native_root(base_url, configured_base))
     if not configured_matches and not explicit_key:
         return {}
@@ -366,7 +367,8 @@ def _lmstudio_server_root(base_url: Optional[str]) -> Optional[str]:
 def _lmstudio_request_headers(api_key: Optional[str] = None) -> dict:
     """HTTP headers for LM Studio native API requests."""
     from hermes_cli.models import _HERMES_USER_AGENT
-    token = str(api_key or "").strip()
+    from agent.command_token_source import materialize_probe_api_key
+    token = materialize_probe_api_key(api_key)
     return {"User-Agent": _HERMES_USER_AGENT, **({"Authorization": f"Bearer {token}"} if token else {})}
 
 
@@ -591,7 +593,8 @@ def ollama_model_supports_thinking(
     if not server_url or not bare_model:
         return None
 
-    token = str(api_key or "").strip()
+    from agent.command_token_source import materialize_probe_api_key
+    token = materialize_probe_api_key(api_key)
     try:
         with httpx.Client(timeout=timeout, headers={"Authorization": f"Bearer {token}"} if token else {}) as client:
             resp = client.post(f"{server_url}/api/show", json={"name": bare_model})

--- a/hermes_cli/models_local.py
+++ b/hermes_cli/models_local.py
@@ -158,8 +158,9 @@ def _get_ollama_native_headers(base_url: Optional[str], *, api_key: Optional[str
     if not configured_matches and not explicit_key:
         return {}
     headers = _get_ollama_request_headers() if configured_matches else {}
-    if explicit_key:
+    if explicit_key or callable(api_key):
         _drop_authorization(headers)
+    if explicit_key:
         headers["Authorization"] = f"Bearer {explicit_key}"
     return headers
 

--- a/tests/agent/test_capability_probe_credentials.py
+++ b/tests/agent/test_capability_probe_credentials.py
@@ -1,0 +1,38 @@
+"""Capability probes materialize credentials without consuming the chat source."""
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from agent import auxiliary_client, image_routing, model_metadata
+from hermes_cli import models_local
+
+
+@pytest.mark.parametrize("credential,expected", [(lambda: "minted", "minted"), ("static", "static")])
+def test_capability_paths_share_concrete_bearer(credential, expected):
+    auxiliary_client.set_runtime_main("custom", "fixture", api_key=credential)
+    try:
+        assert image_routing._resolve_inference_api_key({}, "custom") == expected
+        assert model_metadata._auth_headers(credential) == {"Authorization": f"Bearer {expected}"}
+        assert models_local._lmstudio_request_headers(credential)["Authorization"] == f"Bearer {expected}"
+        requests = []
+        def capture(req):
+            requests.append(req)
+            return httpx.Response(200, json={"capabilities": ["thinking"]})
+        client_type = httpx.Client
+        with patch("httpx.Client", lambda **kwargs: client_type(
+            **kwargs, transport=httpx.MockTransport(capture)
+        )):
+            models_local.ollama_model_supports_thinking("fixture", "http://localhost:11434/v1", credential)
+        assert requests and requests[0].headers["Authorization"] == f"Bearer {expected}"
+        assert auxiliary_client._runtime_main_value("api_key") is credential
+    finally:
+        auxiliary_client.clear_runtime_main()
+
+
+def test_failed_callable_never_becomes_a_bearer():
+    def failed():
+        raise RuntimeError("secret-bearing command failure")
+    for value in (failed, lambda: object(), object(), None):
+        assert model_metadata._auth_headers(value) == {}
+        assert "Authorization" not in models_local._lmstudio_request_headers(value)

--- a/tests/agent/test_capability_probe_credentials.py
+++ b/tests/agent/test_capability_probe_credentials.py
@@ -30,9 +30,31 @@ def test_capability_paths_share_concrete_bearer(credential, expected):
         auxiliary_client.clear_runtime_main()
 
 
-def test_failed_callable_never_becomes_a_bearer():
+def test_failed_callable_never_becomes_a_bearer(monkeypatch):
     def failed():
         raise RuntimeError("secret-bearing command failure")
     for value in (failed, lambda: object(), object(), None):
         assert model_metadata._auth_headers(value) == {}
         assert "Authorization" not in models_local._lmstudio_request_headers(value)
+
+    from hermes_cli import models
+    url = "http://localhost:11434/v1"
+    configured = {"base_url": url, "api_key": "provider-fallback", "extra_headers": {
+        "aUtHoRiZaTiOn": "Bearer configured-fallback", "X-Probe-Fixture": "preserved",
+    }}
+    monkeypatch.setattr(models, "_get_provider_config_dict", lambda _: configured)
+    for value in (failed, lambda: object(), lambda: ""):
+        auxiliary_client.set_runtime_main("custom", "fixture", api_key=value)
+        try:
+            for cfg in ({"model": {"api_key": "model-fallback"}},
+                        {"providers": {"custom": {"api_key": "provider-fallback"}}}):
+                assert image_routing._resolve_inference_api_key(cfg, "custom") == ""
+            assert models_local._get_ollama_native_headers(url, api_key=value) == {
+                "X-Probe-Fixture": "preserved",
+            }
+            assert auxiliary_client._runtime_main_value("api_key") is value
+        finally:
+            auxiliary_client.clear_runtime_main()
+    # An absent explicit credential still permits configured authentication.
+    assert models_local._get_ollama_native_headers(url)["aUtHoRiZaTiOn"] == "Bearer configured-fallback"
+    assert image_routing._resolve_inference_api_key({"model": {"api_key": "model-fallback"}}, "custom") == "model-fallback"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1320,7 +1320,10 @@ Vision, thinking, and native local-model capability probes materialize the same
 callable credential used by chat before building authentication headers. They
 reuse the command token cache without replacing the chat client's callable.
 If a command cannot mint a string token, these best-effort probes send no bearer
-rather than an object representation; chat retains its normal error handling.
+rather than an object representation or a lower-priority configured credential.
+Native local-model probes remove inherited Authorization on a failed explicit
+callable while retaining unrelated configured headers. Chat retains its normal
+error handling.
 
 Enterprise gateways often issue short-lived bearer tokens (SSO/OIDC brokers, cloud IAM, internal auth proxies) rather than static API keys, so a token copied into `.env` goes stale mid-session and requests start returning 401. `key_cmd` names a command that *prints* a token; Hermes runs it and caches the result until shortly before expiry, so long sessions keep working with no restart:
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1316,6 +1316,12 @@ Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accept
 
 #### Command-minted credentials (`key_cmd`)
 
+Vision, thinking, and native local-model capability probes materialize the same
+callable credential used by chat before building authentication headers. They
+reuse the command token cache without replacing the chat client's callable.
+If a command cannot mint a string token, these best-effort probes send no bearer
+rather than an object representation; chat retains its normal error handling.
+
 Enterprise gateways often issue short-lived bearer tokens (SSO/OIDC brokers, cloud IAM, internal auth proxies) rather than static API keys, so a token copied into `.env` goes stale mid-session and requests start returning 401. `key_cmd` names a command that *prints* a token; Hermes runs it and caches the result until shortly before expiry, so long sessions keep working with no restart:
 
 ```yaml


### PR DESCRIPTION
Capability probes materialize callable credentials before building authentication headers, while chat keeps its per-request callable.

Fixes #104460. Extends #104477's runtime-vision fix by @liuhao1024 (coauthor) across the native thinking, local-server, and metadata header paths identified in #87641 by @e8kor. The latter PR's broader catalog-cache and runtime re-resolution changes were not copied: collapsing all callable credentials to one cache identity would need separate scrutiny.

## Changes
- Add one small materialization function in the module that owns command credentials.
- Apply it to runtime vision lookup, native thinking/vision/context headers, local native headers, and metadata discovery headers.
- Failed or non-string mints yield no bearer; no command/error output is logged by the materializer.
- Leave chat's callable and token caching unchanged; document probe behavior.

## Live repro
Real CommandTokenSource subprocess (`printf` of a dummy token), real OpenAI SDK, isolated homes, and a loopback HTTP server; non-loopback sockets blocked.

| Same production surface | Before | After |
|---|---|---|
| Thinking `/api/show`, callable | object repr bearer; 403; unknown capability | minted bearer; 200; thinking supported |
| Runtime vision `/api/show`, callable | object repr bearer; 403; unknown capability | minted bearer; 200; vision supported |
| Static credential thinking control | 200 | 200 |
| Same callable chat control | 200, fixture response | 200, same fixture response |

This is local-wire integration evidence, not a real model or vendor-service result. Scripts/results remain in `/tmp/resolve-089c35aa/auth-routing-evidence/` as `capability-live.py`, `capability-before.json`, and `capability-after.json`.

## Draft validation gates
- The callable and invalid-value regression assertions failed on original source. An initial static-control fixture patched urllib even though thinking uses httpx; that fixture was corrected before implementation. Its initial failure is **not** credited as a product regression.
- Final targeted/sibling suites are queued under the campaign lock. Independent review, affected-directory suites, and exact isolated-head revalidation remain required. **Not merge-ready.**
- Ruff, Windows-footgun, compat-pointer, subprocess-stdin and diff checks passed.
- General model-catalog listing/cache and runtime re-resolution portions of #87641/#99893 remain outside this capability-probe change; no claim those PRs are superseded.

## Infographic
![Capability probes use real tokens](https://v3b.fal.media/files/b/0aa9733d/rklIrwgK5Gv0PTV7_hDcC_ehmKnycF.png)

## Follow-up: failed command precedence
Campaign: #104868.

Independent review reproduced a failed `CommandTokenSource('exit 7')` sending a lower-priority configured bearer. The follow-up keeps declared callable ownership through runtime resolution and strips only inherited Authorization on failed explicit native-probe credentials; unrelated configured headers remain.

**Live repro:** On old head `0955b5c6538`, failed runtime vision sends `Bearer configured-fallback`; with the follow-up it sends no Authorization. A separate native `/api/tags` capture verifies failed command → no Authorization plus preserved `X-Probe-Fixture`, successful command → minted bearer plus preserved header, static override → static bearer plus preserved header. Thinking, runtime vision, and same-callable chat positive controls still succeed; failed chat still raises before HTTP. Real subprocesses and localhost HTTP only; no vendor inference or user credentials. Evidence: `/tmp/resolve-089c35aa/fix-104902-evidence/`.

The existing second invariant now covers configured fallback credentials and mixed-case Authorization; no third test was added. New exact-head invariant replay is queued under the campaign lock. Broader suites and independent new-head review remain gates; draft status is unchanged.
