### PR TITLE
fix(desktop-update): remove owned temporary browser profiles on exit (#104350)

### DIFF
--- a/contributors/emails/rohithpariki@gmail.com
+++ b/contributors/emails/rohithpariki@gmail.com
@@ -1,0 +1,2 @@
+RohithPariki
+# Issue #104350: preserved updater-fix author

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -246,6 +246,7 @@ start_ui() {
   { [ -f "$html" ] && [ -n "$py" ] && [ -n "$browser" ]; } || { log "shim: no renderer; skipping UI"; return; }
 
   UI_PROFILE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/hermes-update-ui-XXXXXXXX")" || {
+    UI_PROFILE_DIR=""
     log "shim: could not allocate a browser profile; skipping UI"
     return
   }

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -72,7 +72,7 @@ RESULT="$HERMES_HOME/.hermes-update-result.json"
 STATUS="${TMPDIR:-/tmp}/hermes-update-status.$$"
 STARTED_AT="$(date +%s)"  # the shim's elapsed clock; see serve-ui.py
 
-UI_SERVER_PID="" UI_BROWSER_PID="" FINAL_CODE=1
+UI_SERVER_PID="" UI_BROWSER_PID="" UI_PROFILE_DIR="" FINAL_CODE=1
 FINAL_MSG="update did not complete"
 DONE_NOTE=""  # set when the update succeeded but the app will NOT reopen itself
 
@@ -267,8 +267,9 @@ start_ui() {
   [ -n "$port" ] || { kill -9 "$UI_SERVER_PID" 2>/dev/null; UI_SERVER_PID=""; return; }
 
   # Throwaway profile: new window/process we own; user's browser untouched.
+  UI_PROFILE_DIR="${TMPDIR:-/tmp}/hermes-update-ui-$$"
   "$py" -c 'import os, signal, sys; os.setsid(); signal.signal(signal.SIGTERM, signal.SIG_DFL); os.execv(sys.argv[1], sys.argv[1:])' \
-    "$browser" --app="http://127.0.0.1:$port/" --user-data-dir="${TMPDIR:-/tmp}/hermes-update-ui-$$" \
+    "$browser" --app="http://127.0.0.1:$port/" --user-data-dir="$UI_PROFILE_DIR" \
     --no-first-run --no-default-browser-check --window-size=280,320 >/dev/null 2>&1 &
   UI_BROWSER_PID=$!
   log "shim: app window on 127.0.0.1:$port"
@@ -290,7 +291,10 @@ stop_ui() { # error/manual outcomes keep the window up briefly so a watching
   if [ -n "$UI_BROWSER_PID" ]; then
     { kill "$UI_BROWSER_PID" && wait "$UI_BROWSER_PID"; } 2>/dev/null
   fi
-  rm -rf "${TMPDIR:-/tmp}/hermes-update-ui-$$" 2>/dev/null || true
+  if [ -n "$UI_PROFILE_DIR" ]; then
+    rm -rf "$UI_PROFILE_DIR" 2>/dev/null || true
+    UI_PROFILE_DIR=""
+  fi
   UI_SERVER_PID="" UI_BROWSER_PID=""
 }
 

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -245,6 +245,10 @@ start_ui() {
   fi
   { [ -f "$html" ] && [ -n "$py" ] && [ -n "$browser" ]; } || { log "shim: no renderer; skipping UI"; return; }
 
+  UI_PROFILE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/hermes-update-ui-XXXXXXXX")" || {
+    log "shim: could not allocate a browser profile; skipping UI"
+    return
+  }
   publish_stage ""
   # The Desktop's final teardown targets the updater process group.  Put both
   # UI processes in their own sessions so neither the HTTP server nor a Chrome
@@ -267,7 +271,6 @@ start_ui() {
   [ -n "$port" ] || { kill -9 "$UI_SERVER_PID" 2>/dev/null; UI_SERVER_PID=""; return; }
 
   # Throwaway profile: new window/process we own; user's browser untouched.
-  UI_PROFILE_DIR="${TMPDIR:-/tmp}/hermes-update-ui-$$"
   "$py" -c 'import os, signal, sys; os.setsid(); signal.signal(signal.SIGTERM, signal.SIG_DFL); os.execv(sys.argv[1], sys.argv[1:])' \
     "$browser" --app="http://127.0.0.1:$port/" --user-data-dir="$UI_PROFILE_DIR" \
     --no-first-run --no-default-browser-check --window-size=280,320 >/dev/null 2>&1 &

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -290,6 +290,7 @@ stop_ui() { # error/manual outcomes keep the window up briefly so a watching
   if [ -n "$UI_BROWSER_PID" ]; then
     { kill "$UI_BROWSER_PID" && wait "$UI_BROWSER_PID"; } 2>/dev/null
   fi
+  rm -rf "${TMPDIR:-/tmp}/hermes-update-ui-$$" 2>/dev/null || true
   UI_SERVER_PID="" UI_BROWSER_PID=""
 }
 

--- a/tests/test_desktop_update_shim_profile_cleanup.py
+++ b/tests/test_desktop_update_shim_profile_cleanup.py
@@ -35,7 +35,7 @@ def test_shim_removes_owned_profile_on_exit(tmp_path, failed):
     env = {**os.environ, "HOME": str(tmp_path), "HERMES_HOME": str(tmp_path),
            "XDG_CONFIG_HOME": str(config), "TMPDIR": str(tmp_path),
            "PATH": f"{bin_dir}:/usr/bin:/bin", "HERMES_SELFTEST_HOLD_SECONDS": "1",
-           "HERMES_UPDATE_SHIM_GRACE_SECONDS": "1", "HERMES_SELFTEST_FAIL": "1" if failed else "0"}
+           "HERMES_UPDATE_SHIM_GRACE_SECONDS": "1", "HERMES_SELFTEST_FAIL": "1" if failed else ""}
     result = subprocess.run(
         ["bash", str(Path(__file__).resolve().parents[1] / "scripts/desktop-update/posix.sh"),
          "--install-root", str(install), "--self-test-ui"],

--- a/tests/test_desktop_update_shim_profile_cleanup.py
+++ b/tests/test_desktop_update_shim_profile_cleanup.py
@@ -1,0 +1,47 @@
+"""The update hand-off cleans only the browser profile it launched."""
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("failed", [False, True])
+def test_shim_removes_owned_profile_on_exit(tmp_path, failed):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    browser = bin_dir / "google-chrome"
+    browser.write_text(
+        '#!/bin/bash\ntrap "exit 0" TERM\n'
+        'for arg in "$@"; do\n'
+        'case "$arg" in --user-data-dir=*) dir="${arg#--user-data-dir=}" ;; esac\n'
+        'done\nmkdir -p "$dir"\nprintf "%s" "$dir" > "$HOME/launched-profile"\n'
+        'while :; do sleep 0.1; done\n', encoding="utf-8",
+    )
+    browser.chmod(0o755)
+    config = tmp_path / ".config"
+    config.mkdir()
+    (config / "mimeapps.list").write_text(
+        '[Default Applications]\nx-scheme-handler/http=google-chrome.desktop\n'
+        'x-scheme-handler/https=google-chrome.desktop\ntext/html=google-chrome.desktop\n',
+        encoding="utf-8",
+    )
+    sibling = tmp_path / "hermes-update-ui-unrelated"
+    sibling.mkdir()
+    (sibling / "keep").write_text("keep", encoding="utf-8")
+    install = tmp_path / "hermes-agent"
+    install.mkdir()
+    env = {**os.environ, "HOME": str(tmp_path), "HERMES_HOME": str(tmp_path),
+           "XDG_CONFIG_HOME": str(config), "TMPDIR": str(tmp_path),
+           "PATH": f"{bin_dir}:/usr/bin:/bin", "HERMES_SELFTEST_HOLD_SECONDS": "1",
+           "HERMES_UPDATE_SHIM_GRACE_SECONDS": "1", "HERMES_SELFTEST_FAIL": "1" if failed else "0"}
+    result = subprocess.run(
+        ["bash", str(Path(__file__).resolve().parents[1] / "scripts/desktop-update/posix.sh"),
+         "--install-root", str(install), "--self-test-ui"],
+        env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == (1 if failed else 0), result.stdout + result.stderr
+    owned = Path((tmp_path / "launched-profile").read_text(encoding="utf-8"))
+    assert not owned.exists()
+    assert (sibling / "keep").read_text(encoding="utf-8") == "keep"

--- a/tests/test_desktop_update_shim_profile_cleanup.py
+++ b/tests/test_desktop_update_shim_profile_cleanup.py
@@ -1,4 +1,4 @@
-"""The update hand-off cleans only the browser profile it launched."""
+"""The update hand-off cleans only an atomically claimed browser profile."""
 import os
 from pathlib import Path
 import subprocess
@@ -7,8 +7,8 @@ import pytest
 
 
 @pytest.mark.linux_only
-@pytest.mark.parametrize("failed", [False, True])
-def test_shim_removes_owned_profile_on_exit(tmp_path, failed):
+@pytest.mark.parametrize("outcome", ["success", "error", "allocation-failed"])
+def test_shim_removes_only_its_owned_profile(tmp_path, outcome):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     browser = bin_dir / "google-chrome"
@@ -20,6 +20,10 @@ def test_shim_removes_owned_profile_on_exit(tmp_path, failed):
         'while :; do sleep 0.1; done\n', encoding="utf-8",
     )
     browser.chmod(0o755)
+    if outcome == "allocation-failed":
+        allocator = bin_dir / "mktemp"
+        allocator.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        allocator.chmod(0o755)
     config = tmp_path / ".config"
     config.mkdir()
     (config / "mimeapps.list").write_text(
@@ -27,21 +31,29 @@ def test_shim_removes_owned_profile_on_exit(tmp_path, failed):
         'x-scheme-handler/https=google-chrome.desktop\ntext/html=google-chrome.desktop\n',
         encoding="utf-8",
     )
-    sibling = tmp_path / "hermes-update-ui-unrelated"
-    sibling.mkdir()
-    (sibling / "keep").write_text("keep", encoding="utf-8")
     install = tmp_path / "hermes-agent"
     install.mkdir()
     env = {**os.environ, "HOME": str(tmp_path), "HERMES_HOME": str(tmp_path),
            "XDG_CONFIG_HOME": str(config), "TMPDIR": str(tmp_path),
            "PATH": f"{bin_dir}:/usr/bin:/bin", "HERMES_SELFTEST_HOLD_SECONDS": "1",
-           "HERMES_UPDATE_SHIM_GRACE_SECONDS": "1", "HERMES_SELFTEST_FAIL": "1" if failed else ""}
-    result = subprocess.run(
-        ["bash", str(Path(__file__).resolve().parents[1] / "scripts/desktop-update/posix.sh"),
+           "HERMES_UPDATE_SHIM_GRACE_SECONDS": "1", "HERMES_SELFTEST_FAIL": "1" if outcome == "error" else ""}
+    process = subprocess.Popen(
+        ["bash", "-c", 'while [ ! -f "$HOME/start" ]; do sleep .05; done; exec bash "$@"', "probe",
+         str(Path(__file__).resolve().parents[1] / "scripts/desktop-update/posix.sh"),
          "--install-root", str(install), "--self-test-ui"],
-        env=env, capture_output=True, text=True, timeout=30,
+        env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
     )
-    assert result.returncode == (1 if failed else 0), result.stdout + result.stderr
-    owned = Path((tmp_path / "launched-profile").read_text(encoding="utf-8"))
-    assert not owned.exists()
-    assert (sibling / "keep").read_text(encoding="utf-8") == "keep"
+    collision = tmp_path / f"hermes-update-ui-{process.pid}"
+    collision.mkdir()
+    (collision / "keep").write_text("keep", encoding="utf-8")
+    (tmp_path / "start").touch()
+    stdout, stderr = process.communicate(timeout=30)
+    assert process.returncode == (1 if outcome == "error" else 0), stdout + stderr
+    launched = tmp_path / "launched-profile"
+    if outcome == "allocation-failed":
+        assert not launched.exists()
+    else:
+        owned = Path(launched.read_text(encoding="utf-8"))
+        assert owned != collision
+        assert not owned.exists()
+    assert (collision / "keep").read_text(encoding="utf-8") == "keep"

--- a/tests/test_desktop_update_shim_profile_cleanup.py
+++ b/tests/test_desktop_update_shim_profile_cleanup.py
@@ -22,7 +22,7 @@ def test_shim_removes_only_its_owned_profile(tmp_path, outcome):
     browser.chmod(0o755)
     if outcome == "allocation-failed":
         allocator = bin_dir / "mktemp"
-        allocator.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        allocator.write_text('#!/bin/sh\nprintf "%s\\n" "$HOME"\nexit 1\n', encoding="utf-8")
         allocator.chmod(0o755)
     config = tmp_path / ".config"
     config.mkdir()


### PR DESCRIPTION
Desktop updates now remove the shim's own temporary browser profile instead of leaving it behind after each update.

Fixes #104350
Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104904

## Changes

- Allocate the optional progress window's profile atomically with `mktemp -d`, capture that exact path, and remove it after the existing browser termination/wait sequence.
- Preserve pre-existing PID-named directories and unrelated browser state; never infer ownership from a predictable path.
- Skip the optional UI if allocation fails, explicitly discarding stdout from a failed allocator so it cannot become a cleanup target. The update path continues unchanged.
- Add one parametrized invariant test covering success, error, and allocation failure with misleading stdout.

**Root cause:** `stop_ui` stopped the browser but never removed its throwaway profile, while the old predictable path did not establish directory ownership.

## Validation

**Live repro:** The production `posix.sh --self-test-ui`, real headless browser, real loopback HTTP server, and isolated HOME/HERMES_HOME/TMPDIR reproduced retained profiles on current `origin/main` (`22c5684b983eac6a81ee015ae80296c4b3dbf5bb`); the identical probe at `b415de3e3c80bbd0c192245c410578283f928b78` removed the owned profile on both success and error while preserving the pre-existing PID path.

| Scenario | Before | After |
| --- | --- | --- |
| Successful shim exit | Real browser profile retained | Owned profile removed; unrelated sentinel preserved |
| Error exit with UI grace | Real browser profile retained | Owned profile removed; unrelated sentinel preserved |
| Pre-existing PID-path collision | Browser reused the existing directory | Separate atomically allocated profile; existing directory preserved |
| Allocator fails while printing HOME | Pre-followup implementation deleted the unrelated sentinel | UI not launched; unrelated sentinel preserved; exit status remains 0 |
| Targeted canonical tests | — | **19 passed, 0 failed**, 3 files, serial `-j 1` under the campaign flock |

Test command: `flock /tmp/hermes-e461-fix-tests.lock env HERMES_PYTHON=/home/teknium/.hermes/hermes-agent/.venv/bin/python bash scripts/run_tests.sh -j 1 tests/test_desktop_update_shim_profile_cleanup.py tests/test_desktop_update_shim_progress.py tests/test_desktop_update_tcc_heal.py`.

Ruff, Bash syntax, Windows-footgun, compatibility-pointer, subprocess-stdin, and whitespace gates passed. Independent read-only review of the exact head found no blocking security or logic issues.

**Limits:** Native execution was on Linux, not macOS. The self-test exercises production shim/UI startup and teardown, not a real update or the full desktop application. No personal browser profile was used. Historical leftovers are not swept; the reported average disk usage was not re-measured. Broader campaign integration and CI remain separate gates.

## Credits

Cherry-picked the original fix from @RohithPariki in #104355, preserving authorship. Captured-path cleanup and the regression-test approach were adapted from @liuhao1024 in #104362; atomic allocation and failed-output handling complete the ownership boundary. Both source PRs are left open for maintainer reconciliation.

## Infographic

![Desktop update shim removes its temporary browser profile on exit](https://files.catbox.moe/6enip4.png)
