### PR TITLE
fix(feishu): topic-group sends — thread_id is not a valid receive_id_type; media & approval notices misrouted

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -124,6 +124,17 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     profile = str(getattr(source, "profile", None) or "").strip()
     if profile:
         metadata["hermes_profile"] = profile
+    # Feishu topic threads: media sends carry only ``thread_id`` metadata, so
+    # the adapter's reply branch never triggers and non-text messages fall
+    # through to a create with receive_id_type='thread_id' — which Feishu's
+    # API rejects outright (99992402: receive_id_type is not a valid enum
+    # value; text only ever worked because streaming metadata already carried
+    # a reply anchor). Carry the anchor for Feishu too so media replies land
+    # in the topic via the reply API.
+    if _platform_name(getattr(source, "platform", None)) == "feishu" and thread_id:
+        anchor = reply_to_message_id or getattr(source, "message_id", None)
+        if anchor is not None:
+            metadata["reply_to_message_id"] = str(anchor)
     return metadata
 
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -178,6 +178,9 @@ async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> byt
 
 
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
+# Feishu rejects msg_type='image'/'file'/'audio' with receive_id_type='thread_id' (99992402).
+# Non-text media must be re-sent via the reply API anchored to a message in the thread.
+_FEISHU_THREAD_ROUTE_INVALID_CODE = 99992402
 
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
 # small footer emoji — a success badge on every message would add noise, so
@@ -3606,7 +3609,42 @@ class FeishuAdapter(BasePlatformAdapter):
             return await self._run_blocking(self._client.im.v1.message.reply, request)
         if thread_id:
             # reply→create fallback inside a topic: thread_id as receive_id keeps it in the topic.
-            receive_id, receive_id_type = thread_id, "thread_id"
+            body = self._build_create_message_body(
+                receive_id=thread_id, msg_type=msg_type, content=payload, uuid_value=str(uuid.uuid4()),
+            )
+            request = self._build_create_message_request("thread_id", body)
+            response = await self._run_blocking(self._client.im.v1.message.create, request)
+            # Feishu rejects non-text media (image/file/audio) sent with
+            # receive_id_type='thread_id' (code 99992402). Re-send via the
+            # reply API anchored to a message in the thread so the media
+            # still lands inside the topic.
+            if (
+                not self._response_succeeded(response)
+                and getattr(response, "code", None) == _FEISHU_THREAD_ROUTE_INVALID_CODE
+                and msg_type != "text"
+            ):
+                logger.info(
+                    "[Feishu] %s send via thread_id rejected (99992402); retrying via reply API in thread",
+                    msg_type,
+                )
+                anchor_id = (metadata or {}).get("reply_to_message_id")
+                if not anchor_id:
+                    anchor_id = await self._fetch_last_message_in_thread(thread_id)
+                if anchor_id:
+                    reply_body = self._build_reply_message_body(
+                        content=payload,
+                        msg_type=msg_type,
+                        reply_in_thread=True,
+                        uuid_value=str(uuid.uuid4()),
+                    )
+                    reply_request = self._build_reply_message_request(anchor_id, reply_body)
+                    return await self._run_blocking(self._client.im.v1.message.reply, reply_request)
+                logger.warning(
+                    "[Feishu] No anchor message found in thread %s; cannot retry %s via reply API",
+                    thread_id,
+                    msg_type,
+                )
+            return response
         elif chat_id.startswith("feishu_user_id:"):
             receive_id, receive_id_type = chat_id.split(":", 1)[1], "user_id"
         else:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -178,8 +178,9 @@ async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> byt
 
 
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
-# Feishu rejects msg_type='image'/'file'/'audio' with receive_id_type='thread_id' (99992402).
-# Non-text media must be re-sent via the reply API anchored to a message in the thread.
+# Feishu rejects receive_id_type='thread_id' for ALL msg_types (99992402).
+# Non-text and text alike must be re-sent via the reply API anchored to a
+# message in the thread.
 _FEISHU_THREAD_ROUTE_INVALID_CODE = 99992402
 
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
@@ -1670,10 +1671,21 @@ class FeishuAdapter(BasePlatformAdapter):
                 "⚠️ Command Approval Required", "orange",
                 self._format_exec_approval(command, description, smart_denied), actions=actions,
             )
