### PR TITLE
fix(mattermost): scope typing notifications to the reply thread

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -293,7 +293,14 @@ class MattermostAdapter(BasePlatformAdapter):
     # --- Optional overrides ---
 
     async def send_typing(self, chat_id: str, metadata: _Metadata = None) -> None:
-        await self._api_post(f"users/{self._bot_user_id}/typing", {"channel_id": chat_id})
+        payload = {"channel_id": chat_id}
+        if self._reply_mode == "thread" and isinstance(metadata, dict):
+            # Gateway thread metadata already carries the root post ID. Keep
+            # typing in that thread without a post lookup on every heartbeat.
+            root_id = metadata.get("thread_id") or metadata.get("root_id")
+            if root_id:
+                payload["parent_id"] = str(root_id)
+        await self._api_post(f"users/{self._bot_user_id}/typing", payload)
 
     async def edit_message(self, chat_id: str, message_id: str, content: str, *, finalize: bool = False) -> SendResult:
         payload = _with_mentions_disabled({"message": self.format_message(content)})

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -98,6 +98,74 @@ def _make_adapter():
     return adapter
 
 
+class TestMattermostTyping:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "reply_mode,metadata,expected_parent",
+        [
+            ("thread", {"thread_id": "root-a"}, "root-a"),
+            ("thread", {"root_id": "root-b"}, "root-b"),
+            ("thread", {"thread_id": "root-a", "root_id": "root-b"}, "root-a"),
+            ("thread", None, None),
+            ("thread", {}, None),
+            ("thread", {"thread_id": ""}, None),
+            ("off", {"thread_id": "root-a"}, None),
+        ],
+    )
+    async def test_typing_http_payload_matches_reply_scope(
+        self, reply_mode, metadata, expected_parent
+    ):
+        # Exercise the real HTTP serialization, not a mocked _api_post.
+        import aiohttp
+        from aiohttp import web
+
+        received = []
+
+        async def typing(request):
+            received.append(await request.json())
+            return web.json_response({"status": "OK"})
+
+        app = web.Application()
+        app.router.add_post("/api/v4/users/bot-id/typing", typing)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        try:
+            site = web.TCPSite(runner, "127.0.0.1", 0)
+            await site.start()
+            port = runner.addresses[0][1]
+            adapter = _make_adapter()
+            adapter._base_url = f"http://127.0.0.1:{port}"
+            adapter._bot_user_id = "bot-id"
+            adapter._reply_mode = reply_mode
+            async with aiohttp.ClientSession() as session:
+                adapter._session = session
+                await adapter.send_typing("channel-1", metadata=metadata)
+            expected = {"channel_id": "channel-1"}
+            if expected_parent is not None:
+                expected["parent_id"] = expected_parent
+            assert received == [expected]
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_gateway_thread_metadata_keeps_concurrent_threads_separate(self):
+        from types import SimpleNamespace
+        from gateway.platforms.base import _thread_metadata_for_source
+
+        adapter = _make_adapter()
+        adapter._reply_mode = "thread"
+        adapter._bot_user_id = "bot-id"
+        adapter._api_post = AsyncMock(return_value={"status": "OK"})
+        for root_id in ("root-a", "root-b", None):
+            source = SimpleNamespace(platform=Platform.MATTERMOST, thread_id=root_id)
+            await adapter.send_typing("channel-1", _thread_metadata_for_source(source))
+        assert [call.args[1] for call in adapter._api_post.await_args_list] == [
+            {"channel_id": "channel-1", "parent_id": "root-a"},
+            {"channel_id": "channel-1", "parent_id": "root-b"},
+            {"channel_id": "channel-1"},
+        ]
+
+
 class TestMattermostFormatMessage:
     def setup_method(self):
         self.adapter = _make_adapter()


### PR DESCRIPTION
Mattermost typing notifications currently include only the channel ID, so clients cannot associate a bot's activity with its reply thread. In thread reply mode, forward the gateway's existing root-post metadata as `parent_id`; preserve channel-level typing for flat replies and absent thread metadata. The heartbeat uses the already-resolved root ID without adding a post lookup on every tick.

Rechecked against upstream main `284d220ba48e25f2e3623b3afe72db8f24a4c2db` and v2026.9.11 (commit `939e45c91d751fadd94dcd1b873ac3cb44846213`): neither contains this typing behavior. Rebased the original patch onto that main; fork branch head is `e9443887f18b35cb2d42049b452f4a870d7cd202`. Original author and author date are preserved. Only the adapter and its tests change (76 insertions, 1 deletion); no additional behavior changes.

Validation in an isolated Linux worktree:
- Latest upstream adapter with the regression tests: 4 expected failures for missing `parent_id`, 4 passes.
- Rebased main plus patch: `scripts/run_tests.sh -j 2 --file-retries 0 tests/gateway/test_mattermost.py tests/gateway/test_base_topic_sessions.py tests/gateway/test_mattermost_plugin_setup.py` passed all 37 tests.
- v2026.9.11 plus the same patch: the same command passed all 37 tests.
- `git diff HEAD^ HEAD --check` passed.
- Local test setup uses a worktree-only venv with pytest-asyncio 1.4.0 and read-only access to installed runtime dependencies. No installed runtime dependencies were changed and no services were restarted.

The tests exercise actual HTTP serialization against a local aiohttp server, cover thread/root metadata precedence and flat-mode fallback, and check that consecutive conversations in one channel keep separate root IDs. This is transport-level local validation, not a live Mattermost client/UI test.
