### PR TITLE
fix: fallback notices show actual cooldown eligibility (#104120)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1827,102 +1827,103 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     construction goes through resolve_provider_client (no duplicated provider→key mappings)."""
     from agent.fallback_cooldown import _arm_rate_limit_cooldown
     cooldown_seconds = _arm_rate_limit_cooldown(agent, reason)
-    if agent._fallback_index >= len(agent._fallback_chain):
-        return _fallback_chain_exhausted(agent, reason)
-    fb = agent._fallback_chain[agent._fallback_index]
-    agent._fallback_index += 1
-    fb_key = _fallback_entry_key(fb)
-    if getattr(agent, "_unavailable_fallback_keys", None) is None:
-        agent._unavailable_fallback_keys = set()
-    unavailable = agent._unavailable_fallback_keys
-    fb_provider = (fb.get("provider") or "").strip().lower()
-    fb_model = (fb.get("model") or "").strip()
-    if _should_skip_fallback_candidate(agent, fb, fb_key, fb_provider, fb_model, unavailable):
-        return agent._try_activate_fallback(reason)
+    while True:
+        if agent._fallback_index >= len(agent._fallback_chain):
+            return _fallback_chain_exhausted(agent, reason)
+        fb = agent._fallback_chain[agent._fallback_index]
+        agent._fallback_index += 1
+        fb_key = _fallback_entry_key(fb)
+        if getattr(agent, "_unavailable_fallback_keys", None) is None:
+            agent._unavailable_fallback_keys = set()
+        unavailable = agent._unavailable_fallback_keys
+        fb_provider = (fb.get("provider") or "").strip().lower()
+        fb_model = (fb.get("model") or "").strip()
+        if _should_skip_fallback_candidate(agent, fb, fb_key, fb_provider, fb_model, unavailable):
+            continue
 
-    try:
-        from agent.auxiliary_client import resolve_provider_client
-        from hermes_cli.fallback_config import resolve_entry_api_key
-        # Pass the entry's base_url/api_key so custom endpoints (Ollama Cloud) resolve instead
-        # of falling through to OpenRouter defaults.
-        fb_base_url_hint = (fb.get("base_url") or "").strip() or None
-        fb_api_key_hint = resolve_entry_api_key(fb)
-        fb_api_mode_explicit, fb_api_mode = _fallback_api_mode_hint(fb, fb_provider, fb_base_url_hint)
-        # Ollama Cloud: OLLAMA_API_KEY from env when the entry has no key. Host match, not
-        # substring — GHSA-76xc-57q6-vm5m.
-        if fb_base_url_hint and base_url_host_matches(fb_base_url_hint, "ollama.com") and not fb_api_key_hint:
-            from agent.secret_scope import get_secret
-            fb_api_key_hint = get_secret("OLLAMA_API_KEY") or None
-        # raw_codex=True: the main agent needs direct responses.stream() access for Codex providers.
-        fb_client, _resolved_fb_model = resolve_provider_client(
-            fb_provider, model=fb_model, raw_codex=True, explicit_base_url=fb_base_url_hint, explicit_api_key=fb_api_key_hint, api_mode=fb_api_mode)
-        if fb_client is None:
-            logger.warning("Fallback to %s failed: provider not configured", fb_provider)
-            unavailable.add(fb_key)
-            return agent._try_activate_fallback(reason)
         try:
-            from hermes_cli.model_normalize import normalize_model_for_provider
-            fb_model = normalize_model_for_provider(fb_model, fb_provider)
-        except Exception as _norm_err:
-            logger.warning("Could not normalize fallback model %r for provider %r: %s", fb_model, fb_provider, _norm_err)
+            from agent.auxiliary_client import resolve_provider_client
+            from hermes_cli.fallback_config import resolve_entry_api_key
+            # Pass the entry's base_url/api_key so custom endpoints (Ollama Cloud) resolve instead
+            # of falling through to OpenRouter defaults.
+            fb_base_url_hint = (fb.get("base_url") or "").strip() or None
+            fb_api_key_hint = resolve_entry_api_key(fb)
+            fb_api_mode_explicit, fb_api_mode = _fallback_api_mode_hint(fb, fb_provider, fb_base_url_hint)
+            # Ollama Cloud: OLLAMA_API_KEY from env when the entry has no key. Host match, not
+            # substring — GHSA-76xc-57q6-vm5m.
+            if fb_base_url_hint and base_url_host_matches(fb_base_url_hint, "ollama.com") and not fb_api_key_hint:
+                from agent.secret_scope import get_secret
+                fb_api_key_hint = get_secret("OLLAMA_API_KEY") or None
+            # raw_codex=True: the main agent needs direct responses.stream() access for Codex providers.
+            fb_client, _resolved_fb_model = resolve_provider_client(
+                fb_provider, model=fb_model, raw_codex=True, explicit_base_url=fb_base_url_hint, explicit_api_key=fb_api_key_hint, api_mode=fb_api_mode)
+            if fb_client is None:
+                logger.warning("Fallback to %s failed: provider not configured", fb_provider)
+                unavailable.add(fb_key)
+                continue
+            try:
+                from hermes_cli.model_normalize import normalize_model_for_provider
+                fb_model = normalize_model_for_provider(fb_model, fb_provider)
+            except Exception as _norm_err:
+                logger.warning("Could not normalize fallback model %r for provider %r: %s", fb_model, fb_provider, _norm_err)
 
-        fb_base_url = str(fb_client.base_url)
-        if not fb_api_mode_explicit and fb_api_mode == "chat_completions":
-            fb_api_mode = _fallback_api_mode_resolved(agent, fb_provider, fb_model, fb_base_url)
+            fb_base_url = str(fb_client.base_url)
+            if not fb_api_mode_explicit and fb_api_mode == "chat_completions":
+                fb_api_mode = _fallback_api_mode_resolved(agent, fb_provider, fb_model, fb_base_url)
 
-        old_model, old_provider, old_base_url = agent.model, agent.provider, agent.base_url
+            old_model, old_provider, old_base_url = agent.model, agent.provider, agent.base_url
 
-        # Clear the per-config context_length override so the fallback model's own context
-        # window is resolved instead of the previous model's stale value.
-        # See #22387.
-        agent._config_context_length = None
-        agent.model, agent.provider, agent.requested_provider = fb_model, fb_provider, fb_provider
-        agent.base_url, agent.api_mode = fb_base_url, fb_api_mode
-        # reasoning_content echo opt-in travels with the active provider; restore_primary_runtime reverts it.
-        agent._reasoning_echo_flag = bool(fb.get("reasoning_echo", False))
-        if hasattr(agent, "_transport_cache"):
-            agent._transport_cache.clear()
-        agent._fallback_activated = True
+            # Clear the per-config context_length override so the fallback model's own context
+            # window is resolved instead of the previous model's stale value.
+            # See #22387.
+            agent._config_context_length = None
+            agent.model, agent.provider, agent.requested_provider = fb_model, fb_provider, fb_provider
+            agent.base_url, agent.api_mode = fb_base_url, fb_api_mode
+            # reasoning_content echo opt-in travels with the active provider; restore_primary_runtime reverts it.
+            agent._reasoning_echo_flag = bool(fb.get("reasoning_echo", False))
+            if hasattr(agent, "_transport_cache"):
+                agent._transport_cache.clear()
+            agent._fallback_activated = True
 
-        _rebind_fallback_credential_pool(agent, fb_provider, fb_model)
-        from agent.client_lifecycle import _swap_fallback_clients
-        _swap_fallback_clients(agent, fb_client, fb_provider, fb_model, fb_base_url, fb_api_mode)
+            _rebind_fallback_credential_pool(agent, fb_provider, fb_model)
+            from agent.client_lifecycle import _swap_fallback_clients
+            _swap_fallback_clients(agent, fb_client, fb_provider, fb_model, fb_base_url, fb_api_mode)
 
-        from agent.agent_runtime_helpers import sync_credential_pool_entry_id
-        sync_credential_pool_entry_id(agent)
+            from agent.agent_runtime_helpers import sync_credential_pool_entry_id
+            sync_credential_pool_entry_id(agent)
 
-        agent._use_prompt_caching, agent._use_native_cache_layout = agent._anthropic_prompt_cache_policy(
-            provider=fb_provider, base_url=fb_base_url, api_mode=fb_api_mode, model=fb_model)
-        agent._ensure_lmstudio_runtime_loaded()  # LM Studio: preload before probing context length
-        _update_fallback_context_compressor(agent)
-        _reresolve_fallback_reasoning_config(agent)
-        _rescope_fallback_extra_body(agent, old_model, old_provider, old_base_url)
-        rewrite_prompt_model_identity(agent, fb_model, fb_provider)
+            agent._use_prompt_caching, agent._use_native_cache_layout = agent._anthropic_prompt_cache_policy(
+                provider=fb_provider, base_url=fb_base_url, api_mode=fb_api_mode, model=fb_model)
+            agent._ensure_lmstudio_runtime_loaded()  # LM Studio: preload before probing context length
+            _update_fallback_context_compressor(agent)
+            _reresolve_fallback_reasoning_config(agent)
+            _rescope_fallback_extra_body(agent, old_model, old_provider, old_base_url)
+            rewrite_prompt_model_identity(agent, fb_model, fb_provider)
 
-        notice = (
-            f"⚠️ Model fallback: {old_model} via {old_provider} unavailable "
-            f"({_fallback_reason_text(reason)}); using {fb_model} via {fb_provider}.")
-        if cooldown_seconds is not None:
-            remaining = max(0, math.ceil(agent._rate_limited_until - time.monotonic()))
-            notice += f" Primary retry eligible in ~{remaining} s; recovery is not guaranteed."
-        _buffer_fallback_notice(agent, notice)
-        # ``_fallback_activated`` is also reused by `/model --once` restoration; separate
-        # provenance so the restore path only emits a recovery notice after a real fallback.
-        agent._provider_fallback_active = True
-        agent._provider_fallback_route = (str(fb_model), str(fb_provider))
-        logger.info("Fallback activated: %s → %s (%s)", old_model, fb_model, fb_provider)
-        # The stale-call streak measured the OLD provider; carrying it over would
-        # short-circuit the fresh fallback before its first stream attempt.
-        _reset_stale_streak(agent)
-        from agent.native_compaction import resolve_native_compaction_capabilities
-        agent.runtime_capabilities = resolve_native_compaction_capabilities(
-            model=agent.model, base_url=agent.base_url, provider=fb_provider, is_codex_backend=fb_provider == "openai-codex")
-        return True
-    except Exception as e:
-        if fb_provider == "nous":
-            unavailable.add(fb_key)
-        logger.error("Failed to activate fallback %s: %s", fb_model, e)
-        return agent._try_activate_fallback(reason)  # try next in chain
+            notice = (
+                f"⚠️ Model fallback: {old_model} via {old_provider} unavailable "
+                f"({_fallback_reason_text(reason)}); using {fb_model} via {fb_provider}.")
+            if cooldown_seconds is not None:
+                remaining = max(0, math.ceil(agent._rate_limited_until - time.monotonic()))
+                notice += f" Primary retry eligible in ~{remaining} s; recovery is not guaranteed."
+            _buffer_fallback_notice(agent, notice)
+            # ``_fallback_activated`` is also reused by `/model --once` restoration; separate
+            # provenance so the restore path only emits a recovery notice after a real fallback.
+            agent._provider_fallback_active = True
+            agent._provider_fallback_route = (str(fb_model), str(fb_provider))
+            logger.info("Fallback activated: %s → %s (%s)", old_model, fb_model, fb_provider)
+            # The stale-call streak measured the OLD provider; carrying it over would
+            # short-circuit the fresh fallback before its first stream attempt.
+            _reset_stale_streak(agent)
+            from agent.native_compaction import resolve_native_compaction_capabilities
+            agent.runtime_capabilities = resolve_native_compaction_capabilities(
+                model=agent.model, base_url=agent.base_url, provider=fb_provider, is_codex_backend=fb_provider == "openai-codex")
+            return True
+        except Exception as e:
+            if fb_provider == "nous":
+                unavailable.add(fb_key)
+            logger.error("Failed to activate fallback %s: %s", fb_model, e)
+            continue  # try next in chain
 
 
 # Keys outside the Chat Completions schema that strict gateways (Fireworks-backed OpenCode

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1716,6 +1716,7 @@ def _fallback_chain_exhausted(agent, reason: "FailoverReason | None") -> bool:
     """Chain exhausted (always False). A non-empty chain walked on a non-rate-limit failure arms a
     short cooldown so next turn's restore_primary_runtime stays gated instead of replaying the whole
     context across every provider again."""
+    from agent.fallback_cooldown import _RATE_LIMIT_FAILOVER_REASONS
     if agent._fallback_chain and reason not in _RATE_LIMIT_FAILOVER_REASONS:
         agent._rate_limited_until = max(
             getattr(agent, "_rate_limited_until", 0) or 0, time.monotonic() + _FALLBACK_EXHAUSTED_COOLDOWN_S)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1712,28 +1712,6 @@ def _rebind_fallback_credential_pool(agent, fb_provider: str, fb_model: str) -> 
             logger.debug("Fallback to %s/%s: could not attach credential pool: %s", fb_provider, fb_model, exc)
 
 
-_RATE_LIMIT_FAILOVER_REASONS = frozenset({FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit})
-
-
-def _arm_rate_limit_cooldown(agent, reason: "FailoverReason | None") -> int | None:
-    """Arm the primary's exponential cooldown (60s → 2m → ... → 4h cap) on CONSECUTIVE rate-limits;
-    restore_primary_runtime resets the counter. Only when leaving the primary: chain-switching from
-    an active fallback means the primary was not the 429 source, so its cooldown is left alone.
-    Return the armed cooldown in seconds, or None when no cooldown was armed."""
-    if reason not in _RATE_LIMIT_FAILOVER_REASONS:
-        return None
-    current_provider = (getattr(agent, "provider", "") or "").strip().lower()
-    primary_provider = ((agent._primary_runtime or {}).get("provider") or "").strip().lower()
-    if getattr(agent, "_fallback_activated", False) and not (primary_provider and current_provider == primary_provider):
-        return None
-    backoff_count = getattr(agent, "_rate_limit_backoff_count", 0)
-    agent._rate_limit_backoff_count = backoff_count + 1
-    backoff_seconds = min(60 * (2 ** backoff_count), 14400)
-    agent._rate_limited_until = time.monotonic() + backoff_seconds
-    logging.info("Rate-limit backoff level %d: cooldown %d s (%.1f min, backoff#%d)", backoff_count, backoff_seconds, backoff_seconds / 60, backoff_count + 1)
-    return backoff_seconds
-
-
 def _fallback_chain_exhausted(agent, reason: "FailoverReason | None") -> bool:
     """Chain exhausted (always False). A non-empty chain walked on a non-rate-limit failure arms a
     short cooldown so next turn's restore_primary_runtime stays gated instead of replaying the whole
@@ -1842,22 +1820,11 @@ def _buffer_fallback_notice(agent, notice: str) -> None:
         agent._pending_fallback_notice = [str(pending), notice] if pending else [notice]
 
 
-def _format_rate_limit_cooldown_suffix(backoff_seconds: int) -> str:
-    """Render an armed rate-limit cooldown as a user-facing duration (" Primary retried in ~16 min.").
-
-    The stored deadline is monotonic-based, so it is rendered as a duration, never as a
-    wall-clock time (unsafe across suspend)."""
-    if backoff_seconds < 60:
-        return f" Primary retried in ~{max(1, int(round(backoff_seconds)))} s."
-    if backoff_seconds < 3600:
-        return f" Primary retried in ~{max(1, int(round(backoff_seconds / 60)))} min."
-    return f" Primary retried in ~{max(1, int(round(backoff_seconds / 3600)))} h."
-
-
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain; False when exhausted. Swaps client,
     model slug and provider in place so the retry loop continues on the new backend; client
     construction goes through resolve_provider_client (no duplicated provider→key mappings)."""
+    from agent.fallback_cooldown import _arm_rate_limit_cooldown
     cooldown_seconds = _arm_rate_limit_cooldown(agent, reason)
     if agent._fallback_index >= len(agent._fallback_chain):
         return _fallback_chain_exhausted(agent, reason)
@@ -1935,7 +1902,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             f"⚠️ Model fallback: {old_model} via {old_provider} unavailable "
             f"({_fallback_reason_text(reason)}); using {fb_model} via {fb_provider}.")
         if cooldown_seconds is not None:
