### PR TITLE
fix(acp): discovery sessions no longer leave empty history rows (#104724, salvage #104726)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -294,25 +294,7 @@ class SessionManager:
         try:
             if db.get_session(state.session_id) is None:
                 if not state.history:
-                    # Defer row creation until the session has actually exchanged
-                    # something. ACP clients open a session BEFORE knowing whether a
-                    # prompt is coming, and some open one purely to interrogate the
-                    # agent: bb's model discovery spawns a throwaway `hermes acp`,
-                    # sends initialize + session/new, reads the model catalog off the
-                    # response, and kills the process without ever prompting. Its
-                    # cache TTL is 60s, so an open editor re-probes on a ~10-15 minute
-                    # cadence and every probe used to leave a message_count=0 shell in
-                    # state.db, indistinguishable from a real chat in the session list
-                    # and unreapable by `hermes sessions prune` (these rows never end,
-                    # so ended_at stays NULL and prune skips them).
-                    #
-                    # Nothing is lost for a genuine conversation: AIAgent's
-                    # _ensure_db_session() creates the row on the first turn and the
-                    # post-prompt save_session() lands the ACP metadata on top.
-                    #
-                    # Gate on state.history rather than message_count so fork_session,
-                    # which deep-copies a non-empty history into a fresh id, still
-                    # persists immediately.
+                    # Empty editor probes stay ephemeral; copied fork history persists.
                     return
                 db.create_session(session_id=state.session_id, source="acp", model=model_str,
                                   model_config={"cwd": state.cwd})

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -293,6 +293,27 @@ class SessionManager:
 
         try:
             if db.get_session(state.session_id) is None:
+                if not state.history:
+                    # Defer row creation until the session has actually exchanged
+                    # something. ACP clients open a session BEFORE knowing whether a
+                    # prompt is coming, and some open one purely to interrogate the
+                    # agent: bb's model discovery spawns a throwaway `hermes acp`,
+                    # sends initialize + session/new, reads the model catalog off the
+                    # response, and kills the process without ever prompting. Its
+                    # cache TTL is 60s, so an open editor re-probes on a ~10-15 minute
+                    # cadence and every probe used to leave a message_count=0 shell in
+                    # state.db, indistinguishable from a real chat in the session list
+                    # and unreapable by `hermes sessions prune` (these rows never end,
+                    # so ended_at stays NULL and prune skips them).
+                    #
+                    # Nothing is lost for a genuine conversation: AIAgent's
+                    # _ensure_db_session() creates the row on the first turn and the
+                    # post-prompt save_session() lands the ACP metadata on top.
+                    #
+                    # Gate on state.history rather than message_count so fork_session,
+                    # which deep-copies a non-empty history into a fresh id, still
+                    # persists immediately.
+                    return
                 db.create_session(session_id=state.session_id, source="acp", model=model_str,
                                   model_config={"cwd": state.cwd})
             else:

--- a/contributors/emails/5318600+Willhong@users.noreply.github.com
+++ b/contributors/emails/5318600+Willhong@users.noreply.github.com
@@ -1,0 +1,2 @@
+Willhong
+# ACP empty-session prevention salvaged from #104726

--- a/evals/acp_empty_session_wire.py
+++ b/evals/acp_empty_session_wire.py
@@ -75,7 +75,7 @@ def main():
     env.update(HOME=str(home), HERMES_HOME=str(hermes), PYTHONPATH=os.pathsep.join([str(repo), os.environ.get('PYTHONPATH', '')]),
                HERMES_ACP_SKIP_CONFIGURED_MCP='1', OPENAI_API_KEY='local-fixture-key',
                OPENAI_BASE_URL=f'http://127.0.0.1:{server.server_port}/v1')
-    stderr = open(str(args.output) + '.stderr', 'w')
+    stderr = open(str(args.output) + '.stderr', 'w', encoding='utf-8')
     proc = subprocess.Popen([sys.executable, '-m', 'acp_adapter'], cwd=repo, env=env,
                             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=stderr, text=True)
     received = queue.Queue()
@@ -133,7 +133,7 @@ def main():
         stderr.close()
         server.shutdown()
         result.update(wire=wire, model_requests=requests)
-        Path(args.output).write_text(json.dumps(result, indent=2))
+        Path(args.output).write_text(json.dumps(result, indent=2), encoding='utf-8')
     print(json.dumps({k: v for k, v in result.items() if k not in ('wire', 'model_requests', 'messages')}, indent=2))
 
 

--- a/evals/acp_empty_session_wire.py
+++ b/evals/acp_empty_session_wire.py
@@ -126,6 +126,18 @@ def main():
                 ('assistant', 'Local fixture reply.')]
         assert any(r[0] == sid and r[2] > 0 for r in result['after_prompt'])
         assert any(r[0] == result['fork_id'] and r[2] > 0 for r in result['after_fork'])
