### PR TITLE
feat(models): gpt-6-astra joins the Codex OAuth -900k picker variants (live-verified 900,901 tokens)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1441,6 +1441,7 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.3-codex-spark": 128_000, "gpt-5.2-codex": 272_000, "gpt-5.4-mini": 272_000,
     "gpt-5.6-sol": 272_000, "gpt-5.6-terra": 272_000, "gpt-5.6-luna": 272_000, "gpt-daybreak-blue-latest": 272_000,
     "gpt-5.5": 272_000, "gpt-5.4": 272_000, "gpt-5.2": 272_000, "gpt-5": 272_000,
+    "gpt-6-astra": 272_000,
 }
 # Codex OAuth advertises 272K for these families but ACCEPTS ~900K+ (verified live; gpt-5.5 and
 # gpt-5.4-mini genuinely reject >272K). 900K keeps ≥11K margin. OPT-IN ONLY via explicit ``-900k``
@@ -1448,13 +1449,15 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
 # The bump fires ONLY when the resolved value is exactly the stale 272,000. ``gpt-5.6`` is a FAMILY
 # PREFIX (``-pro`` slugs aren't routable on Codex); ``gpt-5.4`` is EXACT because gpt-5.4-mini enforces 272K.
 _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES: Dict[str, int] = {"gpt-5.6": 900_000}  # sol / terra / luna
-_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {"gpt-5.4": 900_000, "gpt-daybreak-blue-latest": 900_000}
+# gpt-6-astra: live probe 2026-09-07 on a ChatGPT-subscription account accepted 900,901 input tokens
+# (PROBE_OK) and rejected ~940K with context_length_exceeded; catalog still advertises 272K.
+_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {"gpt-5.4": 900_000, "gpt-daybreak-blue-latest": 900_000, "gpt-6-astra": 900_000}
 _CODEX_OAUTH_STALE_ADVERTISED_CTX = 272_000  # the only advertised value the bump may override
 CODEX_CONTEXT_VARIANT_SUFFIX = "-900k"  # picker-only opt-in suffix; never sent on the wire
 # The ONLY bases eligible for ``-900k``: routable, live-verified. No family prefixing (it would synthesize
 # dead ``-pro`` variants); dated snapshots of the 5.6 bases are allowed. gpt-daybreak-blue-latest is a verified Sol alias.
 _CODEX_900K_SNAPSHOT_BASES = ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna")
-_CODEX_900K_ELIGIBLE_BASES = frozenset({*_CODEX_900K_SNAPSHOT_BASES, "gpt-5.4", "gpt-daybreak-blue-latest"})
+_CODEX_900K_ELIGIBLE_BASES = frozenset({*_CODEX_900K_SNAPSHOT_BASES, "gpt-5.4", "gpt-daybreak-blue-latest", "gpt-6-astra"})
 _CODEX_900K_SNAPSHOT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -534,6 +534,7 @@ class TestCodexOAuthContextLength:
             "gpt-5.6-sol-2026-07-09",  # dated snapshot via gpt-5.6 family prefix
             "gpt-5.4",
             "gpt-daybreak-blue-latest",  # Sol alias; exact verified slug
+            "gpt-6-astra",  # 900,901 input tokens accepted live 2026-09-07; ~940K rejected
         ],
     )
     def test_900k_variant_slug_bumped_to_live_verified_900k(self, slug):
@@ -691,6 +692,7 @@ class TestCodexOAuthContextLength:
         ("gpt-5.6-luna-900k",             True,  900_000, "gpt-5.6-luna"),
         ("gpt-5.4-900k",                  True,  900_000, "gpt-5.4"),
         ("gpt-daybreak-blue-latest-900k", True,  900_000, "gpt-daybreak-blue-latest"),
+        ("gpt-6-astra-900k",              True,  900_000, "gpt-6-astra"),
         # dated snapshot of a routable 5.6 base
         ("gpt-5.6-sol-2026-07-09-900k",   True,  900_000, "gpt-5.6-sol-2026-07-09"),
         # vendor-namespaced variant (display/aux callers) resolves too
@@ -698,6 +700,8 @@ class TestCodexOAuthContextLength:
         # -pro slugs are not routable on Codex OAuth: never a valid variant,
         # never stripped (fails honestly at the API instead)
         ("gpt-5.6-sol-pro-900k",          False, 272_000, "gpt-5.6-sol-pro-900k"),
