### PR TITLE
feat: recover and prioritize individual pooled credentials (salvage #104660–#104664)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -885,6 +885,10 @@ _TOKENS_SINGLETON_PROVIDERS: Dict[str, Tuple[str, str, str, str]] = {
     "xai-oauth": ("xAI OAuth", "xAI", "refresh_xai_oauth_pure", "_is_terminal_xai_oauth_refresh_error"),
 }
 
+# Providers whose pooled OAuth entries ``_refresh_entry_impl`` can actually refresh. Any other
+# provider is returned unchanged by that path, so callers must not report a refresh for them.
+REFRESHABLE_OAUTH_PROVIDERS = frozenset({"anthropic", "nous", *_TOKENS_SINGLETON_PROVIDERS})
+
 # Providers whose refresh tokens are single-use: the sync -> POST -> write-back
 # sequence must be serialized across processes under the auth-store flock.
 _SINGLE_USE_REFRESH_PROVIDERS = ("openai-codex", "xai-oauth", "anthropic")
@@ -1592,7 +1596,10 @@ class CredentialPool(CredentialPoolAdminMixin):
 
         updated = replace(updated, **_MARK_OK)
         self._replace_entry(entry, updated)
-        self._persist()
+        # Declare the cleared id: a borrowed row carries no access_token on disk, so
+        # the merge's token-change bypass cannot apply and a plain persist would copy
+        # the still-binding cooldown back over this success.
+        self._persist(status_cleared_ids=[updated.id])
         # Sync back so _seed_from_singletons() on the next load_pool() sees
         # fresh state instead of re-seeding consumed tokens.
         self._sync_device_code_entry_to_auth_store(updated)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from agent.credential_pool_admin import CredentialPoolAdminMixin
+
 import logging
 import os
 import random
@@ -910,7 +912,7 @@ class _RefreshDone(Exception):
         self.result = result
 
 
-class CredentialPool:
+class CredentialPool(CredentialPoolAdminMixin):
     def __init__(self, provider: str, entries: List[PooledCredential]):
         self.provider = provider
         self._entries = sorted(entries, key=lambda entry: entry.priority)
@@ -2157,90 +2159,6 @@ class CredentialPool:
             self._current_id = refreshed.id
         return refreshed
 
-    def reset_statuses(self) -> int:
-        """Clear exhaustion state on every entry. Returns how many were cleared.
-
-        ``failure_reason`` lives in ``extra``, not a dataclass field, so it is
-        stripped explicitly. The persist declares the cleared ids because the
-        disk-recency merge reads a cleared ``last_status_at`` (None -> epoch 0)
-        as a stale snapshot and would copy a still-binding cooldown back.
-        """
-        with self._lock:
-            stale = [
-                e for e in self._entries
-                if e.last_status or e.last_status_at or e.last_error_code or e.failure_reason
-            ]
-            if stale:
-                stale_ids = {e.id for e in stale}
-                self._entries = [
-                    replace(
-                        e, **_CLEAR_STATUS,
-                        extra={k: v for k, v in e.extra.items() if k != "failure_reason"},
-                    )
-                    if e.id in stale_ids else e
-                    for e in self._entries
-                ]
-                self._persist(status_cleared_ids=list(stale_ids))
-            return len(stale)
-
-    def remove_index(self, index: int) -> Optional[PooledCredential]:
-        with self._lock:
-            if index < 1 or index > len(self._entries):
-                return None
-            removed = self._entries.pop(index - 1)
-            self._entries = [replace(e, priority=p) for p, e in enumerate(self._entries)]
-            persist_pool_entries(
-                self.provider,
-                [entry.to_dict() for entry in self._entries],
-                removed_ids=[removed.id],
-            )
-            if self._current_id == removed.id:
-                self._current_id = None
-            return removed
-
-    def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
-        raw = str(target or "").strip()
-        if not raw:
-            return None, None, "No credential target provided."
-
-        with self._lock:
-            for idx, entry in enumerate(self._entries, start=1):
-                if entry.id == raw:
-                    return idx, entry, None
-
-            label_matches = [
-                (idx, entry)
-                for idx, entry in enumerate(self._entries, start=1)
-                if entry.label.strip().lower() == raw.lower()
-            ]
-            if len(label_matches) == 1:
-                return label_matches[0][0], label_matches[0][1], None
-            if len(label_matches) > 1:
-                return None, None, f'Ambiguous credential label "{raw}". Use the numeric index or entry id instead.'
-            if raw.isdigit():
-                index = int(raw)
-                if 1 <= index <= len(self._entries):
-                    return index, self._entries[index - 1], None
-                return None, None, f"No credential #{index}."
-            return None, None, f'No credential matching "{raw}".'
-
-    def add_entry(self, entry: PooledCredential) -> PooledCredential:
-        with self._lock:
-            entry = replace(entry, priority=_next_priority(self._entries))
-            self._entries.append(entry)
-            borrowed_ids = getattr(self, "_borrowed_root_ids", None)
-            if borrowed_ids:
-                # ``hermes -p <profile> auth add <single-use provider>``: the
-                # profile claims its OWN credential. Persist only profile-owned
-                # rows — copying the borrowed root grant alongside would fork
-                # its single-use refresh token (#100339). Once the profile owns
-                # rows, the root fallback for this provider is shadowed.
-                self._entries = [e for e in self._entries if e.id not in borrowed_ids]
-                write_credential_pool(self.provider, [e.to_dict() for e in self._entries])
-                self._borrowed_root_ids = set()
-            else:
-                self._persist()
-            return entry
 
 
 # --- Seeding --------------------------------------------------------------

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1903,8 +1903,14 @@ class CredentialPool(CredentialPoolAdminMixin):
         self._last_no_entries_log_at = now
         logger.info("credential pool: no available entries (all exhausted or empty)")
 
-    def _select_unlocked(self, *, refresh: bool = True) -> Tuple[Optional[PooledCredential], List[PooledCredential]]:
-        """Select the best available entry; returns ``(entry, pending_refresh)``."""
+    def _select_unlocked(
+        self, *, refresh: bool = True, count: bool = True,
+    ) -> Tuple[Optional[PooledCredential], List[PooledCredential]]:
+        """Select the best available entry; returns ``(entry, pending_refresh)``.
+
+        ``count=False`` skips the ``request_count`` bump for selections that are
+        not going to serve a request (a forced-refresh target lookup).
+        """
         available, pending_refresh = self._available_entries(clear_expired=True, refresh=refresh)
         if not available:
             self._current_id = None
@@ -1919,19 +1925,19 @@ class CredentialPool(CredentialPoolAdminMixin):
             entry = random.choice(available)
         elif self._strategy == STRATEGY_LEAST_USED and len(available) > 1:
             entry = min(available, key=lambda e: e.request_count)
-            # Bump the usage counter so subsequent selections distribute load
-            self._current_id = entry.id
-            return self._adopt(entry, persist=False, request_count=entry.request_count + 1), pending_refresh
-        elif self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
+        else:
             entry = available[0]
+        # Count the selection under every strategy. The counter is ``least_used``'s
+        # baseline and reaches auth.json on the next persist (exhaustion, rotation,
+        # refresh); it used to move only while ``least_used`` was active.
+        if count:
+            entry = self._adopt(entry, persist=False, request_count=entry.request_count + 1)
+        if self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
             rotated = [candidate for candidate in self._entries if candidate.id != entry.id]
             rotated.append(replace(entry, priority=len(self._entries) - 1))
             self._entries = [replace(candidate, priority=idx) for idx, candidate in enumerate(rotated)]
             self._persist()
-            self._current_id = entry.id
-            return self._current_unlocked() or entry, pending_refresh
-        else:
-            entry = available[0]
+            entry = self._find(lambda candidate: candidate.id == entry.id) or entry
         self._current_id = entry.id
         return entry, pending_refresh
 
@@ -2144,7 +2150,7 @@ class CredentialPool(CredentialPoolAdminMixin):
                 if api_key_hint:
                     entry = self._find(lambda e: e.runtime_api_key == api_key_hint)
                 else:
-                    entry = self._current_unlocked() or self._select_unlocked(refresh=False)[0]
+                    entry = self._current_unlocked() or self._select_unlocked(refresh=False, count=False)[0]
             if entry is None:
                 return None
             self._current_id = entry.id

