### PR TITLE
fix(desktop): keep never-pushed branches pinned during update self-heal

### DIFF
--- a/apps/desktop/electron/healed-branch.test.ts
+++ b/apps/desktop/electron/healed-branch.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for electron/healed-branch.ts — the self-heal decision that keeps
+ * never-pushed local branches pinned instead of silently re-pinning the
+ * desktop updater to main.
+ *
+ * The heal path exists for merged-and-deleted upstream branches (bb/gui):
+ * ls-remote exit 2 is treated as "branch gone" and the pin flips to main.
+ * That inference is wrong for a branch that was never pushed — the local ref
+ * is then the only copy of the user's commits, and re-pinning moves the
+ * running code off them without any visible error.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { decideHealedBranch } from './healed-branch'
+
+describe('decideHealedBranch', () => {
+  it('keeps a never-pushed local branch pinned', () => {
+    const decision = decideHealedBranch('hermes-local', {
+      remoteTrackingRefExists: false,
+      commitsBeyondMain: 3
+    })
+
+    expect(decision.branch).toBe('hermes-local')
+    expect(decision.reason).toBe('kept-local-branch')
+  })
+
+  it('keeps a pushed branch that carries commits beyond main', () => {
+    const decision = decideHealedBranch('feature/with-work', {
+      remoteTrackingRefExists: true,
+      commitsBeyondMain: 1
+    })
+
+    expect(decision.branch).toBe('feature/with-work')
+    expect(decision.reason).toBe('kept-local-branch')
+  })
+
+  it('keeps the pin when commits are unknown but the branch was never pushed', () => {
+    const decision = decideHealedBranch('hermes-local', {
+      remoteTrackingRefExists: false,
+      commitsBeyondMain: null
+    })
+
+    expect(decision.branch).toBe('hermes-local')
+    expect(decision.reason).toBe('kept-local-branch')
+  })
+
+  it('heals a fully merged branch even after fetch --prune removed the tracking ref', () => {
+    const decision = decideHealedBranch('bb/gui', {
+      remoteTrackingRefExists: false,
+      commitsBeyondMain: 0
+    })
+
+    expect(decision.branch).toBe('main')
+    expect(decision.reason).toBe('healed-to-main')
+  })
+
+  it('heals a deleted-after-merge branch with nothing beyond main', () => {
+    const decision = decideHealedBranch('bb/gui', {
+      remoteTrackingRefExists: true,
+      commitsBeyondMain: 0
+    })
+
+    expect(decision.branch).toBe('main')
+    expect(decision.reason).toBe('healed-to-main')
+  })
+
+  it('heals when the commit count is unavailable but the branch was pushed', () => {
+    const decision = decideHealedBranch('bb/gui', {
+      remoteTrackingRefExists: true,
+      commitsBeyondMain: null
+    })
+
+    expect(decision.branch).toBe('main')
+    expect(decision.reason).toBe('healed-to-main')
+  })
+})

--- a/apps/desktop/electron/healed-branch.ts
+++ b/apps/desktop/electron/healed-branch.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure decision helper for the branch self-heal used by the desktop updater.
+ *
+ * `git ls-remote --exit-code --heads <remote> <branch>` exits 2 both when a
+ * branch was pushed and later deleted (typically after being merged) AND when
+ * the branch was never pushed at all — a purely local branch. Re-pinning the
+ * updater to main is right in the first case and wrong in the second: for a
+ * local-only branch the branch ref is the only place the user's commits exist,
+ * so silently switching the running code to main discards their checkout.
+ *
+ * The primary fact is commitsBeyondMain: `git rev-list --count
+ * origin/main..<branch>`, the number of commits the branch carries that main
+ * lacks. Zero means every commit is already in main — healing to main loses
+ * nothing, even when a pruned fetch already removed the remote-tracking ref
+ * (the classic merged-and-deleted case). Any positive value means the branch
+ * carries work main lacks, pushed or not — the pin must hold.
+ *
+ * When the commit count is unavailable (no origin/main ref, git error), the
+ * remote-tracking ref decides: present means the branch was fetched/pushed
+ * from the remote at least once, so "gone from the remote" reads as
+ * merged-and-deleted; absent means git never saw the branch on the remote —
+ * it is local-only and must keep its pin.
+ *
+ * Extracted from main.ts so the heal decision is unit testable without
+ * booting Electron (main.ts requires('electron') at load).
+ */
+
+export type HealFacts = {
+  /** Whether refs/remotes/origin/<branch> exists locally. */
+  remoteTrackingRefExists: boolean
+  /** `git rev-list --count origin/main..<branch>`; null when unavailable. */
+  commitsBeyondMain: number | null
+}
+
+export type HealDecision = {
+  /** Branch the updater should follow after the heal decision. */
+  branch: string
+  /** Short machine-readable reason for observability/logging. */
+  reason:
+    | 'healed-to-main' // nothing beyond main (or pushed-then-deleted fallback)
+    | 'kept-local-branch' // carries commits main lacks, or never pushed
+}
+
+function decideHealedBranch(branch: string, facts: HealFacts): HealDecision {
+  if (facts.commitsBeyondMain !== null) {
+    return facts.commitsBeyondMain > 0
+      ? { branch, reason: 'kept-local-branch' }
+      : { branch: 'main', reason: 'healed-to-main' }
+  }
+
+  return facts.remoteTrackingRefExists
+    ? { branch: 'main', reason: 'healed-to-main' }
+    : { branch, reason: 'kept-local-branch' }
+}
+
+export { decideHealedBranch }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -222,6 +222,7 @@ import {
   tightenSecretFileMode,
   writeSecretFileAtomic
 } from './hardening'
