### PR TITLE
fix: Gemini fallback aliases send native thinking requests (#104583, salvage #104584)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1705,10 +1705,8 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent.provider, reason, shared, agent._client_log_context(),
         )
         return provider_client
-    # Aliases of the "gemini" profile (e.g. a "google" fallback_providers entry) must route
-    # through the native client too, else thinking_config gets sent unnested to the raw REST
-    # endpoint and Google 400s with "Unknown name 'thinking_config': Cannot find field." (#hermes-thinking-config-fallback)
-    if agent.provider in {"gemini", "google", "google-gemini", "google-ai-studio"}:
+    from agent.auxiliary_client import _GEMINI_NATIVE_PROVIDER_NAMES
+    if agent.provider in _GEMINI_NATIVE_PROVIDER_NAMES:
         client = _gemini_native_client(agent, client_kwargs, httpx_verify, reason=reason, shared=shared)
         if client is not None:
             return client

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1705,7 +1705,10 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent.provider, reason, shared, agent._client_log_context(),
         )
         return provider_client
-    if agent.provider == "gemini":
+    # Aliases of the "gemini" profile (e.g. a "google" fallback_providers entry) must route
+    # through the native client too, else thinking_config gets sent unnested to the raw REST
+    # endpoint and Google 400s with "Unknown name 'thinking_config': Cannot find field." (#hermes-thinking-config-fallback)
+    if agent.provider in {"gemini", "google", "google-gemini", "google-ai-studio"}:
         client = _gemini_native_client(agent, client_kwargs, httpx_verify, reason=reason, shared=shared)
         if client is not None:
             return client

--- a/contributors/emails/me@charlesji.com
+++ b/contributors/emails/me@charlesji.com
@@ -1,0 +1,2 @@
+szcharlesji
+# Verified author of original PR #104584 commit 5e89544f915acc94ee6b2c2b17726f593b039f67

--- a/tests/agent/test_gemini_alias_native_route.py
+++ b/tests/agent/test_gemini_alias_native_route.py
@@ -1,0 +1,30 @@
+"""Provider aliases preserve the native-vs-compatible client boundary."""
+from types import SimpleNamespace
+
+from openai import OpenAI
+
+from agent.agent_runtime_helpers import create_openai_client
+from agent.gemini_native_adapter import GeminiNativeClient
+from providers import get_provider_profile
+
+
+def test_gemini_aliases_preserve_native_endpoint_selection():
+    profile = get_provider_profile("gemini")
+    for provider in (profile.name, *profile.aliases):
+        for base_url, expected in (
+            ("https://generativelanguage.googleapis.com/v1beta", GeminiNativeClient),
+            ("https://example.invalid/v1", OpenAI),
+        ):
+            agent = SimpleNamespace(
+                provider=provider, model="gemini-flash-latest",
+                _client_log_context=lambda: "test",
+                _build_keepalive_http_client=lambda *a, **k: None,
+            )
+            client = create_openai_client(
+                agent, {"api_key": "test-key", "base_url": base_url},
+                reason="fallback", shared=False,
+            )
+            try:
+                assert isinstance(client, expected), (provider, base_url, type(client))
+            finally:
+                client.close()

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -39,6 +39,11 @@ fallback_providers:
 
 Each entry requires both `provider` and `model`. Entries missing either field are ignored.
 
+Gemini fallback entries accept `gemini`, `google`, `google-gemini`, and
+`google-ai-studio`. On Google's native API endpoint, all use the native Gemini
+client, including its `generationConfig.thinkingConfig` translation. A custom
+OpenAI-compatible base URL continues to use the compatible client instead.
+
 :::note `fallback_model` vs `fallback_providers`
 `fallback_providers` (plural, list) is the current config shape and supports multiple fallbacks tried in order. `fallback_model` (singular) is the legacy single-fallback key — Hermes still honors it for back-compat, but `hermes fallback` writes the current `fallback_providers` key and migrates legacy config on write. When both are set, `fallback_providers` takes priority.
 :::


### PR DESCRIPTION
Gemini fallback aliases now use the native client on Google's API endpoint, so thinking configuration is sent in the native request shape.

Fixes #104583. Salvages #104584 by @szcharlesji (Charles Ji), preserving his substantive commit and authorship. Related duplicate: #104875. Campaign: #104868.

- Reuse the existing Gemini native-provider alias set in client construction rather than adding another copy.
- Add one invariant covering every registered alias on native and custom-compatible URLs.
- Document the fallback alias and endpoint behavior. Thanks to @crazyief for suggesting reuse of the existing alias set and alias-wide regression coverage.

Root cause: fallback activation retains the registered alias, while native client selection previously matched only the canonical `gemini` name.

## Validation

**Live repro:** independently rerun with real SDKs and a loopback HTTP capture server, isolated HOME/HERMES_HOME, baseline `d8a07768c5e` versus this branch. This is local wire-contract integration, not authenticated vendor inference; no paid requests were made.

| Case | Before | After |
|---|---|---|
| Three Google aliases on native URL | Generic client, `/v1beta/chat/completions`, top-level `thinking_config` | Native client, `:generateContent`, nested `generationConfig.thinkingConfig` |
| Canonical Gemini on native URL | Native request | Unchanged |
| All four names on custom-compatible URL | Compatible client/request | Unchanged |

- Regression was red on baseline (`google`: OpenAI rather than GeminiNativeClient), green with fix.
- Prior affected-directory run: 702 files, 8,503 passed, 0 failed, 30 skipped **after one unrelated compression-file retry**; not a clean first-pass claim.
- Independent code review, Ruff, Windows-footgun, compat-pointer and diff checks passed. Rebase only incorporated an unrelated CLI key-handling commit; no duplicate broad suite was launched.

### Draft gate: separate compression-fixture verification

The retry was diagnosed and reproduced separately: cold executor initialization can consume the fixture's 0.2-second fence before the primary worker starts, yielding the exact attempts=1 failure. A separate test-only commit (`fc14f6ff539`, branch `fix/audit-089c35aa-compression-fixture`) warms worker dependencies before the idle-stall test; a delayed-start A/B fails before and passes after without increasing the budgets or changing production code. That commit is deliberately **not included here**.

The targeted wrapper verification could not start because the shared campaign test lock remained occupied for more than seven minutes. Keep this PR draft until that separate fixture run completes and its disposition is reviewed. CI status is not being claimed green.

## Infographic

![Gemini fallback aliases use the native request route](https://v3b.fal.media/files/b/0aa972c9/e9YxVbWltgo85zyWJABXs_upWJHuxF.png)
