### PR TITLE
fix(agent): surface default profile alias in list/show

### DIFF
--- a/hermes_cli/profile_cmd.py
+++ b/hermes_cli/profile_cmd.py
@@ -128,7 +128,7 @@ def _profile_list(args):
         name = format_profile_label(p.name, p.display_name)
         model = (p.model or "—")[:26]
         gw = "running" if p.gateway_running else "stopped"
-        alias = (p.alias_name or p.name) if p.alias_path and not p.is_default else "—"
+        alias = (p.alias_name or p.name) if p.alias_path else "—"
         dist = f"{p.distribution_name}@{p.distribution_version or '?'}"[:30] if p.distribution_name else "—"
         print(f"{marker}{name:<15} {model:<28} {gw:<12} {alias:<12} {dist}")
     print()

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -689,14 +689,25 @@ def list_profiles() -> List[ProfileInfo]:
     """Return info for all profiles, including the default."""
     profiles = []
     default_home = _get_default_hermes_home()
-    if default_home.is_dir():
-        profiles.append(_profile_info("default", default_home, is_default=True))
     named = _iter_named_profile_dirs()
-    if named:
-        alias_map = build_alias_map()  # ONCE, not per profile (was the dominant cost)
-        for entry in named:
-            alias_name = alias_map.get(normalize_profile_name(entry.name))
-            profiles.append(_profile_info(entry.name, entry, is_default=False, alias_name=alias_name))
+    alias_map = build_alias_map() if (default_home.is_dir() or named) else {}
+    # ONCE, not per profile (was the dominant cost); the default gets the same
+    # lookup so a wrapper targeting it (``hermes profile alias default --name x``)
+    # is reported instead of silently dropped.
+    if default_home.is_dir():
+        profiles.append(
+            _profile_info(
+                "default",
+                default_home,
+                is_default=True,
+                alias_name=alias_map.get("default"),
+            )
+        )
+    for entry in named:
+        alias_name = alias_map.get(normalize_profile_name(entry.name))
+        profiles.append(
+            _profile_info(entry.name, entry, is_default=False, alias_name=alias_name)
+        )
     return profiles
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -705,6 +705,36 @@ class TestFindAliasForProfile:
         assert info.alias_path.name == "qiaobusi"
 
 
+    def test_list_profiles_surfaces_default_alias(self, profile_env):
+        """A wrapper activating the root/default profile is reported on its row —
+        ``hermes profile alias default --name coach`` is a supported operation."""
+        from hermes_cli.profiles import create_wrapper_script, list_profiles
+        create_wrapper_script("coach", target="default")
+        info = next(p for p in list_profiles() if p.is_default)
+        assert info.alias_name == "coach"
+        assert info.alias_path is not None
+        assert info.alias_path.name == "coach"
+
+
+    def test_list_profiles_default_without_wrapper_stays_barren(self, profile_env):
+        from hermes_cli.profiles import list_profiles
+        info = next(p for p in list_profiles() if p.is_default)
+        assert info.alias_name is None
+        assert info.alias_path is None
+
+
+    def test_profile_list_table_renders_default_alias(self, profile_env, capsys):
+        from hermes_cli.profile_cmd import _profile_list
+        from hermes_cli.profiles import create_wrapper_script
+        create_wrapper_script("coach", target="default")
+        _profile_list(None)
+        out = capsys.readouterr().out
+        default_row = next(
+            line for line in out.splitlines() if line.lstrip(" ◆").startswith("default")
+        )
+        assert "coach" in default_row
+
+
 # ===================================================================
 # TestRenameProfile
 # ===================================================================


### PR DESCRIPTION
Resolves #105027.

The symptom: `hermes profile list` and `profile show default` render "—" for the default profile's alias even after `hermes profile alias default --name coach`.

The root cause: `list_profiles()` built its own alias_map for only *named* profiles and skipped the default; renderers had a `not p.is_default` guard stripping even existing alias state. And `show default` used the outdated `find_alias_name(profile_name)` helper that hardcoded "default" as unwrappable.

**What changes:**
- `list_profiles()` now hoists `build_alias_map()` and looks up `"default"` explicitly.
- `_profile_list` renderer drops the `not p.is_default` check, relying solely on `p.alias_path`.
- `_profile_show` remains on main (it already calls `find_alias_for_profile(name)`, which correctly resolves default-wrapper paths).

**Coverage:**
- `test_list_profiles_surfaces_default_alias`: programmatic check that `ProfileInfo.alias_name == "coach"`.
- `test_list_profiles_default_without_wrapper_stays_barren`: confirms no false positives for an unwrapped default.
- `test_profile_list_table_renders_default_alias`: live CLI table smoke.

All new tests green; broader profile-suite (test_profile_distribution, test_profile_display_name, test_cron_profile_enumeration_lightweight, test_gateway_multiplex_status, test_deleted_profile_tombstone) passes without regressions.