### PR TITLE
feat(state): persist preloaded skill names (-s) on the session row

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1150,6 +1150,7 @@ def _init_session_state(agent, session_id, session_db, parent_session_id, reason
 
     agent._session_db = session_db  # optional SQLite store (CLI/gateway-provided)
     agent._parent_session_id = parent_session_id
+    agent.preloaded_skills = list(preload_skills or [])
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,
@@ -2215,6 +2216,7 @@ def init_agent(
     gateway_session_key: str = None, skip_context_files: bool = False,
     load_soul_identity: bool = False, skip_memory: bool = False,
     skip_background_review: bool = False, session_db=None, parent_session_id: str = None,
+    preload_skills: List[str] = None,
     iteration_budget: "IterationBudget" = None, run_budget_seconds: Optional[float] = None,
     fallback_model: Dict[str, Any] = None, credential_pool=None, checkpoints_enabled: bool = False,
     checkpoint_max_snapshots: int = 20, checkpoint_max_total_size_mb: int = 500,

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -371,6 +371,22 @@ class CLIAgentSetupMixin:
         _cprint("  Provider setup didn't complete. Run 'hermes model' to retry.")
         return False
 
+    def _loaded_preload_skill_names(self) -> list:
+        """Names of skills successfully loaded via ``-s``/``--skills`` preload.
+
+        Read from the background preload result (joined before agent build),
+        so the AIAgent can persist them on the session row for analytics.
+        Best-effort: never fails agent construction.
+        """
+        try:
+            result = getattr(self, "_preload_skills_result", None)
+            if result and len(result) >= 2 and result[1]:
+                return list(result[1])
+            requested = getattr(self, "_preload_skills_requested", None)
+            return list(requested or [])
+        except Exception:
+            return []
+
     def _resolve_turn_agent_config(self, user_message: str) -> dict:
         """Effective model/runtime config for one turn — always the session's primary
         provider. With `/fast` on (service_tier == "priority") attach request_overrides;

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -46,6 +46,9 @@ def _normalize_skills(skills: object = None) -> list[str]:
     return list(dict.fromkeys(_normalize_toolsets(skills) or []))
 
 
+_loaded_preload_skill_names: list[str] = []  # single-shot process: safe module state
+
+
 def _build_preloaded_skills_prompt(skills: object = None) -> str | None:
     """Load requested skills using the same partial-success contract as CLI chat."""
     parsed_skills = _normalize_skills(skills)
@@ -55,6 +58,9 @@ def _build_preloaded_skills_prompt(skills: object = None) -> str | None:
     from agent.skill_commands import build_preloaded_skills_prompt
 
     skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(parsed_skills)
+    # persisted on the session row (origin_json.preload_skills) so `-s`
+    # sessions are distinguishable in state.db analytics
+    _loaded_preload_skill_names.extend(loaded_skills or [])
     if missing_skills:
         missing_display = ", ".join(missing_skills)
         if not loaded_skills:
@@ -393,6 +399,7 @@ def _run_agent(
             requested_provider=runtime.get("requested_provider"),
             api_mode=runtime.get("api_mode"),
             model=choice.model,
+            preload_skills=_loaded_preload_skill_names,
             enabled_toolsets=toolsets_list,
             quiet_mode=True,
             platform="cli",

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -274,6 +274,7 @@ class SessionSessionsMixin:
         chat_id: str = None, chat_type: str = None, thread_id: str = None,
         parent_session_id: str = None, cwd: str = None, profile_name: Optional[str] = None,
         git_repo_root: str = None, origin_json: str = None, display_name: str = None,
+        preload_skills: Optional[List[str]] = None,
     ) -> None:
         """Upsert a session row, never overwriting what an earlier writer set (the gateway creates a
         bare row before create_session carries the real model/prompt). chat_id/thread_id scope gateway
@@ -304,6 +305,16 @@ class SessionSessionsMixin:
         if not (profile_name or "").strip():
             profile_name = self._own_profile_name()
         def _do(conn):
+            merged_origin_json = origin_json
+            if preload_skills:
+                # merge preloaded skill names into origin_json (analytics:
+                # distinguish `-s` preload sessions; origin_json is an existing
+                # COALESCE'd TEXT column — no schema change).
+                base = json.loads(origin_json) if origin_json else {}
+                if not isinstance(base, dict):
+                    base = {}
+                base.setdefault("preload_skills", list(preload_skills))
+                merged_origin_json = json.dumps(base, ensure_ascii=False)
             system_prompt_hash = self._store_system_prompt(conn, system_prompt)
             conn.execute(
                 """INSERT INTO sessions (
@@ -348,7 +359,7 @@ class SessionSessionsMixin:
                 (
                     session_id, source, user_id, session_key, chat_id, chat_type, thread_id, model,
                     json.dumps(model_config) if model_config else None, system_prompt_hash,
-                    parent_session_id, cwd, profile_name, git_repo_root, origin_json, display_name,
+                    parent_session_id, cwd, profile_name, git_repo_root, merged_origin_json, display_name,
                     time.time(),
                 ),
             )

--- a/run_agent.py
+++ b/run_agent.py
@@ -53,6 +53,28 @@ def _session_source_for_agent(platform: Optional[str]) -> str:
     return str(source or "").strip() or platform or "cli"
 
 
+def _preload_skills_merge(origin: Optional[dict], agent: "AIAgent") -> Optional[dict]:
+    """Attach ``preload_skills`` (from ``-s``/``--skills``) to the origin dict."""
+    names = getattr(agent, "preloaded_skills", None)
+    if names:
+        origin = origin if origin is not None else {}
+        origin.setdefault("preload_skills", list(names))
+    return origin
+
+
+def _session_origin_json(agent: "AIAgent") -> Optional[str]:
+    """Session-row ``origin_json``: gateway origin (when any) + preload skills."""
+    origin = _gateway_origin_json(agent)
+    preload = getattr(agent, "preloaded_skills", None)
+    if not preload:
+        return origin
+    origin = _preload_skills_merge(origin, agent)
+    try:
+        return json.dumps(origin)
+    except Exception:
+        return None
+
+
 def _gateway_origin_json(agent: "AIAgent") -> Optional[str]:
     """Gateway routing ``origin_json`` for a session row; None when the agent carries no gateway identity.
 
@@ -264,6 +286,7 @@ class AIAgent(
         skip_context_files: bool = False, load_soul_identity: bool = False,
         skip_memory: bool = False, skip_background_review: bool = False,
         session_db=None, parent_session_id: str = None,
+        preload_skills: List[str] = None,
         iteration_budget: "IterationBudget" = None, run_budget_seconds: Optional[float] = None,
         fallback_model: Dict[str, Any] = None, credential_pool=None,
         checkpoints_enabled: bool = False, checkpoint_max_snapshots: int = 20,
@@ -341,7 +364,7 @@ class AIAgent(
                 chat_id=getattr(self, "_chat_id", None), chat_type=getattr(self, "_chat_type", None),
                 thread_id=getattr(self, "_thread_id", None),
                 display_name=getattr(self, "_chat_name", None) or getattr(self, "_user_name", None),
-                origin_json=_gateway_origin_json(self), parent_session_id=self._parent_session_id,
+                origin_json=_session_origin_json(self), parent_session_id=self._parent_session_id,
                 cwd=_launch_cwd_for_session(source), profile_name=profile_for_session,
             )
             self._session_db_created = True

--- a/tests/test_preload_skills_persistence.py
+++ b/tests/test_preload_skills_persistence.py
@@ -1,0 +1,85 @@
+"""Regression tests: preloaded skill names persist on the session row.
+
+`hermes chat -s <skill>` / oneshot preload sessions were indistinguishable
+from plain sessions in state.db (preload content lives only in the runtime
+system prompt), blinding per-skill usage analytics. The fix carries the
+preloaded names in ``sessions.origin_json`` under ``preload_skills`` — no
+schema change (origin_json is an existing COALESCE'd TEXT column).
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from hermes_state import SessionDB  # noqa: E402
+
+
+@pytest.fixture()
+def db(tmp_path):
+    db_path = tmp_path / "state.db"
+    store = SessionDB(db_path=db_path)
+    yield store, db_path
+
+
+def _origin_json(db_path, session_id):
+    import sqlite3
+
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT origin_json FROM sessions WHERE id = ?", (session_id,)
+        ).fetchone()
+        return row[0]
+    finally:
+        conn.close()
+
+
+def test_create_session_without_preload_keeps_origin_json_null(db):
+    store, db_path = db
+    store.create_session("sess-plain", "cli")
+    assert _origin_json(db_path, "sess-plain") is None
+
+
+def test_preload_skills_persisted_in_origin_json(db):
+    store, db_path = db
+    store.create_session(
+        "sess-pre", "cli", preload_skills=["hermes-dojo", "lark-im"]
+    )
+    raw = _origin_json(db_path, "sess-pre")
+    assert raw is not None
+    data = json.loads(raw)
+    assert data["preload_skills"] == ["hermes-dojo", "lark-im"]
+
+
+def test_preload_merges_into_existing_origin_json(db):
+    store, db_path = db
+    existing = json.dumps({"gateway": "feishu", "chat_id": "oc_x"})
+    store.create_session("sess-merge", "gateway", origin_json=existing,
+                         preload_skills=["lark-im"])
+    data = json.loads(_origin_json(db_path, "sess-merge"))
+    # both survive
+    assert data["gateway"] == "feishu"
+    assert data["chat_id"] == "oc_x"
+    assert data["preload_skills"] == ["lark-im"]
+
+
+def test_preload_does_not_clobber_existing_preload_field(db):
+    store, db_path = db
+    existing = json.dumps({"preload_skills": ["old-skill"]})
+    store.create_session("sess-keep", "cli", origin_json=existing,
+                         preload_skills=["new-skill"])
+    data = json.loads(_origin_json(db_path, "sess-keep"))
+    # setdefault: first write wins, never clobbered by a later row insert
+    assert data["preload_skills"] == ["old-skill"]
+
+
+def test_ensure_session_forwards_preload(db):
+    store, db_path = db
+    store.ensure_session("sess-ensure", source="cli",
+                         preload_skills=["a", "b"])
+    data = json.loads(_origin_json(db_path, "sess-ensure"))
+    assert data["preload_skills"] == ["a", "b"]


### PR DESCRIPTION
## Summary

- `hermes chat -s <skill>` embeds the preloaded skills **only** in the runtime system prompt. The session row in `state.db` carried no trace of them, so a preload session is indistinguishable from a plain one in analytics.
- This persists the loaded skill names on the session row under `origin_json.preload_skills` — **no schema change** (`origin_json` is an existing COALESCE'd TEXT column already used for gateway origin metadata).

## Motivation

Observability tooling built on state.db (per-skill usage counts, skill-outcome mining, eval harnesses that A/B skills via `-s`) currently cannot see preload sessions at all: the skill names exist only at runtime. Concretely, our skill-outcome miner undercounts every `-s` session and cannot attribute tool-call outcomes to the skill being tested.

## Changes (5 files, +61/−2)

| File | Change |
|---|---|
| `agent/agent_init.py` | accept `preload_skills`, expose `agent.preloaded_skills` |
| `run_agent.py` | `_session_origin_json()` merges `origin_json.preload_skills` into the gateway origin dict at session-row creation |
| `hermes_state_sessions.py` | `_insert_session_row(preload_skills=...)` — merged into `origin_json` via `setdefault` (never clobbers an earlier writer's list) |
| `hermes_cli/cli_agent_setup_mixin.py` | interactive CLI: pass loaded names through `_loaded_preload_skill_names()` |
| `hermes_cli/oneshot.py` | `-q` oneshot: module-level loaded-names capture, passed to AIAgent |

## Design notes

- `origin_json` over a new column: the column already exists, is COALESCE'd across writers, and is the established home for session-origin metadata.
- `setdefault` semantics: a preload list written by an earlier row creation is never clobbered by a later upsert.
- Gateway sessions merge into the existing gateway origin dict (both survive).
- Best-effort by contract: merge failures degrade to the unmodified origin value, never fail agent construction.

## Testing

- 5 new regression tests in `tests/test_preload_skills_persistence.py`: persistence, merge-with-existing-origin, no-clobber, `ensure_session` forwarding, and the no-preload NULL case.
- Full `tests/test_hermes_state.py`: **259 passed, 2 skipped** (no regression).
- `ruff check` clean on all touched files.
- Manually verified end-to-end: `hermes chat -s hermes-dojo ...` row now reads `origin_json.preload_skills = ["hermes-dojo"]`.