+        # not verified above 272K on Codex OAuth: no variant until probed
+        ("gpt-6-astra-pro-900k",          False, 272_000, "gpt-6-astra-pro-900k"),
         # genuine 272K enforcers get no variant
         ("gpt-5.5-900k",                  False, 272_000, "gpt-5.5-900k"),
         ("gpt-5.4-mini-900k",             False, 272_000, "gpt-5.4-mini-900k"),

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -243,16 +243,17 @@ hermes config set compression.codex_gpt55_autoraise_notice false
 
 ### Codex large-context `-900k` picker variants (opt-in)
 
-The ChatGPT Codex backend *advertises* a 272K window for the gpt-5.4 and
-gpt-5.6 (Sol/Terra/Luna) families, but actually accepts ~911K input tokens
-for ChatGPT-subscription accounts (live-verified Aug 2026). Hermes keeps the
+The ChatGPT Codex backend *advertises* a 272K window for the gpt-5.4,
+gpt-5.6 (Sol/Terra/Luna) and gpt-6 Astra families, but actually accepts ~911K
+input tokens for ChatGPT-subscription accounts (live-verified Aug 2026 for 5.4/5.6,
+Sep 2026 for Astra: 900,901 accepted, ~940K rejected). Hermes keeps the
 **advertised 272K as the default** for the base slugs — a bigger window means
 more tokens per request and much faster subscription-usage burn, so the large
 window is strictly opt-in.
 
 To use the large window, pick the explicit `-900k` variant in `/model` (e.g.
 `gpt-5.6-sol-900k`, `gpt-5.6-terra-900k`, `gpt-5.6-luna-900k`,
-`gpt-5.4-900k`). These are Hermes-side aliases: the suffix is stripped before
+`gpt-5.4-900k`, `gpt-6-astra-900k`). These are Hermes-side aliases: the suffix is stripped before
 the model id is sent to the backend, and pricing/usage accounting treats them
 as the base model. Slugs that genuinely enforce 272K (gpt-5.5, gpt-5.4-mini)
 have no `-900k` variant.


### PR DESCRIPTION
## What does this PR do?

Adds `gpt-6-astra` to the Codex OAuth `-900k` picker variants, using the exact mechanism that already serves the gpt-5.6 family and gpt-5.4 (stale-272K advertisement → live-verified 900K bump, opt-in only via the explicit `gpt-6-astra-900k` picker alias).

- `agent/model_metadata.py`: `gpt-6-astra` added to `_CODEX_OAUTH_CONTEXT_FALLBACK` (272K), `_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT` (900K) and `_CODEX_900K_ELIGIBLE_BASES`.
- Existing semantics unchanged: base slug stays 272K and keeps the 85% autoraise from 08b140d1; the `-900k` variant keeps the global threshold; the suffix is stripped before the wire; `-pro` and other relatives get no variant until probed.
- Docs: variant listed in `context-compression-and-caching.md`.

Effort clamping for Astra (#103556) is intentionally **not** in this PR; #103570 / #103696 / #104415 already cover it.

## Live verification (ChatGPT-subscription account, Codex OAuth, Sep 7 2026)

Streaming `POST https://chatgpt.com/backend-api/codex/responses` with the Hermes OAuth token and headers, `reasoning.effort=low`, synthetic filler prompt, `store=false`:

| target | `usage.input_tokens` | result |
|---:|---:|---|
| 5K | 7,064 | `PROBE_OK` (2.7 s) |
| 300K | 299,870 | `PROBE_OK` (8.8 s) |
| 640K | 640,314 | `PROBE_OK` (19.5 s) |
| **900K** | **900,901** | **`PROBE_OK` (29.7 s)** |
| ~940K | — | `context_length_exceeded` (3.3 s) |

Same ceiling as measured for `gpt-5.6-sol` on Aug 16 (911K OK / 925K rejected, bab7be3ca7). The catalog still advertises `context_window: 272000` for the slug, so the existing stale-advertisement override is the right lever.

Also observed on the same endpoint: `reasoning.effort=max` → 200; `ultra` → 400 `invalid_value` ("Supported values are: none, minimal, low, medium, high, xhigh, and max").

## Tests

Two rows added to the existing parametrized contracts in `tests/agent/test_model_metadata.py` (`test_900k_variant_slug_bumped_to_live_verified_900k[gpt-6-astra]`, `test_900k_eligibility_table[gpt-6-astra-900k…]`) plus the negative `gpt-6-astra-pro-900k` row. Both positive rows fail on `main`, pass here.

```
scripts/run_tests.sh tests/agent/test_model_metadata.py tests/hermes_cli/test_gpt56_registration.py tests/hermes_cli/test_codex_models.py
=== 3 files, 141 tests passed, 0 failed ===
```

Refs #103015 (Astra tracker), #103223 (picker; that PR explicitly leaves `-900k` Astra unsynthesized pending verification — this is that verification).
