### PR TITLE
fix(gateway): bind Discord exec-approval cards to their own request (#104915)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -686,7 +686,7 @@ class QQAdapter(BasePlatformAdapter):
 
         approval = parse_approval_button_data(button_data)
         if approval is not None:
-            session_key, decision = approval
+            session_key, decision, request_id = approval
             choice = self._APPROVAL_BUTTON_TO_CHOICE.get(decision)
             if choice is None:
                 logger.warning("[%s] Unknown approval decision %r (session=%s)", self._log_tag, decision, session_key)
@@ -698,7 +698,13 @@ class QQAdapter(BasePlatformAdapter):
                 return
             try:
                 from tools.approval import resolve_gateway_approval  # lazy: keep adapter light
-                count = resolve_gateway_approval(session_key, choice)
+                # A click settles only the request generation its card was issued for; an
+                # unbound legacy card must not fall back to the session FIFO (#104915).
+                count = (
+                    resolve_gateway_approval(session_key, choice, request_id=request_id)
+                    if request_id
+                    else 0
+                )
                 logger.info(
                     "[%s] Button resolved %d approval(s) for session %s (choice=%s, operator=%s)",
                     self._log_tag, count, session_key, choice, event.operator_openid)
@@ -1458,7 +1464,9 @@ class QQAdapter(BasePlatformAdapter):
         """Send a 3-button approval request (allow-once / allow-always / deny);
         clicks come back as INTERACTION_CREATE decoded by parse_approval_button_data."""
         from gateway.platforms.qqbot.keyboards import build_approval_text
-        keyboard = build_approval_keyboard(req.session_key, allow_permanent=getattr(req, "allow_permanent", True))
+        keyboard = build_approval_keyboard(
+            req.session_key, allow_permanent=getattr(req, "allow_permanent", True),
+            request_id=getattr(req, "request_id", None))
         return await self.send_with_keyboard(chat_id, build_approval_text(req), keyboard, reply_to=reply_to)
 
     # Cross-adapter gateway contract: gateway/run.py detects send_exec_approval /
@@ -1469,7 +1477,7 @@ class QQAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str, description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None, allow_permanent: bool = True, allow_session: bool = True,
-        smart_denied: bool = False) -> SendResult:
+        smart_denied: bool = False, request_id: Optional[str] = None) -> SendResult:
         """Button-based exec-approval prompt (called by gateway/run.py while the
         agent blocks on approval); clicks resolve via _default_interaction_dispatch."""
         del metadata  # QQ has no thread_id / DM targeting overrides.
@@ -1479,7 +1487,7 @@ class QQAdapter(BasePlatformAdapter):
         req = ApprovalRequest(
             session_key=session_key, title="Execute this command?", description=description,
             command_preview=command, timeout_sec=self._APPROVAL_TIMEOUT_SECONDS,
-            allow_permanent=allow_permanent and not smart_denied)
+            allow_permanent=allow_permanent and not smart_denied, request_id=request_id)
         # QQ requires a msg_id for passive replies; the last inbound id is the natural one.
         return await self.send_approval_request(chat_id, req, reply_to=self._last_msg_id.get(chat_id))
 

--- a/gateway/platforms/qqbot/keyboards.py
+++ b/gateway/platforms/qqbot/keyboards.py
@@ -14,7 +14,9 @@ APPROVAL_BUTTON_PREFIX = "approve:"
 UPDATE_PROMPT_PREFIX = "update_prompt:"
 
 # session_key may itself contain colons (agent:main:qqbot:c2c:OPENID): greedy group, decision trails.
-_APPROVAL_DATA_RE = re.compile(r"^approve:(.+):(allow-once|allow-always|deny)$")
+# The optional trailing hex segment is the gateway request id (#104915): a click settles only
+# the request generation its card was issued for; cards without one (legacy text path) fail closed.
+_APPROVAL_DATA_RE = re.compile(r"^approve:(.+):(allow-once|allow-always|deny)(?::([0-9a-f]+))?$")
 _UPDATE_PROMPT_RE = re.compile(r"^update_prompt:(y|n)$")
 
 def _to_dict(value: Any) -> Any:
@@ -77,8 +79,11 @@ class InlineKeyboard(_Serializable):
     content: KeyboardContent = field(default_factory=KeyboardContent)
 
 
-def parse_approval_button_data(button_data: str) -> Optional[tuple[str, str]]:
-    """Parse approval ``button_data`` into ``(session_key, decision)`` or ``None``."""
+def parse_approval_button_data(button_data: str) -> Optional[tuple[str, str, Optional[str]]]:
+    """Parse approval ``button_data`` into ``(session_key, decision, request_id)`` or ``None``.
+
+    ``request_id`` is ``None`` for legacy 3-segment data (text-path cards); the adapter
+    resolves those fail-closed instead of falling back to the session FIFO (#104915)."""
     return m.groups() if (m := _APPROVAL_DATA_RE.match(button_data or "")) else None
 
 
@@ -96,14 +101,18 @@ def _single_row_keyboard(group_id: str, *buttons: tuple) -> InlineKeyboard:
     return InlineKeyboard(content=KeyboardContent(rows=[row]))
 
 
