### PR TITLE
fix(desktop): Skills MCP sign-in uses the local callback (#104391, salvage #104728)

### DIFF
--- a/apps/desktop/src/api/mcp.ts
+++ b/apps/desktop/src/api/mcp.ts
@@ -48,31 +48,17 @@ export function saveMcpServers(
   })
 }
 
-/** Start an MCP OAuth flow and return the authorization URL. */
-export function authMcpServer(name: string, profile?: ProfileScope): Promise<McpOAuthFlow> {
-  return window.hermesDesktop.api<McpOAuthFlow>({
-    ...capabilityScoped(profile),
-    path: `/api/mcp/servers/${encodeURIComponent(name)}/auth`,
-    method: 'POST',
-    timeoutMs: 60_000
-  })
-}
+/** Capture the source before the first await. Every OAuth RPC, including
+ *  cleanup after a foreground switch, belongs to this (connection, profile).
+ *  Import the store lazily: it consumes the API barrel during initialization. */
+export function mcpOAuthRpc(scope?: ProfileScope) {
+  const { connectionId = null, profile = 'default' } = capabilityScoped(scope)
 
-export function getMcpOAuthFlow(flowId: string, profile?: ProfileScope): Promise<McpOAuthFlow> {
-  return window.hermesDesktop.api<McpOAuthFlow>({
-    ...capabilityScoped(profile),
-    path: `/api/mcp/oauth/flows/${encodeURIComponent(flowId)}`
-  })
-}
+  return async <T>(action: 'start' | 'poll' | 'callback' | 'cancel', params: Record<string, unknown>): Promise<T> => {
+    const { requestGatewayForAgent } = await import('@/store/gateway')
 
-/** Cancel an in-flight MCP OAuth flow server-side, freeing the per-server
- *  "already in progress" slot so a retry doesn't 409. */
-export function cancelMcpOAuthFlow(flowId: string, profile?: null | string): Promise<{ ok: boolean; status: string }> {
-  return hermesApi<{ ok: boolean; status: string }>({
-    ...profileScoped(profile),
-    path: `/api/mcp/oauth/flows/${encodeURIComponent(flowId)}`,
-    method: 'DELETE'
-  })
+    return requestGatewayForAgent<T>(connectionId, profile, `mcp.servers.oauth.${action}`, params, 60_000)
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -90,16 +76,19 @@ export function listMcpServers(): Promise<{ servers: McpServerSummary[] }> {
 
 /** Add one server to `mcp_servers` (validated + name-collision-checked
  *  server-side — the same endpoint the dashboard's add form uses). */
-export function addMcpServer(body: {
-  name: string
-  url?: string
-  command?: string
-  args?: string[]
-  env?: Record<string, string>
-  auth?: string
-}): Promise<McpServerSummary> {
-  return hermesApi<McpServerSummary>({
-    ...profileScoped(),
+export function addMcpServer(
+  body: {
+    name: string
+    url?: string
+    command?: string
+    args?: string[]
+    env?: Record<string, string>
+    auth?: string
+  },
+  profile?: ProfileScope
+): Promise<McpServerSummary> {
+  return window.hermesDesktop.api<McpServerSummary>({
+    ...capabilityScoped(profile),
     path: '/api/mcp/servers',
     method: 'POST',
     body
@@ -108,9 +97,9 @@ export function addMcpServer(body: {
 
 /** Remove one server from `mcp_servers` (the inline setup card's rollback
  *  when a directory install is cancelled after the config write). */
-export function removeMcpServer(name: string): Promise<{ ok: boolean }> {
-  return hermesApi<{ ok: boolean }>({
-    ...profileScoped(),
+export function removeMcpServer(name: string, profile?: ProfileScope): Promise<{ ok: boolean }> {
+  return window.hermesDesktop.api<{ ok: boolean }>({
+    ...capabilityScoped(profile),
     path: `/api/mcp/servers/${encodeURIComponent(name)}`,
     method: 'DELETE'
   })

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -17,11 +17,9 @@ import { TextTab } from '@/components/ui/text-tab'
 import { Textarea } from '@/components/ui/textarea'
 import { Tip } from '@/components/ui/tooltip'
 import {
-  authMcpServer,
   getActionStatus,
   getLogs,
   getMcpCatalog,
-  getMcpOAuthFlow,
   getUsageAnalytics,
   type HermesGateway,
   installMcpCatalogEntry,
@@ -611,9 +609,8 @@ export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; pr
     try {
       const flow = await completeMcpDesktopOAuth({
         serverName,
-        start: name => authMcpServer(name, profile ?? undefined),
-        status: flowId => getMcpOAuthFlow(flowId, profile ?? undefined),
-        openExternal: url => window.hermesDesktop.openExternal(url)
+        profile,
+        cancelled: () => profileEpoch.current !== epoch
       })
 
       const result: McpTestResult = { ok: true, tools: flow.tools ?? [] }

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -525,6 +525,15 @@ export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; pr
   // write its result into profile B's state after the user switched.
   const profileEpoch = useRef(0)
 
+  // Scoped Skills tabs remount when their owner changes; stop the old native
+  // OAuth waiter even when no app-wide profile-switch event is emitted.
+  useEffect(
+    () => () => {
+      profileEpoch.current += 1
+    },
+    [scopeProfileKey]
+  )
+
   // A profile switch invalidates the config query (see store/profile.ts), which
   // refetches the new backend's mcp.json. Reset ALL per-profile view state — the
   // draft (incl. a dirty one, so profile A's edits can't be saved into B), its

--- a/apps/desktop/src/components/assistant-ui/mcp-setup-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/mcp-setup-tool.tsx
@@ -1,10 +1,10 @@
-import { capabilityScoped } from '@/api/client'
-;('use client')
+'use client'
 
 import { type ToolCallMessagePartProps, useAuiState } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { capabilityScoped } from '@/api/client'
 import { useSessionView } from '@/app/chat/session-view'
 import { ToolFallback } from '@/components/assistant-ui/tool/fallback'
 import { WIDGET_SHELL_CLASS } from '@/components/chat/widget-shell'

--- a/apps/desktop/src/components/assistant-ui/mcp-setup-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/mcp-setup-tool.tsx
@@ -1,4 +1,5 @@
-'use client'
+import { capabilityScoped } from '@/api/client'
+;('use client')
 
 import { type ToolCallMessagePartProps, useAuiState } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
@@ -12,11 +13,8 @@ import { Codicon } from '@/components/ui/codicon'
 import { Input } from '@/components/ui/input'
 import {
   addMcpServer,
-  authMcpServer,
-  cancelMcpOAuthFlow,
   getActionStatus,
   getMcpCatalog,
-  getMcpOAuthFlow,
   installMcpCatalogEntry,
   type McpCatalogEntry,
   removeMcpServer,
@@ -250,6 +248,7 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
 
   const approve = useCallback(async () => {
     cancelRef.current = false
+    const oauthScope = capabilityScoped()
     setWorking(true)
 
     // Poll-boundary abort for the background-install loop; the OAuth flows
@@ -274,11 +273,8 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
       if (action === 'authorize') {
         const flow = await completeMcpDesktopOAuth({
           serverName: server,
-          start: authMcpServer,
-          status: getMcpOAuthFlow,
-          cancelled: () => cancelRef.current,
-          cancel: cancelMcpOAuthFlow,
-          openExternal: url => window.hermesDesktop.openExternal(url)
+          profile: oauthScope,
+          cancelled: () => cancelRef.current
         })
 
         triggerHaptic('submit')
@@ -314,21 +310,18 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
         // flow dies after the config write (cancel, closed OAuth tab), roll
         // the write back — decline means "no server", not an unauthorized
         // entry squatting in mcp_servers (authoritative-write rule).
-        await addMcpServer({ name: known.name, url: known.url })
+        await addMcpServer({ name: known.name, url: known.url }, oauthScope)
 
         let flow
 
         try {
           flow = await completeMcpDesktopOAuth({
             serverName: known.name,
-            start: authMcpServer,
-            status: getMcpOAuthFlow,
-            cancelled: () => cancelRef.current,
-            cancel: cancelMcpOAuthFlow,
-            openExternal: url => window.hermesDesktop.openExternal(url)
+            profile: oauthScope,
+            cancelled: () => cancelRef.current
           })
         } catch (error) {
-          await removeMcpServer(known.name).catch(() => {
+          await removeMcpServer(known.name, oauthScope).catch(() => {
             // Rollback is best-effort; the primary error/cancel wins.
           })
           throw error

--- a/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
@@ -74,176 +74,32 @@ afterEach(() => {
 })
 
 describe('Desktop MCP client callback lifecycle', () => {
-  it.each(['approved', 'cancel-start', 'cancel-poll', 'denial', 'poll', 'browser'])(
-    'preserves explicit local OAuth without a bridge through %s and foreground switches',
-    async outcome => {
-      const { rpc, api, bridge, openExternal } = harness()
-      window.hermesDesktop.mcpOauth = undefined
-      setApiRequestConnection('local')
-      setApiRequestProfile('origin-profile')
-      let cancelled = false
-      rpc.mockImplementation(async (_connection, _profile, method) => {
-        if (method.endsWith('.start')) {
-          setApiRequestConnection('other-gateway')
-          setApiRequestProfile('other-profile')
-          cancelled = outcome === 'cancel-start'
-
-          return started
-        }
-
-        if (method.endsWith('.poll')) {
-          cancelled = outcome === 'cancel-poll'
-
-          if (outcome === 'poll') {
-            throw new Error('poll failed')
-          }
-
-          return outcome === 'denial'
-            ? { ok: true, status: 'error', error_message: 'access_denied' }
-            : { ok: true, status: 'approved', tools }
-        }
-
-        return { ok: true }
-      })
-
-      if (outcome === 'browser') {
-        openExternal.mockRejectedValue(new Error('browser failed'))
-      }
-
-      const action = completeMcpDesktopOAuth({
-        serverName: 'reports',
-        cancelled: () => cancelled,
-        sleep: async () => {}
-      })
-
-      if (outcome === 'approved') {
-        await expect(action).resolves.toMatchObject({ status: 'approved', tools })
-      } else if (outcome.startsWith('cancel-')) {
-        await expect(action).rejects.toBeInstanceOf(McpOAuthCancelled)
-      } else {
-        await expect(action).rejects.toThrow(outcome === 'denial' ? 'access_denied' : `${outcome} failed`)
-      }
-
-      expect(rpc).toHaveBeenCalledWith(
-        'local',
-        'origin-profile',
-        'mcp.servers.oauth.start',
-        { name: 'reports' },
-        60_000
-      )
-      expect(rpc.mock.calls.every(call => call[0] === 'local' && call[1] === 'origin-profile')).toBe(true)
-      expect(rpc.mock.calls.filter(call => call[2].endsWith('.start'))).toHaveLength(1)
-      expect(rpc.mock.calls.filter(call => call[2].endsWith('.cancel'))).toHaveLength(outcome === 'approved' ? 0 : 1)
-      expect(rpc.mock.calls.filter(call => call[2].endsWith('.callback'))).toHaveLength(0)
-      expect(openExternal.mock.calls).toEqual(outcome === 'cancel-start' ? [] : [[authUrl]])
-      expect(bridge.listen).not.toHaveBeenCalled()
-      expect(bridge.wait).not.toHaveBeenCalled()
-      expect(bridge.cancel).not.toHaveBeenCalled()
-      expect(api).not.toHaveBeenCalled()
-    }
-  )
-
-  it.each([
-    { connectionId: null, uri: redirectUri },
-    { connectionId: 'remote-gateway', uri: redirectUri },
-    { connectionId: 'local', uri: 'http://remote.example:49152/callback' },
-    { connectionId: 'local', uri: 'https://127.0.0.1:49152/callback' },
-    { connectionId: 'local', uri: 'http://127.0.0.1:49152/not-callback' },
-    { connectionId: 'local', uri: 'http://user@127.0.0.1:49152/callback' },
-    { connectionId: 'local', uri: 'http://127.0.0.1:49152/callback#fragment' },
-    { connectionId: 'local', uri: '' },
-    { connectionId: 'local', uri: redirectUri, listenerFailure: true }
-  ])('refuses unsafe compatibility paths: %j', async ({ connectionId, uri, listenerFailure }) => {
-    const { rpc, api, bridge, openExternal } = harness()
-    setApiRequestConnection(connectionId)
-
-    if (listenerFailure) {
-      bridge.listen.mockRejectedValue(new Error('listen failed'))
-    } else {
-      window.hermesDesktop.mcpOauth = undefined
-    }
-
-    rpc.mockResolvedValue({
-      ...started,
-      auth_url: `https://idp.example/authorize?state=expected&redirect_uri=${encodeURIComponent(uri)}`
-    })
-    await expect(completeMcpDesktopOAuth({ serverName: 'reports' })).rejects.toThrow()
-    expect(openExternal).not.toHaveBeenCalled()
-    expect(api).not.toHaveBeenCalled()
-
-    if (connectionId !== 'local' || listenerFailure) {
-      expect(rpc).not.toHaveBeenCalled()
-    } else {
-      expect(rpc.mock.calls.map(call => call[2])).toEqual(['mcp.servers.oauth.start', 'mcp.servers.oauth.cancel'])
-    }
-  })
-
-  it('bounds pending polls even after the browser callback arrives', async () => {
-    const { rpc, bridge } = harness()
-    const base = rpc.getMockImplementation()!
-    rpc.mockImplementation(async (...args) =>
-      args[2].endsWith('.poll') ? { ok: true, status: 'pending' } : base(...args)
-    )
-    let now = 0
-    const clock = vi.spyOn(Date, 'now').mockImplementation(() => now)
-
-    try {
-      await expect(
-        completeMcpDesktopOAuth({
-          serverName: 'reports',
-          timeoutMs: 3000,
-          sleep: async () => {
-            now += 1000
-          }
-        })
-      ).rejects.toThrow('Timed out')
-      expect(bridge.cancel).toHaveBeenCalled()
-    } finally {
-      clock.mockRestore()
-    }
-  })
-
-  it.each([null, 'local', 'remote-gateway'])(
-    'relays the client callback and pins %s plus profile across foreground switches',
+  it.each(['local', 'remote-gateway'])(
+    'relays through the native listener and keeps the %s owner after foreground changes',
     async connectionId => {
       const { bridge, api, openExternal, rpc } = harness()
       setApiRequestConnection(connectionId)
       setApiRequestProfile('origin-profile')
+      const callbackResult = { code: 'code-1', state: 'expected', error: null }
+      bridge.wait.mockResolvedValue(callbackResult)
       openExternal.mockImplementation(async () => {
         setApiRequestConnection('other-gateway')
         setApiRequestProfile('other-profile')
-        const cb = { code: 'code-1', state: 'expected', error: null }
-        bridge.wait.mockResolvedValue(cb)
-
-        // The waiter was already armed before the browser opened.
-        return undefined
       })
-      const callbackResult = { code: 'code-1', state: 'expected', error: null }
-      bridge.wait.mockResolvedValue(callbackResult)
-
       const result = await completeMcpDesktopOAuth({ serverName: 'reports', sleep: async () => {} })
-
       expect(result).toMatchObject({ status: 'approved', tools })
-      expect(openExternal).toHaveBeenCalledWith(authUrl)
       expect(rpc).toHaveBeenCalledWith(
         connectionId,
         'origin-profile',
         'mcp.servers.oauth.start',
-        {
-          name: 'reports',
-          client_redirect_uri: redirectUri
-        },
+        { name: 'reports', client_redirect_uri: redirectUri },
         60_000
       )
       expect(rpc).toHaveBeenCalledWith(
         connectionId,
         'origin-profile',
         'mcp.servers.oauth.callback',
-        {
-          name: 'reports',
-          session_id: 'flow-1',
-          ...callbackResult
-        },
+        { name: 'reports', session_id: 'flow-1', ...callbackResult },
         60_000
       )
       expect(rpc.mock.calls.every(call => call[0] === connectionId && call[1] === 'origin-profile')).toBe(true)
@@ -252,131 +108,42 @@ describe('Desktop MCP client callback lifecycle', () => {
     }
   )
 
-  it.each([
-    'cancel-start',
-    'cancel-poll',
-    'browser',
-    'listen',
-    'start',
-    'poll',
-    'relay',
-    'wait',
-    'legacy',
-    'missing-method',
-    'denial',
-    'missing-bridge'
-  ])('cleans up on %s without retargeting or retrying a remote callback', async failure => {
-    const { bridge, callback, api, openExternal, rpc } = harness()
+  it.each(['cancel', 'legacy'])('cleans up the owner before opening an unsafe authorization on %s', async outcome => {
+    const { rpc, bridge, openExternal, api } = harness()
     setApiRequestConnection('remote-gateway')
     setApiRequestProfile('origin-profile')
     let cancelled = false
-    const pendingStart = deferred<typeof started>()
-    const base = rpc.getMockImplementation()!
-    rpc.mockImplementation(async (connection, profile, method, params, timeout) => {
+    rpc.mockImplementation(async (_connection, _profile, method) => {
       if (method.endsWith('.start')) {
-        if (failure === 'missing-method') {
-          throw new Error('Unknown method: mcp.servers.oauth.start')
-        }
+        setApiRequestConnection('other-gateway')
+        setApiRequestProfile('other-profile')
+        cancelled = outcome === 'cancel'
 
-        if (failure === 'start') {
-          throw new Error('start failed')
-        }
-
-        if (failure === 'cancel-start') {
-          cancelled = true
-          setApiRequestConnection('other-gateway')
-          setApiRequestProfile('other-profile')
-          pendingStart.resolve(started)
-
-          return pendingStart.promise
-        }
-
-        if (failure === 'legacy') {
-          return {
-            ...started,
-            auth_url: 'https://idp.example/authorize?state=expected&redirect_uri=http%3A%2F%2Fremote%2Fcallback'
-          }
-        }
+        return outcome === 'legacy'
+          ? { ...started, auth_url: 'https://idp.example/authorize?redirect_uri=http://remote/callback' }
+          : started
       }
 
-      if (method.endsWith('.poll')) {
-        if (failure === 'denial') {
-          return { ok: true, status: 'error', error_message: 'access_denied' }
-        }
-
-        if (failure === 'poll') {
-          throw new Error('poll failed')
-        }
-
-        if (failure === 'cancel-poll') {
-          cancelled = true
-
-          return { ok: true, status: 'pending' }
-        }
-      }
-
-      if (method.endsWith('.callback') && failure === 'relay') {
-        return { ok: false, error_message: 'state mismatch' }
-      }
-
-      return base(connection, profile, method, params, timeout)
+      return { ok: true }
     })
+    const action = completeMcpDesktopOAuth({ serverName: 'reports', cancelled: () => cancelled })
 
-    if (failure === 'browser') {
-      openExternal.mockRejectedValue(new Error('browser failed'))
-    }
-
-    if (failure === 'listen') {
-      bridge.listen.mockRejectedValue(new Error('listen failed'))
-    }
-
-    if (failure === 'wait') {
-      bridge.wait.mockRejectedValue(new Error('wait failed'))
-    }
-
-    if (failure === 'missing-bridge') {
-      window.hermesDesktop.mcpOauth = undefined
-    }
-
-    if (failure === 'cancel-poll' || failure === 'poll') {
-      openExternal.mockResolvedValue(undefined)
-    }
-
-    const action = completeMcpDesktopOAuth({ serverName: 'reports', cancelled: () => cancelled, sleep: async () => {} })
-
-    if (failure.startsWith('cancel-')) {
+    if (outcome === 'cancel') {
       await expect(action).rejects.toBeInstanceOf(McpOAuthCancelled)
     } else {
-      await expect(action).rejects.toThrow()
+      await expect(action).rejects.toThrow('Update the Hermes backend')
     }
 
-    if (!['listen', 'missing-bridge'].includes(failure)) {
-      expect(bridge.cancel).toHaveBeenCalledWith('listener-1')
-    }
-
-    if (!['listen', 'start', 'missing-method', 'missing-bridge'].includes(failure)) {
-      expect(rpc).toHaveBeenCalledWith(
-        'remote-gateway',
-        'origin-profile',
-        'mcp.servers.oauth.cancel',
-        {
-          name: 'reports',
-          session_id: 'flow-1'
-        },
-        60_000
-      )
-    }
-
-    expect(rpc.mock.calls.every(call => call[0] === 'remote-gateway' && call[1] === 'origin-profile')).toBe(true)
-
-    if (failure === 'cancel-start' || failure === 'legacy') {
-      expect(openExternal).not.toHaveBeenCalled()
-    }
-
-    expect(rpc.mock.calls.filter(call => call[2].endsWith('.start'))).toHaveLength(
-      failure === 'listen' || failure === 'missing-bridge' ? 0 : 1
+    expect(openExternal).not.toHaveBeenCalled()
+    expect(bridge.cancel).toHaveBeenCalledWith('listener-1')
+    expect(rpc).toHaveBeenCalledWith(
+      'remote-gateway',
+      'origin-profile',
+      'mcp.servers.oauth.cancel',
+      { name: 'reports', session_id: 'flow-1' },
+      60_000
     )
+    expect(rpc.mock.calls.every(call => call[0] === 'remote-gateway' && call[1] === 'origin-profile')).toBe(true)
     expect(api).not.toHaveBeenCalled()
-    callback.resolve({ code: null, state: null, error: 'cancelled' })
   })
 })

--- a/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
@@ -1,72 +1,278 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { completeMcpDesktopOAuth } from './mcp-dashboard-oauth'
+import { setApiRequestConnection, setApiRequestProfile } from '@/api/client'
+import { requestGatewayForAgent } from '@/store/gateway'
 
-describe('completeMcpDesktopOAuth', () => {
-  it('opens the returned authorization URL and polls through approval', async () => {
-    const openExternal = vi.fn().mockResolvedValue(undefined)
+import { completeMcpDesktopOAuth, McpOAuthCancelled } from './mcp-dashboard-oauth'
 
-    const status = vi
-      .fn()
-      .mockResolvedValueOnce({
-        flow_id: 'flow-1',
-        server_name: 'reports',
-        status: 'authorization_required',
-        authorization_url: 'https://idp.example/authorize',
-        error: null
-      })
-      .mockResolvedValueOnce({
-        flow_id: 'flow-1',
-        server_name: 'reports',
-        status: 'approved',
-        authorization_url: 'https://idp.example/authorize',
-        error: null,
-        tools: [{ name: 'list_reports', description: 'List reports' }]
-      })
+vi.mock('@/store/gateway', () => ({ requestGatewayForAgent: vi.fn() }))
 
-    const result = await completeMcpDesktopOAuth({
-      serverName: 'reports',
-      start: vi.fn().mockResolvedValue({
-        flow_id: 'flow-1',
-        server_name: 'reports',
-        status: 'authorization_required',
-        authorization_url: 'https://idp.example/authorize',
-        error: null
-      }),
-      status,
-      openExternal,
-      sleep: async () => {}
-    })
+const redirectUri = 'http://127.0.0.1:49152/callback'
+const authUrl = `https://idp.example/authorize?state=expected&redirect_uri=${encodeURIComponent(redirectUri)}`
+const started = { ok: true, session_id: 'flow-1', auth_url: authUrl, flow: 'pkce' }
+const tools = [{ name: 'list_reports', description: 'List reports' }]
 
-    expect(openExternal).toHaveBeenCalledWith('https://idp.example/authorize')
-    expect(result.status).toBe('approved')
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: Error) => void
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
   })
 
-  it('retries a transient status failure', async () => {
-    const status = vi.fn().mockRejectedValueOnce(new Error('temporary network failure')).mockResolvedValueOnce({
-      flow_id: 'flow-2',
-      server_name: 'reports',
-      status: 'approved',
-      authorization_url: 'https://idp.example/authorize',
-      error: null,
-      tools: []
+  return { promise, resolve, reject }
+}
+
+function harness() {
+  const callback = deferred<{ code: string | null; state: string | null; error: string | null }>()
+
+  const bridge = {
+    listen: vi.fn().mockResolvedValue({ id: 'listener-1', redirectUri }),
+    wait: vi.fn(() => callback.promise),
+    cancel: vi.fn(async () => {
+      callback.resolve({ code: null, state: null, error: 'cancelled' })
+
+      return true
+    })
+  }
+
+  const api = vi.fn().mockRejectedValue(new Error('Desktop OAuth must not use the remote REST callback'))
+
+  const openExternal = vi.fn(async () => {
+    callback.resolve({ code: 'code-1', state: 'expected', error: null })
+  })
+
+  Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: { mcpOauth: bridge, api, openExternal } })
+  let relayed = false
+  const rpc = vi.mocked(requestGatewayForAgent)
+  rpc.mockImplementation(async (_connection, _profile, method) => {
+    if (method.endsWith('.start')) {
+      return started
+    }
+
+    if (method.endsWith('.callback')) {
+      relayed = true
+
+      return { ok: true }
+    }
+
+    if (method.endsWith('.cancel')) {
+      return { ok: true, status: 'error' }
+    }
+
+    return { ok: true, status: relayed ? 'approved' : 'pending', tools }
+  })
+
+  return { bridge, callback, api, openExternal, rpc }
+}
+
+afterEach(() => {
+  vi.resetAllMocks()
+  setApiRequestConnection(null)
+  setApiRequestProfile(null)
+})
+
+describe('Desktop MCP client callback lifecycle', () => {
+  it('bounds pending polls even after the browser callback arrives', async () => {
+    const { rpc, bridge } = harness()
+    const base = rpc.getMockImplementation()!
+    rpc.mockImplementation(async (...args) =>
+      args[2].endsWith('.poll') ? { ok: true, status: 'pending' } : base(...args)
+    )
+    let now = 0
+    const clock = vi.spyOn(Date, 'now').mockImplementation(() => now)
+
+    try {
+      await expect(
+        completeMcpDesktopOAuth({
+          serverName: 'reports',
+          timeoutMs: 3000,
+          sleep: async () => {
+            now += 1000
+          }
+        })
+      ).rejects.toThrow('Timed out')
+      expect(bridge.cancel).toHaveBeenCalled()
+    } finally {
+      clock.mockRestore()
+    }
+  })
+
+  it.each([null, 'local', 'remote-gateway'])(
+    'relays the client callback and pins %s plus profile across foreground switches',
+    async connectionId => {
+      const { bridge, api, openExternal, rpc } = harness()
+      setApiRequestConnection(connectionId)
+      setApiRequestProfile('origin-profile')
+      openExternal.mockImplementation(async () => {
+        setApiRequestConnection('other-gateway')
+        setApiRequestProfile('other-profile')
+        const cb = { code: 'code-1', state: 'expected', error: null }
+        bridge.wait.mockResolvedValue(cb)
+
+        // The waiter was already armed before the browser opened.
+        return undefined
+      })
+      const callbackResult = { code: 'code-1', state: 'expected', error: null }
+      bridge.wait.mockResolvedValue(callbackResult)
+
+      const result = await completeMcpDesktopOAuth({ serverName: 'reports', sleep: async () => {} })
+
+      expect(result).toMatchObject({ status: 'approved', tools })
+      expect(openExternal).toHaveBeenCalledWith(authUrl)
+      expect(rpc).toHaveBeenCalledWith(
+        connectionId,
+        'origin-profile',
+        'mcp.servers.oauth.start',
+        {
+          name: 'reports',
+          client_redirect_uri: redirectUri
+        },
+        60_000
+      )
+      expect(rpc).toHaveBeenCalledWith(
+        connectionId,
+        'origin-profile',
+        'mcp.servers.oauth.callback',
+        {
+          name: 'reports',
+          session_id: 'flow-1',
+          ...callbackResult
+        },
+        60_000
+      )
+      expect(rpc.mock.calls.every(call => call[0] === connectionId && call[1] === 'origin-profile')).toBe(true)
+      expect(bridge.cancel).toHaveBeenCalledWith('listener-1')
+      expect(api).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each([
+    'cancel-start',
+    'cancel-poll',
+    'browser',
+    'listen',
+    'start',
+    'poll',
+    'relay',
+    'wait',
+    'legacy',
+    'missing-method',
+    'denial',
+    'missing-bridge'
+  ])('cleans up on %s without retargeting or retrying a remote callback', async failure => {
+    const { bridge, callback, api, openExternal, rpc } = harness()
+    setApiRequestConnection('remote-gateway')
+    setApiRequestProfile('origin-profile')
+    let cancelled = false
+    const pendingStart = deferred<typeof started>()
+    const base = rpc.getMockImplementation()!
+    rpc.mockImplementation(async (connection, profile, method, params, timeout) => {
+      if (method.endsWith('.start')) {
+        if (failure === 'missing-method') {
+          throw new Error('Unknown method: mcp.servers.oauth.start')
+        }
+
+        if (failure === 'start') {
+          throw new Error('start failed')
+        }
+
+        if (failure === 'cancel-start') {
+          cancelled = true
+          setApiRequestConnection('other-gateway')
+          setApiRequestProfile('other-profile')
+          pendingStart.resolve(started)
+
+          return pendingStart.promise
+        }
+
+        if (failure === 'legacy') {
+          return {
+            ...started,
+            auth_url: 'https://idp.example/authorize?state=expected&redirect_uri=http%3A%2F%2Fremote%2Fcallback'
+          }
+        }
+      }
+
+      if (method.endsWith('.poll')) {
+        if (failure === 'denial') {
+          return { ok: true, status: 'error', error_message: 'access_denied' }
+        }
+
+        if (failure === 'poll') {
+          throw new Error('poll failed')
+        }
+
+        if (failure === 'cancel-poll') {
+          cancelled = true
+
+          return { ok: true, status: 'pending' }
+        }
+      }
+
+      if (method.endsWith('.callback') && failure === 'relay') {
+        return { ok: false, error_message: 'state mismatch' }
+      }
+
+      return base(connection, profile, method, params, timeout)
     })
 
-    const result = await completeMcpDesktopOAuth({
-      serverName: 'reports',
-      start: vi.fn().mockResolvedValue({
-        flow_id: 'flow-2',
-        server_name: 'reports',
-        status: 'authorization_required',
-        authorization_url: 'https://idp.example/authorize',
-        error: null
-      }),
-      status,
-      openExternal: vi.fn().mockResolvedValue(undefined),
-      sleep: async () => {}
-    })
+    if (failure === 'browser') {
+      openExternal.mockRejectedValue(new Error('browser failed'))
+    }
 
-    expect(result.status).toBe('approved')
-    expect(status).toHaveBeenCalledTimes(2)
+    if (failure === 'listen') {
+      bridge.listen.mockRejectedValue(new Error('listen failed'))
+    }
+
+    if (failure === 'wait') {
+      bridge.wait.mockRejectedValue(new Error('wait failed'))
+    }
+
+    if (failure === 'missing-bridge') {
+      window.hermesDesktop.mcpOauth = undefined
+    }
+
+    if (failure === 'cancel-poll' || failure === 'poll') {
+      openExternal.mockResolvedValue(undefined)
+    }
+
+    const action = completeMcpDesktopOAuth({ serverName: 'reports', cancelled: () => cancelled, sleep: async () => {} })
+
+    if (failure.startsWith('cancel-')) {
+      await expect(action).rejects.toBeInstanceOf(McpOAuthCancelled)
+    } else {
+      await expect(action).rejects.toThrow()
+    }
+
+    if (!['listen', 'missing-bridge'].includes(failure)) {
+      expect(bridge.cancel).toHaveBeenCalledWith('listener-1')
+    }
+
+    if (!['listen', 'start', 'missing-method', 'missing-bridge'].includes(failure)) {
+      expect(rpc).toHaveBeenCalledWith(
+        'remote-gateway',
+        'origin-profile',
+        'mcp.servers.oauth.cancel',
+        {
+          name: 'reports',
+          session_id: 'flow-1'
+        },
+        60_000
+      )
+    }
+
+    expect(rpc.mock.calls.every(call => call[0] === 'remote-gateway' && call[1] === 'origin-profile')).toBe(true)
+
+    if (failure === 'cancel-start' || failure === 'legacy') {
+      expect(openExternal).not.toHaveBeenCalled()
+    }
+
+    expect(rpc.mock.calls.filter(call => call[2].endsWith('.start'))).toHaveLength(
+      failure === 'listen' || failure === 'missing-bridge' ? 0 : 1
+    )
+    expect(api).not.toHaveBeenCalled()
+    callback.resolve({ code: null, state: null, error: 'cancelled' })
   })
 })

--- a/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
@@ -74,6 +74,110 @@ afterEach(() => {
 })
 
 describe('Desktop MCP client callback lifecycle', () => {
+  it.each(['approved', 'cancel-start', 'cancel-poll', 'denial', 'poll', 'browser'])(
+    'preserves explicit local OAuth without a bridge through %s and foreground switches',
+    async outcome => {
+      const { rpc, api, bridge, openExternal } = harness()
+      window.hermesDesktop.mcpOauth = undefined
+      setApiRequestConnection('local')
+      setApiRequestProfile('origin-profile')
+      let cancelled = false
+      rpc.mockImplementation(async (_connection, _profile, method) => {
+        if (method.endsWith('.start')) {
+          setApiRequestConnection('other-gateway')
+          setApiRequestProfile('other-profile')
+          cancelled = outcome === 'cancel-start'
+
+          return started
+        }
+
+        if (method.endsWith('.poll')) {
+          cancelled = outcome === 'cancel-poll'
+
+          if (outcome === 'poll') {
+            throw new Error('poll failed')
+          }
+
+          return outcome === 'denial'
+            ? { ok: true, status: 'error', error_message: 'access_denied' }
+            : { ok: true, status: 'approved', tools }
+        }
+
+        return { ok: true }
+      })
+
+      if (outcome === 'browser') {
+        openExternal.mockRejectedValue(new Error('browser failed'))
+      }
+
+      const action = completeMcpDesktopOAuth({
+        serverName: 'reports',
+        cancelled: () => cancelled,
+        sleep: async () => {}
+      })
+
+      if (outcome === 'approved') {
+        await expect(action).resolves.toMatchObject({ status: 'approved', tools })
+      } else if (outcome.startsWith('cancel-')) {
+        await expect(action).rejects.toBeInstanceOf(McpOAuthCancelled)
+      } else {
+        await expect(action).rejects.toThrow(outcome === 'denial' ? 'access_denied' : `${outcome} failed`)
+      }
+
+      expect(rpc).toHaveBeenCalledWith(
+        'local',
+        'origin-profile',
+        'mcp.servers.oauth.start',
+        { name: 'reports' },
+        60_000
+      )
+      expect(rpc.mock.calls.every(call => call[0] === 'local' && call[1] === 'origin-profile')).toBe(true)
+      expect(rpc.mock.calls.filter(call => call[2].endsWith('.start'))).toHaveLength(1)
+      expect(rpc.mock.calls.filter(call => call[2].endsWith('.cancel'))).toHaveLength(outcome === 'approved' ? 0 : 1)
+      expect(rpc.mock.calls.filter(call => call[2].endsWith('.callback'))).toHaveLength(0)
+      expect(openExternal.mock.calls).toEqual(outcome === 'cancel-start' ? [] : [[authUrl]])
+      expect(bridge.listen).not.toHaveBeenCalled()
+      expect(bridge.wait).not.toHaveBeenCalled()
+      expect(bridge.cancel).not.toHaveBeenCalled()
+      expect(api).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each([
+    { connectionId: null, uri: redirectUri },
+    { connectionId: 'remote-gateway', uri: redirectUri },
+    { connectionId: 'local', uri: 'http://remote.example:49152/callback' },
+    { connectionId: 'local', uri: 'https://127.0.0.1:49152/callback' },
+    { connectionId: 'local', uri: 'http://127.0.0.1:49152/not-callback' },
+    { connectionId: 'local', uri: 'http://user@127.0.0.1:49152/callback' },
+    { connectionId: 'local', uri: 'http://127.0.0.1:49152/callback#fragment' },
+    { connectionId: 'local', uri: '' },
+    { connectionId: 'local', uri: redirectUri, listenerFailure: true }
+  ])('refuses unsafe compatibility paths: %j', async ({ connectionId, uri, listenerFailure }) => {
+    const { rpc, api, bridge, openExternal } = harness()
+    setApiRequestConnection(connectionId)
+
+    if (listenerFailure) {
+      bridge.listen.mockRejectedValue(new Error('listen failed'))
+    } else {
+      window.hermesDesktop.mcpOauth = undefined
+    }
+
+    rpc.mockResolvedValue({
+      ...started,
+      auth_url: `https://idp.example/authorize?state=expected&redirect_uri=${encodeURIComponent(uri)}`
+    })
+    await expect(completeMcpDesktopOAuth({ serverName: 'reports' })).rejects.toThrow()
+    expect(openExternal).not.toHaveBeenCalled()
+    expect(api).not.toHaveBeenCalled()
+
+    if (connectionId !== 'local' || listenerFailure) {
+      expect(rpc).not.toHaveBeenCalled()
+    } else {
+      expect(rpc.mock.calls.map(call => call[2])).toEqual(['mcp.servers.oauth.start', 'mcp.servers.oauth.cancel'])
+    }
+  })
+
   it('bounds pending polls even after the browser callback arrives', async () => {
     const { rpc, bridge } = harness()
     const base = rpc.getMockImplementation()!

--- a/apps/desktop/src/lib/mcp-dashboard-oauth.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.ts
@@ -1,30 +1,27 @@
-export interface McpOAuthFlow {
-  flow_id: string
-  server_name: string
-  status: 'starting' | 'authorization_required' | 'approved' | 'error'
-  authorization_url: string | null
-  error: string | null
-  tools?: Array<{ name: string; description: string }>
-}
+import type { ProfileScope } from '@/api/client'
+import { type McpOAuthFlow, mcpOAuthRpc } from '@/api/mcp'
+
+import { isMissingRpcMethod } from './gateway-rpc'
 
 interface CompleteOptions {
   serverName: string
-  start: (name: string) => Promise<McpOAuthFlow>
-  status: (flowId: string) => Promise<McpOAuthFlow>
-  openExternal: (url: string) => Promise<void>
-  /** Polled between status checks. Returning true cancels: the flow is
-   *  cancelled SERVER-SIDE (freeing the per-server in-progress slot — without
-   *  it a retry 409s until the backend's callback timeout) and the promise
-   *  rejects with `McpOAuthCancelled`. */
+  profile?: ProfileScope
   cancelled?: () => boolean
-  /** Server-side flow cancel, wired to DELETE /api/mcp/oauth/flows/{id}. */
-  cancel?: (flowId: string) => Promise<unknown>
   sleep?: (milliseconds: number) => Promise<void>
   maxPollFailures?: number
+  timeoutMs?: number
 }
 
-/** Thrown when the caller's `cancelled()` tripped — callers branch on this to
- *  skip error toasts for a deliberate user cancel. */
+interface OAuthResult {
+  ok: boolean
+  session_id?: string
+  auth_url?: string
+  status?: 'pending' | 'approved' | 'error'
+  error_message?: string
+  tools?: McpOAuthFlow['tools']
+}
+
+/** Deliberate cancellation is not an error toast. */
 export class McpOAuthCancelled extends Error {
   constructor() {
     super('OAuth cancelled by user')
@@ -33,64 +30,172 @@ export class McpOAuthCancelled extends Error {
 }
 
 const defaultSleep = (milliseconds: number) => new Promise<void>(resolve => window.setTimeout(resolve, milliseconds))
+const UPDATE_BACKEND = 'Update the Hermes backend to support Desktop MCP OAuth callbacks.'
 
+/** The browser and redirect listener live on the Desktop machine, even when
+ *  the token-exchanging gateway is remote. Never fall back to its REST callback. */
 export async function completeMcpDesktopOAuth({
   serverName,
-  start,
-  status,
-  openExternal,
+  profile,
   cancelled,
-  cancel,
   sleep = defaultSleep,
-  maxPollFailures = 3
+  maxPollFailures = 3,
+  timeoutMs = 360_000
 }: CompleteOptions): Promise<McpOAuthFlow> {
-  const started = await start(serverName)
+  const deadline = Date.now() + timeoutMs
+  const rpc = mcpOAuthRpc(profile)
+  const bridge = window.hermesDesktop.mcpOauth
 
-  if (started.status === 'error') {
-    throw new Error(started.error || 'OAuth failed to start')
+  if (!bridge) {
+    throw new Error('Update Hermes Desktop to support MCP OAuth callbacks.')
   }
 
-  if (!started.authorization_url) {
-    throw new Error('OAuth server did not provide an authorization URL')
-  }
+  let listener: { id: string; redirectUri: string } | undefined
+  let sessionId: string | undefined
+  let authUrl: string | undefined
+  let approved = false
+  let closed = false
+  let relayError: unknown
 
-  await openExternal(started.authorization_url)
-
-  let pollFailures = 0
-
-  for (;;) {
+  const checkCancelled = () => {
     if (cancelled?.()) {
-      // Free the backend slot before rejecting; best-effort — the flow also
-      // dies on its own timeout if this request is lost.
-      await cancel?.(started.flow_id).catch(() => {})
       throw new McpOAuthCancelled()
     }
+  }
 
-    let current: McpOAuthFlow
+  const request = async (action: 'start' | 'poll' | 'callback' | 'cancel', params: Record<string, unknown>) => {
+    const result = await rpc<OAuthResult>(action, { name: serverName, ...params })
 
-    try {
-      current = await status(started.flow_id)
-      pollFailures = 0
-    } catch (error) {
-      pollFailures += 1
+    if (!result.ok) {
+      throw new Error(result.error_message || 'MCP OAuth request failed')
+    }
 
-      if (pollFailures >= maxPollFailures) {
-        throw error
+    return result
+  }
+
+  try {
+    checkCancelled()
+    listener = await bridge.listen()
+    checkCancelled()
+    const started = await request('start', { client_redirect_uri: listener.redirectUri })
+    sessionId = started.session_id
+    authUrl = started.auth_url
+    // Start may have created a flow while the user cancelled. Keep its id so
+    // finally can release it, but do not launch a browser after cancellation.
+    checkCancelled()
+
+    if (!sessionId || !authUrl) {
+      throw new Error('OAuth server did not provide an authorization URL and session')
+    }
+
+    // Pre-relay backends silently ignore unknown start params. Do not open an
+    // authorization URL whose DCR/PKCE flow points at a different machine.
+    if (new URL(authUrl).searchParams.get('redirect_uri') !== listener.redirectUri) {
+      throw new Error(UPDATE_BACKEND)
+    }
+
+    const flowId = sessionId
+    void bridge
+      .wait(listener.id)
+      .then(async callback => {
+        if (closed || cancelled?.()) {
+          return
+        }
+
+        if (!callback.state) {
+          throw new Error(callback.error || 'OAuth callback did not include state')
+        }
+
+        await request('callback', { session_id: flowId, ...callback })
+      })
+      .catch(error => {
+        relayError = error
+      })
+
+    await window.hermesDesktop.openExternal(authUrl)
+    let pollFailures = 0
+
+    for (;;) {
+      checkCancelled()
+
+      if (Date.now() >= deadline) {
+        throw new Error('Timed out waiting for MCP OAuth authorization')
+      }
+
+      if (relayError) {
+        throw relayError
+      }
+
+      let current: OAuthResult
+
+      try {
+        current = await request('poll', { session_id: flowId })
+        pollFailures = 0
+      } catch (error) {
+        if (++pollFailures >= maxPollFailures) {
+          throw error
+        }
+
+        await sleep(1000)
+
+        continue
+      }
+
+      checkCancelled()
+
+      if (relayError) {
+        throw relayError
+      }
+
+      if (current.status === 'approved') {
+        approved = true
+
+        return {
+          flow_id: flowId,
+          server_name: serverName,
+          status: 'approved',
+          authorization_url: authUrl,
+          error: null,
+          tools: current.tools
+        }
+      }
+
+      if (current.status === 'error') {
+        throw new Error(current.error_message || 'OAuth authorization failed')
       }
 
       await sleep(1000)
-
-      continue
+    }
+  } catch (error) {
+    if (isMissingRpcMethod(error)) {
+      throw new Error(UPDATE_BACKEND)
     }
 
-    if (current.status === 'approved') {
-      return current
+    throw error
+  } finally {
+    closed = true
+
+    // Stop the native waiter first: its synthetic cancellation is NOT a
+    // provider callback and must never race cleanup back onto the gateway.
+    if (listener) {
+      await bridge.cancel(listener.id).catch(() => {})
     }
 
-    if (current.status === 'error') {
-      throw new Error(current.error || 'OAuth authorization failed')
-    }
+    if (sessionId && !approved) {
+      try {
+        await request('cancel', { session_id: sessionId })
+      } catch (error) {
+        // Relay-capable backends predating oauth.cancel can still release a
+        // waiting worker with a state-checked denial. No HTTP redirect retry.
+        if (isMissingRpcMethod(error) && authUrl) {
+          const state = new URL(authUrl).searchParams.get('state')
 
-    await sleep(1000)
+          if (state) {
+            await request('callback', { session_id: sessionId, state, error: 'access_denied' }).catch(() => {})
+          }
+        }
+        // Network cleanup is best-effort; backend callback timeout is bounded.
+      }
+    }
   }
 }

--- a/apps/desktop/src/lib/mcp-dashboard-oauth.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.ts
@@ -1,4 +1,4 @@
-import type { ProfileScope } from '@/api/client'
+import { capabilityScoped, type ProfileScope } from '@/api/client'
 import { type McpOAuthFlow, mcpOAuthRpc } from '@/api/mcp'
 
 import { isMissingRpcMethod } from './gateway-rpc'
@@ -32,8 +32,8 @@ export class McpOAuthCancelled extends Error {
 const defaultSleep = (milliseconds: number) => new Promise<void>(resolve => window.setTimeout(resolve, milliseconds))
 const UPDATE_BACKEND = 'Update the Hermes backend to support Desktop MCP OAuth callbacks.'
 
-/** The browser and redirect listener live on the Desktop machine, even when
- *  the token-exchanging gateway is remote. Never fall back to its REST callback. */
+/** Remote gateways require the Desktop callback bridge. An explicitly local
+ *  gateway can host its own loopback listener when that capability is absent. */
 export async function completeMcpDesktopOAuth({
   serverName,
   profile,
@@ -43,10 +43,12 @@ export async function completeMcpDesktopOAuth({
   timeoutMs = 360_000
 }: CompleteOptions): Promise<McpOAuthFlow> {
   const deadline = Date.now() + timeoutMs
-  const rpc = mcpOAuthRpc(profile)
+  const scope = capabilityScoped(profile)
+  const rpc = mcpOAuthRpc(scope)
   const bridge = window.hermesDesktop.mcpOauth
 
-  if (!bridge) {
+  // A legacy null connection can resolve to a remote registry primary.
+  if (!bridge && scope.connectionId !== 'local') {
     throw new Error('Update Hermes Desktop to support MCP OAuth callbacks.')
   }
 
@@ -75,9 +77,13 @@ export async function completeMcpDesktopOAuth({
 
   try {
     checkCancelled()
-    listener = await bridge.listen()
-    checkCancelled()
-    const started = await request('start', { client_redirect_uri: listener.redirectUri })
+
+    if (bridge) {
+      listener = await bridge.listen()
+      checkCancelled()
+    }
+
+    const started = await request('start', listener ? { client_redirect_uri: listener.redirectUri } : {})
     sessionId = started.session_id
     authUrl = started.auth_url
     // Start may have created a flow while the user cancelled. Keep its id so
@@ -90,27 +96,51 @@ export async function completeMcpDesktopOAuth({
 
     // Pre-relay backends silently ignore unknown start params. Do not open an
     // authorization URL whose DCR/PKCE flow points at a different machine.
-    if (new URL(authUrl).searchParams.get('redirect_uri') !== listener.redirectUri) {
+    const redirectUri = new URL(authUrl).searchParams.get('redirect_uri')
+
+    if (listener && redirectUri !== listener.redirectUri) {
       throw new Error(UPDATE_BACKEND)
     }
 
+    if (!listener) {
+      // Match the existing backend-hosted listener, not an arbitrary local URL.
+      const redirect = new URL(redirectUri || '')
+
+      if (
+        redirect.protocol !== 'http:' ||
+        redirect.hostname !== '127.0.0.1' ||
+        !redirect.port ||
+        Number(redirect.port) === 0 ||
+        redirect.pathname !== '/callback' ||
+        redirect.username ||
+        redirect.password ||
+        redirect.search ||
+        redirect.hash
+      ) {
+        throw new Error('OAuth server did not provide a local loopback callback URL')
+      }
+    }
+
     const flowId = sessionId
-    void bridge
-      .wait(listener.id)
-      .then(async callback => {
-        if (closed || cancelled?.()) {
-          return
-        }
 
-        if (!callback.state) {
-          throw new Error(callback.error || 'OAuth callback did not include state')
-        }
+    if (bridge && listener) {
+      void bridge
+        .wait(listener.id)
+        .then(async callback => {
+          if (closed || cancelled?.()) {
+            return
+          }
 
-        await request('callback', { session_id: flowId, ...callback })
-      })
-      .catch(error => {
-        relayError = error
-      })
+          if (!callback.state) {
+            throw new Error(callback.error || 'OAuth callback did not include state')
+          }
+
+          await request('callback', { session_id: flowId, ...callback })
+        })
+        .catch(error => {
+          relayError = error
+        })
+    }
 
     await window.hermesDesktop.openExternal(authUrl)
     let pollFailures = 0
@@ -177,7 +207,7 @@ export async function completeMcpDesktopOAuth({
 
     // Stop the native waiter first: its synthetic cancellation is NOT a
     // provider callback and must never race cleanup back onto the gateway.
-    if (listener) {
+    if (bridge && listener) {
       await bridge.cancel(listener.id).catch(() => {})
     }
 

--- a/apps/desktop/src/plugins/hermes-bots/mcp-setup.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/mcp-setup.tsx
@@ -115,7 +115,7 @@ export function McpSetupButton({ profile, entry, onDone, ensureProfile }: McpSet
   const [supported, setSupported] = useState<boolean | null>(null)
   const [keyValues, setKeyValues] = useState<Record<string, string>>({})
   const [message, setMessage] = useState('')
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const oauthEpoch = useRef(0)
   // Holds ONLY the profile this component created on demand. The live prop
   // wins wherever both exist, so there is nothing to mirror into the ref and
   // no render of lag between the parent supplying a profile and us using it.
@@ -142,8 +142,8 @@ export function McpSetupButton({ profile, entry, onDone, ensureProfile }: McpSet
     return null
   }
 
-  // eslint-disable-next-line no-restricted-syntax -- clears a timer handle on unmount, not an atom mirror
   useEffect(() => {
+    const epoch = oauthEpoch
     let alive = true
     mcpSetupSupported().then(ok => {
       if (alive) {
@@ -154,10 +154,7 @@ export function McpSetupButton({ profile, entry, onDone, ensureProfile }: McpSet
     return () => {
       alive = false
 
-      if (pollRef.current) {
-        clearInterval(pollRef.current)
-        pollRef.current = null
-      }
+      epoch.current++
     }
   }, [])
   const isOAuth = (entry.auth || '').toLowerCase() === 'oauth'
@@ -248,180 +245,53 @@ export function McpSetupButton({ profile, entry, onDone, ensureProfile }: McpSet
   }
 
   const beginOAuth = async () => {
-    // A second click (retry, impatient double-click) must not orphan the
-    // previous poll interval — an overwritten pollRef leaks a 2s poller that
-    // runs until unmount and can flip phase from a stale OAuth session.
-    if (pollRef.current) {
-      clearInterval(pollRef.current)
-      pollRef.current = null
-    }
+    const epoch = ++oauthEpoch.current
+
+    const source =
+      profile && typeof profile === 'object'
+        ? { ...profile }
+        : { connectionId: host.state.connectionId.get(), profile: profile || host.state.profile.get() }
 
     setPhase('busy')
     setMessage('')
-    const profile = await resolveProfile()
+    const resolvedProfile = await resolveProfile()
 
-    if (!profile) {
+    if (!resolvedProfile) {
       setPhase('idle')
 
       return
     }
 
-    if (entry.fromCatalog && !entry.installed) {
-      const add = await mcpRpc('mcp.servers.add', {
-        profile,
-        name: entry.name,
-        preset: entry.name
+    const scope = {
+      ...source,
+      profile: typeof resolvedProfile === 'object' ? resolvedProfile.profile : resolvedProfile
+    }
+
+    try {
+      setPhase('oauth')
+      setMessage('Complete sign-in in your browser...')
+      await host.completeMcpOAuth({
+        serverName: entry.name,
+        profile: scope,
+        catalogPreset: entry.fromCatalog && !entry.installed ? entry.name : undefined,
+        cancelled: () => oauthEpoch.current !== epoch
       })
 
-      if (!add.ok) {
-        setPhase('error')
-        setMessage(add.error || 'Could not add server')
-
+      if (oauthEpoch.current !== epoch) {
         return
       }
-    }
 
-    // Client-side callback listener (electron/mcp-oauth-callback-ipc.ts): the
-    // browser always runs on THIS machine, so hosting the OAuth redirect here
-    // works for local AND remote backends alike. Against a remote backend it
-    // is the only working flow — the gateway's own 127.0.0.1 listener is on
-    // the backend host, unreachable from this machine's browser. Falls back
-    // to the legacy gateway-listener flow when the bridge or the gateway-side
-    // callback RPC is unavailable (older builds).
-    const mcpOauthBridge =
-      typeof window !== 'undefined' && window.hermesDesktop && window.hermesDesktop.mcpOauth
-        ? window.hermesDesktop.mcpOauth
-        : null
-
-    let listener: { id: string; redirectUri: string } | null = null
-
-    if (mcpOauthBridge) {
-      try {
-        listener = await mcpOauthBridge.listen()
-      } catch {
-        listener = null
-      }
-    }
-
-    let start = await mcpRpc('mcp.servers.oauth.start', {
-      profile,
-      name: entry.name,
-      ...(listener ? { client_redirect_uri: listener.redirectUri } : {})
-    })
-
-    // Older gateway rejecting the loopback URI shape (or a stale build that
-    // validates differently): retry once on the legacy gateway-listener path.
-    if (!start.ok && listener) {
-      try {
-        await mcpOauthBridge!.cancel(listener.id)
-      } catch {
-        /* listener teardown is best-effort */
-      }
-
-      listener = null
-      start = await mcpRpc('mcp.servers.oauth.start', {
-        profile,
-        name: entry.name
-      })
-    }
-
-    const payload = start.result && (start.result.result || start.result)
-    const authUrl = payload && (payload.auth_url || payload.verification_url)
-    const sessionId = payload && payload.session_id
-
-    if (!start.ok || !authUrl || !sessionId) {
-      if (listener) {
-        try {
-          await mcpOauthBridge!.cancel(listener.id)
-        } catch {
-          /* listener teardown is best-effort */
-        }
+      setPhase('done')
+      host.notify({ kind: 'success', message: entry.name + ' authenticated' })
+      onDone?.()
+    } catch (error) {
+      if (oauthEpoch.current !== epoch) {
+        return
       }
 
       setPhase('error')
-      setMessage(start.error || 'Could not start OAuth')
-
-      return
+      setMessage(error instanceof Error ? error.message : String(error))
     }
-
-    // With a client listener bound: await the provider redirect here and relay
-    // code/state to the gateway. Runs concurrently with the status poll below;
-    // errors surface through the poll (the gateway marks the flow failed).
-    if (listener) {
-      const listenerId = listener.id
-
-      void (async () => {
-        const cb = await mcpOauthBridge!.wait(listenerId)
-
-        if (cb.error === 'cancelled') {
-          return
-        }
-
-        const relay = await mcpRpc('mcp.servers.oauth.callback', {
-          profile,
-          name: entry.name,
-          session_id: sessionId,
-          code: cb.code || undefined,
-          state: cb.state || undefined,
-          error: cb.error || undefined
-        })
-
-        const rp = relay.result && (relay.result.result || relay.result)
-
-        if (!relay.ok || (rp && rp.ok === false)) {
-          setPhase('error')
-          setMessage((rp && rp.error_message) || relay.error || 'OAuth callback relay failed')
-        }
-      })()
-    }
-
-    // Open the auth URL in the native browser, same as provider OAuth.
-    // TODO(bot-mode-types): the plugin SDK's `host` has no `openExternal`, so this
-    // branch is dead and the window bridge / window.open fallbacks are the only
-    // live paths. `ctx.os.openExternal` is the real verb. Kept as-written under
-    // ts-expect-error, which reports itself as unused the day the SDK grows one.
-    try {
-      // @ts-expect-error TODO(bot-mode-types): not on the SDK host, branch is dead
-      if (host.openExternal) {
-        // @ts-expect-error TODO(bot-mode-types): not on the SDK host, branch is dead
-        host.openExternal(authUrl)
-      } else if (typeof window !== 'undefined' && window.hermesDesktop && window.hermesDesktop.openExternal) {
-        window.hermesDesktop.openExternal(authUrl)
-      } else {
-        window.open(authUrl, '_blank')
-      }
-    } catch {
-      /* fall through to poll; user can open the URL from the toast */
-    }
-
-    setPhase('oauth')
-    setMessage('Complete sign-in in your browser...')
-    pollRef.current = setInterval(async () => {
-      const poll = await mcpRpc('mcp.servers.oauth.poll', {
-        profile,
-        name: entry.name,
-        session_id: sessionId
-      })
-
-      const pd = poll.result && (poll.result.result || poll.result)
-      const status = pd && pd.status
-
-      if (status === 'approved') {
-        clearInterval(pollRef.current!)
-        pollRef.current = null
-        setPhase('done')
-        host.notify({
-          kind: 'success',
-          message: entry.name + ' authenticated'
-        })
-        onDone && onDone()
-      } else if (status === 'error') {
-        clearInterval(pollRef.current!)
-        pollRef.current = null
-        setPhase('error')
-        setMessage((pd && pd.error_message) || 'OAuth failed')
-      }
-    }, 2000)
   }
 
   if (supported === false) {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -21,6 +21,7 @@
 import { atom, computed, type ReadableAtom } from 'nanostores'
 import type { ReactNode } from 'react'
 
+import { capabilityScoped } from '@/api/client'
 import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
 import { openSession, type OpenSessionIntent } from '@/app/open-session'
 import type { ClientSessionState } from '@/app/types'
@@ -43,6 +44,7 @@ import { onGatewayEvent } from '@/contrib/events'
 import { registry } from '@/contrib/registry'
 import type { WorkspaceMode } from '@/contrib/types'
 import { deleteProfile, getLogs, getStatus, hermesApi, type HermesGateway } from '@/hermes'
+import { completeMcpDesktopOAuth } from '@/lib/mcp-dashboard-oauth'
 import {
   $gateway,
   activeGatewayConnectionId,
@@ -636,6 +638,27 @@ export const host = {
 
   /** Tail an app log file (`agent` / `errors` / `gateway` / `gui` / …). */
   logs: async (...args: Parameters<typeof getLogs>) => getLogs(...args),
+
+  /** Complete client-local MCP sign-in for a pinned bot profile, optionally
+   *  installing its catalog entry first. Uses the same OAuth flow as Settings. */
+  completeMcpOAuth: async (options: Parameters<typeof completeMcpDesktopOAuth>[0] & { catalogPreset?: string }) => {
+    const profile = capabilityScoped(options.profile)
+
+    if (options.catalogPreset) {
+      const added = await requestGatewayForAgent<{ ok?: boolean; error?: string }>(
+        profile.connectionId ?? null,
+        profile.profile || 'default',
+        'mcp.servers.add',
+        { name: options.serverName, preset: options.catalogPreset }
+      )
+
+      if (!added.ok) {
+        throw new Error(added.error || 'Could not add server')
+      }
+    }
+
+    return completeMcpDesktopOAuth({ ...options, profile })
+  },
 
   /** Navigate the app router (hash routes, e.g. '/command-center?section=system'). */
   navigate: (path: string) => {

--- a/apps/desktop/src/store/suggestion-providers/mcp.ts
+++ b/apps/desktop/src/store/suggestion-providers/mcp.ts
@@ -1,12 +1,5 @@
-import {
-  addMcpServer,
-  authMcpServer,
-  cancelMcpOAuthFlow,
-  getMcpCatalog,
-  getMcpOAuthFlow,
-  listMcpServers,
-  removeMcpServer
-} from '@/hermes'
+import { capabilityScoped } from '@/api/client'
+import { addMcpServer, getMcpCatalog, listMcpServers, removeMcpServer } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { completeMcpDesktopOAuth, McpOAuthCancelled } from '@/lib/mcp-dashboard-oauth'
 import { MCP_DIRECTORY } from '@/lib/mcp-directory'
@@ -190,23 +183,22 @@ export function matchSuggestions(text: string, index: KeywordEntry[]): McpMatch[
 }
 
 async function connect(known: SuggestibleServer, sessionId: string | null, cancelled: () => boolean): Promise<void> {
+  const oauthScope = capabilityScoped()
+
   try {
-    await addMcpServer({ name: known.server, url: known.url })
+    await addMcpServer({ name: known.server, url: known.url }, oauthScope)
 
     try {
       await completeMcpDesktopOAuth({
         serverName: known.server,
-        start: authMcpServer,
-        status: getMcpOAuthFlow,
-        cancelled,
-        cancel: cancelMcpOAuthFlow,
-        openExternal: url => window.hermesDesktop.openExternal(url)
+        profile: oauthScope,
+        cancelled
       })
     } catch (error) {
       // Decline/failure means "no server" — roll back the config write
       // rather than stranding an unauthorized entry (authoritative-write
       // rule). Best-effort; the primary error wins.
-      await removeMcpServer(known.server).catch(() => {})
+      await removeMcpServer(known.server, oauthScope).catch(() => {})
       throw error
     }
 

--- a/apps/desktop/src/store/suggestion-providers/repair.ts
+++ b/apps/desktop/src/store/suggestion-providers/repair.ts
@@ -1,4 +1,4 @@
-import { authMcpServer, cancelMcpOAuthFlow, getMcpOAuthFlow, listMcpServers } from '@/hermes'
+import { listMcpServers } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { completeMcpDesktopOAuth, McpOAuthCancelled } from '@/lib/mcp-dashboard-oauth'
 import { prettyName } from '@/lib/text'
@@ -40,11 +40,7 @@ async function reconnect(server: string, sessionId: string | null, cancelled: ()
   try {
     await completeMcpDesktopOAuth({
       serverName: server,
-      start: authMcpServer,
-      status: getMcpOAuthFlow,
-      cancelled,
-      cancel: cancelMcpOAuthFlow,
-      openExternal: url => window.hermesDesktop.openExternal(url)
+      cancelled
     })
 
     // Fresh tokens reach the live session before the pill claims success.

--- a/contributors/emails/bezerra@live.com
+++ b/contributors/emails/bezerra@live.com
@@ -1,0 +1,2 @@
+lipebez
+# PR #104728 salvage

--- a/evals/desktop_mcp_oauth/README.md
+++ b/evals/desktop_mcp_oauth/README.md
@@ -1,0 +1,19 @@
+# Desktop MCP OAuth integration checks
+
+Run from a checkout with the Python MCP dependencies and Desktop Node dependencies installed.
+Outputs are local receipts; keep them outside the checkout. Neither harness uses real provider credentials.
+
+```bash
+python3 evals/desktop_mcp_oauth/backend_http_fixture.py --repo . --output /tmp/mcp-backend.json
+node evals/desktop_mcp_oauth/renderer_lifecycle.mjs "$PWD" /tmp/mcp-renderer.json approved
+node evals/desktop_mcp_oauth/renderer_lifecycle.mjs "$PWD" /tmp/mcp-scope.json cancel
+node evals/desktop_mcp_oauth/renderer_lifecycle.mjs "$PWD" /tmp/mcp-unmount.json unmount
+```
+
+The backend harness creates disposable HOME/HERMES_HOME directories and a local HTTP OAuth/MCP provider. It exercises production session functions, discovery, dynamic registration, PKCE code exchange, token persistence and fresh-process authenticated MCP access. Wrong state, callback replay, wrong server, wrong profile and cancellation are negative controls. It removes temporary token stores and reports only booleans/paths, never token values.
+
+The renderer harness bundles the real McpTab and its dependencies in Chromium, runs the production native loopback listener with a registration-only Electron IPC adapter, and uses a fixture WebSocket backend. `cancel` changes the component's scope; `unmount` removes it entirely. Both must cancel the original backend session and close its native listener without relaying a callback. `approved` must use the native relay, not REST auth. Set `CHROMIUM_EXECUTABLE` to use an existing Chromium executable; otherwise Playwright's installed browser is used.
+
+These are complementary integration probes, not a single end-to-end Electron/provider test. The renderer backend and Electron registration boundary are fixtures; the Python probe uses production session functions rather than gateway RPC transport. No native Electron application launch or hosted-provider consent is claimed.
+
+For A/B, run the same renderer harness against a baseline checkout by replacing its first positional argument. The approved assertion fails before the shared relay change. For the lifecycle regression, a checkout immediately before the scoped-tab cleanup fails both abandonment assertions. Backend cross-profile callbacks must be rejected even when the session ID and valid state are supplied; the original owner must still be able to finish afterward.

--- a/evals/desktop_mcp_oauth/backend_http_fixture.py
+++ b/evals/desktop_mcp_oauth/backend_http_fixture.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Credential-free live OAuth/MCP persistence probe (no production mocks).
+
+Run with the repository's Python environment:
+  python evals/desktop_mcp_oauth/backend_http_fixture.py --repo . --output receipt.json
+
+The parent creates an ephemeral HOME and re-execs with an environment allowlist.
+Only the redacted receipt survives; token files are verified then deleted with HOME.
+This exercises production session handlers, not Electron or gateway transport.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import contextlib
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+import secrets
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlencode, urlsplit
+
+
+class Provider(ThreadingHTTPServer):
+    def __init__(self):
+        super().__init__(("127.0.0.1", 0), ProviderHandler)
+        self.origin = f"http://127.0.0.1:{self.server_port}"
+        self.events = []
+        self.clients = {}
+        self.codes = {}
+        self.tokens = set()
+        self.pkce_verified = 0
+
+
+class ProviderHandler(BaseHTTPRequestHandler):
+    server: Provider
+
+    def log_message(self, format, *args):
+        pass  # Never log callback queries, codes or bearer headers.
+
+    def reply(self, status, payload=None, headers=None):
+        body = json.dumps(payload).encode() if payload is not None else b""
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        for key, value in (headers or {}).items():
+            self.send_header(key, value)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802
+        path = urlsplit(self.path).path
+        self.server.events.append(["GET", path])
+        if path.startswith("/.well-known/oauth-protected-resource"):
+            return self.reply(200, {"resource": self.server.origin + "/mcp",
+                                    "authorization_servers": [self.server.origin],
+                                    "scopes_supported": ["tools:read"]})
+        if path.startswith("/.well-known/oauth-authorization-server"):
+            return self.reply(200, {
+                "issuer": self.server.origin,
+                "authorization_endpoint": self.server.origin + "/authorize",
+                "token_endpoint": self.server.origin + "/token",
+                "registration_endpoint": self.server.origin + "/register",
+                "response_types_supported": ["code"],
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+                "token_endpoint_auth_methods_supported": ["none"],
+                "code_challenge_methods_supported": ["S256"],
+                "scopes_supported": ["tools:read"],
+            })
+        if path == "/authorize":
+            query = {k: v[0] for k, v in parse_qs(urlsplit(self.path).query).items()}
+            client = self.server.clients.get(query.get("client_id"))
+            if (not client or query.get("redirect_uri") not in client["redirect_uris"]
+                    or query.get("code_challenge_method") != "S256"):
+                return self.reply(400, {"error": "invalid_request"})
+            code = secrets.token_urlsafe(24)
+            self.server.codes[code] = query
+            target = query["redirect_uri"] + "?" + urlencode({"code": code, "state": query["state"]})
+            return self.reply(302, headers={"Location": target})
+        self.reply(405 if path == "/mcp" else 404)
+
+    def do_POST(self):  # noqa: N802
+        path = urlsplit(self.path).path
+        self.server.events.append(["POST", path])
+        body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        if path == "/register":
+            client = json.loads(body)
+            client["client_id"] = secrets.token_urlsafe(16)
+            client["token_endpoint_auth_method"] = "none"
+            self.server.clients[client["client_id"]] = client
+            return self.reply(201, client)
+        if path == "/token":
+            form = {k: v[0] for k, v in parse_qs(body.decode()).items()}
+            auth = self.server.codes.pop(form.get("code"), None)
+            challenge = base64.urlsafe_b64encode(hashlib.sha256(
+                form.get("code_verifier", "").encode()).digest()).rstrip(b"=").decode()
+            if (not auth or challenge != auth["code_challenge"]
+                    or form.get("redirect_uri") != auth["redirect_uri"]
+                    or form.get("client_id") != auth["client_id"]):
+                return self.reply(400, {"error": "invalid_grant"})
+            self.server.pkce_verified += 1
+            token = secrets.token_urlsafe(32)
+            self.server.tokens.add(token)
+            return self.reply(200, {"access_token": token, "token_type": "Bearer",
+                                    "expires_in": 3600, "scope": "tools:read",
+                                    "refresh_token": secrets.token_urlsafe(32)})
+        if path != "/mcp":
+            return self.reply(404)
+        if self.headers.get("Authorization", "").removeprefix("Bearer ") not in self.server.tokens:
+            return self.reply(401, {"error": "unauthorized"}, {"WWW-Authenticate":
+                f'Bearer resource_metadata="{self.server.origin}/.well-known/oauth-protected-resource"'})
+        request = json.loads(body)
+        method = request["method"]
+        self.server.events.append(["MCP", method])
+        if "id" not in request:
+            return self.reply(202)
+        results = {
+            "initialize": {"protocolVersion": request.get("params", {}).get("protocolVersion", "2025-03-26"),
+                           "capabilities": {"tools": {}},
+                           "serverInfo": {"name": "local-oauth-fixture", "version": "1"}},
+            "tools/list": {"tools": [{"name": "fixture_ping", "description": "Local fixture ping",
+                                       "inputSchema": {"type": "object", "properties": {}}}]},
+            "ping": {},
+        }
+        if method not in results:
+            return self.reply(200, {"jsonrpc": "2.0", "id": request["id"],
+                                    "error": {"code": -32601, "message": "Method not found"}})
+        self.reply(200, {"jsonrpc": "2.0", "id": request["id"], "result": results[method]})
+
+    def do_DELETE(self):  # noqa: N802
+        self.reply(200)
+
+
+class CallbackServer(ThreadingHTTPServer):
+    callback: dict[str, str]
+
+
+class CallbackHandler(BaseHTTPRequestHandler):
+    server: CallbackServer
+
+    def log_message(self, format, *args):
+        pass
+
+    def do_GET(self):  # noqa: N802
+        self.server.callback = {k: v[0] for k, v in parse_qs(urlsplit(self.path).query).items()}
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"Local fixture callback captured")
+
+
+@contextlib.contextmanager
+def serving(server):
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(5)
+
+
+def eventually(predicate, label, timeout=25):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = predicate()
+        if result:
+            return result
+        time.sleep(0.05)
+    raise AssertionError(label)
+
+
+def run_probe(repo, receipt):
+    sys.path.insert(0, str(repo))
+    logging.disable(logging.CRITICAL)
+    import httpx
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    from tui_gateway import mcp_oauth_sessions as sessions
+    from tools.mcp_oauth import HermesTokenStorage
+
+    owner = Path(os.environ["HERMES_HOME"])
+    other = owner.parent / "other-profile"
+    other.mkdir()
+    checks = receipt["checks"]
+
+    def check(name, result):
+        checks[name] = bool(result)
+        if not result:
+            raise AssertionError(name)
+
+    with serving(Provider()) as provider, serving(CallbackServer(
+            ("127.0.0.1", 0), CallbackHandler)) as callback, httpx.Client(trust_env=False) as browser:
+        cfg = {"url": provider.origin + "/mcp", "auth": "oauth",
+               "oauth": {"cimd": False, "scope": "tools:read", "timeout": 30}}
+        redirect = f"http://127.0.0.1:{callback.server_port}/callback"
+
+        def begin(name, remote=True):
+            return sessions.start_flow(str(owner), name, cfg, url_timeout=25,
+                                       client_redirect_uri=redirect if remote else None)
+
+        def done(flow, name):
+            sid = flow["session_id"]
+            eventually(lambda: sessions._sessions[sid]["flow"].worker_done, "worker completed")
+            return sessions.poll_flow(sid, name)
+
+        flow = begin("positive")
+        sid = flow["session_id"]
+        check("remote_does_not_bind_backend_listener", sessions._sessions[sid]["httpd"] is None)
+        check("initial_poll_pending", sessions.poll_flow(sid, "positive")["status"] == "pending")
+        check("wrong_state_rejected", not sessions.deliver_callback_flow(
+            sid, "positive", code="invalid", state="invalid")["ok"])
+        check("wrong_state_keeps_pending", sessions.poll_flow(sid, "positive")["status"] == "pending")
+        check("wrong_server_poll_rejected", sessions.poll_flow(sid, "wrong")["status"] == "error")
+        check("wrong_server_callback_rejected", not sessions.deliver_callback_flow(
+            sid, "wrong", code="invalid", state="invalid")["ok"])
+        check("wrong_owner_cancel_rejected", not sessions.cancel_flow(sid, "positive", str(other))["ok"])
+        check("wrong_owner_did_not_cancel", sessions.poll_flow(sid, "positive")["status"] == "pending")
+        response = browser.get(flow["auth_url"], follow_redirects=True)
+        check("real_http_callback_received", response.status_code == 200 and bool(callback.callback.get("code")))
+        captured = callback.callback
+        check("correct_callback_accepted", sessions.deliver_callback_flow(sid, "positive", **captured)["ok"])
+        result = done(flow, "positive")
+        receipt["positive_status"] = result["status"]
+        check("positive_approved", result["status"] == "approved")
+        check("real_mcp_tools_discovered", any(t["name"] == "fixture_ping" for t in result["tools"]))
+        check("callback_replay_rejected", not sessions.deliver_callback_flow(sid, "positive", **captured)["ok"])
+        token_path = owner / "mcp-tokens" / "positive.json"
+        stored = json.loads(token_path.read_text(encoding="utf-8"))
+        check("disk_token_matches_provider", stored["access_token"] in provider.tokens)
+        check("disk_refresh_token_and_absolute_expiry", bool(stored.get("refresh_token")) and stored["expires_at"] > time.time())
+        check("token_file_private", token_path.stat().st_mode & 0o777 == 0o600)
+        reloaded = asyncio.run(HermesTokenStorage("positive", hermes_home=owner).get_tokens())
+        check("fresh_storage_reload", reloaded.access_token in provider.tokens)
+        check("wrong_profile_has_no_token", not (other / "mcp-tokens" / "positive.json").exists())
+        check("config_saved_to_owner", "positive" in (owner / "config.yaml").read_text(encoding="utf-8"))
+        exchanges = provider.pkce_verified
+        cold = subprocess.run([sys.executable, str(Path(__file__).resolve()),
+            "--repo", str(repo), "--output", os.devnull, "--cold-probe"],
+            stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            timeout=40, check=False)
+        check("fresh_process_authenticated_mcp_from_disk", cold.returncode == 0)
+        check("fresh_process_did_not_reauthorize", provider.pkce_verified == exchanges)
+
+        flow = begin("cancelled")
+        sid = flow["session_id"]
+        exchanges = provider.pkce_verified
+        check("owner_cancel_accepted", sessions.cancel_flow(sid, "cancelled", str(owner))["ok"])
+        check("cancel_worker_terminated", done(flow, "cancelled")["status"] == "error")
+        check("cancel_did_not_exchange_or_persist", provider.pkce_verified == exchanges and
+              not (owner / "mcp-tokens" / "cancelled.json").exists())
+        check("callback_after_cancel_rejected", not sessions.deliver_callback_flow(
+            sid, "cancelled", code="invalid", state="invalid")["ok"])
+
+        flow = begin("loopback", remote=False)
+        check("backend_listener_http_success", browser.get(flow["auth_url"], follow_redirects=True).status_code == 200)
+        check("backend_listener_approved", done(flow, "loopback")["status"] == "approved")
+        check("backend_listener_closed", eventually(
+            lambda: sessions._sessions[flow["session_id"]]["httpd"] is None,
+            "backend listener shutdown completed"))
+
+        # Even possession of valid session/state cannot cross the resolved home.
+        flow = begin("owner_boundary")
+        browser.get(flow["auth_url"], follow_redirects=True)
+        override = set_hermes_home_override(other)
+        try:
+            foreign_poll = sessions.poll_flow(flow["session_id"], "owner_boundary")
+            foreign_callback = sessions.deliver_callback_flow(flow["session_id"], "owner_boundary", **callback.callback)
+        finally:
+            reset_hermes_home_override(override)
+        receipt["ownership_boundary"] = {
+            "cancel_owner_enforced": checks["wrong_owner_cancel_rejected"],
+            "cross_profile_poll_rejected": foreign_poll["status"] == "error",
+            "cross_profile_callback_rejected_with_session_and_state": not foreign_callback["ok"],
+        }
+        check("wrong_owner_poll_rejected", foreign_poll["status"] == "error" and "auth_url" not in foreign_poll)
+        check("wrong_owner_callback_rejected", not foreign_callback["ok"])
+        check("owner_callback_after_foreign_attempt_accepted", sessions.deliver_callback_flow(
+            flow["session_id"], "owner_boundary", **callback.callback)["ok"])
+        check("boundary_probe_worker_completed", done(flow, "owner_boundary")["status"] == "approved")
+        check("boundary_exchange_still_persists_only_to_owner", (owner / "mcp-tokens" / "owner_boundary.json").exists()
+              and not (other / "mcp-tokens" / "owner_boundary.json").exists())
+        receipt["http_events"] = provider.events
+        receipt["pkce_exchanges_verified"] = provider.pkce_verified
+        check("real_discovery_dcr_token_http", all(any(path == target for _, path in provider.events)
+              for target in ["/.well-known/oauth-protected-resource", "/register", "/token"]))
+        receipt["persisted_files_verified_then_removed"] = sorted(p.name for p in (owner / "mcp-tokens").iterdir())
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--isolated-worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--cold-probe", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    repo, output = args.repo.resolve(), args.output.resolve()
+    if args.cold_probe:
+        sys.path.insert(0, str(repo))
+        logging.disable(logging.CRITICAL)
+        from hermes_cli.mcp_config import _get_mcp_servers, _probe_single_server
+        from tools.mcp_oauth import suppress_interactive_oauth
+        with suppress_interactive_oauth():
+            tools = _probe_single_server("positive", _get_mcp_servers()["positive"])
+        return 0 if any(name == "fixture_ping" for name, _ in tools) else 1
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if not args.isolated_worker:
+        with tempfile.TemporaryDirectory(prefix="hermes-oauth-http-") as temp:
+            home = Path(temp)
+            (home / ".hermes").mkdir()
+            env = {"PATH": os.environ.get("PATH", ""), "HOME": temp,
+                   "HERMES_HOME": str(home / ".hermes"), "LANG": "C.UTF-8", "TZ": "UTC",
+                   "PYTHONNOUSERSITE": "1"}
+            completed = subprocess.run([sys.executable, str(Path(__file__).resolve()),
+                "--repo", str(repo), "--output", str(output), "--isolated-worker"],
+                env=env, cwd=temp, stdin=subprocess.DEVNULL, timeout=180, check=False)
+        print(json.dumps({"receipt": str(output), "exit_code": completed.returncode, "isolated_home_removed": True}))
+        return completed.returncode
+    receipt = {"checks": {}, "repo": str(repo), "fidelity":
+               "Real production OAuth session functions + real HTTP discovery/DCR/PKCE/token/MCP/callback + real disk persistence; no production mocks; not gateway RPC transport or Electron",
+               "isolated_home": True, "credentials": "ephemeral local fixture only; no token material in receipt"}
+    try:
+        with open(os.devnull, "w", encoding="utf-8") as sink, contextlib.redirect_stdout(sink), contextlib.redirect_stderr(sink):
+            run_probe(repo, receipt)
+        receipt["status"] = "passed"
+    except Exception as exc:
+        receipt["status"] = "failed"
+        receipt["error_type"] = type(exc).__name__
+        receipt["failed_check"] = next((k for k, v in receipt["checks"].items() if not v), None)
+        # Assertions are our fixed labels, not provider bodies or secret-bearing URLs.
+        if isinstance(exc, AssertionError):
+            receipt["assertion"] = str(exc)
+    output.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    return 0 if receipt["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/desktop_mcp_oauth/renderer_lifecycle.mjs
+++ b/evals/desktop_mcp_oauth/renderer_lifecycle.mjs
@@ -187,6 +187,10 @@ try {
     )
     assert(!rpcCalls.some(m => m.method === 'mcp.servers.oauth.callback'), 'no callback after abandonment')
   }
+  if (scenario === 'approved') {
+    assert(approved && hasScope, 'Skills must complete OAuth through its native listener')
+    assert(!requests.some(r => r.path.endsWith('/auth')), 'native flow must not use REST auth')
+  }
   assert.deepEqual(errors, [])
 } finally {
   await browser.close()

--- a/evals/desktop_mcp_oauth/renderer_lifecycle.mjs
+++ b/evals/desktop_mcp_oauth/renderer_lifecycle.mjs
@@ -1,0 +1,196 @@
+import { createRequire } from 'node:module'
+import fs from 'node:fs/promises'
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import path from 'node:path'
+const repo = process.argv[2],
+  out = process.argv[3],
+  scenario = process.argv[4] || 'approved'
+const require = createRequire(path.join(repo, 'package.json'))
+const { build } = require('esbuild')
+const { chromium } = require('playwright')
+const requests = []
+const rpcCalls = []
+const nativeCalls = []
+const handlers = new Map()
+const nativeBuild = await build({
+  entryPoints: [repo + '/apps/desktop/electron/mcp-oauth-callback-ipc.ts'],
+  bundle: true,
+  write: false,
+  platform: 'node',
+  format: 'cjs',
+  external: ['electron']
+})
+const nativeModule = { exports: {} }
+new Function('require', 'module', 'exports', nativeBuild.outputFiles[0].text)(
+  id => (id === 'electron' ? { ipcMain: { handle: (name, fn) => handlers.set(name, fn) } } : require(id)),
+  nativeModule,
+  nativeModule.exports
+)
+nativeModule.exports.registerMcpOauthCallbackIpc()
+const { WebSocketServer } = require('ws')
+const wss = new WebSocketServer({ port: 0, host: '127.0.0.1' })
+await new Promise(r => wss.once('listening', r))
+let approved = false
+let redirectUri
+wss.on('connection', ws =>
+  ws.on('message', raw => {
+    const m = JSON.parse(raw)
+    rpcCalls.push(m)
+    let result = { ok: true }
+    if (m.method === 'mcp.servers.oauth.start') {
+      redirectUri = m.params.client_redirect_uri
+      result = {
+        ok: true,
+        session_id: 'fixture-session',
+        auth_url:
+          'http://127.0.0.1/authorize?state=fixture-state&redirect_uri=' +
+          encodeURIComponent(scenario === 'legacy' ? 'http://remote.invalid/callback' : redirectUri)
+      }
+    }
+    if (m.method === 'mcp.servers.oauth.callback') {
+      approved = m.params.state === 'fixture-state' && m.params.code === 'fixture-code'
+      result = { ok: approved }
+    }
+    if (m.method === 'mcp.servers.oauth.poll')
+      result = { ok: true, status: approved ? 'approved' : 'pending', tools: [] }
+    ws.send(JSON.stringify({ jsonrpc: '2.0', id: m.id, result }))
+  })
+)
+const entry = `import React from 'react'; import {createRoot} from 'react-dom/client';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {McpTab} from '${repo}/apps/desktop/src/app/skills/mcp-tab.tsx';
+import {setApiRequestProfile,setApiRequestConnection} from '${repo}/apps/desktop/src/api/client.ts';
+setApiRequestProfile('profile-b');setApiRequestConnection('fixture-remote');
+const queryClient=new QueryClient({defaultOptions:{queries:{retry:false}}});function Probe(){const [profile,setProfile]=React.useState('profile-b');const [shown,setShown]=React.useState(true);window.cancelFlow=()=>setProfile('profile-c');window.unmountFlow=()=>setShown(false);return <QueryClientProvider client={queryClient}>{shown && <McpTab gateway={null} profile={{connectionId:'fixture-remote',profile}} />}</QueryClientProvider>};createRoot(document.getElementById('root')).render(<Probe/>);`
+const bundle = await build({
+  stdin: { contents: entry, resolveDir: repo, loader: 'tsx' },
+  bundle: true,
+  write: false,
+  format: 'esm',
+  platform: 'browser',
+  jsx: 'automatic',
+  alias: { '@': repo + '/apps/desktop/src', '@hermes/shared': repo + '/apps/shared/src' },
+  define: {
+    'process.env.NODE_ENV': '"production"',
+    'import.meta.env': '{}',
+    'import.meta.env.DEV': 'false',
+    'import.meta.env.PROD': 'true'
+  },
+  loader: { '.woff2': 'dataurl', '.woff': 'dataurl', '.svg': 'dataurl' },
+  logLevel: 'warning'
+})
+const server = http.createServer(async (req, res) => {
+  res.setHeader('Content-Type', req.url === '/app.js' ? 'text/javascript' : 'text/html')
+  res.end(
+    req.url === '/app.js'
+      ? bundle.outputFiles[0].text
+      : '<div id="root"></div><script type="module" src="/app.js"></script>'
+  )
+})
+await new Promise(r => server.listen(0, '127.0.0.1', r))
+const browser = await chromium.launch({
+  headless: true,
+  args: ['--no-sandbox'],
+  ...(process.env.CHROMIUM_EXECUTABLE ? { executablePath: process.env.CHROMIUM_EXECUTABLE } : {})
+})
+try {
+  const page = await browser.newPage()
+  const errors = []
+  page.on('pageerror', e => {
+    errors.push(e.message)
+    console.error(e.stack)
+  })
+  page.on('console', m => console.log(m.type(), m.text()))
+  await page.exposeFunction('recordRequest', r => {
+    requests.push(r)
+    console.log('request', JSON.stringify(r))
+    if (r.path === '/api/config')
+      return { mcp_servers: { reports: { url: 'https://fixture.invalid/mcp', auth: 'oauth' } } }
+    if (r.path.endsWith('/test')) return { ok: false, tools: [], auth_required: true, error: 'OAuth required' }
+    if (r.path.includes('/logs')) return { lines: [] }
+    if (r.path.includes('/catalog')) return { entries: [] }
+    if (r.path.endsWith('/auth'))
+      return { flow_id: 'f', status: 'error', error: 'fixture remote HTTP redirect rejected' }
+    return { ok: true, providers: [] }
+  })
+  await page.exposeFunction('nativeOAuth', async (action, id) => {
+    nativeCalls.push({ action, id })
+    return handlers.get('hermes:mcp-oauth:' + action)({}, id)
+  })
+  await page.exposeFunction('fixtureConnection', async scope => {
+    nativeCalls.push({ action: 'connection', scope })
+    return { wsUrl: 'ws://127.0.0.1:' + wss.address().port, connectionId: scope.connectionId, authMode: 'token' }
+  })
+  await page.exposeFunction('openAuthorization', async url => {
+    nativeCalls.push({ action: 'open', url })
+    if (scenario === 'cancel' || scenario === 'unmount') {
+      await page.evaluate(s => (s === 'unmount' ? window.unmountFlow() : window.cancelFlow()), scenario)
+      return
+    }
+    const u = new URL(url)
+    await fetch(u.searchParams.get('redirect_uri') + '?code=fixture-code&state=' + u.searchParams.get('state'))
+  })
+  await page.addInitScript(() => {
+    window.hermesDesktop = {
+      api: r => window.recordRequest(r),
+      getConnectionFor: r => window.fixtureConnection(r),
+      mcpOauth: {
+        listen: () => {
+          window.nativeListen = true
+          return window.nativeOAuth('listen')
+        },
+        wait: id => window.nativeOAuth('wait', id),
+        cancel: id => window.nativeOAuth('cancel', id)
+      },
+      openExternal: url => window.openAuthorization(url)
+    }
+  })
+  await page.goto('http://127.0.0.1:' + server.address().port)
+  await page.waitForTimeout(1500)
+  console.log('BODY', await page.locator('body').innerText())
+  await page.getByText('Reports', { exact: true }).first().click()
+  await page.waitForTimeout(300)
+  console.log('SELECTED', await page.locator('body').innerText())
+  await page
+    .getByRole('button', { name: /Authenticate|Sign in/ })
+    .first()
+    .click()
+  await page.waitForTimeout(2500)
+  const hasScope = await page.evaluate(() => !!window.nativeListen)
+  const result = {
+    repo,
+    scenario,
+    requests,
+    rpcCalls,
+    nativeCalls,
+    approved,
+    hasScope,
+    errors,
+    text: await page.locator('body').innerText(),
+    fidelity: 'production McpTab + all real renderer imports in headless Chromium; fixture native API transport'
+  }
+  await fs.writeFile(out, JSON.stringify(result, null, 2))
+  console.log(JSON.stringify(result))
+  if (scenario === 'cancel' || scenario === 'unmount') {
+    assert(
+      rpcCalls.some(m => m.method === 'mcp.servers.oauth.cancel'),
+      'abandoned component must cancel backend'
+    )
+    assert(
+      nativeCalls.some(m => m.action === 'cancel'),
+      'abandoned component must close listener'
+    )
+    assert(
+      nativeCalls.filter(m => m.action === 'connection').every(m => m.scope.profile === 'profile-b'),
+      'cleanup must retain original owner'
+    )
+    assert(!rpcCalls.some(m => m.method === 'mcp.servers.oauth.callback'), 'no callback after abandonment')
+  }
+  assert.deepEqual(errors, [])
+} finally {
+  await browser.close()
+  server.close()
+  for (const c of wss.clients) c.terminate()
+  wss.close()
+}

--- a/tests/tui_gateway/test_mcp_oauth_cancel.py
+++ b/tests/tui_gateway/test_mcp_oauth_cancel.py
@@ -34,6 +34,7 @@ def test_cancel_is_scoped_idempotent_and_releases_worker(
 
     monkeypatch.setattr(sessions, "_worker", worker)
     home = str(tmp_path / "origin")
+    monkeypatch.setenv("HERMES_HOME", home)
     result = sessions.start_flow(
         home,
         "reports",
@@ -77,6 +78,43 @@ def test_cancel_is_scoped_idempotent_and_releases_worker(
         rec["flow"].mark_error("test cleanup")
         sessions._shutdown_listener(rec)
         finished.wait(5)
+
+
+@pytest.mark.parametrize("operation", ["poll", "callback", "cancel"])
+def test_session_operations_require_resolved_owner(tmp_path, monkeypatch, operation):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    home = str(tmp_path / "owner")
+    flow = DashboardOAuthFlow(
+        "owned", "reports", None, home, "http://127.0.0.1:49152/callback"
+    )
+    asyncio.run(flow.publish_authorization_url("https://idp.example/authorize?state=test"))
+    monkeypatch.setattr(sessions, "_sessions", {
+        "owned": {"flow": flow, "server_name": "reports", "hermes_home": home, "httpd": None}
+    })
+
+    def invoke():
+        if operation == "poll":
+            return sessions.poll_flow("owned", "reports")
+        if operation == "callback":
+            return sessions.deliver_callback_flow("owned", "reports", code="valid", state="test")
+        from hermes_constants import get_hermes_home
+        return sessions.cancel_flow("owned", "reports", str(get_hermes_home()))
+
+    token = set_hermes_home_override(tmp_path / "other")
+    try:
+        rejected = invoke()
+    finally:
+        reset_hermes_home_override(token)
+    assert "profile mismatch" in (rejected.get("error_message") or "")
+    assert "auth_url" not in rejected
+    assert flow.snapshot()["status"] == "authorization_required"
+    token = set_hermes_home_override(home)
+    try:
+        accepted = invoke()
+    finally:
+        reset_hermes_home_override(token)
+    assert accepted.get("ok", accepted.get("status") == "pending") is True
 
 
 def test_cancel_does_not_revoke_an_approved_flow(tmp_path, monkeypatch):

--- a/tests/tui_gateway/test_mcp_oauth_cancel.py
+++ b/tests/tui_gateway/test_mcp_oauth_cancel.py
@@ -1,0 +1,105 @@
+"""Cancellation wakes the actual callback worker without crossing profile ownership."""
+
+import asyncio
+import threading
+
+import pytest
+
+from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+from tui_gateway import mcp_oauth_sessions as sessions
+
+
+@pytest.mark.parametrize("client_redirect", [False, True])
+def test_cancel_is_scoped_idempotent_and_releases_worker(
+    tmp_path, monkeypatch, client_redirect
+):
+    monkeypatch.setattr(sessions, "_sessions", {})
+    finished = threading.Event()
+
+    def worker(session_id, *_args):
+        flow = sessions._sessions[session_id]["flow"]
+        try:
+            asyncio.run(
+                flow.publish_authorization_url(
+                    "https://idp.example/authorize?state=test"
+                )
+            )
+            asyncio.run(flow.wait_for_callback(timeout=10))
+            flow.mark_approved()
+        except RuntimeError as exc:
+            flow.mark_error(str(exc))
+        finally:
+            flow.mark_worker_done()
+            finished.set()
+
+    monkeypatch.setattr(sessions, "_worker", worker)
+    home = str(tmp_path / "origin")
+    result = sessions.start_flow(
+        home,
+        "reports",
+        {"url": "https://mcp.example"},
+        client_redirect_uri="http://127.0.0.1:49152/callback"
+        if client_redirect
+        else None,
+    )
+    sid = result["session_id"]
+    rec = sessions._sessions[sid]
+    try:
+        assert (
+            sessions.cancel_flow(sid, "reports", str(tmp_path / "other"))["ok"] is False
+        )
+        assert sessions.cancel_flow(sid, "other", home)["ok"] is False
+        assert rec["flow"].snapshot()["status"] == "authorization_required"
+        assert sessions.cancel_flow(sid, "reports", home)["ok"] is True
+        assert finished.wait(5), (
+            "cancel must wake the worker, not leave a 5-minute occupied slot"
+        )
+        assert sessions.poll_flow(sid, "reports")["status"] == "error"
+        assert rec["httpd"] is None
+        assert sessions.cancel_flow(sid, "reports", home)["ok"] is True
+        assert (
+            sessions.deliver_callback_flow(sid, "reports", code="late", state="test")[
+                "ok"
+            ]
+            is False
+        )
+        # A new start can take the per-server slot as soon as the old worker exits.
+        finished.clear()
+        retry = sessions.start_flow(
+            home,
+            "reports",
+            {"url": "https://mcp.example"},
+            client_redirect_uri="http://127.0.0.1:49152/callback",
+        )
+        assert sessions.cancel_flow(retry["session_id"], "reports", home)["ok"] is True
+        assert finished.wait(5)
+    finally:
+        rec["flow"].mark_error("test cleanup")
+        sessions._shutdown_listener(rec)
+        finished.wait(5)
+
+
+def test_cancel_does_not_revoke_an_approved_flow(tmp_path, monkeypatch):
+    home = str(tmp_path)
+    flow = DashboardOAuthFlow(
+        "approved", "reports", None, home, "http://127.0.0.1:49152/callback"
+    )
+    flow.mark_approved()
+    flow.mark_worker_done()
+    monkeypatch.setattr(
+        sessions,
+        "_sessions",
+        {
+            "approved": {
+                "flow": flow,
+                "server_name": "reports",
+                "hermes_home": home,
+                "httpd": None,
+            }
+        },
+    )
+    assert sessions.cancel_flow("approved", "reports", home) == {
+        "ok": True,
+        "status": "approved",
+    }
+    assert sessions.cancel_flow("missing", "reports", home)["ok"] is False

--- a/tests/tui_gateway/test_mcp_oauth_client_callback.py
+++ b/tests/tui_gateway/test_mcp_oauth_client_callback.py
@@ -16,6 +16,7 @@ import threading
 
 import pytest
 
+from hermes_constants import get_hermes_home
 from tools.mcp_dashboard_oauth import DashboardOAuthFlow
 from tui_gateway import mcp_oauth_sessions
 from tui_gateway.mcp_oauth_sessions import (
@@ -106,7 +107,7 @@ def test_start_flow_client_redirect_skips_gateway_listener(monkeypatch):
     )
 
     result = mcp_oauth_sessions.start_flow(
-        "/tmp/hermes-test-home",
+        str(get_hermes_home()),
         "clicky",
         {"url": "https://mcp.example.com/mcp", "auth": "oauth"},
         client_redirect_uri="http://127.0.0.1:8412/callback",
@@ -131,7 +132,7 @@ def test_start_flow_rejects_bad_client_redirect(monkeypatch):
     _fake_worker_publishes_url(monkeypatch)
     with pytest.raises(ValueError):
         mcp_oauth_sessions.start_flow(
-            "/tmp/hermes-test-home",
+            str(get_hermes_home()),
             "clicky2",
             {"url": "https://mcp.example.com/mcp", "auth": "oauth"},
             client_redirect_uri="https://evil.example.com/callback",
@@ -152,7 +153,7 @@ def _make_session(session_id="sess-relay-1", server="hosp", state="s3cr3tstate")
         flow_id=session_id,
         server_name=server,
         profile=None,
-        hermes_home="/tmp/hermes-test-home",
+        hermes_home=str(get_hermes_home()),
         redirect_uri="http://127.0.0.1:9000/callback",
     )
     # Pin the expected state the way publish_authorization_url does.
@@ -166,7 +167,7 @@ def _make_session(session_id="sess-relay-1", server="hosp", state="s3cr3tstate")
     rec = {
         "session_id": session_id,
         "server_name": server,
-        "hermes_home": "/tmp/hermes-test-home",
+        "hermes_home": str(get_hermes_home()),
         "flow": flow,
         "httpd": None,
         "created_at": __import__("time").time(),

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -207,14 +207,19 @@ def start_flow(
     return {"session_id": session_id, "auth_url": auth_url, "flow": "pkce"}
 
 
-def _lookup(session_id: str, server_name: str) -> "tuple[Dict[str, Any] | None, str | None]":
-    """Find a session record; returns ``(rec, None)`` or ``(None, error_message)``."""
+def _lookup(
+    session_id: str, server_name: str, hermes_home: Optional[str] = None,
+) -> "tuple[Dict[str, Any] | None, str | None]":
+    """Find a session belonging to the caller's resolved profile."""
+    from hermes_constants import hermes_home_key
     with _sessions_lock:
         rec = _sessions.get(session_id)
     if rec is None:
         return None, "OAuth session not found or expired"
     if rec["server_name"] != server_name:
         return None, "server name mismatch for session"
+    if hermes_home_key(rec["hermes_home"]) != hermes_home_key(hermes_home):
+        return None, "profile mismatch for session"
     return rec, None
 
 
@@ -239,11 +244,9 @@ def poll_flow(session_id: str, server_name: str) -> Dict[str, Any]:
 
 def cancel_flow(session_id: str, server_name: str, hermes_home: str) -> Dict[str, Any]:
     """Cancel only the owning profile's flow and release its callback waiter."""
-    rec, err = _lookup(session_id, server_name)
+    rec, err = _lookup(session_id, server_name, hermes_home)
     if rec is None:
         return {"ok": False, "error_message": err}
-    if rec["hermes_home"] != hermes_home:
-        return {"ok": False, "error_message": "profile mismatch for session"}
     flow = rec["flow"]
     flow.mark_error("OAuth cancelled by user")
     _shutdown_listener(rec)

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -237,6 +237,19 @@ def poll_flow(session_id: str, server_name: str) -> Dict[str, Any]:
     return out
 
 
+def cancel_flow(session_id: str, server_name: str, hermes_home: str) -> Dict[str, Any]:
+    """Cancel only the owning profile's flow and release its callback waiter."""
+    rec, err = _lookup(session_id, server_name)
+    if rec is None:
+        return {"ok": False, "error_message": err}
+    if rec["hermes_home"] != hermes_home:
+        return {"ok": False, "error_message": "profile mismatch for session"}
+    flow = rec["flow"]
+    flow.mark_error("OAuth cancelled by user")
+    _shutdown_listener(rec)
+    return {"ok": True, "status": flow.snapshot()["status"]}
+
+
 def deliver_callback_flow(
     session_id: str, server_name: str, *, code: Optional[str], state: Optional[str],
     error: Optional[str] = None) -> Dict[str, Any]:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1297,6 +1297,14 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"ok": True, **poll(_str_arg(params, "session_id"), _str_arg(params, "name"))})
 
 
+@_mcp_rpc("oauth.cancel", _NAME_SESSION)
+def _(rid, params: dict) -> dict:
+    """Cancel a flow owned by the resolved profile, waking its callback worker."""
+    home = str(_tools_mod("hermes_constants").get_hermes_home().expanduser().resolve(strict=False))
+    cancel = _tools_mod("tui_gateway.mcp_oauth_sessions").cancel_flow
+    return _ok(rid, cancel(_str_arg(params, "session_id"), _str_arg(params, "name"), home))
+
+
 @_mcp_rpc("oauth.callback", _NAME_SESSION)
 def _(rid, params: dict) -> dict:
     """Relay a client-captured redirect (``code``/``state``/``error``) into a ``client_redirect_uri`` flow."""

--- a/website/docs/guides/oauth-over-ssh.md
+++ b/website/docs/guides/oauth-over-ssh.md
@@ -44,6 +44,14 @@ If your provider isn't in the table, you don't need a tunnel.
 
 ## MCP Servers
 
+**Desktop Skills → MCP:** the native app receives the callback on your computer
+and relays it to the selected connection and profile, so this flow does not need
+an SSH callback tunnel or `dashboard.public_url`. Tokens stay on the owning
+backend profile. Leaving the MCP tab or changing its scope cancels pending
+sign-in. If Desktop asks you to update the backend, update it before retrying;
+it does not fall back to a remote HTTP callback. The terminal workflows below
+are unchanged.
+
 Remote MCP servers (Linear, Sentry, Atlassian, Asana, Figma, etc.) use the same loopback redirect flow. Hermes auto-picks a free port per server and prints the authorize URL when the OAuth flow kicks off — either at startup (when a new server appears in `mcp_servers:`) or when you run `hermes mcp login <server>`.
 
 You have two ways to complete it from a remote host:


### PR DESCRIPTION
Desktop Skills → MCP now completes OAuth through the computer's native loopback callback instead of advertising the remote dashboard's HTTP origin.

- Reuse the existing client relay across Skills, inline setup, suggestions/repair, and Bot Mode; capture the owning connection/profile before asynchronous work.
- Cancel abandoned scoped Skills flows on scope change or unmount, closing the native listener and cancelling the original backend session.
- Enforce canonical profile ownership for backend poll, callback and cancel, in addition to state/replay checks. Tokens remain on the originating backend profile.
- Preserve the explicit local compatibility path when the native bridge is absent; incompatible remote backends receive an update error, never an unsafe REST fallback.
- Document Desktop's no-tunnel flow and add reusable credential-free renderer and real HTTP OAuth/MCP integration probes.

Root cause: Skills used dashboard REST authentication rather than the already-existing native callback relay; component teardown also failed to invalidate pending authentication, and backend poll/callback did not check the resolved profile.

## Validation

**Live repro:** production McpTab on main `22c5684b983eac6a81ee015ae80296c4b3dbf5bb` sends REST `/auth` and never opens the native listener; the fixed renderer completes the native listener → WebSocket callback/poll flow. The identical approved assertion fails on main and passes on this branch.

| Check | Before → after / result |
|---|---|
| Component scope change and full unmount | Before cleanup: backend keeps polling and listener remains open. After: both cancel the original owner and close the listener; both assertions proven red/green. |
| Real backend OAuth provider | 34 checks passed, 3 verified PKCE exchanges: HTTP discovery, dynamic registration, code/state exchange, authenticated MCP tools, private disk storage and fresh-process token reuse. |
| Wrong profile | Valid state/session could poll and deliver a callback before the ownership follow-up; both are rejected afterward, while the original owner can still finish. |
| Negative controls | Wrong state, replay, wrong server, wrong-owner cancellation, callback after cancellation; no token exchange/persistence for cancelled flow. |
| Targeted serial tests | 9 Desktop/native-listener tests and 40 Python tests passed; common campaign flock, one worker, no file parallelism. |
| Precommit | Ruff, touched Desktop ESLint, Windows footguns, plugin-compat pointers, subprocess stdin, and diff whitespace checks passed. |
| Independent review | Read-only review of shared relay callers, gateway profile context and lifecycle cleanup: no actionable findings. |

**Native Electron follow-up:** The exact head was additionally exercised on Linux with Electron 40.10.2 using the actual production main, preload and frozen IPC bridge, production Skills component and OAuth handlers/storage. Real native listener → WebSocket callback/poll → synthetic HTTP DCR/PKCE/token/MCP completed, and `fixture_ping` became available. Scope-change and unmount cancellations closed the listener, cancelled the original backend session and produced no token; the separate backend-hosted loopback control also succeeded. Parent verified the pinned runtime archive hash and inspected the native screenshot.

**Fidelity limits:** Unrelated gateway REST/envelope and the component mounting entry are fixtures. Hosted consent was replaced by loopback HTTP after the native shell-open handoff; no hosted provider consent, packaged installer, Windows/macOS or full application-shell QA is claimed. Four supplementary Desktop checks use native fixture BrowserWindows, not this production main/preload. No user credentials, user profiles or hosted model calls were used. Broader combined integration and CI remain separate gates; no CI-green claim.

Reproduce using `evals/desktop_mcp_oauth/README.md`.

## Credit and tracking

Salvages #104728 by Filipe Bezerra (@lipebez), preserving contributor authorship, with scoped cleanup and backend ownership follow-ups.

Fixes #104391.
Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104904

## Infographic
![Desktop MCP OAuth native callback and profile ownership](https://v3b.fal.media/files/b/0aa97484/oXfxx2gnv0lUdh5tjCFg__novSUSZB.png)
