### PR TITLE
fix(kanban): scope worker guidance to owned task sessions

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1066,10 +1066,10 @@ def _load_tools(agent, enabled_toolsets, disabled_toolsets):
     )
 
     agent.valid_tool_names = {tool["function"]["name"] for tool in agent.tools} if agent.tools else set()
-    # Kanban guidance is session-static (kanban_show iff HERMES_KANBAN_TASK); resolve once.
-    from agent.prompt_builder import KANBAN_GUIDANCE
-    agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+    # Freeze task ownership at init; opted-in board tools do not imply a worker.
+    from agent.system_prompt import resolve_kanban_worker_guidance
+    agent._kanban_worker_guidance = resolve_kanban_worker_guidance(
+        agent.valid_tool_names
     )
     if agent.quiet_mode:
         return

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -269,6 +269,19 @@ def _profile_name_for_home(home: Path) -> str:
         return "default"
 
 
+def resolve_kanban_worker_guidance(valid_tool_names) -> str:
+    """Board-tool access alone does not grant ownership of a dispatched task."""
+    from agent.delegation_context import is_dispatcher_owned_worker_context
+
+    return (
+        KANBAN_GUIDANCE
+        if "kanban_show" in valid_tool_names
+        and os.environ.get("HERMES_KANBAN_TASK")
+        and is_dispatcher_owned_worker_context()
+        else ""
+    )
+
+
 def _tool_guidance_block(agent: Any) -> Optional[str]:
     """Tool-aware behavioral guidance, injected only when the tools are loaded."""
     names = agent.valid_tool_names
@@ -282,10 +295,10 @@ def _tool_guidance_block(agent: Any) -> Optional[str]:
         elif getattr(agent, "_user_profile_enabled", True):
             memory_guidance = USER_PROFILE_GUIDANCE
     # Kanban lifecycle: resolved once at __init__ (_kanban_worker_guidance);
-    # the kanban_show fallback covers code paths that bypass agent_init.
+    # the fallback applies the same ownership rule when agent_init was bypassed.
     _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)
