### PR TITLE
fix(agent): scope usage anchors to the active model route

### DIFF
--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -148,10 +148,10 @@ def compute_session_context_breakdown(agent: Any, messages: Optional[List[dict]]
     # anchoring on the LAST response makes the meter sawtooth. Fall back to the
     # last-response anchor, then measured, then estimated.
     anchor = getattr(agent, "_turn_base_usage_anchor", None)
-    context_used = anchored_context_tokens(messages, anchor, charge_stale_thinking=False)
+    context_used = anchored_context_tokens(messages, anchor, route=agent, charge_stale_thinking=False)
     if context_used is None:
         anchor = getattr(agent, "_usage_anchor", None)
-        context_used = anchored_context_tokens(messages, anchor)
+        context_used = anchored_context_tokens(messages, anchor, route=agent)
     if context_used is None:
         measured_used = int(getattr(comp, "last_prompt_tokens", 0) or 0) if comp else 0
         context_used = measured_used if measured_used > 0 else estimated_total

--- a/agent/image_token_cost.py
+++ b/agent/image_token_cost.py
@@ -110,7 +110,7 @@ def calibrate_from_usage(agent: Any, messages: List[Dict[str, Any]], prompt_toke
     if n_images <= 0:
         return None
     with image_cost_context(0):
-        text_only = anchored_context_tokens(messages, anchor)
+        text_only = anchored_context_tokens(messages, anchor, route=agent)
     if text_only is None:
         return None
     per_image = (real - text_only) // n_images

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -39,7 +39,7 @@ def _preflight_request_tokens(
 ) -> int:
     """Token estimate for automatic preflight compression: a valid provider usage anchor,
     else the checkpoint-pruned native wire payload, else the generic estimator."""
-    anchored = anchored_context_tokens(messages, getattr(agent, "_usage_anchor", None))
+    anchored = anchored_context_tokens(messages, getattr(agent, "_usage_anchor", None), route=agent)
     agent._request_pressure_anchored = anchored is not None
     if anchored is not None:
         return anchored

--- a/agent/turn_preflight.py
+++ b/agent/turn_preflight.py
@@ -270,7 +270,7 @@ def compress_after_tool_results(
     # provider, post-disconnect, gateway restart), kept route-aware (#96995/#97602).
     from agent.usage_anchor import anchored_context_tokens
 
-    _anchored = anchored_context_tokens(messages, getattr(agent, "_usage_anchor", None))
+    _anchored = anchored_context_tokens(messages, getattr(agent, "_usage_anchor", None), route=agent)
     if _anchored is not None:
         _real_tokens = _anchored
     elif _compressor.last_prompt_tokens > 0:

--- a/agent/turn_request_assembly.py
+++ b/agent/turn_request_assembly.py
@@ -244,7 +244,7 @@ def assemble_api_request(
     )
     # Usage-anchored override: real prompt_tokens (incl. system + tool schemas) +
     # delta estimate replaces the whole-history heuristic when the anchor is fresh.
-    _anchored_pressure = anchored_context_tokens(messages, getattr(agent, "_usage_anchor", None))
+    _anchored_pressure = anchored_context_tokens(messages, getattr(agent, "_usage_anchor", None), route=agent)
     agent._request_pressure_anchored = _anchored_pressure is not None
     if _anchored_pressure is not None:
         request_pressure_tokens = _anchored_pressure

--- a/agent/usage_anchor.py
+++ b/agent/usage_anchor.py
@@ -11,7 +11,8 @@ The fingerprint (not ``id()``) is the identity: the gateway re-reads the transcr
 every turn and a resumed session runs in a fresh process, so object identity is never stable
 across the surfaces where the estimate mattered most (#99421, #104462). The anchor also persists
 on the session row (``model_config._usage_anchor``) so a restarted process can restore it; a
-restored anchor is honored only while the durable transcript still matches its fingerprint.
+restored anchor is honored only while both the durable transcript and the active model route
+match. Usage from another model, provider, endpoint or wire format cannot price this request.
 """
 
 from __future__ import annotations
@@ -76,11 +77,33 @@ def _anchor_matches(messages: List[Dict[str, Any]], anchor: Dict[str, Any]) -> b
     return isinstance(fp, str) and bool(fp) and message_fingerprint(base_msg) == fp
 
 
-def anchored_context_tokens(messages: List[Dict[str, Any]], anchor: Optional[Dict[str, Any]], *, charge_stale_thinking: bool = True) -> Optional[int]:
+def _route_fingerprint(route: Any) -> str:
+    from hermes_cli.providers import normalize_provider
+    from hermes_cli.route_identity import normalize_route_base_url
+
+    fields = [str(getattr(route, key, "") or "") for key in ("model", "provider", "base_url", "api_mode")]
+    fields[1] = normalize_provider(fields[1])
+    fields[2] = normalize_route_base_url(fields[2])
+    # Named custom providers persist their menu id, but the agent runs as "custom".
+    # Only fold that alias with a concrete endpoint to distinguish separate servers.
+    if fields[1].startswith("custom:") and fields[2]:
+        fields[1] = "custom"
+    # Do not persist credentials (including userinfo/query strings in custom endpoint URLs).
+    return hashlib.sha256(json.dumps(fields, ensure_ascii=True).encode()).hexdigest()
+
+
+def _route_matches(anchor: Any, route: Any) -> bool:
+    return isinstance(anchor, dict) and anchor.get("route_fp") == _route_fingerprint(route)
+
+
+def anchored_context_tokens(messages: List[Dict[str, Any]], anchor: Optional[Dict[str, Any]], *, route: Any = None, charge_stale_thinking: bool = True) -> Optional[int]:
     """Anchored prompt+completion tokens plus a rough estimate of ONLY the messages appended since;
     None when the anchor is missing or stale. The anchored response's own reply is skipped (already
-    in completion_tokens). ``charge_stale_thinking`` is forwarded to the delta estimate."""
+    in completion_tokens). Runtime consumers pass ``route`` to reject another route's usage,
+    including legacy anchors without provenance. ``charge_stale_thinking`` controls the delta."""
     if not isinstance(anchor, dict) or not isinstance(messages, list) or not _anchor_matches(messages, anchor):
+        return None
+    if route is not None and not _route_matches(anchor, route):
         return None
     from agent.model_metadata import estimate_messages_tokens_rough
 
@@ -103,8 +126,10 @@ def _serialize(anchor: Any) -> Optional[Dict[str, Any]]:
     fp, role = anchor.get("base_last_fp"), anchor.get("base_last_role")
     if pt <= 0 or base_count <= 0 or not isinstance(fp, str) or not fp:
         return None
+    route_fp = anchor.get("route_fp")
     return {"prompt_tokens": pt, "completion_tokens": max(0, ct), "base_count": base_count,
-            "base_last_role": role if isinstance(role, str) else None, "base_last_fp": fp}
+            "base_last_role": role if isinstance(role, str) else None, "base_last_fp": fp,
+            "route_fp": route_fp if isinstance(route_fp, str) else None}
 
 
 def persist_usage_anchor(agent: Any, anchor: Optional[Dict[str, Any]]) -> None:
@@ -122,9 +147,11 @@ def persist_usage_anchor(agent: Any, anchor: Optional[Dict[str, Any]]) -> None:
 
 
 def set_usage_anchor(agent: Any, anchor: Optional[Dict[str, Any]], *, turn_base: bool = False) -> None:
-    """Install ``anchor`` on the agent (``None`` clears) and mirror it to the session row."""
+    """Bind fresh usage to its reporting route (``None`` clears) and mirror it to the session row."""
+    if anchor is not None:
+        anchor = dict(anchor, route_fp=_route_fingerprint(agent))
     agent._usage_anchor = anchor
-    if turn_base or anchor is None:
+    if turn_base or anchor is None or not _route_matches(getattr(agent, "_turn_base_usage_anchor", None), agent):
         agent._turn_base_usage_anchor = anchor
     persist_usage_anchor(agent, anchor)
 
@@ -145,15 +172,15 @@ def restore_usage_anchor(agent: Any, conversation_history: Optional[List[Dict[st
         return
     if anchor is None:
         return
-    if _anchor_matches(conversation_history, anchor):
+    if _anchor_matches(conversation_history, anchor) and _route_matches(anchor, agent):
         agent._usage_anchor = anchor
     else:
         persist_usage_anchor(agent, None)
 
 
-def persisted_anchor_tokens(session_db: Any, session_id: Any, messages: Any) -> Optional[int]:
+def persisted_anchor_tokens(session_db: Any, session_id: Any, messages: Any, *, route: Any) -> Optional[int]:
     """Anchored token figure from the session row's persisted anchor, for callers without a live
-    agent (gateway hygiene); None when absent, unreadable, or stale against ``messages``."""
+    agent (gateway hygiene); None when absent, unreadable, or stale against messages/route."""
     getter = getattr(session_db, "get_session_model_config_value", None)
     if not session_id or not callable(getter) or not isinstance(messages, list):
         return None
@@ -162,4 +189,4 @@ def persisted_anchor_tokens(session_db: Any, session_id: Any, messages: Any) -> 
     except Exception:
         logger.debug("usage anchor load failed", exc_info=True)
         return None
-    return anchored_context_tokens(messages, anchor) if anchor else None
+    return anchored_context_tokens(messages, anchor, route=route) if anchor else None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3967,6 +3967,7 @@ class GatewayRunner(
         base_url: Optional[str]
         api_key: Optional[str]
         data: Any
+        api_mode: str = ""
 
     @dataclasses.dataclass
     class _HygieneAttempt:

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -554,6 +554,7 @@ class GatewayTurnMixin:
                 hs.provider = _hyg_runtime.get("provider") or hs.provider
                 hs.base_url = _hyg_runtime.get("base_url") or hs.base_url
                 hs.api_key = _hyg_runtime.get("api_key") or hs.api_key
+                hs.api_mode = _hyg_runtime.get("api_mode") or ""
 
             if hs.config_context_length is not None:
                 try:
@@ -614,6 +615,7 @@ class GatewayTurnMixin:
                 _session_db = getattr(self, "_session_db", None)
                 _anchored = persisted_anchor_tokens(
                     getattr(_session_db, "_db", _session_db), session_entry.session_id, history,
+                    route=hs,
                 )
             if session_entry.last_prompt_tokens > 0:
                 _approx_tokens, _token_source = session_entry.last_prompt_tokens, "actual"

--- a/hermes_cli/cli_status_bar_mixin.py
+++ b/hermes_cli/cli_status_bar_mixin.py
@@ -287,7 +287,7 @@ class CLIStatusBarMixin:
                 _anchored = anchored_context_tokens(
                     _msgs if isinstance(_msgs, list) else [],
                     getattr(agent, "_turn_base_usage_anchor", None),
-                    charge_stale_thinking=False)
+                    route=agent, charge_stale_thinking=False)
                 if _anchored is not None and _anchored > 0:
                     context_tokens = _anchored
                     anchor = agent._turn_base_usage_anchor

--- a/tests/agent/test_context_display_provenance.py
+++ b/tests/agent/test_context_display_provenance.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from agent.context_breakdown import compute_session_context_breakdown, render_context_breakdown_lines
 from agent.context_compressor import ContextCompressor
-from agent.usage_anchor import capture_usage_anchor
+from agent.usage_anchor import capture_usage_anchor, set_usage_anchor
 
 
 def test_context_provenance_follows_the_selected_number():
@@ -15,7 +15,7 @@ def test_context_provenance_follows_the_selected_number():
         for source in ("local_estimate", "provider_usage", "provider_usage_plus_estimate"):
             if source == "provider_usage":
                 comp.update_from_response({"prompt_tokens": 1234, "completion_tokens": 20})
-                agent._usage_anchor = capture_usage_anchor(1234, 20, messages)
+                set_usage_anchor(agent, capture_usage_anchor(1234, 20, messages))
                 messages.append({"role": "assistant", "content": "fixture answer"})
             elif source == "provider_usage_plus_estimate":
                 messages.append({"role": "user", "content": "a new unpriced question"})

--- a/tests/agent/test_image_token_cost.py
+++ b/tests/agent/test_image_token_cost.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 
 from agent import image_token_cost as itc
 from agent.model_metadata import estimate_messages_tokens_rough
-from agent.usage_anchor import anchored_context_tokens, capture_usage_anchor
+from agent.usage_anchor import anchored_context_tokens, capture_usage_anchor, set_usage_anchor
 
 
 def _img():
@@ -19,7 +19,9 @@ def _img():
 
 
 def _agent(anchor):
-    return SimpleNamespace(_usage_anchor=anchor, model="vision-local", base_url="http://127.0.0.1:8080/v1")
+    agent = SimpleNamespace(model="vision-local", base_url="http://127.0.0.1:8080/v1")
+    set_usage_anchor(agent, anchor)
+    return agent
 
 
 def _isolate(monkeypatch, tmp_path):

--- a/tests/agent/test_turn_base_display_anchor.py
+++ b/tests/agent/test_turn_base_display_anchor.py
@@ -21,7 +21,7 @@ Covers:
 from types import SimpleNamespace
 
 from agent.model_metadata import estimate_messages_tokens_rough
-from agent.usage_anchor import anchored_context_tokens, capture_usage_anchor
+from agent.usage_anchor import anchored_context_tokens, capture_usage_anchor, set_usage_anchor
 
 
 def _msg(role, content, **extra):
@@ -142,6 +142,8 @@ class TestContextBreakdownPrefersTurnBaseAnchor:
                 context_length=1_000_000, last_prompt_tokens=900_000
             ),
         )
+        set_usage_anchor(agent, turn_base, turn_base=True)
+        set_usage_anchor(agent, last_anchor)
         monkeypatch.setattr(
             "agent.system_prompt.build_system_prompt_parts",
             lambda a: {"stable": "sys", "context": "", "volatile": ""},
@@ -165,6 +167,8 @@ class TestContextBreakdownPrefersTurnBaseAnchor:
                 context_length=1_000_000, last_prompt_tokens=1
             ),
         )
+        set_usage_anchor(agent, last_anchor)
+        agent._turn_base_usage_anchor = None
         monkeypatch.setattr(
             "agent.system_prompt.build_system_prompt_parts",
             lambda a: {"stable": "sys", "context": "", "volatile": ""},
@@ -184,6 +188,7 @@ class TestInvalidationSitesClearTurnBaseAnchor:
         agent = SimpleNamespace(_usage_anchor=None, _turn_base_usage_anchor=None, _session_db=None, session_id=None)
         first = capture_usage_anchor(1_000, 10, messages)
         set_usage_anchor(agent, first, turn_base=True)
+        first = agent._turn_base_usage_anchor
         set_usage_anchor(agent, capture_usage_anchor(2_000, 10, messages))
         assert agent._turn_base_usage_anchor is first
         set_usage_anchor(agent, None)

--- a/tests/agent/test_usage_anchor.py
+++ b/tests/agent/test_usage_anchor.py
@@ -173,12 +173,13 @@ class TestAnchorInvalidation:
 
 class TestPreflightConsumer:
     def _agent(self, anchor):
-        return SimpleNamespace(
-            _usage_anchor=anchor,
+        agent = SimpleNamespace(
             tools=None,
             api_mode="",
             provider="openai",
         )
+        set_usage_anchor(agent, anchor)
+        return agent
 
     def test_preflight_prefers_anchor(self):
         messages = _history_with_images(10)

--- a/tests/agent/test_usage_anchor_route.py
+++ b/tests/agent/test_usage_anchor_route.py
@@ -107,6 +107,7 @@ def test_live_route_changes_require_fresh_usage(tmp_path, monkeypatch, transitio
             assert agent._try_activate_fallback()
         _record_usage(agent, history, 60_000)
         assert _pressures(agent, history) == (60_030,) * 3
+        assert compute_session_context_breakdown(agent, history)["context_source"] == "provider_usage"
 
         if transition == "fallback":
             assert agent._try_activate_fallback()
@@ -134,6 +135,9 @@ def test_live_route_changes_require_fresh_usage(tmp_path, monkeypatch, transitio
         assert _pressures(agent, history) == uncalibrated
         assert uncalibrated[0] == expected
         assert not agent._request_pressure_anchored
+        display = compute_session_context_breakdown(agent, history)
+        assert display["context_source"] == "local_estimate"
+        assert display["context_estimated"] is True
 
         # A usage-less response cannot make the previous route's anchor authoritative again.
         _record_usage(agent, history, None, call=2)
@@ -147,6 +151,9 @@ def test_live_route_changes_require_fresh_usage(tmp_path, monkeypatch, transitio
         # Normal response accounting installs the new baseline, including a mid-turn fallback's display anchor.
         _record_usage(agent, history, 12_000, call=3)
         assert _pressures(agent, history) == (12_030,) * 3
+        display = compute_session_context_breakdown(agent, history)
+        assert display["context_source"] == "provider_usage"
+        assert display["context_estimated"] is False
         assert agent.session_prompt_tokens == 60_000 + 12_000  # historical spend is retained
     finally:
         agent.close()

--- a/tests/agent/test_usage_anchor_route.py
+++ b/tests/agent/test_usage_anchor_route.py
@@ -1,0 +1,152 @@
+"""Provider usage prices a transcript only on the route that reported it."""
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.context_breakdown import compute_session_context_breakdown
+from agent.model_metadata import estimate_messages_tokens_rough, estimate_request_tokens_rough
+from agent.turn_context import _preflight_request_tokens
+from agent.turn_request_assembly import assemble_api_request
+from agent.turn_usage import record_response_usage
+from agent.usage_anchor import capture_usage_anchor, restore_usage_anchor, set_usage_anchor
+from hermes_state import SessionDB
+
+
+@pytest.mark.parametrize("provider,change,valid", [
+    ("custom", {}, True),
+    ("custom", {"base_url": "https://ROUTE-A.example:443/v1/"}, True),
+    ("custom", {"api_key": "rotated-test-key"}, True),
+    ("custom", {"model": "route-b-model"}, False),
+    ("custom", {"provider": "another-provider"}, False),
+    ("custom", {"base_url": "https://route-b.example/v1"}, False),
+    ("custom", {"api_mode": "anthropic_messages"}, False),
+    ("custom", {"legacy": True}, False),
+    ("custom", {"provider": "custom:local"}, True),
+    ("custom:local", {"provider": "custom"}, True),
+    ("custom", {"provider": "custom:local", "base_url": "https://route-b.example/v1"}, False),
+], ids=["same-route", "normalized-endpoint", "rotated-key", "model", "provider", "endpoint", "api-mode", "legacy",
+        "runtime-to-menu-provider", "menu-to-runtime-provider", "custom-provider-other-endpoint"])
+def test_restored_usage_requires_same_route(tmp_path, provider, change, valid):
+    from gateway.run_turn import GatewayTurnMixin
+
+    route = dict(model="route-a-model", provider=provider,
+                 base_url="https://route-a.example/v1", api_mode="chat_completions")
+    sid = "route-reload"
+    with SessionDB(tmp_path / "state.db") as db:
+        db.create_session(sid, source="cli")
+        db.append_message(sid, role="user", content="Review the implementation.")
+        history = db.get_messages_as_conversation(sid)
+        agent = SimpleNamespace(**route, session_id=sid, _session_db=db)
+        set_usage_anchor(agent, capture_usage_anchor(60_000, 30, history))
+        if change.get("legacy"):
+            # Before route provenance was recorded, the persisted blob had only transcript identity.
+            db.patch_session_model_config(sid, {"_usage_anchor": capture_usage_anchor(60_000, 30, history)})
+
+    route.update({key: value for key, value in change.items() if key != "legacy"})
+    with SessionDB(tmp_path / "state.db") as db:
+        history = db.get_messages_as_conversation(sid)
+        # Gateway hygiene reads before a live agent exists; exercise the real DB consumer too.
+        gateway = GatewayTurnMixin()
+        gateway._session_db = db
+        settings = SimpleNamespace(**{**route, "api_key": "offline-test-key"},
+                                   config_context_length=200_000, threshold_pct=0.85, hard_msg_limit=5000)
+        entry = SimpleNamespace(session_id=sid, last_prompt_tokens=0)
+        plan = asyncio.run(gateway._hmwa_hygiene_plan(settings, history, entry, sid))
+        assert plan.approx_tokens == (60_030 if valid else estimate_messages_tokens_rough(history))
+
+        resumed = SimpleNamespace(**route, session_id=sid, _session_db=db, _usage_anchor=None, tools=None)
+        restore_usage_anchor(resumed, history)
+        expected = 60_030 if valid else estimate_request_tokens_rough(history, system_prompt="sys")
+        assert _preflight_request_tokens(resumed, history, "sys") == expected
+        assert resumed._request_pressure_anchored is valid
+
+
+def _record_usage(agent, history, prompt_tokens, *, call=1):
+    usage = None if prompt_tokens is None else dict(prompt_tokens=prompt_tokens, completion_tokens=30,
+                                                  total_tokens=prompt_tokens + 30)
+    record_response_usage(agent, SimpleNamespace(usage=usage), messages=history, api_call_count=call,
+                          api_duration=0, compression_attempts=0, max_compression_attempts=3)
+
+
+def _pressures(agent, history):
+    preflight = _preflight_request_tokens(agent, history, "sys")
+    assembled = assemble_api_request(
+        agent, messages=history, current_turn_user_idx=0, _ext_prefetch_cache=None,
+        _plugin_user_context=None, moa_config=None, active_system_prompt="sys",
+        original_user_message=history[0]["content"], pending_moa_prepared_request=None,
+        request_logger=logging.getLogger(__name__),
+    )
+    display = compute_session_context_breakdown(agent, history)
+    return preflight, assembled.request_pressure_tokens, display["context_used"]
+
+
+@pytest.mark.parametrize("transition", ["switch", "fallback", "restore_primary", "failed_switch"])
+def test_live_route_changes_require_fresh_usage(tmp_path, monkeypatch, transition):
+    from agent import image_token_cost
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(image_token_cost, "_LEARNED", {})
+    monkeypatch.setattr(image_token_cost, "_LOADED", True)
+    destination = dict(model="gpt-4.1-mini", provider="custom", api_key="offline-test-key",
+                       base_url="https://route-a.example/v1", api_mode="chat_completions")
+    agent = AIAgent(
+        model="gpt-4.1", provider="custom", api_key="offline-test-key",
+        base_url=destination["base_url"], session_id="live-route", enabled_toolsets=[],
+        quiet_mode=True, skip_context_files=True, skip_memory=True, save_trajectories=False,
+    )
+    try:
+        history = [{"role": "user", "content": "Review the implementation."}]
+        if transition in {"fallback", "restore_primary"}:
+            agent._fallback_chain = [destination]
+        if transition == "restore_primary":
+            assert agent._try_activate_fallback()
+        _record_usage(agent, history, 60_000)
+        assert _pressures(agent, history) == (60_030,) * 3
+
+        if transition == "fallback":
+            assert agent._try_activate_fallback()
+        elif transition == "restore_primary":
+            assert agent._restore_primary_runtime()
+        else:
+            switch_args = {**destination, "new_model": destination["model"], "new_provider": destination["provider"]}
+            del switch_args["model"], switch_args["provider"]
+            if transition == "failed_switch":
+                # Only client construction fails; the real switch must roll back its runtime.
+                with patch.object(agent, "_create_openai_client", side_effect=RuntimeError("client unavailable")):
+                    with pytest.raises(RuntimeError, match="client unavailable"):
+                        agent.switch_model(**switch_args)
+            else:
+                agent.switch_model(**switch_args)
+
+        if transition == "failed_switch":
+            assert _pressures(agent, history) == (60_030,) * 3
+            return
+
+        expected = estimate_request_tokens_rough(history, system_prompt="sys", tools=agent.tools or None)
+        # A foreign anchor must behave exactly like having no reading yet, at every consumer.
+        with patch.object(agent, "_usage_anchor", None), patch.object(agent, "_turn_base_usage_anchor", None):
+            uncalibrated = _pressures(agent, history)
+        assert _pressures(agent, history) == uncalibrated
+        assert uncalibrated[0] == expected
+        assert not agent._request_pressure_anchored
+
+        # A usage-less response cannot make the previous route's anchor authoritative again.
+        _record_usage(agent, history, None, call=2)
+        assert _preflight_request_tokens(agent, history, "sys") == expected
+        image_history = history + [{"role": "assistant", "content": "ok"}, {
+            "role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}],
+        }]
+        assert image_token_cost.calibrate_from_usage(agent, image_history, 64_100) is None
+        assert image_token_cost._LEARNED == {}
+
+        # Normal response accounting installs the new baseline, including a mid-turn fallback's display anchor.
+        _record_usage(agent, history, 12_000, call=3)
+        assert _pressures(agent, history) == (12_030,) * 3
+        assert agent.session_prompt_tokens == 60_000 + 12_000  # historical spend is retained
+    finally:
+        agent.close()


### PR DESCRIPTION
## What does this PR do?

After a model/provider switch, `_usage_anchor` can still price the next request using the previous route's token usage. A resumed session has the same problem when its transcript matches but its route has changed. The compressor resets its own counters on a switch, but the independent anchor previously checked only transcript identity and could override that reset.

Scope usage anchors to the model, provider, normalized endpoint and API mode, and validate that scope at their existing consumers. Different routes and legacy anchors without provenance use the existing estimator until a normal response reports fresh usage. Same-route restarts, equivalent endpoint spellings and credential rotation retain valid readings; no calibration-only model request is added.

## Related Issue

No dedicated issue; found by tracing model-switch and session-restore paths. Related background: #99585 introduced persisted usage anchors.

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/usage_anchor.py`: persist an opaque route fingerprint, reject mismatched readings and establish a new display baseline when a fallback changes routes mid-turn. Canonicalize named custom-provider menu ids against their runtime id while retaining endpoint isolation.
- Pass the current route through preflight/request/post-tool pressure, context display, CLI status, image-cost calibration and gateway persisted-anchor reads. Gateway hygiene carries its resolved API mode.
- Add two parameterized behavior tests covering DB close/reopen, live switch, fallback, primary restoration, failed-switch rollback, usage-less responses and fresh-usage adoption; adapt existing fixtures to install scoped anchors through the normal setter. Preserve the upstream context-source labels and verify that a route switch shows a local estimate until fresh provider usage arrives.

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_usage_anchor_route.py
```

- Identical regression tests on unmodified main `6e2b8e070d`: **9 failed, 6 passed**. The failures demonstrate foreign-route usage being reused, not import/setup errors.
- This branch: **15 passed**. Related agent, model-switch/fallback, CLI and gateway suites: **273 passed across 21 files**, retries disabled.
- Ruff, `git diff --check` and `scripts/check_compat_pointers.py` passed.
- Manually tested the classic CLI on macOS with a custom endpoint: normal reply → `/context` → `/model <other-model> --session` → `/context` before another reply → normal reply → `/context`, then restart/resume and continue. The interim figure used category estimates; after the resumed reply, `/context` matched the persisted destination anchor exactly: **19,937 input + 6 output = 19,943 tokens**. Its fingerprint matched the new model and rejected the previous model. This live manual acceptance used commit `8d3e425dca` before the rebase; the current integration is covered by the automated tests above. The full repository suite and a new live manual run were not performed.

## Checklist

- [x] Read the contributing guide; commit follows Conventional Commits.
- [x] Searched open and closed PRs for duplicate usage-anchor/model-route fixes.
- [x] One focused fix; no unrelated commits.
- [x] Relevant tests run with `scripts/run_tests.sh`; regression proven red on main.
- [x] Manually tested on macOS.
- [x] Updated relevant docstrings; configuration, tool schemas and architecture documentation are N/A.
- [x] Considered cross-platform behavior: this changes Python accounting and existing session persistence, with no OS-specific paths or APIs.