-            return await self._send_interactive_card(
+            result = await self._send_interactive_card(
                 chat_id, card, metadata, "send_exec_approval failed",
                 state_map=self._approval_state, state_id=approval_id, session_key=session_key,
             )
+            if result.success:
+                # Remember the thread context so follow-up notices (e.g. the
+                # expired-approval hint) land back inside the topic instead of
+                # the main chat area.
+                _thread_meta = {
+                    k: v for k, v in (metadata or {}).items()
+                    if k in ("thread_id", "reply_to_message_id")
+                }
+                if _thread_meta:
+                    self._approval_state[approval_id]["thread_metadata"] = _thread_meta
+            return result
         except Exception as exc:
             logger.warning("[Feishu] send_exec_approval failed: %s", exc)
             return SendResult(success=False, error=str(exc))
@@ -2246,6 +2258,7 @@ class FeishuAdapter(BasePlatformAdapter):
                             _chat,
                             "⌛ That approval had already expired — the command "
                             "was not run (it timed out or was resolved elsewhere).",
+                            metadata=state.get("thread_metadata"),
                         )
                     except Exception:
                         logger.debug("[Feishu] expired-approval notice failed", exc_info=True)
@@ -3614,14 +3627,14 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             request = self._build_create_message_request("thread_id", body)
             response = await self._run_blocking(self._client.im.v1.message.create, request)
