### PR TITLE
fix(kanban): budget exhaustion with real worktree work routes to review

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import subprocess
 from contextlib import suppress
 from typing import Any, Callable, List, Optional, Tuple
 
@@ -39,6 +40,46 @@ def _assistant_row_missing_visible_text(msg: dict) -> bool:
     return not flatten_message_text(msg.get("content")).strip()
 
 
+def _worktree_budget_work_evidence(workspace_path: str) -> Tuple[bool, str]:
+    """Cheap git-state probe on a budget-exhausted worktree worker (#104782).
+
+    "Real work" = tracked/untracked changes in the tree, or commits beyond the
+    merge-base with the repo's default branch. Fail-closed: any git error or
+    missing repo returns ``(False, "")`` so unknown states keep the
+    pre-existing ``timed_out`` strike instead of guessing.
+    """
+
+    def _git(*args: str) -> str:
+        proc = subprocess.run(
+            ["git", "-C", workspace_path, *args],
+            capture_output=True, text=True, timeout=15,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr.strip() or f"git {args[0]} failed")
+        return proc.stdout
+
+    try:
+        if _git("status", "--porcelain").strip():
+            return True, "uncommitted changes in the worktree"
+        base = ""
+        with suppress(Exception):
+            base = _git("symbolic-ref", "--short", "refs/remotes/origin/HEAD").strip()
+        if not base:
+            for candidate in ("origin/main", "origin/master", "main", "master"):
+                with suppress(Exception):
+                    _git("rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}")
+                    base = candidate
+                    break
+        if base:
+            merge_base = _git("merge-base", "HEAD", base).strip()
+            ahead = int(_git("rev-list", "--count", f"{merge_base}..HEAD").strip() or 0)
+            if ahead > 0:
+                return True, f"{ahead} commit(s) beyond {base}"
+    except Exception:
+        return False, ""
+    return False, ""
+
+
 def _record_kanban_budget_exhausted(
     kanban_task: str, api_call_count: int, max_iterations: int, logger: logging.Logger
 ) -> None:
