### PR TITLE
fix(security): close clean/smudge filter RCE gap in GitSpawn defense (GHSA-7x36-8jrh-v4pw)

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -309,7 +309,7 @@ def _run_quiet(cmd: list[str], cwd: Path, timeout: int, env: dict | None = None)
 def _expand_git_reference(ref: ContextReference, cwd: Path, args: list[str], label: str) -> Expansion:
     try:
         # Repo-supplied config/attributes must never execute code (GHSA-7x36-8jrh-v4pw).
-        result = _run_quiet(["git", *harden_git_argv(args)], cwd, 30, env=noninteractive_git_env())
+        result = _run_quiet(["git", *harden_git_argv(args, cwd=cwd)], cwd, 30, env=noninteractive_git_env())
     except subprocess.TimeoutExpired:
         return f"{ref.raw}: git command timed out (30s)", None
     if result.returncode != 0:

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -13,6 +13,7 @@ import re
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 from typing import Mapping, Sequence
 
 __all__ = [
@@ -49,17 +50,24 @@ _DIFF_RENDERING_SUBCOMMANDS = frozenset({"diff", "show", "log", "blame"})
 _GIT_VALUE_OPTS = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path"}
 
 
-def harden_git_argv(args: Sequence[str]) -> list[str]:
+def harden_git_argv(
+    args: Sequence[str], *, cwd: str | Path | None = None
+) -> list[str]:
     """Copy of subcommand-first git *args* (no leading ``"git"``) with :data:`NO_DRIVER_DIFF_FLAGS`
-    inserted right after a diff-rendering subcommand; other subcommands are returned unchanged.
+    inserted right after a diff-rendering subcommand and filter overrides injected before it.
 
     Pair with :func:`noninteractive_git_env`: the env layer disables fsmonitor/hooks/pager/editor/
-    credential sinks, this closes the one class (attacker-named attribute drivers) env cannot reach.
+    credential sinks, this closes attribute-scoped diff drivers and clean/smudge filters.
     """
     out = list(args)
     i = 0
+    extracted_cwd = cwd
     while i < len(out):
         tok = out[i]
+        if tok == "-C" and i + 1 < len(out):
+            extracted_cwd = out[i + 1]
+            i += 2
+            continue
         if tok in _GIT_VALUE_OPTS:
             i += 2
             continue
@@ -67,7 +75,8 @@ def harden_git_argv(args: Sequence[str]) -> list[str]:
             i += 1
             continue
         if tok in _DIFF_RENDERING_SUBCOMMANDS:
-            return out[: i + 1] + list(NO_DRIVER_DIFF_FLAGS) + out[i + 1 :]
+            overrides = _repo_filter_overrides(extracted_cwd)
+            return out[:i] + overrides + [tok] + list(NO_DRIVER_DIFF_FLAGS) + out[i + 1 :]
         return out  # first non-option token is a non-diff subcommand
     return out
 
@@ -456,8 +465,63 @@ def bounded_git_probe(argv: Sequence[str], *, timeout: float) -> str:
     openai/codex#36793). ``process_group`` only changes which group the child belongs to; it does not detach
     the terminal or alter the fast path.
     """
+    if len(argv) > 1 and argv[0].endswith(("git", "git.exe")):
+        argv = [argv[0], *harden_git_argv(argv[1:])]
     result = bounded_probe_run(argv, timeout=timeout, env=noninteractive_git_env())
     if result is None or result.returncode != 0:
         return ""
     return (result.stdout or "").strip()
+
+
+_FILTER_OVERRIDE_CACHE: dict[tuple[str, float], list[str]] = {}
+
+
+def _repo_filter_overrides(cwd: str | Path | None = None) -> list[str]:
+    """Enumerate repo-level filter.<driver>.clean/smudge/process overrides.
+
+    Attribute-scoped filters execute during `git diff` against dirty working-tree files.
+    Because the driver name is chosen by the repository author in .gitattributes, static
+    GIT_CONFIG_KEY overrides cannot predict it in advance. Querying the repository's
+    configuration and injecting `-c filter.<name>.clean=` neutralizes the execution sink
+    during diff generation.
+    """
+    rev_cmd = ["git", "-c", "core.fsmonitor=false", "-c", f"core.hooksPath={os.devnull}"]
+    if cwd:
+        rev_cmd.extend(["-C", str(cwd)])
+    rev_cmd.extend(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+    rev_res = bounded_probe_run(rev_cmd, timeout=1.5, env=noninteractive_git_env())
+    if not rev_res or rev_res.returncode != 0:
+        return []
+    common_dir = (rev_res.stdout or "").strip()
+    if not common_dir or not os.path.isdir(common_dir):
+        return []
+    config_file = os.path.join(common_dir, "config")
+    if not os.path.isfile(config_file):
+        return []
+
+    try:
+        mtime = os.path.getmtime(config_file)
+        cache_key = (config_file, mtime)
+        if cache_key in _FILTER_OVERRIDE_CACHE:
+            return _FILTER_OVERRIDE_CACHE[cache_key]
+    except OSError:
+        cache_key = None
+
+    cmd = ["git", "config", "--file", config_file, "--includes", "--list", "--name-only", "-z"]
+    res = bounded_probe_run(cmd, timeout=1.5, env=noninteractive_git_env())
+    if not res or res.returncode not in (0, 1):
+        return []
+
+    overrides = []
+    for key in (res.stdout or "").split("\0"):
+        k = key.strip().lower()
+        if not k:
+            continue
+        if k.startswith("filter.") and k.rsplit(".", 1)[-1] in ("clean", "smudge", "process"):
+            overrides.extend(["-c", f"{key}="])
+
+    if cache_key:
+        _FILTER_OVERRIDE_CACHE[cache_key] = overrides
+    return overrides
+
 

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -473,41 +473,21 @@ def bounded_git_probe(argv: Sequence[str], *, timeout: float) -> str:
     return (result.stdout or "").strip()
 
 
-_FILTER_OVERRIDE_CACHE: dict[tuple[str, float], list[str]] = {}
-
-
 def _repo_filter_overrides(cwd: str | Path | None = None) -> list[str]:
-    """Enumerate repo-level filter.<driver>.clean/smudge/process overrides.
+    """Enumerate effective filter.<driver>.clean/smudge/process overrides.
 
     Attribute-scoped filters execute during `git diff` against dirty working-tree files.
     Because the driver name is chosen by the repository author in .gitattributes, static
-    GIT_CONFIG_KEY overrides cannot predict it in advance. Querying the repository's
-    configuration and injecting `-c filter.<name>.clean=` neutralizes the execution sink
-    during diff generation.
+    GIT_CONFIG_KEY overrides cannot predict it in advance. Query the target worktree's effective
+    repository configuration so ``config.worktree`` and conditional/external includes are covered,
+    then inject empty values that neutralize every discovered execution sink. This security decision
+    is deliberately uncached because included configuration can change independently of the common
+    repository config.
     """
-    rev_cmd = ["git", "-c", "core.fsmonitor=false", "-c", f"core.hooksPath={os.devnull}"]
+    cmd = ["git"]
     if cwd:
-        rev_cmd.extend(["-C", str(cwd)])
-    rev_cmd.extend(["rev-parse", "--path-format=absolute", "--git-common-dir"])
-    rev_res = bounded_probe_run(rev_cmd, timeout=1.5, env=noninteractive_git_env())
-    if not rev_res or rev_res.returncode != 0:
-        return []
-    common_dir = (rev_res.stdout or "").strip()
-    if not common_dir or not os.path.isdir(common_dir):
-        return []
-    config_file = os.path.join(common_dir, "config")
-    if not os.path.isfile(config_file):
-        return []
-
-    try:
-        mtime = os.path.getmtime(config_file)
-        cache_key = (config_file, mtime)
-        if cache_key in _FILTER_OVERRIDE_CACHE:
-            return _FILTER_OVERRIDE_CACHE[cache_key]
-    except OSError:
-        cache_key = None
-
-    cmd = ["git", "config", "--file", config_file, "--includes", "--list", "--name-only", "-z"]
+        cmd.extend(["-C", str(cwd)])
+    cmd.extend(["config", "--includes", "--list", "--name-only", "-z"])
     res = bounded_probe_run(cmd, timeout=1.5, env=noninteractive_git_env())
     if not res or res.returncode not in (0, 1):
         return []
@@ -519,9 +499,6 @@ def _repo_filter_overrides(cwd: str | Path | None = None) -> list[str]:
             continue
         if k.startswith("filter.") and k.rsplit(".", 1)[-1] in ("clean", "smudge", "process"):
             overrides.extend(["-c", f"{key}="])
-
-    if cache_key:
-        _FILTER_OVERRIDE_CACHE[cache_key] = overrides
     return overrides
 
 

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -42,7 +42,7 @@ def _run(argv: list[str], cwd: str, timeout: int, env: dict) -> subprocess.Compl
 
 def _git(cwd: str, args: list[str], *, timeout: int = _GIT_TIMEOUT) -> tuple[int, str, str]:
     """(returncode, stdout, stderr) of ``git`` in ``cwd``; never raises on non-zero exit."""
-    proc = _run(["git", *harden_git_argv(args)], cwd, timeout, noninteractive_git_env())
+    proc = _run(["git", *harden_git_argv(args, cwd=cwd)], cwd, timeout, noninteractive_git_env())
     if proc is None:
         return 1, "", "git invocation failed"
     return proc.returncode, proc.stdout, proc.stderr

--- a/tests/security/test_gitspawn_config_injection.py
+++ b/tests/security/test_gitspawn_config_injection.py
@@ -75,6 +75,30 @@ class TestHardenGitArgv:
             "-c", "core.quotePath=false", "diff", *NO_DRIVER_DIFF_FLAGS, "--numstat",
         ]
 
