### PR TITLE
fix(agent): omit unsupported bypass_cooldown for legacy summary hooks

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5,6 +5,7 @@ import contextlib
 import contextvars
 import copy
 import hashlib
+import inspect
 import json
 import logging
 import sqlite3
@@ -4685,11 +4686,23 @@ Write only the summary body. Do not include any preamble or prefix."""
         focus_topic: Optional[str], memory_context: str, bypass_cooldown: bool,
     ) -> Optional[str]:
         """Run the summary LLM; a cancellation rolls back the handoff scan's self-heal mutation first."""
+        generate_summary = self._generate_summary
+        try:
+            parameters = inspect.signature(generate_summary).parameters
+        except (TypeError, ValueError):
+            # Uninspectable plugin hooks retain the legacy call shape, as at the public engine boundary.
+            parameters = {}
+        summary_kwargs = {}
+        # Older engines override this hook but inherit compress(); the recovery hint is optional.
+        if "bypass_cooldown" in parameters or any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+        ):
+            summary_kwargs["bypass_cooldown"] = bypass_cooldown
         # Focus-topic derivation scans user turns; only pay when a summary is generated.
         try:
-            return self._generate_summary(
+            return generate_summary(
                 turns_to_summarize, focus_topic=focus_topic or self._derive_auto_focus_topic(messages),
-                memory_context=memory_context, bypass_cooldown=bypass_cooldown,
+                memory_context=memory_context, **summary_kwargs,
             )
         except AuxiliaryExplicitCancellation:
             # Cancellation is a true no-op: restore the scan's mutation before the exception escapes.

--- a/tests/agent/test_context_compressor_hook_compat.py
+++ b/tests/agent/test_context_compressor_hook_compat.py
@@ -1,0 +1,63 @@
+"""Inherited compression remains compatible with third-party summary hooks."""
+
+import pytest
+
+from agent.context_compressor import ContextCompressor
+
+
+SUMMARY = "The external engine preserved the deployment decisions."
+
+
+class LegacySummaryEngine(ContextCompressor):
+    def _generate_summary(self, turns_to_summarize, focus_topic=None, memory_context=""):
+        self.summary_calls.append((turns_to_summarize, focus_topic, memory_context))
+        return SUMMARY
+
+
+class ExplicitSummaryEngine(LegacySummaryEngine):
+    def _generate_summary(
+        self, turns_to_summarize, focus_topic=None, memory_context="", bypass_cooldown=None,
+    ):
+        self.received_bypass = bypass_cooldown
+        return super()._generate_summary(turns_to_summarize, focus_topic, memory_context)
+
+
+class KeywordSummaryEngine(LegacySummaryEngine):
+    def _generate_summary(self, turns_to_summarize, focus_topic=None, memory_context="", **kwargs):
+        self.received_bypass = kwargs["bypass_cooldown"]
+        return super()._generate_summary(turns_to_summarize, focus_topic, memory_context)
+
+
+@pytest.mark.parametrize("engine_class", [LegacySummaryEngine, ExplicitSummaryEngine, KeywordSummaryEngine])
+@pytest.mark.parametrize("bypass_cooldown", [False, True])
+def test_compress_dispatches_supported_summary_hook_keywords(monkeypatch, engine_class, bypass_cooldown):
+    monkeypatch.setattr("agent.context_compressor.get_model_context_length", lambda *args, **kwargs: 100_000)
+    engine = engine_class(
+        model="test/model", protect_first_n=2, protect_last_n=2, quiet_mode=True,
+    )
+    engine.summary_calls = []
+    # Keep a real compressible middle window without mocking the boundary selection.
+    engine.tail_token_budget = 100
+    messages = [
+        {
+            "role": "user" if i % 2 == 0 else "assistant",
+            "content": f"Turn {i}: " + "Deployment decision and supporting context. " * 20,
+        }
+        for i in range(20)
+    ]
+
+    compressed = engine.compress(
+        messages, current_tokens=90_000, focus_topic="deployment",
+        memory_context="Keep the rollback plan.", bypass_cooldown=bypass_cooldown,
+    )
+
+    assert len(engine.summary_calls) == 1
+    turns, focus, memory = engine.summary_calls[0]
+    assert turns
+    assert focus == "deployment"
+    assert memory == "Keep the rollback plan."
+    assert len(compressed) < len(messages)
+    assert any(SUMMARY in message.get("content", "") for message in compressed)
+    assert compressed[-1]["content"] == messages[-1]["content"]
+    if engine_class is not LegacySummaryEngine:
+        assert engine.received_bypass is bypass_cooldown


### PR DESCRIPTION
## What does this PR do?

Third-party context engines that subclass `ContextCompressor` and override `_generate_summary()` with the previous signature crash with `TypeError: unexpected keyword argument 'bypass_cooldown'` since #100661's provider-overflow recovery started passing that keyword through (#104176). Compaction aborts and the conversation cannot recover from pressure through that engine (real-world: Compresr 2.9.2's Hermes integration). The public context-engine boundary already filters optional host keywords for engines predating them — the internal hook dispatch had no equivalent check.

The dispatch now inspects the bound `_generate_summary` signature before passing `bypass_cooldown` (a `**kwargs` signature counts as supported). Unsupported → the keyword is omitted: the hook runs its legacy path and only the engine's own cooldown policy applies — `bypass_cooldown` is a host-side recovery hint, so omitting it degrades nothing but the hint.

## Related Issue

Fixes #104176

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` — signature check at the `_generate_summary` dispatch
- `tests/agent/test_context_compressor_hook_compat.py` (new) — legacy three-arg signature subclass completes `compress(..., bypass_cooldown=True)` without TypeError; kwargs/new-signature subclasses still receive the keyword

## How to Test

1. `.venv/bin/python -m pytest tests/agent/test_context_compressor_hook_compat.py -q` → green (2 failures before the fix, both the exact TypeError)
2. Broader: the compressor's main test file (159 passed) + recovery/cancel-guard tests (19 passed) unchanged

## Checklist

### Code
- [x] Contributing Guide read; Conventional Commits followed
- [x] Searched for duplicate PRs
- [x] Only changes related to this fix
- [x] Relevant tests pass; tests added
- [x] Tested on Linux (Python 3.11)

### Documentation & Housekeeping
- [x] N/A
