### PR TITLE
fix(desktop): Markdown hard breaks and code Copy retain whitespace (#97117)

### DIFF
--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -123,19 +123,20 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
   defer = false
 }) => {
   const { t } = useI18n()
-  const trimmed = (code ?? '').replace(/^\n+/, '').trimEnd()
+  // Preserve the parser payload for both display and copy, including whitespace.
+  const content = code ?? ''
 
   // Streaming may hand us empty/incomplete fences — render nothing rather
   // than a transient empty card.
-  if (!trimmed.trim()) {
+  if (!content.trim()) {
     return null
   }
 
-  if (isLikelyProseCodeBlock(language, trimmed)) {
-    return <div className="aui-prose-fence whitespace-pre-wrap wrap-anywhere text-foreground">{trimmed}</div>
+  if (isLikelyProseCodeBlock(language, content)) {
+    return <div className="aui-prose-fence whitespace-pre-wrap wrap-anywhere text-foreground">{content}</div>
   }
 
-  const plain = defer || exceedsHighlightBudget(trimmed)
+  const plain = defer || exceedsHighlightBudget(content)
 
   return (
     <CodeCard data-streaming={defer ? 'true' : undefined}>
@@ -145,15 +146,15 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
         iconClassName="size-2.5"
         label={t.assistant.tool.copyCode}
         showLabel={false}
-        text={trimmed}
+        text={content}
       />
       <CodeCardBody className="[&_pre]:px-3 [&_pre]:py-2.5">
         <ExpandableBlock>
           <Pre className="aui-shiki m-0 overflow-hidden bg-transparent p-0">
             {plain ? (
-              <PlainCode code={trimmed} />
+              <PlainCode code={content} />
             ) : (
-              <LazyShiki code={trimmed} colorReplacements={SHIKI_COLOR_REPLACEMENTS} language={language || 'text'} />
+              <LazyShiki code={content} colorReplacements={SHIKI_COLOR_REPLACEMENTS} language={language || 'text'} />
             )}
           </Pre>
         </ExpandableBlock>

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -224,7 +224,7 @@ describe('toChatMessages', () => {
 
     expect(toolPart?.result).toMatchObject({ image: 'https://cdn.example/cat.png', success: true })
     // The duplicated image is stripped, but the agent's words survive.
-    expect(chatMessageText(message)).toBe('Here you go.')
+    expect(chatMessageText(message)).toBe('Here you go.\n\n')
   })
 
   it('lifts @image directive lines into attachmentRefs instead of inline text', () => {
@@ -270,7 +270,7 @@ describe('toChatMessages', () => {
       }
     ])
 
-    expect(chatMessageText(message)).toBe('what is in this photo?')
+    expect(chatMessageText(message)).toBe('what is in this photo?\n')
     expect((message as { attachmentRefs?: string[] }).attachmentRefs).toEqual([ref])
   })
 

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -34,8 +34,6 @@ export function renderMediaTags(text: string): string {
       (_match, lead: string, value: string, trailer: string) => `${lead}${mediaLink(value)}${trailer}`
     )
     .replace(MEDIA_TAG_RE, (_match, value: string) => mediaLink(value))
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
 }
 
 export function assistantTextPart(text: string, timestamp?: number): ChatMessagePart {

--- a/apps/desktop/src/lib/embedded-images.test.ts
+++ b/apps/desktop/src/lib/embedded-images.test.ts
@@ -12,7 +12,7 @@ describe('extractEmbeddedImages', () => {
   it('lifts a bare data:image URL out of prose', () => {
     const result = extractEmbeddedImages(`describe this ${SAMPLE_PNG_DATA_URL}`)
 
-    expect(result.cleanedText).toBe('describe this')
+    expect(result.cleanedText).toBe('describe this ')
     expect(result.images).toEqual([SAMPLE_PNG_DATA_URL])
   })
 
@@ -79,7 +79,7 @@ describe('extractImageRefs', () => {
     // lifted ref already renders that same attachment.
     const result = extractImageRefs('@image:/tmp/cat.png\nwhat is in this photo?\n[screenshot]')
 
-    expect(result).toEqual({ cleanedText: 'what is in this photo?', refs: ['@image:/tmp/cat.png'] })
+    expect(result).toEqual({ cleanedText: 'what is in this photo?\n', refs: ['@image:/tmp/cat.png'] })
   })
 
   it('keeps [screenshot] when the message carries no image refs', () => {

--- a/apps/desktop/src/lib/embedded-images.ts
+++ b/apps/desktop/src/lib/embedded-images.ts
@@ -143,7 +143,7 @@ export function extractEmbeddedImages(text: string): EmbeddedImageExtraction {
 
   pieces.push(text.slice(appendCursor))
 
-  return { cleanedText: pieces.join('').trim(), images }
+  return { cleanedText: pieces.join(''), images }
 }
 
 export function embeddedImageUrls(text: string): string[] {
@@ -193,5 +193,5 @@ export function extractImageRefs(text: string): { cleanedText: string; refs: str
     cleanedText = cleanedText.replace(SCREENSHOT_PLACEHOLDER_LINE_RE, '')
   }
 
-  return { cleanedText: cleanedText.trim(), refs }
+  return { cleanedText, refs }
 }

--- a/apps/desktop/src/lib/embedded-images.ts
+++ b/apps/desktop/src/lib/embedded-images.ts
@@ -105,13 +105,6 @@ function embeddedImageRemovalRange(text: string, dataStart: number, dataEnd: num
   return { end, start }
 }
 
-function normalizeCleanedText(text: string): string {
-  return text
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim()
-}
-
 export function extractEmbeddedImages(text: string): EmbeddedImageExtraction {
   if (!text || !text.includes(DATA_IMAGE_PREFIX)) {
     return { cleanedText: text, images: [] }
@@ -150,7 +143,7 @@ export function extractEmbeddedImages(text: string): EmbeddedImageExtraction {
 
   pieces.push(text.slice(appendCursor))
 
-  return { cleanedText: normalizeCleanedText(pieces.join('')), images }
+  return { cleanedText: pieces.join('').trim(), images }
 }
 
 export function embeddedImageUrls(text: string): string[] {

--- a/apps/desktop/src/lib/generated-images.test.ts
+++ b/apps/desktop/src/lib/generated-images.test.ts
@@ -30,12 +30,12 @@ describe('stripGeneratedImageEchoes', () => {
       stripGeneratedImageEchoes('Here you go.\n\n![Generated image](https://cdn.example/cat.png)', [
         'https://cdn.example/cat.png'
       ])
-    ).toBe('Here you go.')
+    ).toBe('Here you go.\n\n')
   })
 
   it('removes media links for generated local image paths', () => {
     expect(stripGeneratedImageEchoes('Saved image: [Image: cat.png](#media:%2Ftmp%2Fcat.png)', ['/tmp/cat.png'])).toBe(
-      'Saved image:'
+      'Saved image: '
     )
   })
 })
@@ -71,7 +71,7 @@ describe('dedupeGeneratedImageEchoesInParts', () => {
         }
       ])
     ).toEqual([
-      { text: 'Here is your peacock! Enjoy.', type: 'text' },
+      { text: 'Here is your peacock!  Enjoy.', type: 'text' },
       {
         result: { host_image: '/host/p.png', image: '/host/p.png', success: true },
         toolName: 'image_generate',

--- a/apps/desktop/src/lib/generated-images.ts
+++ b/apps/desktop/src/lib/generated-images.ts
@@ -82,16 +82,16 @@ export function stripGeneratedImageEchoes(text: string, sources: readonly string
     return text
   }
 
-  // Join only the gap left by an image, never normalize unrelated Markdown or code.
+  // Remove only attachment spans; surrounding whitespace may be Markdown syntax.
   let next = text
-    .replace(/([ \t]?)!\[[^\]\n]*\]\([^)\n]*\)([ \t]?)/g, (_match, before: string, after: string) => before || after)
+    .replace(/!\[[^\]\n]*\]\([^)\n]*\)/g, '')
     .replace(/\[[^\]\n]*\]\(\s*#media:[^)\n]*\)/g, '')
 
   for (const source of unique([...sources])) {
     next = next.replace(new RegExp(String.raw`(^|[\s([{])<?${regexEscape(source)}>?(?=$|[\s)\]},.!?])`, 'g'), '$1')
   }
 
-  return next.trim()
+  return next
 }
 
 /** Strip generated-image echoes from text parts, dropping any part left empty.

--- a/apps/desktop/src/lib/generated-images.ts
+++ b/apps/desktop/src/lib/generated-images.ts
@@ -82,17 +82,16 @@ export function stripGeneratedImageEchoes(text: string, sources: readonly string
     return text
   }
 
-  let next = text.replace(/!\[[^\]\n]*\]\([^)\n]*\)/g, '').replace(/\[[^\]\n]*\]\(\s*#media:[^)\n]*\)/g, '')
+  // Join only the gap left by an image, never normalize unrelated Markdown or code.
+  let next = text
+    .replace(/([ \t]?)!\[[^\]\n]*\]\([^)\n]*\)([ \t]?)/g, (_match, before: string, after: string) => before || after)
+    .replace(/\[[^\]\n]*\]\(\s*#media:[^)\n]*\)/g, '')
 
   for (const source of unique([...sources])) {
     next = next.replace(new RegExp(String.raw`(^|[\s([{])<?${regexEscape(source)}>?(?=$|[\s)\]},.!?])`, 'g'), '$1')
   }
 
-  return next
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .replace(/[ \t]{2,}/g, ' ')
-    .trim()
+  return next.trim()
 }
 
 /** Strip generated-image echoes from text parts, dropping any part left empty.

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -664,7 +664,6 @@ export function preprocessMarkdown(text: string): string {
       return leading + transformed + trailing
     })
     .join('')
-    .replace(/[ \t]+\n/g, '\n')
 }
 
 /**

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -12,7 +12,7 @@ const PREVIEW_MARKER_RE = /\[Preview:[^\]]+\]\(#preview[:/][^)]+\)/gi
 
 const FENCE_LINE_RE = /^([ \t]*)(`{3,}|~{3,})([^\n]*)$/
 const EMPTY_FENCE_BLOCK_RE = /(^|\n)[ \t]*(?:`{3,}|~{3,})[^\n]*\n[ \t]*(?:`{3,}|~{3,})[ \t]*(?=\n|$)/g
-const CODE_FENCE_SPLIT_RE = /((?:```|~~~)[\s\S]*?(?:```|~~~))/g
+const CODE_FENCE_SPLIT_RE = /((?:```|~~~)[\s\S]*?(?:```|~~~|$))/g
 const INLINE_CODE_SPLIT_RE = /(`[^`\n]+`)/g
 // Math spans as remark-math will see them: a `$$…$$` block, which may span
 // lines, or a same-line `$…$`. A delimiter escaped as `\$` is prose — that is
@@ -637,31 +637,11 @@ export function preprocessMarkdown(text: string): string {
         return part
       }
 
-      // Whitespace-only segments (e.g. the `\n\n` between two adjacent
-      // fences) must NOT go through stripPreviewTargets — its internal
-      // .trim() would collapse them to '' and glue the surrounding
-      // fences together, producing things like ``````math which the
-      // markdown parser then reads as a single 6-backtick block.
-      if (!part.trim()) {
-        return part
-      }
-
-      // Preserve leading/trailing whitespace around the prose body so
-      // that fence-prose-fence sequences keep their blank-line gaps.
-      // stripPreviewTargets internally calls .trim() on its result for
-      // the benefit of its other (single-segment) callers; here we're
-      // operating on a SEGMENT of a larger document where outer
-      // whitespace is structural and must survive.
-      const leading = part.match(/^\s*/)?.[0] ?? ''
-      const trailing = part.match(/\s*$/)?.[0] ?? ''
-
       // Run only on prose segments so `$5` literals and `\(` inside code
       // blocks stay intact. The HTML-depth clamp belongs here for the same
       // reason: a fenced block renders as code and never reaches rehype-raw,
       // so escaping tags inside one would corrupt the listing for nothing.
-      const transformed = clampHtmlNestingDepth(normalizeVisibleProse(stripPreviewTargets(normalizeProseMath(part))))
-
-      return leading + transformed + trailing
+      return clampHtmlNestingDepth(normalizeVisibleProse(stripPreviewTargets(normalizeProseMath(part))))
     })
     .join('')
 }

