### PR TITLE
fix: legacy context engines keep compressing (salvage #104214)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -22,6 +22,7 @@ from agent.auxiliary_client import (
     extract_content_or_reasoning,
 )
 from agent.context_engine import ContextEngine, sanitize_memory_context
+from agent.context_compressor_summary import SummaryDispatchMixin
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.micro_compaction import MicroCompactionMixin
 from agent.model_metadata import (
@@ -1637,7 +1638,7 @@ Describe agent/tool work only as completed actions, state, or historical work.]"
 }
 
 
-class ContextCompressor(MicroCompactionMixin, ContextEngine):
+class ContextCompressor(SummaryDispatchMixin, MicroCompactionMixin, ContextEngine):
     """Default context engine: prune tool results, protect head/tail, summarize the middle
     with an LLM, and iteratively update the previous summary on later compactions."""
 
@@ -4668,23 +4669,6 @@ Write only the summary body. Do not include any preamble or prefix."""
         # Phase 4: Assemble compressed message list
         compressed = self._assemble_compressed(messages, compress_start, compress_end, scan, summary)
         return self._finalize_compressed(compressed, messages, n_messages)
-
-    def _summarize_window(
-        self, messages: List[Dict[str, Any]], turns_to_summarize: List[Dict[str, Any]], scan: "_HandoffScan",
-        focus_topic: Optional[str], memory_context: str, bypass_cooldown: bool,
-    ) -> Optional[str]:
-        """Run the summary LLM; a cancellation rolls back the handoff scan's self-heal mutation first."""
-        # Focus-topic derivation scans user turns; only pay when a summary is generated.
-        try:
-            return self._generate_summary(
-                turns_to_summarize, focus_topic=focus_topic or self._derive_auto_focus_topic(messages),
-                memory_context=memory_context, bypass_cooldown=bypass_cooldown,
-            )
-        except AuxiliaryExplicitCancellation:
-            # Cancellation is a true no-op: restore the scan's mutation before the exception escapes.
-            self._previous_summary = scan.previous_summary_before
-            self._summary_has_user_turn = scan.has_user_turn_before
-            raise
 
     def _assemble_compressed(
         self, messages: List[Dict[str, Any]], compress_start: int, compress_end: int, scan: "_HandoffScan", summary: str,

--- a/agent/context_compressor_summary.py
+++ b/agent/context_compressor_summary.py
@@ -2,12 +2,28 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from agent.auxiliary_client import AuxiliaryExplicitCancellation
 
 if TYPE_CHECKING:
     from agent.context_compressor import _HandoffScan
+
+
+def _accepts_keyword_argument(callable_obj: Any, name: str) -> bool:
+    """Return whether an inspectable callable accepts ``name`` as a keyword."""
+    try:
+        parameters = inspect.signature(callable_obj).parameters
+    except (TypeError, ValueError):
+        return False
+    if any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()):
+        return True
+    parameter = parameters.get(name)
+    return parameter is not None and parameter.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
 
 
 class SummaryDispatchMixin:
@@ -17,11 +33,14 @@ class SummaryDispatchMixin:
     ) -> Optional[str]:
         """Run the summary LLM; a cancellation rolls back the handoff scan's self-heal mutation first."""
         # Focus-topic derivation scans user turns; only pay when a summary is generated.
+        summary_kwargs: Dict[str, Any] = {
+            "focus_topic": focus_topic or self._derive_auto_focus_topic(messages),
+            "memory_context": memory_context,
+        }
+        if bypass_cooldown and _accepts_keyword_argument(self._generate_summary, "bypass_cooldown"):
+            summary_kwargs["bypass_cooldown"] = True
         try:
-            return self._generate_summary(
-                turns_to_summarize, focus_topic=focus_topic or self._derive_auto_focus_topic(messages),
-                memory_context=memory_context, bypass_cooldown=bypass_cooldown,
-            )
+            return self._generate_summary(turns_to_summarize, **summary_kwargs)
         except AuxiliaryExplicitCancellation:
             # Cancellation is a true no-op: restore the scan's mutation before the exception escapes.
             self._previous_summary = scan.previous_summary_before