-            notice += _format_rate_limit_cooldown_suffix(cooldown_seconds)
+            remaining = max(0, math.ceil(agent._rate_limited_until - time.monotonic()))
+            notice += f" Primary retry eligible in ~{remaining} s; recovery is not guaranteed."
         _buffer_fallback_notice(agent, notice)
         # ``_fallback_activated`` is also reused by `/model --once` restoration; separate
         # provenance so the restore path only emits a recovery notice after a real fallback.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1715,21 +1715,23 @@ def _rebind_fallback_credential_pool(agent, fb_provider: str, fb_model: str) -> 
 _RATE_LIMIT_FAILOVER_REASONS = frozenset({FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit})
 
 
-def _arm_rate_limit_cooldown(agent, reason: "FailoverReason | None") -> None:
+def _arm_rate_limit_cooldown(agent, reason: "FailoverReason | None") -> int | None:
     """Arm the primary's exponential cooldown (60s → 2m → ... → 4h cap) on CONSECUTIVE rate-limits;
     restore_primary_runtime resets the counter. Only when leaving the primary: chain-switching from
-    an active fallback means the primary was not the 429 source, so its cooldown is left alone."""
+    an active fallback means the primary was not the 429 source, so its cooldown is left alone.
+    Return the armed cooldown in seconds, or None when no cooldown was armed."""
     if reason not in _RATE_LIMIT_FAILOVER_REASONS:
-        return
+        return None
     current_provider = (getattr(agent, "provider", "") or "").strip().lower()
     primary_provider = ((agent._primary_runtime or {}).get("provider") or "").strip().lower()
     if getattr(agent, "_fallback_activated", False) and not (primary_provider and current_provider == primary_provider):
-        return
+        return None
     backoff_count = getattr(agent, "_rate_limit_backoff_count", 0)
     agent._rate_limit_backoff_count = backoff_count + 1
     backoff_seconds = min(60 * (2 ** backoff_count), 14400)
     agent._rate_limited_until = time.monotonic() + backoff_seconds
     logging.info("Rate-limit backoff level %d: cooldown %d s (%.1f min, backoff#%d)", backoff_count, backoff_seconds, backoff_seconds / 60, backoff_count + 1)
+    return backoff_seconds
 
 
 def _fallback_chain_exhausted(agent, reason: "FailoverReason | None") -> bool:
@@ -1840,11 +1842,23 @@ def _buffer_fallback_notice(agent, notice: str) -> None:
         agent._pending_fallback_notice = [str(pending), notice] if pending else [notice]
 
 
+def _format_rate_limit_cooldown_suffix(backoff_seconds: int) -> str:
+    """Render an armed rate-limit cooldown as a user-facing duration (" Primary retried in ~16 min.").
+
+    The stored deadline is monotonic-based, so it is rendered as a duration, never as a
+    wall-clock time (unsafe across suspend)."""
+    if backoff_seconds < 60:
+        return f" Primary retried in ~{max(1, int(round(backoff_seconds)))} s."
+    if backoff_seconds < 3600:
+        return f" Primary retried in ~{max(1, int(round(backoff_seconds / 60)))} min."
+    return f" Primary retried in ~{max(1, int(round(backoff_seconds / 3600)))} h."
+
+
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain; False when exhausted. Swaps client,
     model slug and provider in place so the retry loop continues on the new backend; client
     construction goes through resolve_provider_client (no duplicated provider→key mappings)."""
