### PR TITLE
fix(telegram): hold short text until sibling media absorbs it

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -394,6 +394,16 @@ class TelegramAdapter(BasePlatformAdapter):
     _TEXT_BATCH_FAST_DELAY_S = 0.18
     _TEXT_BATCH_SHORT_LEN = 1024
     _TEXT_BATCH_SHORT_DELAY_S = 0.24
+    # Forward-with-comment arrives as a short TEXT update then a media update
+    # (caption = the forwarded post). The fast text flush (180ms) otherwise
+    # starts a turn on the comment alone; the video is queued after that turn.
+    # Wait this long after the normal text delay for a sibling media handler
+    # to start and absorb the pending comment. Same order of magnitude as
+    # photo-album debounce. Adds up to 0.5s latency for lone short texts.
+    _TEXT_SIBLING_MEDIA_GRACE_S = 0.5
+    # If media download is already in flight for this session+sender, wait up
+    # to this long for it to absorb the pending text instead of flushing.
+    _TEXT_MEDIA_INFLIGHT_CAP_S = 20.0
 
     @staticmethod
     def _env_float_clamped(name: str, default: float, *, min_value: Optional[float] = None, max_value: Optional[float] = None) -> float:
@@ -456,6 +466,11 @@ class TelegramAdapter(BasePlatformAdapter):
             "HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS", 1.0, min_value=self._text_batch_delay_seconds, max_value=4.0)
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        # Session+sender → in-flight _handle_media_message count. Text flush
+        # waits on this so a comment is merged into the sibling media event
+        # instead of starting a turn without the attachment.
+        self._media_inflight: Dict[str, int] = {}
+        self._media_inflight_generation = 0
         self._drop_delayed_deliveries = False
         # Held across disconnect: PTB advances the offset before our drop-guard runs, so Telegram won't
         # redeliver — dropping is permanent loss (see _hold_inbound_event).
@@ -3063,6 +3078,10 @@ class TelegramAdapter(BasePlatformAdapter):
             self._media_group_tasks, self._media_group_events, self._pending_photo_batch_tasks,
             self._pending_photo_batches, self._pending_text_batch_tasks, self._pending_text_batches):
             d.clear()
+        inflight = getattr(self, "_media_inflight", None)
+        if inflight is not None:
+            inflight.clear()
+        self._media_inflight_generation = getattr(self, "_media_inflight_generation", 0) + 1
         self._clear_task_attrs_except(
             current_task, "_polling_error_task", "_polling_progress_verifier_task", "_held_inbound_redispatch_task")
 
@@ -5738,20 +5757,215 @@ class TelegramAdapter(BasePlatformAdapter):
         self._apply_topic_recovery(event)
         return super()._text_batch_key(event)
 