--- a/apps/desktop/src/lib/markdown-whitespace.test.ts
+++ b/apps/desktop/src/lib/markdown-whitespace.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { assistantTextPart, renderMediaTags } from './chat-messages/parts'
+import { extractEmbeddedImages } from './embedded-images'
+import { stripGeneratedImageEchoes } from './generated-images'
+import { preprocessMarkdown } from './markdown-preprocess'
+import { stripPreviewTargets } from './preview-targets'
+
+describe('Markdown whitespace semantics', () => {
+  it('preserves hard and soft breaks and fenced whitespace through display preprocessing', () => {
+    for (const input of ['First line  \nSecond line', 'Soft first\nSoft second', '```python\nvalue = 1  \nvalue = 2 \n```']) {
+      expect(preprocessMarkdown(input)).toBe(input)
+    }
+  })
+
+  it('preserves prose hard breaks when media and preview extraction runs', () => {
+    const prose = 'First line  \nSecond line\n\n```python\nvalue = 1  \nvalue = 2 \n\n\nvalue = 3\n```'
+    const image = 'data:image/png;base64,' + 'A'.repeat(64)
+    expect(stripPreviewTargets(prose + '\n\n[Preview: x](#preview:test)')).toContain(prose)
+    expect(renderMediaTags(prose + '\n\nMEDIA: /tmp/image.png')).toContain(prose)
+    expect(assistantTextPart(prose)).toMatchObject({ type: 'text', text: prose })
+    expect(extractEmbeddedImages(prose + '\n\n' + image).cleanedText).toContain(prose)
+    expect(stripGeneratedImageEchoes(prose + '\n\n![result](/tmp/image.png)', ['/tmp/image.png'])).toContain(prose)
+  })
+})

--- a/apps/desktop/src/lib/markdown-whitespace.test.ts
+++ b/apps/desktop/src/lib/markdown-whitespace.test.ts
@@ -1,25 +1,39 @@
 import { describe, expect, it } from 'vitest'
 
 import { assistantTextPart, renderMediaTags } from './chat-messages/parts'
