### PR TITLE
test(cron): cover multiplex delivery credential scope

### DIFF
--- a/tests/cron/test_cron_multiplex_delivery_credentials.py
+++ b/tests/cron/test_cron_multiplex_delivery_credentials.py
@@ -1,0 +1,138 @@
+"""Cron delivery keeps the firing profile's credentials for the full job lifecycle.
+
+A multiplex ticker may run under profile A while ticking profile B with no live
+adapters. Both successful output and escaped-failure alerts must reach the
+standalone Discord sender with B's credential, then restore the caller's empty
+secret scope.
+"""
+
+import pytest
+
+import cron.scheduler as scheduler
+
+
+@pytest.fixture()
+def secondary_discord_delivery(tmp_path, monkeypatch):
+    from agent import secret_scope
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from tools import send_message_tool
+
+    primary_home = tmp_path / "primary"
+    secondary_home = tmp_path / "profiles" / "secondary"
+    primary_home.mkdir()
+    secondary_home.mkdir(parents=True)
+    (secondary_home / ".env").write_text(
+        "DISCORD_BOT_TOKEN=profile-b-credential-value\n",
+        encoding="utf-8",
+    )
+    (secondary_home / "config.yaml").write_text(
+        "platforms:\n  discord:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(primary_home))
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "profile-a-credential-value")
+    monkeypatch.setattr(scheduler, "_launch_external_cron_worker", lambda _job: False)
+    monkeypatch.setattr(
+        scheduler,
+        "create_execution",
+        lambda job_id, **_kwargs: {"id": f"exec-{job_id}"},
+    )
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda _execution_id: {})
+    monkeypatch.setattr(
+        scheduler,
+        "save_job_output",
+        lambda job_id, _output: str(tmp_path / f"{job_id}.md"),
+    )
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(scheduler, "finish_execution", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        scheduler, "load_config", lambda: {"cron": {"wrap_response": False}}
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_upsert_incident_for_failure",
+        lambda *_args, **_kwargs: (False, "incident-test"),
+    )
+    monkeypatch.setattr(scheduler, "_mark_incident_alerted", lambda _incident_id: None)
+
+    sends = []
+
+    async def fake_standalone_sender(pconfig, chat_id, message, **_kwargs):
+        sends.append({
+            "credential": pconfig.token,
+            "chat_id": chat_id,
+            "message": message,
+        })
+        return {"success": True, "message_id": "message-test"}
+
+    original_sender_lookup = send_message_tool._plugin_standalone_sender
+
+    def standalone_sender_lookup(platform_name, **kwargs):
+        if platform_name == "discord":
+            return fake_standalone_sender, None
+        return original_sender_lookup(platform_name, **kwargs)
+
+    monkeypatch.setattr(
+        send_message_tool,
+        "_plugin_standalone_sender",
+        standalone_sender_lookup,
+    )
+
+    previous_multiplex = secret_scope.is_multiplex_active()
+    empty_scope_token = secret_scope.set_secret_scope(None)
+    home_token = set_hermes_home_override(str(secondary_home))
+    secret_scope.set_multiplex_active(True)
+    try:
+        yield sends, secret_scope
+    finally:
+        secret_scope.set_multiplex_active(previous_multiplex)
+        reset_hermes_home_override(home_token)
+        secret_scope.reset_secret_scope(empty_scope_token)
+
+
+def test_secondary_normal_delivery_retains_profile_scope(
+    secondary_discord_delivery, monkeypatch
+):
+    sends, secret_scope = secondary_discord_delivery
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda *_args, **_kwargs: (True, "raw output", "normal result", None),
+    )
+
+    processed = scheduler.run_one_job(
+        {"id": "normal", "name": "normal", "deliver": "discord:channel-b"},
+        adapters=None,
+        loop=None,
+    )
+
+    assert processed is True
+    assert [send["credential"] for send in sends] == ["profile-b-credential-value"]
+    assert [send["chat_id"] for send in sends] == ["channel-b"]
+    assert "normal result" in sends[0]["message"]
+    assert secret_scope.current_secret_scope() is None
+
+
+def test_secondary_failure_alert_retains_profile_scope(
+    secondary_discord_delivery, monkeypatch
+):
+    sends, secret_scope = secondary_discord_delivery
+
+    def raise_during_run(*_args, **_kwargs):
+        raise RuntimeError("provider failed")
+
+    monkeypatch.setattr(scheduler, "run_job", raise_during_run)
+
+    processed = scheduler.run_one_job(
+        {"id": "failure", "name": "failure", "deliver": "discord:channel-b"},
+        adapters=None,
+        loop=None,
+    )
+
+    assert processed is False
+    assert [send["credential"] for send in sends] == ["profile-b-credential-value"]
+    assert [send["chat_id"] for send in sends] == ["channel-b"]
+    assert "failed" in sends[0]["message"].lower()
+    assert secret_scope.current_secret_scope() is None


### PR DESCRIPTION
## What does this PR do?

Adds end-to-end regression coverage for profile-scoped cron delivery in a multiplex process. The tests model primary profile A ticking secondary profile B with `adapters=None`, follow the real standalone Discord configuration path up to the network sender boundary, and prove both successful output and escaped-failure alerts use B's credential before restoring the caller's empty secret scope.

Current `main` already keeps the scope alive through delivery in `cron/scheduler.py`; this test preserves that behavior and fails if the scope is reset before either delivery path.

## Related Issue

- [ASG-58: split Hugin morning/evening intake and use KST bullet format](https://linear.app/asgard-idavoll/issue/ASG-58/split-hugin-morningevening-intake-and-use-kst-bullet-format)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `tests/cron/test_cron_multiplex_delivery_credentials.py`.
- Exercise the real profile home override, secret-scope loader, gateway configuration, cron target resolution, and standalone Discord send path.
- Cover normal-result delivery, escaped-failure alert delivery, secondary-profile credential selection, and exception-safe scope restoration.

## How to Test

1. Run `scripts/run_tests.sh tests/cron/test_cron_multiplex_delivery_credentials.py tests/cron/test_run_one_job.py tests/cron/test_cron_live_delivery_confirmation.py -q -p no:cacheprovider` (43 passed).
2. Move the secret-scope reset back before delivery: both new tests fail because the sender observes profile A's credential; restore the function-level `finally`: both pass using profile B's credential.
3. Run `npm run check`: all Node typechecks and tests pass (TUI 1,746; web 295; tests-js 55); the aggregate command currently exits 1 on 29 existing lint warnings and 0 lint errors. `scripts/run_tests.sh` was also run; the new cron test file passes, while the base-wide run reports 128 unrelated failures across 46 files plus one collection/no-test file.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Pre-PR independent review of base `fc8d15d7797c36cdc78ca9cd4a07187c3cc61c91` and commit `4a4e6490ed7e519ada1a7aac0b35ede685919eba`: APPROVE, must-fix 0, should-fix 0.
