### PR TITLE
fix(gateway): recognize Weixin's rate-limit wording in the delivery ledger's flood classifier

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -74,10 +74,18 @@ FLOOD_RETRY_SLACK_SECONDS = 2.0
 # merely suggests retrying is never mistaken for a flood.
 _RAW_FLOOD_RE = re.compile(r"flood control exceeded.*?retry in\s+(\d+(?:\.\d+)?)", re.IGNORECASE)
 
+# Some adapters describe their own throttling without either the ``flood_control:`` prefix or PTB's
+# wording — e.g. Weixin's circuit breaker fails a send closed with "...cooldown active for 12.3s"
+# (``gateway/platforms/weixin.py``). The cooldown length is still embedded in the text, so it is worth
+# extracting precisely rather than falling back to the generic default every time.
+_COOLDOWN_WAIT_RE = re.compile(r"cooldown active for\s+(\d+(?:\.\d+)?)s", re.IGNORECASE)
+
 
 def _raw_flood_wait(text: str) -> Optional[float]:
-    """Seconds asked for by a flood error still carrying the platform's own wording, else ``None``."""
-    match = _RAW_FLOOD_RE.search(text or "")
+    """Seconds asked for by a flood error still carrying the platform's own wording (PTB's "flood
+    control exceeded... retry in N seconds", or an adapter's own "cooldown active for Ns"), else
+    ``None``."""
+    match = _RAW_FLOOD_RE.search(text or "") or _COOLDOWN_WAIT_RE.search(text or "")
     if not match:
         return None
     try:
@@ -86,11 +94,34 @@ def _raw_flood_wait(text: str) -> Optional[float]:
         return None
 
 
+def _classified_rate_limited(text: str) -> bool:
+    """Whether ``text`` matches the platform-neutral "rate_limited" send-error classification
+    (``gateway.platforms.base.classify_send_error``), so any adapter's rate-limit wording is
+    recognised here too and not just Telegram's. Imported locally (this module is loaded well before
+    ``gateway.platforms.base`` in some paths, e.g. CLI commands that only touch the ledger) and
+    best-effort like everything else in this module."""
+    if not text:
+        return False
+    try:
+        from gateway.platforms.base import classify_send_error
+    except Exception:
+        return False
+    try:
+        return classify_send_error(None, text) == "rate_limited"
+    except Exception:
+        return False
+
+
 def is_flood_error(error: Any) -> bool:
-    """True for a flood refusal: the adapters' fail-closed ``flood_control:<seconds>`` result, or a
-    row still carrying the platform's own flood wording (see ``_RAW_FLOOD_RE``)."""
+    """True for a flood refusal: the adapters' fail-closed ``flood_control:<seconds>`` result, a row
+    still carrying the platform's own flood/cooldown wording (see ``_RAW_FLOOD_RE``), or any other
+    error text the platform-neutral classifier recognises as a rate limit (see
+    ``_classified_rate_limited``) — so an adapter that surfaces a rate limit without either of the
+    two specific shapes above (e.g. Weixin's bare ``RuntimeError``) still gets a timed redelivery
+    instead of being treated as an ordinary failure and retried immediately inside its own cooldown."""
     text = str(error or "").strip().lower()
-    return text.startswith(FLOOD_ERROR_PREFIX) or _raw_flood_wait(text) is not None
+    return (text.startswith(FLOOD_ERROR_PREFIX) or _raw_flood_wait(text) is not None
+            or _classified_rate_limited(text))
 
 
 def flood_wait_seconds(error: Any, default: float = FLOOD_RETRY_DEFAULT_SECONDS) -> float:

--- a/tests/gateway/test_delivery_flood_invariants.py
+++ b/tests/gateway/test_delivery_flood_invariants.py
@@ -5,11 +5,17 @@ import time
 
 from gateway import delivery_ledger as dl
 
+# Weixin's circuit breaker fails a send closed with this shape (gateway/platforms/weixin.py) — a bare
+# error string with neither the ``flood_control:<seconds>`` prefix adapters normally use nor PTB's raw
+# "Flood control exceeded... retry in N seconds" wording, but the same platform-neutral "rate_limited"
+# classification (gateway.platforms.base.classify_send_error) that gates the in-attempt send backoff.
+WEIXIN_RATE_LIMIT_ERROR = 'iLink sendmessage rate limited; cooldown active for 12.3s'
 
