### PR TITLE
fix: resumed MoA requests no longer leak private metadata

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2430,6 +2430,9 @@ def _relay_sync_completion(
     client: Any, kwargs: dict[str, Any], *, provider: str | None = None,
     api_mode: str | None = None, create: Callable[[dict[str, Any]], Any] | None = None,
 ) -> Any:
+    from agent.auxiliary_wire import prepare_chat_messages
+
+    kwargs = prepare_chat_messages(client, kwargs)
     callback = create or (lambda request: client.chat.completions.create(**request))
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     # Isolate only the provider callback so the owning thread can unwind its lease/DB
@@ -2449,6 +2452,9 @@ async def _relay_async_completion(
     client: Any, kwargs: dict[str, Any], *, provider: str | None = None,
     api_mode: str | None = None, create: Callable[[dict[str, Any]], Any] | None = None,
 ) -> Any:
+    from agent.auxiliary_wire import prepare_chat_messages
+
+    kwargs = prepare_chat_messages(client, kwargs)
     callback = create or (lambda request: client.chat.completions.create(**request))
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     if route is None:
@@ -2464,6 +2470,9 @@ async def _relay_async_completion(
 def _relay_sync_stream(
     client: Any, kwargs: dict[str, Any], *, provider: str | None = None, api_mode: str | None = None
 ) -> Any:
+    from agent.auxiliary_wire import prepare_chat_messages
+
+    kwargs = prepare_chat_messages(client, kwargs)
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     if route is None:
         return client.chat.completions.create(**kwargs)

--- a/agent/auxiliary_wire.py
+++ b/agent/auxiliary_wire.py
@@ -1,0 +1,20 @@
+"""Message hygiene at the resolved auxiliary client boundary."""
+
+from openai import AsyncOpenAI, OpenAI
+
+from agent.transports.chat_completions import ChatCompletionsTransport
+
+
+def prepare_chat_messages(client, kwargs: dict) -> dict:
+    """Sanitize actual Chat Completions SDK requests, not native adapter replay.
+
+    Auxiliary and MoA callers can retain a prepared request before the virtual
+    transport sanitizes its copy. The resolved SDK client identifies the wire;
+    native Messages/Responses adapters must retain their reasoning sidecars.
+    """
+    if not isinstance(client, (OpenAI, AsyncOpenAI)) or "messages" not in kwargs:
+        return kwargs
+    messages = ChatCompletionsTransport().convert_messages(
+        kwargs["messages"], model=kwargs.get("model")
+    )
+    return {**kwargs, "messages": messages}

--- a/evals/provider_wire/issue_104359.py
+++ b/evals/provider_wire/issue_104359.py
@@ -1,0 +1,201 @@
+"""Offline production-path wire probe; only loopback HTTP is permitted."""
+
+import os, sys, tempfile, json, socket, threading, copy
+from pathlib import Path
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+
+root = Path(sys.argv[1]).resolve()
+home = tempfile.mkdtemp(prefix="hermes-104359-")
+os.environ.clear()
+os.environ.update(
+    HOME=home,
+    HERMES_HOME=home + "/.hermes",
+    PATH="/usr/bin:/bin",
+    PYTHONDONTWRITEBYTECODE="1",
+    NO_PROXY="*",
+)
+sys.dont_write_bytecode = True
+sys.path.insert(0, str(root))
+os.chdir(home)
+Path(os.environ["HERMES_HOME"]).mkdir()
+# Prevent accidental provider/model metadata egress, even during production imports.
+connect = socket.socket.connect
+blocked = []
+
+
+def local_connect(self, address):
+    if isinstance(address, tuple) and address[0] not in (
+        "127.0.0.1",
+        "::1",
+        "localhost",
+    ):
+        blocked.append(str(address))
+        raise RuntimeError("Non-loopback network blocked")
+    return connect(self, address)
+
+
+socket.socket.connect = local_connect
+captures = []
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        leaks = [
+            f"messages.{i}.{k}"
+            for i, m in enumerate(body.get("messages", []))
+            for k in m
+            if k.startswith("_")
+        ]
+        status = 400 if leaks else 200
+        captures.append({
+            "path": self.path,
+            "status": status,
+            "leaks": leaks,
+            "body": body,
+        })
+        response = (
+            {
+                "error": {
+                    "message": leaks[0] + ": Extra inputs are not permitted",
+                    "type": "invalid_request_error",
+                }
+            }
+            if leaks
+            else {
+                "id": "local-fixture",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "probe-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "local fixture response",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            }
+        )
+        data = json.dumps(response).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+url = f"http://127.0.0.1:{server.server_port}/v1"
+config = {
+    "model": {"provider": "probe-local", "default": "probe-model"},
+    "providers": {
+        "probe-local": {
+            "base_url": url,
+            "api_key": "no-key-required",
+            "api_mode": "chat_completions",
+        }
+    },
+    "moa": {
+        "default_preset": "probe",
+        "presets": {
+            "probe": {
+                "enabled": True,
+                "reference_models": [
+                    {"provider": "probe-local", "model": "probe-model"}
+                ],
+                "aggregator": {"provider": "probe-local", "model": "probe-model"},
+            }
+        },
+    },
+    "prompt_caching": {"enabled": False},
+}
+import yaml
+
+Path(os.environ["HERMES_HOME"], "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+from hermes_state import SessionDB
+from agent.moa_loop import MoAClient
+from agent.turn_request_assembly import _prepare_moa_request
+from agent.transports.chat_completions import ChatCompletionsTransport
+from types import SimpleNamespace
+from openai import OpenAI
+
+db = SessionDB(Path(os.environ["HERMES_HOME"]) / "state.db")
+db.create_session("probe-session", source="cli")
+db.append_message("probe-session", "user", "Remember this token")
+db.append_message("probe-session", "assistant", "Acknowledged")
+history = db.get_messages_as_conversation("probe-session")
+assert all(m.get("_db_persisted") for m in history)
+messages = [
+    {"role": "system", "content": "You are a test assistant"},
+    *history,
+    {"role": "user", "content": "Continue"},
+]
+original = copy.deepcopy(messages)
+client = MoAClient("probe")
+prepared, api_messages, pending = _prepare_moa_request(
+    SimpleNamespace(client=client), messages, None
+)
+transport = ChatCompletionsTransport()
+kwargs = transport.build_kwargs("probe", api_messages)
+assert not any("_db_persisted" in m for m in kwargs["messages"])
+assert any("_db_persisted" in m for m in prepared["messages"])
+kwargs["_moa_prepared_request"] = prepared
+outcomes = {}
+try:
+    client.chat.completions.create(**kwargs)
+    outcomes["moa"] = "success"
+except Exception as exc:
+    outcomes["moa"] = {"type": type(exc).__name__, "message": str(exc)}
+# Identical request after the normal transport sanitation succeeds on same strict local endpoint.
+normal = OpenAI(base_url=url, api_key="no-key-required", max_retries=0)
+result = normal.chat.completions.create(
+    **transport.build_kwargs("probe-model", messages)
+)
+outcomes["direct"] = result.choices[0].message.content
+assert messages == original
+assert (outcomes["moa"] == "success") == (sys.argv[2] == "fixed")
+assert captures[-1]["status"] == 200
+assert any(
+    c["status"] == 200 and "advis" in json.dumps(c["body"]).lower()
+    for c in captures[:-1]
+)
+print(
+    json.dumps(
+        {
+            "repo": str(root),
+            "isolated_home": home,
+            "db_loaded_messages": history,
+            "prepared_marker_present": True,
+            "normal_transport_marker_absent": True,
+            "history_unchanged": messages == original,
+            "outcomes": outcomes,
+            "captures": captures,
+            "blocked_nonloopback_attempts": blocked,
+            "production_imports": {
+                name: sys.modules[name].__file__
+                for name in [
+                    "hermes_state",
+                    "agent.moa_loop",
+                    "agent.auxiliary_client",
+                    "agent.turn_request_assembly",
+                    "agent.transports.chat_completions",
+                ]
+            },
+        },
+        indent=2,
+    )
+)
+server.shutdown()
+db.close()

--- a/tests/agent/test_auxiliary_wire_messages.py
+++ b/tests/agent/test_auxiliary_wire_messages.py
@@ -1,0 +1,49 @@
+"""The final auxiliary destination owns message sanitation, not virtual MoA."""
+import asyncio
+import copy
+from types import SimpleNamespace
+
+import pytest
+from openai import AsyncOpenAI, OpenAI
+
+from agent.auxiliary_client import _relay_async_completion, _relay_sync_completion
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+def test_auxiliary_chat_wire_sanitizes_without_mutating_history(async_mode):
+    history = [{"role": "assistant", "content": "answer", "_db_persisted": True,
+                "timestamp": 12, "tool_calls": [], "reasoning": "private"}]
+    original = copy.deepcopy(history)
+    kwargs = {"model": "fixture-model", "messages": history}
+    captured = []
+    if async_mode:
+        async def run():
+            async with AsyncOpenAI(api_key="fixture", base_url="http://127.0.0.1:1/v1") as client:
+                async def send(request):
+                    captured.append(request)
+                await _relay_async_completion(client, kwargs, create=send)
+        asyncio.run(run())
+    else:
+        with OpenAI(api_key="fixture", base_url="http://127.0.0.1:1/v1") as client:
+            _relay_sync_completion(client, kwargs, create=captured.append)
+    assert captured[0]["messages"] == [{"role": "assistant", "content": "answer"}]
+    assert kwargs["messages"] == original
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+def test_auxiliary_native_adapters_keep_replay_and_tool_fields(async_mode):
+    history = [{"role": "assistant", "content": "", "_db_persisted": True,
+                "codex_reasoning_items": [{"type": "reasoning", "id": "rs_fixture"}],
+                "thinking_blocks": [{"type": "thinking", "thinking": "native", "signature": "sig"}],
+                "tool_calls": [{"id": "call_fixture", "type": "function",
+                                "function": {"name": "fixture", "arguments": "{}"}}]}]
+    kwargs = {"model": "native", "messages": history}
+    captured = []
+    if async_mode:
+        async def send(request):
+            captured.append(request)
+        asyncio.run(_relay_async_completion(SimpleNamespace(), kwargs, create=send))
+    else:
+        _relay_sync_completion(SimpleNamespace(), kwargs, create=captured.append)
+    assert captured[0] is kwargs
+    assert captured[0]["messages"] is history

--- a/tests/agent/test_auxiliary_wire_messages.py
+++ b/tests/agent/test_auxiliary_wire_messages.py
@@ -26,7 +26,9 @@ def test_auxiliary_chat_wire_sanitizes_without_mutating_history(async_mode):
     else:
         with OpenAI(api_key="fixture", base_url="http://127.0.0.1:1/v1") as client:
             _relay_sync_completion(client, kwargs, create=captured.append)
-    assert captured[0]["messages"] == [{"role": "assistant", "content": "answer"}]
+    assert captured[0]["messages"] == [
+        {"role": "assistant", "content": "answer", "reasoning": "private"}
+    ]
     assert kwargs["messages"] == original
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -126,7 +126,11 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
             self.entered = threading.Event()
             self.release = threading.Event()
             self.calls = 0
+            self.token_flushes = 0
             self._lock = threading.Lock()
+
+        def flush_token_counts(self):
+            self.token_flushes += 1
 
         def append_message(self, **kwargs):
             with self._lock:
@@ -178,6 +182,7 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
     assert not normal.is_alive()
     assert not direct.is_alive()
     assert db.rows == ["exactly once"]
+    assert db.token_flushes == 1
 
 
 def test_malformed_memory_config_still_builds_default_store():


### PR DESCRIPTION
Resumed MoA requests no longer leak internal persistence metadata to strict aggregator endpoints.

Campaign: https://github.com/NousResearch/hermes-agent/issues/104904

## Changes
- sync/async/stream auxiliary dispatch.
- Root cause: Prepared requests bypass normal transport copy; sanitize the resolved OpenAI SDK destination without altering native adapters.
- Credit: Boundary approach PR #87840 @Lee-Si-Yoon; broader auxiliary implementation with co-author credit.

## Validation
**Live repro:** before — strict aggregator HTTP 400. After — strict aggregator HTTP 200; normal/advisor controls 200; history unchanged; native Codex encrypted reasoning + function call/output replay survives actual localhost Responses HTTP before and after.

Fidelity: production imports + real SQLite resume + localhost OpenAI SDK HTTP, not live CLI/vendor. Credential-free fixture completions, not vendor inference.

Reusable A/B: `python evals/provider_wire/issue_104359.py REPO_PATH main|fixed`. Baseline SHA: `7874ef9f62b9b533f8d3da6107eb2a52f4be252f`.

Independent read-only review: no blockers. Ruff, Windows footguns and compatibility-pointer checks passed.

**Targeted tests: 208 passed, 0 failed across 3 files** (serial, shared campaign lock): `flock /tmp/hermes-e461-fix-tests.lock bash scripts/run_tests.sh -j 1 tests/agent/test_auxiliary_wire_messages.py tests/agent/test_moa_slot_api_mode.py tests/agent/test_auxiliary_client.py`. The campaign parent owns broad directory integration verification; that separate gate is not claimed complete here.

Fixes #104359.

## Infographic
![Provider wire fixes](https://v3b.fal.media/files/b/0aa9736e/VwkyYHGwmsewqy_Cu5G7B_oN5xc1Tl.png)
