### PR TITLE
fix(desktop): recover the active gateway without reconnecting other sockets (#104074)

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -1356,6 +1356,7 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     const revalidated = deferred<{ ok: boolean; rebuilt: boolean }>()
     desktop.revalidateConnection.mockReturnValue(revalidated.promise)
+    FakeWebSocket.mode = 'fail'
 
     await act(async () => {
       const reconnect = reconnectGateway()
@@ -1369,16 +1370,18 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
       await reconnect
     })
 
-    expect(desktop.revalidateConnection).toHaveBeenCalledOnce()
+    FakeWebSocket.mode = 'open'
+    await advanceBackoff()
+    expect(desktop.revalidateConnection).toHaveBeenCalledTimes(2)
     // The manual reconnect dials the WINDOW-owned primary backend (no profile
     // arg) — same contract as the sleep/wake reconnect: passing the active
     // profile would retarget the primary socket after a live profile swap.
     const lastCall = desktop.getConnection.mock.calls.at(-1) ?? []
     expect(lastCall.length === 0 || lastCall[0] == null || lastCall[0] === '').toBe(true)
-    expect(desktop.getGatewayWsUrl).toHaveBeenCalledTimes(2)
+    expect(desktop.getGatewayWsUrl).toHaveBeenCalledTimes(3)
     expect(oldPrimary.readyState).toBe(FakeWebSocket.CLOSED)
     expect(backgroundSocket.readyState).toBe(FakeWebSocket.OPEN)
-    expect(FakeWebSocket.instances).toHaveLength(3)
+    expect(FakeWebSocket.instances).toHaveLength(4)
     expect($sessionTiles.get()[0]).not.toHaveProperty('runtimeId')
     expect($sessionTiles.get()[1].runtimeId).toBe('runtime-writer')
     expect($busy.get()).toBe(true)

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -15,8 +15,10 @@ import {
   closeSecondaryGateways,
   disposeSecondariesForConnection,
   ensureGatewayForAgent,
+  ensureGatewayForProfile,
   isActivePrimary,
-  requestGatewayForAgent
+  requestGatewayForAgent,
+  retainGatewayForAgent
 } from '@/store/gateway'
 import { reconnectGateway } from '@/store/gateway-reconnect'
 import {
@@ -1323,8 +1325,12 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($awaitingResponse.get()).toBe(false)
   })
 
-  it('manual reconnect revalidates, re-resolves, re-mints, and re-dials the dropped socket', async () => {
-    const desktop = fakeDesktop()
+  it('manual reconnect replaces an open primary without closing background profiles', async () => {
+    const desktop = {
+      ...fakeDesktop(),
+      getConnectionFor: vi.fn(async () => coderConn),
+      getGatewayWsUrlFor: vi.fn(async () => coderConn.wsUrl)
+    }
 
     ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
 
@@ -1332,11 +1338,33 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     await flushAsync()
 
     expect($gatewayState.get()).toBe('open')
-    act(() => FakeWebSocket.instances[0].drop())
-    FakeWebSocket.mode = 'open'
+    vi.useRealTimers()
+    await ensureGatewayForAgent('coder-remote', 'coder')
+    const release = await retainGatewayForAgent('coder-remote', 'coder')
+    await ensureGatewayForProfile('default')
+    vi.useFakeTimers()
+    const backgroundSocket = FakeWebSocket.instances[1]
+    const oldPrimary = FakeWebSocket.instances[0]
+
+    const tiles = ['default', 'writer'].map(profile => ({
+      ownerRoute: { connectionId: 'primary-vps', mode: 'remote' as const, profile, targetProfile: profile },
+      runtimeId: `runtime-${profile}`,
+      storedSessionId: `chat-${profile}`,
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: `primary-vps::${profile}`
+    }))
+
+    const revalidated = deferred<{ ok: boolean; rebuilt: boolean }>()
+    desktop.revalidateConnection.mockReturnValue(revalidated.promise)
 
     await act(async () => {
       const reconnect = reconnectGateway()
+      await vi.advanceTimersByTimeAsync(0)
+      await ensureGatewayForAgent('coder-remote', 'coder')
+      $sessionTiles.set(tiles)
+      $busy.set(true)
+      $awaitingResponse.set(true)
+      revalidated.resolve({ ok: true, rebuilt: false })
       await vi.advanceTimersByTimeAsync(0)
       await reconnect
     })
@@ -1348,8 +1376,38 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     const lastCall = desktop.getConnection.mock.calls.at(-1) ?? []
     expect(lastCall.length === 0 || lastCall[0] == null || lastCall[0] === '').toBe(true)
     expect(desktop.getGatewayWsUrl).toHaveBeenCalledTimes(2)
-    expect(FakeWebSocket.instances).toHaveLength(2)
+    expect(oldPrimary.readyState).toBe(FakeWebSocket.CLOSED)
+    expect(backgroundSocket.readyState).toBe(FakeWebSocket.OPEN)
+    expect(FakeWebSocket.instances).toHaveLength(3)
+    expect($sessionTiles.get()[0]).not.toHaveProperty('runtimeId')
+    expect($sessionTiles.get()[1].runtimeId).toBe('runtime-writer')
+    expect($busy.get()).toBe(true)
+    expect($awaitingResponse.get()).toBe(true)
     expect($gatewayState.get()).toBe('open')
+    release()
+  })
+
+  it('manual reconnect replaces only the active secondary route', async () => {
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = {
+      ...fakeDesktop(),
+      getConnectionFor: vi.fn(async () => coderConn),
+      getGatewayWsUrlFor: vi.fn(async () => coderConn.wsUrl)
+    }
+    render(<Harness />)
+    await flushAsync()
+    vi.useRealTimers()
+    await ensureGatewayForAgent('coder-remote', 'coder')
+    const primarySocket = FakeWebSocket.instances[0]
+    const oldSecondary = FakeWebSocket.instances[1]
+    await reconnectGateway()
+
+    expect(primarySocket.readyState).toBe(FakeWebSocket.OPEN)
+    expect(oldSecondary.readyState).toBe(FakeWebSocket.CLOSED)
+    expect(FakeWebSocket.instances).toHaveLength(3)
+    expect(FakeWebSocket.instances[2].url).toBe(coderConn.wsUrl)
+    expect(activeGateway()?.connectionState).toBe('open')
+    expect(isActivePrimary()).toBe(false)
+    expect($connection.get()?.profile).toBe('coder')
   })
 
   it('power resume force-redials a half-open primary socket that still reports OPEN', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -427,12 +427,12 @@ export function useGatewayBoot({
             })
           }
 
-          scheduleReconnect()
+          scheduleReconnect(manual)
         }
       }
     }
 
