### PR TITLE
fix(agent): strip stray arg tags to line boundary, not end of text

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -58,14 +58,14 @@ _STRAY_TOOL_CALL_CLOSER_PATTERN = re.compile(
     rf'</(?:{"|".join(_TOOL_CALL_TAG_NAMES)}|function)>\s*', re.IGNORECASE
 )
 
-# A tool-call opener with no closer, or GLM-style argument markup
-# (<arg_key>/<arg_value>) outside any closed block, means the stream was
-# cut mid-serialization of a text-channel tool call (#101899). The call
-# can't be recovered; strip from the block-boundary opener (or the line
-# holding the first stray argument tag) to the end of the text.
+# An unclosed tool call is unrecoverable (#101899), so drop its remaining block.
+# Stray argument tags only identify fragment lines, not the rest of the text
+# (#102303). Require a line-start tag or a line-ending closer (wait</arg_value>)
+# so inline prose mentions and subsequent prose survive.
 _UNTERMINATED_TOOL_CALL_PATTERN = re.compile(
     rf'(?:^|\n)[ \t]*<(?:{"|".join(_TOOL_CALL_TAG_NAMES)})\b[^>]*>.*$'
-    r'|(?:^|\n)[^\n<]*</?arg_(?:key|value)\b.*$',
+    r'|(?:^|\n)[ \t]*</?arg_(?:key|value)\b[^\n]*'
+    r'|(?:^|\n)[^\n<]*</arg_(?:key|value)>[ \t\r]*(?=\n|$)',
     re.DOTALL | re.IGNORECASE,
 )
 

--- a/cli.py
+++ b/cli.py
@@ -202,11 +202,13 @@ def _strip_reasoning_tags(text: str) -> str:
         r'</(?:tool_call|tool_calls|tool_result|function_call|function_calls|function)>\s*', '', cleaned,
         flags=re.IGNORECASE,
     )
