### PR TITLE
fix: delivered cron runs stay delivered during retention (#104001, salvage #104002)

### DIFF
--- a/cron/delivery_queue.py
+++ b/cron/delivery_queue.py
@@ -140,6 +140,9 @@ def enqueue(
 ) -> dict:
     """Persist one idempotent delivery request before the worker waits."""
     with _transaction() as conn:
+        # Serialize the tombstone check and insert with retention in other
+        # processes, which can move a terminal delivery into the tombstone table.
+        conn.execute("BEGIN IMMEDIATE")
         tombstone = conn.execute(
             "SELECT terminal_status, finished_at FROM delivery_tombstones "
             "WHERE execution_id=?",

--- a/tests/cron/test_delivery_queue_retention_race.py
+++ b/tests/cron/test_delivery_queue_retention_race.py
@@ -1,0 +1,62 @@
+"""A delivery must stay terminal when retention races a repeated enqueue."""
+
+import sqlite3
+import subprocess
+import sys
+
+
+def test_enqueue_during_retention_never_recreates_delivered_request(tmp_path, monkeypatch):
+    from cron import delivery_queue as queue
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = tmp_path / "deliveries.db"
+    monkeypatch.setattr(queue, "DELIVERY_DB", db)
+    queue.enqueue("execution", {"id": "job"}, "original")
+    sends = []
+    assert queue.drain(lambda *args: sends.append(args)) == 1
+    connect = sqlite3.connect
+    prunes = []
+
+    class InterleavedConnection(sqlite3.Connection):
+        def execute(self, sql, parameters=()):
+            cursor = super().execute(sql, parameters)
+            if sql.startswith("SELECT terminal_status, finished_at FROM delivery_tombstones"):
+                # Pause after the real tombstone lookup, before enqueue can
+                # INSERT. A separate process exercises SQLite's actual lock
+                # boundary rather than the module's process-local RLock.
+                result = subprocess.run(
+                    [sys.executable, "-c", """
+import sqlite3
+import sys
+from cron import delivery_queue as queue
+queue.MAX_TERMINAL_DELIVERIES = 0
+try:
+    with sqlite3.connect(sys.argv[1], timeout=0) as conn:
+        queue._prune_terminal_unlocked(conn)
+except sqlite3.OperationalError as exc:
+    if 'locked' not in str(exc):
+        raise
+    sys.exit(75)
+""", str(db)], capture_output=True, text=True, timeout=30,
+                )
+                assert result.returncode in (0, 75), result.stderr
+                prunes.append(result.returncode)
+            return cursor
+
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            queue.sqlite3, "connect",
+            lambda *args, **kwargs: connect(*args, **kwargs, factory=InterleavedConnection),
+        )
+        replay = queue.enqueue("execution", {"id": "job"}, "duplicate")
+
+    assert prunes, "the concurrent retention path must actually be attempted"
+    # If enqueue held the SQLite writer lock, complete the deferred pruning now.
+    monkeypatch.setattr(queue, "MAX_TERMINAL_DELIVERIES", 0)
+    with queue._transaction() as conn:
+        queue._prune_terminal_unlocked(conn)
+
+    assert replay["status"] == "delivered"
+    assert queue.get_status("execution")["status"] == "delivered"
+    assert queue.drain(lambda *args: sends.append(args)) == 0
+    assert len(sends) == 1


### PR DESCRIPTION
Delivered cron executions can no longer be re-enqueued while terminal retention moves their outcome into a tombstone.

- Serialize the tombstone lookup and conditional insertion with `BEGIN IMMEDIATE`.
- Preserve existing retention limits, polling, schema, and no-retry semantics.
- Salvage @Liuzikaii's minimal fix and cross-process invariant test from #104002; original commit authorship retained.

Root cause: SQLite's implicit transaction did not start at the tombstone SELECT, allowing a separate retention writer to commit before the INSERT.

**Live repro:** identical credential-free production queue probe, fresh interpreter and temporary HOME/HERMES_HOME, real SQLite and independent retention process; local callback replaces messaging transport.

| Scenario | Main `c4a5deeffa959f8ebc891e02c5bcf767aff1dd2a` | Fix |
|---|---|---|
| Retention interleaves with repeated enqueue | replay pending, second drain sends; 2 sends total | retention writer blocked, replay delivered; 1 send total |
| Ordinary repeat before/after retention | no additional sends | no additional sends |

Validation: canonical serial `scripts/run_tests.sh -j 1 --file-retries 0 tests/cron/` under campaign flock: **95 files, 1219 passed, 0 failed, 2 skipped**. Ruff, Windows footguns, compatibility pointers, subprocess stdin, and diff checks pass. Independent read-only Codex review: no blockers. No real messaging platform contacted; Windows-specific tests await CI.

Fixes #104001
Campaign: #104904

## Infographic
![Cron delivery retention atomicity](https://v3b.fal.media/files/b/0aa97353/PuS_rCNdG1dMTnXE_q7ck_CCKR7E41.png)
