### PR TITLE
docs: explain inherited reasoning in same-model background reviews

### DIFF
--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1332,9 +1332,11 @@ Auxiliary task blocks additionally accept a `reasoning_effort` knob:
 |-----|-------------|---------|
 | `reasoning_effort` | Thinking level for that task's LLM calls: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra` | not set (provider default) |
 
-This is the per-task counterpart of the global `agent.reasoning_effort`: run compression at `low` or vision at `none` to cut side-task latency and cost when your main model is an expensive reasoning model, without touching your main chat behavior. It works on every auxiliary task block (`vision`, `compression`, `title_generation`, `curator`, `background_review`, ...), across all three auxiliary wire formats (chat completions, Codex Responses, Anthropic Messages). An explicit `extra_body.reasoning` on the same task wins over the shorthand.
+This is the per-task counterpart of the global `agent.reasoning_effort`: run compression at `low` or vision at `none` to cut side-task latency and cost when your main model is an expensive reasoning model, without touching your main chat behavior. It applies to auxiliary-client tasks such as `vision`, `compression`, `title_generation`, and `curator`, across all three auxiliary wire formats (chat completions, Codex Responses, Anthropic Messages). An explicit `extra_body.reasoning` on the same task wins over the shorthand.
 
-MoA is the one exception: reasoning depth for Mixture-of-Agents is configured **per slot** in the MoA preset (`moa.presets.<name>.reference_models[].reasoning_effort` / `aggregator.reasoning_effort`), not on the `moa_reference`/`moa_aggregator` auxiliary blocks — see [Mixture of Agents](/user-guide/features/mixture-of-agents).
+**Background review is different:** a same-model review fork always inherits the parent's reasoning effort. `auxiliary.background_review.reasoning_effort` is ignored on that path, including when the parent provider/model is explicitly selected. This preserves byte-identical reasoning settings, system prompt, full conversation snapshot, and tool definitions for prompt-cache parity; there is no independent-effort switch for same-model reviews. See [background review reasoning](/user-guide/features/memory#same-model-review-reasoning). The separate routed-fork effort issue is tracked in [#94825](https://github.com/NousResearch/hermes-agent/issues/94825).
+
+**MoA also uses a different configuration:** reasoning depth for Mixture-of-Agents is configured **per slot** in the MoA preset (`moa.presets.<name>.reference_models[].reasoning_effort` / `aggregator.reasoning_effort`), not on the `moa_reference`/`moa_aggregator` auxiliary blocks — see [Mixture of Agents](/user-guide/features/mixture-of-agents).
 
 ```yaml
 auxiliary:

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -332,6 +332,14 @@ identical and skill capture near-identical to the main-model review.
 Leave it at `auto` (or set it to your main model) and nothing changes — the
 review keeps running on the main model with the full warm-cache replay.
 
+### Same-model review reasoning
+
+A review using the same model as the parent **always inherits the parent's reasoning effort**. Setting `auxiliary.background_review.reasoning_effort` does not override it, whether the route is `auto` or explicitly selects the parent provider/model.
+
+Reasoning settings, the system prompt, the full conversation snapshot, and tool definitions stay byte-identical to the parent at fork birth so the review can reuse its prompt-cache prefix. Changing only the review's thinking level would break that parity. There is no independent-effort switch for same-model reviews.
+
+To reduce review work without changing the main conversation's effort, adjust `memory.nudge_interval` / `skills.creation_nudge_interval`, disable automatic reviews as described below, or route reviews to a different model. A different-model route uses a digest and does not share the parent's warm prefix; its separate task-effort bug is tracked in [#94825](https://github.com/NousResearch/hermes-agent/issues/94825). These frequency and routing controls do not decouple same-model reasoning.
+
 ### Disabling automatic reviews (`enabled`)
 
 The review fork can burn a meaningful share of total tokens on busy hosts.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -850,6 +850,8 @@ Hermes 中的每个模型槽位 —— 辅助任务、压缩、回退 —— 使
 `"main"` provider 选项表示"使用我的主 agent 使用的任何 provider" —— 它仅在 `auxiliary:`、`compression:` 和 `fallback_model:` 配置中有效。它**不是**顶级 `model.provider` 设置的有效值。如果您使用自定义 OpenAI 兼容端点，请在 `model:` 部分设置 `provider: custom`。所有主模型 provider 选项请参阅 [AI Providers](/integrations/providers)。
 :::
 
+**后台审查有所不同：** 与主会话使用同一模型的审查分支始终继承主会话的推理强度；`auxiliary.background_review.reasoning_effort` 在这条路径上不会生效，即使显式指定了主会话的 provider/model 也一样。推理设置、系统 prompt、完整会话快照和工具定义保持逐字节一致，以复用 prompt 缓存前缀。没有用于同模型审查的独立推理强度开关。详见[同模型审查的推理强度](/user-guide/features/memory#same-model-review-reasoning)。路由到其他模型时的独立问题见 [#94825](https://github.com/NousResearch/hermes-agent/issues/94825)。
+
 ### 完整辅助配置参考
 
 ```yaml

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory.md
@@ -200,6 +200,14 @@ hermes sessions list    # 浏览过去的会话
 
 **记忆**用于应始终在上下文中的关键事实。**会话搜索**用于"我们上周讨论过 X 吗？"这类需要 Agent 从过去对话中回忆具体内容的查询。
 
