### PR TITLE
fix: memory aliases persist through dispatch and provider mirrors

### DIFF
--- a/agent/inline_tool_executors.py
+++ b/agent/inline_tool_executors.py
@@ -115,7 +115,7 @@ def _memory(agent, args: dict, ctx: InlineToolContext) -> Any:
         "tools.memory_tool", "memory_tool", args,
         (
             ("action", "action"), ("target", "target", "memory"), ("content", "content"),
-            ("old_text", "old_text"), ("operations", "operations"),
+            ("old_text", "old_text"), ("new_text", "new_text"), ("operations", "operations"),
         ),
         store=agent._memory_store,
     )

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -759,7 +759,7 @@ class MemoryManager:
                 old_text = op.get("old_text")
                 if old_text:
                     metadata["old_text"] = str(old_text)
-                self.on_memory_write(action, target, str(op.get("content") or ""), metadata=metadata)
+                self.on_memory_write(action, target, str(op.get("content") or op.get("new_text") or ""), metadata=metadata)
             except Exception as e:
                 logger.debug("notify_memory_tool_write failed for op %s: %s", action, e)
 

--- a/tests/agent/test_inline_tool_executors_memory_args.py
+++ b/tests/agent/test_inline_tool_executors_memory_args.py
@@ -1,72 +1,31 @@
-"""Tests for the ``memory`` inline executor's argument forwarding (agent/inline_tool_executors.py).
-
-The tool schema advertises ``new_text`` as an alias for ``content``
-(tools/memory_tool.py implements it at the ``if content is None and new_text``
-seam), so the executor's arg_specs must forward it — otherwise the allowlist in
-``_call_tool`` silently drops the argument and ``replace`` fails with
-"content is required" even though the caller supplied the value.
-"""
+"""The inline memory alias persists writes and preserves content precedence."""
 
 import json
 from types import SimpleNamespace
-from unittest.mock import patch
 
 from agent.inline_tool_executors import INLINE_TOOL_EXECUTORS, InlineToolContext
