### PR TITLE
fix(update): current gateway successors settle stale receipt warnings (#104448)

### DIFF
--- a/evals/update_obligation_identity.py
+++ b/evals/update_obligation_identity.py
@@ -1,0 +1,83 @@
+"""Disposable process/state-file A/B: run with the checkout path as argv[1].
+
+No services are discovered or restarted. Both children write runtime status
+through production code; only their temporary version fields are altered for
+negative controls. Exit 1 on base, exit 0 when current successors settle.
+"""
+
+import json, os, pathlib, subprocess, sys, tempfile, time
+
+repo = pathlib.Path(sys.argv[1])
+sys.path.insert(0, str(repo))
+root = pathlib.Path(tempfile.mkdtemp(prefix="obligations-live-"))
+os.environ["HOME"] = str(root)
+os.environ["HERMES_HOME"] = str(root / ".hermes")
+from hermes_cli import update_cmd_fleet as fleet, update_receipt as receipts
+
+print("MODULE", fleet.__file__)
+sha = fleet._current_checkout_sha()
+children = []
+rows = []
+try:
+    for name in ["alpha", "beta"]:
+        home = root / ".hermes" / "profiles" / name
+        home.mkdir(parents=True)
+        code = "import sys,time; sys.path.insert(0,sys.argv[1]); from gateway.status import write_runtime_status; write_runtime_status(gateway_state='running'); print('ready',flush=True); time.sleep(120)"
+        p = subprocess.Popen(
+            [sys.executable, "-c", code, str(repo)],
+            cwd=repo,
+            env={**os.environ, "HERMES_HOME": str(home)},
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        children.append(p)
+        assert p.stdout.readline().strip() == "ready", p.stderr.read()
+    d = root / ".hermes/logs/update_receipts"
+    d.mkdir(parents=True)
+    receipt = {
+        "outcome": "failed",
+        "plan": {
+            "runtimes": [
+                {"kind": "gateway", "profile": name, "code_sha": "old", "pid": 1}
+                for name in ["alpha", "beta"]
+            ]
+        },
+    }
+    (d / "latest.json").write_text(json.dumps(receipt))
+
+    def observe(label):
+        row = {
+            "case": label,
+            "fleet": receipts.collect_fleet_versions(),
+            "pending": fleet._pending_fleet_restart_needed(),
+        }
+        rows.append(row)
+        print(json.dumps(row))
+
+    observe("current-successors")
+    home = root / ".hermes/profiles/beta"
+    state = home / "gateway_state.json"
+    payload = json.loads(state.read_text())
+    payload["code_sha"] = "old"
+    state.write_text(json.dumps(payload))
+    observe("stale-beta")
+    payload["code_sha"] = None
+    state.write_text(json.dumps(payload))
+    observe("unknown-beta")
+    children[1].terminate()
+    children[1].wait(timeout=10)
+    observe("missing-beta-with-current-alpha")
+    assert rows[1]["pending"] and rows[2]["pending"] and rows[3]["pending"]
+    print("VERDICT:", "FIXED" if not rows[0]["pending"] else "REPRODUCED")
+    assert json.loads((d / "latest.json").read_text()) == receipt
+    assert not rows[0]["pending"], (
+        "Current identity-matched successors must settle the warning"
+    )
+finally:
+    for p in children:
+        if p.poll() is None:
+            p.terminate()
+        p.wait(timeout=10)
+    print("CLEANUP", [p.returncode for p in children])

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -142,15 +142,59 @@ def _receipt_reports_stale_runtime(expected_sha: str | None = None) -> bool:
     )
 
 
-def _pending_fleet_restart_needed() -> bool:
-    """True when a prior pull still owes the fleet a restart.
+def _live_fleet_covers_receipt(expected_sha: str | None) -> bool:
+    """Require current successors for every recorded runtime, not just any live row.
 
-    See #95294.
+    A PID changes on restart; the stable identity is (runtime kind, profile).
+    The gateway matrix cannot vouch for serve/dashboard or unidentified runtimes.
+    Keep the historical receipt intact: a manual restart is not a successful update.
     """
+    if not expected_sha:
+        return False
+    from hermes_cli.update_receipt import collect_fleet_versions, read_latest_receipt
+
+    try:
+        receipt = read_latest_receipt() or {}
+        plan = receipt.get("plan") or {}
+        runtimes = plan.get("runtimes") or []
+        recorded_fleet = receipt.get("fleet") or []
+        owed = set()
+        entries: list[tuple[object, str | None]] = [(entry, None) for entry in runtimes]
+        entries.extend((entry, "gateway") for entry in recorded_fleet)
+        for entry, default_kind in entries:
+            if not isinstance(entry, dict):
+                return False
+            kind = entry.get("kind", default_kind)
+            profile = entry.get("profile")
+            if kind != "gateway" or not profile or profile == "unknown":
+                return False
+            owed.add((kind, profile))
+        if not owed:
+            return False
+        fleet = collect_fleet_versions()
+        if not fleet or any(
+            row.get("state") != "current" or row.get("code_sha") != expected_sha
+            for row in fleet
+        ):
+            return False
+        return owed <= {("gateway", row.get("profile")) for row in fleet}
+    except Exception as exc:
+        logger.debug("Could not reconcile pending fleet identities: %s", exc)
+        return False
+
+
+def _pending_fleet_restart_needed() -> bool:
+    """Reconcile old restart obligations against current, identity-matched gateways."""
+    from hermes_cli.update_cmd import _current_checkout_sha
+
+    # The marker has no runtime inventory and may belong to a newer, killed update
+    # than latest.json. An older receipt cannot discharge that unknown obligation.
     with suppress(OSError):
         if _fleet_restart_pending_marker_path().is_file():
             return True
-    return _receipt_reports_stale_runtime()
+    if not _receipt_reports_stale_runtime():
+        return False
+    return not _live_fleet_covers_receipt(_current_checkout_sha())
 
 
 def _warn_pending_fleet_restart(*, startup: bool = False) -> None:

--- a/tests/hermes_cli/test_update_obligation_identity.py
+++ b/tests/hermes_cli/test_update_obligation_identity.py
@@ -1,0 +1,86 @@
+"""A historical receipt cannot outweigh complete, identity-matched live evidence."""
+
+import json
+
+import pytest
+
+from hermes_cli import update_cmd, update_cmd_fleet, update_receipt
+from hermes_constants import get_hermes_home
+
+
+@pytest.mark.parametrize("profiles", [["alpha"], ["alpha", "beta"]])
+def test_current_successors_settle_historical_obligations(monkeypatch, profiles):
+    home = get_hermes_home()
+    directory = home / "logs" / "update_receipts"
+    directory.mkdir(parents=True)
+    receipt = {
+        "outcome": "failed",
+        "plan": {
+            "runtimes": [
+                {"kind": "gateway", "profile": p, "pid": 1, "code_sha": "old"}
+                for p in profiles
+            ]
+        },
+    }
+    path = directory / "latest.json"
+    path.write_text(json.dumps(receipt))
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: "new")
+    monkeypatch.setattr(
+        update_receipt,
+        "collect_fleet_versions",
+        lambda: [
+            {"profile": p, "pid": 2, "state": "current", "code_sha": "new"}
+            for p in profiles
+        ],
+    )
+    assert not update_cmd_fleet._pending_fleet_restart_needed()
+    assert (
+        json.loads(path.read_text()) == receipt
+    )  # Historical failure remains truthful.
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "missing",
+        "unknown",
+        "down",
+        "stale",
+        "wrong-sha",
+        "wrong-kind",
+        "unknown-profile",
+        "marker",
+    ],
+)
+def test_every_owed_identity_requires_current_evidence(monkeypatch, bad):
+    home = get_hermes_home()
+    directory = home / "logs" / "update_receipts"
+    directory.mkdir(parents=True)
+    if bad == "marker":
+        (home / "fleet_restart_pending").write_text("expected_sha=new\n")
+    owed = {"kind": "gateway", "profile": "beta", "code_sha": "old"}
+    if bad == "wrong-kind":
+        owed["kind"] = "serve"
+    if bad == "unknown-profile":
+        owed["profile"] = "unknown"
+    (directory / "latest.json").write_text(
+        json.dumps({
+            "outcome": "failed",
+            "plan": {
+                "runtimes": [
+                    {"kind": "gateway", "profile": "alpha", "code_sha": "old"},
+                    owed,
+                ]
+            },
+        })
+    )
+    rows = [{"profile": "alpha", "state": "current", "code_sha": "new"}]
+    if bad != "missing":
+        rows.append({
+            "profile": "beta",
+            "state": bad if bad in {"unknown", "down", "stale"} else "current",
+            "code_sha": "old" if bad == "wrong-sha" else "new",
+        })
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: "new")
+    monkeypatch.setattr(update_receipt, "collect_fleet_versions", lambda: rows)
+    assert update_cmd_fleet._pending_fleet_restart_needed()

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -122,6 +122,8 @@ fails, a restart fails, or a requested service cannot be verified active. The up
 exits nonzero and reports the affected services; recover them with the printed
 commands and retry `hermes update`.
 
+A failed historical receipt does not by itself prove that gateways are still stale. Startup and gateway-status warnings, as well as update catch-up, check the live fleet before acting on receipt-only restart obligations. Every recorded gateway profile must have a live successor on the current checkout; an unrelated current gateway cannot stand in for a missing, down, unknown-version, or non-gateway runtime. A manual gateway restart can therefore settle the warning without rewriting a failed update as successful. A separate pending marker remains authoritative because it can belong to a newer interrupted update whose inventory never reached the receipt.
+
 ### Full pre-update backup: `--backup`
 
 For high-value profiles (production gateways, shared team installs) you can opt into a full pre-pull backup of `HERMES_HOME` (config, auth, sessions, skills, pairing):


### PR DESCRIPTION
Receipt-only restart warnings now settle when **every recorded gateway profile** has a live successor on the current checkout, including after a manual restart.

- Reconcile at `_pending_fleet_restart_needed`, shared by startup/status warnings and update catch-up—not only inside `hermes update`.
- Require full `(runtime kind, profile)` coverage across the receipt plan and fleet matrix. A current gateway from another profile cannot cover missing, down, unknown-version, or non-gateway obligations.
- Keep historical receipts unchanged: observing a current fleet does not turn a failed update into a successful one.
- Keep a separate pending marker authoritative. It has no runtime inventory and may belong to a newer killed updater than the old receipt; this PR does not speculate that its restart completed.
- Include two parameterized invariant tests, a disposable-process A/B harness, and updating documentation.

**Root cause:** an unfinished receipt compares historical pre-update runtime SHAs to today's HEAD without reconciling the same runtime/profile identities against the live fleet.

Addresses the stale-receipt warning in #104448; related #98022. Campaign: #104868.

## Validation

**Live repro:** on base `22c5684b983eac6a81ee015ae80296c4b3dbf5bb`, two real isolated child processes write gateway state through production `write_runtime_status`; the production fleet probe reports both current but the pending-warning predicate remains true. With this change the same surface returns false. The assertion-bearing harness exits **1 before / 0 after**.

| Isolated process/state case | Base | Change |
|---|---|---|
| Both owed profiles have current live successors | Incorrect warning | No warning |
| One successor stamped stale | Warning | Warning |
| One successor version unknown | Warning | Warning |
| One successor stopped, unrelated profile still current | Warning | Warning |

Both child PIDs are terminated and waited on after every run. No production services, user configuration, credentials, or live user receipt stores were inspected or modified. The version-negative controls alter only disposable state-file fields; this is Linux process/state evidence, not a native service-manager restart test.

- Ruff, Windows-footgun scan, compat-pointer scan, subprocess-stdin check, and `git diff --check`: passed.
- Targeted pytest A/B and existing fleet/receipt sibling files: **queued behind the campaign's shared test lock; no pytest-pass claim yet**.
- Independent review: **pending**. Draft until the queued results and review are verified. No merge authorized.

## Prior work and credit

Reported by @duanzhiwei0315 in #104448. @liuhao1024 identified the plausible updater-cgroup kill window and verified that ordinary command-boundary receipt finalization already works. The probe-first direction comes from @zengzheqing (#104295); receipt discharge was developed by @RootZ3n (#100249), with earlier catch-up receipt dismissal by @Sahilvishnaliya (#98689). Reviewed #104656 and #104427 as well. This is a narrow redo rather than a cherry-pick: their happy-path finalizer, fossil-SHA gate, receipt deletion/stamp, or any-current-fleet proof does not establish complete identity coverage at the shared manual-restart warning path. No contributor code was copied.

## Infographic
![Identity-matched live gateways settle stale receipt warnings](https://v3b.fal.media/files/b/0aa97499/TMq6e1xDG2kAJ-ZWvolBg_TQwb9g9f.png)