-    if _kanban_guidance is None and "kanban_show" in names:
-        _kanban_guidance = KANBAN_GUIDANCE
+    if _kanban_guidance is None:
+        _kanban_guidance = resolve_kanban_worker_guidance(names)
     tool_guidance = [
         memory_guidance,
         SESSION_SEARCH_GUIDANCE if "session_search" in names else None,

--- a/tests/agent/test_kanban_guidance_ownership.py
+++ b/tests/agent/test_kanban_guidance_ownership.py
@@ -1,0 +1,115 @@
+"""Worker instructions follow task ownership, not opted-in board access."""
+
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agent.delegation_context import (
+    delegated_child_context,
+    non_dispatcher_owned_context,
+)
+from agent.prompt_builder import KANBAN_GUIDANCE
+from agent.system_prompt import build_system_prompt_parts
+
+
+@pytest.fixture
+def board_profile(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "toolsets: [kanban]\nmodel:\n  context_length: 128000\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    import model_tools
+    from tools.registry import invalidate_check_fn_cache
+
+    invalidate_check_fn_cache()
+    model_tools._clear_tool_defs_cache()
+    # Use real board schemas. Retaining this snapshot in delegated children
+    # also proves ownership is checked even if a caller supplies cached tools.
+    schemas = model_tools.get_tool_definitions(enabled_toolsets=["kanban"], quiet_mode=True)
+    assert {"kanban_show", "kanban_list"} <= {t["function"]["name"] for t in schemas}
+    yield schemas
+    invalidate_check_fn_cache()
+    model_tools._clear_tool_defs_cache()
+
+
+def _initialized_agent(monkeypatch, schemas=None) -> Any:
+    import model_tools
+    from run_agent import AIAgent
+
+    if schemas is not None:
+        monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: schemas)
+    return AIAgent(
+        model="test-model",
+        provider="custom",
+        api_key="test-key",
+        base_url="http://127.0.0.1:1/v1",
+        enabled_toolsets=["kanban"],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+
+
+_CASES = [
+    pytest.param(None, nullcontext, True, False, id="interactive-board"),
+    pytest.param("", nullcontext, True, False, id="empty-task"),
+    pytest.param("t_worker", nullcontext, True, True, id="dispatcher-worker"),
+    pytest.param("t_worker", delegated_child_context, True, False, id="delegated-child"),
+    pytest.param("t_worker", non_dispatcher_owned_context, True, False, id="in-process-cron"),
+    pytest.param("t_worker", nullcontext, False, False, id="worker-without-tools"),
+]
+
+
+def _set_task(monkeypatch, task):
+    if task is None:
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_KANBAN_TASK", task)
+
+
+@pytest.mark.parametrize("task,scope,has_tools,expected", _CASES)
+def test_initialized_prompt_freezes_worker_ownership(
+    monkeypatch, board_profile, task, scope, has_tools, expected
+):
+    _set_task(monkeypatch, task)
+    with scope():
+        schemas = [] if not has_tools else board_profile if scope is delegated_child_context else None
+        agent = _initialized_agent(monkeypatch, schemas)
+        first = build_system_prompt_parts(agent)["stable"]
+        assert (KANBAN_GUIDANCE in first) is expected
+        assert agent._kanban_worker_guidance == (KANBAN_GUIDANCE if expected else "")
+        if has_tools:
+            assert "kanban_show" in agent.valid_tool_names
+            if not task:
+                assert "kanban_list" in agent.valid_tool_names
+
+    # Rebuilds (including compression) retain BOTH positive and negative init
+    # snapshots after ambient task identity / ContextVars change.
+    _set_task(monkeypatch, None if task else "t_later")
+    with non_dispatcher_owned_context():
+        assert build_system_prompt_parts(agent)["stable"] == first
+    assert build_system_prompt_parts(agent)["stable"] == first
+
+
+@pytest.mark.parametrize("task,scope,has_tools,expected", _CASES)
+def test_legacy_prompt_fallback_obeys_worker_ownership(
+    monkeypatch, board_profile, task, scope, has_tools, expected
+):
+    _set_task(monkeypatch, task)
+    with scope():
+        schemas = [] if not has_tools else board_profile if scope is delegated_child_context else None
+        agent = _initialized_agent(monkeypatch, schemas)
+        # Callers bypassing agent_init have no guidance snapshot. Exercise the
+        # real prompt assembly, not a copy of the eligibility expression.
+        del agent._kanban_worker_guidance
+        assert (KANBAN_GUIDANCE in agent._build_system_prompt()) is expected


### PR DESCRIPTION
## Fix

Kanban-enabled interactive profiles receive the assigned-worker protocol even when they have no assigned task. Tool visibility was widened to support orchestrators, but prompt initialization and its fallback still treated `kanban_show` as worker identity.

Both paths now require a task binding and canonical dispatcher ownership as well as the tool. The decision remains session-static. Interactive board access stays available, while delegated children and non-owning cron contexts do not receive worker instructions.

This adapts the fix from #102857 to current main's split modules, credits its contributor, and adds real initialization/prompt/cache regression coverage. It is a salvage candidate for the same issue, not a separate fix to merge alongside #102857. Related alternatives: #64186, #68608, #95857. No new configuration, schemas, SOUL changes or board lifecycle changes.

## Verification

- Canonical scoped suite: **101 files, 1,444 passed, 0 failed, 2 skipped**. Covers prompt assembly, compression, cron, Kanban tools, delegation and board behavior.
- Original regression: **8 failed, 4 passed**. Independently reverting initialization or fallback wiring produces **4 failed, 8 passed** each. Restored regression: **12 passed**.
- Ruff and diff checks pass.
- Installed-runtime reproduction: full `AIAgent` initialization with real board-tool resolution emits the wrong guidance before the patch. Afterward, `kanban_show` and `kanban_list` remain available and worker guidance is absent. Assigned-worker, delegated-child and non-owner cron checks pass through both initialization and fallback paths. These probes make no inference calls or live board mutations.
- Patched gateway restarted successfully. A human conversational Slack/Telegram turn has not yet been verified.

Command:
```sh
scripts/run_tests.sh tests/agent/test_kanban_guidance_ownership.py tests/agent/test_system_prompt.py tests/agent/test_prompt_builder.py tests/test_compaction_prompt_rebuild.py tests/cron/ tests/tools/test_kanban_tools.py tests/tools/test_delegate_tool.py tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_core_functionality.py -q --file-retries 0
```