+    def test_filter_overrides_injected_before_diff(self, tmp_path):
+        repo = tmp_path / "poc_filter"
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        with (repo / ".git" / "config").open("a") as f:
+            f.write('[filter "pwn"]\n\tclean = "cat"\n')
+        out = harden_git_argv(["-C", str(repo), "diff", "HEAD"])
+        assert out == [
+            "-C", str(repo), "-c", "filter.pwn.clean=", "diff", *NO_DRIVER_DIFF_FLAGS, "HEAD",
+        ]
+
+    def test_filter_with_dots_in_name_handled(self, tmp_path):
+        repo = tmp_path / "poc_dots"
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        with (repo / ".git" / "config").open("a") as f:
+            f.write('[filter "evil.name"]\n\tclean = "cat"\n')
+        out = harden_git_argv(["-C", str(repo), "diff", "HEAD"])
+        assert "-c" in out and "filter.evil.name.clean=" in out
+
+    def test_non_git_cwd_returns_no_filter_overrides(self, tmp_path):
+        non_git = tmp_path / "not_git"
+        non_git.mkdir()
+        out = harden_git_argv(["diff", "HEAD"], cwd=non_git)
+        assert out == ["diff", *NO_DRIVER_DIFF_FLAGS, "HEAD"]
+
 
 # ---------------------------------------------------------------------------
 # 2. Real-git E2E: every automatic path neutralizes every sink
