### PR TITLE
test: core Kanban review checks run without optional ACP

### DIFF
--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -106,12 +106,17 @@ def test_review_tools_are_gated_and_visible_to_kanban_workers(
     assert "kanban_request_review" in names
     assert "kanban_request_changes" in names
 
-    from acp_adapter.tools import _POLISHED_TOOLS
     from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
 
-    assert "kanban_request_changes" in _POLISHED_TOOLS
     assert "kanban_request_changes" in EXPOSED_TOOLS
     assert "kanban_request_changes" in resolve_toolset("kanban")
+
+
+def test_review_changes_are_exposed_in_acp() -> None:
+    pytest.importorskip("acp", reason="ACP adapter requires the optional acp extra")
+    from acp_adapter.tools import _POLISHED_TOOLS
+
+    assert "kanban_request_changes" in _POLISHED_TOOLS
 
 
 def test_review_cli_round_trip_preserves_handoff(


### PR DESCRIPTION
Core Kanban review checks now run without requiring the optional ACP dependency.

- Move only the ACP polished-tool assertion into its own optional-dependency test.
- Keep worker-tool visibility, MCP exposure, and Kanban toolset assertions unconditional in the original test.
- Use `pytest.importorskip("acp")` only inside the ACP test; no file-level skip or production change.

**Root cause:** a core review-surface test imported the optional adapter midway through otherwise dependency-independent assertions.

**Live repro (test integration):** baseline campaign recorded `test_review_tools_are_gated_and_visible_to_kanban_workers` failing on the absent optional ACP import. The repaired file reports **10 passed** in the canonical runner on the currently available dependency environment. Explicit absent/present dependency controls are queued separately and are not claimed complete yet.

Validation: `scripts/run_tests.sh -j 1 --file-retries 0 tests/hermes_cli/test_kanban_review_surfaces.py` (file consumed from the existing eight-file campaign run); Ruff, Windows footguns, compatibility pointers, and diff checks passed. The wider campaign is not all-green: unrelated updater-fixture corrections are separate.

Tracked in #104868. No user-facing documentation changes: test fixture only.

## Infographic
![Reliable test fixtures](https://v3b.fal.media/files/b/0aa9755b/3vM6LJ51pP0r0yeMBgJU9_ne9El8Wa.png)
