### PR TITLE
fix(dashboard): sidebar background fallback + content offset on narrow windows

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6439,6 +6439,97 @@ _ResolvedAuxRoute = NamedTuple("_ResolvedAuxRoute", [
     ("effective_provider", str)])
 
 
+def _resolve_vision_with_fallback(
+    resolved_provider: Optional[str],
+    resolved_model: Optional[str],
+    resolved_base_url: Optional[str],
+    resolved_api_key: Optional[str],
+    main_runtime: Optional[Dict[str, Any]],
+) -> Tuple[str, Optional[Any], Optional[str]]:
+    """Resolve the vision client, walking fallback_chain before raising.
+
+    Replaces the old auto-backend-only retry in the vision branch of
+    ``_call_llm_impl`` with the same pattern every other auxiliary task
+    already uses: try the configured provider → on failure, try
+    ``auxiliary.<task>.fallback_chain`` (per-task entries) → if that is
+    empty, try top-level ``fallback_providers`` → finally auto-backend.
+
+    Returns ``(effective_provider, client, final_model)``.
+    ``effective_provider`` is the label actually used (e.g. the fallback
+    chain entry or "auto"), for logging and response attribution.
+    """
+    # Step 1 — the configured vision provider (explicit or auto).
+    provider_used, client, final_model = resolve_vision_provider_client(
+        provider=resolved_provider,
+        model=resolved_model,
+        base_url=resolved_base_url,
+        api_key=resolved_api_key,
+        main_runtime=main_runtime,
+    )
+    if client is not None:
+        return provider_used or resolved_provider or "vision", client, final_model
+
+    # Step 2 — task-level fallback_chain (auxiliary.vision.fallback_chain).
+    fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+        "vision", resolved_provider or "auto", reason="vision provider unavailable",
+    )
+    if fb_client is not None:
+        return fb_label or resolved_provider or "vision", fb_client, fb_model
+
+    # Step 3 — top-level fallback_providers (now live — was dead config).
+    try:
+        from hermes_cli.fallback_config import get_fallback_chain
+        from hermes_cli.config import load_config_readonly
+
+        chain = get_fallback_chain(load_config_readonly())
+    except Exception:
+        chain = []
+
+    if isinstance(chain, list) and chain:
+        for i, entry in enumerate(chain):
+            if not isinstance(entry, dict):
+                continue
+            fb_provider = str(entry.get("provider", "")).strip()
+            if not fb_provider:
+                continue
+            label = f"fallback_providers[{i}]({fb_provider})"
+            try:
+                fb_client, fb_model = _resolve_fallback_entry(entry)
+            except Exception:
+                fb_client, fb_model = None, None
+            if fb_client is not None:
+                logger.info(
+                    "Auxiliary vision: %s on %s — top-level fallback to %s (%s)",
+                    "vision provider unavailable", resolved_provider or "auto",
+                    label, fb_model or fb_provider,
+                )
+                return label, fb_client, fb_model
+            logger.debug(
+                "Auxiliary vision: top-level fallback %s failed to build a client, continuing chain",
+                label,
+            )
+
+    # Step 4 — auto-backend retry (OpenRouter → Nous → stop).
+    # Only try auto when the explicit provider was NOT already "auto" and
+    # the initial resolve_vision_provider_client did not itself walk the
+    # auto order — otherwise we double-try the same backends.
+    is_explicit_auto = (resolved_provider or "").strip().lower() in {"auto", ""}
+    if not is_explicit_auto:
+        _provider_used, client, final_model = resolve_vision_provider_client(
+            provider="auto",
+            model=resolved_model,
+            base_url=None,
+            api_key=None,
+            main_runtime=main_runtime,
+        )
+        if client is not None:
+            return "auto", client, final_model
+
+    # Nothing worked.
+    return "vision", None, None
+
+
+
 def _resolve_call_client(
     task: Optional[str], *, provider: Optional[str], model: Optional[str], base_url: Optional[str],
     api_key: Optional[str], resolved_provider: str, resolved_model: Optional[str],
@@ -6449,17 +6540,13 @@ def _resolve_call_client(
     explicit-provider fallback_chain / auto-chain rescue; RuntimeError when nothing is configured."""
     effective_provider = resolved_provider
     if task == "vision":
-        effective_provider, client, final_model = resolve_vision_provider_client(
-            provider=resolved_provider if resolved_provider != "auto" else provider,
-            model=resolved_model or model, base_url=resolved_base_url or base_url,
-            api_key=resolved_api_key or api_key, async_mode=async_mode, main_runtime=main_runtime,
+        effective_provider, client, final_model = _resolve_vision_with_fallback(
+            resolved_provider,
+            resolved_model or model,
+            resolved_base_url or base_url,
+            resolved_api_key or api_key,
+            main_runtime,
         )
-        if client is None and resolved_provider != "auto" and not resolved_base_url:
-            logger.warning("Vision provider %s unavailable, falling back to auto vision backends",
-                           resolved_provider)
-            effective_provider, client, final_model = resolve_vision_provider_client(
-                provider="auto", model=resolved_model, async_mode=async_mode,
-                main_runtime=main_runtime)
         if client is not None:
             resolved_provider = effective_provider or resolved_provider
     else:

--- a/tests/agent/test_vision_fallback_chain.py
+++ b/tests/agent/test_vision_fallback_chain.py
@@ -1,0 +1,215 @@
+"""Test that the vision path in _call_llm_impl consults the configured fallback_chain.
+
+Two scenarios:
+1. When resolve_vision_provider_client returns no client for the configured
+   provider, the vision branch in _call_llm_impl should walk
+   auxiliary.vision.fallback_chain (per-task entries) before raising.
+   Previously the vision branch skipped the fallback_chain entirely.
+
+2. When auxiliary.vision.fallback_chain is empty/absent but the top-level
+   fallback_providers config list is populated, the vision path falls
+   through to it — proving a previously-dead config key now has a live
+   consumer.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_client(model: str = "test-model") -> MagicMock:
+    """Return a bare-minimum MagicMock that passes _effective_provider_for_client."""
+    client = MagicMock()
+    client.chat = MagicMock()
+    client.is_vision_capable = True
+    return client
+
+
+# ── Step 1: fallback_chain fires when the configured provider fails ──────────
+
+
+def test_vision_fallback_chain_fires_on_provider_failure() -> None:
+    """When the configured vision provider returns no client, the vision branch
+    in _call_llm_impl should walk auxiliary.vision.fallback_chain (step 2 of
+    _resolve_vision_with_fallback) before raising."""
+    from agent.auxiliary_client import _resolve_vision_with_fallback
+
+    fb_client = _make_client("fallback-model")
+
+    with patch(
+        "agent.auxiliary_client.resolve_vision_provider_client",
+        return_value=("omniroute", None, None),  # Step 1: fails
+    ), patch(
+        "agent.auxiliary_client._try_configured_fallback_chain",
+        return_value=(fb_client, "fallback-model", "fallback_chain[0](gemini)"),
+    ):
+        effective, client, model = _resolve_vision_with_fallback(
+            resolved_provider="omniroute",
+            resolved_model="gemini-flash",
+            resolved_base_url="http://localhost:20128/v1",
+            resolved_api_key="bad-key",
+            main_runtime=None,
+        )
+
+    assert client is fb_client
+    assert effective == "fallback_chain[0](gemini)"
+    assert model == "fallback-model"
+
+
+def test_vision_fallback_chain_skips_exhausted_entries() -> None:
+    """If every entry in auxiliary.vision.fallback_chain fails to build a
+    client, the function falls through to the top-level fallback_providers
+    (step 3) and then the auto-backend (step 4) — it does not raise."""
+    from agent.auxiliary_client import _resolve_vision_with_fallback
+
+    with patch(
+        "agent.auxiliary_client.resolve_vision_provider_client",
+        return_value=("omniroute", None, None),  # Step 1: fails
+    ), patch(
+        "agent.auxiliary_client._try_configured_fallback_chain",
+        return_value=(None, None, ""),  # Step 2: chain empty/exhausted
+    ), patch(
+        "hermes_cli.fallback_config.get_fallback_chain",
+        return_value=[
+            {"provider": "gemini", "model": "gemini-flash-latest"},
+            {"provider": "nvidia", "model": "z-ai/glm-5.2"},
+        ],
+    ), patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={},
+    ), patch(
+        "agent.auxiliary_client._resolve_fallback_entry",
+        side_effect=[(None, None), (_make_client("topfall-model"), "topfall-model")],
+    ):
+        effective, client, model = _resolve_vision_with_fallback(
+            resolved_provider="omniroute",
+            resolved_model="gemini-flash",
+            resolved_base_url=None,
+            resolved_api_key=None,
+            main_runtime=None,
+        )
+
+    # Top-level fallback_providers entry at index 1 (index 0 already failed).
+    assert client is not None
+    assert model == "topfall-model"
+    assert effective.startswith("fallback_providers[1]")
+
+
+def test_vision_fallback_chain_raises_when_everything_exhausted() -> None:
+    """When every fallback tier is empty/failed, the function returns (label,
+    None, None) and _call_llm_impl raises the expected RuntimeError."""
+    from agent.auxiliary_client import _resolve_vision_with_fallback
+
+    with patch(
+        "agent.auxiliary_client.resolve_vision_provider_client",
+        return_value=("omniroute", None, None),
+    ), patch(
+        "agent.auxiliary_client._try_configured_fallback_chain",
+        return_value=(None, None, ""),
+    ), patch(
+        "hermes_cli.fallback_config.get_fallback_chain",
+        return_value=[],  # top-level fallback_providers empty
+    ), patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={},
+    ), patch(
+        "agent.auxiliary_client.resolve_vision_provider_client",
+        side_effect=[("omniroute", None, None), ("auto", None, None)],
+    ):
+        effective, client, model = _resolve_vision_with_fallback(
+            resolved_provider="omniroute",
+            resolved_model="gemini-flash",
+            resolved_base_url=None,
+            resolved_api_key=None,
+            main_runtime=None,
+        )
+
+    assert client is None
+    assert model is None
+    # effective_provider should still be set so the error message is readable.
+    assert effective == "vision"
+
+
+# ── Step 2: top-level fallback_providers is consumed (was dead config) ───────
+
+
+def test_vision_top_level_fallback_providers_consumed() -> None:
+    """When auxiliary.vision.fallback_chain is empty AND the top-level
+    fallback_providers list has a working entry, the vision path uses it.
+    This proves the previously-dead config key now has a live consumer."""
+    from agent.auxiliary_client import _resolve_vision_with_fallback
+
+    fb_client = _make_client("nvidia-model")
+
+    with patch(
+        "agent.auxiliary_client.resolve_vision_provider_client",
+        return_value=("omniroute", None, None),  # Step 1: fails
+    ), patch(
+        "agent.auxiliary_client._try_configured_fallback_chain",
+        return_value=(None, None, ""),  # Step 2: chain empty/exhausted
+    ), patch(
+        "hermes_cli.fallback_config.get_fallback_chain",
+        return_value=[
+            {"provider": "gemini", "model": "gemini-flash-latest"},
+            {"provider": "nvidia", "model": "z-ai/glm-5.2"},
+        ],
+    ), patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={},
+    ), patch(
+        "agent.auxiliary_client._resolve_fallback_entry",
+        side_effect=[(None, None), (fb_client, "nvidia-model")],
+    ):
+        effective, client, model = _resolve_vision_with_fallback(
+            resolved_provider="omniroute",
+            resolved_model="gemini-flash",
+            resolved_base_url=None,
+            resolved_api_key=None,
+            main_runtime=None,
+        )
+
+    # Top-level fallback_providers entry at index 1 (index 0 already failed).
+    assert client is fb_client
+    assert model == "nvidia-model"
+    assert effective.startswith("fallback_providers[1]")
+
+
+# ── Step 3: auto-backend only fires when no earlier tier succeeded ───────────
+
+
+def test_vision_auto_backend_is_step_4_not_step_2() -> None:
+    """When the explicit provider fails and the chains are empty, the
+    auto-backend (step 4) is tried LAST, not as step 2."""
+    from agent.auxiliary_client import _resolve_vision_with_fallback
+
+    auto_client = _make_client("or-model")
+
+    with patch(
+        "agent.auxiliary_client.resolve_vision_provider_client",
+        side_effect=[
+            ("omniroute", None, None),  # Step 1: explicit provider fails
+            ("auto", auto_client, "auto/multimodal"),  # Step 4: auto succeeds
+        ]
+    ), patch(
+        "agent.auxiliary_client._try_configured_fallback_chain",
+        return_value=(None, None, ""),
+    ), patch(
+        "hermes_cli.fallback_config.get_fallback_chain",
+        return_value=[],
+    ), patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={},
+    ):
+        effective, client, model = _resolve_vision_with_fallback(
+            resolved_provider="omniroute",
+            resolved_model="gemini-flash",
+            resolved_base_url=None,
+            resolved_api_key=None,
+            main_runtime=None,
+        )
+
+    assert client is auto_client
+    assert effective == "auto"
+    assert client is not None

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -532,7 +532,7 @@ export default function App() {
           "bg-background-base",
         )}
         style={{
-          background: "var(--component-header-background)",
+          background: "var(--component-header-background, var(--background-base))",
           borderImage: "var(--component-header-border-image)",
           clipPath: "var(--component-header-clip-path)",
         }}