+    def _inbound_sender_id(self, event: MessageEvent) -> str:
+        """Stable per-message sender id for sibling-media pairing (not the session key).
+
+        Group-observe attribution strips ``source.user_id``; fall back to
+        ``raw_message.from_user`` so the same person still matches.
+        """
+        source = getattr(event, "source", None)
+        if source is not None:
+            sender = getattr(source, "user_id_alt", None) or getattr(source, "user_id", None)
+            if sender:
+                return str(sender)
+        raw = getattr(event, "raw_message", None)
+        user = getattr(raw, "from_user", None) if raw is not None else None
+        uid = getattr(user, "id", None) if user is not None else None
+        if uid:
+            return str(uid)
+        if source is not None and getattr(source, "chat_type", None) in {"dm", "private"} and getattr(source, "chat_id", None):
+            return f"dm:{source.chat_id}"
+        return ""
+
+    def _sibling_media_key(self, event: MessageEvent) -> str:
+        """Session+sender key so one user's in-flight media does not hold another's text."""
+        return f"{self._text_batch_key(event)}:{self._inbound_sender_id(event)}"
+
+    def _begin_media_inflight(self, key: str) -> int:
+        generation = getattr(self, "_media_inflight_generation", 0)
+        inflight = getattr(self, "_media_inflight", None)
+        if inflight is None:
+            self._media_inflight = {}
+            inflight = self._media_inflight
+        inflight[key] = inflight.get(key, 0) + 1
+        return generation
+
+    def _end_media_inflight(self, key: str, generation: Optional[int] = None) -> None:
+        if generation is not None and generation != getattr(self, "_media_inflight_generation", 0):
+            return
+        inflight = getattr(self, "_media_inflight", None)
+        if not inflight:
+            return
+        remaining = inflight.get(key, 0) - 1
+        if remaining <= 0:
+            inflight.pop(key, None)
+        else:
+            inflight[key] = remaining
+
+    def _absorb_pending_text_into_media_event(self, event: MessageEvent) -> bool:
+        """Merge a pending text-batch comment into a sibling media event.
+
+        Telegram forward-with-comment is two updates: the user's comment
+        (TEXT) and the forwarded post (media + caption). Absorb the comment
+        so one turn sees both. Returns True if a pending batch was consumed.
+        Same-sender only — a shared topic must not steal another user's text.
+
+        Lookup uses the admission-time batch key. Group-observe attribution
+        may rewrite ``event.source`` after we snapshotted; the pin is the
+        conversation the comment was already queued on.
+        """
+        snapshot = getattr(event, "_sibling_pending", None)
+        key = getattr(event, "_sibling_pending_key", None)
+        if snapshot is None or not key:
+            return False
+        pending = self._pending_text_batches.get(key)
+        if pending is not snapshot:
+            return False
+        # Re-check the pending object (it can grow / mix senders while media
+        # downloads). Do not re-check sender vs ``event``: group-observe
+        # attribution may have rewritten event.source after we snapshotted.
+        if not self._pending_text_is_sibling_comment(pending):
+            return False
+        pending = self._pending_text_batches.pop(key, None)
+        task = self._pending_text_batch_tasks.pop(key, None)
+        if task is not None and not task.done():
+            task.cancel()
+        if pending is None:
+            return False
+        comment = (pending.text or "").strip()
+        caption = (event.text or "").strip()
+        if comment and not caption:
+            event.text = comment
+        elif comment and caption:
+            # Comment is the user's instruction; caption is the forwarded post.
+            event.text = self._merge_caption(comment, caption)
+        logger.info(
+            "[Telegram] Merged pending text (%d chars) into media event %s",
+            len(comment),
+            key,
+        )
+        return True
+
+    def _mark_sibling_absorb_eligibility(self, event: MessageEvent) -> None:
+        """Snapshot the pending text batch this media event may consume.
+
+        Only the comment already buffered at media admission is eligible
+        (text-first, media-second). A later short text after the inflight
+        cap must start its own turn.
+        """
+        pending_key = self._text_batch_key(event)
+        pending = self._pending_text_batches.get(pending_key)
+        sender = self._inbound_sender_id(event)
+        if (
+            self._pending_text_is_sibling_comment(pending)
+            and sender
+            and sender == self._inbound_sender_id(pending)
+        ):
+            event._sibling_pending = pending  # type: ignore[attr-defined]
+            event._sibling_pending_key = pending_key  # type: ignore[attr-defined]
+            pending._sibling_media_claimed = True  # type: ignore[attr-defined]
+        else:
+            event._sibling_pending = None  # type: ignore[attr-defined]
+            event._sibling_pending_key = None  # type: ignore[attr-defined]
+
+    @staticmethod
+    def _copy_sibling_pending(src: MessageEvent, dest: MessageEvent) -> MessageEvent:
+        """Keep the admission snapshot if attribution replaced the event object."""
+        if dest is src:
+            return dest
+        dest._sibling_pending = getattr(src, "_sibling_pending", None)  # type: ignore[attr-defined]
+        dest._sibling_pending_key = getattr(src, "_sibling_pending_key", None)  # type: ignore[attr-defined]
+        return dest
+
+    async def _dispatch_media_event(self, event: MessageEvent) -> None:
+        """Absorb a sibling comment (if any) then dispatch. Media-path only."""
+        self._absorb_pending_text_into_media_event(event)
+        if self._should_drop_delayed_delivery():
+            self._hold_inbound_event(event, where="media-dispatch")
+            return
+        try:
+            await self.handle_message(event)
+        except asyncio.CancelledError:
+            self._hold_inbound_event(event, where="media-dispatch-cancelled")
+            raise
+
+    async def _wait_for_sibling_media(self, key: str) -> None:
+        """After the normal text delay, wait briefly (and while same-sender media is in flight)
+        so a forward-with-comment media update can absorb this batch."""
+        grace = float(getattr(self, "_TEXT_SIBLING_MEDIA_GRACE_S", 0) or 0)
+        inflight_cap = float(getattr(self, "_TEXT_MEDIA_INFLIGHT_CAP_S", 0) or 0)
+        pending = self._pending_text_batches.get(key)
+        if not self._pending_text_is_sibling_comment(pending):
+            return
+        sibling_key = self._sibling_media_key(pending)
+        inflight = getattr(self, "_media_inflight", {}) or {}
+        if grace > 0:
+            grace_deadline = time.monotonic() + grace
+            while time.monotonic() < grace_deadline:
+                if self._pending_text_batches.get(key) is None:
+                    return
+                if inflight.get(sibling_key, 0) > 0:
+                    break
+                await asyncio.sleep(0.05)
+                inflight = getattr(self, "_media_inflight", {}) or {}
+        pending = self._pending_text_batches.get(key)
+        inflight = getattr(self, "_media_inflight", {}) or {}
+        # Only the batch that in-flight media already claimed may wait on the
+        # download. A replacement short text from the same sender must flush
+        # instead of sitting behind a download that cannot absorb it.
+        if (
+            inflight.get(sibling_key, 0) > 0
+            and inflight_cap > 0
+            and getattr(pending, "_sibling_media_claimed", False)
+        ):
+            inflight_deadline = time.monotonic() + inflight_cap
+            while inflight.get(sibling_key, 0) > 0 and time.monotonic() < inflight_deadline:
+                if self._pending_text_batches.get(key) is None:
+                    return
+                await asyncio.sleep(0.05)
+                inflight = getattr(self, "_media_inflight", {}) or {}
+
+    def _pending_text_is_sibling_comment(self, pending: Optional[MessageEvent]) -> bool:
+        """True for a short text-only comment that sibling media may absorb."""
+        if pending is None:
+            return False
+        if pending.is_command() or (pending.media_urls or []):
+            return False
+        if len(pending.text or "") > self._TEXT_BATCH_SHORT_LEN:
+            return False
+        if getattr(pending, "_sibling_media_mixed", False):
+            return False
+        return True
+
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text chunk, or hold it while delayed delivery must be dropped."""
         if self._should_drop_delayed_delivery():
             self._hold_inbound_event(event, where="text-enqueue")
             return
+        key = self._text_batch_key(event)
+        existing = self._pending_text_batches.get(key)
+        if existing is not None and self._inbound_sender_id(existing) != self._inbound_sender_id(event):
+            # Base still concatenates same-session text; do not let sibling media
+            # steal another sender's words from that mixed buffer.
+            existing._sibling_media_mixed = True  # type: ignore[attr-defined]
         super()._enqueue_text_event(event)
 
-    async def _flush_buffered(self, pending: dict, tasks: dict, key: str, delay: float, where: str, log_fn=None) -> None:
-        """Shared delayed-flush body: sleep, pop, hold if teardown started, else dispatch. A cancel after
-        the pop but before durable dispatch re-holds the event (never lose it)."""
+    async def _flush_buffered(
+        self, pending: dict, tasks: dict, key: str, delay: float, where: str, log_fn=None,
+        hold: Optional[Callable[[str], Awaitable[None]]] = None,
+    ) -> None:
+        """Shared delayed-flush body: sleep, optional hold, pop, re-hold if teardown started, else dispatch.
+        A cancel after the pop but before durable dispatch re-holds the event (never lose it).
+
+        ``hold`` is text-batch only (sibling-media grace). Photo/album callers omit it so their
+        timing stays byte-identical.
+        """
         current_task = asyncio.current_task()
         event = None
         try:
             await asyncio.sleep(delay)
+            if hold is not None:
+                await hold(key)
             event = pending.pop(key, None)
             if not event:
                 return
@@ -5788,7 +6002,8 @@ class TelegramAdapter(BasePlatformAdapter):
             delay = self._text_batch_delay_seconds
         await self._flush_buffered(
             self._pending_text_batches, self._pending_text_batch_tasks, key, delay, "text",
-            lambda ev: logger.info("[Telegram] Flushing text batch %s (%d chars)", key, len(ev.text or "")))
+            lambda ev: logger.info("[Telegram] Flushing text batch %s (%d chars)", key, len(ev.text or "")),
+            hold=self._wait_for_sibling_media)
 
     # -- Photo batching --
 
@@ -5821,6 +6036,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _enqueue_photo_event(self, batch_key: str, event: MessageEvent) -> None:
         """Merge photo events into a pending batch and schedule flush."""
+        self._absorb_pending_text_into_media_event(event)
         if self._should_drop_delayed_delivery():
             self._hold_inbound_event(event, where="photo-enqueue")
             return
@@ -5856,7 +6072,7 @@ class TelegramAdapter(BasePlatformAdapter):
             if not allowed:
                 event.text = self._append_observed_note(event.text, note or "")
                 logger.info("[Telegram] Skipped oversized user %s (size=%s)", kind, getattr(source, "file_size", None))
-                await self.handle_message(event)
+                await self._dispatch_media_event(event)
                 return True
             file_obj = await source.get_file()
             data = await file_obj.download_as_bytearray()
@@ -5877,7 +6093,7 @@ class TelegramAdapter(BasePlatformAdapter):
     async def _dispatch_with_text(self, event: MessageEvent, text: str) -> bool:
         """Replace the event text with a user-facing note and dispatch it; returns True (handled)."""
         event.text = text
-        await self.handle_message(event)
+        await self._dispatch_media_event(event)
         return True
 
     @staticmethod
@@ -5936,7 +6152,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._set_cached_media(
                     event, await cache_video_from_bytes_async(bytes(video_bytes), ext=ext), SUPPORTED_VIDEO_TYPES[ext], MessageType.VIDEO,
                     "[Telegram] Cached user video document at %s")
-                await self.handle_message(event)
+                await self._dispatch_media_event(event)
                 return True
             # Any file type is accepted (authorization is the gate, not the extension); unknown types get
             # application/octet-stream. Image documents already returned above.
@@ -5969,6 +6185,34 @@ class TelegramAdapter(BasePlatformAdapter):
         return False
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle incoming media messages, downloading images to local cache.
+
+        Marks the session+sender in-flight so a pending text-batch comment
+        (Telegram forward-with-comment) waits and is merged into this media event.
+        """
+        if not update.message:
+            return
+        if not self._is_user_authorized_from_message(update.message):
+            self._log_blocked_user(update.message, level=logging.INFO, what="media from unauthorized user")
+            return
+        if not self._should_process_message(update.message):
+            await self._handle_media_message_unlocked(update, context)
+            return
+        msg = update.message
+        # Match text-batch keys: comments are attributed before enqueue.
+        probe = self._apply_telegram_group_observe_attribution(
+            self._build_message_event(
+                msg, self._media_message_type(msg), update_id=update.update_id,
+            )
+        )
+        key = self._sibling_media_key(probe)
+        generation = self._begin_media_inflight(key)
+        try:
+            await self._handle_media_message_unlocked(update, context)
+        finally:
+            self._end_media_inflight(key, generation)
+
+    async def _handle_media_message_unlocked(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
         msg = update.message
         if not msg:
@@ -5988,12 +6232,18 @@ class TelegramAdapter(BasePlatformAdapter):
         if msg.caption:
             from plugins.platforms.telegram.telegram_context import group_trigger_text
             event.text = group_trigger_text(self, msg, msg.caption)
-        # Stickers: _handle_sticker overwrites event.text with its vision description, so observe attribution must run after it.
+        # Text batches are attributed on enqueue. Attribute a view first so the
+        # snapshot key matches, then pin before any await. Stickers overwrite
+        # event.text and need the raw identity for a single later attribution.
+        attributed = self._apply_telegram_group_observe_attribution(event)
+        self._mark_sibling_absorb_eligibility(attributed)
         if msg.sticker:
             await self._handle_sticker(msg, event)
-            await self.handle_message(self._apply_telegram_group_observe_attribution(event))
+            event = self._copy_sibling_pending(
+                attributed, self._apply_telegram_group_observe_attribution(event))
+            await self._dispatch_media_event(event)
             return
-        event = self._apply_telegram_group_observe_attribution(event)
+        event = attributed
         # Cache photo locally: Telegram's file URLs expire (~1 hour) before vision may run.
         if msg.photo:
             try:
@@ -6024,11 +6274,12 @@ class TelegramAdapter(BasePlatformAdapter):
         if media_group_id:
             await self._queue_media_group_event(str(media_group_id), event)
             return
-        await self.handle_message(event)
+        await self._dispatch_media_event(event)
 
     async def _queue_media_group_event(self, media_group_id: str, event: MessageEvent) -> None:
         """Debounce album items (shared media_group_id) into one MessageEvent so the second image isn't
         treated as a new message interrupting the first."""
+        self._absorb_pending_text_into_media_event(event)
         if self._should_drop_delayed_delivery():
             self._hold_inbound_event(event, where="media-group-enqueue")
             return

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -7,7 +7,7 @@ from the same session and aggregate them before dispatching.
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -36,6 +36,8 @@ def _make_adapter():
     adapter._pending_photo_batch_tasks = {}
     adapter._media_group_events = {}
     adapter._media_group_tasks = {}
+    adapter._media_inflight = {}
+    adapter._media_inflight_generation = 0
     adapter._polling_error_task = None
     adapter._polling_heartbeat_task = None
     adapter._app = None
@@ -43,6 +45,10 @@ def _make_adapter():
     adapter._set_status_indicator = AsyncMock()
     adapter._release_platform_lock = lambda: None
     adapter._text_batch_delay_seconds = 0.1  # fast for tests
+    # Existing tests assert dispatch at delay+ε; keep sibling-media hold off
+    # unless a test enables it explicitly.
+    adapter._TEXT_SIBLING_MEDIA_GRACE_S = 0
+    adapter._TEXT_MEDIA_INFLIGHT_CAP_S = 0
     adapter._active_sessions = {}
     adapter._pending_messages = {}
     adapter._message_handler = AsyncMock()
@@ -54,11 +60,22 @@ def _make_adapter():
     return adapter
 
 
-def _make_event(text: str, chat_id: str = "12345") -> MessageEvent:
+def _make_event(
+    text: str,
+    chat_id: str = "12345",
+    user_id: str = "1",
+    chat_type: str = "dm",
+    message_type: MessageType = MessageType.TEXT,
+) -> MessageEvent:
     return MessageEvent(
         text=text,
-        message_type=MessageType.TEXT,
-        source=SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"),
+        message_type=message_type,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=chat_id,
+            chat_type=chat_type,
+            user_id=user_id,
+        ),
     )
 
 
