### PR TITLE
perf: session search batches indexed context lookups

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -966,7 +966,7 @@ class SessionSearchMixin:
                 batch = matches[start:start + 500]
                 contexts = {match["id"]: [] for match in batch}
                 try:
-                    sql = _CONTEXT_WINDOW_SQL.format(ids=",".join("?" for _ in batch))
+                    sql = _CONTEXT_WINDOW_SQL.format(ids=",".join("?" for _ in contexts))
                     with self._read_ctx() as conn:
                         rows = conn.execute(sql, list(contexts)).fetchall()
                     for row in rows:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -970,14 +970,16 @@ class SessionSearchMixin:
                     with self._read_ctx() as conn:
                         rows = conn.execute(sql, list(contexts)).fetchall()
                     for row in rows:
-                        contexts[row["match_id"]].append({
-                            "role": row["role"],
-                            "content": _flatten_text(self._decode_content(row["content"]))[:200],
-                        })
+                        contexts[row["match_id"]].append(row)
                 except Exception:
                     contexts = {}
                 for match in batch:
-                    match["context"] = contexts.get(match["id"], [])
+                    try:
+                        match["context"] = [
+                            {"role": row["role"], "content": _flatten_text(self._decode_content(row["content"]))[:200]}
+                            for row in contexts.get(match["id"], [])]
+                    except Exception:
+                        match["context"] = []
         # No route selects full content; the pop guards any future one that does.
         for match in matches:
             match.pop("content", None)

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -47,37 +47,21 @@ _LIKE_COALESCED_COLUMN_SQL = (
 )
 # ``sort`` -> ORDER BY for the FTS routes; unknown values are rank-only (user input passes through).
 _FTS_ORDER_BY = {"newest": "ORDER BY m.timestamp DESC, rank", "oldest": "ORDER BY m.timestamp ASC, rank"}
