### PR TITLE
fix: Desktop-only backends run due idle skill maintenance

### DIFF
--- a/hermes_cli/web_server_sessions.py
+++ b/hermes_cli/web_server_sessions.py
@@ -230,14 +230,56 @@ def _maybe_auto_archive_for_profile(profile: Optional[str]) -> None:
         _log.debug("opportunistic auto-archive skipped: %s", exc)
 
 
+def _skill_maintenance_idle_for(started_at: float) -> Optional[float]:
+    """Measure chat inactivity, not socket inactivity (Desktop stays connected)."""
+    import tui_gateway.server as gateway
+
+    with gateway._sessions_lock:
+        if any(session.get("running") for session in gateway._sessions.values()):
+            return None
+        last_active = max(
+            [started_at] + [float(session.get("last_active") or started_at)
+                            for session in gateway._sessions.values()])
+    return max(0.0, time.time() - last_active)
+
+
+def _maybe_run_skill_maintenance(started_at: float) -> None:
+    from hermes_constants import get_hermes_home
+    from hermes_cli.profiles import _check_gateway_running
+
+    # A live messaging gateway already owns these chores for this profile.
+    if _check_gateway_running(get_hermes_home()):
+        return
+
+    from agent.curator import maybe_run_curator
+    from tools.skills_sync_client import maybe_pull_skills
+    from tools.skills_sync_client_org import maybe_pull_org_skills
+
+    try:
+        idle_for = _skill_maintenance_idle_for(started_at)
+        if idle_for is not None:
+            maybe_run_curator(idle_for_seconds=idle_for)
+    except Exception as exc:
+        _log.debug("serve curator tick skipped: %s", exc)
+    for pull in (maybe_pull_skills, maybe_pull_org_skills):
+        try:
+            pull()
+        except Exception as exc:
+            _log.debug("serve skill sync tick skipped: %s", exc)
+
+
 async def _auto_archive_ticker_loop(
     interval_s: float = 3600.0, initial_delay_s: float = 90.0) -> None:
-    """Poll-rate timer for the auto-archive sweep (primary profile), so a
-    long-idle Desktop keeps sweeping without any ``/api/sessions`` request.
-    The real cadence is still owned by state_meta inside ``maybe_auto_archive``."""
+    """Poll maintenance for this serve profile, including Desktop-only installs.
+
+    Individual chores own their config/interval gates. Curator additionally uses
+    real chat inactivity; merely keeping a Desktop WebSocket open is not activity.
+    """
+    started_at = time.time()
 
     def _sweep() -> None:
         _maybe_auto_archive_for_profile(None)
+        _maybe_run_skill_maintenance(started_at)
 
     await asyncio.sleep(initial_delay_s)
     while True:

--- a/hermes_cli/web_server_sessions.py
+++ b/hermes_cli/web_server_sessions.py
@@ -234,12 +234,17 @@ def _skill_maintenance_idle_for(started_at: float) -> Optional[float]:
     """Measure chat inactivity, not socket inactivity (Desktop stays connected)."""
     import tui_gateway.server as gateway
 
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home().resolve()
     with gateway._sessions_lock:
-        if any(session.get("running") for session in gateway._sessions.values()):
+        sessions = [session for session in gateway._sessions.values()
+                    if Path(session.get("profile_home") or home).resolve() == home]
+        if any(session.get("running") for session in sessions):
             return None
         last_active = max(
-            [started_at] + [float(session.get("last_active") or started_at)
-                            for session in gateway._sessions.values()])
+            [started_at, gateway._closed_session_activity.get(str(home), 0)]
+            + [float(session.get("last_active") or started_at) for session in sessions])
     return max(0.0, time.time() - last_active)
 
 

--- a/tests/hermes_cli/test_serve_skill_maintenance.py
+++ b/tests/hermes_cli/test_serve_skill_maintenance.py
@@ -7,6 +7,53 @@ import pytest
 
 
 @pytest.mark.asyncio