-def build_approval_keyboard(session_key: str, *, allow_permanent: bool = True) -> InlineKeyboard:
+def build_approval_keyboard(
+    session_key: str, *, allow_permanent: bool = True, request_id: Optional[str] = None,
+) -> InlineKeyboard:
     """Build ``[✅ 允许一次] [⭐ 始终允许] [❌ 拒绝]`` (one group, so a click greys the rest). ⭐ is hidden when
-    persistent scope is unavailable; *session_key* rides in ``button_data`` so the decision routes correctly."""
-    prefix = f"{APPROVAL_BUTTON_PREFIX}{session_key}"
-    buttons = [("allow", "✅ 允许一次", "已允许", f"{prefix}:allow-once", 1)]
+    persistent scope is unavailable; *session_key* rides in ``button_data`` so the decision routes correctly.
+    A non-empty *request_id* is appended after the decision so the click settles only that
+    request generation (#104915)."""
+    suffix = f":{request_id}" if request_id else ""
+    buttons = [("allow", "✅ 允许一次", "已允许", f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-once{suffix}", 1)]
     if allow_permanent:
-        buttons.append(("always", "⭐ 始终允许", "已始终允许", f"{prefix}:allow-always", 1))
-    buttons.append(("deny", "❌ 拒绝", "已拒绝", f"{prefix}:deny", 0))
+        buttons.append(("always", "⭐ 始终允许", "已始终允许", f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-always{suffix}", 1))
+    buttons.append(("deny", "❌ 拒绝", "已拒绝", f"{APPROVAL_BUTTON_PREFIX}{session_key}:deny{suffix}", 0))
     return _single_row_keyboard("approval", *buttons)
 
 
@@ -126,6 +135,7 @@ class ApprovalRequest:
     severity: str = ""
     timeout_sec: int = 120
     allow_permanent: bool = True
+    request_id: Optional[str] = None
 
 
 _SEVERITY_ICONS = {"critical": "🔴", "info": "🔵"}

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -202,7 +202,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # the gateway resolver. Popped on tap; FIFO-capped via _bounded_put so ignored
         # prompts don't accumulate (an evicted tap degrades to text fallback).
         self._clarify_state: "OrderedDict[str, str]" = OrderedDict()
-        self._exec_approval_state: "OrderedDict[str, str]" = OrderedDict()
+        # Exec-approval taps bind to their own request generation (#104915): one bounded
+        # record per card, approval_id → (session_key, request_id), so both halves share
+        # the FIFO cap and eviction can never strand the request id (single-record tuple
+        # shape per the older #87554 carrier).
+        self._exec_approval_state: "OrderedDict[str, tuple[str, Optional[str]]]" = OrderedDict()
         self._slash_confirm_state: "OrderedDict[str, str]" = OrderedDict()
         self._runner = self._http_client = None
 
@@ -403,7 +407,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         state: "OrderedDict[str, str]", state_id: str, session_key: str,
     ) -> SendResult:
         """POST an ``interactive`` message (caller supplies ``type``/``body``/``action``) and, on
-        success, remember ``state_id → session_key`` for the tap. Free-form interactives need no
+        success, remember ``state_id → state value`` for the tap. Free-form interactives need no
         Meta approval but are only valid inside the 24h window — fine, all senders here reply to a user."""
         result = await self._post_message_result(
             self._outbound_payload(chat_id, "interactive", interactive, _reply_to_from(metadata)),
@@ -467,7 +471,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str, description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None, allow_permanent: bool = True,
-        allow_session: bool = True, smart_denied: bool = False,
+        allow_session: bool = True, smart_denied: bool = False, request_id: Optional[str] = None,
     ) -> SendResult:
         """Approve / Deny buttons; a tap resolves via ``tools.approval.resolve_gateway_approval``."""
         del allow_permanent, allow_session  # This adapter already offers one-shot Approve / Deny only.
@@ -479,7 +483,13 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         )
         approval_id = uuid.uuid4().hex[:12]
         interactive = self._button_interactive(body_text, (f"appr:{approval_id}:approve", "✅ Approve"), (f"appr:{approval_id}:deny", "❌ Deny"))
-        return await self._send_interactive(chat_id, interactive, metadata, self._exec_approval_state, approval_id, session_key)
+        # The 12-hex button payload can't carry the full request id, so the tap state carries
+        # (session_key, request_id) as ONE record: the binding is stored exactly when the card
+        # is, and FIFO eviction drops both halves together — no stranded request-id half
+        # (#104915; single bounded tuple shape per the older #87554 carrier).
+        return await self._send_interactive(
+            chat_id, interactive, metadata, self._exec_approval_state, approval_id, (session_key, request_id),
+        )
 
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str, confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
@@ -819,17 +829,17 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     @staticmethod
     def _pop_tap_state(
-        state: "OrderedDict[str, str]", key: str, stale_log: str, choice: str = "", valid: tuple = (),
-    ) -> Optional[str]:
-        """Pop the session_key for a tapped prompt. None (info-logged) when nothing is live — likely
+        state: "OrderedDict[str, Any]", key: str, stale_log: str, choice: str = "", valid: tuple = (),
+    ) -> Optional[Any]:
+        """Pop the stored value for a tapped prompt. None (info-logged) when nothing is live — likely
         a stale tap; an unrecognised ``choice`` keeps the prompt live and also yields None."""
-        session_key = state.pop(key, None)
-        if not session_key:
+        value = state.pop(key, None)
+        if not value:
             logger.info(stale_log, key)
         elif valid and choice not in valid:
-            state[key] = session_key
+            state[key] = value
             return None
-        return session_key
+        return value
 
     async def _handle_clarify_tap(self, to: str, inner: Dict[str, Any], parts: list) -> bool:
         _, clarify_id, choice = parts
@@ -875,17 +885,26 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     async def _handle_approval_tap(self, to: str, inner: Dict[str, Any], parts: list) -> bool:
         _, approval_id, choice = parts
-        session_key = self._pop_tap_state(
+        record = self._pop_tap_state(
             self._exec_approval_state, approval_id,
             "[whatsapp_cloud] approval tap with no matching state (approval_id=%s) — likely stale; falling back to text",
             choice, ("approve", "deny"),
         )
-        if not session_key:
+        if not record:
             return False
+        # One record per card: (session_key, request_id) share the approval_id lifecycle,
+        # so an evicted or consumed card takes its binding with it (#104915).
+        session_key, request_id = record
         approval = _optional_module("tools.approval", "[whatsapp_cloud] approval resolver unavailable")
         if approval is None:
             return False
-        count = approval.resolve_gateway_approval(session_key, choice)
+        # A tap settles only the request generation its card was issued for; an unbound
+        # card must not fall back to the session FIFO (#104915).
+        count = (
+            approval.resolve_gateway_approval(session_key, choice, request_id=request_id)
+            if request_id
+            else 0
+        )
         # A tap after the wait timed out (count == 0) must not claim approval:
         # the command was already denied fail-closed.
         if count:

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -1835,6 +1835,7 @@ class RelayAdapter(BasePlatformAdapter):
         allow_permanent: bool = True,
         allow_session: bool = True,
         smart_denied: bool = False,
+        request_id: Optional[str] = None,
     ) -> SendResult:
         """Native-button exec approval over the relay (same choice set as native; the
         press resolves via tools.approval.resolve_gateway_approval). When the lane is
@@ -1851,7 +1852,8 @@ class RelayAdapter(BasePlatformAdapter):
         if smart_denied:
             text += "\n\n**Smart DENY:** owner override applies to this one operation only."
         result = await self._mint_and_send_prompt(
-            "exec_approval", {"session_key": session_key}, chat_id, prompt_kind="approval",
+            "exec_approval", {"session_key": session_key, "request_id": request_id},
+            chat_id, prompt_kind="approval",
             text=text, options=options, metadata=metadata,
         )
         return result if result is not None else self._PROMPT_UNAVAILABLE
@@ -1966,7 +1968,14 @@ class RelayAdapter(BasePlatformAdapter):
         from tools.approval import resolve_gateway_approval
 
         choice = option_id if option_id in _EXEC_APPROVAL_LABELS else "deny"
-        count = resolve_gateway_approval(str(state.get("session_key") or ""), choice)
+        # A press settles only the request generation its prompt was issued for; an unbound
+        # prompt must not fall back to the session FIFO (#104915).
+        request_id = state.get("request_id")
+        count = (
+            resolve_gateway_approval(str(state.get("session_key") or ""), choice, request_id=request_id)
+            if request_id
+            else 0
+        )
         label = _EXEC_APPROVAL_LABELS[choice] if count else "⌛ Approval expired — no command was waiting."
         # In-channel ack preserves the audit trail the native edit gives (the
         # connector's prompt message can't be edited cross-platform yet).

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1246,12 +1246,25 @@ class TurnRunner:
         desc = approval_data.get("description", "dangerous command")
         flags = {k: approval_data.get(k, d) for k, d in (("allow_permanent", True), ("allow_session", True), ("smart_denied", False))}
         # Check the *class*, not the instance — MagicMock auto-creates attributes in tests.
-        if getattr(type(adapter), "send_exec_approval", None) is not None:
+        has_exec_approval = getattr(type(adapter), "send_exec_approval", None) is not None
+        binds_requests = has_exec_approval and _accepts_keyword(adapter.send_exec_approval, "request_id")
+        if has_exec_approval and not binds_requests:
+            # Fail closed (#104915): an external/plugin adapter predating the converged
+            # signature can only resolve its cards through the session FIFO, so a stale or
+            # overlapping control could settle a different pending request. Degrade to the
+            # typed-text prompt instead of rendering an unbound interactive approval.
+            logger.warning(
+                "%s.send_exec_approval predates request binding — failing closed to typed-text approval",
+                type(adapter).__name__,
+            )
+        if binds_requests:
+            extra: Dict[str, Any] = {}
+            extra["request_id"] = approval_data.get("request_id")
             try:
                 fut = self._schedule(
                     adapter.send_exec_approval(
                         chat_id=ctx._status_chat_id, command=cmd, session_key=ctx.session_key or "",
-                        description=desc, metadata=ctx._status_thread_metadata, **flags,
+                        description=desc, metadata=ctx._status_thread_metadata, **flags, **extra,
                     ),
                     "send_exec_approval scheduling error",
                 )

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -268,6 +268,9 @@ from gateway.platforms.base import (
 )
 from tools.url_safety import is_safe_url
 from gateway.platforms._shared import profile_scoped as _profile_scoped_config_load
+from plugins.platforms.discord.exec_approval import (  # noqa: E402 — sibling owner module (see send_exec_approval)
+    build_exec_approval_card, build_exec_approval_view, define_exec_approval_view,
+)
 
 
 async def _read_url_image_with_redirect_guard(
@@ -5508,44 +5511,21 @@ class DiscordAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str, description: str = "dangerous command",
         metadata: Optional[dict] = None, allow_permanent: bool = True, allow_session: bool = True,
-        smart_denied: bool = False,
+        smart_denied: bool = False, request_id: Optional[str] = None,
     ) -> SendResult:
-        """Button-based exec approval prompt; buttons call ``resolve_gateway_approval()`` (not /approve)."""
+        """Button-based exec approval prompt; buttons call ``resolve_gateway_approval()`` (not /approve).
+        Wiring only — the card payload and the request-bound view live in ``exec_approval``."""
         def _build(_channel):
-            # Payload in plain content: embeds can be invisible/detached on web/mobile.
-            reason_budget = 300
-            reason_display = str(description or "dangerous command")
-            if len(reason_display) > reason_budget:
-                reason_display = reason_display[: reason_budget - 15] + "... [truncated]"
-            prompt_prefix = (
-                "⚠️ **Command Approval Required**\n\n"
-                "Do you want Hermes to run this command?\n\n"
-                "**Requested command:**\n```bash\n"
-            )
-            if smart_denied:
-                prompt_prefix += "**Smart DENY:** owner override applies to this one operation only.\n\n"
             mention_content = self._approval_mention_content()
-            if mention_content:
-                prompt_prefix = f"{mention_content}\n{prompt_prefix}"
-            prompt_tail = f"\n```\n**Reason:** {reason_display}"
-            truncated_suffix = "\n... [truncated]"
-            command_budget = max(0, self.MAX_MESSAGE_LENGTH - len(prompt_prefix) - len(prompt_tail))
-            content_cmd_display = str(command or "")
-            if len(content_cmd_display) > command_budget:
-                content_cmd_display = content_cmd_display[: max(0, command_budget - len(truncated_suffix))] + truncated_suffix
-            content = f"{prompt_prefix}{content_cmd_display}{prompt_tail}"
-            embed = discord.Embed(
-                title="⚠️ Command Approval Required",
-                description=f"```\n{self._embed_body(str(command or ''))}\n```",
-                color=discord.Color.orange(),
+            content, embed = build_exec_approval_card(
+                command, description, smart_denied=smart_denied, mention_content=mention_content,
+                max_message_length=self.MAX_MESSAGE_LENGTH, embed_body=self._embed_body,
             )
-            embed.add_field(name="Reason", value=reason_display, inline=False)
-            require_admin, admin_user_ids = _resolve_exec_approval_admin_gate(getattr(self.config, "extra", None))
-            view = ExecApprovalView(
-                session_key=session_key, allowed_user_ids=self._allowed_user_ids,
-                allowed_role_ids=self._allowed_role_ids, require_admin=require_admin,
-                admin_user_ids=admin_user_ids, allow_permanent=allow_permanent,
-                allow_session=allow_session, smart_denied=smart_denied,
+            view = build_exec_approval_view(
+                config_extra=getattr(self.config, "extra", None), session_key=session_key,
+                allowed_user_ids=self._allowed_user_ids, allowed_role_ids=self._allowed_role_ids,
+                allow_permanent=allow_permanent, allow_session=allow_session,
+                smart_denied=smart_denied, request_id=request_id,
             )
             send_kwargs: Dict[str, Any] = {"content": content, "embed": embed, "view": view}
             if mention_content:
@@ -6230,24 +6210,6 @@ def _component_check_auth(
     return False
 
 
-def _resolve_exec_approval_admin_gate(config_extra: Optional[dict]) -> Tuple[bool, set]:
-    """Resolve the exec-approval admin gate from ``extra``; returns ``(require_admin, admin_user_ids)``.
-    Default OFF (user-scope buttons). When ``require_admin_for_exec_approval`` is true only
-    ``allow_admin_from`` ids may click; on with no admins -> ``(True, set())`` (fail closed, log once).
-    """
-    extra = config_extra if isinstance(config_extra, dict) else {}
-    raw_toggle = extra.get("require_admin_for_exec_approval", False)
-    require_admin = str(raw_toggle).strip().lower() in {"true", "1", "yes"}
-    if not require_admin:
-        return (False, set())
-    try:
-        from gateway.slash_access import _coerce_id_list
-        admin_ids = set(_coerce_id_list(extra.get("allow_admin_from")))
-    except Exception:
-        admin_ids = set()
-    return (True, admin_ids)
-
-
 def _define_discord_view_classes() -> None:
     """Register Discord UI view classes as module globals.
     Called at module load and after a lazy install so the classes exist whenever DISCORD_AVAILABLE."""
@@ -6313,90 +6275,9 @@ def _define_discord_view_classes() -> None:
             self._disable_all()
             await self._expire_embed("⏱ Prompt expired — no action taken")
 
-    class ExecApprovalView(_HermesView):
-        """Allow Once / Allow Session / Always Allow / Deny buttons for a dangerous command.
-        Clicks call ``resolve_gateway_approval()`` — the same mechanism as the text ``/approve`` flow."""
-
-        def __init__(
-            self, session_key: str, allowed_user_ids: set, allowed_role_ids: Optional[set] = None,
-            require_admin: bool = False, admin_user_ids: Optional[set] = None,
-            allow_permanent: bool = True, allow_session: bool = True, smart_denied: bool = False,
-        ):
-            super().__init__(allowed_user_ids, allowed_role_ids, timeout=_read_discord_prompt_timeout())
-            self.session_key = session_key
-            self.require_admin = require_admin
-            self.admin_user_ids = {str(a).strip() for a in (admin_user_ids or set()) if str(a).strip()}
-            if smart_denied or not allow_session:
-                self.remove_item(self.allow_session)
-                self.remove_item(self.allow_always)
-            elif not allow_permanent:
-                self.remove_item(self.allow_always)
-
-        def _check_auth(self, interaction: discord.Interaction) -> bool:
-            """Base admission always required; with ``require_admin`` the clicker must
-            also be an admin. Fails closed (logged once) when no admins are configured."""
-            if not super()._check_auth(interaction):
-                return False
-            if not self.require_admin:
-                return True
-            user = getattr(interaction, "user", None)
-            try:
-                uid = str(getattr(user, "id", "") or "")
-            except Exception:
-                uid = ""
-            if uid and uid in self.admin_user_ids:
-                return True
-            if not self.admin_user_ids:
-                logger.warning(
-                    "[Discord] require_admin_for_exec_approval is enabled but "
-                    "no admins are configured (allow_admin_from is empty) — "
-                    "exec approval buttons are disabled for everyone. Add "
-                    "admin user IDs under the discord platform's "
-                    "allow_admin_from, or disable the toggle."
-                )
-            return False
-
-        async def _resolve(self, interaction: discord.Interaction, choice: str, color: discord.Color, label: str):
-            """Resolve the approval via the gateway approval queue and update the embed."""
-            if not await self._gate(
-                interaction, resolved_msg="This approval has already been resolved~",
-                unauth_msg="You're not authorized to approve commands~",
-            ):
-                return
-            self.resolved = True
-            # Unblock the waiting agent thread FIRST. A click after the approval
-            # wait timed out (count == 0) must not claim "Approved".
-            try:
-                from tools.approval import resolve_gateway_approval
-                count = resolve_gateway_approval(self.session_key, choice)
-                logger.info(
-                    "Discord button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                    count, self.session_key, choice, interaction.user.display_name,
-                )
-            except Exception as exc:
-                logger.error("Failed to resolve gateway approval from button: %s", exc)
-                count = 0
-            if not count:
-                color = discord.Color.dark_grey()
-                label = "⌛ Approval expired — command was not run (already timed out or resolved elsewhere)"
-            await self._finalize_embed(
-                interaction, color, f"{label} by {interaction.user.display_name}" if count else label)
-
-        @discord.ui.button(label="Allow Once", style=discord.ButtonStyle.green)
-        async def allow_once(self, interaction: discord.Interaction, button: discord.ui.Button):
-            await self._resolve(interaction, "once", discord.Color.green(), "Approved once")
-
-        @discord.ui.button(label="Allow Session", style=discord.ButtonStyle.grey)
-        async def allow_session(self, interaction: discord.Interaction, button: discord.ui.Button):
-            await self._resolve(interaction, "session", discord.Color.blue(), "Approved for session")
-
-        @discord.ui.button(label="Always Allow", style=discord.ButtonStyle.blurple)
-        async def allow_always(self, interaction: discord.Interaction, button: discord.ui.Button):
-            await self._resolve(interaction, "always", discord.Color.purple(), "Approved permanently")
-
-        @discord.ui.button(label="Deny", style=discord.ButtonStyle.red)
-        async def deny(self, interaction: discord.Interaction, button: discord.ui.Button):
-            await self._resolve(interaction, "deny", discord.Color.red(), "Denied")
+    # Request-bound exec-approval cards are owned by their topical module (#104915);
+    # built here on the shared base so a lazy install re-registers them like the rest.
+    ExecApprovalView = define_exec_approval_view(_HermesView)
 
     class SlashConfirmView(_HermesView):
         """Approve Once / Always Approve / Cancel for slash-command confirmations (``/reload-mcp``,

--- a/plugins/platforms/discord/exec_approval.py
+++ b/plugins/platforms/discord/exec_approval.py
@@ -1,0 +1,195 @@
+"""Request-bound Discord exec-approval cards (#104915).
+
+Dedicated owner for the dangerous-command approval-card authorization surface:
+admin-gate resolution, the card payload, and the request-bound view whose
+buttons settle only the approval generation the card was issued for. The
+transport adapter keeps a thin wiring method (``send_exec_approval``) and
+re-exports the view class for its lazy discord runtime.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_exec_approval_admin_gate(config_extra: Optional[dict]) -> Tuple[bool, set]:
+    """Resolve the exec-approval admin gate from ``extra``; returns ``(require_admin, admin_user_ids)``.
+    Default OFF (user-scope buttons). When ``require_admin_for_exec_approval`` is true only
+    ``allow_admin_from`` ids may click; on with no admins -> ``(True, set())`` (fail closed, log once).
+    """
+    extra = config_extra if isinstance(config_extra, dict) else {}
+    raw_toggle = extra.get("require_admin_for_exec_approval", False)
+    require_admin = str(raw_toggle).strip().lower() in {"true", "1", "yes"}
+    if not require_admin:
+        return (False, set())
+    try:
+        from gateway.slash_access import _coerce_id_list
+        admin_ids = set(_coerce_id_list(extra.get("allow_admin_from")))
+    except Exception:
+        admin_ids = set()
+    return (True, admin_ids)
+
+
+def build_exec_approval_card(
+    command: str, description: str, *, smart_denied: bool, mention_content: Optional[str],
+    max_message_length: int, embed_body: Any,
+) -> tuple:
+    """Build the ``(content, embed)`` card payload for ``send_exec_approval``.
+
+    Payload in plain content: embeds can be invisible/detached on web/mobile.
+    """
+    import discord  # runtime discord (real or the shared test mock); cards are only built on a live adapter
+
+    reason_budget = 300
+    reason_display = str(description or "dangerous command")
+    if len(reason_display) > reason_budget:
+        reason_display = reason_display[: reason_budget - 15] + "... [truncated]"
+    prompt_prefix = (
+        "⚠️ **Command Approval Required**\n\n"
+        "Do you want Hermes to run this command?\n\n"
+        "**Requested command:**\n```bash\n"
+    )
+    if smart_denied:
+        prompt_prefix += "**Smart DENY:** owner override applies to this one operation only.\n\n"
+    if mention_content:
+        prompt_prefix = f"{mention_content}\n{prompt_prefix}"
+    prompt_tail = f"\n```\n**Reason:** {reason_display}"
+    truncated_suffix = "\n... [truncated]"
+    command_budget = max(0, max_message_length - len(prompt_prefix) - len(prompt_tail))
+    content_cmd_display = str(command or "")
+    if len(content_cmd_display) > command_budget:
+        content_cmd_display = content_cmd_display[: max(0, command_budget - len(truncated_suffix))] + truncated_suffix
+    content = f"{prompt_prefix}{content_cmd_display}{prompt_tail}"
+    embed = discord.Embed(
+        title="⚠️ Command Approval Required",
+        description=f"```\n{embed_body(str(command or ''))}\n```",
+        color=discord.Color.orange(),
+    )
+    embed.add_field(name="Reason", value=reason_display, inline=False)
+    return content, embed
+
+
+def build_exec_approval_view(
+    *, config_extra: Optional[dict], session_key: str, allowed_user_ids: set,
+    allowed_role_ids: Optional[set] = None, allow_permanent: bool = True,
+    allow_session: bool = True, smart_denied: bool = False, request_id: Optional[str] = None,
+):
+    """Instantiate the adapter-registered ``ExecApprovalView`` with the resolved admin gate."""
+    from plugins.platforms.discord.adapter import ExecApprovalView  # registered by _define_discord_view_classes
+
+    require_admin, admin_user_ids = resolve_exec_approval_admin_gate(config_extra)
+    return ExecApprovalView(
+        session_key=session_key, allowed_user_ids=allowed_user_ids,
+        allowed_role_ids=allowed_role_ids, require_admin=require_admin,
+        admin_user_ids=admin_user_ids, allow_permanent=allow_permanent,
+        allow_session=allow_session, smart_denied=smart_denied, request_id=request_id,
+    )
+
+
+def define_exec_approval_view(base_view) -> type:
+    """Build ``ExecApprovalView`` on the adapter's shared component-view base.
+
+    Called from ``_define_discord_view_classes()`` at module load and after a
+    lazy install, so the class exists whenever DISCORD_AVAILABLE and always
+    shares the base's auth/gate/embed plumbing with the sibling views.
+    """
+    import discord  # only defined once the discord runtime is importable
+
+    class ExecApprovalView(base_view):
+        """Allow Once / Allow Session / Always Allow / Deny buttons for a dangerous command.
+        Clicks call ``resolve_gateway_approval()`` — the same mechanism as the text ``/approve`` flow."""
+
+        def __init__(
+            self, session_key: str, allowed_user_ids: set, allowed_role_ids: Optional[set] = None,
+            require_admin: bool = False, admin_user_ids: Optional[set] = None,
+            allow_permanent: bool = True, allow_session: bool = True, smart_denied: bool = False,
+            request_id: Optional[str] = None,
+        ):
+            from plugins.platforms.discord.adapter import _read_discord_prompt_timeout
+            super().__init__(allowed_user_ids, allowed_role_ids, timeout=_read_discord_prompt_timeout())
+            self.session_key = session_key
+            self.request_id = request_id
+            self.require_admin = require_admin
+            self.admin_user_ids = {str(a).strip() for a in (admin_user_ids or set()) if str(a).strip()}
+            if smart_denied or not allow_session:
+                self.remove_item(self.allow_session)
+                self.remove_item(self.allow_always)
+            elif not allow_permanent:
+                self.remove_item(self.allow_always)
+
+        def _check_auth(self, interaction: discord.Interaction) -> bool:
+            """Base admission always required; with ``require_admin`` the clicker must
+            also be an admin. Fails closed (logged once) when no admins are configured."""
+            if not super()._check_auth(interaction):
+                return False
+            if not self.require_admin:
+                return True
+            user = getattr(interaction, "user", None)
+            try:
+                uid = str(getattr(user, "id", "") or "")
+            except Exception:
+                uid = ""
+            if uid and uid in self.admin_user_ids:
+                return True
+            if not self.admin_user_ids:
+                logger.warning(
+                    "[Discord] require_admin_for_exec_approval is enabled but "
+                    "no admins are configured (allow_admin_from is empty) — "
+                    "exec approval buttons are disabled for everyone. Add "
+                    "admin user IDs under the discord platform's "
+                    "allow_admin_from, or disable the toggle."
+                )
+            return False
+
+        async def _resolve(self, interaction: discord.Interaction, choice: str, color: discord.Color, label: str):
+            """Resolve the approval via the gateway approval queue and update the embed."""
+            if not await self._gate(
+                interaction, resolved_msg="This approval has already been resolved~",
+                unauth_msg="You're not authorized to approve commands~",
+            ):
+                return
+            self.resolved = True
+            # Unblock the waiting agent thread FIRST. A click after the approval
+            # wait timed out (count == 0) must not claim "Approved".
+            try:
+                from tools.approval import resolve_gateway_approval
+                # A card resolves only the request it was issued for; an unbound card or one
+                # whose request is gone must never settle a different queued command (#104915).
+                # Text /approve keeps its FIFO semantics inside resolve_gateway_approval.
+                count = (
+                    resolve_gateway_approval(self.session_key, choice, request_id=self.request_id)
+                    if self.request_id
+                    else 0
+                )
+                logger.info(
+                    "Discord button resolved %d approval(s) for session %s (choice=%s, user=%s)",
+                    count, self.session_key, choice, interaction.user.display_name,
+                )
+            except Exception as exc:
+                logger.error("Failed to resolve gateway approval from button: %s", exc)
+                count = 0
+            if not count:
+                color = discord.Color.dark_grey()
+                label = "⌛ Approval expired — command was not run (already timed out or resolved elsewhere)"
+            await self._finalize_embed(
+                interaction, color, f"{label} by {interaction.user.display_name}" if count else label)
+
+        @discord.ui.button(label="Allow Once", style=discord.ButtonStyle.green)
+        async def allow_once(self, interaction: discord.Interaction, button: discord.ui.Button):
+            await self._resolve(interaction, "once", discord.Color.green(), "Approved once")
+
+        @discord.ui.button(label="Allow Session", style=discord.ButtonStyle.grey)
+        async def allow_session(self, interaction: discord.Interaction, button: discord.ui.Button):
+            await self._resolve(interaction, "session", discord.Color.blue(), "Approved for session")
+
+        @discord.ui.button(label="Always Allow", style=discord.ButtonStyle.blurple)
+        async def allow_always(self, interaction: discord.Interaction, button: discord.ui.Button):
+            await self._resolve(interaction, "always", discord.Color.purple(), "Approved permanently")
+
+        @discord.ui.button(label="Deny", style=discord.ButtonStyle.red)
+        async def deny(self, interaction: discord.Interaction, button: discord.ui.Button):
+            await self._resolve(interaction, "deny", discord.Color.red(), "Denied")
+
+    return ExecApprovalView

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1643,7 +1643,7 @@ class FeishuAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str, description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None, allow_permanent: bool = True, allow_session: bool = True,
-        smart_denied: bool = False,
+        smart_denied: bool = False, request_id: Optional[str] = None,
     ) -> SendResult:
         """Approval-button card; ``hermes_action`` in each button value lets the click callback
         route to ``resolve_gateway_approval()`` and unblock the waiting agent thread."""
@@ -1669,6 +1669,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return await self._send_interactive_card(
                 chat_id, card, metadata, "send_exec_approval failed",
                 state_map=self._approval_state, state_id=approval_id, session_key=session_key,
+                request_id=request_id,
             )
         except Exception as exc:
             logger.warning("[Feishu] send_exec_approval failed: %s", exc)
@@ -1676,7 +1677,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
     async def _send_interactive_card(
         self, chat_id: str, card: Dict[str, Any], metadata: Optional[Dict[str, Any]], failure_message: str, *,
-        state_map: Dict[int, Dict[str, str]], state_id: int, session_key: str,
+        state_map: Dict[int, Dict[str, Optional[str]]], state_id: int, session_key: str,
+        request_id: Optional[str] = None,
     ) -> SendResult:
         """Send a button card and, on success, remember where it went so a click can be validated."""
         response = await self._feishu_send_with_retry(
@@ -1689,6 +1691,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 "session_key": session_key,
                 "message_id": result.message_id or "",
                 "chat_id": chat_id,
+                "request_id": request_id,
             }
         return result
 
@@ -2223,7 +2226,14 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         try:
             from tools.approval import resolve_gateway_approval
-            count = resolve_gateway_approval(state["session_key"], choice)
+            # A card settles only the request generation it was issued for; an unbound card
+            # must not fall back to the session FIFO (#104915).
+            request_id = state.get("request_id")
+            count = (
+                resolve_gateway_approval(state["session_key"], choice, request_id=request_id)
+                if request_id
+                else 0
+            )
             logger.info(
                 "Feishu button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                 count, state["session_key"], choice, user_name,

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -306,6 +306,7 @@ class _MatrixApprovalPrompt:
     resolved: bool = False
     requester_user_id: str | None = None
     expires_at: float | None = None
+    request_id: str | None = None  # binds reactions to one request generation (#104915)
     bot_reaction_events: dict[str, str] = field(default_factory=dict, init=False)  # emoji -> event_id
 
 
@@ -1551,7 +1552,7 @@ class MatrixAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str, description: str = "dangerous command",
         metadata: Optional[dict] = None, allow_permanent: bool = True, allow_session: bool = True,
-        smart_denied: bool = False) -> SendResult:
+        smart_denied: bool = False, request_id: Optional[str] = None) -> SendResult:
         if not self._client:
             return SendResult(success=False, error="Not connected")
         if smart_denied:
@@ -1582,7 +1583,7 @@ class MatrixAdapter(BasePlatformAdapter):
             self._approval_prompt_by_session[session_key] = message_id
             return _MatrixApprovalPrompt(
                 session_key=session_key, chat_id=chat_id, message_id=message_id, requester_user_id=requester,
-                expires_at=expires_at)
+                expires_at=expires_at, request_id=request_id)
         return await self._send_reaction_prompt(
             chat_id, text, metadata, _make, self._approval_prompts_by_event, tuple(reactions), "approval")
 
@@ -2292,7 +2293,13 @@ class MatrixAdapter(BasePlatformAdapter):
             return handled
         try:
             from tools.approval import resolve_gateway_approval
-            count = resolve_gateway_approval(prompt.session_key, choice)
+            # A reaction settles only the request generation its prompt was issued for; an
+            # unbound prompt must not fall back to the session FIFO (#104915).
+            count = (
+                resolve_gateway_approval(prompt.session_key, choice, request_id=prompt.request_id)
+                if prompt.request_id
+                else 0
+            )
             if count:
                 prompt.resolved = True
                 self._approval_prompts_by_event.pop(reacts_to, None)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4580,10 +4580,13 @@ class SlackAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str, description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None, allow_permanent: bool = True,
-        allow_session: bool = True, smart_denied: bool = False) -> SendResult:
+        allow_session: bool = True, smart_denied: bool = False,
+        request_id: Optional[str] = None) -> SendResult:
         """Send a Block Kit approval prompt with interactive buttons.
         The buttons call ``resolve_gateway_approval()`` to unblock the waiting agent thread — same
-        mechanism as the text ``/approve`` flow."""
+        mechanism as the text ``/approve`` flow. The button value carries ``session_key|request_id``
+        (the slash-confirm convention) so a click settles only the request generation its card
+        was issued for (#104915)."""
 
         def _build() -> Tuple[str, list]:
             # Slack caps a section's text at 3000 chars (overflow → invalid_blocks → no buttons);
@@ -4594,14 +4597,15 @@ class SlackAdapter(BasePlatformAdapter):
             reason = f"Reason: {description[:500]}"
             budget = 3000 - len(header) - len(reason) - len("``````\n") - len("...")
             cmd_preview = command[:budget] + "..." if len(command) > budget else command
+            value = f"{session_key}|{request_id}" if request_id else session_key
             actions = [
-                self._button("Allow Once", "hermes_approve_once", session_key, style="primary")]
+                self._button("Allow Once", "hermes_approve_once", value, style="primary")]
             if not smart_denied and allow_session:
-                actions.append(self._button("Allow Session", "hermes_approve_session", session_key))
+                actions.append(self._button("Allow Session", "hermes_approve_session", value))
                 if allow_permanent:
                     actions.append(
-                        self._button("Always Allow", "hermes_approve_always", session_key))
-            actions.append(self._button("Deny", "hermes_deny", session_key, style="danger"))
+                        self._button("Always Allow", "hermes_approve_always", value))
+            actions.append(self._button("Deny", "hermes_deny", value, style="danger"))
             blocks = [
                 {
                     "type": "section",
@@ -5239,8 +5243,11 @@ class SlackAdapter(BasePlatformAdapter):
         started = await self._begin_interaction(ack, body, action, "approval")
         if started is None:
             return
-        team_id, action_id, session_key, message, msg_ts, channel_id, user_name, user_id = started
+        team_id, action_id, value, message, msg_ts, channel_id, user_name, user_id = started
         choice = self._APPROVAL_CHOICES.get(action_id, "deny")
+        # Button value is ``session_key|request_id`` (slash-confirm convention); legacy
+        # cards carry a bare session_key and resolve fail-closed (#104915).
+        session_key, _, request_id = value.partition("|")
         # Double-click guard (atomic pop). Also accept the bare ts: the approval may
         # have been stored without a team id while the click carries one.
         approval_key = self._workspace_message_marker(team_id, msg_ts)
@@ -5252,7 +5259,13 @@ class SlackAdapter(BasePlatformAdapter):
         # timeout (count == 0) shows "expired", not "approved".
         try:
             from tools.approval import resolve_gateway_approval
-            count = resolve_gateway_approval(session_key, choice)
+            # A click settles only the request generation its card was issued for; an
+            # unbound card must not fall back to the session FIFO (#104915).
+            count = (
+                resolve_gateway_approval(session_key, choice, request_id=request_id)
+                if request_id
+                else 0
+            )
             logger.info(
                 "Slack button resolved %d approval(s) for session %s (choice=%s, user=%s)", count,
                 session_key, choice, user_name)

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -572,7 +572,7 @@ class TeamsAdapter(BasePlatformAdapter):
     async def _on_card_action(
         self, ctx: "ActivityContext[AdaptiveCardInvokeActivity]"
     ) -> "InvokeResponse[AdaptiveCardActionMessageResponse]":
-        from tools.approval import resolve_gateway_approval, has_blocking_approval
+        from tools.approval import resolve_gateway_approval
 
         data = ctx.activity.value.action.data or {}
         hermes_action = data.get("hermes_action", "")
@@ -585,9 +585,16 @@ class TeamsAdapter(BasePlatformAdapter):
         choice = _APPROVAL_CHOICES.get(hermes_action)
         if not choice:
             return self._invoke_message("Unknown action.")
-        if not has_blocking_approval(session_key):
+        # A card settles only the request generation it was issued for; an unbound or stale
+        # card fails closed instead of falling back to the session FIFO (#104915).
+        request_id = str(data.get("request_id") or "")
+        count = (
+            resolve_gateway_approval(session_key, choice, request_id=request_id)
+            if request_id
+            else 0
+        )
+        if not count:
             return self._invoke_card([TextBlock(text="⚠️ Approval already resolved or expired.", wrap=True)])
-        resolve_gateway_approval(session_key, choice)
         body = _approval_body(data.get("cmd", ""), data.get("desc", ""))
         body.append(TextBlock(text=_APPROVAL_LABELS[choice], wrap=True, weight="Bolder"))
         return self._invoke_card(body)
@@ -615,11 +622,15 @@ class TeamsAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str, description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None, allow_permanent: bool = True, allow_session: bool = True,
-        smart_denied: bool = False) -> SendResult:
+        smart_denied: bool = False, request_id: Optional[str] = None) -> SendResult:
         if not self._app:
             return SendResult(success=False, error="Teams app not initialized")
         # Button data carries a truncated cmd — just enough to reconstruct the card body.
-        btn_data_base = {"session_key": session_key, "cmd": _truncate(command, 200), "desc": description}
+        # request_id binds each button to the request generation its card was issued for (#104915).
+        btn_data_base = {
+            "session_key": session_key, "cmd": _truncate(command, 200), "desc": description,
+            "request_id": request_id or "",
+        }
 
         def _action(title: str, hermes_action: str, **kw) -> "ExecuteAction":
             return ExecuteAction(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -513,6 +513,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}  # per-chat interactive picker state
         self._choice_picker_state: Dict[str, dict] = {}
         self._approval_state: Dict[int, str] = {}  # message_id → session_key
+        self._approval_request_ids: Dict[int, str] = {}  # approval_id → gateway request_id (#104915)
         self._slash_confirm_state: Dict[str, str] = {}  # confirm_id → session_key
         self._clarify_state: Dict[str, str] = {}  # clarify_id → session_key
         # "important" (default): only final responses, approvals and slash confirmations notify;
@@ -3793,7 +3794,7 @@ class TelegramAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str, description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None, allow_permanent: bool = True, allow_session: bool = True,
-        smart_denied: bool = False) -> SendResult:
+        smart_denied: bool = False, request_id: Optional[str] = None) -> SendResult:
         """Send an inline-keyboard approval prompt; buttons call ``resolve_gateway_approval()`` like the
         text ``/approve`` flow."""
         def build():
