### PR TITLE
fix(desktop): preserve branch-pin for local and unmerged branches during updater healing (#105042)

### DIFF
--- a/apps/desktop/electron/branch-healer.test.ts
+++ b/apps/desktop/electron/branch-healer.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for electron/branch-healer.ts — self-healing logic for the desktop
+ * updater branch-pin (#105042).
+ *
+ * Run with: node --test apps/desktop/electron/branch-healer.test.ts
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolveHealedBranch, type BranchHealerDeps } from './branch-healer.ts'
+
+function createMockDeps(overrides: Partial<BranchHealerDeps> = {}): {
+  deps: BranchHealerDeps
+  logs: string[]
+  writtenConfig: () => { branch: string } | null
+} {
+  const logs: string[] = []
+  let writtenConfig: { branch: string } | null = null
+
+  const deps: BranchHealerDeps = {
+    runGit: async () => ({ code: 0, stdout: '', stderr: '' }),
+    getOriginUrl: async () => 'https://github.com/NousResearch/hermes-agent.git',
+    isOfficialSshRemote: () => false,
+    officialRepoHttpsUrl: 'https://github.com/NousResearch/hermes-agent.git',
+    rememberLog: (msg: string) => logs.push(msg),
+    readDesktopUpdateConfig: () => ({ branch: 'feature' }),
+    writeDesktopUpdateConfig: (cfg: { branch: string }) => {
+      writtenConfig = cfg
+    },
+    ...overrides
+  }
+
+  return { deps, logs, writtenConfig: () => writtenConfig }
+}
+
+test('resolveHealedBranch: returns main or falsy branch immediately without git calls', async () => {
+  let gitCalled = false
+  const { deps } = createMockDeps({
+    runGit: async () => {
+      gitCalled = true
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  assert.equal(await resolveHealedBranch(deps, '/fake/root', 'main'), 'main')
+  assert.equal(await resolveHealedBranch(deps, '/fake/root', ''), 'main')
+  assert.equal(gitCalled, false)
+})
+
+test('resolveHealedBranch: keeps branch when remote still publishes it (ls-remote exit 0)', async () => {
+  const { deps, writtenConfig } = createMockDeps({
+    runGit: async (args: string[]) => {
+      if (args[0] === 'ls-remote') {
+        return { code: 0, stdout: 'abc1234 refs/heads/feature\n', stderr: '' }
+      }
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  const result = await resolveHealedBranch(deps, '/fake/root', 'feature')
+  assert.equal(result, 'feature')
+  assert.equal(writtenConfig(), null)
+})
+
+test('resolveHealedBranch: keeps branch on transient network failure (ls-remote exit 128)', async () => {
+  const { deps, writtenConfig } = createMockDeps({
+    runGit: async (args: string[]) => {
+      if (args[0] === 'ls-remote') {
+        return { code: 128, stdout: '', stderr: 'fatal: could not resolve host' }
+      }
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  const result = await resolveHealedBranch(deps, '/fake/root', 'feature')
+  assert.equal(result, 'feature')
+  assert.equal(writtenConfig(), null)
+})
+
+test('resolveHealedBranch: keeps branch when exit 2 but branch is purely local (no remote-tracking ref or upstream)', async () => {
+  const { deps, writtenConfig } = createMockDeps({
+    runGit: async (args: string[]) => {
+      if (args[0] === 'ls-remote') {
+        return { code: 2, stdout: '', stderr: '' }
+      }
+      if (args[0] === 'rev-parse') {
+        // neither refs/remotes/origin/feature nor feature@{upstream} exist
+        return { code: 1, stdout: '', stderr: 'fatal: Needed a single revision' }
+      }
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  const result = await resolveHealedBranch(deps, '/fake/root', 'hermes-local')
+  assert.equal(result, 'hermes-local')
+  assert.equal(writtenConfig(), null)
+})
+
+test('resolveHealedBranch: keeps branch when exit 2 and remote ref existed, but branch carries unmerged commits', async () => {
+  const { deps, writtenConfig } = createMockDeps({
+    runGit: async (args: string[]) => {
+      if (args[0] === 'ls-remote') {
+        return { code: 2, stdout: '', stderr: '' }
+      }
+      if (args[0] === 'rev-parse') {
+        // remote tracking ref existed
+        return { code: 0, stdout: 'abc123\n', stderr: '' }
+      }
+      if (args[0] === 'rev-list') {
+        // 3 unmerged commits
+        return { code: 0, stdout: '3\n', stderr: '' }
+      }
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  const result = await resolveHealedBranch(deps, '/fake/root', 'feature-unmerged')
+  assert.equal(result, 'feature-unmerged')
+  assert.equal(writtenConfig(), null)
+})
+
+test('resolveHealedBranch: heals to main and persists config when exit 2, remote ref existed, and 0 unmerged commits', async () => {
+  const { deps, writtenConfig } = createMockDeps({
+    runGit: async (args: string[]) => {
+      if (args[0] === 'ls-remote') {
+        return { code: 2, stdout: '', stderr: '' }
+      }
+      if (args[0] === 'rev-parse') {
+        // remote tracking ref existed
+        return { code: 0, stdout: 'abc123\n', stderr: '' }
+      }
+      if (args[0] === 'rev-list') {
+        // 0 unmerged commits (fully merged into main)
+        return { code: 0, stdout: '0\n', stderr: '' }
+      }
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  })
+
+  const result = await resolveHealedBranch(deps, '/fake/root', 'bb/gui')
+  assert.equal(result, 'main')
+  assert.deepEqual(writtenConfig(), { branch: 'main' })
+})

--- a/apps/desktop/electron/branch-healer.ts
+++ b/apps/desktop/electron/branch-healer.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure helpers for self-healing the desktop updater's tracked branch (#105042).
+ *
+ * If origin published a branch (e.g. a PR branch or shared feature branch) that was
+ * merged into main and deleted on the remote, the desktop updater self-heals by
+ * falling back to main and persisting that choice.
+ *
+ * However, exit code 2 from `git ls-remote --exit-code --heads <remote> <branch>`
+ * only indicates that the ref is absent on the remote. That is true for a branch
+ * deleted after merge, but it is equally true for a purely local branch that was
+ * never pushed to origin.
+ *
+ * To avoid silently re-pinning a developer's local checkout and abandoning their
+ * unmerged code:
+ * 1. Verify that the branch was actually tracked remotely (has a remote-tracking
+ *    ref like `refs/remotes/origin/<branch>` or an `@upstream` configured).
+ *    If no remote tracking ref exists, it is a local-only branch: keep the pin.
+ * 2. Verify that the branch carries no unmerged commits relative to origin/main
+ *    (or main). If the branch carries local commits not yet in main, do not re-pin.
+ *
+ * Extracted so the healing logic can be unit-tested without booting Electron.
+ */
+
+export interface RunGitResult {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+export interface BranchHealerDeps {
+  runGit: (args: string[], options?: { cwd?: string }) => Promise<RunGitResult>
+  getOriginUrl: (updateRoot: string) => Promise<string>
+  isOfficialSshRemote: (url: string) => boolean
+  officialRepoHttpsUrl?: string
+  rememberLog?: (msg: string) => void
+  readDesktopUpdateConfig?: () => { branch: string }
+  writeDesktopUpdateConfig?: (config: { branch: string }) => void
+}
+
+export async function resolveHealedBranch(
+  deps: BranchHealerDeps,
+  updateRoot: string,
+  branch: string
+): Promise<string> {
+  if (!branch || branch === 'main') {
+    return branch || 'main'
+  }
+
+  const {
+    runGit,
+    getOriginUrl,
+    isOfficialSshRemote,
+    officialRepoHttpsUrl = 'https://github.com/NousResearch/hermes-agent.git',
+    rememberLog = () => {},
+    readDesktopUpdateConfig = () => ({ branch: 'main' }),
+    writeDesktopUpdateConfig = () => {}
+  } = deps
+
+  const originUrl = await getOriginUrl(updateRoot)
+  const remote = isOfficialSshRemote(originUrl) ? officialRepoHttpsUrl : 'origin'
+  const probe = await runGit(['ls-remote', '--exit-code', '--heads', remote, branch], { cwd: updateRoot })
+
+  // Exit 2 means no matching ref on the remote. Any other non-zero code is an error
+  // (e.g. transient network failure), which must never strand the user on the wrong branch.
+  if (probe.code !== 2) {
+    return branch
+  }
+
+  // Probe returned 2: the ref does not exist on remote.
+  // Distinguish "deleted upstream after merge" from "never pushed / purely local branch":
+  // Check if a remote-tracking ref or upstream exists for this branch.
+  const remoteTracking = await runGit(['rev-parse', '--verify', '--quiet', `refs/remotes/origin/${branch}`], {
+    cwd: updateRoot
+  })
+  const upstream = await runGit(['rev-parse', '--verify', '--quiet', `${branch}@{upstream}`], { cwd: updateRoot })
+  const hasRemoteRef = remoteTracking.code === 0 || upstream.code === 0
+
+  if (!hasRemoteRef) {
+    rememberLog(`[updates] branch '${branch}' has no remote-tracking ref (never pushed); keeping branch pin`)
+    return branch
+  }
+
+  // Branch was once tracked, but verify it carries no unmerged commits before re-pinning to main.
+  let unmergedCheck = await runGit(['rev-list', '--count', `origin/main..${branch}`], { cwd: updateRoot })
+  if (unmergedCheck.code !== 0) {
+    unmergedCheck = await runGit(['rev-list', '--count', `main..${branch}`], { cwd: updateRoot })
+  }
+
+  if (unmergedCheck.code === 0) {
+    const count = parseInt(unmergedCheck.stdout.trim(), 10)
+    if (!isNaN(count) && count > 0) {
+      rememberLog(`[updates] origin/${branch} is gone, but branch carries ${count} unmerged commit(s); keeping branch pin`)
+      return branch
+    }
+  }
+
+  rememberLog(`[updates] origin/${branch} is gone (merged?); falling back to main`)
+  const config = readDesktopUpdateConfig()
+
+  if (config.branch !== 'main') {
+    writeDesktopUpdateConfig({ ...config, branch: 'main' })
+  }
+
+  return 'main'
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -391,6 +391,7 @@ import {
 } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
+import { resolveHealedBranch as resolveHealedBranchImpl } from './branch-healer'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import {
   collectRelaunchArgs,
@@ -3114,26 +3115,19 @@ function emitUpdateProgress(payload) {
 // "ref absent" (exit 2), never on a transient network error, so a flaky
 // connection can't strand a user on the wrong branch.
 async function resolveHealedBranch(updateRoot, branch) {
-  if (!branch || branch === 'main') {
-    return branch || 'main'
-  }
-
-  const originUrl = await getOriginUrl(updateRoot)
-  const remote = isOfficialSshRemote(originUrl) ? OFFICIAL_REPO_HTTPS_URL : 'origin'
-  const probe = await runGit(['ls-remote', '--exit-code', '--heads', remote, branch], { cwd: updateRoot })
-
-  if (probe.code !== 2) {
-    return branch
-  }
-
-  rememberLog(`[updates] origin/${branch} is gone (merged?); falling back to main`)
-  const config = readDesktopUpdateConfig()
-
-  if (config.branch !== 'main') {
-    writeDesktopUpdateConfig({ ...config, branch: 'main' })
-  }
-
-  return 'main'
+  return resolveHealedBranchImpl(
+    {
+      runGit,
+      getOriginUrl,
+      isOfficialSshRemote,
+      officialRepoHttpsUrl: OFFICIAL_REPO_HTTPS_URL,
+      rememberLog,
+      readDesktopUpdateConfig,
+      writeDesktopUpdateConfig
+    },
+    updateRoot,
+    branch
+  )
 }
 
 async function checkUpdates() {


### PR DESCRIPTION
## Summary
Fixes #105042.

`resolveHealedBranch()` in `apps/desktop/electron/main.ts` treated `git ls-remote --exit-code --heads <remote> <branch>` exit code 2 as definitive proof that a branch "is gone (merged?)" and silently re-pinned the desktop updater to `main`.

Exit code 2 only signifies *no matching ref on the remote*. While this is true for a remote branch deleted after merge, it is equally true for a **purely local branch that was never pushed** to origin. As a result, the desktop's own branch-pin (intended to keep a non-main checkout from being switched to `main`) was defeated by the healer, causing the updater to switch the local checkout to `main`, fast-forward to `origin/main`, and restart gateways on upstream code—silently abandoning running local modifications.

## Root Cause
`ls-remote` alone cannot distinguish between:
1. A remote-published branch that was merged and deleted upstream.
2. A local-only branch that was never published to origin.
3. A branch that was once pushed but carries unmerged local commits not yet in `main`.

## Solution
1. **Remote tracking verification**: Check whether the branch was ever tracked remotely (`refs/remotes/origin/<branch>` or `<branch>@{upstream}`). If neither exists, the branch is purely local; retain the branch pin without re-pinning to `main`.
2. **Unmerged commits guard**: Check `git rev-list --count origin/main..<branch>` (with fallback to `main..<branch>`). If the branch carries unmerged commits, retain the branch pin so local development work is not abandoned.
3. **Safe healing**: Only when the branch was a known remote branch, no longer exists on origin (exit 2), AND carries 0 unmerged commits does the updater heal to `main` and persist that update configuration.
4. **Modularity & Unit tests**: Extracted healing logic into `apps/desktop/electron/branch-healer.ts` (pure dependency-injected pattern mirroring `update-remote.ts` and `update-gate.ts`) and added unit test suite (`apps/desktop/electron/branch-healer.test.ts`) covering all probe, tracking, and merge scenarios.

## Testing
- Added unit tests in `apps/desktop/electron/branch-healer.test.ts`:
  - `returns main or falsy branch immediately without git calls`
  - `keeps branch when remote still publishes it (ls-remote exit 0)`
  - `keeps branch on transient network failure (ls-remote exit 128)`
  - `keeps branch when exit 2 but branch is purely local (no remote-tracking ref or upstream)`
  - `keeps branch when exit 2 and remote ref existed, but branch carries unmerged commits`
  - `heals to main and persists config when exit 2, remote ref existed, and 0 unmerged commits`
- Verified unit test suite: 6/6 passing.
- Verified existing CLI update parked branch tests: 22/22 passing (`tests/hermes_cli/test_update_parked_branch_guard.py`).