### PR TITLE
fix(cron): completed scheduled runs no longer replay after snapshot rollback (#104790)

### DIFF
--- a/contributors/emails/holny@foxmail.com
+++ b/contributors/emails/holny@foxmail.com
@@ -1,0 +1,2 @@
+holny
+# Issue #104790 and occurrence guard #104323

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -115,6 +115,11 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_executions_status_claimed "
         "ON executions(status, claimed_at DESC, id DESC)"
     )
+    add_column_if_missing(conn, "executions", "scheduled_instant", "scheduled_instant TEXT")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_executions_occurrence "
+        "ON executions(job_id, scheduled_instant) WHERE status='completed'"
+    )
 
 
 @contextmanager
@@ -172,8 +177,12 @@ def _prune_unlocked(conn: sqlite3.Connection) -> None:
     )
 
 
-def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
+def create_execution(
+    job_id: str, *, source: str, scheduled_instant: Optional[str] = None,
+) -> Dict[str, Any]:
     """Persist a claimed attempt before executor/provider dispatch."""
+    from cron.occurrences import scheduled_instant as canonical_instant
+
     now = _hermes_now().isoformat()
     execution_id = uuid.uuid4().hex
     pid = os.getpid()
@@ -181,14 +190,28 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
         conn.execute(
             """INSERT INTO executions
                (id, job_id, source, process_id, pid, process_started_at,
-                status, claimed_at)
-               VALUES (?, ?, ?, ?, ?, ?, 'claimed', ?)""",
+                status, claimed_at, scheduled_instant)
+               VALUES (?, ?, ?, ?, ?, ?, 'claimed', ?, ?)""",
             (execution_id, str(job_id), str(source), _PROCESS_ID, pid,
-             _process_start_time(pid), now),
+             _process_start_time(pid), now, canonical_instant(scheduled_instant)),
         )
         record = _fetch(conn, execution_id)
     _emit_execution_state(record)
     return record  # type: ignore[return-value]
+
+
+def set_execution_occurrence(execution_id: str, instant: Optional[str]) -> None:
+    """Bind the store-claimed snapshot before a provider hands it to a worker."""
+    from cron.occurrences import scheduled_instant
+
+    with _transaction() as conn:
+        cur = conn.execute(
+            "UPDATE executions SET scheduled_instant=? WHERE id=? AND status='claimed' "
+            "AND handoff_pending=0 AND process_id=? AND pid=?",
+            (scheduled_instant(instant), execution_id, _PROCESS_ID, os.getpid()),
+        )
+        if cur.rowcount != 1:
+            raise RuntimeError("Cron occurrence could not be bound before dispatch")
 
 
 def mark_execution_handoff_pending(execution_id: str) -> Optional[Dict[str, Any]]:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2939,7 +2939,7 @@ def _evaluate_due_job(job: Dict[str, Any], scan: _DueScan, run_claim_ttl: float)
         return False
 
     # Only the dispatch snapshot carries this field; never infer it from a later stamp.
-    job["_scheduled_instant"] = None if manual_run else scheduled_instant(d.next_run_dt.isoformat())
+    job["_scheduled_instant"] = None if manual_run else scheduled_instant(job.get("next_run_at"))
 
     if not manual_run and kind == "cron" and _reanchor_stale_cron(d):
         return False

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2503,6 +2503,17 @@ def claim_job_for_fire(
         now = _hermes_now()
         if _claim_is_live(job.get("fire_claim"), now, claim_ttl_seconds):
             return False  # someone holds a fresh claim
+        from cron.occurrences import completed_occurrence, scheduled_instant
+
+        manual = force or job.get("manual_run_at") == job.get("next_run_at")
+        instant = None if manual else scheduled_instant(job.get("next_run_at"))
+        if instant and completed_occurrence(job, instant):
+            if job.get("schedule", {}).get("kind") in {"cron", "interval"}:
+                nxt = compute_next_run(job["schedule"], now.isoformat())
+                if nxt:
+                    job["next_run_at"] = nxt
+                    save_jobs(jobs)
+            return False
         if force:
             _activate_job_record(job)
         # Per-acquisition token: a process may legitimately reclaim its own stale lease, and the
@@ -2513,7 +2524,7 @@ def claim_job_for_fire(
             if nxt:
                 job["next_run_at"] = nxt
         save_jobs(jobs)
-        return copy.deepcopy(job) if return_job else True
+        return dict(copy.deepcopy(job), _scheduled_instant=instant) if return_job else True
 
     return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
 
@@ -2914,11 +2925,21 @@ def _evaluate_due_job(job: Dict[str, Any], scan: _DueScan, run_claim_ttl: float)
     # into both fields, and any rewrite of next_run_at (edit, re-anchor, fire-claim advance) must
     # invalidate the marker. Do not "fix" this with _ensure_aware normalization.
     manual_run = job.get("manual_run_at") == next_run
+    from cron.occurrences import completed_occurrence, scheduled_instant
+
+    if not manual_run and completed_occurrence(job, next_run):
+        new_next = d.recompute_next() if recurring else None
+        if new_next:
+            scan.persist(job["id"], next_run_at=new_next)
+        return False
     if kind == "cron" and not manual_run and _repair_timezone_shifted_cron(d):
         return False
     d.next_run_dt = _rearm_stale_error_recurring(d)
     if d.next_run_dt > now:
         return False
+
+    # Only the dispatch snapshot carries this field; never infer it from a later stamp.
+    job["_scheduled_instant"] = None if manual_run else scheduled_instant(d.next_run_dt.isoformat())
 
     if not manual_run and kind == "cron" and _reanchor_stale_cron(d):
         return False

--- a/cron/occurrences.py
+++ b/cron/occurrences.py
@@ -1,0 +1,36 @@
+"""Exact scheduled identities, independent of mutable jobs.json dispatch stamps."""
+from datetime import datetime, timezone
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def scheduled_instant(value):
+    """Canonicalize aware instants; legacy/ambiguous values carry no exact identity."""
+    if not isinstance(value, str):
+        return None
+    try:
+        instant = datetime.fromisoformat(value)
+        if instant.tzinfo is None:
+            return None
+        return instant.astimezone(timezone.utc).isoformat()
+    except ValueError:
+        return None
+
+
+def completed_occurrence(job, instant):
+    """Unknown/failed/pruned attempts cannot prove completion: keep them eligible."""
+    from cron.executions import _transaction
+
+    instant = scheduled_instant(instant)
+    if instant is None:
+        return False
+    try:
+        with _transaction() as conn:
+            return conn.execute(
+                "SELECT 1 FROM executions WHERE job_id=? AND scheduled_instant=? "
+                "AND status='completed' LIMIT 1", (str(job['id']), instant)
+            ).fetchone() is not None
+    except Exception:
+        logger.warning("Cannot check completed occurrence for job %s", job['id'], exc_info=True)
+        return False

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2517,7 +2517,8 @@ def run_one_job(
     # API fires) crosses this seam.  Ensure the detached worker has a durable
     # attempt to adopt before any launch can occur.
     if not job.get("execution_id"):
-        execution = create_execution(job["id"], source="direct")
+        execution = create_execution(
+            job["id"], source="direct", scheduled_instant=job.get("_scheduled_instant"))
         job["execution_id"] = execution["id"]
 
     execution_id = str(job["execution_id"])
@@ -2878,7 +2879,8 @@ def _run_one_job_body(
 
     execution_id = job.get("execution_id")
     if not execution_id:
-        execution_id = create_execution(job["id"], source="direct")["id"]
+        execution_id = create_execution(
+            job["id"], source="direct", scheduled_instant=job.get("_scheduled_instant"))["id"]
     delivery_attempted = False
     delivery_error = None
     from agent.secret_scope import (
@@ -3628,6 +3630,7 @@ def _process_due_job(job: dict, adapters, loop, verbose: bool) -> bool:
     # CAS returns the persisted record; bool fallback only for older test doubles.
     claimed_job = dict(claimed) if isinstance(claimed, dict) else dict(job)
     claimed_job["execution_id"] = job["execution_id"]
+    claimed_job["_scheduled_instant"] = job.get("_scheduled_instant")
     return run_one_job(claimed_job, adapters=adapters, loop=loop, verbose=verbose)
 
 
@@ -3681,7 +3684,8 @@ def _submit_with_guard(job: dict, pool: concurrent.futures.ThreadPoolExecutor, p
         return None
     # Record the attempt before dispatch; recovery marks abandoned rows unknown (no retry).
     try:
-        execution = create_execution(job_id, source="builtin")
+        execution = create_execution(
+            job_id, source="builtin", scheduled_instant=job.get("_scheduled_instant"))
         dispatched_job = dict(job, execution_id=execution["id"])
         _ctx = contextvars.copy_context()
     except Exception as execution_err:

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -148,7 +148,7 @@ class CronScheduler(ABC):
     def claim_fire(self, job_id: str, *, force: bool = False) -> dict | None:
         """Durably claim one fire + create its audit attempt. Transports call this synchronously
         before acknowledging, then pass the exact snapshot to ``fire_claimed`` off-thread."""
-        from cron.executions import create_execution, finish_execution
+        from cron.executions import create_execution, finish_execution, set_execution_occurrence
         from cron.jobs import claim_job_for_fire
 
         execution = create_execution(job_id, source=self.name)
@@ -157,6 +157,8 @@ class CronScheduler(ABC):
             claim_kwargs["force"] = True
         try:
             claimed_job = claim_job_for_fire(job_id, **claim_kwargs)
+            if isinstance(claimed_job, dict):
+                set_execution_occurrence(execution["id"], claimed_job.get("_scheduled_instant"))
         except BaseException as exc:
             finish_execution(
                 execution["id"], success=False,

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -164,7 +164,7 @@ class TestRunningJobGuard:
 
         called = []
 
-        def create_execution_side_effect(job_id, source):
+        def create_execution_side_effect(job_id, source, **kwargs):
             if job_id == "failing-job":
                 raise RuntimeError("execution ledger unavailable")
             return {"id": f"{job_id}-execution"}

--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -426,7 +426,7 @@ def test_gateway_tool_run_without_adapter_objects_hands_off(monkeypatch):
 
     assert scheduler.run_one_job(job, adapters=None) is True
 
-    created.assert_called_once_with("tool-job", source="direct")
+    created.assert_called_once_with("tool-job", source="direct", scheduled_instant=None)
     assert job["execution_id"] == "exec-tool"
     launch.assert_called_once_with(job)
     run.assert_not_called()
@@ -443,7 +443,7 @@ def test_shared_run_path_creates_execution_before_managed_handoff(monkeypatch):
 
     assert scheduler.run_one_job(job, adapters={"discord": object()}) is True
 
-    created.assert_called_once_with("manual-job", source="direct")
+    created.assert_called_once_with("manual-job", source="direct", scheduled_instant=None)
     assert job["execution_id"] == "exec-new"
     launch.assert_called_once_with(job)
 

--- a/tests/cron/test_scheduled_occurrence.py
+++ b/tests/cron/test_scheduled_occurrence.py
@@ -9,6 +9,10 @@ import pytest
 
 
 _FIRE = """
