### PR TITLE
test: mocked CLI updates no longer reach the host runtime fleet

### DIFF
--- a/tests/hermes_cli/conftest.py
+++ b/tests/hermes_cli/conftest.py
@@ -1,4 +1,4 @@
-"""Fixtures shared across hermes_cli kanban tests."""
+"""Fixtures shared across hermes_cli tests."""
 
 from __future__ import annotations
 
@@ -54,3 +54,34 @@ def _suppress_concurrent_hermes_gate(request, monkeypatch):
         lambda *_a, **_k: [],
         raising=False,
     )
+
+
+@pytest.fixture
+def isolated_update_runtime(monkeypatch, tmp_path, request):
+    """Keep mocked updater flows off the host checkout and runtime fleet."""
+    from hermes_cli import gateway, main, update_cmd, update_cmd_fleet
+    from hermes_cli import update_inventory, update_receipt
+
+    checkout = tmp_path / "isolated-update-checkout"
+    (checkout / ".git").mkdir(parents=True)
+    (checkout / "apps" / "desktop").mkdir(parents=True)
+    monkeypatch.setattr(main, "PROJECT_ROOT", checkout)
+    if hasattr(request.module, "PROJECT_ROOT"):
+        monkeypatch.setattr(request.module, "PROJECT_ROOT", checkout)
+
+    # A real purge would discard the module objects patched below.
+    monkeypatch.setattr(main, "_purge_stale_hermes_modules", lambda: None)
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda *a, **k: [])
+    monkeypatch.setattr(gateway, "find_profile_gateway_processes", lambda *a, **k: [])
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda *a, **k: set())
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(main, "_pause_windows_gateways_for_update", lambda: None)
+    monkeypatch.setattr(main, "_resume_windows_gateways_after_update", lambda *a, **k: None)
+    monkeypatch.setattr(main, "_detect_venv_python_processes", lambda: [])
+    monkeypatch.setattr(main, "_restore_active_tool_dependencies", lambda *a, **k: None)
+    monkeypatch.setattr(update_cmd, "_clear_windows_venv_holders_or_exit", lambda *a, **k: None)
+    monkeypatch.setattr(update_cmd, "_finish_dashboard_update_cleanup", lambda *a, **k: None)
+    monkeypatch.setattr(update_cmd, "_apply_pending_fleet_restart_catchup", lambda *a, **k: None)
+    monkeypatch.setattr(update_cmd_fleet, "_restart_macos_launchd_gateways", lambda *a, **k: None)
+    monkeypatch.setattr(update_inventory, "collect_runtime_inventory", lambda: None)
+    monkeypatch.setattr(update_receipt, "collect_fleet_versions", lambda *a, **k: [])

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -79,21 +79,8 @@ def _patch_managed_uv(request):
 
 
 @pytest.fixture(autouse=True)
-def _patch_gateway_discovery():
-    """Keep cmd_update's gateway auto-restart phase off this machine's gateways.
-
-    The restart phase used to swallow every exception at debug level, so these
-    end-to-end tests never noticed it touching real gateway discovery. Since
-    the phase is surfaced (#78574: an aborted restart now fails the update),
-    an unmocked ``find_gateway_pids`` on a box with a live gateway reaches the
-    conftest live-system guard and turns into a spurious ``sys.exit(1)``.
-    Discovery returning nothing makes the phase a clean no-op for every test
-    in this module (none of them assert on gateway restarts).
-    """
-    with patch("hermes_cli.gateway.find_gateway_pids", return_value=[]), \
-         patch("hermes_cli.gateway.supports_systemd_services", return_value=False), \
-         patch("hermes_cli.gateway.find_profile_gateway_processes", return_value=[]):
-        yield
+def _patch_gateway_discovery(isolated_update_runtime):
+    pass
 
 
 class TestCmdUpdateNpmLockfileCache:
