### PR TITLE
fix: fallback requests retain command-minted credentials (#104360)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2037,34 +2037,6 @@ def _should_skip_fallback_candidate(agent, fb: dict, fb_key: tuple, fb_provider:
     return False
 
 
-def _swap_fallback_clients(agent, fb_client, fb_provider: str, fb_model: str, fb_base_url: str, fb_api_mode: str) -> None:
-    """Install the fallback client(s) in place, honoring request_timeout_seconds (None = SDK default)."""
-    timeout = get_provider_request_timeout(fb_provider, fb_model)
-    if fb_api_mode == "anthropic_messages":
-        from agent.anthropic_adapter import build_anthropic_client
-        from agent.anthropic_credentials import resolve_anthropic_token, _is_oauth_token
-        is_anthropic = fb_provider == "anthropic"
-        effective_key = fb_client.api_key or (resolve_anthropic_token() if is_anthropic else None) or ""
-        agent.api_key = agent._anthropic_api_key = effective_key
-        agent._anthropic_base_url = fb_base_url
-        agent._anthropic_client = build_anthropic_client(effective_key, fb_base_url, timeout=timeout)
-        agent._is_anthropic_oauth = _is_oauth_token(effective_key) if is_anthropic else False
-        agent.client, agent._client_kwargs = None, {}
-        return
-    agent.api_key = fb_client.api_key
-    agent.client = fb_client
-    # Keep provider headers resolve_provider_client() baked into fb_client (SDK: _custom_headers), else
-    # later request-client rebuilds drop them and User-Agent-sentinel providers (Kimi Coding) 403.
-    fb_headers = getattr(fb_client, "_custom_headers", None) or getattr(fb_client, "default_headers", None)
-    agent._client_kwargs = {"api_key": fb_client.api_key, "base_url": fb_base_url}
-    if fb_headers:
-        agent._client_kwargs["default_headers"] = dict(fb_headers)
-    if timeout is not None:
-        agent._client_kwargs["timeout"] = timeout
-        # Rebuild now so the timeout applies to the very next request, not only after a rotation rebuild.
-        agent._replace_primary_openai_client(reason="fallback_timeout_apply")
-
-
 def _update_fallback_context_compressor(agent) -> None:
     """Point compression limits at the fallback model's context window (not the primary's),
     respecting the explicit model.context_length config override."""
@@ -2197,6 +2169,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent._fallback_activated = True
 
         _rebind_fallback_credential_pool(agent, fb_provider, fb_model)
+        from agent.client_lifecycle import _swap_fallback_clients
         _swap_fallback_clients(agent, fb_client, fb_provider, fb_model, fb_base_url, fb_api_mode)
 
         from agent.agent_runtime_helpers import sync_credential_pool_entry_id

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -65,23 +65,26 @@ def _valid_credential_pair(api_key: Any, base_url: Any) -> bool:
 def _swap_fallback_clients(agent, fb_client, fb_provider: str, fb_model: str, fb_base_url: str, fb_api_mode: str) -> None:
     """Install the fallback client(s) in place, honoring request_timeout_seconds (None = SDK default)."""
     timeout = get_provider_request_timeout(fb_provider, fb_model)
+    # The SDK exposes an empty/stale api_key when a rotating source is installed.
+    key_provider = getattr(fb_client, "_api_key_provider", None)
+    credential = key_provider if callable(key_provider) else fb_client.api_key
     if fb_api_mode == "anthropic_messages":
         from agent.anthropic_adapter import build_anthropic_client
         from agent.anthropic_credentials import resolve_anthropic_token, _is_oauth_token
         is_anthropic = fb_provider == "anthropic"
-        effective_key = fb_client.api_key or (resolve_anthropic_token() if is_anthropic else None) or ""
+        effective_key = credential or (resolve_anthropic_token() if is_anthropic else None) or ""
         agent.api_key = agent._anthropic_api_key = effective_key
         agent._anthropic_base_url = fb_base_url
         agent._anthropic_client = build_anthropic_client(effective_key, fb_base_url, timeout=timeout)
         agent._is_anthropic_oauth = _is_oauth_token(effective_key) if is_anthropic else False
         agent.client, agent._client_kwargs = None, {}
         return
-    agent.api_key = fb_client.api_key
+    agent.api_key = credential
     agent.client = fb_client
     # Keep provider headers resolve_provider_client() baked into fb_client (SDK: _custom_headers), else
     # later request-client rebuilds drop them and User-Agent-sentinel providers (Kimi Coding) 403.
     fb_headers = getattr(fb_client, "_custom_headers", None) or getattr(fb_client, "default_headers", None)
-    agent._client_kwargs = {"api_key": fb_client.api_key, "base_url": fb_base_url}
+    agent._client_kwargs = {"api_key": credential, "base_url": fb_base_url}
     if fb_headers:
         agent._client_kwargs["default_headers"] = dict(fb_headers)
     if timeout is not None:

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -76,7 +76,10 @@ def _swap_fallback_clients(agent, fb_client, fb_provider: str, fb_model: str, fb
         agent.api_key = agent._anthropic_api_key = effective_key
         agent._anthropic_base_url = fb_base_url
         agent._anthropic_client = build_anthropic_client(effective_key, fb_base_url, timeout=timeout)
-        agent._is_anthropic_oauth = _is_oauth_token(effective_key) if is_anthropic else False
+        agent._is_anthropic_oauth = (
+            _is_oauth_token(effective_key)
+            if is_anthropic and isinstance(effective_key, str) else False
+        )
         agent.client, agent._client_kwargs = None, {}
         return
     agent.api_key = credential

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -62,6 +62,34 @@ def _valid_credential_pair(api_key: Any, base_url: Any) -> bool:
     return bool(isinstance(api_key, str) and api_key.strip() and isinstance(base_url, str) and base_url.strip())
 
 
+def _swap_fallback_clients(agent, fb_client, fb_provider: str, fb_model: str, fb_base_url: str, fb_api_mode: str) -> None:
+    """Install the fallback client(s) in place, honoring request_timeout_seconds (None = SDK default)."""
+    timeout = get_provider_request_timeout(fb_provider, fb_model)
+    if fb_api_mode == "anthropic_messages":
+        from agent.anthropic_adapter import build_anthropic_client
+        from agent.anthropic_credentials import resolve_anthropic_token, _is_oauth_token
+        is_anthropic = fb_provider == "anthropic"
+        effective_key = fb_client.api_key or (resolve_anthropic_token() if is_anthropic else None) or ""
+        agent.api_key = agent._anthropic_api_key = effective_key
+        agent._anthropic_base_url = fb_base_url
+        agent._anthropic_client = build_anthropic_client(effective_key, fb_base_url, timeout=timeout)
+        agent._is_anthropic_oauth = _is_oauth_token(effective_key) if is_anthropic else False
+        agent.client, agent._client_kwargs = None, {}
+        return
+    agent.api_key = fb_client.api_key
+    agent.client = fb_client
+    # Keep provider headers resolve_provider_client() baked into fb_client (SDK: _custom_headers), else
+    # later request-client rebuilds drop them and User-Agent-sentinel providers (Kimi Coding) 403.
+    fb_headers = getattr(fb_client, "_custom_headers", None) or getattr(fb_client, "default_headers", None)
+    agent._client_kwargs = {"api_key": fb_client.api_key, "base_url": fb_base_url}
+    if fb_headers:
+        agent._client_kwargs["default_headers"] = dict(fb_headers)
+    if timeout is not None:
+        agent._client_kwargs["timeout"] = timeout
+        # Rebuild now so the timeout applies to the very next request, not only after a rotation rebuild.
+        agent._replace_primary_openai_client(reason="fallback_timeout_apply")
+
+
 class ClientLifecycleMixin:
     def _client_log_context(self) -> str:
         thread = threading.current_thread()

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -66,7 +66,7 @@ def _swap_fallback_clients(agent, fb_client, fb_provider: str, fb_model: str, fb
     """Install the fallback client(s) in place, honoring request_timeout_seconds (None = SDK default)."""
     timeout = get_provider_request_timeout(fb_provider, fb_model)
     # The SDK exposes an empty/stale api_key when a rotating source is installed.
-    key_provider = getattr(fb_client, "_api_key_provider", None)
+    key_provider = vars(fb_client).get("_api_key_provider")
     credential = key_provider if callable(key_provider) else fb_client.api_key
     if fb_api_mode == "anthropic_messages":
         from agent.anthropic_adapter import build_anthropic_client

--- a/contributors/emails/99405975+snipecoder@users.noreply.github.com
+++ b/contributors/emails/99405975+snipecoder@users.noreply.github.com
@@ -1,0 +1,2 @@
+snipecoder
+# PR #102244 mechanism credit

--- a/contributors/emails/bgwillwork@outlook.com
+++ b/contributors/emails/bgwillwork@outlook.com
@@ -1,0 +1,2 @@
+BGwill-OUTLOOK
+# PR #102721 fallback slice

--- a/evals/provider_fallback/probe_104360.py
+++ b/evals/provider_fallback/probe_104360.py
@@ -1,0 +1,221 @@
+import os, sys, tempfile, json, socket, threading
+from pathlib import Path
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+os.environ.clear()
+home = tempfile.mkdtemp(prefix="hermes-104360-")
+os.environ.update(
+    HOME=home,
+    HERMES_HOME=home + "/.hermes",
+    PATH="/usr/bin:/bin",
+    PYTHONDONTWRITEBYTECODE="1",
+)
+Path(os.environ["HERMES_HOME"]).mkdir()
+sys.dont_write_bytecode = True
+repo = sys.argv[1]
+sys.path.insert(0, repo)
+original = socket.socket.connect
+blocked = []
+
+
+def connect(s, address):
+    if isinstance(address, tuple) and address[0] not in ["127.0.0.1", "::1"]:
+        blocked.append(str(address))
+        raise RuntimeError("nonloopback blocked")
+    return original(s, address)
+
+
+socket.socket.connect = connect
+captures = []
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        auth = self.headers.get("Authorization")
+        status = (
+            200
+            if auth in ("Bearer fixture-command-token", "Bearer rotated-fixture-token")
+            else 401
+        )
+        captures.append(dict(path=self.path, auth=auth, status=status, body=body))
+        data = (
+            {
+                "id": "fixture",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "fixture-only"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+            if status == 200
+            else {
+                "error": {
+                    "message": "Credential was not sent or was of an unsupported type",
+                    "type": "auth_error",
+                }
+            }
+        )
+        if self.path.endswith("/messages") and status == 200:
+            data = {
+                "id": "fixture",
+                "type": "message",
+                "role": "assistant",
+                "model": body["model"],
+                "content": [{"type": "text", "text": "fixture-only"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            }
+        raw = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+url = f"http://127.0.0.1:{server.server_port}/serving-endpoints"
+import yaml
+
+config = {
+    "model": {"provider": "fixture-provider", "default": "model-a"},
+    "providers": {
+        "fixture-provider": {
+            "base_url": url,
+            "key_cmd": "/usr/bin/printf fixture-command-token",
+            "models": ["model-a", "model-b"],
+        }
+    },
+    "fallback_providers": [{"provider": "fixture-provider", "model": "model-b"}],
+}
+Path(os.environ["HERMES_HOME"] + "/config.yaml").write_text(
+    yaml.safe_dump(config), encoding="utf-8"
+)
+from hermes_cli.runtime_provider import resolve_runtime_provider
+from agent.auxiliary_client import resolve_provider_client
+
+try:
+    from agent.client_lifecycle import _swap_fallback_clients
+except ImportError:
+    from agent.chat_completion_helpers import _swap_fallback_clients
+from openai import OpenAI
+from types import SimpleNamespace
+
+runtime = resolve_runtime_provider(requested="fixture-provider", target_model="model-a")
+out = {"runtime_key_callable": callable(runtime["api_key"]), "cases": []}
+
+
+def request(label, client, model):
+    try:
+        client.chat.completions.create(
+            model=model, messages=[{"role": "user", "content": "offline fixture probe"}]
+        )
+        result = "200"
+    except Exception as e:
+        result = type(e).__name__ + ": " + str(e)
+    out["cases"].append({
+        "label": label,
+        "result": result,
+        "sdk_key": client.api_key,
+        "sdk_provider_callable": callable(getattr(client, "_api_key_provider", None)),
+    })
+
+
+direct = OpenAI(api_key=runtime["api_key"], base_url=runtime["base_url"], max_retries=0)
+request("direct-runtime", direct, "model-a")
+fb, _ = resolve_provider_client("fixture-provider", model="model-b", raw_codex=True)
+out["fresh_fallback_sdk_key"] = fb.api_key
+out["fresh_fallback_provider_callable"] = callable(
+    getattr(fb, "_api_key_provider", None)
+)
+agent = SimpleNamespace()
+_swap_fallback_clients(
+    agent, fb, "fixture-provider", "model-b", str(fb.base_url), "chat_completions"
+)
+out["saved_rebuild_key_callable"] = callable(agent._client_kwargs["api_key"])
+request("bare-fallback-first-request", agent.client, "model-b")
+rebuilt = OpenAI(**agent._client_kwargs, max_retries=0)
+request("fallback-rebuilt-from-production-kwargs", rebuilt, "model-b")
+# Configured timeout forces the production swap to rebuild before its first request.
+config["providers"]["fixture-provider"]["request_timeout_seconds"] = 15
+Path(os.environ["HERMES_HOME"] + "/config.yaml").write_text(
+    yaml.safe_dump(config), encoding="utf-8"
+)
+from hermes_cli.config import load_config_readonly
+from hermes_cli.timeouts import get_provider_request_timeout
+
+out["timeout_resolved"] = get_provider_request_timeout("fixture-provider", "model-b")
+fb2, _ = resolve_provider_client("fixture-provider", model="model-b", raw_codex=True)
+from agent.client_lifecycle import ClientLifecycleMixin
+
+
+class ProbeAgent(ClientLifecycleMixin):
+    pass
+
+
+a2 = ProbeAgent()
+a2.provider = "fixture-provider"
+a2.model = "model-b"
+a2.base_url = str(fb2.base_url)
+_swap_fallback_clients(
+    a2, fb2, "fixture-provider", "model-b", str(fb2.base_url), "chat_completions"
+)
+request("timeout-fallback-first-request", a2.client, "model-b")
+# The rebuild must retain the live source, not just the most recent minted key.
+token_path = Path(home) / "rotating-token"
+token_path.write_text("fixture-command-token")
+for dynamic in (False, True):
+    source = (lambda: token_path.read_text()) if dynamic else "fixture-command-token"
+    fresh = OpenAI(api_key=source, base_url=url, max_retries=0)
+    holder = SimpleNamespace()
+    _swap_fallback_clients(
+        holder, fresh, "fixture-static", "model-b", url, "codex_responses"
+    )
+    derived = OpenAI(**holder._client_kwargs, max_retries=0)
+    for token in ("fixture-command-token", "rotated-fixture-token"):
+        token_path.write_text(token)
+        request(f"rotation-{dynamic}-{token}", derived, "model-b")
+        assert captures[-1]["auth"] == "Bearer " + (
+            token if dynamic else "fixture-command-token"
+        )
+    fresh.close()
+    derived.close()
+token_path.write_text("fixture-command-token")
+source = lambda: token_path.read_text()
+fresh = OpenAI(api_key=source, base_url=url, max_retries=0)
+holder = SimpleNamespace()
+_swap_fallback_clients(holder, fresh, "anthropic", "model-b", url, "anthropic_messages")
+for token in ("fixture-command-token", "rotated-fixture-token"):
+    token_path.write_text(token)
+    response = holder._anthropic_client.messages.create(
+        model="model-b", max_tokens=8, messages=[{"role": "user", "content": "fixture"}]
+    )
+    assert response.content[0].text == "fixture-only"
+    assert captures[-1]["auth"] == "Bearer " + token
+out["anthropic_rotating_handoff"] = "200,200"
+fresh.close()
+holder._anthropic_client.close()
+out["captures"] = captures
+out["blocked"] = blocked
+out["production_imports"] = {
+    n: sys.modules[n].__file__
+    for n in [
+        "hermes_cli.runtime_provider",
+        "agent.auxiliary_client",
+        "agent.client_lifecycle",
+    ]
+}
+print(json.dumps(out, indent=2))
+server.shutdown()
+assert captures[0]["status"] == 200
+assert captures[1]["status"] == 200
+assert captures[2]["status"] == 200
+assert captures[3]["status"] == 200

--- a/tests/agent/test_fallback_dynamic_credential.py
+++ b/tests/agent/test_fallback_dynamic_credential.py
@@ -1,0 +1,35 @@
+"""Fallback rebuilds retain the credential source, not its last token."""
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from openai import OpenAI
+
+from agent.client_lifecycle import _swap_fallback_clients
+
+
+@pytest.mark.parametrize("mode", ["chat_completions", "codex_responses"])
+@pytest.mark.parametrize("dynamic", [False, True])
+def test_fallback_rebuild_preserves_rotating_and_static_credentials(mode, dynamic):
+    token = ["first-token"]
+    source = (lambda: token[0]) if dynamic else token[0]
+    captured = []
+
+    def respond(request):
+        captured.append(request.headers.get("Authorization"))
+        return httpx.Response(200, json={"id": "fixture", "choices": []})
+
+    client = OpenAI(api_key=source, base_url="http://localhost:1234/v1")
+    agent = SimpleNamespace()
+    _swap_fallback_clients(agent, client, "fixture", "fixture", str(client.base_url), mode)
+    rebuilt = OpenAI(**agent._client_kwargs, http_client=httpx.Client(transport=httpx.MockTransport(respond)))
+    try:
+        for value in ("first-token", "rotated-token"):
+            token[0] = value
+            rebuilt.chat.completions.create(model="fixture", messages=[])
+        expected = ["Bearer first-token", "Bearer rotated-token" if dynamic else "Bearer first-token"]
+        assert captured == expected
+        assert agent.api_key is source
+    finally:
+        client.close()
+        rebuilt.close()

--- a/tests/agent/test_fallback_dynamic_credential.py
+++ b/tests/agent/test_fallback_dynamic_credential.py
@@ -33,3 +33,17 @@ def test_fallback_rebuild_preserves_rotating_and_static_credentials(mode, dynami
     finally:
         client.close()
         rebuilt.close()
+
+
+def test_anthropic_fallback_keeps_callable_without_treating_it_as_oauth_text():
+    source = lambda: "fixture-token"  # noqa: E731
+    client = OpenAI(api_key=source, base_url="http://localhost:1234/v1")
+    agent = SimpleNamespace()
+    try:
+        _swap_fallback_clients(agent, client, "anthropic", "fixture", str(client.base_url), "anthropic_messages")
+        assert agent.api_key is source
+        assert agent._anthropic_api_key is source
+        assert agent._is_anthropic_oauth is False
+        agent._anthropic_client.close()
+    finally:
+        client.close()

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -115,8 +115,8 @@ The fallback activates automatically when the primary model fails with:
 
 When triggered, Hermes:
 
-1. Resolves credentials for the fallback provider
-2. Builds a new API client
+1. Resolves credentials for the fallback provider (including named custom providers using `key_cmd`)
+2. Builds a new API client, preserving a dynamic credential source across timeout and request-client rebuilds
 3. Swaps the model, provider, and client in-place
 4. Resets the retry counter and continues the conversation
 


### PR DESCRIPTION
Named custom-provider fallbacks retain command-minted credentials across client rebuilds instead of sending unauthenticated requests.

## Changes
- Preserve the SDK-installed callable credential source in agent state and rebuild kwargs.
- Colocate fallback handoff with client lifecycle, including Anthropic bearer-hook handoff; only static strings undergo OAuth-prefix classification.
- Preserve static-key behavior, request headers, timeout handling, and token rotation.

Root cause: the SDK stores callable credentials separately and exposes an empty or stale `api_key`; copying only that attribute loses the refreshable source.

## Validation
Reproduce with `python -B evals/provider_fallback/probe_104360.py <repository-path>` using the project environment.
**Live repro:** direct and bare named fallback requests returned 200 on base, while rebuilt and timeout-first fallback requests omitted Authorization and returned 401. The identical production resolver/handoff/lifecycle path now returns 200 for all four cases. Additional local HTTP controls verify static credentials remain static, callable credentials rotate, and actual Anthropic SDK requests carry both successive bearer tokens under `provider=anthropic`.

- **39 tests passed, 0 failed** in 3 targeted files, using `flock` + `scripts/run_tests.sh -j 1`.
- Ruff, Windows footgun scan, compatibility-pointer scan, and `git diff --check` passed.
- Independent Codex review and campaign-parent review completed; repaired synthesized mock attributes and callable-to-OAuth-string classification findings, then reran live controls and targeted tests.
- Fidelity: real SDKs + credential-free localhost HTTP fixtures with isolated HOME/HERMES_HOME; not an enterprise endpoint or full interactive turn-loop test. Broad-directory integration remains with the campaign parent.

## Scope and credit
Credits: @snipecoder #102244 for callable-source diagnosis; @BGwill-OUTLOOK #102721 for the fallback slice. Only this corrective slice is included, with contributor mappings and coauthor credit. No reasoning, replay, cache, output-cap override, or recovery-schedule changes. #104485 remains separate.

Fixes #104360.
Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104904

## Infographic
![Fallback authentication fix](https://v3b.fal.media/files/b/0aa9738c/WLom7VG-k1KzpLg7pWm58_AEXuDJUb.png)