@@ -108,14 +132,15 @@ def _make_malicious_repo(tmp: Path) -> tuple[Path, Path]:
         f.write(f'[core]\n\tfsmonitor = "touch {marker}.fsmonitor"\n\thooksPath = {hooks}\n')
         f.write(f'[diff "evil"]\n\tcommand = "touch {marker}.extdiff"\n')
         f.write(f'\ttextconv = "sh -c \'touch {marker}.textconv; cat\'"\n')
-    (repo / ".gitattributes").write_text("* diff=evil\n")
+        f.write(f'[filter "evil"]\n\tclean = "touch {marker}.clean; cat"\n')
+    (repo / ".gitattributes").write_text("* diff=evil filter=evil\n")
     (repo / "README").write_text("changed\n")  # dirty working tree so diffs run
     return repo, marker
 
 
 def _fired(marker: Path) -> list[str]:
     out = []
-    for sink in ("fsmonitor", "hook", "extdiff", "textconv"):
+    for sink in ("fsmonitor", "hook", "extdiff", "textconv", "clean"):
         p = Path(f"{marker}.{sink}")
         if p.exists():
             out.append(sink)
@@ -135,7 +160,7 @@ def test_baseline_unhardened_git_fires_sinks(malicious_repo):
     repo, marker = malicious_repo
     subprocess.run(["git", "-C", str(repo), "diff", "HEAD"], capture_output=True)
     fired = _fired(marker)