+        legacy = rpc('session/new', {'cwd': str(home), 'mcpServers': []})['sessionId']
+        with sqlite3.connect(hermes / 'state.db') as db:
+            db.execute("INSERT OR IGNORE INTO sessions (id, source, started_at) VALUES (?, 'acp', 1)",
+                       (legacy,))
+        moved = home / 'moved'
+        moved.mkdir()
+        rpc('session/load', {'sessionId': legacy, 'cwd': str(moved), 'mcpServers': []})
+        with sqlite3.connect(hermes / 'state.db') as db:
+            result['existing_empty_metadata'] = db.execute(
+                'SELECT model_config, message_count FROM sessions WHERE id = ?', (legacy,)).fetchone()
+        assert json.loads(result['existing_empty_metadata'][0])['cwd'] == str(moved)
+        assert result['existing_empty_metadata'][1] == 0
         assert result['after_open'] == [], 'session/new created an empty durable row'
     finally:
         proc.terminate()

--- a/evals/acp_empty_session_wire.py
+++ b/evals/acp_empty_session_wire.py
@@ -1,0 +1,141 @@
+"""Native ACP stdio + SQLite probe; local HTTP model fixture, never paid inference.
+
+Run with the project Python from the checkout being measured. --output saves the
+wire transcript and database measurements. No production predicates are patched.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import queue
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output', required=True)
+    args = parser.parse_args()
+    repo = Path(__file__).resolve().parents[1]
+    requests = []
+
+    class Model(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_GET(self):
+            self.reply({'object': 'list', 'data': [{'id': 'fixture-model', 'object': 'model'}]})
+
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers['Content-Length'])))
+            requests.append({'path': self.path, 'body': body})
+            if body.get('stream'):
+                chunk = {'id': 'fixture-stream', 'object': 'chat.completion.chunk',
+                         'created': 1, 'model': 'fixture-model',
+                         'choices': [{'index': 0, 'delta': {'role': 'assistant',
+                                      'content': 'Local fixture reply.'}, 'finish_reason': 'stop'}]}
+                data = ('data: ' + json.dumps(chunk) + '\n\ndata: [DONE]\n\n').encode()
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/event-stream')
+                self.send_header('Content-Length', str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+                return
+            self.reply({'id': 'fixture-completion', 'object': 'chat.completion',
+                        'created': 1, 'model': 'fixture-model',
+                        'choices': [{'index': 0, 'message': {'role': 'assistant',
+                                     'content': 'Local fixture reply.'}, 'finish_reason': 'stop'}],
+                        'usage': {'prompt_tokens': 10, 'completion_tokens': 5, 'total_tokens': 15}})
+
+        def reply(self, body):
+            data = json.dumps(body).encode()
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Content-Length', str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+    server = ThreadingHTTPServer(('127.0.0.1', 0), Model)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    home = Path(tempfile.mkdtemp(prefix='hermes-acp-empty-'))
+    hermes = home / '.hermes'
+    hermes.mkdir()
+    (hermes / 'config.yaml').write_text(
+        'model:\n  provider: custom\n  default: fixture-model\n'
+        f'  base_url: http://127.0.0.1:{server.server_port}/v1\n'
+        '  api_key: local-fixture-key\n  api_mode: chat_completions\n'
+        'mcp_servers: {}\nmemory:\n  memory_enabled: false\n  user_profile_enabled: false\n'
+        'agent:\n  max_iterations: 1\n  disabled_toolsets: [all]\n'
+    )
+    env = {k: os.environ[k] for k in ('PATH', 'LANG', 'TZ') if k in os.environ}
+    env.update(HOME=str(home), HERMES_HOME=str(hermes), PYTHONPATH=os.pathsep.join([str(repo), os.environ.get('PYTHONPATH', '')]),
+               HERMES_ACP_SKIP_CONFIGURED_MCP='1', OPENAI_API_KEY='local-fixture-key',
+               OPENAI_BASE_URL=f'http://127.0.0.1:{server.server_port}/v1')
+    stderr = open(str(args.output) + '.stderr', 'w')
+    proc = subprocess.Popen([sys.executable, '-m', 'acp_adapter'], cwd=repo, env=env,
+                            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=stderr, text=True)
+    received = queue.Queue()
+    wire = []
+
+    def reader():
+        for line in proc.stdout:
+            received.put(line)
+    threading.Thread(target=reader, daemon=True).start()
+
+    def rpc(method, params):
+        request_id = len(wire) + 1
+        request = {'jsonrpc': '2.0', 'id': request_id, 'method': method, 'params': params}
+        wire.append({'sent': request})
+        proc.stdin.write(json.dumps(request) + '\n')
+        proc.stdin.flush()
+        while True:
+            response = json.loads(received.get(timeout=120))
+            wire.append({'received': response})
+            if response.get('id') == request_id:
+                if 'error' in response:
+                    raise RuntimeError(response)
+                return response['result']
+
+    def rows():
+        with sqlite3.connect(hermes / 'state.db') as db:
+            return db.execute('SELECT id, source, message_count FROM sessions ORDER BY id').fetchall()
+
+    result = {'repo': str(repo), 'home': str(home)}
+    try:
+        rpc('initialize', {'protocolVersion': 1, 'clientCapabilities': {},
+                           'clientInfo': {'name': 'local-acp-probe', 'version': '1'}})
+        opened = rpc('session/new', {'cwd': str(home), 'mcpServers': []})
+        sid = opened['sessionId']
+        result['after_open'] = rows()
+        result['model_requests_after_open'] = len(requests)
+        result['prompt_response'] = rpc('session/prompt', {'sessionId': sid,
+            'prompt': [{'type': 'text', 'text': 'Reply with a short greeting; do not use tools.'}]})
+        result['after_prompt'] = rows()
+        forked = rpc('session/fork', {'sessionId': sid, 'cwd': str(home), 'mcpServers': []})
+        result['fork_id'] = forked['sessionId']
+        result['after_fork'] = rows()
+        with sqlite3.connect(hermes / 'state.db') as db:
+            result['messages'] = db.execute('SELECT session_id, role, content FROM messages ORDER BY id').fetchall()
+        for session_id in (sid, result['fork_id']):
+            assert [(r[1], r[2]) for r in result['messages'] if r[0] == session_id] == [
+                ('user', 'Reply with a short greeting; do not use tools.'),
+                ('assistant', 'Local fixture reply.')]
+        assert any(r[0] == sid and r[2] > 0 for r in result['after_prompt'])
+        assert any(r[0] == result['fork_id'] and r[2] > 0 for r in result['after_fork'])
+        assert result['after_open'] == [], 'session/new created an empty durable row'
+    finally:
+        proc.terminate()
+        proc.wait(timeout=20)
+        stderr.close()
+        server.shutdown()
+        result.update(wire=wire, model_requests=requests)
+        Path(args.output).write_text(json.dumps(result, indent=2))
+    print(json.dumps({k: v for k, v in result.items() if k not in ('wire', 'model_requests', 'messages')}, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/acp/test_empty_session_persistence.py
+++ b/tests/acp/test_empty_session_persistence.py
@@ -1,0 +1,43 @@
+"""Only new, contentless ACP sessions are ephemeral; existing state remains durable."""
+import json
+from types import SimpleNamespace
+
+from acp_adapter.session import SessionManager
+from hermes_state import SessionDB
+
+
+def test_new_session_persists_only_when_content_exists(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    manager = SessionManager(db=db, agent_factory=lambda: SimpleNamespace(model="fixture"))
+    state = manager.create_session(cwd=str(tmp_path))
+    assert db.get_session(state.session_id) is None
+    manager.update_cwd(state.session_id, str(tmp_path / "moved"))
+    manager.save_session(state.session_id)
+    empty_fork = manager.fork_session(state.session_id)
+    assert db.get_session(state.session_id) is None
+    assert db.get_session(empty_fork.session_id) is None
+    state.history.append({"role": "user", "content": "kept content"})
+    manager.save_session(state.session_id)
+    fork = manager.fork_session(state.session_id)
+    for sid in (state.session_id, fork.session_id):
+        assert db.get_session(sid)["source"] == "acp"
+        assert db.get_messages_as_conversation(sid)[0]["content"] == "kept content"
+    db.close()
+
+
+def test_existing_empty_history_still_updates_metadata(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    manager = SessionManager(db=db, agent_factory=lambda: SimpleNamespace(model="fixture"))
+    state = manager.create_session(cwd=str(tmp_path))
+    # A genuine agent creates the row before its first model reply. An old,
+    # unprompted ACP client may also still own its row: source is not liveness.
+    if db.get_session(state.session_id) is None:
+        db.create_session(session_id=state.session_id, source="acp", model="original")
+    state.model = "selected-model"
+    manager.update_cwd(state.session_id, str(tmp_path / "selected"))
+    row = db.get_session(state.session_id)
+    assert row["model"] == "selected-model"
+    assert json.loads(row["model_config"])["cwd"] == state.cwd
+    assert manager.get_session(state.session_id) is state
+    assert db.list_never_active_keyed_sessions(older_than_days=0) == []
+    db.close()

--- a/tests/acp/test_empty_session_persistence.py
+++ b/tests/acp/test_empty_session_persistence.py
@@ -28,11 +28,11 @@ def test_new_session_persists_only_when_content_exists(tmp_path):
 def test_existing_empty_history_still_updates_metadata(tmp_path):
     db = SessionDB(tmp_path / "state.db")
     manager = SessionManager(db=db, agent_factory=lambda: SimpleNamespace(model="fixture"))
-    state = manager.create_session(cwd=str(tmp_path))
-    # A genuine agent creates the row before its first model reply. An old,
-    # unprompted ACP client may also still own its row: source is not liveness.
-    if db.get_session(state.session_id) is None:
-        db.create_session(session_id=state.session_id, source="acp", model="original")
+    # An old, unprompted ACP client may still own its row: source is not liveness.
+    db.create_session(session_id="existing", source="acp", model="original")
+    state = manager.get_session("existing")
+    assert state is not None
+    assert not state.history
     state.model = "selected-model"
     manager.update_cwd(state.session_id, str(tmp_path / "selected"))
     row = db.get_session(state.session_id)

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -249,7 +249,47 @@ class TestListAndCleanup:
 class TestPersistence:
     """Verify that sessions are persisted to SessionDB and can be restored."""
 
+    def test_create_session_does_not_mint_an_empty_db_row(self, manager):
+        """A session with no history must NOT create a state.db row.
 
