### PR TITLE
fix(tui_gateway): scope /loop and /heartbeat idle-poll ticks to the session profile home

### DIFF
--- a/tests/tui_gateway/test_loop_heartbeat_profile_scope.py
+++ b/tests/tui_gateway/test_loop_heartbeat_profile_scope.py
@@ -1,0 +1,220 @@
+"""Regression tests: the /loop and /heartbeat idle-poll tick drivers must bind the session's OWN
+profile home before touching ``LoopManager``/``HeartbeatManager`` state.
+
+``hermes_cli.goals._get_session_db()`` (which both ``hermes_cli.loops`` and ``hermes_cli.heartbeat``
+delegate to) caches its ``SessionDB`` handle keyed on ``str(get_hermes_home())``. Under multiplex, a
+Desktop/TUI session bound to a secondary profile (``session["profile_home"]``) must read/write THAT
+profile's ``state.db`` for its loop/heartbeat state, not whatever profile happens to be the process's
+current ``HERMES_HOME`` at poll time.
+
+``tui_gateway/methods_tools.py::_cmd_goal`` already binds ``_session_profile_runtime_scope(session)``
+before touching ``GoalManager``; the sibling ``/loop`` command handler (``_cmd_loop``) and the two
+per-session poller-thread tick drivers in ``tui_gateway/session_notifications.py``
+(``_maybe_fire_tui_heartbeat_tick`` / ``_maybe_fire_tui_loop_tick``) previously constructed
+``LoopManager``/``HeartbeatManager`` directly, without binding the session's profile home first — a
+secondary-profile session's due loop/heartbeat tick would silently look at (or clobber) the launch
+profile's DB instead of its own, wedging automation for any session not on the "currently
+home-scoped" profile.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    # tests/conftest.py's autouse fixture re-points hermes_state.DEFAULT_DB_PATH to ITS OWN
+    # per-test fake home (a module-level constant pinned once collection has imported
+    # hermes_state), so a bare SessionDB() would otherwise ignore both HERMES_HOME and any
+    # context-local hermes_home override and always resolve to that pinned path. Undo the pin so
+    # SessionDB() resolves at CALL time via get_hermes_home() again — the same restore
+    # tests/tui_gateway/test_goal_command.py's identical fixture performs, for the identical
+    # reason (goals.py / loops.py / heartbeat.py all bottom out in a bare SessionDB()).
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", hermes_state._IMPORT_DEFAULT_DB_PATH)
+
+    # Bust the goal-module DB cache (shared by loops.py/heartbeat.py) so it re-resolves HERMES_HOME.
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+@pytest.fixture()
+def server(hermes_home, monkeypatch):
+    # Mocks are scoped to the initial import only (see tests/tui_gateway/test_protocol.py).
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+
+    monkeypatch.setattr(mod, "_hermes_home", hermes_home)
+    monkeypatch.setattr(mod, "_cfg_cache", None)
+    monkeypatch.setattr(mod, "_cfg_mtime", None)
+    monkeypatch.setattr(mod, "_cfg_path", None)
+    yield mod
+    mod._sessions.clear()
+    mod._pending.clear()
+    mod._answers.clear()
+
+
+@pytest.fixture()
+def secondary_profile(tmp_path):
+    secondary = tmp_path / "profiles" / "secondary"
+    secondary.mkdir(parents=True)
+    (secondary / "config.yaml").write_text("", encoding="utf-8")
+    return secondary
+
+
+def _poller_session(session_key: str, profile_home) -> dict:
+    return {
+        "session_key": session_key,
+        "profile_home": str(profile_home),
+        "history_lock": threading.Lock(),
+        "running": False,
+    }
+
+
+def _wire_stub_dispatch(server, monkeypatch):
+    """Capture status.update emits and turn submissions without running a real turn."""
+    emits: list = []
+    submits: list = []
+    monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: emits.append((event, sid, payload)))
+
+    def fake_submit(rid, sid, session, text, **kwargs):
+        submits.append(text)
+        with session["history_lock"]:
+            session["running"] = False
+        return True
+
+    monkeypatch.setattr(server, "_run_prompt_submit", fake_submit)
+    return emits, submits
+
+
+class TestHeartbeatTickProfileScope:
+    def test_heartbeat_tick_fires_from_the_session_own_profile(self, server, monkeypatch, secondary_profile):
+        from hermes_cli.heartbeat import HeartbeatManager
+
+        session_key = "hb-secondary-session"
+        # Seed a DUE heartbeat directly in the secondary profile's DB.
+        with server._session_profile_runtime_scope({"profile_home": str(secondary_profile)}):
+            mgr = HeartbeatManager(session_id=session_key)
+            mgr.set("check the deploy", 60)
+            mgr.state.created_at -= 120  # backdate so it's immediately due
+            from hermes_cli.heartbeat import save_heartbeat
+
+            save_heartbeat(session_key, mgr.state)
+
+        # The launch (default) profile has no heartbeat for this key.
+        assert HeartbeatManager(session_id=session_key).state is None
+
+        session = _poller_session(session_key, secondary_profile)
+        emits, submits = _wire_stub_dispatch(server, monkeypatch)
+
+        server._maybe_fire_tui_heartbeat_tick("sid-hb", session)
+
+        assert submits, "heartbeat tick never dispatched — it did not see the secondary profile's due state"
+        assert "check the deploy" in submits[0]
+        assert any(e == "status.update" for e, _, _ in emits)
+
+        # And the fire was persisted into the SECONDARY profile's DB, not the launch one.
+        with server._session_profile_runtime_scope({"profile_home": str(secondary_profile)}):
+            assert HeartbeatManager(session_id=session_key).state.fire_count == 1
+        assert HeartbeatManager(session_id=session_key).state is None  # launch profile still untouched
+
+    def test_heartbeat_tick_is_a_noop_without_a_profile_home(self, server, monkeypatch):
+        """No profile_home (single-profile deployment): falls back to the process HERMES_HOME, unchanged."""
+        from hermes_cli.heartbeat import HeartbeatManager, save_heartbeat
+
+        session_key = "hb-launch-session"
+        mgr = HeartbeatManager(session_id=session_key)
+        mgr.set("launch profile heartbeat", 60)
+        mgr.state.created_at -= 120
+        save_heartbeat(session_key, mgr.state)
+
+        session = {
+            "session_key": session_key,
+            "history_lock": threading.Lock(),
+            "running": False,
+        }
+        emits, submits = _wire_stub_dispatch(server, monkeypatch)
+
+        server._maybe_fire_tui_heartbeat_tick("sid-hb2", session)
+
+        assert submits, "heartbeat tick must still fire for a session with no profile_home"
+        assert "launch profile heartbeat" in submits[0]
+
+
+class TestLoopTickProfileScope:
+    def test_loop_tick_fires_from_the_session_own_profile(self, server, monkeypatch, secondary_profile):
+        from hermes_cli.loops import LoopManager
+
+        session_key = "loop-secondary-session"
+        with server._session_profile_runtime_scope({"profile_home": str(secondary_profile)}):
+            mgr = LoopManager(session_id=session_key)
+            mgr.set("ping the service")  # self-paced: next_due_at = now, immediately due
+
+        assert LoopManager(session_id=session_key).state is None  # launch profile: nothing there
+
+        session = _poller_session(session_key, secondary_profile)
+        emits, submits = _wire_stub_dispatch(server, monkeypatch)
+
+        server._maybe_fire_tui_loop_tick("sid-loop", session)
+
+        assert submits, "loop tick never dispatched — it did not see the secondary profile's due loop"
+        assert "ping the service" in submits[0]
+
+        with server._session_profile_runtime_scope({"profile_home": str(secondary_profile)}):
+            assert LoopManager(session_id=session_key).state.ticks_fired == 1
+        assert LoopManager(session_id=session_key).state is None  # launch profile untouched
+
+
+class TestCmdLoopProfileScope:
+    def test_cmd_loop_persists_into_the_session_own_profile(self, server, secondary_profile):
+        from hermes_cli.loops import LoopManager
+
+        sid = "sid-cmdloop"
+        session_key = "loop-cmd-secondary-session"
+        session = {
+            "session_key": session_key,
+            "profile_home": str(secondary_profile),
+            "history": [],
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "running": False,
+            "attached_images": [],
+            "cols": 120,
+        }
+        server._sessions[sid] = session
+
+        handler = server._methods["command.dispatch"]
+        result = handler(1, {"session_id": sid, "name": "loop", "arg": "keep checking status"})
+
+        assert "error" not in result, result
+
+        # The loop landed in the SECONDARY profile's DB.
+        with server._session_profile_runtime_scope(session):
+            state = LoopManager(session_id=session_key).state
+            assert state is not None
+            assert "keep checking status" in state.prompt
+
+        # ...and did NOT leak into the launch profile's DB.
+        assert LoopManager(session_id=session_key).state is None

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -698,17 +698,18 @@ def _cmd_goal(rid, params, session, name, arg):
 
 
 def _cmd_loop(rid, params, session, name, arg):
-    sid_key, loops, err = _session_key_or_err(rid, session, "hermes_cli.loops", "loops")
-    if err:
-        return err
-    result = loops.dispatch_loop_command(loops.LoopManager(session_id=sid_key), arg)
-    output = result.get("output") or ""
-    if result.get("created"):
-        with contextlib.suppress(Exception):
-            if loops.goal_blocks_loop_tick(sid_key):
-                output += ("\nNote: an active /goal is driving this session — loop "
-                           "wakeups defer until the goal finishes, pauses, or parks.")
-    return _exec_out(rid, output)
+    with _session_profile_runtime_scope(session or {}):
+        sid_key, loops, err = _session_key_or_err(rid, session, "hermes_cli.loops", "loops")
+        if err:
+            return err
+        result = loops.dispatch_loop_command(loops.LoopManager(session_id=sid_key), arg)
+        output = result.get("output") or ""
+        if result.get("created"):
+            with contextlib.suppress(Exception):
+                if loops.goal_blocks_loop_tick(sid_key):
+                    output += ("\nNote: an active /goal is driving this session — loop "
+                               "wakeups defer until the goal finishes, pauses, or parks.")
+        return _exec_out(rid, output)
 
 
 def _cmd_undo(rid, params, session, name, arg):

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -186,6 +186,12 @@ def _maybe_fire_tui_heartbeat_tick(sid: str, session: dict) -> None:
     idle session first (a racing user prompt wins), then re-enter through ``_run_prompt_submit`` as a
     plain user turn. A dispatch that never starts a turn rewinds the persisted fire so the tick stays
     due instead of being silently consumed.
+
+    Runs on the per-session poller thread (``_notification_poller_loop``), not an asyncio task, so no
+    ContextVar state is inherited from a turn — ``HeartbeatManager`` (via ``hermes_cli.goals._get_session_db``,
+    cached per ``get_hermes_home()``) must be bound to the session's own profile home explicitly, the same way
+    ``_cmd_goal`` binds it for ``/goal``, or a secondary-profile session's heartbeat reads/writes whichever
+    profile happens to be the process-wide HERMES_HOME at that moment.
     """
     try:
         from hermes_cli.heartbeat import HeartbeatManager
