### PR TITLE
fix(desktop): API keys follow the selected Settings profile (#103993)

### DIFF
--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -15,6 +15,8 @@ const startManualLocalEndpoint = vi.fn()
 const onboarding = atom({ manual: false })
 
 vi.mock('@/hermes', () => ({
+  setApiRequestProfile: vi.fn(),
+  getProfiles: async () => ({ profiles: (await import('@/store/profile')).$profiles.get() }),
   disconnectOAuthProvider: (providerId: string) => disconnectOAuthProvider(providerId),
   getEnvVars: (profile?: string) => getEnvVars(profile),
   setEnvVar: (key: string, value: string, profile?: string) => setEnvVar(key, value, profile),
@@ -100,15 +102,26 @@ describe('ProvidersSettings', () => {
     const { $activeGatewayProfile, $profiles } = await import('@/store/profile')
     $activeGatewayProfile.set('profile-a')
     $settingsScopeOverride.set('profile-b')
-    $profiles.set([{ name: 'profile-a' }, { name: 'profile-b' }] as never)
+    $profiles.set(
+      ['profile-a', 'profile-b'].map(name => ({
+        name,
+        has_env: false,
+        is_default: false,
+        model: null,
+        path: '',
+        provider: null,
+        skill_count: 0
+      }))
+    )
     getEnvVars.mockResolvedValue({ WIDGET_API_KEY: keyVar({ provider: 'widget', provider_label: 'Widget' }) })
     const { ProvidersSettings } = await import('./providers-settings')
+
     try {
-      render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="keys" />)
+      const { container } = render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="keys" />)
       await screen.findByText('Widget')
       expect(getEnvVars).toHaveBeenLastCalledWith('profile-b')
       expect(screen.getByText('Applies to')).toBeTruthy()
-      const input = document.querySelector('input[type="password"]')!
+      const input = container.querySelector('input[type="password"]')!
       fireEvent.focus(input)
       fireEvent.change(input, { target: { value: 'fixture-key' } })
       fireEvent.click(screen.getByRole('button', { name: 'Save' }))

--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -9,13 +9,15 @@ import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 const listOAuthProviders = vi.fn()
 const disconnectOAuthProvider = vi.fn()
 const getEnvVars = vi.fn()
+const setEnvVar = vi.fn()
 const startManualProviderOAuth = vi.fn()
 const startManualLocalEndpoint = vi.fn()
 const onboarding = atom({ manual: false })
 
 vi.mock('@/hermes', () => ({
   disconnectOAuthProvider: (providerId: string) => disconnectOAuthProvider(providerId),
-  getEnvVars: () => getEnvVars(),
+  getEnvVars: (profile?: string) => getEnvVars(profile),
+  setEnvVar: (key: string, value: string, profile?: string) => setEnvVar(key, value, profile),
   listOAuthProviders: () => listOAuthProviders()
 }))
 
@@ -93,6 +95,33 @@ async function renderProvidersSettings() {
 }
 
 describe('ProvidersSettings', () => {
+  it('reads and saves API keys for the shared Settings target and reloads when it changes', async () => {
+    const { $settingsScopeOverride } = await import('@/store/settings-scope')
+    const { $activeGatewayProfile, $profiles } = await import('@/store/profile')
+    $activeGatewayProfile.set('profile-a')
+    $settingsScopeOverride.set('profile-b')
+    $profiles.set([{ name: 'profile-a' }, { name: 'profile-b' }] as never)
+    getEnvVars.mockResolvedValue({ WIDGET_API_KEY: keyVar({ provider: 'widget', provider_label: 'Widget' }) })
+    const { ProvidersSettings } = await import('./providers-settings')
+    try {
+      render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="keys" />)
+      await screen.findByText('Widget')
+      expect(getEnvVars).toHaveBeenLastCalledWith('profile-b')
+      expect(screen.getByText('Applies to')).toBeTruthy()
+      const input = document.querySelector('input[type="password"]')!
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: 'fixture-key' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await waitFor(() => expect(setEnvVar).toHaveBeenCalledWith('WIDGET_API_KEY', 'fixture-key', 'profile-b'))
+      fireEvent.click(screen.getByRole('button', { name: 'profile-a' }))
+      await waitFor(() => expect(getEnvVars).toHaveBeenLastCalledWith(undefined))
+    } finally {
+      cleanup()
+      $settingsScopeOverride.set(null)
+      $activeGatewayProfile.set('default')
+      $profiles.set([])
+    }
+  })
   it('disconnects a connected provider account and refreshes the accounts list', async () => {
     await renderProvidersSettings()
 

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -25,6 +25,7 @@ import { confirm } from '@/store/confirm'
 import { $localModelsEnabled } from '@/store/local-models-flag'
 import { notify, notifyError } from '@/store/notifications'
 import { $desktopOnboarding, startManualLocalEndpoint, startManualProviderOAuth } from '@/store/onboarding'
+import { $settingsRequestProfile } from '@/store/settings-scope'
 import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
 import { isKeyVar, ProviderKeyRows } from './credential-key-ui'
@@ -33,6 +34,7 @@ import { SettingsCategoryHeading, useEnvCredentials } from './env-credentials'
 import { providerGroup, providerMeta, providerPriority } from './helpers'
 import { LocalModelsSettings } from './local-models-settings'
 import { SettingsContent, SettingsSkeleton } from './primitives'
+import { SettingsProfileScope } from './profile-scope'
 
 // The embedded terminal (and thus the "run disconnect command" path) only
 // exists in the Electron desktop shell, not the web dashboard.
@@ -347,7 +349,11 @@ export function ProvidersSettings({
   view
 }: ProvidersSettingsProps) {
   const { t } = useI18n()
-  const { rowProps, vars } = useEnvCredentials()
+  // Shared settings "Applies to" scope: read + edit the selected profile's
+  // env store instead of the active one. Undefined → active profile.
+  // See https://github.com/NousResearch/hermes-agent/issues/103993
+  const scopeProfile = useStore($settingsRequestProfile)
+  const { rowProps, vars } = useEnvCredentials(scopeProfile)
   const [oauthProviders, setOauthProviders] = useState<OAuthProvider[]>([])
   const [openProvider, setOpenProvider] = useState<null | string>(null)
   const [disconnecting, setDisconnecting] = useState<null | string>(null)
@@ -474,6 +480,7 @@ export function ProvidersSettings({
 
     return (
       <SettingsContent>
+        <SettingsProfileScope className="mb-5" />
         <LocalEndpointRow onOpen={startManualLocalEndpoint} />
         {keyGroups.length > 0 ? (
           <div className="grid gap-3">
@@ -523,6 +530,7 @@ export function ProvidersSettings({
 
   return (
     <SettingsContent>
+      <SettingsProfileScope className="mb-5" />
       <OAuthPicker
         disconnecting={disconnecting}
         onDisconnect={provider => void handleDisconnect(provider)}

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -349,9 +349,7 @@ export function ProvidersSettings({
   view
 }: ProvidersSettingsProps) {
   const { t } = useI18n()
-  // Shared settings "Applies to" scope: read + edit the selected profile's
-  // env store instead of the active one. Undefined → active profile.
-  // See https://github.com/NousResearch/hermes-agent/issues/103993
+  // Match the shared Settings target for credential reads and writes.
   const scopeProfile = useStore($settingsRequestProfile)
   const { rowProps, vars } = useEnvCredentials(scopeProfile)
   const [oauthProviders, setOauthProviders] = useState<OAuthProvider[]>([])
@@ -530,7 +528,6 @@ export function ProvidersSettings({
 
   return (
     <SettingsContent>
-      <SettingsProfileScope className="mb-5" />
       <OAuthPicker
         disconnecting={disconnecting}
         onDisconnect={provider => void handleDisconnect(provider)}

--- a/contributors/emails/29462570+jordan-thirkle@users.noreply.github.com
+++ b/contributors/emails/29462570+jordan-thirkle@users.noreply.github.com
@@ -1,0 +1,2 @@
+jordan-thirkle
+# PR #104017 salvage


### PR DESCRIPTION
Providers → API Keys now reads and saves credentials for the profile selected in Settings **Applies to**, rather than silently returning to the active chat profile.

- Reuse `$settingsRequestProfile` for the existing credential hook, including its read and write operations.
- Show the existing shared selector on API Keys. Do not add it to OAuth Accounts: those operations have a different scope and a selector there would be misleading.
- Cover selected-profile read/save and changing back to the active profile with one behavioral renderer regression.

**Root cause:** `ProvidersSettings` called `useEnvCredentials()` without the Settings override even though neighboring settings surfaces supplied it.

## Validation

**Live repro:** production `ProvidersSettings` and its real renderer dependency graph, bundled with production React and exercised in an isolated Chromium page. Native API transport used a credential-free fixture; real API helpers were not replaced.

| Scenario | Main control (`c4a5deeffa959f8ebc891e02c5bcf767aff1dd2a`) | Fixed |
|---|---|---|
| Active profile-a; Settings profile-b | GET and PUT `/api/env` target profile-a; no selector | GET and PUT target profile-b; shared selector visible |
| Select profile-a in API Keys | Selector absent | Reload issues GET for profile-a |
| Replay captured save through real Python env handler in fresh HOME/HERMES_HOME | Dummy key only in profile-a/.env | Dummy key only in profile-b/.env |

- Serialized Vitest: **15 passed, 0 failed, 3 files** (`providers-settings`, `keys-settings`, `profile-scope`), under the campaign flock with one worker. Broader directory integration is owned by the campaign parent.
- Touched-file ESLint, Prettier, `git diff --check`, compatibility-pointer and Windows-footgun checks passed.
- Independent read-only review confirmed credential scope and fallback semantics. Its unrelated keypad warning came from a two-dot comparison after main advanced, not this three-dot PR diff; the branch was rebased and the final diff contains only these settings changes, the test and contributor attribution.

**Limits:** actual production component in Chromium, not an installed Electron/Windows build. Native transport fixture, no real credentials or provider calls, no paid usage. The backend persistence check replays the captured renderer request rather than exercising native IPC end to end.

## Credits

Salvaged #104017 by @jordan-thirkle, preserving original commit authorship and contributor mapping. Follow-up narrows the selector to API Keys and adds behavioral verification.

Fixes #103993.
Campaign tracker: #104904.

## Infographic

![Desktop API keys follow the selected Settings profile](https://v3b.fal.media/files/b/0aa97395/ED0h4fzX9O5b2kc6aBNuH_k8gGiWjg.png)
