### PR TITLE
feat(desktop): Ctrl/Cmd+Enter confirms the batch clarify card and parks focus on open questions

### DIFF
--- a/apps/desktop/e2e/batch-clarify-chord.spec.ts
+++ b/apps/desktop/e2e/batch-clarify-chord.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * E2E batch clarify CONFIRM CHORD — Ctrl/Cmd+Enter locks the whole batch
+ * without touching the "Confirm and continue" button, including from inside
+ * an "Other" text field mid-typing (where plain Enter is a newline).
+ *
+ * Each test gets its OWN app fixture (one describe per test): the mock scripts
+ * the batch clarify only on a conversation's FIRST completion — a second
+ * identical trigger in the same session falls through to the canned reply so
+ * the quiz cannot loop forever. The button-driven card flow lives in
+ * batch-clarify.spec.ts; this file exercises the keyboard path end to end:
+ * composer → gateway → agent → clarify tool → clarify.request → renderer.
+ */
+
+import { type Page } from '@playwright/test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { BATCH_CLARIFY_QUESTIONS, BATCH_CLARIFY_TRIGGER } from './mock-server'
+import { expect, test } from './test'
+
+/** Send the trigger and wait for the single live batch card to mount. */
+async function openBatchCard(page: Page) {
+  const composer = page.locator('[contenteditable="true"]').first()
+  await composer.waitFor({ state: 'visible', timeout: 10_000 })
+
+  await composer.click()
+  await composer.type(BATCH_CLARIFY_TRIGGER, { delay: 20 })
+  await page.keyboard.press('Enter')
+
+  const batchCard = page.locator('form[data-clarify-batch]')
+  await batchCard.first().waitFor({ state: 'visible', timeout: 60_000 })
+  await expect(batchCard).toHaveCount(1)
+
+  return batchCard
+}
+
+test.describe('batch clarify confirm chord — lock from an Other box', () => {
+  let fixture: MockBackendFixture
+
+  test.beforeAll(async () => {
+    fixture = await setupMockBackend()
+    await waitForAppReady(fixture, 120_000)
+  })
+
+  test.afterAll(async () => {
+    await fixture?.cleanup()
+  })
+
+  test('Ctrl+Enter from inside an Other box locks the whole batch', async () => {
+    const { page } = fixture
+    const batchCard = await openBatchCard(page)
+
+    const confirmButton = batchCard.locator('button[type="submit"]')
+    await expect(confirmButton).toContainText('Confirm and continue')
+    // The chord hint rides the button, matching the approval bar's convention.
+    await expect(confirmButton).toContainText(/⌘⏎|Ctrl⏎/u)
+
+    // Stage q0 by pick, q1 by typing into its "Other" row…
+    await batchCard.getByRole('button', { name: /Coffee/ }).click()
+    const otherBoxes = batchCard.getByPlaceholder('Other (type your answer)')
+    await expect(otherBoxes).toHaveCount(2)
+    await otherBoxes.nth(1).click()
+    await otherBoxes.nth(1).type('evening', { delay: 15 })
+
+    // …and confirm from INSIDE that text field with the chord, never the button.
+    await otherBoxes.nth(1).press('Control+Enter')
+
+    // The settled card lists both questions with their locked answers.
+    const settled = page.locator('[data-clarify-settled]')
+    await settled.waitFor({ state: 'visible', timeout: 30_000 })
+    await expect(settled.getByText(BATCH_CLARIFY_QUESTIONS[0].question)).toBeVisible()
+    await expect(settled.getByText('Coffee', { exact: true })).toBeVisible()
+    await expect(settled.getByText(BATCH_CLARIFY_QUESTIONS[1].question)).toBeVisible()
+    await expect(settled.getByText('evening')).toBeVisible()
+
+    // No live card lingers after settle.
+    await expect(page.locator('form[data-clarify-batch]')).toHaveCount(0)
+  })
+})
+
+test.describe('batch clarify confirm chord — park on the open question', () => {
+  let fixture: MockBackendFixture
+
+  test.beforeAll(async () => {
+    fixture = await setupMockBackend()
+    await waitForAppReady(fixture, 120_000)
+  })
+
+  test.afterAll(async () => {
+    await fixture?.cleanup()
+  })
+
+  test('Ctrl+Enter with a question still open parks on it instead of locking', async () => {
+    const { page } = fixture
+    const batchCard = await openBatchCard(page)
+
+    // Stage only q0, then fire the chord from the transcript with q1 blank.
+    await batchCard.getByRole('button', { name: /Coffee/ }).click()
+    await page.keyboard.press('Control+Enter')
+
+    // Nothing locked yet — the first unanswered question owns the caret.
+    const otherBoxes = batchCard.getByPlaceholder('Other (type your answer)')
+    await expect(otherBoxes.nth(1)).toBeFocused()
+    await expect(batchCard.locator('button[type="submit"]')).toBeDisabled()
+
+    // Answer it and confirm: the same chord now completes the batch.
+    await otherBoxes.nth(1).type('evening', { delay: 15 })
+    await otherBoxes.nth(1).press('Control+Enter')
+
+    const settled = page.locator('[data-clarify-settled]')
+    await settled.waitFor({ state: 'visible', timeout: 30_000 })
+    await expect(settled.getByText('evening')).toBeVisible()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -704,6 +704,78 @@ describe('ClarifyTool batch card', () => {
     })
   })
 
+  it('confirm chord (Ctrl/Cmd+Enter) submits the batch from anywhere once all staged', async () => {
+    const request = renderLiveBatch()
+
+    fireEvent.click(screen.getByRole('button', { name: /red/ }))
+    fireEvent.change(screen.getByPlaceholderText('Type your answer…'), { target: { value: 'packet' } })
+    expect(screen.getByText('2 of 2 answered')).toBeTruthy()
+
+    // While the composer area has focus — not just from inside the card.
+    fireEvent.keyDown(window, { ctrlKey: true, key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(2)
+    })
+    expect(request).toHaveBeenNthCalledWith(1, 'clarify.respond', {
+      answer: 'red',
+      question_id: 'q0',
+      request_id: 'request-batch'
+    })
+    expect(request).toHaveBeenNthCalledWith(2, 'clarify.respond', {
+      answer: 'packet',
+      question_id: 'q1',
+      request_id: 'request-batch'
+    })
+  })
+
+  it('confirm chord mid-typing in an Other box locks the typed answer', async () => {
+    const request = renderLiveBatch()
+
+    fireEvent.click(screen.getByRole('button', { name: /red/ }))
+
+    const other = screen.getByPlaceholderText('Type your answer…') as HTMLTextAreaElement
+    fireEvent.focus(other)
+    fireEvent.change(other, { target: { value: 'packet' } })
+
+    // The chord fires while the caret is inside the Other textarea.
+    fireEvent.keyDown(other, { bubbles: true, cancelable: true, ctrlKey: true, key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(2)
+    })
+    expect(request).toHaveBeenNthCalledWith(2, 'clarify.respond', {
+      answer: 'packet',
+      question_id: 'q1',
+      request_id: 'request-batch'
+    })
+  })
+
+  it('confirm chord with a question still open parks on it instead of locking', async () => {
+    const request = renderLiveBatch()
+
+    // Stage only q0; q1 (Other box) is still blank.
+    fireEvent.click(screen.getByRole('button', { name: /red/ }))
+
+    fireEvent.keyDown(window, { ctrlKey: true, key: 'Enter' })
+
+    // Nothing submitted; the first unanswered textarea owns the caret.
+    expect(request).not.toHaveBeenCalled()
+    const other = screen.getByPlaceholderText('Type your answer…') as HTMLTextAreaElement
+    expect(document.activeElement).toBe(other)
+  })
+
+  it('plain Enter inside an Other box stays a newline, not a submit', () => {
+    const request = renderLiveBatch()
+
+    const other = screen.getByPlaceholderText('Type your answer…') as HTMLTextAreaElement
+    fireEvent.focus(other)
+    fireEvent.keyDown(other, { bubbles: true, cancelable: true, key: 'Enter' })
+
+    // Bare Enter never locks — only the confirm chord or the button does.
+    expect(request).not.toHaveBeenCalled()
+  })
+
   it('renders the settled batch with all questions and answers', () => {
     renderClarify(
       <ClarifyTool

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -24,7 +24,9 @@ import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { CircleLetterA, Loader2, MessageQuestion } from '@/lib/icons'
+import { isConfirmChord } from '@/lib/keybinds/chords'
 import { visibleClarifyCard } from '@/lib/keybinds/composer-focus-keys'
+import { isMacPlatform } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 import {
   bareChoice,
@@ -874,7 +876,8 @@ function BatchQuestionBlock({
   onDraft,
   onToggle,
   question,
-  staged
+  staged,
+  textareaRef
 }: {
   disabled: boolean
   locked: boolean
@@ -882,6 +885,7 @@ function BatchQuestionBlock({
   onToggle: (choice: string) => void
   question: ClarifyQuestion
   staged: { choices: string[]; draft: string }
+  textareaRef?: (el: HTMLTextAreaElement | null) => void
 }) {
   const { t } = useI18n()
   const copy = t.assistant.clarify
@@ -919,6 +923,7 @@ function BatchQuestionBlock({
               disabled={disabled}
               onChange={event => onDraft(event.target.value)}
               placeholder={copy.other}
+              ref={textareaRef}
               rows={1}
               size="sm"
               value={staged.draft}
@@ -931,6 +936,7 @@ function BatchQuestionBlock({
           disabled={disabled}
           onChange={event => onDraft(event.target.value)}
           placeholder={copy.placeholder}
+          ref={textareaRef}
           rows={1}
           size="sm"
           value={staged.draft}
@@ -955,12 +961,20 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
   const gateway = useStore($gateway)
 
   // qids only exist on the gateway request — args are a hydration-race
-  // fallback for display, never answerable (no ids to respond with).
-  const questions = request?.questions ?? []
+  // fallback for display, never answerable (no ids to respond with). Stable
+  // per request; without useMemo the confirm-chord effect below would
+  // resubscribe on every keystroke.
+  const questions = useMemo(() => request?.questions ?? [], [request?.questions])
   const ready = Boolean(request?.requestId) && questions.length > 0
 
   const [staged, setStaged] = useState<Record<string, { choices: string[]; draft: string }>>({})
   const [submitting, setSubmitting] = useState(false)
+  // Per-question refs, index-aligned with `questions` — the confirm chord
+  // parks the caret on the first unanswered question.
+  const questionRefs = useRef<(HTMLTextAreaElement | null)[]>([])
+  // Identity for the confirm-chord visible-card check — this element carries
+  // `data-clarify-batch`, i.e. the one `visibleClarifyCard()` resolves.
+  const formRef = useRef<HTMLFormElement | null>(null)
 
   // Reconnect replay: answers the server already locked (an earlier window's
   // partial progress) pre-stage their questions so the restored card shows
@@ -1112,6 +1126,50 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
     }
   }, [gateway, onAnswered, request])
 
+  // Ctrl/Cmd+Enter confirms the batch from anywhere — including mid-typing in
+  // an "Other" box, where plain Enter inserts a newline on purpose. Capture
+  // phase so the composer's Ctrl+Enter (queue) never double-fires on the same
+  // press; visibleClarifyCard() is the same resolver the global gates use, so
+  // a card parked in a background session never answers from an inactive tab.
+  // Not everything staged: park on the first unanswered question instead of
+  // locking a partial batch.
+  useEffect(() => {
+    if (!ready) {
+      return
+    }
+
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (!isConfirmChord(event) || event.defaultPrevented) {
+        return
+      }
+
+      if (visibleClarifyCard() !== formRef.current) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      if (submitting) {
+        return
+      }
+
+      const open = questions.findIndex(question => stagedAnswer(question) === null)
+
+      if (open >= 0) {
+        questionRefs.current[open]?.focus()
+
+        return
+      }
+
+      void confirmAll()
+    }
+
+    window.addEventListener('keydown', onKeyDown, true)
+
+    return () => window.removeEventListener('keydown', onKeyDown, true)
+  }, [confirmAll, ready, questions, stagedAnswer, submitting])
+
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault()
@@ -1132,7 +1190,7 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
   }
 
   return (
-    <form className="my-1.5 grid gap-4" data-clarify-batch={questions.length} onSubmit={handleSubmit}>
+    <form className="my-1.5 grid gap-4" data-clarify-batch={questions.length} onSubmit={handleSubmit} ref={formRef}>
       <ClarifyShell className="grid gap-3">
         <div className="flex items-start gap-2">
           <span className="flex-1 text-[0.6875rem] leading-4 text-(--ui-text-tertiary)">
@@ -1140,7 +1198,7 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
           </span>
           <MessageQuestion aria-hidden className={CLARIFY_ICON_CLASS} />
         </div>
-        {questions.map(question => (
+        {questions.map((question, index) => (
           <BatchQuestionBlock
             disabled={submitting}
             key={question.qid}
@@ -1149,6 +1207,9 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
             onToggle={choice => toggleChoice(question, choice)}
             question={question}
             staged={stageFor(question.qid)}
+            textareaRef={el => {
+              questionRefs.current[index] = el
+            }}
           />
         ))}
       </ClarifyShell>
@@ -1164,7 +1225,7 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
             <>
               {copy.confirmAndContinueLabel}
               <span aria-hidden className="ml-0.5 text-[0.625rem] opacity-70">
-                ⏎
+                {isMacPlatform() ? '⌘⏎' : 'Ctrl⏎'}
               </span>
             </>
           )}

--- a/apps/desktop/src/lib/keybinds/chords.ts
+++ b/apps/desktop/src/lib/keybinds/chords.ts
@@ -11,3 +11,20 @@ export function isComposerChord(event: KeyboardEvent): boolean {
 
   return mod && !event.shiftKey && event.key.toLowerCase() === 'l'
 }
+
+/**
+ * True when the event is the universal blocking-prompt confirm chord:
+ * ⌘⏎ on macOS, Ctrl+Enter elsewhere (⌃⏎ also folds into it via the
+ * explicit ctrlKey check). Shift/Alt variants are different gestures, not
+ * confirms. Consumers: the tool-approval bar, the batch clarify card's
+ * confirm, and the type-to-focus gate that must yield exactly these keys.
+ */
+export function isConfirmChord(event: {
+  key: string
+  metaKey: boolean
+  ctrlKey: boolean
+  shiftKey: boolean
+  altKey: boolean
+}): boolean {
+  return event.key === 'Enter' && (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
+}

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.test.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.test.ts
@@ -5,6 +5,7 @@ import { $activeTreeGroup, $hoveredTreeGroup } from '@/components/pane-shell/tre
 import { $switcherOpen, closeSwitcher } from '@/store/session-switcher'
 
 import {
+  clarifyCardOwnsKey,
   composerFocusBlockedBySurface,
   composerFocusKeysAllowed,
   isActivateOnEnterTarget,
@@ -39,6 +40,54 @@ describe('isActivateOnEnterTarget', () => {
     expect(isActivateOnEnterTarget(button)).toBe(true)
     expect(isActivateOnEnterTarget(child)).toBe(true)
     expect(isActivateOnEnterTarget(document.createElement('div'))).toBe(false)
+  })
+})
+
+describe('clarifyCardOwnsKey', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  it('a single card owns only Enter and its rendered rows', () => {
+    const card = document.createElement('div')
+    card.setAttribute('data-clarify-choices', '1')
+    document.body.append(card)
+
+    const event = (key: string, mods: Partial<KeyboardEventInit> = {}) =>
+      new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...mods })
+
+    expect(clarifyCardOwnsKey(event('Enter'))).toBe(true)
+    expect(clarifyCardOwnsKey(event('a'))).toBe(true)
+    expect(clarifyCardOwnsKey(event('1'))).toBe(true)
+    // One choice ⇒ rows A (choice) + B (Other); "c" is past the last row.
+    expect(clarifyCardOwnsKey(event('b'))).toBe(true)
+    expect(clarifyCardOwnsKey(event('c'))).toBe(false)
+    expect(clarifyCardOwnsKey(event('Enter', { ctrlKey: true }))).toBe(false)
+  })
+
+  it('a batch card owns only the confirm chord — never plain Enter or letters', () => {
+    const card = document.createElement('div')
+    card.setAttribute('data-clarify-batch', '2')
+    document.body.append(card)
+
+    const event = (key: string, mods: Partial<KeyboardEventInit> = {}) =>
+      new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...mods })
+
+    expect(clarifyCardOwnsKey(event('Enter', { ctrlKey: true }))).toBe(true)
+    expect(clarifyCardOwnsKey(event('Enter', { metaKey: true }))).toBe(true)
+    // Plain Enter and typed letters stay with the composer / the Other box.
+    expect(clarifyCardOwnsKey(event('Enter'))).toBe(false)
+    expect(clarifyCardOwnsKey(event('a'))).toBe(false)
+    expect(clarifyCardOwnsKey(event('1'))).toBe(false)
+    // Shift/Alt variants are a different gesture, not the confirm chord.
+    expect(clarifyCardOwnsKey(event('Enter', { shiftKey: true, ctrlKey: true }))).toBe(false)
+    expect(clarifyCardOwnsKey(event('Enter', { altKey: true, ctrlKey: true }))).toBe(false)
+  })
+
+  it('no live card owns nothing', () => {
+    document.body.replaceChildren()
+
+    expect(clarifyCardOwnsKey(new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true }))).toBe(false)
   })
 })
 

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
@@ -11,6 +11,7 @@ import { queryAllVisible } from '@/components/pane-shell/pane-visibility'
 import { $activeTreeGroup, $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
 import { switcherActive } from '@/store/session-switcher'
 
+import { isConfirmChord } from './chords'
 import { isEditableTarget, isFocusWithin } from './combo'
 
 /** `composer.focus` defaults that need the surface/target gate. */
@@ -46,8 +47,10 @@ const BLOCKING_OVERLAY =
 
 // Blockers that live INSIDE a chat surface. Inactive tabs stay mounted, so this
 // one has to be visible-scoped: a clarify card waiting in a background thread
-// must not take the foreground composer's letter keys.
-const BLOCKING_IN_SURFACE = '[data-clarify-choices]'
+// must not take the foreground composer's letter keys. Batch cards (the
+// multi-question form) resolve through their own marker — they carry no
+// per-question shortcuts, so they never claim letters/digits.
+const BLOCKING_IN_SURFACE = '[data-clarify-choices],[data-clarify-batch]'
 
 /** The layout-tree zone a pane is rendered in — see `tree/renderer/tree-group`. */
 const TREE_GROUP = '[data-tree-group]'
@@ -122,8 +125,17 @@ export function clarifyCardOwnsKey(event: KeyboardEvent): boolean {
     return false
   }
 
+  // A batch card (multi-question form) binds only the confirm chord — it has
+  // no per-question rows to claim letters/digits for. Everything else falls
+  // through, so typing a message instead of answering keeps working.
+  if (card.hasAttribute('data-clarify-batch')) {
+    return isConfirmChord(event)
+  }
+
   if (event.key === 'Enter') {
-    return true
+    // Bare Enter only — the single card's own listener ignores modifier
+    // chords, and Ctrl/Cmd+Enter belongs to confirm gestures elsewhere.
+    return !event.metaKey && !event.ctrlKey && !event.altKey
   }
 
   // "Other" is the row past the last choice, hence the +1.


### PR DESCRIPTION
Ctrl/Cmd+Enter confirms the batch clarify card and parks focus on open questions

## Summary

The batch clarify card (the multi-question "N of M answered" / **Confirm and
continue** form) is the one blocking prompt with no keyboard path to its
confirm action. The single-question card confirms with plain **Enter**, the
tool-approval bar accepts with **Ctrl/Cmd+Enter**, but the batch card only
responds to a mouse click — and its per-question "Other" fields insert a
newline on Enter, so a user typing a custom answer must reach for the mouse to
submit the batch.

This adds **Ctrl/Cmd+Enter → confirm** for the batch card, from anywhere the
card is live (including mid-typing inside an "Other" box, where plain Enter
remains a newline on purpose).

## Behavior

| State on Ctrl/Cmd+Enter | Result |
| --- | --- |
| Every question staged | locks the batch (identical to clicking **Confirm and continue**) |
| Some question blank | parks the caret on the first unanswered question; nothing is submitted — a partial batch is never silently locked |
| Card in a background session/tab | no-op for that card; the visible card resolves via the same `visibleClarifyCard()` ladder the global gates use |
| While submitting | ignored (idempotent) |

The button's hint span changes from `⏎` (which was not actually bound) to
`Ctrl⏎` / `⌘⏎`, matching the approval bar's existing hint convention.

## Design notes (why each judgment call)

1. **Chord, not bare Enter.** The single card owns bare Enter; the batch card
   cannot, because free-text "Other" rows need Enter for newlines. A modifier
   chord is unambiguous from every focus position.
2. **Focus-park on the not-all-staged branch** mirrors the single card's
   existing `activateActive()` fallback (Enter with nothing staged focuses the
   "Other" row) and the platform convention of focusing the first missing
   field on a blocked form submit.
3. **Capture-phase window listener** follows the established pattern in
   `components/assistant-ui/tool/approval.tsx` (its Ctrl+Enter → Run / Esc →
   Reject listener). `preventDefault` + `stopPropagation` keeps the composer's
   Ctrl+Enter (queue-message) handler from double-firing on the same press —
   blocking prompts outrank the composer while parked, same as the approval
   bar.
4. **Single-card Enter narrowing (one-line alignment).** While adding tests we
   found `clarifyCardOwnsKey` claimed *any* Enter for a live single card,
   including Ctrl/Cmd+Enter, while the card's own listener ignores modifier
   chords. The gate now returns true for bare Enter only, so the type-to-focus
   gate agrees with the card's actual key handling. No visible behavior
   changes; it removes a latent conflict with confirm gestures elsewhere.
5. **Batch cards join the visible-card resolver.** `visibleClarifyCard()` /
   `clarifyCardOwnsKey` now resolve `form[data-clarify-batch]` too, so a batch
   card parked in an inactive tab can never answer from an off-screen press
   (inactive tabs stay mounted). Batch cards claim ONLY the confirm chord —
   never letters/digits — so typing a message instead of answering keeps
   working, consistent with the single card's per-key ownership contract.
6. **Rebindability**: the chord is hardcoded to match the existing
   approval-bar chord; promoting blocking-prompt confirms into the rebindable
   keybinds registry is a natural follow-up but out of scope here.

## Testing

- Unit (`vitest`): resolver matrix for single vs. batch ownership (Enter,
  letters, digits, chord variants), chord-locks-when-complete,
  chord-locks-typed-Other-content, chord-parks-on-open-question,
  plain-Enter-never-locks. Full desktop suite green (871 files / 9352 tests).
- E2E (`playwright`, real chain composer → gateway → agent → mock → renderer,
  new `e2e/batch-clarify-chord.spec.ts`): chord locks the whole batch from
  inside an Other box; chord with an open question parks focus, then the same
  chord completes. Each test uses its own app fixture because the mock scripts
  the batch clarify only on a conversation's first completion (anti-quiz-loop
  design in `e2e/mock-server.ts`).
- `tsc` and `eslint` clean; all four locales untouched (no new strings — the
  hint is a platform-conditional glyph, not copy).

## Files

- `src/lib/keybinds/chords.ts` — add `isConfirmChord` beside `isComposerChord`
- `src/lib/keybinds/composer-focus-keys.ts` — resolve batch cards; batch owns
  only the confirm chord; single card = bare Enter only
- `src/components/assistant-ui/clarify-tool.tsx` — confirm-chord listener,
  per-question refs, hint, `useMemo` for the questions array
- `src/components/assistant-ui/clarify-tool.test.tsx` — batch keyboard tests
- `src/lib/keybinds/composer-focus-keys.test.ts` — ownership matrix tests
- `e2e/batch-clarify-chord.spec.ts` — new; chord path end-to-end