@@ -193,53 +199,58 @@ def _maybe_fire_tui_heartbeat_tick(sid: str, session: dict) -> None:
         return
     if not (sid_key := session.get("session_key") or ""):
         return
-    mgr = HeartbeatManager(session_id=sid_key)
-    if not mgr.is_active() or not mgr.state.is_due() or not _notif_claim_turn(session):
-        return  # not due, or busy — the tick coalesces to the next idle poll
-    if not (prompt := mgr.due_prompt()):
-        _notif_release_turn(session)
-        return
-    started = False
-    try:
-        _emit("status.update", sid, {"kind": "heartbeat", "text": f"♥ heartbeat #{mgr.state.fire_count} firing…"})
-        started = bool(_run_prompt_submit(f"__heartbeat__{int(time.time() * 1000)}", sid, session, prompt))
-    except Exception as exc:
-        _notif_log_failure("heartbeat dispatch failed", exc)
-    if not started:
-        # _run_prompt_submit releases ``running`` itself when it refuses the turn; make it unconditional.
-        _notif_release_turn(session)
-        with contextlib.suppress(Exception):
-            mgr.abandon_fire()
+    with _session_profile_runtime_scope(session or {}):
+        mgr = HeartbeatManager(session_id=sid_key)
+        if not mgr.is_active() or not mgr.state.is_due() or not _notif_claim_turn(session):
+            return  # not due, or busy — the tick coalesces to the next idle poll
+        if not (prompt := mgr.due_prompt()):
+            _notif_release_turn(session)
+            return
+        started = False
+        try:
+            _emit("status.update", sid, {"kind": "heartbeat", "text": f"♥ heartbeat #{mgr.state.fire_count} firing…"})
+            started = bool(_run_prompt_submit(f"__heartbeat__{int(time.time() * 1000)}", sid, session, prompt))
+        except Exception as exc:
+            _notif_log_failure("heartbeat dispatch failed", exc)
+        if not started:
+            # _run_prompt_submit releases ``running`` itself when it refuses the turn; make it unconditional.
+            _notif_release_turn(session)
+            with contextlib.suppress(Exception):
+                mgr.abandon_fire()
 
 
 def _maybe_fire_tui_loop_tick(sid: str, session: dict) -> None:
     """Fire a due /loop wakeup for an idle TUI/Desktop/dashboard session (per-session poller, coarse cadence). Claims
-    the session (running=True) before dispatching so a racing user prompt wins; the post-turn hook completes the tick."""
+    the session (running=True) before dispatching so a racing user prompt wins; the post-turn hook completes the tick.
+
+    Runs on the per-session poller thread, so ``LoopManager`` (like ``HeartbeatManager`` above) must be bound to
+    the session's own profile home explicitly — mirrors ``_cmd_goal``'s ``_session_profile_runtime_scope`` wrap."""
     try:
         from hermes_cli.loops import LoopManager, goal_blocks_loop_tick
     except Exception:
         return
     if not (sid_key := session.get("session_key") or ""):
         return
-    mgr = LoopManager(session_id=sid_key)
-    if not mgr.is_due() or goal_blocks_loop_tick(sid_key) or not _notif_claim_turn(session):
-        return  # busy — stays due, next poll retries
-    if not (wakeup := mgr.fire_tick()):
-        _notif_release_turn(session)
-        return
-    rid = f"__loop__{int(time.time() * 1000)}"
-    try:
-        _notif_loop_status(sid, f"↻ /loop wakeup #{mgr.state.ticks_fired if mgr.state else '?'} firing…")
-        if wakeup.lstrip().startswith("/"):
-            _notif_slash_loop_tick(rid, sid, session, mgr, wakeup)
-        else:
-            _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, wakeup)
-    except Exception as exc:
-        _notif_log_failure("loop wakeup dispatch failed", exc)
-        _notif_release_turn(session)
-        with contextlib.suppress(Exception):
-            mgr.abandon_tick()
+    with _session_profile_runtime_scope(session or {}):
+        mgr = LoopManager(session_id=sid_key)
+        if not mgr.is_due() or goal_blocks_loop_tick(sid_key) or not _notif_claim_turn(session):
+            return  # busy — stays due, next poll retries
+        if not (wakeup := mgr.fire_tick()):
+            _notif_release_turn(session)
+            return
+        rid = f"__loop__{int(time.time() * 1000)}"
+        try:
+            _notif_loop_status(sid, f"↻ /loop wakeup #{mgr.state.ticks_fired if mgr.state else '?'} firing…")
+            if wakeup.lstrip().startswith("/"):
+                _notif_slash_loop_tick(rid, sid, session, mgr, wakeup)
+            else:
+                _emit("message.start", sid)
+                _run_prompt_submit(rid, sid, session, wakeup)
+        except Exception as exc:
+            _notif_log_failure("loop wakeup dispatch failed", exc)
+            _notif_release_turn(session)
+            with contextlib.suppress(Exception):
+                mgr.abandon_tick()
 
 
 def _kb_first_line(value: Any, limit: int) -> str:


### PR DESCRIPTION
## Summary

Under `gateway.multiplex_profiles`, a Desktop/TUI/dashboard session bound to a **secondary** profile (`session["profile_home"]`) could have its `/loop` and `/heartbeat` idle-poll ticks silently read/write the **wrong** profile's `state.db` — wedging automation (never firing, or firing against a different session's persisted state) for any session that is not on the profile currently sitting in the process's ambient `HERMES_HOME`.

## Root cause

`hermes_cli/goals.py::_get_session_db()` caches its `SessionDB` handle keyed on `str(get_hermes_home())`; `hermes_cli/loops.py` and `hermes_cli/heartbeat.py` both delegate to it. Three call sites in `tui_gateway` constructed `LoopManager`/`HeartbeatManager` directly, without first binding `HERMES_HOME` (and secrets/terminal policy) to the session's own profile:

- `tui_gateway/session_notifications.py::_maybe_fire_tui_heartbeat_tick()` — the per-session poller-thread driver for due `/heartbeat` ticks.
- `tui_gateway/session_notifications.py::_maybe_fire_tui_loop_tick()` — the same poller's driver for due `/loop` wakeups.
- `tui_gateway/methods_tools.py::_cmd_loop()` — the `/loop` command handler itself.

The established fix for this exact class of bug already exists in the same window: `tui_gateway/methods_tools.py::_cmd_goal()` wraps its entire body in `_session_profile_runtime_scope(session)` (`tui_gateway/model_switch.py`) before touching `GoalManager`. `_cmd_loop` — `_cmd_goal`'s direct sibling in the same `_SLASH_BUILTINS` dispatch table — never got the same treatment, and the two poller-thread tick functions (added in a separate, more recent PR, #104224, that split them out of `tui_gateway/server.py` into `session_notifications.py`) never had it either.

The poller-thread angle matters here: `_notification_poller_loop` calls both tick functions synchronously from a raw `threading.Thread` body (`_start_notification_poller`), not from an asyncio task, so there is no inherited `ContextVar` state to lean on — the profile scope has to be installed explicitly inside each tick, which is exactly what `_session_profile_runtime_scope` does (it's a plain `@contextlib.contextmanager`, safe to enter from any thread).

## Fix

Wrap the DB-touching body of all three functions in `_session_profile_runtime_scope(session or {})`, mirroring `_cmd_goal` exactly — no new mechanism introduced. When `session["profile_home"]` is unset (single-profile deployments), `_session_profile_runtime_scope` is a no-op (`yield` immediately), so existing behavior for non-multiplex sessions is unchanged.

## Tests

New `tests/tui_gateway/test_loop_heartbeat_profile_scope.py`:
- `_maybe_fire_tui_heartbeat_tick` fires a heartbeat seeded in a secondary profile's own `state.db`, and the fire is persisted there (not in the launch profile's DB).
- Same for `_maybe_fire_tui_loop_tick`.
- `_cmd_loop` (via `command.dispatch`) persists a new `/loop` into the session's own profile DB, not the launch profile's.
- A control test confirms the heartbeat tick still fires normally for a session with no `profile_home` (single-profile fallback path untouched).

Mutation-verified: reverting the production fix (`git apply`/`git checkout --` round-trip) makes the three profile-scope-dependent tests fail (the tick sees no due state / the loop lands in the wrong DB); the no-`profile_home` control test still passes either way. Reapplying the fix makes all four pass.

```
python -m pytest tests/tui_gateway/test_loop_heartbeat_profile_scope.py -q            # 4 passed
python -m pytest tests/tui_gateway/test_heartbeat_tui_tick.py tests/tui_gateway/test_loop_command.py tests/tui_gateway/test_kanban_notify_poller.py tests/tui_gateway/test_goal_command.py -q   # 43 passed
ruff check tui_gateway/session_notifications.py tui_gateway/methods_tools.py tests/tui_gateway/test_loop_heartbeat_profile_scope.py   # All checks passed
```

## Prior art / Scope note

- **#90821** ("scope /loop state to the session profile home") targets the same underlying bug for `/loop` only (not `/heartbeat`, which didn't exist as a session-owner-driven tick yet at that PR's base). It predates a subsequent file-decomposition refactor: at its base commit, `_maybe_fire_tui_loop_tick` still lived inline in `tui_gateway/server.py` and `/loop` was dispatched from an `if name == "loop":` branch rather than the current named `_cmd_loop` function in the `_SLASH_BUILTINS` dict. Its raw diff no longer applies to current `main` (`git apply --check` fails on both hunks — confirmed empirically). This PR supersedes its scope with the current file layout, adds the `/heartbeat` half it couldn't have covered, and uses the `_session_profile_runtime_scope` helper that didn't exist yet at its base (its own diff manually pairs `set_hermes_home_override`/`reset_hermes_home_override`, which is exactly what that helper now wraps).
- **#104224** ("drive due /heartbeat ticks from the session-owner poller") is the PR that introduced `_maybe_fire_tui_heartbeat_tick` (merged 2026-09-06, already in this branch's base). It intentionally mirrors `_maybe_fire_tui_loop_tick`'s existing shape and claim/dispatch/rewind structure, but neither function had profile scoping at that point — this PR is the direct sibling-gap follow-up.
- No other open PR targets `tui_gateway/session_notifications.py`, `_maybe_fire_tui_heartbeat_tick`, `_maybe_fire_tui_loop_tick`, or `_cmd_loop` (fresh search across multiple keyword combinations, all states, immediately before opening this PR). PR #80273 ("scope each heartbeat poll to the profile that owns it") and #87955/#101275 are a different subsystem (the messaging-gateway's own `gateway/run.py`/`_poll_loop` heartbeat/loop watchers, not the TUI/Desktop per-session poller) — no overlap.