+import json
+import os
+from pathlib import Path
+import subprocess
 import sys
 from cron import jobs, scheduler
 from cron.scheduler_provider import InProcessCronScheduler
@@ -17,7 +21,23 @@ if sys.argv[1] == 'builtin':
 else:
     provider = InProcessCronScheduler()
     for job in jobs.load_jobs():
-        provider.fire_due(job['id'], force=sys.argv[1] == 'manual')
+        if sys.argv[1] != 'worker':
+            provider.fire_due(job['id'], force=sys.argv[1] == 'manual')
+            continue
+        from cron.executions import mark_execution_handoff_pending
+        claim = provider.claim_fire(job['id'])
+        if claim is None:
+            continue
+        mark_execution_handoff_pending(claim['execution_id'])
+        home = Path(os.environ['HERMES_HOME'])
+        payload = home / (claim['execution_id'] + '.json')
+        ack = home / (claim['execution_id'] + '.ready')
+        payload.write_text(json.dumps({'job': claim, 'profile_home': str(home),
+                                       'multiplex_active': False}))
+        subprocess.run([sys.executable, '-m', 'cron.scheduler',
+                        '--external-worker-file', str(payload), '--ack-file', str(ack)],
+                       stdin=subprocess.DEVNULL, check=True, timeout=60)
+        assert json.loads(ack.read_text())['pid'] != os.getpid()
 """
 
 
@@ -32,7 +52,7 @@ def _fire(home, mode):
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-@pytest.mark.parametrize('mode', ['builtin', 'provider'])
+@pytest.mark.parametrize('mode', ['builtin', 'provider', 'worker'])
 def test_completed_occurrence_survives_restart_and_prestamp_rollback(tmp_path, mode):
     from datetime import timedelta
     from hermes_time import now

--- a/tests/cron/test_scheduled_occurrence.py
+++ b/tests/cron/test_scheduled_occurrence.py
@@ -1,0 +1,127 @@
+"""Completed scheduled attempts survive a jobs.json rollback, not just a process restart."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+_FIRE = """
+import sys
+from cron import jobs, scheduler
+from cron.scheduler_provider import InProcessCronScheduler
+if sys.argv[1] == 'builtin':
+    scheduler.tick(verbose=False, sync=True)
+else:
+    provider = InProcessCronScheduler()
+    for job in jobs.load_jobs():
+        provider.fire_due(job['id'], force=sys.argv[1] == 'manual')
+"""
+
+
+def _fire(home, mode):
+    env = {k: v for k, v in os.environ.items()
+           if not k.startswith(('HERMES_', '_HERMES_'))
+           and not k.endswith(('_API_KEY', '_TOKEN'))}
+    env['HERMES_HOME'] = str(home)
+    env['PYTHONPATH'] = str(Path(__file__).resolve().parents[2])
+    result = subprocess.run([sys.executable, '-c', _FIRE, mode], env=env,
+                            stdin=subprocess.DEVNULL, capture_output=True, text=True, timeout=90)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize('mode', ['builtin', 'provider'])
+def test_completed_occurrence_survives_restart_and_prestamp_rollback(tmp_path, mode):
+    from datetime import timedelta
+    from hermes_time import now
+
+    home = tmp_path / mode
+    cron = home / 'cron'
+    cron.mkdir(parents=True)
+    effect = home / 'effects.txt'
+    (home / 'scripts').mkdir()
+    script = home / 'scripts' / 'effect.py'
+    script.write_text(f"from pathlib import Path\np = Path({str(effect)!r})\n"
+                      "with p.open('a') as f: f.write('effect\\n')\nprint('done')\n")
+    slot = (now() - timedelta(minutes=30)).isoformat()
+    job = {'id': 'occurrence', 'name': 'occurrence', 'prompt': '',
+           'schedule': {'kind': 'interval', 'minutes': 240},
+           'next_run_at': slot, 'enabled': True, 'state': 'scheduled',
+           'script': str(script), 'no_agent': True, 'deliver': 'local',
+           'repeat': {'times': None, 'completed': 0}}
+    snapshot = json.dumps({'jobs': [job]})
+    store = cron / 'jobs.json'
+    store.write_text(snapshot)
+    _fire(home, mode)
+    assert effect.read_text().splitlines() == ['effect']
+    store.write_text(snapshot)  # no last_dispatch stamp, no post-completion fields
+    _fire(home, mode)  # a fresh interpreter, same authoritative ledger
+    assert effect.read_text().splitlines() == ['effect'], 'completed occurrence executed twice'
+
+    # A different missed slot must remain runnable despite the completed row.
+    job['next_run_at'] = (now() - timedelta(minutes=10)).isoformat()
+    store.write_text(json.dumps({'jobs': [job]}))
+    _fire(home, mode)
+    assert len(effect.read_text().splitlines()) == 2
+    # Manual force is not a completion of the pending scheduled slot.
+    job['next_run_at'] = (now() - timedelta(minutes=5)).isoformat()
+    pending = json.dumps({'jobs': [job]})
+    store.write_text(pending)
+    _fire(home, 'manual')
+    store.write_text(pending)
+    _fire(home, mode)
+    assert len(effect.read_text().splitlines()) == 4
+
+
+def test_ledger_migration_and_completion_identity(tmp_path, monkeypatch):
+    import sqlite3
+    from cron import executions, jobs
+    from cron.occurrences import completed_occurrence
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    db = tmp_path / 'executions.db'
+    monkeypatch.setattr(executions, 'EXECUTIONS_FILE', db)
+    # Pre-migration schema, not initialized by the implementation under test.
+    with sqlite3.connect(db) as conn:
+        conn.execute('''CREATE TABLE executions (
+            id TEXT PRIMARY KEY, job_id TEXT NOT NULL, source TEXT NOT NULL,
+            process_id TEXT NOT NULL, pid INTEGER NOT NULL, process_started_at INTEGER,
+            status TEXT NOT NULL, claimed_at TEXT NOT NULL,
+            started_at TEXT, finished_at TEXT, error TEXT)''')
+        conn.execute("INSERT INTO executions VALUES "
+                     "('legacy','job','builtin','old',-1,NULL,'completed',"
+                     "'2026-01-01T00:00:00Z',NULL,NULL,NULL)")
+    slot = '2026-01-01T00:00:00+00:00'
+    job = {'id': 'job'}
+    assert not completed_occurrence(job, slot)
+    with sqlite3.connect(db) as conn:
+        assert conn.execute('SELECT id, scheduled_instant FROM executions').fetchall() == [('legacy', None)]
+    for status in ('failed', 'unknown', 'running', 'claimed'):
+        row = executions.create_execution('job', source='control', scheduled_instant=slot)
+        with sqlite3.connect(db) as conn:
+            conn.execute('UPDATE executions SET status=? WHERE id=?', (status, row['id']))
+        assert not completed_occurrence(job, slot)
+    row = executions.create_execution('job', source='builtin', scheduled_instant=slot)
+    executions.finish_execution(row['id'], success=True)
+    executions.create_execution('job', source='manual')  # latest row is not the completed one
+    assert completed_occurrence(job, '2026-01-01T08:00:00+0800')
+    assert not completed_occurrence(job, '2026-01-01T00:00:01Z')
+    assert not completed_occurrence({'id': 'other'}, slot)
+
+    # Provider capture is before next_run_at advances; adoption cannot lose identity.
+    with jobs.use_cron_store(tmp_path / 'cron'):
+        stored = jobs.create_job(prompt='test', schedule='every 4h')
+        rows = jobs.load_jobs()
+        rows[0]['next_run_at'] = slot
+        jobs.save_jobs(rows)
+        claim = InProcessCronScheduler().claim_fire(stored['id'])
+        assert claim is not None
+        assert claim['_scheduled_instant'] == slot
+        assert claim['next_run_at'] != slot
+        assert '_scheduled_instant' not in jobs.load_jobs()[0]
+        executions.mark_execution_handoff_pending(claim['execution_id'])
+        adopted = executions.adopt_claimed_execution(claim['execution_id'])
+        assert adopted is not None
+        assert adopted['scheduled_instant'] == slot

--- a/tests/cron/test_scheduled_occurrence.py
+++ b/tests/cron/test_scheduled_occurrence.py
@@ -145,3 +145,15 @@ def test_ledger_migration_and_completion_identity(tmp_path, monkeypatch):
         adopted = executions.adopt_claimed_execution(claim['execution_id'])
         assert adopted is not None
         assert adopted['scheduled_instant'] == slot
+
+        # A runnable legacy wall-clock value cannot establish an exact UTC identity.
+        from datetime import timedelta
+        from hermes_time import now
+        naive = jobs.create_job(prompt='legacy', schedule='every 4h')
+        rows = jobs.load_jobs()
+        for item in rows:
+            if item['id'] == naive['id']:
+                item['next_run_at'] = (now() - timedelta(minutes=10)).replace(tzinfo=None).isoformat()
+        jobs.save_jobs(rows)
+        due = next(item for item in jobs.get_due_jobs() if item['id'] == naive['id'])
+        assert due['_scheduled_instant'] is None

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -404,7 +404,8 @@ def test_claim_fire_persists_attempt_before_fire_claimed(monkeypatch):
     monkeypatch.setattr(
         executions,
         "create_execution",
-        lambda jid, source: events.append("ledger") or {"id": "exec-1"},
+        lambda jid, source, _create=executions.create_execution:
+        events.append("ledger") or _create(jid, source=source),
     )
     monkeypatch.setattr(
         sched,
@@ -417,9 +418,9 @@ def test_claim_fire_persists_attempt_before_fire_claimed(monkeypatch):
 
     assert events == ["ledger", "claim"]
     assert claimed is not None
-    assert claimed["execution_id"] == "exec-1"
+    assert executions.get_execution(claimed["execution_id"])["status"] == "claimed"
     assert provider.fire_claimed(claimed) is True
-    assert events == ["ledger", "claim", ("run", "exec-1")]
+    assert events == ["ledger", "claim", ("run", claimed["execution_id"])]
 
 
 def test_fire_due_forwards_manual_force_to_store_claim(monkeypatch):

--- a/tests/plugins/test_chronos_cron.py
+++ b/tests/plugins/test_chronos_cron.py
@@ -136,8 +136,11 @@ def test_fire_due_rearms_next_oneshot(chronos, monkeypatch):
     assert fake.provisions[0]["fire_at"] == "2026-06-18T12:05:00+00:00"
 
 
-def test_fire_due_rearms_after_claimed_job_failure(chronos, monkeypatch):
+def test_fire_due_rearms_after_claimed_job_failure(chronos, monkeypatch, tmp_path):
     """A claimed attempt is consumed even when the job pipeline reports failure."""
+    import cron.executions as executions
+
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", tmp_path / "executions.db")
     prov, fake = chronos
     claimed = {"id": "j1", "fire_claim": {"by": "owner-1"}}
     persisted = {
@@ -147,10 +150,6 @@ def test_fire_due_rearms_after_claimed_job_failure(chronos, monkeypatch):
     }
 
     monkeypatch.setattr("cron.jobs.claim_job_for_fire", lambda jid, **kw: claimed)
-    monkeypatch.setattr(
-        "cron.executions.create_execution",
-        lambda jid, source: {"id": "exec-1"},
-    )
     monkeypatch.setattr("cron.scheduler.run_one_job", lambda *args, **kwargs: False)
     monkeypatch.setattr("cron.jobs.get_job", lambda jid: persisted)
 

--- a/tests/tools/test_delegate_control_actions.py
+++ b/tests/tools/test_delegate_control_actions.py
@@ -11,6 +11,8 @@ backgrounded) and never consume the per-turn subagent spawn cap.
 import json
 import weakref
 
+import pytest
+
 from tools.delegate_tool import (
     _handle_control_action,
     _is_descendant_of,
@@ -638,48 +640,73 @@ def test_child_completion_with_collapsed_container_task_id_suppressed(monkeypatc
     assert reg.completion_queue.qsize() == 0
 
 
-def test_spawn_local_stamps_owner_task_id_and_event_carries_it(monkeypatch):
+@pytest.fixture
+def notification_child(tmp_path):
+    """Pipe-mode children have DEVNULL stdin; release through a real file."""
+    import sys
+
+    gate = tmp_path / "release"
+    script = tmp_path / "child.py"
+    script.write_text(
+        "import pathlib, sys, time\n"
+        "gate = pathlib.Path(sys.argv[1])\n"
+        "deadline = time.monotonic() + 15\n"
+        "while not gate.exists():\n"
+        "    if time.monotonic() > deadline: raise TimeoutError('gate not released')\n"
+        "    time.sleep(0.01)\n"
+        "print('notification-child-finished')\n",
+        encoding="utf-8",
+    )
+    try:
+        yield f'"{sys.executable}" "{script}" "{gate}"', gate
+    finally:
+        gate.touch()
+
+
+def test_spawn_local_stamps_owner_task_id_and_event_carries_it(monkeypatch, notification_child):
     """spawn_local(owner_task_id=...) survives to the completion event, so a
     real subagent-spawned process (collapsed task_id) is suppressed on
     drain. Exercises the actual spawn -> _move_to_finished -> drain path."""
-    import sys
-
     import hermes_cli.config as _cfg
     from tools.process_registry import ProcessRegistry
 
     monkeypatch.setattr(_cfg, "read_raw_config", lambda *a, **k: {})
     reg = ProcessRegistry()
+    command, gate = notification_child
     session = reg.spawn_local(
-        command=f'"{sys.executable}" -c "input(); print(\'owner-stamp-e2e\')"',
+        command=command,
         task_id="default",
         owner_task_id="sa-9-supp0006",
     )
     session.notify_on_complete = True
     assert session.owner_task_id == "sa-9-supp0006"
     # Do not let a fast child exit before notification admission is configured.
-    reg.write_stdin(session.id, "release\n")
+    gate.touch()
     event = reg.completion_queue.get(timeout=15)
+    assert event["exit_code"] == 0
+    assert "notification-child-finished" in event["output"]
     reg.completion_queue.put(event)
     assert reg.drain_notifications() == []
 
 
-def test_spawn_local_without_owner_defaults_to_task_id(monkeypatch):
+def test_spawn_local_without_owner_defaults_to_task_id(monkeypatch, notification_child):
     """Backward compat: callers that don't pass owner_task_id behave exactly
     as before (owner falls back to task_id; parent-owned still delivers)."""
-    import sys
-
     import hermes_cli.config as _cfg
     from tools.process_registry import ProcessRegistry
 
     monkeypatch.setattr(_cfg, "read_raw_config", lambda *a, **k: {})
     reg = ProcessRegistry()
+    command, gate = notification_child
     session = reg.spawn_local(
-        command=f'"{sys.executable}" -c "input(); print(\'parent-e2e\')"', task_id="default",
+        command=command, task_id="default",
     )
     session.notify_on_complete = True
     assert session.owner_task_id == "default"
-    reg.write_stdin(session.id, "release\n")
+    gate.touch()
     event = reg.completion_queue.get(timeout=15)
+    assert event["exit_code"] == 0
+    assert "notification-child-finished" in event["output"]
     reg.completion_queue.put(event)
     results = reg.drain_notifications()
     assert len(results) == 1

--- a/tests/tools/test_delegate_control_actions.py
+++ b/tests/tools/test_delegate_control_actions.py
@@ -642,7 +642,7 @@ def test_spawn_local_stamps_owner_task_id_and_event_carries_it(monkeypatch):
     """spawn_local(owner_task_id=...) survives to the completion event, so a
     real subagent-spawned process (collapsed task_id) is suppressed on
     drain. Exercises the actual spawn -> _move_to_finished -> drain path."""
-    import time as _time
+    import sys
 
     import hermes_cli.config as _cfg
     from tools.process_registry import ProcessRegistry
@@ -650,38 +650,37 @@ def test_spawn_local_stamps_owner_task_id_and_event_carries_it(monkeypatch):
     monkeypatch.setattr(_cfg, "read_raw_config", lambda *a, **k: {})
     reg = ProcessRegistry()
     session = reg.spawn_local(
-        command="echo owner-stamp-e2e",
+        command=f'"{sys.executable}" -c "input(); print(\'owner-stamp-e2e\')"',
         task_id="default",
         owner_task_id="sa-9-supp0006",
     )
     session.notify_on_complete = True
     assert session.owner_task_id == "sa-9-supp0006"
-    deadline = _time.time() + 15
-    while not session.exited and _time.time() < deadline:
-        _time.sleep(0.05)
-    assert session.exited, "test process should exit promptly"
-    _time.sleep(0.3)  # let the reader thread enqueue the completion event
+    # Do not let a fast child exit before notification admission is configured.
+    reg.write_stdin(session.id, "release\n")
+    event = reg.completion_queue.get(timeout=15)
+    reg.completion_queue.put(event)
     assert reg.drain_notifications() == []
 
 
 def test_spawn_local_without_owner_defaults_to_task_id(monkeypatch):
     """Backward compat: callers that don't pass owner_task_id behave exactly
     as before (owner falls back to task_id; parent-owned still delivers)."""
-    import time as _time
+    import sys
 
     import hermes_cli.config as _cfg
     from tools.process_registry import ProcessRegistry
 
     monkeypatch.setattr(_cfg, "read_raw_config", lambda *a, **k: {})
     reg = ProcessRegistry()
-    session = reg.spawn_local(command="echo parent-e2e", task_id="default")
+    session = reg.spawn_local(
+        command=f'"{sys.executable}" -c "input(); print(\'parent-e2e\')"', task_id="default",
+    )
     session.notify_on_complete = True
     assert session.owner_task_id == "default"
-    deadline = _time.time() + 15
-    while not session.exited and _time.time() < deadline:
-        _time.sleep(0.05)
-    assert session.exited
-    _time.sleep(0.3)
+    reg.write_stdin(session.id, "release\n")
+    event = reg.completion_queue.get(timeout=15)
+    reg.completion_queue.put(event)
     results = reg.drain_notifications()
     assert len(results) == 1
     assert "completed normally" in results[0][1]

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -334,6 +334,19 @@ Inspect recent attempts with `hermes cron runs [job-id] --limit 20` (alias:
 `history`). Terminal history is bounded; active attempts are never pruned. The
 ledger is included in quick backups.
 
+Scheduled attempts also record their exact scheduled instant, separately from
+the time they were claimed. If an old `jobs.json` snapshot re-arms an occurrence
+that the retained ledger records as completed, Hermes skips that replay and
+re-anchors recurring jobs. This works even when the snapshot predates the
+dispatch stamp or the original run started late. Explicit manual runs do not
+consume a scheduled occurrence's identity.
+
+This is not an exactly-once side-effect guarantee: legacy rows without an
+identity, pruned history, unavailable ledgers, and interrupted attempts cannot
+prove completion. Restoring the ledger itself to an older backup also removes
+that evidence. External fire callbacks identify the currently accepted store
+claim, not an upstream scheduled slot absent from the callback.
+
 ### Repeated-failure review nudge
 
 Each job tracks a `failure_streak` — consecutive failed runs (delivery


### PR DESCRIPTION
Completed scheduled cron occurrences no longer execute again when an older jobs.json snapshot is restored while the execution ledger survives.

Fixes #104790. Campaign: #104868. Related: #104312, #104323.

## Changes
- Add nullable, canonical UTC `scheduled_instant` to the execution ledger using the existing additive migration path.
- Capture the accepted occurrence before due scanning / fire claiming advances the schedule; carry it through builtin dispatch, provider claims, direct fallback creation, and worker handoff.
- Check **any retained completed row for this job and exact instant**, independently of mutable dispatch stamps and claim-time windows. Manual/unclassified direct attempts have no scheduled identity.
- Document retention, legacy, unavailable-ledger, and external-callback limits. Preserve failed/unknown eligibility instead of inferring completion.

Root cause: the ledger previously recorded when an attempt was claimed, not which scheduled occurrence it served.

## Live repro / validation
Real production entry points, fresh Python processes, isolated filesystem + SQLite, local no-agent scripts. No paid inference, live user state, or external recipients.

| Surface / control | Base `22c5684b983` | This branch |
|---|---|---|
| Builtin `tick()`: complete a 30-minute-late occurrence, restore a pre-stamp snapshot, restart and tick again | **2 script writes** | **1 script write** |
| Provider `claim_fire` / `fire_due`: same rollback | **2 script writes** | **1 script write** |
| Actual `python -m cron.scheduler --external-worker-file …` process adoption: same rollback | **2 script writes** | **1 script write** |
| Distinct missed occurrence after the suppressed replay | — | Executes; **2 cumulative writes** |
| Explicit manual force followed by the still-pending scheduled occurrence | — | Both execute; **4 cumulative writes** |
| Pre-migration SQLite schema and legacy completed row | — | Row preserved, identity NULL |
| Failed / unknown / running / claimed rows; different job / different instant | — | Do not prove completion |
| Offset-equivalent timestamps; later unrelated attempt | — | Exact completed match still found |
| Provider snapshot and worker ownership adoption | — | Original identity survives schedule advancement and adoption |

Two invariant test functions (one parametrized over three execution surfaces). Ruff, Windows-footgun scan, compat-pointer scan, subprocess-stdin scan, and `git diff --check` passed.

**Independent review:** repeated all three real rollback/restart A/B surfaces and distinct/manual controls. Twelve unfinished-status recovery cases stayed runnable; an eight-process pre-migration ledger/store-claim race had one winner, and two concurrent distinct jobs both completed. Review found and fixed builtin capture inventing a UTC identity for a naive stored timestamp: the script still executes, but its identity is now NULL (live RED/GREEN). The provider ordering and Chronos re-arm tests now use real isolated ledger rows rather than nonexistent mocked execution IDs. The CI notification flake was reproduced as a child exiting before `notify_on_complete` assignment; its two existing owner-routing tests now gate child exit on stdin and await the actual queue event rather than a sleep (no production notification semantics changed). A real local failing no-agent script also verified Chronos records the failed attempt and re-arms once through a fixture transport.

**Draft gate:** the original canonical `tests/cron` run completed with **1221 passed, 1 failed, 2 skipped**. Its lone failure was the provider test fixture fixed above. A fresh canonical directory run on the review fix is queued under the campaign-wide `tests.lock`; no all-green regression claim yet. A first-ever WAL-mode switch race also reproduced on the immutable baseline; this separate existing SQLite initialization limitation is not an occurrence-migration failure. No native systemd gateway restart was performed; worker adoption was exercised in isolated subprocesses.

## Limits and credit
This is not an exactly-once side-effect guarantee. Legacy rows do not invent an identity; there is no approximate legacy fallback on main. Pruned/rolled-back ledger history and interrupted attempts cannot prove completion. A callback lacking an upstream scheduled slot identifies the store claim accepted at that moment, not a hypothetical remote slot.

Credit @holny for #104790 and the earlier guard proposal #104323, and @strzhao for the pre-stamp rollback / late-claim analysis. This is a focused exact-identity implementation rather than importing the earlier window heuristic. Related script-context proposals #94951 and #77402 were reviewed for overlap; neither supplies this completed-ledger suppression contract.

## Infographic
![Exact scheduled occurrence identity prevents completed cron replay](https://v3b.fal.media/files/b/0aa973f5/Sb7TlD75wL4gFUT-Kjo7r_jFFnDcdX.png)
