### PR TITLE
fix: cron stores remain importable across execution-module upgrades (#104155, salvage #104185)

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -2,7 +2,7 @@
 
 The ledger records what is known about each attempt; it is not a retry queue. Interrupted attempts
 become ``unknown`` only after their exact owner process is proved gone. Terminal states are
-immutable. Also hosts the SQLite ledger helpers shared with ``cron.incidents`` / ``cron.notepad``.
+immutable.
 """
 
 from __future__ import annotations
@@ -14,8 +14,9 @@ import time
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
+from cron.ledger import ledger_transaction, open_ledger, prepare_ledger
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
@@ -28,48 +29,6 @@ HANDOFF_ADOPTION_GRACE_SECONDS = 30.0
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
-
-
-# --- shared SQLite ledger plumbing --------------------------------------------------------------
-
-def open_ledger(path: Path) -> sqlite3.Connection:
-    """Open a profile-local ledger DB, creating its ``cron/`` dir with the store's permissions."""
-    from cron.jobs import _ensure_cron_dir
-
-    _ensure_cron_dir(path.parent)
-    return sqlite3.connect(path, timeout=5)
-
-
-def prepare_ledger(
-    conn: sqlite3.Connection, *, db_label: str, synchronous_full: bool = True
-) -> None:
-    """Row factory + busy timeout + WAL (with fallback) + optional ``synchronous=FULL``."""
-    from hermes_state_wal import apply_wal_with_fallback
-
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA busy_timeout=5000")
-    apply_wal_with_fallback(conn, db_label=db_label)
-    if synchronous_full:
-        conn.execute("PRAGMA synchronous=FULL")
-
-
-@contextmanager
-def ledger_transaction(
-    lock: threading.RLock,
-    connect: Callable[[], sqlite3.Connection],
-    initialize_schema: Callable[[sqlite3.Connection], None],
-) -> Iterator[sqlite3.Connection]:
-    """Open a connection, commit/rollback on exit, always close. ``sqlite3.Connection``'s own
-    context manager does NOT close (leaks WAL/SHM fds until GC); schema init runs inside the
-    ``try`` so a PRAGMA/DDL failure after ``connect()`` still closes."""
-    with lock:
-        conn = connect()
-        try:
-            initialize_schema(conn)
-            with conn:
-                yield conn
-        finally:
-            conn.close()
 
 
 # --- executions ledger --------------------------------------------------------------------------

--- a/cron/incidents.py
+++ b/cron/incidents.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from cron import executions as _executions
-from cron.executions import ledger_transaction, open_ledger, prepare_ledger
+from cron.ledger import ledger_transaction, open_ledger, prepare_ledger
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 

--- a/cron/ledger.py
+++ b/cron/ledger.py
@@ -1,0 +1,47 @@
+"""SQLite connection and transaction helpers shared by cron ledgers."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Callable, Iterator
+
+
+def open_ledger(path: Path) -> sqlite3.Connection:
+    """Open a profile-local ledger DB, creating its cron directory securely."""
+    from cron.jobs import _ensure_cron_dir
+
+    _ensure_cron_dir(path.parent)
+    return sqlite3.connect(path, timeout=5)
+
+
+def prepare_ledger(
+    conn: sqlite3.Connection, *, db_label: str, synchronous_full: bool = True
+) -> None:
+    """Configure row access, busy timeout, WAL, and optional full synchronization."""
+    from hermes_state_wal import apply_wal_with_fallback
+
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=5000")
+    apply_wal_with_fallback(conn, db_label=db_label)
+    if synchronous_full:
+        conn.execute("PRAGMA synchronous=FULL")
+
+
+@contextmanager
+def ledger_transaction(
+    lock: threading.RLock,
+    connect: Callable[[], sqlite3.Connection],
+    initialize_schema: Callable[[sqlite3.Connection], None],
+) -> Iterator[sqlite3.Connection]:
+    """Initialize, transact on, and always close one ledger connection."""
+    with lock:
+        conn = connect()
+        try:
+            initialize_schema(conn)
+            with conn:
+                yield conn
+        finally:
+            conn.close()

--- a/cron/notepad.py
+++ b/cron/notepad.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from cron.executions import ledger_transaction, open_ledger, prepare_ledger
+from cron.ledger import ledger_transaction, open_ledger, prepare_ledger
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 

--- a/tests/cron/test_upgrade_module_skew.py
+++ b/tests/cron/test_upgrade_module_skew.py
@@ -1,0 +1,33 @@
+"""Cron imports remain usable when a daemon spans an on-disk upgrade."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_lazy_cron_stores_do_not_require_new_symbols_on_cached_executions_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script = """
+import sys
+import cron.executions as executions
+
+for name in ("ledger_transaction", "open_ledger", "prepare_ledger"):
+    delattr(executions, name)
+sys.modules.pop("cron.incidents", None)
+sys.modules.pop("cron.notepad", None)
+
+import cron.incidents
+import cron.notepad
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Cron incident and notepad stores no longer fail to import when an upgrade leaves the older execution module cached.

- Move shared SQLite connection/transaction plumbing into `cron.ledger`, consumed directly by all three stores.
- Preserve existing database paths, locking, rollback, and connection closure.
- No fallback definitions, compatibility aliases, or daemon restart machinery added.
- Salvage @fangliquanflq's #104185 with original commit authorship.

Root cause: newly loaded stores imported newly added helpers from an execution module already cached before those helpers existed.

**Live repro:** isolated HOME/HERMES_HOME, real pre-refactor cron package (`281cc00db669e2403d07e15ac20e93a549362f91`) imported first, then actual on-disk cron files replaced while retaining the cached module identities.

| Probe | Main cron files | Fixed cron files |
|---|---|---|
| Historical cached executions + new lazy stores | exact `cannot import name ledger_transaction` | imports and real incident/notepad writes succeed |
| Historical executions + current scheduler prompt | stores cannot import | notepad injection, completed execution, incident persistence, and real SQLite rollback pass |
| Fresh interpreter | control | store operations and rollback pass |

Scope limitation: replacing the entire historical cron package also exposes a separate old prompt dependency on removed `tools.cronjob_tools._scan_cron_skill_assembled`. This PR fixes the reported ledger import boundary, not arbitrary multi-release hot upgrades; a restart remains appropriate for a fully consistent daemon. No production daemon or user state was touched.

Validation: canonical serial runner under campaign flock, four impacted cron files: **67 passed, 0 failed**. Broader cron-directory integration is owned by the parent campaign.

Independent read-only review: no findings; no semantic drift or compatibility aliases. Ruff, Windows footguns, compatibility-pointer, subprocess-stdin, and diff checks pass.

Related: #104155
Campaign: #104904

## Infographic
![Cron ledger upgrade boundary](https://v3b.fal.media/files/b/0aa9736e/3AfzrHVVlF4_0hakanPJH_wej8C9Fp.png)
