### PR TITLE
fix(desktop): tool edits and failed rebuilds keep the session profile

### DIFF
--- a/evals/desktop_bug_campaign/persistence_live.py
+++ b/evals/desktop_bug_campaign/persistence_live.py
@@ -20,7 +20,10 @@ def main():
     parser.add_argument('--port', type=int, default=18020)
     parser.add_argument('--compress', action='store_true')
     parser.add_argument('--reset', action='store_true')
+    parser.add_argument('--failure', action='store_true', help='inject one model-config preparation failure')
+    parser.add_argument('--observe', action='store_true', help='inspect ownership without injecting failure')
     args = parser.parse_args()
+    observe = args.observe or args.failure
     args.out.mkdir(parents=True, exist_ok=True)
     home = Path(tempfile.mkdtemp(prefix='persistence-live-'))
     profile = home / 'profiles' / 'worker'
@@ -66,6 +69,9 @@ def main():
     env.update(HERMES_HOME=str(home), HOME=str(home / 'os-home'), HERMES_DASHBOARD_SESSION_TOKEN='persistence-fixture-token', HERMES_IGNORE_RULES='1', PYTHONPATH=str(args.repo), OPENAI_API_KEY='local-fixture')
     log = (args.out / 'serve.log').open('w')
     cmd = [sys.executable, '-m', 'hermes_cli.main', 'serve', '--isolated', '--port', str(args.port)]
+    if observe:
+        cmd = [sys.executable, str(Path(__file__).with_name('rebuild_observer.py')),
+               'serve', '--isolated', '--port', str(args.port)]
     proc = subprocess.Popen(cmd, cwd=args.repo, env=env, stdin=subprocess.DEVNULL, stdout=log, stderr=subprocess.STDOUT)
     transcript = []
     result = {'home': str(home), 'command': cmd, 'sha': subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=args.repo, text=True).strip()}
@@ -111,6 +117,11 @@ def main():
             result['created'] = created
             sid, key = created['session_id'], created['stored_session_id']
             turn(sid, 'PERSISTENCE_BEFORE')
+            launch_before = (home / 'config.yaml').read_bytes()
+            if observe:
+                result['ownership_before'] = rpc('probe.ownership', {'session_id': sid})
+            if args.failure:
+                (home / 'fail-rebuild').touch()
             if args.compress:
                 for i in range(12):
                     turn(sid, f'Historical note {i}: ' + ('The worker keeps the project history and decisions in its own profile. ' * 100))
@@ -119,15 +130,29 @@ def main():
                     result['generations'] = db.execute('SELECT role, content, GROUP_CONCAT(active), COUNT(*) FROM messages WHERE session_id=? GROUP BY role, content HAVING COUNT(*)>1', (key,)).fetchall()
                     result['duplicate_active_groups'] = db.execute('SELECT COUNT(*) FROM (SELECT role, content FROM messages WHERE session_id=? AND active=1 GROUP BY role, content HAVING COUNT(*)>1)', (key,)).fetchone()[0]
             if args.reset:
-                result['reset'] = rpc('tools.configure', {'session_id': sid, 'profile': 'worker', 'action': 'disable', 'names': ['terminal']})
+                try:
+                    result['reset'] = rpc('tools.configure', {'session_id': sid, 'action': 'enable', 'names': ['web']})
+                except RuntimeError as exc:
+                    if not args.failure or 'probe config read failure' not in str(exc):
+                        raise
+                    result['expected_failure'] = str(exc)
+                result['launch_config_unchanged'] = (home / 'config.yaml').read_bytes() == launch_before
+                result['worker_tools'] = yaml.safe_load((profile / 'config.yaml').read_text())['platform_toolsets']['cli']
             else:
                 (profile / 'SOUL.md').write_text('Capabilities changed for the worker.\n')
+            if observe and args.reset:
+                result['ownership_after_failure'] = rpc('probe.ownership', {'session_id': sid})
             turn(sid, 'PERSISTENCE_AFTER_REBUILD')
+            if observe and not args.reset:
+                result['ownership_after_failure'] = rpc('probe.ownership', {'session_id': sid})
             result['stores'] = {}
             for name, p in [('launch', home), ('worker', profile)]:
                 with sqlite3.connect(p / 'state.db') as db:
                     result['stores'][name] = db.execute('SELECT role, content, active FROM messages WHERE session_id=? ORDER BY id', (key,)).fetchall()
             result['wrong_profile_writes'] = any('PERSISTENCE_AFTER_REBUILD' in str(row) for row in result['stores']['launch'])
