### PR TITLE
fix: Kanban retains completed graphs and parent tenants (#104215)

### DIFF
--- a/cron/AGENTS.md
+++ b/cron/AGENTS.md
@@ -33,7 +33,7 @@ Durable SQLite-backed board letting multiple profiles/workers collaborate. Users
 zero outside a kanban task (footprint ladder rung 3).
 
 - **CLI:** `hermes_cli/kanban.py` facade + 14 `kanban_*.py` siblings (`boards`, `db`, `db_connect`,
-  `db_dispatch`, `db_notify`, `workspace`, ...). Verbs: `init, create, list (ls), show, assign, link,
+  `db_dispatch`, `db_notify`, `db_graph` (task initialization and decomposition), `workspace`, ...). Verbs: `init, create, list (ls), show, assign, link,
   unlink, comment, attach, attachments, attach-rm, complete, request-review, request-changes,
   reopen-review, block, unblock, archive, tail`, plus `watch, stats, runs, log, assignees, heartbeat,
   notify-*, dispatch, daemon, gc`. Argparse alias dispatch must accept both `list` and `ls` (root).

--- a/evals/kanban_graph_identity.py
+++ b/evals/kanban_graph_identity.py
@@ -1,0 +1,86 @@
+"""Credential-free SQLite integration probe; run with --repo PATH."""
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import importlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--child", action="store_true")
+    args = parser.parse_args()
+    if not args.child:
+        with tempfile.TemporaryDirectory(prefix="kanban-identity-") as home:
+            env = {"HOME": home, "HERMES_HOME": home + "/hermes", "PATH": os.defpath,
+                   "LANG": "C.UTF-8", "TZ": "UTC", "PYTHONDONTWRITEBYTECODE": "1"}
+            return subprocess.run(
+                [sys.executable, str(Path(__file__).resolve()), "--repo", str(args.repo), "--child"],
+                cwd=args.repo, env=env, check=False,
+            ).returncode
+    sys.path.insert(0, str(args.repo))
+    from hermes_cli import kanban_db as kb, kanban_db_connect as kbc
+    from hermes_cli.kanban_db_dispatch import dispatch_once
+    from tools.kanban_tools import _handle_create
+    from hermes_cli.kanban_decompose import _apply_fanout, _Routing
+    graph = importlib.import_module("hermes_cli.kanban_db_graph") if (args.repo / "hermes_cli/kanban_db_graph.py").exists() else kb
+    decompose = graph.decompose_triage_task
+    specs = [{"title": "work", "assignee": "default"}]
+    with kbc.connect_closing() as conn:
+        parent = kb.create_task(conn, title="prerequisite", tenant="business-a")
+        root = kb.create_task(conn, title="root", triage=True, tenant="business-a", parents=[parent])
+        downstream = kb.create_task(conn, title="downstream", parents=[root], tenant="business-a")
+        child = kb.create_task(conn, title="manual child", parents=[parent])
+        tool = json.loads(_handle_create({"title": "tool child", "assignee": "default", "parents": [parent]}))
+        assert tool["ok"]
+        out = {"db_tenant": kb.get_task(conn, child).tenant,
+               "tool_tenant": kb.get_task(conn, tool["task_id"]).tenant}
+        first = decompose(conn, root, root_assignee="default", children=specs)
+        assert first and kb.get_task(conn, first[0]).tenant == "business-a"
+        assert conn.execute("SELECT 1 FROM task_links WHERE parent_id=? AND child_id=?", (parent, root)).fetchone()
+        assert conn.execute("SELECT 1 FROM task_links WHERE parent_id=? AND child_id=?", (root, downstream)).fetchone()
+        out["legitimate_prelinked_first_fanout"] = True
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='triage' WHERE id=?", (root,))
+        out["repeat_refused"] = decompose(conn, root, root_assignee="default", children=specs) is None
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='done' WHERE id=?", (root,))
+            conn.execute("UPDATE task_events SET created_at=0 WHERE task_id=?", (root,))
+        kb.gc_events(conn, older_than_seconds=1)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='triage' WHERE id=?", (root,))
+        out["retention_repeat_refused"] = decompose(conn, root, root_assignee="default", children=specs) is None
+        ids = list(conn.execute("SELECT id FROM tasks ORDER BY id"))
+        for _ in range(3):
+            dispatch_once(conn, max_spawn=0)
+        out["three_dispatch_ticks_stable"] = ids == list(conn.execute("SELECT id FROM tasks ORDER BY id"))
+        ingress_root = kb.create_task(conn, title="ingress", tenant="business-a", triage=True)
+        routing = _Routing("default", "default", True, [], {"default"})
+        assert _apply_fanout(ingress_root, {"tasks": specs}, routing, "probe").ok
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='triage' WHERE id=?", (ingress_root,))
+        out["fanout_ingress_repeat_refused"] = not _apply_fanout(ingress_root, {"tasks": specs}, routing, "probe").ok
+        race_root = kb.create_task(conn, title="race", tenant="business-a", triage=True)
+    barrier = threading.Barrier(2)
+    def race():
+        with kbc.connect_closing() as conn:
+            barrier.wait(timeout=10)
+            return decompose(conn, race_root, root_assignee="default", children=specs)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = list(pool.map(lambda _: race(), range(2)))
+    out["concurrent_winners"] = sum(value is not None for value in outcomes)
+    with kbc.connect_closing() as conn:
+        out["integrity"] = conn.execute("PRAGMA integrity_check").fetchone()[0]
+    assert out["three_dispatch_ticks_stable"] and out["concurrent_winners"] == 1 and out["integrity"] == "ok"
+    print(json.dumps(out, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1242,7 +1242,7 @@ def create_task(
     ``project_source_task_id``: cross-profile fallback when ``project_id`` is not
     in the active profile's projects.db — see ``_resolve_project_link``.
     """
-    from hermes_cli.kanban_db_graph import _initial_task_status
+    from hermes_cli.kanban_db_graph import initial_task_state
     from hermes_cli.kanban_pr_acceptance import validate_contract
 
     completion_contract = validate_contract(completion_contract)
@@ -1304,7 +1304,7 @@ def create_task(
             # allow_nested: graph builders compose create_task under one outer
             # commit so the dispatcher never sees a half-built graph.
             with write_txn(conn, allow_nested=True):
-                task_status = _initial_task_status(conn, parents, initial_status, triage)
+                task_status, tenant = initial_task_state(conn, parents, initial_status, triage, tenant)
                 # Project worktree: fresh dir under the repo + deterministic
                 # branch, instead of the random ``wt/<id>`` worker fallback.
                 if project_obj is not None and workspace_kind == "worktree":
@@ -3848,11 +3848,11 @@ def task_age(task: Task) -> dict:
 # --- Retention + garbage collection ---
 
 def gc_events(conn: sqlite3.Connection, *, older_than_seconds: int = 30 * 24 * 3600) -> int:
-    """Delete events older than the cutoff on done/archived tasks only; returns the count."""
+    """Prune old done/archived events, retaining decomposition identity until task deletion."""
     cutoff = int(time.time()) - int(older_than_seconds)
     with write_txn(conn):
         cur = conn.execute(
-            "DELETE FROM task_events WHERE created_at < ? AND task_id IN "
+            "DELETE FROM task_events WHERE created_at < ? AND kind != 'decomposed' AND task_id IN "
             "(SELECT id FROM tasks WHERE status IN ('done', 'archived'))", (cutoff,),
         )
     return int(cur.rowcount or 0)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1242,7 +1242,9 @@ def create_task(
     ``project_source_task_id``: cross-profile fallback when ``project_id`` is not
     in the active profile's projects.db — see ``_resolve_project_link``.
     """
+    from hermes_cli.kanban_db_graph import _initial_task_status
     from hermes_cli.kanban_pr_acceptance import validate_contract
+
     completion_contract = validate_contract(completion_contract)
     model_override, provider_override = _validate_model_override(model_override, provider_override)
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
@@ -1365,30 +1367,6 @@ def create_task(
 
 def _board_meta_for(board: Optional[str]) -> dict:
     return read_board_metadata(board if board else get_current_board())
-
-
-def _initial_task_status(
-    conn: sqlite3.Connection, parents: tuple[str, ...], initial_status: str, triage: bool,
-) -> str:
-    """Status for a new task: ``blocked``/``triage`` when parked by the caller,
-    else ``ready`` unless a parent is not yet ``done`` (-> ``todo``). Parent ids
-    are validated in every mode (even triage) so link rows never dangle."""
-    if parents:
-        missing = _missing_task_ids(conn, parents)
-        if missing:
-            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
-    if initial_status == "blocked":
-        return "blocked"
-    if triage:
-        return "triage"
-    if parents:
-        rows = conn.execute(
-            "SELECT status FROM tasks WHERE id IN "
-            "(" + ",".join("?" * len(parents)) + ")", parents,
-        ).fetchall()
-        if any(r["status"] != "done" for r in rows):
-            return "todo"
-    return "ready"
 
 
 def _project_branch_name(project_obj: Any, task_id: str, title: Optional[str]) -> Optional[str]:
@@ -3494,153 +3472,6 @@ def specify_triage_task(
     # flips to 'ready' now instead of idling until the next tick.
     recompute_ready(conn)
     return True
-
-
-def _validate_children_graph(children: list) -> None:
-    """DB-free shape check + Kahn's cycle check on the sibling graph (a cycle
-    would deadlock every involved child in ``todo`` forever)."""
-    for idx, child in enumerate(children):
-        if not isinstance(child, dict):
-            raise ValueError(f"child[{idx}] is not a dict")
-        title = child.get("title")
-        if not isinstance(title, str) or not title.strip():
-            raise ValueError(f"child[{idx}].title is required")
-        parents_idx = child.get("parents") or []
-        if not isinstance(parents_idx, list):
-            raise ValueError(f"child[{idx}].parents must be a list")
-        for p in parents_idx:
-            if not isinstance(p, int) or p < 0 or p >= len(children):
-                raise ValueError(f"child[{idx}].parents[{p}] is not a valid index into children")
-            if p == idx:
-                raise ValueError(f"child[{idx}] cannot list itself as a parent")
-
-    in_deg = [0] * len(children)
-    adj: list[list[int]] = [[] for _ in children]
-    for i, c in enumerate(children):
-        for p in (c.get("parents") or []):
-            adj[p].append(i)
-            in_deg[i] += 1
-    queue = [i for i in range(len(children)) if in_deg[i] == 0]
-    seen = 0
-    while queue:
-        seen += 1
-        for nb in adj[queue.pop()]:
-            in_deg[nb] -= 1
-            if in_deg[nb] == 0:
-                queue.append(nb)
-    if seen != len(children):
-        raise ValueError("cyclic dependency detected in decomposed children list")
-
-
-def decompose_triage_task(
-    conn: sqlite3.Connection, task_id: str, *, root_assignee: Optional[str], children: list[dict],
-    author: Optional[str] = None, auto_promote: bool = True,
-) -> Optional[list[str]]:
-    """Fan a triage task out into children and move the root to ``todo``; the root
-    waits on every child and wakes (``ready``) when all are done.
-
-    ``children``: dicts of ``title`` (required), ``body``, ``assignee``,
-    ``parents`` (indices into this list), optional workspace overrides.
-    Returns child ids in input order, or None when the root is missing / not
-    in triage. Atomic: a malformed entry aborts the whole fan-out.
-    """
-    if not children:
-        return None
-    if root_assignee is not None:
-        root_assignee = _canonical_assignee(root_assignee)
-    _validate_children_graph(children)
-
-    # ONE txn so the fan-out is atomic; helpers that open their own write_txn
-    # (create_task, link_tasks, add_comment) must not be called in here.
-    now = int(time.time())
-    with write_txn(conn):
-        root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
-            "FROM tasks WHERE id = ?", (task_id,),
-        ).fetchone()
-        if root_row is None or root_row["status"] != "triage":
-            return None
-        child_ids = [
-            _insert_decomposed_child(conn, task_id, root_row, child, author, now)
-            for child in children
-        ]
-        # Sibling edges within the decomposed graph.
-        for idx, child in enumerate(children):
-            for p_idx in child.get("parents") or []:
-                parent_id, child_id = child_ids[p_idx], child_ids[idx]
-                _link(conn, parent_id, child_id)
-                _append_event(conn, child_id, "linked", {"parent": parent_id, "child": child_id})
-        # Root waits for the whole graph: link it under EVERY child (simpler
-        # than computing leaves; cycle-free since the root is only ever a child).
-        for cid in child_ids:
-            _link(conn, cid, task_id)
-        # Flip the root triage -> todo, assignee -> orchestrator.
-        sets = ["status = 'todo'"]
-        params: list[Any] = []
-        if root_assignee is not None:
-            sets.append("assignee = ?")
-            params.append(root_assignee)
-        params.append(task_id)
-        conn.execute(f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", tuple(params))
-        if author and author.strip():
-            _insert_comment(
-                conn, task_id, author.strip(),
-                "Decomposed into " + ", ".join(child_ids)
-                + ". Root will wake when all children complete.",
-                now,
-            )
-        _append_event(
-            conn, task_id, "decomposed", {"child_ids": child_ids, "root_assignee": root_assignee},
-        )
-    # Outside the txn (own IMMEDIATE txn). ``auto_promote=False`` leaves the
-    # children in ``todo`` for manual-review-first workflows.
-    if auto_promote:
-        recompute_ready(conn)
-    return child_ids
-
-
-def _insert_decomposed_child(
-    conn: sqlite3.Connection, root_id: str, root_row: sqlite3.Row, child: dict,
-    author: Optional[str], now: int,
-) -> str:
-    """Insert one decomposed child as ``todo`` (linked under the root later so
-    the dispatcher only ever sees a coherent graph); returns its id.
-
-    Workspace: per-child override wins, else inherit the root's kind. Path
-    inherits only when kinds match (a 'dir' child must not point at the
-    root's worktree) and NEVER for worktrees — siblings dispatch concurrently
-    and one shared checkout would put them all on the first sibling's branch
-    with no lock; leaving it unset makes dispatch materialize a fresh
-    ``<repo>/.worktrees/<child-id>`` per child from the board anchor.
-    """
-    root_ws_kind = root_row["workspace_kind"] or "scratch"
-    child_ws_kind = child.get("workspace_kind") or root_ws_kind
-    if child.get("workspace_path"):
-        child_ws_path = child.get("workspace_path")
-    elif child_ws_kind == "worktree":
-        child_ws_path = None
-    elif child_ws_kind == root_ws_kind:
-        child_ws_path = root_row["workspace_path"]
-    else:
-        child_ws_path = None
-    new_id = _new_task_id()
-    body = child.get("body")
-    conn.execute(
-        "INSERT INTO tasks "
-        "(id, title, body, assignee, status, workspace_kind, "
-        " workspace_path, tenant, created_at, created_by) "
-        "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
-        (
-            new_id, child["title"].strip(), body if isinstance(body, str) else None,
-            _canonical_assignee(child.get("assignee")), child_ws_kind, child_ws_path,
-            root_row["tenant"], now, (author or "decomposer"),
-        ),
-    )
-    _append_event(
-        conn, new_id, "created", {"by": author or "decomposer", "from_decompose_of": root_id},
-    )
-    _inherit_notify_subs(conn, new_id, (root_id,), created_at=now)
-    return new_id
 
 
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:

--- a/hermes_cli/kanban_db_graph.py
+++ b/hermes_cli/kanban_db_graph.py
@@ -5,30 +5,33 @@ import sqlite3
 import time
 from typing import Any, Optional
 
-def _initial_task_status(
-    conn: sqlite3.Connection, parents: tuple[str, ...], initial_status: str, triage: bool,
-) -> str:
-    """Status for a new task: ``blocked``/``triage`` when parked by the caller,
-    else ``ready`` unless a parent is not yet ``done`` (-> ``todo``). Parent ids
-    are validated in every mode (even triage) so link rows never dangle."""
-    from hermes_cli.kanban_db import _missing_task_ids
+def initial_task_state(
+    conn: sqlite3.Connection, parents: tuple[str, ...], initial_status: str,
+    triage: bool, tenant: Optional[str],
+) -> tuple[str, Optional[str]]:
+    """Resolve state and tenant under the creator's write transaction.
 
+    Parent order breaks ties in this soft namespace; explicit tenant wins.
+    Validate parents even for parked tasks so links never dangle.
+    """
+    rows = {}
     if parents:
-        missing = _missing_task_ids(conn, parents)
+        rows = {row["id"]: row for row in conn.execute(
+            "SELECT id, status, tenant FROM tasks WHERE id IN "
+            "(" + ",".join("?" * len(parents)) + ")", parents,
+        )}
+        missing = [pid for pid in parents if pid not in rows]
         if missing:
             raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+        if tenant is None:
+            tenant = next((rows[pid]["tenant"] for pid in parents if rows[pid]["tenant"]), None)
     if initial_status == "blocked":
-        return "blocked"
+        return "blocked", tenant
     if triage:
-        return "triage"
-    if parents:
-        rows = conn.execute(
-            "SELECT status FROM tasks WHERE id IN "
-            "(" + ",".join("?" * len(parents)) + ")", parents,
-        ).fetchall()
-        if any(r["status"] != "done" for r in rows):
-            return "todo"
-    return "ready"
+        return "triage", tenant
+    if any(row["status"] != "done" for row in rows.values()):
+        return "todo", tenant
+    return "ready", tenant
 
 
 def _validate_children_graph(children: list) -> None:
@@ -77,7 +80,7 @@ def decompose_triage_task(
     ``children``: dicts of ``title`` (required), ``body``, ``assignee``,
     ``parents`` (indices into this list), optional workspace overrides.
     Returns child ids in input order, or None when the root is missing / not
-    in triage. Atomic: a malformed entry aborts the whole fan-out.
+    in triage, or has already decomposed. Atomic: malformed entries abort fan-out.
     """
     from hermes_cli.kanban_db import (
         _canonical_assignee, _link, _append_event, _insert_comment,
@@ -99,6 +102,13 @@ def decompose_triage_task(
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if root_row is None or root_row["status"] != "triage":
+            return None
+        # Dependency links alone do not imply lineage. The completion event is
+        # committed with the graph, and survives re-triage or unlinking.
+        if conn.execute(
+            "SELECT 1 FROM task_events WHERE task_id = ? AND kind = 'decomposed' LIMIT 1",
+            (task_id,),
+        ).fetchone():
             return None
         child_ids = [
             _insert_decomposed_child(conn, task_id, root_row, child, author, now)
@@ -185,5 +195,3 @@ def _insert_decomposed_child(
     )
     _inherit_notify_subs(conn, new_id, (root_id,), created_at=now)
     return new_id
-
-

--- a/hermes_cli/kanban_db_graph.py
+++ b/hermes_cli/kanban_db_graph.py
@@ -1,0 +1,189 @@
+"""Task graph initialization and atomic decomposition persistence."""
+from __future__ import annotations
+
+import sqlite3
+import time
+from typing import Any, Optional
+
+def _initial_task_status(
+    conn: sqlite3.Connection, parents: tuple[str, ...], initial_status: str, triage: bool,
+) -> str:
+    """Status for a new task: ``blocked``/``triage`` when parked by the caller,
+    else ``ready`` unless a parent is not yet ``done`` (-> ``todo``). Parent ids
+    are validated in every mode (even triage) so link rows never dangle."""
+    from hermes_cli.kanban_db import _missing_task_ids
+
+    if parents:
+        missing = _missing_task_ids(conn, parents)
+        if missing:
+            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+    if initial_status == "blocked":
+        return "blocked"
+    if triage:
+        return "triage"
+    if parents:
+        rows = conn.execute(
+            "SELECT status FROM tasks WHERE id IN "
+            "(" + ",".join("?" * len(parents)) + ")", parents,
+        ).fetchall()
+        if any(r["status"] != "done" for r in rows):
+            return "todo"
+    return "ready"
+
+
+def _validate_children_graph(children: list) -> None:
+    """DB-free shape check + Kahn's cycle check on the sibling graph (a cycle
+    would deadlock every involved child in ``todo`` forever)."""
+    for idx, child in enumerate(children):
+        if not isinstance(child, dict):
+            raise ValueError(f"child[{idx}] is not a dict")
+        title = child.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise ValueError(f"child[{idx}].title is required")
+        parents_idx = child.get("parents") or []
+        if not isinstance(parents_idx, list):
+            raise ValueError(f"child[{idx}].parents must be a list")
+        for p in parents_idx:
+            if not isinstance(p, int) or p < 0 or p >= len(children):
+                raise ValueError(f"child[{idx}].parents[{p}] is not a valid index into children")
+            if p == idx:
+                raise ValueError(f"child[{idx}] cannot list itself as a parent")
+
+    in_deg = [0] * len(children)
+    adj: list[list[int]] = [[] for _ in children]
+    for i, c in enumerate(children):
+        for p in (c.get("parents") or []):
+            adj[p].append(i)
+            in_deg[i] += 1
+    queue = [i for i in range(len(children)) if in_deg[i] == 0]
+    seen = 0
+    while queue:
+        seen += 1
+        for nb in adj[queue.pop()]:
+            in_deg[nb] -= 1
+            if in_deg[nb] == 0:
+                queue.append(nb)
+    if seen != len(children):
+        raise ValueError("cyclic dependency detected in decomposed children list")
+
+
+def decompose_triage_task(
+    conn: sqlite3.Connection, task_id: str, *, root_assignee: Optional[str], children: list[dict],
+    author: Optional[str] = None, auto_promote: bool = True,
+) -> Optional[list[str]]:
+    """Fan a triage task out into children and move the root to ``todo``; the root
+    waits on every child and wakes (``ready``) when all are done.
+
+    ``children``: dicts of ``title`` (required), ``body``, ``assignee``,
+    ``parents`` (indices into this list), optional workspace overrides.
+    Returns child ids in input order, or None when the root is missing / not
+    in triage. Atomic: a malformed entry aborts the whole fan-out.
+    """
+    from hermes_cli.kanban_db import (
+        _canonical_assignee, _link, _append_event, _insert_comment,
+        write_txn, recompute_ready,
+    )
+
+    if not children:
+        return None
+    if root_assignee is not None:
+        root_assignee = _canonical_assignee(root_assignee)
+    _validate_children_graph(children)
+
+    # ONE txn so the fan-out is atomic; helpers that open their own write_txn
+    # (create_task, link_tasks, add_comment) must not be called in here.
+    now = int(time.time())
+    with write_txn(conn):
+        root_row = conn.execute(
+            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if root_row is None or root_row["status"] != "triage":
+            return None
+        child_ids = [
+            _insert_decomposed_child(conn, task_id, root_row, child, author, now)
+            for child in children
+        ]
+        # Sibling edges within the decomposed graph.
+        for idx, child in enumerate(children):
+            for p_idx in child.get("parents") or []:
+                parent_id, child_id = child_ids[p_idx], child_ids[idx]
+                _link(conn, parent_id, child_id)
+                _append_event(conn, child_id, "linked", {"parent": parent_id, "child": child_id})
+        # Root waits for the whole graph: link it under EVERY child (simpler
+        # than computing leaves; cycle-free since the root is only ever a child).
+        for cid in child_ids:
+            _link(conn, cid, task_id)
+        # Flip the root triage -> todo, assignee -> orchestrator.
+        sets = ["status = 'todo'"]
+        params: list[Any] = []
+        if root_assignee is not None:
+            sets.append("assignee = ?")
+            params.append(root_assignee)
+        params.append(task_id)
+        conn.execute(f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", tuple(params))
+        if author and author.strip():
+            _insert_comment(
+                conn, task_id, author.strip(),
+                "Decomposed into " + ", ".join(child_ids)
+                + ". Root will wake when all children complete.",
+                now,
+            )
+        _append_event(
+            conn, task_id, "decomposed", {"child_ids": child_ids, "root_assignee": root_assignee},
+        )
+    # Outside the txn (own IMMEDIATE txn). ``auto_promote=False`` leaves the
+    # children in ``todo`` for manual-review-first workflows.
+    if auto_promote:
+        recompute_ready(conn)
+    return child_ids
+
+
+def _insert_decomposed_child(
+    conn: sqlite3.Connection, root_id: str, root_row: sqlite3.Row, child: dict,
+    author: Optional[str], now: int,
+) -> str:
+    """Insert one decomposed child as ``todo`` (linked under the root later so
+    the dispatcher only ever sees a coherent graph); returns its id.
+
+    Workspace: per-child override wins, else inherit the root's kind. Path
+    inherits only when kinds match (a 'dir' child must not point at the
+    root's worktree) and NEVER for worktrees — siblings dispatch concurrently
+    and one shared checkout would put them all on the first sibling's branch
+    with no lock; leaving it unset makes dispatch materialize a fresh
+    ``<repo>/.worktrees/<child-id>`` per child from the board anchor.
+    """
+    from hermes_cli.kanban_db import (
+        _new_task_id, _canonical_assignee, _append_event, _inherit_notify_subs,
+    )
+
+    root_ws_kind = root_row["workspace_kind"] or "scratch"
+    child_ws_kind = child.get("workspace_kind") or root_ws_kind
+    if child.get("workspace_path"):
+        child_ws_path = child.get("workspace_path")
+    elif child_ws_kind == "worktree":
+        child_ws_path = None
+    elif child_ws_kind == root_ws_kind:
+        child_ws_path = root_row["workspace_path"]
+    else:
+        child_ws_path = None
+    new_id = _new_task_id()
+    body = child.get("body")
+    conn.execute(
+        "INSERT INTO tasks "
+        "(id, title, body, assignee, status, workspace_kind, "
+        " workspace_path, tenant, created_at, created_by) "
+        "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+        (
+            new_id, child["title"].strip(), body if isinstance(body, str) else None,
+            _canonical_assignee(child.get("assignee")), child_ws_kind, child_ws_path,
+            root_row["tenant"], now, (author or "decomposer"),
+        ),
+    )
+    _append_event(
+        conn, new_id, "created", {"by": author or "decomposer", "from_decompose_of": root_id},
+    )
+    _inherit_notify_subs(conn, new_id, (root_id,), created_at=now)
+    return new_id
+
+

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -290,7 +290,7 @@ def _apply_fanout(task_id: str, parsed: dict, routing: _Routing, author: str) ->
         logger.exception("decompose: DB error on task %s", task_id)
         return DecomposeOutcome(task_id, False, f"DB error: {type(exc).__name__}")
     if child_ids is None:
-        return DecomposeOutcome(task_id, False, "task moved out of triage before decomposition")
+        return DecomposeOutcome(task_id, False, "task already decomposed or moved out of triage")
     return DecomposeOutcome(
         task_id, True, f"decomposed into {len(child_ids)} children", fanout=True, child_ids=child_ids,
     )

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_db_graph import decompose_triage_task
 from hermes_cli import kanban_db_connect as kbc
 from hermes_cli import profiles as profiles_mod
 from hermes_cli.kanban_specify import (
@@ -275,7 +276,7 @@ def _apply_fanout(task_id: str, parsed: dict, routing: _Routing, author: str) ->
         return DecomposeOutcome(task_id, False, reason)
     try:
         with kbc.connect_closing() as conn:
-            child_ids = kb.decompose_triage_task(
+            child_ids = decompose_triage_task(
                 conn,
                 task_id,
                 root_assignee=routing.orchestrator,

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -1,4 +1,4 @@
-"""Tests for kb.decompose_triage_task — the DB-layer atomic fan-out
+"""Tests for decompose_triage_task — the DB-layer atomic fan-out
 from the triage column. LLM-free by design.
 """
 
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_db_graph import decompose_triage_task
 from hermes_cli import kanban_db_connect as kbc
 
 
@@ -43,7 +44,7 @@ def test_decompose_creates_children_and_promotes_root(kanban_home):
         {"title": "build it", "body": "write code", "assignee": "engineer", "parents": [0]},
     ]
     with kbc.connect() as conn:
-        child_ids = kb.decompose_triage_task(
+        child_ids = decompose_triage_task(
             conn,
             tid,
             root_assignee="orchestrator",
@@ -72,7 +73,7 @@ def test_decompose_creates_children_and_promotes_root(kanban_home):
 def test_decompose_records_audit_comment_and_event(kanban_home):
     with kbc.connect() as conn:
         tid = _create_triage(conn)
-        child_ids = kb.decompose_triage_task(
+        child_ids = decompose_triage_task(
             conn,
             tid,
             root_assignee="orch",

--- a/tests/hermes_cli/test_kanban_graph_identity.py
+++ b/tests/hermes_cli/test_kanban_graph_identity.py
@@ -1,0 +1,55 @@
+"""Graph identity is completion history, not prerequisite edges."""
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_db_graph import decompose_triage_task
+from hermes_cli import kanban_db_connect as kbc
+
+
+def test_completed_decomposition_survives_retriage(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    with kbc.connect_closing() as conn:
+        prerequisite = kb.create_task(conn, title="prerequisite", tenant="business-a")
+        root = kb.create_task(conn, title="root", triage=True, tenant="business-a", parents=[prerequisite])
+        downstream = kb.create_task(conn, title="downstream", parents=[root], tenant="business-a")
+        specs = [{"title": "work", "assignee": "default"}]
+        first = decompose_triage_task(conn, root, root_assignee="default", children=specs)
+        assert first and kb.get_task(conn, first[0]).tenant == "business-a"
+        assert conn.execute("SELECT 1 FROM task_links WHERE parent_id=? AND child_id=?", (prerequisite, root)).fetchone()
+        assert conn.execute("SELECT 1 FROM task_links WHERE parent_id=? AND child_id=?", (root, downstream)).fetchone()
+        # Retention must not erase the identity of a completed fan-out.
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='done' WHERE id=?", (root,))
+            conn.execute("UPDATE task_events SET created_at=0 WHERE task_id=?", (root,))
+        assert kb.gc_events(conn, older_than_seconds=1) > 0
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='triage' WHERE id=?", (root,))
+        before = list(conn.execute("SELECT id FROM tasks ORDER BY id"))
+        assert decompose_triage_task(conn, root, root_assignee="default", children=specs) is None
+        assert list(conn.execute("SELECT id FROM tasks ORDER BY id")) == before
+        assert conn.execute("SELECT count(*) FROM task_events WHERE task_id=? AND kind='decomposed'", (root,)).fetchone()[0] == 1
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+
+
+def test_parent_tenant_is_inherited_at_creation_boundary(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("HERMES_TENANT", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from tools.kanban_tools import _handle_create
+    with kbc.connect_closing() as conn:
+        unscoped = kb.create_task(conn, title="unscoped")
+        parent = kb.create_task(conn, title="parent", tenant="business-a")
+        for explicit, expected in [(None, "business-a"), ("business-b", "business-b")]:
+            child = kb.create_task(conn, title="child", parents=[unscoped, parent], tenant=explicit)
+            assert kb.get_task(conn, child).tenant == expected
+        result = json.loads(_handle_create({"title": "tool child", "assignee": "default", "parents": [parent]}))
+        assert result["ok"]
+        assert kb.get_task(conn, result["task_id"]).tenant == "business-a"
+        with pytest.raises(ValueError, match="unknown parent"):
+            kb.create_task(conn, title="invalid", parents=["missing"])
+        assert kb.get_task(conn, unscoped).tenant is None

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import pytest
 
 from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_db_graph import decompose_triage_task
 from hermes_cli import kanban_db_connect as kbc
 from hermes_cli import kanban_db_workspace as kbw
 
@@ -78,7 +79,7 @@ def test_decompose_worktree_children_get_own_workspace(kanban_home):
         )
         conn.commit()
 
-        child_ids = kb.decompose_triage_task(
+        child_ids = decompose_triage_task(
             conn,
             root,
             root_assignee="orchestrator",

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -632,6 +632,16 @@ The kanban board has two ways to handle a task you drop into the Triage column:
 
 **Auto (default)** — `kanban.auto_decompose: true`. The gateway-embedded dispatcher runs the **decomposer** on each tick, capped by `kanban.auto_decompose_per_tick` (default 3 tasks per tick) so a bulk-load of triage tasks doesn't burst-spend the auxiliary LLM. The decomposer uses the built-in decomposition prompt plus the `auxiliary.kanban_decomposer` model path, reads your installed profiles + their descriptions, and asks the LLM to produce a JSON task graph: which tasks to spawn, who they go to, and which depend on which. The original triage task becomes the parent of every leaf in the graph, so it stays alive until the whole graph completes - and then promotes back to `ready` so its assignee (`kanban.orchestrator_profile`, or the active default profile when unset) can judge completion and add more tasks if the work isn't done. This is the "drop a one-liner, walk away" flow.
 
+A completed built-in fan-out is recorded atomically with its child graph. Moving
+that root back to Triage does not create another graph; ordinary prerequisite
+links do not prevent a task's first decomposition. The completion marker survives
+event retention until the task is deleted. This is not semantic deduplication of
+independently created manual graphs, nor a repair for previously pruned history.
+
+When a new task omits its tenant, creation inherits the first nonempty tenant
+among its parents, in supplied order. An explicit tenant (including the worker's
+active tenant passed by tools) wins. Boards remain the hard isolation boundary.
+
 **Manual** — `kanban.auto_decompose: false`. Triage tasks stay in triage until you act. Click the **⚗ Decompose** button on a card, run `hermes kanban decompose <id>` (or `--all`), or use `/kanban decompose <id>` from a chat. This matches the pre-decomposer behavior of the board, useful when you want full control over what runs when.
 
 **Important boundary:** Manual mode disables only the built-in Triage decomposer. It does not prevent a profile from calling `kanban_create`, and it does not disable creator-session wake-ups. With `kanban.auto_subscribe_on_create: true`, a task's terminal event resumes the originating agent with a synthetic status turn so it can inspect the handoff and decide whether genuinely new follow-up work is needed. Set `auto_subscribe_on_create: false` when task completion should remain passive. For provenance, built-in decomposer children use `created_by=auto-decomposer`; tasks created by a resumed profile carry that profile name instead.


### PR DESCRIPTION
Kanban retains completed fan-out identity across re-triage and event retention, and newly created tasks inherit omitted tenant metadata from their parents.

## Changes
- Extract graph initialization and decomposition persistence into `kanban_db_graph.py` in a separate mechanical commit; migrate in-tree callers without compatibility aliases.
- Check the existing `decomposed` completion event inside the graph's `BEGIN IMMEDIATE` transaction. Keep that marker during event GC until task deletion.
- Resolve parent tenant inheritance once inside task creation: first nonempty parent in supplied order, explicit tenant wins. No tool-layer fallback duplication or swallowed SQL errors.
- Preserve legitimate pre-existing prerequisite/downstream links: dependency edges are not evidence of decomposition lineage.

Root cause: triage status alone forgets completed decomposition after re-triage, while manual task creation previously persisted a NULL tenant even when its parent had one.

## Validation
**Live repro:** fresh-interpreter, isolated-HOME SQLite integration on main `22c5684b983` versus this branch, using the identical `evals/kanban_graph_identity.py --repo PATH` probe.

| Invariant | Main | Fixed |
|---|---|---|
| DB and tool create inherit `business-a` | both NULL | both `business-a` |
| Same-tenant completed decomposition refused after re-triage | false | true |
| Repeat refused after real event GC | false | true |
| Production fan-out ingress refuses repeat | false | true |
| Legitimately prelinked root permits first fan-out | passes | passes |
| Two competing SQLite connections | one winner | one winner |
| Three `dispatch_once(max_spawn=0)` bookkeeping ticks | stable IDs | stable IDs |
| SQLite integrity | ok | ok |

- Two new invariant tests proven red before the fix; retention lifecycle separately reproduced red before retaining markers.
- Serial shared-lock runner: **41 passed, 0 failed across 5 targeted files** after rebase.
- Ruff, Windows footgun, compatibility-pointer, subprocess-stdin, and diff-whitespace checks passed.
- Independent review found marker retention was necessary; addressed and re-reviewed with no remaining concrete defects in this scope.

## Scope
Addresses #104215; campaign https://github.com/NousResearch/hermes-agent/issues/104904.
This does **not** infer semantic identity for independently created manual graphs, repair historical duplicates, or reconstruct completion markers pruned before this change. No issue-closing claim for that broader scenario. The live probe uses real DB/tool/fan-out ingress and dispatcher bookkeeping, not model requests, spawned workers, or browser UI.

Credit: #104263 by @kyssta-exe identified useful tenant-inheritance/persistence-guard directions. Its blanket dependency-link rejection would block legitimate first decompositions, so no candidate commit or suggested test suite was applied.

## Infographic
![Kanban graph identity and tenant inheritance](https://v3b.fal.media/files/b/0aa97456/W3_Rbxj972R6kJd-h4ILQ_3j3lcU0p.png)