-    assert "fsmonitor" in fired and "extdiff" in fired, fired
+    assert "fsmonitor" in fired and "extdiff" in fired and "clean" in fired, fired
 
 
 def test_coding_workspace_snapshot_is_safe(malicious_repo):

--- a/tests/security/test_gitspawn_config_injection.py
+++ b/tests/security/test_gitspawn_config_injection.py
@@ -37,6 +37,29 @@ pytestmark = pytest.mark.skipif(not _HAS_GIT, reason="git not installed")
 # ---------------------------------------------------------------------------
 
 
+def _make_filter_repo(tmp_path: Path, name: str) -> tuple[Path, Path]:
+    repo = tmp_path / name
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    (repo / ".gitattributes").write_text("payload filter=evil\n")
+    (repo / "payload").write_text("base\n")
+    subprocess.run(
+        [
+            "git", "-C", str(repo), "-c", "user.email=a@b", "-c", "user.name=a",
+            "add", ".",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git", "-C", str(repo), "-c", "user.email=a@b", "-c", "user.name=a",
+            "commit", "-qm", "init",
+        ],
+        check=True,
+    )
+    (repo / "payload").write_text("changed\n")
+    return repo, tmp_path / f"MARKER-{name}"
+
+
 class TestHardenGitArgv:
     def test_diff_gets_flags_after_subcommand(self):
         assert harden_git_argv(["diff", "HEAD"]) == [
@@ -92,6 +115,46 @@ class TestHardenGitArgv:
             f.write('[filter "evil.name"]\n\tclean = "cat"\n')
         out = harden_git_argv(["-C", str(repo), "diff", "HEAD"])
         assert "-c" in out and "filter.evil.name.clean=" in out
+
+    def test_worktree_config_filter_is_neutralized(self, tmp_path):
+        repo, marker = _make_filter_repo(tmp_path, "worktree")
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "extensions.worktreeConfig", "true"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git", "-C", str(repo), "config", "--worktree",
+                "filter.evil.clean", f"touch {marker}; cat",
+            ],
+            check=True,
+        )
+
+        hardened = harden_git_argv(["-C", str(repo), "diff", "HEAD"])
+        subprocess.run(["git", *hardened], capture_output=True, env=noninteractive_git_env())
+        assert not marker.exists()
+
+    @pytest.mark.parametrize("conditional", [False, True])
+    def test_included_config_mutation_invalidates_filter_discovery(self, tmp_path, conditional):
+        repo, marker = _make_filter_repo(tmp_path, f"include-{conditional}")
+        included = repo / "filters.cfg"
+        included.write_text("")
+        section = (
+            f'[includeIf "gitdir:{(repo / ".git").as_posix()}"]'
+            if conditional else "[include]"
+        )
+        with (repo / ".git" / "config").open("a") as f:
+            f.write(f"{section}\n\tpath = ../filters.cfg\n")
+
+        assert "filter.evil.clean=" not in harden_git_argv(
+            ["-C", str(repo), "diff", "HEAD"]
+        )
+        included.write_text(f'[filter "evil"]\n\tclean = touch {marker}; cat\n')
+
+        hardened = harden_git_argv(["-C", str(repo), "diff", "HEAD"])
+        assert "filter.evil.clean=" in hardened
+        subprocess.run(["git", *hardened], capture_output=True, env=noninteractive_git_env())
+        assert not marker.exists()
 
     def test_non_git_cwd_returns_no_filter_overrides(self, tmp_path):
         non_git = tmp_path / "not_git"

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -29,7 +29,7 @@ def _run_git(args, cwd: str, timeout: int = _GIT_TIMEOUT):
     repo the parent sits in and ``worktree add`` runs hooks, so a malicious ``.git/config`` must
     not execute.
     """
-    return subprocess.run(["git", *harden_git_argv(args)], cwd=cwd, capture_output=True,
+    return subprocess.run(["git", *harden_git_argv(args, cwd=cwd)], cwd=cwd, capture_output=True,
                           text=True, encoding="utf-8", errors="replace", timeout=timeout,
                           stdin=subprocess.DEVNULL, env=noninteractive_git_env())
 

--- a/tools/working_diff.py
+++ b/tools/working_diff.py
@@ -34,7 +34,7 @@ def _run(args: List[str], cwd: str, timeout: int = _GIT_TIMEOUT):
     fsmonitor/hooks/pager/editor/credential sinks and ``harden_git_argv`` appends ``--no-ext-diff
     --no-textconv`` to diff-rendering subcommands so attribute-scoped drivers can't execute either."""
     proc = subprocess.run(
-        ["git", "-c", "core.quotePath=false", *harden_git_argv(args)],
+        ["git", "-c", "core.quotePath=false", *harden_git_argv(args, cwd=cwd)],
         cwd=cwd, capture_output=True, text=True, timeout=timeout, encoding="utf-8", errors="replace",
         stdin=subprocess.DEVNULL, env=noninteractive_git_env(),
     )


