### PR TITLE
fix(desktop): sidebar follows focused session panes (#88517, salvage #88691)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/chat-sidebar.integration.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chat-sidebar.integration.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { group, split } from '@/components/pane-shell/tree/model'
+import { $layoutTree, noteActiveTreeGroup } from '@/components/pane-shell/tree/store'
+import { SidebarProvider } from '@/components/ui/sidebar'
+import { registry } from '@/contrib/registry'
+import { $selectedStoredSessionId, $sessions } from '@/store/session'
+import { $removedSessionIds } from '@/store/session-removal'
+import { makeSessionInfo } from '@/test/session-info'
+
+import { type AppView, ROUTES_AREA, SIDEBAR_NAV_AREA } from '../../routes'
+
+import { ChatSidebar } from './index'
+
+const noop = () => {}
+
+const noopAsync = async () => {}
+
+const sessionRows = [
+  makeSessionInfo({ id: 'tile-one', last_active: 2, profile: 'default', started_at: 1, title: 'Tile one' }),
+  makeSessionInfo({ id: 'tile-two', last_active: 2, profile: 'default', started_at: 1, title: 'Tile two' })
+]
+
+const renderSidebar = (pathname: string, currentView: AppView) =>
+  render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <SidebarProvider>
+        <ChatSidebar
+          currentView={currentView}
+          onArchiveSession={noop}
+          onBranchSession={noop}
+          onDeleteSession={noop}
+          onLoadMoreSessions={noop}
+          onManageCronJob={noop}
+          onNavigate={noop}
+          onNewSessionInWorkspace={noop}
+          onNewSessionSplit={noop}
+          onResumeSession={noop}
+          onTriggerCronJob={noopAsync}
+        />
+      </SidebarProvider>
+    </MemoryRouter>
+  )
+
+const currentButtons = () =>
+  screen.queryAllByRole('button').filter(button => button.classList.contains('bg-(--ui-control-active-background)'))
+
+const expectOnlyCurrent = (label: string | null) => {
+  const button = label ? screen.getByRole('button', { name: label }) : null
+
+  expect(currentButtons()).toEqual(button ? [button] : [])
+}
+
+const expectOnlySelectedSession = (title: string | null) => {
+  const rows = ['Tile one', 'Tile two']
+    .map(label => screen.queryByText(label)?.closest('.group.row-hover'))
+    .filter(row => row !== undefined)
+
+  const selectedRows = rows.filter(row => row?.className.includes('bg-(--ui-row-active-background)'))
+  const expected = title ? [screen.getByText(title).closest('.group.row-hover')] : []
+
+  expect(selectedRows).toEqual(expected)
+}
+
+const focus = (groupId: null | string) => act(() => noteActiveTreeGroup(groupId))
+
+describe('ChatSidebar navigation activity', () => {
+  let disposeContributions: () => void
+
+  beforeEach(() => {
+    disposeContributions = registry.registerMany([
+      { area: ROUTES_AREA, id: 'kanban-page', data: { path: '/kanban' }, render: () => null },
+      { area: ROUTES_AREA, id: 'reports-page', data: { path: '/reports' }, render: () => null },
+      { area: SIDEBAR_NAV_AREA, id: 'kanban-nav', data: { codicon: 'project', label: 'Kanban', path: '/kanban' } },
+      { area: SIDEBAR_NAV_AREA, id: 'reports-nav', data: { codicon: 'graph', label: 'Reports', path: '/reports' } }
+    ])
+    $selectedStoredSessionId.set('tile-one')
+    $sessions.set(sessionRows)
+    $removedSessionIds.set(new Set())
+    $layoutTree.set(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'workspace-group' }),
+        group(['session-tile:tile-one'], { active: 'session-tile:tile-one', id: 'tile-one-group' }),
+        group(['session-tile:tile-two'], { active: 'session-tile:tile-two', id: 'tile-two-group' })
+      ])
+    )
+    noteActiveTreeGroup('workspace-group')
+  })
+
+  afterEach(() => {
+    cleanup()
+    disposeContributions()
+    $selectedStoredSessionId.set(null)
+    $sessions.set([])
+    $removedSessionIds.set(new Set())
+    $layoutTree.set(null)
+    noteActiveTreeGroup(null)
+  })
+
+  it('keeps navigation and session activity coherent with the focused pane', () => {
+    renderSidebar('/kanban', 'extension')
+    expectOnlyCurrent('Kanban')
+    expectOnlySelectedSession(null)
+
+    focus('tile-one-group')
+    expectOnlyCurrent(null)
+    expectOnlySelectedSession('Tile one')
+
+    focus('tile-two-group')
+    expectOnlyCurrent(null)
+    expectOnlySelectedSession('Tile two')
+
+    focus(null)
+    expectOnlyCurrent('Kanban')
+    expectOnlySelectedSession(null)
+
+    focus('tile-two-group')
+    act(() => {
+      $removedSessionIds.set(new Set(['tile-two']))
+      $sessions.set([sessionRows[0]])
+    })
+    expectOnlyCurrent(null)
+    expectOnlySelectedSession(null)
+
+    act(() => {
+      $removedSessionIds.set(new Set())
+      $sessions.set(sessionRows)
+    })
+
+    for (const [pathname, currentView, label] of [
+      ['/skills', 'skills', 'Capabilities'],
+      ['/messaging', 'messaging', 'Messaging'],
+      ['/artifacts', 'artifacts', 'Artifacts'],
+      ['/cron', 'cron', 'Scheduled jobs']
+    ] as const) {
+      cleanup()
+      focus('workspace-group')
+      renderSidebar(pathname, currentView)
+      expectOnlyCurrent(label)
+      expectOnlySelectedSession(null)
+
+      focus('tile-one-group')
+      expectOnlyCurrent(null)
+      expectOnlySelectedSession('Tile one')
+    }
+
+    cleanup()
+    focus('workspace-group')
+    renderSidebar('/reports', 'extension')
+    expectOnlyCurrent('Reports')
+
+    cleanup()
+    disposeContributions()
+    disposeContributions = noop
+    focus('workspace-group')
+    renderSidebar('/kanban', 'extension')
+    expect(screen.queryByRole('button', { name: 'Kanban' })).toBeNull()
+    expectOnlyCurrent(null)
+    expectOnlySelectedSession(null)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -128,7 +128,7 @@ import {
 import { $sessionDotStateById, sessionStatusBucket } from '@/store/session-dot-state'
 import { $unconfirmedPinWrites } from '@/store/session-pin-sync'
 import { $removedSessionIds } from '@/store/session-removal'
-import { $focusedStoredSessionId, $workingSessionIds } from '@/store/session-states'
+import { $focusedSessionIsTile, $focusedStoredSessionId, $workingSessionIds } from '@/store/session-states'
 import { ackAllSessionsRead } from '@/store/session-unread'
 import { markSessionUnread } from '@/store/session-unread-remote'
 import { $archivedSessions, loadArchivedSessions } from '@/store/sidebar-archive'
@@ -325,7 +325,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
 }
 
 export function ChatSidebar({
-  currentView,
+  currentView: routeView,
   onNavigate,
   onLoadMoreSessions,
   onLoadMoreMessaging,
@@ -395,6 +395,8 @@ export function ChatSidebar({
   // The sidebar highlight tracks the FOCUSED session — the interacted tile's
   // tab, else the main selection — so it stays 1:1 with whatever tab is active.
   const selectedSessionId = useStore($focusedStoredSessionId)
+  const focusedSessionIsTile = useStore($focusedSessionIsTile)
+  const currentView = focusedSessionIsTile ? 'chat' : routeView
   const sessions = useStore($sessions)
   const cronSessions = useStore($cronSessions)
   const cronJobs = useStore($cronJobs)
@@ -1518,7 +1520,7 @@ export function ChatSidebar({
                   (item.id === 'cron' && currentView === 'cron') ||
                   (item.id === 'session-import' && currentView === 'session-import') ||
                   // Contributed rows light up at their own route.
-                  (Boolean(item.route) && pathname === item.route)
+                  (currentView === 'extension' && Boolean(item.route) && pathname === item.route)
 
                 const isNewSession = item.id === 'new-session'
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1895,40 +1895,44 @@ export function reopenLastClosedTile(): void {
 // timer / model) reads these instead of the primary-only atoms.
 // ---------------------------------------------------------------------------
 
-/** Stored id of the focused session (the interacted zone's tile, else the
- *  primary's selection). Null on a fresh draft. */
-export const $focusedStoredSessionId = computed(
-  [$activeTreeGroup, $layoutTree, $selectedStoredSessionId, $workspaceMode],
-  (groupId, tree, selected, workspaceMode) => {
-    const active = groupId && tree ? findGroup(tree, groupId)?.active : undefined
+/** Focused pane identity, retaining Bot Mode's main-zone fallback. */
+const $focusedTreePaneId = computed([$activeTreeGroup, $layoutTree, $workspaceMode], (groupId, tree, workspaceMode) => {
+  const active = groupId && tree ? findGroup(tree, groupId)?.active : undefined
 
-    if (active?.startsWith(TILE_PANE_PREFIX)) {
-      return active.slice(TILE_PANE_PREFIX.length)
-    }
-
-    // The interaction tracker can point at sidebar CHROME while a chat still
-    // holds the main zone's active tab — clicking a Bots-pane roster row moves
-    // it to the sidebar group, whose active pane ('hermes-bots:pane') is not a
-    // session tile. In sessions mode the primary selection answers, exactly as
-    // always. In Bot Mode that fallback alone publishes a NULL "focused"
-    // edge: bot chats open as TILES and never set $selectedStoredSessionId,
-    // so the selection is null while the chat is plainly on screen. The Bots
-    // plugin reads that null edge as "the chat lost the center", releases its
-    // open claim, and re-asserts the Bots home over the still-visible chat —
-    // the reported "clicking a bot chat jumps to the list" (#96062). Bot
-    // Mode's on-screen truth is the main zone's active TILE; only when the
-    // main zone holds no tile (chat closed) does the selection answer, so a
-    // genuine close still lets the home return.
-    if (workspaceMode === 'bots' && tree) {
-      const mainActive = findGroupOfPane(tree, 'workspace')?.active
-
-      if (mainActive?.startsWith(TILE_PANE_PREFIX)) {
-        return mainActive.slice(TILE_PANE_PREFIX.length)
-      }
-    }
-
-    return selected
+  if (active?.startsWith(TILE_PANE_PREFIX)) {
+    return active
   }
+
+  // The interaction tracker can point at sidebar CHROME while a chat still
+  // holds the main zone's active tab — clicking a Bots-pane roster row moves
+  // it to the sidebar group, whose active pane ('hermes-bots:pane') is not a
+  // session tile. In sessions mode the primary selection answers, exactly as
+  // always. In Bot Mode that fallback alone publishes a NULL "focused"
+  // edge: bot chats open as TILES and never set $selectedStoredSessionId,
+  // so the selection is null while the chat is plainly on screen. The Bots
+  // plugin reads that null edge as "the chat lost the center", releases its
+  // open claim, and re-asserts the Bots home over the still-visible chat —
+  // the reported "clicking a bot chat jumps to the list" (#96062). Bot
+  // Mode's on-screen truth is the main zone's active TILE; only when the
+  // main zone holds no tile (chat closed) does the selection answer, so a
+  // genuine close still lets the home return.
+  if (workspaceMode === 'bots' && tree) {
+    const mainActive = findGroupOfPane(tree, 'workspace')?.active
+
+    if (mainActive?.startsWith(TILE_PANE_PREFIX)) {
+      return mainActive
+    }
+  }
+
+  return active
+})
+
+export const $focusedSessionIsTile = computed($focusedTreePaneId, active =>
+  Boolean(active?.startsWith(TILE_PANE_PREFIX))
+)
+
+export const $focusedStoredSessionId = computed([$focusedTreePaneId, $selectedStoredSessionId], (active, selected) =>
+  active?.startsWith(TILE_PANE_PREFIX) ? active.slice(TILE_PANE_PREFIX.length) : selected
 )
 
 /** Every session currently OPEN as a surface: the primary's selection plus

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -36,6 +36,8 @@ That uses your current config, keys, sessions, and skills.
 
 The desktop app is organized as a chat-first window with a left sidebar for navigation. It's built to allow managing multiple simultaneous agent conversations, configuring messaging providers, creating artifacts, browsing projects' folder structures, and working on multiple projects at once.
 
+Sidebar selection follows the focused chat pane. Opening or focusing a session tab clears a page's highlight, including contributed pages such as Kanban, even when the workspace retains that page's route.
+
 ### Chat
 
 The center of the app. You get:


### PR DESCRIPTION
Desktop sidebar activity follows the focused session pane instead of retaining a stale page highlight.

## Changes
- Derive focused tile identity from the pane tree, preserving Bot Mode's existing fallback.
- Use the focused view for built-in and contributed navigation, including Kanban.
- Add a rendered sidebar invariant and document the visible behavior.

Root cause: the sidebar trusted the retained workspace route even when a session tile owned focus.

## Validation
**Live repro:** historical campaign Electron reproduction recorded Kanban highlighted while a resumed session was visible; the candidate cleared the highlight without changing the retained route. This publication did not rerun local tests or live probes.

Published as a draft at the user's direction for public CI first; local suite gates are not asserted green here.

## Attribution and scope
Related to #88517; campaign tracker #104839. Adapted the focused-pane derivation and rendered sidebar invariant from @MarcoFernstaedt's #88691, with credit retained in the existing commit. Fresh duplicate sweep found #88691 remains open; this is the campaign's reduced salvage, not an independent competing design. No issue or source PR is closed by this draft.

## Infographic
Campaign context, not a claim that every campaign item is complete:
![Desktop bug campaign context](https://v3b.fal.media/files/b/0aa970ff/01HBIjxrk8-g59IYVhD6F_GOQaUsZH.png)