-    _arm_rate_limit_cooldown(agent, reason)
+    cooldown_seconds = _arm_rate_limit_cooldown(agent, reason)
     if agent._fallback_index >= len(agent._fallback_chain):
         return _fallback_chain_exhausted(agent, reason)
     fb = agent._fallback_chain[agent._fallback_index]
@@ -1917,9 +1931,12 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _rescope_fallback_extra_body(agent, old_model, old_provider, old_base_url)
         rewrite_prompt_model_identity(agent, fb_model, fb_provider)
 
-        _buffer_fallback_notice(agent, (
+        notice = (
             f"⚠️ Model fallback: {old_model} via {old_provider} unavailable "
-            f"({_fallback_reason_text(reason)}); using {fb_model} via {fb_provider}."))
+            f"({_fallback_reason_text(reason)}); using {fb_model} via {fb_provider}.")
+        if cooldown_seconds is not None:
+            notice += _format_rate_limit_cooldown_suffix(cooldown_seconds)
+        _buffer_fallback_notice(agent, notice)
         # ``_fallback_activated`` is also reused by `/model --once` restoration; separate
         # provenance so the restore path only emits a recovery notice after a real fallback.
         agent._provider_fallback_active = True

--- a/agent/fallback_cooldown.py
+++ b/agent/fallback_cooldown.py
@@ -1,0 +1,28 @@
+"""Primary rate-limit cooldown arming, shared by fallback switches."""
+import logging
+import time
+
+from agent.error_classifier import FailoverReason
+
+_RATE_LIMIT_FAILOVER_REASONS = frozenset({FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit})
+
+
+def _arm_rate_limit_cooldown(agent, reason: "FailoverReason | None") -> int | None:
+    """Arm the primary's exponential cooldown (60s → 2m → ... → 4h cap) on CONSECUTIVE rate-limits;
+    restore_primary_runtime resets the counter. Only when leaving the primary: chain-switching from
+    an active fallback means the primary was not the 429 source, so its cooldown is left alone.
+    Return the armed cooldown in seconds, or None when no cooldown was armed."""
+    if reason not in _RATE_LIMIT_FAILOVER_REASONS:
+        return None
+    current_provider = (getattr(agent, "provider", "") or "").strip().lower()
+    primary_provider = ((agent._primary_runtime or {}).get("provider") or "").strip().lower()
+    if getattr(agent, "_fallback_activated", False) and not (primary_provider and current_provider == primary_provider):
+        return None
+    backoff_count = getattr(agent, "_rate_limit_backoff_count", 0)
+    agent._rate_limit_backoff_count = backoff_count + 1
+    backoff_seconds = min(60 * (2 ** backoff_count), 14400)
+    agent._rate_limited_until = time.monotonic() + backoff_seconds
+    logging.info("Rate-limit backoff level %d: cooldown %d s (%.1f min, backoff#%d)", backoff_count, backoff_seconds, backoff_seconds / 60, backoff_count + 1)
+    return backoff_seconds
+
+