+## 同模型审查的推理强度 {#same-model-review-reasoning}
+
+后台审查与主会话使用同一模型时，**始终继承主会话的推理强度**。`auxiliary.background_review.reasoning_effort` 不会覆盖该设置；`auto` 路由和显式指定主会话的 provider/model 都遵循此规则。
+
+分支创建时，推理设置、系统 prompt、完整会话快照和工具定义保持与主会话逐字节一致，以复用 prompt 缓存前缀。只改变审查的推理强度会破坏这种一致性。没有用于同模型审查的独立推理强度开关。
+
+若要减少审查工作而不改变主会话的推理强度，可以调整 `memory.nudge_interval` / `skills.creation_nudge_interval`，通过 `auxiliary.background_review.enabled: false` 禁用自动审查，或将审查路由到其他模型。其他模型使用会话摘要，不共享主会话的预热缓存前缀；其任务推理强度的独立问题见 [#94825](https://github.com/NousResearch/hermes-agent/issues/94825)。频率和路由控制并不会分离同模型审查的推理强度。
+
 ## 配置
 
 ```yaml


### PR DESCRIPTION
Background-review documentation now states that same-model forks always inherit the parent’s reasoning effort.

Addresses the documentation portion of #104116. Campaign: #104904. This does not implement the requested independent-effort feature; no such switch is introduced.

- Correct the configuration reference’s universal-effort claim.
- Explain the same-model exception and byte-identical reasoning/system/snapshot/tools cache-parity rationale in the memory guide, including explicit same-provider/model routes.
- Link routed-fork effort to its separate issue #94825; distinguish existing frequency/disable/routing controls from same-model effort.
- Include the corresponding zh-Hans notes. Four Markdown files only; zero runtime/config changes.

**Root cause:** documentation described every auxiliary task as honoring per-task effort, while same-model background review deliberately inherits the parent.

**Live repro:** before and after, real AIAgent parent/fork calls through production HTTP transport to an isolated localhost protocol fixture preserve parent `ultra` despite task `low` (wire effort `max`). Auto and explicit same-model routes keep equal tools/system and identical replay. The routed contrast uses a digest and remains tracked separately. The runtime is intentionally unchanged; the documentation mismatch is corrected. No vendor inference or cache-cost measurement was performed.

| Validation | Result |
|---|---|
| `npm run build` | Both English and zh-Hans static sites generated successfully |
| New memory-guide anchors | Present in both built locales |
| Main/fix localhost fork-wire probes | Same-model reasoning, tools, system and replay parity verified |
| Runtime diff | Empty |
| Independent Codex review | No findings |
| Diff whitespace check | Passed |

Build output includes repository-wide existing broken-anchor warnings; no new link was reported by independent review, and the newly added cross-locale targets were checked in the built HTML. No pytest run claimed for a docs-only change. No merge/deploy performed.

## Infographic
![Same-model reviews inherit reasoning](https://v3b.fal.media/files/b/0aa97376/q3uNRkpCcKp8Vo1P3Eivd_UdWn9NQ4.png)
