### PR TITLE
fix(desktop): skip roster republish when the 5s poll content is unchanged

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/roster-fingerprint.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-fingerprint.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Roster payload fingerprints: the content-level change detection that keeps
+ * the 5s roster poll from republishing identical payloads (new object graph
+ * → new array reference → every shared-atom subscriber re-renders, and on
+ * macOS the pane churn drops IME input-method focus).
+ *
+ * Pinned behaviors:
+ *  - same content, different references/order ⇒ same fingerprint;
+ *  - any observable field (labels, session activity, source status, avatar
+ *    flag, server ui_meta) ⇒ different fingerprint;
+ *  - local-only payload noise (ui_meta image data URLs, revisions bookkeeping,
+ *    ghost twins) never changes the fingerprint.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { rosterPayloadFingerprint } from './roster-fingerprint'
+import type { RosterRow } from './types'
+
+/** A realistic rich row as profiles.list returns it. */
+function bot(overrides: Partial<RosterRow> = {}): RosterRow {
+  return {
+    name: 'scribe',
+    display_name: 'Scribe',
+    title: 'Scribe',
+    has_avatar: true,
+    connectionId: 'local',
+    connectionKind: 'local',
+    connectionLabel: 'Local',
+    remoteSource: false,
+    sourceReachable: true,
+    canonical_session: {
+      id: 'sess-1',
+      resolved_id: 'sess-1',
+      last_active: 1_753_000_000,
+      preview: 'hello',
+      title: 'Bot Chat'
+    },
+    last_session: {
+      last_active: 1_752_900_000,
+      preview: 'older work'
+    },
+    worker_session: { last_active: 1_752_950_000 },
+    ui_meta: {
+      'hermes-bots': {
+        sectionId: 'writing',
+        color: '#c0ffee',
+        groups: ['docs'],
+        pinned: true,
+        title: 'Scribe'
+      }
+    },
+    ...overrides
+  }
+}
+
+describe('rosterPayloadFingerprint', () => {
+  it('ignores object identity: same content, fresh references', () => {
+    const a = rosterPayloadFingerprint([bot()])
+    const b = rosterPayloadFingerprint([bot()])
+
+    expect(a).toBe(b)
+  })
+
+  it('ignores wire order and the pane pin/activity sort', () => {
+    const base = [bot(), bot({ name: 'researcher', display_name: 'Researcher' })]
+    const shuffled = [bot({ name: 'researcher', display_name: 'Researcher' }), bot()]
+
+    expect(rosterPayloadFingerprint(base)).toBe(rosterPayloadFingerprint(shuffled))
+  })
+
+  it('distinguishes same-named rows across connections', () => {
+    const local = rosterPayloadFingerprint([bot({ connectionId: 'local' })])
+    const remote = rosterPayloadFingerprint([bot({ connectionId: 'ssh::box' })])
+
+    expect(local).not.toBe(remote)
+  })
+
+  it('ignores offline-owner ghost twins', () => {
+    const plain = rosterPayloadFingerprint([bot()])
+    const withGhost = rosterPayloadFingerprint([
+      bot(),
+      { ghost: true, name: 'scribe', connectionId: 'local', remoteSource: false }
+    ])
+
+    expect(plain).toBe(withGhost)
+  })
+
+  it('detects identity and label changes', () => {
+    const base = rosterPayloadFingerprint([bot()])
+
+    for (const changed of [
+      bot({ name: 'scribe2' }),
+      bot({ display_name: 'Scribe Prime' }),
+      bot({ title: 'Prime' }),
+      bot({ handle: '@scribe' }),
+      bot({ description: 'writes' })
+    ]) {
+      expect(rosterPayloadFingerprint([changed])).not.toBe(base)
+    }
+  })
+
+  it('detects session-activity changes (age, unread watermark, sort)', () => {
+    const base = rosterPayloadFingerprint([bot()])
+
+    expect(
+      rosterPayloadFingerprint([bot({ canonical_session: { id: 'sess-1', last_active: 1_753_100_000 } })])
+    ).not.toBe(base)
+    expect(rosterPayloadFingerprint([bot({ last_session: { last_active: 1_753_000_001 } })])).not.toBe(base)
+    expect(rosterPayloadFingerprint([bot({ worker_session: { last_active: 1_753_000_002 } })])).not.toBe(base)
+  })
+
+  it('detects source/status and avatar-flag changes', () => {
+    const base = rosterPayloadFingerprint([bot()])
+
+    for (const changed of [
+      bot({ sourceReachable: false }),
+      bot({ sourceError: 'ssh: refused' }),
+      bot({ remoteSource: true, connectionId: 'ssh::box', connectionKind: 'ssh' }),
+      bot({ has_avatar: false }),
+      bot({ targetProfile: 'other' })
+    ]) {
+      expect(rosterPayloadFingerprint([changed])).not.toBe(base)
+    }
+  })
+
+  it('detects server ui_meta changes (sections, pins, hidden, meta title)', () => {
+    const base = rosterPayloadFingerprint([bot()])
+
+    for (const ui of [
+      { 'hermes-bots': { sectionId: 'research', pinned: true, title: 'Scribe' } },
+      { 'hermes-bots': { sectionId: 'writing', pinned: false, title: 'Scribe' } },
+      { 'hermes-bots': { sectionId: 'writing', pinned: true, title: 'Scribe', hidden: true } }
+    ]) {
+      expect(rosterPayloadFingerprint([bot({ ui_meta: ui })])).not.toBe(base)
+    }
+  })
+
+  it('ignores local-only payload noise: image data URLs and revisions', () => {
+    const base = rosterPayloadFingerprint([bot()])
+
+    const withImage = {
+      ...bot(),
+      ui_meta: {
+        'hermes-bots': { ...bot().ui_meta!['hermes-bots']!, image: `data:image/png;base64,${'A'.repeat(4096)}` }
+      }
+    }
+
+    const withRevisions = bot({ ui_meta_revisions: { 'hermes-bots': 7 } })
+
+    expect(rosterPayloadFingerprint([withImage])).toBe(base)
+    expect(rosterPayloadFingerprint([withRevisions])).toBe(base)
+  })
+
+  it('ignores foreign ui_meta keys', () => {
+    const hermesBots = bot().ui_meta!['hermes-bots']
+
+    const base = rosterPayloadFingerprint([bot()])
+    const foreign = rosterPayloadFingerprint([
+      bot({ ui_meta: { 'hermes-bots': hermesBots, 'other-plugin': { thing: 1 } } })
+    ])
+
+    expect(foreign).toBe(base)
+  })
+
+  it('treats missing hermes-bots meta as its own content', () => {
+    const base = rosterPayloadFingerprint([bot()])
+    const bare = rosterPayloadFingerprint([{ ...bot(), ui_meta: undefined }])
+    const foreignOnly = rosterPayloadFingerprint([bot({ ui_meta: { 'other-plugin': { thing: 1 } } })])
+
+    // No hermes-bots meta ⇒ no server overlay to apply — distinct content.
+    expect(bare).not.toBe(base)
+    expect(foreignOnly).toBe(bare)
+  })
+
+  it('treats an empty roster as stable content', () => {
+    expect(rosterPayloadFingerprint([])).toBe(rosterPayloadFingerprint([]))
+    expect(rosterPayloadFingerprint([])).not.toBe(rosterPayloadFingerprint([bot()]))
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/roster-fingerprint.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-fingerprint.ts
@@ -1,0 +1,111 @@
+/**
+ * Roster payload fingerprints for content-change detection.
+ *
+ * The desktop polls the roster every 5s (useRoster refetchInterval) and React
+ * Query hands back a fresh object graph each time. The pane republishes that
+ * graph to shared atoms — a new array reference re-renders every subscriber
+ * and re-runs avatar/meta/label side effects even when nothing changed; on
+ * macOS that churn drops IME input-method focus. These helpers reduce a
+ * payload to a stable content string so the pane can skip the whole publish
+ * when the roster is substantively identical.
+ *
+ * The fingerprint deliberately covers only what the pane's consumers observe:
+ * identity, labels, source/status, session activity, avatar flags and the
+ * server `hermes-bots` ui_meta overlay. Transient envelope noise (fetchedAt),
+ * write bookkeeping (ui_meta_revisions) and foreign ui_meta keys are left out
+ * — none of the shared-roster read paths consume them, so an unchanged
+ * fingerprint means an unchanged observable roster.
+ */
+
+import type { BotMeta, CanonicalSession, RosterRow, SessionPreview } from './types'
+
+/** Deterministic serializer: nested wire objects (route, ui_meta) can arrive
+ *  with any key order, so sort keys instead of trusting insertion order. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return String(JSON.stringify(value))
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`
+  }
+
+  const object = value as Record<string, unknown>
+
+  return `{${Object.keys(object)
+    .sort()
+    .map(key => `${JSON.stringify(key)}:${stableStringify(object[key])}`)
+    .join(',')}}`
+}
+
+/** Normalize a canonical/last session to the fields that drive activity
+ *  signals (age label, pulse dot, unread watermark, recency sort) and
+ *  previews. Not in the normalized shape: nothing else about a session
+ *  reaches the pane or the shared-roster consumers. */
+function sessionFingerprint(session: CanonicalSession | SessionPreview | null | undefined) {
+  if (!session || typeof session !== 'object') {
+    return null
+  }
+
+  const { id, last_active, preview, resolved_id, root_title, title } = session as CanonicalSession
+
+  return { id, last_active, preview, resolved_id, root_title, title }
+}
+
+/** Server `hermes-bots` ui_meta minus the local-only payload bits: image
+ *  data URLs (and derived pet state) never come from the server
+ *  (mergeServerMeta preserves them locally), and a multi-KB data URL must not
+ *  ride the fingerprint — it would be re-serialized on every poll. */
+function metaFingerprint(meta: BotMeta | null | undefined) {
+  if (!meta || typeof meta !== 'object') {
+    return null
+  }
+
+  const copy = { ...meta }
+  delete copy.image
+
+  return stableStringify(copy)
+}
+
+/** One stable content string for a roster payload: non-ghost rows reduced to
+ *  their observable fields, ordered by (connectionId, name, content) so wire
+ *  order and the pane's pin/activity sort never count as change. */
+export function rosterPayloadFingerprint(roster: RosterRow[]): string {
+  const entries = (Array.isArray(roster) ? roster : [])
+    .filter(row => !row?.ghost)
+    .map(row => {
+      const meta = row.ui_meta?.['hermes-bots']
+
+      // Fixed key order: an identical payload hashes identically.
+      const normalized = {
+        canonical_session: sessionFingerprint(row.canonical_session),
+        connectionId: row.connectionId,
+        connectionKind: row.connectionKind,
+        connectionLabel: row.connectionLabel,
+        description: row.description,
+        display_name: row.display_name,
+        handle: row.handle,
+        has_avatar: row.has_avatar,
+        last_session: sessionFingerprint(row.last_session),
+        name: row.name,
+        remoteSource: row.remoteSource,
+        route: row.route ? stableStringify(row.route) : null,
+        sourceError: row.sourceError,
+        sourceMissing: row.sourceMissing,
+        sourceReachable: row.sourceReachable,
+        sourceScoped: row.sourceScoped,
+        targetProfile: row.targetProfile,
+        title: row.title,
+        ui_meta: metaFingerprint(meta),
+        worker_session: row.worker_session ? { last_active: row.worker_session.last_active } : null
+      }
+
+      const content = stableStringify(normalized)
+      const key = `${row.connectionId || ''}\u0000${row.name}\u0000${content}`
+
+      return { content, key }
+    })
+    .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
+
+  return entries.map(entry => entry.content).join('\n')
+}

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane-lifecycle.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane-lifecycle.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { $lastRoster } from './data'
 import type { useRoster } from './data'
 import { displayName } from './labels'
+import { rosterPayloadFingerprint } from './roster-fingerprint'
 import { mergeServerMeta, pullServerAvatars } from './profile-ops'
 import { trackInboundActivity } from './roster-actions'
 import { botRosterMeta, botWorkspaceOwnerKey } from './routing'
@@ -32,7 +33,20 @@ export function usePublishRosterSnapshot({ data, live, roster, allMeta, activeSo
     // feeds merge caching, group membership, creation, and durable sync. These
     // writes must settle after render: other subscribers of the same atoms
     // would otherwise be updated while BotsPane was still rendering.
-    $lastRoster.set(roster.filter(row => !row?.ghost))
+    const snapshot = roster.filter(row => !row?.ghost)
+
+    // The 5s poll refetches unconditionally and React Query hands back a fresh
+    // object graph every time. Republishing it re-renders every shared-atom
+    // subscriber and re-runs the avatar/meta/label side effects below even
+    // when nothing changed — on macOS that pane churn drops IME input-method
+    // focus (SCIM). Compare CONTENT against the last published snapshot and
+    // skip the whole publish when the roster is substantively identical;
+    // $lastRoster still holds that same content, so nothing is lost.
+    if (rosterPayloadFingerprint(snapshot) === rosterPayloadFingerprint($lastRoster.get())) {
+      return
+    }
+
+    $lastRoster.set(snapshot)
     // Tabs caption a bot chat by its bot (#99152); republished with the
     // roster so a rename follows and tiles restored at boot resolve.
     roster.forEach(bot => {


### PR DESCRIPTION
## What this fixes

The desktop Bots plugin (`hermes-bots`) polls the union agent roster every 5s via `useRoster` (`refetchInterval: 5000, staleTime: 5000` in `data.ts`). React Query hands back a **fresh object graph on every poll**, so the pane's `useEffect([data])` in `roster-pane.tsx` republishes that graph unconditionally:

- `$lastRoster.set(...)` — new array reference → every shared-atom subscriber re-renders
- per-bot `setWorkspaceOwnerLabel`, `mergeServerMeta`, `pullServerAvatars` (may fetch avatars), `trackInboundActivity`, `backfillMessagingProtocol`

On macOS this pane churn repeatedly tears down / re-registers the Electron input-method (IME) client. The result: while typing Chinese (SCIM), the candidate window periodically jumps back to screen origin (top-left) and the in-progress composition is dropped — typing feels "interrupted". The renderer also sits at 40-64% CPU from the perpetual republish + re-render cycle.

## Root cause

5s unconditional poll + content-independent republish. The data is **identical** between polls, but the object identity changes, so every subscriber re-renders and every side effect re-runs even when nothing changed.

## The fix

Content-level change detection at the single republish point. New pure module `roster-fingerprint.ts` reduces a roster payload to a stable content string (identity, labels, source/status, session activity, avatar flag, server `hermes-bots` ui_meta — deliberately excluding wire order, `fetchedAt` envelope noise, local-only `ui_meta` image data URLs, and ghost rows). `roster-pane.tsx` computes the fingerprint before publishing and skips the **entire** side-effect block when the content is substantively identical.

Polling frequency is unchanged — roster freshness is unaffected; only needless republish/re-render is skipped.

## Verification

- 12 new unit tests (`roster-fingerprint.test.ts`) — all pass:
  - same content, fresh references/order ⇒ same fingerprint
  - identity / labels / session activity / source status / avatar flag / server ui_meta changes ⇒ different fingerprint
  - local-only noise (ui_meta image data URLs, revisions bookkeeping, ghost twins) ⇒ never changes it
- `tsc --noEmit` clean for the touched files.

## Related issues

This is part of the desktop "typing focus loss" family already tracked upstream:
- #102913 (Bot relay spawn-storm → typing focus loss)
- #100473 (Desktop app loses focus randomly while typing)
- #100675 (Bots page causes non-active pane rebuild every ~5s)
- #104094 (sessions.changed forces transcript refresh → pane flicker)

None of the existing PRs (#103525 etc.) address the **5s roster republish** path — they target the 30s relay drain loop or gateway heartbeat broadcast. This PR closes the roster-poll part of the picture.
