### PR TITLE
fix(desktop): read full slash-command descriptions (#104729, salvage #104743)

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -146,6 +146,8 @@ trigger within 300ms opens instantly. The cooldown starts on close, so a
 hover a second later waits again. Close is immediate. `OverflowTip` stays
 on its own longer delay (list titles must not trail while scanning).
 
+**Slash descriptions.** Keep autocomplete rows single-line and ellipsized, but reveal the complete catalog description in the shared themed tooltip when hovering anywhere on a slash row. Size that tooltip to the window with collision padding and word wrapping; it must not intercept row selection. Catalog and completion producers preserve the full author-supplied description.
+
 **Keybind hints in tooltips.** On a tipped button bound to a rebindable hotkey,
 use `<TipKeybindLabel actionId="..." />` — it reads the i18n label and the
 current combo from `$bindings`. Pass `text={...}` only when the label is

--- a/apps/desktop/src/app/chat/composer/trigger-popover-description.test.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover-description.test.tsx
@@ -1,0 +1,24 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+
+import { ComposerTriggerPopover } from './trigger-popover'
+
+afterEach(cleanup)
+
+it('reveals the complete slash description on hover without intercepting selection', async () => {
+  const description = 'Complete command help '.repeat(20)
+  const item = { id: '/proof', type: 'slash', label: 'proof', metadata: { display: '/proof', meta: description } }
+  const onPick = vi.fn()
+  render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <ComposerTriggerPopover activeIndex={0} items={[item]} kind="/" loading={false} onHover={vi.fn()} onPick={onPick} />
+    </I18nProvider>
+  )
+  const row = screen.getByRole('button')
+  fireEvent.pointerMove(row, { pointerType: 'mouse' })
+  expect((await screen.findByRole('tooltip')).textContent).toBe(description)
+  fireEvent.click(row)
+  expect(onPick).toHaveBeenCalledWith(item)
+})

--- a/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
@@ -106,6 +107,93 @@ describe('ComposerTriggerPopover keyboard scrolling', () => {
       </I18nProvider>
     )
   }
