### PR TITLE
fix(gateway): adopt the user D-Bus session when systemd starts the gateway

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2064,6 +2064,26 @@ def _ensure_user_systemd_env() -> None:
             os.environ["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path={bus_path}"
 
 
+def _adopt_user_bus_when_started_by_systemd() -> None:
+    """Point a systemd-launched gateway at its own user bus before it boots (#104893).
+
+    A *system*-level unit (``/etc/systemd/system``, ``User=<someone>``) is exec'd with
+    neither ``XDG_RUNTIME_DIR`` nor ``DBUS_SESSION_BUS_ADDRESS``, and a process environment
+    is fixed at exec time — so ``systemd-run --user`` fails for the whole lifetime of that
+    gateway even once ``/run/user/<uid>/bus`` is up.  Every restart-safe worker crosses that
+    seam (``tools.process_registry.restart_safe_gateway_child_argv``) and it fails closed by
+    design, so cron and Kanban dispatch died at every fire on headless service installs.
+    ``_ensure_user_systemd_env`` derives both values from our own uid and adopts them only
+    when the runtime dir is really ours and the socket really exists, so a host with no user
+    manager keeps its honest "unavailable" verdict instead of a fabricated bus address.
+    Doing it here rather than at the dispatch seam matters: worker environments are snapshots
+    of ``os.environ`` taken at different points, so the adoption has to precede all of them.
+    """
+    if os.name != "posix" or not os.environ.get("INVOCATION_ID"):
+        return
+    _ensure_user_systemd_env()
+
+
 def _wait_for_user_dbus_socket(timeout: float = 3.0) -> bool:
     """Poll up to ``timeout`` s for a user systemd control socket (user@.service takes a moment after enable-linger)."""
     deadline = time.monotonic() + timeout
@@ -4528,6 +4548,8 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
     _absorb = _windows_gateway_should_absorb_console_controls()
     if _absorb:
         _absorb_windows_console_controls()
+
+    _adopt_user_bus_when_started_by_systemd()
 
     # Refresh the systemd unit on every boot so restart settings stay current even after an
     # exit-code-75 respawn (stale-code or /restart), which bypasses `hermes gateway restart`.

--- a/tests/hermes_cli/test_gateway_user_bus_adoption.py
+++ b/tests/hermes_cli/test_gateway_user_bus_adoption.py
@@ -1,0 +1,83 @@
+"""#104893: a systemd-launched gateway must adopt its own user bus at boot.
+
+A *system*-level unit (``/etc/systemd/system``, ``User=<someone>``) is exec'd with
+neither ``XDG_RUNTIME_DIR`` nor ``DBUS_SESSION_BUS_ADDRESS``, and a process environment
+is fixed at exec time.  ``systemd-run --user`` is the seam every restart-safe cron and
+Kanban worker crosses, and it fails closed by design — so on a headless service install
+every agent-driven scheduled job died at dispatch, even once the user manager was up.
+"""
+
+import os
+
+import pytest
+
+import hermes_cli.gateway as gw
+
+
+class _BootReached(Exception):
+    """Stands in for the first boot step past the adoption call."""
+
+
+def _fake_user_bus(monkeypatch, *, present: bool) -> str:
+    """Fake the on-disk state ``loginctl enable-linger`` leaves behind (or its absence)."""
+    runtime_dir = f"/run/user/{os.getuid()}"
+    monkeypatch.setattr(
+        gw, "_runtime_dir_is_ours", lambda d: present and str(d) == runtime_dir)
+    monkeypatch.setattr(
+        gw, "_path_exists_safe", lambda p: present and str(p) == f"{runtime_dir}/bus")
+    return runtime_dir
+
+
+def _service_manager_env(monkeypatch) -> None:
+    """The environment systemd hands a system-level unit: no bus, but INVOCATION_ID."""
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+    monkeypatch.setenv("INVOCATION_ID", "system-unit-104893")
+
+
+@pytest.mark.linux_only
+def test_service_gateway_boot_adopts_its_user_bus(monkeypatch):
+    runtime_dir = _fake_user_bus(monkeypatch, present=True)
+    _service_manager_env(monkeypatch)
+    for guard in (
+        "_guard_official_docker_root_gateway",
+        "_guard_named_profile_under_multiplexer",
+        "_guard_supervised_gateway_conflict",
+        "_guard_existing_gateway_process_conflict",
+        "_apply_startup_watchdog_config",
+    ):
+        monkeypatch.setattr(gw, guard, lambda *_a, **_kw: None)
+
+    def _stop_here() -> bool:
+        raise _BootReached
+
+    # First boot step after the adoption — stop there instead of starting a gateway.
+    monkeypatch.setattr(gw, "supports_systemd_services", _stop_here)
+
+    with pytest.raises(_BootReached):
+        gw.run_gateway()
+
+    assert os.environ["XDG_RUNTIME_DIR"] == runtime_dir
+    assert os.environ["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={runtime_dir}/bus"
+
+    # Worker environments are snapshots of os.environ taken at various points in the
+    # dispatch paths, so the bus address must also survive the secret scrubber they all
+    # go through — otherwise systemd-run still cannot connect and the fix is a no-op.
+    from tools.environments.local import build_subprocess_env
+
+    worker_env = build_subprocess_env(scrub_secrets=True)
+    assert worker_env["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={runtime_dir}/bus"
+
+
+@pytest.mark.linux_only
+def test_absent_user_bus_is_never_fabricated(monkeypatch):
+    """Fail closed, never invent. With no user manager the env must stay bare so the
+    scope probe keeps reaching its honest "unavailable" verdict — a bus address pointing
+    at nothing would turn a clear dispatch refusal into a confusing connect failure."""
+    _fake_user_bus(monkeypatch, present=False)
+    _service_manager_env(monkeypatch)
+
+    gw._adopt_user_bus_when_started_by_systemd()
+
+    assert "XDG_RUNTIME_DIR" not in os.environ
+    assert "DBUS_SESSION_BUS_ADDRESS" not in os.environ

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -234,9 +234,15 @@ def restart_safe_gateway_child_argv(
     if not _is_supervised_gateway_process() or not os.environ.get("INVOCATION_ID"):
         return command
     if not _systemd_run_user_scope_available():
+        # This text is what the operator actually sees: it is stored as the cron
+        # execution's error and printed on the job row, so it names the remedy
+        # rather than only the symptom.
         raise RuntimeError(
             "cannot create restart-safe systemd scope for gateway child: "
-            "systemd-run --user --scope is unavailable"
+            "systemd-run --user --scope is unavailable — this gateway has no reachable "
+            f"user D-Bus session (expected /run/user/{os.getuid()}/bus). On a system-level "  # windows-footgun: ok — behind the _IS_LINUX return above
+            "service install, run `sudo loginctl enable-linger <gateway-user>` and restart "
+            "the gateway."
         )
     scoped = _build_systemd_scope_argv(command, unit_suffix=unit_suffix)
     if scoped == command:


### PR DESCRIPTION
## Summary

Fixes #104893.

A **system**-level unit (`/etc/systemd/system`, `User=<someone>`) is exec'd with neither `XDG_RUNTIME_DIR` nor `DBUS_SESSION_BUS_ADDRESS`, and a process environment is fixed at exec time. So `systemd-run --user --scope` fails for the entire lifetime of that gateway — even after `loginctl enable-linger` brings the user manager up and `/run/user/<uid>/bus` is reachable. That is the seam every restart-safe worker crosses (`tools/process_registry.py::restart_safe_gateway_child_argv`), and it fails closed by design, so on headless systemd hosts every agent-driven cron job and every Kanban dispatch died at launch with nothing but `error` on the job row.

The reporter's own measurements make the shape clear: 2/2 and 7/7 fires failed across two hosts from the first fire after the update, and `enable-linger` **alone** did not fix it — the load-bearing half of their manual workaround was a drop-in adding the two `Environment=` lines to the unit.

### The fix

`hermes_cli/gateway.py::_ensure_user_systemd_env()` already does exactly what that drop-in does: it derives both values from our own uid and adopts them **only** when `/run/user/<uid>` is really ours and the socket really exists. It was simply wired exclusively to the `systemctl` management paths (`_systemd_scope_preamble` → `_preflight_user_systemd`), never to the gateway's own boot. This calls it from `run_gateway()`, the single in-process boot every entry point goes through (`gateway run` from the unit's `ExecStart`, plus the `_cmd_start` foreground fallbacks), gated on POSIX + `INVOCATION_ID` — the same marker the consuming seam requires.

**Why boot and not the dispatch seam.** Worker environments are `os.environ` snapshots taken at different points: cron builds `worker_env` *after* the scope check (`cron/scheduler.py`), Kanban builds `env` *before* it (`hermes_cli/kanban_db_dispatch.py::_default_spawn`). Normalizing inside the probe would make the verdict right while the Kanban worker still got a bus-less env — probe passes, spawn fails. One adoption before every snapshot fixes both call paths.

### What is deliberately *not* changed

- **The fail-closed posture stays.** The issue is explicit that falling back to in-process execution is not wanted, and the comment at the raise site documents why. With no user manager at all, the probe still reports unavailable and dispatch still refuses.
- **No auto `enable-linger`, no new startup preflight hook, no config knob.** The remaining genuine-failure case only needed to become *actionable*, and the raise already reaches the operator: `run_one_job` logs it and stores it as the execution's error. So the message now names the remedy (`sudo loginctl enable-linger <gateway-user>` + restart) alongside the symptom, rather than adding a second reporting path. Existing tests matching `systemd-run --user --scope is unavailable` / `restart-safe systemd scope` still match.
- Nothing is fabricated: a host with no `/run/user/<uid>` keeps a bare environment, so the probe's verdict stays honest instead of pointing `systemd-run` at a bus that doesn't exist.

After this, `enable-linger` + a gateway restart is sufficient on a system-service install; the drop-in override is no longer needed.

## Test plan

Two invariant tests in `tests/hermes_cli/test_gateway_user_bus_adoption.py` (`linux_only`, matching the existing markers on this machinery in `tests/cron/test_restart_safe_worker.py`):

- `test_service_gateway_boot_adopts_its_user_bus` — drives the **real** `run_gateway()` boot with the service-manager environment (bus vars absent, `INVOCATION_ID` set) and a live `/run/user/<uid>/bus`, then asserts the bus address reaches the worker env the dispatch paths build via `build_subprocess_env(scrub_secrets=True)`. That last assertion matters: if those keys were ever added to the scrubber's strip list the whole fix would be a silent no-op.
- `test_absent_user_bus_is_never_fabricated` — no user manager, no env mutation.

Both **red on base** (the first on the behaviour, `KeyError: 'XDG_RUNTIME_DIR'`), green with the fix, verified on a POSIX host by temporarily swapping the marker.

```
scripts/run_tests.sh tests/cron/ tests/hermes_cli/ tests/gateway/ tests/tools/test_process_registry.py
```

Everything in the touched areas passes (`tests/cron/` 100%, `tests/hermes_cli/test_gateway*.py`, `test_kanban_gateway_restart_handoff.py`). This macOS dev host has 20 pre-existing failures in unrelated files (wecom callback, buzz adapter, scale-to-zero, launchd hints, `test_process_registry.py`'s unmarked systemd-cgroup tests); I confirmed the identical set on a clean `upstream/main` worktree, so none of them come from this change.

```
scripts/check-windows-footguns.py hermes_cli/gateway.py tools/process_registry.py   # clean
```