### PR TITLE
fix(desktop): hidden worktree lanes stay hidden (#103985)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -9,7 +9,7 @@ import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { displayPath } from '@/lib/display-path'
-import { $dismissedWorktreeIds, dismissWorktree, setWorkspaceNodeOpen } from '@/store/layout'
+import { $dismissedWorktreeIds, $removedWorktreeIds, dismissWorktree, setWorkspaceNodeOpen } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { removeWorktreePath } from '@/store/projects'
 
@@ -101,6 +101,7 @@ function RepoFlatSection({
   const s = t.sidebar
   const [open, toggleOpen] = useWorkspaceNodeOpen(repo.id)
   const dismissedWorktrees = useStore($dismissedWorktreeIds)
+  const removedWorktrees = useStore($removedWorktreeIds)
 
   // The repo's session lanes already come fully built from the backend; this
   // only injects empty VISUAL lanes from a live `git worktree list`.
@@ -131,11 +132,11 @@ function RepoFlatSection({
   )
 
   // Main lanes are always visible; linked worktrees can be user-dismissed.
-  // A live `git worktree list` hit wins over an old dismissal: if git says the
-  // worktree exists again (or still exists after "hide from sidebar"), surface it.
+  // Discovery may resurrect a removed worktree, never an explicit sidebar hide.
   const ordered = overlaidGroups.filter(
     group =>
-      group.isMain || !dismissedWorktrees.includes(group.id) || (group.path && discoveredWorktreePaths.has(group.path))
+      group.isMain || !dismissedWorktrees.includes(group.id) ||
+      (removedWorktrees.includes(group.id) && group.path && discoveredWorktreePaths.has(group.path))
   )
 
   // Removal asks how: actually `git worktree remove` it, or just hide the lane
@@ -151,7 +152,7 @@ function RepoFlatSection({
 
     try {
       await removeWorktreePath(repo.path, group.path, { force })
-      dismissWorktree(group.id)
+      dismissWorktree(group.id, { removed: true })
     } catch (err) {
       // git refuses a non-force remove on a dirty/locked worktree — offer force
       // rather than dead-ending on an error toast.

--- a/apps/desktop/src/app/chat/sidebar/sessions-section-new-session-drag.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section-new-session-drag.test.tsx
@@ -3,7 +3,8 @@ import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
-import { switchBranchInRepo } from '@/store/projects'
+import { $dismissedWorktreeIds, dismissWorktree, restoreWorktree } from '@/store/layout'
+import { removeWorktreePath, switchBranchInRepo } from '@/store/projects'
 
 import {
   EnteredProjectContent,
@@ -148,9 +149,21 @@ function commitLatestDrag() {
   commit({ anchor: 'workspace', before: 'session-tile:next', dir: 'right' })
 }
 
+function renderEnteredProjectWithLiveWorktree() {
+  return render(
+    <EnteredProjectContent
+      project={project({ repos: [{ groups: [group()], id: '/repo', label: 'Repo', path: '/repo', sessionCount: 0 }] })}
+      renderRows={() => null}
+      repoWorktrees={{ '/repo': [{ branch: 'feature', detached: false, isMain: false, locked: false, path: '/repo/.worktrees/feature' }] }}
+    />
+  )
+}
+
 afterEach(cleanup)
 
 beforeEach(() => {
+  $dismissedWorktreeIds.set([])
+  vi.mocked(removeWorktreePath).mockReset()
   noop.mockClear()
   startNewSessionDrag.mockReset()
   vi.mocked(switchBranchInRepo).mockReset()
@@ -430,5 +443,27 @@ describe('flat-list date-divider new-session drag source', () => {
     fireEvent.pointerDown(screen.getByRole('button', { name: 'New session' }), { button: 0 })
 
     expect(startNewSessionDrag).not.toHaveBeenCalled()
+  })
+})
+
+
+describe('explicit worktree dismissal', () => {
+  it('resurfaces removed worktrees on discovery but not a subsequent explicit hide', async () => {
+    dismissWorktree('/repo/.worktrees/feature', { removed: true })
+    renderEnteredProjectWithLiveWorktree()
+    expect(screen.getByTitle(/feature/)).toBeTruthy()
+    dismissWorktree('/repo/.worktrees/feature')
+    await waitFor(() => expect(screen.queryByTitle(/feature/)).toBeNull())
+  })
+
+  it('hides a live lane without removing the worktree and permits explicit restore', async () => {
+    renderEnteredProjectWithLiveWorktree()
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Actions' }), { button: 0, ctrlKey: false })
+    fireEvent.click(await screen.findByText('Remove worktree…'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove from sidebar' }))
+    await waitFor(() => expect(screen.queryByTitle(/feature/)).toBeNull())
+    expect(removeWorktreePath).not.toHaveBeenCalled()
+    restoreWorktree('/repo/.worktrees/feature')
+    await waitFor(() => expect(screen.getByTitle(/feature/)).toBeTruthy())
   })
 })

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -206,6 +206,13 @@ export const $dismissedWorktreeIds = persistentAtom(
   [] as string[],
   Codecs.stringArray
 )
+// Only successful git removals may reappear on discovery. Explicit hides,
+// including legacy dismissals without provenance, remain hidden.
+export const $removedWorktreeIds = persistentAtom(
+  'hermes.desktop.removedWorktrees',
+  [] as string[],
+  Codecs.stringArray
+)
 export const $sidebarPinsOpen = atom(true)
 export const $sidebarRecentsOpen = atom(true)
 // Cron-job sessions live in their own section below recents, collapsed by
@@ -467,8 +474,9 @@ export function filterVisibleProjects<T extends { id: string; isAuto?: boolean }
   return projects.filter(project => !(project.isAuto && dismissed.has(project.id)))
 }
 
-// Hide a worktree row after it's been removed via git.
-export function dismissWorktree(id: string): void {
+export function dismissWorktree(id: string, { removed = false }: { removed?: boolean } = {}): void {
+  const removedIds = $removedWorktreeIds.get().filter(worktreeId => worktreeId !== id)
+  $removedWorktreeIds.set(removed ? [...removedIds, id] : removedIds)
   const current = $dismissedWorktreeIds.get()
 
   if (!current.includes(id)) {
@@ -479,6 +487,7 @@ export function dismissWorktree(id: string): void {
 // A hidden worktree becomes visible again as soon as the user explicitly starts
 // or opens work there (for example, selecting an already-checked-out branch).
 export function restoreWorktree(id: string): void {
+  $removedWorktreeIds.set($removedWorktreeIds.get().filter(worktreeId => worktreeId !== id))
   const current = $dismissedWorktreeIds.get()
 
   if (current.includes(id)) {


### PR DESCRIPTION
Explicitly hiding a live worktree now removes its lane from the Desktop sidebar without deleting the worktree.

Fixes #103985. Campaign: #104904.

- Persist successful Git-removal provenance separately from explicit hides.
- Let discovery resurface removed/recreated worktrees, but never override an explicit hide.
- Preserve existing explicit restore behavior and treat legacy dismissals as durable hides.

Root cause: live discovery unconditionally re-admitted every dismissed lane, defeating the non-destructive dialog choice.

**Live repro:** the production `EnteredProjectContent` rendered in isolated Chromium with discovery data from a real temporary Git repository and linked worktree. Before: Hide persisted the dismissal but the lane remained. After: the lane disappears, main remains, Git still discovers the worktree, its directory remains, and explicit restore shows it again. No browser errors. This verifies the actual renderer, not native Electron IPC.

| Validation | Result |
|---|---|
| Existing renderer and dismissal test files | 15 passed, 0 failed, 2 files, serialized under campaign flock |
| Renderer TypeScript | Passed |
| Touched ESLint and `git diff --check` | Passed |
| Independent read-only review | No blockers for this commit |

Broader directory integration is owned by the campaign parent. No app/user configuration, backend, bot identity, or on-disk worktree removal behavior changed.

Credits: slim salvage of @Tranquil-Flow's earliest substantive fix #103992; contributor coauthor retained. The provenance list avoids a generic metadata codec/helper and makes explicit hides durable even before a discovery scan completes.

## Infographic

![Hide means hide](https://v3b.fal.media/files/b/0aa973d5/RdLlfco0lsL_lz0hO3mq4_pN73Yx4S.png)