--- a/evals/provider_fallback/probe_104120.py
+++ b/evals/provider_fallback/probe_104120.py
@@ -1,0 +1,204 @@
+import os, sys, tempfile, pathlib, json, threading, time, socket
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+
+ROOT = sys.argv[1]
+home = tempfile.mkdtemp(prefix="hermes-104120-")
+os.environ.clear()
+os.environ.update(
+    HOME=home,
+    HERMES_HOME=home + "/.hermes",
+    PATH="/usr/bin:/bin",
+    PYTHONDONTWRITEBYTECODE="1",
+    TOKENIZERS_PARALLELISM="false",
+)
+pathlib.Path(home + "/.hermes").mkdir()
+pathlib.Path(home + "/.hermes/config.yaml").write_text(
+    "model:\n  context_length: 131072\nagent:\n  api_max_retries: 0\ncompression:\n  enabled: false\n",
+    encoding="utf-8",
+)
+os.chdir(home)
+sys.path.insert(0, ROOT)
+# Egress safety boundary, not a patched production predicate.
+real_connect = socket.socket.connect
+
+
+def local_connect(self, address):
+    if isinstance(address, tuple) and address[0] not in (
+        "127.0.0.1",
+        "::1",
+        "localhost",
+    ):
+        raise RuntimeError("Blocked non-loopback egress: " + str(address))
+    return real_connect(self, address)
+
+
+socket.socket.connect = local_connect
+requests = []
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"data": []}).encode())
+
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        model = body.get("model")
+        status = (
+            429
+            if model == "primary-rate" or model == "fallback-rate"
+            else 401
+            if model == "primary-auth"
+            else 200
+        )
+        requests.append({"path": self.path, "model": model, "status": status})
+        response = (
+            {
+                "error": {
+                    "message": "Rate limit exceeded"
+                    if status == 429
+                    else "Invalid API key",
+                    "type": "rate_limit_error"
+                    if status == 429
+                    else "authentication_error",
+                }
+            }
+            if status != 200
+            else {
+                "id": "chatcmpl-local",
+                "object": "chat.completion",
+                "created": 1,
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "LOCAL_OK"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 2,
+                    "total_tokens": 7,
+                },
+            }
+        )
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(response).encode())
+
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+url = f"http://127.0.0.1:{server.server_port}/v1"
+from run_agent import AIAgent
+from agent.error_classifier import classify_api_error
+from agent.agent_runtime_helpers import restore_primary_runtime
+
+results = []
+for label, model, chain in [
+    ("primary_rate", "primary-rate", ["fallback-ok"]),
+    ("non_rate_auth", "primary-auth", ["fallback-ok"]),
+    ("fallback_chain", "primary-rate", ["fallback-rate", "fallback-ok"]),
+    ("skipped_first", "primary-rate", ["primary-rate", "fallback-ok"]),
+    ("unconfigured_first", "primary-rate", ["unconfigured", "fallback-ok"]),
+]:
+    agent = AIAgent(
+        base_url=url,
+        api_key="local-not-a-secret",
+        provider="openai",
+        api_mode="chat_completions",
+        model=model,
+        enabled_toolsets=[],
+        quiet_mode=True,
+        skip_memory=True,
+        skip_context_files=True,
+        skip_background_review=True,
+        max_iterations=4,
+        fallback_model=[
+            (
+                {"provider": "unconfigured-fixture", "model": "missing"}
+                if m == "unconfigured"
+                else {
+                    "provider": "custom",
+                    "model": m,
+                    "base_url": url,
+                    "api_key": "local-not-a-secret",
+                    "api_mode": "chat_completions",
+                }
+            )
+            for m in chain
+        ],
+    )
+    transitions = []
+    for step in range(len(chain) + 1):
+        agent.client.max_retries = 0
+        try:
+            response = agent.client.chat.completions.create(
+                model=agent.model,
+                messages=[{"role": "user", "content": "Reply LOCAL_OK"}],
+            )
+            answer = response.choices[0].message.content
+            break
+        except Exception as exc:
+            classified = classify_api_error(exc)
+            before = getattr(agent, "_rate_limited_until", 0)
+            before_count = getattr(agent, "_rate_limit_backoff_count", 0)
+            switched = agent._try_activate_fallback(classified.reason)
+            after = getattr(agent, "_rate_limited_until", 0)
+            transitions.append({
+                "reason": str(classified.reason),
+                "switched": switched,
+                "before_deadline": before,
+                "after_deadline": after,
+                "remaining_seconds": max(0, after - time.monotonic()),
+                "backoff_before": before_count,
+                "backoff_after": getattr(agent, "_rate_limit_backoff_count", 0),
+                "notice": getattr(agent, "_pending_fallback_notice", [])[:],
+                "active_model": agent.model,
+            })
+            if not switched:
+                raise
+    agent._emit_pending_fallback_notice()
+    restored = restore_primary_runtime(agent)
+    results.append({
+        "case": label,
+        "transitions": transitions,
+        "answer": answer,
+        "restore_before_expiry": restored,
+        "model_after_restore": agent.model,
+    })
+    agent.close()
+server.shutdown()
+print(
+    json.dumps(
+        {
+            "repo": ROOT,
+            "home": home,
+            "scope": "Real AIAgent init, real OpenAI SDK HTTP errors and success, real classifier and fallback/restore; not full conversation loop",
+            "requests": requests,
+            "results": results,
+        },
+        indent=2,
+    )
+)
+assert len(results) == 5 and all(x["answer"] == "LOCAL_OK" for x in results)
+assert results[0]["transitions"][0]["remaining_seconds"] > 0
+assert results[1]["transitions"][0]["after_deadline"] == 0
+assert (
+    results[2]["transitions"][1]["before_deadline"]
+    == results[2]["transitions"][1]["after_deadline"]
+)
+assert "Primary retry eligible in ~" in results[0]["transitions"][0]["notice"][-1]
+assert "Primary retry eligible" not in results[1]["transitions"][0]["notice"][-1]
+assert "Primary retry eligible" not in results[2]["transitions"][1]["notice"][-1]
+assert all(r["transitions"][0]["backoff_after"] == 1 for r in results[3:])
+print(
+    "PROBE_OK: armed cooldown notice only; skipped and unconfigured entries do not compound backoff"
+)

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -173,9 +173,10 @@ class TestFallbackChainAdvancement:
                 (None, None),                    # broken provider
                 (_mock_client(), "gpt-4o"),       # fallback succeeds
             ]
-            assert agent._try_activate_fallback() is True
+            assert agent._try_activate_fallback(FailoverReason.rate_limit) is True
             assert agent.model == "gpt-4o"
             assert agent._fallback_index == 2
+            assert agent._rate_limit_backoff_count == 1
 
     def test_skips_provider_that_raises_to_next(self):
         """If resolve_provider_client raises, skip to next in chain."""

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -112,7 +112,8 @@ class TestFallbackChainAdvancement:
             assert agent.model == "gpt-4o"
             assert agent._fallback_activated is True
 
-    def test_records_user_visible_switch_with_reason(self):
+    @patch("time.monotonic", return_value=1000.0)
+    def test_records_user_visible_switch_with_reason(self, _clock):
         agent = _make_agent(
             fallback_model={"provider": "zai", "model": "glm-5.2"},
         )
@@ -126,12 +127,14 @@ class TestFallbackChainAdvancement:
 
         expected = (
             "⚠️ Model fallback: gpt-5.6-sol via openai-codex unavailable "
-            "(rate limit); using glm-5.2 via zai."
+            "(rate limit); using glm-5.2 via zai. "
+            "Primary retry eligible in ~60 s; recovery is not guaranteed."
         )
         assert agent._pending_fallback_notice == [expected]
         assert agent._retry_status_buffer[-1] == ("status", expected)
 
