### PR TITLE
fix: file sync preserves host saves during upload (#103998)

### DIFF
--- a/tests/tools/test_file_sync.py
+++ b/tests/tools/test_file_sync.py
@@ -280,8 +280,8 @@ class TestConcurrency:
                 for path in sorted(tmp_path.glob("*.png"))
             ]
 
-        def upload(host_path, _remote_path):
-            if host_path == str(new_file):
+        def upload(_host_path, remote_path):
+            if remote_path == f"/root/.hermes/cache/images/{new_file.name}":
                 upload_started.set()
                 sync_back_transport_started.wait(timeout=1.0)
                 release_upload.set()

--- a/tests/tools/test_file_sync.py
+++ b/tests/tools/test_file_sync.py
@@ -20,7 +20,7 @@ def tmp_files(tmp_path):
     files = {}
     for name in ("cred_a.json", "cred_b.json", "skill_main.py"):
         p = tmp_path / name
-        p.write_text(f"content of {name}")
+        p.write_text(f"content of {name}", encoding="utf-8")
         files[name] = str(p)
     return files
 
@@ -70,7 +70,7 @@ class TestMtimeSkip:
 
         # Add a new file
         new_file = tmp_path / "new_skill.py"
-        new_file.write_text("new content")
+        new_file.write_text("new content", encoding="utf-8")
         tmp_files["new_skill.py"] = str(new_file)
         # Recreate manager with updated file list
         mgr._get_files_fn = _make_get_files(tmp_files)
@@ -185,7 +185,7 @@ class TestRateLimiting:
         upload.reset_mock()
 
         new_file = tmp_path / "env_forced.txt"
-        new_file.write_text("env forced")
+        new_file.write_text("env forced", encoding="utf-8")
         tmp_files["env_forced.txt"] = str(new_file)
         mgr._get_files_fn = _make_get_files(tmp_files)
 
@@ -247,7 +247,7 @@ class TestEdgeCases:
     def test_file_disappears_between_list_and_upload(self, tmp_path):
         """File listed by get_files but deleted before _file_mtime_key reads it."""
         f = tmp_path / "ephemeral.txt"