--- a/agent/context_compressor_summary.py
+++ b/agent/context_compressor_summary.py
@@ -46,4 +46,3 @@ class SummaryDispatchMixin:
             self._previous_summary = scan.previous_summary_before
             self._summary_has_user_turn = scan.has_user_turn_before
             raise
-

--- a/agent/context_compressor_summary.py
+++ b/agent/context_compressor_summary.py
@@ -37,8 +37,8 @@ class SummaryDispatchMixin:
             "focus_topic": focus_topic or self._derive_auto_focus_topic(messages),
             "memory_context": memory_context,
         }
-        if bypass_cooldown and _accepts_keyword_argument(self._generate_summary, "bypass_cooldown"):
-            summary_kwargs["bypass_cooldown"] = True
+        if _accepts_keyword_argument(self._generate_summary, "bypass_cooldown"):
+            summary_kwargs["bypass_cooldown"] = bypass_cooldown
         try:
             return self._generate_summary(turns_to_summarize, **summary_kwargs)
         except AuxiliaryExplicitCancellation:

--- a/agent/context_compressor_summary.py
+++ b/agent/context_compressor_summary.py
@@ -1,0 +1,30 @@
+"""Summary-hook dispatch and cancellation rollback for context compression."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from agent.auxiliary_client import AuxiliaryExplicitCancellation
+
+if TYPE_CHECKING:
+    from agent.context_compressor import _HandoffScan
+
+
+class SummaryDispatchMixin:
+    def _summarize_window(
+        self, messages: List[Dict[str, Any]], turns_to_summarize: List[Dict[str, Any]], scan: "_HandoffScan",
+        focus_topic: Optional[str], memory_context: str, bypass_cooldown: bool,
+    ) -> Optional[str]:
+        """Run the summary LLM; a cancellation rolls back the handoff scan's self-heal mutation first."""
+        # Focus-topic derivation scans user turns; only pay when a summary is generated.
+        try:
+            return self._generate_summary(
+                turns_to_summarize, focus_topic=focus_topic or self._derive_auto_focus_topic(messages),
+                memory_context=memory_context, bypass_cooldown=bypass_cooldown,
+            )
+        except AuxiliaryExplicitCancellation:
+            # Cancellation is a true no-op: restore the scan's mutation before the exception escapes.
+            self._previous_summary = scan.previous_summary_before
+            self._summary_has_user_turn = scan.has_user_turn_before
+            raise
+