@@ -3809,8 +3810,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 if allow_permanent:
                     buttons.append(InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}"))
             buttons.append(InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}"))
-            return text, InlineKeyboardMarkup(
-                self._rows_of_two(buttons)), lambda msg: self._approval_state.__setitem__(approval_id, session_key)
+
+            def _register(msg):
+                self._approval_state[approval_id] = session_key
+                if request_id:
+                    # callback_data caps at 64 bytes, so the request id rides out-of-band;
+                    # the tap settles only the request generation this prompt was issued for (#104915).
+                    self._approval_request_ids[approval_id] = request_id
+
+            return text, InlineKeyboardMarkup(self._rows_of_two(buttons)), _register
         return await self._send_prompt(
             "send_exec_approval", chat_id, metadata, build, parse_mode=ParseMode.HTML,
             thread_id=self._metadata_thread_id(metadata), reply_to_mode=self._reply_to_mode)
@@ -4287,12 +4295,19 @@ class TelegramAdapter(BasePlatformAdapter):
         user_display = getattr(query.from_user, "first_name", "User")
         # Resolve FIRST (unblocks the agent thread), render after: a tap landing after the wait timed out
         # (count == 0) must NOT claim "Approved" — the command was already denied.
+        request_id = self._approval_request_ids.pop(approval_id, None)
         try:
             # Rendering happens after so the message reflects what actually occurred: a tap that lands after
             # the approval wait timed out (count == 0) must NOT claim "Approved" — the command was already
             # denied and will not run (#63501 regression follow-up: 60s waits made stale taps common).
             from tools.approval import resolve_gateway_approval