-            # Feishu rejects non-text media (image/file/audio) sent with
-            # receive_id_type='thread_id' (code 99992402). Re-send via the
-            # reply API anchored to a message in the thread so the media
-            # still lands inside the topic.
+            # Feishu's create API rejects receive_id_type='thread_id' with
+            # 99992402 for ALL message types — 'thread_id' is not one of the
+            # documented receive_id_type enum values. Re-send via the reply
+            # API anchored to a message in the thread so the message still
+            # lands inside the topic.
             if (
                 not self._response_succeeded(response)
                 and getattr(response, "code", None) == _FEISHU_THREAD_ROUTE_INVALID_CODE
-                and msg_type != "text"
             ):
                 logger.info(
                     "[Feishu] %s send via thread_id rejected (99992402); retrying via reply API in thread",

--- a/tests/gateway/test_feishu_thread_media_routing.py
+++ b/tests/gateway/test_feishu_thread_media_routing.py
@@ -1,0 +1,170 @@
+"""Feishu topic-thread routing: media/anchor metadata and reply-API fallback.
+
+Real-API facts under test (verified against open.feishu.cn):
+- create-message with receive_id_type='thread_id' returns 99992402 for ALL
+  msg_types — 'thread_id' is not a documented receive_id_type enum value.
+- reply API with an in-thread anchor succeeds and lands in the topic.
+
+So the gateway must carry a reply anchor for Feishu thread sends
+(_thread_metadata_for_source), and the adapter must fall back to the reply
+API when a thread_id create is still attempted.
+"""
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.platforms.base import _thread_metadata_for_source
+
+
+def _feishu_source(thread_id="omt_abc123", message_id="om_root", chat_type="group"):
+    return SimpleNamespace(
+        platform=SimpleNamespace(value="feishu") if not isinstance(thread_id, str) else SimpleNamespace(value="feishu"),
+        chat_id="oc_chat1",
+        chat_name="topic group",
+        chat_type=chat_type,
+        user_id="ou_user",
+        user_name="user",
+        thread_id=thread_id,
+        message_id=message_id,
+        reply_to_message_id=None,
+        scope_id=None,
+        is_bot=False,
+    )
+
+
+class TestThreadMetadataForSource:
+    def test_feishu_thread_carries_reply_anchor(self):
+        """Root fix: Feishu thread metadata must carry reply_to_message_id
+        so media sends route through the reply API, not the dead thread_id
+        create path."""
+        source = _feishu_source()
+        meta = _thread_metadata_for_source(source)
+        assert meta["thread_id"] == "omt_abc123"
+        assert meta["reply_to_message_id"] == "om_root"
+
+    def test_feishu_thread_explicit_reply_anchor_wins(self):
+        source = _feishu_source()
+        meta = _thread_metadata_for_source(source, reply_to_message_id="om_parent")
+        assert meta["reply_to_message_id"] == "om_parent"
+
+    def test_feishu_no_thread_no_anchor(self):
+        source = _feishu_source(thread_id=None)
+        meta = _thread_metadata_for_source(source)
+        assert meta in (None, {})
+
+    def test_feishu_thread_without_message_id_has_no_anchor(self):
+        source = _feishu_source(message_id=None)
+        meta = _thread_metadata_for_source(source)
+        assert meta["thread_id"] == "omt_abc123"
+        assert "reply_to_message_id" not in meta
+
+
+class TestSendRawMessageThreadFallback:
+    """_send_raw_message must fall back to the reply API when the thread_id
+    create is rejected with 99992402 — for ALL message types."""
+
+    def _make_adapter(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter, _FEISHU_THREAD_ROUTE_INVALID_CODE
+
+        adapter = object.__new__(FeishuAdapter)
+        self._rejected = SimpleNamespace(code=_FEISHU_THREAD_ROUTE_INVALID_CODE, success=False, msg="field validation failed")
+        self._reply_ok = SimpleNamespace(code=0, success=True, msg="success", data=SimpleNamespace(message_id="om_new"))
+        self._create_fn = SimpleNamespace()  # marker for self._client.im.v1.message.create
+        self._reply_fn = SimpleNamespace()   # marker for self._client.im.v1.message.reply
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(
+                create=self._create_fn, reply=self._reply_fn))),
+        )
+
+        async def fake_run_blocking(fn, req):
+            if fn is self._create_fn:
+                return self._rejected
+            return self._reply_ok
+
+        adapter._run_blocking = fake_run_blocking
+        adapter._build_create_message_body = lambda **kw: kw
+        adapter._build_create_message_request = lambda rtype, body: SimpleNamespace(receive_id_type=rtype)
+        adapter._build_reply_message_body = lambda **kw: kw
+        adapter._build_reply_message_request = lambda anchor, body: SimpleNamespace(anchor=anchor)
+        adapter._response_succeeded = lambda r: getattr(r, "code", None) == 0
+        adapter._fetch_last_message_in_thread = AsyncMock(return_value="om_anchor")
+        return adapter
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("msg_type,payload", [
+        ("image", '{"image_key": "img_v3_x"}'),
+        ("text", '{"text": "hi"}'),
+        ("post", '{"post": {}}'),
+        ("interactive", '{}'),
+    ])
+    async def test_rejected_thread_create_falls_back_to_reply(self, msg_type, payload):
+        adapter = self._make_adapter()
+        response = await adapter._send_raw_message(
+            chat_id="oc_chat1",
+            msg_type=msg_type,
+            payload=payload,
+            reply_to=None,
+            metadata={"thread_id": "omt_abc123"},
+        )
+        assert getattr(response, "code", None) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_anchor_returns_original_failure(self):
+        adapter = self._make_adapter()
+        adapter._fetch_last_message_in_thread = AsyncMock(return_value=None)
+        from plugins.platforms.feishu.adapter import _FEISHU_THREAD_ROUTE_INVALID_CODE
+
+        response = await adapter._send_raw_message(
+            chat_id="oc_chat1",
+            msg_type="image",
+            payload='{"image_key": "img_v3_x"}',
+            reply_to=None,
+            metadata={"thread_id": "omt_abc123"},
+        )
+        assert getattr(response, "code", None) == _FEISHU_THREAD_ROUTE_INVALID_CODE
+
+
+class TestApprovalExpiredNoticeThreadRouting:
+    """The expired-approval notice must reuse the approval card's thread
+    metadata so it lands in the topic, not the main chat."""
+
+    @pytest.mark.asyncio
+    async def test_notice_carries_thread_metadata(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._approval_state = {
+            1: {
+                "session_key": "feishu:oc_chat1:omt_abc123",
+                "message_id": "om_card",
+                "chat_id": "oc_chat1",
+                "thread_metadata": {"thread_id": "omt_abc123", "reply_to_message_id": "om_root"},
+            },
+        }
+        adapter._is_interactive_operator_authorized = lambda open_id: True
+        sent = {}
+
+        def fake_resolve(session_key, choice):
+            return 0
+
+        async def fake_send(chat_id, content, reply_to=None, metadata=None):
+            sent["metadata"] = metadata
+            return SimpleNamespace(success=True)
+
+        import tools.approval as approval_mod
+        original = approval_mod.resolve_gateway_approval
+        approval_mod.resolve_gateway_approval = fake_resolve
+        adapter.send = fake_send
+        try:
+            await adapter._resolve_approval(
+                approval_id=1, choice="approve_once",
+                user_name="user", open_id="ou_user", chat_id="oc_chat1",
+            )
+        finally:
+            approval_mod.resolve_gateway_approval = original
+
+        assert sent["metadata"] == {"thread_id": "omt_abc123", "reply_to_message_id": "om_root"}


### PR DESCRIPTION
## Problem

In Feishu topic groups (threads), image/file sends failed 100% with:

```
[Feishu] Failed to send image: [99992402] field validation failed
```

Non-text media in topics silently never reached the user. Separately,
the "approval had already expired" notice landed in the main chat area
instead of the topic the approval card lives in.

## Root cause (verified against the real OpenAPI, not inferred)

Feishu's create-message API rejects `receive_id_type='thread_id'` with
99992402 for **ALL** message types — `thread_id` is not one of the
documented enum values (`open_id/union_id/user_id/email/chat_id`). The
API response's `field_violations` points at `receive_id_type` itself,
not `msg_type`.

Text replies still worked in topics only because streaming metadata
carries a `reply_to_message_id` anchor, which routes sends through the
reply API before the thread_id create path is reached. Media sends
build metadata via `_thread_metadata_for_source()`, which dropped the
computed anchor for Feishu (only Telegram DM topics carried it), so
media fell through to the dead thread_id create path.

## Fix

1. `gateway/platforms/base.py` — `_thread_metadata_for_source()` now
   carries `reply_to_message_id` for Feishu thread sends, mirroring the
   Telegram DM topic handling. Root-cause fix: media sends route
   through the reply API and land inside the topic.
2. `plugins/platforms/feishu/adapter.py` — `_send_raw_message()` keeps
   a fallback: if a thread_id create is still attempted and rejected
   with 99992402, re-send via the reply API anchored to the last
   message in the thread (safety net for anchor-less sends, e.g. empty
   threads). Applies to all msg_types since the rejection is not
   type-specific.
3. `plugins/platforms/feishu/adapter.py` — the approval card send now
   records its thread metadata in `_approval_state`, and the
   expired-approval notice reuses it so the notice lands back in the
   topic.

## Testing

- Real-API verification: create with `receive_id_type=thread_id`
  returns 99992402 for text/image/file alike; reply with an in-thread
  anchor succeeds for text and image, GetMessage confirms the reply
  lands in the topic (`thread_id` preserved).
- New unit tests (10 cases) in
  `tests/gateway/test_feishu_thread_media_routing.py`: anchor metadata
  construction, reply-API fallback across msg_types, no-anchor safety,
  approval-notice thread routing.
- Existing suites green: `test_telegram_thread_fallback.py` (20
  passed), feishu gateway tests (224 passed, 1 skipped).
