### PR TITLE
fix(agent): add opt-in compact prompt for local qwen3.5

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1303,6 +1303,13 @@ def _apply_agent_section(agent, _agent_cfg):
     # of each other (gates in agent/system_prompt.py).
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
     agent._execution_guidance = _agent_section.get("execution_guidance", "auto")
+    # Explicit compatibility mode for small local models that are degraded by
+    # the full agent scaffold.  Prompt assembly applies stricter model,
+    # endpoint, and tool-session gates; this profile-scoped switch alone is not
+    # sufficient to activate the compact prompt.
+    agent._local_compact_prompt = (
+        _agent_section.get("local_compact_prompt", False) is True
+    )
 
     # Wall-clock run budget from config — only when the constructor arg was not given.
     if agent.run_budget_seconds is None:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -585,12 +585,52 @@ def _join_tier(parts: List[Optional[str]]) -> str:
     return "\n\n".join(p.strip() for p in parts if p and p.strip())
 
 
+def _use_local_compact_prompt(agent: Any) -> bool:
+    """Return whether the narrowly scoped local qwen3.5 prompt applies.
+
+    This deliberately accepts only literal loopback hostnames.  DNS names,
+    RFC1918/LAN addresses, wildcard binds, and malformed/unknown endpoints
+    fail closed to the normal Hermes prompt.
+    """
+    hostname = str(getattr(agent, "_base_url_hostname", "") or "").lower().rstrip(".")
+    return (
+        getattr(agent, "_local_compact_prompt", False) is True
+        and "qwen3.5" in str(getattr(agent, "model", "") or "").lower()
+        and hostname in {"localhost", "127.0.0.1", "::1"}
+        and bool(getattr(agent, "valid_tool_names", None))
+    )
+
+
+def _compact_prompt_parts(agent: Any, system_message: Optional[str]) -> Dict[str, str]:
+    """Build the compact qwen3.5 prompt while preserving caller instructions.
+
+    ``agent.ephemeral_system_prompt`` remains an API-time suffix owned by the
+    normal request path; ``system_message`` is retained here for callers that
+    supply session-local instructions during prompt construction.
+    """
+    from agent.prompt_builder import execution_guidance_text
+
+    stable = _join_tier([
+        "You are Hermes Agent, built by Nous Research. Complete the user's actual task using the available tools.",
+        TASK_COMPLETION_GUIDANCE,
+        TOOL_USE_ENFORCEMENT_GUIDANCE,
+        execution_guidance_text(agent.valid_tool_names),
+    ])
+    return {"stable": stable, "context": _join_tier([system_message]), "volatile": ""}
+
+
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
     """Assemble the system prompt as three ordered cache tiers: ``stable`` (through
     the coding operating brief when a workspace snapshot follows), ``context``
     (snapshot, remaining session-stable guidance, caller ``system_message``,
     context files) and ``volatile`` (skills index, memory, user profile, external
     memory block, timestamp line).  Never re-rendered mid-session."""
