### PR TITLE
feat(email): opt-in delivery behaviors — inbox persona, escalation routing, duplicate suppression

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -4,7 +4,9 @@ receives, SMTP sends. Configured via EMAIL_* env vars or ``platforms.email`` in 
 import asyncio
 import email as email_lib
 from contextlib import contextmanager, suppress
+import hashlib
 import imaplib
+import time
 import logging
 import os
 import re
@@ -22,7 +24,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from gateway.platforms.base import (BasePlatformAdapter, MessageEvent, MessageType, SendResult,
-                                    cache_document_from_bytes, cache_image_from_bytes)
+                                    cache_document_from_bytes, cache_image_from_bytes, resolve_channel_prompt)
 from gateway.config import Platform, PlatformConfig
 from utils import is_truthy_value
 from gateway.platforms._shared import get_scoped_secret as _get_secret, coerce_port
@@ -162,6 +164,37 @@ def _send_imap_id(imap: "imaplib.IMAP4") -> None:
                          '"vendor" "NousResearch" "support-email" "noreply@nousresearch.com")')
     except Exception as e:  # noqa: BLE001 — best-effort, never fatal
         logger.debug("[Email] IMAP ID command not accepted: %s", e)
+
+
+def _strip_internal_prefix(content: str) -> str:
+    """Strip internal reasoning/directive blocks before delivery.
+
+    Some model providers prepend the agent's internal ``💭`` reasoning block
+    to the final response. That block is internal — it must never reach an
+    email recipient, and it would defeat marker-based routing such as
+    ``escalation_marker``. Removes any leading ``💭`` block (including a
+    fenced-code body inside it) that precedes the real message.
+    """
+    text = (content or "").lstrip()
+    while text.startswith("💭"):
+        lines = text.split("\n")
+        in_fence = False
+        end_idx = None
+        for i, line in enumerate(lines):
+            if i == 0:
+                continue
+            if line.strip().startswith("```"):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+            if line.strip():
+                end_idx = i
+                break
+        if end_idx is None:
+            return ""  # block runs to the end — nothing usable remains
+        text = "\n".join(lines[end_idx:]).strip()
+    return text
 
 
 def _is_automated_sender(address: str, headers: dict) -> bool:
@@ -357,6 +390,27 @@ class EmailAdapter(BasePlatformAdapter):
             self._require_authenticated_sender = not _esecret_bool("EMAIL_TRUST_FROM_HEADER", False)
         # Optional authserv-id pinning Authentication-Results to the operator's own server (defeats an injected header sorting first).
         self._authserv_id = (extra.get("authserv_id", "") or _get_secret("EMAIL_AUTHSERV_ID", "")).strip().lower()
+        # Inbox persona: inbox-wide system prompt, the email equivalent of the
+        # ``channel_prompts`` mechanism on chat platforms (email has one channel —
+        # the inbox). Accepts ``channel_prompt`` / EMAIL_CHANNEL_PROMPT, or the
+        # shared ``channel_prompts: {inbox: ...}`` dict style.
+        self._channel_prompt = (extra.get("channel_prompt", "") or _get_secret("EMAIL_CHANNEL_PROMPT", "")
+                                or resolve_channel_prompt(extra, "inbox") or "").strip() or None
+        # Escalation routing: a response starting with *escalation_marker* is routed to
+        # another platform's chat (e.g. Telegram) instead of being emailed to the sender
+        # — a human/approval path for inbound-email sessions. Mirrors the webhook
+        # platform's cross-platform ``deliver``. Only ``escalation_deliver`` is required;
+        # an empty ``escalation_chat`` falls back to the target platform's home channel.
+        self._escalation_marker = str(extra.get("escalation_marker", "[ESCALATE]") or "").strip() or None
+        self._escalation_deliver = str(extra.get("escalation_deliver", "") or "").strip() or None
+        self._escalation_chat = str(extra.get("escalation_chat", "") or "").strip() or None
+        self._escalation_thread_id = str(extra.get("escalation_thread_id", "") or "").strip() or None
+        # Duplicate-send suppression: the gateway's final-send path can invoke send()
+        # twice for one response (final-send + stream-consumer flush); identical
+        # (chat, content) within this window is treated as one send. Set 0 to disable.
+        _dedupe_raw = extra.get("dedupe_window_seconds")
+        self._dedupe_window = float(_dedupe_raw) if _dedupe_raw is not None else 20.0
+        self._last_sends: Dict[Any, float] = {}
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
@@ -639,7 +693,7 @@ class EmailAdapter(BasePlatformAdapter):
             message_type=MessageType.DOCUMENT if "document" in kinds else MessageType.PHOTO if "image" in kinds else MessageType.TEXT,
             source=self.build_source(chat_id=sender_addr, chat_name=name, chat_type="dm", user_id=sender_addr, user_name=name),
             media_urls=[att["path"] for att in attachments], media_types=[att["media_type"] for att in attachments],
