### PR TITLE
fix(desktop): failed project loads no longer look empty (#104280)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -94,7 +94,6 @@ import {
   ALL_PROJECTS,
   enterProject,
   exitProjectScope,
-  fetchProjectSessions,
   openProjectCreate,
   refreshProjects,
   refreshProjectTree,
@@ -176,10 +175,11 @@ import {
   useRepoWorktreeMap
 } from './projects'
 import { WorktreeDialog } from './projects/worktree-dialog'
-import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
+import { SidebarBlankState, SidebarLoadErrorState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
 import { buildSessionByAnyId, resolvePinnedSessions } from './session-index'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
+import { useEnteredProjectSessions } from './use-entered-project-sessions'
 
 // Non-session groups (messaging platforms) stay compact: show a few rows up
 // front, reveal more in larger steps on demand. Keeps a busy platform from
@@ -985,29 +985,8 @@ export function ChatSidebar({
 
   // Entering a project lazily hydrates its full lanes (repo -> lane -> sessions)
   // from the backend — same grouping/ids as the overview, just with rows.
-  const [enteredProjectTree, setEnteredProjectTree] = useState<SidebarProjectTree | null>(null)
-
-  useEffect(() => {
-    if (!enteredProjectId || !gatewayReady) {
-      setEnteredProjectTree(null)
-
-      return
-    }
-
-    let cancelled = false
-
-    void fetchProjectSessions(enteredProjectId).then(project => {
-      if (!cancelled) {
-        setEnteredProjectTree(project)
-      }
-    })
-
-    return () => {
-      cancelled = true
-    }
-    // `projectTree` in deps: re-hydrate after a tree refresh so the entered view
-    // stays current with new/ended sessions.
-  }, [enteredProjectId, gatewayReady, projectTree])
+  const { project: enteredProjectTree, failed: projectLoadFailed, loading: projectLoading, retry: retryProject } =
+    useEnteredProjectSessions(enteredProjectId, gatewayReady, projectTree, `${activeConnectionId}:${profileScope}`)
 
   // Prefer the hydrated tree; fall back to the overview node (empty lanes) while
   // the drill-in fetch is in flight, so the header/structure render immediately.
@@ -1708,6 +1687,7 @@ export function ChatSidebar({
               />
             )}
 
+            {!trimmedQuery && inProject && projectLoadFailed && <SidebarLoadErrorState onRetry={retryProject} />}
             {!trimmedQuery && (
               <SidebarSessionsSection
                 activeProjectId={activeProjectId}
@@ -1733,7 +1713,7 @@ export function ChatSidebar({
                 )}
                 dndSensors={dndSensors}
                 emptyState={
-                  showSessionSkeletons ? (
+                  inProject && projectLoadFailed ? null : showSessionSkeletons || (inProject && projectLoading) ? (
                     <SidebarSessionSkeletons />
                   ) : (
                     <div className="grid min-h-16 place-items-center rounded-lg px-2 text-center text-xs text-(--ui-text-tertiary)">

--- a/apps/desktop/src/app/chat/sidebar/section-states.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.tsx
@@ -53,3 +53,23 @@ export function SidebarPinnedEmptyState() {
     </div>
   )
 }
+
+// A failed drill-in load must not share the "no sessions yet" copy — that
+// reads as data loss. Borrows the row chrome so it resolves into the rows it
+// replaces without the list stepping sideways.
+export function SidebarLoadErrorState({ onRetry }: { onRetry: () => void }) {
+  const { t } = useI18n()
+
+  return (
+    <div className="grid min-h-16 place-items-center rounded-lg px-2 text-center">
+      <div className="flex flex-col items-center gap-2">
+        <Codicon className="text-(--ui-text-quaternary)" name="error" size="1rem" />
+        <p className="text-xs text-(--ui-text-tertiary)">{t.sidebar.projectLoadFailed}</p>
+        <Button className="mt-0.5 text-(--ui-text-secondary)" onClick={onRetry} size="sm" variant="ghost">
+          <Codicon name="refresh" size="0.75rem" />
+          {t.common.retry}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/use-entered-project-sessions.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/use-entered-project-sessions.test.ts
@@ -1,0 +1,34 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { fetchProjectSessions } from '@/store/projects'
+
+import { useEnteredProjectSessions } from './use-entered-project-sessions'
+
+vi.mock('@/store/projects', () => ({ fetchProjectSessions: vi.fn() }))
+afterEach(cleanup)
+
+it('ignores departed drill-ins and clears failure on retry', async () => {
+  let failOld!: (error: Error) => void
+  vi.mocked(fetchProjectSessions)
+    .mockImplementationOnce(() => new Promise((_, reject) => { failOld = reject }))
+    .mockResolvedValueOnce(null)
+    .mockRejectedValueOnce(new Error('failed'))
+    .mockResolvedValueOnce(null)
+  const tree: never[] = []
+
+  const { result, rerender } = renderHook(
+    ({ id }) => useEnteredProjectSessions(id, true, tree, 'default'),
+    { initialProps: { id: 'old' } }
+  )
+
+  rerender({ id: 'current' })
+  await waitFor(() => expect(result.current.loading).toBe(false))
+  await act(async () => failOld(new Error('late error')))
+  expect(result.current.failed).toBe(false)
+  act(() => result.current.retry())
+  await waitFor(() => expect(result.current.failed).toBe(true))
+  act(() => result.current.retry())
+  await waitFor(() => expect(result.current.loading).toBe(false))
+  expect(result.current.failed).toBe(false)
+})

--- a/apps/desktop/src/app/chat/sidebar/use-entered-project-sessions.ts
+++ b/apps/desktop/src/app/chat/sidebar/use-entered-project-sessions.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+
+import { fetchProjectSessions } from '@/store/projects'
+
+import type { SidebarProjectTree } from './projects/workspace-groups'
+
+// The mounted drill-in owns its outcome. A global error flag lets a departed
+// project's slow failure overwrite the next project's successful load.
+export function useEnteredProjectSessions(
+  projectId: string | undefined,
+  ready: boolean,
+  treeRevision: readonly SidebarProjectTree[],
+  scope: string
+) {
+  const [project, setProject] = useState<SidebarProjectTree | null>(null)
+  const [failed, setFailed] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [retryToken, setRetryToken] = useState(0)
+
+  useEffect(() => { setProject(null) }, [projectId, scope])
+
+  useEffect(() => {
+    let cancelled = false
+    setFailed(false)
+
+    if (!projectId || !ready) {
+      setProject(null)
+      setLoading(false)
+
+      return
+    }
+
+    setLoading(true)
+    void fetchProjectSessions(projectId)
+      .then(next => { if (!cancelled) { setProject(next) } })
+      .catch(() => { if (!cancelled) { setFailed(true) } })
+      .finally(() => { if (!cancelled) { setLoading(false) } })
+
+    return () => { cancelled = true }
+  }, [projectId, ready, treeRevision, scope, retryToken])
+
+  return { project, failed, loading, retry: () => setRetryToken(token => token + 1) }
+}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1752,6 +1752,7 @@ export const ar = defineLocale({
     shiftClickHint: 'استخدم Shift للتحديد المتعدد',
     noWorkspace: 'بدون مساحة عمل',
     projectEmpty: 'لا توجد جلسات بعد',
+    projectLoadFailed: 'تعذر تحميل الجلسات',
     noSessions: 'لا توجد جلسات بعد',
     noFilterMatches: 'لا توجد جلسات تطابق عوامل التصفية هذه',
     projects: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2378,6 +2378,7 @@ export const en: Translations = {
     shiftClickHint: 'Shift-click a chat to pin',
     noWorkspace: 'No workspace',
     projectEmpty: 'No sessions yet',
+    projectLoadFailed: 'Could not load sessions',
     noSessions: 'No sessions yet',
     noFilterMatches: 'No sessions match these filters',
     projects: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2052,6 +2052,7 @@ export const ja = defineLocale({
     shiftClickHint: 'Shift クリックでピン留め · ドラッグで並べ替え',
     noWorkspace: 'ワークスペースなし',
     projectEmpty: 'セッションはまだありません',
+    projectLoadFailed: 'セッションの読み込みに失敗しました',
     noSessions: 'セッションはまだありません',
     noFilterMatches: 'このフィルターに一致するセッションはありません',
     projects: {

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2414,6 +2414,7 @@ export const ru = defineLocale({
     shiftClickHint: 'Shift-клик по чату, чтобы закрепить',
     noWorkspace: 'Без рабочего пространства',
     projectEmpty: 'Сеансов пока нет',
+    projectLoadFailed: 'Не удалось загрузить сеансы',
     noSessions: 'Сеансов пока нет',
     noFilterMatches: 'Нет сеансов по этим фильтрам',
     projects: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2024,6 +2024,7 @@ export interface Translations {
     shiftClickHint: string
     noWorkspace: string
     projectEmpty: string
+    projectLoadFailed: string
     noSessions: string
     noFilterMatches: string
     projects: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1977,6 +1977,7 @@ export const zhHant = defineLocale({
     shiftClickHint: 'Shift + 點擊聊天以釘選 · 拖曳以重新排序',
     noWorkspace: '無工作區',
     projectEmpty: '尚無工作階段',
+    projectLoadFailed: '會話載入失敗',
     noSessions: '尚無工作階段',
     noFilterMatches: '沒有工作階段符合這些篩選條件',
     projects: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2544,6 +2544,7 @@ export const zh: Translations = {
     shiftClickHint: 'Shift+ 单击对话以置顶 · 拖动以重新排序',
     noWorkspace: '无工作区',
     projectEmpty: '暂无会话',
+    projectLoadFailed: '会话加载失败',
     noSessions: '暂无会话',
     noFilterMatches: '没有会话符合这些筛选条件',
     projects: {

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -133,6 +133,14 @@ describe('project scope', () => {
 })
 
 describe('projects RPC profile forwarding', () => {
+  it('distinguishes a failed drill-in from an empty project', async () => {
+    const failure = new Error('gateway read failed')
+    const request = vi.fn().mockRejectedValueOnce(failure).mockResolvedValueOnce({ project: null })
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as unknown as ReturnType<typeof activeGateway>)
+    await expect(fetchProjectSessions('p_123')).rejects.toBe(failure)
+    await expect(fetchProjectSessions('p_123')).resolves.toBeNull()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     $activeGatewayProfile.set('default')

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -513,9 +513,16 @@ let projectSessionsRefreshGeneration = 0
 
 export async function fetchProjectSessions(projectId: string): Promise<SidebarProjectTree | null> {
   const generation = ++projectSessionsRefreshGeneration
+  const profile = projectProfile()
+
+  if (!profile) {
+    return null
+  }
+
+  let context: ActiveProjectsContext | undefined
 
   try {
-    const context = await activeProjectsContext()
+    context = await activeProjectsContext()
 
     const res = await gatewayRequestOn<{ project: SidebarProjectTree | null }>(
       context.gateway,
@@ -528,8 +535,13 @@ export async function fetchProjectSessions(projectId: string): Promise<SidebarPr
     }
 
     return res.project ?? null
-  } catch {
-    return null
+  } catch (error) {
+    if (generation !== projectSessionsRefreshGeneration || profile !== projectProfile() ||
+        (context && !stillOnProjectsContext(context))) {
+      return null
+    }
+
+    throw error
   }
 }
 


### PR DESCRIPTION
A failed project drill-in now shows “Could not load sessions” with Retry instead of pretending the project is empty.

Fixes #104280. Campaign: #104904.

- Propagate current drill-in failures separately from valid empty results; ignore obsolete scope outcomes.
- Keep loading/error/retry with the mounted drill-in rather than a shared global error flag.
- Preserve cached rows and display retry even when existing lanes make the section nonempty.
- Reuse the existing sidebar chrome and translate the failure text in all six locales.

Root cause: `fetchProjectSessions` swallowed failures into the same `null` used for empty data, and the sidebar had no recovery state.

**Live repro:** full production `ChatSidebar` in isolated Chromium with a real `HermesGateway` JSON-RPC WebSocket to a localhost fixture. Before: failed `projects.project_sessions` displayed “No sessions yet”, no Retry. After: identical failure displayed “Could not load sessions” and Retry without the false empty text. Changing the fixture to a successful empty response and clicking Retry cleared the error and displayed “No sessions yet”. Zero page errors.

| Validation | Result |
|---|---|
| Project store + mounted drill-in hook | 42 passed, 0 failed, 2 files; campaign flock, one worker |
| Renderer TypeScript | Passed |
| Touched ESLint / diff check | Passed |
| Independent review | No concrete bugs found |

This validates the real renderer and WebSocket path, not native Electron or a user database. No user configuration, sessions, or application state modified. Broad directory integration is owned by the campaign parent.

Credits: @elvin-du's #104301 error presentation and locale hunks salvaged with coauthor attribution. The candidate's global error flag was replaced by mounted-scope state to avoid cross-project races.

## Infographic

![Failed is not empty](https://v3b.fal.media/files/b/0aa973e2/0uCiHxq6fDdADG2soxMDN_nMhq20sq.png)
