### PR TITLE
fix(dashboard-auth): trust server-resolved client IP for auth limits

### DIFF
--- a/hermes_cli/dashboard_auth/request_utils.py
+++ b/hermes_cli/dashboard_auth/request_utils.py
@@ -17,9 +17,16 @@ _NEXT_DENY_PREFIXES = ("/login", "/auth/", "/api/auth/")
 
 
 def client_ip(request: Request) -> str:
-    """First ``X-Forwarded-For`` hop, else the peer address."""
-    fwd = request.headers.get("x-forwarded-for", "")
-    return fwd.split(",")[0].strip() if fwd else (request.client.host if request.client else "")
+    """Return the direct peer IP for audit/rate-limit decisions.
+
+    Do not read ``X-Forwarded-For`` here. ``/auth/password-login`` uses this
+    value as its online-guessing rate-limit key, and clients can spoof
+    forwarded headers when they reach the dashboard directly. Uvicorn's
+    trusted proxy handling may already rewrite ``request.client`` for
+    deployments that explicitly enable trusted forwarded headers; otherwise
+    the safe default is the socket peer.
+    """
+    return request.client.host if request.client else ""
 
 
 def extract_bearer(request: Request) -> str:

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -319,9 +319,10 @@ async def auth_callback(
 
 
 # --- Public: password (non-redirect) login ---------------------------------
-# Brute-force throttle: a process-local sliding window per client IP. Best-effort
-# defence-in-depth on top of the provider's constant-time verify (resets on restart; behind a
-# proxy the IP is the proxy's unless X-Forwarded-For).
+# Brute-force throttle: a process-local sliding window per client IP, reset on restart.
+# Behind a trusted proxy, the server/proxy layer must normalize the client address
+# exposed as ``request.client``; otherwise all requests share the proxy's bucket.
+# This is defence-in-depth, not the only line of defence.
 _PW_RATE_MAX_ATTEMPTS = 10
 _PW_RATE_WINDOW_SEC = 60.0
 _pw_attempts: Dict[str, Deque[float]] = defaultdict(deque)

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -224,6 +224,37 @@ def _native_authorize_params(challenge, **overrides):
     return params
 
 
+@pytest.mark.parametrize("forwarded_template", ["198.51.100.{i}", ", 198.51.100.{i}"],
+                         ids=["rotated-address", "empty-first-hop"])
+def test_native_authorize_spoofed_forwarded_headers_cannot_bypass_pending_cap(
+    gated_client, forwarded_template,
+):
+    # The public OAuth entry point must limit one peer before allocating the
+    # global pending store, even when XFF rotates or has an empty first hop.
+    _verifier, challenge = _make_pkce()
+    params = _native_authorize_params(challenge, provider="stub")
+    for i in range(native_flow._MAX_PENDING_PER_IP):
+        response = gated_client.get(
+            "/auth/native/authorize", params=params,
+            headers={"X-Forwarded-For": forwarded_template.format(i=i)},
+        )
+        assert response.status_code == 302
+
+    blocked = gated_client.get(
+        "/auth/native/authorize", params=params,
+        headers={"X-Forwarded-For": forwarded_template.format(i=native_flow._MAX_PENDING_PER_IP)},
+    )
+    assert blocked.status_code == 503
+    assert "too many pending" in blocked.json()["detail"]
+
+    # Exhausting one peer's allowance must leave room for another real peer.
+    other_client = TestClient(
+        web_server.app, base_url=gated_client.base_url,
+        client=("203.0.113.10", 50000), follow_redirects=False,
+    )
+    assert other_client.get("/auth/native/authorize", params=params).status_code == 302
+
+
 def test_native_authorize_empty_provider_auto_selects_oauth_with_password_also_registered(
     gated_client,
 ):

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -337,6 +337,25 @@ class TestRateLimit:
         )
         assert good.status_code == 429
 
+    def test_spoofed_x_forwarded_for_does_not_reset_rate_limit(self, gated_app):
+        # X-Forwarded-For is attacker-controlled unless it came from a trusted
+        # reverse proxy, so direct dashboard requests must not be able to pick
+        # fresh rate-limit buckets by rotating the header value.
+        for i in range(10):
+            resp = gated_app.post(
+                "/auth/password-login",
+                headers={"X-Forwarded-For": f"198.51.100.{i}"},
+                json={"provider": "testpw", "username": "admin", "password": "WRONG"},
+            )
+            assert resp.status_code == 401
+
+        blocked = gated_app.post(
+            "/auth/password-login",
+            headers={"X-Forwarded-For": "198.51.100.250"},
+            json={"provider": "testpw", "username": "admin", "password": "hunter2"},
+        )
+        assert blocked.status_code == 429
+
 
 # ---------------------------------------------------------------------------
 # Login page rendering

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -13,10 +13,12 @@ provider, flip ``app.state.auth_required = True``, drive a ``TestClient``.
 from __future__ import annotations
 
 import time
+from typing import Any, cast
 
 import pytest
 
 from fastapi.testclient import TestClient
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from hermes_cli import web_server
 from hermes_cli.dashboard_auth import (
@@ -30,7 +32,8 @@ from hermes_cli.dashboard_auth import (
 )
 from hermes_cli.dashboard_auth.cookies import SESSION_AT_COOKIE, SESSION_RT_COOKIE
 from hermes_cli.dashboard_auth.login_page import render_login_html
-from hermes_cli.dashboard_auth.routes import _reset_password_rate_limit
+from hermes_cli.dashboard_auth.routes import _PW_RATE_MAX_ATTEMPTS, _reset_password_rate_limit
+from hermes_cli.web_server_lifecycle import _dashboard_forwarded_allow_ips
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
 
 
@@ -337,24 +340,47 @@ class TestRateLimit:
         )
         assert good.status_code == 429
 
-    def test_spoofed_x_forwarded_for_does_not_reset_rate_limit(self, gated_app):
+    @pytest.mark.parametrize(
+        "peer, forwarded_suffix",
+        [("203.0.113.9", ""), ("127.0.0.1", ", 203.0.113.9"),
+         ("172.18.0.9", ", 203.0.113.9")],
+        ids=["direct", "loopback-proxy", "configured-proxy"],
+    )
+    def test_spoofed_x_forwarded_for_does_not_reset_rate_limit(
+        self, gated_app, peer, forwarded_suffix,
+    ):
         # X-Forwarded-For is attacker-controlled unless it came from a trusted