+            if observe:
+                rpc('session.close', {'session_id': sid})
+                result['ownership_after_close'] = rpc('probe.ownership', {'session_id': sid})
     finally:
         proc.terminate()
         try:
@@ -136,6 +161,7 @@ def main():
             proc.kill()
             proc.wait()
         model.shutdown()
+        model.server_close()
         log.close()
         (args.out / 'wire.json').write_text(json.dumps(transcript, indent=2))
         result['model_requests'] = requests
@@ -143,6 +169,14 @@ def main():
         print(json.dumps({k: result[k] for k in ('sha', 'home', 'wrong_profile_writes', 'duplicate_active_groups') if k in result}, indent=2))
     assert not result['wrong_profile_writes'], 'rebuild wrote the next turn to launch state.db'
     assert any('PERSISTENCE_AFTER_REBUILD' in str(row) for row in result['stores']['worker'])
+    if args.reset:
+        assert result['launch_config_unchanged'], 'tools.configure changed launch config'
+        assert 'web' in result['worker_tools'], 'tools.configure did not change worker config'
+    if observe:
+        before, after = result['ownership_before'], result['ownership_after_failure']
+        assert before['owns_db'] and after['owns_db'], 'rebuild lost reachable DB owner'
+        assert (before['agent'] == after['agent']) is args.failure, 'unexpected replacement outcome'
+        assert str(profile / 'state.db') not in result['ownership_after_close']['refs'], 'teardown leaked profile DB ref'
     if args.compress:
         assert result['compression']['status'] == 'compressed'
         assert result['generations'], 'compaction must retain archived generations'

--- a/evals/desktop_bug_campaign/persistence_live.py
+++ b/evals/desktop_bug_campaign/persistence_live.py
@@ -18,6 +18,7 @@ def main():
     parser.add_argument('--repo', type=Path, required=True)
     parser.add_argument('--out', type=Path, required=True)
     parser.add_argument('--port', type=int, default=18020)
+    parser.add_argument('--invalid-targets', action='store_true')
     parser.add_argument('--compress', action='store_true')
     parser.add_argument('--reset', action='store_true')
     parser.add_argument('--failure', action='store_true', help='inject one model-config preparation failure')
@@ -94,7 +95,7 @@ def main():
                     receipt.write(json.dumps(row) + '\n')
                 print(str(row)[:250], flush=True)
                 return row
-            def rpc(method, params):
+            def rpc(method, params, allow_error=False):
                 nonlocal counter
                 counter += 1
                 ws.send(json.dumps({'jsonrpc': '2.0', 'id': counter, 'method': method, 'params': params}))
@@ -102,6 +103,8 @@ def main():
                     row = receive()
                     if row.get('id') == counter:
                         if 'error' in row:
+                            if allow_error:
+                                return row
                             raise RuntimeError(row)
                         return row['result']
             def turn(sid, text):
@@ -137,7 +140,9 @@ def main():
                         raise
                     result['expected_failure'] = str(exc)
                 result['launch_config_unchanged'] = (home / 'config.yaml').read_bytes() == launch_before
-                result['worker_tools'] = yaml.safe_load((profile / 'config.yaml').read_text())['platform_toolsets']['cli']
+                sys.path.insert(0, str(args.repo))
+                from hermes_cli.config import read_user_config_raw
+                result['worker_tools'] = read_user_config_raw(profile / 'config.yaml')['platform_toolsets']['cli']
             else:
                 (profile / 'SOUL.md').write_text('Capabilities changed for the worker.\n')
             if observe and args.reset:
@@ -150,6 +155,16 @@ def main():
                 with sqlite3.connect(p / 'state.db') as db:
                     result['stores'][name] = db.execute('SELECT role, content, active FROM messages WHERE session_id=? ORDER BY id', (key,)).fetchall()
             result['wrong_profile_writes'] = any('PERSISTENCE_AFTER_REBUILD' in str(row) for row in result['stores']['launch'])