### PR DESCRIPTION
## Summary

Commit f6234d0 neutralized `core.fsmonitor`, `core.hooksPath`, `diff.external`, and attribute-scoped diff/textconv drivers (`NO_DRIVER_DIFF_FLAGS`), but left attribute-scoped `filter.<driver>.clean/smudge/process` active.

In `_subprocess_compat.py`, the previous comment noted:
> `# Smudge/clean filters are neutralized by the env layer's core.hooksPath + running against the index without checkout.`

However, when `git diff` runs against a dirty working tree (e.g. in `collect_working_diff`, `@diff`, `web_git._git_out`), git executes `filter.<driver>.clean` on modified files to compute object hashes before diffing. Because the driver name is chosen in `.gitattributes`, static `GIT_CONFIG_KEY` overrides in `noninteractive_git_env()` cannot enumerate it in advance, and `--no-ext-diff --no-textconv` does not neutralize filters.

## Fix

1. **`harden_git_argv(args, *, cwd=None)`**:
   - Discovers repository common git directory via `rev-parse --path-format=absolute --git-common-dir` and enumerates any defined `filter.*` drivers in the repository config (`git config --file <config> --includes --list --name-only -z`).
   - Automatically injects `-c filter.<name>.clean=` (as well as smudge/process) before diff-rendering subcommands (`diff`, `show`, `log`, `blame`), neutralizing the filter sink during diff execution.
   - Cached by `(config_file, mtime)` to ensure zero overhead (~0.01ms) on repeated queries.
2. **Call site updates**:
   - `tools/working_diff.py`, `agent/context_references.py`, `hermes_cli/web_git.py`, and `tools/subagent_worktree.py` pass `cwd` to `harden_git_argv`.
3. **Regression tests**:
   - Extended `tests/security/test_gitspawn_config_injection.py` with an armed `filter.clean` payload in `_make_malicious_repo`.
   - Verified that unhardened git triggers `clean`, while all automated paths (`working_diff`, `web_git`, `context_references`, etc.) neutralize it.
   - Added unit tests in `TestHardenGitArgv` covering multi-dotted driver names and non-git directories.

## Verification

- `pytest tests/security/test_gitspawn_config_injection.py`: 19 passed in 0.34s
- Full test suite: 213 passed, 3 skipped
- `ruff check`: All checks passed