### PR TITLE
fix(tools): handle infinite output limits

### DIFF
--- a/tests/tools/test_tool_output_limits.py
+++ b/tests/tools/test_tool_output_limits.py
@@ -74,7 +74,9 @@ class TestOverrides:
 
 
 class TestCoercion:
-    @pytest.mark.parametrize("bad", [None, "not a number", -1, 0, [], {}])
+    @pytest.mark.parametrize(
+        "bad", [None, "not a number", -1, 0, [], {}, float("inf"), float("-inf")]
+    )
     def test_invalid_values_fall_back_to_defaults(self, bad):
         cfg = {"tool_output": {"max_bytes": bad, "max_lines": bad, "max_line_length": bad}}
         with patch("hermes_cli.config.load_config", return_value=cfg):

--- a/tools/tool_output_limits.py
+++ b/tools/tool_output_limits.py
@@ -18,7 +18,7 @@ def _coerce_int(value: Any, default: int, minimum: int) -> int:
     """Return ``value`` as an int >= ``minimum``, or ``default`` on any issue."""
     try:
         iv = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return default
     return default if iv < minimum else iv
 


### PR DESCRIPTION
## What does this PR do?

Treats positive and negative infinity as malformed integer limits instead of allowing `int()` to raise `OverflowError`. This preserves the documented never-raises behavior when PyYAML parses `.inf` or `-.inf` in `tool_output` or hook spill settings.

## Related Issue

N/A — found during source audit; no matching issue or PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/tool_output_limits.py`: fall back to the configured default on `OverflowError`.
- `tests/tools/test_tool_output_limits.py`: cover positive and negative infinity for all three output limits.

## How to Test

1. Parse this configuration with PyYAML and return it from `load_config()`:

   ```yaml
   tool_output:
     max_bytes: .inf
   ```

2. Call `get_tool_output_limits()`.
3. Verify `max_bytes` is `50000` rather than an `OverflowError`.

The focused test passes all 17 tests:

```bash
scripts/run_tests.sh tests/tools/test_tool_output_limits.py -q
```

Ruff and the Windows-footgun check pass for both changed files. The full suite was also attempted with `.[all,dev]`; 26 unrelated integration files still fail because optional providers and machine-local state are not hermetic here, so the full-suite checkbox remains unchecked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (x86_64), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — configuration coercion is covered by regression tests.
