### PR TITLE
fix: classic CLI session titles follow the active skin (#104216, salvage #104222)

### DIFF
--- a/contributors/emails/p.minervini@gmail.com
+++ b/contributors/emails/p.minervini@gmail.com
@@ -1,0 +1,2 @@
+pminervini
+# PR #104222 salvage

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -481,7 +481,7 @@ _STYLE_TEMPLATES = {
     "placeholder": "{dim} italic", "prompt": "{prompt}", "prompt-working": "{dim} italic",
     "hint": "{dim} italic",
     "status-bar": "bg:{status_bg} {status_text}", "status-bar-strong": "bg:{status_bg} {status_strong} bold",
-    "status-bar-session-title": "bg:{status_strong} {status_bg} bold",
+    "status-bar-session-title": "bg:{badge_bg} {badge_fg} bold",
     "status-bar-dim": "bg:{status_bg} {status_dim}", "status-bar-good": "bg:{status_bg} {status_good} bold",
     "status-bar-warn": "bg:{status_bg} {status_warn} bold", "status-bar-bad": "bg:{status_bg} {status_bad} bold",
     "status-bar-critical": "bg:{status_bg} {status_critical} bold",
@@ -512,4 +512,7 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
     palette: Dict[str, str] = {}
     for name, key, fallback in _STYLE_PALETTE:
         palette[name] = skin.get_color(key, palette[fallback[1:]] if fallback.startswith("@") else fallback)
+    palette["badge_bg"] = skin.colors.get(
+        "status_bar_strong", skin.colors.get("banner_title", "#FFD700"))
+    palette["badge_fg"] = skin.colors.get("status_bar_bg", "#1a1a2e")
     return {cls: tpl.format(**palette) for cls, tpl in _STYLE_TEMPLATES.items()}

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -512,6 +512,7 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
     palette: Dict[str, str] = {}
     for name, key, fallback in _STYLE_PALETTE:
         palette[name] = skin.get_color(key, palette[fallback[1:]] if fallback.startswith("@") else fallback)
+    # This badge paints both sides; foreground-only light remapping destroys its contrast.
     palette["badge_bg"] = skin.colors.get(
         "status_bar_strong", skin.colors.get("banner_title", "#FFD700"))
     palette["badge_fg"] = skin.colors.get("status_bar_bg", "#1a1a2e")

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -481,6 +481,7 @@ _STYLE_TEMPLATES = {
     "placeholder": "{dim} italic", "prompt": "{prompt}", "prompt-working": "{dim} italic",
     "hint": "{dim} italic",
     "status-bar": "bg:{status_bg} {status_text}", "status-bar-strong": "bg:{status_bg} {status_strong} bold",
+    "status-bar-session-title": "bg:{status_strong} {status_bg} bold",
     "status-bar-dim": "bg:{status_bg} {status_dim}", "status-bar-good": "bg:{status_bg} {status_good} bold",
     "status-bar-warn": "bg:{status_bg} {status_warn} bold", "status-bar-bad": "bg:{status_bg} {status_bad} bold",
     "status-bar-critical": "bg:{status_bg} {status_critical} bold",

--- a/tests/cli/test_cli_light_mode.py
+++ b/tests/cli/test_cli_light_mode.py
@@ -134,10 +134,29 @@ class TestLightModeRemap:
 
 
 class TestSkinConfigHook:
-    """The salvage wraps SkinConfig.get_color at module import time so
-    every skin color read goes through the light-mode remap.  Verify
-    the hook installed and functions correctly.
-    """
+    """Exercise the installed color hook, including self-painted badge colors."""
+
+    @pytest.mark.parametrize("skin_name", ["default", "sisyphus"])
+    def test_badge_preserves_its_paired_colors_in_light_mode(
+        self, cli_mod, monkeypatch, skin_name
+    ):
+        from hermes_cli.skin_engine import (
+            get_active_skin, get_prompt_toolkit_style_overrides, set_active_skin,
+        )
+
+        monkeypatch.setenv("HERMES_LIGHT", "1")
+        previous = get_active_skin().name
+        try:
+            set_active_skin(skin_name)
+            skin = get_active_skin()
+            background = skin.colors.get("status_bar_strong", skin.colors.get("banner_title", "#FFD700"))
+            foreground = skin.colors.get("status_bar_bg", "#1a1a2e")
+            assert get_prompt_toolkit_style_overrides()["status-bar-session-title"] == (
+                f"bg:{background} {foreground} bold"
+            )
+        finally:
+            set_active_skin(previous)
+
 
     def test_hook_installed(self, cli_mod):
         from hermes_cli.skin_engine import SkinConfig

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -258,6 +258,9 @@ class TestCliBrandingHelpers:
         assert overrides["status-bar-strong"] == (
             f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('status_bar_strong')} bold"
         )
+        assert overrides["status-bar-session-title"] == (
+            f"bg:{skin.get_color('status_bar_strong')} {skin.get_color('status_bar_bg')} bold"
+        )
         assert overrides["status-bar-critical"] == (
             f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('status_bar_critical')} bold"
         )

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -273,3 +273,26 @@ class TestCliBrandingHelpers:
         overrides = get_prompt_toolkit_style_overrides()
         assert overrides["status-bar"] == f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('banner_text')}"
         assert overrides["voice-status"] == f"bg:{skin.get_color('voice_status_bg')} {skin.get_color('ui_label')}"