+            if args.invalid_targets:
+                result['target_controls'] = {str(p): rpc('session.list', {'profile': p}) for p in (None, 'default', 'worker')}
+                rpc('session.close', {'session_id': sid})
+                before = (home / 'config.yaml').read_bytes()
+                result['stale_session'] = rpc('tools.configure', {'session_id': sid, 'action': 'enable', 'names': ['terminal']}, allow_error=True)
+                profile.rename(home / 'removed-worker')
+                result['invalid_profiles'] = {name: {method: rpc(method, dict(params, profile=name), allow_error=True) for method, params in [('session.list', {}), ('config.get', {'key': 'full'}), ('config.set', {'key': 'busy', 'value': 'steer'})]} for name in ('worker', 'unknown')}
+                result['invalid_config_unchanged'] = before == (home / 'config.yaml').read_bytes()
+                result['global_tools'] = rpc('tools.configure', {'action': 'enable', 'names': ['terminal']})
+                result['global_config_changed'] = before != (home / 'config.yaml').read_bytes()
             if observe:
                 rpc('session.close', {'session_id': sid})
                 result['ownership_after_close'] = rpc('probe.ownership', {'session_id': sid})
@@ -169,6 +184,11 @@ def main():
         print(json.dumps({k: result[k] for k in ('sha', 'home', 'wrong_profile_writes', 'duplicate_active_groups') if k in result}, indent=2))
     assert not result['wrong_profile_writes'], 'rebuild wrote the next turn to launch state.db'
     assert any('PERSISTENCE_AFTER_REBUILD' in str(row) for row in result['stores']['worker'])
+    if args.invalid_targets:
+        assert 'error' in result['stale_session'], 'stale session changed launch config'
+        assert all('error' in reply for replies in result['invalid_profiles'].values() for reply in replies.values())
+        assert result['invalid_config_unchanged']
+        assert result['global_config_changed'] and not result['global_tools']['reset']
     if args.reset:
         assert result['launch_config_unchanged'], 'tools.configure changed launch config'
         assert 'web' in result['worker_tools'], 'tools.configure did not change worker config'

--- a/evals/desktop_bug_campaign/rebuild_observer.py
+++ b/evals/desktop_bug_campaign/rebuild_observer.py
@@ -1,0 +1,44 @@
+"""Probe-only serve bootstrap: observe real ownership and inject config-read failure.
+
+Not imported by production. The failure seam raises once during model-target
+preparation; agent construction, rebuild predicates, WebSocket dispatch, and
+SessionDB teardown remain real.
+"""
+import inspect
+import os
+from pathlib import Path
+
+from tui_gateway import server
+import hermes_state_registry as registry
+
+
+original_target = server._config_model_target
+marker = Path(os.environ["HERMES_HOME"]) / "fail-rebuild"
+
+
+def config_target():
+    if marker.exists() and any(frame.function in {"_reset_session_agent", "_sync_bot_capabilities"}
+                               for frame in inspect.stack()):
+        marker.unlink()
+        raise OSError("probe config read failure")
+    return original_target()
+
+
+server._config_model_target = config_target
+
+
+def ownership(rid, params):
+    session = server._sessions.get(params["session_id"])
+    agent = (session or {}).get("agent")
+    with registry._lock:
+        refs = {str(path): generation.refcount for path, generation in registry._generations.items()}
+    return server._ok(rid, {"agent": id(agent) if agent else None,
+                            "owns_db": bool(getattr(agent, "_owns_session_db", False)),
+                            "refs": refs})
+
+
+server._methods["probe.ownership"] = ownership
+
+if __name__ == "__main__":
+    from hermes_cli.main import main
+    main()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15451,6 +15451,7 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
     """session.branch must copy history into the parent's profile state.db."""
     profile_home = tmp_path / "profiles" / "mlperf"
     profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     seen: dict = {"msgs": []}
 
     class LaunchDB:
@@ -15889,6 +15890,7 @@ def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_pa
 
     profile_home = tmp_path / "profiles" / "mlperf"
     profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (profile_home / ".env").write_text(
         "PROXMOX_TOKEN=mlperf-secret\n", encoding="utf-8"
     )
