### PR TITLE
fix(kanban): watch identifies its initial board (#104242)

### DIFF
--- a/hermes_cli/kanban_ops.py
+++ b/hermes_cli/kanban_ops.py
@@ -249,7 +249,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
 def _cmd_watch(args: argparse.Namespace) -> int:
     """Live-stream task_events to the terminal."""
     kinds = {k.strip() for k in args.kinds.split(",") if k.strip()} if args.kinds else None
-    print("Watching kanban events. Ctrl-C to stop.", flush=True)
+    print(f"Watching kanban events on board '{kb.get_current_board()}'. Ctrl-C to stop.", flush=True)
     # Seed cursor at the latest id so we don't replay history.
     with kbc.connect_closing() as conn:
         cursor = int(conn.execute("SELECT COALESCE(MAX(id), 0) AS m FROM task_events").fetchone()["m"])

--- a/hermes_cli/kanban_ops.py
+++ b/hermes_cli/kanban_ops.py
@@ -249,7 +249,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
 def _cmd_watch(args: argparse.Namespace) -> int:
     """Live-stream task_events to the terminal."""
     kinds = {k.strip() for k in args.kinds.split(",") if k.strip()} if args.kinds else None
-    print(f"Watching kanban events on board '{kb.get_current_board()}'. Ctrl-C to stop.", flush=True)
+    print(f"Watching kanban events (initial board '{kb.get_current_board()}'). Ctrl-C to stop.", flush=True)
     # Seed cursor at the latest id so we don't replay history.
     with kbc.connect_closing() as conn:
         cursor = int(conn.execute("SELECT COALESCE(MAX(id), 0) AS m FROM task_events").fetchone()["m"])

--- a/tests/hermes_cli/test_kanban_watch_banner.py
+++ b/tests/hermes_cli/test_kanban_watch_banner.py
@@ -16,8 +16,11 @@ from hermes_cli.kanban_parser import build_parser
 )
 def test_watch_names_resolved_board(tmp_path, monkeypatch, capsys, environment, explicit, expected):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
     monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    kb.create_board("alpha")
+    kb.create_board("beta")
     kb.set_current_board("alpha")
     if environment:
         monkeypatch.setenv("HERMES_KANBAN_BOARD", environment)

--- a/tests/hermes_cli/test_kanban_watch_banner.py
+++ b/tests/hermes_cli/test_kanban_watch_banner.py
@@ -33,4 +33,4 @@ def test_watch_names_resolved_board(tmp_path, monkeypatch, capsys, environment, 
 
     monkeypatch.setattr(kanban_ops.time, "sleep", interrupt)
     assert kanban_command(parser.parse_args(argv)) == 0
-    assert f"board '{expected}'" in capsys.readouterr().out
+    assert f"initial board '{expected}'" in capsys.readouterr().out

--- a/tests/hermes_cli/test_kanban_watch_banner.py
+++ b/tests/hermes_cli/test_kanban_watch_banner.py
@@ -1,0 +1,33 @@
+"""Watch identifies the board selected by the production command parser."""
+
+import argparse
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_ops
+from hermes_cli.kanban import kanban_command
+from hermes_cli.kanban_parser import build_parser
+
+
+@pytest.mark.parametrize(
+    "environment,explicit,expected",
+    [(None, None, "alpha"), ("beta", None, "beta"), ("alpha", "beta", "beta")],
+)
+def test_watch_names_resolved_board(tmp_path, monkeypatch, capsys, environment, explicit, expected):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    kb.set_current_board("alpha")
+    if environment:
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", environment)
+    parser = argparse.ArgumentParser()
+    build_parser(parser.add_subparsers())
+    argv = ["kanban"] + (["--board", explicit] if explicit else []) + ["watch"]
+
+    def interrupt(_interval):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(kanban_ops.time, "sleep", interrupt)
+    assert kanban_command(parser.parse_args(argv)) == 0
+    assert f"board '{expected}'" in capsys.readouterr().out


### PR DESCRIPTION
Kanban watch now names its resolved initial board at startup, so a wrong-board subscription is visible immediately.

Fixes #104242, following the reporter's [narrowed diagnosis](https://github.com/NousResearch/hermes-agent/issues/104242#issuecomment-5559192560). Campaign: #104904.

## Changes
- Use the existing board resolver in the flushed startup banner; no path inference or new routing logic.
- Explicitly say **initial board**: an unscoped watch already follows later persisted-current-board changes, and this patch does not change that behavior.
- Cover persisted current-board selection, environment selection, and explicit `--board` precedence in one parameterized invariant test.

Root cause: the startup message omitted the board that the command had already resolved, making a wrong-board watch look like delayed event delivery. The reporter retracted the original latency claim; this patch does not alter buffering, polling, gateways, or task dispatch.

## Validation
**Live repro:** fresh production CLI parser/command subprocesses attached to real PTYs, isolated HOME/HERMES_HOME, real SQLite stores, and no model or daemon.

| Scenario | Main | Fixed |
|---|---|---|
| Persisted alpha, environment beta, explicit beta | All three banners omit the board | All three name the correct initial board |
| Complete a task on the selected board | Event arrives while watch remains running | Same |
| Complete beta while watching alpha | No beta event | Same |
| Switch persisted board after startup | Unscoped watch follows the switch | Same; banner explicitly describes initial selection |
| Regression test against main | 3 failed on missing board text | 3 passed, 0 failed |

Targeted tests use `scripts/run_tests.sh -j 1 tests/hermes_cli/test_kanban_watch_banner.py` under the shared campaign flock. Ruff, Windows-footgun, plugin-compat-pointer, and whitespace checks pass. Broad `tests/hermes_cli/` integration is owned by the campaign coordinator and is not claimed by this focused receipt.

Independent read-only review identified that an unscoped watcher can change boards after startup; the banner wording was tightened to a point-in-time statement rather than changing existing watch semantics. No additional design blocker was found in the follow-up review.

## Credit
Slim adaptation of [anombyte93/hermes-agent@d06d2a49c5](https://github.com/anombyte93/hermes-agent/commit/d06d2a49c5), retaining contributor co-authorship. Related buffering PR #104352 does not address the narrowed board-banner defect.

## Infographic
![Kanban watch names its initial board](https://v3b.fal.media/files/b/0aa97395/wx1eN5iHBZn6udkQ4gHZp_7T4TeXIl.png)
