### PR TITLE
fix(gateway): bot discriminator for profile_routes and secondary adapter isolation (#104933)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2333,6 +2333,36 @@ class BasePlatformAdapter(ABC):
         :meth:`_session_key_profile` so adapter-level keys leave ``agent:main:``."""
         self._owner_profile = None if (name := (profile_name or "").strip() or None) == "default" else name
 
+    def bot_identifier(self) -> Optional[str]:
+        """Return the bot username or ID for this adapter, if discoverable."""
+        for attr in ("_current_bot_username", "current_bot_username"):
+            fn = getattr(self, attr, None)
+            if callable(fn):
+                with contextlib.suppress(Exception):
+                    val = fn()
+                    if val:
+                        return str(val).lstrip("@").strip()
+        for attr in (
+            "_bot_username", "bot_username", "_bot_username_observed",
+            "_bot_id", "bot_id", "_bot_user_id", "bot_user_id",
+        ):
+            val = getattr(self, attr, None)
+            if isinstance(val, (str, int)) and str(val).strip():
+                return str(val).lstrip("@").strip()
+        client = getattr(self, "_client", None)
+        if client is not None:
+            user = getattr(client, "user", None)
+            if user is not None:
+                val = getattr(user, "name", None) or getattr(user, "id", None)
+                if val:
+                    return str(val).lstrip("@").strip()
+        bot = getattr(self, "_bot", None)
+        if bot is not None:
+            val = getattr(bot, "username", None) or getattr(bot, "id", None)
+            if val:
+                return str(val).lstrip("@").strip()
+        return None
+
     def _session_key_profile(self, source: Optional[Any] = None) -> Optional[str]:
         """Profile namespace for an adapter-derived session key. Ingress runs BEFORE the runner
         stamps ``source.profile``, so without this every bot in a multiplexed gateway shares one
@@ -4162,28 +4192,36 @@ class BasePlatformAdapter(ABC):
         scope_id: Optional[str] = None, guild_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None, message_id: Optional[str] = None,
         role_authorized: bool = False, auto_thread_created: bool = False,
-        auto_thread_initial_name: Optional[str] = None) -> SessionSource:
+        auto_thread_initial_name: Optional[str] = None,
+        bot: Optional[str] = None) -> SessionSource:
         """Build a SessionSource; with ``gateway.profile_routes`` configured the matching
         profile is stamped on ``source.profile`` for per-profile HERMES_HOME isolation."""
         def _opt(value) -> Optional[str]:
             return str(value) if value else None
+        resolved_bot = bot or self.bot_identifier()
         fields = dict(
             platform=self.platform, chat_id=str(chat_id), chat_name=chat_name, chat_type=chat_type,
             user_id=_opt(user_id), user_name=user_name, thread_id=_opt(thread_id),
             chat_topic=(chat_topic or "").strip() or None, user_id_alt=user_id_alt,
             chat_id_alt=chat_id_alt, is_bot=is_bot, scope_id=_opt(scope_id),
             guild_id=_opt(guild_id), parent_chat_id=_opt(parent_chat_id),
-            message_id=_opt(message_id))
+            message_id=_opt(message_id), bot=_opt(resolved_bot))
+        owner_profile = getattr(self, "_owner_profile", None)
         profile, profile_route_rejected = None, False  # profile from configured routes, if any
         if self.gateway_runner is not None:
             from gateway.profile_routing import ProfileRouteRejected
             try:
-                profile = self.gateway_runner._profile_name_for_source(SessionSource(**fields))
+                profile = self.gateway_runner._profile_name_for_source(
+                    SessionSource(**fields),
+                    adapter_profile=owner_profile,
+                )
             except ProfileRouteRejected:
                 profile_route_rejected = True
             except Exception:
                 logger.warning("Profile resolution failed for %s/%s, defaulting to active profile",
                                self.platform, chat_id, exc_info=True)
