### PR TITLE
test: restore kanban fixture module isolation

### DIFF
--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -19,14 +19,31 @@ import pytest
 
 @pytest.fixture()
 def isolated_kanban_home(monkeypatch):
-    """Spin up a fresh HERMES_HOME with a clean kanban DB."""
+    """Spin up a fresh HERMES_HOME with a clean kanban DB.
+
+    The fresh-import sandbox must restore the pre-test module graph. Leaving
+    the temporary Hermes modules installed makes later test files resolve
+    different singletons than the session fixtures patched, which makes the
+    full suite order-dependent even though each file passes in isolation.
+    """
     test_home = tempfile.mkdtemp(prefix="kanban_cli_passthrough_")
     os.makedirs(os.path.join(test_home, "profiles", "default"), exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", test_home)
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
-    yield test_home
+    module_prefixes = ("hermes_cli", "hermes_state")
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name.startswith(module_prefixes) or name == "hermes_constants"
+    }
+    for name in saved_modules:
+        del sys.modules[name]
+    try:
+        yield test_home
+    finally:
+        for name in list(sys.modules):
+            if name.startswith(module_prefixes) or name == "hermes_constants":
+                del sys.modules[name]
+        sys.modules.update(saved_modules)
 
 
 def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -16,18 +16,30 @@ import pytest
 
 @pytest.fixture()
 def isolated_kanban_home(monkeypatch):
-    """Spin up a fresh HERMES_HOME with a clean kanban DB."""
+    """Spin up a fresh HERMES_HOME with a clean kanban DB.
+
+    Restore the pre-test Hermes module graph after the fresh import so later
+    tests keep using the same module singletons as their fixtures.
+    """
     test_home = tempfile.mkdtemp(prefix="kanban_default_assignee_test_")
     monkeypatch.setenv("HERMES_HOME", test_home)
     # Force-reimport so the fresh HERMES_HOME is picked up.
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
-    from hermes_cli import kanban_db
-    yield kanban_db, test_home
-    # Cleanup is best-effort; tempfile dir survives but pytest isolation
-    # gives each test its own monkeypatched HERMES_HOME so no cross-test
-    # contamination.
+    module_prefixes = ("hermes_cli", "hermes_state")
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name.startswith(module_prefixes) or name == "hermes_constants"
+    }
+    for name in saved_modules:
+        del sys.modules[name]
+    try:
+        from hermes_cli import kanban_db
+        yield kanban_db, test_home
+    finally:
+        for name in list(sys.modules):
+            if name.startswith(module_prefixes) or name == "hermes_constants":
+                del sys.modules[name]
+        sys.modules.update(saved_modules)
 
 
 def _fake_spawn(*args, **kwargs):

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -16,16 +16,31 @@ import pytest
 
 @pytest.fixture()
 def isolated_kanban_home_with_profiles(monkeypatch):
-    """Spin up a fresh HERMES_HOME with kanban DB + alpha/beta profiles."""
+    """Spin up a fresh HERMES_HOME with kanban DB + alpha/beta profiles.
+
+    Restore the pre-test Hermes module graph after the fresh import so later
+    tests keep using the same module singletons as their fixtures.
+    """
     test_home = tempfile.mkdtemp(prefix="kanban_per_profile_cap_test_")
     for prof in ("alpha", "beta", "default"):
         os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", test_home)
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
-    from hermes_cli import kanban_db
-    yield kanban_db
+    module_prefixes = ("hermes_cli", "hermes_state")
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name.startswith(module_prefixes) or name == "hermes_constants"
+    }
+    for name in saved_modules:
+        del sys.modules[name]
+    try:
+        from hermes_cli import kanban_db
+        yield kanban_db
+    finally:
+        for name in list(sys.modules):
+            if name.startswith(module_prefixes) or name == "hermes_constants":
+                del sys.modules[name]
+        sys.modules.update(saved_modules)
 
 
 def _fake_spawn(*args, **kwargs):


### PR DESCRIPTION
## Summary

Restore the pre-test `hermes_*` module graph after the three Kanban fixtures temporarily remove modules from `sys.modules`.

Each fixture needs a fresh import so its temporary `HERMES_HOME` is captured, but leaving those reloaded modules installed leaks alternate module singletons into later test files. The later tests patch the original session modules, while production calls resolve the leaked reloaded modules; the result is order-dependent failures despite every file passing in isolation.

The fixtures now save the exact matching module objects, remove the temporary graph in a `finally` block, and restore the saved graph. This covers normal teardown and fixture/test errors without touching production code.

## Reproduction

On clean upstream `origin/main` at `8d24bc24e1e6d58fcc0184ac8225376a8392564a`:

```text
14 failed, 308 passed, 2 skipped
```

The 14 failures, in collection/order occurrence, were:

1. `tests/hermes_cli/test_kanban_db.py::test_rate_limit_exit_requeues_without_counting_failure`
2. `tests/hermes_cli/test_kanban_db.py::test_connect_works_when_wal_is_silently_refused`
3. `tests/hermes_cli/test_kanban_decompose.py::test_decompose_with_fanout_creates_children`
4. `tests/hermes_cli/test_kanban_decompose.py::test_decompose_fanout_false_invalid_llm_assignee_uses_default`
5. `tests/hermes_cli/test_kanban_dispatch_tick_hook.py::test_active_tick_fires_hook_with_outcome_ok`
6. `tests/hermes_cli/test_kanban_dispatch_tick_hook.py::test_tick_hook_fires_after_dispatch_lock_released`
7. `tests/hermes_cli/test_kanban_lifecycle_hooks.py::test_claim_fires_hook`
8. `tests/hermes_cli/test_kanban_swarm.py::test_create_swarm_graph_is_atomic_and_rolls_back_partial_build`
9. `tests/hermes_cli/test_kanban_task_updated_hook.py::test_assign_fires_updated_with_changed_fields`
10. `tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py::test_dispatch_spawn_fires_worker_spawned`
11. `tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py::test_crash_reclaim_fires_worker_exited`
12. `tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py::test_stale_claim_reclaim_fires_hook`
13. `tests/hermes_cli/test_kanban_write_guard.py::test_connect_raises_when_kanban_home_is_real_root`
14. `tests/hermes_cli/test_kanban_write_guard.py::test_connect_raises_for_explicit_db_path_under_real_root`

The three leaking fixtures are:

- `tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py::isolated_kanban_home`
- `tests/hermes_cli/test_kanban_default_assignee.py::isolated_kanban_home`
- `tests/hermes_cli/test_kanban_per_profile_cap.py::isolated_kanban_home_with_profiles`

## Verification

All commands ran in a clean environment (`TZ=UTC`, `LANG=C.UTF-8`, `PYTHONHASHSEED=0`, credentials unset):

- Clean latest upstream baseline: `14 failed, 308 passed, 2 skipped`.
- Shared-process patched slice (latest upstream tip): `322 passed, 2 skipped`.
- Shared-process patched slice repeat: `322 passed, 2 skipped`.
- Canonical CI-parity runner: `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py -q --tb=short` -> `49 files, 322 tests passed, 0 failed, 2 skipped`.
- `git diff --check` passed.
- Targeted `compileall` passed.

No production/live Hermes install was touched.
