### PR TITLE
fix: API session preflight and unknown delivery errors

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -106,6 +106,11 @@ class DeliveryTarget:
     thread_id: Optional[str] = None
     is_origin: bool = False
     is_explicit: bool = False  # True if chat_id was explicitly specified
+    # Raw target string when the platform name is unknown. The platform falls
+    # back to LOCAL for routing, but the original name is preserved so
+    # deliver() can report {success: False, error: unknown_platform} instead
+    # of silently misrouting to local files.
+    unknown_platform: Optional[str] = None
 
     @classmethod
     def parse(cls, target: str, origin: Optional[SessionSource] = None) -> "DeliveryTarget":
@@ -114,12 +119,14 @@ class DeliveryTarget:
         if target.lower() == "origin":
             return (cls(platform=origin.platform, chat_id=origin.chat_id, thread_id=origin.thread_id, is_origin=True)
                     if origin else cls(platform=Platform.LOCAL, is_origin=True))
-        # Platform names are case-insensitive; chat/thread ids keep case. Unknown platforms -> local.
+        # Platform names are case-insensitive; chat/thread ids keep case. Unknown platforms ->
+        # LOCAL for routing but preserve the raw target so deliver() reports
+        # unknown_platform instead of silently saving locally.
         parts = target.split(":", 2)
         try:
             platform = Platform(parts[0].lower())
         except ValueError:
-            return cls(platform=Platform.LOCAL)
+            return cls(platform=Platform.LOCAL, unknown_platform=target)
         return (cls(platform=platform, chat_id=parts[1], thread_id=parts[2] if len(parts) > 2 else None, is_explicit=True)
                 if len(parts) > 1 else cls(platform=platform))
 
@@ -127,6 +134,8 @@ class DeliveryTarget:
         """Convert back to string format."""
         if self.is_origin:
             return "origin"
+        if self.unknown_platform:
+            return self.unknown_platform
         if self.platform == Platform.LOCAL:
             return "local"
         parts = [self.platform.value, self.chat_id, self.thread_id if self.chat_id else None]
@@ -159,6 +168,10 @@ class DeliveryRouter:
         """Deliver content to all targets; returns per-target results keyed by target string."""
         results = {}
         for target in targets:
+            if target.unknown_platform:
+                results[target.to_string()] = {
+                    "success": False, "error": f"unknown_platform: {target.unknown_platform}"}
+                continue
             # Skip targets proven permanently unreachable (deleted group, blocked bot, deactivated user) —
             # re-sending each tick wastes flood-control budget. Self-healing: a later successful send
             # clears the flag. LOCAL/origin-without-chat targets are never dead-tracked.

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -134,7 +134,7 @@ class DeliveryTarget:
         """Convert back to string format."""
         if self.is_origin:
             return "origin"
-        if self.unknown_platform:
+        if self.unknown_platform is not None:
             return self.unknown_platform
         if self.platform == Platform.LOCAL:
             return "local"
@@ -168,7 +168,7 @@ class DeliveryRouter:
         """Deliver content to all targets; returns per-target results keyed by target string."""
         results = {}
         for target in targets:
-            if target.unknown_platform:
+            if target.unknown_platform is not None:
                 results[target.to_string()] = {
                     "success": False, "error": f"unknown_platform: {target.unknown_platform}"}
                 continue

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -771,7 +771,7 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key"}
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key, X-Hermes-Session-Id"}
 _SECURITY_HEADERS = {
     "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=()",

--- a/tests/gateway/test_api_session_preflight.py
+++ b/tests/gateway/test_api_session_preflight.py
@@ -1,0 +1,36 @@
+"""The browser can send the advertised continuation header only from allowed origins."""
+
+import secrets
+
+import pytest
+from aiohttp import ClientSession
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, _STATIC_FEATURE_FLAGS
+
+
+@pytest.mark.asyncio
+async def test_continuation_preflight_preserves_origin_allowlist():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={
+        "host": "127.0.0.1", "port": 0, "key": secrets.token_hex(32),
+        "cors_origins": ["https://allowed.example"],
+    }))
+    assert await adapter.connect()
+    try:
+        port = adapter._site._server.sockets[0].getsockname()[1]
+        header = _STATIC_FEATURE_FLAGS["session_continuity_header"]
+        async with ClientSession() as client:
+            for origin, expected in [("https://allowed.example", 200), ("https://denied.example", 403)]:
+                async with client.options(f"http://127.0.0.1:{port}/v1/chat/completions", headers={
+                    "Origin": origin, "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": f"Authorization, Content-Type, {header}",
+                }) as response:
+                    assert response.status == expected
+                    if expected == 200:
+                        allowed = {h.strip().lower() for h in response.headers["Access-Control-Allow-Headers"].split(",")}
+                        assert header.lower() in allowed
+                        assert response.headers["Access-Control-Allow-Origin"] == origin
+                    else:
+                        assert "Access-Control-Allow-Origin" not in response.headers
+    finally:
+        await adapter.disconnect()

