### PR TITLE
fix: make desktop error messages selectable and copyable

### DIFF
--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -461,7 +461,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   if (tile?.error) {
     return (
       <div className="grid h-full place-items-center p-4">
-        <div className="max-w-[24rem] space-y-2 text-center font-mono text-[11px]">
+        <div className="max-w-[24rem] space-y-2 text-center font-mono text-[11px]" data-selectable-text="true">
           <div className="text-(--ui-danger,#f87171)">Couldn't open this session</div>
           <div className="break-words text-(--ui-text-quaternary)">{tile.error}</div>
           <Button onClick={() => patchSessionTile(storedSessionId, { error: undefined })} size="sm" variant="outline">

--- a/apps/desktop/src/components/ui/error-state.tsx
+++ b/apps/desktop/src/components/ui/error-state.tsx
@@ -21,6 +21,7 @@ export function ErrorBanner({ children, className }: { children: ReactNode; clas
         'flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-destructive',
         className
       )}
+      data-selectable-text="true"
     >
       <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
       <span className="min-w-0 whitespace-pre-wrap break-words">{children}</span>
@@ -45,7 +46,7 @@ export interface ErrorStateProps {
 // Dialog callers can pass DialogTitle/DialogDescription for accessibility.
 export function ErrorState({ children, className, description, icon, title }: ErrorStateProps) {
   return (
-    <div className={cn('grid gap-5', className)}>
+    <div className={cn('grid gap-5', className)} data-selectable-text="true">
       <div className="flex flex-col items-center gap-3 text-center">
         {icon ?? <ErrorIcon />}
 


### PR DESCRIPTION
## Problem

The desktop app applies a global `user-select: none` rule (`apps/desktop/src/styles.css:767-768`). Specific surfaces opt back in via `data-selectable-text="true"`, which triggers the `[data-selectable-text='true'], [data-selectable-text='true'] * { user-select: text }` rule at `styles.css:1235-1238`. This pattern is already used by ~20 surfaces (log view, terminal output, notifications, chat transcript, preview console, kanban drawer, etc.).

The error display components were missing this attribute, so error messages could not be selected or copied:

- **`ErrorState`** — used by the React error boundary, boot-failure overlay, update errors, session-import errors, and contrib pane boundaries
- **`ErrorBanner`** — used by messaging platform errors and MCP config pane errors
- **Session tile error view** — the "Couldn't open this session" message that shows the session ID and error detail

Users hitting these errors couldn't copy the session ID or error text to file an issue or debug.

## Fix

Add `data-selectable-text="true"` to three root elements:

| File | Element | Lines |
|---|---|---|
| `apps/desktop/src/components/ui/error-state.tsx` | `ErrorBanner` root `<div>` | +1 |
| `apps/desktop/src/components/ui/error-state.tsx` | `ErrorState` root `<div>` | modified 1 |
| `apps/desktop/src/app/chat/session-tile.tsx` | Session tile error `<div>` | modified 1 |

This follows the exact same pattern already established by `LogView`, `terminal-output`, `notifications`, `preview-console`, `chat/log-tail`, and 14 other surfaces.

## Coverage

All canonical error surfaces in the app use one of these two shared components:

- **`ErrorState`** → `error-boundary.tsx` (React boundary fallback), `updates-overlay.tsx` (update/boot failure), `session-import/index.tsx` (scan/preview errors), `contrib/react/boundary.tsx` (pane fallback), `chat/index.tsx` (chat session error)
- **`ErrorBanner`** → `messaging/index.tsx` (platform connection errors), `skills/mcp-tab.tsx` (MCP server config errors)

Plus the inline session tile error view in `session-tile.tsx`.

Note: some ad-hoc inline error displays (e.g. form validation messages in dialogs, status-stack rows) also lack the attribute, but those are out of scope — they're either short transient messages or sit inside parent containers that already carry the attribute.

## Verification

- ✅ TypeScript typecheck passes (`tsc --noEmit`)
- ✅ ESLint passes on both changed files (prop ordering per `perfectionist/sort-jsx-props`)
- ✅ All 12 existing error-boundary tests pass (`vitest run src/components/error-boundary.test.tsx`)
- ✅ Branch rebased onto latest upstream `main` (`693641aa`)