@@ -15981,6 +15983,7 @@ def test_session_branch_uses_persisted_display_history_after_compaction(monkeypa
     """A live branch must copy the complete visible transcript, not the compacted model tail."""
     profile_home = tmp_path / "profiles" / "mlperf"
     profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     seen: dict = {"msgs": []}
 
     display_history = [
@@ -20663,7 +20666,7 @@ def test_prompt_submit_passes_persist_user_message_to_agent(monkeypatch):
         server._sessions.pop("sid", None)
 
 
-def test_prompt_submit_releases_old_history_before_heap_trim(monkeypatch):
+def test_prompt_submit_releases_old_history_before_heap_trim(monkeypatch, tmp_path):
     """The trim boundary must not retain the just-pruned history snapshots."""
     observed = {}
     cleanup_order = []
@@ -20702,7 +20705,10 @@ def test_prompt_submit_releases_old_history_before_heap_trim(monkeypatch):
         observed["run_kwargs"] = caller_locals.get("run_kwargs")
 
     session = _session(agent=_Agent())
-    session["profile_home"] = "/tmp/test-profile"
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    session["profile_home"] = str(profile_home)
     session["history"] = [
         {"role": "tool", "tool_call_id": "old", "content": "x" * 20_000}
     ]

--- a/tests/tui_gateway/test_profile_rebuild_commit.py
+++ b/tests/tui_gateway/test_profile_rebuild_commit.py
@@ -32,6 +32,16 @@ def test_tools_configure_uses_live_session_profile(tmp_path, monkeypatch, explic
     assert "terminal" not in yaml.safe_load((profile / "config.yaml").read_text())["platform_toolsets"]["cli"]
     assert seen == [profile]
     assert get_hermes_home() == home
+    worker_before = (profile / "config.yaml").read_bytes()
+    monkeypatch.delitem(server._sessions, "profile-tools")
+    response = server._methods["tools.configure"](2, params)
+    assert response["error"]["code"] == 4001
+    assert (home / "config.yaml").read_bytes() == launch_before
+    assert (profile / "config.yaml").read_bytes() == worker_before
+    response = server._methods["tools.configure"](3, {"action": "disable", "names": ["terminal"]})
+    assert "error" not in response and not response["result"]["reset"]
+    assert (home / "config.yaml").read_bytes() != launch_before
+    assert (profile / "config.yaml").read_bytes() == worker_before
 
 
 @pytest.mark.parametrize("path", ["reset", "capabilities"])

--- a/tests/tui_gateway/test_profile_rebuild_commit.py
+++ b/tests/tui_gateway/test_profile_rebuild_commit.py
@@ -1,0 +1,80 @@
+"""Session-only tools ingress and rebuild failure preserve profile isolation."""
+import threading
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+
+@pytest.mark.parametrize("explicit_profile", [None, "default"])
+def test_tools_configure_uses_live_session_profile(tmp_path, monkeypatch, explicit_profile):
+    from tui_gateway import server
+    from hermes_constants import get_hermes_home
+
+    home = tmp_path / ".hermes"
+    profile = home / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    config = {"platform_toolsets": {"cli": ["terminal", "web"]}}
+    for path in (home, profile):
+        (path / "config.yaml").write_text(yaml.safe_dump(config))
+    launch_before = (home / "config.yaml").read_bytes()
+    seen = []
+    monkeypatch.setattr(server, "_reset_session_agent", lambda *_: seen.append(get_hermes_home()) or {})
+    monkeypatch.setitem(server._sessions, "profile-tools", {"profile_home": str(profile)})
+    params = {"session_id": "profile-tools", "action": "disable", "names": ["terminal"]}
+    if explicit_profile is not None:
+        params["profile"] = explicit_profile
+    response = server._methods["tools.configure"](1, params)
+    assert "error" not in response
+    assert (home / "config.yaml").read_bytes() == launch_before
+    assert "terminal" not in yaml.safe_load((profile / "config.yaml").read_text())["platform_toolsets"]["cli"]
+    assert seen == [profile]
+    assert get_hermes_home() == home
+
+
+@pytest.mark.parametrize("path", ["reset", "capabilities"])
+@pytest.mark.parametrize("has_agent_db", [True, False])
+def test_rebuild_preparation_failure_keeps_reachable_owner(tmp_path, monkeypatch, path, has_agent_db):
+    from tui_gateway import server
+    from hermes_state import SessionDB
+    from hermes_constants import get_hermes_home
+
+    home = tmp_path / ".hermes"
+    profile = home / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    db = SessionDB(db_path=profile / "state.db")
+    old = SimpleNamespace(_session_db=db if has_agent_db else None,
+                          _owns_session_db=has_agent_db, _session_title_hint="Bot Chat")
+    session = {"agent": old, "profile_home": str(profile), "session_key": "profile-key",
+               "bot_caps_seen": "before", "source": "desktop", "cwd": str(tmp_path),
+               "history": [], "history_lock": threading.Lock(), "history_version": 0}
+    built = []
+    def make_agent(*_args, session_db=None, **_kwargs):
+        replacement = SimpleNamespace(_session_db=session_db, _owns_session_db=False)
+        built.append(replacement)
+        return replacement
+    def fail_config():
+        raise RuntimeError("preparation failed")
+    monkeypatch.setattr(server, "_make_agent", make_agent)
+    monkeypatch.setattr(server, "_config_model_target", fail_config)
+    monkeypatch.setattr("tools.bot_mode_probe.capability_fingerprint", lambda _: "after")
+    try:
+        if path == "reset":
+            with pytest.raises(RuntimeError, match="preparation failed"):
+                server._reset_session_agent("profile-tools", session)
+        else:
+            server._sync_bot_capabilities("profile-tools", session)
+        assert session["agent"] is old
+        assert old._owns_session_db is has_agent_db
+        assert not built, "prepare config before allocating a replacement"
+        assert get_hermes_home() == home
+        db.create_session("still-owned", "tui")
+    finally:
+        db.close()
+        for agent in built:
+            if agent._session_db is not db and agent._owns_session_db:
+                agent._session_db.close()

--- a/tests/tui_gateway/test_profile_target_unavailable.py
+++ b/tests/tui_gateway/test_profile_target_unavailable.py
@@ -1,0 +1,40 @@
+"""An unavailable explicit target must never become the launch profile."""
+from pathlib import Path
+
+import pytest
+
+
+def test_explicit_profile_target_never_falls_back(tmp_path, monkeypatch):
+    from tui_gateway import server
+    from hermes_state import SessionDB
+
+    home = tmp_path / ".hermes"
+    worker = home / "profiles" / "worker"
+    worker.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(server, "_hermes_home", home)
+    for path, marker in ((home, "launch"), (worker, "worker")):
+        (path / "config.yaml").write_text(f"terminal:\n  cwd: /{marker}\n")
+        with SessionDB(db_path=path / "state.db") as db:
+            db.create_session(marker, "tui")
+    for name, marker in ((None, "launch"), ("default", "launch"), ("DEFAULT", "launch"), ("worker", "worker")):
+        with server._profile_db({"profile": name}) as db:
+            assert db.get_session(marker)
+        response = server._methods["config.get"](1, {"profile": name, "key": "full"})
+        assert response["result"]["config"]["terminal"]["cwd"] == f"/{marker}"
+    before = (home / "config.yaml").read_bytes()
+    worker.rename(worker.with_name("gone"))
+    for name in ("worker", "unknown"):
+        with pytest.raises(FileNotFoundError):
+            with server._profile_db({"profile": name}):
+                pytest.fail("unavailable profile reached a database")
+        with pytest.raises(FileNotFoundError):
+            server._methods["config.set"](2, {"profile": name, "key": "busy", "value": "steer"})
+        assert (home / "config.yaml").read_bytes() == before
+    # A real resolution I/O failure must propagate, too (no predicate patch).
+    profiles = home / "profiles"
+    profiles.rename(home / "saved-profiles")
+    profiles.symlink_to("profiles")
+    with pytest.raises((OSError, RuntimeError)):
+        server._profile_home("worker")

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -858,7 +858,7 @@ def test_record_repos_writes_to_the_requested_profiles_projects_db(monkeypatch, 
 
 
 def test_projects_without_a_profile_stay_on_the_launch_home(monkeypatch, tmp_path):
-    """Omitted/blank/unknown profile is a no-op — the pre-scoping behavior."""
+    """Only omitted/blank profiles use launch data; unknown targets fail closed."""
     launch_home = _profile_dir(tmp_path, "launch")
     coder_home = _profile_dir(tmp_path, "coder")
     repo = tmp_path / "repos" / "launch-only"
@@ -873,11 +873,14 @@ def test_projects_without_a_profile_stay_on_the_launch_home(monkeypatch, tmp_pat
 
         omitted = _call("projects.list")
         blank = _call("projects.list", {"profile": ""})
-        unknown = _call("projects.list", {"profile": "not-a-profile"})
+        with pytest.raises(FileNotFoundError, match="not-a-profile"):
+            _call("projects.list", {"profile": "not-a-profile"})
+        with pytest.raises(FileNotFoundError, match="not-a-profile"):
+            _call("projects.create", {"profile": "not-a-profile", "name": "Wrong target"})
+        assert _call("projects.list") == omitted
 
     assert [p["name"] for p in omitted["projects"]] == ["Launch only"]
     assert blank == omitted
-    assert unknown == omitted
     assert omitted["active_id"] == created["id"]
 
     assert _cached_repo_labels(launch_home) == ["only"]

--- a/tui_gateway/agent_callbacks.py
+++ b/tui_gateway/agent_callbacks.py
@@ -358,7 +358,7 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
 
 
 def _rebuild_session_agent(sid: str, session: dict, **kwargs):
-    """Rebuild on the session's profile, transferring its DB ownership without acquiring a second ref.
+    """Prepare and install a replacement on the session's profile, then transfer DB ownership.
 
     An unscoped _make_agent defaults to the launch store: named-profile Bot Chat turns then disappear
     from the profile's replay even though they were successfully written to another database (#104079).
@@ -371,6 +371,8 @@ def _rebuild_session_agent(sid: str, session: dict, **kwargs):
     opened = session_db is None and bool(profile_home)
     scopes = _bind_build_profile_scopes(profile_home) if profile_home else None
     try:
+        # Resolve fallible config before allocating a replacement or moving its handle.
+        config_model_seen = _config_model_target()
         if opened:
             session_db = _open_profile_session_db(profile_home)
         agent = _make_agent(sid, session["session_key"], session_db=session_db, **kwargs)
@@ -384,17 +386,24 @@ def _rebuild_session_agent(sid: str, session: dict, **kwargs):
             _release_build_profile_scopes(scopes)
     # Only a DEDICATED handle carries ownership; the shared launch handle outlives every agent and
     # _transfer_db_to_agent refuses it.
-    owned = opened or bool(getattr(old_agent, "_owns_session_db", False))
-    if owned and _transfer_db_to_agent(agent, session_db):
-        if old_agent is not None:
-            old_agent._owns_session_db = False
-    elif opened:
-        with contextlib.suppress(Exception):
-            session_db.close()
+    with _sessions_lock:
+        session.update(agent=agent, config_model_seen=config_model_seen)
+        owned = opened or bool(getattr(old_agent, "_owns_session_db", False))
+        if owned and _transfer_db_to_agent(agent, session_db):
+            if old_agent is not None:
+                old_agent._owns_session_db = False
+        elif opened:
+            with contextlib.suppress(Exception):
+                session_db.close()
     return agent
 
 
 def _reset_session_agent(sid: str, session: dict) -> dict:
+    updates = dict(
+        attached_images=[], queued_prompt=None,
+        _queued_prompt_generation=int(session.get("_queued_prompt_generation", 0)) + 1,
+        edit_snapshots={}, image_counter=0, running=False, show_reasoning=_load_show_reasoning(),
+        tool_progress_mode=_load_tool_progress_mode(), tool_started_at={})
     tokens = _set_session_context(session["session_key"])
     try:
         # /new is a full conversation boundary: session-scoped runtime overrides (/model,
@@ -408,12 +417,7 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
             context_cwd_is_launch_artifact=_context_cwd_is_launch_artifact(session))
     finally:
         _clear_session_context(tokens)
-    session.update(
-        agent=new_agent, config_model_seen=_config_model_target(), attached_images=[],
-        queued_prompt=None,
-        _queued_prompt_generation=int(session.get("_queued_prompt_generation", 0)) + 1,
-        edit_snapshots={}, image_counter=0, running=False, show_reasoning=_load_show_reasoning(),
-        tool_progress_mode=_load_tool_progress_mode(), tool_started_at={})
+    session.update(updates)
     session.pop("queued_prompts", None)
     with session["history_lock"]:
         session["history"] = []

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -985,7 +985,11 @@ def _(rid, params: dict) -> dict:
 @_rpc("tools.configure", 5035)
 def _(rid, params: dict) -> dict:
     sid = params.get("session_id", "")
-    session = _sessions.get(sid)
+    session = None
+    if sid:
+        session, err = _sess_nowait(params, rid)
+        if err:
+            return err
     # The client sends session_id, not profile; the live session is authoritative.
     home = (session or {}).get("profile_home")
     scopes = _bind_build_profile_scopes(home) if home else None

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -984,6 +984,19 @@ def _(rid, params: dict) -> dict:
 
 @_rpc("tools.configure", 5035)
 def _(rid, params: dict) -> dict:
+    sid = params.get("session_id", "")
+    session = _sessions.get(sid)
+    # The client sends session_id, not profile; the live session is authoritative.
+    home = (session or {}).get("profile_home")
+    scopes = _bind_build_profile_scopes(home) if home else None
+    try:
+        return _configure_session_tools(rid, params, sid, session)
+    finally:
+        if scopes is not None:
+            _release_build_profile_scopes(scopes)
+
+
+def _configure_session_tools(rid, params: dict, sid: str, session) -> dict:
     action = str(params.get("action", "") or "").strip().lower()
     targets = [str(name).strip() for name in params.get("names", []) or [] if str(name).strip()]
     if action not in {"disable", "enable"}:
@@ -1000,8 +1013,6 @@ def _(rid, params: dict) -> dict:
         tc._apply_toolset_change(cfg, "cli", toolset_targets, action)
     missing_servers = tc._apply_mcp_change(cfg, mcp_targets, action) if mcp_targets else set()
     hc.save_config(cfg)
-    sid = params.get("session_id", "")
-    session = _sessions.get(sid)
     info = _reset_session_agent(sid, session) if session else None
     enabled = sorted(tc._get_platform_tools(hc.load_config(), "cli", include_default_mcp_servers=False))
     changed = [

--- a/tui_gateway/model_switch.py
+++ b/tui_gateway/model_switch.py
@@ -280,7 +280,6 @@ def _sync_bot_capabilities(sid: str, session: dict) -> None:
         finally:
             _clear_session_context(tokens)
         new_agent._session_title_hint = "Bot Chat"
-        session.update(agent=new_agent, config_model_seen=_config_model_target())
         _emit("notice", sid, {"message": "Capabilities updated — this bot's tools and prompt were refreshed."})
     except Exception as e:
         logger.warning("Bot capability sync failed for %s: %s", sid, e)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -460,13 +460,12 @@ def _profile_home(profile: str | None) -> Path | None:
     """Resolve a named profile's home on THIS host, or None for the launch profile."""
     if not (name := (profile or "").strip()):
         return None
-    try:
-        from hermes_cli import profiles as profiles_mod
-        home = Path(profiles_mod.get_profile_dir(name))
-    except Exception:
-        return None
-    if home.resolve() == Path(_hermes_home).resolve() or not home.exists():
-        return None  # already the launch profile (no override needed), or no such profile
+    from hermes_cli import profiles as profiles_mod
+    home = Path(profiles_mod.get_profile_dir(name))
+    if not home.is_dir():
+        raise FileNotFoundError(f"Profile '{name}' does not exist.")
+    if home.resolve() == Path(_hermes_home).resolve():
+        return None  # already the launch profile (no override needed)
     _served_profile_homes.add(home)  # the change watcher must stat every served sibling store too
     return home
 

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -17,6 +17,10 @@ Releasing the outgoing agent must not close the handle inherited by its replacem
 even when the client supplies only `session_id`. Rebuilds prepare model configuration
 before allocating a replacement, then install the agent and transfer ownership
 together; preparation failure leaves the existing agent responsible for teardown.
+Explicit profiles that cannot be resolved or whose directory has disappeared fail
+before accessing launch configuration or history. A stale `tools.configure`
+session ID likewise returns `session not found` without changing configuration;
+omitting the session ID still supports the global settings operation.
 
 In-place compaction archives old rows with `active=0` and inserts the retained
 context as `active=1` rows. A protected message can therefore legitimately appear

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -13,6 +13,10 @@ including when one `hermes serve` process serves several profiles. In-session
 agent rebuilds (Bot Chat capability refresh and `tools.configure`) must retain
 that session's database handle and bind its profile home during construction.
 Releasing the outgoing agent must not close the handle inherited by its replacement.
+`tools.configure` resolves configuration from the live session's `profile_home`,
+even when the client supplies only `session_id`. Rebuilds prepare model configuration
+before allocating a replacement, then install the agent and transfer ownership
+together; preparation failure leaves the existing agent responsible for teardown.
 
 In-place compaction archives old rows with `active=0` and inserts the retained
 context as `active=1` rows. A protected message can therefore legitimately appear


### PR DESCRIPTION
Tool changes and rebuild failures now stay attached to the live Desktop session's profile and reachable database owner.

**Stacked follow-up to #104842**, based on its exact head `194074d75528326843f07bceb0bc88f7cffc9c34`; base branch is `fix/desktop-profile-rebuild-store`, not `main`. The original branch and its existing scoped validation receipt are unchanged.

- Scope `tools.configure` config load/save, reset, and response readback from the live session's `profile_home`; the real client sends `session_id` without `profile`.
- Prepare model configuration before constructing a replacement. Install the replacement and transfer dedicated DB ownership together under the session registry lock; both reset and capability refresh use that path.
- Add rebuild invariants and extend target-isolation regression coverage, extend the reusable serve/WebSocket probe with session-only ingress plus failure/ownership controls, and document the contract.

Root cause: the previous fix scoped reconstruction but not the configuration write, and transferred ownership before fallible model-target preparation and session installation.

## Live repro

Actual isolated `hermes serve`, WebSocket dispatch, real AIAgent construction and SQLite with a credential-free loopback model. Failure arms inject one model-config read error through a probe-only bootstrap; rebuild predicates, construction and teardown remain production code.

| Scenario | Base #104842 | Follow-up `cba2b4dfe66172af253fd92e293aebccc0f6c011` |
| --- | --- | --- |
| Session-ID-only tool enable | Launch config changed; worker unchanged | Launch byte-identical; worker tool enabled |
| Failed tools reset | Same old agent, ownership false; profile ref leaked after close | Same old agent remains owner; close releases profile ref |
| Failed capability refresh | Same old agent, ownership false; profile ref leaked after close | Same old agent remains owner; close releases profile ref |
| Successful reset and refresh controls | Existing persistence fix retained | New agent owns DB; profile ref released on close |

Each final live arm persisted four rows in the worker store and zero in the launch store. Four final controls/failure arms passed on the committed head. All probe listener ports were closed afterward. Probe commands use `evals/desktop_bug_campaign/persistence_live.py --repo <checkout> --out <receipt-dir>`, with `--observe` / `--failure` and optional `--reset`.

## Validation

- RED on base: six new parameterized cases failed for wrong-profile writes or ownership loss/allocation before preparation.
- GREEN: four focused files, 41 passed / 0 failed; two sibling files, 672 passed / 0 failed. Both runs used the campaign `flock` and `scripts/run_tests.sh -j 1`.
- Initial independent review was superseded by parent review identifying two additional fail-open gaps; the correction received independent read-only review with no P1/P2 findings.
- Ruff, Windows-footgun scan, compatibility-pointer check, subprocess-stdin check and `git diff --check` passed.
- Parent owns the broad combined integration harness and CI monitoring. Native Electron, Windows, multi-hour automatic compression and concurrent close-during-build stress are not claimed. Intentional archive generations remain untouched.

Addresses the independent-review findings for #104079. Prior substantive work remains in #104842 with @HexLab98 (#104143) and @liuhao1024 (#101740) credited there; this PR is only the corrective delta. No issue closure or merge is requested automatically.

Campaign: https://github.com/NousResearch/hermes-agent/issues/104904.

## Infographic

![Profile-safe rebuilds](https://v3b.fal.media/files/b/0aa9741e/gD_fb8VUm16W_OI9FIfBC_k8SeUSTn.png)

## Final-review corrections

- Missing, disappeared, non-directory, or failed explicit profile resolution no longer falls back to launch history/configuration. Existing omitted/default/launch resolution is preserved.
- A stale nonempty `tools.configure` session ID returns existing error 4001 before config read/write; genuinely sessionless global settings remain supported.
- Actual CI run 34108999632 had one root failure: `test_config_read_guard` rejected raw config YAML readback in the live eval. It now uses `read_user_config_raw(explicit_path)`; no allowlist relaxation. Aggregate failure was downstream only.
- Live WebSocket A/B on prior head: stale session wrote launch config and all six missing-profile list/get/set calls succeeded. Fixed: stale session rejected, all six calls rejected, launch config byte-identical; real worker reset/history and global configuration controls succeed. No changed predicate is patched.
- Four old full-file fixtures needed real temporary profile-root binding after fail-closed resolution; assertions remain intact.
- Final serial recheck: **6 files, 665 passed / 0 failed**. The committed-head live replay passed at `50aa1ba618c50ee14f664aff17c9ddf5de398555` (4 worker message rows, 0 launch rows; all 6 unavailable-profile requests rejected). Raw wire receipts and SHA-256 evidence are recorded in the campaign final results. Parent accepted the exact-head source, independent review and live evidence. CI on the new push and broad combined coverage are separate; no CI-green or merge claim.
