### PR TITLE
docs(pricing): refresh GPT-5.6 cache rates and guidance

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -155,9 +155,9 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
     # OpenAI GPT-5.6 (Sol/Terra/Luna). Cache write = 1.25x input, cache read =
     # 0.10x input. "-pro" high-effort modes bill at the same per-token rates
     # (aliased below); "Sol Fast mode" is a separate tier, not covered.
-    ("openai", "https://openai.com/index/previewing-gpt-5-6-sol/", "openai-gpt-5.6-2026-07", {
-        "gpt-5.6-sol": ("5.00", "30.00", "0.50", "6.25"), "gpt-5.6-terra": ("2.50", "15.00", "0.25", "3.125"),
-        "gpt-5.6-luna": ("1.00", "6.00", "0.10", "1.25"),
+    ("openai", "https://developers.openai.com/api/docs/pricing", "openai-gpt-5.6-2026-09-04", {
+        "gpt-5.6-sol": ("4.00", "20.00", "0.40", "5.00"), "gpt-5.6-terra": ("2.00", "12.00", "0.20", "2.50"),
+        "gpt-5.6-luna": ("0.20", "1.20", "0.02", "0.25"),
     }),
     # Claude 4.5/4.6/4.7/4.8 Opus share $5/$25 (new tokenizer, up to 35% more tokens).
     ("anthropic", _ANTHROPIC_URL, "anthropic-pricing-2026-05", {

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -105,6 +105,28 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert float(entry.cache_read_cost_per_million) == 0.003625
 
 
+def test_gpt_56_official_pricing_snapshot():
+    """Keep GPT-5.6 accounting aligned with the dated OpenAI snapshot."""
+    expected = {
+        "gpt-5.6-sol": ("4.00", "20.00", "0.40", "5.00"),
+        "gpt-5.6-terra": ("2.00", "12.00", "0.20", "2.50"),
+        "gpt-5.6-luna": ("0.20", "1.20", "0.02", "0.25"),
+    }
+
+    for model, rates in expected.items():
+        entry = get_pricing_entry(model, provider="openai")
+        assert entry is not None, model
+        assert (
+            entry.input_cost_per_million,
+            entry.output_cost_per_million,
+            entry.cache_read_cost_per_million,
+            entry.cache_write_cost_per_million,
+        ) == tuple(Decimal(rate) for rate in rates)
+        assert entry.pricing_version == "openai-gpt-5.6-2026-09-04"
+        assert entry.source == "official_docs_snapshot"
+        assert entry.source_url == "https://developers.openai.com/api/docs/pricing"
+
+
 def test_bundled_pricing_skips_endpoint_metadata(monkeypatch):
     """An exact bundled price must not block on the provider's /models API."""
     monkeypatch.setattr(

--- a/website/docs/developer-guide/agent-loop.md
+++ b/website/docs/developer-guide/agent-loop.md
@@ -71,7 +71,10 @@ run_conversation()
      - codex_responses: convert to Responses API input items
      - anthropic_messages: convert via anthropic_adapter.py
   6. Inject ephemeral prompt layers (budget warnings, context pressure)
-  7. Apply prompt caching markers if on Anthropic
+  7. Apply the provider-specific prompt-cache policy
+     - Anthropic: explicit `cache_control` markers
+     - OpenAI Responses: stable `prompt_cache_key` plus append-only history
+     - Other compatible providers: only fields supported by that transport
   8. Make interruptible API call (_interruptible_api_call)
   9. Parse response:
      - If tool_calls: execute them, append results, loop back to step 5

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -1,7 +1,7 @@
 # Context Compression and Caching
 
-Hermes Agent uses a dual compression system and Anthropic prompt caching to
-manage context window usage efficiently across long conversations.
+Hermes Agent uses a dual compression system and provider-specific prompt
+caching to manage context window usage efficiently across long conversations.
 
 Source files: `agent/context_engine.py` (ABC), `agent/context_compressor.py` (default engine),
 `agent/prompt_caching.py`, `gateway/run_turn.py` (session hygiene), `agent/compression_facade.py` (search for `_compress_context`)
@@ -465,12 +465,43 @@ text for this purpose.
 ```
 
 
-## Prompt Caching (Anthropic)
+## Prompt Caching
+
+Prompt caching reuses the provider's computed prefix state; it does not reuse
+a previous answer. Exact prefix stability still matters: system instructions,
+tool definitions, their ordering, and prior messages must remain stable.
+Hermes therefore freezes its system prompt and tool set for a conversation and
+appends new turns instead of rebuilding earlier context.
+
+### OpenAI Responses (GPT-5.6+)
+
+The `codex_responses` transport sends a deterministic, content-addressed
+`prompt_cache_key` derived from the stable instructions and tool schemas.
+Conversation history remains append-only, allowing OpenAI's implicit latest
+user/tool breakpoint to reuse earlier turns. The key is a routing hint, not a
+correctness boundary and not a cache-hit guarantee.
+
+GPT-5.6+ requires at least 1,024 visible input tokens for a cacheable prefix.
+Its cache lifetime is at least 30 minutes after the latest write or reuse.
+Cache reads cost 0.1x the uncached input rate and writes cost 1.25x. Hermes
+tracks ordinary input, cache reads, and cache writes separately from
+`usage.input_tokens_details`; raw SSE dicts and SDK usage objects normalize to
+the same counters.
+
+Hermes intentionally keeps implicit breakpoints for its append-only agent
+loop. Explicit-only breakpoints are valuable for batch systems with one large
+stable rubric and a changing suffix, but adding a synthetic boundary to the
+generic agent loop would change the rendered prompt and can break
+OpenAI-compatible relays. Such batch callers should implement the boundary in
+their own provider adapter and verify the exact runtime.
+
+Reference: [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching).
+
+### Anthropic
 
 Source: `agent/prompt_caching.py`
 
-Reduces input token costs by ~75% on multi-turn conversations by caching the
-conversation prefix. Uses Anthropic's `cache_control` breakpoints.
+Uses Anthropic's `cache_control` breakpoints to cache the conversation prefix.
 
 ### Strategy: system_and_3
 
@@ -517,6 +548,8 @@ The marker is applied differently based on content type:
 3. **Compression cache interaction**: After compression, the cache is invalidated
    for the compressed region but the system prompt cache survives. The rolling
    3-message window re-establishes caching within 1-2 turns.
+   Fewer total input tokens can still cost less even when the first
+   post-compression request has a lower cache-hit rate.
 
 4. **TTL selection**: Default is `5m` (5 minutes). Use `1h` for long-running
    sessions where the user takes breaks between turns.

--- a/website/docs/guides/tips.md
+++ b/website/docs/guides/tips.md
@@ -133,11 +133,11 @@ Memory is a frozen snapshot — changes made during a session don't appear in th
 
 ### Don't Break the Prompt Cache
 
-Most LLM providers cache the conversation prefix (system prompt + history). If you keep your system prompt stable (same context files, same memory), subsequent messages in a session get **cache hits** that are significantly cheaper. The cache is keyed to the model and account — so an explicit `/model` switch, an [automatic provider fallback](../user-guide/features/fallback-providers.md), or a [credential-pool rotation](../user-guide/features/credential-pools.md) all force the next turn to re-read the entire conversation at full input price. Occasional switches are fine; frequent switching in a long session multiplies your cost.
+Many LLM providers cache the exact rendered conversation prefix, including system instructions, tool definitions, and history. Hermes keeps these stable and append-only within a session. An explicit `/model` switch, an [automatic provider fallback](../user-guide/features/fallback-providers.md), a [credential-pool rotation](../user-guide/features/credential-pools.md), or a change to earlier context makes the next request cold. Occasional switches are fine; frequent switching in a long session multiplies cost.
 
 ### Use /compress Before Hitting Limits
 
-Long sessions accumulate tokens. When you notice responses slowing down or getting truncated, run `/compress`. This summarizes the conversation history, preserving key context while dramatically reducing token count. Use `/usage` to check where you stand.
+Long sessions accumulate tokens. When you notice responses slowing down or getting truncated, run `/compress`. This summarizes the conversation history and reduces token count. Compression changes the prefix, so the first request afterwards may have a lower cache-hit rate; the smaller context can still be cheaper overall. Use `/usage` and `agent.log` to inspect reported token and cache counters.
 
 ### Delegate for Parallel Work
 
@@ -149,7 +149,7 @@ Instead of running terminal commands one at a time, ask the agent to write a scr
 
 ### Choose the Right Model
 
-Use `/model` to switch models mid-session. Use a frontier model (Claude Sonnet/Opus, GPT-4o) for complex reasoning and architecture decisions. Switch to a faster model for simple tasks like formatting, renaming, or boilerplate generation. Keep in mind each switch resets the prompt cache (see above), so on long sessions it's often cheaper to start a fresh session on the other model than to bounce back and forth.
+Choose the model that matches the task before starting a long session. If you switch with `/model` mid-session, expect a cold prefix on the next request because cache state is model-specific. Prefer a new session when you are changing both the task and the model.
 
 :::tip
 Run `/usage` periodically to see your token consumption. Run `/insights` for a broader view of usage patterns over the last 30 days. To see what your *fixed* per-message cost is before any conversation — system prompt, skills index, memory, tool schemas — run [`hermes prompt-size`](/reference/cli-commands#hermes-prompt-size) (works offline).


### PR DESCRIPTION
## Summary

- refresh the official GPT-5.6 Sol, Terra, and Luna price snapshot, including cache-read and cache-write rates
- document OpenAI Responses prompt-cache behavior alongside the existing Anthropic guidance
- clarify the cache impact of compression and model/provider changes

## Validation

- `scripts/run_tests.sh -j 1 tests/agent/test_usage_pricing.py -q` — 49 passed
- source commit: `9a739fd3e02be419b0750238f063917426ccd60b`

This does not add a provider or change model routing. It updates accounting data, its behavioral regression test, and documentation.