### PR TITLE
fix: safe rollback preserves literal filenames (#103995)

### DIFF
--- a/tests/tools/test_checkpoint_path_roundtrip.py
+++ b/tests/tools/test_checkpoint_path_roundtrip.py
@@ -1,0 +1,55 @@
+"""Checkpoint file names must survive Git's machine-readable path output."""
+
+from tools import checkpoint_manager as checkpoints
+
+
+def test_safe_restore_preserves_exact_paths_and_user_edits(tmp_path, monkeypatch):
+    monkeypatch.setattr(checkpoints, "CHECKPOINT_BASE", tmp_path / "checkpoints")
+    work = tmp_path / "project"
+    work.mkdir()
+    (work / "AGENTS.md").write_text("Project instructions\n", encoding="utf-8")
+    names = [" leading.txt", "报告.txt", "ordinary.txt"]
+    for name in names:
+        (work / name).write_text("original\n", encoding="utf-8")
+    preserved = work / " 用户修改.txt"
+    preserved.write_text("original\n", encoding="utf-8")
+    manager = checkpoints.CheckpointManager(enabled=True)
+    assert manager.ensure_checkpoint(str(work))
+    target = manager.list_checkpoints(str(work))[0]["hash"]
+
+    for name in names:
+        (work / name).write_text("agent edit\n", encoding="utf-8")
+        manager.record_agent_write(str(work / name))
+    preserved.write_text("agent edit\n", encoding="utf-8")
+    manager.record_agent_write(str(preserved))
+    preserved.write_text("user edit\n", encoding="utf-8")
+
+    result = manager.restore(str(work), target, safe=True)
+
+    assert result["success"]
+    assert set(result["restored_files"]) == set(names)
+    assert result["skipped_user_edits"] == [preserved.name]
+    assert all((work / name).read_text(encoding="utf-8") == "original\n" for name in names)
+    assert preserved.read_text(encoding="utf-8") == "user edit\n"
+
+
+def test_size_cap_applies_to_leading_space_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(checkpoints, "CHECKPOINT_BASE", tmp_path / "checkpoints")
+    work = tmp_path / "project"
+    work.mkdir()
+    (work / "small.txt").write_text("keep\n", encoding="utf-8")
+    name = " oversized.bin"
+    (work / name).write_bytes(b"x" * (1024 * 1024 + 1))
+    manager = checkpoints.CheckpointManager(enabled=True, max_file_size_mb=1)
+    assert manager.ensure_checkpoint(str(work))
+    target = manager.list_checkpoints(str(work))[0]["hash"]
+    store = checkpoints._store_path()
+
+    included, _, _ = checkpoints._run_git(
+        ["cat-file", "-e", f"{target}:small.txt"], store, str(work)
+    )
+    oversized_included, _, _ = checkpoints._run_git(
+        ["cat-file", "-e", f"{target}:{name}"], store, str(work), allowed_returncodes={128}
+    )
+    assert included
+    assert not oversized_included

--- a/tests/tools/test_checkpoint_path_roundtrip.py
+++ b/tests/tools/test_checkpoint_path_roundtrip.py
@@ -1,14 +1,27 @@
 """Checkpoint file names must survive Git's machine-readable path output."""
 
+import os
+
+import pytest
+
 from tools import checkpoint_manager as checkpoints
 
 
-def test_safe_restore_preserves_exact_paths_and_user_edits(tmp_path, monkeypatch):
+@pytest.mark.parametrize("names", [
+    [" leading.txt", "报告.txt", "ordinary.txt"],
+    pytest.param(
+        [b" raw-\xff.txt", b"carriage\rreturn.txt", b"crlf\r\nname.txt"],
+        marks=pytest.mark.linux_only,
+        id="posix-byte-paths",
+    ),
+])
+def test_safe_restore_preserves_exact_paths_and_user_edits(tmp_path, monkeypatch, names):
+    names = [os.fsdecode(name) for name in names]
     monkeypatch.setattr(checkpoints, "CHECKPOINT_BASE", tmp_path / "checkpoints")
     work = tmp_path / "project"
     work.mkdir()
     (work / "AGENTS.md").write_text("Project instructions\n", encoding="utf-8")
-    names = [" leading.txt", "报告.txt", "ordinary.txt"]
+
     for name in names:
         (work / name).write_text("original\n", encoding="utf-8")
     preserved = work / " 用户修改.txt"
@@ -33,12 +46,17 @@ def test_safe_restore_preserves_exact_paths_and_user_edits(tmp_path, monkeypatch
     assert preserved.read_text(encoding="utf-8") == "user edit\n"
 
 
-def test_size_cap_applies_to_leading_space_paths(tmp_path, monkeypatch):
+@pytest.mark.parametrize("name", [
+    " oversized.bin",
+    pytest.param(b" oversized-\xff.bin", marks=pytest.mark.linux_only, id="posix-byte-path"),
+])
+def test_size_cap_applies_to_leading_space_paths(tmp_path, monkeypatch, name):
+    name = os.fsdecode(name)
     monkeypatch.setattr(checkpoints, "CHECKPOINT_BASE", tmp_path / "checkpoints")
     work = tmp_path / "project"
     work.mkdir()
     (work / "small.txt").write_text("keep\n", encoding="utf-8")
-    name = " oversized.bin"
+
     (work / name).write_bytes(b"x" * (1024 * 1024 + 1))
     manager = checkpoints.CheckpointManager(enabled=True, max_file_size_mb=1)
     assert manager.ensure_checkpoint(str(work))

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -203,8 +203,14 @@ def _git_env(store: Path, working_dir: str, index_file: Optional[Path] = None) -
 
 def _git_subprocess(cmd: List[str], env: dict, timeout: int, cwd: Optional[str] = None):
     # creationflags suppresses the per-call conhost flash on Windows (no-op on POSIX).
-    return subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout,
-                          env=env, cwd=cwd, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
+    # Text mode both replaces undecodable path bytes and normalizes CR/CRLF.
+    text_options = {} if "-z" in cmd else {"text": True, "encoding": "utf-8", "errors": "replace"}
+    result = subprocess.run(cmd, capture_output=True, timeout=timeout, **text_options,
+                            env=env, cwd=cwd, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
+    if "-z" in cmd:
+        result.stdout = os.fsdecode(result.stdout)
+        result.stderr = result.stderr.decode("utf-8", errors="replace")
+    return result
 
 
 def _repair_bare_repo_dirs(store: Path) -> None:

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -251,7 +251,9 @@ def _run_git(args: List[str], store: Path, working_dir: str, timeout: int = _GIT
         return False, "", str(exc)
 
     ok = result.returncode == 0
-    stdout, stderr = result.stdout.strip(), result.stderr.strip()
+    # NUL-delimited output contains literal paths, including leading spaces.
+    stdout = result.stdout if "-z" in args else result.stdout.strip()
+    stderr = result.stderr.strip()
     if not ok and result.returncode not in (allowed_returncodes or set()):
         logger.error("Git command failed: %s (rc=%d) stderr=%s",
                      " ".join(cmd), result.returncode, stderr)
@@ -596,7 +598,7 @@ class CheckpointManager:
         if err:
             return err
 
-        (ok, names_out, err), = _diff_staged_tree(p, ["diff", "--name-only", commit_hash, "--cached"])
+        (ok, names_out, err), = _diff_staged_tree(p, ["diff", "--name-only", "-z", commit_hash, "--cached"])
         if not ok:
             return {"success": False, "error": f"Could not compute changed files: {err}"}
 
@@ -604,7 +606,7 @@ class CheckpointManager:
         if not ledger:
             return {"success": True, "restore": [], "skipped": [], "ledger_empty": True}
         out: Dict[str, List[str]] = {"restore": [], "skipped": []}
-        for rel in filter(None, (line.strip() for line in names_out.splitlines())):
+        for rel in filter(None, names_out.split("\x00")):
             abs_path = Path(p.abs_dir) / rel
             entry = ledger.get(str(abs_path))
             recorded = entry.get("sha256") if isinstance(entry, dict) else None
@@ -855,7 +857,7 @@ class CheckpointManager:
             return
         ok, stdout, _ = _run_git(["ls-files", "--cached", "-z"], store, working_dir, index_file=index_file)
         abs_workdir = _normalize_path(working_dir)
-        # NUL-separated; _run_git's strip() leaves NULs alone.
+        # NUL-separated literal paths; whitespace is part of the file name.
         oversize = [rel for rel in (stdout if ok else "").split("\x00") if rel and self._exceeds_size_cap(abs_workdir / rel)]
         if not oversize:
             return


### PR DESCRIPTION
Safe rollback now restores literal filenames without discarding genuine user edits, and checkpoint size caps also cover leading-space names.

Fixes #103995. Campaign: #104904. Salvages #103996 by @Liuzikaii with original commit authorship preserved.

## Changes
- Capture NUL-delimited Git output as bytes and decode with `os.fsdecode`, avoiding lossy replacement and CR/CRLF translation; retain normal text handling for other commands.
- Read changed paths with `git diff --name-only -z` and split only on NULs.
- Cover exact-path safe restore, user-edit preservation, and the leading-space size cap with two parameterized invariant tests, including native Linux byte filenames.

Root cause: display-oriented Git filename parsing, unconditional whitespace trimming, and text-mode decoding changed literal paths before the rollback ledger and size-cap checks used them.

## Validation
**Live repro:** production `CheckpointManager`, real Git and filesystem, fresh interpreters with isolated HOME/HERMES_HOME on native Linux; no predicate mocks.

| Check | Main `d8a07768c5ee` | Fixed branch |
| --- | --- | --- |
| Restore plain, Unicode, leading-space, tab and newline filenames | 1 of 5 restored | 5 of 5 restored |
| Separate user edit | Preserved | Preserved |
| Leading-space file over 1 MiB cap | Incorrectly included | Excluded |
| Ordinary oversized file control | Excluded | Excluded |

- Additional real-I/O A/B on the first fix versus the follow-up: a non-UTF-8 byte filename plus CR and CRLF names restored **0/3 → 3/3**; a separate raw-byte user edit stayed preserved; a raw-byte oversized filename changed from included to excluded. This addresses the independent campaign review's byte-round-trip finding.
- Canonical targeted regressions on the final follow-up: **57 passed, 0 failed**, two files, `scripts/run_tests.sh tests/tools/test_checkpoint_path_roundtrip.py tests/tools/test_checkpoint_manager.py -j 1 --file-retries 0`, serialized through the campaign flock.
- Original shipped regressions were proven red on main: **2 failed** for the expected restore and size-cap symptoms.
- Independent read-only reviews of both original fix and byte-preservation follow-up: no actionable correctness findings. Initial reviewer sandbox could not run tests; the separate canonical run above supplies execution evidence.
- Ruff, Windows-footgun diff gate, compat-pointer and subprocess-stdin checks, attribution mapping, and whitespace checks passed.
- Full `tests/tools/` directory remains pending the parent campaign integration harness; native Windows and remote-service validation were not run. CI pending.

## Infographic
![Safe rollback preserves literal filenames](https://v3b.fal.media/files/b/0aa973a6/iPtJA1fi65-LJdSQwI7FD_STmhi53z.png)