-        # reverse proxy, so direct dashboard requests must not be able to pick
-        # fresh rate-limit buckets by rotating the header value.
-        for i in range(10):
-            resp = gated_app.post(
+        # reverse proxy. Even behind an appending proxy, the client-supplied
+        # first hop must not override Uvicorn's resolved client address.
+        trusted = _dashboard_forwarded_allow_ips({"trusted_proxies": ["172.18.0.0/16"]})
+        # Uvicorn and Starlette expose incompatible static ASGI type aliases.
+        app = cast(Any, ProxyHeadersMiddleware(cast(Any, web_server.app), trusted_hosts=trusted))
+        client = TestClient(app, base_url=gated_app.base_url, client=(peer, 50000))
+        for i in range(_PW_RATE_MAX_ATTEMPTS):
+            resp = client.post(
                 "/auth/password-login",
-                headers={"X-Forwarded-For": f"198.51.100.{i}"},
+                headers={"X-Forwarded-For": f"198.51.100.{i}{forwarded_suffix}"},
                 json={"provider": "testpw", "username": "admin", "password": "WRONG"},
             )
             assert resp.status_code == 401
 
-        blocked = gated_app.post(
+        blocked = client.post(
             "/auth/password-login",
-            headers={"X-Forwarded-For": "198.51.100.250"},
+            headers={"X-Forwarded-For": f"198.51.100.250{forwarded_suffix}"},
             json={"provider": "testpw", "username": "admin", "password": "hunter2"},
         )
         assert blocked.status_code == 429
+
+        # Another real client must retain its own budget, including when both
+        # clients reach the dashboard through the same trusted proxy.
+        other_peer = peer if forwarded_suffix else "203.0.113.10"
+        other_client = TestClient(app, base_url=gated_app.base_url, client=(other_peer, 50001))
+        allowed = other_client.post(
+            "/auth/password-login",
+            headers={"X-Forwarded-For": "203.0.113.10"},
+            json={"provider": "testpw", "username": "admin", "password": "hunter2"},
+        )
+        assert allowed.status_code == 200
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Integrates the security fix from #40285 into the current shared dashboard-auth client-IP helper, preserving the original authorship. Untrusted `X-Forwarded-For` values must not select password-login rate-limit buckets or native-login admission identities.

Use the ASGI server's `request.client.host` instead of reparsing raw forwarding headers. This retains Uvicorn's trusted-proxy normalization while removing the application-level override of that trust decision. The change also applies consistently to sibling auth-audit call sites.

## Related Issue

Related to #40285. This is an authorship-preserving integration onto main, not an independent rediscovery or a request to automatically close the original PR. Its route-local helper has since moved into `hermes_cli/dashboard_auth/request_utils.py`.

Both original commits were cherry-picked with `-x` and their original author names, emails, and dates preserved:

- `adc96915086820262df58aba490fe8d4eef9d4ee` → `e06a99cf4d98ce0dd312a1d61f09ab2efb354e9a`: hinotoi-agent's security fix.
- `2823abcaf6ca52d63790e8a5d1fcb58f59998e67` → `54bf0720dc758d9e474ba5c1d288fa402e273324`: Hinotoi Agent's trusted-proxy comment correction.
- Additional regression coverage is a separate BearHuddleston-authored commit, `e8faf1d2b95610166b374283843dce14c22ef426`.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/dashboard_auth/request_utils.py`: use the server-resolved client address for shared auth attribution; never read raw XFF here.
- `hermes_cli/dashboard_auth/routes.py`: clarify that trusted-proxy normalization belongs to the server/proxy layer. Preserve the current route refactor.
- `tests/hermes_cli/test_dashboard_auth_password_login.py`: extend the original regression through real Uvicorn proxy middleware for direct clients, loopback proxies, and explicitly trusted proxy networks; verify distinct real clients retain separate budgets.
- `tests/hermes_cli/test_dashboard_auth_native_flow.py`: cover rotating forwarded addresses and empty first hops at the public OAuth native-admission boundary; verify another real peer can still start sign-in.

## How to Test

Run with the repository's test environment. On a Linux host already using port 9119, an isolated network namespace avoids colliding with the live service:

```bash
export HERMES_PYTHON=/path/to/project/.venv/bin/python
unshare --user --map-root-user --net -- scripts/run_tests.sh \
  tests/hermes_cli/test_dashboard_auth*.py \
  tests/plugins/test_plugin_dashboard_auth_contract.py \
  -q --file-retries 0
```

Result on the PR head: **188 tests passed across 15 files**. No live service was stopped. Without namespace isolation, two existing server-startup tests hit the occupied host port; the exact same failures reproduced on the base.

The final behavior regressions were also replayed on the unfixed base, `c4a5deeffa959f8ebc891e02c5bcf767aff1dd2a`, using:

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_dashboard_auth_password_login.py \
  tests/hermes_cli/test_dashboard_auth_native_flow.py \
  -k spoofed -q --file-retries 0
```

All five parametrized cases failed at the intended security assertions on that base and passed with the fix: password throttling returned 200 instead of 429, and native admission returned 302 instead of 503.

Additional checks:

```bash
ruff check hermes_cli/dashboard_auth/request_utils.py \
  hermes_cli/dashboard_auth/routes.py \
  tests/hermes_cli/test_dashboard_auth_password_login.py \
  tests/hermes_cli/test_dashboard_auth_native_flow.py
git diff c4a5deeffa959f8ebc891e02c5bcf767aff1dd2a HEAD --check
```

Both passed. `ty check --python /path/to/project/.venv --output-format concise` on those same four paths reports only the two diagnostics also present on the exact base: nullable `revoke_session` input and the existing rate-limit test's possibly unset response. No new diagnostics remain.

An independent static review found no actionable defects. The full repository suite and a live reverse-proxy deployment were not tested locally.

### Compatibility and remaining limits

Trusted proxies must supply an authentic client hop and be covered by the existing bounded allowlist. Clients behind an unconfigured proxy share the proxy's bucket rather than controlling their own identity. Existing process-local limits, restart behavior, and shared budgets behind NAT are unchanged. No provider, configuration, dependency, or live-service changes are included.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] Commit messages follow Conventional Commits.
- [x] Searched existing issues/PRs; this intentionally carries #40285 forward with attribution.
- [x] Only changes related to this security fix are included.
- [x] Targeted tests pass through `scripts/run_tests.sh` (188 tests).
- [ ] Full repository test suite passed — not run locally.
- [x] Added regression tests and verified the failure on the unfixed base.
- [x] Tested on Linux. Windows and macOS were not exercised locally.

### Documentation & Housekeeping

- [x] Updated the relevant helper docstring and proxy comment.
- [x] Configuration example updates: N/A; no configuration keys changed.
- [x] Architecture/workflow documentation updates: N/A; current refactor is preserved.
- [x] Cross-platform impact considered; production change is platform-independent request attribution. The namespace command above is Linux-only test isolation.
- [x] Tool descriptions/schemas: N/A.
