### PR TITLE
fix(tests): lifecycle fixtures no longer race background work

### DIFF
--- a/tests/agent/test_compression_attempt_lifecycle.py
+++ b/tests/agent/test_compression_attempt_lifecycle.py
@@ -100,7 +100,8 @@ class TestWorkerTeardownOnCeiling:
             worker=cooperative_worker,
             messages=original,
             system_prompt_fallback="fallback",
-            idle_timeout_seconds=0.1,
+            # Keep idle expiry out of this total-ceiling test under runner load.
+            idle_timeout_seconds=2.0,
             total_ceiling_seconds=0.2,
             fence=fence,
             stall_fallback=False,

--- a/tests/agent/test_compression_worker_isolation_76354.py
+++ b/tests/agent/test_compression_worker_isolation_76354.py
@@ -159,7 +159,8 @@ def test_host_timeout_releases_pool_slot_while_protected_provider_is_still_block
     agent._cached_system_prompt = "sys"
     monkeypatch.setattr(
         "agent.conversation_compression.resolve_context_compression_timeouts",
-        lambda cfg=None: (0.05, 0.1),
+        # Allow provider-thread startup under the parallel runner before timing out.
+        lambda cfg=None: (2.0, 4.0),
     )
 
     provider_started = threading.Event()
@@ -167,7 +168,7 @@ def test_host_timeout_releases_pool_slot_while_protected_provider_is_still_block
 
     def _blocked_provider(_kwargs):
         provider_started.set()
-        assert release_provider.wait(timeout=10)
+        assert release_provider.wait(timeout=30)
         return "late-provider-result"
 
     def _compress_with_protected_provider(msgs, **_kwargs):
@@ -182,10 +183,10 @@ def test_host_timeout_releases_pool_slot_while_protected_provider_is_still_block
             live, "sys", approx_tokens=120_000
         )
         assert returned is live
-        assert provider_started.wait(timeout=1)
+        assert provider_started.wait(timeout=5)
         assert not release_provider.is_set()
 
-        deadline = time.time() + 1
+        deadline = time.time() + 5
         while time.time() < deadline:
             with cc._compress_admission_lock:
                 if cc._compress_admitted_count == 0:

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -37,6 +37,12 @@ from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
+@pytest.fixture(autouse=True)
+def _disable_background_titles(monkeypatch):
+    # Persistence assertions must not race a title worker writing to pytest capture.
+    monkeypatch.setattr("agent.title_generator.maybe_auto_title", lambda *args, **kwargs: None)
+
+
 def _make_tool_defs(*names: str) -> list:
     return [
         {


### PR DESCRIPTION
Lifecycle tests isolate their intended deadlines and background work instead of failing on unrelated scheduling.

- Keep the idle timeout outside the total-ceiling test's deadline.
- Give the protected provider worker time to start before deliberately timing out its owner; retain the slot-release and blocked-provider assertions.
- Disable unrelated automatic title generation in the persistence-only fixture, preserving real tool dispatch and SQLite assertions.
- Test-only changes: no production timeout or runtime behavior changes. Discovered while validating #104867 and kept separate from that feature.

Root cause: competing synthetic deadlines and a background title worker escaped the tests' intended scope; the latter wrote to pytest capture during teardown and crashed the subprocess.

## Validation

| Check | Before | After |
|---|---|---|
| Inject 250 ms at OS-thread entry, same two timeout tests | 2 failed: premature worker-return assertion and provider never started | 2 passed, 0 failed |
| Full affected test files | Timing failures and a captured native crash in the title-worker/capture path | 35 passed, 0 failed across 3 files, retries disabled |
| Independent review | — | Actual late-imported title seam verified; persistence assertions remain intact |

Ruff, Windows-footgun scan, compatibility-pointer check and `git diff --check` passed.

## Infographic

![Reliable timeout tests](https://v3b.fal.media/files/b/0aa9729b/kEGpke6YNYOa5f2keGbT__IkXUfm9A.png)
