### PR TITLE
Startup update checks avoid SSH host-key prompts by default (#104591, salvage #104599)

### DIFF
--- a/evals/update_check_ssh_pty.py
+++ b/evals/update_check_ssh_pty.py
@@ -1,0 +1,154 @@
+"""Linux live Git/OpenSSH PTY probe; fixture ssh config, no user state."""
+import json
+import os
+from pathlib import Path
+import pty
+import pwd
+import select
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+BASE = Path(os.environ['AUDIT_DIR'])
+REPO = Path(os.environ['AUDIT_REPO'])
+BASE.mkdir(parents=True, exist_ok=True)
+env = {'PATH': f'{BASE}/bin:/usr/bin:/bin', 'HOME': str(BASE/'home'),
+       'HERMES_HOME': str(BASE/'hermes'), 'PYTHONPATH': str(REPO),
+       'PYTHONDONTWRITEBYTECODE': '1', 'AUDIT_DIR': str(BASE), 'AUDIT_REPO': str(REPO)}
+for name in ('home', 'hermes', 'bin'):
+    (BASE/name).mkdir(exist_ok=True)
+sys.path.insert(0, str(REPO))
+from hermes_cli import banner
+
+if len(sys.argv) > 1:
+    os.environ.clear()
+    os.environ.update(env)
+    case = json.loads((BASE/'case.json').read_text())
+    os.environ.update(case['env'])
+    start = time.monotonic()
+    result = banner._check_via_local_git(BASE/'checkout')
+    print('PRODUCTION_RETURN '+json.dumps({'result': result, 'elapsed': time.monotonic()-start}), flush=True)
+    time.sleep(2)
+    sys.exit(0)
+
+
+def run(args, **kw):
+    return subprocess.run(args, env=env, stdin=subprocess.DEVNULL, capture_output=True,
+                          text=True, check=True, timeout=15, **kw).stdout.strip()
+
+
+def git(*args):
+    return run(['git', '-C', str(BASE/'checkout'), *args])
+
+
+def probe(name, extra_env):
+    (BASE/'case.json').write_text(json.dumps({'env': extra_env}))
+    child, fd = pty.fork()
+    if child == 0:
+        python = str(REPO/'.venv/bin/python')
+        os.execve(python, [python, '-B', __file__, 'child'], env)
+    text = ''
+    start = time.monotonic()
+    try:
+        while time.monotonic()-start < 13:
+            ready, _, _ = select.select([fd], [], [], .2)
+            if ready:
+                try:
+                    data = os.read(fd, 65536)
+                except OSError:
+                    break
+                if not data:
+                    break
+                text += data.decode(errors='replace')
+        descendants = []
+        for path in Path('/proc').iterdir():
+            if not path.name.isdigit():
+                continue
+            try:
+                pid = int(path.name)
+                if os.getpgid(pid) == child and pid != child:
+                    cmd = (path/'cmdline').read_bytes().replace(b'\0', b' ').decode(errors='replace')
+                    if cmd:
+                        descendants.append({'pid': pid, 'cmdline': cmd})
+            except (OSError, ProcessLookupError):
+                pass
+        returned = [line.split('PRODUCTION_RETURN ', 1)[1] for line in text.splitlines()
+                    if 'PRODUCTION_RETURN ' in line]
+        return {'name': name, 'pty': text, 'prompt': 'Are you sure you want' in text,
+                'return': json.loads(returned[-1]) if returned else None,
+                'live_descendants': descendants}
+    finally:
+        os.close(fd)
+        try:
+            os.killpg(child, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        os.waitpid(child, 0)
+
+
+for key in ('host_key', 'client_key'):
+    run(['ssh-keygen', '-q', '-t', 'ed25519', '-N', '', '-f', str(BASE/key)])
+(BASE/'authorized_keys').write_text((BASE/'client_key.pub').read_text())
+(BASE/'checkout').mkdir()
+git('init', '-b', 'main')
+git('-c', 'user.name=Probe', '-c', 'user.email=probe@localhost', 'commit', '--allow-empty', '-m', 'probe')
+run(['git', 'clone', '--bare', str(BASE/'checkout'), str(BASE/'remote.git')])
+with socket.socket() as sock:
+    sock.bind(('127.0.0.1', 0))
+    port = sock.getsockname()[1]
+user = pwd.getpwuid(os.getuid()).pw_name
+config = BASE/'sshd_config'
+config.write_text(f'Port {port}\nListenAddress 127.0.0.1\nHostKey {BASE}/host_key\nPidFile {BASE}/sshd.pid\nAuthorizedKeysFile {BASE}/authorized_keys\nPasswordAuthentication no\nKbdInteractiveAuthentication no\nUsePAM no\nStrictModes no\nLogLevel VERBOSE\n')
+ssh_config = BASE/'ssh_config'
+ssh_config.write_text(f'Host *\n User {user}\n UserKnownHostsFile {BASE}/known_hosts\n GlobalKnownHostsFile /dev/null\n IdentityFile {BASE}/client_key\n ConnectTimeout 3\n')
+wrapper = BASE/'bin/ssh'
+wrapper.write_text(f'#!/bin/sh\nexec /usr/bin/ssh -F {ssh_config} "$@"\n')
+wrapper.chmod(0o700)
+git('remote', 'add', 'origin', f'ssh://{user}@127.0.0.1:{port}{BASE}/remote.git')
+log = (BASE/'sshd.log').open('w')
+server = subprocess.Popen(['/usr/sbin/sshd', '-D', '-e', '-f', str(config)], env=env,
+                          stdin=subprocess.DEVNULL, stdout=log, stderr=log, start_new_session=True)
+agent = None
+rows = []
+try:
+    for _ in range(40):
+        if server.poll() is not None:
+            raise RuntimeError('sshd exited: '+(BASE/'sshd.log').read_text())
+        try:
+            with socket.create_connection(('127.0.0.1', port), timeout=.2) as conn:
+                assert conn.recv(256).startswith(b'SSH-')
+            break
+        except OSError:
+            time.sleep(.1)
+    else:
+        raise RuntimeError('sshd readiness timed out')
+    rows.append(probe('unofficial_unknown_host_default', {}))
+    pub = (BASE/'host_key.pub').read_text().split()
+    (BASE/'known_hosts').write_text(f'[127.0.0.1]:{port} {pub[0]} {pub[1]}\n')
+    rows.append(probe('trusted_host_file_key', {}))
+    agent = subprocess.Popen(['ssh-agent', '-D', '-a', str(BASE/'agent.sock')], env=env,
+                             stdin=subprocess.DEVNULL, stdout=log, stderr=log, start_new_session=True)
+    for _ in range(40):
+        if (BASE/'agent.sock').exists():
+            break
+        time.sleep(.1)
+    env['SSH_AUTH_SOCK'] = str(BASE/'agent.sock')
+    run(['ssh-add', str(BASE/'client_key')])
+    ssh_config.write_text(ssh_config.read_text().replace(f'IdentityFile {BASE}/client_key', 'IdentityFile none'))
+    rows.append(probe('trusted_host_agent_key', {'SSH_AUTH_SOCK': str(BASE/'agent.sock')}))
+    (BASE/'known_hosts').unlink()
+    rows.append(probe('explicit_interactive_override', {'GIT_SSH_COMMAND': 'ssh -o BatchMode=no'}))
+finally:
+    for proc in (agent, server):
+        if proc is not None:
+            os.killpg(proc.pid, signal.SIGTERM)
+            proc.wait(timeout=5)
+    log.close()
+result = {'platform': sys.platform, 'production': banner.__file__, 'rows': rows,
+          'isolation': 'PATH ssh adapter only adds -F fixture config; execs real /usr/bin/ssh; loopback sshd and disposable git repos',
+          'server_stopped': server.poll() is not None, 'agent_stopped': agent is None or agent.poll() is not None}
+(BASE/'result.json').write_text(json.dumps(result, indent=2))
+print(json.dumps(result, indent=2))
+

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -243,8 +243,9 @@ def noninteractive_git_env(base: "Mapping[str, str] | None" = None) -> dict[str,
     child of a fetch/ls-remote fails instead of prompting — ssh bypasses ``stdin=DEVNULL`` and
     opens ``/dev/tty`` directly (#104591); an agent-authenticated ssh still succeeds, and an
     explicit user ``GIT_SSH_COMMAND`` env var still takes precedence over this config-layer pin.
-    ``GIT_ASKPASS``/``SSH_ASKPASS`` are deliberately left alone: a *working* askpass helper or
-    ssh-agent should still succeed non-interactively. Pair with
+    ``GIT_ASKPASS``/``SSH_ASKPASS`` env vars are left alone, but OpenSSH BatchMode disables
+    passphrase/password prompts, including SSH askpass. Usable keys and ssh-agent authentication
+    still work; Git's own working askpass helper is unaffected. Pair with
     ``stdin=subprocess.DEVNULL``. Internal plumbing only — the agent-facing terminal tool has its
     own policy layer and visible PTY.
 

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -224,6 +224,11 @@ _GIT_CONFIG_OVERRIDES = {
     "core.editor": "true",
     "sequence.editor": "true",
     "diff.external": "",
+    # ssh itself bypasses stdin=DEVNULL/GIT_TERMINAL_PROMPT and opens /dev/tty directly — an
+    # unknown host key (or password auth) prompts there and steals the caller's terminal (#104591).
+    # BatchMode makes ssh fail instead of prompting; a working ssh-agent still succeeds. Injected
+    # at the config layer so an explicit user GIT_SSH_COMMAND (env) still takes precedence.
+    "core.sshCommand": "ssh -o BatchMode=yes",
 }
 
 
@@ -234,8 +239,12 @@ def noninteractive_git_env(base: "Mapping[str, str] | None" = None) -> dict[str,
     prompting), ``GCM_INTERACTIVE=Never`` (no Git Credential Manager dialog), and isolated git
     config: inherited ``GIT_CONFIG_*`` injection, global/system config, pagers, editors, fsmonitor,
     external diff and hooks are all disabled so a user's repo/global config cannot hang or mutate
-    Hermes's plumbing calls. ``GIT_ASKPASS``/``SSH_ASKPASS`` are deliberately left alone: a
-    *working* askpass helper or ssh-agent should still succeed non-interactively. Pair with
+    Hermes's plumbing calls. ``core.sshCommand`` is pinned to ``ssh -o BatchMode=yes`` so the ssh
+    child of a fetch/ls-remote fails instead of prompting — ssh bypasses ``stdin=DEVNULL`` and
+    opens ``/dev/tty`` directly (#104591); an agent-authenticated ssh still succeeds, and an
+    explicit user ``GIT_SSH_COMMAND`` env var still takes precedence over this config-layer pin.
+    ``GIT_ASKPASS``/``SSH_ASKPASS`` are deliberately left alone: a *working* askpass helper or
+    ssh-agent should still succeed non-interactively. Pair with
     ``stdin=subprocess.DEVNULL``. Internal plumbing only — the agent-facing terminal tool has its
     own policy layer and visible PTY.
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -180,8 +180,8 @@ def _git_run(args: list[str], *, cwd: Optional[Path] = None, timeout: int = 5, t
         return None
 
 
-def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str]:
-    result = _git_run(args, cwd=cwd, timeout=timeout)
+def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5, network: bool = False) -> Optional[str]:
+    result = _git_run(args, cwd=cwd, timeout=timeout, network=network)
     if result is None or result.returncode != 0:
         return None
     return (result.stdout or "").strip()
@@ -262,7 +262,12 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
 
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
-    origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
+    # Probe the origin URL under the same config-isolated env as the fetch below. A plain
+    # get-url applies a global url.<https>.insteadOf rewrite, so an SSH origin masquerades as
+    # HTTPS, the SSH-avoiding fast path is skipped — and the fetch, whose env drops global
+    # config (GIT_CONFIG_GLOBAL=/dev/null), dials the raw SSH origin; its host-key prompt opens
+    # /dev/tty directly and steals the CLI's keystrokes (#104591).
+    origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir, network=True)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
         if not head_rev:

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -149,7 +149,10 @@ def test_check_via_local_git_insteadof_rewrite_routes_to_ssh_fastpath(tmp_path, 
     setup_env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull}
     setup_cmds = [
         ["git", "init", "-q"],
-        ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+        # Pinned identity: with global/system config nulled, CI runners whose bare
+        # hostname makes git's auto-detected ident "user@host.(none)" reject the commit.
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "--allow-empty", "-q", "-m", "init"],
         ["git", "remote", "add", "origin", "git@github.com:NousResearch/hermes-agent.git"],
         ["git", "rev-parse", "HEAD"],
     ]

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -179,6 +179,8 @@ def test_check_via_local_git_insteadof_rewrite_routes_to_ssh_fastpath(tmp_path, 
         calls.append((list(args), kwargs))
         if args[1] == "ls-remote":
             return MagicMock(returncode=0, stdout=f"{head_sha}\trefs/heads/main\n")
+        if args[1] == "fetch":
+            return MagicMock(returncode=1, stdout="")
         return real_run(args, **kwargs)
 
     monkeypatch.setattr(banner.subprocess, "run", spy_run)

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -55,7 +55,7 @@ def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
     repo_dir = tmp_path / "repo"
     (repo_dir / ".git").mkdir(parents=True)
 
-    def fake_git_stdout(args, *, cwd, timeout=5):
+    def fake_git_stdout(args, *, cwd, timeout=5, network=False):
         if args == ["remote", "get-url", "origin"]:
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
@@ -82,7 +82,7 @@ def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
     repo_dir = tmp_path / "repo"
     (repo_dir / ".git").mkdir(parents=True)
 
-    def fake_git_stdout(args, *, cwd, timeout=5):
+    def fake_git_stdout(args, *, cwd, timeout=5, network=False):
         if args == ["remote", "get-url", "origin"]:
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
@@ -110,7 +110,7 @@ def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
     repo_dir = tmp_path / "repo"
     (repo_dir / ".git").mkdir(parents=True)
 
-    def fake_git_stdout(args, *, cwd, timeout=5):
+    def fake_git_stdout(args, *, cwd, timeout=5, network=False):
         if args == ["remote", "get-url", "origin"]:
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
@@ -126,3 +126,68 @@ def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
         behind = banner._check_via_local_git(repo_dir)
 
     assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
+
+
+def test_check_via_local_git_insteadof_rewrite_routes_to_ssh_fastpath(tmp_path, monkeypatch):
+    """#104591: the origin-URL probe must run under the fetch's config-isolated env.
+
+    A global ``url.<https>.insteadOf`` rewrite makes a plain ``git remote get-url origin``
+    report HTTPS for an SSH origin, so the SSH-avoiding fast path is skipped — while the
+    fetch itself drops global config (``GIT_CONFIG_GLOBAL=/dev/null``), dials the raw SSH
+    origin, and its host-key prompt opens /dev/tty and steals the CLI's keystrokes. With the
+    probe under the same isolated env both sides observe the raw SSH URL and the HTTPS
+    ls-remote fast path runs instead — no fetch, no ssh child.
+    """
+    import os
+    import subprocess
+
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    # Config-isolated setup so the developer's own global git config can't leak in.
+    setup_env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull}
+    setup_cmds = [
+        ["git", "init", "-q"],
+        ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+        ["git", "remote", "add", "origin", "git@github.com:NousResearch/hermes-agent.git"],
+        ["git", "rev-parse", "HEAD"],
+    ]
+    head_sha = None
+    for argv in setup_cmds:
+        done = subprocess.run(
+            argv, cwd=repo_dir, env=setup_env, check=True, capture_output=True, text=True)
+        if argv[1] == "rev-parse":
+            head_sha = done.stdout.strip()
+    assert head_sha
+
+    # Global config (visible only without GIT_CONFIG_GLOBAL isolation) rewrites SSH to HTTPS.
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".gitconfig").write_text(
+        '[url "https://github.com/"]\n\tinsteadOf = git@github.com:\n', encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # Git for Windows resolves global config here too
+
+    calls = []
+    real_run = banner.subprocess.run
+
+    def spy_run(args, **kwargs):
+        calls.append((list(args), kwargs))
+        if args[1] == "ls-remote":
+            return MagicMock(returncode=0, stdout=f"{head_sha}\trefs/heads/main\n")
+        return real_run(args, **kwargs)
+
+    monkeypatch.setattr(banner.subprocess, "run", spy_run)
+
+    behind = banner._check_via_local_git(repo_dir)
+
+    # Same upstream tip as HEAD: the SSH fast path concludes "not behind".
+    assert behind == 0
+    assert not any(args[1] == "fetch" for args, _ in calls), (
+        "insteadOf rewrite must not smuggle the check into the fetch branch")
+    probe = next(
+        (kwargs for args, kwargs in calls if args[1:3] == ["remote", "get-url"]), None)
+    assert probe is not None
+    assert probe["env"]["GIT_CONFIG_GLOBAL"] == os.devnull, (
+        "the origin-URL probe must observe the URL the isolated fetch will dial")

--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -113,7 +113,8 @@ class TestNoninteractiveGitEnv:
         assert values["core.sshCommand"] == "ssh -o BatchMode=yes"
         # Config-layer pin only: GIT_SSH_COMMAND is never set or overridden here, so a user's
         # explicit env var still takes precedence over core.sshCommand.
-        assert env.get("GIT_SSH_COMMAND") == os.environ.get("GIT_SSH_COMMAND")
+        override = "ssh -i custom-key -o BatchMode=no"
+        assert noninteractive_git_env({"GIT_SSH_COMMAND": override})["GIT_SSH_COMMAND"] == override
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -97,6 +97,24 @@ class TestNoninteractiveGitEnv:
         assert values["sequence.editor"] == "true"
         assert values["diff.external"] == ""
 
+    def test_ssh_host_key_prompts_fail_closed(self):
+        """core.sshCommand is pinned to BatchMode ssh (#104591).
+
+        ssh bypasses ``stdin=DEVNULL`` and ``GIT_TERMINAL_PROMPT`` — an unknown host key (or
+        password auth) opens ``/dev/tty`` directly and steals the caller's terminal. Under this
+        env the ssh child of a git fetch must fail fast instead of prompting; an
+        agent-authenticated ssh still succeeds.
+        """
+        env = noninteractive_git_env({})
+        values = {
+            env[f"GIT_CONFIG_KEY_{idx}"]: env[f"GIT_CONFIG_VALUE_{idx}"]
+            for idx in range(int(env["GIT_CONFIG_COUNT"]))
+        }
+        assert values["core.sshCommand"] == "ssh -o BatchMode=yes"
+        # Config-layer pin only: GIT_SSH_COMMAND is never set or overridden here, so a user's
+        # explicit env var still takes precedence over core.sshCommand.
+        assert env.get("GIT_SSH_COMMAND") == os.environ.get("GIT_SSH_COMMAND")
+
 
 # ---------------------------------------------------------------------------
 # 2. Real-git E2E: 401 remote fails fast instead of prompting

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -91,7 +91,7 @@ def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     # Simulate a non-shallow, non-SSH-remote checkout
-    def mock_git_stdout(args, *, cwd, timeout=5):
+    def mock_git_stdout(args, *, cwd, timeout=5, network=False):
         if args[:2] == ["remote", "get-url"]:
             return "https://github.com/NousResearch/hermes-agent.git"
         if args[:2] == ["rev-parse", "--is-shallow-repository"]:
@@ -142,7 +142,7 @@ def test_check_via_local_git_fetch_failure_keeps_positive_stale_count(tmp_path, 
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
-    def mock_git_stdout(args, *, cwd, timeout=5):
+    def mock_git_stdout(args, *, cwd, timeout=5, network=False):
         if args[:2] == ["remote", "get-url"]:
             return "https://github.com/NousResearch/hermes-agent.git"
         if args[:2] == ["rev-parse", "--is-shallow-repository"]:
@@ -180,7 +180,7 @@ def test_check_via_local_git_fetch_failure_rev_list_error_returns_none(tmp_path,
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
-    def mock_git_stdout(args, *, cwd, timeout=5):
+    def mock_git_stdout(args, *, cwd, timeout=5, network=False):
         if args[:2] == ["remote", "get-url"]:
             return "https://github.com/NousResearch/hermes-agent.git"
         if args[:2] == ["rev-parse", "--is-shallow-repository"]:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -152,6 +152,24 @@ Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERM
 
 ## Update Behavior
 
+### Background checks and SSH authentication
+
+The startup update check reads the origin URL with the same isolated Git
+configuration used for its network calls. Global `url.*.insteadOf` rewrites
+therefore cannot hide an official SSH remote from the public HTTPS check.
+
+Hermes's isolated internal Git commands default to `ssh -o BatchMode=yes`:
+unknown host keys, passwords, and encrypted keys needing a passphrase fail
+instead of opening a terminal prompt. Trusted hosts with usable keys or an
+SSH agent continue to authenticate. This does not change your Git or SSH
+configuration on disk, or commands you run in the terminal tool.
+
+The internal default overrides repository `core.sshCommand` settings. An
+explicit `GIT_SSH_COMMAND` environment variable still takes precedence, so
+custom identity or transport commands can be retained there. Include
+`-o BatchMode=yes` in such an override if it must remain non-interactive;
+an override that permits prompting can still interrupt a background check.
+
 `hermes update` settings live under `updates` in `config.yaml`:
 
 ```yaml


### PR DESCRIPTION
Startup update checks no longer bypass the official SSH-to-HTTPS fast path because of a global Git URL rewrite, and isolated internal Git defaults to fail-fast SSH.

Closes #104591. Campaign: #104868.

## Changes
- Resolve the origin URL under the same isolated Git configuration as the fetch.
- Default isolated internal Git to `ssh -o BatchMode=yes`, retaining explicitly supplied `GIT_SSH_COMMAND` precedence.
- Preserve usable SSH file-key and agent authentication; document prompt-dependent authentication and override limitations.
- Include a reproducible Linux Git/OpenSSH PTY fixture in `evals/update_check_ssh_pty.py` and two regression invariants.

**Root cause:** the origin probe applied global `insteadOf` rewrites while the fetch ignored them, and OpenSSH reads `/dev/tty` independently of Git's disabled stdin.

## Live repro
Real production `banner._check_via_local_git`, real Git and OpenSSH, disposable loopback sshd, controlling PTYs and fresh HOME/HERMES_HOME; no model calls or production services.

| Case | Current-main baseline | This branch |
|---|---|---|
| Official SSH origin masked by a global HTTPS rewrite | Host-key prompt; production returned after 10.057s; SSH still alive after 13s with launcher reparented to PID 1 | No prompt or live SSH descendant; returned unknown behind-count sentinel in 1.480s |
| Unofficial SSH remote, unknown host, default transport | Host-key prompt; returned after 10.054s | No prompt; failed closed in 0.059s |
| Trusted host + file key | Update check returned `0` in 0.127s | Returned `0` in 0.134s |
| Trusted host + fresh SSH agent | Returned `0` in 0.140s | Returned `0` in 0.127s |
| Explicit `GIT_SSH_COMMAND='ssh -o BatchMode=no'`, unknown host | Prompt observed | Prompt still observed, as required by override precedence |

No-rewrite and repository-local rewrite controls remained consistent. All fixture sshd/agent processes were stopped. The unofficial/auth fixture uses a PATH adapter that only adds `-F` for disposable SSH configuration before execing real `/usr/bin/ssh`; it does not add BatchMode itself.

**Limits:** this is native Linux production-function/PTY integration, not a full interactive Hermes session or native macOS verification. This is not a universal non-interactivity guarantee: explicit SSH commands may re-enable prompts. The shared internal default replaces repository `core.sshCommand`; custom transport/identity commands must use explicit `GIT_SSH_COMMAND`. OpenSSH BatchMode disables SSH askpass/password/passphrase prompting; usable keys and agents remain supported, and Git askpass is unchanged.

## Validation status
- Ruff, Windows-footgun scan (1466 files), compatibility-pointer check, subprocess-stdin check and `git diff --check`: passed.
- Two regression invariants plus three targeted files are queued **once**, serially under the campaign's shared `tests.lock`: baseline red followed by branch green. No unit-test pass is claimed yet.
- Draft pending executed test receipts, independent review, and review of the shared helper's auth/override trade-off. Parent owns CI watching and the merge gate. **Do not merge.**

Local proof receipts: `/tmp/resolve-089c35aa/updater-591-{recovery-before,recovery-after,auth-before,auth-after}/result.json`; queued results: `/tmp/resolve-089c35aa/updater-591-unit-results.json`.

## Credit
Salvaged the substantive commits and test correction from the earliest candidate, @liuhao1024's #104599, retaining original commit authorship and existing contributor mapping. @Bruce-Yii independently identified the same origin-probe mismatch in #104647; its narrower banner-only SSH default was also evaluated. Neither contributor PR has been closed.

## Infographic
![SSH update-check defaults and authentication controls](https://v3b.fal.media/files/b/0aa97498/qjdKr0oFvQbnDxGZe1zPS_qYdYN2As.png)