+import { decideHealedBranch } from './healed-branch'
 import { cursorPointInWindow } from './hud-cursor'
 import { startHudGameOverlayWatch } from './hud-game-overlay'
 import { applyHudResetBounds, defaultHudBounds } from './hud-geometry'
@@ -3112,7 +3113,10 @@ function emitUpdateProgress(payload) {
 // every later check/apply follows main — no manual flip, even for already-
 // installed clients. Read-only ls-remote probe; only flips on a definitive
 // "ref absent" (exit 2), never on a transient network error, so a flaky
-// connection can't strand a user on the wrong branch.
+// connection can't strand a user on the wrong branch. Exit 2 also fires for
+// branches that were never pushed, so before re-pinning we consult the local
+// facts (remote-tracking ref, commits beyond main) — a local-only branch is
+// the only place those commits exist and must keep its pin.
 async function resolveHealedBranch(updateRoot, branch) {
   if (!branch || branch === 'main') {
     return branch || 'main'
@@ -3123,6 +3127,24 @@ async function resolveHealedBranch(updateRoot, branch) {
   const probe = await runGit(['ls-remote', '--exit-code', '--heads', remote, branch], { cwd: updateRoot })
 
   if (probe.code !== 2) {
+    return branch
+  }
+
+  // The probe may target the HTTPS URL directly (official SSH installs), but
+  // local remote-tracking refs always live under the origin/ namespace — the
+  // two lookups below are local-only and never touch the network.
+  const trackingRef = await runGit(['rev-parse', '--verify', '--quiet', `refs/remotes/origin/${branch}`], { cwd: updateRoot })
+  const beyondMain = await runGit(['rev-list', '--count', `origin/main..${branch}`], { cwd: updateRoot })
+  const commitsBeyondMain = beyondMain.code === 0 ? Number.parseInt((beyondMain.stdout || '').trim(), 10) : null
+
+  const decision = decideHealedBranch(branch, {
+    remoteTrackingRefExists: trackingRef.code === 0,
+    commitsBeyondMain: Number.isFinite(commitsBeyondMain as number) ? commitsBeyondMain : null
+  })
+
+  if (decision.reason === 'kept-local-branch') {
+    rememberLog(`[updates] origin/${branch} is gone but the branch is local-only or ahead of main; keeping the pin on ${branch}`)
+
     return branch
   }
 


### PR DESCRIPTION
## Summary

`resolveHealedBranch()` (apps/desktop/electron/main.ts) treats `git ls-remote --exit-code --heads <remote> <branch>` **exit 2** as proof that a tracked branch is "gone (merged?)" and silently re-pins the desktop updater to `main`. Exit 2 only means *no matching ref on the remote* — it fires identically for a **never-pushed local branch**, whose ref is the only place the user's local commits exist. The result defeats the branch-pin one call after it is set: the checkout is moved to `main` and the running code silently stops being the user's commits (`git status` stays clean, fleet reports `state=current`).

Fix: before healing, consult local facts —
- primary: `git rev-list --count origin/main..<branch>` — any commits beyond main mean healing would move the running code off the user's work → **keep the pin**;
- fallback (count unavailable, e.g. no `origin/main`): `refs/remotes/origin/<branch>` — present means the branch was pushed and later deleted → heal to main; absent means never pushed → **keep the pin**.

The decision lives in a pure helper `electron/healed-branch.ts` (main.ts can't be loaded without Electron — same extraction pattern as `update-remote.ts`), so it is unit-testable in the existing vitest `electron` project. Healing still fires for the classic merged-and-deleted case, including after `fetch --prune` removed the tracking ref (verified against a real scratch repo: never-pushed → count 1, merged-deleted → count 0, both with pruned refs).

## Testing

- `npx vitest run electron/healed-branch.test.ts --project electron` — 6 passed (mutational RED: replacing the decision with unconditional heal fails 3 tests)
- `npx tsc --build tsconfig.electron.json` — clean
- `eslint` on all three touched files — clean after `--fix` (import order)
- full `vitest --project electron`: 2141 passed; the single `managed-ssh-update` failure reproduces on clean `main` (verified via `git stash -u`), unrelated to this diff
- live scratch-repo verification of the git facts (`ls-remote` exit 2 in both scenarios, distinguishing count 1 vs 0)

Fixes #105042