--- a/agent/credential_pool_admin.py
+++ b/agent/credential_pool_admin.py
@@ -1,0 +1,101 @@
+"""Locked credential-pool administration and target resolution."""
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, Optional, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent.credential_pool import PooledCredential
+
+
+class CredentialPoolAdminMixin:
+    def reset_statuses(self) -> int:
+        """Clear exhaustion state on every entry. Returns how many were cleared.
+
+        ``failure_reason`` lives in ``extra``, not a dataclass field, so it is
+        stripped explicitly. The persist declares the cleared ids because the
+        disk-recency merge reads a cleared ``last_status_at`` (None -> epoch 0)
+        as a stale snapshot and would copy a still-binding cooldown back.
+        """
+        from agent.credential_pool import _CLEAR_STATUS
+
+        with self._lock:
+            stale = [
+                e for e in self._entries
+                if e.last_status or e.last_status_at or e.last_error_code or e.failure_reason
+            ]
+            if stale:
+                stale_ids = {e.id for e in stale}
+                self._entries = [
+                    replace(
+                        e, **_CLEAR_STATUS,
+                        extra={k: v for k, v in e.extra.items() if k != "failure_reason"},
+                    )
+                    if e.id in stale_ids else e
+                    for e in self._entries
+                ]
+                self._persist(status_cleared_ids=list(stale_ids))
+            return len(stale)
+
+    def remove_index(self, index: int) -> Optional[PooledCredential]:
+        from agent.credential_pool import persist_pool_entries
+
+        with self._lock:
+            if index < 1 or index > len(self._entries):
+                return None
+            removed = self._entries.pop(index - 1)
+            self._entries = [replace(e, priority=p) for p, e in enumerate(self._entries)]
+            persist_pool_entries(
+                self.provider,
+                [entry.to_dict() for entry in self._entries],
+                removed_ids=[removed.id],
+            )
+            if self._current_id == removed.id:
+                self._current_id = None
+            return removed
+
+    def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
+        raw = str(target or "").strip()
+        if not raw:
+            return None, None, "No credential target provided."
+
+        with self._lock:
+            for idx, entry in enumerate(self._entries, start=1):
+                if entry.id == raw:
+                    return idx, entry, None
+
+            label_matches = [
+                (idx, entry)
+                for idx, entry in enumerate(self._entries, start=1)
+                if entry.label.strip().lower() == raw.lower()
+            ]
+            if len(label_matches) == 1:
+                return label_matches[0][0], label_matches[0][1], None
+            if len(label_matches) > 1:
+                return None, None, f'Ambiguous credential label "{raw}". Use the numeric index or entry id instead.'
+            if raw.isdigit():
+                index = int(raw)
+                if 1 <= index <= len(self._entries):
+                    return index, self._entries[index - 1], None
+                return None, None, f"No credential #{index}."
+            return None, None, f'No credential matching "{raw}".'
+
+    def add_entry(self, entry: PooledCredential) -> PooledCredential:
+        from agent.credential_pool import _next_priority, write_credential_pool
+
+        with self._lock:
+            entry = replace(entry, priority=_next_priority(self._entries))
+            self._entries.append(entry)
+            borrowed_ids = getattr(self, "_borrowed_root_ids", None)
+            if borrowed_ids:
+                # ``hermes -p <profile> auth add <single-use provider>``: the
+                # profile claims its OWN credential. Persist only profile-owned
+                # rows — copying the borrowed root grant alongside would fork
+                # its single-use refresh token (#100339). Once the profile owns
+                # rows, the root fallback for this provider is shadowed.
+                self._entries = [e for e in self._entries if e.id not in borrowed_ids]
+                write_credential_pool(self.provider, [e.to_dict() for e in self._entries])
+                self._borrowed_root_ids = set()
+            else:
+                self._persist()
+            return entry

--- a/agent/credential_pool_admin.py
+++ b/agent/credential_pool_admin.py
@@ -67,6 +67,23 @@ class CredentialPoolAdminMixin:
                 self._current_id = None
             return removed
 
+    def move_entry(self, credential_id: str, priority: int) -> Optional[PooledCredential]:
+        """Place an entry at a clamped zero-based position and persist contiguous priorities."""
+        from agent.credential_pool import _normalize_pool_priorities
+
+        with self._lock:
+            entry = self._find(lambda e: e.id == credential_id)
+            if entry is None:
+                return None
+            others = [e for e in self._entries if e.id != credential_id]
+            others.insert(max(0, min(int(priority), len(others))), entry)
+            entries = [replace(e, priority=p) for p, e in enumerate(others)]
+            # Apply load-time ordering now so the reported position survives reload.
+            _normalize_pool_priorities(self.provider, entries)
+            self._entries = sorted(entries, key=lambda e: e.priority)
+            self._persist()
+            return self._find(lambda e: e.id == credential_id)
+
     def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
         raw = str(target or "").strip()
         if not raw:

--- a/agent/credential_pool_admin.py
+++ b/agent/credential_pool_admin.py
@@ -8,7 +8,24 @@ if TYPE_CHECKING:
     from agent.credential_pool import PooledCredential
 
 
+def _cleared_status_copy(entry: PooledCredential) -> PooledCredential:
+    from agent.credential_pool import _CLEAR_STATUS
+
+    return replace(entry, **_CLEAR_STATUS,
+                   extra={k: v for k, v in entry.extra.items() if k != "failure_reason"})
+
+
 class CredentialPoolAdminMixin:
+    def reset_status(self, credential_id: str) -> Optional[PooledCredential]:
+        """Clear only the target's local error state, preserving sibling cooldowns."""
+        with self._lock:
+            entry = self._find(lambda e: e.id == credential_id)
+            if entry is None:
+                return None
+            cleared = _cleared_status_copy(entry)
+            self._replace_entry(entry, cleared)
+            self._persist(status_cleared_ids=[cleared.id])
+            return cleared
     def reset_statuses(self) -> int:
         """Clear exhaustion state on every entry. Returns how many were cleared.
 
@@ -27,11 +44,7 @@ class CredentialPoolAdminMixin:
             if stale:
                 stale_ids = {e.id for e in stale}
                 self._entries = [
-                    replace(
-                        e, **_CLEAR_STATUS,
-                        extra={k: v for k, v in e.extra.items() if k != "failure_reason"},
-                    )
-                    if e.id in stale_ids else e
+                    _cleared_status_copy(e) if e.id in stale_ids else e
                     for e in self._entries
                 ]
                 self._persist(status_cleared_ids=list(stale_ids))

--- a/contributors/emails/brian@brianle.xyz
+++ b/contributors/emails/brian@brianle.xyz
@@ -1,0 +1,2 @@
+0xble
+# Credential-pool CLI operations salvage

--- a/evals/auth_pool_controls.py
+++ b/evals/auth_pool_controls.py
@@ -5,6 +5,7 @@ No vendor requests or real credentials are used. The token URL alone is redirect
 the production parser, command, pool refresh, HTTP client, and persistence execute.
 """
 import argparse
+import base64
 import json
 import os
 from pathlib import Path
@@ -32,8 +33,10 @@ def main():
         def do_POST(self):
             payload = parse_qs(self.rfile.read(int(self.headers["Content-Length"])).decode())
             requests.append({"grant_type": payload.get("grant_type"),
-                             "target_grant": payload.get("refresh_token") == ["fixture-refresh-1"]})
-            body = ({"access_token": "fixture-new-access", "refresh_token": "fixture-new-refresh"}
+                             "target_grant": (payload.get("refresh_token") == ["fixture-refresh-1"]
+                                              or self.headers.get("x-nous-refresh-token") == "fixture-refresh-1")})
+            body = ({"access_token": nous_new_token if self.path == "/api/oauth/token" else "fixture-new-access",
+                     "refresh_token": "fixture-new-refresh", "expires_in": 3600, "scope": "inference:invoke"}
                     if response_status == 200 else {"error": "invalid_grant" if response_status == 401 else "unavailable"})
             self.send_response(response_status)
             self.send_header("Content-Type", "application/json")
@@ -43,6 +46,12 @@ def main():
         def log_message(self, format, *values):
             pass
 
+    def token(subject):
+        encode = lambda value: base64.urlsafe_b64encode(json.dumps(value).encode()).decode().rstrip("=")
+        return encode({"alg": "none"}) + "." + encode({"sub": subject, "exp": int(time.time()) + 3600,
+                                                        "scope": "inference:invoke"}) + ".fixture"
+
+    nous_new_token = token("singleton-renewed")
     server = ThreadingHTTPServer(("127.0.0.1", 0), Endpoint)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -59,6 +68,8 @@ def main():
         *[(f"refresh-{status}", "openai-codex", ["refresh", "openai-codex", "row1"], status)
           for status in (200, 503, 401)],
     ]
+    cases.extend((name, "nous", ["refresh", "nous", target], None) for name, target in
+                 (("nous-independent", "row0"), ("nous-singleton", "row1")))
     results = []
     try:
         for name, provider, command, status in cases:
@@ -73,12 +84,24 @@ def main():
                              access_token=f"fixture-access-{i}", refresh_token=f"fixture-refresh-{i}",
                              priority=i, last_status="exhausted", last_status_at=now,
                              last_error_code=429, last_error_reset_at=now+3600) for i in range(2)]
+                providers = {}
+                if provider == "nous":
+                    for row in rows:
+                        row.update(auth_type="oauth", source="manual:device_code")
+                    state = dict(access_token=token("singleton"), refresh_token="fixture-refresh-1",
+                                 expires_at=now+3600, portal_base_url=f"http://127.0.0.1:{server.server_port}",
+                                 scope="inference:invoke", inference_base_url="https://inference-api.nousresearch.com/v1")
+                    rows[1].update(source="device_code", **state)
+                    providers["nous"] = state
                 store = home / "auth.json"