@@ -530,3 +547,254 @@ class TestHoldInboundAcrossReconnect:
         await adapter._redispatch_held_inbound()
         held_texts = [e.text for e in adapter._held_inbound_events]
         assert held_texts == ["boom", "after"]
+
+
+class TestSiblingMediaAbsorb:
+    def test_absorb_pending_text_prepends_comment_to_caption(self):
+        """Forward-with-comment: comment TEXT is merged into the media caption."""
+        adapter = _make_adapter()
+        comment = _make_event("Додай у календар")
+        media = _make_event("🔥 5 ВЕРЕСНЯ announcement", message_type=MessageType.VIDEO)
+        adapter._pending_text_batches[adapter._text_batch_key(comment)] = comment
+        adapter._mark_sibling_absorb_eligibility(media)
+
+        absorbed = adapter._absorb_pending_text_into_media_event(media)
+
+        assert absorbed is True
+        assert media.text.startswith("Додай у календар")
+        assert "🔥 5 ВЕРЕСНЯ announcement" in media.text
+        assert adapter._pending_text_batches == {}
+        assert adapter._pending_text_batch_tasks == {}
+
+    def test_absorb_refuses_without_admission_snapshot(self):
+        """A media event that never snapshotted must not steal a later comment."""
+        adapter = _make_adapter()
+        comment = _make_event("Додай у календар")
+        media = _make_event("forwarded caption", message_type=MessageType.VIDEO)
+        adapter._pending_text_batches[adapter._text_batch_key(comment)] = comment
+
+        assert adapter._absorb_pending_text_into_media_event(media) is False
+        assert adapter._pending_text_batches[adapter._text_batch_key(comment)] is comment
+
+    def test_absorb_refuses_different_sender(self):
+        adapter = _make_adapter()
+        adapter.config.extra["group_sessions_per_user"] = False
+        comment = _make_event("hello", user_id="1", chat_type="group", chat_id="-100")
+        media = _make_event("caption", user_id="2", chat_type="group", chat_id="-100")
+        assert adapter._text_batch_key(comment) == adapter._text_batch_key(media)
+        adapter._pending_text_batches[adapter._text_batch_key(comment)] = comment
+        adapter._mark_sibling_absorb_eligibility(media)
+
+        assert getattr(media, "_sibling_pending", None) is None
+        assert adapter._absorb_pending_text_into_media_event(media) is False
+        assert adapter._pending_text_batches[adapter._text_batch_key(comment)] is comment
+
+    def test_absorb_refuses_replacement_comment_after_snapshot(self):
+        """Inflight media may only consume the comment that was pending at admission."""
+        adapter = _make_adapter()
+        original = _make_event("first comment")
+        replacement = _make_event("second comment")
+        media = _make_event("forwarded caption", message_type=MessageType.VIDEO)
+        key = adapter._text_batch_key(original)
+        adapter._pending_text_batches[key] = original
+        adapter._mark_sibling_absorb_eligibility(media)
+        adapter._pending_text_batches[key] = replacement
+
+        assert adapter._absorb_pending_text_into_media_event(media) is False
+        assert adapter._pending_text_batches[key] is replacement
+
+    @pytest.mark.asyncio
+    async def test_mixed_sender_buffer_is_not_a_sibling_comment(self):
+        adapter = _make_adapter()
+        adapter.config.extra["group_sessions_per_user"] = False
+        first = _make_event("from-one", user_id="1", chat_type="group", chat_id="-100")
+        second = _make_event("from-two", user_id="2", chat_type="group", chat_id="-100")
+        assert adapter._text_batch_key(first) == adapter._text_batch_key(second)
+        try:
+            adapter._enqueue_text_event(first)
+            adapter._enqueue_text_event(second)
+            pending = adapter._pending_text_batches[adapter._text_batch_key(first)]
+            assert getattr(pending, "_sibling_media_mixed", False) is True
+            assert adapter._pending_text_is_sibling_comment(pending) is False
+        finally:
+            tasks = [t for t in adapter._pending_text_batch_tasks.values() if t is not None]
+            for task in tasks:
+                task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_flush_skips_when_media_absorbs_comment(self):
+        """Comment must not start its own turn once sibling media absorbs it."""
+        adapter = _make_adapter()
+        adapter._text_batch_delay_seconds = 0.05
+        adapter._TEXT_SIBLING_MEDIA_GRACE_S = 0.4
+        adapter._TEXT_MEDIA_INFLIGHT_CAP_S = 2.0
+        comment = _make_event("Додай у календар")
+        media = _make_event("forwarded caption", message_type=MessageType.VIDEO)
+        adapter._enqueue_text_event(comment)
+        adapter._mark_sibling_absorb_eligibility(media)
+        adapter._begin_media_inflight(adapter._sibling_media_key(comment))
+
+        await asyncio.sleep(0.08)
+        adapter.handle_message.assert_not_called()
+
+        await adapter._dispatch_media_event(media)
+        adapter._end_media_inflight(adapter._sibling_media_key(comment))
+
+        await asyncio.sleep(0.2)
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert "Додай у календар" in dispatched.text
+        assert "forwarded caption" in dispatched.text
+
+    @pytest.mark.asyncio
+    async def test_short_text_still_flushes_when_no_sibling_media(self):
+        """Grace must not swallow a lone short message if no media arrives."""
+        adapter = _make_adapter()
+        adapter._text_batch_delay_seconds = 0.05
+        adapter._TEXT_SIBLING_MEDIA_GRACE_S = 0.15
+        adapter._TEXT_MEDIA_INFLIGHT_CAP_S = 0
+        adapter._enqueue_text_event(_make_event("ok"))
+        await asyncio.sleep(0.35)
+        adapter.handle_message.assert_called_once()
+        assert adapter.handle_message.call_args[0][0].text == "ok"
+
+    @pytest.mark.asyncio
+    async def test_inflight_hold_skips_unclaimed_replacement(self):
+        """A later short text must not sit behind a download that cannot absorb it."""
+        adapter = _make_adapter()
+        adapter._text_batch_delay_seconds = 0.05
+        adapter._TEXT_SIBLING_MEDIA_GRACE_S = 0.05
+        adapter._TEXT_MEDIA_INFLIGHT_CAP_S = 2.0
+        original = _make_event("first")
+        media = _make_event("caption", message_type=MessageType.VIDEO)
+        sibling_key = adapter._sibling_media_key(original)
+        adapter._pending_text_batches[adapter._text_batch_key(original)] = original
+        adapter._mark_sibling_absorb_eligibility(media)
+        adapter._pending_text_batches.pop(adapter._text_batch_key(original), None)
+        adapter._begin_media_inflight(sibling_key)
+
+        replacement = _make_event("second")
+        adapter._enqueue_text_event(replacement)
+        await asyncio.sleep(0.25)
+        adapter.handle_message.assert_called_once()
+        assert adapter.handle_message.call_args[0][0].text == "second"
+        adapter._end_media_inflight(sibling_key)
+
+    def test_observe_attribution_same_sender_still_pairs(self):
+        """Group-observe strips source.user_id; pairing falls back to raw_message.from_user."""
+        adapter = _make_adapter()
+        adapter.config.extra["group_sessions_per_user"] = False
+        comment = _make_event("hello", user_id="1", chat_type="group", chat_id="-100")
+        media = _make_event("caption", user_id="1", chat_type="group", chat_id="-100", message_type=MessageType.VIDEO)
+        comment.source.user_id = None
+        comment.source.user_name = None
+        media.source.user_id = None
+        media.source.user_name = None
+        comment.raw_message = SimpleNamespace(from_user=SimpleNamespace(id=1))
+        media.raw_message = SimpleNamespace(from_user=SimpleNamespace(id=1))
+        adapter._pending_text_batches[adapter._text_batch_key(comment)] = comment
+        adapter._mark_sibling_absorb_eligibility(media)
+
+        assert adapter._absorb_pending_text_into_media_event(media) is True
+        assert "hello" in media.text
+        assert adapter._pending_text_batches == {}
+
+    def test_observe_attribution_different_sender_does_not_pair(self):
+        adapter = _make_adapter()
+        adapter.config.extra["group_sessions_per_user"] = False
+        comment = _make_event("hello", user_id="1", chat_type="group", chat_id="-100")
+        media = _make_event("caption", user_id="2", chat_type="group", chat_id="-100", message_type=MessageType.VIDEO)
+        comment.source.user_id = None
+        media.source.user_id = None
+        comment.raw_message = SimpleNamespace(from_user=SimpleNamespace(id=1))
+        media.raw_message = SimpleNamespace(from_user=SimpleNamespace(id=2))
+        adapter._pending_text_batches[adapter._text_batch_key(comment)] = comment
+        adapter._mark_sibling_absorb_eligibility(media)
+
+        assert getattr(media, "_sibling_pending", None) is None
+        assert adapter._absorb_pending_text_into_media_event(media) is False
+        assert adapter._pending_text_batches[adapter._text_batch_key(comment)] is comment
+
+    @pytest.mark.asyncio
+    async def test_handle_media_absorbs_comment_before_flush(self):
+        """Real media handler: short TEXT then VIDEO become one turn (no forward_origin)."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        config = PlatformConfig(enabled=True, token="test-token")
+        adapter = TelegramAdapter(config)
+        adapter.handle_message = AsyncMock()
+        adapter._is_user_authorized_from_message = lambda _msg: True
+        adapter._should_process_message = lambda _msg, is_command=False: True
+        adapter._text_batch_delay_seconds = 0.05
+        adapter._TEXT_SIBLING_MEDIA_GRACE_S = 0.4
+        adapter._TEXT_MEDIA_INFLIGHT_CAP_S = 2.0
+
+        comment = _make_event("Додай у календар", chat_id="12345", user_id="1")
+        adapter._enqueue_text_event(comment)
+
+        file_obj = AsyncMock()
+        file_obj.download_as_bytearray = AsyncMock(return_value=bytearray(b"video-bytes"))
+        file_obj.file_path = "videos/file.mp4"
+        video = MagicMock()
+        video.get_file = AsyncMock(return_value=file_obj)
+        video.file_size = 1024
+        msg = MagicMock()
+        msg.message_id = 99
+        msg.text = ""
+        msg.caption = "forwarded caption"
+        msg.date = None
+        msg.photo = None
+        msg.video = video
+        msg.audio = None
+        msg.voice = None
+        msg.sticker = None
+        msg.document = None
+        msg.media_group_id = None
+        msg.forward_origin = None
+        msg.forward_date = None
+        msg.forward_from = None
+        msg.reply_to_message = None
+        msg.chat = MagicMock(id=12345, type="private", title=None, full_name="Test User", is_forum=False)
+        msg.from_user = MagicMock(id=1, full_name="Test User", username="test", is_bot=False)
+        msg.message_thread_id = None
+        msg.is_topic_message = False
+        msg.reply_text = AsyncMock()
+        update = MagicMock(message=msg, update_id=7)
+
+        entered = asyncio.Event()
+        released = asyncio.Event()
+
+        async def _slow_cache(*_a, **_k):
+            entered.set()
+            await released.wait()
+            return "/tmp/fake-video.mp4"
+
+        media_task = None
+        try:
+            with patch(
+                "plugins.platforms.telegram.adapter.cache_video_from_bytes_async",
+                _slow_cache,
+            ):
+                media_task = asyncio.create_task(adapter._handle_media_message(update, MagicMock()))
+                await asyncio.wait_for(entered.wait(), timeout=2)
+                await asyncio.sleep(0.12)
+                adapter.handle_message.assert_not_called()
+                released.set()
+                await asyncio.wait_for(media_task, timeout=2)
+            adapter.handle_message.assert_called_once()
+            dispatched = adapter.handle_message.call_args[0][0]
+            assert "Додай у календар" in dispatched.text
+            assert "forwarded caption" in dispatched.text
+            assert dispatched.media_urls == ["/tmp/fake-video.mp4"]
+        finally:
+            released.set()
+            if media_task is not None and not media_task.done():
+                media_task.cancel()
+                await asyncio.gather(media_task, return_exceptions=True)
+            tasks = [t for t in adapter._pending_text_batch_tasks.values() if t is not None]
+            for task in tasks:
+                task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)


### PR DESCRIPTION
## What does this PR do?

Telegram **forward-with-comment** arrives as two updates: a short TEXT
comment, then media whose caption is the forwarded post. Upstream's ~180ms
fast text flush starts a turn on the comment alone; any `media_urls` on the
later update are queued until that turn ends (`busy_input_mode: steer` never
splices media mid-turn).

This holds a short text-only batch for a sibling-media grace (~0.5s) and, if
same-sender media is already downloading, up to a 20s inflight cap. The media
path snapshots the pending comment at admission (object identity + batch key)
and merges it into the media event at dispatch, so one turn sees both.

Not a duplicate of #46101 (no matching PR found in the searches performed
for `TEXT_SIBLING_MEDIA` / `_absorb_pending_text_into_media_event` / this
title). #46101 merges **forwarded** batch attachments into a turn when a
download is already pending (`has_startup_media_pending` / `forward_origin`;
"startup" there means the start of a turn, not of a conversation). This
covers ordinary TEXT with no `forward_origin` that arrives *before* media,
so #46101's fast path still flushes the comment.

## Related Issue

No dedicated issue. Adjacent, not a duplicate:

- #46101 — forwarded-batch startup merge (pending download / `forward_origin`)
- #74965 — album items split across turns (different race)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py` — sibling-media grace + inflight
  wait on text flush; snapshot/absorb on the media path; same-sender only
- `tests/gateway/test_telegram_text_batching.py` — unit coverage for absorb,
  mixed-sender refuse, inflight hold, observe-mode pairing, and a real
  `_handle_media_message` regression (TEXT then VIDEO, no `forward_origin`)

## How to Test

1. Focused suites (worktree, `PYTHONPATH` pinned to this tree):
   `pytest tests/gateway/test_telegram_text_batching.py tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_caption_merge.py -q`
   → 76 passed.
2. Manual: in a Telegram DM, forward a video/photo *with a short comment*
   (the client sends TEXT then media). One agent turn should see both the
   comment and the attachment. A lone short text still flushes after grace
   (~0.5s extra).
3. Full `pytest tests/ -q` was **not** run locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux; focused automated tests only

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (asyncio timing; no OS-specific APIs)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. Local log line on merge:
`[Telegram] Merged pending text (N chars) into media event …`

## Risk Assessment

Medium — every short text-only batch waits up to **0.5s** extra; a claimed
comment can wait on a same-sender download up to **20s**. Photo-album flush
timing is unchanged (`hold=` is text-batch only). Mixed-sender buffers and
later replacement text are not absorbed. Draft until CI + a real Telegram
forward-with-comment are checked.
