### PR TITLE
fix(codex_responses): skip empty assistant fallback when a serialized function_call follows reasoning

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -487,10 +487,21 @@ def _chat_messages_to_responses_input(
         emit(message_items, msg)
         if not message_items:
             # Every reasoning item needs a following item (else missing_following_item), hence the "" fallback.
-            fallback = content_parts or (content_text if content_text.strip() else "" if reasoning_items else None)
+            # BUT a trailing function_call is itself a following item — and several Responses backends
+            # (Volcengine ARK api/plan) reject a synthetic {"role":"assistant","content":""} item with
+            # 400 MissingParameter: missing input.content (#volc-vision, reproduced on v0.21 2026-09-07:
+            # any thinking-only + tool-call assistant turn 400s on its next replay). So compute the
+            # function_call items first and only fall back to "" when nothing follows the reasoning.
+            tool_call_items = _replay_tool_call_items(msg, start_index=len(items))
+            fallback = content_parts or (
+                content_text if content_text.strip()
+                else "" if reasoning_items and not tool_call_items else None
+            )
             if fallback is not None:
                 emit([{"role": "assistant", "content": fallback}], msg)
-        emit(_replay_tool_call_items(msg, start_index=len(items)), msg)
+        else:
+            tool_call_items = _replay_tool_call_items(msg, start_index=len(items))
+        emit(tool_call_items, msg)
     # The server renders nothing placed before a compaction item, so pre-checkpoint history is
     # dead weight and plaintext asks / merged summaries silently vanish. Keep the newest checkpoint
     # first, retain pre-checkpoint USER and SUMMARY messages within a token budget, leave the tail.

--- a/tests/agent/test_codex_responses_empty_assistant_fallback.py
+++ b/tests/agent/test_codex_responses_empty_assistant_fallback.py
@@ -1,0 +1,78 @@
+"""Thinking-only assistant turns must not emit a synthetic empty-content assistant
+item on the Responses wire.
+
+Volcengine ARK api/plan rejects {"role": "assistant", "content": ""} with
+400 MissingParameter: missing input.content. The "" fallback exists to satisfy
+OpenAI's "every reasoning item needs a following item" rule, but a trailing
+function_call IS a following item — so when the turn has tool_calls, the empty
+message is redundant and toxic on strict backends (#volc-vision, reproduced
+2026-09-07 on v0.21 with doubao-seed-evolving / glm-5.3-flash).
+"""
+from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+
+def _thinking_only_turn_messages():
+    return [
+        {"role": "user", "content": "看看这张图"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_abc", "type": "function",
+                "function": {"name": "vision_analyze", "arguments": '{"image": "x.png"}'},
+            }],
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "ENC123", "summary": []},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_abc", "content": "图片内容是..."},
+    ]
+
+
+def test_thinking_only_tool_turn_has_no_empty_assistant_item():
+    items = _chat_messages_to_responses_input(_thinking_only_turn_messages())
+    types = [it.get("type") for it in items]
+    assert "reasoning" in types and "function_call" in types
+    assert not [
+        it for it in items
+        if it.get("role") == "assistant" and it.get("content") == ""
+    ]
+
+
+def test_reasoning_with_no_following_item_still_gets_empty_fallback():
+    """OpenAI requires a following item after reasoning; with no tool_calls and
+    no text there is nothing to follow, so the "" fallback must remain."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "ENC123", "summary": []},
+            ],
+        },
+    ]
+    items = _chat_messages_to_responses_input(messages)
+    assert any(
+        it.get("role") == "assistant" and it.get("content") == "" for it in items
+    )
+
+
+def test_text_reply_turn_keeps_content_after_reasoning():
+    """A text reply replays its own content after the reasoning items — the
+    fallback path must not change it."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "你好！",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "ENC123", "summary": []},
+            ],
+        },
+    ]
+    items = _chat_messages_to_responses_input(messages)
+    assistant_texts = [
+        it.get("content") for it in items if it.get("role") == "assistant"
+    ]
+    assert "你好！" in assistant_texts


### PR DESCRIPTION
## Summary

Fixes #75202. Supersedes #75250 / #83959 (closed unmerged).

When the codex_responses adapter replays a thinking-only assistant turn (encrypted reasoning + tool_calls, no visible text), it emits `{"role": "assistant", "content": ""}` as the reasoning item's required follower. Strict Responses backends — concretely **Volcengine Ark Agent Plan** (`/api/plan/v3/responses`) — reject that item with `400 MissingParameter: missing input.content`, and because the poisoned wire replays every turn, the session is bricked.

## Root cause

`_chat_messages_to_responses_input()` computed the "" fallback *before* looking at tool_calls, so it could not know that a serialized `function_call` was about to follow the reasoning items. A trailing `function_call` **is** a valid follower for a reasoning item (that is exactly what #75250's review flagged: checking the raw `tool_calls` list is not enough — the *serialized* items must be known first).

## Change

Compute `_replay_tool_call_items()` first, then decide the fallback:

- reasoning + serialized function_call → no empty item at all (function_call is the follower)
- reasoning + nothing following → keep the "" fallback (OpenAI's `missing_following_item` rule is preserved)
- reasoning + visible text → unchanged (text itself follows)

## Verification

E2E against the real Ark Agent Plan endpoint (doubao-seed-evolving, 2026-09-07):

1. Live call: got `encrypted_content` + `function_call` (get_time) — HTTP 200
2. Old wire (reasoning + empty assistant + fc + fco): **HTTP 400** `MissingParameter: missing input.content` — reproduced
3. Patched wire (reasoning + fc + fco, no empty item): **HTTP 200**, model answered the tool flow correctly

Unit tests: `tests/agent/test_codex_responses_empty_assistant_fallback.py` (3 cases: no-empty-on-tool-turn, empty-fallback-kept-when-nothing-follows, text-turn-unchanged), plus existing `test_codex_responses_adapter.py` (26) and `test_stale_replay_prune.py` — all green.

## Note

One deliberate trade-off: with a synthetic fallback emitted, `function_call` hash-derived call_ids index off by one vs. the old order. Explicit/canonical call_ids (the overwhelmingly common path) are unaffected; the deterministic hash fallback only shifts in the rare no-explicit-id case, and the tool side pairs via its own stored `tool_call_id`, so pairing is stable.