-# One row before + the hit + one row after, in (timestamp, id) order.
+# Indexed neighbor seeks avoid scanning whole sessions for a sparse set of hits.
 _CONTEXT_WINDOW_SQL = """WITH target AS (
-                               SELECT session_id, timestamp, id
-                               FROM messages
-                               WHERE id = ?
-                           )
-                           SELECT role, content
-                           FROM (
-                               SELECT m.id, m.timestamp, m.role, m.content
-                               FROM messages m
-                               JOIN target t ON t.session_id = m.session_id
-                               WHERE (m.timestamp < t.timestamp)
-                                  OR (m.timestamp = t.timestamp AND m.id < t.id)
-                               ORDER BY m.timestamp DESC, m.id DESC
-                               LIMIT 1
-                           )
-                           UNION ALL
-                           SELECT role, content
-                           FROM messages
-                           WHERE id = ?
-                           UNION ALL
-                           SELECT role, content
-                           FROM (
-                               SELECT m.id, m.timestamp, m.role, m.content
-                               FROM messages m
-                               JOIN target t ON t.session_id = m.session_id
-                               WHERE (m.timestamp > t.timestamp)
-                                  OR (m.timestamp = t.timestamp AND m.id > t.id)
-                               ORDER BY m.timestamp ASC, m.id ASC
-                               LIMIT 1
-                           )"""
+    SELECT session_id, timestamp, id FROM messages WHERE id IN ({ids})
+)
+SELECT t.id AS match_id, m.role, m.content
+FROM target t JOIN messages m ON m.id IN (
+    t.id,
+    (SELECT p.id FROM messages p
+     WHERE p.session_id = t.session_id AND (p.timestamp, p.id) < (t.timestamp, t.id)
+     ORDER BY p.timestamp DESC, p.id DESC LIMIT 1),
+    (SELECT n.id FROM messages n
+     WHERE n.session_id = t.session_id AND (n.timestamp, n.id) > (t.timestamp, t.id)
+     ORDER BY n.timestamp, n.id LIMIT 1)
+)
+ORDER BY t.id, m.timestamp, m.id"""
 # Unified Ideographs, Extension A, Extension B, CJK Symbols, Hiragana, Katakana, Hangul Syllables.
 _CJK_RANGES = (
     (0x4E00, 0x9FFF), (0x3400, 0x4DBF), (0x20000, 0x2A6DF), (0x3000, 0x303F), (0x3040, 0x309F),
@@ -976,18 +960,24 @@ class SessionSearchMixin:
 
     def _finalize_search_matches(
         self, matches: List[Dict[str, Any]], result_fields: Optional[Collection[str]] = None) -> List[Dict[str, Any]]:
-        """Attach neighboring messages (1 before + after, only when the projection consumes
-        ``context``) and trim full content. Each context query takes its own read txn."""
+        """Attach neighboring messages in bounded batches, only when context is requested."""
         if result_fields is None or "context" in result_fields:
-            for match in matches:
+            for start in range(0, len(matches), 500):
+                batch = matches[start:start + 500]
+                contexts = {match["id"]: [] for match in batch}
                 try:
+                    sql = _CONTEXT_WINDOW_SQL.format(ids=",".join("?" for _ in batch))
                     with self._read_ctx() as conn:
-                        rows = conn.execute(_CONTEXT_WINDOW_SQL, (match["id"], match["id"])).fetchall()
-                        match["context"] = [
-                            {"role": r["role"], "content": _flatten_text(self._decode_content(r["content"]))[:200]}
-                            for r in rows]
+                        rows = conn.execute(sql, list(contexts)).fetchall()
+                    for row in rows:
+                        contexts[row["match_id"]].append({
+                            "role": row["role"],
+                            "content": _flatten_text(self._decode_content(row["content"]))[:200],
+                        })
                 except Exception:
-                    match["context"] = []
+                    contexts = {}
+                for match in batch:
+                    match["context"] = contexts.get(match["id"], [])
         # No route selects full content; the pop guards any future one that does.
         for match in matches:
             match.pop("content", None)

--- a/tests/test_session_search_context_batch.py
+++ b/tests/test_session_search_context_batch.py
@@ -1,0 +1,27 @@
+"""Batched context preserves neighboring rows and projection fast paths."""
+
+from hermes_state import SessionDB
+
+
+def test_search_context_batches_hits_without_cross_session_neighbors(tmp_path):
+    with SessionDB(db_path=tmp_path / "search.db") as db:
+        for sid in ("one", "two"):
+            db.create_session(sid, "cli")
+            for i in range(5):
+                db.append_message(sid, "user", f"{sid} needleprobe {i}")
+        sql = []
+        with db._read_ctx() as conn:
+            conn.set_trace_callback(sql.append)
+        rows = db.search_messages("needleprobe", limit=20)
+        assert len(rows) == 10
+        for row in rows:
+            contents = [r["content"] for r in row["context"]]
+            assert all(c.startswith(row["session_id"]) for c in contents)
+            indices = [int(c.rsplit(" ", 1)[1]) for c in contents]
+            assert indices == list(range(indices[0], indices[-1] + 1))
+            assert len(indices) in (2, 3)
+        assert sum("WITH target AS" in q for q in sql) == 1
+        sql.clear()
+        projected = db.search_messages("needleprobe", fields=["id"], limit=20)
+        assert len(projected) == len(rows)
+        assert not any("WITH target AS" in q for q in sql)

--- a/tests/test_session_search_context_batch.py
+++ b/tests/test_session_search_context_batch.py
@@ -25,3 +25,20 @@ def test_search_context_batches_hits_without_cross_session_neighbors(tmp_path):
         projected = db.search_messages("needleprobe", fields=["id"], limit=20)
         assert len(projected) == len(rows)
         assert not any("WITH target AS" in q for q in sql)
+
+
+def test_context_batches_keep_tied_timestamp_order_and_duplicate_hits(tmp_path):
+    with SessionDB(db_path=tmp_path / "ties.db") as db:
+        db.create_session("ties", "cli")
+        db.append_messages_batch("ties", [
+            {"role": "user", "content": f"needleprobe {i}", "timestamp": 10.0}
+            for i in range(502)
+        ])
+        rows = db.search_messages("needleprobe", limit=502)
+        assert len(rows) == 502
+        by_id = sorted(rows, key=lambda row: row["id"])
+        for i, row in enumerate(by_id):
+            expected = [f"needleprobe {j}" for j in range(max(0, i - 1), min(502, i + 2))]
+            assert [r["content"] for r in row["context"]] == expected
+        duplicate = db._finalize_search_matches([dict(by_id[250]), dict(by_id[250])])
+        assert duplicate[0]["context"] == duplicate[1]["context"] == by_id[250]["context"]


### PR DESCRIPTION
Session search now enriches a batch of hits with one indexed neighbor query instead of opening a query for every hit.

- Batch up to 500 match IDs, preserving one previous/self/next row ordered by `(timestamp, id)` and session isolation.
- Use indexed scalar neighbor seeks rather than scanning entire matching sessions with LAG/LEAD.
- Keep projections that omit context query-free, preserve per-match decoding failure isolation, and tolerate duplicate IDs.

Root cause: `_finalize_search_matches` performed one separate read transaction/query per result.

**Live repro:** Fresh processes, isolated HOME/HERMES_HOME, actual SQLite and public SessionDB persistence/search APIs, no predicate mocking. Main `d8a07768c5ee59afae62e9fb51d45e1e30aa74da` versus the fix, two sessions containing 10,000 messages each, 20 FTS hits, seven timed reads:

| Measure | Main | Fix |
|---|---:|---:|
| Context queries | 20 | 1 |
| Median search latency, local fixture | 35.12 ms | 0.65 ms |
| Projection excluding context | 0 context queries | 0 context queries |

Full context outputs were identical. Additional actual SQLite controls passed on both arms for 502 tied-timestamp messages, chunk boundaries, CJK search and repeated match IDs. These are local library measurements, not a claim about whole CLI/model-turn latency.

Validation: canonical `flock` + `scripts/run_tests.sh -j 1` focused context file: **2 passed, 0 failed**. Ruff and diff whitespace passed. Independent read-only review found a duplicate-ID parameter-count defect; corrected it. Broad `test_hermes_state.py` execution was stopped after several minutes without a file receipt so it would not monopolize the campaign lock; **no broad-suite green claim**. Broad directories are parent integration-owned.

Relates to #104340; does not close the umbrella. No redundant YAML cache, buffered trajectory writes, output-path migration, Docker memoization, cron/skill TTL or shared async-executor changes. Durability and configuration freshness are untouched.

Credit: @DevvGwardo's #104296 identified the N+1 slice; co-author credit retained. The proposed whole-session LAG/LEAD implementation was replaced with bounded indexed seeks.

Campaign: https://github.com/NousResearch/hermes-agent/issues/104904

## Infographic
![Related tool reliability fixes](https://v3b.fal.media/files/b/0aa9736a/OFyfIuEHUnnpmXhpzZ4or_LCpmGqHW.png)