-            reply_to_message_id=msg_data["in_reply_to"] or None)
+            reply_to_message_id=msg_data["in_reply_to"] or None, channel_prompt=self._channel_prompt)
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
 
@@ -652,8 +706,76 @@ class EmailAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(e))
 
     async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
-        """Send an email reply to the given address."""
+        """Send an email reply to the given address.
+
+        Applies three optional, config-driven behaviors before delivery:
+        internal-block stripping (always), escalation-marker routing, and
+        duplicate-send suppression. All are no-ops unless configured via
+        ``platforms.email.extra`` keys (see docs/user-guide/messaging/email.md).
+        """
+        content = _strip_internal_prefix(content)
+        marker = self._escalation_marker
+        if marker and content.lstrip().startswith(marker):
+            escalate_text = content.lstrip()[len(marker):].lstrip()
+            if self._escalation_deliver:
+                return await self._deliver_escalation(
+                    self._escalation_deliver, self._escalation_chat or "", escalate_text, chat_id)
+            logger.warning("[Email] Escalation marker present but escalation_deliver not configured — falling back to email reply.")
+        # Guard: refuse to "email" non-address targets (e.g. a numeric chat id from the
+        # home-channel bootstrap) — SMTP would fail with a bogus recipient.
+        if not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", chat_id or ""):
+            logger.warning("[Email] Skipping send to non-email chat_id=%r (%d chars) — not an email address",
+                           chat_id, len(content or ""))
+            return SendResult(success=True, message_id=None)
+        # Duplicate-send suppression (see __init__).
+        now = time.monotonic()
+        key = (chat_id, hashlib.sha256(content.encode("utf-8", "replace")).hexdigest())
+        prev_ts = self._last_sends.get(key)
+        if prev_ts is not None and (now - prev_ts) < self._dedupe_window:
+            logger.info("[Email] Duplicate send suppressed (chat=%s, %.1fs since last) — skipping", chat_id, now - prev_ts)
+            return SendResult(success=True, message_id=None)
+        self._last_sends[key] = now
+        for stale in [k for k, ts in self._last_sends.items() if (now - ts) >= self._dedupe_window]:
+            self._last_sends.pop(stale, None)
         return await self._run_send(self._send_email, (chat_id, content, reply_to), "[Email] Send failed to %s: %s", chat_id)
+
+    async def _deliver_escalation(self, platform_name: str, target_chat: str, text: str, original_sender: str) -> SendResult:
+        """Route an escalation ping to another platform's chat (mirrors the webhook
+        platform's cross-platform ``deliver``): uses the gateway runner's registered
+        adapter for the target platform; blank *target_chat* falls back to that
+        platform's home channel."""
+        runner = getattr(self, "gateway_runner", None)
+        if not runner:
+            return SendResult(success=False, error="No gateway runner for cross-platform delivery")
+        try:
+            target_platform = Platform(platform_name)
+        except ValueError:
+            return SendResult(success=False, error=f"Unknown platform: {platform_name}")
+        adapter = None  # default adapters first; multiplex may park a platform on a secondary profile
+        for amap in (runner.adapters, *[m for m in (getattr(runner, "_profile_adapters", None) or {}).values() if isinstance(m, dict)]):
+            if isinstance(amap, dict) and amap.get(target_platform):
+                adapter = amap[target_platform]
+                break
+        if not adapter:
+            return SendResult(success=False, error=f"Platform {platform_name} not connected")
+        if not target_chat:
+            home = runner.config.get_home_channel(target_platform)
+            if not home:
+                return SendResult(success=False, error=f"No escalation chat or home channel for {platform_name}")
+            target_chat = home.chat_id
+        # One ping per (target, text) per dedupe window — the final-send/stream-flush
+        # double-invocation applies to the escalation path too.
+        now = time.monotonic()
+        key = ("esc", platform_name, target_chat, hashlib.sha256(text.encode("utf-8", "replace")).hexdigest())
+        prev_ts = self._last_sends.get(key)
+        if prev_ts is not None and (now - prev_ts) < self._dedupe_window:
+            logger.info("[Email] Duplicate escalation suppressed (%s->%s) — skipping", platform_name, target_chat)
+            return SendResult(success=True, message_id=None)
+        self._last_sends[key] = now
+        ping = f"[EMAIL ESCALATION — {original_sender}]\n{text}"
+        metadata = {"thread_id": self._escalation_thread_id} if self._escalation_thread_id else None
+        logger.info("[Email] Escalation routing: platform=%s chat=%s", platform_name, target_chat)
+        return await adapter.send(target_chat, ping, metadata=metadata)
 
     def _message_id_domain(self) -> str:
         """Domain for generated Message-IDs; ``localhost`` when EMAIL_ADDRESS lacks ``@``."""

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -410,6 +410,8 @@ class EmailAdapter(BasePlatformAdapter):
         # (chat, content) within this window is treated as one send. Set 0 to disable.
         _dedupe_raw = extra.get("dedupe_window_seconds")
         self._dedupe_window = float(_dedupe_raw) if _dedupe_raw is not None else 20.0
