### PR TITLE
fix(agent): scope learned image-token costs to the active profile

### DIFF
--- a/agent/image_token_cost.py
+++ b/agent/image_token_cost.py
@@ -26,8 +26,24 @@ _MIN_PLAUSIBLE, _MAX_PLAUSIBLE = 64, 32_768
 _EMA_ALPHA = 0.5
 
 _image_cost_var: ContextVar[Optional[int]] = ContextVar("hermes_image_token_cost", default=None)
-_LEARNED: Dict[str, int] = {}
-_LOADED = False
+# Learned costs, per profile: a process serving more than one profile in the same process
+# (desktop multiplex) must not let one profile's calibration bleed into another's, even though
+# the on-disk file path is already resolved per-profile via get_hermes_home(). Keyed by
+# hermes_home_key() first, then by the model@host key from _key() -- same shape as the other
+# established per-profile registries (agent.secret_sources.registry._SCOPED_SOURCES).
+_LEARNED: Dict[str, Dict[str, int]] = {}
+# hermes_home_key()s whose on-disk file has already been loaded into _LEARNED this process.
+_LOADED_SCOPES: set = set()
+
+
+def _scope() -> str:
+    from hermes_constants import hermes_home_key
+
+    return hermes_home_key()
+
+
+def _learned_for_scope(scope: str) -> Dict[str, int]:
+    return _LEARNED.setdefault(scope, {})
 
 
 def _cache_path():
@@ -43,21 +59,23 @@ def _key(model: Any, base_url: Any) -> str:
 
 
 def _load() -> None:
-    global _LOADED
-    if _LOADED:
+    """Load the active profile's on-disk learned costs, once per profile per process."""
+    scope = _scope()
+    if scope in _LOADED_SCOPES:
         return
-    _LOADED = True
+    _LOADED_SCOPES.add(scope)
     from agent.model_metadata import _load_json_dict
 
+    learned = _learned_for_scope(scope)
     for k, v in _load_json_dict(_cache_path()).items():
         if isinstance(v, int) and _MIN_PLAUSIBLE <= v <= _MAX_PLAUSIBLE:
-            _LEARNED[k] = v
+            learned[k] = v
 
 
 def learned_image_token_cost(model: Any, base_url: Any) -> int:
-    """Learned per-image cost for ``model@host``, else the flat default."""
+    """Learned per-image cost for ``model@host`` in the active profile, else the flat default."""
     _load()
-    return _LEARNED.get(_key(model, base_url), DEFAULT_IMAGE_TOKEN_COST)
+    return _learned_for_scope(_scope()).get(_key(model, base_url), DEFAULT_IMAGE_TOKEN_COST)
 
 
 def current_image_token_cost() -> int:
