### PR TITLE
fix(desktop): restored async reports retain formatted result bodies (#101078)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -150,6 +150,7 @@ const _chatMessageFieldsExhaustive: {
 } = {}
 
 const COMPARED_FIELDS = [
+  'asyncResult',
   'id',
   'role',
   'pending',

--- a/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
@@ -1,6 +1,7 @@
 import { MessagePrimitive, useAuiState } from '@assistant-ui/react'
 import { type FC } from 'react'
 
+import { MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
 import { messageContentText } from '@/components/assistant-ui/thread/content'
 import { MessageTimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
 import { SCAFFOLD_LABEL_CLASS } from '@/components/chat/scaffold-row'
@@ -15,9 +16,25 @@ const REVIEW_NOTE_RE = /^review:(?<label>[^:\n]+):?\s*(?<detail>[\s\S]*)$/
 
 export const SystemMessage: FC = () => {
   const text = useAuiState(s => messageContentText(s.message.content))
+  const asyncResult = useAuiState(s => s.message.metadata.custom?.asyncResult)
 
   if (!text) {
     return null
+  }
+
+  if (typeof asyncResult === 'string' && asyncResult) {
+    return (
+      <MessagePrimitive.Root
+        className="flex w-full min-w-0 flex-col gap-2 self-start py-1"
+        data-role="system"
+        data-slot="aui_system-message-root"
+      >
+        <div className="text-[0.6875rem] leading-5 text-muted-foreground/55">
+          {text} <MessageTimelineTimestamp />
+        </div>
+        <MarkdownTextContent isRunning={false} text={asyncResult} />
+      </MessagePrimitive.Root>
+    )
   }
 
   // The self-improvement review saved something to memory/skills — the same

--- a/apps/desktop/src/lib/async-report.test.ts
+++ b/apps/desktop/src/lib/async-report.test.ts
@@ -38,7 +38,7 @@ describe('async report hydration', () => {
   })
 
   it('separates batch result blocks without leaking preambles or transcript plumbing', () => {
-    const content = `[ASYNC DELEGATION BATCH COMPLETE — batch]\nPrivate instructions\nRole: leaf\n\n--- ✓ TASK 1/2: private goal  (status=completed) ---\n${report}\nFull live transcript (complete tool/assistant trace): /private/path\n\n--- ✓ TASK 2/2  (status=completed) ---\nPlain result`
+    const content = `[ASYNC DELEGATION BATCH COMPLETE — batch]\nPrivate instructions\nRole: leaf\n\n--- ✓ TASK 1/2: private goal  (status=completed) ---\n${report}\nFull live transcript (complete tool/assistant trace): /private/path\n\n--- ✓ TASK 2/2: private goal\nprivate continuation  (status=completed) ---\nPlain result`
     expect(hydrate(content).metadata.custom.asyncResult).toBe(`${report}\n\nPlain result`)
     expect(
       hydrate('[ASYNC DELEGATION COMPLETE — malformed]\nPrivate instructions').metadata.custom.asyncResult

--- a/apps/desktop/src/lib/async-report.test.ts
+++ b/apps/desktop/src/lib/async-report.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { toChatMessages } from '@/lib/chat-messages/hydration'
+import { toRuntimeMessage } from '@/lib/chat-runtime'
+
+const report = '# Report\n\n**Conclusion:** ready\n\n| Task | Status |\n|---|---|\n| probe | ok |'
+
+const envelope = (body: string) =>
+  `[ASYNC DELEGATION COMPLETE — probe]\nPrivate instructions\nOriginal goal: private goal\nRole: leaf\n--- RESULT ---\n${body}`
+
+function hydrate(content: string) {
+  return toRuntimeMessage(
+    toChatMessages([
+      {
+        role: 'user',
+        content,
+        display_kind: 'async_delegation_complete',
+        display_metadata: { delegation_id: 'probe', task_count: 1 }
+      }
+    ])[0]
+  )
+}
+
+describe('async report hydration', () => {
+  it('keeps only result bodies beside compact system metadata across current and legacy deliveries', () => {
+    for (const input of [
+      envelope(report),
+      envelope(
+        `Cron job 'probe' (id) finished its manual run.\nResult: ok\nDelivery target: local\n--- JOB OUTPUT ---\n${report}`
+      ),
+      report
+    ]) {
+      const message = hydrate(input)
+      expect(message.role).toBe('system')
+      expect(message.content).toEqual([{ type: 'text', text: '1 background agent finished' }])
+      expect(message.metadata.custom.asyncResult).toBe(report)
+    }
+  })
+
+  it('separates batch result blocks without leaking preambles or transcript plumbing', () => {
+    const content = `[ASYNC DELEGATION BATCH COMPLETE — batch]\nPrivate instructions\nRole: leaf\n\n--- ✓ TASK 1/2: private goal  (status=completed) ---\n${report}\nFull live transcript (complete tool/assistant trace): /private/path\n\n--- ✓ TASK 2/2  (status=completed) ---\nPlain result`
+    expect(hydrate(content).metadata.custom.asyncResult).toBe(`${report}\n\nPlain result`)
+    expect(
+      hydrate('[ASYNC DELEGATION COMPLETE — malformed]\nPrivate instructions').metadata.custom.asyncResult
+    ).toBeUndefined()
+    expect(hydrate('').metadata.custom.asyncResult).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/lib/chat-messages/hydration.ts
+++ b/apps/desktop/src/lib/chat-messages/hydration.ts
@@ -166,7 +166,8 @@ function asyncResultBody(content: string): string | undefined {
 
   if (content.startsWith('[ASYNC DELEGATION')) {
     if (content.startsWith('[ASYNC DELEGATION BATCH COMPLETE')) {
-      bodies = content.split(/^--- [✓✗⚠] TASK [^\n]+ ---\r?\n/gm).slice(1)
+      // Task goals can span lines; stopping at a newline leaks the next goal and transcript footer.
+      bodies = content.split(/^--- [✓✗⚠] TASK \d+\/\d+(?:: [\s\S]*?)? {2}\(status=[^\n]*\) ---\r?\n/gm).slice(1)
     } else {
       const result = content.match(/^--- (?:RESULT|ERROR) ---\r?\n/m)
       bodies = result ? [content.slice(result.index! + result[0].length)] : []

--- a/apps/desktop/src/lib/chat-messages/hydration.ts
+++ b/apps/desktop/src/lib/chat-messages/hydration.ts
@@ -159,6 +159,33 @@ function messageReactions(metadata: SessionMessage['display_metadata']): Message
   )
 }
 
+// Only parse producer-owned boundaries, never render the model's task preamble.
+// Older backends can persist an unwrapped result rather than an envelope.
+function asyncResultBody(content: string): string | undefined {
+  let bodies = [content]
+
+  if (content.startsWith('[ASYNC DELEGATION')) {
+    if (content.startsWith('[ASYNC DELEGATION BATCH COMPLETE')) {
+      bodies = content.split(/^--- [✓✗⚠] TASK [^\n]+ ---\r?\n/gm).slice(1)
+    } else {
+      const result = content.match(/^--- (?:RESULT|ERROR) ---\r?\n/m)
+      bodies = result ? [content.slice(result.index! + result[0].length)] : []
+    }
+  }
+
+  return (
+    bodies
+      .map(body => {
+        const output = body.startsWith('Cron job ') ? body.match(/^--- JOB OUTPUT ---\r?\n/m) : null
+        const result = output ? body.slice(output.index! + output[0].length) : body
+
+        return result.replace(/\nFull live transcript \(complete tool\/assistant trace\): [^\n]*\n*$/, '').trim()
+      })
+      .filter(Boolean)
+      .join('\n\n') || undefined
+  )
+}
+
 function timelineDisplayContent(message: SessionMessage, content: string): string {
   if (message.display_kind === 'model_switch') {
     return 'model changed'
@@ -381,6 +408,9 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       id: `${message.timestamp || Date.now()}-${index}-${displayRole}`,
       role: displayRole,
       parts,
+      ...(message.display_kind === 'async_delegation_complete'
+        ? { asyncResult: asyncResultBody(displayContentForMessage(message.role, message.content || content)) }
+        : {}),
       timestamp: earliestTimestamp(message.timestamp, ...parts.map(part => part.timestamp)),
       ...(rowId !== undefined ? { rowId } : {}),
       ...(reactions.length ? { reactions } : {}),

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -18,6 +18,8 @@ export type ChatMessage = {
   id: string
   role: SessionMessage['role']
   parts: ChatMessagePart[]
+  /** Result body only; the system text remains the compact completion label. */
+  asyncResult?: string
   timestamp?: number
   completedAt?: number
   pending?: boolean

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -459,7 +459,7 @@ export function toRuntimeMessage(message: ChatMessage): ThreadMessage {
       role,
       content: [textPart(text)],
       createdAt,
-      metadata: { custom: timelineMeta }
+      metadata: { custom: { ...timelineMeta, ...(message.asyncResult ? { asyncResult: message.asyncResult } : {}) } }
     } as ThreadMessage
   }
 

--- a/evals/desktop_bug_campaign/async-report-README.md
+++ b/evals/desktop_bug_campaign/async-report-README.md
@@ -1,0 +1,35 @@
+# Async report rendering probe
+
+Offline integration proof for Desktop async completion reports. The producer creates
+synthetic output, passes it through the real cron manual-completion formatter,
+process notification formatter, durable delivery and SQLite, then reads actual rows.
+The browser imports production hydration, runtime, SystemMessage and Desktop CSS.
+No model, scheduled job or user configuration is used.
+
+From the repository root with the normal Python and npm dependencies installed:
+
+```sh
+export HOME=$(mktemp -d)
+export HERMES_HOME="$HOME/.hermes"
+export ASYNC_REPORT_ARTIFACT_DIR=$(mktemp -d)
+# If Chromium is installed outside the temporary HOME, set
+# PLAYWRIGHT_BROWSERS_PATH to that installation's browser cache.
+.venv/bin/python evals/desktop_bug_campaign/async-report-producer.py "$ASYNC_REPORT_ARTIFACT_DIR/producer.json"
+node evals/desktop_bug_campaign/async-report-vite.mjs
+# In another shell with the same environment:
+node evals/desktop_bug_campaign/async-report-live.mjs before
+node evals/desktop_bug_campaign/async-report-live.mjs after
+```
+
+The Vite probe binds loopback port 18164. Stop it after verification. The pinned
+baseline hydration is from commit `a688e7d5ff9aeaaa9c97d28c316467f89ab8c943`;
+all other renderer modules are the current checkout. Compare the emitted JSON and
+screenshots: cron/delegation/batch/legacy Markdown headings and tables are absent
+before and present after, plain results survive, malformed envelopes remain compact,
+and task goals/context/transcript footer paths do not render. Batch goals include a
+multiline case because the producer does not flatten them.
+
+This is producer/store integration plus live Chromium rendering, **not** scheduled
+execution, completion-poller/HTTP/WebSocket E2E, Bot Chat routing, or native macOS QA.
+The `process` case means an async-delegation event through the process notification
+formatter, not a terminal-process completion event. All fixtures are synthetic.

--- a/evals/desktop_bug_campaign/async-report-live.mjs
+++ b/evals/desktop_bug_campaign/async-report-live.mjs
@@ -1,0 +1,24 @@
+import { chromium } from '../../node_modules/playwright/index.mjs'
+import fs from 'node:fs'
+import { execFileSync } from 'node:child_process'
+const a='/home/teknium/.hermes/cache/desktop-bugs-74848ed3/followups/async-reports'
+const tag=process.argv[2]??'after'
+const browser=await chromium.launch({headless:false,args:['--no-sandbox']})
+const page=await browser.newPage({viewport:{width:1400,height:1000}})
+const errors=[];page.on('pageerror',e=>errors.push(String(e)))
+const producer=JSON.parse(fs.readFileSync(`${a}/producer.json`,'utf8'))
+const cases={}
+for (const [name, entry] of Object.entries(producer.cases)) {
+  await page.goto('http://127.0.0.1:18164/async-report-probe.html'+(tag==='before'?'?baseline':''),{waitUntil:'domcontentloaded',timeout:120000})
+  await page.waitForFunction(()=>typeof window.renderProducer==='function')
+  const projected=await page.evaluate(rows=>window.renderProducer(rows),entry.rows)
+  await page.waitForSelector('#producer [data-role="system"]')
+  if (projected.hydrated[0].asyncResult?.includes('# Generated')) await page.waitForSelector('#producer table')
+  const dom=await page.locator('#producer').evaluate(el=>({text:el.textContent,headings:el.querySelectorAll('h1').length,tables:el.querySelectorAll('table').length,strong:el.querySelectorAll('strong').length,html:el.innerHTML}))
+  cases[name]={...projected,dom}
+  if (name==='cron') { await page.locator('#producer').scrollIntoViewIfNeeded(); await page.waitForTimeout(800); await page.locator('#producer').screenshot({path:`${a}/${tag}.png`}) }
+}
+const result={cases,errors,sourceSha:execFileSync('git',['rev-parse','HEAD'],{encoding:'utf8'}).trim()}
+fs.writeFileSync(`${a}/${tag}.json`,JSON.stringify(result,null,2))
+console.log(JSON.stringify({errors,cases:Object.fromEntries(Object.entries(cases).map(([name,c])=>[name,{headings:c.dom.headings,tables:c.dom.tables,privateLeak:c.dom.text.includes('PRIVATE'),body:c.hydrated[0].asyncResult??null}]))},null,2))
+await browser.close()

--- a/evals/desktop_bug_campaign/async-report-live.mjs
+++ b/evals/desktop_bug_campaign/async-report-live.mjs
@@ -1,9 +1,10 @@
 import { chromium } from '../../node_modules/playwright/index.mjs'
 import fs from 'node:fs'
 import { execFileSync } from 'node:child_process'
-const a='/home/teknium/.hermes/cache/desktop-bugs-74848ed3/followups/async-reports'
+const a=process.env.ASYNC_REPORT_ARTIFACT_DIR
+if (!a) throw new Error('Set ASYNC_REPORT_ARTIFACT_DIR to an offline artifact directory')
 const tag=process.argv[2]??'after'
-const browser=await chromium.launch({headless:false,args:['--no-sandbox']})
+const browser=await chromium.launch({headless:true,args:['--no-sandbox']})
 const page=await browser.newPage({viewport:{width:1400,height:1000}})
 const errors=[];page.on('pageerror',e=>errors.push(String(e)))
 const producer=JSON.parse(fs.readFileSync(`${a}/producer.json`,'utf8'))

--- a/evals/desktop_bug_campaign/async-report-probe.html
+++ b/evals/desktop_bug_campaign/async-report-probe.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset="utf-8"></head><body><div id="root"></div><script type="module" src="FIXTURE_ENTRY"></script></body></html>

--- a/evals/desktop_bug_campaign/async-report-probe.tsx
+++ b/evals/desktop_bug_campaign/async-report-probe.tsx
@@ -1,0 +1,28 @@
+import '@/styles.css'
+import { createRoot } from 'react-dom/client'
+import { AssistantRuntimeProvider, ThreadPrimitive, useExternalStoreRuntime, type ThreadMessage } from '@assistant-ui/react'
+import type { ReactNode } from 'react'
+import type { SessionMessage } from '@/types/hermes'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from '@/lib/query-client'
+import { I18nProvider } from '@/i18n'
+import { ThemeProvider } from '@/themes/context'
+import { RootTooltipProvider } from '@/components/ui/tooltip'
+import { SystemMessage } from '@/components/assistant-ui/thread/system-message'
+import { toChatMessages } from '@/lib/chat-messages/hydration'
+import { toChatMessages as baselineHydrate } from '@baseline-hydration'
+import { toRuntimeMessage } from '@/lib/chat-runtime'
+function Providers({children}: {children: ReactNode}) {
+  return <QueryClientProvider client={queryClient}><I18nProvider><ThemeProvider><RootTooltipProvider>{children}</RootTooltipProvider></ThemeProvider></I18nProvider></QueryClientProvider>
+}
+function Delivery({messages}: {messages: ThreadMessage[]}) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({messages, isRunning:false, onNew:async()=>{}})
+  return <AssistantRuntimeProvider runtime={runtime}><ThreadPrimitive.Root><ThreadPrimitive.Messages components={{Message: SystemMessage}}/></ThreadPrimitive.Root></AssistantRuntimeProvider>
+}
+Object.assign(window, {renderProducer(rows: SessionMessage[]) {
+  const hydrated = (location.search.includes('baseline') ? baselineHydrate : toChatMessages)(rows)
+  const runtime = hydrated.map(toRuntimeMessage)
+  const mount = document.createElement('section'); mount.id = 'producer'; mount.style.cssText='padding:24px; max-width:960px; margin:auto'; document.body.append(mount)
+  createRoot(mount).render(<Providers><Delivery messages={runtime}/></Providers>)
+  return {hydrated,runtime}
+}})

--- a/evals/desktop_bug_campaign/async-report-producer.py
+++ b/evals/desktop_bug_campaign/async-report-producer.py
@@ -1,0 +1,61 @@
+"""Real offline completion producers -> durable SQLite rows; never run a model."""
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import time
+
+repo = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(repo))
+output = Path(sys.argv[1])
+with tempfile.TemporaryDirectory(prefix="async-report-producer-") as temporary:
+    home = Path(temporary)
+    for key in list(os.environ):
+        if key.startswith("HERMES_") or key.endswith(("_API_KEY", "_TOKEN")):
+            os.environ.pop(key, None)
+    os.environ.update(HOME=str(home), HERMES_HOME=str(home / ".hermes"))
+    from cron.jobs import create_job, save_job_output
+    from gateway.wake import persist_delegation_delivery
+    from hermes_state import SessionDB
+    from tools.cronjob_tools import _manual_run_completion
+    from tools.process_registry_notifications import format_process_notification
+
+    report = "# Generated inspection\n\n**Conclusion:** attention needed.\n\n| Strategy | Status |\n|---|---|\n| Canary | running |\n\nFirst line  \nSecond line\n\n```python\nvalue = 1  \nvalue = 2 \n```"
+    job = create_job(prompt="Offline fixture; never run", schedule="0 0 * * *", name="Markdown probe", deliver="local")
+    save_job_output(job["id"], report)
+    result = _manual_run_completion({"success": True}, job["id"], job["name"], "local", time.time())
+    common = dict(type="async_delegation", delegation_id="report-probe", goal="PRIVATE GOAL", context="PRIVATE CONTEXT")
+    events = {
+        "cron": dict(common, **result),
+        "process": dict(common, status="completed", summary=report),
+        "batch": dict(common, is_batch=True, goals=["PRIVATE FIRST", "PRIVATE SECOND"], results=[
+            dict(task_index=0, status="completed", summary=report, live_transcript="/private/transcript"),
+            dict(task_index=1, status="completed", summary="Plain batch result"),
+        ]),
+        "legacy": dict(common, status="completed", summary=report),
+        "plain": dict(common, status="completed", summary="Plain result"),
+        "malformed": dict(common, status="completed"),
+    }
+    db = SessionDB(db_path=home / "delivery.db")
+
+    class DeliveryStore:
+        def _ensure_session_db(self):
+            return db
+
+    cases = {}
+    for name, event in events.items():
+        envelope = format_process_notification(event)
+        assert envelope is not None
+        if name == "legacy":
+            envelope = report
+        elif name == "malformed":
+            envelope = "[ASYNC DELEGATION COMPLETE — malformed]\nPRIVATE INSTRUCTIONS"
+        db.create_session(session_id=name, source="desktop")
+        asyncio.run(persist_delegation_delivery(DeliveryStore(), text=envelope, session_id=name, evt=event))
+        rows = db.get_messages_as_conversation(name, include_row_ids=True)
+        cases[name] = dict(envelope=envelope, rows=rows, stored_exactly=rows[0]["content"] == envelope)
+    output.write_text(json.dumps({"report": report, "cases": cases}, indent=2), encoding="utf-8")
+    print(json.dumps({"cases": len(cases), "stored_exactly": all(c["stored_exactly"] for c in cases.values()), "producer": "cron save/formatter -> process formatter -> durable delivery -> SQLite readback", "model_requests": 0}))
+    db.close()

--- a/evals/desktop_bug_campaign/async-report-producer.py
+++ b/evals/desktop_bug_campaign/async-report-producer.py
@@ -30,7 +30,7 @@ with tempfile.TemporaryDirectory(prefix="async-report-producer-") as temporary:
     events = {
         "cron": dict(common, **result),
         "process": dict(common, status="completed", summary=report),
-        "batch": dict(common, is_batch=True, goals=["PRIVATE FIRST", "PRIVATE SECOND"], results=[
+        "batch": dict(common, is_batch=True, goals=["PRIVATE FIRST", "PRIVATE SECOND\nPRIVATE CONTINUATION"], results=[
             dict(task_index=0, status="completed", summary=report, live_transcript="/private/transcript"),
             dict(task_index=1, status="completed", summary="Plain batch result"),
         ]),

--- a/evals/desktop_bug_campaign/async-report-vite.mjs
+++ b/evals/desktop_bug_campaign/async-report-vite.mjs
@@ -3,7 +3,9 @@ import fs from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import path from 'node:path'
 const root = path.resolve(import.meta.dirname, '../../apps/desktop')
-const artifactDir = process.env.NAVIGATION_ARTIFACT_DIR ?? '/home/teknium/.hermes/cache/desktop-bugs-74848ed3/followups/async-reports'
+const artifactDir = process.env.ASYNC_REPORT_ARTIFACT_DIR
+if (!artifactDir) throw new Error('Set ASYNC_REPORT_ARTIFACT_DIR to an offline artifact directory')
+fs.mkdirSync(artifactDir, {recursive:true})
 const fixture = path.join(import.meta.dirname, 'async-report-probe.tsx')
 const baseline = path.join(artifactDir, 'baseline-hydration.ts')
 fs.writeFileSync(baseline, execFileSync('git', ['show', 'a688e7d5ff9aeaaa9c97d28c316467f89ab8c943:apps/desktop/src/lib/chat-messages/hydration.ts'], {encoding:'utf8'}).replaceAll("from './", "from '@/lib/chat-messages/"))

--- a/evals/desktop_bug_campaign/async-report-vite.mjs
+++ b/evals/desktop_bug_campaign/async-report-vite.mjs
@@ -1,0 +1,32 @@
+import { createServer } from '../../node_modules/vite/dist/node/index.js'
+import fs from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+const root = path.resolve(import.meta.dirname, '../../apps/desktop')
+const artifactDir = process.env.NAVIGATION_ARTIFACT_DIR ?? '/home/teknium/.hermes/cache/desktop-bugs-74848ed3/followups/async-reports'
+const fixture = path.join(import.meta.dirname, 'async-report-probe.tsx')
+const baseline = path.join(artifactDir, 'baseline-hydration.ts')
+fs.writeFileSync(baseline, execFileSync('git', ['show', 'a688e7d5ff9aeaaa9c97d28c316467f89ab8c943:apps/desktop/src/lib/chat-messages/hydration.ts'], {encoding:'utf8'}).replaceAll("from './", "from '@/lib/chat-messages/"))
+const server = await createServer({
+  resolve: {alias: {'@baseline-hydration': baseline}},
+  root,
+  configFile: path.join(root, 'vite.config.ts'),
+  // Keep the node_modules segment: Babel must not compile optimized deps.
+  cacheDir: path.join(artifactDir, 'node_modules/.vite'),
+  plugins: [{
+    name: 'async-report-probe',
+    configureServer(server) {
+      server.middlewares.use('/async-report-probe.html', async (_req, res, next) => {
+        try {
+          const source = fs.readFileSync(path.join(import.meta.dirname, 'async-report-probe.html'), 'utf8')
+          const html = await server.transformIndexHtml('/async-report-probe.html', source.replace('FIXTURE_ENTRY', `/@fs/${fixture}`))
+          res.setHeader('Content-Type', 'text/html')
+          res.end(html)
+        } catch (error) { next(error) }
+      })
+    }
+  }],
+  server: {host: '127.0.0.1', port: 18164, strictPort: true}
+})
+await server.listen()
+server.printUrls()

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -51,6 +51,8 @@ The center of the app. You get:
 - **A conversation timeline rail** — long chats get a slim rail of markers along the edge of the transcript, one per prompt. Hover it to pop open the list of prompts, click one to jump straight to that point in the conversation. (It appears once the chat has a handful of turns.)
 - **Find in page** — press **Cmd/Ctrl+F** to open a find bar that searches the rendered chat transcript. Enter / Shift+Enter (or Cmd/Ctrl+G / Cmd/Ctrl+Shift+G while the bar is open) step through matches; Esc closes it.
 
+Async cron and delegation completions keep a compact timeline label and render the result body (including job output) as Markdown. Task instructions and delivery envelopes are not shown as report content.
+
 #### Status bar
 
 The bar along the bottom of the chat shows live session state and exposes quick controls without opening Settings:


### PR DESCRIPTION
Desktop async cron and delegation reports remain readable after transcript hydration, with Markdown result bodies beside compact completion labels.

## Changes
- Preserve result-only content through hydration, reconciliation and runtime metadata; render it with the existing Desktop Markdown component while keeping system-row semantics.
- Strip delegation preambles, cron output wrappers and batch transcript footers rather than rendering the complete internal notification.
- Handle multiline batch goals without exposing the next task's goal or the preceding transcript path; retain plain legacy results and compact status for envelopes without a recognizable result boundary.
- Add two invariant tests and a reproducible offline producer → SQLite → live Chromium renderer probe, plus user documentation.

Root cause: hydration replaced persisted completion content with a count label, and system messages did not use the Markdown renderer.

Fixes #101078. Part of the Desktop reliability tracker #104839.
Related earlier proposal: #101083 by @Gyarados4157. This implementation keeps the result body separate instead of rendering the entire original envelope.

## Validation

**Live repro:** using actual SQLite readbacks from synthetic offline completion producers, cron/delegation/batch/legacy headings and tables each changed from **0 before → 1 after**. Plain results survived, malformed envelopes stayed compact, and no task goal, context, instruction preamble or transcript footer appeared in the rendered cases. The independent review reproduced and fixed a multiline-batch-goal leak before delivery.

| Gate | Result |
|---|---|
| Real cron saved output → manual-completion formatter → process notification formatter → durable delivery → SQLite | Six exact persisted/read-back cases; no model requests |
| Production hydration → runtime → SystemMessage + Desktop CSS in live Chromium | Six cases checked; no page errors; heading, emphasis, table and code verified visually |
| Multiline batch boundary regression | Failed before review fix with exposed goal/transcript footer; passed afterward |
| Mirrored Desktop unit gates | 1,684 passed across 160 files; final result-boundary invariants rerun after equivalent regex lint cleanup |
| Three TypeScript projects, touched-file ESLint, Python Ruff, Windows footguns, compatibility pointers, subprocess stdin, diff whitespace | Passed |

### Fidelity limits
The fixtures were generated offline with temporary `HOME` and `HERMES_HOME`; no user configuration or conversation data was used. The before renderer imports pinned baseline hydration with the current renderer modules. This verifies real producer/store integration and live Chromium rendering, **not** scheduled cron execution, completion-poller/HTTP/WebSocket E2E, Bot Chat routing, native macOS, or a model turn. The probe's `process` case is an async-delegation event passed through the process notification formatter, not a terminal-process completion. Markdown whitespace cleanup (#97117) is outside this change. The infographic below describes the broader campaign, not additional test coverage.

## Infographic
![Desktop reliability campaign: reproduce, fix, verify](https://v3b.fal.media/files/b/0aa970ff/01HBIjxrk8-g59IYVhD6F_GOQaUsZH.png)