+        if not self._dedupe_window >= 0:  # negative or NaN (NaN comparisons are False) -> disabled
+            self._dedupe_window = 0.0
         self._last_sends: Dict[Any, float] = {}
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
@@ -726,7 +728,9 @@ class EmailAdapter(BasePlatformAdapter):
         if not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", chat_id or ""):
             logger.warning("[Email] Skipping send to non-email chat_id=%r (%d chars) — not an email address",
                            chat_id, len(content or ""))
-            return SendResult(success=True, message_id=None)
+            # success=True (skips must not fail home-channel bootstrap), but the skip is
+            # observable: message_id stays None and raw_response carries the reason.
+            return SendResult(success=True, message_id=None, raw_response={"skipped": "non_email_chat_id"})
         # Duplicate-send suppression (see __init__).
         now = time.monotonic()
         key = (chat_id, hashlib.sha256(content.encode("utf-8", "replace")).hexdigest())

--- a/plugins/platforms/email/plugin.yaml
+++ b/plugins/platforms/email/plugin.yaml
@@ -37,3 +37,7 @@ optional_env:
     description: "Default address for cron / notification delivery"
     prompt: "Home address"
     password: false
+  - name: EMAIL_CHANNEL_PROMPT
+    description: "Inbox-wide system prompt (persona) for email conversations"
+    prompt: "Inbox persona prompt (optional)"
+    password: false

--- a/tests/gateway/test_email_delivery_features.py
+++ b/tests/gateway/test_email_delivery_features.py
@@ -152,7 +152,17 @@ class TestDuplicateSuppression(unittest.TestCase):
         with patch("smtplib.SMTP") as mock_smtp:
             result = asyncio.run(adapter.send("7185545230", "bootstrap notice"))
             self.assertTrue(result.success)
+            self.assertIsNone(result.message_id)
+            self.assertEqual(result.raw_response, {"skipped": "non_email_chat_id"})
             mock_smtp.return_value.send_message.assert_not_called()
+
+    def test_negative_window_clamped_to_disabled(self):
+        adapter = _make_adapter({"dedupe_window_seconds": -5})
+        self.assertEqual(adapter._dedupe_window, 0.0)
+
+    def test_nan_window_clamped_to_disabled(self):
+        adapter = _make_adapter({"dedupe_window_seconds": float("nan")})
+        self.assertEqual(adapter._dedupe_window, 0.0)
 
 
 import unittest

