### PR TITLE
fix: unsupported video input no longer becomes text-only success

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -43,6 +43,7 @@ _FULLWIDTH_PIPE = "\uff5c"
 
 _TEXT_PART_TYPES = {"text", "input_text", "output_text"}
 _IMAGE_PART_TYPES = {"image_url", "input_image"}
+_VIDEO_PART_TYPES = {"video", "video_url", "input_video"}
 _OUTPUT_TEXT_TYPES = {"output_text", "text"}
 _ASSISTANT_IMAGE_PLACEHOLDER = "[Assistant image omitted during replay]"
 _INCOMPLETE_STATUSES = {"queued", "in_progress", "incomplete"}
@@ -181,7 +182,13 @@ def _input_image_part(part: Dict[str, Any], role: str = "user", *, keep_empty_ur
 def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> List[Dict[str, Any]]:
     """Chat-style multimodal content → Responses API input parts ([] if not a list). Text is
     ``input_text`` (user) / ``output_text`` (assistant) — the API rejects the wrong type per role;
-    ``input_image`` is only legal on user messages (see :func:`_input_image_part`)."""
+    ``input_image`` is only legal on user messages (see :func:`_input_image_part`). Unsupported
+    video parts fail closed instead of silently turning a video request into a text-only request."""
+    for part in _as_list(content):
+        if isinstance(part, dict) and (ptype := _part_type(part)) in _VIDEO_PART_TYPES:
+            raise ValueError(
+                f"Codex Responses does not support {ptype} input; use a video-capable provider."
+            )
     text_type = _text_type_for(role)
     converted: List[Dict[str, Any]] = []
     for kind, payload in _iter_content_parts(_as_list(content)):

--- a/evals/provider_wire/issue_104282.py
+++ b/evals/provider_wire/issue_104282.py
@@ -1,0 +1,125 @@
+"""Live localhost Responses adapter video rejection/control probe."""
+
+import os, sys, tempfile, json, threading
+from pathlib import Path
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+
+root = Path(sys.argv[1]).resolve()
+arm = sys.argv[2]
+home = tempfile.mkdtemp(prefix="video-wire-")
+os.environ.clear()
+os.environ.update(HOME=home, HERMES_HOME=home, PATH="/usr/bin:/bin", NO_PROXY="*")
+sys.path.insert(0, str(root))
+os.chdir(home)
+sys.dont_write_bytecode = True
+captures = []
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        captures.append(body)
+        response = {
+            "id": "resp_fixture",
+            "object": "response",
+            "status": "completed",
+            "model": "gpt-5.5",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_fixture",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "local fixture response",
+                            "annotations": [],
+                        }
+                    ],
+                }
+            ],
+        }
+        events = [
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": response["output"][0],
+            },
+            {"type": "response.completed", "response": response},
+        ]
+        data = "".join(
+            "event: " + e["type"] + "\ndata: " + json.dumps(e) + "\n\n" for e in events
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+from openai import OpenAI
+from agent.auxiliary_client import _CodexCompletionsAdapter
+from agent.codex_responses_adapter import _preflight_codex_input_items
+
+client = OpenAI(
+    api_key="fixture",
+    base_url=f"http://127.0.0.1:{server.server_port}/v1",
+    max_retries=0,
+)
+adapter = _CodexCompletionsAdapter(client, "gpt-5.5")
+outcomes = {}
+for kind in ["video_url", "video", "input_video", "image_url"]:
+    key = "image_url" if kind == "image_url" else kind
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": kind,
+                    key: {
+                        "url": "data:video/mp4;base64,AAAA"
+                        if kind != "image_url"
+                        else "data:image/png;base64,AAAA"
+                    },
+                },
+                {"type": "text", "text": "Describe the input"},
+            ],
+        }
+    ]
+    prior = len(captures)
+    try:
+        result = adapter.create(messages=messages)
+        outcomes[kind] = {
+            "outcome": "success",
+            "content": result.choices[0].message.content,
+            "http_calls": len(captures) - prior,
+        }
+    except ValueError as e:
+        outcomes[kind] = {
+            "outcome": "rejected",
+            "error": str(e),
+            "http_calls": len(captures) - prior,
+        }
+    expected = "rejected" if arm == "fixed" and kind != "image_url" else "success"
+    assert outcomes[kind]["outcome"] == expected, outcomes
+assert captures[-1]["input"][0]["content"][0]["type"] == "input_image"
+assert outcomes["image_url"]["content"] == "local fixture response"
+print(
+    json.dumps(
+        {
+            "repo": str(root),
+            "outcomes": outcomes,
+            "captures": captures,
+            "adapter_module": sys.modules["agent.auxiliary_client"].__file__,
+        },
+        indent=2,
+    )
+)
+client.close()
+server.shutdown()

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3616,6 +3616,22 @@ class TestCodexAuxiliaryToolMessageConversion:
         assert not any(it.get("role") == "tool" for it in input_items)
         assert kwargs["instructions"] == "sys"
 
+    def test_video_input_fails_before_responses_request(self):
+        responses = MagicMock()
+        adapter = _CodexCompletionsAdapter(SimpleNamespace(responses=responses), "gpt-5.5")
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,AAAA"}},
+                {"type": "text", "text": "Describe the video"},
+            ],
+        }]
+
+        with pytest.raises(ValueError, match="does not support video_url input"):
+            adapter.create(messages=messages)
+
+        responses.create.assert_not_called()
+
 
 class TestCodexAuxiliaryAdapterNullOutputRecovery:
     def test_recovers_output_item_when_terminal_event_has_null_output(self):

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -48,6 +48,16 @@ def test_chat_content_keeps_images_on_user_role():
     }]
 
 
+def test_chat_content_rejects_video_instead_of_sending_text_only():
+    content = [
+        {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,AAAA"}},
+        {"type": "text", "text": "Describe the video"},
+    ]
+
+    with pytest.raises(ValueError, match="does not support video_url input"):
+        _chat_messages_to_responses_input([{"role": "user", "content": content}])
+
+
 def test_preflight_rewrites_raw_assistant_images_to_text_markers():
     raw = [{
         "role": "assistant",

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -48,35 +48,13 @@ def test_chat_content_keeps_images_on_user_role():
     }]
 
 
-def test_chat_content_rejects_video_instead_of_sending_text_only():
+@pytest.mark.parametrize("part_type", ["video_url", "video", "input_video"])
+def test_chat_content_rejects_video_instead_of_sending_text_only(part_type):
     content = [
-        {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,AAAA"}},
+        {"type": part_type, part_type: {"url": "data:video/mp4;base64,AAAA"}},
         {"type": "text", "text": "Describe the video"},
     ]
-
-    with pytest.raises(ValueError, match="does not support video_url input"):
-        _chat_messages_to_responses_input([{"role": "user", "content": content}])
-
-
-def test_chat_content_rejects_video_type_instead_of_sending_text_only():
-    """``video`` type (without _url suffix) must also fail closed."""
-    content = [
-        {"type": "video", "video": {"url": "data:video/mp4;base64,AAAA"}},
-        {"type": "text", "text": "Describe the video"},
-    ]
-
-    with pytest.raises(ValueError, match="does not support video input"):
-        _chat_messages_to_responses_input([{"role": "user", "content": content}])
-
-
-def test_chat_content_rejects_input_video_type_instead_of_sending_text_only():
-    """``input_video`` type (Responses API native) must also fail closed."""
-    content = [
-        {"type": "input_video", "input_video": {"url": "data:video/mp4;base64,AAAA"}},
-        {"type": "text", "text": "Describe the video"},
-    ]
-
-    with pytest.raises(ValueError, match="does not support input_video input"):
+    with pytest.raises(ValueError, match=f"does not support {part_type} input"):
         _chat_messages_to_responses_input([{"role": "user", "content": content}])
 
 

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -58,6 +58,28 @@ def test_chat_content_rejects_video_instead_of_sending_text_only():
         _chat_messages_to_responses_input([{"role": "user", "content": content}])
 
 
+def test_chat_content_rejects_video_type_instead_of_sending_text_only():
+    """``video`` type (without _url suffix) must also fail closed."""
+    content = [
+        {"type": "video", "video": {"url": "data:video/mp4;base64,AAAA"}},
+        {"type": "text", "text": "Describe the video"},
+    ]
+
+    with pytest.raises(ValueError, match="does not support video input"):
+        _chat_messages_to_responses_input([{"role": "user", "content": content}])
+
+
+def test_chat_content_rejects_input_video_type_instead_of_sending_text_only():
+    """``input_video`` type (Responses API native) must also fail closed."""
+    content = [
+        {"type": "input_video", "input_video": {"url": "data:video/mp4;base64,AAAA"}},
+        {"type": "text", "text": "Describe the video"},
+    ]
+
+    with pytest.raises(ValueError, match="does not support input_video input"):
+        _chat_messages_to_responses_input([{"role": "user", "content": content}])
+
+
 def test_preflight_rewrites_raw_assistant_images_to_text_markers():
     raw = [{
         "role": "assistant",


### PR DESCRIPTION
Explicit unsupported-video rejection prevents text-only false success.

Campaign: https://github.com/NousResearch/hermes-agent/issues/104904

## Changes
- Reject video/video_url/input_video in shared Chat→Responses converter; fallback also fails before HTTP.
- Root cause: Shared Responses converter discarded unknown video parts.
- Credit: Salvaged PR #104292 @fangliquanflq with @crazyief co-author intact; tests consolidated.

## Validation
**Live repro:** before — Three video variants each sent text-only HTTP and returned fixture success. After — Three video variants rejected with zero HTTP; image positive control sends input_image and succeeds.

Fidelity: production auxiliary adapter + actual localhost Responses SSE, not full video tool/paid vendor. Credential-free fixture completions, not vendor inference.

Reusable A/B: `python evals/provider_wire/issue_104282.py REPO_PATH main|fixed`. Baseline SHA: `7874ef9f62b9b533f8d3da6107eb2a52f4be252f`.

Independent read-only review: no blockers. Ruff, Windows footguns and compatibility-pointer checks passed.

**Targeted tests: 228 passed, 0 failed across 2 files** (serial, shared campaign lock): `flock /tmp/hermes-e461-fix-tests.lock bash scripts/run_tests.sh -j 1 tests/agent/test_codex_responses_adapter.py tests/agent/test_auxiliary_client.py`. The campaign parent owns broad directory integration verification; that separate gate is not claimed complete here.

Fixes #104282.

## Infographic
![Provider wire fixes](https://v3b.fal.media/files/b/0aa9736e/VwkyYHGwmsewqy_Cu5G7B_oN5xc1Tl.png)
