### PR TITLE
Fix null ACP interruption responses

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -890,7 +890,7 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             except Exception:
                 logger.debug("Could not emit ACP provenance update after rotation for %s", session_id, exc_info=True)
 
-        final_response = result.get("final_response", "")
+        final_response = result.get("final_response") or ""
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         # The local "waiting for model" interrupt status is metadata, not prose; stop_reason carries it.
         from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -142,6 +142,23 @@ async def test_acp_steer_slash_command_injects_into_running_agent():
 
 
 @pytest.mark.asyncio
+async def test_acp_interrupted_turn_accepts_null_final_response():
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    fake.run_conversation = lambda **_kwargs: {
+        "final_response": None,
+        "messages": [],
+        "interrupted": True,
+    }
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="original request")],
+    )
+
+    assert response.stop_reason == "end_turn"
+
+
+@pytest.mark.asyncio
 async def test_acp_cancel_publishes_hard_stop_while_holding_runtime_lock():
     acp_agent, state, fake, _conn = make_agent_and_state()
     state.is_running = True


### PR DESCRIPTION
## Summary

- normalize a null `final_response` from interrupted Hermes turns before ACP response filtering
- prevent expected Paseo steer/replacement cancellation from becoming JSON-RPC `-32603`
- cover the interrupted/null response boundary with a regression test

## Root cause

Paseo's generic ACP provider falls back from active-turn steering to replacing the running turn. The cancellation path may return `final_response: null`; Hermes called `.startswith()` on that value while filtering its local interruption marker, converting a valid cancellation into a failed ACP turn.

## Verification

- `uv run --extra acp --with pytest --with pytest-asyncio python -m pytest tests/acp_adapter/test_acp_commands.py -q -o 'addopts='` — 4 passed
- live Paseo/Hermes reproduction before fix — `turn_failed`, code `-32603`, `'NoneType' object has no attribute 'startswith'`
- same reproduction after fix — clean `turn_canceled` followed by replacement turn; no `turn_failed`
- queue-gate smoke test — agent returned `QUEUE OK`; `paseo-queue.service` remained at `NRestarts=0`