-    function scheduleReconnect() {
+    function scheduleReconnect(manual?: { profile: string; activationEpoch: number }) {
       if (cancelled || reconnecting || reconnectTimer !== null || gatewayOpen() || $gatewaySwitching.get()) {
         return
       }
@@ -445,7 +445,7 @@ export function useGatewayBoot({
       reconnectAttempt += 1
       reconnectTimer = setTimeout(() => {
         reconnectTimer = null
-        void attemptReconnect()
+        void attemptReconnect(manual)
       }, delay)
     }
 

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -20,11 +20,13 @@ import {
 import { resetBackgroundPollingGuard } from '@/store/composer-status'
 import {
   $gateway,
+  activeGateway,
   activeGatewayConnectionId,
   closeLegacySecondaryGateways,
   closeSecondaryGateways,
   configureGatewayRegistry,
   disposeSecondariesForConnection,
+  ensureActiveGatewayOpen,
   ensureGatewayForProfile,
   gatewayActivationEpoch,
   isActivePrimary,
@@ -299,7 +301,7 @@ export function useGatewayBoot({
       }, LIVENESS_REPROBE_DELAY_MS)
     }
 
-    const attemptReconnect = async () => {
+    const attemptReconnect = async (manual?: { profile: string; activationEpoch: number }) => {
       if (cancelled || reconnecting || gatewayOpen() || $gatewaySwitching.get()) {
         return
       }
@@ -370,23 +372,29 @@ export function useGatewayBoot({
         // A legacy remote primary has no registry identity to scope by; fall
         // back to preserving only Bot runtimes owned by provably-live
         // secondaries so the restarted backend's own tiles still rebind.
+        const primaryConnectionId = primaryRuntimeConnectionId(conn)
         resetTileRuntimeBindings(
-          primaryRuntimeConnectionId(conn) ?? { liveConnectionIds: liveSecondaryConnectionIds() }
+          manual && primaryConnectionId
+            ? { connectionId: primaryConnectionId, profile: manual.profile }
+            : (primaryConnectionId ?? { liveConnectionIds: liveSecondaryConnectionIds() })
         )
         // The status-stack poll guard latches session ids the OLD runtime
         // reported gone (4001). A respawned backend re-mints runtimes, so
         // those ids may be live again after re-resume — clear the latch with
         // the same lifetime as the runtime bindings it shadows.
         resetBackgroundPollingGuard()
+
         // Same staleness, other half: pre-reconnect busy flags are keyed by
         // those dead runtime ids and would never receive their terminal
         // busy:false — clear them or the sidebar running arc lies forever
         // (#53902/#73082). A genuinely live turn re-asserts busy on its next
         // post-reconnect event.
-        reconcileBusyStatesOnReconnect()
-        // Resync state that may have moved on the backend while we were asleep.
-        await callbacksRef.current.refreshHermesConfig().catch(() => undefined)
-        await callbacksRef.current.refreshSessions().catch(() => undefined)
+        // A manual retry may finish after the user has moved to another route.
+        if (!manual || (isActivePrimary() && gatewayActivationEpoch() === manual.activationEpoch)) {
+          reconcileBusyStatesOnReconnect()
+          await callbacksRef.current.refreshHermesConfig().catch(() => undefined)
+          await callbacksRef.current.refreshSessions().catch(() => undefined)
+        }
       } catch (err) {
         // OAuth session expired mid-reconnect: surface the actionable "sign in
         // again" recovery overlay once instead of silently looping the backoff
@@ -855,7 +863,34 @@ export function useGatewayBoot({
     const forceReconnectNow = () => reconnectNow({ forceOpenSocket: true })
     const offPowerResume = desktop.onPowerResume?.(() => void forceReconnectNow())
     const offConnectionApplied = desktop.onConnectionApplied?.(() => void softSwitch())
-    const offGatewayReconnect = registerGatewayReconnect(forceReconnectNow)
+
+    const offGatewayReconnect = registerGatewayReconnect(async () => {
+      if (cancelled || !bootCompleted || $gatewaySwitching.get()) {
+        return
+      }
+
+      // Explicit recovery targets the route the user is viewing, not every
+      // warm profile. A responsive ping does not prove delivery is unstuck.
+      if (!isActivePrimary()) {
+        activeGateway()?.close()
+
+        if (!(await ensureActiveGatewayOpen())) {
+          throw new Error('Hermes gateway is not connected')
+        }
+
+        return
+      }
+
+      gateway.close()
+      clearReconnectTimer()
+      reconnectAttempt = 0
+      reconnectFailingSince = null
+      escalated = false
+      await attemptReconnect({
+        profile: normalizeProfileKey($activeGatewayProfile.get()),
+        activationEpoch: gatewayActivationEpoch()
+      })
+    })
 
     // Registry lifecycle: a removed connection's secondaries must close NOW
     // (remote/cloud have no local process whose death would drop the socket —

--- a/apps/desktop/src/app/shell/gateway-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/gateway-menu-panel.test.tsx
@@ -71,7 +71,7 @@ describe('GatewayMenuPanel reconnect action', () => {
 
   afterEach(() => cleanup())
 
-  it('shows reconnect only while disconnected and disables it in flight', async () => {
+  it('shows reconnect while disconnected and disables it in flight', async () => {
     let finish: (() => void) | undefined
     mocks.reconnectGateway.mockImplementation(
       () =>
@@ -92,10 +92,12 @@ describe('GatewayMenuPanel reconnect action', () => {
     await act(async () => finish?.())
   })
 
-  it('hides reconnect while the socket is open', async () => {
+  it('allows recovery when an open socket stops delivering', async () => {
     renderPanel('open')
     await act(async () => undefined)
 
-    expect(screen.queryByRole('button', { name: 'Reconnect gateway' })).toBeNull()
+    const reconnect = screen.getByRole('button', { name: 'Reconnect gateway' })
+    await act(async () => fireEvent.click(reconnect))
+    expect(mocks.reconnectGateway).toHaveBeenCalledOnce()
   })
 })

--- a/apps/desktop/src/app/shell/gateway-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/gateway-menu-panel.tsx
@@ -171,20 +171,19 @@ export function GatewayMenuPanel({
           </span>
         </div>
         <div className="flex shrink-0 items-center gap-0.5">
-          {!gatewayOpen && (
-            <Tip label={copy.reconnectGateway}>
-              <Button
-                aria-label={copy.reconnectGateway}
-                className="text-muted-foreground hover:text-foreground"
-                disabled={reconnecting}
-                onClick={reconnect}
-                size="icon-xs"
-                variant="ghost"
-              >
-                <RefreshCw className={cn(reconnecting && 'animate-spin')} />
-              </Button>
-            </Tip>
-          )}
+          {/* An open transport can still be wedged; recovery must remain reachable. */}
+          <Tip label={copy.reconnectGateway}>
+            <Button
+              aria-label={copy.reconnectGateway}
+              className="text-muted-foreground hover:text-foreground"
+              disabled={reconnecting}
+              onClick={reconnect}
+              size="icon-xs"
+              variant="ghost"
+            >
+              <RefreshCw className={cn(reconnecting && 'animate-spin')} />
+            </Button>
+          </Tip>
           <Tip label={copy.openSystem}>
             <Button
               aria-label={copy.openSystem}

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -428,6 +428,10 @@ another profile's agent plugins without switching the whole app (the backend
 
 ## Troubleshooting
 
+### Reconnect without restarting the app
+
+If a Desktop chat or bot stops responding while the connection still shows **Connected**, select that bot/profile or gateway, open the status bar's gateway menu, and click **Reconnect gateway**. Reconnect stays available for open, connecting, and disconnected transports. It redials the active route without restarting Desktop or deliberately closing other routes' sockets. In-flight requests on the selected socket can be interrupted; this is an explicit recovery action, not a backend or model restart.
+
 ### Failed turns name the failing layer
 
 When a turn fails, the chat renders an error card that names **which layer


### PR DESCRIPTION
Desktop's existing **Reconnect gateway** action can recover the active chat route without deliberately tearing down unrelated sockets.

## Changes
- Keep the existing menu action visible even when WebSocket state is `open`; a ping response does not prove chat delivery is healthy.
- Route explicit recovery through the existing primary/secondary reconnect paths for the **active route only**, rather than the wake handler's all-secondary force-close.
- Scope manual primary tile invalidation to connection + profile, guard foreground reconciliation after navigation, and preserve that context through retry backoff.
- Document the action and its interruption boundary. No new gateway picker, backend reset API, model restart, or automatic wake-policy change.

**Root cause:** the menu hid manual recovery on open transports, while its registered handler used a global secondary reconnect and only ping-checked the primary.

## Validation
**Live repro:** actual production React menu + boot hook, gateway registry and RPC client in isolated Chromium, with three real loopback WebSocket connections (all profile `default`). Electron IPC/ancillary REST and JSON-RPC peer are fixtures; no production predicates are mocked.

| Scenario | Before | After |
|---|---|---|
| Current main menu, open transport | Reconnect hidden | Reconnect visible |
| Open secondary with wedged delivery | Target recovers, unrelated secondary changes socket `2 → 4` | Target `3 → 4`; primary `1` and unrelated secondary `2` unchanged |
| Open primary with wedged delivery but responsive ping | Target stays socket `1`, delivery still times out; both secondaries churn | Target `1 → 5`, delivery succeeds; secondaries `4` and `2` unchanged |
| Closed / connecting controls | Existing recovery available | Available; real delayed handshake reaches open and RPC succeeds |

- **45 tests passed across 2 files**, Vitest `--maxWorkers 1 --no-file-parallelism` under campaign-wide `flock`. Includes a failed initial manual primary dial followed by retry after navigation: same-connection other-profile runtime and foreground busy/awaiting state are preserved. Regression was red before retaining scoped retry context.
- Renderer TypeScript check, touched-file ESLint/format checks, Windows-footgun scan, compatibility-pointer check, and `git diff --check` passed.
- Independent review found and prompted fixes for connection-wide invalidation and lost retry context; final bounded re-review cleared the retry blocker.

## Scope and limitations
Related to #104074; recovery slice only. **The historical Windows pool-starvation / local model delivery hang was not reproduced**, and this does not claim to fix its underlying cause or every latch in that report. Native packaged Electron and real model turns were not exercised. In-flight requests on the selected socket can be interrupted by explicit reconnect. Automatic wake/online recovery remains unchanged.

Uses the reconnect surface already introduced by merged #80694; no contributor implementation was copied.

Campaign: https://github.com/NousResearch/hermes-agent/issues/104904

## Native Electron follow-up

This exact head was also exercised in Electron 40.10.2 with the production menu/hook/registry/RPC client and three real renderer WebSockets. The recovery button remains visible and enabled while ping responds but delivery stalls; both primary and secondary recovery replace only the selected socket. The unrelated healthy socket retains its identity and continues serving RPCs. Closed/connecting controls recover too; parent verified the published head and inspected the native screenshot.

Fidelity: native component BrowserWindow with fixture main/preload/REST and loopback RPC peer, not a packaged app. All three routes use the default profile; this does not claim two profiles on one connection, full Bot Mode shell recovery, inference-pool starvation or native Windows/macOS suspension behavior. The linked baseline is the prior component/browser A/B, not a newly repeated whole-main native baseline.

## Infographic
![Active-route recovery and socket isolation](https://v3b.fal.media/files/b/0aa974c1/Sb1RBzw0_RyjmIFaKCBnp_ZTeTOANL.png)