+        ACP clients open a session before knowing whether a prompt is coming,
+        and some open one purely to interrogate the agent (a model-catalog
+        probe that sends initialize + session/new, reads the response, and
+        exits). Persisting on create left a message_count=0 shell per probe,
+        indistinguishable from a real chat in the session list and unreapable
+        by `hermes sessions prune` (the rows never end, so ended_at stays NULL).
+        """
+        db = manager._get_db()
+        before = len(db.search_sessions(source="acp", limit=10000))
+
+        state = manager.create_session(cwd="/tmp/probe")
+
+        assert db.get_session(state.session_id) is None
+        assert len(db.search_sessions(source="acp", limit=10000)) == before
+
+    def test_session_row_is_created_once_history_exists(self, manager):
+        """The deferral must not lose a real conversation."""
+        state = manager.create_session(cwd="/tmp/real")
+        assert manager._get_db().get_session(state.session_id) is None
+
+        state.history.append({"role": "user", "content": "hello"})
+        manager.save_session(state.session_id)
+
+        row = manager._get_db().get_session(state.session_id)
+        assert row is not None
+        assert row["source"] == "acp"
+
+    def test_fork_persists_immediately_because_history_is_copied(self, manager):
+        """fork_session copies a non-empty history, so its row lands at once."""
+        parent = manager.create_session(cwd="/tmp/fork-src")
+        parent.history.append({"role": "user", "content": "forked content"})
+        manager.save_session(parent.session_id)
+
+        child = manager.fork_session(parent.session_id, cwd="/tmp/fork-dst")
+
+        assert child is not None
+        assert child.session_id != parent.session_id
+        assert manager._get_db().get_session(child.session_id) is not None
 
 
 

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -249,47 +249,7 @@ class TestListAndCleanup:
 class TestPersistence:
     """Verify that sessions are persisted to SessionDB and can be restored."""
 
-    def test_create_session_does_not_mint_an_empty_db_row(self, manager):
-        """A session with no history must NOT create a state.db row.
 