-                store.write_text(json.dumps({"version": 1, "providers": {}, "credential_pool": {provider: rows}}), encoding="utf-8")
+                store.write_text(json.dumps({"version": 1, "providers": providers, "active_provider": provider, "credential_pool": {provider: rows}}), encoding="utf-8")
                 env = {k: v for k, v in os.environ.items() if not any(t in k for t in
                        ("TOKEN", "API_KEY", "SECRET", "PASSWORD", "HERMES", "PYTEST"))}
-                env.update(HOME=temp, HERMES_HOME=temp, PYTHONPATH=str(Path(args.repo).absolute()), TERM="xterm")
-                bootstrap = ("import sys; from hermes_cli import auth_codex; "
+                env.update(HOME=temp, HERMES_HOME=temp, HERMES_SHARED_AUTH_DIR=str(home / "shared"), PYTHONPATH=str(Path(args.repo).absolute()), TERM="xterm")
+                bootstrap = ("import sys, httpx; original_send=httpx.Client.send; "
+                             "httpx.Client.send=lambda self, request, **kw: original_send(self, request, **kw) "
+                             "if request.url.host == '127.0.0.1' else (_ for _ in ()).throw(AssertionError('NONLOCAL_NETWORK')); "
+                             "from hermes_cli import auth_codex; "
                              f"auth_codex.CODEX_OAUTH_TOKEN_URL='http://127.0.0.1:{server.server_port}/token'; "
                              "from hermes_cli.main import main; "
                              f"sys.argv=['hermes','auth',*{command!r}]; main()")
@@ -102,16 +125,26 @@ def main():
                 exit_code = child.wait(timeout=30)
                 disk = json.loads(store.read_text(encoding="utf-8"))["credential_pool"][provider]
                 results.append({"case": name, "exit": exit_code, "output": output,
-                                "wire": list(requests), "secrets_printed": "fixture-" in output,
+                                "wire": list(requests), "secrets_printed": "fixture-" in output or ".fixture" in output,
                                 "disk": [{k: e.get(k) for k in ("id", "priority", "last_status", "last_error_reset_at", "request_count")}
                                          for e in disk],
-                                "target_rotated": any(e["id"] == "row1" and e.get("access_token") == "fixture-new-access" for e in disk),
+                                "target_refresh_rotated": any(e["id"] == "row1" and e.get("refresh_token") == "fixture-new-refresh" for e in disk),
+                                "target_rotated": any(e["id"] == "row1" and e.get("access_token") == (nous_new_token if provider == "nous" else "fixture-new-access") for e in disk),
+                                "independent_tokens_preserved": all(next(e for e in disk if e["id"] == "row0").get(k) == rows[0].get(k) for k in ("access_token", "refresh_token")),
                                 "sibling_cooldown_preserved": next(e for e in disk if e["id"] == "row0").get("last_error_reset_at") == now+3600})
     finally:
         server.shutdown()
         thread.join(timeout=5)
         server.server_close()
     Path(args.output).write_text(json.dumps({"repo": args.repo, "cases": results}, indent=2), encoding="utf-8")
+    independent = next(r for r in results if r["case"] == "nous-independent")
+    assert independent["exit"] != 0 and not independent["wire"], independent
+    assert independent["independent_tokens_preserved"] and independent["sibling_cooldown_preserved"], independent
+    singleton = next(r for r in results if r["case"] == "nous-singleton")
+    assert singleton["exit"] == 0 and singleton["target_rotated"] and singleton["target_refresh_rotated"], singleton
+    assert len(singleton["wire"]) == 1 and singleton["wire"][0]["target_grant"], singleton
+    assert singleton["sibling_cooldown_preserved"] and singleton["independent_tokens_preserved"], singleton
+    assert all(not r["secrets_printed"] and "NONLOCAL_NETWORK" not in r["output"] for r in results)
     print(json.dumps([{"case": r["case"], "exit": r["exit"], "posts": len(r["wire"]),
                        "target_rotated": r["target_rotated"], "secrets_printed": r["secrets_printed"]} for r in results], indent=2))
 

--- a/evals/auth_pool_controls.py
+++ b/evals/auth_pool_controls.py
@@ -1,0 +1,120 @@
+"""Live PTY auth controls with isolated homes and a loopback OAuth server.
+
+Usage: python evals/auth_pool_controls.py REPO OUTPUT_JSON
+No vendor requests or real credentials are used. The token URL alone is redirected;
+the production parser, command, pool refresh, HTTP client, and persistence execute.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs
+
+import errno
+import pty
+import subprocess
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repo")
+    parser.add_argument("output")
+    args = parser.parse_args()
+    requests = []
+    response_status = 200
+
+    class Endpoint(BaseHTTPRequestHandler):
+        def do_POST(self):
+            payload = parse_qs(self.rfile.read(int(self.headers["Content-Length"])).decode())
+            requests.append({"grant_type": payload.get("grant_type"),
+                             "target_grant": payload.get("refresh_token") == ["fixture-refresh-1"]})
+            body = ({"access_token": "fixture-new-access", "refresh_token": "fixture-new-refresh"}
+                    if response_status == 200 else {"error": "invalid_grant" if response_status == 401 else "unavailable"})
+            self.send_response(response_status)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(body).encode())
+
+        def log_message(self, format, *values):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Endpoint)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    cases = [
+        ("target-reset", "openrouter", ["reset", "openrouter", "row1"], None),
+        ("all-reset", "openrouter", ["reset", "openrouter"], None),
+        ("ambiguous-reset", "openrouter", ["reset", "openrouter", "shared"], None),
+        ("priority", "openrouter", ["priority", "openrouter", "row1", "0"], None),
+        ("priority-clamp", "openrouter", ["priority", "openrouter", "row0", "99"], None),
+        ("priority-missing", "openrouter", ["priority", "openrouter", "missing", "0"], None),
+        ("add-priority", "openrouter", ["add", "openrouter", "--api-key", "fixture-new", "--label", "new", "--priority", "0"], None),
+        ("refresh-api-key", "openrouter", ["refresh", "openrouter", "row1"], None),
+        ("refresh-ambiguous", "openai-codex", ["refresh", "openai-codex"], None),
+        *[(f"refresh-{status}", "openai-codex", ["refresh", "openai-codex", "row1"], status)
+          for status in (200, 503, 401)],
+    ]
+    results = []
+    try:
+        for name, provider, command, status in cases:
+            response_status = status or 200
+            requests.clear()
+            with tempfile.TemporaryDirectory(prefix="auth-pool-pty-") as temp:
+                home = Path(temp)
+                now = time.time()
+                rows = [dict(id=f"row{i}", label="shared" if name == "ambiguous-reset" else f"account{i}",
+                             source="manual:device_code" if provider == "openai-codex" else "manual",
+                             auth_type="oauth" if provider == "openai-codex" else "api_key",
+                             access_token=f"fixture-access-{i}", refresh_token=f"fixture-refresh-{i}",
+                             priority=i, last_status="exhausted", last_status_at=now,
+                             last_error_code=429, last_error_reset_at=now+3600) for i in range(2)]
+                store = home / "auth.json"
+                store.write_text(json.dumps({"version": 1, "providers": {}, "credential_pool": {provider: rows}}), encoding="utf-8")
+                env = {k: v for k, v in os.environ.items() if not any(t in k for t in
+                       ("TOKEN", "API_KEY", "SECRET", "PASSWORD", "HERMES", "PYTEST"))}
+                env.update(HOME=temp, HERMES_HOME=temp, PYTHONPATH=str(Path(args.repo).absolute()), TERM="xterm")
+                bootstrap = ("import sys; from hermes_cli import auth_codex; "
+                             f"auth_codex.CODEX_OAUTH_TOKEN_URL='http://127.0.0.1:{server.server_port}/token'; "
+                             "from hermes_cli.main import main; "
+                             f"sys.argv=['hermes','auth',*{command!r}]; main()")
+                master, slave = pty.openpty()
+                child = subprocess.Popen([sys.executable, "-c", bootstrap], cwd=args.repo,
+                                         env=env, stdin=slave, stdout=slave, stderr=slave)
+                os.close(slave)
+                chunks = []
+                while True:
+                    try:
+                        chunk = os.read(master, 65536)
+                        if not chunk:
+                            break
+                        chunks.append(chunk)
+                    except OSError as exc:
+                        if exc.errno != errno.EIO:
+                            raise
+                        break
+                os.close(master)
+                output = b"".join(chunks).decode("utf-8")
+                exit_code = child.wait(timeout=30)
+                disk = json.loads(store.read_text(encoding="utf-8"))["credential_pool"][provider]
+                results.append({"case": name, "exit": exit_code, "output": output,
+                                "wire": list(requests), "secrets_printed": "fixture-" in output,
+                                "disk": [{k: e.get(k) for k in ("id", "priority", "last_status", "last_error_reset_at", "request_count")}
+                                         for e in disk],
+                                "target_rotated": any(e["id"] == "row1" and e.get("access_token") == "fixture-new-access" for e in disk),
+                                "sibling_cooldown_preserved": next(e for e in disk if e["id"] == "row0").get("last_error_reset_at") == now+3600})
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+    Path(args.output).write_text(json.dumps({"repo": args.repo, "cases": results}, indent=2), encoding="utf-8")
+    print(json.dumps([{"case": r["case"], "exit": r["exit"], "posts": len(r["wire"]),
+                       "target_rotated": r["target_rotated"], "secrets_printed": r["secrets_printed"]} for r in results], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -75,6 +75,7 @@ Examples:
     hermes auth remove <p> <t>    Remove pooled credential by index, id, or label
     hermes auth reset <p> [t]     Clear exhaustion status for a provider, or one credential
     hermes auth priority <p> <t> <n>  Move a pooled credential to priority n (0 = tried first)
+    hermes auth refresh <p> [t]   Refresh a pooled OAuth credential and clear its cooldown
     hermes model                  Select default model
     hermes fallback [list]        Show fallback provider chain
     hermes fallback add           Add a fallback provider (same picker as `hermes model`)

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -74,6 +74,7 @@ Examples:
     hermes auth list              List pooled credentials
     hermes auth remove <p> <t>    Remove pooled credential by index, id, or label
     hermes auth reset <p> [t]     Clear exhaustion status for a provider, or one credential
+    hermes auth priority <p> <t> <n>  Move a pooled credential to priority n (0 = tried first)
     hermes model                  Select default model
     hermes fallback [list]        Show fallback provider chain
     hermes fallback add           Add a fallback provider (same picker as `hermes model`)

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -73,7 +73,7 @@ Examples:
     hermes auth add <provider>    Add a pooled credential
     hermes auth list              List pooled credentials
     hermes auth remove <p> <t>    Remove pooled credential by index, id, or label
-    hermes auth reset <provider>  Clear exhaustion status for a provider
+    hermes auth reset <p> [t]     Clear exhaustion status for a provider, or one credential
     hermes model                  Select default model
     hermes fallback [list]        Show fallback provider chain
     hermes fallback add           Add a fallback provider (same picker as `hermes model`)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -258,18 +258,19 @@ def _ask(prompt: str, reader: Callable[[str], str] | None = None) -> str | None:
         return None
 
 
-def _add_nous_oauth_credential(args, provider: str) -> None:
+def _add_nous_oauth_credential(args, provider: str) -> PooledCredential:
     """``hermes auth add nous --type oauth``: shared-credential import, else device-code login."""
     custom_label = (getattr(args, "label", None) or "").strip() or None
     timeout = getattr(args, "timeout", None) or 15.0
 
-    def _persist(creds: dict, what: str) -> None:
+    def _persist(creds: dict, what: str) -> PooledCredential:
         # `--label` is embedded into providers.nous so label_from_token doesn't overwrite it on every
         # subsequent load_pool("nous").
         entry = auth_mod.persist_nous_credentials(creds, label=custom_label)
         shown_label = entry.label if entry is not None else label_from_token(
             creds.get("access_token", ""), f"{provider}-oauth-1")
         print(f'{what} {provider} OAuth {"device-code " if what == "Saved" else ""}credentials: "{shown_label}"')
+        return entry
 
     # Codex-style auto-import: a shared Nous credential at <hermes-root>/shared/nous_auth.json
     # (written by any previous login) makes `hermes --profile <name> auth add nous --type oauth`
@@ -286,8 +287,7 @@ def _add_nous_oauth_credential(args, provider: str) -> None:
             print("Rehydrating Nous session from shared credentials...")
             rehydrated = auth_mod._try_import_shared_nous_state(timeout_seconds=timeout)
             if rehydrated is not None:
-                _persist(rehydrated, "Imported")
-                return
+                return _persist(rehydrated, "Imported")
             # Expired refresh_token, portal down, etc. — fall through to device-code.
             print("Could not refresh shared credentials — falling back to device-code login.")
 
@@ -297,7 +297,7 @@ def _add_nous_oauth_credential(args, provider: str) -> None:
         client_id=getattr(args, "client_id", None), scope=getattr(args, "scope", None),
         open_browser=not getattr(args, "no_browser", False), timeout_seconds=timeout,
         insecure=bool(getattr(args, "insecure", False)), ca_bundle=getattr(args, "ca_bundle", None))
-    _persist(creds, "Saved")
+    return _persist(creds, "Saved")
 
 
 def _unsuppress_provider_sources(provider: str) -> None:
@@ -312,7 +312,7 @@ def _unsuppress_provider_sources(provider: str) -> None:
         pass
 
 
-def _add_api_key_credential(args, provider: str, pool) -> None:
+def _add_api_key_credential(args, provider: str, pool) -> PooledCredential:
     token = ((getattr(args, "api_key", None) or "").strip()
              or masked_secret_prompt("Paste your API key: ").strip())
     if not token:
@@ -325,8 +325,9 @@ def _add_api_key_credential(args, provider: str, pool) -> None:
     entry = PooledCredential(
         provider=provider, id=uuid.uuid4().hex[:6], label=label, auth_type=AUTH_TYPE_API_KEY,
         priority=0, source=SOURCE_MANUAL, access_token=token, base_url=_provider_base_url(provider))
-    pool.add_entry(entry)
+    entry = pool.add_entry(entry)
     print(f'Added {provider} credential #{len(pool.entries())}: "{label}"')
+    return entry
 
 
 def auth_add_command(args) -> None:
@@ -350,19 +351,18 @@ def auth_add_command(args) -> None:
         _unsuppress_provider_sources(provider)
 
     wanted_priority = getattr(args, "priority", None)
-    before = {entry.id for entry in pool.entries()}
-    _add_credential(args, provider, pool, requested_type)
+    entry = _add_credential(args, provider, pool, requested_type)
     if wanted_priority is not None:
-        _place_added_credential(provider, before, int(wanted_priority))
+        placed_pool = load_pool(provider)
+        moved = placed_pool.move_entry(entry.id, int(wanted_priority))
+        _report_priority(provider, placed_pool, moved, int(wanted_priority), "Placed", "at")
 
 
-def _add_credential(args, provider: str, pool, requested_type: str) -> None:
+def _add_credential(args, provider: str, pool, requested_type: str) -> PooledCredential:
     if requested_type == AUTH_TYPE_API_KEY:
-        _add_api_key_credential(args, provider, pool)
-        return
+        return _add_api_key_credential(args, provider, pool)
     if provider == "nous":
-        _add_nous_oauth_credential(args, provider)
-        return
+        return _add_nous_oauth_credential(args, provider)
 
     spec = _OAUTH_ADD_SPECS.get(provider)
     if spec is None:
@@ -379,38 +379,13 @@ def _add_credential(args, provider: str, pool, requested_type: str) -> None:
         provider=provider, id=uuid.uuid4().hex[:6], label=label, auth_type=AUTH_TYPE_OAUTH, priority=0,
         source=spec.source, access_token=token, **spec.fields(creds, provider))
     first_credential = not pool.entries()
-    pool.add_entry(entry)
+    entry = pool.add_entry(entry)
     # The first Codex/xAI credential becomes the active provider (as the old singleton save path
     # did implicitly); subsequent adds leave the active provider as-is.
     if spec.activate_first and first_credential:
         auth_mod.mark_provider_active_if_unset(provider)
     print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
-
-
-def _place_added_credential(provider: str, before_ids: set, priority: int) -> None:
-    """Move the credential `auth add` just created to *priority*.
-
-    Every add path (api key, OAuth spec, Nous) persists through the pool, so the
-    new row is the one id that was not there before the add. Reloading rather
-    than reusing the add's pool object keeps this correct for paths that write
-    their own store.
-    """
-    pool = load_pool(provider)
-    entries = pool.entries()
-    added = [entry for entry in entries if entry.id not in before_ids]
-    if len(added) == 1:
-        target = added[0]
-    elif not added and len(entries) == 1:
-        # The add updated the sole existing row in place (a repeat Nous login).
-        target = entries[0]
-    else:
-        # The credential was saved; only the placement is unresolved, so do not fail.
-        print(f"note: could not identify the credential just added to {provider}; set its "
-              f"priority with `hermes auth priority {provider} <target> {priority}`.",
-              file=sys.stderr)
-        return
-    moved = pool.move_entry(target.id, priority)
-    _report_priority(provider, pool, moved, priority, "Placed", "at")
+    return entry
 
 
 def _report_priority(provider: str, pool, moved, requested: int, verb: str, prep: str) -> None:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -528,6 +528,12 @@ def auth_refresh_command(args) -> None:
         raise SystemExit(
             f"{provider} credential #{index} ({matched.label}) is not a refreshable OAuth "
             f"credential.")
+    # Nous's resolver is singleton-bound, not an independent-account refresher.
+    if provider == "nous" and matched.source != "device_code":
+        raise SystemExit(
+            f"nous credential #{index} ({matched.label}) is not a refreshable OAuth "
+            "credential: only the device_code singleton supports refresh. "
+            "Reauthenticate with `hermes auth add nous --type oauth`.")
     refreshed = pool.try_refresh_matching(credential_id=matched.id)
     if refreshed is None:
         after = next((e for e in pool.entries() if e.id == matched.id), None)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -442,9 +442,19 @@ def auth_remove_command(args) -> None:
 
 def auth_reset_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
+    target = getattr(args, "target", None)
     pool = load_pool(provider)
-    count = pool.reset_statuses()
-    print(f"Reset status on {count} {provider} credentials")
+    if target is None or not str(target).strip():
+        count = pool.reset_statuses()
+        print(f"Reset status on {count} {provider} credentials")
+        return
+    index, matched, error = pool.resolve_target(target)
+    if matched is None or index is None:
+        raise SystemExit(f"{error} Provider: {provider}.")
+    cleared = pool.reset_status(matched.id)
+    if cleared is None:
+        raise SystemExit(f'No credential matching "{target}" for provider {provider}.')
+    print(f"Reset status on {provider} credential #{index} ({cleared.label})")
 
 
 def auth_status_command(args) -> None:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -14,7 +14,7 @@ import uuid
 from agent.credential_pool import (
     AUTH_TYPE_API_KEY, AUTH_TYPE_OAUTH, CUSTOM_POOL_PREFIX, SOURCE_MANUAL,
     SOURCE_MANUAL_DEVICE_CODE, STATUS_EXHAUSTED, STRATEGY_FILL_FIRST, STRATEGY_ROUND_ROBIN,
-    STRATEGY_RANDOM, STRATEGY_LEAST_USED, PooledCredential, _exhausted_until,
+    STRATEGY_RANDOM, STRATEGY_LEAST_USED, PooledCredential, REFRESHABLE_OAUTH_PROVIDERS, _exhausted_until,
     _normalize_custom_pool_name, get_pool_strategy, label_from_token, list_custom_pool_providers,
     load_pool)
 import hermes_cli.auth as auth_mod
@@ -523,6 +523,52 @@ def auth_reset_command(args) -> None:
     print(f"Reset status on {provider} credential #{index} ({cleared.label})")
 
 
+def auth_refresh_command(args) -> None:
+    """`hermes auth refresh <provider> [target]`: force one pooled OAuth entry to refresh.
+
+    A successful refresh rotates the stored tokens and clears the entry's local
+    exhaustion block, returning it to rotation before its persisted
+    ``last_error_reset_at`` elapses. It proves the grant is alive, not that the
+    provider's quota is back: if the account is still capped, the next request
+    429s and benches it again. Failure leaves the pool's own verdict in place.
+    """
+    provider = _normalize_provider(getattr(args, "provider", ""))
+    target = getattr(args, "target", None)
+    pool = load_pool(provider)
+    entries = pool.entries()
+    if not entries:
+        raise SystemExit(f"No {provider} credentials in the pool.")
+    if target is None or not str(target).strip():
+        if len(entries) != 1:
+            raise SystemExit(
+                f"{provider} has {len(entries)} credentials; pass an index, entry id, or exact "
+                f"label (see `hermes auth list {provider}`).")
+        index, matched = 1, entries[0]
+    else:
+        index, matched, error = pool.resolve_target(target)
+        if matched is None or index is None:
+            raise SystemExit(f"{error} Provider: {provider}.")
+    if (provider not in REFRESHABLE_OAUTH_PROVIDERS or matched.auth_type != AUTH_TYPE_OAUTH
+            or not matched.refresh_token):
+        raise SystemExit(
+            f"{provider} credential #{index} ({matched.label}) is not a refreshable OAuth "
+            f"credential.")
+    refreshed = pool.try_refresh_matching(credential_id=matched.id)
+    if refreshed is None:
+        after = next((e for e in pool.entries() if e.id == matched.id), None)
+        state = "removed from pool" if after is None else (after.last_status or "unknown")
+        raise SystemExit(
+            f"Refresh failed for {provider} credential #{index} ({matched.label}); "
+            f"status now: {state}.")
+    status = refreshed.last_status or "ok"
+    if status == "ok":
+        print(f"Refreshed {provider} credential #{index} ({refreshed.label}); status: ok")
+    else:
+        # A peer already rotated this grant and the pool adopted it without clearing status.
+        print(f"Adopted current tokens for {provider} credential #{index} ({refreshed.label}); "
+              f"status still: {status}")
+
+
 def auth_status_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", "") or "")
     if not provider:
@@ -727,7 +773,7 @@ def _interactive_strategy() -> None:
 
 _AUTH_ACTIONS = {
     "add": auth_add_command, "list": auth_list_command, "remove": auth_remove_command,
-    "reset": auth_reset_command, "priority": auth_priority_command, "status": auth_status_command,
+    "reset": auth_reset_command, "priority": auth_priority_command, "refresh": auth_refresh_command, "status": auth_status_command,
     "logout": auth_logout_command,
     "spotify": auth_spotify_command}
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -349,6 +349,14 @@ def auth_add_command(args) -> None:
     if not is_custom:
         _unsuppress_provider_sources(provider)
 
+    wanted_priority = getattr(args, "priority", None)
+    before = {entry.id for entry in pool.entries()}
+    _add_credential(args, provider, pool, requested_type)
+    if wanted_priority is not None:
+        _place_added_credential(provider, before, int(wanted_priority))
+
+
+def _add_credential(args, provider: str, pool, requested_type: str) -> None:
     if requested_type == AUTH_TYPE_API_KEY:
         _add_api_key_credential(args, provider, pool)
         return
@@ -377,6 +385,64 @@ def auth_add_command(args) -> None:
     if spec.activate_first and first_credential:
         auth_mod.mark_provider_active_if_unset(provider)
     print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+
+
+def _place_added_credential(provider: str, before_ids: set, priority: int) -> None:
+    """Move the credential `auth add` just created to *priority*.
+
+    Every add path (api key, OAuth spec, Nous) persists through the pool, so the
+    new row is the one id that was not there before the add. Reloading rather
+    than reusing the add's pool object keeps this correct for paths that write
+    their own store.
+    """
+    pool = load_pool(provider)
+    entries = pool.entries()
+    added = [entry for entry in entries if entry.id not in before_ids]
+    if len(added) == 1:
+        target = added[0]
+    elif not added and len(entries) == 1:
+        # The add updated the sole existing row in place (a repeat Nous login).
+        target = entries[0]
+    else:
+        # The credential was saved; only the placement is unresolved, so do not fail.
+        print(f"note: could not identify the credential just added to {provider}; set its "
+              f"priority with `hermes auth priority {provider} <target> {priority}`.",
+              file=sys.stderr)
+        return
+    moved = pool.move_entry(target.id, priority)
+    _report_priority(provider, pool, moved, priority, "Placed", "at")
+
+
+def _report_priority(provider: str, pool, moved, requested: int, verb: str, prep: str) -> None:
+    """Print the effective priority and say why it differs from the request, if it does."""
+    print(f'{verb} {provider} credential "{moved.label}" {prep} priority {moved.priority} '
+          f"(#{moved.priority + 1} in `hermes auth list {provider}`)")
+    size = len(pool.entries())
+    if moved.priority != requested:
+        if requested < 0 or requested >= size:
+            reason = f"the pool has {size} credentials, so it was clamped"
+        else:
+            reason = "anthropic keeps manually added credentials ahead of seeded ones"
+        print(f"note: requested priority {requested}; effective priority is {moved.priority} "
+              f"because {reason}.", file=sys.stderr)
+    strategy = get_pool_strategy(provider)
+    if strategy != STRATEGY_FILL_FIRST:
+        print(f"note: {provider} uses the {strategy} strategy; priority only orders "
+              f"fill_first selection.", file=sys.stderr)
+
+
+def auth_priority_command(args) -> None:
+    """`hermes auth priority <provider> <target> <priority>`: reorder one pooled credential."""
+    provider = _normalize_provider(getattr(args, "provider", ""))
+    pool = load_pool(provider)
+    index, matched, error = pool.resolve_target(getattr(args, "target", None))
+    if matched is None or index is None:
+        raise SystemExit(f"{error} Provider: {provider}.")
+    requested = int(getattr(args, "priority"))
+    moved = pool.move_entry(matched.id, requested)
+    if moved is None:
+        raise SystemExit(f'No credential matching "{getattr(args, "target", None)}" for provider {provider}.')
+    _report_priority(provider, pool, moved, requested, "Set", "to")
 
 
 def auth_list_command(args) -> None:
@@ -661,7 +727,8 @@ def _interactive_strategy() -> None:
 
 _AUTH_ACTIONS = {
     "add": auth_add_command, "list": auth_list_command, "remove": auth_remove_command,
-    "reset": auth_reset_command, "status": auth_status_command, "logout": auth_logout_command,
+    "reset": auth_reset_command, "priority": auth_priority_command, "status": auth_status_command,
+    "logout": auth_logout_command,
     "spotify": auth_spotify_command}
 
 

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -292,7 +292,7 @@ _CLI_FAMILIES: dict[str, tuple[_CliSurface, str]] = {
     "memory": (_sub("memory", "build_memory_parser", "cmd_memory"), "status, *off, *reset"),
     "auth": (
         _sub("auth", "build_auth_parser", "cmd_auth"),
-        "list, status, *reset, *add, *remove, *logout, spotify status, *spotify login, "
+        "list, status, *reset, *priority, *add, *remove, *logout, spotify status, *spotify login, "
         "*spotify logout"),
     "pairing": (
         _sub("pairing", "build_pairing_parser", "cmd_pairing"),

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -292,7 +292,7 @@ _CLI_FAMILIES: dict[str, tuple[_CliSurface, str]] = {
     "memory": (_sub("memory", "build_memory_parser", "cmd_memory"), "status, *off, *reset"),
     "auth": (
         _sub("auth", "build_auth_parser", "cmd_auth"),
-        "list, status, *reset, *priority, *add, *remove, *logout, spotify status, *spotify login, "
+        "list, status, *reset, *priority, *refresh, *add, *remove, *logout, spotify status, *spotify login, "
         "*spotify logout"),
     "pairing": (
         _sub("pairing", "build_pairing_parser", "cmd_pairing"),

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -16,6 +16,10 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
         "--type", dest="auth_type", choices=["oauth", "api-key", "api_key"],
         help="Credential type to add")
     auth_add.add_argument("--label", help="Optional display label")
+    auth_add.add_argument(
+        "--priority", type=int,
+        help="Place the new credential at this priority (0 = tried first under fill_first); "
+             "appends last when omitted")
     auth_add.add_argument("--api-key", help="API key value (otherwise prompted securely)")
     auth_add.add_argument("--portal-url", help="Nous portal base URL")
     auth_add.add_argument("--inference-url", help="Nous inference base URL")
@@ -39,6 +43,11 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_reset.add_argument(
         "target", nargs="?",
         help="Optional credential index, entry id, or exact label; clears every credential when omitted")
+    auth_priority = auth_subparsers.add_parser(
+        "priority", help="Move a pooled credential to a priority (0 = tried first under fill_first)")
+    auth_priority.add_argument("provider", help="Provider id")
+    auth_priority.add_argument("target", help="Credential index, entry id, or exact label")
+    auth_priority.add_argument("priority", type=int, help="New priority; others are renumbered")
     auth_status = auth_subparsers.add_parser("status", help="Show auth status for a provider")
     auth_status.add_argument("provider", help="Provider id")
     auth_logout = auth_subparsers.add_parser(

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -34,8 +34,11 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_remove.add_argument("provider", help="Provider id")
     auth_remove.add_argument("target", help="Credential index, entry id, or exact label")
     auth_reset = auth_subparsers.add_parser(
-        "reset", help="Clear exhaustion status for all credentials for a provider")
+        "reset", help="Clear exhaustion status for a provider's credentials (all, or one target)")
     auth_reset.add_argument("provider", help="Provider id")
+    auth_reset.add_argument(
+        "target", nargs="?",
+        help="Optional credential index, entry id, or exact label; clears every credential when omitted")
     auth_status = auth_subparsers.add_parser("status", help="Show auth status for a provider")
     auth_status.add_argument("provider", help="Provider id")
     auth_logout = auth_subparsers.add_parser(

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -48,6 +48,12 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_priority.add_argument("provider", help="Provider id")
     auth_priority.add_argument("target", help="Credential index, entry id, or exact label")
     auth_priority.add_argument("priority", type=int, help="New priority; others are renumbered")
+    auth_refresh = auth_subparsers.add_parser(
+        "refresh", help="Refresh a pooled OAuth credential's tokens and clear its cooldown")
+    auth_refresh.add_argument("provider", help="Provider id")
+    auth_refresh.add_argument(
+        "target", nargs="?",
+        help="Credential index, entry id, or exact label (required when the pool holds more than one)")
     auth_status = auth_subparsers.add_parser("status", help="Show auth status for a provider")
     auth_status.add_argument("provider", help="Provider id")
     auth_logout = auth_subparsers.add_parser(

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -337,7 +337,7 @@ TIPS = [
     "hermes curator pin <skill> hard-fences a skill against both auto-archival and the agent's skill_manage tool.",
     'hermes curator rollback restores skills from a pre-run snapshot — backups live under skills/.curator_backups/.',
     # --- Credential Pools & Routing ---
-    'hermes auth reset <provider> clears all cooldowns and exhaustion flags on a credential pool.',
+    'hermes auth reset <provider> [target] clears cooldowns and exhaustion flags on a whole credential pool, or on one credential by index, id, or label.',
     'credential_pool_strategies.<provider>: round_robin cycles keys evenly instead of the fill_first default.',
     'use_gateway: true per-tool routes web, image, tts, or browser through your Nous subscription — no extra keys.',
     'provider_routing.data_collection: deny excludes data-storing providers on OpenRouter.',

--- a/tests/agent/test_credential_pool_operations.py
+++ b/tests/agent/test_credential_pool_operations.py
@@ -1,0 +1,70 @@
+"""Durable pool administration and selection invariants."""
+import time
+from dataclasses import replace
+
+import pytest
+
+from agent.credential_pool import CredentialPool, PooledCredential
+from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+
+def _pool(provider="openrouter", *, exhausted=False):
+    rows = [PooledCredential(
+        provider=provider, id=f"row{i}", label=f"account{i}", source="manual",
+        auth_type="api_key", access_token=f"fixture-{i}", priority=i,
+        last_status="exhausted" if exhausted else None,
+        last_status_at=time.time() if exhausted else None,
+        last_error_code=429 if exhausted else None,
+        last_error_reset_at=time.time() + 3600 if exhausted else None,
+    ) for i in range(2)]
+    write_credential_pool(provider, [e.to_dict() for e in rows])
+    return CredentialPool(provider, rows)
+
+
+def test_target_reset_preserves_sibling_cooldown():
+    pool = _pool(exhausted=True)
+    before = read_credential_pool(pool.provider)
+    assert pool.reset_status("missing") is None
+    assert read_credential_pool(pool.provider) == before
+    assert pool.reset_status("row1").last_status is None
+    after = {e["id"]: e for e in read_credential_pool(pool.provider)}
+    assert after["row0"] == before[0]
+    assert after["row1"].get("last_error_reset_at") is None
+    assert pool.reset_statuses() == 1
+    assert all(e.get("last_status") is None for e in read_credential_pool(pool.provider))
+
+
+@pytest.mark.parametrize("strategy", ["fill_first", "round_robin", "random", "least_used"])
+def test_selection_counts_only_returned_selections(strategy):
+    pool = _pool()
+    pool._strategy = strategy
+    selected = [pool.select().id for _ in range(2)]
+    assert {e.id: e.request_count for e in pool.entries()} == {
+        e.id: selected.count(e.id) for e in pool.entries()}
+    pool.reset_status("row0")  # existing persistence boundary, not a selection
+    assert sum(e.get("request_count", 0) for e in read_credential_pool(pool.provider)) == 2
+    pool._current_id = None
+    pool.try_refresh_matching()  # API key is not refreshable; lookup must not count
+    assert sum(e.request_count for e in pool.entries()) == 2
+    assert pool.peek() is not None
+    assert sum(e.request_count for e in pool.entries()) == 2
+
+
+def test_priority_persists_contiguous_order_without_clearing_cooldown():
+    pool = _pool(exhausted=True)
+    before = {e.id: e.last_error_reset_at for e in pool.entries()}
+    assert pool.move_entry("row1", -5).priority == 0
+    assert [e["id"] for e in read_credential_pool(pool.provider)] == ["row1", "row0"]
+    assert pool.move_entry("row1", 99).priority == 1
+    assert [(e.id, e.priority) for e in pool.entries()] == [("row0", 0), ("row1", 1)]
+    assert {e.id: e.last_error_reset_at for e in pool.entries()} == before
+    snapshot = read_credential_pool(pool.provider)
+    assert pool.move_entry("missing", 0) is None
+    assert read_credential_pool(pool.provider) == snapshot
+
+
+def test_priority_honors_anthropic_manual_first():
+    pool = _pool("anthropic")
+    pool._entries[1] = replace(pool._entries[1], source="env:ANTHROPIC_API_KEY")
+    assert pool.move_entry("row1", 0).priority == 1
+    assert [e.id for e in pool.entries()] == ["row0", "row1"]

--- a/tests/hermes_cli/test_auth_pool_operations.py
+++ b/tests/hermes_cli/test_auth_pool_operations.py
@@ -12,6 +12,14 @@ from hermes_cli import auth_commands
 from hermes_cli.auth import read_credential_pool, write_credential_pool
 
 
+@pytest.fixture(autouse=True)
+def isolated_external_auth_stores(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared"))
+
+
 def _rows():
     return [dict(id=f"row{i}", label=f"account{i}", source="manual:device_code",
                  auth_type="oauth", access_token=f"fixture-access-{i}",

--- a/tests/hermes_cli/test_auth_pool_operations.py
+++ b/tests/hermes_cli/test_auth_pool_operations.py
@@ -1,0 +1,104 @@
+"""OAuth control commands against a loopback token endpoint."""
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
+from urllib.parse import parse_qs
+
+import pytest
+
+from hermes_cli import auth_commands
+from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+
+def _rows():
+    return [dict(id=f"row{i}", label=f"account{i}", source="manual:device_code",
+                 auth_type="oauth", access_token=f"fixture-access-{i}",
+                 refresh_token=f"fixture-refresh-{i}", priority=i,
+                 last_status="exhausted", last_status_at=time.time(),
+                 last_error_code=429, last_error_reset_at=time.time()+3600)
+            for i in range(2)]
+
+
+@pytest.mark.parametrize("status", [200, 503, 401])
+def test_refresh_uses_target_grant_and_preserves_sibling(monkeypatch, status):
+    from hermes_cli import auth_codex
+    requests = []
+
+    class Endpoint(BaseHTTPRequestHandler):
+        def do_POST(self):
+            requests.append(parse_qs(self.rfile.read(int(self.headers["Content-Length"])).decode()))
+            body = ({"access_token": "fixture-new-access", "refresh_token": "fixture-new-refresh"}
+                    if status == 200 else {"error": "invalid_grant" if status == 401 else "unavailable"})
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(body).encode())
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Endpoint)
+    worker = threading.Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    monkeypatch.setattr(auth_codex, "CODEX_OAUTH_TOKEN_URL", f"http://127.0.0.1:{server.server_port}/token")
+    from agent.credential_pool import PooledCredential
+    rows = [PooledCredential.from_dict("openai-codex", row).to_dict() for row in _rows()]
+    write_credential_pool("openai-codex", rows)
+    before = read_credential_pool("openai-codex")
+    try:
+        args = SimpleNamespace(provider="openai-codex", target="row1")
+        if status == 200:
+            auth_commands.auth_refresh_command(args)
+        else:
+            with pytest.raises(SystemExit, match="Refresh failed"):
+                auth_commands.auth_refresh_command(args)
+        after = {e["id"]: e for e in read_credential_pool("openai-codex")}
+        assert requests == [{"grant_type": ["refresh_token"], "refresh_token": ["fixture-refresh-1"],
+                             "client_id": [auth_codex.CODEX_OAUTH_CLIENT_ID]}]
+        assert after["row0"] == before[0], (after["row0"], before[0])
+        target = after["row1"]
+        if status == 200:
+            assert target["access_token"] == "fixture-new-access"
+            assert target["refresh_token"] == "fixture-new-refresh"
+            assert target.get("last_error_reset_at") is None
+            assert target["last_status"] == "ok"
+        else:
+            # Manual grants remain in the pool on terminal failure; only
+            # singleton-seeded grants are removed by the existing quarantine.
+            assert target["last_status"] == "exhausted"
+            assert target["access_token"] == before[1]["access_token"]
+    finally:
+        server.shutdown()
+        worker.join(timeout=5)
+        server.server_close()
+
+
+def test_add_priority_places_reauthenticated_row_in_multi_entry_pool(monkeypatch):
+    rows = _rows()
+    rows[1]["source"] = "device_code"
+    write_credential_pool("nous", rows)
+    monkeypatch.setattr(auth_commands.auth_mod, "_read_shared_nous_state", lambda: None)
+    monkeypatch.setattr(auth_commands.auth_mod, "_nous_device_code_login", lambda **_kwargs: {
+        "access_token": "fixture-renewed", "refresh_token": "fixture-renewed-refresh",
+        "agent_key": "fixture-agent-key", "expires_at": time.time() + 3600,
+    })
+    auth_commands.auth_add_command(SimpleNamespace(
+        provider="nous", auth_type="oauth", priority=0, label="reauthenticated"))
+    entries = read_credential_pool("nous")
+    assert [e["id"] for e in entries] == ["row1", "row0"]
+    assert entries[0]["priority"] == 0
+
+
+def test_refresh_rejects_ambiguous_and_non_oauth_targets():
+    rows = _rows()
+    write_credential_pool("openai-codex", rows)
+    with pytest.raises(SystemExit, match="pass an index"):
+        auth_commands.auth_refresh_command(SimpleNamespace(provider="openai-codex", target=None))
+    with pytest.raises(SystemExit, match="No credential matching"):
+        auth_commands.auth_refresh_command(SimpleNamespace(provider="openai-codex", target="missing"))
+    rows[0].update(auth_type="api_key", source="manual")
+    write_credential_pool("openrouter", rows[:1])
+    with pytest.raises(SystemExit, match="not a refreshable"):
+        auth_commands.auth_refresh_command(SimpleNamespace(provider="openrouter", target=None))

--- a/tests/hermes_cli/test_auth_pool_operations.py
+++ b/tests/hermes_cli/test_auth_pool_operations.py
@@ -110,3 +110,9 @@ def test_refresh_rejects_ambiguous_and_non_oauth_targets():
     write_credential_pool("openrouter", rows[:1])
     with pytest.raises(SystemExit, match="not a refreshable"):
         auth_commands.auth_refresh_command(SimpleNamespace(provider="openrouter", target=None))
+    # Nous's resolver refreshes only its singleton, never an independent pool grant.
+    write_credential_pool("nous", _rows())
+    before = read_credential_pool("nous")
+    with pytest.raises(SystemExit, match="not a refreshable"):
+        auth_commands.auth_refresh_command(SimpleNamespace(provider="nous", target="row0"))
+    assert read_credential_pool("nous") == before

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -581,7 +581,9 @@ hermes auth list                                         # Show all pools
 hermes auth list openrouter                              # Show specific provider
 hermes auth add openrouter --api-key sk-or-v1-xxx        # Add API key
 hermes auth add anthropic --type oauth                   # Add OAuth credential
+hermes auth add openai-codex --type oauth --priority 0   # Add an account and try it first
 hermes auth remove openrouter 2                          # Remove by index
+hermes auth priority openrouter backup-key 0             # Move a credential to the front of fill_first order
 hermes auth reset openrouter                             # Clear cooldowns
 hermes auth reset openrouter 2                           # Clear the cooldown on one credential
 hermes auth status anthropic                             # Show auth status for a provider
@@ -589,7 +591,7 @@ hermes auth logout anthropic                             # Log out and clear sto
 hermes auth spotify                                      # Authenticate Hermes with Spotify via PKCE
 ```
 
-Subcommands: `add`, `list`, `remove`, `reset`, `status`, `logout`, `spotify`. When called with no subcommand, launches the interactive management wizard.
+Subcommands: `add`, `list`, `remove`, `reset`, `priority`, `status`, `logout`, `spotify`. When called with no subcommand, launches the interactive management wizard.
 
 ## `hermes status`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -586,12 +586,13 @@ hermes auth remove openrouter 2                          # Remove by index
 hermes auth priority openrouter backup-key 0             # Move a credential to the front of fill_first order
 hermes auth reset openrouter                             # Clear cooldowns
 hermes auth reset openrouter 2                           # Clear the cooldown on one credential
+hermes auth refresh openai-codex work                    # Refresh one OAuth credential and clear its cooldown
 hermes auth status anthropic                             # Show auth status for a provider
 hermes auth logout anthropic                             # Log out and clear stored auth state
 hermes auth spotify                                      # Authenticate Hermes with Spotify via PKCE
 ```
 
-Subcommands: `add`, `list`, `remove`, `reset`, `priority`, `status`, `logout`, `spotify`. When called with no subcommand, launches the interactive management wizard.
+Subcommands: `add`, `list`, `remove`, `reset`, `priority`, `refresh`, `status`, `logout`, `spotify`. When called with no subcommand, launches the interactive management wizard.
 
 ## `hermes status`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -583,6 +583,7 @@ hermes auth add openrouter --api-key sk-or-v1-xxx        # Add API key
 hermes auth add anthropic --type oauth                   # Add OAuth credential
 hermes auth remove openrouter 2                          # Remove by index
 hermes auth reset openrouter                             # Clear cooldowns
+hermes auth reset openrouter 2                           # Clear the cooldown on one credential
 hermes auth status anthropic                             # Show auth status for a provider
 hermes auth logout anthropic                             # Log out and clear stored auth state
 hermes auth spotify                                      # Authenticate Hermes with Spotify via PKCE

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -116,6 +116,7 @@ Type [1/2]:
 | `hermes auth add <provider> --type oauth` | Add an OAuth credential via browser login |
 | `hermes auth remove <provider> <index>` | Remove credential by 1-based index |
 | `hermes auth reset <provider>` | Clear all cooldowns/exhaustion status |
+| `hermes auth reset <provider> <target>` | Clear the cooldown on one credential by index, id, or label |
 
 ## Rotation Strategies
 

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -121,6 +121,12 @@ Type [1/2]:
 | `hermes auth reset <provider> <target>` | Clear the cooldown on one credential by index, id, or label |
 | `hermes auth refresh <provider> [target]` | Refresh one OAuth credential's tokens and return it to rotation (proves the grant is alive; the next request re-checks quota) |
 
+For Nous, `auth refresh` supports only the login's `device_code` singleton.
+Independent Nous pool accounts are rejected before refresh; their tokens and
+cooldowns are preserved. Reauthenticate with `hermes auth add nous --type oauth`
+to update the singleton; this does not refresh an independent account. Other
+providers retain their existing source-specific refresh support.
+
 ## Rotation Strategies
 
 Priority positions are zero-based and clamp to the pool's ends; displayed targets

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -114,6 +114,8 @@ Type [1/2]:
 | `hermes auth add <provider>` | Add a credential (prompts for type and key) |
 | `hermes auth add <provider> --type api-key --api-key <key>` | Add an API key non-interactively |
 | `hermes auth add <provider> --type oauth` | Add an OAuth credential via browser login |
+| `hermes auth add <provider> --priority 0` | Add a credential and place it first in the `fill_first` order |
+| `hermes auth priority <provider> <target> <n>` | Move a credential to priority `n` (0 = tried first); the rest are renumbered |
 | `hermes auth remove <provider> <index>` | Remove credential by 1-based index |
 | `hermes auth reset <provider>` | Clear all cooldowns/exhaustion status |
 | `hermes auth reset <provider> <target>` | Clear the cooldown on one credential by index, id, or label |
@@ -130,7 +132,7 @@ credential_pool_strategies:
 
 | Strategy | Behavior |
 |----------|----------|
-| `fill_first` (default) | Use the first healthy key until it's exhausted, then move to the next |
+| `fill_first` (default) | Use the first healthy key until it's exhausted, then move to the next; order is each credential's `priority` (`hermes auth priority` changes it) |
 | `round_robin` | Cycle through keys evenly, rotating after each selection |
 | `least_used` | Always pick the key with the lowest request count |
 | `random` | Random selection among healthy keys |

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -119,6 +119,7 @@ Type [1/2]:
 | `hermes auth remove <provider> <index>` | Remove credential by 1-based index |
 | `hermes auth reset <provider>` | Clear all cooldowns/exhaustion status |
 | `hermes auth reset <provider> <target>` | Clear the cooldown on one credential by index, id, or label |
+| `hermes auth refresh <provider> [target]` | Refresh one OAuth credential's tokens and return it to rotation (proves the grant is alive; the next request re-checks quota) |
 
 ## Rotation Strategies
 

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -123,6 +123,20 @@ Type [1/2]:
 
 ## Rotation Strategies
 
+Priority positions are zero-based and clamp to the pool's ends; displayed targets
+are one-based indices, entry IDs, or unambiguous exact labels. `auth add --priority`
+also places an existing entry updated by reauthentication. Anthropic keeps manual
+credentials ahead of seeded credentials, so the command reports the effective
+position when that rule changes it. Other strategies may override priority, and
+reordering does not rebind credentials already held by a running session.
+
+Every successful pool selection increments `request_count`, regardless of strategy.
+Refresh-only lookups and peeks do not count. These are selection counters, not
+billing totals or a count of every inference request: a cached credential can serve
+multiple requests. Counts remain in memory until the next existing pool write
+(for example rotation, exhaustion, refresh, or an administrative change); this does
+not add a disk write per selection.
+
 Configure via `hermes auth` → "Set rotation strategy" or in `config.yaml`:
 
 ```yaml
@@ -220,7 +234,7 @@ For the full data flow diagram, see [`docs/credential-pool-flow.excalidraw`](htt
 
 The credential pool integrates at the provider resolution layer:
 
-1. **`agent/credential_pool.py`** — Pool manager: storage, selection, rotation, cooldowns
+1. **`agent/credential_pool.py`** — Pool manager: storage, selection, rotation, cooldowns; **`agent/credential_pool_admin.py`** owns locked target resolution, reset, add, removal, and priority mutations
 2. **`hermes_cli/auth_commands.py`** — CLI commands and interactive wizard
 3. **`hermes_cli/runtime_provider.py`** — Pool-aware credential resolution
 4. **`agent/turn_api_error.py`** — Error recovery: 429/402/401 → pool rotation → fallback


### PR DESCRIPTION
Credential-pool operators can recover, refresh, and reorder one account without resetting its siblings, and every selection strategy now maintains its selection counter.

## Changes
- `hermes auth reset <provider> [target]` clears one entry by index, ID, or unambiguous label; omitting the target retains the pool-wide reset.
- `hermes auth refresh <provider> [target]` uses the pool's forced OAuth refresh path and preserves its failure verdict. Target omission is allowed only for a single-entry pool. Nous refresh supports only the `device_code` singleton; independent Nous sources fail before invoking that resolver and preserve their tokens/cooldowns. Refresh success proves the grant is alive, **not** that provider quota is restored.
- `hermes auth priority <provider> <target> <N>` and `auth add --priority N` use clamped zero-based positions, contiguous numbering, and Anthropic's existing manual-first ordering. All add paths return their saved identity, including an in-place Nous reauthentication in a multi-entry pool.
- Every selection strategy increments `request_count`; refresh-only lookup does not. Counts persist at existing pool-write boundaries, not after every selection, and are not billing/per-inference totals.
- Locked administration methods move to `agent/credential_pool_admin.py` before adding the new mutations. User docs, parser help, console integration, contributor mapping, and a reproducible PTY/loopback-wire harness are included.

Root cause: the CLI lacked targeted pool operations, while selection counting lived only in the `least_used` branch; successful borrowed-token refreshes also needed explicit cooldown-clearing intent during persistence.

## Live repro
| Surface | Before | After |
|---|---|---|
| Real PTY targeted reset | Exit 2: target not accepted | Exit 0, only target cleared; sibling timestamp preserved |
| Real PTY priority / add placement | Exit 2: command/flag absent | Exit 0; exact disk order and clamping verified |
| Real PTY OAuth refresh + loopback HTTP 200 | Exit 2; no POST | One POST for selected grant; both tokens rotated on disk; sibling cooldown preserved |
| Same refresh with HTTP 503 / terminal 401 | Command absent | One POST each; exit 1, no false success, sibling preserved; existing manual-entry quarantine semantics retained |
| Ambiguous reset, missing priority target, API-key refresh, ambiguous refresh | Unsupported action/target | Explicit rejection; zero token requests |
| Two selections, each strategy | Default, round-robin, random stay at zero | All count exactly the returned selections; refresh-only lookup adds zero |
| Real PTY independent Nous account beside singleton | Exit 0, no POST, target token unchanged but cooldown erased | Exit 1 with singleton-only reauthentication guidance; no POST, tokens/cooldown preserved |
| Real PTY Nous singleton positive control | One loopback POST; both tokens rotated | Same successful source-bound singleton behavior; independent sibling preserved |

Validation: **14 real-PTY controls**, **7 fresh-process production-I/O invariant cases**, and **3 loopback refresh status cases** passed after rebasing. No secret text printed. The PTY before tree carries only the separately reviewed list-display fix (#104874) atop the same original baseline; the original current-main missing-capability receipt also reconfirmed all four premises. This is local integration/live-surface evidence, **not vendor verification**.

Harness: `evals/auth_pool_controls.py REPO OUTPUT_JSON`. Detailed campaign receipts: `/tmp/resolve-089c35aa/auth-operations-{pty-before,pty-after,invariants-final,wire-final}.json`.

Ruff, Windows-footgun scan, compat-pointer scan, subprocess-stdin scan, and `git diff --check` pass. The Nous follow-up has a real native-PTY RED → GREEN invariant and 14 checked controls. Its canonical regression RED runs against a frozen pre-fix archive; focused GREEN is queued behind the campaign-wide test lock. Prior affected-directory results were not green (10 failures are being classified/repaired in separate lanes); no full-suite-green claim. **Draft validation gates:** await canonical receipts and independent parent re-review. No merge is authorized.

## Attribution and scope
Salvages #104660, #104661, #104663, and #104664 by @0xble (Brian Le), with substantive implementations preserved under his authorship. Follow-ups extract administration, replace mock-heavy duplicated tests with focused I/O invariants, and fix the candidate's ambiguous set-difference add-placement mechanism. Related older move-to-front work #17527 / #67285 was reviewed; this does not claim their singleton switching, durable pinning, or live-session rebinding scope. #104874 remains separate and untouched.

Addresses #104634, #104635, #104637, #104638.
Campaign tracker: #104868.

## Infographic
![Credential pool controls](https://v3b.fal.media/files/b/0aa97350/QMPl9aXglXIVtdy0JkwVG_bnAEqZGe.png)
