### PR TITLE
fix(desktop): resolve Docker paths for file previews

### DIFF
--- a/hermes_cli/web_routers/files.py
+++ b/hermes_cli/web_routers/files.py
@@ -155,8 +155,44 @@ def _io_errors(denied: str, failed: str):
         raise HTTPException(status_code=500, detail=f"{failed}: {exc}")
 
 
+def _translate_fs_container_path(target: Path) -> Path:
+    """Resolve an agent-visible container path for an authenticated fs request.
+
+    A Desktop SSH ``serve --isolated`` process can reach this route after the
+    process-wide terminal config bridge made an early, unsuccessful one-shot
+    attempt.  Retry under the current profile's complete terminal policy, but
+    never replace an already-bound policy/refusal scope.
+    """
+    try:
+        from gateway.platforms.base import _translate_docker_container_media_path
+        from tools.terminal_scope import (
+            build_profile_terminal_scope,
+            get_terminal_scope,
+            reset_terminal_scope,
+            set_terminal_scope,
+        )
+
+        translated = _translate_docker_container_media_path(target)
+        if translated is not None or get_terminal_scope() is not None:
+            return translated or target
+
+        token = set_terminal_scope(build_profile_terminal_scope(get_hermes_home()))
+        try:
+            return _translate_docker_container_media_path(target) or target
+        finally:
+            reset_terminal_scope(token)
+    except Exception:
+        return target
+
+
 def _fs_regular_file(path: Path) -> tuple[Path, os.stat_result]:
     target = _fs_path(str(path))
+    # Desktop transcripts contain the path exactly as the agent saw it.  With
+    # the Docker terminal backend that is commonly `/workspace/...`, while the
+    # authenticated filesystem API runs on the host.  Reuse the gateway's
+    # existing volume translator so previews and downloads resolve the same
+    # MEDIA path that native messaging delivery already accepts.
+    target = _translate_fs_container_path(target)
     try:
         st = target.stat()
     except (FileNotFoundError, NotADirectoryError):

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -68,6 +68,56 @@ def test_fs_download_streams_file_without_data_url_cap(client, tmp_path, monkeyp
     assert "report%20with%20spaces.pdf" in response.headers["content-disposition"]
 
 
+def test_fs_download_translates_docker_volume_path_to_host(client, tmp_path, monkeypatch):
+    host_workspace = tmp_path / "AI-Workspace"
+    host_workspace.mkdir()
+    target = host_workspace / "generated report.docx"
+    target.write_bytes(b"generated-document")
+    monkeypatch.setattr(
+        "gateway.platforms.base._translate_docker_container_media_path",
+        lambda path: target if path == Path("/workspace/projects/generated report.docx") else None,
+    )
+
+    response = client.get(
+        "/api/fs/download",
+        params={"path": "/workspace/projects/generated report.docx"},
+    )
+
+    assert response.status_code == 200
+    assert response.content == b"generated-document"
+
+
+def test_fs_download_retries_docker_translation_with_profile_terminal_scope(
+    client, tmp_path, monkeypatch,
+):
+    target = tmp_path / "generated report.docx"
+    target.write_bytes(b"isolated-desktop-document")
+
+    from tools.terminal_scope import get_terminal_scope
+
+    def translate(path):
+        if path == Path("/workspace/projects/generated report.docx") and get_terminal_scope() is not None:
+            return target
+        return None
+
+    monkeypatch.setattr(
+        "gateway.platforms.base._translate_docker_container_media_path",
+        translate,
+    )
+    monkeypatch.setattr(
+        "tools.terminal_scope.build_profile_terminal_scope",
+        lambda _home: {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_VOLUMES": "[]"},
+    )
+
+    response = client.get(
+        "/api/fs/download",
+        params={"path": "/workspace/projects/generated report.docx"},
+    )
+
+    assert response.status_code == 200
+    assert response.content == b"isolated-desktop-document"
+
+
 def test_fs_download_rejects_sensitive_files(client, tmp_path):
     target = tmp_path / ".env"
     target.write_text("SECRET=1")


### PR DESCRIPTION
## What does this PR do?

Fixes remote Hermes Desktop previews and downloads for artifacts created by a Docker terminal backend. The transcript contains the agent-visible container path (for example, `/workspace/projects/report.docx`), while the authenticated Desktop filesystem API runs on the host and previously returned 404 for that path.

This reuses the gateway's existing Docker-volume translator before filesystem access. For SSH `serve --isolated` sessions, it retries translation under the active profile's terminal scope while preserving any already-bound terminal policy/refusal scope.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Translate agent-visible Docker paths before authenticated Desktop filesystem reads.
- Load the active profile's terminal scope when an isolated Desktop server has not bound one yet.
- Add regression tests for direct translation and isolated-profile fallback.

## How to Test

1. Configure a Docker terminal volume such as `/host/workspace:/workspace/projects`.
2. Generate a file through the terminal and request `/api/fs/download?path=/workspace/projects/...`.
3. Confirm the route returns the host file while sensitive-file protections remain active.

## Verification

- `python -m pytest -q tests/hermes_cli/test_web_server_fs.py` — 7 passed.
- Live reproduction on macOS: the exact generated DOCX returned 404 using its container path before translation; its mapped host path returned 200 and 2,531,430 bytes.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits.
- [x] My PR contains only changes related to this fix.
- [x] I've added tests for the bug fix.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] Documentation changes are N/A; no user-facing config changed.
- [x] `cli-config.yaml.example` changes are N/A; no config keys changed.
- [x] Contributor workflow documentation changes are N/A.
- [x] Cross-platform impact was considered; translation is only applied when a Docker volume mapping resolves.
- [x] Tool descriptions/schemas changes are N/A.
