### PR TITLE
fix: MCP pagination retains the original call error (salvage #104164)

### DIFF
--- a/tests/tools/test_mcp_list_pagination.py
+++ b/tests/tools/test_mcp_list_pagination.py
@@ -81,7 +81,7 @@ class TestTypeErrorPropagation:
     def test_type_error_from_modern_list_call_propagates(self):
         calls = {"n": 0}
 
-        async def broken_list(**kwargs):
+        async def broken_list(*, params=None):
             calls["n"] += 1
             if calls["n"] == 1:
                 return SimpleNamespace(tools=[_tool("first")], nextCursor="page-2")

--- a/tests/tools/test_mcp_list_pagination.py
+++ b/tests/tools/test_mcp_list_pagination.py
@@ -7,6 +7,8 @@ past page 1. Port of the invariant behind anomalyco/opencode#35439/#35500.
 """
 
 import asyncio
+
+import pytest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -68,3 +70,38 @@ class TestDiscoveryUsesPagination:
 
         asyncio.run(server._discover_tools())
         assert [t.name for t in server._tools] == ["first", "second"]
+
+
+class TestTypeErrorPropagation:
+    """#104150: a TypeError raised INSIDE the list call (e.g. a server
+    response decode failure) must propagate — it must not be caught by the
+    mcp-2.0/1.x calling-convention fallback and replaced by a misleading
+    'unexpected keyword argument cursor' error."""
+
+    def test_type_error_from_modern_list_call_propagates(self):
+        calls = {"n": 0}
+
+        async def broken_list(**kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return SimpleNamespace(tools=[_tool("first")], nextCursor="page-2")
+            raise TypeError("server response decode failed")
+
+        with pytest.raises(TypeError, match="server response decode failed"):
+            asyncio.run(_paginate_full_list(broken_list, "tools", "srv"))
+
+        assert calls["n"] == 2, "the legacy-cursor retry must not run"
+
+    def test_legacy_signature_still_uses_cursor_fallback(self):
+        """A genuinely 1.x-shaped method (no params kwarg) keeps working."""
+        calls = {"n": 0}
+
+        async def legacy_list(cursor=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return SimpleNamespace(tools=[_tool("first")], nextCursor="p2")
+            return SimpleNamespace(tools=[_tool("second")], nextCursor=None)
+
+        items = asyncio.run(_paginate_full_list(legacy_list, "tools", "srv"))
+        assert [t.name for t in items] == ["first", "second"]
+        assert calls["n"] == 2

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -252,6 +252,26 @@ _JSONRPC_METHOD_NOT_FOUND = -32601
 _MCP_LIST_MAX_PAGES = 50
 
 
+def _list_method_accepts_params(list_method) -> bool:
+    """True when *list_method* accepts the mcp 2.0 ``params=`` keyword.
+
+    Probing the signature instead of catching TypeError around the call keeps
+    a TypeError raised INSIDE the list call — e.g. a server response decode
+    failure — propagating, rather than being replaced by a misleading
+    legacy-cursor retry error (#104150).
+    """
+    import inspect
+
+    try:
+        sig = inspect.signature(list_method)
+    except (TypeError, ValueError):
+        return True  # can't introspect — assume the modern convention
+    return any(
+        param.name == "params" or param.kind == inspect.Parameter.VAR_KEYWORD
+        for param in sig.parameters.values()
+    )
+
+
 async def _paginate_full_list(list_method, items_attr: str, server_name: str,
                               cache_meta_out: Optional[dict] = None):
     """Drain a paginated ``list_*`` call by following ``nextCursor``; ``cache_meta_out`` gets the
@@ -263,12 +283,17 @@ async def _paginate_full_list(list_method, items_attr: str, server_name: str,
             result = await list_method()
         else:
             # mcp 2.0 takes params=PaginatedRequestParams, 1.x takes cursor=.
-            try:
+            # Signature-probed (see _list_method_accepts_params) instead of
+            # try/except TypeError: a TypeError from inside the list call
+            # must propagate, not trigger the legacy fallback (#104150).
+            if _list_method_accepts_params(list_method):
                 import mcp.types as _types  # late: keeps the SDK import lazy
                 _params_cls = getattr(_types, "PaginatedRequestParams", None)
-                result = await (list_method(params=_params_cls(cursor=cursor)) if _params_cls is not None
-                                else list_method(cursor=cursor))
-            except TypeError:
+                if _params_cls is not None:
+                    result = await list_method(params=_params_cls(cursor=cursor))
+                else:
+                    result = await list_method(cursor=cursor)
+            else:
                 result = await list_method(cursor=cursor)
         if cache_meta_out is not None and not items:
             for key, snake, camel in (("ttl_ms", "ttl_ms", "ttlMs"), ("cache_scope", "cache_scope", "cacheScope")):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -252,26 +252,6 @@ _JSONRPC_METHOD_NOT_FOUND = -32601
 _MCP_LIST_MAX_PAGES = 50
 
 
-def _list_method_accepts_params(list_method) -> bool:
-    """True when *list_method* accepts the mcp 2.0 ``params=`` keyword.
-
-    Probing the signature instead of catching TypeError around the call keeps
-    a TypeError raised INSIDE the list call — e.g. a server response decode
-    failure — propagating, rather than being replaced by a misleading
-    legacy-cursor retry error (#104150).
-    """
-    import inspect
-
-    try:
-        sig = inspect.signature(list_method)
-    except (TypeError, ValueError):
-        return True  # can't introspect — assume the modern convention
-    return any(
-        param.name == "params" or param.kind == inspect.Parameter.VAR_KEYWORD
-        for param in sig.parameters.values()
-    )
-
-
 async def _paginate_full_list(list_method, items_attr: str, server_name: str,
                               cache_meta_out: Optional[dict] = None):
     """Drain a paginated ``list_*`` call by following ``nextCursor``; ``cache_meta_out`` gets the
@@ -283,10 +263,20 @@ async def _paginate_full_list(list_method, items_attr: str, server_name: str,
             result = await list_method()
         else:
             # mcp 2.0 takes params=PaginatedRequestParams, 1.x takes cursor=.
-            # Signature-probed (see _list_method_accepts_params) instead of
-            # try/except TypeError: a TypeError from inside the list call
-            # must propagate, not trigger the legacy fallback (#104150).
-            if _list_method_accepts_params(list_method):
+            # Inspect before awaiting: an internal TypeError is not a signature mismatch.
+            import inspect
+
+            try:
+                signature = inspect.signature(list_method)
+            except (TypeError, ValueError):
+                accepts_params = True  # Opaque callables use the current SDK convention.
+            else:
+                accepts_params = any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD
+                    or (p.name == "params" and p.kind != inspect.Parameter.POSITIONAL_ONLY)
+                    for p in signature.parameters.values()
+                )
+            if accepts_params:
                 import mcp.types as _types  # late: keeps the SDK import lazy
                 _params_cls = getattr(_types, "PaginatedRequestParams", None)
                 if _params_cls is not None:


### PR DESCRIPTION
MCP pagination now preserves the original failure from a modern list call instead of replacing it with a misleading legacy-cursor error.

Fixes #104150. Campaign tracker: #104904.

- Determine the accepted keyword from the callable signature before awaiting a subsequent page.
- Preserve genuine `cursor=` legacy callables; do not retry internal `TypeError`s.
- Keep the fix local to the existing paginator and retain two behavioral regressions.

Root cause: the compatibility handler caught errors from inside an otherwise valid modern call.

**Live repro:** On base `c4a5deeffa959f8ebc891e02c5bcf767aff1dd2a`, a real MCP 2.0 StreamableHTTP session drained two pages successfully, but an explicitly injected decoder error after the second real HTTP call surfaced as `unexpected keyword argument 'cursor'`. The identical isolated fixture on this branch preserves `server response decode failed` with exactly two calls and no legacy retry.

Validation: `flock /tmp/hermes-e461-fix-tests.lock bash scripts/run_tests.sh -j 1 tests/tools/test_mcp_list_pagination.py` — 5 passed, 0 failed. Touched-file Ruff, Windows-footgun scan, compatibility-pointer scan and `git diff --check` pass. Independent read-only Codex review: no findings. Broader directories are coordinated centrally by the campaign; no CI-green claim.

Boundary: real loopback HTTP and real SDK, with the decoder fault deliberately injected at the list-call boundary; not a naturally failing vendor decoder.

Credit: cherry-picked @holny's #104164 (`6b96089de3d631d35a6f6c3a80d25cedb41af43b`), preserving authorship and adding the contributor mapping. Follow-up trims the standalone helper and pins the report's exact params-only error surface. Original report: @Xuxyyy.

## Infographic
![Reliable skills and MCP](https://v3b.fal.media/files/b/0aa97376/7jszQO-ENDdUu6NCrD0N0_Thya7aFq.png)
