### PR TITLE
fix(tui-gateway): reconnect after abandoned orphan interrupts (salvage #104186)

### DIFF
--- a/evals/liveness/ws_orphan_reconnect.py
+++ b/evals/liveness/ws_orphan_reconnect.py
@@ -1,0 +1,163 @@
+"""Real WS/session.create/disconnect/timers/RPC integration; offline model boundary.
+Usage: python evals/liveness/ws_orphan_reconnect.py REPO [redetach]
+Seeds a post-interrupt queued envelope to reproduce the bypass-writer schedule,
+not the exact naturally arriving queue race. No lifecycle predicate is patched.
+"""
+import json
+import os
+from pathlib import Path
+import socket
+import sys
+import tempfile
+import threading
+import time
+
+repo = Path(sys.argv[1]).resolve()
+home = tempfile.mkdtemp(prefix="hermes-orphan-wire-")
+os.environ.clear()
+os.environ.update(HOME=home, HERMES_HOME=home + "/.hermes", PATH="/usr/bin:/bin")
+sys.path.insert(0, str(repo))
+from tui_gateway import server as s
+from tui_gateway.ws import handle_ws
+from fastapi import FastAPI, WebSocket
+import uvicorn
+from websockets.sync.client import connect
+
+
+def wait_for(predicate, label):
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError(label)
+
+
+class Agent:
+    def __init__(self):
+        self.interrupted = threading.Event()
+
+    def interrupt(self, *args, **kwargs):
+        self.interrupted.set()
+
+    def get_activity_summary(self):
+        return {"seconds_since_activity": 100000}
+
+
+# Only construction and model execution are offline doubles.
+def build(sid):
+    session = s._sessions[sid]
+    session["agent"] = Agent()
+    session["agent_ready"].set()
+
+
+s._schedule_agent_build = build
+s._run_prompt_submit = lambda *args, **kwargs: None
+s._WS_ORPHAN_REAP_GRACE_S = 0.1
+s._WS_ORPHAN_INTERRUPT_REAP_POLL_S = 0.5
+app = FastAPI()
+
+
+@app.websocket("/api/ws")
+async def ws_endpoint(ws: WebSocket):
+    await handle_ws(ws)
+
+
+sock = socket.socket()
+sock.bind(("127.0.0.1", 0))
+url = f"ws://127.0.0.1:{sock.getsockname()[1]}/api/ws"
+uv = uvicorn.Server(uvicorn.Config(app, log_level="error", lifespan="off"))
+thread = threading.Thread(target=uv.run, kwargs={"sockets": [sock]}, daemon=True)
+thread.start()
+wait_for(lambda: uv.started, "uvicorn not ready")
+sequence = 0
+
+
+def rpc(ws, method, params):
+    global sequence
+    sequence += 1
+    ws.send(json.dumps({"jsonrpc": "2.0", "id": sequence, "method": method, "params": params}))
+    while True:
+        for line in ws.recv(timeout=15).splitlines():
+            obj = json.loads(line)
+            if obj.get("id") == sequence:
+                return obj
+
+
+def detached_running():
+    ws = connect(url)
+    reply = rpc(ws, "session.create", {})
+    sid = reply["result"]["session_id"]
+    session = s._sessions[sid]
+    transport = session["transport"]
+    stop = threading.Event()
+    worker = threading.Thread(target=stop.wait, daemon=True)
+    worker.start()
+    with session["history_lock"]:
+        session.update(running=True, _run_thread=worker)
+    ws.close()
+    assert session["agent"].interrupted.wait(15), "orphan did not interrupt"
+    wait_for(lambda: sid in s._pending_ws_reaps, "settlement not registered")
+    assert session["_client_gone_interrupt_requested"]
+    return sid, session, transport, stop, worker
+
+
+trace = {"source": s.__file__, "home": home, "fidelity": "actual WebSocket, offline model boundary"}
+try:
+    # Negative: an orphan which never reconnects must still be reaped.
+    sid, session, dead, stop, worker = detached_running()
+    stop.set()
+    worker.join(2)
+    with session["history_lock"]:
+        session["running"] = False
+    wait_for(lambda: sid not in s._sessions, "unreconnected orphan was not reclaimed")
+    assert sid not in s._pending_ws_reaps
+    trace["negative_unreconnected_reaped"] = True
+
+    sid, session, dead, stop, worker = detached_running()
+    if len(sys.argv) > 2 and sys.argv[2] == "redetach":
+        with session["history_lock"]:
+            session["running"] = False
+            session["queued_prompt"] = {"text": "queued writer", "transport": dead}
+        assert s._drain_queued_prompt("drain", sid, session)
+        session["running"] = True
+        session["agent"].interrupted.clear()
+        assert s._close_sessions_for_transport(dead) == (0, 1)
+        assert session["agent"].interrupted.wait(15)
+        trace["fresh_detachment_polls"] = session["_client_gone_interrupt_polls"]
+        stop.set()
+        worker.join(2)
+        assert trace["fresh_detachment_polls"] == 1, "new detachment inherited old poll budget"
+        trace["result"] = "PASS fresh detachment"
+        raise SystemExit(0)
+    with connect(url) as ws:
+        guarded = rpc(ws, "session.resume", {"session_id": session["session_key"]})
+        assert guarded.get("error", {}).get("code") == 4009, guarded
+        trace["negative_settling_guard"] = 4009
+        # Queue-arrival schedule fixture; the transport write is production.
+        with session["history_lock"]:
+            session["running"] = False
+            session["queued_prompt"] = {"text": "queued writer", "transport": dead}
+        assert s._drain_queued_prompt("drain", sid, session)
+        assert session["transport"] is dead
+        stop.set()
+        worker.join(2)
+        session["running"] = False
+        wait_for(lambda: sid not in s._pending_ws_reaps, "owning settlement not retired")
+        trace["flag_after_poll"] = session.get("_client_gone_interrupt_requested")
+        trace["polls_after_poll"] = session.get("_client_gone_interrupt_polls")
+        trace["responses"] = {}
+        for method in ("session.resume", "session.activate", "prompt.submit"):
+            target = session["session_key"] if method == "session.resume" else sid
+            reply = rpc(ws, method, {"session_id": target, "text": "probe"})
+            trace["responses"][method] = {"success": "result" in reply, "error": reply.get("error")}
+        assert trace["flag_after_poll"] is None, "abandoned interrupt claim remains"
+        assert trace["polls_after_poll"] is None
+        assert all(r["success"] for r in trace["responses"].values()), trace
+        trace["result"] = "PASS"
+finally:
+    for sid in list(s._sessions):
+        s._cancel_ws_orphan_reap(sid)
+    uv.should_exit = True
+    thread.join(5)
+    print(json.dumps(trace, indent=2), file=sys.stderr, flush=True)

--- a/tests/tui_gateway/test_ws_orphan_races.py
+++ b/tests/tui_gateway/test_ws_orphan_races.py
@@ -100,7 +100,8 @@ def test_obsolete_orphan_cannot_replace_new_detachment(monkeypatch, phase):
     assert timers == [old, newest]
 
 
-def test_orphan_interrupt_claim_clears_when_session_leaves_detached_state(monkeypatch):
+@pytest.mark.parametrize("transition", ["retire", "redetach"])
+def test_orphan_interrupt_claim_clears_when_session_leaves_detached_state(monkeypatch, transition):
     timers = []
 
     class Timer:
@@ -129,6 +130,17 @@ def test_orphan_interrupt_claim_clears_when_session_leaves_detached_state(monkey
     assert session["_client_gone_interrupt_requested"]
 
     session["transport"] = object()
+    if transition == "redetach":
+        # The bypass writer disconnects before the old settlement can retire.
+        assert server._close_sessions_for_transport(session["transport"]) == (0, 1)
+        timers[2].callback()
+        assert session["_client_gone_interrupt_requested"]
+        assert session["_client_gone_interrupt_polls"] == 1
+        replacement = server._pending_ws_reaps[sid]
+        timers[1].callback()
+        assert server._pending_ws_reaps[sid] is replacement
+        assert session["_client_gone_interrupt_requested"]
+        return
     timers[1].callback()
 
     assert "_client_gone_interrupt_requested" not in session

--- a/tests/tui_gateway/test_ws_orphan_races.py
+++ b/tests/tui_gateway/test_ws_orphan_races.py
@@ -100,6 +100,43 @@ def test_obsolete_orphan_cannot_replace_new_detachment(monkeypatch, phase):
     assert timers == [old, newest]
 
 
+def test_orphan_interrupt_claim_clears_when_session_leaves_detached_state(monkeypatch):
+    timers = []
+
+    class Timer:
+        def __init__(self, _delay, callback):
+            self.callback = callback
+            timers.append(self)
+
+        def start(self):
+            pass
+
+        def cancel(self):
+            pass
+
+    sid = "writer-rebound"
+    session = dict(transport=server._detached_ws_transport, running=True)
+    monkeypatch.setattr(server, "_sessions", {sid: session})
+    monkeypatch.setattr(server, "_pending_ws_reaps", {})
+    monkeypatch.setattr(server.threading, "Timer", Timer)
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 20)
+    monkeypatch.setattr(server, "_WS_ORPHAN_ACTIVITY_STALE_S", 0)
+    monkeypatch.setattr(server, "_session_has_active_delegations", lambda *a: False)
+    monkeypatch.setattr(server, "_interrupt_session_turn", lambda *a, **kw: False)
+
+    server._schedule_ws_orphan_reap(sid)
+    timers[0].callback()
+    assert session["_client_gone_interrupt_requested"]
+
+    session["transport"] = object()
+    timers[1].callback()
+
+    assert "_client_gone_interrupt_requested" not in session
+    assert "_client_gone_interrupt_polls" not in session
+    assert server._reattach_refusal(1, sid, session) is None
+    assert sid not in server._pending_ws_reaps
+
+
 @pytest.mark.parametrize("path", ["unpersisted", "reuse", "eager", "activate", "prompt"])
 @pytest.mark.parametrize("claim", ["already_claimed", "wins_lock", "retired"])
 def test_reconnect_cannot_cross_orphan_interrupt_claim(monkeypatch, path, claim):

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -623,6 +623,7 @@ def _close_sessions_for_transport(transport, *, end_reason: str = "ws_disconnect
                 else:
                     current["transport"] = _detached_ws_transport
                     current.pop("_client_gone_interrupt_requested", None)
+                    current.pop("_client_gone_interrupt_polls", None)
                     should_schedule_reap = True
                     # Register before releasing the detachment claim: an old disconnect
                     # must not arm its first timer over a reconnect's newer detachment.

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -519,7 +519,16 @@ def _schedule_ws_orphan_reap(
             if _pending_ws_reaps.get(sid) is not timer:
                 return
             current = _sessions.get(sid)
-            if current is None or not _ws_session_is_detached(current):
+            if current is None:
+                _pending_ws_reaps.pop(sid, None)
+                return
+            if not _ws_session_is_detached(current):
+                # This Timer is abandoning the interrupt claim because another
+                # writer moved the live record off the detached transport.
+                # Do not leave reattach RPCs fenced with 4009, or let this
+                # generation's settlement polls shorten a later detachment.
+                current.pop("_client_gone_interrupt_requested", None)
+                current.pop("_client_gone_interrupt_polls", None)
                 _pending_ws_reaps.pop(sid, None)
                 return
             if _session_has_active_delegations(sid, current):


### PR DESCRIPTION
Sessions can reconnect after an orphan-interrupt timer abandons its claim, without waiting for idle teardown.

- Retire both the interrupt flag and settlement count when the **owning** timer observes a live session that has left detached state.
- Start each new detachment with a fresh settlement budget, even if reconnect/re-detach supersedes the old timer before its cleanup runs.
- Preserve timer-identity fencing, active-delegation/fresh-activity exemptions, and reclamation of sessions that never reconnect.
- Add one parameterized invariant regression and a reusable isolated WebSocket probe in `evals/liveness/ws_orphan_reconnect.py`.

**Root cause:** the timer retired its registration without retiring its interrupt state; fresh detachments also inherited the previous timer's settlement count.

## Validation

**Live repro:** actual localhost WebSocket with production `session.create`, disconnect handling, orphan timers, queued-prompt transport writer, and all three reattach RPCs. Fresh interpreter and isolated `HOME`/`HERMES_HOME` per arm.

| Scenario | Main `c4a5deeffa959f8ebc891e02c5bcf767aff1dd2a` | Fix |
|---|---|---|
| Owning poll observes bypass-writer reattachment | Flag and poll count remain; resume/activate/prompt.submit all return 4009 | Both fields absent; all three RPCs succeed |
| Bypass writer re-detaches before old settlement | New generation starts at poll 2 | New generation starts at poll 1 |
| Interrupt still settling | Reattach rejected with 4009 | Still rejected with 4009 |
| Orphan never reconnects | Session reclaimed | Still reclaimed |

```sh
python evals/liveness/ws_orphan_reconnect.py /path/to/repo
python evals/liveness/ws_orphan_reconnect.py /path/to/repo redetach
flock /tmp/hermes-e461-fix-tests.lock bash scripts/run_tests.sh -j 1 \
  tests/tui_gateway/test_ws_orphan_races.py \
  tests/tui_gateway/test_isolated_orphan_activity.py \
  tests/test_tui_gateway_server.py
```

Targeted runner: **3 discovered files, 668 passed, 0 failed**. Ruff, Windows-footgun, compatibility-pointer, subprocess-stdin and whitespace checks passed. Independent read-only review found the inherited poll budget; the follow-up reproduced and fixed it, and independent re-review found no remaining blocker.

**Limits:** model construction/execution are offline doubles; no vendor call or native Desktop renderer is involved. The queued envelope is seeded after interruption to exercise the reported writer ordering, not a naturally arriving queue race. Full touched-directory coverage is owned by the parent campaign harness; the preliminary directory run was stopped following campaign coordination and is not claimed green.

## Credit and scope

Salvages the earliest suitable patch, #104186 by @fangliquanflq, preserving the contributor's authorship. @holny claimed the issue earlier and independently implemented #104189; that investigation is acknowledged. The fresh-detachment budget fix is a separately authored follow-up.

Fixes #104160.
Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104904

No changes to canonical Bot Chats, active-turn leases, provider retries, or prompt/cache policy. No merge or issue/contributor-PR closure is performed by this campaign lane.

## Infographic
![Orphan reconnect without lockout](https://v3b.fal.media/files/b/0aa97344/-YElEvHjkOGO72me9qsJ4_KkTaxxWZ.png)
