### PR TITLE
fix: Windows staged app promotion releases reopened app locks

### DIFF
--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -207,6 +207,10 @@ def _swap_staged_desktop_app(desktop_dir: Path, staging_dir: Path) -> Optional[P
         shutil.rmtree(previous, ignore_errors=True)
         moved_aside = live_root.exists()
         if moved_aside:
+            # A Desktop may have reopened during the long packaging step.
+            stopped = _stop_desktop_processes_locking_build(desktop_dir)
+            if stopped:
+                logger.info("stopped desktop processes before staged app promotion: %s", stopped)
             os.rename(live_root, previous)
         try:
             os.rename(staged_root, live_root)
@@ -669,11 +673,15 @@ def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
         # Wait for the handles (and thus the file locks) to actually release.
         with contextlib.suppress(Exception):
             _, alive = psutil.wait_procs(victims, timeout=5)
+            killed = []
             for proc in alive:
                 try:
                     proc.kill()
+                    killed.append(proc)
                 except Exception:
                     continue
+            if killed:
+                psutil.wait_procs(killed, timeout=5)
     return stopped
 
 

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -46,6 +46,8 @@ When you run `hermes update`, the following steps occur:
 
 If the maintained updater script is missing (for example after antivirus quarantine), the legacy update forwarder fails instead of reporting a successful hand-off. Repair the installation and review the security software's quarantine report before retrying; do not disable antivirus protection. Before reporting success, the maintained updater checks the CLI import, Windows executable header, ASAR header and packaged main entry, readable renderer HTML with a local module entry, initial module files, and current build stamp. These are minimum artifact checks, not a full dependency audit or an application/backend launch test. Missing Python is reported before waiting for Desktop shutdown; dependency repair is still allowed to run as part of the update. Electron checks maintained handoff prerequisites before stopping backends when that layout is present; genuine legacy-flat updater layouts remain supported, so not every missing updater file is detected before backend shutdown.
 
+On Windows, a Desktop reopened during packaging is stopped again immediately before the staged build is promoted. This cleanup is restricted to executables inside that checkout's Desktop release tree; unrelated installations are not stopped. A remaining lock still makes staged promotion fail rather than bypassing the rename error.
+
 ### Updating against a non-default branch: `--branch`
 
 By default `hermes update` tracks `origin/main`. Pass `--branch <name>` to update against a different branch — useful for QA channels, feature branches, or release-candidate testing:


### PR DESCRIPTION
Windows staged promotion stops a reopened app holding the live release before swapping builds.

- Reuse install-scoped cleanup immediately before promotion and wait after forced termination; retain rollback and document behavior.
- Source-only salvage of #101887 from @fangliquanflq, adapted to the current topical module, with original co-author credit retained. Excludes mocked-platform tests, ephemeral Windows workflows and private campaign probes/trajectories.

Root cause: the app can reopen during packaging and acquire fresh locks after the earlier cleanup.

Related: #101878. Campaign tracker: #104839. This draft covers the promotion mechanism, not every full-update scenario.

## Validation

**Live repro (historical native lane, not this split head):** a real ready Electron process with cwd inside disposable live release produced WinError32. Before: promotion returned None, new generation absent, locker alive. After: promotion returned the live executable, new generation present, locker stopped; the fixture preserved the old executable.

[Before](https://github.com/NousResearch/hermes-agent/actions/runs/34097643131) → [after](https://github.com/NousResearch/hermes-agent/actions/runs/34097991249), original source head `583bb7d84dfd881879889e13f8e9c51b0935586e`.

The combined lane passed 27 native Electron-project tests; these are neither 27 promotion-specific tests nor post-split gates. Force-kill fallback was not separately forced; full packaging/application restart was not exercised. Native split validation remains missing. No new local suites were run for this publication, per explicit user instruction; full source diff and whitespace were checked. Historical campaign aggregate: 8,998 passed / 10 failed, not a clean result and not a publication prerequisite. Draft CI is asynchronous; no green or merge claim.

## Infographic

Campaign context only: this existing overview covers the broader Desktop reliability campaign, not validation of this individual split.

![Desktop reliability campaign overview](https://v3b.fal.media/files/b/0aa970ff/01HBIjxrk8-g59IYVhD6F_GOQaUsZH.png)
