### PR TITLE
fix(desktop): stop re-trimming stream-completion text after echo extraction

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -498,16 +498,24 @@ export function useMessageStream({
           return state
         }
 
-        const authoritativeText = renderMediaTags(text).trim()
+        // renderMediaTags/stripGeneratedImageEchoes no longer trim internally
+        // (#markdown-whitespace saga) so boundary whitespace the model
+        // actually sent — a blank line before a code fence, the gap an
+        // extracted generated-image echo leaves behind — survives into the
+        // bubble. Re-trimming here would silently reproduce that destructive
+        // stripping and make a live-streamed reply render differently than
+        // the same message re-hydrated from storage. Only USE .trim() to
+        // decide whether there is real (non-whitespace) content.
+        const authoritativeText = renderMediaTags(text)
 
-        if (!authoritativeText) {
+        if (!authoritativeText.trim()) {
           return state
         }
 
         const streamId = state.streamId
 
         const replaceTextPart = (parts: ChatMessagePart[]) => {
-          const visibleText = stripGeneratedImageEchoes(authoritativeText, generatedImageEchoSources(parts)).trim()
+          const visibleText = stripGeneratedImageEchoes(authoritativeText, generatedImageEchoSources(parts))
 
           return mergeFinalAssistantText(parts, visibleText, occurredAt)
         }
@@ -586,14 +594,23 @@ export function useMessageStream({
         }
 
         const streamId = state.streamId
-        const finalText = renderMediaTags(text).trim()
+        // renderMediaTags/stripGeneratedImageEchoes no longer trim internally
+        // (#markdown-whitespace saga) so boundary whitespace the model
+        // actually sent survives into the bubble. Re-trimming finalText here
+        // would silently reproduce that destructive stripping and make a
+        // live-streamed reply render differently than the same message
+        // re-hydrated from storage — keep the raw text and use `hasFinalText`
+        // (below) wherever the code only needs to know "is there real text",
+        // not the text itself.
+        const finalText = renderMediaTags(text)
+        const hasFinalText = Boolean(finalText.trim())
         // Structured failure from the terminal frame wins over the legacy text
         // heuristic ("Error: <provider detail>" texts don't match the regexes).
         const completionError = failure?.error ?? completionErrorText(finalText)
         // A partial failure's `text` is streamed output the user should keep,
         // not the error string — settle it like a normal reply AND mark the
         // bubble failed, instead of stripping the text.
-        const keepFailedPartialText = Boolean(failure?.partial && finalText)
+        const keepFailedPartialText = Boolean(failure?.partial && hasFinalText)
         const interimBoundaryPending = state.interimBoundaryPending
 
         // Wall-clock seconds this turn actually ran (message.start stamped
@@ -603,7 +620,7 @@ export function useMessageStream({
           : undefined
 
         const replaceTextPart = (parts: ChatMessagePart[]) => {
-          const visibleFinalText = stripGeneratedImageEchoes(finalText, generatedImageEchoSources(parts)).trim()
+          const visibleFinalText = stripGeneratedImageEchoes(finalText, generatedImageEchoSources(parts))
 
           return mergeFinalAssistantText(parts, visibleFinalText, occurredAt)
         }
@@ -673,12 +690,12 @@ export function useMessageStream({
             // text merge — replaces the interim's text with the full final.)
             const finalContinuesInterim = Boolean(
               existing.interim &&
-              finalText &&
+              hasFinalText &&
               existingText &&
               (finalText === existingText || finalText.startsWith(existingText) || existingText.startsWith(finalText))
             )
 
-            if (existing.pending || (!interimBoundaryPending && finalText && existingText === finalText)) {
+            if (existing.pending || (!interimBoundaryPending && hasFinalText && existingText === finalText)) {
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )
@@ -708,10 +725,10 @@ export function useMessageStream({
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )
-            } else if (finalText) {
+            } else if (hasFinalText) {
               nextMessages = [...prev, newAssistantFromCompletion()]
             }
-          } else if (finalText) {
+          } else if (hasFinalText) {
             nextMessages = [...prev, newAssistantFromCompletion()]
           }
         }
@@ -750,9 +767,9 @@ export function useMessageStream({
           // history — hydrate to catch up instead of leaving the transcript
           // blank until restart (#88036). A non-empty frame still settles
           // locally, so the user-tail guard keeps applying there.
-          (!unresolvedUserTail || !finalText) &&
-          !(localVisibleText && !finalText) &&
-          (state.adoptedRunningTurn || !state.sawAssistantPayload || !finalText)
+          (!unresolvedUserTail || !hasFinalText) &&
+          !(localVisibleText && !hasFinalText) &&
+          (state.adoptedRunningTurn || !state.sawAssistantPayload || !hasFinalText)
 
         return {
           ...state,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/stream-generated-image-whitespace.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/stream-generated-image-whitespace.test.tsx
@@ -1,0 +1,83 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { chatMessageText } from '@/lib/chat-messages'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+const SID = 'session-1'
+
+// Mirrors the fixture the "retain Markdown boundary and code-copy whitespace"
+// saga (55ad5afa12) proved for the hydration path: an assistant reply whose
+// generated-image echo sits at the very end of the text, leaving a trailing
+// blank line once the echo is stripped. chat-messages.test.ts and
+// generated-images.test.ts now assert the stripped result keeps that
+// trailing '\n\n' — stripGeneratedImageEchoes no longer trims it away.
+const IMAGE_URL = 'https://cdn.example/cat.png'
+const RAW_TEXT = `Here you go.\n\n![Generated image](${IMAGE_URL})`
+const EXPECTED_VISIBLE_TEXT = 'Here you go.\n\n'
+
+function mountStream(): MessageStreamHarness {
+  return renderMessageStream(SID)
+}
+
+const start = (stream: MessageStreamHarness) =>
+  act(() => stream.handleEvent({ payload: {}, session_id: SID, type: 'message.start' }))
+
+const toolComplete = (stream: MessageStreamHarness) =>
+  act(() =>
+    stream.handleEvent({
+      payload: {
+        name: 'image_generate',
+        result: { host_image: IMAGE_URL, image: IMAGE_URL, success: true }
+      },
+      session_id: SID,
+      type: 'tool.complete'
+    })
+  )
+
+const interim = (stream: MessageStreamHarness, text: string) =>
+  act(() =>
+    stream.handleEvent({ payload: { already_streamed: true, text }, session_id: SID, type: 'message.interim' })
+  )
+
+const complete = (stream: MessageStreamHarness, text: string) =>
+  act(() => stream.handleEvent({ payload: { text }, session_id: SID, type: 'message.complete' }))
+
+function lastAssistantText(stream: MessageStreamHarness): string {
+  const last = [...stream.state().messages].reverse().find(m => m.role === 'assistant' && !m.hidden)
+
+  return last ? chatMessageText(last) : ''
+}
+
+describe('useMessageStream generated-image echo whitespace parity with hydration', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('preserves the trailing whitespace a stripped generated-image echo leaves behind on message.complete', async () => {
+    const stream = mountStream()
+    await start(stream)
+    await toolComplete(stream)
+
+    await complete(stream, RAW_TEXT)
+
+    // Before the fix, completeAssistantMessage re-trimmed the output of
+    // stripGeneratedImageEchoes, collapsing this to 'Here you go.' — the
+    // exact destructive behavior the hydration-path saga eliminated.
+    expect(lastAssistantText(stream)).toBe(EXPECTED_VISIBLE_TEXT)
+  })
+
+  it('preserves the trailing whitespace a stripped generated-image echo leaves behind on message.interim', async () => {
+    const stream = mountStream()
+    await start(stream)
+    await toolComplete(stream)
+
+    await interim(stream, RAW_TEXT)
+
+    // Same parity check for finalizeInterimAssistantMessage — it re-trimmed
+    // stripGeneratedImageEchoes's output the same way completeAssistantMessage
+    // did.
+    expect(lastAssistantText(stream)).toBe(EXPECTED_VISIBLE_TEXT)
+  })
+})


### PR DESCRIPTION
## Summary

- `renderMediaTags` and `stripGeneratedImageEchoes` stopped trimming their own output as of the "retain Markdown boundary and code-copy whitespace" saga (3e1b7af, 55ad5af, merged as #104980), so a session re-hydrated from storage now preserves boundary whitespace — e.g. the trailing blank line a stripped generated-image echo leaves behind (`chat-messages.test.ts` and `generated-images.test.ts` assert `'Here you go.\n\n'`, not `'Here you go.'`).
- That saga never touched `use-message-stream/index.ts`. `finalizeInterimAssistantMessage` and `completeAssistantMessage` still call `.trim()` immediately after calling those now non-trimming helpers, reproducing the exact destructive stripping the saga removed — but only on the **live-streaming** completion path, not the hydration path.
- Net effect: the same assistant message can render with different boundary whitespace depending on whether it's currently streaming in live or gets re-hydrated from the session store (e.g. after a reload/resume).

## Root cause

Two call sites in `apps/desktop/src/app/session/hooks/use-message-stream/index.ts` re-trim the text right after the helpers whose whole job (post-saga) is to preserve it:

```ts
// finalizeInterimAssistantMessage
const authoritativeText = renderMediaTags(text).trim()
...
const visibleText = stripGeneratedImageEchoes(authoritativeText, generatedImageEchoSources(parts)).trim()

// completeAssistantMessage
const finalText = renderMediaTags(text).trim()
...
const visibleFinalText = stripGeneratedImageEchoes(finalText, generatedImageEchoSources(parts)).trim()
```

`finalText`'s truthiness is also used throughout `completeAssistantMessage` as an "is there real completion text" gate (interim-continuity checks, append-vs-settle branching, the post-turn hydrate decision) — those checks needed to keep working the same way even once the text itself stops being trimmed.

## Fix

- Stop calling `.trim()` on the output of `renderMediaTags`/`stripGeneratedImageEchoes` — pass the text through as-is, matching what `chat-messages/hydration.ts` already does.
- Where the code only needs to know whether there's real (non-whitespace) content — not the content itself — check `.trim()` without mutating the stored value. `completeAssistantMessage` gets a `hasFinalText` boolean used everywhere `finalText`'s truthiness previously gated a branch; `finalizeInterimAssistantMessage` keeps its early-return `.trim()` check but doesn't strip the value it stores.

## Testing

New `stream-generated-image-whitespace.test.tsx`, mirroring the saga's own fixture (a reply whose generated-image echo sits at the end of the text, leaving `'Here you go.\n\n'` once stripped) and the existing `use-message-stream` test harness (`renderMessageStream`, driving real `tool.complete` / `message.interim` / `message.complete` gateway events):

- `preserves the trailing whitespace a stripped generated-image echo leaves behind on message.complete`
- `preserves the trailing whitespace a stripped generated-image echo leaves behind on message.interim`

Mutation-verify: reverted `index.ts` only (patch-file method), reran the new test — both failed with `expected 'Here you go.' to be 'Here you go.\n\n'`, i.e. exactly the bug being fixed. Reapplied the fix — both pass again.

Commands run:
- `npx vitest run src/app/session/hooks/use-message-stream/stream-generated-image-whitespace.test.tsx` → 2 passed
- `npx vitest run src/app/session/hooks/use-message-stream/` → 27 files, 157 passed
- `npx vitest run src/lib/generated-images.test.ts src/lib/chat-messages.test.ts src/lib/markdown-whitespace.test.ts` → 3 files, 85 passed
- `npx tsc -p . --noEmit` (renderer tsconfig, which covers this `src/` path) → clean

## Scope note

Checked for competitors before opening: #45067 ("correct streamed assistant text order and newline handling") touches this same file but is scoped to reasoning/text part *ordering* only — its own body explicitly says an earlier revision carried "a `finalText` trim change for newline handling" that was **dropped** because it wasn't covered by a test, so this gap is intentionally still open. The merged saga PR #104980 never touched `use-message-stream/index.ts`. No open or merged PR addresses the live-stream re-trim gap this PR fixes.