+
+    def test_session_title_badge_preserves_paired_colors(self, monkeypatch):
+        from hermes_cli.skin_engine import (
+            SkinConfig,
+            get_prompt_toolkit_style_overrides,
+            set_active_skin,
+        )
+
+        original_get_color = SkinConfig.get_color
+        monkeypatch.setattr(
+            SkinConfig,
+            "get_color",
+            lambda self, key, fallback="": (
+                "#1A1A1A"
+                if original_get_color(self, key, fallback) == "#F5F5F5"
+                else original_get_color(self, key, fallback)
+            ),
+        )
+        set_active_skin("sisyphus")
+
+        assert get_prompt_toolkit_style_overrides()["status-bar-session-title"] == (
+            "bg:#F5F5F5 #202020 bold"
+        )

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -273,26 +273,3 @@ class TestCliBrandingHelpers:
         overrides = get_prompt_toolkit_style_overrides()
         assert overrides["status-bar"] == f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('banner_text')}"
         assert overrides["voice-status"] == f"bg:{skin.get_color('voice_status_bg')} {skin.get_color('ui_label')}"
-
-    def test_session_title_badge_preserves_paired_colors(self, monkeypatch):
-        from hermes_cli.skin_engine import (
-            SkinConfig,
-            get_prompt_toolkit_style_overrides,
-            set_active_skin,
-        )
-
-        original_get_color = SkinConfig.get_color
-        monkeypatch.setattr(
-            SkinConfig,
-            "get_color",
-            lambda self, key, fallback="": (
-                "#1A1A1A"
-                if original_get_color(self, key, fallback) == "#F5F5F5"
-                else original_get_color(self, key, fallback)
-            ),
-        )
-        set_active_skin("sisyphus")
-
-        assert get_prompt_toolkit_style_overrides()["status-bar-session-title"] == (
-            "bg:#F5F5F5 #202020 bold"
-        )


### PR DESCRIPTION
Classic CLI session-title badges follow the active skin instead of remaining yellow.

- Preserve @pminervini's substantive commits from #104222.
- Derive the inverted badge from the skin's existing status-bar colors; no new settings.
- Preserve the paired foreground/background in light terminals so remapping cannot make the self-painted badge dark-on-dark.

Root cause: the classic CLI's title-badge style had no skin override.

**Live repro:** real `HermesCLI.run()` in a PTY, isolated home, custom skin, and `/title Example session`: before `bg:#FFD700 #1a1a2e`; after `bg:#C9F4FF #0D1728`. The title was rendered in both runs. No provider request was issued.

| Validation | Result |
|---|---|
| Custom skin, real CLI PTY | Correct skin pair |
| Default and Sisyphus, real CLI PTY with light mode | Correct original high-contrast pairs |
| Installed light-mode hook regression | Unsafe remapped version: 2 failures; corrected version: both pass |
| Three scoped serial test files | 48 passed, 0 failed |
| Ruff, Windows footguns, compat pointers, whitespace | Passed |

Independent review caught the light-remapping regression in an attempted simplification; the final fix retains the contributor's paired-color treatment and adds coverage. Broader combined-directory coverage is tracked in the campaign.

Fixes #104216. Supersedes #104222.
Campaign: #104904.

## Infographic
![Session titles follow the active skin](https://v3b.fal.media/files/b/0aa9737e/bIv4KL1Ai6hF5g0uNmEC4_3MLgXCuQ.png)