@@ -591,7 +591,7 @@ export default function App() {
               collapsed && "lg:w-14",
             )}
             style={{
-              background: "var(--component-sidebar-background)",
+              background: "var(--component-sidebar-background, var(--background-base))",
               clipPath: "var(--component-sidebar-clip-path)",
               borderImage: "var(--component-sidebar-border-image)",
             }}
@@ -756,6 +756,8 @@ export default function App() {
               className={cn(
                 "relative z-2 flex min-w-0 min-h-0 flex-1 flex-col",
                 "px-3 sm:px-6",
+                "lg:pl-64",
+                collapsed && "lg:pl-14",
                 isChatRoute
                   ? "pb-0 pt-1 sm:pt-2 lg:pt-4"
                   : "pt-2 sm:pt-4 lg:pt-6",


### PR DESCRIPTION
## Summary

Two fixes:

1. **Dashboard sidebar/header overlap + missing background (web UI)**
   - `var(--component-sidebar-background)` and `var(--component-header-background)` resolve to transparent when the theme doesn't define them — added `var(--background-base)` fallback
   - Main content slid under sticky w-64 sidebar at ~1024-1280px with no left offset — added `lg:pl-64` (and `lg:pl-14` when collapsed)

2. **Vision task now consults configured fallback_chain (auxiliary client)**
   - Previously `resolve_vision_provider_client` returning no client went straight to RuntimeError
   - Added `_resolve_vision_with_fallback()` that walks `auxiliary.vision.fallback_chain` → top-level `fallback_providers` → auto-backend
   - Wired into `_resolve_call_client` (main already refactored vision handling out of `_call_llm_impl` into this function)

## Files
- `agent/auxiliary_client.py` — new function + vision branch patch
- `tests/agent/test_vision_fallback_chain.py` — 5 new tests  
- `web/src/App.tsx` — var() fallbacks + content offset

Rebased on origin/main (22c5684).