@@ -118,14 +136,15 @@ def calibrate_from_usage(agent: Any, messages: List[Dict[str, Any]], prompt_toke
         return None
     key = _key(getattr(agent, "model", None), getattr(agent, "base_url", None))
     _load()
-    prior = _LEARNED.get(key)
+    learned_dict = _learned_for_scope(_scope())
+    prior = learned_dict.get(key)
     learned = per_image if prior is None else int(prior + _EMA_ALPHA * (per_image - prior))
-    _LEARNED[key] = learned
+    learned_dict[key] = learned
     _image_cost_var.set(learned)
     try:
         from utils import atomic_json_write
 
-        atomic_json_write(_cache_path(), dict(_LEARNED), indent=0, separators=(",", ":"))
+        atomic_json_write(_cache_path(), dict(learned_dict), indent=0, separators=(",", ":"))
     except Exception:
         logger.debug("image token cost persist failed", exc_info=True)
     logger.info(

--- a/tests/agent/test_image_token_cost.py
+++ b/tests/agent/test_image_token_cost.py
@@ -24,7 +24,7 @@ def _agent(anchor):
 
 def _isolate(monkeypatch, tmp_path):
     monkeypatch.setattr(itc, "_LEARNED", {})
-    monkeypatch.setattr(itc, "_LOADED", True)
+    monkeypatch.setattr(itc, "_LOADED_SCOPES", {itc._scope()})
     monkeypatch.setattr(itc, "_cache_path", lambda: tmp_path / "image_token_costs.json")
 
 
@@ -46,7 +46,7 @@ def test_residual_on_an_image_delta_teaches_the_per_image_cost(monkeypatch, tmp_
         assert estimate_messages_tokens_rough([_img()]) >= 4_000
     # Persisted per model@host: a fresh process starts calibrated.
     monkeypatch.setattr(itc, "_LEARNED", {})
-    monkeypatch.setattr(itc, "_LOADED", False)
+    monkeypatch.setattr(itc, "_LOADED_SCOPES", set())
     assert itc.learned_image_token_cost("vision-local", "http://127.0.0.1:8080/v1") == 4_000
     assert itc.learned_image_token_cost("other-model", "http://127.0.0.1:8080/v1") == itc.DEFAULT_IMAGE_TOKEN_COST
 
@@ -63,3 +63,60 @@ def test_nothing_learned_without_images_or_anchor(monkeypatch, tmp_path):
     assert itc.calibrate_from_usage(_agent(None), history, 50_000) is None
     assert itc.calibrate_from_usage(_agent(anchor), history, 10_001) is None  # residual < plausible floor
     assert itc._LEARNED == {}
+
+
+def _learn_in(home, tokens_per_image):
+    """Calibrate one image's cost while the given profile's home override is active."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(str(home))
+    try:
+        history = [{"role": "user", "content": "start"}, {"role": "assistant", "content": "ok"}]
+        anchor = capture_usage_anchor(10_000, 5, history)
+        history += [_img(), {"role": "assistant", "content": "looking"}]
+        agent = _agent(anchor)
+        with itc.image_cost_context(0):
+            text_only = anchored_context_tokens(history, anchor)
+        with itc.image_cost_context(None):
+            return itc.calibrate_from_usage(agent, history, text_only + tokens_per_image)
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _current_in(home):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(str(home))
+    try:
+        return itc.learned_image_token_cost("vision-local", "http://127.0.0.1:8080/v1")
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_learned_costs_are_profile_scoped(monkeypatch, tmp_path):
+    """A process serving two profiles in the same process (desktop multiplex) must not let one
+    profile's learned per-image cost bleed into another's, even though both loads happen off the
+    same in-memory module -- and switching back to a profile already seen this process must still
+    see its own learned value, not reload/lose it (#70328 follow-up)."""
+    monkeypatch.setattr(itc, "_LEARNED", {})
+    monkeypatch.setattr(itc, "_LOADED_SCOPES", set())
+
+    prof_a = tmp_path / "profA"
+    prof_b = tmp_path / "profB"
+    for p in (prof_a, prof_b):
+        (p / "cache").mkdir(parents=True)
+
+    assert _learn_in(prof_a, 4_000) == 4_000
+    # Profile B, touched for the first time in the SAME process, must not inherit A's value.
+    assert _current_in(prof_b) == itc.DEFAULT_IMAGE_TOKEN_COST
+    assert _learn_in(prof_b, 900) == 900
+    # Switching back to A must still see A's own learned value, unaffected by B's calibration.
+    assert _current_in(prof_a) == 4_000
+
+    # Each profile's on-disk file holds only its own learned data -- no cross-write.
+    import json
+
+    a_file = json.loads((prof_a / "cache" / "image_token_costs.json").read_text())
+    b_file = json.loads((prof_b / "cache" / "image_token_costs.json").read_text())
+    assert list(a_file.values()) == [4_000]
+    assert list(b_file.values()) == [900]


### PR DESCRIPTION
## Summary

- `agent/image_token_cost.py` (added earlier today, #104575) keeps the learned per-image
  token cost in a module-level `_LEARNED: Dict[str, int]` dict, loaded once per process behind
  a bare `_LOADED` boolean.
- The on-disk cache path (`_cache_path()`) already resolves per-profile through
  `get_hermes_home()`, but the **in-memory** dict and the load-once guard did not — they were
  shared across every profile served by the same OS process.
- In a single-process multi-profile runtime (desktop `tui_gateway` multiplex), the first profile
  to touch this module loads its file and flips `_LOADED = True` for the whole process. A second
  profile that later calls `learned_image_token_cost()`/`calibrate_from_usage()` never gets its
  own file loaded — it silently inherits the first profile's in-memory learned costs, and any
  new calibration it performs gets persisted back to *its own* file but seeded from the wrong
  starting point (or, depending on ordering, a profile's real prior calibration is lost entirely
  because its own load never ran).

## Fix

Scope `_LEARNED` and the load-once guard by `hermes_home_key()`, mirroring the existing
per-profile registry shape already used in this codebase (e.g.
`agent/secret_sources/registry.py`'s `_SCOPED_SOURCES: Dict[str, Dict[str, SecretSource]]`):

- `_LEARNED` becomes `Dict[profile_key, Dict[model_key, cost]]`.
- `_LOADED` (bool) becomes `_LOADED_SCOPES: set` of profile keys already loaded from disk.
- `calibrate_from_usage()` now reads/writes the active profile's own sub-dict, and persists only
  that profile's own data to its own file.

Public function signatures (`learned_image_token_cost`, `current_image_token_cost`,
`image_cost_context`, `bind_image_token_cost`, `calibrate_from_usage`) are unchanged — this is an
internal-state fix, no callers elsewhere in the codebase needed changes.

## Severity note

This is a correctness/hygiene fix, not a security or credential issue. The blast radius is
calibration-value contamination between profiles in a shared-process multiplex deployment, which
can make the compression-trigger's image-token estimate less accurate for a secondary profile
(over- or under-estimating context size until that profile relearns its own value) — it does not
expose secrets or cross-profile message content.

## Testing

- Extended `tests/agent/test_image_token_cost.py`:
  - Updated the existing `_isolate()` helper and both existing tests for the new
    `_LOADED_SCOPES` shape (no behavior change to those two tests).
  - Added `test_learned_costs_are_profile_scoped`, using this repo's established
    `set_hermes_home_override`/`reset_hermes_home_override` two-profile pattern (see
    `tests/hermes_cli/test_models.py::test_entitlement_cache_is_profile_scoped`) with real temp
    directories. It proves: a second profile touched for the first time in the same process does
    NOT inherit the first profile's learned cost; each profile's on-disk file holds only its own
    data; and switching back to an already-seen profile still returns its own learned value.
- `uv run --frozen python -m pytest tests/agent/test_image_token_cost.py tests/agent/test_context_estimator_multimodal.py tests/agent/test_compressor_image_tokens.py tests/agent/test_turn_usage_log_line.py -q` → 13 passed.
- Mutation-verify: reverting the fix causes all 3 tests in `test_image_token_cost.py` to fail
  (the old module has no `_scope()`/`_LOADED_SCOPES`). To confirm the new test targets the actual
  behavioral bug (not just a missing-attribute error), also ran a second, narrower mutation with
  the new fix's shape intact but `_scope()` hardcoded to a constant (simulating the old
  process-shared behavior) — `test_learned_costs_are_profile_scoped` fails exactly as expected
  (`profile B` reads `4000` instead of the default `1500`, i.e. profile A's learned value leaked
  into profile B). Restored the fix afterward.

## Competitor check

`gh pr list --repo NousResearch/hermes-agent --search "image_token_cost"` /
`"image token cost"` / `"learned cost profile"` / `"profile-scoped image token"` /
`"multiplex image"` across all states — no open or merged PR touches profile-scoping of
`agent/image_token_cost.py`'s in-memory state. The only related PRs are the merged feature PR
that introduced this module (#104575) and an unrelated merged follow-up about the watchdog
estimator (#104757).