--- a/tests/gateway/test_delivery_unknown_target.py
+++ b/tests/gateway/test_delivery_unknown_target.py
@@ -1,0 +1,24 @@
+"""Unknown destinations must not acknowledge a successful local delivery."""
+
+from pathlib import Path
+
+import pytest
+
+from gateway.config import GatewayConfig
+from gateway.delivery import DeliveryRouter, DeliveryTarget
+
+
+@pytest.mark.asyncio
+async def test_unknown_destination_fails_without_writing_and_local_still_works(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    router = DeliveryRouter(GatewayConfig())
+    raw = "MisspelledPlatform:ChatID:ThreadID"
+    result = await router.deliver("must not save", [DeliveryTarget.parse(raw)], job_id="bad")
+    assert not any(receipt["success"] for receipt in result.values()), result
+    assert raw in result
+    assert result[raw]["error"] == f"unknown_platform: {raw}"
+    assert not list(tmp_path.rglob("*.txt"))
+    assert not list(tmp_path.rglob("*.md"))
+    result = await router.deliver("explicit local marker", [DeliveryTarget.parse("local")], job_id="good")
+    assert result["local"]["success"]
+    assert "explicit local marker" in Path(result["local"]["result"]["path"]).read_text(encoding="utf-8")

--- a/tests/gateway/test_delivery_unknown_target.py
+++ b/tests/gateway/test_delivery_unknown_target.py
@@ -9,11 +9,13 @@ from gateway.delivery import DeliveryRouter, DeliveryTarget
 
 
 @pytest.mark.asyncio
-async def test_unknown_destination_fails_without_writing_and_local_still_works(tmp_path, monkeypatch):
+@pytest.mark.parametrize("raw", ["MisspelledPlatform:ChatID:ThreadID", "", "   "])
+async def test_unknown_destination_fails_without_writing_and_local_still_works(tmp_path, monkeypatch, raw):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     router = DeliveryRouter(GatewayConfig())
-    raw = "MisspelledPlatform:ChatID:ThreadID"
-    result = await router.deliver("must not save", [DeliveryTarget.parse(raw)], job_id="bad")
+    target = DeliveryTarget.parse(raw)
+    raw = raw.strip()
+    result = await router.deliver("must not save", [target], job_id="bad")
     assert not any(receipt["success"] for receipt in result.values()), result
     assert raw in result
     assert result[raw]["error"] == f"unknown_platform: {raw}"

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -699,6 +699,7 @@ API_SERVER_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 When CORS is enabled:
 - **Preflight responses** include `Access-Control-Max-Age: 600` (10 minute cache)
 - **SSE streaming responses** include CORS headers so browser EventSource clients work correctly
+- **`X-Hermes-Session-Id`** is an allowed request header, so browsers on an allowlisted origin can request session continuation.
 - **`Idempotency-Key`** is an allowed request header — clients can send it for deduplication (responses are cached by key for 5 minutes)
 
 Most documented frontends such as Open WebUI connect server-to-server and do not need CORS at all.


### PR DESCRIPTION
Browser clients can send the session-continuation header, and misspelled delivery destinations return errors instead of claiming a local delivery.

- Permit `X-Hermes-Session-Id` in the existing API CORS request-header allowlist; preserve origin validation.
- Preserve unknown destination text and return `success: false` with `unknown_platform: <target>`; include blank destinations, without writing local output.
- Keep explicit local delivery and recognized-but-unconfigured platform errors unchanged.

Root cause: the CORS list omitted the header read by the chat route, while delivery parsing discarded unknown names into `LOCAL`.

**Live repro:** Actual loopback `APIServerAdapter` HTTP and real file-backed `DeliveryRouter`, fresh isolated homes, main `d8a07768c5ee59afae62e9fb51d45e1e30aa74da` versus this branch. Main omitted the session header and returned local success for a misspelled target; the fixed branch allows the header and returns an explicit failure. Denied origins remain HTTP 403, explicit local output persists, and unconfigured Telegram remains a failure. No model calls or external platform messages were sent.

| Validation | Result |
|---|---|
| Canonical serial runner, four targeted API/delivery files | 127 passed, 0 failed |
| Real HTTP/filesystem positive and negative controls | Passed |
| Ruff, compat-pointer check, diff whitespace | Passed |
| Independent read-only review | Blank-target truthiness finding addressed; no CORS origin regression found |

Relates to #104341. The FIFO queue endpoint is explicitly excluded as a new feature, not implemented or claimed solved. Broader CORS PATCH, Session-Key, and response-header exposure proposals remain outside this demonstrated-bug slice. Broad directory testing is owned by the campaign integration pass.

Credits: delivery slice adapted from @DevvGwardo's #104296; earliest CORS proposal @Frowtek's #40171 credited, narrowed to the demonstrated request-header omission. Both co-author trailers retained.

Campaign: https://github.com/NousResearch/hermes-agent/issues/104904

## Infographic
![Related tool reliability fixes](https://v3b.fal.media/files/b/0aa9736a/OFyfIuEHUnnpmXhpzZ4or_LCpmGqHW.png)