+    # The compact path is explicit, model-specific, loopback-only, and only
+    # meaningful when tools are loaded.  Checking before the full build also
+    # avoids scanning context, skills, memory, and plugins that will not be sent.
+    if _use_local_compact_prompt(agent):
+        return _compact_prompt_parts(agent, system_message)
+
     # Model context window scales the context-file caps; stable per conversation.
     _cc_len = getattr(getattr(agent, "context_compressor", None), "context_length", None)
     _ctx_len = _cc_len if isinstance(_cc_len, int) and _cc_len > 0 else None

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -127,6 +127,10 @@ DEFAULT_CONFIG = {
         # "auto" = gpt/codex/grok/deepseek/kimi/qwen/glm/minimax/mimo/mistral; true/false = force;
         # or a list of model-name substrings.
         "execution_guidance": "auto",
+        # Opt-in compact system prompt for tool-enabled qwen3.5 sessions on a
+        # strict loopback endpoint. Other models and non-loopback endpoints
+        # always retain the normal prompt; disabled by default.
+        "local_compact_prompt": False,
         # When the model narrates an action ("I'll go check the logs...") but emits no tool call,
         # inject a "continue now, execute the tools" nudge and loop (max 2 nudges/turn). Corrective
         # sibling of tool_use_enforcement. "auto" = codex_responses api_mode only; true = all

--- a/tests/agent/test_local_compact_prompt.py
+++ b/tests/agent/test_local_compact_prompt.py
@@ -1,0 +1,158 @@
+"""Regression tests for the opt-in local qwen3.5 compact system prompt."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.system_prompt import (
+    _use_local_compact_prompt,
+    build_system_prompt,
+    build_system_prompt_parts,
+)
+from agent.turn_context import build_api_messages
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+
+def _gate_agent(**overrides):
+    values = {
+        "_local_compact_prompt": True,
+        "model": "qwen3.5:9b-64k",
+        "_base_url_hostname": "127.0.0.1",
+        "valid_tool_names": {"terminal"},
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.mark.parametrize("hostname", ["localhost", "127.0.0.1", "::1", "LOCALHOST."])
+def test_compact_prompt_activates_for_supported_loopback_hosts(hostname):
+    assert _use_local_compact_prompt(_gate_agent(_base_url_hostname=hostname))
+
+
+def test_compact_prompt_is_disabled_by_default():
+    assert DEFAULT_CONFIG["agent"]["local_compact_prompt"] is False
+    assert not _use_local_compact_prompt(_gate_agent(_local_compact_prompt=False))
+    assert not _use_local_compact_prompt(_gate_agent(_local_compact_prompt="true"))
+
+
+@pytest.mark.parametrize(
+    ("model", "hostname", "tools"),
+    [
+        ("qwen3.5:9b-64k", "api.b.ai", {"terminal"}),
+        ("qwen3.5:9b-64k", "192.168.1.10", {"terminal"}),
+        ("qwen3.5:9b-64k", "0.0.0.0", {"terminal"}),
+        ("qwen3.5:9b-64k", "ollama.example.com", {"terminal"}),
+        ("qwen3:8b", "127.0.0.1", {"terminal"}),
+        ("qwen3.5:9b-64k", "127.0.0.1", set()),
+    ],
+)
+def test_compact_prompt_fails_closed_outside_narrow_scope(model, hostname, tools):
+    assert not _use_local_compact_prompt(
+        _gate_agent(model=model, _base_url_hostname=hostname, valid_tool_names=tools)
+    )
+
+
+def test_compact_prompt_keeps_execution_discipline_and_caller_prompt():
+    parts = build_system_prompt_parts(
+        _gate_agent(), system_message="PROFILE LOCAL INSTRUCTION"
+    )
+    assert "Hermes Agent" in parts["stable"]
+    assert "tool" in parts["stable"].lower()
+    assert "fabricat" in parts["stable"].lower()
+    assert parts["context"] == "PROFILE LOCAL INSTRUCTION"
+    assert parts["volatile"] == ""
+
+
+def test_profile_ephemeral_prompt_is_still_appended_at_api_time():
+    agent = _gate_agent(ephemeral_system_prompt="EPHEMERAL PROFILE INSTRUCTION")
+    agent._copy_reasoning_content_for_api = lambda *_args: None
+    agent._should_sanitize_tool_calls = lambda: False
+    system_prompt = build_system_prompt(agent)
+    messages, effective = build_api_messages(
+        agent,
+        [{"role": "user", "content": "do the task"}],
+        current_turn_user_idx=0,
+        ext_prefetch_cache=None,
+        plugin_user_context=None,
+        moa_config=None,
+        active_system_prompt=system_prompt,
+    )
+    assert effective == system_prompt + "\n\nEPHEMERAL PROFILE INSTRUCTION"
+    assert messages[0] == {"role": "system", "content": effective}
+
+
+def _normal_agent(**overrides):
+    values = {
+        "load_soul_identity": False,
+        "skip_context_files": True,
+        "valid_tool_names": {"terminal"},
+        "_task_completion_guidance": True,
+        "_parallel_tool_call_guidance": True,
+        "_tool_use_enforcement": "auto",
+        "_execution_guidance": "auto",
+        "_environment_probe": False,
+        "_bot_mode_protocol": False,
+        "_kanban_worker_guidance": "",
+        "_memory_enabled": False,
+        "_user_profile_enabled": False,
+        "_memory_store": None,
+        "_memory_manager": None,
+        "_local_compact_prompt": False,
+        "_base_url_hostname": "api.b.ai",
+        "model": "qwen3.5:9b-64k",
+        "provider": "bai",
+        "platform": "cli",
+        "pass_session_id": False,
+        "session_id": "",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _normal_parts(agent):
+    with (
+        patch("agent.prompt_builder.load_soul_md", return_value=""),
+        patch("agent.prompt_builder.build_environment_hints", return_value=""),
+        patch("agent.system_prompt._coding_parts", return_value=([], [], [])),
+        patch("agent.system_prompt._post_workspace_parts", return_value=[]),
+        patch("agent.system_prompt._skills_prompt", return_value=""),
+        patch("agent.system_prompt._frozen_plugin_prompt_sections", return_value=()),
+        patch("agent.system_prompt._timestamp_line", return_value="STAMP"),
+    ):
+        return build_system_prompt_parts(agent)
+
+
+def test_bai_cloud_request_uses_original_prompt_even_when_opted_in():
+    baseline = _normal_parts(_normal_agent())
+    opted_in = _normal_parts(_normal_agent(_local_compact_prompt=True))
+    assert opted_in == baseline
+    assert "STAMP" in opted_in["volatile"]
+
+
+def test_bai_cloud_serialized_messages_are_identical_when_opted_in():
+    def wire_request(agent):
+        agent.ephemeral_system_prompt = ""
+        agent._copy_reasoning_content_for_api = lambda *_args: None
+        agent._should_sanitize_tool_calls = lambda: False
+        prompt = "\n\n".join(filter(None, _normal_parts(agent).values()))
+        return build_api_messages(
+            agent,
+            [{"role": "user", "content": "do the task"}],
+            current_turn_user_idx=0,
+            ext_prefetch_cache=None,
+            plugin_user_context=None,
+            moa_config=None,
+            active_system_prompt=prompt,
+        )
+
+    assert wire_request(_normal_agent()) == wire_request(
+        _normal_agent(_local_compact_prompt=True)
+    )
+
+
+def test_inactive_feature_leaves_normal_prompt_assembly_byte_identical():
+    without_attribute = _normal_agent()
+    del without_attribute._local_compact_prompt
+    explicit_false = _normal_agent(_local_compact_prompt=False)
+    assert _normal_parts(without_attribute) == _normal_parts(explicit_false)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1820,6 +1820,25 @@ The injected block covers:
 
 The gate is independent of `tool_use_enforcement` — either can be on without the other. The guidance is chosen once at session start keyed on the model name, so the system prompt stays byte-stable (and prompt-cache-friendly) for the life of the conversation. Gemini/Gemma are excluded from the auto list because they receive the more specific Google operational guidance; Claude is excluded because it doesn't exhibit these failure modes — opt any model in with `true` or a substring list.
 
+## Compact Prompt for Local qwen3.5
+
+Some small local models can call tools reliably with a concise agent prompt but
+degrade when the full Hermes scaffold is present. Hermes provides an explicit,
+profile-scoped compatibility option for this case:
+
+```yaml
+agent:
+  local_compact_prompt: true
+```
+
+The option defaults to `false` and currently activates only for tool-enabled
+qwen3.5 sessions whose provider endpoint is literal loopback (`localhost`,
+`127.0.0.1`, or `::1`). Cloud, LAN, other-model, and tool-free sessions keep the
+normal Hermes prompt. The compact prompt keeps Hermes identity and execution,
+tool-use, and no-fabrication discipline; profile-local ephemeral system
+instructions are still appended. It does not alter tool schemas, and it does
+not guarantee that every small model will become a reliable agent.
+
 ## Tool-Loop Guardrails
 
 Hermes detects when the agent is stuck in an unproductive tool-calling loop — the same tool call failing repeatedly, the same tool failing over and over, or an idempotent call returning the same result with no progress. By default it injects a **warning** into the tool result so the model self-corrects. Interactive CLI, TUI, Desktop, and ACP sessions remain warning-only because a person can intervene; unattended gateway and cron sessions enable hard stops by default.


### PR DESCRIPTION
## Problem

Small local qwen3.5 models can support structured tool calling directly, but
the full Hermes system scaffold can cause them to fabricate or describe tool
results instead of dispatching structured tool calls.

Related to #25041.

## Root-cause evidence

Controlled testing isolated the system prompt as the primary trigger:

- Native Ollama `/api/chat`: 5/5 structured tool calls
- Ollama OpenAI `/v1/chat/completions`: 5/5
- Exact full Hermes request replay: 1/5
- Full Hermes prompt with a tiny synthetic tool: 5/5
- Minimal neutral prompt with the real terminal/process schemas: 5/5
- Compact Hermes prompt retaining execution and tool discipline: 5/5

This indicates that the tool schemas and Ollama compatibility layer work, but
the full agent scaffold can overwhelm tool selection for this model class.

## Fix

Add an explicitly opt-in, profile-scoped configuration option:

```yaml
agent:
  local_compact_prompt: true
```

The compact prompt retains:

- Hermes identity
- Actual task-completion guidance
- Mandatory tool use for execution and inspection requests
- No-fabrication discipline
- Execution guidance for the currently loaded tools
- Profile-local and ephemeral system instructions

The option does not modify or simplify tool schemas.

Activation is deliberately narrow and requires all of:

- The option is the literal boolean `true`
- A qwen3.5 model
- A literal loopback endpoint (`localhost`, `127.0.0.1`, or `::1`)
- A tool-enabled session

DNS, LAN, wildcard, cloud, other-model, malformed-endpoint, and tool-free
sessions retain the normal system prompt.

## Safety and backwards compatibility

- Disabled by default
- Explicit opt-in required
- Fails closed to the existing prompt
- No automatic activation based on model name alone
- No effect on B.AI or ordinary cloud providers
- No change to tool schemas or provider adapters
- Existing prompt assembly remains byte-identical while inactive

## Tests

Targeted canonical test wrapper:

- 65 passed
- 0 failed

Coverage includes activation gating, default-disabled behavior, B.AI/cloud
isolation, non-qwen models, non-loopback endpoints, no-tools sessions,
localhost/IPv4/IPv6 loopback handling, profile and ephemeral instructions, and
byte-identical normal request construction.

Additional checks:

- Ruff passed
- Windows footgun checker passed
- `git diff --check` passed

Full repository wrapper:

- 45,161 passed
- 11 failed
- 402 skipped

All 11 assertion failures were reproduced on untouched upstream main in this
environment and are unrelated to this change. One doctor test file also hit
the runner timeout without producing a failed assertion.

Manual qwen3.5 qualification:

- 10/10 fresh sessions emitted genuine structured terminal calls
- Each command executed against a fresh random input
- Real stdout matched an independently calculated SHA-256
- Every final response consumed the actual tool result
- Every session recorded `tool_turns >= 1`

Practical validation also passed:

1. Unpredictable terminal command
2. Temporary file create/read/delete
3. Combined terminal and filesystem workflow

## Manual validation hardware

- AMD Ryzen 5 5600X
- NVIDIA RTX 2060 6 GB
- Ollama with `qwen3.5:9b-64k`

This hardware is only the manual validation environment and is not required
by the feature.

## Limitations

The option is intended for local models whose tool selection is degraded by
the full Hermes prompt. It does not guarantee reliable agent behavior for
every small model.
