### PR TITLE
test(desktop): UI checks keep cold imports outside assertion deadlines

### DIFF
--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -1,6 +1,9 @@
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+// Collect the component graph before the behavioral test deadline starts.
+import { GatewaySettings } from './gateway-settings'
+
 const getConnectionConfig = vi.fn()
 const saveConnectionConfig = vi.fn()
 
@@ -37,8 +40,6 @@ afterEach(() => {
 
 describe('GatewaySettings', () => {
   it('loads the machine-level connection config (no profile scoping)', async () => {
-    const { GatewaySettings } = await import('./gateway-settings')
-
     render(<GatewaySettings />)
     expect(await screen.findByText('Local gateway')).toBeTruthy()
     expect(

--- a/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
@@ -7,6 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ToolsetConfig } from '@/types/hermes'
 
+// Collect the component graph before the behavioral test deadline starts.
+import { ToolsetConfigPanel } from './toolset-config-panel'
+
 // EnvVarField navigates to Settings → Keys via useNavigate, so every render
 // needs a router context. The navigate spy asserts the deep-link target.
 const navigateSpy = vi.fn()
@@ -183,7 +186,6 @@ describe('ToolsetConfigPanel', () => {
       })
     )
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     expect(await screen.findByText('OpenAI TTS Model')).toBeTruthy()
@@ -199,7 +201,6 @@ describe('ToolsetConfigPanel', () => {
   })
 
   it('renders no inline voice fields for rows without tts_provider (older backend)', async () => {
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     await screen.findByText('Microsoft Edge TTS')
@@ -208,7 +209,6 @@ describe('ToolsetConfigPanel', () => {
   })
 
   it('lists providers from the config endpoint', async () => {
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     expect(await screen.findByText('Microsoft Edge TTS')).toBeTruthy()
@@ -217,7 +217,6 @@ describe('ToolsetConfigPanel', () => {
   })
 
   it('expands a provider on row click and activates it via the explicit button', async () => {
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     // Row click only expands — browsing details must not rewrite config.
@@ -240,7 +239,6 @@ describe('ToolsetConfigPanel', () => {
         })
     )
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     // Edge auto-expands (first configured provider); activate it explicitly.
@@ -292,7 +290,6 @@ describe('ToolsetConfigPanel', () => {
       default: 'z-image-turbo'
     })
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="image_gen" />)
 
     // Both catalog rows render with their picker metadata.
@@ -306,7 +303,6 @@ describe('ToolsetConfigPanel', () => {
   })
 
   it('does not fetch model catalogs for toolsets without them', async () => {
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     await screen.findByText('Microsoft Edge TTS')
@@ -314,7 +310,6 @@ describe('ToolsetConfigPanel', () => {
   })
 
   it('saves an API key for a provider env var', async () => {
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     // Select the keyed provider so its env vars render.
@@ -373,7 +368,6 @@ describe('ToolsetConfigPanel', () => {
       })
     )
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
     // The active provider's env-var field only renders when it's the expanded
@@ -420,7 +414,6 @@ describe('ToolsetConfigPanel', () => {
         running: false
       })
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
     fireEvent.click(await screen.findByRole('button', { name: /Run setup/ }))
@@ -454,7 +447,6 @@ describe('ToolsetConfigPanel', () => {
     // Spawn failed server-side — must NOT proceed to poll a non-existent action.
     runToolsetPostSetup.mockResolvedValue({ ok: false, pid: 0, name: 'tools-post-setup' })
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
     fireEvent.click(await screen.findByRole('button', { name: /Run setup/ }))
@@ -493,7 +485,6 @@ describe('ToolsetConfigPanel', () => {
       running: false
     })
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
     fireEvent.click(await screen.findByRole('button', { name: /Run setup/ }))
@@ -531,7 +522,6 @@ describe('ToolsetConfigPanel', () => {
       })
     )
 
-    const { ToolsetConfigPanel } = await import('./toolset-config-panel')
     render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
     // Installed confirmation replaces the contradictory install prompt…
@@ -585,7 +575,6 @@ describe('ToolsetConfigPanel', () => {
         })
       )
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       await screen.findByText('Microsoft Edge TTS')
@@ -623,7 +612,6 @@ describe('ToolsetConfigPanel', () => {
         })
       )
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       await screen.findByText('ElevenLabs')
@@ -637,7 +625,6 @@ describe('ToolsetConfigPanel', () => {
       // Older backend (no `status` field): keyless rows keep the legacy
       // Ready pill, keyed-and-unset rows keep no pill. Narrow compat path —
       // desktop and backend update on separate clocks.
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       await screen.findByText('Microsoft Edge TTS')
@@ -674,7 +661,6 @@ describe('ToolsetConfigPanel', () => {
         })
       )
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       expect(await screen.findByText('ELEVENLABS_API_KEY')).toBeTruthy()
@@ -717,7 +703,6 @@ describe('ToolsetConfigPanel', () => {
         })
       )
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
       await screen.findByText('Local Browser')
@@ -754,7 +739,6 @@ describe('ToolsetConfigPanel', () => {
         running: false
       })
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
       fireEvent.click(await screen.findByRole('button', { name: /Re-run setup/ }))
@@ -782,7 +766,6 @@ describe('ToolsetConfigPanel', () => {
         })
       )
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
       await screen.findByText('Local Browser')
@@ -830,7 +813,6 @@ describe('ToolsetConfigPanel', () => {
         feature: 'browser'
       })
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
       // The single Nous row auto-expands; activate via the explicit button.
@@ -875,7 +857,6 @@ describe('ToolsetConfigPanel', () => {
       const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
 
       try {
-        const { ToolsetConfigPanel } = await import('./toolset-config-panel')
         render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
         await screen.findByRole('button', { name: /Nous Subscription/ })
@@ -918,7 +899,6 @@ describe('ToolsetConfigPanel', () => {
         provider: 'Nous Subscription (Browser Use cloud)'
       })
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="browser" />)
 
       await screen.findByRole('button', { name: /Nous Subscription/ })
@@ -957,7 +937,6 @@ describe('ToolsetConfigPanel', () => {
         })
       )
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       const trigger = await screen.findByRole('button', { name: /^Actions$/ })
@@ -970,7 +949,6 @@ describe('ToolsetConfigPanel', () => {
     it('hides "Manage in API Keys" while the key is unset', async () => {
       // Default config(): ElevenLabs key is not set. An unset key is managed
       // right here via Set — no point bouncing the user to another page.
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       // Expand the keyed provider so its env row renders. Wait for the
@@ -1029,7 +1007,6 @@ describe('ToolsetConfigPanel', () => {
     it('shows the resolved per-capability backends as badges', async () => {
       getToolsetConfig.mockResolvedValue(webConfig())
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="web" />)
 
       expect(await screen.findByText('Search: searxng')).toBeTruthy()
@@ -1043,7 +1020,6 @@ describe('ToolsetConfigPanel', () => {
       getToolsetConfig.mockResolvedValue(webConfig())
       selectToolsetProvider.mockResolvedValue({ ok: true, name: 'web', provider: 'SearXNG', capability: 'search' })
 
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="web" />)
 
       // Active/expanded provider is search-only SearXNG.
@@ -1062,7 +1038,6 @@ describe('ToolsetConfigPanel', () => {
     })
 
     it('does not render capability chrome for non-web toolsets', async () => {
-      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
       render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="tts" />)
 
       await screen.findByText('Microsoft Edge TTS')

--- a/apps/desktop/src/store/session-unread-tile.test.ts
+++ b/apps/desktop/src/store/session-unread-tile.test.ts
@@ -1,16 +1,18 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 // The completed-unread dot is keyed on the FOCUSED session, not the selected
 // one. A tile is never $selectedStoredSessionId, so keying either half on the
 // selection left a tiled session's dot green with no way to clear it.
 
 describe('completed-unread dot follows the focused session', () => {
-  beforeEach(() => {
-    vi.resetModules()
-  })
+  const disposers: (() => void)[] = []
 
   afterEach(() => {
-    vi.resetModules()
+    // Undo the registrations and store writes this file makes, so the next
+    // test starts clean without paying to rebuild the module graph.
+    while (disposers.length > 0) {
+      disposers.pop()?.()
+    }
   })
 
   async function setup() {
@@ -21,14 +23,23 @@ describe('completed-unread dot follows the focused session', () => {
     const session = await import('./session')
     const states = await import('./session-states')
 
+    // `declareDefaultTree` only seeds `$layoutTree` when it is empty, so the
+    // layout has to be cleared here or the second test would adopt the first
+    // test's tree instead of the one it declares.
+    tree.$layoutTree.set(null)
+    tree.$activeTreeGroup.set(null)
+
     for (const id of ['workspace', 'session-tile:tiled']) {
-      registry.register({
-        area: 'panes',
-        data: id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
-        id,
-        render: () => null,
-        title: id
-      })
+      disposers.push(
+        registry.register({
+          area: 'panes',
+          data:
+            id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
+          id,
+          render: () => null,
+          title: id
+        })
+      )
     }
 
     // The workspace holds the primary chat, a second zone holds the tile.

--- a/apps/desktop/src/store/session-unread-tile.test.ts
+++ b/apps/desktop/src/store/session-unread-tile.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
+import * as model from '@/components/pane-shell/tree/model'
+// Cold transforms belong to collection, not the first unread assertion's budget.
+import * as tree from '@/components/pane-shell/tree/store'
+import { registry } from '@/contrib/registry'
+import { createClientSessionState } from '@/lib/chat-runtime'
+
+import * as session from './session'
+import * as states from './session-states'
+
 // The completed-unread dot is keyed on the FOCUSED session, not the selected
 // one. A tile is never $selectedStoredSessionId, so keying either half on the
 // selection left a tiled session's dot green with no way to clear it.
@@ -16,13 +25,6 @@ describe('completed-unread dot follows the focused session', () => {
   })
 
   async function setup() {
-    const tree = await import('@/components/pane-shell/tree/store')
-    const model = await import('@/components/pane-shell/tree/model')
-    const { registry } = await import('@/contrib/registry')
-    const { createClientSessionState } = await import('@/lib/chat-runtime')
-    const session = await import('./session')
-    const states = await import('./session-states')
-
     // `declareDefaultTree` only seeds `$layoutTree` when it is empty, so the
     // layout has to be cleared here or the second test would adopt the first
     // test's tree instead of the one it declares.
@@ -33,8 +35,7 @@ describe('completed-unread dot follows the focused session', () => {
       disposers.push(
         registry.register({
           area: 'panes',
-          data:
-            id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
+          data: id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
           id,
           render: () => null,
           title: id


### PR DESCRIPTION
Desktop UI regression checks no longer spend their first test's behavioral deadline compiling the cold module graph.

- Collect GatewaySettings, ToolsetConfigPanel, and unread-tile dependencies statically, before the test timer starts; retain every assertion and the existing 15,000ms timeout.
- Preserve @anhtahaylove's unread fixture cleanup from #101478 (cherry-picked with original authorship). That PR removes repeated module reconstruction but still leaves the first cold import inside the timed test; this adds the missing collection boundary and covers both settings siblings.
- No production changes, timeout increases, skips, retries, or probe instrumentation ship.

**Cause:** the first cases dynamically import heavy graphs inside `it`, charging cold Vite transforms against the same deadline used for the behavioral assertions.

**Live repro:** on fetched main `8d24bc24e1`, a temporary Vite transform plugin delayed only the three entry modules by 16 seconds: all three original cases failed with `Test timed out in 15000ms`; with this repair and the identical delayed-transform probe, all 32 tests in the three files passed. This is controlled mechanism evidence, not a measurement of the historical runners' exact transform scheduling. The probe was removed before commit.

| Validation | Result |
| --- | --- |
| Controlled cold-transform baseline | 3/3 selected cases timeout at 15,000ms |
| Same controlled transform after repair | 32/32 pass, 3 files |
| Normal targeted run after removing probe | 32/32 pass, 3 files |
| Touched-file ESLint / Prettier; diff whitespace | pass |
| Broad local gates | intentionally deferred to CI under draft-first publication direction |

Historical logs: #105056 times out in GatewaySettings; #105057 in unread-tile and first TTS panel case; #105066 repeats unread-tile. The same first cases pass close to the deadline on sibling runs. Merged #99446 widened Testing Library's inner waitFor deadline but does not address cold imports exhausting Vitest's outer deadline.

Related: #101478, #99446, #105056, #105057, #105066. No merge or closure requested. After this repair lands with approval, rebase blocked feature branches onto that main and force-push with lease; rerunning old runs reuses their old merge snapshots.

## Infographic
![Desktop UI cold-import deadline repair](https://v3b.fal.media/files/b/0aa97856/I0A3OYSpabtyXbtiqdOKB_YqkkbD8e.png)
