### PR TITLE
fix(desktop): suppress debounced draft stash during session swap (#104995)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -122,6 +122,14 @@ export function useComposerDraft({
   sessionIdRef.current = sessionId
   const queueEditStateRef = useRef<QueueEditState | null>(queueEditRef.current)
   queueEditStateRef.current = queueEditRef.current
+  // Suppresses the debounced stash while the swap effect is actively resuming
+  // a different session. Without this, `resumeSession` paints the selection
+  // and syncs the (empty initial) composer runtime before the swap effect's
+  // `takeSessionDraft` runs — the runtime's `sync()` schedules `stashAt(scope, '')`
+  // which fires 250 ms later and clobbers the draft the swap cleanup already
+  // saved (#104995). Set by the swap effect on entry, cleared by the effect's
+  // cleanup synchronously before it reads `syncDraftFromEditor()`.
+  const resumingSessionRef = useRef(false)
 
   const [focusRequestId, setFocusRequestId] = useState(0)
 
@@ -321,6 +329,10 @@ export function useComposerDraft({
         return
       }
 
+      if (resumingSessionRef.current) {
+        return
+      }
+
       const scope = draftScopeRef.current
       const entry = { scope, text }
       pendingDraftPersistRef.current = entry
@@ -411,11 +423,13 @@ export function useComposerDraft({
     window.clearTimeout(draftPersistTimerRef.current)
     pendingDraftPersistRef.current = null
     draftScopeRef.current = activeQueueSessionKey
+    resumingSessionRef.current = true
 
     const { attachments, text } = takeSessionDraft(activeQueueSessionKey)
     loadIntoComposer(text, attachments)
 
     return () => {
+      resumingSessionRef.current = false
       const latestText = syncDraftFromEditor()
       const editing = queueEditStateRef.current
 


### PR DESCRIPTION
## Summary

Fixes #104995 — session navigation from the sidebar (cross-session switches and same-session re-clicks) no longer clears the composer's typed-but-unsent draft.

---

## Root cause

The debounced stash (line ~339) was landing _after_ the swap effect's cleanup had already saved the draft — clobbering it with an empty string. The swap effect clears `draftPersistTimerRef.current` on entry (line 411), but the runtime subscription's `sync()` schedules a **new** debounced stash _after_ `resumeSession` paints the selection and binds the (initially empty) composer runtime — and that timer lives in the old session's closure, so the new effect can't see or cancel it. 250 ms later the empty stash fires under the **incoming** session key and overwrites the draft the swap cleanup had just saved.

---

## Solution

Suppress the debounced stash entirely while a session swap is in flight:

1. The swap effect sets `resumingSessionRef.current = true` on entry.
2. The runtime subscription's `sync()` bails early if `resumingSessionRef.current` is true — no debounced stash scheduled.
3. The effect's cleanup sets `resumingSessionRef.current = false` **before** reading `syncDraftFromEditor()` — so the cleanup's own explicit stash (the authoritative one) always runs.

The swap effect's cleanup already handles both directions explicitly (lines 419–425): it reads the immediate DOM text (`syncDraftFromEditor()`) and stashes it under the correct key. The runtime's debounced stash is redundant during this window and only risks the race described above.

---

## Testing

- Verified the existing `use-composer-draft.test.tsx` suite still passes (9/9 green).
- Manually repro'd the issue on `main` (cross-session switch cleared the draft, same-session re-click cleared it the first time).
- Applied the fix: both scenarios now preserve the draft as expected.

---

## Affected surface

**Desktop only** — `apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts`. No changes to the storage format, no runtime migrations, no existing stashes affected. The fix is purely a guard in the debounce path; the cleanup's explicit stash (which was already correct) remains unchanged.