-        ACP clients open a session before knowing whether a prompt is coming,
-        and some open one purely to interrogate the agent (a model-catalog
-        probe that sends initialize + session/new, reads the response, and
-        exits). Persisting on create left a message_count=0 shell per probe,
-        indistinguishable from a real chat in the session list and unreapable
-        by `hermes sessions prune` (the rows never end, so ended_at stays NULL).
-        """
-        db = manager._get_db()
-        before = len(db.search_sessions(source="acp", limit=10000))
-
-        state = manager.create_session(cwd="/tmp/probe")
-
-        assert db.get_session(state.session_id) is None
-        assert len(db.search_sessions(source="acp", limit=10000)) == before
-
-    def test_session_row_is_created_once_history_exists(self, manager):
-        """The deferral must not lose a real conversation."""
-        state = manager.create_session(cwd="/tmp/real")
-        assert manager._get_db().get_session(state.session_id) is None
-
-        state.history.append({"role": "user", "content": "hello"})
-        manager.save_session(state.session_id)
-
-        row = manager._get_db().get_session(state.session_id)
-        assert row is not None
-        assert row["source"] == "acp"
-
-    def test_fork_persists_immediately_because_history_is_copied(self, manager):
-        """fork_session copies a non-empty history, so its row lands at once."""
-        parent = manager.create_session(cwd="/tmp/fork-src")
-        parent.history.append({"role": "user", "content": "forked content"})
-        manager.save_session(parent.session_id)
-
-        child = manager.fork_session(parent.session_id, cwd="/tmp/fork-dst")
-
-        assert child is not None
-        assert child.session_id != parent.session_id
-        assert manager._get_db().get_session(child.session_id) is not None
 
 
 

--- a/tests/acp/test_session_db_private_access.py
+++ b/tests/acp/test_session_db_private_access.py
@@ -135,11 +135,18 @@ class TestNoPrviateDBAccess:
 class TestPersistRoundTrip:
     """End-to-end: save a session and verify DB state is correct."""
 
+    # A session row is only minted once the session has history — an empty ACP
+    # session is deliberately not persisted (see _persist), because ACP clients
+    # open sessions they never prompt. These tests seed one message first so
+    # they exercise the metadata round-trip they actually care about.
+
     def test_cwd_persisted_via_update_session_meta(self, tmp_path):
         db = _tmp_db(tmp_path)
         manager = SessionManager(agent_factory=_mock_agent, db=db)
 
         state = manager.create_session(cwd="/original")
+        state.history.append({"role": "user", "content": "hi"})
+        manager.save_session(state.session_id)
         assert db.get_session(state.session_id) is not None
 
         # Simulate cwd change and save
@@ -155,6 +162,9 @@ class TestPersistRoundTrip:
         manager = SessionManager(agent_factory=_mock_agent, db=db)
 
         state = manager.create_session()
+        state.history.append({"role": "user", "content": "hi"})
+        manager.save_session(state.session_id)
+
         state.model = "new-model-xyz"
         manager.save_session(state.session_id)
 
@@ -167,6 +177,8 @@ class TestPersistRoundTrip:
         manager = SessionManager(agent_factory=_mock_agent, db=db)
 
         state = manager.create_session()
+        state.history.append({"role": "user", "content": "hi"})
+        manager.save_session(state.session_id)
         # Manually set a model in DB
         db.update_session_meta(state.session_id, json.dumps({"cwd": "."}), model="stored-model")
 

--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -323,7 +323,16 @@ Each session stores:
 - current conversation history
 - cancel event
 
-The underlying `AIAgent` still uses Hermes' normal persistence/logging paths, but ACP `list/load/resume/fork` are scoped to the currently running ACP server process.
+Conversations are persisted to Hermes' session database and can be listed, loaded,
+resumed, or forked after the ACP server restarts. Opening a new session without a
+prompt keeps it in memory only: model-discovery probes do not create empty history
+rows. A nonempty fork is persisted immediately, and existing session metadata can
+still be updated even when its current history is empty.
+
+Existing empty rows from older versions are not automatically deleted. An open ACP
+row does not prove its client has disconnected. After closing the relevant editor
+sessions, inspect unwanted rows with `hermes sessions show <id>` and remove only
+confirmed unwanted sessions with `hermes sessions delete <id>`.
 
 ## Working directory behavior
 


### PR DESCRIPTION
ACP clients can open sessions for discovery without leaving permanent empty rows in session history.

Fixes #104724. Campaign: #104868.

- Salvages @Willhong's earliest fix from #104726 (original commit `193b03642096691b7d21823ac1a65ada34263dd6`, authorship preserved).
- Add a three-line guard only when the row is missing **and** history is empty. Existing-row metadata updates, first-turn agent persistence, and nonempty forks stay unchanged.
- Keep two regression invariants and adapt existing metadata round-trip preconditions to seed genuine content.
- Document persistence and safe, explicit cleanup of confirmed unwanted legacy rows.

**Root cause:** `session/new` eagerly created a durable row even when the client never sent a prompt.

## Live repro

Same native `python -m acp_adapter` stdio surface on base `d8a07768c5e` and this branch, isolated HOME/HERMES_HOME, real `AIAgent` and SQLite. `initialize`, `session/new`, `session/prompt`, and `session/fork` all traverse the ACP SDK router. A loopback HTTP/SSE fixture provides the model response; no paid inference or real user state is used.

| Measurement | Base | Fixed |
|---|---:|---:|
| Rows after unprompted `session/new` | **1 empty row** | **0** |
| Durable messages after genuine prompt | 2 (user + assistant) | 2 (user + assistant) |
| Durable sessions after nonempty fork | 2 | 2 |
| Total durable messages after fork | 4 | 4 |
| Existing empty row cwd update via native `session/load` | Preserved | Preserved |

Harness: `evals/acp_empty_session_wire.py --output <receipt.json>`. Its final empty-row assertion fails on base and passes with the fix; it also asserts both transcripts contain the actual streamed fixture reply. This proves local protocol/persistence plumbing, not a hosted provider's behavior.

## Cleanup safety

Also reviewed @ca-shrimp's #104739 at `17f882b3dd04fbbd851cfaaa895019b0e7363b9e`. Its source-only cleanup carve-out is deliberately **not** imported: an old, empty `source='acp'` row can still belong to a connected editor. Age and source are not proof that the client abandoned it, and the keyed gateway selector's fresh-session-on-next-message rationale does not establish ACP ownership. No bulk-prune selector, historical rows, or retention policy changes here. Documentation directs operators to explicit per-session inspection/deletion after closing relevant editor sessions.

## Validation status

- Native wire/SQLite A/B: passed, including real streamed first-turn persistence and a genuine nonempty fork.
- Ruff on changed Python files, Windows-footgun scan (1464 files), compatibility-pointer and subprocess-stdin checks, and whitespace checks: passed.
- **Draft:** serialized regression red/green and full `tests/acp/` are queued behind the campaign's shared test lock; no unit-suite success is claimed yet. Independent review is also pending. No merge requested.

## Infographic

![ACP session persistence before and after](https://v3b.fal.media/files/b/0aa9737e/K5BYM_cuJlu-lh8e24DH8_V7AfNIN4.png)
