### PR TITLE
fix(cli): planned gateway restarts no longer trigger failure alerts (#104251, salvage #104272)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2812,6 +2812,7 @@ Environment="HERMES_SUPERVISED_CHILD=1"
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -258,6 +258,21 @@ class TestGeneratedSystemdUnits:
         unit = gateway_cli.generate_systemd_unit(system=False)
         assert "TimeoutStopSec=60" in unit
 
+    def test_restart_exit_code_is_also_declared_a_success_status(self):
+        """#104251: a planned restart (gateway/restart.py's exit 75) is force-restarted
+        via RestartForceExitStatus, but without SuccessExitStatus=75 too, systemd still
+        classifies the exit as a failure -- the unit flips to ``failed``/``Result=exit-code``
+        and any OnFailure= alert unit fires on every routine restart (hermes update,
+        hermes gateway restart, the in-app restart). SuccessExitStatus=75 keeps the same
+        force-restart behavior while letting the unit land back in ``active``/``success``,
+        so OnFailure= stays reserved for actual failures."""
+        unit = gateway_cli.generate_systemd_unit(system=False)
+        assert f"SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        # Must still force an actual restart on that exit code -- SuccessExitStatus alone
+        # would otherwise let the process stay stopped instead of being relaunched.
+        assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert f"RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}" in unit
+
     def test_unit_stop_budget_beats_drain_only_formula_with_real_loaders(
         self, monkeypatch
     ):


### PR DESCRIPTION
Planned systemd gateway restarts no longer trigger `OnFailure` alerts, while fatal configuration exits still do.

- Add the planned restart code to `SuccessExitStatus`; retain `RestartForceExitStatus`, `RestartPreventExitStatus`, restart policy, and legacy-unit recovery behavior.
- Pin the generated-policy relationship in one regression test.

Root cause: systemd classified exit 75 as a failure before restarting because the generated unit did not declare it successful. This does not claim to fix a start-limit wedge; the limiter is already disabled.

**Live repro:** native Linux systemd 259.5 user manager (`SystemState=degraded`, reachable). Disposable, task-owned workers used restart directives from the real generator:

| Scenario | Before | After |
|---|---|---|
| Planned exit 75 | Restarted once; real `OnFailure` alert fired | Restarted once; no alert |
| Fatal exit 78 | Failed, alert fired, no restart | Same |

No real user gateway was restarted. Owned units were stopped and the alert template removed. The short probe uses `RestartSec=0.2` rather than 5 seconds; no gateway application is launched.

Validation: `scripts/run_tests.sh -j 1 tests/hermes_cli/test_gateway_service.py` under the shared test lock: **104 passed, 0 failed, 1 skipped**. Ruff, Windows-footgun, compatibility-pointer, subprocess-stdin, and diff checks passed. Independent read-only review: no findings. Broader directory integration is coordinated by the campaign parent.

Salvaged from #104272 by @Edizzier, with authorship preserved. Earlier analysis in #13604 by @jkausel-ai; #104655 is a later duplicate.

Fixes #104251
Campaign: #104904

## Infographic
![Reliable updates: planned restart, cleanup, recovery and passive checks](https://v3b.fal.media/files/b/0aa97388/cXMPjNPhGDl_fmKPjlaC8_tS3RrZp9.png)
