### PR TITLE
fix(cli): keep quiet scanner warnings on stderr

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3020,10 +3020,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
                 ensure_installed(log_failures=False) is None and is_platform_supported()
                 and (self.config.get("security", {}) or {}).get("tirith_enabled", True)
             ):
-                _cprint(
-                    f"  {_DIM}⚠ tirith security scanner enabled but not available "
-                    f"— command scanning will use pattern matching only{_RST}"
+                warning = (
+                    "⚠ tirith security scanner enabled but not available "
+                    "— command scanning will use pattern matching only"
                 )
+                if self.tool_progress_mode == "off":
+                    print(f"  {warning}", file=sys.stderr)
+                else:
+                    _cprint(f"  {_DIM}{warning}{_RST}")
         except Exception:
             pass
 

--- a/tests/cli/test_security_warning_streams.py
+++ b/tests/cli/test_security_warning_streams.py
@@ -1,0 +1,49 @@
+"""Security warnings stay visible without corrupting quiet CLI answers."""
+
+from unittest.mock import patch
+
+import pytest
+
+from cli import HermesCLI
+
+
+@pytest.mark.parametrize("quiet", [True, False])
+def test_missing_scanner_warning_preserves_output_streams(quiet, capsys):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.config = {"security": {"tirith_enabled": True}}
+    cli.tool_progress_mode = "off" if quiet else "full"
+    cli._tirith_security_checked = False
+    with (
+        patch("tools.tirith_security.ensure_installed", return_value=None) as install,
+        patch("tools.tirith_security.is_platform_supported", return_value=True),
+    ):
+        cli._ensure_tirith_security()
+        cli._ensure_tirith_security()
+
+    install.assert_called_once_with(log_failures=False)
+    captured = capsys.readouterr()
+    diagnostic = captured.err if quiet else captured.out
+    assert diagnostic.count("tirith security scanner enabled but not available") == 1
+    assert "pattern matching only" in diagnostic
+    assert (captured.out if quiet else captured.err) == ""
+
+
+@pytest.mark.parametrize(
+    "installed,supported,enabled",
+    [("tirith", True, True), (None, False, True), (None, True, False)],
+)
+def test_scanner_warning_only_when_security_is_degraded(
+    installed, supported, enabled, capsys
+):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.config = {"security": {"tirith_enabled": enabled}}
+    cli.tool_progress_mode = "off"
+    cli._tirith_security_checked = False
+    with (
+        patch("tools.tirith_security.ensure_installed", return_value=installed),
+        patch("tools.tirith_security.is_platform_supported", return_value=supported),
+    ):
+        cli._ensure_tirith_security()
+
+    captured = capsys.readouterr()
+    assert captured.out == captured.err == ""


### PR DESCRIPTION
## What does this PR do?

Keep the Tirith availability warning on stderr when the CLI runs with `tool_progress_mode == "off"`, as set by `hermes chat -Q`. Preserve the existing styled stdout warning in normal interactive mode.

On current main (`22c5684b983eac6a81ee015ae80296c4b3dbf5bb`), `_init_agent()` calls `_ensure_tirith_security()` before the quiet turn runs. When Tirith is enabled but unavailable on a supported platform, that method writes its warning through `_cprint()` to stdout. Piped consumers therefore receive a security diagnostic mixed into the answer. Quiet callback neutralization does not cover this initialization path.

This change keeps the warning visible. It does not disable scanning, change installation behavior, alter approval policy, or redirect process-wide stdout.

## Related Issue

Related: #93220 (already closed; its callback fixes are present on main). This addresses the separate initialization warning that remains, not the already-fixed reasoning/diff callbacks. Also checked #1452: that change quieted installer logging, not this CLI-rendered availability warning.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: route the existing warning to stderr in quiet mode; preserve interactive styling.
- `tests/cli/test_security_warning_streams.py`: check stream separation, warning visibility, once-only checking, and absence of warnings when installed, unsupported, or disabled.

## How to Test

```bash
scripts/run_tests.sh tests/cli/test_security_warning_streams.py tests/cli/test_resume_quiet_stderr.py tests/test_cli_quiet_stdout_leak.py tests/tools/test_tirith_security.py tests/hermes_cli/test_mcp_discovery_timing.py --file-retries 0 -j 4 -q
```

- Before the production change, the new regression file reports **1 failed, 4 passed** on the base above: the quiet warning is missing from stderr.
- With the fix, the five focused files report **68 passed, 0 failed**, without retries.
- New test file: Ruff passes. Staged changes: `git diff --cached --check` and `scripts/check-windows-footguns.py` pass.

Manual reproduction with configured provider credentials and Tirith enabled but unavailable on a supported host:

```bash
hermes chat -Q -q "Reply only OK" > answer.txt 2> diagnostics.txt
```

The availability warning belongs in `diagnostics.txt`, not `answer.txt`. Tests reproduce scanner availability deterministically without installation or network calls. Live-provider end-to-end execution on this upstream base and native Linux/Windows validation were **not run**.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched existing PRs and issues, including open and closed results.
- [x] This PR contains only changes related to this fix, based directly on public main.
- [ ] Full test suite (not run; focused canonical-runner results are listed above).
- [x] I've added behavioral regression tests.
- [x] Tested on macOS with Python 3.11.

### Documentation & Housekeeping

- [x] Documentation: N/A, restores the existing quiet-output contract.
- [x] Config example: N/A, no config keys changed.
- [x] Architecture/workflow docs: N/A.
- [x] Cross-platform impact considered; standard Python stream routing, Windows footgun check passed. Native Linux/Windows remain unverified.
- [x] Tool descriptions/schemas: N/A, tool behavior is unchanged.
