### PR TITLE
fix(execute-code): helper instructions no longer cause NameError (salvage #83772)

### DIFF
--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -254,7 +254,7 @@ TIPS = [
     "The terminal tool annotates common exit codes: grep returning 1 = 'No matches found (not an error)'.",
     "Failed foreground terminal commands auto-retry up to 3 times with exponential backoff (2s, 4s, 8s).",
     "Bare sudo commands are auto-rewritten to pipe SUDO_PASSWORD from .env — no interactive prompt needed.",
-    "execute_code has built-in helpers: json_parse() for tolerant parsing, shell_quote(), and retry() with backoff.",
+    "execute_code helpers require explicit imports: from hermes_tools import json_parse, shell_quote, retry.",
     "execute_code's 7 sandbox tools (web_search, terminal, read/write/search/patch) use RPC — never enter context.",
     "Reading the same file region 3+ times triggers a warning. At 4+, it's hard-blocked to prevent loops.",
     "write_file and patch detect if a file was externally modified since the last read and warn about staleness.",

--- a/tests/tools/test_execute_helper_contract.py
+++ b/tests/tools/test_execute_helper_contract.py
@@ -1,0 +1,58 @@
+"""Execute the helper usage taught by the public schema and recovery hints."""
+
+import json
+import re
+
+import pytest
+
+from tools import code_execution_tool
+from tools.code_kernel import shutdown_all_kernels
+from tools.registry import registry
+
+
+PROBE = '''
+from __future__ import annotations
+{imports}
+import json
+print(json.dumps([json_parse('{{"value": 7}}')["value"],
+                  shell_quote("two words"), retry(lambda: "ok", delay=0)]))
+'''
+
+
+@pytest.fixture(autouse=True)
+def local_kernel(tmp_path, monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("code_execution:\n  mode: strict\n", encoding="utf-8")
+    shutdown_all_kernels()
+    yield
+    shutdown_all_kernels()
+
+
+def run(code, reset=False):
+    return json.loads(registry.dispatch("execute_code", {"code": code, "reset": reset},
+                                        task_id="helper-contract", enabled_tools=[]))
+
+
+def test_schema_helper_instructions_work_across_kernel_lifetimes():
+    description = registry.get_schema("execute_code")["description"]
+    imports = "\n".join(re.findall(r"`(from hermes_tools import [\w, ]+)`", description))
+    for reset, reused in ((False, False), (False, True), (True, False)):
+        result = run(PROBE.format(imports=imports), reset=reset)
+        assert result["status"] == "success", result
+        assert json.loads(result["output"]) == [7, "'two words'", "ok"]
+        assert result["kernel"]["reused"] is reused
+
+
+def test_missing_helper_recovery_instructions_execute():
+    for helper in ("json_parse", "shell_quote", "retry"):
+        failed = run(f"print({helper})", reset=True)
+        assert failed["status"] == "error", failed
+        instruction = re.search(r"from hermes_tools import \w+", failed["hint"])
+        assert instruction, failed
+        recovered = run(instruction.group() + f"\nprint(callable({helper}))")
+        assert recovered["status"] == "success", recovered
+        assert recovered["output"].strip() == "True"
+        skew = code_execution_tool._sandbox_failure_hint(
+            f"ImportError: cannot import name '{helper}' from 'hermes_tools'")
+        assert instruction.group() in skew

--- a/tests/tools/test_sandbox_failure_hints.py
+++ b/tests/tools/test_sandbox_failure_hints.py
@@ -16,11 +16,11 @@ class TestSandboxFailureHint:
         assert "read_file" in h and "terminal" in h
         assert "normal tool call" in h
 
-    def test_builtin_helper_import_redirects(self):
+    def test_helper_import_failure_reports_module_skew(self):
         err = "ImportError: cannot import name 'json_parse' from 'hermes_tools'"
         h = _sandbox_failure_hint(err)
-        assert "BUILT-IN" in h
-        assert "no import" in h.lower()
+        assert "from hermes_tools import json_parse" in h
+        assert "sys.path" in h
 
     def test_missing_third_party_module(self):
         err = "ModuleNotFoundError: No module named 'matplotlib'"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -144,8 +144,10 @@ _TOOL_STUBS = {
 def _missing_hermes_tools_import_hint(m, enabled_tools) -> str:
     missing = m.group(1)
     if missing in {"json_parse", "shell_quote", "retry"}:
-        return (f"{missing} is a BUILT-IN helper in the sandbox — no import "
-                f"needed. Remove it from the import line and call {missing}(...) directly.")
+        return (f"Import helpers with `from hermes_tools import {missing}`. "
+                "If that import failed, the generated module may be stale or another "
+                "hermes_tools may be first on sys.path. Check hermes_tools.__file__ "
+                "and retry with reset=true.")
     available = sorted(SANDBOX_ALLOWED_TOOLS & set(enabled_tools or SANDBOX_ALLOWED_TOOLS))
     return (f"'{missing}' is not available inside the execute_code sandbox. "
             f"Importable tools here: {', '.join(available)}. For anything "
@@ -153,13 +155,13 @@ def _missing_hermes_tools_import_hint(m, enabled_tools) -> str:
 
 
 # (regex, formatter(match, enabled_tools)) — first match wins. Production mining (state.db) ranked
-# these as the top execute_code failure classes: hermes_tools import misuse, importing the built-in
-# helpers, treating tool results as strings, importing third-party packages absent from the sandbox.
+# these as the top execute_code failure classes: hermes_tools import misuse, missing helper
+# imports, treating tool results as strings, importing third-party packages absent from the sandbox.
 _FAILURE_HINT_RULES = (
     (r"cannot import name '(\w+)' from 'hermes_tools'", _missing_hermes_tools_import_hint),
     (r"NameError: name '(json_parse|shell_quote|retry)' is not defined",
-     lambda m, _: f"{m.group(1)} is built into the generated sandbox module — "
-                  "call it directly at module scope without importing it."),
+     lambda m, _: f"Import {m.group(1)} before calling it: "
+                  f"from hermes_tools import {m.group(1)}"),
     (r"ModuleNotFoundError: No module named '([\w.]+)'",
      lambda m, _: f"'{m.group(1)}' is not installed in the sandbox interpreter. "
                   "Use Python stdlib inside execute_code, or run the code via "
@@ -850,7 +852,8 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         "Limits: 5-minute timeout, max 50 tool calls per call. Stdout over "
         "50KB shows head/tail inline; the FULL text is auto-saved to a file whose path rides in the result.\n\n"
         f"{cwd_note}\n\n"
-        "Built-in helpers (no import): json_parse(text) — tolerant "
+        "Helpers require imports: `from hermes_tools import json_parse, shell_quote, retry`. "
+        "json_parse(text) — tolerant "
         "json.loads for terminal() output; shell_quote(s) — shlex.quote for "
         "dynamic shell args; retry(fn, max_attempts=3, delay=2) — exponential backoff."
     )


### PR DESCRIPTION
execute_code now teaches the helper imports that actually work instead of prescribing calls that raise `NameError`.

**Additional tool fix discovered during campaign #104904**, not one of its original issue repairs. Slim credited adaptation of #83772 by @yuzilongleif-collab; #87163 was already closed as its duplicate. No issue or original PR is closed by this change.

- Correct the schema, helper recovery hints, and CLI tip to use `from hermes_tools import json_parse, shell_quote, retry`.
- Keep existing helper implementations, persistent namespaces, transports, permissions and execution behavior unchanged.
- Add two production-registry invariants that execute the exposed schema and recovery instructions, including a leading `__future__` import and fresh/reused/reset kernels.

Root cause: all three helpers are exports of generated `hermes_tools.py`, but instructions described them as preloaded globals. This reproduces on current main `22c5684b983eac6a81ee015ae80296c4b3dbf5bb`; it is not merely live-runtime skew.

## Validation

**Live repro:** unchanged main follows its no-import guidance → `NameError` and the erroneous module-scope hint; corrected guidance → `[7, "'two words'", "ok"]`. Both new invariant tests failed on main; both pass after the instruction-only fix.

| Surface | Before | After |
|---|---|---|
| Local production registry, fresh/reused/reset | All three globals absent; explicit imports work | Same runtime; advertised imports work |
| Real production per-call staging and script execution | Advertised usage fails; explicit imports work | Advertised usage works |
| Missing-helper recovery | Recommends the same failing bare call | Executable import instruction for each helper |

Per-call evidence uses the real production staging runner with actual `LocalEnvironment` shell I/O, not a remote network host. Local calls use the production registry and real child interpreter under isolated `HERMES_HOME`; no handcrafted execution namespace. The live campaign process was not restarted or updated.

Serial campaign-locked `scripts/run_tests.sh -j 1` across helper-contract, execution, execution-modes, kernel, hints and CLI-tip files: **120 passed, 0 failed across 6 files**. Ruff, Windows-footgun scan, compat-pointer check and `git diff --check` passed. Independent final-diff review: no blocking correctness/security findings. Broad combined-directory testing remains with the campaign parent; no CI-green claim or watcher.

## Infographic
![execute-code-helper-import-contract](https://v3b.fal.media/files/b/0aa974f3/b4G875bvPoQJ_gN5exoCV_Nn6gwfDy.png)