+
+  describe('full description tooltip', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    const descItem = {
+      id: '/skill-command',
+      type: 'slash',
+      label: 'skill-command',
+      metadata: {
+        command: '/skill-command',
+        display: '/skill-command',
+        group: 'Skills',
+        meta: 'This is a long skill command description that exceeds the single truncated line shown in the row',
+        rawText: '/skill-command',
+        action: ''
+      }
+    }
+
+    function popoverWithDesc() {
+      return (
+        <I18nProvider configClient={null} initialLocale="en">
+          <ComposerTriggerPopover
+            activeIndex={0}
+            items={[descItem]}
+            kind="/"
+            loading={false}
+            onHover={vi.fn()}
+            onPick={vi.fn()}
+          />
+        </I18nProvider>
+      )
+    }
+
+    it('wraps the row button in a tooltip trigger', () => {
+      render(popoverWithDesc())
+      const button = screen.getByRole('button')
+      const trigger = button.closest('[data-slot="tooltip-trigger"]')
+      expect(trigger).toBeTruthy()
+      expect(trigger?.getAttribute('data-state')).toBe('closed')
+    })
+
+    it.skip('shows the full description after settled hover', () => {
+      vi.useFakeTimers()
+      const { container } = render(popoverWithDesc())
+
+      const trigger = container.querySelector('[data-slot="tooltip-trigger"]') as HTMLElement
+      expect(trigger).toBeTruthy()
+
+      act(() => {
+        fireEvent.pointerEnter(trigger)
+        vi.advanceTimersByTime(700)
+      })
+
+      expect(screen.getByRole('tooltip').textContent).toContain(descItem.metadata.meta)
+    })
+
+    it('stays closed for an item without a description', () => {
+      vi.useFakeTimers()
+
+      const noDescItem = { ...descItem, metadata: { ...descItem.metadata, meta: '' } }
+
+      const { container } = render(
+        <I18nProvider configClient={null} initialLocale="en">
+          <ComposerTriggerPopover
+            activeIndex={0}
+            items={[noDescItem]}
+            kind="/"
+            loading={false}
+            onHover={vi.fn()}
+            onPick={vi.fn()}
+          />
+        </I18nProvider>
+      )
+
+      const button = container.querySelector('button[type="button"]') as HTMLElement
+
+      act(() => {
+        fireEvent.pointerEnter(button)
+        vi.advanceTimersByTime(500)
+      })
+
+      expect(screen.queryByRole('tooltip')).toBeNull()
+    })
+  })
+
 
   it('keeps keyboard navigation visible and restores the group header on wrap', () => {
     const { container, rerender } = render(popover(0))

--- a/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
@@ -1,5 +1,4 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { act } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
@@ -107,93 +106,6 @@ describe('ComposerTriggerPopover keyboard scrolling', () => {
       </I18nProvider>
     )
   }
-
-  describe('full description tooltip', () => {
-    afterEach(() => {
-      vi.useRealTimers()
-    })
-
-    const descItem = {
-      id: '/skill-command',
-      type: 'slash',
-      label: 'skill-command',
-      metadata: {
-        command: '/skill-command',
-        display: '/skill-command',
-        group: 'Skills',
-        meta: 'This is a long skill command description that exceeds the single truncated line shown in the row',
-        rawText: '/skill-command',
-        action: ''
-      }
-    }
-
-    function popoverWithDesc() {
-      return (
-        <I18nProvider configClient={null} initialLocale="en">
-          <ComposerTriggerPopover
-            activeIndex={0}
-            items={[descItem]}
-            kind="/"
-            loading={false}
-            onHover={vi.fn()}
-            onPick={vi.fn()}
-          />
-        </I18nProvider>
-      )
-    }
-
-    it('wraps the row button in a tooltip trigger', () => {
-      render(popoverWithDesc())
-      const button = screen.getByRole('button')
-      const trigger = button.closest('[data-slot="tooltip-trigger"]')
-      expect(trigger).toBeTruthy()
-      expect(trigger?.getAttribute('data-state')).toBe('closed')
-    })
-
-    it.skip('shows the full description after settled hover', () => {
-      vi.useFakeTimers()
-      const { container } = render(popoverWithDesc())
-
-      const trigger = container.querySelector('[data-slot="tooltip-trigger"]') as HTMLElement
-      expect(trigger).toBeTruthy()
-
-      act(() => {
-        fireEvent.pointerEnter(trigger)
-        vi.advanceTimersByTime(700)
-      })
-
-      expect(screen.getByRole('tooltip').textContent).toContain(descItem.metadata.meta)
-    })
-
-    it('stays closed for an item without a description', () => {
-      vi.useFakeTimers()
-
-      const noDescItem = { ...descItem, metadata: { ...descItem.metadata, meta: '' } }
-
-      const { container } = render(
-        <I18nProvider configClient={null} initialLocale="en">
-          <ComposerTriggerPopover
-            activeIndex={0}
-            items={[noDescItem]}
-            kind="/"
-            loading={false}
-            onHover={vi.fn()}
-            onPick={vi.fn()}
-          />
-        </I18nProvider>
-      )
-
-      const button = container.querySelector('button[type="button"]') as HTMLElement
-
-      act(() => {
-        fireEvent.pointerEnter(button)
-        vi.advanceTimersByTime(500)
-      })
-
-      expect(screen.queryByRole('tooltip')).toBeNull()
-    })
-  })
-
 
   it('keeps keyboard navigation visible and restores the group header on wrap', () => {
     const { container, rerender } = render(popover(0))

--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -4,6 +4,7 @@ import { Fragment, useEffect, useRef } from 'react'
 import { referenceKind, referenceStyle } from '@/components/assistant-ui/reference-kinds'
 import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
+import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 
@@ -199,34 +200,36 @@ export function ComposerTriggerPopover({
           return (
             <Fragment key={item.id}>
               {showHeader && <div className={cn(GROUP_HEADER_CLASS, isFirstHeader ? 'pt-0.5' : 'pt-2')}>{group}</div>}
-              <button
-                className={ROW_CLASS}
-                data-highlighted={active ? '' : undefined}
-                onClick={() => onPick(item)}
-                onMouseEnter={() => {
-                  // React bails out when hovering the already-active row. Do
-                  // not leave a marker behind for a later items refresh.
-                  hoverIndexRef.current = index === activeIndex ? -1 : index
-                  onHover(index)
-                }}
-                type="button"
-              >
-                {isEmoji ? (
-                  // The emoji is its own icon — a glyph column beside it reads
-                  // as decoration.
-                  <span className="min-w-0 shrink truncate leading-5 text-foreground">{display}</span>
-                ) : (
-                  <>
-                    <span className="grid size-4 shrink-0 place-items-center text-(--ref-color)" data-ref={refKind}>
-                      <Codicon name={referenceStyle(refKind).codicon} size="0.875rem" />
-                    </span>
-                    <span className="min-w-0 shrink truncate font-medium leading-5 text-foreground">{display}</span>
-                    {description && (
-                      <span className="min-w-0 flex-1 truncate leading-5 text-(--ui-text-tertiary)">{description}</span>
-                    )}
-                  </>
-                )}
-              </button>
+              <Tip delayDuration={400} label={description || undefined} sideOffset={4}>
+                <button
+                  className={ROW_CLASS}
+                  data-highlighted={active ? '' : undefined}
+                  onClick={() => onPick(item)}
+                  onMouseEnter={() => {
+                    // React bails out when hovering the already-active row. Do
+                    // not leave a marker behind for a later items refresh.
+                    hoverIndexRef.current = index === activeIndex ? -1 : index
+                    onHover(index)
+                  }}
+                  type="button"
+                >
+                  {isEmoji ? (
+                    // The emoji is its own icon — a glyph column beside it reads
+                    // as decoration.
+                    <span className="min-w-0 shrink truncate leading-5 text-foreground">{display}</span>
+                  ) : (
+                    <>
+                      <span className="grid size-4 shrink-0 place-items-center text-(--ref-color)" data-ref={refKind}>
+                        <Codicon name={referenceStyle(refKind).codicon} size="0.875rem" />
+                      </span>
+                      <span className="min-w-0 shrink truncate font-medium leading-5 text-foreground">{display}</span>
+                      {description && (
+                        <span className="min-w-0 flex-1 truncate leading-5 text-(--ui-text-tertiary)">{description}</span>
+                      )}
+                    </>
+                  )}
+                </button>
+              </Tip>
             </Fragment>
           )
         })

--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -200,7 +200,13 @@ export function ComposerTriggerPopover({
           return (
             <Fragment key={item.id}>
               {showHeader && <div className={cn(GROUP_HEADER_CLASS, isFirstHeader ? 'pt-0.5' : 'pt-2')}>{group}</div>}
-              <Tip delayDuration={400} label={description || undefined} sideOffset={4}>
+              <Tip
+                className="max-w-[calc(100vw-2rem)] wrap-anywhere"
+                collisionPadding={16}
+                delayDuration={400}
+                label={kind === '/' ? description : undefined}
+                sideOffset={4}
+              >
                 <button
                   className={ROW_CLASS}
                   data-highlighted={active ? '' : undefined}

--- a/hermes_cli/commands_completion.py
+++ b/hermes_cli/commands_completion.py
@@ -43,11 +43,6 @@ def _personalities_from_cli_config() -> Dict[str, Any]:
     return _personalities_memo[1]
 
 
-def _short_desc(info: Mapping[str, Any], default: str) -> str:
-    """Full description, passed through to the completion menu."""
-    return str(info.get("description", default))
-
-
 def _file_size_label(path: str) -> str:
     """Return a compact human-readable file size, or '' on error."""
     try:
@@ -334,7 +329,7 @@ class SlashCommandCompleter(Completer):
             # Exact match: trailing space keeps the dropdown open for the next stacked token.
             yield _completion(
                 f"{cmd} " if cmd == word_key else cmd, current_word, cmd,
-                f"⚡ {_short_desc(info, 'Skill command')}")
+                f"⚡ {info.get('description', 'Skill command')}")
 
     @staticmethod
     def _completion_text(cmd_name: str, word: str) -> str:
@@ -454,16 +449,16 @@ class SlashCommandCompleter(Completer):
             if cmd[1:].startswith(word):
                 skill_count = len(info.get("skills", []))
                 yield _cmd_completion(
-                    cmd[1:], f"▣ {_short_desc(info, 'Skill bundle')} ({skill_count} skills)")
+                    cmd[1:], f"▣ {info.get('description', 'Skill bundle')} ({skill_count} skills)")
         for cmd, info in self._iter_skill_commands().items():
             if cmd[1:].startswith(word):
-                yield _cmd_completion(cmd[1:], f"⚡ {_short_desc(info, 'Skill command')}")
+                yield _cmd_completion(cmd[1:], f"⚡ {info.get('description', 'Skill command')}")
         try:
             from hermes_cli.plugins import get_plugin_commands
             for cmd_name, cmd_info in get_plugin_commands().items():
                 if cmd_name.startswith(word):
                     yield _cmd_completion(
-                        cmd_name, f"🔌 {_short_desc(cmd_info, 'Plugin command')}")
+                        cmd_name, f"🔌 {cmd_info.get('description', 'Plugin command')}")
         except Exception:
             pass
 

--- a/hermes_cli/commands_completion.py
+++ b/hermes_cli/commands_completion.py
@@ -44,9 +44,8 @@ def _personalities_from_cli_config() -> Dict[str, Any]:
 
 
 def _short_desc(info: Mapping[str, Any], default: str) -> str:
-    """50-char description preview used in completion menus."""
-    description = str(info.get("description", default))
-    return description[:50] + ("..." if len(description) > 50 else "")
+    """Full description, passed through to the completion menu."""
+    return str(info.get("description", default))
 
 
 def _file_size_label(path: str) -> str:

--- a/tests/tui_gateway/test_command_description_fidelity.py
+++ b/tests/tui_gateway/test_command_description_fidelity.py
@@ -1,0 +1,25 @@
+"""Command descriptions survive both catalog and completion transport."""
+
+from prompt_toolkit.completion import CompleteEvent
+from prompt_toolkit.document import Document
+
+
+def test_full_descriptions_survive_catalog_and_completion(monkeypatch):
+    from agent import skill_commands
+    from hermes_cli import plugins
+    from hermes_cli.commands_completion import SlashCommandCompleter
+    from tui_gateway import server
+
+    description = "Read the entire description before selecting a command. " * 8
+    skills = {"/proof-skill": {"name": "proof-skill", "description": description}}
+    monkeypatch.setattr(skill_commands, "scan_skill_commands", lambda: skills)
+    monkeypatch.setattr(plugins, "get_plugin_commands", lambda: {"proof-plugin": {"description": description}})
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"quick_commands": {"proof-quick": {"description": description}}})
+    catalog = server._methods["commands.catalog"](1, {})["result"]
+    pairs = dict(catalog["pairs"])
+    for name in ("/proof-skill", "/proof-plugin", "/proof-quick"):
+        assert pairs[name] == description
+    completer = SlashCommandCompleter(skill_commands_provider=lambda: skills)
+    completions = list(completer.get_completions(Document("/proof"), CompleteEvent()))
+    assert len(completions) == 2
+    assert all(description in completion.display_meta_text for completion in completions)

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -151,7 +151,7 @@ def _rewind_or_err(rid, session, keep: int, value_err: tuple, fail_prefix: str, 
 
 
 def _clip(text: str, n: int = 120) -> str:
-    return text[:n] + ("…" if len(text) > n else "")
+    return text
 
 
 def _exec_out(rid, output: str) -> dict:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -150,10 +150,6 @@ def _rewind_or_err(rid, session, keep: int, value_err: tuple, fail_prefix: str, 
         return None, _err(rid, 5008, f"{fail_prefix}{exc}")
 
 
-def _clip(text: str, n: int = 120) -> str:
-    return text
-
-
 def _exec_out(rid, output: str) -> dict:
     """command.dispatch display-only result."""
     return _ok(rid, {"type": "exec", "output": output})
@@ -376,7 +372,7 @@ def _catalog_quick_commands(cat: _Catalog) -> None:
         qtype = qc.get("type", "")
         default_desc = {"exec": f"exec: {qc.get('command', '')}", "alias": f"alias → {qc.get('target', '')}"}
         desc = str(qc.get("description") or default_desc.get(qtype, qtype or "quick command"))
-        cat.add(f"/{qname}", _clip(desc), "User commands")
+        cat.add(f"/{qname}", desc, "User commands")
 
 
 def _catalog_plugin_commands(cat: _Catalog) -> None:
@@ -387,7 +383,7 @@ def _catalog_plugin_commands(cat: _Catalog) -> None:
         key = f"/{pname}"
         if not isinstance(info, dict) or key.lower() in cat.canon:
             continue
-        cat.add(key, _clip(str(info.get("description") or "Plugin command")), "Plugin commands")
+        cat.add(key, str(info.get("description") or "Plugin command"), "Plugin commands")
         mode = info.get("argument_mode")
         if mode not in {"options", "text", "mixed"}:
             mode = "text" if str(info.get("args_hint") or "").strip() else None
@@ -398,7 +394,7 @@ def _catalog_skills(cat: _Catalog, skills: dict[str, dict]) -> None:
     """Append skill pairs and fill ``skills`` = ``{key: {usage, origin}}`` (every consumer ranks by them)."""
     usage, origin_of = _skill_usage_lookup()
     for k, info in sorted(_tools_mod("agent.skill_commands").scan_skill_commands().items()):
-        cat.pairs.append([k, _clip(str(info.get("description", "Skill")))])
+        cat.pairs.append([k, str(info.get("description", "Skill"))])
         name = str(info.get("name") or k.lstrip("/"))
         skills[k] = {"usage": usage(name), "origin": origin_of(name)}
 


### PR DESCRIPTION
Slash-command rows now reveal the complete author-supplied description in a wide themed tooltip without changing command selection.

Fixes #104729. Salvages #104743 by @kokhlo (Konstantin Khlopkov), preserving the original contributor commit. Campaign: #104868.

- Preserve full skill, plugin, bundle and quick-command descriptions through their existing catalog/completion paths; remove the obsolete clipping helpers instead of retaining identity wrappers.
- Keep compact rows, with the existing themed tooltip constrained to the window and collision padding, including wrapping of long unbroken text. Non-slash rows remain unchanged.
- Replace skipped/structural assertions with two behavioral invariants; document the interaction in Desktop DESIGN.md.

Root cause: producers clipped descriptions before rendering, and the shared autocomplete row no longer exposed overflow text.

## Validation

**Live repro:** Real native Electron 40.10.2, production renderer and `hermes serve`, isolated HOME/HERMES_HOME, no inference calls or messaging gateway. On current-main base `7874ef9f62b9b533f8d3da6107eb2a52f4be252f`, the on-disk quick-command description was clipped at 120 characters and native hover revealed no tooltip. After this change its complete 235-character description appears in a 1290px tooltip inside a 1355px viewport. Native click still inserts `/tooltip-proof`; ArrowDown + Tab still selects `/save`. Before/after screenshots were independently vision-checked, and the native full-text/width assertion fails before and passes after.

| Check | Result |
| --- | --- |
| Desktop TypeScript (all three configs) | Passed |
| Whole Desktop ESLint | 0 errors, 135 existing warnings |
| Ruff, Windows footguns, compat pointers, diff check | Passed |
| Python regression + composer suite | Locked local receipt: Python 1 passed; composer 51 files / 419 tests passed. CI run [34108653152](https://github.com/NousResearch/hermes-agent/actions/runs/34108653152), attempt 1: Python 45,448 passed / 0 failed / 447 skipped; every tracked affected Python file has a runner row (947/947). Desktop UI 735 files / 7,304 tests passed. |
| Independent code/native review | Passed bounded producer/tooltip behavior, full text and viewport fit, pointer selection and ArrowDown + Tab. Unit RED receipts remain queued separately. |

This PR remains **draft** pending the queued unit RED assertions. Completed CI is tied to this head via merge checkout `a0766d1764160500147023e6200ec52478079445`; downloaded Python runner logs contain no failed-file/retry rows. No duplicate green directory suite was launched. Native proof receipts: `/tmp/resolve-089c35aa/desktop-evidence/slash-native-{before,after}.{json,png}`, with the assertion harness `slash-native.mjs`. This branch is independent of hover PR #104881 and does not alter it.

## Infographic
![Full slash-command help](https://v3b.fal.media/files/b/0aa9743c/Et7vkyup-5OKxR_IApvGP_WDOF10Qf.png)


## Parent final validation
Parent final validation: repaired a corrupted disposable baseline fixture from exact git bytes, then repeated canonical producer test: intended description-truncation assertion FAIL on baseline, PASS on published head. Existing UI baseline tooltip assertion fails as intended. Independent native review and reconciled full CI coverage pass. All validation gates complete.