-def record(oid, *, profile=None):
-    dl.record_obligation(obligation_id=oid, session_key='session-' + oid, platform='telegram',
+
+def record(oid, *, profile=None, platform='telegram', error='flood_control:185'):
+    dl.record_obligation(obligation_id=oid, session_key='session-' + oid, platform=platform,
                          chat_id='123', thread_id='77', content='.' * 3000, adapter_profile=profile)
-    dl.mark_failed(oid, 'flood_control:185')
+    dl.mark_failed(oid, error)
 
 
 def read(oid):
@@ -59,3 +65,66 @@ def test_boot_adopts_waiting_rows_without_spending_or_losing_deadline():
     claimed = dl.sweep_failed_for_runtime('telegram', now=original['updated_at'] + 186)
     assert len(claimed) == 1 and claimed[0]['needs_marker']
     assert read('boot')['state'] == 'attempting' and read('boot')['last_error'] is None
+
+
+def test_weixin_rate_limit_text_classifies_as_flood_and_extracts_its_own_wait():
+    """``is_flood_error``/``flood_wait_seconds`` must recognise Weixin's own rate-limit wording (no
+    ``flood_control:`` prefix, no PTB text) via the platform-neutral classifier, and read the cooldown
+    seconds Weixin itself embeds rather than falling back to the generic default."""
+    assert dl.is_flood_error(WEIXIN_RATE_LIMIT_ERROR)
+    assert dl.flood_wait_seconds(WEIXIN_RATE_LIMIT_ERROR) == 12.3
+    # An ordinary Weixin failure (not rate-limited) must still read as an ordinary failure.
+    assert not dl.is_flood_error('iLink sendmessage error: ret=1 errcode=2 errmsg=unknown error')
+
+
+def test_weixin_rate_limit_arms_timed_redelivery_not_immediate_retry():
+    """The ledger must treat a Weixin rate-limit failure exactly like a Telegram flood failure: adopted
+    without spending an attempt while still inside the wait, then claimable once it has passed — never
+    claimed as an ordinary failure that spends an attempt inside the still-active cooldown."""
+    record('weixin-due', platform='weixin', error=WEIXIN_RATE_LIMIT_ERROR)
+    stamp = read('weixin-due')['updated_at']
+    # Still inside Weixin's own 12.3s cooldown: the runtime sweep must not claim it yet.
+    assert dl.sweep_failed_for_runtime('weixin', now=stamp + 11) == []
+    assert read('weixin-due')['attempts'] == 0
+    # Past the cooldown: claimable, carries a marker (rate-limit wording), and clears the stale error.
+    claimed = dl.sweep_failed_for_runtime('weixin', now=stamp + 13)
+    assert [r['obligation_id'] for r in claimed] == ['weixin-due']
+    assert claimed[0]['needs_marker'] and 'rate limit' in claimed[0]['marker']
+    assert read('weixin-due')['last_error'] is None
+
+
+def test_weixin_rate_limit_boot_adoption_does_not_spend_attempt():
+    """A dead-owner boot sweep must adopt a still-cooling-down Weixin rate-limit row (no attempt spent,
+    deadline preserved) exactly as it does for Telegram's ``flood_control:`` rows — not treat it as an
+    ordinary failed row and immediately spend a redelivery attempt inside the cooldown."""
+    record('weixin-boot', platform='weixin', error=WEIXIN_RATE_LIMIT_ERROR)
+    original = read('weixin-boot')
+    with sqlite3.connect(dl._db_path()) as conn:
+        conn.execute("UPDATE delivery_obligations SET owner_pid=NULL, owner_started_at=NULL, adapter_profile=NULL")
+    claimed = dl.sweep_recoverable(now=original['updated_at'] + 5,
+                                    deliverable_targets={('weixin', None)})
+    assert len(claimed) == 1 and claimed[0].get('adopted')
+    adopted = read('weixin-boot')
+    assert adopted['owner_pid'] == os.getpid()
+    assert adopted['adapter_profile'] == 'default'
+    assert adopted['attempts'] == 0 and adopted['updated_at'] == original['updated_at']
+    assert adopted['last_error'] == WEIXIN_RATE_LIMIT_ERROR
+    # A second boot-sweep pass finds this process still the live owner: nothing more to adopt.
+    assert dl.sweep_recoverable(now=original['updated_at'] + 6) == []
+    # Still inside the cooldown: the runtime sweep (this process claiming its own adopted row) must wait.
+    assert dl.sweep_failed_for_runtime('weixin', now=original['updated_at'] + 11) == []
+    # Past the deadline: claimed, marker set, error cleared.
+    claimed = dl.sweep_failed_for_runtime('weixin', now=original['updated_at'] + 13)
+    assert len(claimed) == 1 and claimed[0]['needs_marker']
+    assert read('weixin-boot')['state'] == 'attempting' and read('weixin-boot')['last_error'] is None
+
+
+def test_telegram_flood_detection_unaffected_by_broader_classifier():
+    """Widening ``is_flood_error`` to also consult the platform-neutral classifier must not change
+    Telegram's own, already-correct behavior for its two established shapes."""
+    assert dl.is_flood_error('flood_control:185')
+    assert dl.is_flood_error('Flood control exceeded. Retry in 185 seconds')
+    assert dl.flood_wait_seconds('flood_control:185') == 185.0
+    assert dl.flood_wait_seconds('Flood control exceeded. Retry in 185 seconds') == 185.0
+    # A permanent Telegram rejection must never be mistaken for a flood.
+    assert not dl.is_flood_error('Forbidden: bot was blocked by the user')


### PR DESCRIPTION
## Summary

`is_flood_error()` (`gateway/delivery_ledger.py`) only recognized Telegram's two flood shapes: the
adapters' fail-closed `flood_control:<seconds>` prefix, and python-telegram-bot's raw `"Flood control
exceeded... Retry in N seconds"` text. This function gates whether a final-send failure gets a timed
redelivery armed (`_schedule_flood_redelivery`) and whether the boot/runtime sweeps
(`sweep_recoverable`, `sweep_failed_for_runtime`) treat a failed row as still inside its penalty window
(adopt without spending an attempt, wait for the deadline) or as an ordinary failure (claim and resend
immediately).

Weixin's rate-limit circuit breaker fails a send closed with neither shape —
`"iLink sendmessage rate limited; cooldown active for {N}s"` (`gateway/platforms/weixin.py`, a bare
`SendResult(success=False, error=str(exc))`, no `retry_after`/`flood_control:` framing) — so a Weixin
send throttled by iLink never got a flood timer armed. The row sat as an ordinary `failed` row, and the
next boot sweep or reconnect-triggered sweep claimed and resent it immediately, spending a redelivery
attempt inside the still-active cooldown instead of waiting it out — defeating the point of the
flood-ledger mechanism for this one platform.

## Fix

Widened `is_flood_error()` to also recognize the platform-neutral rate-limit classification already
used by `_send_with_retry`'s in-attempt backoff — `classify_send_error()` in
`gateway/platforms/base.py` (imported locally inside the new `_classified_rate_limited()` helper, best-
effort, to avoid a module-load-order dependency between `delivery_ledger.py` and the much larger
`gateway/platforms/base.py`) — rather than hand-rolling a second, Weixin-specific regex. This is the
same chokepoint `_is_rate_limited_error()` already wraps for the in-attempt backoff decision, so any
future adapter whose error text matches "flood"/"too many requests"/"retry after"/"rate limit" gets the
ledger's timed-redelivery treatment too, not just Weixin.

Also extended the wait-seconds extraction (`_raw_flood_wait`, used by `flood_wait_seconds` /
`flood_not_before`) with a second regex, `_COOLDOWN_WAIT_RE`, matching Weixin's own embedded
`"cooldown active for Ns"` figure — so the redelivery timer honors the platform's actual cooldown
instead of falling back to the generic 60s default every time.

```python
_COOLDOWN_WAIT_RE = re.compile(r"cooldown active for\s+(\d+(?:\.\d+)?)s", re.IGNORECASE)
```

## Why this approach over a scoped Weixin-only pattern

Reusing `classify_send_error()` was judged safer and more maintainable than adding a narrow
Weixin-specific literal match:
- It's the *same* classification the send-retry path already trusts for "is this transient/rate-limited," so the ledger and the in-attempt backoff can't drift out of sync on what counts as a flood.
- It automatically covers any other adapter whose error text says "rate limit"/"too many requests"/"retry after" without a dedicated `flood_control:` prefix, closing the same class of gap ahead of time rather than one platform at a time.
- Verified no regression risk: `_RETRYABLE_ERROR_PATTERNS` (the separate "transient"/network-error bucket) doesn't overlap with the `rate_limited` classifier's patterns, and `is_flood_error()` is only ever called on the row's `last_error` string — never on `"send_path_degraded"` or blocked/forbidden/not-found texts, which the classifier correctly leaves unmatched (covered by a new regression assertion).

## Testing

Extended `tests/gateway/test_delivery_flood_invariants.py` (the current, focused successor to the
older/larger flood-retry test file) with four new tests:
- `test_weixin_rate_limit_text_classifies_as_flood_and_extracts_its_own_wait` — unit-level: `is_flood_error()` recognizes the Weixin text, `flood_wait_seconds()` reads the embedded `12.3` figure (not the generic default), and an *ordinary* (non-rate-limited) Weixin failure is correctly left unmatched.
- `test_weixin_rate_limit_arms_timed_redelivery_not_immediate_retry` — end-to-end through `sweep_failed_for_runtime`: a Weixin flood row is *not* claimed while still inside its cooldown, and *is* claimed (with the rate-limit marker) once the deadline passes.
- `test_weixin_rate_limit_boot_adoption_does_not_spend_attempt` — end-to-end through `sweep_recoverable` + `sweep_failed_for_runtime`: a dead-owner Weixin flood row is adopted without spending an attempt while cooling down, then claimed normally past the deadline (mirrors the existing Telegram boot-adoption test).
- `test_telegram_flood_detection_unaffected_by_broader_classifier` — confirms Telegram's two established shapes and the "permanent rejection is not a flood" invariant are unchanged.

Ran: `tests/gateway/test_delivery_flood_invariants.py`, `test_delivery_ledger.py`, `test_delivery.py`,
`test_weixin.py`, `test_restart_redelivery_dedup.py`, `test_send_error_classification.py` — 109 passed.
`ruff check` on both changed files: clean.

**Mutation-verified**: reverted `gateway/delivery_ledger.py` via patch file (tests kept), reran the
four new tests — 3 of 4 failed as expected (`AssertionError`s on the exact behaviors the fix adds); the
Telegram-only invariant test correctly still passed since it doesn't exercise the new code path.
Reapplied the fix — all 6 tests in the file pass again.

## Competitor check

Fresh search across `weixin flood` / `is_flood_error` / `delivery_ledger weixin` / `weixin rate limit` /
`flood_control weixin` / `delivery ledger rate limit` / `flood-capped` / `delivery_ledger`, all states,
right before pushing:

- **#58256** ("avoid fallback sends during Weixin cooldown", open since 2026-07-04) — read the actual diff. It touches `gateway/platforms/base.py`'s `_send_with_retry` (in-attempt fallback/notice avoidance) and `gateway/platforms/weixin.py`'s `send()` (adds `error_kind`/`retry_after` to `SendResult`, via a `_retry_after_from_error` extractor using the same `cooldown active for Ns` wording). It does **not** touch `gateway/delivery_ledger.py` at all, and its base commit predates current `main`'s `_send_with_retry` (which already has equivalent, differently-shaped rate-limit handling — likely converged on independently). No overlap with this PR's target file; noted here as complementary, adjacent prior art for the in-attempt/`SendResult`-enrichment layer, not the post-exhaustion ledger layer this PR fixes.
- **#94423** ("make rate-limited sends observable and recoverable (#94146)", open) — also only touches `gateway/platforms/weixin.py` + its own tests; also does not touch `delivery_ledger.py`.
- **#104950** ("recover flood-refused replies after the penalty (#104799, salvage #103669)") — **merged today**, and already an ancestor of this branch's base. It built the general timed-redelivery machinery this PR extends (the event-woken per-bot-identity worker, `pending_flood_retries`, the `sweep_recoverable`/`sweep_failed_for_runtime` deadline enforcement — all read and relied on above) and validated it end-to-end for Telegram, but its own `is_flood_error()` stayed Telegram-only; this PR is the direct, non-duplicate follow-up for Weixin.
- **#103877** ("replay flood_control sends instead of stranding them") — closed 2026-09-05, explicitly described in #104950's body as an inferior/superseded candidate ("bare allowlist does not protect the penalty window or arrange a timed wake"). Not a live competitor.
- No other open or recently-closed PR touches `is_flood_error`, `flood_wait_seconds`, or Weixin's rate-limit text in `delivery_ledger.py`.