+        elif owner_profile:
+            profile = owner_profile
         source = SessionSource(**fields, profile=profile, role_authorized=role_authorized,
                                auto_thread_created=auto_thread_created,
                                auto_thread_initial_name=auto_thread_initial_name)

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -57,23 +57,41 @@ class ProfileRoute:
     guild_id: Optional[str] = None
     chat_id: Optional[str] = None
     thread_id: Optional[str] = None
+    bot: Optional[str] = None
     enabled: bool = True
 
     @property
     def specificity(self) -> int:
         """Higher value = more specific match."""
-        return 2 * bool(self.guild_id) + 4 * bool(self.chat_id) + 8 * bool(self.thread_id)
+        return (
+            2 * bool(self.guild_id)
+            + 4 * bool(self.chat_id)
+            + 8 * bool(self.thread_id)
+            + 16 * bool(self.bot)
+        )
 
     def matches(
         self, platform: str, guild_id: Optional[str] = None, chat_id: Optional[str] = None,
         thread_id: Optional[str] = None, parent_chat_id: Optional[str] = None,
+        bot: Optional[str] = None, adapter_profile: Optional[str] = None,
     ) -> bool:
         """True if every discriminator the route declares holds (AND).
 
         ``chat_id`` matches the channel directly or as the parent of a thread/forum post; WhatsApp
         ``chat_id`` also matches across number/JID/LID after the exact check (groups/broadcasts stay exact-only).
+        If ``adapter_profile`` is set (dedicated secondary adapter), a generic route without an
+        explicit ``bot`` discriminator does not match so it cannot hijack the secondary adapter.
         """
         if not self.enabled or self.platform != platform:
+            return False
+        if self.bot:
+            if not bot:
+                return False
+            if self.bot.lstrip("@").lower() != str(bot).lstrip("@").lower():
+                return False
+        elif adapter_profile is not None:
+            # Generic route without explicit bot discriminator must not hijack
+            # messages arriving at a dedicated secondary profile's adapter.
             return False
         if self.thread_id and self.thread_id != thread_id:
             return False
@@ -133,11 +151,16 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
         except (ValueError, ImportError):
             logger.warning("Skipping profile route %s: invalid profile name %r", name, profile)
             continue
+        bot_raw = entry.get("bot") or entry.get("bot_id") or entry.get("bot_username")
+        bot_val = _coerce_route_id(bot_raw)
+        if bot_val is not None:
+            bot_val = str(bot_val).strip().lstrip("@") or None
         routes.append(ProfileRoute(
             name=name, platform=platform, profile=profile,
             guild_id=_coerce_route_id(entry.get("guild_id")),
             chat_id=_coerce_route_id(entry.get("chat_id")),
             thread_id=_coerce_route_id(entry.get("thread_id")),
+            bot=bot_val,
             enabled=entry.get("enabled", True),
         ))
     routes.sort(key=lambda r: r.specificity, reverse=True)
@@ -148,9 +171,13 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
 def match_profile_route(
     routes: List[ProfileRoute], platform: str, guild_id: Optional[str] = None, chat_id: Optional[str] = None,
     thread_id: Optional[str] = None, parent_chat_id: Optional[str] = None,
+    bot: Optional[str] = None, adapter_profile: Optional[str] = None,
 ) -> Optional[ProfileRoute]:
     """Return the first (most specific) matching route, or None."""
     for route in routes:
-        if route.matches(platform, guild_id=guild_id, chat_id=chat_id, thread_id=thread_id, parent_chat_id=parent_chat_id):
+        if route.matches(
+            platform, guild_id=guild_id, chat_id=chat_id, thread_id=thread_id,
+            parent_chat_id=parent_chat_id, bot=bot, adapter_profile=adapter_profile,
+        ):
             return route
     return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4237,28 +4237,32 @@ class GatewayRunner(
                 agent._last_flushed_db_idx = 0
         agent._api_call_count = 0
 
-    def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
+    def _profile_name_for_source(
+        self, source: SessionSource, adapter_profile: Optional[str] = None
+    ) -> Optional[str]:
         """Resolve the profile name for an inbound source via configured routes (most specific wins).
         ``None`` = default/active profile. Gated on ``multiplex_profiles``, since the scoped run only
         activates under multiplexing; otherwise keys would be profile-namespaced while the agent ran in
         ``agent:main``."""
         config = getattr(self, "config", None)
         if not getattr(config, "multiplex_profiles", False):
-            return None
+            return adapter_profile
         routes = getattr(config, "profile_routes", None)
         if not routes:
-            return None
+            return adapter_profile
         from gateway.profile_routing import ProfileRouteRejected, match_profile_route
         try:
             matched = match_profile_route(
                 routes, platform=source.platform.value, guild_id=getattr(source, "guild_id", None),
                 chat_id=source.chat_id, thread_id=getattr(source, "thread_id", None),
-                parent_chat_id=getattr(source, "parent_chat_id", None))
+                parent_chat_id=getattr(source, "parent_chat_id", None),
+                bot=getattr(source, "bot", None),
+                adapter_profile=adapter_profile)
         except Exception:
             logger.warning(
                 "Profile route matching failed for %s/%s, falling back to default",
                 source.platform, source.chat_id, exc_info=True)
-            return None
+            return adapter_profile
         if matched:
             try:
                 served = {name for name, _home in _multiplex_profile_homes(config)}