-        f.write_text("here now")
+        f.write_text("here now", encoding="utf-8")
 
         upload = MagicMock()
         mgr = FileSyncManager(

--- a/tests/tools/test_file_sync_upload_snapshot.py
+++ b/tests/tools/test_file_sync_upload_snapshot.py
@@ -1,0 +1,52 @@
+"""Upload hashes must describe the bytes received by the remote sandbox."""
+
+import hashlib
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from tools.environments.file_sync import FileSyncManager
+
+
+@pytest.mark.parametrize("bulk", [False, True])
+@pytest.mark.parametrize("edit_before_read", [False, True])
+def test_host_save_during_upload_survives_unchanged_remote(
+    tmp_path, monkeypatch, bulk, edit_before_read,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    host = tmp_path / "home" / "skills" / "example" / "SKILL.md"
+    host.parent.mkdir(parents=True)
+    host.write_bytes(b"original skill")
+    remote_path = "/root/.hermes/skills/example/SKILL.md"
+    remote = tmp_path / "remote.md"
+
+    def upload(source, destination):
+        assert destination == remote_path
+        if edit_before_read:
+            host.write_bytes(b"saved while upload is starting")
+        remote.write_bytes(Path(source).read_bytes())
+        host.write_bytes(b"new local version saved before upload acknowledgement")
+
+    def download(destination):
+        with tarfile.open(destination, "w") as archive:
+            archive.add(remote, arcname=remote_path.lstrip("/"))
+
+    manager = FileSyncManager(
+        get_files_fn=lambda: [(str(host), remote_path)],
+        upload_fn=upload,
+        bulk_upload_fn=(lambda files: [upload(*pair) for pair in files]) if bulk else None,
+        delete_fn=lambda paths: None,
+        bulk_download_fn=download,
+    )
+    manager.sync(force=True)
+    saved = host.read_bytes()
+    assert manager._pushed_hashes[remote_path] == hashlib.sha256(remote.read_bytes()).hexdigest()
+    manager.sync_back()
+    assert host.read_bytes() == saved
+
+    # A subsequent cycle still detects and uploads the newer local version.
+    manager._upload_fn = lambda source, destination: remote.write_bytes(Path(source).read_bytes())
+    manager._bulk_upload_fn = None
+    manager.sync(force=True)
+    assert remote.read_bytes() == saved

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -162,10 +162,19 @@ class FileSyncManager:
         prev_files = dict(self._synced_files)
         prev_hashes = dict(self._pushed_hashes)
         try:
-            self._push(to_upload, to_delete)
+            # Hash and upload the same bytes: the original may be saved while
+            # the transport is reading it or waiting for remote acknowledgement.
+            with tempfile.TemporaryDirectory(prefix="hermes-sync-push-") as staging:
+                staged_files = []
+                pushed_hashes = {}
+                for index, (host_path, remote_path) in enumerate(to_upload):
+                    staged_path = os.path.join(staging, str(index))
+                    shutil.copy2(host_path, staged_path)
+                    pushed_hashes[remote_path] = _sha256_file(staged_path)
+                    staged_files.append((staged_path, remote_path))
+                self._push(staged_files, to_delete)
             # Commit (all succeeded).
-            for host_path, remote_path in to_upload:
-                self._pushed_hashes[remote_path] = _sha256_file(host_path)
+            self._pushed_hashes.update(pushed_hashes)
             for p in to_delete:
                 new_files.pop(p, None)
                 self._pushed_hashes.pop(p, None)


### PR DESCRIPTION
File sync now preserves host saves made during upload instead of overwriting them with unchanged remote content.

Fixes #103998. Campaign: #104904. Salvages #103999 by @Liuzikaii with original commit authorship preserved.

## Changes
- Stage each upload in a private temporary directory, hash that snapshot, and upload the same bytes for both single and bulk transports.
- Keep the host-path change tracker and transaction rollback behavior intact.
- Add a parameterized invariant covering saves before transport reads and before upload acknowledgement, plus subsequent upload of the newer local version.
- Adapt the concurrency fixture to identify the remote destination and explicitly encode its existing text fixtures as UTF-8.

Root cause: upload acknowledgement hashed mutable host paths, so the sync-back baseline could describe a newer host save rather than the bytes actually uploaded.

## Validation
**Live repro:** production `FileSyncManager`, real filesystem copies, hashes and tar download transport, fresh interpreters with isolated HOME/HERMES_HOME on native Linux; no predicate mocks or remote-service claims.

| Check | Main `d8a07768c5ee` | Fixed branch |
| --- | --- | --- |
| Save during upload, single and bulk (four race cases) | New host save overwritten in 4/4 | New host save preserved in 4/4 |
| Baseline hash matches uploaded snapshot (six scenarios) | Mismatch in four races | Matches in 6/6 |
| Host save after acknowledgement (two controls) | Preserved | Preserved |
| Subsequent remote edit (six controls) | Applied | Applied |

- Canonical targeted regressions: **19 passed, 0 failed**, two files, `scripts/run_tests.sh tests/tools/test_file_sync.py tests/tools/test_file_sync_upload_snapshot.py -j 1 --file-retries 0`, serialized through the campaign flock.
- Independent read-only review: no actionable correctness findings.
- Ruff, Windows-footgun diff gate, compat-pointer and subprocess-stdin checks, attribution mapping, and whitespace checks passed.
- Full `tests/tools/` directory remains pending the parent campaign integration harness; native Windows and real remote-service validation were not run. CI pending.

## Infographic
![File sync preserves host saves](https://v3b.fal.media/files/b/0aa97392/svGVGiQPNHfOsw600NUfq_JbsvVksx.png)
