### PR TITLE
fix(agent): strip oldest images and retry on provider per-prompt image count limits

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1627,6 +1627,7 @@ _FALLBACK_REASON_LABELS = {
     FailoverReason.context_overflow: "context window exceeded",
     FailoverReason.payload_too_large: "request payload too large",
     FailoverReason.image_too_large: "image payload too large",
+    FailoverReason.too_many_images: "too many images in one prompt",
     FailoverReason.model_not_found: "model not found",
     FailoverReason.provider_policy_blocked: "provider policy blocked the request",
     FailoverReason.content_policy_blocked: "content policy blocked the request",

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1262,6 +1262,107 @@ def evict_stale_outbound_tool_images(
     return _retire_stale_tool_result_images(api_messages, keep_newest=keep_newest)
 
 
+def _count_image_parts(content: Any) -> int:
+    """Count image parts in a message's ``content`` value.
+
+    Handles the two shapes that carry images:
+
+    * the native ``{_multimodal: True, content: [...]}`` envelope that
+      ``vision_analyze`` returns;
+    * OpenAI/Anthropic-style content-part lists (user uploads, tool
+      results, assistant echoes).
+
+    String content (and anything else) counts as ``0``.
+    """
+    if isinstance(content, dict) and content.get("_multimodal"):
+        content = content.get("content")
+    if not isinstance(content, list):
+        return 0
+    return sum(1 for p in content if _is_image_part(p))
+
+
+def strip_images_to_count_limit(
+    api_messages: List[Dict[str, Any]],
+    max_images: Optional[int],
+) -> int:
+    """Strip image parts to bring the total under ``max_images``.
+
+    Protects the last message when it is a user message carrying images
+    (the user's most recent intent). Strips oldest-first from all other
+    messages. When ``max_images`` is ``None`` the ``_MAX_KEEP_TOOL_IMAGES``
+    constant is used as the target.
+
+    Returns the number of image parts removed, or ``0`` when nothing could
+    be stripped — either no images are present, or the protected message
+    alone already meets/exceeds the target (in which case stripping the
+    rest cannot get under the limit and the caller should surface the
+    original error).
+
+    Mutates ``api_messages`` in place — this is a send-path rewrite; the
+    persisted history is untouched.
+    """
+    if not api_messages:
+        return 0
+    target = _MAX_KEEP_TOOL_IMAGES if max_images is None else max_images
+    if target < 0:
+        target = 0
+
+    total = sum(
+        _count_image_parts(m.get("content"))
+        for m in api_messages
+        if isinstance(m, dict)
+    )
+    if total <= target:
+        return 0
+
+    # Protect the last message only when it is a user message with images.
+    protected_idx = -1
+    last = api_messages[-1]
+    if (
+        isinstance(last, dict)
+        and last.get("role") == "user"
+        and _content_has_images(last.get("content"))
+    ):
+        protected_idx = len(api_messages) - 1
+    protected_count = (
+        _count_image_parts(api_messages[protected_idx].get("content"))
+        if protected_idx >= 0
+        else 0
+    )
+
+    # If the protected message alone exceeds the target, no amount of
+    # stripping elsewhere helps — the caller surfaces the original error.
+    if protected_idx >= 0 and protected_count > target:
+        return 0
+
+    stripped = 0
+    remaining = total
+    for i, msg in enumerate(api_messages):
+        if remaining <= target:
+            break
+        if not isinstance(msg, dict):
+            continue
+        if i == protected_idx:
+            continue
+        count = _count_image_parts(msg.get("content"))
+        if count == 0:
+            continue
+        if msg.get("role") == "tool":
+            new_msg = _strip_images_from_tool_msg(msg)
+            if new_msg is None:
+                continue
+            api_messages[i] = new_msg
+        else:
+            new_content = _strip_images_from_content(msg.get("content"))
+            if new_content is msg.get("content"):
+                continue
+            msg["content"] = new_content
+            drop_stale_api_content(msg)
+        stripped += count
+        remaining -= count
+    return stripped
+
+
 def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
     """Shrink long string leaves in a tool-call arguments JSON blob, keeping it valid (providers 400 on malformed args)."""
     try:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -340,6 +340,46 @@ def _is_stale_copilot_credential_error(status_code: Optional[int], error_message
     ))
 
 
+def _image_error_max_count(error: Exception) -> Optional[int]:
+    """Extract a provider-reported per-prompt image *count* ceiling.
+
+    Confirmed local-engine wordings:
+      vLLM:   ``"At most 2 image(s) may be provided in one prompt."`` → 2
+      SGLang: ``"Image count 5 exceeds limit 2 per request."`` → 2
+
+    Returns the parsed integer when it is sane (1–64), else ``None`` so the
+    caller falls back to the default keep-window.
+    """
+    parts = []
+    for value in (
+        error,
+        getattr(error, "message", None),
+        getattr(error, "body", None),
+    ):
+        if value:
+            try:
+                parts.append(str(value))
+            except Exception:
+                pass
+    text = " ".join(parts).lower()
+    if "image" not in text:
+        return None
+    match = re.search(
+        r"(?:at most|no more than|maximum of|maximum number of|too many)\s+(\d+)\s+image",
+        text,
+    ) or re.search(r"(\d+)\s+image\(s\)\s+may be provided", text) \
+        or re.search(r"exceeds limit\s+(\d+)", text)
+    if not match:
+        return None
+    try:
+        count = int(match.group(1))
+    except ValueError:
+        return None
+    if 1 <= count <= 64:
+        return count
+    return None
+
+
 def _pressure_with_real_floor(compressor: Any, rough_tokens: int) -> int:
     """Floor the ROUGH pre-API pressure estimate at the last REAL prompt size.
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -37,6 +37,9 @@ class FailoverReason(enum.Enum):
     payload_too_large = "payload_too_large"  # 413 — compress payload
     image_too_large = "image_too_large"   # Native image part exceeds provider's per-image limit — shrink and retry
     image_corrupt = "image_corrupt"       # Provider can't decode image bytes — strip and retry (shrinking won't help)
+    too_many_images = "too_many_images"   # Provider rejects more than N images in one prompt — strip oldest and retry
+
+    # Model / provider policy
     model_not_found = "model_not_found"  # 404 or invalid model — fallback to different model
     provider_policy_blocked = "provider_policy_blocked"  # Aggregator account data/privacy policy excluded the only endpoint
     content_policy_blocked = "content_policy_blocked"  # Provider safety filter rejected this prompt — don't retry unchanged
@@ -348,6 +351,7 @@ _V_CONTEXT_OVERFLOW = _v(_R.context_overflow, should_compress=True)
 _V_PAYLOAD_TOO_LARGE = _v(_R.payload_too_large, should_compress=True)
 _V_OVERLOADED, _V_SERVER_ERROR, _V_TIMEOUT, _V_UNKNOWN = map(_v, (_R.overloaded, _R.server_error, _R.timeout, _R.unknown))
 _V_IMAGE_TOO_LARGE, _V_IMAGE_CORRUPT = _v(_R.image_too_large), _v(_R.image_corrupt)
+_V_TOO_MANY_IMAGES = _v(_R.too_many_images)
 _V_MULTIMODAL, _V_INVALID_ENCRYPTED = _v(_R.multimodal_tool_content_unsupported), _v(_R.invalid_encrypted_content)
 _V_REASONING_MANDATORY = _v(_R.reasoning_mandatory, should_compress=False, should_fallback=False)
 # A reasoning-mandatory route answering ``reasoning: {enabled: false}`` (Nous Portal + OpenRouter wording).
@@ -545,6 +549,8 @@ def _by_message(c: _Ctx) -> Optional[Verdict]:
     head = _first_match(c.msg, _MESSAGE_HEAD_RULES)
     if head is not None:
         return head
+    if _is_image_count_limit(c.msg):
+        return _V_TOO_MANY_IMAGES
     usage_limit = any(p in c.msg for p in _USAGE_LIMIT_PATTERNS)
     return _classify_402(c.msg, dict) if usage_limit else _first_match(c.msg, _MESSAGE_TAIL_RULES)
 
@@ -713,6 +719,11 @@ def _classify_400(c: _Ctx) -> Verdict:
             "error=%.200s", c.num_messages, c.approx_tokens, msg,
         )
         return _V_FORMAT_ERROR
+    # Image-count limit from 400 (vLLM's ``--limit-mm-per-prompt``). Checked
+    # before context_overflow so the count-limit 400 is not mis-routed into
+    # the compression loop.
+    if _is_image_count_limit(msg):
+        return _V_TOO_MANY_IMAGES
     verdict = _first_match(msg, _400_TAIL_RULES)
     if verdict is not None:
         return verdict
@@ -788,6 +799,40 @@ def _is_server_injected_param_rejection(error_msg: str, provider: str) -> bool:
 _CODEX_MASKED_REPLAY_MESSAGE = "request blocked."
 
 
+def _is_image_count_limit(error_msg: str) -> bool:
+    """True when a 400 body indicates a per-prompt image *count* limit.
+
+    Distinct from ``_IMAGE_TOO_LARGE_PATTERNS`` (per-image byte/dimension
+    ceiling) and ``_IMAGE_CORRUPT_PATTERNS`` (undecodable bytes): the
+    provider decoded every image fine but rejects the request because it
+    carries more images than its per-prompt limit allows.
+
+    Confirmed local-engine wordings:
+      vLLM:   ``"At most 2 image(s) may be provided in one prompt."``
+      Ollama: contains ``"too many"`` + ``"image"``
+      SGLang: ``"Image count 5 exceeds limit 2 per request."``
+
+    ``error_msg`` is lowercased upstream — match accordingly.  The
+    ``"image"`` gate keeps this from firing on non-image count limits
+    (e.g. a max-tool-calls ceiling that happens to use the same phrasing).
+    """
+    if "image" not in error_msg:
+        return False
+    return any(
+        p in error_msg
+        for p in (
+            "at most",
+            "too many",
+            "no more than",
+            "maximum number",
+            "may be provided in one prompt",
+            "exceeds limit",
+        )
+    )
+
+
+
+
 def _is_codex_masked_replay_rejection(c: "_Ctx") -> bool:
     """HTTP 400 / status-less ``{code: invalid_prompt, message: "Request blocked."}`` from
     ``openai-codex`` — as an SDK error body, a Responses ``error`` SSE frame, or the
@@ -830,6 +875,7 @@ def _build_error_msg(error: Exception, body: Any) -> str:
     (OpenAI SDK's APIStatusError.__str__ omits the body, so it is appended)."""
     raw_msg = str(error).lower()
     body_msg = metadata_msg = ""
+
     if isinstance(body, dict):
         err_obj = _error_obj(body)
         body_msg = str(err_obj.get("message") or "").lower() or str(body.get("message") or "").lower()
@@ -853,6 +899,7 @@ def _body_message_candidates(body: dict) -> Iterator[Any]:
 
 def _from_cause_chain(error: Exception, pick: Callable[[Any], Any], default: Any) -> Any:
     """First non-None ``pick(exc)`` over the error and its __cause__/__context__ chain (max 5 deep)."""
+
     current = error
     for _ in range(5):
         found = pick(current)

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -543,6 +543,34 @@ def recover_after_classification(
             return True, recovered_with_pool
         logger.info("image-corrupt recovery: no image parts found to strip; surfacing original error.")
 
+    # Local engine per-prompt image count limit (vLLM --limit-mm-per-prompt, SGLang
+    # limit_mm_data_per_request, Ollama).  Strip oldest images to fit the reported
+    # ceiling and retry once.  Gated to local endpoints: we only have confirmed
+    # error-message patterns for local engines.
+    if (
+        classified.reason == FailoverReason.too_many_images
+        and not _retry.too_many_images_retry_attempted
+    ):
+        from agent.model_metadata import is_local_endpoint
+        from agent.error_surface import _is_custom_endpoint
+        _base_url = getattr(agent, "base_url", "") or ""
+        _provider = getattr(agent, "provider", "") or ""
+        if is_local_endpoint(_base_url) or _is_custom_endpoint(_provider):
+            _retry.too_many_images_retry_attempted = True
+            from agent.conversation_loop import _image_error_max_count
+            from agent.context_compressor import strip_images_to_count_limit
+            _limit = _image_error_max_count(api_error)
+            if isinstance(api_messages, list):
+                _stripped = strip_images_to_count_limit(api_messages, _limit)
+                if _stripped > 0:
+                    _vlines(agent, f"⚠️  Provider image limit ({_limit or 'default'}) — stripped {_stripped} image(s) and retrying...")
+                    logger.warning(
+                        "%stoo-many-images recovery: stripped %d image(s) to limit %s",
+                        agent.log_prefix, _stripped, _limit,
+                    )
+                    return True, recovered_with_pool
+            logger.info("too-many-images recovery: no image parts to strip; surfacing original error.")
+
     # Anthropic OAuth subscription rejected the 1M-context beta: disable it for this
     # session, rebuild the client, retry once. Reactive so capable subscriptions keep 1M.
     if (

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -31,6 +31,7 @@ class TurnRetryState:
     native_compaction_reject_retry_attempted: bool = False
     image_shrink_retry_attempted: bool = False
     multimodal_tool_content_retry_attempted: bool = False
+    too_many_images_retry_attempted: bool = False
     reasoning_mandatory_retry_attempted: bool = False
     oauth_1m_beta_retry_attempted: bool = False
     llama_cpp_grammar_retry_attempted: bool = False

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -61,7 +61,7 @@ class TestFailoverReason:
             "overloaded", "server_error", "timeout",
             "ssl_cert_verification",
             "context_overflow", "payload_too_large", "image_too_large",
-            "image_corrupt",
+            "image_corrupt", "too_many_images",
             "model_not_found", "format_error",
             "invalid_encrypted_content",
             "multimodal_tool_content_unsupported",

--- a/tests/agent/test_too_many_images_recovery.py
+++ b/tests/agent/test_too_many_images_recovery.py
@@ -1,0 +1,311 @@
+"""Reactive recovery for provider per-prompt image *count* limits.
+
+vLLM's ``--limit-mm-per-prompt`` rejects a request that carries more images
+than the deployment allows with a 400 like
+``"At most 2 image(s) may be provided in one prompt."``.  Every image decoded
+fine — the request simply has too many.  Before this fix the 400 fell through
+to a non-retryable ``format_error`` and the session stalled.
+
+Covers the three pieces independently:
+
+  1. ``agent/error_classifier.py``: the count-limit 400 classifies as
+     ``FailoverReason.too_many_images`` (retryable), not ``format_error`` /
+     ``image_too_large`` / ``image_corrupt``.
+  2. ``agent/conversation_loop._image_error_max_count``: parses the ceiling
+     out of the error text, returning ``None`` when unparseable.
+  3. ``agent/context_compressor.strip_images_to_count_limit``: strips the
+     oldest image payloads (user uploads and tool results alike, protecting
+     the newest user turn) on the per-call copy, leaving persisted history
+     untouched.
+"""
+
+from __future__ import annotations
+
+from agent.conversation_loop import _image_error_max_count
+from agent.context_compressor import (
+    _MAX_KEEP_TOOL_IMAGES,
+    _count_image_parts,
+    strip_images_to_count_limit,
+)
+from agent.error_classifier import FailoverReason, classify_api_error
+
+
+class _FakeApiError(Exception):
+    """Stand-in for an openai.BadRequestError with status_code + body."""
+
+    def __init__(self, status_code: int, message: str, body: dict | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body or {"error": {"message": message}}
+        self.response = None  # required by some code paths
+
+
+_VLLM_COUNT_MSG = "At most 2 image(s) may be provided in one prompt. (parameter=image)"
+
+
+# ─── Classifier ──────────────────────────────────────────────────────────────
+
+
+class TestTooManyImagesClassification:
+    def test_vllm_count_limit_400(self):
+        """vLLM's exact wording must classify as too_many_images, retryable."""
+        err = _FakeApiError(status_code=400, message=_VLLM_COUNT_MSG)
+        result = classify_api_error(err, provider="vllm", model="qwen2.5-vl")
+        assert result.reason == FailoverReason.too_many_images
+        assert result.retryable is True
+
+    def test_too_many_images_variant(self):
+        err = _FakeApiError(
+            status_code=400, message="Too many images in request (max 4)"
+        )
+        result = classify_api_error(err, provider="vllm", model="qwen2.5-vl")
+        assert result.reason == FailoverReason.too_many_images
+
+    def test_no_more_than_variant(self):
+        err = _FakeApiError(
+            status_code=400,
+            message="No more than 4 images may be provided in one prompt",
+        )
+        result = classify_api_error(err, provider="vllm", model="qwen2.5-vl")
+        assert result.reason == FailoverReason.too_many_images
+
+    def test_image_too_large_not_misrouted(self):
+        """A per-image *size* ceiling is image_too_large, not a count limit."""
+        err = _FakeApiError(
+            status_code=400,
+            message="messages.0.content.1.image.source.base64: image exceeds 5 MB maximum",
+        )
+        result = classify_api_error(err, provider="anthropic", model="claude-sonnet-4-6")
+        assert result.reason == FailoverReason.image_too_large
+        assert result.reason != FailoverReason.too_many_images
+
+    def test_image_corrupt_not_misrouted(self):
+        """An undecodable-image 400 is image_corrupt, not a count limit."""
+        err = _FakeApiError(status_code=400, message="Invalid PNG image.")
+        result = classify_api_error(err, provider="xai", model="grok-5")
+        assert result.reason == FailoverReason.image_corrupt
+        assert result.reason != FailoverReason.too_many_images
+
+    def test_sglang_exceeds_limit(self):
+        """SGLang's ``limit_mm_data_per_request`` wording."""
+        err = _FakeApiError(
+            status_code=400,
+            message="Image count 5 exceeds limit 2 per request.",
+        )
+        result = classify_api_error(err, provider="sglang", model="qwen2.5-vl")
+        assert result.reason == FailoverReason.too_many_images
+        assert result.retryable is True
+
+    def test_unrelated_400_not_misrouted(self):
+        """A generic 400 with no image-count phrasing must not match."""
+        err = _FakeApiError(
+            status_code=400, message="messages: unexpected role \"tool\" at index 3"
+        )
+        result = classify_api_error(err, provider="minimax", model="MiniMax-M3")
+        assert result.reason != FailoverReason.too_many_images
+
+
+# ─── _image_error_max_count ──────────────────────────────────────────────────
+
+
+class TestImageErrorMaxCount:
+    def test_parses_vllm_message(self):
+        err = _FakeApiError(status_code=400, message=_VLLM_COUNT_MSG)
+        assert _image_error_max_count(err) == 2
+
+    def test_parses_no_more_than(self):
+        err = _FakeApiError(
+            status_code=400, message="No more than 4 images may be provided"
+        )
+        assert _image_error_max_count(err) == 4
+
+    def test_parses_from_body(self):
+        """The count can live on the error body, not just the message."""
+        err = _FakeApiError(
+            status_code=400,
+            message="BadRequestError",
+            body={"error": {"message": "At most 3 image(s) may be provided"}},
+        )
+        assert _image_error_max_count(err) == 3
+
+    def test_parses_sglang_exceeds_limit(self):
+        """SGLang: ``"Image count 5 exceeds limit 2 per request."`` → 2."""
+        err = _FakeApiError(
+            status_code=400,
+            message="Image count 5 exceeds limit 2 per request.",
+        )
+        assert _image_error_max_count(err) == 2
+
+    def test_unparseable_returns_none(self):
+        err = _FakeApiError(
+            status_code=400, message="Too many images in one prompt"
+        )
+        assert _image_error_max_count(err) is None
+
+    def test_no_image_mention_returns_none(self):
+        err = _FakeApiError(status_code=400, message="At most 2 tool calls allowed")
+        assert _image_error_max_count(err) is None
+
+
+# ─── strip_images_to_count_limit ─────────────────────────────────────────────
+
+
+def _user_with_images(n: int, *, tag: str = "U") -> dict:
+    parts = [{"type": "text", "text": f"{tag} text"}]
+    for i in range(n):
+        parts.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{tag}{i}"},
+            }
+        )
+    return {"role": "user", "content": parts}
+
+
+def _tool_with_images(i: int) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": f"call_{i}",
+                    "type": "function",
+                    "function": {
+                        "name": "vision_analyze",
+                        "arguments": f'{{"image_url":"shot{i}.png"}}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": f"call_{i}",
+            "content": [
+                {"type": "text", "text": f"Image attached natively shot {i}"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,T{i}"},
+                },
+            ],
+        },
+    ]
+
+
+def _total_images(messages: list[dict]) -> int:
+    return sum(_count_image_parts(m.get("content")) for m in messages)
+
+
+class TestStripImagesToCountLimit:
+    def test_strips_oldest_keeps_newest(self):
+        """4 images across user + tool, limit 2, last msg is a tool result.
+
+        The newest user turn is NOT the last message, so nothing is protected
+        and the two oldest images (the first user upload) are stripped.
+        """
+        msgs = [
+            _user_with_images(2, tag="OLD"),
+            *_tool_with_images(0),
+            *_tool_with_images(1),
+        ]
+        assert _total_images(msgs) == 4
+        stripped = strip_images_to_count_limit(msgs, 2)
+        assert stripped == 2
+        assert _total_images(msgs) == 2
+        # The two tool images (newest) survive; the user upload is stripped.
+        user = msgs[0]
+        assert _count_image_parts(user["content"]) == 0
+        assert _count_image_parts(msgs[2]["content"]) == 1  # tool 0
+        assert _count_image_parts(msgs[4]["content"]) == 1  # tool 1
+
+    def test_protected_user_turn_exceeds_limit_no_strip(self):
+        """The newest user turn alone exceeds the limit → nothing to strip.
+
+        User uploads 4 images in the latest message, limit 3: stripping the
+        older images cannot get under the limit, so the caller surfaces the
+        original error (returns 0, no mutation).
+        """
+        msgs = [
+            _user_with_images(1, tag="OLD"),
+            _user_with_images(4, tag="NEW"),
+        ]
+        assert _total_images(msgs) == 5
+        stripped = strip_images_to_count_limit(msgs, 3)
+        assert stripped == 0
+        assert _total_images(msgs) == 5  # untouched
+
+    def test_protected_user_turn_kept_older_stripped(self):
+        """Newest user turn fits under the limit → strip older images only.
+
+        Stripping is whole-message (oldest-first), consistent with the rest of
+        the compressor: the older user turn's image parts are all removed,
+        which is enough to get under the limit.
+        """
+        msgs = [
+            _user_with_images(2, tag="OLD"),
+            _user_with_images(1, tag="NEW"),
+        ]
+        assert _total_images(msgs) == 3
+        stripped = strip_images_to_count_limit(msgs, 2)
+        assert stripped == 2
+        assert _total_images(msgs) <= 2
+        assert _count_image_parts(msgs[0]["content"]) == 0  # older stripped
+        assert _count_image_parts(msgs[1]["content"]) == 1  # protected kept
+
+    def test_none_falls_back_to_constant(self):
+        """max_images=None uses _MAX_KEEP_TOOL_IMAGES as the target."""
+        msgs = [
+            _user_with_images(1, tag="OLD"),
+            *_tool_with_images(0),
+            *_tool_with_images(1),
+            *_tool_with_images(2),
+            *_tool_with_images(3),
+        ]
+        # 1 user + 4 tool = 5 images; target = _MAX_KEEP_TOOL_IMAGES (3).
+        assert _total_images(msgs) == 5
+        stripped = strip_images_to_count_limit(msgs, None)
+        assert _total_images(msgs) == _MAX_KEEP_TOOL_IMAGES
+        assert stripped == 5 - _MAX_KEEP_TOOL_IMAGES
+
+    def test_no_images_returns_zero(self):
+        msgs = [{"role": "user", "content": "hello"}]
+        assert strip_images_to_count_limit(msgs, 2) == 0
+
+    def test_under_limit_returns_zero(self):
+        msgs = [_user_with_images(1, tag="A")]
+        assert strip_images_to_count_limit(msgs, 2) == 0
+
+    def test_multimodal_envelope_tool_handled(self):
+        """A vision_analyze _multimodal envelope is counted and stripped."""
+        msgs = [
+            _user_with_images(1, tag="OLD"),
+            {
+                "role": "tool",
+                "tool_call_id": "call_x",
+                "content": {
+                    "_multimodal": True,
+                    "content": [
+                        {"type": "text", "text": "attached"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,ENV"},
+                        },
+                    ],
+                    "text_summary": "screenshot summary",
+                },
+            },
+        ]
+        assert _total_images(msgs) == 2
+        stripped = strip_images_to_count_limit(msgs, 1)
+        assert stripped == 1
+        # The user upload (older) is stripped; the envelope tool result kept.
+        assert _count_image_parts(msgs[0]["content"]) == 0
+        assert _count_image_parts(msgs[1]["content"]) == 1
+
+    def test_does_not_rewrite_persisted_history(self):
+        """The strip mutates only the passed list; a separate history is safe."""
+        history = [_user_with_images(2, tag="OLD"), *_tool_with_images(0)]
+        outbound = [dict(m) for m in history]  # shallow per-call clone
+        strip_images_to_count_limit(outbound, 1)
+        assert _total_images(history) == 3  # original untouched
+        assert _total_images(outbound) == 1


### PR DESCRIPTION
## Problem

When you use a local inference engine (vLLM, SGLang, Ollama) with a vision model, the engine can reject your request if it contains too many images. For example, if you start vLLM with `--limit-mm-per-prompt 2`, any request with 3 or more images gets a 400 error.

Before this fix, Hermes did not recognize this kind of error. It treated it as a generic "format error" (non-retryable), which meant the conversation would stop permanently. The user would see an error and the session would be stuck.

## What this PR does

Only for local providers, when the agent receives a 400 error that says "too many images", it now:

1. **Recognizes the error** — checks if the error message matches known patterns from local engines (e.g. "At most 2 image(s) may be provided", "exceeds limit 2 per request").
2. **Reads the limit** — extracts the number from the error message (e.g. "2" from "At most **2** image(s)...").
3. **Removes old images** — strips the oldest images from the conversation so the total count fits under the limit. The most recent user message is protected (its images are kept).
4. **Retries once** — sends the request again with fewer images, within the accepted limit extracted in step 2. If it still fails, the original error is shown to the user.

This only activates for **local endpoints** (localhost, private IP, or known local provider names like `ollama`, `vllm`, `llama.cpp`). Cloud providers are not affected.

## Error messages from local engines

| Engine | How to set the limit | What the 400 error says |
|--------|---------------------|------------------------|
| vLLM | `--limit-mm-per-prompt 2` | `At most 2 image(s) may be provided in one prompt.` |
| SGLang | `--limit-mm-data-per-request '{"image": 2}'` | `Image count 5 exceeds limit 2 per request.` |
| Ollama | (depends on the model) | contains the words `too many` and `image` |
| llama.cpp | (no image count limit) | N/A — only context-size overflow is possible |

## Tests

- `tests/agent/test_too_many_images_recovery.py` — 21 tests covering: error classification for each engine, limit parsing, image stripping logic, and the full retry flow.
- `tests/agent/test_error_classifier.py` — 134 tests (enum membership updated).

All tests pass.