### PR TITLE
fix(cli): report the default profile's wrapper alias in list/show

### DIFF
--- a/hermes_cli/profile_cmd.py
+++ b/hermes_cli/profile_cmd.py
@@ -128,7 +128,7 @@ def _profile_list(args):
         name = format_profile_label(p.name, p.display_name)
         model = (p.model or "—")[:26]
         gw = "running" if p.gateway_running else "stopped"
-        alias = (p.alias_name or p.name) if p.alias_path and not p.is_default else "—"
+        alias = (p.alias_name or p.name) if p.alias_path else "—"
         dist = f"{p.distribution_name}@{p.distribution_version or '?'}"[:30] if p.distribution_name else "—"
         print(f"{marker}{name:<15} {model:<28} {gw:<12} {alias:<12} {dist}")
     print()

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -689,14 +689,17 @@ def list_profiles() -> List[ProfileInfo]:
     """Return info for all profiles, including the default."""
     profiles = []
     default_home = _get_default_hermes_home()
-    if default_home.is_dir():
-        profiles.append(_profile_info("default", default_home, is_default=True))
     named = _iter_named_profile_dirs()
-    if named:
-        alias_map = build_alias_map()  # ONCE, not per profile (was the dominant cost)
-        for entry in named:
-            alias_name = alias_map.get(normalize_profile_name(entry.name))
-            profiles.append(_profile_info(entry.name, entry, is_default=False, alias_name=alias_name))
+    # Built ONCE, not per profile (was the dominant cost); the default profile's
+    # wrapper alias is resolved from the same map as the named ones.
+    alias_map = build_alias_map()
+    if default_home.is_dir():
+        profiles.append(
+            _profile_info("default", default_home, is_default=True, alias_name=alias_map.get("default"))
+        )
+    for entry in named:
+        alias_name = alias_map.get(normalize_profile_name(entry.name))
+        profiles.append(_profile_info(entry.name, entry, is_default=False, alias_name=alias_name))
     return profiles
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -524,6 +524,20 @@ class TestListProfiles:
         assert "alpha" in names
         assert "beta" in names
 
+    def test_default_profile_surfaces_custom_alias(self, profile_env):
+        from hermes_cli.profiles import create_wrapper_script
+
+        create_wrapper_script("coach", target="default")
+        info = next(p for p in list_profiles() if p.is_default)
+        assert info.alias_name == "coach"
+        assert info.alias_path is not None
+        assert info.alias_path.name == "coach"
+
+    def test_default_without_wrapper_reports_no_alias(self, profile_env):
+        info = next(p for p in list_profiles() if p.is_default)
+        assert info.alias_name is None
+        assert info.alias_path is None
+
 
 # ===================================================================
 # TestActiveProfile
@@ -703,6 +717,36 @@ class TestFindAliasForProfile:
         assert info.alias_name == "qiaobusi"
         assert info.alias_path is not None
         assert info.alias_path.name == "qiaobusi"
+
+
+    def test_profile_list_renders_default_alias(self, profile_env, capsys):
+        from hermes_cli.profile_cmd import _profile_list
+        from hermes_cli.profiles import create_wrapper_script
+
+        create_wrapper_script("coach", target="default")
+        _profile_list(args=None)
+        out = capsys.readouterr().out
+        default_row = next(line for line in out.splitlines() if "default" in line)
+        assert "coach" in default_row
+
+
+    def test_profile_list_renders_dash_for_default_without_wrapper(self, profile_env, capsys):
+        from hermes_cli.profile_cmd import _profile_list
+
+        _profile_list(args=None)
+        out = capsys.readouterr().out
+        default_row = next(line for line in out.splitlines() if "default" in line)
+        assert "—" in default_row
+
+
+    def test_profile_status_prints_default_alias(self, profile_env, capsys):
+        from hermes_cli.profile_cmd import _profile_status
+        from hermes_cli.profiles import create_wrapper_script
+
+        create_wrapper_script("coach", target="default")
+        _profile_status(args=None)
+        out = capsys.readouterr().out
+        assert "Alias:          coach → hermes -p default" in out
 
 
 # ===================================================================


### PR DESCRIPTION
## What does this PR do?

`hermes profile list` always rendered the default (root) profile's Alias column as `—`, and `hermes profile` (status) omitted the `Alias:` line entirely, even when a wrapper script for the default profile exists and works. Aliasing the default profile is a supported operation (`create_wrapper_script` documents letting an alias point at any profile), so this is purely a reporting defect with two independent gaps downstream of a correct `build_alias_map()`:

1. `list_profiles()` only built the alias map inside the named-profiles loop, so the default entry's `ProfileInfo` was always constructed with `alias_name=None` — `hermes profile show` reads `alias_path`, hence it dropped the line too.
2. The list renderer additionally hard-forced the default's alias cell to `—` (`if p.alias_path and not p.is_default`).

The fix hoists `build_alias_map()` above the default branch (still built exactly once per call) and resolves the default's alias from the same map as named profiles, then drops the `is_default` override in the renderer. Downstream consumers (TUI, gateway, tools, plugins) don't read `alias_name`/`alias_path`; the only other consumer is the web profiles API, whose `has_alias` now reports `true` for the default when a wrapper exists — consistent with named profiles.

## Related Issue

Fixes #105027

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` — `list_profiles()`: build the alias map once up front and pass `alias_name=alias_map.get("default")` when constructing the default profile's `ProfileInfo`.
- `hermes_cli/profile_cmd.py` — `_profile_list()`: drop the `and not p.is_default` condition so the default's Alias column renders from `alias_path` like every other row.
- `tests/hermes_cli/test_profiles.py` — 5 regression tests: default surfaces its custom alias via `list_profiles()` (fields), default without a wrapper still reports no alias, `profile list` renders the alias for the default row (and `—` without a wrapper), and `profile` status prints the `Alias: coach → hermes -p default` line.

## How to Test

1. `python -m pytest tests/hermes_cli/test_profiles.py -q` — Observed result: 61 passed, 2 skipped (including the 5 new tests).
2. `python -m pytest tests/hermes_cli/test_profiles_sidebar_cache.py tests/hermes_cli/test_profiles_sidebar_scope.py tests/hermes_cli/test_profile_export_default_path.py tests/hermes_cli/test_profile_display_name.py tests/hermes_cli/test_profile_distribution.py tests/hermes_cli/test_web_profiles_off_loop.py tests/hermes_cli/test_web_server_profile_unification.py tests/hermes_cli/test_dashboard_profiles_nav_label.py -q` — Observed result: 140 passed (downstream consumers of `list_profiles()`).
3. Manual repro of the issue scenario in an isolated HOME: `create_wrapper_script("coach", target="default")` then `hermes profile list` / `hermes profile` — Observed result: the default row shows `coach` in the Alias column and status prints `Alias: coach → hermes -p default`; without a wrapper the column still renders `—`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

After the fix, with `~/.local/bin/coach` → `hermes -p default`:

```text
$ hermes profile list

 Profile          Model            Gateway      Alias        Distribution
 ───────────────    ───────────    ───────────    ───────────    ─────────────
 ◆default         —                stopped      coach        —

$ hermes profile

Active profile: default
Path:           ~/.hermes
Gateway:        stopped
Skills:         0 installed
Alias:          coach → hermes -p default
```