-from tools.memory_tool import MemoryStore
+from tools.memory_tool_store import MemoryStore
 
 
-def _agent(store):
-    return SimpleNamespace(_memory_store=store, _memory_manager=None)
+def test_memory_alias_persists_with_content_precedence(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+    agent = SimpleNamespace(_memory_store=store, _memory_manager=None)
+    ctx = InlineToolContext(effective_task_id="task-1", tool_call_id="call-1")
 
+    def call(**args):
+        return json.loads(INLINE_TOOL_EXECUTORS["memory"](agent, args, ctx))
 
-def _ctx():
-    return InlineToolContext(effective_task_id="task-1", tool_call_id="call-1")
-
-
-class TestMemoryExecutorForwardsNewText:
-    def test_replace_via_new_text_alias_succeeds(self):
-        """End-to-end root-cause lock: replace with only ``new_text`` must work."""
-        store = MemoryStore(memory_char_limit=500, user_char_limit=300)
-        INLINE_TOOL_EXECUTORS["memory"](
-            _agent(store),
-            {"action": "add", "target": "memory", "content": "Household has two cars: a hatchback and an estate."},
-            _ctx(),
-        )
-        result = INLINE_TOOL_EXECUTORS["memory"](
-            _agent(store),
-            {
-                "action": "replace",
-                "target": "memory",
-                "old_text": "Household has two cars: a hatchback and an estate.",
-                "new_text": "Household has two cars: a hatchback and a saloon.",
-            },
-            _ctx(),
-        )
-        payload = json.loads(result)
-        assert payload["success"] is True, payload
-        assert "a saloon" in store.memory_entries[0]
-        assert not any("an estate" in entry for entry in store.memory_entries)
-
-    def test_new_text_is_forwarded_to_memory_tool(self):
-        """The executor's arg_specs must pass ``new_text`` through to the tool."""
-        with patch("tools.memory_tool.memory_tool") as tool:
-            tool.return_value = "{}"
-            INLINE_TOOL_EXECUTORS["memory"](
-                _agent(store=object()),
-                {"action": "replace", "target": "memory", "old_text": "A", "new_text": "B"},
-                _ctx(),
-            )
-        assert tool.call_args.kwargs["new_text"] == "B"
-
-    def test_content_wins_when_both_set(self):
-        """Documented precedence: when both are forwarded, ``content`` wins."""
-        with patch("tools.memory_tool.memory_tool") as tool:
-            tool.return_value = "{}"
-            INLINE_TOOL_EXECUTORS["memory"](
-                _agent(store=object()),
-                {"action": "replace", "target": "memory", "old_text": "A", "content": "C", "new_text": "B"},
-                _ctx(),
-            )
-        kwargs = tool.call_args.kwargs
-        assert kwargs["content"] == "C"
-        assert kwargs["new_text"] == "B"
+    assert call(action="add", target="user", content="Household owns an estate.")["success"]
+    result = call(action="replace", target="user", old_text="Household owns an estate.",
+                  new_text="Household owns a saloon.")
+    assert result["success"], result
+    path = tmp_path / "memories" / "USER.md"
+    assert "Household owns a saloon." in path.read_text(encoding="utf-8")
+    result = call(action="replace", target="user", old_text="Household owns a saloon.",
+                  content="Household owns a hatchback.", new_text="Household owns a van.")
+    assert result["success"], result
+    persisted = path.read_text(encoding="utf-8")
+    assert "Household owns a hatchback." in persisted
+    assert "van" not in persisted
+    assert "saloon" not in persisted

--- a/tests/agent/test_inline_tool_executors_memory_args.py
+++ b/tests/agent/test_inline_tool_executors_memory_args.py
@@ -1,0 +1,72 @@
+"""Tests for the ``memory`` inline executor's argument forwarding (agent/inline_tool_executors.py).
+
+The tool schema advertises ``new_text`` as an alias for ``content``
+(tools/memory_tool.py implements it at the ``if content is None and new_text``
+seam), so the executor's arg_specs must forward it — otherwise the allowlist in
+``_call_tool`` silently drops the argument and ``replace`` fails with
+"content is required" even though the caller supplied the value.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.inline_tool_executors import INLINE_TOOL_EXECUTORS, InlineToolContext
+from tools.memory_tool import MemoryStore
+
+
+def _agent(store):
+    return SimpleNamespace(_memory_store=store, _memory_manager=None)
+
+
+def _ctx():
+    return InlineToolContext(effective_task_id="task-1", tool_call_id="call-1")
+
+
+class TestMemoryExecutorForwardsNewText:
+    def test_replace_via_new_text_alias_succeeds(self):
+        """End-to-end root-cause lock: replace with only ``new_text`` must work."""
+        store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+        INLINE_TOOL_EXECUTORS["memory"](
+            _agent(store),
+            {"action": "add", "target": "memory", "content": "Household has two cars: a hatchback and an estate."},
+            _ctx(),
+        )
+        result = INLINE_TOOL_EXECUTORS["memory"](
+            _agent(store),
+            {
+                "action": "replace",
+                "target": "memory",
+                "old_text": "Household has two cars: a hatchback and an estate.",
+                "new_text": "Household has two cars: a hatchback and a saloon.",
+            },
+            _ctx(),
+        )
+        payload = json.loads(result)
+        assert payload["success"] is True, payload
+        assert "a saloon" in store.memory_entries[0]
+        assert not any("an estate" in entry for entry in store.memory_entries)
+
+    def test_new_text_is_forwarded_to_memory_tool(self):
+        """The executor's arg_specs must pass ``new_text`` through to the tool."""
+        with patch("tools.memory_tool.memory_tool") as tool:
+            tool.return_value = "{}"
+            INLINE_TOOL_EXECUTORS["memory"](
+                _agent(store=object()),
+                {"action": "replace", "target": "memory", "old_text": "A", "new_text": "B"},
+                _ctx(),
+            )
+        assert tool.call_args.kwargs["new_text"] == "B"
+
+    def test_content_wins_when_both_set(self):
+        """Documented precedence: when both are forwarded, ``content`` wins."""
+        with patch("tools.memory_tool.memory_tool") as tool:
+            tool.return_value = "{}"
+            INLINE_TOOL_EXECUTORS["memory"](
+                _agent(store=object()),
+                {"action": "replace", "target": "memory", "old_text": "A", "content": "C", "new_text": "B"},
+                _ctx(),
+            )
+        kwargs = tool.call_args.kwargs
+        assert kwargs["content"] == "C"
+        assert kwargs["new_text"] == "B"

--- a/tests/agent/test_inline_tool_executors_memory_args.py
+++ b/tests/agent/test_inline_tool_executors_memory_args.py
@@ -10,7 +10,23 @@ from tools.memory_tool_store import MemoryStore
 def test_memory_alias_persists_with_content_precedence(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     store = MemoryStore(memory_char_limit=500, user_char_limit=300)
-    agent = SimpleNamespace(_memory_store=store, _memory_manager=None)
+    from agent.memory_manager import MemoryManager
+
+    class Sink:
+        name = "test-sink"
+        writes = []
+
+        def get_tool_schemas(self):
+            return []
+
+        def on_memory_write(self, action, target, content, metadata=None):
+            self.writes.append((action, target, content))
+
+    sink = Sink()
+    manager = MemoryManager()
+    manager.add_provider(sink)
+    agent = SimpleNamespace(_memory_store=store, _memory_manager=manager,
+                            _build_memory_write_metadata=lambda **kwargs: kwargs)
     ctx = InlineToolContext(effective_task_id="task-1", tool_call_id="call-1")
 
     def call(**args):
@@ -22,6 +38,7 @@ def test_memory_alias_persists_with_content_precedence(tmp_path, monkeypatch):
     assert result["success"], result
     path = tmp_path / "memories" / "USER.md"
     assert "Household owns a saloon." in path.read_text(encoding="utf-8")
+    assert sink.writes[-1] == ("replace", "user", "Household owns a saloon.")
     result = call(action="replace", target="user", old_text="Household owns a saloon.",
                   content="Household owns a hatchback.", new_text="Household owns a van.")
     assert result["success"], result
@@ -29,3 +46,8 @@ def test_memory_alias_persists_with_content_precedence(tmp_path, monkeypatch):
     assert "Household owns a hatchback." in persisted
     assert "van" not in persisted
     assert "saloon" not in persisted
+    assert sink.writes[-1] == ("replace", "user", "Household owns a hatchback.")
+    result = call(target="user", operations=[{"action": "replace", "old_text": "Household owns a hatchback.",
+                                             "new_text": "Household owns a coupe."}])
+    assert result["success"], result
+    assert sink.writes[-1] == ("replace", "user", "Household owns a coupe.")


### PR DESCRIPTION
Memory writes using the documented `new_text` alias now reach both the built-in file store and external-provider mirroring.

- Forward `new_text` through the shared inline executor used by agent tool dispatch.
- Resolve the alias in the successful-write mirror path, including batch operations; keep explicit `content` precedence and success/staging gates.
- Replace mock-forwarding checks with a real file-persistence and MemoryManager/provider-bridge invariant.

Root cause: the inline argument allowlist discarded the alias; after that was restored, independent review found that provider mirroring still read only `content`.

**Live repro:** Fresh isolated processes importing production code, real `MemoryStore` and `MemoryManager`, and a local file-backed provider sink. Main `d8a07768c5ee59afae62e9fb51d45e1e30aa74da` fails alias-only replacement with `content is required`, leaving the native file unchanged. The first dispatch-only fix exposed an empty mirror write. This branch persists the alias text to both stores; explicit content wins. This is library-integration evidence, not a paid model or full interactive agent-loop test.

| Validation | Result |
|---|---|
| Inline persistence + memory tool files, canonical serial runner | 46 passed, 0 failed |
| Final alias/provider-bridge files, canonical serial runner | 7 passed, 0 failed |
| Real native and provider-sink file readback | Passed |
| Ruff, compat-pointer and diff-whitespace checks | Passed |
| Independent read-only review | Provider-mirror finding fixed and verified |

Fixes #104093 (the dropped-alias/persistence defect; model narration behavior is not claimed tested).

Salvaged @liuhao1024's #104097 commit with original authorship preserved; trimmed tests and added the provider-mirror correction. Earlier #88685/#96085 target dispatch branches removed by the table refactor. Broad directory testing is owned by the campaign integration pass.

Campaign: https://github.com/NousResearch/hermes-agent/issues/104904

## Infographic
![Related tool reliability fixes](https://v3b.fal.media/files/b/0aa9736a/OFyfIuEHUnnpmXhpzZ4or_LCpmGqHW.png)