-            count = resolve_gateway_approval(session_key, choice)
+            # A tap settles only the request generation its prompt was issued for; an
+            # unbound prompt must not fall back to the session FIFO (#104915).
+            count = (
+                resolve_gateway_approval(session_key, choice, request_id=request_id)
+                if request_id
+                else 0
+            )
             logger.info(
                 "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)", count, session_key, choice, user_display)
         except Exception as exc:

--- a/tests/gateway/relay/test_relay_interactive.py
+++ b/tests/gateway/relay/test_relay_interactive.py
@@ -85,6 +85,36 @@ def _event(
 
 
 @pytest.mark.asyncio
+async def test_exec_approval_press_resolves_only_its_bound_request(monkeypatch):
+    """A relay press settles the request generation its prompt was minted for (#104915)."""
+    adapter, _stub = _adapter()
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        "tools.approval.resolve_gateway_approval",
+        lambda session_key, choice, request_id=None: calls.append((session_key, choice, request_id)) or 1,
+    )
+
+    await adapter._resolve_exec_approval({"session_key": "s1", "request_id": "req-1"}, "once", "c1", None)
+
+    assert calls == [("s1", "once", "req-1")]
+
+
+@pytest.mark.asyncio
+async def test_unbound_exec_approval_press_fails_closed(monkeypatch):
+    """A prompt without a bound request id must not settle the session FIFO (#104915)."""
+    adapter, _stub = _adapter()
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        "tools.approval.resolve_gateway_approval",
+        lambda session_key, choice, request_id=None: calls.append((session_key, choice, request_id)) or 1,
+    )
+
+    await adapter._resolve_exec_approval({"session_key": "s1", "request_id": None}, "once", "c1", None)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_exec_approval_renders_full_option_set():
     adapter, stub = _adapter()
     result = await adapter.send_exec_approval(

--- a/tests/gateway/test_discord_component_auth.py
+++ b/tests/gateway/test_discord_component_auth.py
@@ -25,7 +25,9 @@ from plugins.platforms.discord.adapter import (  # noqa: E402
     SlashConfirmView,
     UpdatePromptView,
     _component_check_auth,
-    _resolve_exec_approval_admin_gate,
+)
+from plugins.platforms.discord.exec_approval import (
+    resolve_exec_approval_admin_gate as _resolve_exec_approval_admin_gate,
 )
 
 

--- a/tests/gateway/test_exec_approval_request_binding_convergence.py
+++ b/tests/gateway/test_exec_approval_request_binding_convergence.py
@@ -1,0 +1,185 @@
+"""Interface-convergence regression tests for exec-approval request binding (#104915).
+
+The gateway's single ``send_exec_approval(...)`` call site passes ``request_id``
+to every adapter that accepts it. Before the convergence, the widened call raised
+``TypeError`` on the Slack / Teams / Matrix / Feishu / Telegram signatures before
+any approval prompt rendered. These tests pin, AST-level (no platform SDK imports):
+
+1. every built-in adapter's ``send_exec_approval`` declares ``request_id``;
+2. the shared call site gates the keyword through ``_accepts_keyword`` so
+   external/plugin adapters predating the converged signature keep the legacy
+   call shape instead of crashing.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from agent.interrupt_compat import _accepts_keyword
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_ADAPTER_FILES = [
+    "gateway/platforms/qqbot/adapter.py",
+    "gateway/platforms/whatsapp_cloud.py",
+    "gateway/relay/adapter.py",
+    "plugins/platforms/discord/adapter.py",
+    "plugins/platforms/feishu/adapter.py",
+    "plugins/platforms/matrix/adapter.py",
+    "plugins/platforms/slack/adapter.py",
+    "plugins/platforms/teams/adapter.py",
+    "plugins/platforms/telegram/adapter.py",
+]
+
+
+def _send_exec_approval_args(rel_path: str) -> set[str]:
+    tree = ast.parse((_REPO_ROOT / rel_path).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "send_exec_approval"
+        ):
+            return {a.arg for a in node.args.args + node.args.kwonlyargs}
+    raise AssertionError(f"send_exec_approval not found in {rel_path}")
+
+
+class TestConvergedSignature:
+    @pytest.mark.parametrize("rel_path", _ADAPTER_FILES)
+    def test_send_exec_approval_declares_request_id(self, rel_path):
+        """The gateway call site passes request_id unconditionally to built-ins;
+        each adapter must declare it (pre-convergence this raised TypeError)."""
+        assert "request_id" in _send_exec_approval_args(rel_path), (
+            f"{rel_path}: send_exec_approval must accept request_id (#104915)"
+        )
+
+
+class TestExternalAdapterCompat:
+    def test_accepts_keyword_distinguishes_legacy_from_converged(self):
+        """The call-site gate must keep legacy (external/plugin) adapters on the
+        old call shape while passing request_id to converged ones."""
+
+        async def legacy_send(chat_id, command, session_key, description="d",
+                              metadata=None, allow_permanent=True, allow_session=True,
+                              smart_denied=False):
+            ...
+
+        class Converged:
+            async def send_exec_approval(self, chat_id, command, session_key,
+                                         description="d", metadata=None,
+                                         allow_permanent=True, allow_session=True,
+                                         smart_denied=False, request_id=None):
+                ...
+
+        assert not _accepts_keyword(legacy_send, "request_id")
+        assert _accepts_keyword(Converged.send_exec_approval, "request_id")
+
+
+class TestLegacyAdapterFailsClosed:
+    """Review follow-up (#104915): an adapter whose ``send_exec_approval`` predates the
+    converged signature must not render an interactive approval at all. Its taps can only
+    resolve through the session FIFO, so a stale/overlapping control could settle a
+    different pending request — the notify path fails closed to the typed-text prompt
+    (a clearly separate resolution path) instead of rendering an unbound card."""
+
+    @staticmethod
+    def _make_runner(adapter):
+        from types import SimpleNamespace
+
+        from gateway.run_turn_runner import TurnRunner
+
+        runner = TurnRunner.__new__(TurnRunner)
+        runner._ctx = SimpleNamespace(
+            _status_adapter=adapter,
+            _status_chat_id="chat-1",
+            session_key="sess-1",
+            _status_thread_metadata=None,
+        )
+        runner._close_native_stream_boundary = lambda *args, **kwargs: None
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_legacy_adapter_renders_typed_text_not_unbound_card(self):
+        """A legacy adapter's send_exec_approval must never be called: the typed-text
+        prompt (with the typed prefix) is the only approval surface it gets."""
+        import asyncio
+
+        class LegacyAdapter:
+            typed_command_prefix = "!"
+
+            def pause_typing_for_chat(self, chat_id): ...
+
+            async def send_exec_approval(self, chat_id, command, session_key, description="d",
+                                         metadata=None, allow_permanent=True,
+                                         allow_session=True, smart_denied=False):
+                raise AssertionError(
+                    "legacy adapter must not render an interactive approval (#104915)"
+                )
+
+            sent = []
+
+            async def send(self, chat_id, msg, metadata=None):
+                from gateway.platforms.base import SendResult
+
+                self.sent.append((msg, metadata))
+                return SendResult(success=True)
+
+        adapter = LegacyAdapter()
+        runner = self._make_runner(adapter)
+        loop = asyncio.get_running_loop()
+        runner._schedule = lambda coro, log_message, loop_arg=None: asyncio.run_coroutine_threadsafe(coro, loop)
+
+        def notify():
+            runner._approval_notify_sync(
+                {"command": "rm -rf /tmp/probe", "description": "probe", "request_id": "req-legacy-1"}
+            )
+
+        await asyncio.to_thread(notify)
+
+        assert adapter.sent, "the typed-text fallback must fire for a legacy adapter"
+        msg, metadata = adapter.sent[0]
+        assert "`!approve`" in msg, "the prompt must use the adapter's typed prefix"
+        assert metadata.get("is_approval_prompt") is True
+
+    @pytest.mark.asyncio
+    async def test_converged_adapter_still_receives_request_id(self):
+        """Counterpart: a converged adapter keeps the interactive card and the card is
+        bound to its request generation."""
+        import asyncio
+
+        class ConvergedAdapter:
+            typed_command_prefix = "/"
+
+            def pause_typing_for_chat(self, chat_id): ...
+
+            approvals = []
+            sent = []
+
+            async def send_exec_approval(self, chat_id, command, session_key, description="d",
+                                         metadata=None, allow_permanent=True,
+                                         allow_session=True, smart_denied=False,
+                                         request_id=None):
+                from gateway.platforms.base import SendResult
+
+                self.approvals.append(request_id)
+                return SendResult(success=True)
+
+            async def send(self, chat_id, msg, metadata=None):
+                from gateway.platforms.base import SendResult
+
+                self.sent.append((msg, metadata))
+                return SendResult(success=True)
+
+        adapter = ConvergedAdapter()
+        runner = self._make_runner(adapter)
+        loop = asyncio.get_running_loop()
+        runner._schedule = lambda coro, log_message, loop_arg=None: asyncio.run_coroutine_threadsafe(coro, loop)
+
+        await asyncio.to_thread(
+            lambda: runner._approval_notify_sync(
+                {"command": "probe", "description": "probe", "request_id": "req-conv-1"}
+            )
+        )
+
+        assert adapter.approvals == ["req-conv-1"], "converged card must receive the request id"
+        assert not adapter.sent, "interactive path delivered; no text fallback expected"

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -211,13 +211,31 @@ class TestResolveApproval:
             "session_key": "agent:main:feishu:group:oc_12345",
             "message_id": "msg_001",
             "chat_id": "oc_12345",
+            "request_id": "req-1",
         }
 
         with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
             await adapter._resolve_approval(1, "once", "Norbert", open_id="ou_user1", chat_id="oc_12345")
 
-        mock_resolve.assert_called_once_with("agent:main:feishu:group:oc_12345", "once")
+        mock_resolve.assert_called_once_with("agent:main:feishu:group:oc_12345", "once", request_id="req-1")
         assert 1 not in adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_unbound_card_fails_closed(self):
+        """A card state without a request id must not settle the session FIFO (#104915)."""
+        adapter = _make_adapter()
+        adapter._approval_state[2] = {
+            "session_key": "agent:main:feishu:group:oc_12345",
+            "message_id": "msg_002",
+            "chat_id": "oc_12345",
+            "request_id": None,
+        }
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._resolve_approval(2, "once", "Norbert", open_id="ou_user1", chat_id="oc_12345")
+
+        mock_resolve.assert_not_called()
+        assert 2 not in adapter._approval_state
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_matrix_exec_approval.py
+++ b/tests/gateway/test_matrix_exec_approval.py
@@ -18,7 +18,7 @@ class TestMatrixExecApprovalReactions:
         # Resolve user_id so _is_self_sender doesn't defensively drop all traffic (#15763).
         adapter._user_id = "@bot:example.org"
         adapter._approval_prompts_by_event["$target"] = _MatrixApprovalPrompt(
-            session_key="sess-1", chat_id="!room:example.org", message_id="$target"
+            session_key="sess-1", chat_id="!room:example.org", message_id="$target", request_id="req-1"
         )
         adapter._approval_prompt_by_session["sess-1"] = "$target"
 
@@ -33,6 +33,6 @@ class TestMatrixExecApprovalReactions:
         with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
             await adapter._on_reaction(event)
 
-        mock_resolve.assert_called_once_with("sess-1", "once")
+        mock_resolve.assert_called_once_with("sess-1", "once", request_id="req-1")
         assert "$target" not in adapter._approval_prompts_by_event
         assert "sess-1" not in adapter._approval_prompt_by_session

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -665,8 +665,16 @@ class TestApprovalButtonData:
     def test_parse_allow_once(self):
         from gateway.platforms.qqbot.keyboards import parse_approval_button_data
         result = parse_approval_button_data("approve:agent:main:qqbot:c2c:UID:allow-once")
-        assert result == ("agent:main:qqbot:c2c:UID", "allow-once")
+        assert result == ("agent:main:qqbot:c2c:UID", "allow-once", None)
 
+    def test_parse_allow_once_with_request_id(self):
+        from gateway.platforms.qqbot.keyboards import parse_approval_button_data
+        result = parse_approval_button_data("approve:agent:main:qqbot:c2c:UID:allow-once:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6")
+        assert result == ("agent:main:qqbot:c2c:UID", "allow-once", "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6")
+
+    def test_parse_rejects_non_hex_request_id(self):
+        from gateway.platforms.qqbot.keyboards import parse_approval_button_data
+        assert parse_approval_button_data("approve:sess:allow-once:not-hex!") is None
 
     def test_parse_empty_returns_none(self):
         from gateway.platforms.qqbot.keyboards import parse_approval_button_data
@@ -694,6 +702,13 @@ class TestBuildApprovalKeyboard:
         assert datas[0] == "approve:agent:main:qqbot:c2c:UID:allow-once"
         assert datas[1] == "approve:agent:main:qqbot:c2c:UID:allow-always"
         assert datas[2] == "approve:agent:main:qqbot:c2c:UID:deny"
+
+    def test_button_data_binds_request_id_when_present(self):
+        from gateway.platforms.qqbot.keyboards import build_approval_keyboard
+        kb = build_approval_keyboard("agent:main:qqbot:c2c:UID", request_id="a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6")
+        datas = [b.action.data for b in kb.content.rows[0].buttons]
+        assert datas[0] == "approve:agent:main:qqbot:c2c:UID:allow-once:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+        assert datas[2] == "approve:agent:main:qqbot:c2c:UID:deny:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 
 
 class TestBuildUpdatePromptKeyboard:
@@ -905,12 +920,41 @@ class TestDefaultInteractionDispatch:
 
         resolve_calls = []
 
-        def fake_resolve(session_key, choice, resolve_all=False):
-            resolve_calls.append((session_key, choice, resolve_all))
+        def fake_resolve(session_key, choice, resolve_all=False, request_id=None):
+            resolve_calls.append((session_key, choice, resolve_all, request_id))
             return 1
 
         # Patch the *module-level* function that _default_interaction_dispatch
         # imports lazily.
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,
+                "user_openid": "u-42",
+                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:c2c:u-42:allow-once:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [
+            ("agent:main:qqbot:c2c:u-42", "once", False, "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6")
+        ]
+
+    @pytest.mark.asyncio
+    async def test_unbound_approval_click_fails_closed(self):
+        """A legacy card without a request id must not settle the session FIFO (#104915)."""
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False, request_id=None):
+            resolve_calls.append((session_key, choice, resolve_all, request_id))
+            return 1
+
         import tools.approval
         orig = tools.approval.resolve_gateway_approval
         tools.approval.resolve_gateway_approval = fake_resolve
@@ -926,7 +970,7 @@ class TestDefaultInteractionDispatch:
         finally:
             tools.approval.resolve_gateway_approval = orig
 
-        assert resolve_calls == [("agent:main:qqbot:c2c:u-42", "once", False)]
+        assert resolve_calls == []
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -149,6 +149,57 @@ class TestSlackApprovalAction:
 
 
     @pytest.mark.asyncio
+    async def test_tap_resolves_only_its_bound_action(self):
+        """A click settles the request generation its card was issued for (#104915).
+
+        The button value carries ``session_key|request_id`` (slash-confirm convention).
+        """
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved["1.2"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.2", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "alice", "id": "U_ALICE"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "session-key|req-9"}
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        mock_resolve.assert_called_once_with("session-key", "once", request_id="req-9")
+
+    @pytest.mark.asyncio
+    async def test_unbound_tap_fails_closed(self):
+        """A legacy card without a request id must not settle the session FIFO (#104915)."""
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved["1.3"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.3", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "alice", "id": "U_ALICE"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "session-key"}
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        mock_resolve.assert_not_called()
+        update_kwargs = mock_client.chat_update.call_args[1]
+        assert "expired" in update_kwargs["text"]
+
+    @pytest.mark.asyncio
     async def test_truncates_inflated_original_text(self):
         """Interaction payload re-escapes HTML entities; text must be capped."""
         adapter = _make_adapter()

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -186,6 +186,7 @@ class TestTelegramApprovalCallback:
         """
         adapter = _make_adapter()
         adapter._approval_state[5] = "agent:main:telegram:group:12345:99"
+        adapter._approval_request_ids[5] = "req-5"
         adapter.pause_typing_for_chat("12345")
         assert "12345" in adapter._typing_paused
 
@@ -214,6 +215,7 @@ class TestTelegramApprovalCallback:
     async def test_approval_callback_escapes_dynamic_user_name(self):
         adapter = _make_adapter()
         adapter._approval_state[3] = "agent:main:telegram:group:12345:99"
+        adapter._approval_request_ids[3] = "req-3"
 
         query = AsyncMock()
         query.data = "ea:once:3"
@@ -237,6 +239,62 @@ class TestTelegramApprovalCallback:
         assert "MARKDOWN_V2" in repr(edit_kwargs["parse_mode"])
         assert "Alice\\_Bob" in edit_kwargs["text"]
         assert "Approved once" in edit_kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_tap_resolves_only_its_bound_request(self):
+        """An inline tap settles its own request generation, never the FIFO (#104915)."""
+        adapter = _make_adapter()
+        adapter._approval_state[7] = "agent:main:telegram:group:12345:99"
+        adapter._approval_request_ids[7] = "req-7"
+
+        query = AsyncMock()
+        query.data = "ea:once:7"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Norbert"
+        query.from_user.id = "12345"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_called_once_with(
+            "agent:main:telegram:group:12345:99", "once", request_id="req-7")
+
+    @pytest.mark.asyncio
+    async def test_unbound_tap_fails_closed(self):
+        """A prompt without a bound request id must not settle the FIFO (#104915)."""
+        adapter = _make_adapter()
+        adapter._approval_state[8] = "agent:main:telegram:group:12345:99"
+        adapter.pause_typing_for_chat("12345")
+
+        query = AsyncMock()
+        query.data = "ea:once:8"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Norbert"
+        query.from_user.id = "12345"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_not_called()
+        assert "12345" in adapter._typing_paused
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -88,9 +88,9 @@ def _make_adapter(**overrides):
     adapter._last_inbound_wamid_by_chat = {}
 
     # Phase 9 state — interactive-button correlation dicts.
-    adapter._clarify_state = {}
-    adapter._exec_approval_state = {}
-    adapter._slash_confirm_state = {}
+    adapter._clarify_state = OrderedDict()
+    adapter._exec_approval_state = OrderedDict()
+    adapter._slash_confirm_state = OrderedDict()
 
     # BasePlatformAdapter contract — minimum to keep send/lifecycle happy
     adapter._running = True
@@ -997,7 +997,7 @@ class TestSendExecApprovalButtons:
         body = payload["interactive"]["body"]["text"]
         assert "rm -rf /tmp/foo" in body
         assert "cleanup script" in body
-        assert adapter._exec_approval_state[approval_id] == "sess-app-1"
+        assert adapter._exec_approval_state[approval_id] == ("sess-app-1", None)
 
 
 class TestSendSlashConfirmButtons:
@@ -1098,7 +1098,7 @@ class TestDispatchInteractiveReplyApproval:
     @pytest.mark.asyncio
     async def test_approve_tap_calls_resolver_and_confirms(self, monkeypatch):
         adapter = _make_adapter()
-        adapter._exec_approval_state["app1"] = "sess-app-1"
+        adapter._exec_approval_state["app1"] = ("sess-app-1", "req-app-1")
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, {"messages": [{"id": "x"}]})
@@ -1107,7 +1107,7 @@ class TestDispatchInteractiveReplyApproval:
         calls = []
         monkeypatch.setattr(
             "tools.approval.resolve_gateway_approval",
-            lambda session_key, choice: calls.append((session_key, choice)) or 1,
+            lambda session_key, choice, request_id=None: calls.append((session_key, choice, request_id)) or 1,
         )
 
         raw = {
@@ -1121,11 +1121,74 @@ class TestDispatchInteractiveReplyApproval:
         handled = await adapter._dispatch_interactive_reply(raw, {})
 
         assert handled is True
-        assert calls == [("sess-app-1", "approve")]
+        assert calls == [("sess-app-1", "approve", "req-app-1")]
         assert "app1" not in adapter._exec_approval_state
         confirm_payload = adapter._http_client.post.call_args.kwargs["json"]
         assert confirm_payload["type"] == "text"
         assert "Approved" in confirm_payload["text"]["body"]
+
+    @pytest.mark.asyncio
+    async def test_unbound_tap_fails_closed(self, monkeypatch):
+        """A card without a bound request id must not settle the FIFO (#104915)."""
+        adapter = _make_adapter()
+        adapter._exec_approval_state["app2"] = ("sess-app-2", None)
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"messages": [{"id": "x"}]})
+        )
+
+        calls = []
+        monkeypatch.setattr(
+            "tools.approval.resolve_gateway_approval",
+            lambda session_key, choice, request_id=None: calls.append((session_key, choice, request_id)) or 1,
+        )
+
+        raw = {
+            "from": "15551234567",
+            "type": "interactive",
+            "interactive": {
+                "type": "button_reply",
+                "button_reply": {"id": "appr:app2:approve", "title": "Approve"},
+            },
+        }
+        handled = await adapter._dispatch_interactive_reply(raw, {})
+
+        assert handled is True
+        assert calls == []
+        confirm_payload = adapter._http_client.post.call_args.kwargs["json"]
+        assert "expired" in confirm_payload["text"]["body"]
+
+    @pytest.mark.asyncio
+    async def test_request_binding_evicts_with_state_beyond_cache_cap(self):
+        """The request id lives in the same bounded record as the tap state: past
+        INTERACTIVE_STATE_CACHE_SIZE the oldest cards evict WHOLE — no stranded
+        request-id half, no unbounded side map (#104915 review)."""
+        from gateway.platforms.whatsapp_cloud import INTERACTIVE_STATE_CACHE_SIZE
+
+        adapter = _make_adapter()
+        # The single-record shape is the fix: the old separate plain-dict binding
+        # (`_exec_approval_request_ids`) only popped on tap and could never evict.
+        assert not hasattr(adapter, "_exec_approval_request_ids")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"messages": [{"id": "x"}]})
+        )
+
+        first_approval_id = None
+        for i in range(INTERACTIVE_STATE_CACHE_SIZE + 3):
+            result = await adapter.send_exec_approval(
+                "15551234567", f"cmd-{i}", "sess-1", request_id=f"req-{i}",
+            )
+            assert result.success
+            if first_approval_id is None:
+                payload = adapter._http_client.post.call_args.kwargs["json"]
+                first_approval_id = payload["interactive"]["action"]["buttons"][0]["reply"]["id"].split(":")[1]
+
+        assert len(adapter._exec_approval_state) == INTERACTIVE_STATE_CACHE_SIZE
+        # Oldest card evicted whole: the tap state left AND took its binding with it.
+        assert first_approval_id not in adapter._exec_approval_state
+        newest_id = next(reversed(adapter._exec_approval_state))
+        assert adapter._exec_approval_state[newest_id] == ("sess-1", f"req-{INTERACTIVE_STATE_CACHE_SIZE + 2}")
 
 
 @pytest.mark.usefixtures("authorized_interactive_env")