-    # Unterminated opener / stray <arg_key>/<arg_value> markup = stream cut
-    # mid tool-call serialization (#101899); strip to end of text.
+    # Unclosed calls are unrecoverable (#101899), but stray argument markup
+    # only identifies fragment lines (#102303). Keep inline prose and later
+    # lines while still removing a line-ending fragment like wait</arg_value>.
     cleaned = re.sub(
         r'(?:^|\n)[ \t]*<(?:tool_call|tool_calls|tool_result|function_call|function_calls)\b[^>]*>.*$'
-        r'|(?:^|\n)[^\n<]*</?arg_(?:key|value)\b.*$',
+        r'|(?:^|\n)[ \t]*</?arg_(?:key|value)\b[^\n]*'
+        r'|(?:^|\n)[^\n<]*</arg_(?:key|value)>[ \t\r]*(?=\n|$)',
         '',
         cleaned,
         flags=re.DOTALL | re.IGNORECASE,

--- a/tests/run_agent/test_strip_reasoning_tags_cli.py
+++ b/tests/run_agent/test_strip_reasoning_tags_cli.py
@@ -6,6 +6,9 @@ final displayed assistant text (after streaming) without depending on the
 AIAgent instance. It must stay in sync with run_agent.py::_strip_think_blocks
 for tool-call tag coverage."""
 
+from functools import partial
+
+import pytest
 
 from agent.agent_runtime_helpers import strip_think_blocks
 from cli import _strip_reasoning_tags
@@ -39,11 +42,37 @@ class TestToolCallStripping:
     def test_empty_string(self):
         assert _strip_reasoning_tags("") == ""
 
-    def test_cut_tool_call_stripped_to_visible_prefix(self):
-        """Both strippers drop the unrecoverable tail; only prose survives."""
-        assert _strip_reasoning_tags(_CUT_FRAGMENT) == "Both gates started."
-        assert strip_think_blocks(None, _CUT_FRAGMENT).strip() == "Both gates started."
-        assert strip_think_blocks(None, "Waiting.\n<tool_call>process_manage").strip() == "Waiting."
+    @pytest.mark.parametrize(
+        "stripper", [_strip_reasoning_tags, partial(strip_think_blocks, None)],
+        ids=["display", "storage"],
+    )
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            (_CUT_FRAGMENT, "Both gates started."),
+            (_CUT_FRAGMENT.split("\n", 1)[1], ""),
+            (_CUT_FRAGMENT + "\nThird line must survive.",
+             "Both gates started.\nThird line must survive."),
+            ("Waiting.\n<tool_call>process_manage", "Waiting."),
+        ],
+        ids=["original-fragment", "fragment-only", "prose-after-fragment", "unclosed-call"],
+    )
+    def test_cut_tool_call_stripped_to_visible_prefix(self, stripper, text, expected):
+        """A cut call is unrecoverable, but unrelated prose must not be lost."""
+        assert stripper(text).strip() == expected
+
+    @pytest.mark.parametrize(
+        "stripper", [_strip_reasoning_tags, partial(strip_think_blocks, None)],
+        ids=["display", "storage"],
+    )
+    @pytest.mark.parametrize("tag", ["arg_key", "arg_value", "/arg_key", "/arg_value"])
+    def test_bracketed_arg_tag_prose_and_tail_survive(self, stripper, tag):
+        text = (
+            "First line stays.\n"
+            f"The <{tag}> holds the parameter name.\n"
+            "Third line must survive."
+        )
+        assert stripper(text) == text
 
     def test_complete_block_and_inline_prose_mentions_untouched(self):
         for out in (_strip_reasoning_tags(_COMPLETE_WITH_PROSE),
@@ -51,4 +80,3 @@ class TestToolCallStripping:
             assert "Use <function> in JS. The arg_key field maps to arg_value." in out
             assert out.rstrip().endswith("Done.")
             assert "<tool_call>" not in out
-

--- a/tests/run_agent/test_strip_reasoning_tags_cli.py
+++ b/tests/run_agent/test_strip_reasoning_tags_cli.py
@@ -4,7 +4,8 @@ XML stripping added in openclaw/openclaw#67318 port.
 The CLI has its own copy of the stripper because it needs to run on the
 final displayed assistant text (after streaming) without depending on the
 AIAgent instance. It must stay in sync with run_agent.py::_strip_think_blocks
-for tool-call tag coverage."""
+for tool-call tag coverage.
+"""
 
 from functools import partial
 
@@ -25,6 +26,11 @@ _COMPLETE_WITH_PROSE = (
     "<tool_call>x<arg_key>a</arg_key><arg_value>1</arg_value></tool_call>\nDone."
 )
 
+_STRIPPERS = [
+    pytest.param(_strip_reasoning_tags, id="display"),
+    pytest.param(partial(strip_think_blocks, None), id="storage"),
+]
+
 
 class TestToolCallStripping:
     def test_tool_call_block_stripped(self):
@@ -32,12 +38,6 @@ class TestToolCallStripping:
         result = _strip_reasoning_tags(text)
         assert "<tool_call>" not in result
         assert "result" in result
-
-
-
-
-
-
 
     def test_empty_string(self):
         assert _strip_reasoning_tags("") == ""
@@ -61,10 +61,7 @@ class TestToolCallStripping:
         """A cut call is unrecoverable, but unrelated prose must not be lost."""
         assert stripper(text).strip() == expected
 
-    @pytest.mark.parametrize(
-        "stripper", [_strip_reasoning_tags, partial(strip_think_blocks, None)],
-        ids=["display", "storage"],
-    )
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
     @pytest.mark.parametrize("tag", ["arg_key", "arg_value", "/arg_key", "/arg_value"])
     def test_bracketed_arg_tag_prose_and_tail_survive(self, stripper, tag):
         text = (
@@ -80,3 +77,122 @@ class TestToolCallStripping:
             assert "Use <function> in JS. The arg_key field maps to arg_value." in out
             assert out.rstrip().endswith("Done.")
             assert "<tool_call>" not in out
+
+
+class TestEndOfLineArgTagStripping:
+    """The new third alternative in the regex matches </arg_value> only at
+    end of line (followed by whitespace + newline or EOF)."""
+
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
+    def test_arg_value_at_eol_with_trailing_newline(self, stripper):
+        """</arg_value> at end of line followed by newline → stripped."""
+        text = "Both gates started.\nwait</arg_value>\nThird line."
+        result = stripper(text).strip()
+        assert "Both gates started." in result
+        assert "Third line." in result
+        assert "wait</arg_value>" not in result
+
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
+    def test_arg_value_at_eof_no_newline(self, stripper):
+        """</arg_value> at very end of text (no trailing newline) → stripped."""
+        text = "Both gates started.\nwait</arg_value>"
+        result = stripper(text).strip()
+        assert result == "Both gates started."
+
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
+    def test_arg_value_with_trailing_spaces_then_newline(self, stripper):
+        """</arg_value> followed by spaces then newline → stripped."""
+        text = "Both gates started.\nwait</arg_value>   \nThird line."
+        result = stripper(text).strip()
+        assert "Both gates started." in result
+        assert "Third line." in result
+        assert "wait</arg_value>" not in result
+
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
+    def test_arg_value_with_crlf(self, stripper):
+        """Windows \r\n line endings: </arg_value>\r\n → stripped."""
+        text = "Both gates started.\r\nwait</arg_value>\r\nThird line."
+        result = stripper(text).strip()
+        assert "Both gates started." in result
+        assert "Third line." in result
+        assert "wait</arg_value>" not in result
+
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
+    def test_arg_value_mid_line_with_more_text(self, stripper):
+        """</arg_value> in the middle of a line (more text after) → NOT stripped."""
+        text = "The result was wait</arg_value> and then more."
+        result = stripper(text).strip()
+        assert result == text
+
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
+    def test_arg_value_mid_line_then_newline(self, stripper):
+        """</arg_value> followed by more text on same line → NOT stripped."""
+        text = "First line.\nThe result was wait</arg_value> and then more.\nThird line."
+        result = stripper(text).strip()
+        assert "First line." in result
+        assert "The result was wait</arg_value> and then more." in result
+        assert "Third line." in result
+
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
+    def test_arg_key_at_eol(self, stripper):
+        """</arg_key> at end of line → stripped (same as </arg_value>)."""
+        text = "Both gates started.\nwait</arg_key>\nThird line."
+        result = stripper(text).strip()
+        assert "Both gates started." in result
+        assert "Third line." in result
+        assert "wait</arg_key>" not in result
+
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
+    def test_multiple_fragment_lines(self, stripper):
+        """Multiple consecutive fragment lines → all stripped, prose survives."""
+        text = (
+            "Both gates started.\n"
+            "wait</arg_value>\n"
+            "<arg_key>session_id</arg_key>\n"
+            "<arg_value>abc</arg_value>\n"
+            "Third line."
+        )
+        result = stripper(text).strip()
+        assert "Both gates started." in result
+        assert "Third line." in result
+        assert "wait</arg_value>" not in result
+        assert "<arg_key>" not in result
+        assert "<arg_value>" not in result
+
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
+    def test_empty_line_between_fragments(self, stripper):
+        """Empty lines between fragments should not affect stripping."""
+        text = "Both gates started.\n\nwait</arg_value>\n\nThird line."
+        result = stripper(text).strip()
+        assert "Both gates started." in result
+        assert "Third line." in result
+        assert "wait</arg_value>" not in result
+
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
+    def test_arg_value_at_eol_with_tabs(self, stripper):
+        """</arg_value> with tab indentation at end of line → stripped."""
+        text = "Both gates started.\n\twait</arg_value>\nThird line."
+        result = stripper(text).strip()
+        assert "Both gates started." in result
+        assert "Third line." in result
+        assert "wait</arg_value>" not in result
+
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
+    def test_prose_mention_of_arg_value_not_stripped(self, stripper):
+        """Inline prose like 'the arg_value field' must NOT be stripped."""
+        text = "The arg_value field contains the parameter value."
+        result = stripper(text).strip()
+        assert result == text
+
+    @pytest.mark.parametrize("stripper", _STRIPPERS)
+    def test_prose_mention_with_tool_call(self, stripper):
+        """Prose mentioning arg_value alongside a real tool call."""
+        text = (
+            "The arg_value field maps to the value.\n"
+            "<tool_call>process_data<arg_key>x</arg_key><arg_value>1</arg_value></tool_call>\n"
+            "Done."
+        )
+        result = stripper(text).strip()
+        assert "The arg_value field maps to the value." in result
+        assert "Done." in result
+        assert "<tool_call>" not in result


### PR DESCRIPTION
## What does this PR do?

The #101899 fix stripped stray `<arg_key>`/`<arg_value>` markup with a `.*$` DOTALL pattern — to end of TEXT (#102303). Any ordinary prose line mentioning the tags in brackets, plus every line after it, was deleted from both the stored transcript and the display copy:

    First line stays.
    The <arg_key> holds the parameter name.
    Third line must survive.
    → both strippers returned just 'First line stays.'

The strip is now bounded to the fragment line: line-start tags and line-ending closers (e.g. `wait</arg_value>`) still clean fully — the #101899 fragment shape reduces to its clean first line — while inline prose mentions and everything after them survive. The pre-existing prose test only covered unbracketed mentions; the bracketed regression shape is now covered.

## Related Issue

Fixes #102303

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py`, `cli.py` — both strippers bound the tag strip to the line boundary
- `tests/run_agent/test_strip_reasoning_tags_cli.py` — the issue's 3-line repro, line-ending fragment cleanup, unbracketed-mention case preserved

## How to Test

1. Targeted test file green (16 passed after; 10 failing before the fix)
2. Direct: run the 3-line repro through both strippers — all three lines survive with the bracketed tags removed from the middle line only

## Checklist

### Code
- [x] Contributing Guide read; Conventional Commits followed
- [x] Searched for duplicate PRs
- [x] Only changes related to this fix
- [x] Relevant tests pass; tests added
- [x] Tested on Linux (Python 3.11)

### Documentation & Housekeeping
- [x] N/A