@@ -47,6 +88,13 @@ def _record_kanban_budget_exhausted(
     Routed via ``_record_task_failure`` (not ``kanban_block``) so it counts toward the
     consecutive-failure circuit breaker. Idempotent via the ``_end_run`` CAS
     (``WHERE ended_at IS NULL``), so safe from multiple exit paths.
+
+    A worktree worker with real work behind the exhaustion is not a stuck task
+    (#104782): it hands off to review via ``request_review`` — which clears the
+    claim and ends the run with the same CAS idempotence but never touches
+    ``consecutive_failures`` — instead of spending a failure strike on
+    work that was actually produced. Only positive git evidence routes here;
+    anything unknowable (scratch workspace, git failure) keeps the strike.
 
     This is a bounded fallback (#87096): the CAS invariant in ``_end_run`` (``WHERE ended_at IS NULL``)
     guarantees idempotence — if another path already closed the run this is a no-op — so it is safe to call
@@ -58,18 +106,52 @@ def _record_kanban_budget_exhausted(
         from hermes_cli import kanban_db_dispatch as _kbd
         _conn = _kbc.connect()
         try:
-            _kbd._record_task_failure(
-                _conn,
-                kanban_task,
-                error=(
-                    f"Iteration budget exhausted ({api_call_count}/{max_iterations}) — "
-                    "task could not complete within the allowed iterations"
-                ),
-                outcome="timed_out",
-                release_claim=True,
-                end_run=True,
-                event_payload_extra={"budget_used": api_call_count, "budget_max": max_iterations},
-            )
+            _handed_off = False
+            with suppress(Exception):
+                _row = _conn.execute(
+                    "SELECT workspace_kind, workspace_path, current_run_id "
+                    "FROM tasks WHERE id = ?",
+                    (kanban_task,),
+                ).fetchone()
+                if (
+                    _row is not None
+                    and _row["workspace_kind"] == "worktree"
+                    and (_row["workspace_path"] or "").strip()
+                ):
+                    _has_work, _evidence = _worktree_budget_work_evidence(
+                        _row["workspace_path"].strip()
+                    )
+                    if _has_work:
+                        _handed_off, _reason = _kb.request_review(
+                            _conn,
+                            kanban_task,
+                            summary=(
+                                f"Iteration budget exhausted ({api_call_count}/{max_iterations}) "
+                                f"with {_evidence} — routed to review instead of a "
+                                "failure strike (#104782)"
+                            ),
+                            expected_run_id=_row["current_run_id"],
+                            with_reason=True,
+                        )
+                        if not _handed_off:
+                            logger.warning(
+                                "Budget-exhausted review handoff for task %s failed (%s); "
+                                "recording the failure strike instead",
+                                kanban_task, _reason,
+                            )
+            if not _handed_off:
+                _kbd._record_task_failure(
+                    _conn,
+                    kanban_task,
+                    error=(
+                        f"Iteration budget exhausted ({api_call_count}/{max_iterations}) — "
+                        "task could not complete within the allowed iterations"
+                    ),
+                    outcome="timed_out",
+                    release_claim=True,
+                    end_run=True,
+                    event_payload_extra={"budget_used": api_call_count, "budget_max": max_iterations},
+                )
         finally:
             with suppress(Exception):
                 _conn.close()

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -1,5 +1,7 @@
 """Regression tests for iteration-limit exit normalization (#61631)."""
 
+import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -373,3 +375,114 @@ def test_bounded_fallback_does_not_fire_when_budget_not_exhausted(monkeypatch):
     record.assert_not_called()
 
 
+
+
+# ---------------------------------------------------------------------------
+# #104782: budget exhaustion with real worktree work is not a stuck task
+# ---------------------------------------------------------------------------
+
+
+def _git(*args, cwd):
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True)
+
+
+def _worktree_for(tmp_path, task_id, *, evidence):
+    """Build a repo + linked worktree workspace; returns the worktree path.
+
+    evidence: "commits" (a commit beyond the base branch), "dirty" (untracked
+    changes), "clean" (untouched worktree), "not_a_repo" (plain directory).
+    """
+    repo = tmp_path / f"repo-{task_id}"
+    repo.mkdir()
+    if evidence == "not_a_repo":
+        return repo
+    _git("init", "-b", "main", cwd=repo)
+    _git("config", "user.email", "t@example.com", cwd=repo)
+    _git("config", "user.name", "t", cwd=repo)
+    (repo / "base.txt").write_text("base\n")
+    _git("add", ".", cwd=repo)
+    _git("commit", "-m", "base", cwd=repo)
+    wt = tmp_path / f"wt-{task_id}"
+    _git("worktree", "add", "-b", f"wt/{task_id}", str(wt), cwd=repo)
+    if evidence == "commits":
+        (wt / "work.txt").write_text("real work\n")
+        _git("add", ".", cwd=wt)
+        _git("commit", "-m", "real work", cwd=wt)
+    elif evidence == "dirty":
+        (wt / "scratch.txt").write_text("untracked but real\n")
+    return wt
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return home
+
+
+def _running_worktree_task(workspace_path):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+
+    conn = kbc.connect()
+    task_id = kb.create_task(
+        conn, title="wt worker", assignee="builder",
+        workspace_kind="worktree", workspace_path=str(workspace_path),
+    )
+    claimed = kb.claim_task(conn, task_id, claimer="builder:test")
+    assert claimed is not None, "task must claim ready -> running"
+    return conn, task_id
+
+
+@pytest.mark.parametrize("evidence", ["commits", "dirty"])
+def test_budget_exhaustion_with_worktree_work_routes_to_review(
+    monkeypatch, kanban_home, tmp_path, evidence
+):
+    """#104782: a budget-exhausted worktree worker with real work behind it
+    hands off to review WITHOUT a circuit-breaker strike — the failure counter
+    stays at zero and the run ends ``review_requested``."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    wt = _worktree_for(tmp_path, "task-wt-1", evidence=evidence)
+    conn, task_id = _running_worktree_task(wt)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    agent = _LimitAgent()
+
+    _finalize(agent, final_response=None, exit_reason="unknown")
+
+    task = conn.execute(
+        "SELECT status, consecutive_failures FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    assert task["status"] == "review"
+    assert task["consecutive_failures"] == 0
+    run = conn.execute(
+        "SELECT outcome, status, ended_at FROM task_runs WHERE task_id = ?", (task_id,)
+    ).fetchone()
+    assert run["outcome"] == "review_requested"
+    assert run["ended_at"] is not None
+
+
+@pytest.mark.parametrize("evidence", ["clean", "not_a_repo"])
+def test_budget_exhaustion_without_worktree_evidence_still_strikes(
+    monkeypatch, kanban_home, tmp_path, evidence
+):
+    """#104782 invariant arm: no git evidence of work → the strike path is
+    unchanged (failure counter advances, run ends ``timed_out``)."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    wt = _worktree_for(tmp_path, "task-wt-2", evidence=evidence)
+    conn, task_id = _running_worktree_task(wt)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    agent = _LimitAgent()
+
+    _finalize(agent, final_response=None, exit_reason="unknown")
+
+    task = conn.execute(
+        "SELECT consecutive_failures FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    assert task["consecutive_failures"] == 1
+    run = conn.execute(
+        "SELECT outcome, ended_at FROM task_runs WHERE task_id = ?", (task_id,)
+    ).fetchone()
+    assert run["outcome"] == "timed_out"
+    assert run["ended_at"] is not None


### PR DESCRIPTION
## What does this PR do?

When a kanban worktree worker runs out of iteration budget, `_record_kanban_budget_exhausted` records the same `timed_out` failure strike as a genuinely stuck task — and since the failure limit is 2, a task whose work actually finished right as the budget ran out gets tripped to `blocked` on the second occurrence, even though the work itself is fine.

This adds a cheap git-state check before recording the failure: if the task's worktree has uncommitted changes or commits beyond the base branch, the task is handed to review via `request_review` (claim cleared, run closed with the same CAS idempotence, failure counter untouched). Anything unknowable — scratch workspaces, git errors, unresolvable base — keeps the existing strike, so the fix only diverts on positive evidence.

## Related Issue

Fixes #104782

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_finalizer.py`: new `_worktree_budget_work_evidence()` — `git status --porcelain` for tree changes, `rev-list --count merge-base..HEAD` against the default branch for commits; fail-closed `(False, "")` on any git error. `_record_kanban_budget_exhausted()` routes worktree tasks with positive evidence to `kb.request_review(expected_run_id=...)` instead of `_record_task_failure`; handoff failure or missing evidence falls back to the unchanged strike path.
- `tests/agent/test_turn_finalizer_iteration_limit_exit.py`: invariant tests — real worktree work (commits / untracked changes) routes to review with `consecutive_failures == 0` and the run ending `review_requested`; clean worktree / non-git workspace still strikes (`timed_out`, counter +1).

## How to Test

1. `scripts/run_tests.sh tests/agent/test_turn_finalizer_iteration_limit_exit.py` — 13 passed (4 new)
2. On main: budget-exhausted worktree worker with a commit in the worktree ends with `consecutive_failures = 1` and run outcome `timed_out`
3. On this branch: same setup ends with task status `review`, failure counter untouched, run outcome `review_requested`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A