### PR TITLE
fix: unavailable home links report storage errors, not broken YAML (#104771)

### DIFF
--- a/contributors/emails/320556551+ca-shrimp@users.noreply.github.com
+++ b/contributors/emails/320556551+ca-shrimp@users.noreply.github.com
@@ -1,0 +1,2 @@
+ca-shrimp
+# Inspired by PR 104774

--- a/contributors/emails/craigrichardson@Craigs-Mac-mini.local
+++ b/contributors/emails/craigrichardson@Craigs-Mac-mini.local
@@ -1,0 +1,2 @@
+CraigRichardsonRMPM
+# Inspired by PR 103735

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -657,30 +657,8 @@ def ensure_hermes_home():
     assert_named_profile_home_live(home)
     if key in _HERMES_HOME_ENSURED and home.is_dir():
         return
-    if is_managed():
-        # Activation creates the dirs; verify, then seed SOUL.md. logs/curator may be unknown to
-        # the activation script (inside an already-secured logs/). umask(0o007) => SOUL.md is 0660.
-        old_umask = os.umask(0o007)
-        try:
-            if not home.is_dir():
-                raise RuntimeError(f"HERMES_HOME {home} does not exist.")
-            for subdir in ("cron", "sessions", "logs", "memories"):
-                if not (home / subdir).is_dir():
-                    raise RuntimeError(f"{home / subdir} does not exist.")
-            (home / "logs" / "curator").mkdir(parents=True, exist_ok=True)
-            _ensure_default_soul_md(home)
-        finally:
-            os.umask(old_umask)
-    else:
-        home.mkdir(parents=True, exist_ok=True)
-        _secure_dir(home)
-        for subdir in _HERMES_HOME_SUBDIRS:
-            d = home / subdir
-            d.mkdir(parents=True, exist_ok=True)
-            _secure_dir(d)
-        _ensure_default_soul_md(home)
-
-    _HERMES_HOME_ENSURED.add(key)
+    from hermes_cli.config_home import initialize_home
+    initialize_home(home, _HERMES_HOME_SUBDIRS, _HERMES_HOME_ENSURED)
 
 
 # ---- Config loading/saving ----
@@ -1222,8 +1200,9 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
     if config is None:
         try:
             config = load_config()
-        except Exception:
-            return [ConfigIssue("error", "Could not load config.yaml", "Run 'hermes setup' to create a valid config")]
+        except Exception as exc:
+            from hermes_cli.config_home import config_load_issue
+            return [config_load_issue(exc)]
 
     issues: List[ConfigIssue] = []
     _validate_voice(config, issues)

--- a/hermes_cli/config_home.py
+++ b/hermes_cli/config_home.py
@@ -1,0 +1,78 @@
+"""Directory initialization and storage diagnostics for the active Hermes home."""
+
+import os
+from pathlib import Path
+
+
+class HomeInitializationError(RuntimeError):
+    """The home skeleton is unavailable, not an invalid YAML document."""
+
+
+def _directory_links(path: Path) -> list[Path]:
+    return [part for part in (*reversed(path.parents), path) if part.is_symlink()]
+
+
+def _ensure_directory(path: Path, *, create: bool, secure: bool) -> None:
+    from hermes_cli.config import _secure_dir
+
+    detail = ""
+    try:
+        links = _directory_links(path)
+        detail = "; ".join(f"{link} -> {link.readlink()}" for link in links)
+        # Never materialize a missing mount's target on the underlying disk.
+        for link in links:
+            if not link.is_dir():
+                raise FileNotFoundError(f"Directory link is unavailable: {link}")
+        if create:
+            path.mkdir(parents=True, exist_ok=True)
+        elif not path.is_dir():
+            raise FileNotFoundError(f"Required directory does not exist: {path}")
+        # The operator owns permissions beyond a link, including logs/curator.
+        if secure and not links:
+            _secure_dir(path)
+    except OSError as exc:
+        raise HomeInitializationError(
+            f"Cannot initialize Hermes directory {path}: {exc}. "
+            + (f"Directory links: {detail}. " if detail else "")
+            + "Check the directory/link target, mount availability and access permissions; "
+            "restore the mount or repair the link before retrying. "
+            "Hermes has not replaced the link or created its missing target."
+        ) from exc
+
+
+def initialize_home(home: Path, subdirs: tuple[str, ...], ensured: set[str]) -> None:
+    from hermes_cli.config import _ensure_default_soul_md, is_managed
+
+    managed = is_managed()
+    old_umask = os.umask(0o007) if managed else None
+    try:
+        _ensure_directory(home, create=not managed, secure=not managed)
+        required = ("cron", "sessions", "logs", "memories") if managed else subdirs
+        for subdir in required:
+            _ensure_directory(home / subdir, create=not managed, secure=not managed)
+        if managed:
+            _ensure_directory(home / "logs" / "curator", create=True, secure=False)
+        try:
+            _ensure_default_soul_md(home)
+        except OSError as exc:
+            raise HomeInitializationError(
+                f"Cannot initialize Hermes home {home}: {exc}. "
+                "Check storage availability and access permissions."
+            ) from exc
+    finally:
+        if old_umask is not None:
+            os.umask(old_umask)
+    # Plugin discovery rebinds the resolved home. Do not repeat chmod through
+    # that spelling after the operator-owned symlink boundary has been lost.
+    ensured.update((str(home), str(home.resolve())))
+
+
+def config_load_issue(exc: Exception):
+    from hermes_cli.config import ConfigIssue
+
+    if isinstance(exc, (HomeInitializationError, OSError)):
+        return ConfigIssue(
+            "error", f"Hermes storage is unavailable: {exc}",
+            "Check the reported path, link target, mount and permissions; keep config.yaml unchanged.",
+        )
+    return ConfigIssue("error", "Could not load config.yaml", "Run 'hermes setup' to create a valid config")

--- a/tests/hermes_cli/test_home_directory_diagnostics.py
+++ b/tests/hermes_cli/test_home_directory_diagnostics.py
@@ -1,0 +1,66 @@
+"""Home initialization must respect operator-owned links and diagnose storage."""
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import config
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("subdir", (".", *config._HERMES_HOME_SUBDIRS))
+def test_unavailable_directory_links_are_diagnosed_without_creating_targets(tmp_path, monkeypatch, subdir):
+    home = tmp_path / "hermes"
+    link = home / subdir
+    link.parent.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "unmounted" / "external"
+    link.symlink_to(target, target_is_directory=True)
+    monkeypatch.setattr(config, "get_hermes_home", lambda: home)
+    monkeypatch.setattr(config, "is_managed", lambda: False)
+    config._HERMES_HOME_ENSURED.discard(str(home))
+
+    issues = config.validate_config_structure()
+
+    assert issues
+    text = " ".join(str(issue) for issue in issues)
+    assert str(link) in text and str(target) in text
+    assert "mount" in text.lower() and "setup" not in text.lower()
+    assert link.is_symlink() and link.readlink() == target
+    assert not target.parent.exists()
+    assert str(home) not in config._HERMES_HOME_ENSURED
+
+    target.mkdir(parents=True, mode=0o750)
+    config.ensure_hermes_home()
+    assert link.is_symlink() and target.stat().st_mode & 0o777 == 0o750
+    assert str(home) in config._HERMES_HOME_ENSURED
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("linked", ("plain", "logs", "home"))
+def test_initialization_preserves_external_directory_modes(tmp_path, monkeypatch, linked):
+    home = tmp_path / "hermes"
+    target = tmp_path / "shared"
+    target.mkdir(mode=0o750)
+    if linked == "home":
+        home.symlink_to(target, target_is_directory=True)
+    else:
+        home.mkdir()
+    curator = target / "curator"
+    curator.mkdir(mode=0o750)
+    if linked == "logs":
+        (home / "logs").symlink_to(target, target_is_directory=True)
+    monkeypatch.setattr(config, "get_hermes_home", lambda: home)
+    monkeypatch.setattr(config, "is_managed", lambda: False)
+    config._HERMES_HOME_ENSURED.discard(str(home))
+
+    config.ensure_hermes_home()
+    monkeypatch.setattr(config, "get_hermes_home", lambda: home.resolve())
+    config.ensure_hermes_home()
+
+    assert all((home / name).is_dir() for name in config._HERMES_HOME_SUBDIRS)
+    assert (home / "SOUL.md").is_file()
+    if linked != "plain":
+        assert (home if linked == "home" else home / "logs").is_symlink()
+        assert target.stat().st_mode & 0o777 == 0o750
+        assert curator.stat().st_mode & 0o777 == 0o750
+    else:
+        assert (home / "logs").stat().st_mode & 0o777 == 0o700

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -171,6 +171,26 @@ The same pattern works on Arch (the installer uses pacman with the same sudo-det
 
 For more diagnostics, run `hermes doctor` — it will tell you exactly what's missing and how to fix it.
 
+### Symlinked home directories and external storage
+
+Hermes supports a symlinked `HERMES_HOME` and symlinked home subdirectories,
+including `hooks`, `skills`, `sessions`, and `logs`. During home initialization,
+existing directory links are preserved, and permissions on linked directories
+(and descendants such as `logs/curator`) are left to their owner.
+
+If a link target is missing, inaccessible, or not a directory, initialization
+stops with a storage error naming the path and link target. Hermes does **not**
+replace the link or create its missing target: doing so could write data onto
+the local disk while an external or NAS volume is unmounted. Check the reported
+link, restore the mount or correct its target, and verify access permissions
+before retrying. For a deliberately new dotfiles target, create it yourself only
+after confirming the intended storage is available.
+
+`hermes doctor` reports these failures as storage problems, not invalid YAML.
+Keep your existing `config.yaml`; running `hermes setup` is not the repair for an
+unavailable directory. This is a directory-availability check, not a mount monitor:
+an existing directory cannot establish that the intended volume is mounted.
+
 ## Install method auto-detection
 
 Hermes auto-detects whether it was installed via the git installer, Docker, or NixOS, and `hermes update` prints the matching update command for that path. There's no env var to set — the detection is based on the install layout (`~/.hermes/hermes-agent/` checkout, Docker image stamp, or Nix store path). `hermes doctor` also surfaces the detected method under its environment summary.


### PR DESCRIPTION
Unavailable home-directory links now produce actionable storage diagnostics without replacing links, creating missing external targets, or mislabeling valid YAML.

Fixes #104771. Campaign: #104868.

## Changes
- Extract directory initialization into `hermes_cli/config_home.py`; `config.py` becomes smaller.
- Diagnose unavailable links, directory/file conflicts and initialization I/O errors with path, target, mount and permission guidance. Managed installations retain their explicit directory requirements.
- Preserve permissions across linked directories, including `logs/curator`. Memoize the resolved alias after successful initialization so plugin discovery cannot repeat chmod after losing the symlink spelling.
- Keep configuration bytes and configured links intact; a missing mount/target remains an operator repair, not an implicit local-directory creation.
- Document recovery and add two filesystem invariants covering the initialized directory family and linked/ordinary permissions.

Root cause: `mkdir(exist_ok=True)` rejects dangling links, and config validation previously converted every initialization exception into a generic YAML/setup diagnosis.

## Validation
**Live repro:** actual Linux `hermes doctor` under a controlling PTY, fresh disposable `HOME` and `HERMES_HOME` for every arm, current-main base `22c5684b983` versus this branch.

| Scenario | Before | After |
|---|---|---|
| Missing hooks target | `Could not load config.yaml`; setup guidance | Storage error names link/target and mount/permissions; link retained, target absent |
| Unavailable-mount-style target | Same misleading YAML diagnosis | Actionable storage diagnosis; no target directory materialized |
| Existing file where a directory is required | YAML diagnosis | Storage error; file retained |
| Healthy logs symlink | Target mode clamped from `0750` to `0700` | Target remains `0750` |
| Healthy home-root symlink | Target clamped to `0700`, including during plugin discovery | Target remains `0750` |
| Ordinary home | Initializes normally | Initializes normally |

- All six live-doctor fixture arms retained the original `config.yaml` bytes.
- A separate fresh-process production-import matrix passed **17/17** unavailable-link → operator repair → successful retry cases across unmanaged and managed initialization. It verified failure is not memoized and the external target is never auto-created.
- Ruff, Windows-footgun scan, compat-pointer scan and `git diff --check` passed.
- Canonical baseline: 13 intended assertion failures and 1 passing control. Fixed: 169 passed, 0 failed, 5 skipped across all six files. Independent review found no blocking defects; additional link/permission controls passed 8/8, including setgid preservation. CI is green on `abcda38e0c4727fa18bca054c555f176450600e6`.

Evidence retained in the campaign workspace: `home-link-doctor-before.json`, `home-link-doctor-verified.json`, `home-link-matrix.json`, and `home-link-validation-summary.json` under `/tmp/resolve-089c35aa/`.

Scope: these are real Linux filesystem/CLI probes, not native macOS or a real NAS outage. The unavailable-mount control uses an absent external-directory tree in a disposable home. This is not mount monitoring; an existing directory cannot prove the intended volume is mounted. No user home or mounted volume was modified.

## Contributor credit and candidate differences
Thanks to @souravghosh1987 for #104771, @ca-shrimp for #104774, and @CraigRichardsonRMPM for #103735. This is a focused redo with co-author credit and contributor mappings: #104774's automatic target creation is unsafe when a mount is absent; #103735 only skips unavailable `sessions` and misses the sibling directory/error-diagnosis class. Neither candidate is merged or closed by this PR.

## Infographic
![Safe home-directory links and storage diagnostics](https://v3b.fal.media/files/b/0aa9748f/VEEd222ClKmxkjv7zGQYJ_0GU2Q2dv.png)
