### PR TITLE
fix(gateway): scope profile routes by receiving bot

### DIFF
--- a/docs/profile-routing.md
+++ b/docs/profile-routing.md
@@ -9,7 +9,7 @@
 By default a single gateway run uses one profile (memory, persona, tools). **Profile-based
 routing** lets one gateway instance serve **multiple isolated profiles**, selecting which
 profile handles an inbound message based on *where the message came from* — the platform,
-server (`guild_id`), channel (`chat_id`), and/or thread (`thread_id`).
+bot (`bot`), server (`guild_id`), channel (`chat_id`), and/or thread (`thread_id`).
 
 This is the inbound counterpart to multiplexing: instead of running N gateways, run one
 gateway and route per-community / per-channel / per-thread to a dedicated profile. Each
@@ -45,6 +45,13 @@ profile_routes:
     chat_id: "-1001234567890"
     profile: tg-profile
 
+  # Pin one user's DM to one specific bot; the leading @ is optional.
+  - name: tg-admin-dm
+    platform: telegram
+    bot: "@admin_bot"
+    chat_id: "72719239"
+    profile: ops
+
   # Route a single Discord thread.
   - name: standup-thread
     platform: discord
@@ -64,6 +71,7 @@ profile_routes:
 | `guild_id` | no | Server/guild (Discord). |
 | `chat_id` | no | Channel/group/DM id. |
 | `thread_id` | no | Thread id within a channel. |
+| `bot` | no | Receiving bot username or id; usernames are case-insensitive and may start with `@`. |
 | `enabled` | no | Default `true`; set `false` to disable a route without removing it. |
 
 ## Matching rules
@@ -72,6 +80,7 @@ A route matches an inbound source when **every discriminator the route declares 
 (conjunctive / AND). A field the route leaves unset is ignored.
 
 - **`platform`** must equal the source platform exactly.
+- **`bot`** (if set) must identify the adapter that received the event.
 - **`thread_id`** (if set) must equal the source thread id.
 - **`chat_id`** (if set) must match the source channel **or** its parent — a thread in a
   channel matches the channel's route (hierarchical match for Discord forums/threads).
@@ -84,13 +93,16 @@ When multiple routes match, the **most specific** one wins. Specificity is addit
 
 | Discriminator | Weight |
 |---|---|
+| `bot` | 16 |
 | `thread_id` | 8 |
 | `chat_id` | 4 |
 | `guild_id` | 2 |
 | (platform only) | 0 |
 
 So a thread route (8) beats a channel route (4) beats a guild route (2) within the same server.
-If no route matches, the message uses the default/active profile.
+If no route matches, the message uses the receiving adapter's profile, or the default/active
+profile for the primary adapter. A route without `bot` cannot override a dedicated secondary
+adapter; this prevents a generic DM `chat_id` route from hijacking another bot's traffic.
 
 ## How it works at runtime
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2333,6 +2333,24 @@ class BasePlatformAdapter(ABC):
         :meth:`_session_key_profile` so adapter-level keys leave ``agent:main:``."""
         self._owner_profile = None if (name := (profile_name or "").strip() or None) == "default" else name
 
+    def _profile_route_bot_identities(self) -> tuple[str, ...]:
+        """Return bot usernames and ids used by ``gateway.profile_routes``."""
+        identities: list[str] = []
+
+        def add(value: Any) -> None:
+            if isinstance(value, (str, int)) and str(value).strip():
+                identities.append(str(value))
+
+        username = getattr(self, "_current_bot_username", None)
+        if callable(username):
+            add(username())
+        for attr in ("_bot_username", "bot_username", "_bot_user_id", "bot_user_id"):
+            add(getattr(self, attr, None))
+        bot = getattr(self, "_bot", None)
+        for attr in ("username", "id"):
+            add(getattr(bot, attr, None))
+        return tuple(dict.fromkeys(identities))
+
     def _session_key_profile(self, source: Optional[Any] = None) -> Optional[str]:
         """Profile namespace for an adapter-derived session key. Ingress runs BEFORE the runner
         stamps ``source.profile``, so without this every bot in a multiplexed gateway shares one
@@ -4174,11 +4192,18 @@ class BasePlatformAdapter(ABC):
             chat_id_alt=chat_id_alt, is_bot=is_bot, scope_id=_opt(scope_id),
             guild_id=_opt(guild_id), parent_chat_id=_opt(parent_chat_id),
             message_id=_opt(message_id))