@@ -1134,6 +1121,7 @@ class TestNodeRuntimeNpmResolution:
         from hermes_cli import update_cmd
 
         desktop_dir = PROJECT_ROOT / "apps" / "desktop"
+        (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
         packaged_exe = desktop_dir / "release" / "win-unpacked" / "Hermes.exe"
         build_ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
 

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -12,7 +12,20 @@ import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli.main import cmd_update
+
+
+@pytest.fixture(autouse=True)
+def _isolate_update(isolated_update_runtime, monkeypatch):
+    import shutil
+    from hermes_cli import managed_uv, update_cmd
+
+    monkeypatch.setattr(managed_uv, "resolve_uv", lambda **kw: shutil.which("uv"))
+    monkeypatch.setattr(managed_uv, "ensure_uv", lambda **kw: shutil.which("uv"))
+    monkeypatch.setattr(managed_uv, "update_managed_uv", lambda **kw: None)
+    monkeypatch.setattr(update_cmd, "_post_update_sqlite_runtime_status", lambda: (True, None))
 
 
 def _make_run_side_effect(


### PR DESCRIPTION
Mocked updater tests now stay off the host checkout and runtime fleet while preserving their existing prompt, migration, branch, and desktop-build assertions.

Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104904

## Changes
- Give `test_cmd_update.py` and `test_update_yes_flag.py` an opt-in shared temporary checkout and empty runtime inventory/fleet.
- Keep module-bound discovery mocks alive across the simulated update; isolate unrelated restart, cleanup, and dependency-restoration phases at their actual lookup bindings.
- Create the desktop test's `package.json` prerequisite in its temporary checkout. Real fleet verification remains enabled; dedicated fleet and module-purge tests do not consume the new fixture.

Root cause: simulated updater flows purged patched modules and rediscovered real host processes, while their checkout still pointed into the developer repository.

## Validation
**Live repro (mocked updater flow with real host boundary guard):** the existing clean-base campaign run reported 42 passed / 5 failed in `test_cmd_update.py` and 3 passed / 3 failed in `test_update_yes_flag.py`; failures reached the live-system signal guard. The standalone current-main-based tree reports 47 passed and 6 passed respectively, without disabling that guard. This is test-fixture integration evidence, not a real installation or gateway restart.

| Canonical serial run, retries disabled | Result |
|---|---|
| Changed updater suites plus dedicated fleet-restart and stale-module-purge controls | **81 passed, 0 failed**, 4 files |
| All three originally requested campaign suites, including unchanged quickstart | **58 passed, 1 failed**, 3 files |

The remaining quickstart failure is the same HTTP 400 preflight failure covered by already-open #105015. Its exact duplicate CPU-input commit was deliberately excluded from this PR; Linux/NVIDIA production support is unchanged. The three-file run is disclosed rather than presented as fully green.

Both runs used `flock /tmp/hermes-e461-fix-tests.lock bash scripts/run_tests.sh -j 1 --file-retries 0`. Ruff, Windows-footgun, compatibility-pointer, subprocess-stdin, contributor-attribution, and diff checks passed. Independent read-only review found no blocking issues. The yes-flag `shutil.which('uv')` seam was retained: all three updater callers explicitly patch `shutil.which` to `None`, so those lambdas do not read the host PATH in these flows.

## Scope and overlap
- Three test files only; no production code, provider/shim integration fixes, new flags, or error suppression.
- Related prior diagnosis: #88366 by @jckm14 covers yes-flag gateway discovery; this shared fixture also handles module-purge persistence, checkout/inventory isolation and `test_cmd_update.py`. #98070 by @sylvesterkaczmarek covers the same purge/mock mechanism in different fixture files, which are not transplanted here. No external commits are represented as cherry-picked.
- No full-suite, native Windows/macOS, real updater-installation, or CI-green claim. Wider campaign integration remains separate.

## Infographic
![Isolated updater test fixtures](https://v3b.fal.media/files/b/0aa9774f/nLyhbIrIb7qjED-oByjQ7_dU5LP7Bo.png)