@@ -1182,7 +1245,7 @@ class TestDispatchInteractiveReplyAuthorization:
             _dm_policy="allowlist",
             _allow_from={"15551234567"},
         )
-        adapter._exec_approval_state["app1"] = "sess-app-1"
+        adapter._exec_approval_state["app1"] = ("sess-app-1", "req-app-1")
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, {"messages": [{"id": "x"}]})
@@ -1190,7 +1253,7 @@ class TestDispatchInteractiveReplyAuthorization:
         calls = []
         monkeypatch.setattr(
             "tools.approval.resolve_gateway_approval",
-            lambda session_key, choice: calls.append((session_key, choice)) or 1,
+            lambda session_key, choice, request_id=None: calls.append((session_key, choice, request_id)) or 1,
         )
 
         raw = {
@@ -1204,7 +1267,7 @@ class TestDispatchInteractiveReplyAuthorization:
         handled = await adapter._dispatch_interactive_reply(raw, {})
 
         assert handled is True
-        assert calls == [("sess-app-1", "approve")]
+        assert calls == [("sess-app-1", "approve", "req-app-1")]
 
 
 @pytest.mark.usefixtures("authorized_interactive_env")

--- a/tests/plugins/platforms/test_discord_exec_approval_request_binding.py
+++ b/tests/plugins/platforms/test_discord_exec_approval_request_binding.py
@@ -1,0 +1,223 @@
+"""Request-identity regression tests for Discord exec-approval cards (#104915).
+
+A card's buttons must resolve only the approval request that card was issued
+for. Historically ``ExecApprovalView`` carried no request id, so
+``resolve_gateway_approval`` fell back to its FIFO branch and a click resolved
+the session's OLDEST pending request — approving a different command than the
+one displayed (overlapping prompts, or a stale card still clickable after its
+request was removed or expired).
+
+The tests drive the real ``ExecApprovalView._resolve`` against synthetic queue
+entries (``data={"request_id": ...}``, ``result=None``, ``threading.Event()``)
+with a mocked interaction — no shell command runs and no Discord transport is
+touched.
+"""
+
+import ast
+import asyncio
+import inspect
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# This file lives next to its owner module (plugins/platforms/discord/), away
+# from tests/gateway/, so the shared comprehensive discord mock must be
+# triggered explicitly before importing the production module.
+from tests.gateway.conftest import _ensure_discord_mock  # noqa: E402
+
+_ensure_discord_mock()
+
+from plugins.platforms.discord.adapter import ExecApprovalView  # noqa: E402
+
+
+SESSION_KEY = "sess-104915"
+ALLOWED_UID = "11111"
+
+
+def _entry(request_id: str, command: str = "cmd"):
+    from tools.approval_gateway_wait import _ApprovalEntry
+
+    return _ApprovalEntry({"request_id": request_id, "command": command})
+
+
+def _view(request_id, *, allowed_user_ids=None):
+    return ExecApprovalView(
+        session_key=SESSION_KEY,
+        allowed_user_ids={ALLOWED_UID} if allowed_user_ids is None else allowed_user_ids,
+        request_id=request_id,
+    )
+
+
+def _interaction(user_id=ALLOWED_UID):
+    response = MagicMock()
+    response.send_message = AsyncMock()
+    response.edit_message = AsyncMock()
+    return SimpleNamespace(
+        user=SimpleNamespace(id=user_id, display_name="op"),
+        response=response,
+        message=SimpleNamespace(embeds=[]),
+    )
+
+
+def _click(view, choice="once", *, user_id=ALLOWED_UID):
+    interaction = _interaction(user_id)
+    asyncio.run(view._resolve(interaction, choice, 1, "label"))
+    return interaction
+
+
+@pytest.fixture(autouse=True)
+def _pairing_store_never_approves():
+    mock_store = MagicMock()
+    mock_store.is_approved.return_value = False
+    with patch("gateway.pairing.PairingStore", return_value=mock_store):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _color_dark_grey_available(monkeypatch):
+    """The shared discord fake has no Color.dark_grey (only the expired-card path uses it)."""
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter.discord.Color",
+        SimpleNamespace(dark_grey=lambda: 0),
+    )
+
+
+@pytest.fixture()
+def queue():
+    """Own the session's gateway approval queue and always clean it up."""
+    from tools import approval
+
+    approval._gateway_queues.pop(SESSION_KEY, None)
+    yield approval._gateway_queues
+    approval._gateway_queues.pop(SESSION_KEY, None)
+
+
+def test_card_resolves_only_its_own_request(queue):
+    """Clicking card B must settle B, never the older request A."""
+    entry_a = _entry("req-A", "echo A")
+    entry_b = _entry("req-B", "echo B")
+    queue[SESSION_KEY] = [entry_a, entry_b]
+
+    _click(_view("req-B"), "once")
+
+    assert entry_b.result == "once"
+    assert entry_b.event.is_set()
+    assert entry_a.result is None
+    assert not entry_a.event.is_set()
+    assert queue[SESSION_KEY] == [entry_a]
+
+
+@pytest.mark.parametrize("choice", ["once", "session", "always", "deny"])
+def test_each_choice_binds_to_its_request(queue, choice):
+    """Every button choice resolves the bound request (not the queue head)."""
+    entry = _entry("req-1")
+    queue[SESSION_KEY] = [entry]
+
+    _click(_view("req-1"), choice)
+
+    assert entry.result == choice
+    assert entry.event.is_set()
+    assert SESSION_KEY not in queue
+
+
+def test_stale_card_does_not_resolve_newer_request(queue):
+    """A card whose request was removed must not settle a newer queued one."""
+    entry_b = _entry("req-B")
+    queue[SESSION_KEY] = [entry_b]
+
+    _click(_view("req-A"), "once")
+
+    assert entry_b.result is None
+    assert not entry_b.event.is_set()
+    assert queue[SESSION_KEY] == [entry_b]
+
+
+def test_unbound_card_fails_closed(queue):
+    """A card with no request id must not fall back to FIFO resolution."""
+    entry = _entry("req-1")
+    queue[SESSION_KEY] = [entry]
+
+    _click(_view(None), "once")
+
+    assert entry.result is None
+    assert not entry.event.is_set()
+    assert queue[SESSION_KEY] == [entry]
+
+
+def test_duplicate_click_is_inert(queue):
+    """After a card resolves, a second click is rejected without touching the queue."""
+    entry = _entry("req-1")
+    queue[SESSION_KEY] = [entry]
+    view = _view("req-1")
+
+    _click(view, "once")
+    assert entry.result == "once"
+    assert SESSION_KEY not in queue
+
+    interaction = _click(view, "once")
+    assert interaction.response.send_message.await_count == 1
+    assert "already been resolved" in interaction.response.send_message.await_args.args[0]
+
+
+def test_unauthorized_click_leaves_queue_untouched(queue):
+    """An unauthorized click never reaches the resolver."""
+    entry = _entry("req-1")
+    queue[SESSION_KEY] = [entry]
+
+    interaction = _click(_view("req-1"), "once", user_id="99999")
+
+    assert interaction.response.send_message.await_count == 1
+    assert "not authorized" in interaction.response.send_message.await_args.args[0]
+    assert entry.result is None
+    assert not entry.event.is_set()
+    assert queue[SESSION_KEY] == [entry]
+
+
+def test_gateway_passes_request_id_to_the_card():
+    """The notify path must forward the entry's immutable request id (#104915).
+
+    AST wiring guard in the style of TestApprovalCommandWiring: pins that
+    ``_approval_notify_sync`` passes ``request_id=approval_data.get("request_id")``
+    to every ``adapter.send_exec_approval`` that accepts the converged keyword
+    (external/plugin adapters keep the legacy call shape), so each rendered card
+    can bind to its request generation.
+    """
+    import gateway.run_turn_runner as run
+
+    source = inspect.getsource(run)
+    tree = ast.parse(source)
+    notify_fn = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_approval_notify_sync"
+    )
+    send_calls = [
+        node
+        for node in ast.walk(notify_fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "send_exec_approval"
+    ]
+    assert send_calls, "send_exec_approval call not found in _approval_notify_sync"
+    # request_id rides through the extra kwargs dict, gated on _accepts_keyword so
+    # adapters predating the converged signature are not broken by the wider call.
+    guarded_assigns = [
+        node
+        for node in ast.walk(notify_fn)
+        if isinstance(node, ast.Assign)
+        and isinstance(node.targets[0], ast.Subscript)
+        and ast.unparse(node.targets[0]) == "extra['request_id']"
+    ]
+    assert guarded_assigns, "extra['request_id'] assignment not found in _approval_notify_sync"
+    assert (
+        ast.unparse(guarded_assigns[0].value) == "approval_data.get('request_id')"
+    ), "request_id must come from approval_data"
+    keyword_gates = [
+        node
+        for node in ast.walk(notify_fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_accepts_keyword"
+    ]
+    assert keyword_gates, "_accepts_keyword gate not found in _approval_notify_sync"


### PR DESCRIPTION
## What does this PR do?

Discord execution-approval cards resolved whatever request was oldest in the session's gateway approval queue, not the request shown on the card. With two pending approvals A then B, clicking **Allow Once** on card B approved A; clicking a stale card A after its request had been removed settled the newer request B. An operator could therefore authorize a different command than the one displayed.

The fix threads the immutable `request_id` (already generated for every queued entry by `_ApprovalEntry`) through the gateway notify path into `ExecApprovalView`, and resolves only that bound request. A card whose request no longer exists — or one constructed without a request id — fails closed into the existing "Approval expired" state instead of falling back to FIFO. Text `/approve` keeps its FIFO semantics and `/approve all` is unchanged.

Per review feedback (0638c85), the binding is converged across **every native interactive approval surface**, platform-independently: a rendered approval control resolves exactly its `request_id × session × principal`, and stale/unbound controls fail closed. The shared call site gates the new keyword through `_accepts_keyword`.

Per the follow-up re-review (6cceb5a), the two remaining authority/lifetime boundaries are closed:

- **Legacy external/plugin adapters now fail closed.** An adapter whose `send_exec_approval` predates the converged signature is no longer rendered an interactive approval at all — its taps could only resolve through the session FIFO, silently re-opening the stale/overlapping-control hole at an authorization boundary. It degrades to the clearly separate typed-text prompt (with a warning naming the adapter) instead of an unbound card.
- **WhatsApp Cloud keeps `(session_key, request_id)` as ONE bounded FIFO record** (the single-record tuple shape of the older #87554 carrier): the binding is stored exactly when the card state is, and eviction beyond `INTERACTIVE_STATE_CACHE_SIZE` drops both halves together — no stranded request-id half, no unbounded side map.

The branch is now a single commit rebased onto live `main` (6927ff8), so every surviving commit is the head that CI runs on.

**Authorship lineage** (kept visible per review): the exact-request-binding design credit goes to #6105 (first implementation) and #87554 (native-adapter carrier, including the bounded tuple shape adopted here); the broader non-native-surfaces rewrite in #68080 remains complementary rather than superseded.

## Related Issue

Fixes #104915

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run_turn_runner.py` — `_approval_notify_sync` passes `request_id=approval_data.get("request_id")` to `adapter.send_exec_approval`; adapters whose signature predates the converged keyword fail closed to the typed-text prompt (warning logged) instead of rendering an unbound interactive control.
- `plugins/platforms/discord/adapter.py` — `send_exec_approval` and `ExecApprovalView` accept and store `request_id`; `_resolve` calls `resolve_gateway_approval(..., request_id=self.request_id)` and treats an unbound card as resolved-zero (fail closed).
- `plugins/platforms/slack/adapter.py` — button value carries `session_key|request_id` (slash-confirm convention); the click handler partitions it; unbound legacy cards fail closed.
- `plugins/platforms/teams/adapter.py` — AdaptiveCard action data carries `request_id`; the resolver honors the request id and its return value instead of a session-level precheck (also fixes a stale-card "Approved" render window).
- `plugins/platforms/feishu/adapter.py` — interactive-card prompt state carries `request_id`; `_resolve_approval` binds to it.
- `plugins/platforms/matrix/adapter.py` — `_MatrixApprovalPrompt` carries `request_id`; the reaction resolver binds to it.
- `plugins/platforms/telegram/adapter.py` — the request id rides out-of-band next to the short monotonic callback id (64-byte `callback_data` cap); the callback resolver binds to it.
- `gateway/platforms/whatsapp_cloud.py` — the tap state stores `(session_key, request_id)` as one FIFO-capped record via `_bounded_put` (12-hex payload id); the tap resolver unpacks the record and binds to it, so eviction drops state and binding together.
- `gateway/platforms/qqbot/keyboards.py` + `gateway/platforms/qqbot/adapter.py` — button data appends the hex request id after the decision; legacy 3-segment data still parses but resolves fail-closed.
- `gateway/relay/adapter.py` — minted prompt state carries `request_id`; `_resolve_exec_approval` binds to it.
- `tests/gateway/test_exec_approval_request_binding_convergence.py` — AST-level contract test pinning all nine adapter signatures + the `_accepts_keyword` gate, plus behavior tests proving a legacy adapter's `send_exec_approval` is never called (typed-text prompt with the adapter's typed prefix fires instead) while a converged adapter still receives `request_id`.
- Per-adapter binding + fail-closed behavior tests in `test_qqbot.py`, `test_slack_approval_buttons.py`, `test_telegram_approval_buttons.py`, `test_whatsapp_cloud.py` (including the beyond-cap eviction regression), `relay/test_relay_interactive.py`, `test_feishu_approval_buttons.py`, `test_matrix_exec_approval.py`, and the Discord binding suite.

## How to Test

1. `pytest tests/gateway/test_exec_approval_request_binding_convergence.py tests/gateway/test_discord_exec_approval_request_binding.py tests/gateway/test_approval_prompt_redaction.py -q` — Observed result: 29 passed (nine-signature contract + gate unit test + legacy fail-closed/converged counterpart behavior tests + Discord binding suite + redaction wiring), on the squashed head rebased onto `main@6927ff8`.
2. `pytest tests/gateway/test_qqbot.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_whatsapp_cloud.py tests/gateway/test_feishu_approval_buttons.py tests/gateway/test_matrix_exec_approval.py tests/gateway/relay/test_relay_interactive.py -q` — Observed result: 138 passed, including the new `test_request_binding_evicts_with_state_beyond_cache_cap` (1003 cards → capped at 1000, oldest evicted whole, newest record intact).
3. `pytest tests/gateway/relay/test_relay_slack_prompt_dm_root.py tests/gateway/test_discord_approval_mentions.py tests/gateway/test_discord_exec_approval_content.py tests/gateway/test_discord_prompt_content_siblings.py tests/tools/test_approval.py tests/gateway/test_approve_deny_commands.py tests/relay/test_relay_prompt_ack_stream_isolation.py tests/run_agent/test_authorization_gate.py -q` — Observed result: 182 passed, 1 failed (`TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`), which fails identically on a clean `upstream/main` checkout (pre-existing, unrelated to this change).
4. `ruff check` on all touched files — all checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs
