### PR TITLE
fix(cli): pinned installs can opt out of passive update checks (#104275, salvage #104347)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1989,6 +1989,9 @@ telemetry:
 # Update Behavior
 # =============================================================================
 updates:
+  # Disable passive CLI/banner update checks with `hermes config set updates.check false`.
+  # Explicit `hermes update --check` and `hermes update` remain available.
+  check: true
   # Create a full HERMES_HOME zip before every `hermes update`.
   # Backups land in ~/.hermes/backups/ and can be restored with `hermes import`.
   # Off by default because large homes can add minutes to every update.

--- a/hermes_cli/_startup_fast.py
+++ b/hermes_cli/_startup_fast.py
@@ -167,7 +167,7 @@ def print_fast_version_info(*, check_updates: bool = True) -> None:
         from hermes_cli.banner import UPDATE_AVAILABLE_NO_COUNT, check_for_updates
         from hermes_cli.config import recommended_update_command
 
-        behind = check_for_updates()
+        behind = check_for_updates(passive=True)
         if behind == UPDATE_AVAILABLE_NO_COUNT:
             print(f"Update available — run '{recommended_update_command()}'")
         elif behind and behind > 0:

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -321,7 +321,7 @@ def _read_json(path: Path) -> Optional[dict]:
     return blob if isinstance(blob, dict) else None
 
 
-def check_for_updates() -> Optional[int]:
+def check_for_updates(*, passive: bool = False) -> Optional[int]:
     """Check whether a Hermes update is available.
 
     If ``HERMES_REVISION`` is set (nix builds embed it), compare it to upstream main via
@@ -331,7 +331,7 @@ def check_for_updates() -> Optional[int]:
         from hermes_cli.config import load_config
         return load_config().get("updates", {}).get("check", True) is False
 
-    if _quiet(_read_config_opt_out) is True:
+    if passive and _quiet(_read_config_opt_out) is True:
         return None
 
     cache_file = get_hermes_home() / ".update_check"
@@ -452,7 +452,7 @@ def prefetch_update_check():
     """Kick off update check in a background daemon thread."""
     def _run():
         global _update_result
-        _update_result = check_for_updates()
+        _update_result = check_for_updates(passive=True)
         _update_check_done.set()
     _daemon(None, _run)
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -327,6 +327,13 @@ def check_for_updates() -> Optional[int]:
     If ``HERMES_REVISION`` is set (nix builds embed it), compare it to upstream main via
     ``git ls-remote``; otherwise count commits behind ``origin/main`` in the local checkout.
     """
+    def _read_config_opt_out():
+        from hermes_cli.config import load_config
+        return load_config().get("updates", {}).get("check", True) is False
+
+    if _quiet(_read_config_opt_out) is True:
+        return None
+
     cache_file = get_hermes_home() / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
     # Docker images have no working tree (the image excludes `.git`) and set no HERMES_REVISION.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2077,6 +2077,8 @@ DEFAULT_CONFIG = {
     },
 
     "updates": {
+        # Passive version/banner checks only; explicit `hermes update --check` remains enabled.
+        "check": True,
         # Pre-update backup. quick = snapshot small critical state (pairing JSONs, cron jobs,
         # config.yaml, .env, auth.json, profile DBs) into <HERMES_HOME>/state-snapshots/, skipping
         # files >1 GiB; restore via ``/snapshot``. full = quick PLUS a ``hermes backup`` zip in

--- a/tests/hermes_cli/test_passive_update_opt_out.py
+++ b/tests/hermes_cli/test_passive_update_opt_out.py
@@ -1,0 +1,41 @@
+"""Passive opt-out keeps explicit update checks available."""
+import json
+import subprocess
+import time
+
+from hermes_constants import get_hermes_home
+
+
+def test_passive_check_obeys_config_before_using_cached_notice(monkeypatch):
+    from hermes_cli import banner
+
+    home = get_hermes_home()
+    (home / ".update_check").write_text(json.dumps({
+        "ts": time.time(), "behind": 17, "rev": None, "ver": banner.VERSION,
+    }), encoding="utf-8")
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    config = home / "config.yaml"
+    config.write_text("updates:\n  check: true\n", encoding="utf-8")
+    assert banner.check_for_updates() == 17
+    config.write_text("updates:\n  check: false\n", encoding="utf-8")
+    assert banner.check_for_updates() is None
+
+
+def test_explicit_check_fetches_local_origin_despite_passive_opt_out(tmp_path, monkeypatch, capsys):
+    from hermes_cli import main
+    from hermes_cli.update_cmd import _cmd_update_check
+
+    remote = tmp_path / "remote"
+    local = tmp_path / "checkout"
+    def git(*args):
+        return subprocess.run(["git", *map(str, args)], check=True, capture_output=True, text=True)
+    git("init", "-b", "main", remote)
+    git("-C", remote, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "commit", "--allow-empty", "-m", "initial")
+    git("clone", remote, local)
+    git("-C", remote, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "commit", "--allow-empty", "-m", "next")
+    monkeypatch.setattr(main, "PROJECT_ROOT", local)
+    (get_hermes_home() / "config.yaml").write_text("updates:\n  check: false\n", encoding="utf-8")
+    _cmd_update_check()
+    output = capsys.readouterr().out
+    assert "Fetching from origin" in output
+    assert "1 commit" in output

--- a/tests/hermes_cli/test_passive_update_opt_out.py
+++ b/tests/hermes_cli/test_passive_update_opt_out.py
@@ -16,9 +16,10 @@ def test_passive_check_obeys_config_before_using_cached_notice(monkeypatch):
     monkeypatch.delenv("HERMES_REVISION", raising=False)
     config = home / "config.yaml"
     config.write_text("updates:\n  check: true\n", encoding="utf-8")
-    assert banner.check_for_updates() == 17
+    assert banner.check_for_updates(passive=True) == 17
     config.write_text("updates:\n  check: false\n", encoding="utf-8")
-    assert banner.check_for_updates() is None
+    assert banner.check_for_updates(passive=True) is None
+    assert banner.check_for_updates() == 17
 
 
 def test_explicit_check_fetches_local_origin_despite_passive_opt_out(tmp_path, monkeypatch, capsys):

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -20,6 +20,16 @@ This pulls the latest code from `main`, updates dependencies, and prompts you to
 `hermes update` automatically detects new configuration options and prompts you to add them. If you skipped that prompt, you can manually run `hermes config check` to see missing options, then `hermes config migrate` to interactively add them.
 :::
 
+### Passive update notices
+
+Pinned or noninteractive installations can disable passive CLI version and banner update checks:
+
+```bash
+hermes config set updates.check false
+```
+
+This suppresses both cached update notices and passive update-check network requests. The default is `true`. Explicit `hermes update --check` and `hermes update` still work; this setting does not control the Desktop application's updater.
+
 ### What happens during an update
 
 When you run `hermes update`, the following steps occur:


### PR DESCRIPTION
Pinned installations can disable passive CLI update checks with `hermes config set updates.check false`, without disabling explicit updates.

- Add the setting to the existing `updates` config section, its defaults, example, and updating guide; no new environment variable.
- Gate the version and background-banner consumers before cached or network update work.
- Keep the existing direct checker explicit by default, so dashboard/Desktop checks and `hermes update --check` retain their behavior.

Root cause: passive callers ignored config and always ran the update checker.

**Live repro:** actual CLI `--version` in a PTY, fresh processes with isolated `HOME`/`HERMES_HOME`, using a deliberately seeded current cache (17 commits is fixture data, not an upstream measurement):

| Config | Before | After |
|---|---|---|
| `updates.check: true` | Update notice printed | Same |
| `updates.check: false` | Update notice printed | No notice |

A separate real local Git fixture exercised production `_cmd_update_check()` with passive checks disabled: it fetched the local origin and reported the real one-commit difference. No vendor network calls, user checkout changes, or user service restarts were used.

Validation: serialized `scripts/run_tests.sh -j 1 tests/hermes_cli/test_passive_update_opt_out.py tests/hermes_cli/test_update_check.py`: **9 passed, 0 failed**. The regression also verifies direct checks remain available under the opt-out. Ruff, Windows-footgun, compatibility-pointer, subprocess-stdin and diff checks passed. Independent follow-up review: no findings. Parent coordinates broad directory integration.

Adapted the config-only portion of #104347 by @RohithPariki with co-author credit; omitted its environment flag and unrelated Bot Mode docs. Earlier standalone-opt-out discussion: #12132.

Fixes #104275
Campaign: #104904

## Infographic
![Reliable updates: passive config opt-out with explicit updates preserved](https://v3b.fal.media/files/b/0aa97388/cXMPjNPhGDl_fmKPjlaC8_tS3RrZp9.png)