+async def test_removed_sessions_keep_profile_idle_watermark(tmp_path, monkeypatch):
+    import time
+    from pathlib import Path
+
+    import tui_gateway.server as gateway
+    from agent.curator import load_state, save_state
+    from hermes_cli.web_server_sessions import _auto_archive_ticker_loop, _skill_maintenance_idle_for
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / "skills").mkdir()
+    (tmp_path / "config.yaml").write_text(
+        "curator:\n  enabled: true\n  interval_hours: 168\n"
+        "  min_idle_hours: 0.002\n  prune_builtins: false\n", encoding="utf-8")
+    save_state({"last_run_at": "2020-01-01T00:00:00+00:00", "run_count": 0})
+    # Let the actual timer age past its idle threshold before recent activity.
+    task = asyncio.create_task(_auto_archive_ticker_loop(interval_s=.05, initial_delay_s=8))
+    try:
+        await asyncio.sleep(7.5)
+        for reason in ("tui_close", "ws_orphan_reap"):
+            recent = time.time()
+            with gateway._sessions_lock:
+                gateway._sessions["watermark"] = {
+                    "last_active": recent, "running": False, "profile_home": str(tmp_path)}
+            assert gateway._close_session_by_id("watermark", end_reason=reason)
+            assert _skill_maintenance_idle_for(recent - 3600) < 2
+        # An active sibling profile must not hold this profile's idle clock.
+        with gateway._sessions_lock:
+            gateway._sessions["other-profile"] = {
+                "running": True, "profile_home": str(tmp_path / "other")}
+        assert _skill_maintenance_idle_for(recent - 3600) is not None
+        await asyncio.sleep(2)
+        assert load_state()["run_count"] == 0
+        async with asyncio.timeout(12):
+            while "consolidation off" not in (load_state().get("last_run_summary") or ""):
+                await asyncio.sleep(.05)
+        assert "consolidation off" in load_state()["last_run_summary"]
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+        with gateway._sessions_lock:
+            gateway._sessions.pop("other-profile", None)
+            gateway._sessions.pop("watermark", None)
+
+
+@pytest.mark.asyncio
 async def test_serve_timer_runs_due_curator_once_and_honors_pause(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / "skills").mkdir()

--- a/tests/hermes_cli/test_serve_skill_maintenance.py
+++ b/tests/hermes_cli/test_serve_skill_maintenance.py
@@ -1,0 +1,45 @@
+"""Exercise the real periodic maintenance loop with isolated on-disk state."""
+import asyncio
+import json
+from contextlib import suppress
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_serve_timer_runs_due_curator_once_and_honors_pause(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "skills").mkdir()
+    (tmp_path / "config.yaml").write_text(
+        "curator:\n  enabled: true\n  consolidate: false\n  interval_hours: 168\n"
+        "  min_idle_hours: 0\n  prune_builtins: false\n", encoding="utf-8")
+    from agent.curator import load_state, save_state, set_paused
+    from hermes_cli.web_server_sessions import _auto_archive_ticker_loop
+
+    save_state({"last_run_at": "2020-01-01T00:00:00+00:00", "run_count": 0, "paused": True})
+    task = asyncio.create_task(_auto_archive_ticker_loop(interval_s=.02, initial_delay_s=0))
+    try:
+        await asyncio.sleep(.15)
+        assert load_state()["run_count"] == 0
+        set_paused(False)
+        # Active turns must suppress maintenance even with a zero idle threshold.
+        import tui_gateway.server as gateway
+        with gateway._sessions_lock:
+            gateway._sessions['maintenance-test'] = {"running": True}
+        try:
+            await asyncio.sleep(.15)
+            assert load_state()["run_count"] == 0
+        finally:
+            with gateway._sessions_lock:
+                gateway._sessions.pop('maintenance-test', None)
+        async with asyncio.timeout(8):
+            while load_state()["run_count"] == 0:
+                await asyncio.sleep(.02)
+        await asyncio.sleep(.15)
+        state = json.loads((tmp_path / "skills" / ".curator_state").read_text())
+        assert state["run_count"] == 1
+        assert "consolidation off" in state["last_run_summary"]
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -310,12 +310,21 @@ def _attach_worker(sid: str, session: dict, worker) -> None:
     worker.close()
 
 
+# Wall-clock timestamps, like session last_active; retained after close/reap.
+_closed_session_activity: dict[str, float] = {}
+
+
 def _pop_session_by_id(sid: str) -> dict | None:
     """Atomically detach one live session from the registry — the ownership claim for teardown (a concurrent
     close/reaper no-ops). Separate from ``_teardown_session``: slow finalization must not run under the resume lock."""
     with _sessions_lock:
         session = _sessions.pop(sid, None)
         if session is not None:
+            from hermes_constants import get_hermes_home
+
+            home = str(Path(session.get("profile_home") or get_hermes_home()).resolve())
+            last_active = time.time() if session.get("running") else float(session.get("last_active") or 0)
+            _closed_session_activity[home] = max(_closed_session_activity.get(home, 0), last_active)
             session["_closing"] = True
             session["_sid"] = sid  # out of _sessions now, so teardown can't recover the live id by scanning
     return session

