### PR TITLE
fix(update): migrate default config.yaml on named-profile update

### DIFF
--- a/hermes_cli/update_cmd_config.py
+++ b/hermes_cli/update_cmd_config.py
@@ -55,28 +55,22 @@ def _migrate_sibling_profile_configs() -> list[tuple[str, int, int]]:
     91277 Phase 2 (fleet-wide config migration; #20438/#54926/#79048): the shared checkout serves every
     profile, but ``hermes update`` historically migrated only the active profile's config — siblings drifted
     versions until their gateway hit a config the new code couldn't read.
+
+    Enumeration matches pre-update snapshots (#66140): default lives at
+    ``_get_default_hermes_home()``, not under ``profiles/``, so a named-profile
+    ``hermes update`` still migrates it.
     """
     from hermes_cli.update_cmd import _run_config_check_fresh, _run_migrate_config_fresh
     migrated: list[tuple[str, int, int]] = []
     with _best_effort('Sibling profile enumeration failed: %s'):
         from hermes_constants import (
             get_process_hermes_home, reset_hermes_home_override, set_hermes_home_override)
-        from hermes_cli.profiles import _get_profiles_root, _PROFILE_ID_RE
-        active_home = get_process_hermes_home()
-        root = _get_profiles_root()
-        if not root.is_dir():
-            return migrated
-        for entry in sorted(root.iterdir()):
-            if not entry.is_dir() or not _PROFILE_ID_RE.match(entry.name):
-                continue
-            try:
-                if entry.resolve() == Path(active_home).resolve():
-                    continue
-            except OSError:
-                continue
-            if not (entry / "config.yaml").is_file():
+        from hermes_cli.backup import _sibling_profile_homes
+        active_home = Path(get_process_hermes_home())
+        for name, profile_home in _sibling_profile_homes(active_home):
+            if not (profile_home / "config.yaml").is_file():
                 continue  # profile never configured — nothing to migrate
-            token = set_hermes_home_override(entry)
+            token = set_hermes_home_override(profile_home)
             try:
                 current_ver, latest_ver = _run_config_check_fresh()
                 if current_ver >= latest_ver:
@@ -84,9 +78,9 @@ def _migrate_sibling_profile_configs() -> list[tuple[str, int, int]]:
                 _run_migrate_config_fresh(interactive=False, quiet=True)
                 after_ver, _ = _run_config_check_fresh()
                 if after_ver > current_ver:
-                    migrated.append((entry.name, current_ver, after_ver))
+                    migrated.append((name, current_ver, after_ver))
             except Exception as exc:
-                logger.debug("Config migration for profile %s failed: %s", entry.name, exc)
+                logger.debug("Config migration for profile %s failed: %s", name, exc)
             finally:
                 reset_hermes_home_override(token)
     return migrated

--- a/tests/hermes_cli/test_sibling_config_migration.py
+++ b/tests/hermes_cli/test_sibling_config_migration.py
@@ -33,10 +33,19 @@ def _latest_version() -> int:
     return int(DEFAULT_CONFIG["_config_version"])
 
 
-def _setup(monkeypatch, tmp_path, active_home: Path):
+def _setup(monkeypatch, tmp_path, active_home: Path, *, default_home: Path | None = None):
     import hermes_cli.profiles as profiles_mod
 
     monkeypatch.setattr(profiles_mod, "_get_profiles_root", lambda: tmp_path / "profiles")
+    # Default lives at the install root, not under profiles/. Absent unless a
+    # test passes default_home, so the original named-profile cases stay
+    # focused on profiles/ and cannot pick up the process HERMES_HOME.
+    missing = tmp_path / "no-such-default-home"
+    monkeypatch.setattr(
+        profiles_mod,
+        "_get_default_hermes_home",
+        lambda: default_home if default_home is not None else missing,
+    )
     import hermes_constants
 
     monkeypatch.setattr(
@@ -126,3 +135,50 @@ def test_override_is_reset_after_run(monkeypatch, tmp_path):
     before = get_hermes_home_override()
     update_cmd._migrate_sibling_profile_configs()
     assert get_hermes_home_override() == before
+
+
+def test_named_active_migrates_default_outside_profiles(monkeypatch, tmp_path):
+    """Default lives at the install root, not under profiles/. A named-profile
+    update must still migrate it. Snapshots already treat default as a sibling
+    (#66140). Walking profiles/ only leaves it behind."""
+    default_home = _write_profile(tmp_path, "default-home", 12)
+    active = _write_profile(tmp_path / "profiles", "work", _latest_version())
+    _setup(monkeypatch, tmp_path, active, default_home=default_home)
+
+    migrated = update_cmd._migrate_sibling_profile_configs()
+
+    names = [m[0] for m in migrated]
+    assert "default" in names
+    entry = next(m for m in migrated if m[0] == "default")
+    assert entry[1] == 12 and entry[2] == _latest_version()
+    on_disk = yaml.safe_load((default_home / "config.yaml").read_text())
+    assert on_disk["_config_version"] == _latest_version()
+    assert on_disk["model"]["provider"] == "nous"
+    # named active is the invoking home: its own migrate path handles it
+    assert "work" not in names
+
+
+def test_default_active_still_migrates_named_siblings(monkeypatch, tmp_path):
+    """Invoking from default must still migrate named profiles under profiles/."""
+    default_home = _write_profile(tmp_path, "default-home", _latest_version())
+    sibling = _write_profile(tmp_path / "profiles", "research", 12)
+    _setup(monkeypatch, tmp_path, default_home, default_home=default_home)
+
+    migrated = update_cmd._migrate_sibling_profile_configs()
+
+    names = [m[0] for m in migrated]
+    assert "default" not in names
+    assert "research" in names
+    on_disk = yaml.safe_load((sibling / "config.yaml").read_text())
+    assert on_disk["_config_version"] == _latest_version()
+    assert yaml.safe_load((default_home / "config.yaml").read_text())["_config_version"] == _latest_version()
+
+
+def test_default_without_config_yaml_is_skipped(monkeypatch, tmp_path):
+    default_home = tmp_path / "default-home"
+    default_home.mkdir()
+    active = _write_profile(tmp_path / "profiles", "work", _latest_version())
+    _setup(monkeypatch, tmp_path, active, default_home=default_home)
+
+    assert update_cmd._migrate_sibling_profile_configs() == []
+    assert not (default_home / "config.yaml").exists()


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

#92918 migrates sibling `config.yaml` files after the active profile. The sweep walked `_get_profiles_root()` only. Default lives at `_get_default_hermes_home()`, so `hermes -p work update` left `~/.hermes/config.yaml` on the old `_config_version`.

Pre-update snapshots already treat default as a sibling via `_sibling_profile_homes` (#66140). Config migration now uses that same list. The active home is still skipped. A home with no `config.yaml` is still skipped. The ContextVar HERMES_HOME override is unchanged.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #105013

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `hermes_cli/update_cmd_config.py`: `_migrate_sibling_profile_configs` enumerates siblings through `_sibling_profile_homes` instead of walking `profiles/` itself.
- `tests/hermes_cli/test_sibling_config_migration.py`: named-active migrates default outside `profiles/`, default-active still migrates named siblings, default with no `config.yaml` is skipped. Existing cases mock an absent default home so they stay about `profiles/`.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `scripts/run_tests.sh tests/hermes_cli/test_sibling_config_migration.py tests/hermes_cli/test_backup_all_profiles.py tests/hermes_cli/test_update_config_migration_on_current.py -q`
2. New test `test_named_active_migrates_default_outside_profiles` fails on current main: the sweep returns no `default` row and the default file stays at v12. With the fix the file reaches the latest `_config_version` and user settings survive.

Ran on Windows 11 with Python 3.11:

```
=== Summary: 3 files, 23 tests passed, 0 failed ===
```

`test_sibling_config_migration.py` is 9 passed (6 existing + 3 new).

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
Before: named-active sweep returns no default row, default config.yaml stays at v12
After:  default is migrated to latest _config_version, work (active) is skipped
```

```
tests/hermes_cli/test_sibling_config_migration.py: 9 passed
```