-import { extractEmbeddedImages } from './embedded-images'
+import { extractEmbeddedImages, extractImageRefs } from './embedded-images'
 import { stripGeneratedImageEchoes } from './generated-images'
 import { preprocessMarkdown } from './markdown-preprocess'
 import { stripPreviewTargets } from './preview-targets'
 
+const samples = [
+  'First line  \nSecond line',
+  'Soft first\nSoft second',
+  '    value = 1\n\n',
+  '```python\nvalue = 1  ',
+  '```python\n\nvalue = 1  \nvalue = 2 \n\n\n```'
+]
+
 describe('Markdown whitespace semantics', () => {
-  it('preserves hard and soft breaks and fenced whitespace through display preprocessing', () => {
-    for (const input of ['First line  \nSecond line', 'Soft first\nSoft second', '```python\nvalue = 1  \nvalue = 2 \n```']) {
+  it('preserves significant whitespace through display preprocessing', () => {
+    for (const input of samples) {
       expect(preprocessMarkdown(input)).toBe(input)
+      expect(preprocessMarkdown('\n\n' + input)).toBe('\n\n' + input)
     }
   })
 
-  it('preserves prose hard breaks when media and preview extraction runs', () => {
-    const prose = 'First line  \nSecond line\n\n```python\nvalue = 1  \nvalue = 2 \n\n\nvalue = 3\n```'
+  it('preserves text outside removed media and preview spans', () => {
     const image = 'data:image/png;base64,' + 'A'.repeat(64)
-    expect(stripPreviewTargets(prose + '\n\n[Preview: x](#preview:test)')).toContain(prose)
-    expect(renderMediaTags(prose + '\n\nMEDIA: /tmp/image.png')).toContain(prose)
-    expect(assistantTextPart(prose)).toMatchObject({ type: 'text', text: prose })
-    expect(extractEmbeddedImages(prose + '\n\n' + image).cleanedText).toContain(prose)
-    expect(stripGeneratedImageEchoes(prose + '\n\n![result](/tmp/image.png)', ['/tmp/image.png'])).toContain(prose)
+    for (const input of samples) {
+      expect(assistantTextPart(input)).toMatchObject({ type: 'text', text: input })
+      expect(renderMediaTags(input)).toBe(input)
+      // Prefix attachments so the unfinished fence remains the document end.
+      expect(stripPreviewTargets('[Preview: x](#preview:test)' + input)).toBe(input)
+      expect(extractEmbeddedImages(image + '\n' + input).cleanedText).toBe('\n' + input)
+      expect(stripGeneratedImageEchoes('![result](/tmp/image.png)\n' + input, ['/tmp/image.png'])).toBe('\n' + input)
+      expect(extractImageRefs('@image:/tmp/image.png\n' + input).cleanedText).toBe(input)
+      expect(extractEmbeddedImages(input + '\n\n' + image).cleanedText).toBe(input + '\n\n')
+      expect(stripGeneratedImageEchoes(input + '\n\n![result](/tmp/image.png)', ['/tmp/image.png'])).toBe(input + '\n\n')
+    }
   })
 })

--- a/apps/desktop/src/lib/preview-targets.test.ts
+++ b/apps/desktop/src/lib/preview-targets.test.ts
@@ -22,6 +22,6 @@ describe('preview target detection', () => {
     expect(stripPreviewTargets('ready\n/tmp/mycelium-bunnies.html\nopen it')).toBe(
       'ready\n/tmp/mycelium-bunnies.html\nopen it'
     )
-    expect(stripPreviewTargets('[Preview: demo.html](#preview:%2Ftmp%2Fdemo.html)\nopen it')).toBe('open it')
+    expect(stripPreviewTargets('[Preview: demo.html](#preview:%2Ftmp%2Fdemo.html)\nopen it')).toBe('\nopen it')
   })
 })

--- a/apps/desktop/src/lib/preview-targets.ts
+++ b/apps/desktop/src/lib/preview-targets.ts
@@ -1,11 +1,7 @@
 const PREVIEW_MARKDOWN_RE = /\[Preview:[^\]]+\]\((?<href>#preview[:/][^)]+)\)/gi
 
 export function stripPreviewTargets(text: string): string {
-  return text
-    .replace(PREVIEW_MARKDOWN_RE, '')
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim()
+  return text.replace(PREVIEW_MARKDOWN_RE, '').trim()
 }
 
 export function extractPreviewTargets(text: string): string[] {

--- a/apps/desktop/src/lib/preview-targets.ts
+++ b/apps/desktop/src/lib/preview-targets.ts
@@ -1,7 +1,7 @@
 const PREVIEW_MARKDOWN_RE = /\[Preview:[^\]]+\]\((?<href>#preview[:/][^)]+)\)/gi
 
 export function stripPreviewTargets(text: string): string {
-  return text.replace(PREVIEW_MARKDOWN_RE, '').trim()
+  return text.replace(PREVIEW_MARKDOWN_RE, '')
 }
 
 export function extractPreviewTargets(text: string): string[] {

--- a/evals/desktop_bug_campaign/markdown-README.md
+++ b/evals/desktop_bug_campaign/markdown-README.md
@@ -1,0 +1,26 @@
+# Markdown rendering probe
+
+This uses the production Desktop components in a real Chromium renderer, without
+starting an agent or making a model request. It is not a native Electron/backend
+transport E2E test.
+
+From the worktree root, with the campaign's locked dependencies and Xvfb ready:
+
+```sh
+.venv/bin/python evals/desktop_bug_campaign/markdown-producer.py /home/teknium/.hermes/cache/desktop-bugs-74848ed3/navigation-markdown/producer.json
+node evals/desktop_bug_campaign/navigation-vite.mjs
+# In another terminal:
+DISPLAY=:208 PLAYWRIGHT_BROWSERS_PATH=/home/teknium/.hermes/cache/desktop-bugs-74848ed3/navigation-markdown/browsers node evals/desktop_bug_campaign/navigation-markdown-live.mjs after
+```
+
+The producer isolates both HOME and HERMES_HOME, saves a deterministic report via
+`save_job_output`, formats it through the cron completion and process-notification
+producers, persists an actual delivery row, and reads it back from SQLite. It does
+not execute the scheduled job. The browser feeds that row through hydration,
+runtime conversion, and `SystemMessage`, independently of the assistant Markdown
+samples. JSON receipts and screenshots go to the campaign artifact directory.
+
+The browser is a receipt collector: compare `hardBr`, `softBr`, `breaks`, `outputs`,
+`errors`, and `producer.dom`. Hard-break samples should emit a `br`; the soft-break
+control should not. The separate async report loss (#101078) is not repaired by
+the whitespace fix (#97117).

--- a/evals/desktop_bug_campaign/markdown-README.md
+++ b/evals/desktop_bug_campaign/markdown-README.md
@@ -1,26 +1,29 @@
-# Markdown rendering probe
+# Markdown whitespace live probe
 
-This uses the production Desktop components in a real Chromium renderer, without
-starting an agent or making a model request. It is not a native Electron/backend
-transport E2E test.
+This fixture now runs Markdown ONLY: no producer.json, hydration, SystemMessage,
+backend, model request, or notification delivery. The separate async-report lane
+owns #101078. Historical combined producer harness: commit 07a4da338bc, files
+navigation-markdown-{probe.tsx,live.mjs}; markdown-producer.py is unchanged.
 
-From the worktree root, with the campaign's locked dependencies and Xvfb ready:
+From the worktree root (locked workspace dependencies installed):
 
 ```sh
-.venv/bin/python evals/desktop_bug_campaign/markdown-producer.py /home/teknium/.hermes/cache/desktop-bugs-74848ed3/navigation-markdown/producer.json
 node evals/desktop_bug_campaign/navigation-vite.mjs
-# In another terminal:
-DISPLAY=:208 PLAYWRIGHT_BROWSERS_PATH=/home/teknium/.hermes/cache/desktop-bugs-74848ed3/navigation-markdown/browsers node evals/desktop_bug_campaign/navigation-markdown-live.mjs after
+PLAYWRIGHT_BROWSERS_PATH=/home/teknium/.hermes/cache/desktop-bugs-74848ed3/navigation-markdown/browsers node evals/desktop_bug_campaign/navigation-markdown-live.mjs after
 ```
 
-The producer isolates both HOME and HERMES_HOME, saves a deterministic report via
-`save_job_output`, formats it through the cron completion and process-notification
-producers, persists an actual delivery row, and reads it back from SQLite. It does
-not execute the scheduled job. The browser feeds that row through hydration,
-runtime conversion, and `SystemMessage`, independently of the assistant Markdown
-samples. JSON receipts and screenshots go to the campaign artifact directory.
+Vite requires owned port 18160 (strictPort); verify the HTML references this
+worktree's probe entry. Chromium is headless; no Xvfb/native Electron needed.
+NAVIGATION_ARTIFACT_DIR overrides the default campaign receipt directory.
 
-The browser is a receipt collector: compare `hardBr`, `softBr`, `breaks`, `outputs`,
-`errors`, and `producer.dom`. Hard-break samples should emit a `br`; the soft-break
-control should not. The separate async report loss (#101078) is not repaired by
-the whitespace fix (#97117).
+The harness asserts 30 cases: five actual ingress functions, each with hard/soft
+breaks, first-line indented code, unfinished fence with terminal spaces, closed
+code with a final-space line, and leading/trailing blank lines. It waits for real
+Shiki, reads code textContent, clicks the code-card Copy control, and reads the
+real browser clipboard. Code expectations include the Markdown parser's final LF;
+we preserve its raw payload rather than arbitrarily trimming it. Nonzero exit
+means a failed assertion or page error. JSON and screenshot are retained.
+
+Unit invariants live in src/lib/markdown-whitespace.test.ts (exactly two tests).
+Run all verification under campaign tests.lock. This is production-component
+Chromium proof, NOT native Electron/backend/transport or macOS proof.

--- a/evals/desktop_bug_campaign/markdown-producer.py
+++ b/evals/desktop_bug_campaign/markdown-producer.py
@@ -1,0 +1,43 @@
+"""Collect real cron completion producer + durable delivery, without inference."""
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import time
+
+repo = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(repo))
+output = Path(sys.argv[1])
+with tempfile.TemporaryDirectory(prefix="markdown-producer-") as temporary:
+    home = Path(temporary)
+    for key in list(os.environ):
+        if key.startswith("HERMES_") or key.endswith(("_API_KEY", "_TOKEN")):
+            os.environ.pop(key, None)
+    os.environ.update(HOME=str(home), HERMES_HOME=str(home / ".hermes"))
+    from cron.jobs import create_job, save_job_output
+    from gateway.wake import persist_delegation_delivery
+    from hermes_state import SessionDB
+    from tools.cronjob_tools import _manual_run_completion
+    from tools.process_registry_notifications import format_process_notification
+
+    report = "# Generated inspection\n\n**Conclusion:** attention needed.\n\n| Strategy | Status |\n|---|---|\n| Canary | running |\n\nFirst line  \nSecond line\n\n```python\nvalue = 1  \nvalue = 2 \n```"
+    job = create_job(prompt="Offline fixture; never run", schedule="0 0 * * *", name="Markdown probe", deliver="local")
+    save_job_output(job["id"], report)
+    result = _manual_run_completion({"success": True}, job["id"], job["name"], "local", time.time())
+    event = dict(result, type="async_delegation", delegation_id="markdown-probe", goal="Inspect a generated report")
+    envelope = format_process_notification(event)
+    assert envelope is not None
+    db = SessionDB(db_path=home / "delivery.db")
+    db.create_session(session_id="markdown-probe", source="desktop")
+
+    class DeliveryStore:
+        def _ensure_session_db(self):
+            return db
+
+    asyncio.run(persist_delegation_delivery(DeliveryStore(), text=envelope, session_id="markdown-probe", evt=event))
+    rows = db.get_messages_as_conversation("markdown-probe", include_row_ids=True)
+    output.write_text(json.dumps({"report": report, "result": result, "envelope": envelope, "rows": rows}, indent=2), encoding="utf-8")
+    print(json.dumps({"producer": "save_job_output -> _manual_run_completion -> format_process_notification -> persist_delegation_delivery -> SessionDB readback", "rows": len(rows), "report_preserved": report in rows[0]["content"], "display_kind": rows[0].get("display_kind"), "model_requests": 0}))
+    db.close()

--- a/evals/desktop_bug_campaign/navigation-markdown-README.md
+++ b/evals/desktop_bug_campaign/navigation-markdown-README.md
@@ -1,0 +1,14 @@
+# Navigation / Markdown campaign probe
+
+This fixture mounts the production `MarkdownTextContent` component in Chromium and records its DOM, preprocessed text, screenshot and renderer errors. It is **component-level live renderer evidence**, not a full Desktop navigation or backend test. Global Desktop CSS is intentionally not loaded; hard versus soft break assertions inspect emitted `<br>` elements, not CSS wrapping. No backend or model request is made.
+
+From the repository root, with the locked Desktop dependencies available:
+
+```sh
+node evals/desktop_bug_campaign/navigation-vite.mjs
+DISPLAY=:208 PLAYWRIGHT_BROWSERS_PATH=/home/teknium/.hermes/cache/desktop-bugs-74848ed3/navigation-markdown/browsers node evals/desktop_bug_campaign/navigation-markdown-live.mjs before
+```
+
+The server uses port 18160. The campaign artifact directory is currently explicit in the runner; it is outside the source tree. Use a dedicated Xvfb display and isolated browser process. Vite's unique cache directory must include a `node_modules` segment: otherwise the React Compiler processes optimized dependency bundles and startup can stall.
+
+Baseline source: `08b140d14e6c1d49f9b7ad02c9437fe940d54d65`. Observed two-space hard break loses both spaces and emits zero `<br>`; ordinary soft break also emits zero `<br>`; fenced code loses trailing spaces. This is a reproduction only, not a fix or a passing regression test.

--- a/evals/desktop_bug_campaign/navigation-markdown-README.md
+++ b/evals/desktop_bug_campaign/navigation-markdown-README.md
@@ -1,14 +1,5 @@
 # Navigation / Markdown campaign probe
 
-This fixture mounts the production `MarkdownTextContent` component in Chromium and records its DOM, preprocessed text, screenshot and renderer errors. It is **component-level live renderer evidence**, not a full Desktop navigation or backend test. Global Desktop CSS is intentionally not loaded; hard versus soft break assertions inspect emitted `<br>` elements, not CSS wrapping. No backend or model request is made.
+See [markdown-README.md](markdown-README.md) for the maintained Markdown-only probe and commands. It mounts production Desktop Markdown components and CSS in isolated Chromium, inspects hard/soft breaks and highlighted code, and clicks the actual code-card Copy control before reading the browser clipboard. This is component-level live renderer evidence, not native Electron, navigation, backend transport, or macOS verification. No backend or model request is made.
 
-From the repository root, with the locked Desktop dependencies available:
-
-```sh
-node evals/desktop_bug_campaign/navigation-vite.mjs
-DISPLAY=:208 PLAYWRIGHT_BROWSERS_PATH=/home/teknium/.hermes/cache/desktop-bugs-74848ed3/navigation-markdown/browsers node evals/desktop_bug_campaign/navigation-markdown-live.mjs before
-```
-
-The server uses port 18160. The campaign artifact directory is currently explicit in the runner; it is outside the source tree. Use a dedicated Xvfb display and isolated browser process. Vite's unique cache directory must include a `node_modules` segment: otherwise the React Compiler processes optimized dependency bundles and startup can stall.
-
-Baseline source: `08b140d14e6c1d49f9b7ad02c9437fe940d54d65`. Observed two-space hard break loses both spaces and emits zero `<br>`; ordinary soft break also emits zero `<br>`; fenced code loses trailing spaces. This is a reproduction only, not a fix or a passing regression test.
+The earlier combined notification fixture is retained in git history at `07a4da338bc`; async-report source changes belong to a separate lane.

--- a/evals/desktop_bug_campaign/navigation-markdown-live.mjs
+++ b/evals/desktop_bug_campaign/navigation-markdown-live.mjs
@@ -1,0 +1,16 @@
+import { chromium } from '../../node_modules/playwright/index.mjs'
+import fs from 'node:fs'
+const a='/home/teknium/.hermes/cache/desktop-bugs-74848ed3/navigation-markdown'
+const tag=process.argv[2]??'before'
+const browser=await chromium.launch({headless:false,args:['--no-sandbox']})
+const page=await browser.newPage({viewport:{width:1400,height:1000}})
+const errors=[];page.on('pageerror',e=>errors.push(String(e)))
+await page.goto('http://127.0.0.1:18160/navigation-markdown-probe.html',{waitUntil:'domcontentloaded',timeout:120000})
+await page.waitForSelector('#hard p',{timeout:90000})
+await page.waitForTimeout(6000)
+await page.waitForSelector('#hard p',{timeout:90000})
+const result=await page.evaluate(()=>({inputs:window.probeInputs,outputs:window.probeOutputs,hardBr:document.querySelectorAll('#hard br').length,softBr:document.querySelectorAll('#soft br').length,text:document.body.innerText,html:document.querySelector('main').innerHTML}))
+result.errors=errors
+await page.screenshot({path:`${a}/markdown-${tag}.png`,fullPage:true})
+fs.writeFileSync(`${a}/markdown-${tag}.json`,JSON.stringify(result,null,2));console.log(JSON.stringify(result,null,2))
+await browser.close()

--- a/evals/desktop_bug_campaign/navigation-markdown-live.mjs
+++ b/evals/desktop_bug_campaign/navigation-markdown-live.mjs
@@ -1,5 +1,6 @@
 import { chromium } from '../../node_modules/playwright/index.mjs'
 import fs from 'node:fs'
+import { execFileSync } from 'node:child_process'
 const a='/home/teknium/.hermes/cache/desktop-bugs-74848ed3/navigation-markdown'
 const tag=process.argv[2]??'before'
 const browser=await chromium.launch({headless:false,args:['--no-sandbox']})
@@ -9,8 +10,14 @@ await page.goto('http://127.0.0.1:18160/navigation-markdown-probe.html',{waitUnt
 await page.waitForSelector('#hard p',{timeout:90000})
 await page.waitForTimeout(6000)
 await page.waitForSelector('#hard p',{timeout:90000})
-const result=await page.evaluate(()=>({inputs:window.probeInputs,outputs:window.probeOutputs,hardBr:document.querySelectorAll('#hard br').length,softBr:document.querySelectorAll('#soft br').length,text:document.body.innerText,html:document.querySelector('main').innerHTML}))
+const result=await page.evaluate(()=>({inputs:window.probeInputs,outputs:window.probeOutputs,ingress:window.ingress,hardBr:document.querySelectorAll('#hard br').length,softBr:document.querySelectorAll('#soft br').length,breaks:Object.fromEntries(Object.keys(window.ingress).map(k=>[k,document.querySelectorAll(`#${k} br`).length])),text:document.body.innerText,html:document.querySelector('main').innerHTML}))
+const producer = JSON.parse(fs.readFileSync(`${a}/producer.json`, 'utf8'))
+result.producer = await page.evaluate(rows => window.renderProducer(rows), producer.rows)
+await page.waitForSelector('#producer [data-role="system"]')
+result.producer.dom = await page.locator('#producer').evaluate(el=>({text:el.textContent,headings:el.querySelectorAll('h1').length,tables:el.querySelectorAll('table').length,html:el.innerHTML}))
 result.errors=errors
+result.sourceSha=execFileSync('git', ['rev-parse', 'HEAD'], {encoding:'utf8'}).trim()
+result.codeText=await page.locator('#code code').textContent()
 await page.screenshot({path:`${a}/markdown-${tag}.png`,fullPage:true})
 fs.writeFileSync(`${a}/markdown-${tag}.json`,JSON.stringify(result,null,2));console.log(JSON.stringify(result,null,2))
 await browser.close()

--- a/evals/desktop_bug_campaign/navigation-markdown-live.mjs
+++ b/evals/desktop_bug_campaign/navigation-markdown-live.mjs
@@ -1,23 +1,33 @@
 import { chromium } from '../../node_modules/playwright/index.mjs'
 import fs from 'node:fs'
 import { execFileSync } from 'node:child_process'
-const a='/home/teknium/.hermes/cache/desktop-bugs-74848ed3/navigation-markdown'
-const tag=process.argv[2]??'before'
-const browser=await chromium.launch({headless:false,args:['--no-sandbox']})
-const page=await browser.newPage({viewport:{width:1400,height:1000}})
-const errors=[];page.on('pageerror',e=>errors.push(String(e)))
-await page.goto('http://127.0.0.1:18160/navigation-markdown-probe.html',{waitUntil:'domcontentloaded',timeout:120000})
-await page.waitForSelector('#hard p',{timeout:90000})
-await page.waitForTimeout(6000)
-await page.waitForSelector('#hard p',{timeout:90000})
-const result=await page.evaluate(()=>({inputs:window.probeInputs,outputs:window.probeOutputs,ingress:window.ingress,hardBr:document.querySelectorAll('#hard br').length,softBr:document.querySelectorAll('#soft br').length,breaks:Object.fromEntries(Object.keys(window.ingress).map(k=>[k,document.querySelectorAll(`#${k} br`).length])),text:document.body.innerText,html:document.querySelector('main').innerHTML}))
-const producer = JSON.parse(fs.readFileSync(`${a}/producer.json`, 'utf8'))
-result.producer = await page.evaluate(rows => window.renderProducer(rows), producer.rows)
-await page.waitForSelector('#producer [data-role="system"]')
-result.producer.dom = await page.locator('#producer').evaluate(el=>({text:el.textContent,headings:el.querySelectorAll('h1').length,tables:el.querySelectorAll('table').length,html:el.innerHTML}))
-result.errors=errors
-result.sourceSha=execFileSync('git', ['rev-parse', 'HEAD'], {encoding:'utf8'}).trim()
-result.codeText=await page.locator('#code code').textContent()
-await page.screenshot({path:`${a}/markdown-${tag}.png`,fullPage:true})
-fs.writeFileSync(`${a}/markdown-${tag}.json`,JSON.stringify(result,null,2));console.log(JSON.stringify(result,null,2))
+const artifact = process.env.NAVIGATION_ARTIFACT_DIR ?? '/home/teknium/.hermes/cache/desktop-bugs-74848ed3/navigation-markdown'
+const tag = process.argv[2] ?? 'after'
+const browser = await chromium.launch({headless: true, args: ['--no-sandbox']})
+const context = await browser.newContext({permissions: ['clipboard-read', 'clipboard-write']})
+const page = await context.newPage()
+const errors = []
+page.on('pageerror', error => errors.push(String(error)))
+await page.goto('http://127.0.0.1:18160/navigation-markdown-probe.html', {waitUntil: 'networkidle', timeout:120000})
+await page.waitForSelector('#assistant-code .shiki')
+const cases = await page.evaluate(() => window.markdownCases)
+const results = {}
+for (const [id, sample] of Object.entries(cases)) {
+  const section = page.locator(`#${id}`)
+  const dom = await section.evaluate(el => ({breaks: el.querySelectorAll('br').length, code: el.querySelector('code')?.textContent ?? null, highlighted: !!el.querySelector('.shiki')}))
+  let copy = null
+  if (await section.locator('[data-slot="code-card"] button').count()) {
+    await section.locator('[data-slot="code-card"] button').first().click({force:true})
+    copy = await page.evaluate(() => navigator.clipboard.readText())
+  }
+  const expectedCode = {indented:'value = 1\n', unfinished:'value = 1  \n', code:'value = 1  \nvalue = 2 \n', blanks:'\nvalue = 1  \n\n\n'}[sample.kind]
+  const passed = expectedCode === undefined ? dom.breaks === (sample.kind === 'hard' ? 1 : 0) : dom.code === expectedCode && copy === expectedCode
+  results[id] = {...sample, ...dom, copy, expectedCode, passed}
+}
+const result = {sourceSha:execFileSync('git', ['rev-parse','HEAD'], {encoding:'utf8'}).trim(), results, errors, passed:Object.values(results).every(row => row.passed) && errors.length === 0}
+fs.mkdirSync(artifact, {recursive:true})
+fs.writeFileSync(`${artifact}/markdown-${tag}.json`, JSON.stringify(result,null,2))
+await page.screenshot({path:`${artifact}/markdown-${tag}.png`, fullPage:true})
+console.log(JSON.stringify(result,null,2))
 await browser.close()
+process.exitCode = result.passed ? 0 : 1

--- a/evals/desktop_bug_campaign/navigation-markdown-probe.html
+++ b/evals/desktop_bug_campaign/navigation-markdown-probe.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset="utf-8"></head><body><div id="root"></div><script type="module" src="FIXTURE_ENTRY"></script></body></html>

--- a/evals/desktop_bug_campaign/navigation-markdown-probe.tsx
+++ b/evals/desktop_bug_campaign/navigation-markdown-probe.tsx
@@ -1,47 +1,35 @@
 import { createRoot } from 'react-dom/client'
-import { AssistantRuntimeProvider, ThreadPrimitive, useExternalStoreRuntime, type ThreadMessage } from '@assistant-ui/react'
 import type { ReactNode } from 'react'
-import type { SessionMessage } from '@/types/hermes'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from '@/lib/query-client'
 import { I18nProvider } from '@/i18n'
 import { ThemeProvider } from '@/themes/context'
 import { RootTooltipProvider } from '@/components/ui/tooltip'
 import { MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
-import { SystemMessage } from '@/components/assistant-ui/thread/system-message'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
-import { toChatMessages } from '@/lib/chat-messages/hydration'
-import { toRuntimeMessage } from '@/lib/chat-runtime'
 import { assistantTextPart, renderMediaTags } from '@/lib/chat-messages/parts'
 import { stripGeneratedImageEchoes } from '@/lib/generated-images'
 import { extractEmbeddedImages } from '@/lib/embedded-images'
 import { stripPreviewTargets } from '@/lib/preview-targets'
-const hard = 'First line  \nSecond line'
-const soft = 'Soft first\nSoft second'
-const code = '```python\nvalue = 1  \nvalue = 2 \n```'
-const corpus = hard + '\n\n' + code
-const image = 'data:image/png;base64,' + 'A'.repeat(64)
-const assistant = assistantTextPart(corpus)
-const ingress = {
-  assistant: assistant.type === 'text' ? assistant.text : '',
-  media: renderMediaTags(corpus + '\n\nMEDIA: /tmp/image.png'),
-  preview: stripPreviewTargets(corpus + '\n\n[Preview: x](#preview:test)'),
-  embedded: extractEmbeddedImages(corpus + '\n\n' + image).cleanedText,
-  generated: stripGeneratedImageEchoes(corpus + '\n\n![result](/tmp/image.png)', ['/tmp/image.png'])
+const samples = {
+  hard: 'First line  \nSecond line',
+  soft: 'Soft first\nSoft second',
+  indented: '    value = 1\n\n',
+  unfinished: '```python\nvalue = 1  ',
+  code: '```python\nvalue = 1  \nvalue = 2 \n```',
+  blanks: '```python\n\nvalue = 1  \n\n\n```'
 }
-Object.assign(window, {probeInputs:{hard,soft,code}, probeOutputs:{hard:preprocessMarkdown(hard),soft:preprocessMarkdown(soft),code:preprocessMarkdown(code)}, ingress})
+const image = 'data:image/png;base64,' + 'A'.repeat(64)
+const ingress = {
+  assistant: (text: string) => { const part = assistantTextPart(text); return part.type === 'text' ? part.text : '' },
+  media: (text: string) => renderMediaTags('MEDIA: /tmp/image.png\n\n' + text),
+  preview: (text: string) => stripPreviewTargets('[Preview: x](#preview:test)\n\n' + text),
+  embedded: (text: string) => extractEmbeddedImages(image + '\n\n' + text).cleanedText,
+  generated: (text: string) => stripGeneratedImageEchoes('![result](/tmp/image.png)\n\n' + text, ['/tmp/image.png'])
+}
+const cases = Object.fromEntries(Object.entries(ingress).flatMap(([name, apply]) => Object.entries(samples).map(([kind, input]) => [`${name}-${kind}`, {kind, input, text: apply(input)}])))
+Object.assign(window, {markdownCases: cases, preprocessMarkdown})
 function Providers({children}: {children: ReactNode}) {
   return <QueryClientProvider client={queryClient}><I18nProvider><ThemeProvider><RootTooltipProvider>{children}</RootTooltipProvider></ThemeProvider></I18nProvider></QueryClientProvider>
 }
-function Delivery({messages}: {messages: ThreadMessage[]}) {
-  const runtime = useExternalStoreRuntime<ThreadMessage>({messages, isRunning:false, onNew:async()=>{}})
-  return <AssistantRuntimeProvider runtime={runtime}><ThreadPrimitive.Root><ThreadPrimitive.Messages components={{Message: SystemMessage}}/></ThreadPrimitive.Root></AssistantRuntimeProvider>
-}
-Object.assign(window, {renderProducer(rows: SessionMessage[]) {
-  const hydrated = toChatMessages(rows)
-  const runtime = hydrated.map(toRuntimeMessage)
-  const mount = document.createElement('section'); mount.id = 'producer'; document.body.append(mount)
-  createRoot(mount).render(<Providers><Delivery messages={runtime}/></Providers>)
-  return {hydrated,runtime}
-}})
-createRoot(document.getElementById('root')!).render(<Providers><main style={{padding:40}}><h1>Production Markdown renderer probe</h1>{Object.entries({hard,soft,code,...ingress}).map(([id,text])=><section id={id} key={id}><h2>{id}</h2><MarkdownTextContent text={text} isRunning={false}/></section>)}</main></Providers>)
+createRoot(document.getElementById('root')!).render(<Providers><main style={{padding:40}}><h1>Production Markdown renderer probe</h1>{Object.entries(cases).map(([id, {text}]) => <section id={id} key={id}><h2>{id}</h2><MarkdownTextContent text={text} isRunning={false}/></section>)}</main></Providers>)

--- a/evals/desktop_bug_campaign/navigation-markdown-probe.tsx
+++ b/evals/desktop_bug_campaign/navigation-markdown-probe.tsx
@@ -1,3 +1,4 @@
+import '@/styles.css'
 import { createRoot } from 'react-dom/client'
 import type { ReactNode } from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'

--- a/evals/desktop_bug_campaign/navigation-markdown-probe.tsx
+++ b/evals/desktop_bug_campaign/navigation-markdown-probe.tsx
@@ -1,0 +1,13 @@
+import { createRoot } from 'react-dom/client'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from '@/lib/query-client'
+import { I18nProvider } from '@/i18n'
+import { ThemeProvider } from '@/themes/context'
+import { RootTooltipProvider } from '@/components/ui/tooltip'
+import { MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
+import { preprocessMarkdown } from '@/lib/markdown-preprocess'
+const hard = 'First line  \nSecond line'
+const soft = 'Soft first\nSoft second'
+const code = '```python\nvalue = 1  \nvalue = 2 \n```'
+Object.assign(window, {probeInputs:{hard,soft,code}, probeOutputs:{hard:preprocessMarkdown(hard),soft:preprocessMarkdown(soft),code:preprocessMarkdown(code)}})
+createRoot(document.getElementById('root')!).render(<QueryClientProvider client={queryClient}><I18nProvider><ThemeProvider><RootTooltipProvider><main style={{padding:40}}><h1>Production Markdown renderer probe</h1>{Object.entries({hard,soft,code}).map(([id,text])=><section id={id} key={id}><h2>{id}</h2><MarkdownTextContent text={text} isRunning={false}/></section>)}</main></RootTooltipProvider></ThemeProvider></I18nProvider></QueryClientProvider>)

--- a/evals/desktop_bug_campaign/navigation-markdown-probe.tsx
+++ b/evals/desktop_bug_campaign/navigation-markdown-probe.tsx
@@ -1,13 +1,47 @@
 import { createRoot } from 'react-dom/client'
+import { AssistantRuntimeProvider, ThreadPrimitive, useExternalStoreRuntime, type ThreadMessage } from '@assistant-ui/react'
+import type { ReactNode } from 'react'
+import type { SessionMessage } from '@/types/hermes'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from '@/lib/query-client'
 import { I18nProvider } from '@/i18n'
 import { ThemeProvider } from '@/themes/context'
 import { RootTooltipProvider } from '@/components/ui/tooltip'
 import { MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
+import { SystemMessage } from '@/components/assistant-ui/thread/system-message'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
+import { toChatMessages } from '@/lib/chat-messages/hydration'
+import { toRuntimeMessage } from '@/lib/chat-runtime'
+import { assistantTextPart, renderMediaTags } from '@/lib/chat-messages/parts'
+import { stripGeneratedImageEchoes } from '@/lib/generated-images'
+import { extractEmbeddedImages } from '@/lib/embedded-images'
+import { stripPreviewTargets } from '@/lib/preview-targets'
 const hard = 'First line  \nSecond line'
 const soft = 'Soft first\nSoft second'
 const code = '```python\nvalue = 1  \nvalue = 2 \n```'
-Object.assign(window, {probeInputs:{hard,soft,code}, probeOutputs:{hard:preprocessMarkdown(hard),soft:preprocessMarkdown(soft),code:preprocessMarkdown(code)}})
-createRoot(document.getElementById('root')!).render(<QueryClientProvider client={queryClient}><I18nProvider><ThemeProvider><RootTooltipProvider><main style={{padding:40}}><h1>Production Markdown renderer probe</h1>{Object.entries({hard,soft,code}).map(([id,text])=><section id={id} key={id}><h2>{id}</h2><MarkdownTextContent text={text} isRunning={false}/></section>)}</main></RootTooltipProvider></ThemeProvider></I18nProvider></QueryClientProvider>)
+const corpus = hard + '\n\n' + code
+const image = 'data:image/png;base64,' + 'A'.repeat(64)
+const assistant = assistantTextPart(corpus)
+const ingress = {
+  assistant: assistant.type === 'text' ? assistant.text : '',
+  media: renderMediaTags(corpus + '\n\nMEDIA: /tmp/image.png'),
+  preview: stripPreviewTargets(corpus + '\n\n[Preview: x](#preview:test)'),
+  embedded: extractEmbeddedImages(corpus + '\n\n' + image).cleanedText,
+  generated: stripGeneratedImageEchoes(corpus + '\n\n![result](/tmp/image.png)', ['/tmp/image.png'])
+}
+Object.assign(window, {probeInputs:{hard,soft,code}, probeOutputs:{hard:preprocessMarkdown(hard),soft:preprocessMarkdown(soft),code:preprocessMarkdown(code)}, ingress})
+function Providers({children}: {children: ReactNode}) {
+  return <QueryClientProvider client={queryClient}><I18nProvider><ThemeProvider><RootTooltipProvider>{children}</RootTooltipProvider></ThemeProvider></I18nProvider></QueryClientProvider>
+}
+function Delivery({messages}: {messages: ThreadMessage[]}) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({messages, isRunning:false, onNew:async()=>{}})
+  return <AssistantRuntimeProvider runtime={runtime}><ThreadPrimitive.Root><ThreadPrimitive.Messages components={{Message: SystemMessage}}/></ThreadPrimitive.Root></AssistantRuntimeProvider>
+}
+Object.assign(window, {renderProducer(rows: SessionMessage[]) {
+  const hydrated = toChatMessages(rows)
+  const runtime = hydrated.map(toRuntimeMessage)
+  const mount = document.createElement('section'); mount.id = 'producer'; document.body.append(mount)
+  createRoot(mount).render(<Providers><Delivery messages={runtime}/></Providers>)
+  return {hydrated,runtime}
+}})
+createRoot(document.getElementById('root')!).render(<Providers><main style={{padding:40}}><h1>Production Markdown renderer probe</h1>{Object.entries({hard,soft,code,...ingress}).map(([id,text])=><section id={id} key={id}><h2>{id}</h2><MarkdownTextContent text={text} isRunning={false}/></section>)}</main></Providers>)

--- a/evals/desktop_bug_campaign/navigation-vite.mjs
+++ b/evals/desktop_bug_campaign/navigation-vite.mjs
@@ -1,0 +1,28 @@
+import { createServer } from '../../node_modules/vite/dist/node/index.js'
+import fs from 'node:fs'
+import path from 'node:path'
+const root = path.resolve(import.meta.dirname, '../../apps/desktop')
+const artifactDir = process.env.NAVIGATION_ARTIFACT_DIR ?? '/home/teknium/.hermes/cache/desktop-bugs-74848ed3/navigation-markdown'
+const fixture = path.join(import.meta.dirname, 'navigation-markdown-probe.tsx')
+const server = await createServer({
+  root,
+  configFile: path.join(root, 'vite.config.ts'),
+  // Keep the node_modules segment: Babel must not compile optimized deps.
+  cacheDir: path.join(artifactDir, 'node_modules/.vite'),
+  plugins: [{
+    name: 'navigation-markdown-probe',
+    configureServer(server) {
+      server.middlewares.use('/navigation-markdown-probe.html', async (_req, res, next) => {
+        try {
+          const source = fs.readFileSync(path.join(import.meta.dirname, 'navigation-markdown-probe.html'), 'utf8')
+          const html = await server.transformIndexHtml('/navigation-markdown-probe.html', source.replace('FIXTURE_ENTRY', `/@fs/${fixture}`))
+          res.setHeader('Content-Type', 'text/html')
+          res.end(html)
+        } catch (error) { next(error) }
+      })
+    }
+  }],
+  server: {host: '127.0.0.1', port: 18160, strictPort: true}
+})
+await server.listen()
+server.printUrls()

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -41,7 +41,7 @@ The desktop app is organized as a chat-first window with a left sidebar for navi
 The center of the app. You get:
 
 - **Streaming responses** with live tool activity and structured tool-call summaries as the agent works.
-- **Markdown line breaks** follow Markdown semantics: two trailing spaces create a hard line break; an ordinary newline stays a soft break. Media and preview extraction preserve these breaks and whitespace inside fenced code blocks.
+- **Markdown line breaks** follow Markdown semantics: two trailing spaces create a hard line break; an ordinary newline stays a soft break. Media and preview extraction preserve text outside removed attachment spans, including first-line code indentation and unfinished fenced-code spacing. Code display and Copy preserve leading blank lines, trailing spaces, and terminal blank lines from the Markdown parser.
 - **The same conversation history** as every other Hermes surface — sessions started here resume in the CLI/TUI and vice versa.
 - **Drag-and-drop files** anywhere in the chat area to attach them to your next message.
 - **A right-hand preview rail** — render web pages, files, and tool outputs side by side while you keep chatting.

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -41,6 +41,7 @@ The desktop app is organized as a chat-first window with a left sidebar for navi
 The center of the app. You get:
 
 - **Streaming responses** with live tool activity and structured tool-call summaries as the agent works.
+- **Markdown line breaks** follow Markdown semantics: two trailing spaces create a hard line break; an ordinary newline stays a soft break. Media and preview extraction preserve these breaks and whitespace inside fenced code blocks.
 - **The same conversation history** as every other Hermes surface — sessions started here resume in the CLI/TUI and vice versa.
 - **Drag-and-drop files** anywhere in the chat area to attach them to your next message.
 - **A right-hand preview rail** — render web pages, files, and tool outputs side by side while you keep chatting.


### PR DESCRIPTION
Desktop Markdown now preserves hard breaks and significant code whitespace through media extraction, rendering, and Copy.

## Context

Addresses #97117; Desktop reliability campaign tracker #104839. This is the Markdown-only source PR: async-report hydration (#101078), navigation, and other campaign fixes are not included.

## Changes

- Remove document-wide trailing-space, blank-line, and boundary trims from Markdown/media/preview processing; preserve text outside removed attachment spans.
- Shield unfinished fenced code through end-of-document, including after leading media or blank segments.
- Feed the same untrimmed Markdown-parser payload to Shiki display and the actual code-card Copy control. Preserve the parser's terminal LF intentionally; parsed code is not claimed byte-identical to fenced Markdown source.
- Extend two whitespace invariants, update extraction expectations and user documentation, and maintain the browser harness under `evals/desktop_bug_campaign/` with production Desktop CSS.

Root cause: generic whitespace cleanup erased Markdown syntax and the highlighter separately trimmed code before display and copy.

Credit: @andrea9292 reported the deterministic reproduction; @Jackal991's #97175 and @wooyongbin3-cpu's #97431 investigated hard-break preservation. This deletion-based implementation also covers sibling ingestion paths and code boundaries; it does not claim their patches were cherry-picked.

## Validation

**Live repro:** Identical final Chromium harness against current-main production files (`d8a07768c5ee59afae62e9fb51d45e1e30aa74da`) passes 5/30 cases; fixed production files pass 30/30, with zero page errors. Five ingress paths each cover hard/soft breaks, indented code, unfinished fences, final-space code, and leading/trailing code blank lines. All 20 code cases compare real DOM text and browser clipboard after clicking the actual code-card Copy button.

| Check | Result |
| --- | --- |
| Hard breaks, each ingress | 0 → 1 emitted break |
| Soft-break controls, each ingress | 0 → 0 emitted breaks |
| Code DOM and actual Copy | Spaces/blank lines lost → parser payload retained |
| Fresh scoped Vitest rerun under campaign serial lock | 148 passed / 6 files |
| Earlier final source directory gate | 1764 passed / 184 files; recorded by implementation pass |
| Fresh broad directory rerun | Timed out; not represented as a fresh pass |
| Static gates rerun | Windows footguns, compat pointers, subprocess stdin, diff whitespace passed |
| Earlier source lint gate | Three TypeScript projects and ESLint passed |

Fidelity: production Desktop components and CSS in isolated real Chromium, with before/after screenshots and clipboard readback. Not native Electron, backend/transport E2E, GPU, or macOS verification. Both HOME and HERMES_HOME sandboxed; no model/vendor requests. Local receipts are `markdown-delivery-{base,after}.{json,png}` and `delivery-scoped-final.log` in the campaign's navigation-markdown artifact directory. Screenshot review confirms hard versus soft layout; byte claims come from DOM/clipboard assertions, not image inspection.

## Infographic

Campaign context illustration for #104839, not a Markdown-specific implementation diagram or proof of unrelated fixes in this PR. Image checked for legibility and spelling.

![Desktop reliability campaign context](https://v3b.fal.media/files/b/0aa970ff/01HBIjxrk8-g59IYVhD6F_GOQaUsZH.png)