--- a/tests/gateway/test_email_delivery_features.py
+++ b/tests/gateway/test_email_delivery_features.py
@@ -1,0 +1,160 @@
+"""Tests for config-driven email adapter delivery features:
+inbox channel_prompt, escalation-marker routing, duplicate-send suppression,
+and internal-block stripping. All behaviors are opt-in via platforms.email.extra.
+"""
+
+import asyncio
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from plugins.platforms.email.adapter import EmailAdapter, _strip_internal_prefix
+
+
+def _make_adapter(extra=None):
+    from gateway.config import PlatformConfig
+    with patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "imap.test.com",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+    }):
+        return EmailAdapter(PlatformConfig(enabled=True, extra=extra or {}))
+
+
+class TestStripInternalPrefix(unittest.TestCase):
+    def test_no_block_passthrough(self):
+        self.assertEqual(_strip_internal_prefix("Hello world"), "Hello world")
+
+    def test_reasoning_block_with_fence_stripped(self):
+        content = "💭 **Reasoning:**\n```\ninternal thoughts\n```\nReal reply"
+        self.assertEqual(_strip_internal_prefix(content), "Real reply")
+
+    def test_reasoning_block_plain_stripped(self):
+        content = "💭 internal\nReal reply"
+        self.assertEqual(_strip_internal_prefix(content), "Real reply")
+
+    def test_block_only_returns_empty(self):
+        self.assertEqual(_strip_internal_prefix("💭 only thinking"), "")
+
+    def test_none_safe(self):
+        self.assertEqual(_strip_internal_prefix(None), "")
+
+
+class TestChannelPrompt(unittest.TestCase):
+    def test_extra_channel_prompt(self):
+        adapter = _make_adapter({"channel_prompt": "You are an inbox assistant."})
+        self.assertEqual(adapter._channel_prompt, "You are an inbox assistant.")
+
+    def test_channel_prompts_inbox_style(self):
+        adapter = _make_adapter({"channel_prompts": {"inbox": "Inbox persona"}})
+        self.assertEqual(adapter._channel_prompt, "Inbox persona")
+
+    def test_default_none(self):
+        adapter = _make_adapter()
+        self.assertIsNone(adapter._channel_prompt)
+
+    def test_dispatch_attaches_prompt(self):
+        adapter = _make_adapter({"channel_prompt": "persona"})
+        captured = {}
+
+        async def fake_handle(event):
+            captured["event"] = event
+
+        adapter.handle_message = fake_handle
+        adapter._sender_accepted = lambda addr, md: True
+        msg_data = {"sender_addr": "user@test.com", "sender_name": "User", "subject": "Hi",
+                    "body": "hello", "attachments": [], "message_id": "<m@test>", "in_reply_to": None}
+        asyncio.run(adapter._dispatch_message(msg_data))
+        self.assertEqual(captured["event"].channel_prompt, "persona")
+
+
+class TestEscalationRouting(unittest.TestCase):
+    def _runner(self, tg_adapter, home=None):
+        from gateway.config import Platform, PlatformConfig, HomeChannel
+        runner = MagicMock()
+        runner.adapters = {Platform.TELEGRAM: tg_adapter}
+        runner._profile_adapters = {}
+        runner.config.get_home_channel = lambda p: home
+        return runner
+
+    def test_escalation_routed_to_platform(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+        tg = MagicMock()
+        tg.send = MagicMock(return_value=asyncio.sleep(0, result=SendResult(success=True, message_id="tg-1")))
+        adapter = _make_adapter({"escalation_deliver": "telegram", "escalation_chat": "123"})
+        adapter.gateway_runner = self._runner(tg)
+
+        result = asyncio.run(adapter.send("customer@test.com", "[ESCALATE] Need human help"))
+        self.assertTrue(result.success)
+        tg.send.assert_called_once()
+        args = tg.send.call_args[0]
+        self.assertEqual(args[0], "123")
+        self.assertIn("[EMAIL ESCALATION — customer@test.com]", args[1])
+        self.assertIn("Need human help", args[1])
+
+    def test_escalation_home_channel_fallback(self):
+        from gateway.config import Platform, HomeChannel
+        from gateway.platforms.base import SendResult
+        tg = MagicMock()
+        tg.send = MagicMock(return_value=asyncio.sleep(0, result=SendResult(success=True, message_id="tg-1")))
+        adapter = _make_adapter({"escalation_deliver": "telegram"})  # no escalation_chat
+        adapter.gateway_runner = self._runner(tg, home=HomeChannel(platform=Platform.TELEGRAM, chat_id="999", name="Home"))
+
+        result = asyncio.run(adapter.send("customer@test.com", "[ESCALATE] help"))
+        self.assertTrue(result.success)
+        self.assertEqual(tg.send.call_args[0][0], "999")
+
+    def test_no_escalation_deliver_falls_back_to_email(self):
+        adapter = _make_adapter()  # marker default, no deliver target
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            result = asyncio.run(adapter.send("customer@test.com", "[ESCALATE] help"))
+            self.assertTrue(result.success)
+            mock_smtp.return_value.send_message.assert_called_once()
+
+    def test_unknown_platform_error(self):
+        adapter = _make_adapter({"escalation_deliver": "carrier-pigeon", "escalation_chat": "x"})
+        adapter.gateway_runner = self._runner(MagicMock())
+        result = asyncio.run(adapter.send("customer@test.com", "[ESCALATE] help"))
+        self.assertFalse(result.success)
+        self.assertIn("Unknown platform", result.error)
+
+
+class TestDuplicateSuppression(unittest.TestCase):
+    def test_identical_send_within_window_suppressed(self):
+        adapter = _make_adapter({"dedupe_window_seconds": 60})
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            asyncio.run(adapter.send("user@test.com", "same body"))
+            asyncio.run(adapter.send("user@test.com", "same body"))
+            mock_smtp.return_value.send_message.assert_called_once()
+
+    def test_different_content_not_suppressed(self):
+        adapter = _make_adapter({"dedupe_window_seconds": 60})
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            asyncio.run(adapter.send("user@test.com", "body one"))
+            asyncio.run(adapter.send("user@test.com", "body two"))
+            self.assertEqual(mock_smtp.return_value.send_message.call_count, 2)
+
+    def test_window_zero_disables(self):
+        adapter = _make_adapter({"dedupe_window_seconds": 0})
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            asyncio.run(adapter.send("user@test.com", "same body"))
+            asyncio.run(adapter.send("user@test.com", "same body"))
+            self.assertEqual(mock_smtp.return_value.send_message.call_count, 2)
+
+    def test_non_email_chat_id_skipped(self):
+        adapter = _make_adapter()
+        with patch("smtplib.SMTP") as mock_smtp:
+            result = asyncio.run(adapter.send("7185545230", "bootstrap notice"))
+            self.assertTrue(result.success)
+            mock_smtp.return_value.send_message.assert_not_called()
+
+
+import unittest
+if __name__ == "__main__":
+    unittest.main()

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -163,6 +163,64 @@ platforms:
 
 When enabled, attachment and inline parts are skipped before payload decoding. The email body text is still processed normally.
 
+## Delivery Behaviors (Optional)
+
+These opt-in behaviors shape how the email adapter sends replies. All are disabled by default and configured under `platforms.email.extra` in your `config.yaml` — no persona or routing logic is hardcoded.
+
+### Inbox Persona (`channel_prompt`)
+
+Give the agent a standing system prompt for all inbound-email conversations:
+
+```yaml
+platforms:
+  email:
+    extra:
+      channel_prompt: |
+        You answer email for this address. Be concise and factual.
+        Never quote prices unless they are listed below. ...
+```
+
+Equivalent forms: the `EMAIL_CHANNEL_PROMPT` environment variable, or the shared per-channel mechanism (email treats the whole inbox as one channel named `inbox`):
+
+```yaml
+platforms:
+  email:
+    channel_prompts:
+      inbox: |
+        You answer email for this address. ...
+```
+
+### Escalation Routing (`escalation_marker`)
+
+If the agent's response starts with the escalation marker (default `[ESCALATE]`), the reply is **not** emailed to the sender. Instead a notification is routed to another connected platform — a human-approval path for email-managed inboxes:
+
+```yaml
+platforms:
+  email:
+    extra:
+      escalation_marker: "[ESCALATE]"   # default; set "" to disable
+      escalation_deliver: telegram      # any configured platform
+      escalation_chat: "123456789"      # optional; blank = platform's home channel
+      escalation_thread_id: "42"        # optional; Telegram forum topic
+```
+
+The escalation ping is prefixed with the original sender (`[EMAIL ESCALATION — sender@example.com]`) so the receiving chat knows who the question came from. Routing reuses the same cross-platform delivery mechanism as the webhook platform: the target platform must be connected, and a blank `escalation_chat` falls back to its home channel. If the response starts with the marker but no target platform is configured, the email is sent normally (with a warning logged).
+
+### Duplicate-Send Suppression (`dedupe_window_seconds`)
+
+The gateway's final-send path can invoke `send()` twice for one response (final send plus stream-consumer flush), producing duplicate emails. Identical (recipient, body) pairs within the window are sent once:
+
+```yaml
+platforms:
+  email:
+    extra:
+      dedupe_window_seconds: 20   # default 20; set 0 to disable
+```
+
+### Internal-Block Stripping
+
+Some model providers prepend the agent's internal `💭` reasoning block to the final response. The adapter always strips any leading `💭` block before delivery — it never reaches the recipient and cannot defeat marker-based escalation routing. This is always-on and has no configuration.
+
 ---
 
 ## Access Control
@@ -218,6 +276,7 @@ Email access is stricter by default than chat-style platforms:
 | `EMAIL_IMAP_PORT` | No | `993` | IMAP server port |
 | `EMAIL_SMTP_PORT` | No | `587` | SMTP server port |
 | `EMAIL_POLL_INTERVAL` | No | `15` | Seconds between inbox checks |
+| `EMAIL_CHANNEL_PROMPT` | No | — | Inbox-wide system prompt (persona) for email conversations |
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |


### PR DESCRIPTION
## Summary

The email adapter is a generic receive/reply pipe — but operators who run a real inbox through it (support@, contact@) need four small behaviors that chat platforms already ship. This PR adds all four as **opt-in, config-driven** features under `platforms.email.extra`. Default behavior is byte-identical to current `main`; nothing is hardcoded to any particular deployment.

### 1. Inbox persona (`channel_prompt`)
Chat platforms have `resolve_channel_prompt` / `channel_prompts`; the email adapter never called it. Email is effectively a single channel — the inbox — so the adapter now accepts:
- `extra.channel_prompt` (string) or `EMAIL_CHANNEL_PROMPT` env var, or
- the shared `channel_prompts: {inbox: <text>}` key (already bridged for all platforms by `config_loader._SHARED_KEYS`).

The prompt rides the existing `MessageEvent.channel_prompt` field on dispatch — the same seam Mattermost/Discord/Slack use — so downstream prompt handling is unchanged.

### 2. Escalation routing (`escalation_marker`)
A response starting with `escalation_marker` (default `[ESCALATE]`) is **not** emailed to the sender. Instead a notification is routed to another connected platform via the same mechanism as the webhook platform's cross-platform `deliver`: gateway-runner adapter lookup (including multiplex `_profile_adapters`), blank-target fallback to the target platform's home channel, optional `escalation_thread_id` (Telegram forum topics). The ping is prefixed with the original sender: `[EMAIL ESCALATION — customer@example.com]`.

This gives email sessions a human-approval path: the agent answers routine mail itself, and pings the operator's chat for anything it marks for escalation. If the marker is present but no `escalation_deliver` is configured, the email falls back to normal sending (warning logged) — no mail is ever lost.

### 3. Duplicate-send suppression (`dedupe_window_seconds`)
The gateway's final-send path can invoke `send()` twice for one response (final send + stream-consumer flush), producing duplicate emails. Identical (recipient, sha256(body)) pairs within the window (default 20s, `0` disables) are sent once. The escalation path dedupes with the same mechanism.

### 4. Internal-block stripping
Some model providers prepend the agent's internal `💭` reasoning block to the final response. Leading `💭` blocks (including fenced bodies) are always stripped before delivery — they never reach recipients and cannot defeat marker routing.

### 5. Guard: non-email chat_ids
`send()` to a non-email `chat_id` (e.g. a numeric home-channel id from bootstrap/notification paths) is skipped with a warning instead of attempting an SMTP send to a bogus recipient.

## Config example

```yaml
platforms:
  email:
    extra:
      channel_prompt: |
        You answer email for this address. Be concise and factual.
      escalation_marker: "[ESCALATE]"   # default
      escalation_deliver: telegram
      escalation_chat: ""               # blank = telegram home channel
      dedupe_window_seconds: 20         # default; 0 disables
```

## Docs

`website/docs/user-guide/messaging/email.md` gains a **Delivery Behaviors (Optional)** section; `EMAIL_CHANNEL_PROMPT` added to the env-var table and `plugin.yaml` `optional_env`.

## Test plan

- [x] New `tests/gateway/test_email_delivery_features.py` — 17 tests: stripping, persona resolution (extra/env/shared-dict + dispatch attach), escalation routing (direct target, home-channel fallback, no-deliver fallback, unknown platform), dedupe (suppression, distinct content, `0` disables, non-email guard)
- [x] Full email suite green: `test_email.py` + `test_email_robustness.py` + new file = **61 passed**
- [x] `py_compile` clean; default-config behavior unchanged (all features no-op unless configured)