-    def test_records_sequential_switches_in_order(self):
+    @patch("time.monotonic", return_value=1000.0)
+    def test_records_sequential_switches_in_order(self, _clock):
         agent = _make_agent(
             fallback_model=[
                 {"provider": "zai", "model": "glm-5.2"},
@@ -153,7 +156,8 @@ class TestFallbackChainAdvancement:
 
         assert agent._pending_fallback_notice == [
             "⚠️ Model fallback: gpt-5.6-sol via openai-codex unavailable "
-            "(rate limit); using glm-5.2 via zai.",
+            "(rate limit); using glm-5.2 via zai. "
+            "Primary retry eligible in ~60 s; recovery is not guaranteed.",
             "⚠️ Model fallback: glm-5.2 via zai unavailable "
             "(provider overloaded); using deepseek-v4-flash via deepseek.",
         ]

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -129,7 +129,9 @@ Prompt caches are keyed to the model (and on most providers, the account) servin
 :::info Per-Turn, Not Per-Session
 Fallback is **turn-scoped**: each new user message starts with the primary model restored. If the primary fails mid-turn, fallback activates for that turn only. On the next message, Hermes tries the primary again. Within a single turn, fallback activates at most once — if the fallback also fails, normal error handling takes over (retries, then error message). This prevents cascading failover loops within a turn while giving the primary model a fresh chance every turn.
 
-The per-turn retry is **reset-aware**: when the primary's credentials report a rate-limit reset time that hasn't elapsed yet (subscription windows like Claude Pro/Max's 5-hour blocks or Codex weekly limits report these as hours or days), Hermes skips the doomed retry and stays on the fallback until the reset passes — avoiding two pointless provider switches (and two prompt-cache invalidations) per turn. The moment the reset time elapses, the next turn goes back to the primary automatically. Transient 429s without a reset time keep the existing behavior: a short cooldown, then retry every turn.
+The per-turn retry is **reset-aware**: when the primary's credentials report a rate-limit reset time that hasn't elapsed yet (subscription windows like Claude Pro/Max's 5-hour blocks or Codex weekly limits report these as hours or days), Hermes skips the doomed retry and stays on the fallback until the reset passes — avoiding two pointless provider switches (and two prompt-cache invalidations) per turn. Expiry makes the primary eligible for a later retry; it does not schedule a retry or guarantee recovery. Transient 429s without a reset time use an exponential cooldown.
+
+When a switch arms that cooldown, the fallback notice includes its approximate remaining duration, for example: `Primary retry eligible in ~60 s; recovery is not guaranteed.` Non-rate-limit switches and switches from an already-active cross-provider fallback do not announce a new primary cooldown.
 :::
 
 ### Examples


### PR DESCRIPTION
Fallback notices show the primary cooldown that was actually armed, without promising recovery when it expires.

## Changes
- Retain the cooldown arming result and display the approximate remaining monotonic duration.
- Omit the suffix for non-rate-limit switches and already-active cross-provider fallback switches.
- Walk skipped/unconfigured candidates iteratively so one originating error arms the cooldown once, rather than escalating it on each recursive attempt.
- Keep cooldown arming in a topical sibling and document retry eligibility, not scheduled recovery.

Root cause: the notice discarded the computed deadline; recursive candidate skipping also repeated cooldown arming for the same failure.

## Validation
Reproduce with `python -B evals/provider_fallback/probe_104120.py <repository-path>` using the project environment.
**Live repro:** base armed a cooldown after HTTP 429 but omitted its duration. Fixed notices include `Primary retry eligible in ~60 s; recovery is not guaranteed.` HTTP 401 and active-fallback HTTP 429 omit a new cooldown suffix. A skipped-first/successful-second chain and an unconfigured-first/successful-second chain previously raised backoff twice; both now arm once. All five real SDK/local HTTP scenarios finish with LOCAL_OK; primary restoration remains blocked before expiry.

- **87 tests passed, 0 failed** in 4 targeted files through `flock` + `scripts/run_tests.sh -j 1`.
- Ruff, Windows footgun scan, compatibility-pointer scan, and `git diff --check` passed.
- Independent Codex review and campaign-parent review completed. The parent's recursive-arming finding was reproduced live, fixed, and reverified.
- Fidelity: real AIAgent construction, SDK HTTP errors/success, classifier, fallback, notice emission and restore; not a full conversation-loop or native UI test. Broad-directory integration remains with the campaign parent.

## Scope and credit
Salvages @Halldrix's substantive commit from #104130, retaining authorship. Removed overpromising wording and redundant formatter. No default reasoning, replay, prompt-cache, or recovery-schedule changes.

Fixes #104120.
Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104904

## Infographic
![Cooldown notice fix](https://v3b.fal.media/files/b/0aa97392/tgExOyWL4uuluo6cAcoTe_2mXwWS8S.png)
