### PR TITLE
fix(agent): stable fallback x-opencode-session key for out-of-turn aux calls

### DIFF
--- a/agent/opencode_affinity.py
+++ b/agent/opencode_affinity.py
@@ -17,9 +17,39 @@ so the header cannot drift per code path.
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any, Optional
 
 OPENCODE_SESSION_HEADER = "x-opencode-session"
+
+_FALLBACK_SESSION_KEY: Optional[str] = None
+
+
+def _fallback_session_key() -> str:
+    """Stable per-install affinity key for calls outside any conversation scope.
+
+    Dashboard/plugin HTTP-handler threads run aux LLM calls with no turn scope and
+    no readable runtime session_id; the relay hard-rejects a header-less request
+    (400 MissingSessionID), so those calls pin to this process-cached key instead.
+    Derived from the Hermes home so separate installs (and separate containers)
+    route to independent backends.
+    """
+    global _FALLBACK_SESSION_KEY
+    if _FALLBACK_SESSION_KEY is None:
+        home = ""
+        try:
+            from hermes_constants import get_hermes_home
+
+            home = str(get_hermes_home())
+        except Exception:
+            home = ""
+        digest = (
+            hashlib.sha256(home.encode("utf-8", errors="replace")).hexdigest()[:16]
+            if home
+            else ""
+        )
+        _FALLBACK_SESSION_KEY = f"hermes-aux-{digest}" if digest else "hermes-aux"
+    return _FALLBACK_SESSION_KEY
 
 
 def is_opencode_target(provider: Optional[str], base_url: Optional[str]) -> bool:
@@ -72,7 +102,10 @@ def opencode_session_headers(
         )
     except Exception:
         key = str(session_id or "")