--- a/tests/agent/test_context_compressor_summary_hook_compat.py
+++ b/tests/agent/test_context_compressor_summary_hook_compat.py
@@ -1,0 +1,78 @@
+"""Compatibility coverage for third-party summary hook overrides."""
+
+from agent.context_compressor import ContextCompressor
+
+
+class _LegacySummaryCompressor(ContextCompressor):
+    """Model an engine released before ``bypass_cooldown`` was added."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            model="test-model",
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+            config_context_length=40_960,
+        )
+        self.summary_calls: list[tuple[list[dict], str | None, str]] = []
+
+    def _generate_summary(
+        self,
+        turns_to_summarize: list[dict],
+        focus_topic: str | None = None,
+        memory_context: str = "",
+    ) -> str:
+        self.summary_calls.append((turns_to_summarize, focus_topic, memory_context))
+        return "## Goal\nPreserve compatibility with legacy summary hooks."
+
+
+class _KwargsSummaryCompressor(_LegacySummaryCompressor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.summary_kwargs: list[dict[str, object]] = []
+
+    def _generate_summary(
+        self,
+        turns_to_summarize: list[dict],
+        focus_topic: str | None = None,
+        memory_context: str = "",
+        **kwargs: object,
+    ) -> str:
+        self.summary_kwargs.append(kwargs)
+        return "## Goal\nPreserve bypass semantics for extensible hooks."
+
+
+def _messages() -> list[dict]:
+    messages = [{"role": "system", "content": "system"}]
+    messages.extend(
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"turn-{index} " + "context " * 1_000,
+        }
+        for index in range(14)
+    )
+    return messages
+
+
+def test_compress_omits_bypass_cooldown_for_legacy_summary_override() -> None:
+    compressor = _LegacySummaryCompressor()
+    messages = _messages()
+
+    compressed = compressor.compress(
+        messages,
+        current_tokens=30_000,
+        memory_context="plugin memory",
+        bypass_cooldown=True,
+    )
+
+    assert len(compressed) < len(messages)
+    assert len(compressor.summary_calls) == 1
+    assert compressor.summary_calls[0][2] == "plugin memory"
+
+
+def test_compress_passes_bypass_cooldown_to_kwargs_summary_override() -> None:
+    compressor = _KwargsSummaryCompressor()
+
+    compressor.compress(_messages(), current_tokens=30_000, bypass_cooldown=True)
+
+    assert compressor.summary_kwargs == [{"bypass_cooldown": True}]

--- a/tests/agent/test_context_compressor_summary_hook_compat.py
+++ b/tests/agent/test_context_compressor_summary_hook_compat.py
@@ -1,5 +1,7 @@
 """Compatibility coverage for third-party summary hook overrides."""
 
+import pytest
+
 from agent.context_compressor import ContextCompressor
 
 
@@ -8,71 +10,66 @@ class _LegacySummaryCompressor(ContextCompressor):
 
     def __init__(self) -> None:
         super().__init__(
-            model="test-model",
-            protect_first_n=2,
-            protect_last_n=2,
-            quiet_mode=True,
-            config_context_length=40_960,
+            model="test-model", protect_first_n=2, protect_last_n=2,
+            quiet_mode=True, config_context_length=40_960,
         )
-        self.summary_calls: list[tuple[list[dict], str | None, str]] = []
+        self.summary_calls = []
 
-    def _generate_summary(
-        self,
-        turns_to_summarize: list[dict],
-        focus_topic: str | None = None,
-        memory_context: str = "",
-    ) -> str:
-        self.summary_calls.append((turns_to_summarize, focus_topic, memory_context))
+    def _generate_summary(self, turns_to_summarize, focus_topic=None, memory_context=""):
+        self.summary_calls.append((focus_topic, memory_context, {}))
         return "## Goal\nPreserve compatibility with legacy summary hooks."
 
 
 class _KwargsSummaryCompressor(_LegacySummaryCompressor):
-    def __init__(self) -> None:
-        super().__init__()
-        self.summary_kwargs: list[dict[str, object]] = []
-
-    def _generate_summary(
-        self,
-        turns_to_summarize: list[dict],
-        focus_topic: str | None = None,
-        memory_context: str = "",
-        **kwargs: object,
-    ) -> str:
-        self.summary_kwargs.append(kwargs)
+    def _generate_summary(self, turns_to_summarize, focus_topic=None, memory_context="", **kwargs):
+        self.summary_calls.append((focus_topic, memory_context, kwargs))
         return "## Goal\nPreserve bypass semantics for extensible hooks."
 
 
-def _messages() -> list[dict]:
-    messages = [{"role": "system", "content": "system"}]
-    messages.extend(
-        {
-            "role": "user" if index % 2 == 0 else "assistant",
-            "content": f"turn-{index} " + "context " * 1_000,
-        }
-        for index in range(14)
-    )
-    return messages
+class _ExplicitSummaryCompressor(_KwargsSummaryCompressor):
+    def _generate_summary(self, turns_to_summarize, focus_topic=None, memory_context="", *, bypass_cooldown=True):
+        return super()._generate_summary(
+            turns_to_summarize, focus_topic, memory_context, bypass_cooldown=bypass_cooldown,
+        )
 
 
-def test_compress_omits_bypass_cooldown_for_legacy_summary_override() -> None:
-    compressor = _LegacySummaryCompressor()
+class _PositionalSummaryCompressor(_LegacySummaryCompressor):
+    def _generate_summary(self, turns_to_summarize, bypass_cooldown=False, /, focus_topic=None, memory_context=""):
+        return super()._generate_summary(turns_to_summarize, focus_topic, memory_context)
+
+
+def _messages():
+    return [{"role": "system", "content": "system"}] + [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"turn-{i} " + "context " * 1_000}
+        for i in range(14)
+    ]
+
+
+@pytest.mark.parametrize("bypass", [False, True])
+@pytest.mark.parametrize("engine", [
+    _LegacySummaryCompressor, _KwargsSummaryCompressor,
+    _ExplicitSummaryCompressor, _PositionalSummaryCompressor,
+])
+def test_compress_calls_supported_summary_signature_once(engine, bypass):
+    compressor = engine()
     messages = _messages()
-
     compressed = compressor.compress(
-        messages,
-        current_tokens=30_000,
-        memory_context="plugin memory",
-        bypass_cooldown=True,
+        messages, current_tokens=30_000, focus_topic="compatibility",
+        memory_context="plugin memory", bypass_cooldown=bypass,
     )
-
+    expected = {"bypass_cooldown": bypass} if isinstance(compressor, _KwargsSummaryCompressor) else {}
     assert len(compressed) < len(messages)
+    assert compressor.summary_calls == [("compatibility", "plugin memory", expected)]
+
+
+@pytest.mark.parametrize("bypass", [False, True])
+def test_summary_hook_type_error_is_not_retried(bypass):
+    class FailingCompressor(_KwargsSummaryCompressor):
+        def _generate_summary(self, *args, **kwargs):
+            super()._generate_summary(*args, **kwargs)
+            raise TypeError("inside stateful hook")
+
+    compressor = FailingCompressor()
+    with pytest.raises(TypeError, match="inside stateful hook"):
+        compressor.compress(_messages(), current_tokens=30_000, bypass_cooldown=bypass)
     assert len(compressor.summary_calls) == 1
-    assert compressor.summary_calls[0][2] == "plugin memory"
-
-
-def test_compress_passes_bypass_cooldown_to_kwargs_summary_override() -> None:
-    compressor = _KwargsSummaryCompressor()
-
-    compressor.compress(_messages(), current_tokens=30_000, bypass_cooldown=True)
-
-    assert compressor.summary_kwargs == [{"bypass_cooldown": True}]


### PR DESCRIPTION
Legacy context engines can compact again without accepting the newer summary-hook keyword.

Fixes #104176. Campaign: #104904.

- Inspect the bound summary hook before passing `bypass_cooldown`; legacy and positional-only signatures omit it.
- Supporting hooks receive the exact `False` / `True` value. Invoke once; do not catch-and-retry hook `TypeError`.
- Move existing dispatch/cancellation rollback into a small topical mixin before adding compatibility behavior, rather than growing the compressor module.
- Two invariant tests (10 parameterized cases) cover signature dispatch and stateful hook errors.

**Root cause:** inherited `compress()` unconditionally forwarded a new optional keyword into existing extension overrides.

**Live repro:** current main `d8a07768c5ee59afae62e9fb51d45e1e30aa74da` fails legacy and positional-only hooks at both bypass values; this branch compresses the same 60-message fixture to 8 messages with one hook invocation. Modern explicit/kwargs hooks preserve both values; a hook-raised TypeError is propagated after one invocation. Fresh process and isolated HOME/HERMES_HOME, real inherited compressor, network blocked. This is library integration with local extension fixtures, not execution of a third-party package or provider inference.

| Validation | Result |
|---|---|
| Serial wrapper, compatibility + compression-attempt lifecycle files (`flock`, `-j 1`) | 22 passed, 0 failed, 2 files |
| Expanded main/fix live A/B | 10 scenarios per arm, expected outcomes verified |
| ruff, Windows footgun scan, compatibility-pointer scan | Passed |
| Independent Codex review | No findings |
| Broad tests/agent directory | Parent campaign integration; not claimed here |

An additional cancellation-file test attempt timed out waiting for the shared test lock (zero tests run); cancellation rollback was mechanically preserved and independently reviewed. No CI-green claim; no merge requested.

## Credit
Salvages #104214 by @fangliquanflq (original commit `9ed006c657df6366aaf2f009a1bc98ca786367f7`, author preserved). The follow-up also preserves explicit false values, which the candidate omitted. Existing contributor mapping already credits this email.

## Infographic
![Legacy context engines keep compressing](https://v3b.fal.media/files/b/0aa9736b/-izjjrdvleiFowtnc08sF_aybREWHn.png)