-        profile, profile_route_rejected = None, False  # profile from configured routes, if any
+        adapter_profile = (
+            getattr(self, "_owner_profile", None)
+            or getattr(self, "_hermes_profile_name", None)
+        )
+        profile, profile_route_rejected = adapter_profile, False
         if self.gateway_runner is not None:
             from gateway.profile_routing import ProfileRouteRejected
             try:
-                profile = self.gateway_runner._profile_name_for_source(SessionSource(**fields))
+                profile = self.gateway_runner._profile_name_for_source(
+                    SessionSource(**fields), bot=self._profile_route_bot_identities(),
+                    adapter_profile=adapter_profile,
+                )
             except ProfileRouteRejected:
                 profile_route_rejected = True
             except Exception:

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -1,9 +1,10 @@
 """Profile-based routing: route guilds/channels/threads to different profiles.
 
 Matching priority, most specific first (``gateway.profile_routes`` in config.yaml):
-platform + chat_id + thread_id (14) → platform + chat_id (6) → platform + guild_id (2)
-→ default profile. For Discord threads/forum posts ``parent_chat_id`` carries the
-direct parent, so a channel route also matches any thread/post under it.
+bot (16) + platform/chat/thread discriminators (up to 14) → platform + chat_id +
+thread_id (12) → platform + chat_id (4) → platform + guild_id (2) → default profile.
+For Discord threads/forum posts ``parent_chat_id`` carries the direct parent, so a
+channel route also matches any thread/post under it.
 """
 
 from __future__ import annotations
@@ -57,16 +58,19 @@ class ProfileRoute:
     guild_id: Optional[str] = None
     chat_id: Optional[str] = None
     thread_id: Optional[str] = None
+    bot: Optional[str] = None
     enabled: bool = True
 
     @property
     def specificity(self) -> int:
         """Higher value = more specific match."""
-        return 2 * bool(self.guild_id) + 4 * bool(self.chat_id) + 8 * bool(self.thread_id)
+        return (2 * bool(self.guild_id) + 4 * bool(self.chat_id)
+                + 8 * bool(self.thread_id) + 16 * bool(self.bot))
 
     def matches(
         self, platform: str, guild_id: Optional[str] = None, chat_id: Optional[str] = None,
         thread_id: Optional[str] = None, parent_chat_id: Optional[str] = None,
+        bot: Optional[str | tuple[str, ...]] = None,
     ) -> bool:
         """True if every discriminator the route declares holds (AND).
 
@@ -74,6 +78,8 @@ class ProfileRoute:
         ``chat_id`` also matches across number/JID/LID after the exact check (groups/broadcasts stay exact-only).
         """
         if not self.enabled or self.platform != platform:
+            return False
+        if self.bot and not _bot_identity_matches(self.bot, bot):
             return False
         if self.thread_id and self.thread_id != thread_id:
             return False
@@ -85,6 +91,22 @@ class ProfileRoute:
         ):
             return False
         return not (self.guild_id and self.guild_id != guild_id)
+
+
+def _normalize_bot_identity(value: Any) -> Optional[str]:
+    """Normalize a bot username or id for route matching."""
+    if value is None:
+        return None
+    normalized = str(value).strip().lstrip("@").lower()
+    return normalized or None
+
+
+def _bot_identity_matches(
+    expected: str, actual: Optional[str | tuple[str, ...]],
+) -> bool:
+    """Return whether a route bot matches any identity exposed by an adapter."""
+    candidates = actual if isinstance(actual, tuple) else (actual,)
+    return any(expected == _normalize_bot_identity(candidate) for candidate in candidates)
 
 
 def _coerce_route_id(value: Any) -> Optional[str]:
@@ -138,6 +160,7 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
             guild_id=_coerce_route_id(entry.get("guild_id")),
             chat_id=_coerce_route_id(entry.get("chat_id")),
             thread_id=_coerce_route_id(entry.get("thread_id")),
+            bot=_normalize_bot_identity(entry.get("bot")),
             enabled=entry.get("enabled", True),
         ))
     routes.sort(key=lambda r: r.specificity, reverse=True)
@@ -148,9 +171,15 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
 def match_profile_route(
     routes: List[ProfileRoute], platform: str, guild_id: Optional[str] = None, chat_id: Optional[str] = None,
     thread_id: Optional[str] = None, parent_chat_id: Optional[str] = None,
+    bot: Optional[str | tuple[str, ...]] = None, require_bot: bool = False,
 ) -> Optional[ProfileRoute]:
     """Return the first (most specific) matching route, or None."""
     for route in routes:
-        if route.matches(platform, guild_id=guild_id, chat_id=chat_id, thread_id=thread_id, parent_chat_id=parent_chat_id):
+        if require_bot and not route.bot:
+            continue
+        if route.matches(
+            platform, guild_id=guild_id, chat_id=chat_id, thread_id=thread_id,
+            parent_chat_id=parent_chat_id, bot=bot,
+        ):
             return route
     return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4237,8 +4237,12 @@ class GatewayRunner(
                 agent._last_flushed_db_idx = 0
         agent._api_call_count = 0
 
-    def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
+    def _profile_name_for_source(
+        self, source: SessionSource, *, bot: Optional[str | tuple[str, ...]] = None,
+        adapter_profile: Optional[str] = None,
+    ) -> Optional[str]:
         """Resolve the profile name for an inbound source via configured routes (most specific wins).
+        A dedicated secondary adapter keeps ``adapter_profile`` unless a bot-qualified route matches.
         ``None`` = default/active profile. Gated on ``multiplex_profiles``, since the scoped run only
         activates under multiplexing; otherwise keys would be profile-namespaced while the agent ran in
         ``agent:main``."""
@@ -4247,18 +4251,19 @@ class GatewayRunner(
             return None
         routes = getattr(config, "profile_routes", None)
         if not routes:
-            return None
+            return adapter_profile
         from gateway.profile_routing import ProfileRouteRejected, match_profile_route
         try:
             matched = match_profile_route(
                 routes, platform=source.platform.value, guild_id=getattr(source, "guild_id", None),
                 chat_id=source.chat_id, thread_id=getattr(source, "thread_id", None),
-                parent_chat_id=getattr(source, "parent_chat_id", None))
+                parent_chat_id=getattr(source, "parent_chat_id", None), bot=bot,
+                require_bot=bool(adapter_profile))
         except Exception:
             logger.warning(
-                "Profile route matching failed for %s/%s, falling back to default",
+                "Profile route matching failed for %s/%s, falling back to adapter profile",
                 source.platform, source.chat_id, exc_info=True)
-            return None
+            return adapter_profile
         if matched:
             try:
                 served = {name for name, _home in _multiplex_profile_homes(config)}
@@ -4277,7 +4282,7 @@ class GatewayRunner(
             "No profile route matched: platform=%s chat_id=%s thread_id=%s parent_chat_id=%s",
             source.platform.value, source.chat_id,
             getattr(source, "thread_id", None), getattr(source, "parent_chat_id", None))
-        return None
+        return adapter_profile
 
     def _resolve_profile_home_for_source(self, source: SessionSource) -> "Path":
         """Resolve which profile's HERMES_HOME serves this source: ``source.profile``, then

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -8,7 +8,7 @@ import pytest
 
 from gateway.session import SessionSource, build_session_key
 from gateway.run import GatewayRunner
-from gateway.profile_routing import ProfileRoute, ProfileRouteRejected
+from gateway.profile_routing import ProfileRoute, ProfileRouteRejected, parse_profile_routes
 from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent
 
@@ -372,6 +372,64 @@ class TestAdapterToSessionKeyIntegration:
         assert key.startswith("agent:coder:"), key
         # A default-profile key would land in agent:main — must differ.
         assert key != build_session_key(source, profile=None)
+
+    def test_generic_route_does_not_override_secondary_adapter_profile(self, mock_runner):
+        mock_runner.config.profile_routes = [
+            ProfileRoute(
+                name="admin-dm",
+                platform="telegram",
+                profile="ops",
+                chat_id="72719239",
+            )
+        ]
+        adapter = _stub_adapter(Platform.TELEGRAM, mock_runner)
+        setattr(adapter, "_hermes_profile_name", "team-b")
+
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=[
+                ("default", Path("/profiles/default")),
+                ("ops", Path("/profiles/ops")),
+                ("team-b", Path("/profiles/team-b")),
+            ],
+        ):
+            source = adapter.build_source(chat_id="72719239", chat_type="dm")
+
+        assert source.profile == "team-b"
+
+    def test_bot_route_targets_only_the_named_secondary_adapter(self, mock_runner):
+        route = parse_profile_routes([
+            {
+                "name": "admin-bot-dm",
+                "platform": "telegram",
+                "profile": "ops",
+                "chat_id": "72719239",
+                "bot": "@admin_bot",
+            }
+        ])[0]
+        mock_runner.config.profile_routes = [route]
+
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=[
+                ("default", Path("/profiles/default")),
+                ("ops", Path("/profiles/ops")),
+                ("team-b", Path("/profiles/team-b")),
+            ],
+        ):
+            admin_adapter = _stub_adapter(Platform.TELEGRAM, mock_runner)
+            admin_adapter.set_owner_profile("team-b")
+            setattr(admin_adapter, "_bot_username", "admin_bot")
+            other_adapter = _stub_adapter(Platform.TELEGRAM, mock_runner)
+            other_adapter.set_owner_profile("team-b")
+            setattr(other_adapter, "_bot_username", "my_secondary_bot")
+
+            assert admin_adapter.build_source(
+                chat_id="72719239", chat_type="dm"
+            ).profile == "ops"
+            assert other_adapter.build_source(
+                chat_id="72719239", chat_type="dm"
+            ).profile == "team-b"
 
     @pytest.mark.asyncio
     async def test_adapter_drops_rejected_route_before_dispatch(self, mock_runner):

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -279,6 +279,13 @@ gateway:
       chat_id: "-1001234567890"
       profile: tg-profile
 
+    # One user's DM to one specific Telegram bot (@ is optional)
+    - name: tg-admin-dm
+      platform: telegram
+      bot: "@admin_bot"
+      chat_id: "72719239"
+      profile: ops
+
     # A WhatsApp DM — write the phone number; JID and LID forms also match
     - name: owner-whatsapp
       platform: whatsapp
@@ -286,10 +293,14 @@ gateway:
       profile: owner
 ```
 
-Routes are matched most-specific-first (`thread_id` > `chat_id` > `guild_id`),
+Routes are matched most-specific-first (`bot` > `thread_id` > `chat_id` > `guild_id`),
 all declared fields must hold (AND), and a route keyed on a channel also
-matches threads/forum posts whose parent is that channel. Messages that match
-no route stay on the default/active profile. The routed profile gets the full
+matches threads/forum posts whose parent is that channel. Bot usernames are
+case-insensitive and may include a leading `@`. A generic route without `bot`
+does not override a dedicated secondary adapter, because Telegram DMs to
+different bots share the same user `chat_id`; an unmatched event stays on the
+receiving adapter's profile (or the default/active profile for the primary
+adapter). The routed profile gets the full
 per-profile isolation described above (config, skills, memory, credentials,
 session namespace). Routing works on every platform adapter, not just Discord.
 


### PR DESCRIPTION
## Summary

Multiplexed secondary adapters can share the same DM `chat_id`, allowing a generic `profile_routes` entry to override the profile that owns the receiving bot. This adds an optional bot discriminator and preserves the dedicated adapter profile unless an explicitly bot-qualified route matches.

---

## Changes

- `gateway/profile_routing.py`: parse and match normalized bot usernames/IDs, include bot scope in route specificity, and support requiring bot-qualified routes.
- `gateway/platforms/base.py`: pass receiving-bot identities and adapter ownership into profile resolution.
- `gateway/run.py`: keep a dedicated secondary adapter's profile for generic or unmatched routes while allowing explicit bot-qualified overrides.
- `tests/gateway/test_profile_resolution.py`: add two regressions covering generic-route isolation and bot-specific routing.
- `docs/profile-routing.md`: document the new route field and fallback behavior.
- `website/docs/user-guide/multi-profile-gateways.md`: document operator configuration for bot-scoped DM routes.

## How to Test

```bash
python -m pytest tests/gateway/test_profile_routing.py tests/gateway/test_profile_resolution.py tests/gateway/test_multiplex_adapter_session_key_namespace.py tests/cron/test_cron_multiplex_profile_route_preflight.py tests/cron/test_cron_multiplex_shared_route_delivery.py -q
# 58 passed

ruff check gateway/profile_routing.py gateway/run.py gateway/platforms/base.py tests/gateway/test_profile_resolution.py
# All checks passed!

python scripts/check-windows-footguns.py gateway/profile_routing.py gateway/run.py gateway/platforms/base.py tests/gateway/test_profile_resolution.py
# No Windows footguns found (4 files scanned)
```

The canonical `scripts/run_tests.sh` entrypoint could not launch per-file subprocesses in the Termux sandbox (`PermissionError(13)`), so no full-suite pass is claimed.

## Checklist

- [x] Focused tests pass — 58/58
- [x] Regression tests fail on the pre-fix behavior
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed
- [x] No hardcoded profile paths or non-secret `.env` settings

## Risk & Impact

Low. Existing primary/shared-bot routes retain their behavior; only dedicated secondary adapters require an explicit `bot` discriminator before a route may override their owning profile.

Type: Bug fix

Closes #104933