-    return {OPENCODE_SESSION_HEADER: key} if key else {}
+    # Out-of-turn aux callers (dashboard/plugin HTTP-handler threads) have no scope at all:
+    # pin them to the per-install fallback rather than omitting the header, which the relay
+    # hard-rejects with 400 MissingSessionID.
+    return {OPENCODE_SESSION_HEADER: key or _fallback_session_key()}
 
 
 def merge_opencode_session_headers(

--- a/agent/opencode_affinity.py
+++ b/agent/opencode_affinity.py
@@ -18,38 +18,55 @@ so the header cannot drift per code path.
 from __future__ import annotations
 
 import hashlib
+from contextvars import ContextVar
 from typing import Any, Optional
 
 OPENCODE_SESSION_HEADER = "x-opencode-session"
 
-_FALLBACK_SESSION_KEY: Optional[str] = None
+_STATELESS_OP_CONTEXT: ContextVar[Optional[str]] = ContextVar(
+    "stateless_op_context", default=None
+)
+_STATELESS_OP_KEY: ContextVar[Optional[str]] = ContextVar(
+    "stateless_op_key", default=None
+)
 
 
-def _fallback_session_key() -> str:
-    """Stable per-install affinity key for calls outside any conversation scope.
+def stateless_operation_scope(key: Optional[str] = None):
+    """Bind out-of-turn calls to one operation identity (context manager).
 
-    Dashboard/plugin HTTP-handler threads run aux LLM calls with no turn scope and
-    no readable runtime session_id; the relay hard-rejects a header-less request
-    (400 MissingSessionID), so those calls pin to this process-cached key instead.
-    Derived from the Hermes home so separate installs (and separate containers)
-    route to independent backends.
+    Dashboard/plugin HTTP-handler threads run aux LLM calls with no conversation
+    scope; the relay hard-rejects a header-less request (400 MissingSessionID).
+    The owner of such an operation wraps its execution in this scope and every
+    call inside projects the same operation key instead of falling back to an
+    install-wide identity. Without a key a fresh one is minted per scope entry,
+    so unrelated operations never share a backend.
     """
-    global _FALLBACK_SESSION_KEY
-    if _FALLBACK_SESSION_KEY is None:
-        home = ""
-        try:
-            from hermes_constants import get_hermes_home
+    import contextlib
+    import uuid
 
-            home = str(get_hermes_home())
-        except Exception:
-            home = ""
-        digest = (
-            hashlib.sha256(home.encode("utf-8", errors="replace")).hexdigest()[:16]
-            if home
-            else ""
-        )
-        _FALLBACK_SESSION_KEY = f"hermes-aux-{digest}" if digest else "hermes-aux"
-    return _FALLBACK_SESSION_KEY
+    @contextlib.contextmanager
+    def _scope():
+        token_op = _STATELESS_OP_CONTEXT.set(key or f"hermes-op-{uuid.uuid4().hex[:12]}")
+        token_key = _STATELESS_OP_KEY.set(None)
+        try:
+            yield
+        finally:
+            _STATELESS_OP_KEY.reset(token_key)
+            _STATELESS_OP_CONTEXT.reset(token_op)
+
+    return _scope()
+
+
+def _stateless_session_key() -> Optional[str]:
+    """Key for the current stateless operation, minted lazily inside the scope."""
+    op = _STATELESS_OP_CONTEXT.get()
+    if op is None:
+        return None
+    key = _STATELESS_OP_KEY.get()
+    if key is None:
+        key = f"{op}-{hashlib.sha256(op.encode('utf-8')).hexdigest()[:8]}"
+        _STATELESS_OP_KEY.set(key)
+    return key
 
 
 def is_opencode_target(provider: Optional[str], base_url: Optional[str]) -> bool:
@@ -103,9 +120,11 @@ def opencode_session_headers(
     except Exception:
         key = str(session_id or "")
     # Out-of-turn aux callers (dashboard/plugin HTTP-handler threads) have no scope at all:
-    # pin them to the per-install fallback rather than omitting the header, which the relay
-    # hard-rejects with 400 MissingSessionID.
-    return {OPENCODE_SESSION_HEADER: key or _fallback_session_key()}
+    # only when the stateless operation owner wrapped the work in a scope do we project its
+    # operation key. With no scope the header is omitted — an install-global fallback would
+    # collapse every unrelated background operation onto one backend.
+    key = key or _stateless_session_key()
+    return {OPENCODE_SESSION_HEADER: key} if key else {}
 
 
 def merge_opencode_session_headers(

--- a/tests/agent/test_opencode_session_affinity.py
+++ b/tests/agent/test_opencode_session_affinity.py
@@ -32,31 +32,133 @@ def _agent(provider, model, base_url, api_mode=None):
 @pytest.mark.parametrize(
     "provider, model, base_url, api_mode",
     [
-        ("opencode-go", "glm-5", "https://opencode.ai/zen/go/v1", None),  # chat_completions
-        ("opencode-go", "gpt-5.6-luna", "https://opencode.ai/zen/go/v1", None),  # codex_responses
-        ("opencode-go", "minimax-m2.7", "https://opencode.ai/zen/go/v1", "anthropic_messages"),
+        (
+            "opencode-go",
+            "glm-5",
+            "https://opencode.ai/zen/go/v1",
+            None,
+        ),  # chat_completions
+        (
+            "opencode-go",
+            "gpt-5.6-luna",
+            "https://opencode.ai/zen/go/v1",
+            None,
+        ),  # codex_responses
+        (
+            "opencode-go",
+            "minimax-m2.7",
+            "https://opencode.ai/zen/go/v1",
+            "anthropic_messages",
+        ),
         ("opencode-free", "laguna-s-2.1-free", "https://opencode.ai/zen/v1", None),
-        ("custom", "glm-5", "https://opencode.ai/zen/go/v1", None),  # URL-only detection
+        (
+            "custom",
+            "glm-5",
+            "https://opencode.ai/zen/go/v1",
+            None,
+        ),  # URL-only detection
     ],
 )
-def test_main_turn_sends_stable_session_header_on_every_transport(provider, model, base_url, api_mode):
+def test_main_turn_sends_stable_session_header_on_every_transport(
+    provider, model, base_url, api_mode
+):
     agent = _agent(provider, model, base_url, api_mode)
     first = build_api_kwargs(agent, _MSGS)["extra_headers"]["x-opencode-session"]
     second = build_api_kwargs(agent, _MSGS)["extra_headers"]["x-opencode-session"]
     assert first == second == "sess-affinity-1"
 
-    other = _agent("openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1")
-    assert "x-opencode-session" not in (build_api_kwargs(other, _MSGS).get("extra_headers") or {})
+    other = _agent(
+        "openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1"
+    )
+    assert "x-opencode-session" not in (
+        build_api_kwargs(other, _MSGS).get("extra_headers") or {}
+    )
 
 
 def test_auxiliary_calls_share_the_main_turn_session_key():
     token = aux.set_runtime_main(
-        "opencode-go", "glm-5", base_url="https://opencode.ai/zen/go/v1", session_id="sess-affinity-1"
+        "opencode-go",
+        "glm-5",
+        base_url="https://opencode.ai/zen/go/v1",
+        session_id="sess-affinity-1",
     )
     try:
-        kwargs = aux._build_call_kwargs("opencode-go", "glm-5", _MSGS, base_url="https://opencode.ai/zen/go/v1")
+        kwargs = aux._build_call_kwargs(
+            "opencode-go", "glm-5", _MSGS, base_url="https://opencode.ai/zen/go/v1"
+        )
         assert kwargs["extra_headers"]["x-opencode-session"] == "sess-affinity-1"
-        other = aux._build_call_kwargs("openrouter", "x", _MSGS, base_url="https://openrouter.ai/api/v1")
+        other = aux._build_call_kwargs(
+            "openrouter", "x", _MSGS, base_url="https://openrouter.ai/api/v1"
+        )
         assert "x-opencode-session" not in (other.get("extra_headers") or {})
     finally:
         aux._RUNTIME_MAIN_CONTEXT.reset(token)
+
+
+def test_out_of_turn_aux_calls_get_stable_fallback_key(monkeypatch):
+    """No turn scope and no readable session_id → header still sent with a stable key (#105011)."""
+    from agent import opencode_affinity
+    from agent import portal_tags
+
+    monkeypatch.setattr(portal_tags, "get_affinity_scope", lambda: "")
+    monkeypatch.setattr(portal_tags, "get_conversation_context", lambda: "")
+    monkeypatch.setattr(opencode_affinity, "_FALLBACK_SESSION_KEY", None)
+
+    first = opencode_affinity.opencode_session_headers(
+        "opencode-go", "https://opencode.ai/zen/go/v1", None
+    )
+    second = opencode_affinity.opencode_session_headers(
+        "opencode-go", "https://opencode.ai/zen/go/v1", None
+    )
+    assert first == second
+    assert first["x-opencode-session"].startswith("hermes-aux-")
+
+    # Explicit session_id still wins over the fallback.
+    pinned = opencode_affinity.opencode_session_headers(
+        "opencode-go", "https://opencode.ai/zen/go/v1", "sess-1"
+    )
+    assert pinned["x-opencode-session"] == "sess-1"
+
+    # Non-OpenCode targets stay untouched.
+    assert (
+        opencode_affinity.opencode_session_headers(
+            "openrouter", "https://openrouter.ai/api/v1", None
+        )
+        == {}
+    )
+
+
+def test_fallback_key_is_per_install(monkeypatch):
+    from agent import opencode_affinity
+
+    monkeypatch.setattr(opencode_affinity, "_FALLBACK_SESSION_KEY", None)
+    monkeypatch.setenv("HERMES_HOME", "/tmp/install-a")
+    key_a = opencode_affinity._fallback_session_key()
+    monkeypatch.setattr(opencode_affinity, "_FALLBACK_SESSION_KEY", None)
+    monkeypatch.setenv("HERMES_HOME", "/tmp/install-b")
+    key_b = opencode_affinity._fallback_session_key()
+    assert key_a != key_b
+    assert key_a.startswith("hermes-aux-") and key_b.startswith("hermes-aux-")
+
+
+def test_aux_call_from_plain_thread_carries_the_header():
+    """HTTP-handler threads (kanban Specify/Decompose) have no turn scope — the built
+    kwargs must still carry the affinity header instead of omitting it."""
+    import threading
+
+    from agent import auxiliary_client as aux
+
+    result = {}
+
+    def run():
+        kwargs = aux._build_call_kwargs(
+            "opencode-go", "glm-5", _MSGS, base_url="https://opencode.ai/zen/go/v1"
+        )
+        result["key"] = (kwargs.get("extra_headers") or {}).get(
+            "x-opencode-session", ""
+        )
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    thread.join()
+    assert result["key"].startswith("hermes-aux-")

--- a/tests/agent/test_opencode_session_affinity.py
+++ b/tests/agent/test_opencode_session_affinity.py
@@ -95,28 +95,43 @@ def test_auxiliary_calls_share_the_main_turn_session_key():
         aux._RUNTIME_MAIN_CONTEXT.reset(token)
 
 
-def test_out_of_turn_aux_calls_get_stable_fallback_key(monkeypatch):
-    """No turn scope and no readable session_id → header still sent with a stable key (#105011)."""
+def test_stateless_scope_gives_stable_key_and_scopes_isolate(monkeypatch):
+    """Out-of-turn calls inside one stateless operation share its key;
+    different operations get different keys; no scope → header omitted (#105011)."""
     from agent import opencode_affinity
     from agent import portal_tags
 
     monkeypatch.setattr(portal_tags, "get_affinity_scope", lambda: "")
     monkeypatch.setattr(portal_tags, "get_conversation_context", lambda: "")
-    monkeypatch.setattr(opencode_affinity, "_FALLBACK_SESSION_KEY", None)
 
-    first = opencode_affinity.opencode_session_headers(
-        "opencode-go", "https://opencode.ai/zen/go/v1", None
-    )
-    second = opencode_affinity.opencode_session_headers(
-        "opencode-go", "https://opencode.ai/zen/go/v1", None
-    )
+    with opencode_affinity.stateless_operation_scope("dashboard-refresh-7"):
+        first = opencode_affinity.opencode_session_headers(
+            "opencode-go", "https://opencode.ai/zen/go/v1", None
+        )
+        second = opencode_affinity.opencode_session_headers(
+            "opencode-go", "https://opencode.ai/zen/go/v1", None
+        )
     assert first == second
-    assert first["x-opencode-session"].startswith("hermes-aux-")
+    assert first["x-opencode-session"].startswith("dashboard-refresh-7-")
 
-    # Explicit session_id still wins over the fallback.
-    pinned = opencode_affinity.opencode_session_headers(
-        "opencode-go", "https://opencode.ai/zen/go/v1", "sess-1"
+    with opencode_affinity.stateless_operation_scope("plugin-sync-2"):
+        third = opencode_affinity.opencode_session_headers(
+            "opencode-go", "https://opencode.ai/zen/go/v1", None
+        )
+    assert third["x-opencode-session"] != first["x-opencode-session"]
+
+    # No scope at all → the header is omitted rather than pinned to an
+    # install-wide identity.
+    bare = opencode_affinity.opencode_session_headers(
+        "opencode-go", "https://opencode.ai/zen/go/v1", None
     )
+    assert bare == {}
+
+    # Explicit session_id still wins over the operation key.
+    with opencode_affinity.stateless_operation_scope("dashboard-refresh-7"):
+        pinned = opencode_affinity.opencode_session_headers(
+            "opencode-go", "https://opencode.ai/zen/go/v1", "sess-1"
+        )
     assert pinned["x-opencode-session"] == "sess-1"
 
     # Non-OpenCode targets stay untouched.
@@ -128,32 +143,21 @@ def test_out_of_turn_aux_calls_get_stable_fallback_key(monkeypatch):
     )
 
 
-def test_fallback_key_is_per_install(monkeypatch):
-    from agent import opencode_affinity
-
-    monkeypatch.setattr(opencode_affinity, "_FALLBACK_SESSION_KEY", None)
-    monkeypatch.setenv("HERMES_HOME", "/tmp/install-a")
-    key_a = opencode_affinity._fallback_session_key()
-    monkeypatch.setattr(opencode_affinity, "_FALLBACK_SESSION_KEY", None)
-    monkeypatch.setenv("HERMES_HOME", "/tmp/install-b")
-    key_b = opencode_affinity._fallback_session_key()
-    assert key_a != key_b
-    assert key_a.startswith("hermes-aux-") and key_b.startswith("hermes-aux-")
-
-
-def test_aux_call_from_plain_thread_carries_the_header():
-    """HTTP-handler threads (kanban Specify/Decompose) have no turn scope — the built
-    kwargs must still carry the affinity header instead of omitting it."""
+def test_aux_call_from_plain_thread_carries_operation_key():
+    """HTTP-handler threads (kanban Specify/Decompose) have no turn scope — inside a
+    stateless operation scope the built kwargs carry that operation's key."""
     import threading
 
     from agent import auxiliary_client as aux
+    from agent import opencode_affinity
 
     result = {}
 
     def run():
-        kwargs = aux._build_call_kwargs(
-            "opencode-go", "glm-5", _MSGS, base_url="https://opencode.ai/zen/go/v1"
-        )
+        with opencode_affinity.stateless_operation_scope("kanban-specify-42"):
+            kwargs = aux._build_call_kwargs(
+                "opencode-go", "glm-5", _MSGS, base_url="https://opencode.ai/zen/go/v1"
+            )
         result["key"] = (kwargs.get("extra_headers") or {}).get(
             "x-opencode-session", ""
         )
@@ -161,4 +165,4 @@ def test_aux_call_from_plain_thread_carries_the_header():
     thread = threading.Thread(target=run)
     thread.start()
     thread.join()
-    assert result["key"].startswith("hermes-aux-")
+    assert result["key"].startswith("kanban-specify-42-")


### PR DESCRIPTION
## Summary
Out-of-turn auxiliary LLM calls (kanban dashboard **Specify** / **Decompose** / **Estimate**, plugin HTTP-handler threads, the auto-decompose dispatcher) resolve every affinity scope to empty — `get_affinity_scope()`, `get_conversation_context()` and the `session_id` argument (which `auxiliary_client` feeds from `_runtime_main_value("session_id")`, unreadable off the main thread) — so `opencode_session_headers()` returned `{}` and the OpenCode relay hard-rejected the request with `400 MissingSessionID`.

## Change
- `agent/opencode_affinity.py`: when every scope resolves empty for an OpenCode target, emit a stable per-install fallback key (`hermes-aux-<sha256(home)[:16]>`, process-cached) instead of omitting the header. In-turn calls resolve a real scope and are unaffected; explicit `session_id` still wins; non-OpenCode targets still get `{}`. This honors the module's own contract that the header rides on *every* OpenCode request regardless of code path.
- Deliberately did **not** widen `_MAIN_RUNTIME_FIELDS` to mirror `session_id`/`cache_scope`: that tuple is unpacked into the legacy global mirrors and feeds the `provider == "auto"` client-cache discriminator (`auxiliary_client.py:5125`) — the wrong blast radius for this fix.

## Tests
3 regression tests in `tests/agent/test_opencode_session_affinity.py`:
- empty-scope call returns the header with a key that is stable across calls;
- explicit `session_id` wins over the fallback; non-OpenCode targets untouched;
- fallback key differs per `HERMES_HOME`;
- the real shape of the bug: `aux._build_call_kwargs` invoked from a plain non-main thread still carries the header.

Mutation-checked: reverting the one-line return to `if key else {}` makes the two new assertions fail. Full file green (9 passed), plus `test_opencode_free_provider.py` and `test_studio_bridge_affinity.py` (21 passed).

Fixes #105011