### PR TITLE
fix(update): detached builds no longer hide progress from the watchdog (#104537)

### DIFF
--- a/evals/update_streaming/live_output.py
+++ b/evals/update_streaming/live_output.py
@@ -1,0 +1,87 @@
+"""Disposable subprocess/tee probe; never invokes an actual update.
+
+Run with the checkout's Python. --step drives the native Windows hand-off
+watchdog fixture; otherwise print a live before/after JSON receipt.
+"""
+import argparse
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+
+def run_child(mode):
+    if mode == "silent":
+        time.sleep(12)
+    else:
+        for _ in range(24):
+            os.write(1, b"build-progress ")
+            time.sleep(.5)
+    return 7
+
+
+def step(mode):
+    from hermes_cli.main_dashboard import _install_hangup_protection, _finalize_update_output
+    from hermes_cli.main import _run_logged_subprocess
+    state = _install_hangup_protection(gateway_mode=True)
+    try:
+        return _run_logged_subprocess([sys.executable, __file__, "--child", mode]).returncode
+    finally:
+        _finalize_update_output(state)
+
+
+def probe():
+    from hermes_cli.main_dashboard import _install_hangup_protection, _finalize_update_output
+    from hermes_cli.main import _run_logged_subprocess
+    receipts = []
+    for gateway in (False, True):
+        with tempfile.TemporaryDirectory(prefix="update-output-") as temp:
+            os.environ["HERMES_HOME"] = temp
+            os.environ["HOME"] = temp
+            os.environ["USERPROFILE"] = temp
+            screen, original = io.StringIO(), sys.stdout
+            sys.stdout = screen
+            state = _install_hangup_protection(gateway_mode=gateway)
+            result = []
+            started = time.monotonic()
+            thread = threading.Thread(target=lambda: result.append(_run_logged_subprocess(
+                [sys.executable, __file__, "--child", "progress"])))
+            thread.start()
+            log = Path(temp) / "logs" / "update.log"
+            while time.monotonic() - started < 5:
+                text = log.read_text(encoding="utf-8") if log.exists() else ""
+                if "build-progress" in text:
+                    break
+                time.sleep(.02)
+            early = "build-progress" in text
+            observed = time.monotonic() - started
+            alive = thread.is_alive()
+            thread.join(20)
+            _finalize_update_output(state)
+            sys.stdout = original
+            assert not thread.is_alive()
+            receipts.append(dict(gateway=gateway, progress_before_exit=early,
+                observed_seconds=round(observed, 3), alive_at_observation=alive,
+                exit_code=result[0].returncode, captured_progress=result[0].stdout.count("build-progress"),
+                screen_bytes=len(screen.getvalue()), log_bytes=log.stat().st_size if log.exists() else 0))
+    print(json.dumps({"platform":sys.platform,"rows":receipts}, indent=2))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--child", choices=("silent", "progress"))
+    parser.add_argument("--step", choices=("silent", "progress"))
+    args = parser.parse_args()
+    if args.child:
+        raise SystemExit(run_child(args.child))
+    if args.step:
+        raise SystemExit(step(args.step))
+    probe()

--- a/evals/update_streaming/watchdog.ps1
+++ b/evals/update_streaming/watchdog.ps1
@@ -1,0 +1,44 @@
+param([string]$Python, [string]$Receipt, [int]$ExpectedProgressCode = 7)
+$ErrorActionPreference = 'Stop'
+$repo = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+$temp = Join-Path ([IO.Path]::GetTempPath()) ('update-watchdog-' + [guid]::NewGuid())
+New-Item -ItemType Directory $temp | Out-Null
+$env:HOME = $temp
+$env:USERPROFILE = $temp
+$env:HERMES_HOME = $temp
+$LogDir = Join-Path $temp 'logs'
+New-Item -ItemType Directory $LogDir | Out-Null
+$script:Ui = $null
+$script:TreeSafeToFinalize = $true
+function Write-HandoffLog([string]$Message) {
+    Add-Content -LiteralPath (Join-Path $temp 'handoff.log') -Value $Message -Encoding UTF8
+}
+# Execute the maintained process/job/watchdog boundary, not a reimplementation.
+# Deliberately omit all actual update, service, marker and Desktop launch phases.
+$source = [IO.File]::ReadAllText((Join-Path $repo 'scripts/desktop-update/windows.ps1'))
+$start = $source.IndexOf('$script:StepDrainGraceSeconds = 20')
+$end = $source.IndexOf('$finalCode = 1', $start)
+if ($start -lt 0 -or $end -lt $start) { throw 'SETUP FAIL: handoff boundary not found' }
+. ([scriptblock]::Create($source.Substring($start, $end - $start)))
+$script:StepIdleTimeoutSeconds = 3
+$script:StepDrainGraceSeconds = 2
+$rows = @()
+try {
+    foreach ($mode in @('progress', 'silent')) {
+        Remove-Item -LiteralPath $script:StepProgressLogPath -ErrorAction SilentlyContinue
+        $clock = [Diagnostics.Stopwatch]::StartNew()
+        $result = Invoke-HermesStep $Python @((Join-Path $PSScriptRoot 'live_output.py'), '--step', $mode) $mode
+        $rows += @{ mode=$mode; code=$result.Code; seconds=$clock.Elapsed.TotalSeconds; tree_quiesced=$result.TreeQuiesced; job_assigned=$result.StartedAfterJobAssignment; output=$result.Output }
+    }
+    @{ platform='native Windows'; python=$Python; rows=$rows } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $Receipt -Encoding UTF8
+    if ($rows[0].code -ne $ExpectedProgressCode) { throw "progress code $($rows[0].code), expected $ExpectedProgressCode" }
+    if ($rows[1].code -ne 124) { throw "silent child escaped watchdog: $($rows[1].code)" }
+    foreach ($row in $rows) {
+        if (-not $row.tree_quiesced -or -not $row.job_assigned) { throw 'unsafe child lifecycle' }
+        if ($row.output.Length -ne 0) { throw 'build output leaked to screen pipe' }
+    }
+    Write-Host ('VERDICT: progress={0}, silent=124; private Windows job quiesced' -f $rows[0].code)
+} finally {
+    Copy-Item -LiteralPath (Join-Path $temp 'handoff.log') -Destination ($Receipt + '.log') -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $temp -Recurse -Force
+}

--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -325,16 +325,14 @@ class _UpdateOutputStream:
 def _install_hangup_protection(gateway_mode: bool = False):
     """Protect ``cmd_update`` from SIGHUP (→ SIG_IGN, inherited by pip/git children) and broken pipes
     (stdio wrapped in ``_UpdateOutputStream``). SIGINT/SIGTERM are left alone — legitimate cancels.
-    No-op in gateway mode (already detached). Returns state for ``_finalize_update_output``."""
+    Gateway updates are already detached, but still need the log mirror for the
+    Desktop progress watchdog. Returns state for ``_finalize_update_output``."""
     state = {
         "prev_stdout": sys.stdout, "prev_stderr": sys.stderr, "log_file": None, "installed": False}
 
-    if gateway_mode:
-        return state
-
     import signal as _signal
 
-    if hasattr(_signal, "SIGHUP"):
+    if not gateway_mode and hasattr(_signal, "SIGHUP"):
         # Non-main thread: update still runs, just without hangup protection.
         with contextlib.suppress(ValueError, OSError):
             _signal.signal(_signal.SIGHUP, _signal.SIG_IGN)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -415,25 +415,50 @@ def _log_only_write(text: str) -> None:
         return
     stream = _m().sys.stdout
     log_file = getattr(stream, "_log", None)
-    if log_file is None:
-        return
     with suppress(Exception):
-        log_file.write(text if text.endswith("\n") else text + "\n")
-        log_file.flush()
+        if log_file is None:
+            log_path = get_hermes_home() / "logs" / "update.log"
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with log_path.open("a", encoding="utf-8") as fallback:
+                fallback.write(text)
+        else:
+            log_file.write(text)
+            log_file.flush()
 
 
 def _run_logged_subprocess(cmd, *, cwd=None, env=None):
-    """Run ``cmd`` with combined output captured into update.log only; returns the
-    ``CompletedProcess`` so the caller can surface the output on failure."""
-    # Check if there are updates. On shallow checkouts `rev-list --count` walks the truncated graph and can
-    # report the entire remote ancestry (e.g. "Found 9980 new commit(s)" on a depth-1 install — #53479). The
-    # zero/nonzero gate is still sound (HEAD == origin/<branch> counts 0), so keep it, but treat the shallow
-    # NUMBER as unknown and recover the real one via the GitHub compare API when possible.
-    result = subprocess.run(
-        cmd, cwd=cwd, env=env, check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-        text=True, encoding="utf-8", errors="replace")
-    _log_only_write(result.stdout or "")
-    return result
+    """Stream combined build output to update.log, retaining it for failure reporting."""
+    import codecs
+    import io
+    from hermes_cli._subprocess_compat import kill_process_tree, windows_hide_flags
+
+    child_env = dict(os.environ if env is None else env)
+    child_env.setdefault("PYTHONUNBUFFERED", "1")
+    spawn = {"creationflags": windows_hide_flags()} if os.name == "nt" else {"process_group": 0}
+    proc = subprocess.Popen(
+        cmd, cwd=cwd, env=child_env, stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **spawn)
+    # read1 delivers partial lines too; incremental decoding preserves split UTF-8
+    # and the universal-newline behavior callers previously got from text=True.
+    decoder = io.IncrementalNewlineDecoder(codecs.getincrementaldecoder("utf-8")("replace"), True)
+    output = []
+    try:
+        while True:
+            chunk = proc.stdout.read1(8192)
+            text = decoder.decode(chunk, final=not chunk)
+            output.append(text)
+            _log_only_write(text)
+            if not chunk:
+                break
+        return subprocess.CompletedProcess(cmd, proc.wait(), stdout="".join(output))
+    except BaseException:
+        # Unlike Popen.__exit__, do not wait for a cancelled build to finish.
+        kill_process_tree(proc)
+        with suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=5)
+        raise
+    finally:
+        proc.stdout.close()
 
 
 def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):

--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -199,9 +199,8 @@ class TestFinalizeUpdateOutput:
 
 class TestLogOnlyWrite:
 
-    def test_noop_without_update_stream(self, monkeypatch):
-        """When stdout isn't the mirroring update stream (no ``_log``), it must
-        be a silent no-op rather than crash."""
+    def test_plain_stdout_keeps_build_output_off_screen(self, monkeypatch):
+        """An unwrapped stdout must not receive log-only build output."""
         plain = io.StringIO()
         monkeypatch.setattr(sys, "stdout", plain)
         _log_only_write("something")  # should not raise

--- a/tests/hermes_cli/test_update_live_output.py
+++ b/tests/hermes_cli/test_update_live_output.py
@@ -1,0 +1,86 @@
+"""Live output must reach disk before exit, without concealing silence."""
+import io
+import os
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+from hermes_cli import main_dashboard as output
+from hermes_cli import update_cmd
+
+
+@pytest.mark.parametrize("gateway", [False, True, None])
+def test_child_progress_reaches_log_before_exit(tmp_path, monkeypatch, gateway):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    terminal = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", terminal)
+    state = output._install_hangup_protection(gateway) if gateway is not None else None
+    log = tmp_path / "logs" / "update.log"
+    release = tmp_path / "release"
+    ready = tmp_path / "ready"
+    script = tmp_path / "child.py"
+    script.write_text(
+        "import os, pathlib, sys, time\n"
+        f"pathlib.Path({str(ready)!r}).touch()\n"
+        "os.write(1, b'progress: ' + bytes([0xe2, 0x82]))\n"
+        "time.sleep(.1)\n"
+        "os.write(2, bytes([0xac, 0xff]))\n"
+        f"while not pathlib.Path({str(release)!r}).exists(): time.sleep(.02)\n"
+        "print(' done', flush=True)\n"
+        "sys.exit(7)\n", encoding="utf-8")
+    results = []
+    worker = threading.Thread(target=lambda: results.append(
+        update_cmd._run_logged_subprocess([sys.executable, str(script)])))
+    try:
+        worker.start()
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            text = log.read_text(encoding="utf-8") if log.exists() else ""
+            if "progress: €�" in text:
+                break
+            time.sleep(.02)
+        assert ready.exists(), "child fixture never started"
+        assert "progress: €�" in text, "output withheld while child waits for release"
+        assert worker.is_alive()
+        size = log.stat().st_size
+        time.sleep(.3)
+        assert log.stat().st_size == size, "silence must not manufacture progress"
+        assert terminal.getvalue() == ""
+        if gateway is not None:
+            assert state["installed"]
+            print("update stage", flush=True)
+            assert "update stage" in log.read_text(encoding="utf-8")
+    finally:
+        release.touch()
+        worker.join(10)
+        output._finalize_update_output(state)
+    assert not worker.is_alive()
+    assert results[0].returncode == 7
+    assert results[0].stdout == "progress: €� done\n"
+    assert results[0].stderr is None
+
+
+def test_cancelled_output_reader_reaps_child(tmp_path, monkeypatch):
+    pidfile = tmp_path / "pid"
+    child = tmp_path / "cancel_child.py"
+    child.write_text(
+        "import os, pathlib, time\n"
+        f"pathlib.Path({str(pidfile)!r}).write_text(str(os.getpid()), encoding='utf-8')\n"
+        "print('started', flush=True)\n"
+        "time.sleep(30)\n", encoding="utf-8")
+
+    class CancelLog:
+        def write(self, text):
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(sys, "stdout", output._UpdateOutputStream(io.StringIO(), CancelLog()))
+    started = time.monotonic()
+    with pytest.raises(KeyboardInterrupt):
+        update_cmd._run_logged_subprocess([sys.executable, str(child)])
+    assert time.monotonic() - started < 10
+    import psutil
+    assert not psutil.pid_exists(int(pidfile.read_text(encoding="utf-8")))

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -266,6 +266,13 @@ chats decide who replies: [Bot Mode: A Roster of Agents](./bot-mode.md).
 
 The app checks for updates in the background and offers a one-click update when one is ready.
 
+During a local update, detailed build output streams into the active profile's
+`logs/update.log`, including detached `--gateway` updates. It stays out of the
+terminal but is available for troubleshooting before the build finishes. The
+Windows hand-off counts new output in this log as progress; a child that produces
+no output is still subject to the idle watchdog. Process liveness alone does not
+reset that watchdog, and cancelling an update does not wait for its build to finish.
+
 The desktop app and the Hermes backend it talks to update on separate clocks — the app package on your machine, the backend wherever it runs. When more than one update target exists (a remote gateway, or several registered gateways), the update affordances (**Update now** on the About panel, the ⌘K **Update Hermes** row, and the update-ready toast) update **everything**: the connected backend first, then every other eligible registered gateway (Hermes Cloud entries are platform-managed and skipped), and the desktop app itself last, since applying the client update relaunches the app. Single-machine installs keep the one-button experience.
 
 After any backend update, the app also re-checks its own version and warns with a one-click **Update desktop app** action if the GUI is still behind — so updating a remote backend can never silently leave you on a stale desktop build.


### PR DESCRIPTION
Detached updates now expose build progress to the Windows watchdog while keeping genuinely silent stalls cancellable.

Fixes #104537. Campaign: #104868.

- Restore the `--gateway` stdout/stderr tee into the active profile's `logs/update.log`.
- Stream combined build output as bytes arrive, including partial lines; retain UTF-8 replacement, universal-newline decoding, return codes and captured failure output without printing build noise to the terminal.
- Keep a profile-scoped log fallback when stdout has no tee. On cancellation, terminate the owned child tree and bound the wait instead of waiting for a build to finish.
- Do not add liveness heartbeats or increase watchdog timeouts: a silent child remains a real timeout candidate.

Root cause: the detached updater skipped its log sink, and the build helper buffered output until exit even when the sink existed.

## Validation

**Live repro:** the same real 12-second subprocess/tee fixture on Linux withheld progress until exit in terminal mode and wrote no log in gateway mode on base `22c5684b983`; independent verification on head `27874cf2e48fb2b5283048a19e4556670ed7f256` exposed partial-line progress in **0.020s terminal / 0.041s gateway** while the child remained alive. Both returned the fixture's intentional exit 7, preserved all 24 output chunks and emitted zero build bytes to the screen.

| Evidence | Result |
|---|---|
| Linux real subprocess + tee | Before/after verified; harness `evals/update_streaming/live_output.py` |
| Native Windows private-job handoff watchdog | [A/B proof run](https://github.com/NousResearch/hermes-agent/actions/runs/34110608540): progressing child **124 at 3.07s → intentional exit 7 at 13.06s**; silent control **124 → 124**. Fresh downloaded JSON receipts and actual Windows checkout log independently verified |
| Two invariants / four parameterized rows | Local base: **4 intended assertion failures** (withheld progress / cancellation exceeded bound), not collection failures. Native Windows output tests: **15 passed in 3.05s** |
| Local targeted output/handoff/stale-warning tests | Completed original serial queue: **28 passed, 0 failed across 4 files**; no duplicate suite launched |
| Affected-directory CI coverage | [Python job](https://github.com/NousResearch/hermes-agent/actions/runs/34110834189/job/101706506919), workflow attempt 1: **836/836 tracked `tests/hermes_cli/test_*.py` files** matched to actual successful per-file log rows, none missing. Whole runner final summary: **3,754 files; 45,456 passed, 0 failed, 442 skipped**; retry caveat below |
| CI checkout / other test jobs | PR-head-associated run checked out merge `46c11f4` of this exact head into `22c5684b983`; not a bare-head checkout. E2E **63 passed / 7 skipped**, macOS **34 passed / 1 skipped**, Windows **175 passed / 1 skipped**; docs checks passed |
| Real Linux SIGINT cleanup | Silent output-reader interruption returned in **0.053s**; owned child and inherited-pipe grandchild both stopped. Normal exits 0/7, decoding/newline handling, cwd/env, stdin EOF and stderr behavior independently checked |
| Ruff, Windows footguns, compat pointers, subprocess stdin, diff check | Passed |
| Independent implementation review | Passed on clean, unchanged head; no blocking implementation defect found. Draft/readiness remains the parent's decision |

**CI retry disclosure:** the final green summary is not a first-attempt-clean result. Outside the affected directory, `tests/cron/test_cron_script.py::TestScriptTimeoutTreeKill::test_timeout_leaves_no_setsid_grandchild` failed because an own-session grandchild survived the script timeout (**31 passed, 1 failed, 1 skipped**); the runner's automatic second attempt returned **32 passed, 1 skipped**. This PR changes neither the cron source/test nor `agent/deadline.py`. No affected-directory file was marked flaky. The cron flake is surfaced for parent triage, not silently waived or fixed by this PR. Canonical watcher: **25 pass, 0 pending, 0 fail, 13 skip**; green is not merge approval.

The Windows harness runs the maintained `Invoke-HermesStep` / private-job watchdog boundary with a shortened test-only idle budget, a real build subprocess and disposable HOME/HERMES_HOME. It performs no checkout updates, service changes, dependency mutation or Desktop relaunch. Private-job assignment and empty screen pipes were verified. Timeout rows prove termination to zero active job processes; successful `TreeQuiesced=true` alone does **not** prove arbitrary successful descendants are absent, and normally launched services may survive by design.

Native proof commit `c9ec2def0a8ed337a6b86b0ab0e08ac87351e8d3` differs from this PR head only in `.github/workflows/windows-venv-e2e.yml`; complete tracked-tree comparison and production/test/harness/dependency blob identities were independently verified. This is **source-equivalent native proof, not literally an exact-head Actions run**; the temporary proof branch must not merge. Native keyboard Ctrl+C during silent synchronous ReadFile was not newly exercised. Full affected-directory coverage is now reconciled from completed CI rather than duplicated locally. The pre-existing inherited-output-pipe EOF limitation after a successful build is unchanged.

## Credit

Gateway tee adapted from @fangliquanflq's #97402 with author credit retained. Streaming/root-cause work: @Artemonim (#101850) and @lEWFkRAD (#104843). This combines the missing sink and streaming fixes; it deliberately does not adopt alive-child heartbeats that could hide a genuinely stalled build.

## Infographic

![Update progress reaches the log](https://v3b.fal.media/files/b/0aa974b8/gGO2sLFO126oAlRgMEm0o_aVAcFNmo.png)
