### PR TITLE
fix(tests): resolve 7 macOS-only test failures (portability gaps, not…

### DIFF
--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -3063,8 +3063,16 @@ class TestInboundMediaAuthorizationGate:
     async def test_live_media_redacts_long_path_before_bounding(self, tmp_path):
         parent = tmp_path
         private_parts = []
-        for index in range(6):
-            part = f"private-{index}-" + ("x" * 150)
+        # 3 segments x ~70 chars is still a long, multi-segment path (enough to
+        # exercise per-segment redaction) while staying well under macOS's
+        # ~1024-byte PATH_MAX once stacked on pytest's own tmp_path prefix — the
+        # original 6 x 150-char segments (~960 bytes on their own) could exceed
+        # it and fail .mkdir() with ENAMETOOLONG before the adapter is ever
+        # exercised (#105054). The actual >900-char message bound below comes
+        # from the padded "z" * 1_000 error text, not from the path length, so
+        # shortening the path doesn't weaken what this test verifies.
+        for index in range(3):
+            part = f"private-{index}-" + ("x" * 60)
             private_parts.append(part)
             parent = parent / part
             parent.mkdir()

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -220,6 +220,18 @@ def test_unreadable_schema_without_cli_names_the_sqlite3_requirement(
     import hermes_cli.session_lost_and_found as laf
 
     monkeypatch.setattr(laf, "find_sqlite3_cli", lambda: None)
+    # find_sqlite3_cli_refusal() reads a process-global set by the last REAL
+    # find_sqlite3_cli() call, which this test does not make (it's mocked
+    # above). Left unpinned, that global carries over from whatever an
+    # earlier test in this file happened to leave behind by probing the
+    # actual on-PATH sqlite3 CLI — e.g. "wal_reset_vulnerable" on a machine
+    # whose CLI predates the WAL-reset fix (macOS's bundled 3.51.0 among
+    # others), which routes recover_session_database() through a different,
+    # version-specific message that doesn't mention ".recover" at all. Pin it
+    # to "missing" so this test deterministically exercises the "no CLI on
+    # PATH at all" scenario its name and assertions describe, independent of
+    # the host's actual sqlite3 CLI or any other test's ordering (#105054).
+    monkeypatch.setattr(laf, "find_sqlite3_cli_refusal", lambda: {"reason": "missing"})
     with pytest.raises(SessionRecoverySourceError) as excinfo:
         recover_session_database(
             source,

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -157,7 +157,12 @@ def test_add_contributor_refuses_a_case_collision(tmp_path, monkeypatch):
     monkeypatch.setattr(mod, "EMAILS_DIR", d)
 
     assert mod.add_contributor("agent@example-host.local", "otherperson") == 1
-    assert not (d / "agent@example-host.local").exists()
+    # Not `not (d / "agent@example-host.local").exists()`: on a case-insensitive
+    # filesystem (default macOS/Windows) that's trivially true regardless of
+    # what add_contributor() did — the differently-cased path already "exists"
+    # because it's the same file as the fixture. A directory listing is
+    # filesystem-agnostic and actually proves no new file was written (#105054).
+    assert sorted(p.name for p in d.iterdir()) == ["agent@Example-Host.local"]
 
 
 def test_add_contributor_refuses_case_collision_even_for_same_login(emails_dir, capsys):

--- a/tests/test_guest_durability_barriers.py
+++ b/tests/test_guest_durability_barriers.py
@@ -8,6 +8,7 @@ the guest entry point applies it directly.
 """
 
 import sqlite3
+import sys
 
 import pytest
 
@@ -47,7 +48,14 @@ def test_guest_barriers_leave_synchronous_alone_when_unset(monkeypatch, tmp_path
         conn.execute("PRAGMA journal_mode=DELETE")
         conn.execute("PRAGMA synchronous=1")
         apply_durability_barriers(conn)
-        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 1
+        # On macOS, _enforce_macos_synchronous_full() unconditionally forces
+        # synchronous=FULL (2) as part of every barrier (re)application —
+        # regardless of journal mode — because APFS has different fsync
+        # durability semantics than Linux; that override is intentional, not a
+        # bug (#105054). An unset database.synchronous config only leaves the
+        # caller's value alone on platforms where the override is a no-op.
+        expected = 2 if sys.platform == "darwin" else 1
+        assert conn.execute("PRAGMA synchronous").fetchone()[0] == expected
     finally:
         conn.close()
 

--- a/tests/tools/test_code_kernel.py
+++ b/tests/tools/test_code_kernel.py
@@ -353,11 +353,15 @@ class TestKernelOwnershipAndLifecycle(unittest.TestCase):
                 t.join()
         self.assertEqual([r["status"] for r in results], ["success"] * 6)
         self.assertEqual(len(_KERNELS), 1)
+        # `-c` (count) is a GNU/procps-only pgrep flag: macOS's BSD pgrep has no
+        # `-c` at all (usage error on stderr, empty stdout, exit 2), so count
+        # matched PID lines ourselves instead — portable across both (#105054).
         live = subprocess.run(
-            ["pgrep", "-fc", "-P", str(os.getpid()), "hermes_kernel_runner"],
+            ["pgrep", "-f", "-P", str(os.getpid()), "hermes_kernel_runner"],
             capture_output=True, text=True,
-        ).stdout.strip()
-        self.assertEqual(live, "1")
+        ).stdout
+        live_count = len([line for line in live.splitlines() if line.strip()])
+        self.assertEqual(live_count, 1)
 
 
 class TestPerCellRpcAuthority(unittest.TestCase):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -413,8 +413,14 @@ class TestDelegateTask(unittest.TestCase):
                 child_db = kwargs["session_db"]
                 self.assertIsInstance(child_db, SessionDB)
                 self.assertIsNot(child_db, parent_db)
+                # Compare resolved paths: on macOS, /tmp and /var are symlinks to
+                # /private/tmp and /private/var, so whichever of the parent-side vs.
+                # child-side db-path derivation resolves the symlink (and whichever
+                # doesn't) can produce a string mismatch even though both point at the
+                # identical file on disk. Path.resolve() on both sides makes the
+                # assertion symlink-invariant (#105054).
                 self.assertEqual(
-                    str(child_db.db_path), str(parent_db.db_path)
+                    str(child_db.db_path.resolve()), str(parent_db.db_path.resolve())
                 )
             finally:
                 if child_db is not None:

--- a/tests/tools/test_local_setsid_descendant_sweep.py
+++ b/tests/tools/test_local_setsid_descendant_sweep.py
@@ -146,3 +146,37 @@ def test_kill_process_survives_psutil_snapshot_failure(monkeypatch):
     # escalation path completed despite the snapshot failure.
     assert killpg_calls[0] == (67890, signal.SIGTERM)
     assert (67890, 0) in killpg_calls
+
+
+def test_kill_process_group_posix_tolerates_permission_error_on_sigterm(monkeypatch):
+    """#105054: a process group that already exited by the time we signal it
+    is not a cleanup failure. ESRCH (-> ProcessLookupError) is the expected
+    "already gone" errno and was already caught here; macOS can return EPERM
+    (-> PermissionError) instead for an already-gone group in the same race —
+    exercised directly against the module-level helper rather than through
+    LocalEnvironment._kill_process, whose own broader ``except OSError``
+    fallback would otherwise mask a regression here."""
+    from tools.environments.local import _kill_process_group_posix
+
+    proc = SimpleNamespace(
+        pid=12345,
+        _hermes_pgid=67890,
+        poll=lambda: 0,
+        wait=lambda timeout=None: 0,
+    )
+    killpg_calls = []
+
+    def fake_getpgid(_pid):
+        return 67890
+
+    def fake_killpg(pgid, sig):
+        killpg_calls.append((pgid, sig))
+        if sig == signal.SIGTERM:
+            raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr(os, "getpgid", fake_getpgid)
+    monkeypatch.setattr(os, "killpg", fake_killpg)
+
+    _kill_process_group_posix(proc)  # must not raise
+
+    assert killpg_calls == [(67890, signal.SIGTERM)]

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -672,6 +672,13 @@ def _kill_process_group_posix(proc) -> None:
                 proc.wait(timeout=0.2)
     except ProcessLookupError:
         pass
+    except PermissionError:
+        # A process group that already exited by the time we signalled it is not a
+        # cleanup failure. ESRCH (-> ProcessLookupError) is the expected "already
+        # gone" errno, but macOS can return EPERM instead for an already-gone group
+        # in this race, same as the killpg(pgid, 0) probe in _wait_for_group_exit
+        # already tolerates (#105054).
+        pass
     _sweep_escaped_descendants(descendants, pgid)
 
 


### PR DESCRIPTION
… product bugs)

A full-suite run on macOS (arm64, Darwin 25.6.0) found 7 failures that are all macOS-vs-Linux-CI portability gaps in the tests themselves, not functional defects. Two even cover product code doing something more correct on macOS than the test (written/validated against Linux CI) expected. Each is fixed at its own specific root cause:

1. tests/hermes_cli/test_session_recovery_lost_and_found.py:: test_unreadable_schema_without_cli_names_the_sqlite3_requirement

   find_sqlite3_cli_refusal() reads a process-global set by the last REAL find_sqlite3_cli() call. The test only mocks find_sqlite3_cli itself, so the global carries over from whatever an earlier test in the same file happened to leave behind by probing the actual on-PATH sqlite3 CLI -- e.g. "wal_reset_vulnerable" on a machine whose CLI predates the WAL-reset fix (macOS's bundled 3.51.0 among others). That routes recover_session_database() through a different, version-specific message that never mentions ".recover" at all, failing the assertion. Pinned find_sqlite3_cli_refusal() to {"reason": "missing"} alongside the existing find_sqlite3_cli mock so the test deterministically exercises the "no CLI on PATH at all" scenario its name and assertions describe, independent of the host's actual CLI or test ordering. Reproduced the failure directly (stale wal_reset_vulnerable global -> ".recover" absent from the message) and confirmed the fix's mock sidesteps it regardless.

2. tests/test_guest_durability_barriers.py:: test_guest_barriers_leave_synchronous_alone_when_unset

   _enforce_macos_synchronous_full() in hermes_state_wal.py deliberately forces PRAGMA synchronous=FULL on every barrier (re)application on macOS -- APFS has different fsync durability semantics than Linux, so this override is intentional product behavior, not a bug. The test's "leave synchronous alone when unset" expectation only holds where that override is a no-op. Made the assertion platform-aware (expects FULL/2 on darwin, the caller's value of 1 elsewhere) so it verifies the correct behavior on both platforms instead of just skipping macOS coverage. Confirmed by mocking sys.platform="darwin": synchronous does come back as 2, matching the new platform-aware expectation.

3. tests/scripts/test_contributor_map.py:: test_add_contributor_refuses_a_case_collision

   The fixture writes agent@Example-Host.local, then asserts agent@example-host.local doesn't exist afterward. On a case-insensitive filesystem (default macOS/Windows) that's trivially true regardless of what add_contributor() did -- it's the same file as the fixture. The refusal itself is already covered by the == 1 return-code assertion. Replaced the misleading .exists() check with a directory listing (matching the pattern the sibling case-collision test already uses), which is filesystem-agnostic and actually proves no new file was written.

4. tests/tools/test_code_kernel.py:: TestKernelOwnershipAndLifecycle::test_parallel_cells_share_one_kernel_process

   `pgrep -c` (count) is a GNU/procps-only flag -- macOS's BSD pgrep has no -c at all (usage error on stderr, empty stdout, exit 2). Replaced with a portable pgrep -f -P <pid> <pattern> plus counting non-empty output lines in Python, which behaves identically on GNU and BSD pgrep.

5. tests/gateway/test_buzz_adapter.py:: TestInboundMediaAuthorizationGate::test_live_media_redacts_long_path_before_bounding

   The test built a path from 6 nested ~160-char segments (~960 bytes on their own) and called .mkdir() -- stacked on pytest's own tmp_path prefix, this can exceed macOS's ~1024-byte PATH_MAX (OSError: [Errno 63] File name too long) before the adapter is ever exercised. Reduced to 3 segments of ~70 chars (~210 bytes total): still a long, multi-segment path that exercises per-segment redaction, but with enough margin to stay well under the limit regardless of tmp_path depth. The >900-char message-bound assertion is driven by the test's separate "z" * 1_000 padded error text, not the path length, so this doesn't weaken what the test verifies.

6. tests/tools/test_delegate.py:: TestDelegateTask::test_child_dedicated_db_follows_parents_db_path

   On macOS, /tmp and /var are symlinks to /private/tmp and /private/var, so whichever of the parent-side vs. child-side db-path derivation resolves the symlink (and whichever doesn't) can produce a string mismatch even though both point at the identical file on disk. Compared .resolve()d paths on both sides instead of raw strings, making the assertion symlink-invariant.

7. tests/tools/test_read_file_utf8_binary_regression.py -- root cause in tools/environments/local.py::_kill_process_group_posix

   The SIGTERM os.killpg() call was only guarded against ProcessLookupError (ESRCH). A process group that has already exited by the time it's signalled can return EPERM instead of ESRCH on macOS for this exact race, raising an uncaught PermissionError during ripgrep subprocess cleanup. The sibling alive-probe in _wait_for_group_exit already tolerates PermissionError for the identical reason; added the same tolerance to _kill_process_group_posix's own SIGTERM/SIGKILL try block. Added a direct unit test against the module-level helper (bypassing LocalEnvironment._kill_process's own broader `except OSError` fallback, which would otherwise mask a regression here) that mocks os.killpg to raise PermissionError on SIGTERM and asserts the function does not raise. Confirmed RED against the unmodified source (this new test is the only one that fails; the sibling snapshot-failure test in the same file is unaffected) and GREEN with the fix.

Ran the full suite of all 7 touched test files (316 tests) green, plus the one skip each file already had (psutil-optional / live-system-guard marker, pre-existing and unrelated). ruff check is clean on all 8 touched files.

Fixes #105054


Claude-Session: https://claude.ai/code/session_01LUtGTop5iGKi5vfWnKnwET

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