--- a/website/docs/user-guide/features/curator.md
+++ b/website/docs/user-guide/features/curator.md
@@ -16,10 +16,14 @@ Tracks [issue #7816](https://github.com/NousResearch/hermes-agent/issues/7816).
 
 ## How it runs
 
-The curator is triggered by an inactivity check, not a cron daemon. On CLI session start, and on a recurring tick inside the gateway's cron-ticker thread, Hermes checks whether:
+The curator is triggered by an inactivity check, not a cron job. On CLI session start, during gateway housekeeping, and on the Desktop/`hermes serve` maintenance timer, Hermes checks whether:
 
 1. Enough time has passed since the last curator run (`interval_hours`, default **7 days**), and
 2. The agent has been idle long enough (`min_idle_hours`, default **2 hours**).
+
+Desktop and other `hermes serve` backends share the existing hourly maintenance timer (first poll after 90 seconds), independently of cron jobs. They measure inactivity from process startup and the most recent chat activity, and skip curator while a turn is running. A connected but inactive window does not block maintenance. This timer also polls personal and organization Skill Sync, subject to those features' own opt-in gates. A running messaging gateway for the same profile owns these chores instead.
+
+The timer services its backend's profile. In-flight maintenance runs in a worker thread; closing the backend does not cooperatively interrupt that pass. Starting multiple independent serve processes for the same profile can still race the curator's interval check.
 
 If both are true, it spawns a background fork of `AIAgent` — the same pattern used by the memory/skill self-improvement nudges. The fork runs in its own prompt cache and never touches the active conversation.
 

--- a/website/docs/user-guide/features/curator.md
+++ b/website/docs/user-guide/features/curator.md
@@ -21,7 +21,7 @@ The curator is triggered by an inactivity check, not a cron job. On CLI session 
 1. Enough time has passed since the last curator run (`interval_hours`, default **7 days**), and
 2. The agent has been idle long enough (`min_idle_hours`, default **2 hours**).
 
-Desktop and other `hermes serve` backends share the existing hourly maintenance timer (first poll after 90 seconds), independently of cron jobs. They measure inactivity from process startup and the most recent chat activity, and skip curator while a turn is running. A connected but inactive window does not block maintenance. This timer also polls personal and organization Skill Sync, subject to those features' own opt-in gates. A running messaging gateway for the same profile owns these chores instead.
+Desktop and other `hermes serve` backends share the existing hourly maintenance timer (first poll after 90 seconds), independently of cron jobs. They measure inactivity from process startup and the most recent chat activity in the same profile, retaining that activity timestamp after a session closes or is reaped, and skip curator while a turn in that profile is running. A connected but inactive window does not block maintenance. This timer also polls personal and organization Skill Sync, subject to those features' own opt-in gates. A running messaging gateway for the same profile owns these chores instead.
 
 The timer services its backend's profile. In-flight maintenance runs in a worker thread; closing the backend does not cooperatively interrupt that pass. Starting multiple independent serve processes for the same profile can still race the curator's interval check.
 


### PR DESCRIPTION
Desktop-only and plain serve backends now run due idle skill maintenance without requiring a messaging gateway.

- Extend the existing hourly auto-archive timer (first poll at 90 seconds), rather than adding another long-lived loop.
- Measure this profile's real session inactivity, suppress curator during running turns, and retain recent activity after atomic close/orphan-reap. An active sibling profile does not suppress this profile's chores.
- Stand down when the same profile has a live messaging gateway. Poll existing personal/org skill-sync gates and retain curator's interval, pause, enabled, idle, and consolidation settings.
- Include two real-timer/on-disk invariants and user documentation; preserve original and review-follow-up commits separately.

Root cause: serve had no periodic curator/skill-sync call site; measuring only sessions still in the registry also forgot recent activity on close/reap.

## Validation

**Live repro:** real isolated Linux `hermes serve`, deliberately due curator, minimum idle 0 and consolidation off: baseline **run_count 0 after 100 seconds → split fix 1** after the actual initial timer. The completed pass reports `auto: no changes; llm: skipped (consolidation off)`.

The session-removal review probe previously jumped immediately to about 3600 seconds idle after a recent close. The fixed real asyncio timer and on-disk state preserve explicit-close/orphan-reap activity, prevent the early pass, then permit an eventual pass. A separate OS process holding the actual gateway runtime lock keeps the same-profile curator at 0; releasing it permits 1. No liveness predicate is patched.

- Post-split canonical serial runner: **6 files / 55 tests passed, 0 failed**, retries disabled, including both maintenance invariants plus archive, session-control, ownership teardown, and gateway-owned reap regressions.
- Ruff, Windows-footgun scan (1464 files), compatibility-pointer, subprocess-stdin, and diff checks passed.
- Independent source/follow-up review and added-line security scan: no remaining blocking findings. Full Python test directories were not run.

Fidelity: real backend processes, timers, configuration files, curator state, and runtime-lock/liveness plumbing; the lock owner is an isolated lock-host fixture, **not** an adapter-connected messaging daemon. Both HOME and HERMES_HOME isolated; no vendor/model calls, external skill-sync service calls, native macOS, or packaged Electron claims. Existing same-profile multi-serve races and noncooperative in-flight shutdown are not changed. Private probes/receipts and ephemeral workflows are not shipped. CI status is not claimed here.

Credit: Jackal991, earliest candidate #95453; this rewrite uses the existing timer and measured inactivity rather than a second infinite-idle loop. Original credit and subsequent authorship remain in the commit history.
Related: #95441. Tracker: #104839.

## Infographic

![Desktop reliability campaign overview](https://v3b.fal.media/files/b/0aa970ff/01HBIjxrk8-g59IYVhD6F_GOQaUsZH.png)
