### PR TITLE
fix(serve): live SSH isolated session token for WebSocket HTML

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -302,10 +302,26 @@ _SSH_RUNTIME_PURELIB: Optional[Tuple[str, int, int]] = None
 _SSH_RUNTIME_MARKER: Optional[str] = None
 
 
+def _session_token() -> str:
+    """Live dashboard/WS token. SSH isolated must HMAC the same value HTML injects."""
+    try:
+        tok = getattr(app.state, "session_token", None)
+        if tok:
+            return tok
+    except Exception:
+        pass
+    return _SESSION_TOKEN
+
+
 def _apply_ssh_session_token(token: str) -> None:
     global _SESSION_TOKEN
     if token:
         _SESSION_TOKEN = token
+        os.environ["HERMES_DASHBOARD_SESSION_TOKEN"] = token
+        try:
+            app.state.session_token = token
+        except Exception:
+            pass
 
 
 def _apply_ssh_owner_nonce(nonce: Optional[str]) -> None:
@@ -383,11 +399,12 @@ def _has_valid_session_token(request: Request) -> bool:
     ``Authorization`` (Caddy ``basic_auth``); the legacy Bearer path stays for
     older dashboard bundles.
     """
+    live = _session_token()
     session_header = request.headers.get(_SESSION_HEADER_NAME, "")
-    if session_header and hmac.compare_digest(session_header.encode(), _SESSION_TOKEN.encode()):
+    if session_header and hmac.compare_digest(session_header.encode(), live.encode()):
         return True
     auth = request.headers.get("authorization", "")
-    return hmac.compare_digest(auth.encode(), f"Bearer {_SESSION_TOKEN}".encode())
+    return hmac.compare_digest(auth.encode(), f"Bearer {live}".encode())
 
 
 # Routes that may also authenticate via ``?token=`` (download links opened by
@@ -399,7 +416,7 @@ def _has_valid_query_token(request: Request, path: str) -> bool:
     if path not in _QUERY_TOKEN_API_PATHS:
         return False
     token = request.query_params.get("token", "")
-    return bool(token) and hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode())
+    return bool(token) and hmac.compare_digest(token.encode(), _session_token().encode())
 
 
 def _require_token(request: Request) -> None:
@@ -1373,6 +1390,10 @@ def start_server(
     """
     _apply_ssh_session_token(ssh_session_token or "")
     _apply_ssh_owner_nonce(ssh_owner_nonce)
+    try:
+        app.state.session_token = _SESSION_TOKEN
+    except Exception:
+        pass
 
     # Dashboard-mode starts don't route through main.py's `serve` path, which
     # applies the same RLIMIT_NOFILE floor (policy in resource_limits, #81547).

--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -121,7 +121,7 @@ def mount_spa(application: FastAPI):
             if full_path == "" and not gated:
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_server()._SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_server()._session_token())};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -152,7 +152,7 @@ def mount_spa(application: FastAPI):
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_server()._SESSION_TOKEN}";'
+        token_js = "" if gated else f"window.__HERMES_SESSION_TOKEN__={json.dumps(_server()._session_token())};"
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"

--- a/tests/hermes_cli/test_ssh_isolated_session_token.py
+++ b/tests/hermes_cli/test_ssh_isolated_session_token.py
@@ -1,0 +1,43 @@
+"""SSH-isolated dashboard token must be read live, not copied at import."""
+
+import os
+from hermes_cli import web_server as ws
+
+try:
+    import pytest
+
+    @pytest.fixture(autouse=True)
+    def restore_session_token():
+        orig_token = ws._SESSION_TOKEN
+        orig_env = os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN")
+        orig_state = getattr(ws.app.state, "session_token", None)
+        yield
+        ws._SESSION_TOKEN = orig_token
+        if orig_env is not None:
+            os.environ["HERMES_DASHBOARD_SESSION_TOKEN"] = orig_env
+        else:
+            os.environ.pop("HERMES_DASHBOARD_SESSION_TOKEN", None)
+        if hasattr(ws.app.state, "session_token"):
+            if orig_state is not None:
+                ws.app.state.session_token = orig_state
+            else:
+                delattr(ws.app.state, "session_token")
+
+except ImportError:
+    pass
+
+
+def test_session_token_getter_tracks_ssh_apply():
+    token = "ab" * 32
+    ws._apply_ssh_session_token(token)
+    assert ws._session_token() == token
+    assert len(ws._session_token()) == 64
+
+
+def test_from_import_of_module_global_does_not_track_rebind():
+    """`from module import _SESSION_TOKEN` copies the str; apply() rebinds."""
+    captured = ws._SESSION_TOKEN
+    ws._apply_ssh_session_token("cd" * 32)
+    assert captured != ws._SESSION_TOKEN
+    assert ws._session_token() == ws._SESSION_TOKEN
+    assert ws._session_token() != captured


### PR DESCRIPTION
## Summary
Desktop SSH to a remote `hermes serve --isolated` backend could SSH and pass HTTP `/api/health` while the renderer looped `Could not connect to Hermes gateway`.

`from hermes_cli.web_server import _SESSION_TOKEN` copied the string at import time. `_apply_ssh_session_token` later rebound the module global to the 64-hex SSH file token, but headless HTML still injected the import-time value. Desktop adopted the HTML token; `/api/ws` HMAC used the SSH token and returned 403.

## Test plan
- [x] Live: tunneled `/api/ws?token=` against isolated serve returns `101 Switching Protocols`
- [x] Live: `/api/health` 200
- [ ] `scripts/run_tests.sh tests/hermes_cli/test_ssh_isolated_session_token.py`