@@ -4274,10 +4278,11 @@ class GatewayRunner(
                 raise ProfileRouteRejected(matched.name)
             return matched.profile
         logger.debug(
-            "No profile route matched: platform=%s chat_id=%s thread_id=%s parent_chat_id=%s",
+            "No profile route matched: platform=%s chat_id=%s thread_id=%s parent_chat_id=%s bot=%s adapter_profile=%s",
             source.platform.value, source.chat_id,
-            getattr(source, "thread_id", None), getattr(source, "parent_chat_id", None))
-        return None
+            getattr(source, "thread_id", None), getattr(source, "parent_chat_id", None),
+            getattr(source, "bot", None), adapter_profile)
+        return adapter_profile
 
     def _resolve_profile_home_for_source(self, source: SessionSource) -> "Path":
         """Resolve which profile's HERMES_HOME serves this source: ``source.profile``, then

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -84,6 +84,8 @@ class SessionSource:
     role_authorized: bool = False  # adapter granted access via role, not user ID
     # Multiplex profile this message routes to (None => active/default); namespaces the key.
     profile: Optional[str] = None
+    # Bot username or ID associated with this source/adapter
+    bot: Optional[str] = None
     # Transport-local fail-closed signal: explicit profile route whose target is not served.
     profile_route_rejected: bool = field(default=False, repr=False, compare=False)
     # Discord auto-thread metadata: explicit so pre-existing/renamed threads are never renamed.
@@ -123,7 +125,7 @@ class SessionSource:
     # optionals around the dual-written scope pair.
     _ALWAYS_FIELDS = ("chat_id", "chat_name", "chat_type", "user_id", "user_name", "thread_id", "chat_topic")
     _OPTIONAL_PRE_SCOPE = ("user_id_alt", "chat_id_alt")
-    _OPTIONAL_POST_SCOPE = ("parent_chat_id", "message_id", "profile")
+    _OPTIONAL_POST_SCOPE = ("parent_chat_id", "message_id", "profile", "bot")
     _OPTIONAL_TAIL = ("auto_thread_initial_name", "prospective_thread_id")
 
     def to_dict(self) -> Dict[str, Any]:

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -236,6 +236,48 @@ class TestNonDiscordProfileRouting:
         source = adapter.build_source(chat_id="route-chat", chat_type="group")
         assert source.profile is None
 
+    def test_secondary_adapter_not_hijacked_by_generic_route(self, mock_runner):
+        """A generic chat_id route without a bot discriminator must NOT hijack messages
+        arriving at a dedicated secondary adapter (#104933)."""
+        mock_runner.config.multiplex_profiles = True
+        mock_runner.config.profile_routes = [
+            ProfileRoute(
+                name="admin-dm",
+                platform="telegram",
+                profile="ops",
+                chat_id="72719239",
+            )
+        ]
+        adapter = _stub_adapter(Platform.TELEGRAM, mock_runner)
+        adapter.set_owner_profile("team_b")
+        source = adapter.build_source(chat_id="72719239", chat_type="dm")
+        assert source.profile == "team_b"
+
+    def test_secondary_adapter_explicit_bot_route(self, mock_runner):
+        """An explicit route specifying the secondary bot matches even when arriving
+        at a dedicated secondary adapter."""
+        mock_runner.config.multiplex_profiles = True
+        mock_runner.config.profile_routes = [
+            ProfileRoute(
+                name="bot-dm",
+                platform="telegram",
+                profile="special",
+                chat_id="72719239",
+                bot="teamb_bot",
+            )
+        ]
+        adapter = _stub_adapter(Platform.TELEGRAM, mock_runner)
+        adapter.set_owner_profile("team_b")
+        adapter._bot_username = "teamb_bot"
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=[("default", Path("/profiles/default")),
+                          ("team_b", Path("/profiles/team_b")),
+                          ("special", Path("/profiles/special"))],
+        ):
+            source = adapter.build_source(chat_id="72719239", chat_type="dm")
+            assert source.profile == "special"
+
 
 class TestGatewayRunnerInjection:
     """``BasePlatformAdapter`` declares ``gateway_runner`` so the gateway's

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -16,6 +16,10 @@ class TestProfileRoute:
                          guild_id="g", chat_id="c", thread_id="t")
         assert r.specificity == 14  # 2 + 4 + 8
 
+    def test_specificity_bot(self):
+        r = ProfileRoute(name="b", platform="telegram", profile="p",
+                         bot="my_bot", chat_id="c")
+        assert r.specificity == 20  # 4 + 16
 
     def test_frozen(self):
         r = ProfileRoute(name="x", platform="discord", profile="p")
@@ -45,6 +49,34 @@ class TestProfileRouteMatching:
         assert not r.matches("discord", guild_id="999", chat_id="222")
         # guild matches but chat differs -> NO match
         assert not r.matches("discord", guild_id="111", chat_id="333")
+
+    def test_bot_exact_and_case_insensitive_matching(self):
+        r = ProfileRoute(name="b", platform="telegram", profile="team_b", bot="my_bot")
+        # Exact match
+        assert r.matches("telegram", bot="my_bot")
+        # Case insensitive and ignores leading @
+        assert r.matches("telegram", bot="@MY_BOT")
+        assert r.matches("telegram", bot="My_Bot")
+        # Mismatch
+        assert not r.matches("telegram", bot="other_bot")
+        assert not r.matches("telegram", bot=None)
+
+    def test_adapter_profile_prevents_generic_route_hijack(self):
+        # Generic route with chat_id but no bot discriminator
+        r = ProfileRoute(name="admin_dm", platform="telegram", profile="ops", chat_id="72719239")
+        # Normal primary adapter (adapter_profile=None) matches
+        assert r.matches("telegram", chat_id="72719239", adapter_profile=None)
+        # Dedicated secondary adapter (adapter_profile="team_b") does NOT match (not hijacked)
+        assert not r.matches("telegram", chat_id="72719239", adapter_profile="team_b")
+
+    def test_adapter_profile_allows_explicit_bot_route(self):
+        # Explicit route with bot discriminator matches even if adapter_profile is set
+        r = ProfileRoute(
+            name="explicit_override", platform="telegram", profile="ops",
+            chat_id="72719239", bot="team_b_bot"
+        )
+        assert r.matches("telegram", chat_id="72719239", bot="team_b_bot", adapter_profile="team_b")
+        assert not r.matches("telegram", chat_id="72719239", bot="other_bot", adapter_profile="team_b")
 
 
 class TestParseProfileRoutes:
@@ -86,15 +118,37 @@ class TestParseProfileRoutes:
         assert match_profile_route(routes, "discord", chat_id="123") is None
         assert sum("can never match" in rec.message for rec in caplog.records) == 2
 
+    def test_parse_bot_variants(self):
+        routes = parse_profile_routes([
+            {"name": "b1", "platform": "telegram", "profile": "p1", "bot": "@my_bot"},
+            {"name": "b2", "platform": "telegram", "profile": "p2", "bot_id": 123456},
+            {"name": "b3", "platform": "telegram", "profile": "p3", "bot_username": "other_bot"},
+        ])
+        by_name = {r.name: r for r in routes}
+        assert by_name["b1"].bot == "my_bot"
+        assert by_name["b2"].bot == "123456"
+        assert by_name["b3"].bot == "other_bot"
+
 
 class TestMatchProfileRoute:
-
 
     def test_no_match_returns_none(self):
         routes = [
             ProfileRoute(name="r", platform="telegram", profile="p"),
         ]
         assert match_profile_route(routes, "discord") is None
+
+    def test_match_profile_route_bot_and_adapter_profile(self):
+        routes = [
+            ProfileRoute(name="generic_dm", platform="telegram", profile="ops", chat_id="12345"),
+            ProfileRoute(name="bot_specific", platform="telegram", profile="custom", bot="special_bot"),
+        ]
+        # Primary adapter matches generic
+        assert match_profile_route(routes, "telegram", chat_id="12345", adapter_profile=None).name == "generic_dm"
+        # Secondary adapter skips generic
+        assert match_profile_route(routes, "telegram", chat_id="12345", adapter_profile="team_b") is None
+        # Secondary adapter with matching bot matches
+        assert match_profile_route(routes, "telegram", chat_id="12345", bot="special_bot", adapter_profile="team_b").name == "bot_specific"
 
 
 class TestSessionKeyIntegration:


### PR DESCRIPTION
Fixes #104933

### Summary
In a multiplexed gateway setup (`gateway.multiplex_profiles: true`), multiple profiles can declare their own dedicated platform adapters (e.g. distinct Telegram bot tokens, Slack apps, Discord bots) in `~/.hermes/profiles/<name>/.env`.

Previously, `ProfileRoute` only modeled `(platform, guild_id, chat_id, thread_id)`. Because it lacked a `bot` discriminator, generic routes (e.g. an admin DM route like `chat_id: '72719239', profile: ops`) acted as greedy catch-alls across **all** bot adapters on that gateway instance. When the user sent a DM to another dedicated bot (e.g. `@my_secondary_bot` owned by profile `team_b`), the secondary adapter's inbound messages were hijacked and routed into profile `ops`.

### Changes
1. **Extend `ProfileRoute`**:
   - Added optional `bot: Optional[str] = None` field.
   - Updated `specificity` calculation to give `+16` weighting to bot-scoped rules.
   - Updated `matches()` to match `bot` case-insensitively (stripping leading `@`).
2. **Prevent Secondary Adapter Hijacking**:
   - If an adapter has an `_owner_profile` (dedicated secondary adapter), generic routes that do not specify a `bot` discriminator will NOT match, preventing unwanted hijacking.
   - Explicit routes that declare `bot` matching the secondary adapter's bot will still match if specifically intended.
   - If no route matches on a dedicated adapter, resolution falls back cleanly to the adapter's own profile.
3. **Configuration Parsing**:
   - `parse_profile_routes` supports `bot`, `bot_id`, and `bot_username`, coerces integer IDs, and normalizes `@` prefixes.
4. **Adapter & Session Integration**:
   - Added `bot_identifier()` helper on `BasePlatformAdapter` to automatically resolve bot username/id across platforms (Telegram, Discord, Slack, etc.).
   - Added `bot: Optional[str] = None` to `SessionSource` with byte-stable roundtrip serialization.
5. **Tests**:
   - Added 8 new unit tests across `tests/gateway/test_profile_routing.py` and `tests/gateway/test_profile_resolution.py` covering specificity weighting, exact/case-insensitive matching, `@` prefix handling, hijack prevention for secondary adapters, explicit override support, and YAML route parsing.

### Verification
- `pytest tests/gateway/test_profile_routing.py tests/gateway/test_profile_resolution.py` passes 37/37 tests.
- `pytest tests/run_agent/test_session_source.py` passes 2/2 tests.
- Syntax & compilation verified clean.