### PR TITLE
feat(security): add external install scanner gates

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2251,6 +2251,12 @@ _SECURITY_COMMENT = """
 #   tirith_path: "tirith"
 #   tirith_timeout: 5
 #   tirith_fail_open: true
+#   external_scanner:
+#     mode: report  # or block_high
+#     fail_on_incomplete: false
+#     scan_plugins: false
+#     scan_mcp: false
+#     baseline: ""  # operator-controlled SkillSpector baseline
 """
 
 _FALLBACK_COMMENT = """

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1595,6 +1595,17 @@ DEFAULT_CONFIG = {
         "tirith_path": "tirith",
         "tirith_timeout": 5,
         "tirith_fail_open": True,
+        # Optional second-opinion scanner for quarantined skills and, when opted in,
+        # plugin/MCP source trees. Native Hermes guards remain the primary enforcement.
+        # "report" never blocks; "block_high" blocks unsuppressed SkillSpector
+        # high/critical findings. Incomplete scans fail open unless explicitly changed.
+        "external_scanner": {
+            "mode": "report",
+            "fail_on_incomplete": False,
+            "scan_plugins": False,
+            "scan_mcp": False,
+            "baseline": "",
+        },
         "website_blocklist": {"enabled": False, "domains": [], "shared_files": []},
         # IDs of supply-chain advisories the user has read and acted on; acked ones stop the startup
         # banner. Add via `hermes doctor --ack <id>`; remove by editing the list. Catalog:

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -360,6 +360,21 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
             raise CatalogError(f"bootstrap step failed (exit {rc}): {cmd}")
 
 
+def _scan_mcp_tree(path: Path, label: str) -> None:
+    """Run the optional external static scanner and enforce its configured policy."""
+    from tools.skillevaluator_scan import (external_surface_enabled, format_tier1_report,
+                                           run_tier1_scan, should_allow_tier1)
+    if not external_surface_enabled("mcp"):
+        return
+    report = run_tier1_scan(path)
+    if report.available:
+        for line in format_tier1_report(report).splitlines():
+            _say(f"  {line}", Colors.DIM)
+    allowed, reason = should_allow_tier1(report)
+    if not allowed:
+        raise CatalogError(f"External security scan blocked MCP '{label}': {reason}")
+
+
 def _do_git_install(entry: CatalogEntry) -> Path:
     """Clone the entry's repo into ``~/.hermes/mcp-installs/<name>`` and run bootstrap. Returns the dir."""
     assert entry.install is not None and entry.install.type == "git"
@@ -395,6 +410,8 @@ def _do_git_install(entry: CatalogEntry) -> Path:
         if _git("-C", str(dest), "checkout", install.ref) != 0:
             raise CatalogError(f"git checkout {install.ref} failed")
 
+    # Scan untrusted source before any bootstrap command can execute it.
+    _scan_mcp_tree(dest, f"{entry.name} source")
     if install.bootstrap:
         _run_bootstrap(dest, install.bootstrap)
     return dest
@@ -619,6 +636,9 @@ def install_entry(entry: CatalogEntry, *, enable: bool = True) -> None:
         _say(f"  Source: {entry.source}", Colors.DIM)
     print()
 
+    # Scan the declarative manifest before prompting for credentials, cloning,
+    # running bootstrap commands, or writing config.
+    _scan_mcp_tree(entry.manifest_path.parent, f"{entry.name} manifest")
     install_dir = _do_git_install(entry) if entry.install is not None else None
 
     if entry.auth.type == "api_key":

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -362,15 +362,14 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
 
 def _scan_mcp_tree(path: Path, label: str) -> None:
     """Run the optional external static scanner and enforce its configured policy."""
-    from tools.skillevaluator_scan import (external_surface_enabled, format_tier1_report,
-                                           run_tier1_scan, should_allow_tier1)
-    if not external_surface_enabled("mcp"):
+    from tools.skillevaluator_scan import evaluate_external_surface, format_tier1_report
+    evaluation = evaluate_external_surface(path, "mcp")
+    if evaluation is None:
         return
-    report = run_tier1_scan(path)
+    report, allowed, reason = evaluation
     if report.available:
         for line in format_tier1_report(report).splitlines():
             _say(f"  {line}", Colors.DIM)
-    allowed, reason = should_allow_tier1(report)
     if not allowed:
         raise CatalogError(f"External security scan blocked MCP '{label}': {reason}")
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -156,18 +156,19 @@ def _scan_plugin_tree(plugin_dir: Path, identifier: str, *, force: bool, scan_de
                 scan_result=result)
         logger.info("plugin scan passed for %s: %s", plugin_dir.name, reason)
 
-    from tools.skillevaluator_scan import (external_surface_enabled, format_tier1_report,
-                                           run_tier1_scan, should_allow_tier1)
-    if external_surface_enabled("plugins"):
-        external = run_tier1_scan(plugin_dir)
+    from tools.skillevaluator_scan import evaluate_external_surface, format_tier1_report
+    external_evaluation = evaluate_external_surface(plugin_dir, "plugins")
+    if external_evaluation is not None:
+        external, external_allowed, external_reason = external_evaluation
         if external.available:
-            logger.info("external plugin scan for %s:\n%s", plugin_dir.name,
-                        format_tier1_report(external))
-        external_allowed, external_reason = should_allow_tier1(external)
+            formatted = format_tier1_report(external)
+            logger.info("external plugin scan for %s:\n%s", plugin_dir.name, formatted)
+        else:
+            formatted = ""
         if not external_allowed:
             raise PluginScanBlocked(
                 f"External security scan blocked plugin install: {external_reason}\n\n"
-                f"{format_tier1_report(external)}",
+                f"{formatted}",
                 scan_result=external,
             )
     return result

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -132,29 +132,44 @@ def _scan_plugin_tree(plugin_dir: Path, identifier: str, *, force: bool, scan_de
     ``scan_decision_cb(result)``); dangerous → always blocked (:class:`PluginScanBlocked`).
     Returns the ScanResult, or None when scanning is disabled.
     """
-    if not _scan_on_install_enabled():
-        return None
-    from tools.plugin_guard import format_scan_report, scan_plugin, should_allow_plugin_install
-    result = scan_plugin(plugin_dir, source=identifier)
-    allowed, reason = should_allow_plugin_install(result, force=force)
+    result = None
+    if _scan_on_install_enabled():
+        from tools.plugin_guard import format_scan_report, scan_plugin, should_allow_plugin_install
+        result = scan_plugin(plugin_dir, source=identifier)
+        allowed, reason = should_allow_plugin_install(result, force=force)
 
-    if allowed is None and scan_decision_cb is not None:
-        try:
-            if scan_decision_cb(result):
-                allowed = True
-                reason = "Caution verdict accepted by user"
-        except Exception:
-            logger.exception("plugin scan decision callback failed")
+        if allowed is None and scan_decision_cb is not None:
+            try:
+                if scan_decision_cb(result):
+                    allowed = True
+                    reason = "Caution verdict accepted by user"
+            except Exception:
+                logger.exception("plugin scan decision callback failed")
 
-    if allowed is not True:
-        raise PluginScanBlocked(
-            f"Security scan blocked plugin install: {reason}\n\n"
-            f"{format_scan_report(result)}\n"
-            "Review the findings above. Install only plugins from sources "
-            "you trust. (Scanning can be configured via "
-            "plugins.scan_on_install in config.yaml.)",
-            scan_result=result)
-    logger.info("plugin scan passed for %s: %s", plugin_dir.name, reason)
+        if allowed is not True:
+            raise PluginScanBlocked(
+                f"Security scan blocked plugin install: {reason}\n\n"
+                f"{format_scan_report(result)}\n"
+                "Review the findings above. Install only plugins from sources "
+                "you trust. (Scanning can be configured via "
+                "plugins.scan_on_install in config.yaml.)",
+                scan_result=result)
+        logger.info("plugin scan passed for %s: %s", plugin_dir.name, reason)
+
+    from tools.skillevaluator_scan import (external_surface_enabled, format_tier1_report,
+                                           run_tier1_scan, should_allow_tier1)
+    if external_surface_enabled("plugins"):
+        external = run_tier1_scan(plugin_dir)
+        if external.available:
+            logger.info("external plugin scan for %s:\n%s", plugin_dir.name,
+                        format_tier1_report(external))
+        external_allowed, external_reason = should_allow_tier1(external)
+        if not external_allowed:
+            raise PluginScanBlocked(
+                f"External security scan blocked plugin install: {external_reason}\n\n"
+                f"{format_tier1_report(external)}",
+                scan_result=external,
+            )
     return result
 
 

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -701,7 +701,15 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         return
     # Advisory second opinion — warn-and-continue by design (PII-class findings are
     # informational); the install confirmation below is where the user decides.
-    _print_tier1_advisory(q_path, c)
+    tier1_report = _print_tier1_advisory(q_path, c)
+    if tier1_report is not None:
+        from tools.skillevaluator_scan import should_allow_tier1
+        tier1_allowed, tier1_reason = should_allow_tier1(tier1_report)
+        if not tier1_allowed:
+            _install_blocked(c, bundle, tier1_reason, "external_high",
+                             f"{len(tier1_report.findings)}_external_findings")
+            c.print(f"[yellow]Quarantine preserved for review:[/] {q_path}\n")
+            return
     metadata_lines = _format_extra_metadata_lines(extra_metadata)
     if metadata_lines:
         c.print(Panel("\n".join(metadata_lines), title="Upstream Metadata", border_style="blue"))
@@ -723,28 +731,30 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     _finish_change(c, invalidate_cache, "Skill will be available", "activate")
 
 
-def _print_tier1_advisory(skill_dir, console) -> None:
+def _print_tier1_advisory(skill_dir, console):
     """Advisory SkillEvaluator Tier 1 report. Never raises/blocks: scanner missing, disabled via
     ``skills.tier1_advisory: false``, or erroring all degrade to silence. Secrets render red."""
     try:
         from tools.skillevaluator_scan import (format_tier1_report, run_tier1_scan,
                                                tier1_advisory_enabled)
         if not tier1_advisory_enabled():
-            return
+            return None
         report = run_tier1_scan(Path(skill_dir))
         if not report.available:
-            return
+            return report
         text = format_tier1_report(report)
         if not report.findings:
             console.print(f"[dim]{text}[/]")
-            return
+            return report
         console.print(Panel(text, title="SkillEvaluator Tier 1 (advisory)",
                             border_style="red" if report.secrets_findings else "yellow"))
         if report.secrets_findings:
             console.print("[bold red]Possible credentials detected above.[/] "
                           "Review the flagged lines before using this skill.\n")
+        return report
     except Exception as exc:  # advisory only — never break an install
         logging.getLogger(__name__).debug("Tier 1 advisory scan skipped: %s", exc)
+        return None
 
 
 # --- list / check / update / audit ---

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -467,6 +467,37 @@ class TestInstall:
         # The rejected entry must not have been persisted.
         assert "evil" not in (load_config().get("mcp_servers") or {})
 
+    def test_external_high_finding_blocks_before_config_write(
+        self, catalog_dir, monkeypatch
+    ):
+        _write_manifest(catalog_dir, "demo", _basic_manifest())
+        from hermes_cli import mcp_catalog as mc
+        from hermes_cli.config import load_config
+        from tools.skillevaluator_scan import Tier1Finding, Tier1Report
+
+        report = Tier1Report(
+            available=True,
+            passed=False,
+            scanner="skillspector",
+            findings=[Tier1Finding(
+                check="SC-009", validator="mcp_tool_poisoning", severity="critical",
+                message="Tool description contains hidden instructions", scanner="skillspector",
+            )],
+        )
+        monkeypatch.setattr(
+            "tools.skillevaluator_scan.external_surface_enabled",
+            lambda surface: surface == "mcp",
+        )
+        monkeypatch.setattr("tools.skillevaluator_scan.run_tier1_scan", lambda path: report)
+        monkeypatch.setattr(
+            "tools.skillevaluator_scan.should_allow_tier1",
+            lambda result: (False, "critical external finding"),
+        )
+
+        with pytest.raises(mc.CatalogError, match="External security scan"):
+            mc.install_entry(_entry("demo"), enable=True)
+        assert "demo" not in (load_config().get("mcp_servers") or {})
+
 
     def test_install_with_api_key_prompts_and_saves(self, catalog_dir, monkeypatch):
         body = _basic_manifest(

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -485,13 +485,8 @@ class TestInstall:
             )],
         )
         monkeypatch.setattr(
-            "tools.skillevaluator_scan.external_surface_enabled",
-            lambda surface: surface == "mcp",
-        )
-        monkeypatch.setattr("tools.skillevaluator_scan.run_tier1_scan", lambda path: report)
-        monkeypatch.setattr(
-            "tools.skillevaluator_scan.should_allow_tier1",
-            lambda result: (False, "critical external finding"),
+            "tools.skillevaluator_scan.evaluate_external_surface",
+            lambda path, surface: (report, False, "critical external finding"),
         )
 
         with pytest.raises(mc.CatalogError, match="External security scan"):

--- a/tests/tools/test_plugin_guard.py
+++ b/tests/tools/test_plugin_guard.py
@@ -226,6 +226,38 @@ class TestInstallIntegration:
         # Nothing got installed.
         assert not (plugins_dir / "test-plugin").exists()
 
+    def test_external_high_finding_blocks_before_install(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd as pc
+        from tools.skillevaluator_scan import Tier1Finding, Tier1Report
+
+        repo = tmp_path / "repo"
+        self._make_git_repo(repo, BASE_FILES)
+        plugins_dir = tmp_path / "installed"
+        plugins_dir.mkdir()
+        monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins_dir)
+        monkeypatch.setattr(
+            "tools.skillevaluator_scan.external_surface_enabled",
+            lambda surface: surface == "plugins",
+        )
+        report = Tier1Report(
+            available=True,
+            passed=False,
+            scanner="skillspector",
+            findings=[Tier1Finding(
+                check="SC-001", validator="supply_chain", severity="high",
+                message="Unpinned dependency", scanner="skillspector",
+            )],
+        )
+        monkeypatch.setattr("tools.skillevaluator_scan.run_tier1_scan", lambda path: report)
+        monkeypatch.setattr(
+            "tools.skillevaluator_scan.should_allow_tier1",
+            lambda result: (False, "high external finding"),
+        )
+
+        with pytest.raises(pc.PluginScanBlocked, match="external"):
+            pc._install_plugin_core(f"file://{repo}", force=False)
+        assert not (plugins_dir / "test-plugin").exists()
+
     def test_caution_plugin_accepted_via_callback(self, tmp_path, monkeypatch):
         from hermes_cli import plugins_cmd as pc
 

--- a/tests/tools/test_plugin_guard.py
+++ b/tests/tools/test_plugin_guard.py
@@ -235,10 +235,6 @@ class TestInstallIntegration:
         plugins_dir = tmp_path / "installed"
         plugins_dir.mkdir()
         monkeypatch.setattr(pc, "_plugins_dir", lambda: plugins_dir)
-        monkeypatch.setattr(
-            "tools.skillevaluator_scan.external_surface_enabled",
-            lambda surface: surface == "plugins",
-        )
         report = Tier1Report(
             available=True,
             passed=False,
@@ -248,10 +244,9 @@ class TestInstallIntegration:
                 message="Unpinned dependency", scanner="skillspector",
             )],
         )
-        monkeypatch.setattr("tools.skillevaluator_scan.run_tier1_scan", lambda path: report)
         monkeypatch.setattr(
-            "tools.skillevaluator_scan.should_allow_tier1",
-            lambda result: (False, "high external finding"),
+            "tools.skillevaluator_scan.evaluate_external_surface",
+            lambda path, surface: (report, False, "high external finding"),
         )
 
         with pytest.raises(pc.PluginScanBlocked, match="external"):

--- a/tests/tools/test_skillevaluator_scan.py
+++ b/tests/tools/test_skillevaluator_scan.py
@@ -7,6 +7,7 @@ The adapter (tools/skillevaluator_scan.py) must:
 """
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -24,6 +25,7 @@ from tools.skillevaluator_scan import (  # noqa: E402
     _parse_skillspector_report,
     format_tier1_report,
     run_tier1_scan,
+    should_allow_tier1,
     tier1_advisory_enabled,
 )
 
@@ -55,6 +57,27 @@ class TestParseReport:
         assert report.available
         assert report.passed
         assert report.findings == []
+
+    def test_security_validator_findings_are_attributed_to_skillspector(self):
+        raw = {
+            "overall_passed": False,
+            "results": [{
+                "validator": "Security Scan",
+                "passed": False,
+                "findings": [_finding("tool_poisoning", severity="high")],
+            }],
+        }
+        report = _parse_report(raw)
+        assert report.findings[0].scanner == "skillspector"
+
+        with mock.patch(
+            "hermes_cli.config.load_config",
+            return_value={"security": {"external_scanner": {
+                "mode": "block_high", "fail_on_incomplete": False,
+            }}},
+        ):
+            allowed, _ = should_allow_tier1(report)
+        assert not allowed
 
     def test_pii_email_is_advisory_not_secrets(self):
         report = _parse_report(_report_json([
@@ -167,12 +190,14 @@ class TestRunTier1Scan:
         assert not report.available
         assert report.findings == []
 
-    def test_scanner_timeout_degrades(self, tmp_path):
+    def test_scanner_timeout_degrades_without_resetting_budget(self, tmp_path):
         with mock.patch("tools.skillevaluator_scan.shutil.which", return_value="/usr/bin/skillevaluator"), \
              mock.patch("tools.skillevaluator_scan.subprocess.run",
-                        side_effect=subprocess.TimeoutExpired(cmd="x", timeout=1)):
+                        side_effect=subprocess.TimeoutExpired(cmd="x", timeout=1)) as runner:
             report = run_tier1_scan(tmp_path)
         assert not report.available
+        assert "timed out" in report.error
+        assert runner.call_count == 1
 
     def test_scanner_launch_failure_degrades(self, tmp_path):
         with mock.patch("tools.skillevaluator_scan.shutil.which", return_value="/usr/bin/skillevaluator"), \
@@ -203,6 +228,50 @@ class TestRunTier1Scan:
         assert not report.passed
         assert len(report.findings) == 1
         assert report.findings[0].check == "emails"
+
+    def test_real_subprocess_report_and_policy_chain(
+        self, tmp_path, monkeypatch,
+    ):
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        payload = {
+            "risk_assessment": {"score": 8, "severity": "HIGH"},
+            "analysis_completeness": {"is_complete": True},
+            "issues": [{
+                "id": "data-exfiltration-001",
+                "category": "Data Exfiltration",
+                "severity": "HIGH",
+                "finding": "Reads a credential and sends it remotely",
+            }],
+        }
+        scanner = bin_dir / "skillspector"
+        scanner.write_text(
+            f"#!{sys.executable}\n"
+            "import json, sys\n"
+            "from pathlib import Path\n"
+            f"payload = {payload!r}\n"
+            "flag = '--output' if '--output' in sys.argv else '-o'\n"
+            "out = Path(sys.argv[sys.argv.index(flag) + 1])\n"
+            "out.write_text(json.dumps(payload))\n"
+        )
+        os.chmod(scanner, 0o755)
+
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# test\n")
+        monkeypatch.setenv("PATH", str(bin_dir))
+
+        report = run_tier1_scan(skill_dir)
+        monkeypatch.setitem(
+            should_allow_tier1.__globals__, "_external_scanner_config",
+            lambda: {"mode": "block_high", "fail_on_incomplete": False},
+        )
+        allowed, reason = should_allow_tier1(report)
+
+        assert report.scanner == "skillspector"
+        assert report.findings[0].scanner == "skillspector"
+        assert not allowed, reason
+        assert "high/critical" in reason
 
 
 class TestFormatReport:
@@ -277,9 +346,11 @@ class TestInstallPathHelper:
     def test_helper_silent_when_unavailable(self, tmp_path):
         from hermes_cli.skills_hub import _print_tier1_advisory
         console = mock.MagicMock()
+        report = Tier1Report(available=False)
         with mock.patch("tools.skillevaluator_scan.run_tier1_scan",
-                        return_value=Tier1Report(available=False)):
-            _print_tier1_advisory(tmp_path, console)
+                        return_value=report):
+            returned = _print_tier1_advisory(tmp_path, console)
+        assert returned is report
         console.print.assert_not_called()
 
     def test_helper_silent_when_disabled(self, tmp_path):

--- a/tests/tools/test_skillevaluator_scan.py
+++ b/tests/tools/test_skillevaluator_scan.py
@@ -19,8 +19,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from tools.skillevaluator_scan import (  # noqa: E402
     SECRETS_CLASS_CHECKS,
+    TIER1_CHECKS,
     Tier1Finding,
     Tier1Report,
+    _config_bool,
+    _merge_security_report,
     _parse_report,
     _parse_skillspector_report,
     format_tier1_report,
@@ -182,22 +185,39 @@ class TestParseSkillSpectorReport:
         assert finding.line == 9
         assert finding.scanner == "skillspector"
 
+    def test_merge_deduplicates_identical_findings(self):
+        finding = Tier1Finding(
+            check="SC-1", validator="security", severity="high",
+            message="same", file="SKILL.md", line=4, scanner="skillspector",
+        )
+        base = Tier1Report(available=True, passed=False, findings=[finding])
+        security = Tier1Report(
+            available=True, passed=False, findings=[finding], scanner="skillspector",
+        )
+        merged = _merge_security_report(base, security)
+        assert merged.findings == [finding]
+
 
 class TestRunTier1Scan:
+    def test_skillevaluator_does_not_repeat_security_scan(self):
+        assert "security" not in TIER1_CHECKS.split(",")
+
     def test_scanner_missing_degrades(self, tmp_path):
         with mock.patch("tools.skillevaluator_scan.shutil.which", return_value=None):
             report = run_tier1_scan(tmp_path)
         assert not report.available
         assert report.findings == []
 
-    def test_scanner_timeout_degrades_without_resetting_budget(self, tmp_path):
+    def test_scanner_timeout_preserves_budget_for_direct_security(self, tmp_path):
         with mock.patch("tools.skillevaluator_scan.shutil.which", return_value="/usr/bin/skillevaluator"), \
              mock.patch("tools.skillevaluator_scan.subprocess.run",
                         side_effect=subprocess.TimeoutExpired(cmd="x", timeout=1)) as runner:
-            report = run_tier1_scan(tmp_path)
+            report = run_tier1_scan(tmp_path, timeout=12)
         assert not report.available
         assert "timed out" in report.error
-        assert runner.call_count == 1
+        assert runner.call_count == 2
+        assert runner.call_args_list[0].kwargs["timeout"] == 4
+        assert runner.call_args_list[1].kwargs["timeout"] <= 12
 
     def test_scanner_launch_failure_degrades(self, tmp_path):
         with mock.patch("tools.skillevaluator_scan.shutil.which", return_value="/usr/bin/skillevaluator"), \
@@ -217,8 +237,16 @@ class TestRunTier1Scan:
         payload = _report_json([_finding("emails")])
 
         def fake_run(cmd, **kwargs):
-            outdir = Path(cmd[cmd.index("-o") + 1])
-            (outdir / "skillevaluator-output-1.json").write_text(json.dumps(payload))
+            if cmd[0] == "skillevaluator":
+                outdir = Path(cmd[cmd.index("-o") + 1])
+                (outdir / "skillevaluator-output-1.json").write_text(json.dumps(payload))
+            else:
+                report_file = Path(cmd[cmd.index("--output") + 1])
+                report_file.write_text(json.dumps({
+                    "risk_assessment": {"score": 0, "severity": "LOW"},
+                    "analysis_completeness": {"is_complete": True},
+                    "issues": [],
+                }))
             return subprocess.CompletedProcess(cmd, 1, "", "")
 
         with mock.patch("tools.skillevaluator_scan.shutil.which", return_value="/usr/bin/skillevaluator"), \
@@ -314,6 +342,20 @@ class TestFormatReport:
 
 
 class TestConfigGate:
+    def test_config_bool_handles_false_like_strings(self):
+        assert not _config_bool("false", default=True)
+        assert not _config_bool("off", default=True)
+        assert _config_bool("true")
+        assert _config_bool(None, default=True)
+
+    def test_fail_on_incomplete_string_false_stays_fail_open(self):
+        report = Tier1Report(available=False)
+        allowed, _ = should_allow_tier1(
+            report,
+            config={"mode": "block_high", "fail_on_incomplete": "false"},
+        )
+        assert allowed
+
     def test_default_enabled(self):
         with mock.patch("hermes_cli.config.load_config", return_value={}):
             assert tier1_advisory_enabled()

--- a/tests/tools/test_skillevaluator_scan.py
+++ b/tests/tools/test_skillevaluator_scan.py
@@ -21,6 +21,7 @@ from tools.skillevaluator_scan import (  # noqa: E402
     Tier1Finding,
     Tier1Report,
     _parse_report,
+    _parse_skillspector_report,
     format_tier1_report,
     run_tier1_scan,
     tier1_advisory_enabled,
@@ -134,6 +135,29 @@ class TestParseReport:
     def test_complete_failed_check_still_fails(self):
         report = _parse_report(_report_json([_finding("emails")]))
         assert not report.passed
+
+
+class TestParseSkillSpectorReport:
+    def test_parses_skillspector_211_finding_schema(self):
+        report = _parse_skillspector_report({
+            "risk_assessment": {"score": 8, "severity": "HIGH"},
+            "analysis_completeness": {"is_complete": True},
+            "issues": [{
+                "id": "data-exfiltration-001",
+                "category": "Data Exfiltration",
+                "severity": "HIGH",
+                "finding": "Reads a credential and sends it remotely",
+                "explanation": "Source and sink occur in the same instruction.",
+                "remediation": "Remove the outbound transfer.",
+                "location": {"path": "SKILL.md", "start_line": 9},
+            }],
+        })
+        finding = report.findings[0]
+        assert finding.check == "data-exfiltration-001"
+        assert finding.message.startswith("Reads a credential")
+        assert finding.file == "SKILL.md"
+        assert finding.line == 9
+        assert finding.scanner == "skillspector"
 
 
 class TestRunTier1Scan:

--- a/tools/skillevaluator_scan.py
+++ b/tools/skillevaluator_scan.py
@@ -15,6 +15,7 @@ import logging
 import shutil
 import subprocess
 import tempfile
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List
@@ -23,9 +24,10 @@ logger = logging.getLogger(__name__)
 
 SCANNER_BIN = "skillevaluator"
 SKILLSPECTOR_BIN = "skillspector"
-# Keyless, deterministic checks (schema/quality are index-pipeline hygiene, not install-time signal). `security`
-# invokes NVIDIA SkillSpector (static rules, no LLM); when absent it reports status="incomplete".
-TIER1_CHECKS = "pii,unicode,lint,license,security"
+# Keyless deterministic hygiene checks. Security is run once, directly through
+# SkillSpector, because SkillEvaluator v0.1.0 rejects valid SkillSpector v2.11
+# metadata and otherwise causes an immediate duplicate scan.
+TIER1_CHECKS = "pii,unicode,lint,license"
 SCAN_TIMEOUT_SECONDS = 120
 
 # pii_patterns.yaml categories indicating a possible REAL credential (not PII hygiene) — the only prompt-worthy ones.
@@ -89,22 +91,38 @@ class Tier1Report:
         return [f for f in self.findings if f.is_secrets_class]
 
 
+_FALSE_STRINGS = frozenset({"false", "0", "no", "off"})
+_TRUE_STRINGS = frozenset({"true", "1", "yes", "on"})
+
+
+def _config_bool(value, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _FALSE_STRINGS:
+            return False
+        if normalized in _TRUE_STRINGS:
+            return True
+        return default
+    return bool(value)
+
+
 def tier1_advisory_enabled() -> bool:
     """``skills.tier1_advisory`` (default True; safe because the scan is a no-op without the binary)."""
     try:
         from hermes_cli.config import load_config
         skills_cfg = load_config().get("skills") or {}
         value = skills_cfg.get("tier1_advisory", True) if isinstance(skills_cfg, dict) else True
-        return value.strip().lower() not in ("false", "0", "no", "off") if isinstance(value, str) else bool(value)
+        return _config_bool(value, default=True)
     except Exception:
         return True
 
 
 def _external_scanner_config() -> dict:
     try:
-        from hermes_cli.config import load_config
-        security = load_config().get("security") or {}
-        scanner = security.get("external_scanner") or {} if isinstance(security, dict) else {}
+        from hermes_cli.config import cfg_get, load_config
+        scanner = cfg_get(load_config(), "security", "external_scanner", default={})
         return scanner if isinstance(scanner, dict) else {}
     except Exception:
         return {}
@@ -115,20 +133,19 @@ def external_surface_enabled(surface: str) -> bool:
     key = {"plugins": "scan_plugins", "mcp": "scan_mcp"}.get(surface, "")
     if not key:
         return False
-    value = _external_scanner_config().get(key, False)
-    return value.strip().lower() not in ("false", "0", "no", "off") if isinstance(value, str) else bool(value)
+    return _config_bool(_external_scanner_config().get(key), default=False)
 
 
-def should_allow_tier1(report: Tier1Report) -> tuple[bool, str]:
+def should_allow_tier1(report: Tier1Report, config: dict | None = None) -> tuple[bool, str]:
     """Evaluate operator policy while keeping report-only as the safe default.
 
     ``block_high`` blocks only unsuppressed high/critical findings. SkillSpector
     applies the configured baseline before this point. Missing or incomplete
     scanners remain advisory unless ``fail_on_incomplete`` is explicitly true.
     """
-    config = _external_scanner_config()
+    config = config if isinstance(config, dict) else _external_scanner_config()
     mode = str(config.get("mode") or "report").strip().lower()
-    fail_on_incomplete = bool(config.get("fail_on_incomplete", False))
+    fail_on_incomplete = _config_bool(config.get("fail_on_incomplete"), default=False)
     if mode != "block_high":
         return True, "External scanner is report-only"
     if not report.available:
@@ -214,12 +231,13 @@ def _parse_skillspector_report(report: dict) -> Tier1Report:
     )
 
 
-def _configured_baseline() -> str:
+def _configured_baseline(config: dict | None = None) -> str:
     """Return the operator-controlled SkillSpector baseline path, if configured."""
-    return str(_external_scanner_config().get("baseline", "")).strip()
+    config = config if isinstance(config, dict) else _external_scanner_config()
+    return str(config.get("baseline", "")).strip()
 
 
-def _run_skillspector(skill_dir: Path, timeout: int) -> Tier1Report:
+def _run_skillspector(skill_dir: Path, timeout: int, *, baseline: str | None = None) -> Tier1Report:
     unavailable = lambda why: Tier1Report(available=False, error=why, scanner="skillspector")  # noqa: E731
     if shutil.which(SKILLSPECTOR_BIN) is None:
         return unavailable("SkillSpector not on PATH")
@@ -227,7 +245,7 @@ def _run_skillspector(skill_dir: Path, timeout: int) -> Tier1Report:
         report_file = Path(outdir) / "report.json"
         cmd = [SKILLSPECTOR_BIN, "scan", str(skill_dir), "--no-llm", "--format", "json",
                "--output", str(report_file)]
-        baseline = _configured_baseline()
+        baseline = _configured_baseline() if baseline is None else baseline
         if baseline:
             cmd.extend(["--baseline", baseline, "--show-suppressed"])
         try:
@@ -248,10 +266,19 @@ def _run_skillspector(skill_dir: Path, timeout: int) -> Tier1Report:
 
 
 def _merge_security_report(base: Tier1Report, security: Tier1Report) -> Tier1Report:
-    """Merge a native SkillSpector result into SkillEvaluator's partial report."""
+    """Merge distinct hygiene and security results, deduplicating defensively."""
     incomplete = [name for name in base.incomplete_checks if name != "Security Scan"]
     incomplete.extend(name for name in security.incomplete_checks if name not in incomplete)
-    findings = [*base.findings, *security.findings]
+    if not security.available and "SkillSpector security" not in incomplete:
+        incomplete.append("SkillSpector security")
+    findings: List[Tier1Finding] = []
+    seen = set()
+    for finding in [*base.findings, *security.findings]:
+        key = (finding.scanner, finding.check, finding.severity, finding.file,
+               finding.line, finding.message)
+        if key not in seen:
+            findings.append(finding)
+            seen.add(key)
     return Tier1Report(
         available=base.available or security.available,
         passed=base.passed and security.passed and not findings,
@@ -262,41 +289,76 @@ def _merge_security_report(base: Tier1Report, security: Tier1Report) -> Tier1Rep
         risk_score=security.risk_score,
         risk_severity=security.risk_severity,
         recommendation=security.recommendation,
-        analysis_complete=security.analysis_complete,
+        analysis_complete=security.available and security.analysis_complete,
         llm_used=security.llm_used,
         suppressed_count=security.suppressed_count,
     )
 
 
 def run_tier1_scan(skill_dir: Path, timeout: int = SCAN_TIMEOUT_SECONDS) -> Tier1Report:
-    """Run SkillEvaluator Tier 1 over one skill dir; any failure returns ``available=False``, never raises."""
+    """Run distinct hygiene and static-security checks within one total budget."""
     unavailable = lambda why: Tier1Report(available=False, error=why)  # noqa: E731
-    if shutil.which(SCANNER_BIN) is None:
-        return _run_skillspector(skill_dir, timeout)
-    with tempfile.TemporaryDirectory(prefix="se-tier1-") as outdir:
-        try:
-            subprocess.run([SCANNER_BIN, "validate", str(skill_dir), "--checks", TIER1_CHECKS, "--no-dedup",
-                            "-r", "json", "-o", outdir], capture_output=True, text=True, encoding="utf-8", errors="replace",
-                           stdin=subprocess.DEVNULL, timeout=timeout)
-        except subprocess.TimeoutExpired:
-            return unavailable(f"scan timed out after {timeout}s")
-        except OSError as exc:
-            fallback = _run_skillspector(skill_dir, timeout)
-            return fallback if fallback.available else unavailable(f"scanner failed to launch: {exc}")
-        if not (reports := sorted(Path(outdir).glob("skillevaluator-output-*.json"))):
-            return _run_skillspector(skill_dir, timeout)
-        try:
-            parsed = json.loads(reports[-1].read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
-            return unavailable(f"unparseable report: {exc}")
-        if not isinstance(parsed, dict):
-            return unavailable("unexpected report shape")
-        report = _parse_report(parsed)
-        if "Security Scan" in report.incomplete_checks:
-            security = _run_skillspector(skill_dir, timeout)
-            if security.available:
-                return _merge_security_report(report, security)
-        return report
+    config = _external_scanner_config()
+    budget = max(1, int(timeout))
+    deadline = time.monotonic() + budget
+    hygiene = unavailable("SkillEvaluator not on PATH")
+
+    if shutil.which(SCANNER_BIN) is not None:
+        # Reserve most of the total budget for the security scan, which is the
+        # install-time enforcement signal. Hygiene checks are advisory.
+        evaluator_timeout = max(1, min(30, budget // 3))
+        with tempfile.TemporaryDirectory(prefix="se-tier1-") as outdir:
+            try:
+                subprocess.run(
+                    [SCANNER_BIN, "validate", str(skill_dir), "--checks", TIER1_CHECKS,
+                     "--no-dedup", "-r", "json", "-o", outdir],
+                    capture_output=True, text=True, encoding="utf-8", errors="replace",
+                    stdin=subprocess.DEVNULL, timeout=evaluator_timeout,
+                )
+            except subprocess.TimeoutExpired:
+                hygiene = unavailable(f"SkillEvaluator timed out after {evaluator_timeout}s")
+            except OSError as exc:
+                hygiene = unavailable(f"SkillEvaluator failed to launch: {exc}")
+            else:
+                reports = sorted(Path(outdir).glob("skillevaluator-output-*.json"))
+                if not reports:
+                    hygiene = unavailable("SkillEvaluator produced no JSON report")
+                else:
+                    try:
+                        parsed = json.loads(reports[-1].read_text(encoding="utf-8"))
+                    except (json.JSONDecodeError, OSError) as exc:
+                        hygiene = unavailable(f"unparseable SkillEvaluator report: {exc}")
+                    else:
+                        hygiene = _parse_report(parsed) if isinstance(parsed, dict) else unavailable(
+                            "unexpected SkillEvaluator report shape")
+
+    remaining = int(deadline - time.monotonic())
+    security = (_run_skillspector(
+        skill_dir, max(1, remaining), baseline=_configured_baseline(config),
+    ) if remaining > 0 else Tier1Report(
+        available=False, error=f"total scan budget exhausted after {budget}s",
+        scanner="skillspector", analysis_complete=False,
+    ))
+    if hygiene.available:
+        return _merge_security_report(hygiene, security)
+    if security.available:
+        return security
+    return unavailable("; ".join(part for part in (hygiene.error, security.error) if part))
+
+
+def evaluate_external_surface(path: Path, surface: str) -> tuple[Tier1Report, bool, str] | None:
+    """Scan a plugin or MCP tree once and evaluate policy from one config snapshot."""
+    key = {"plugins": "scan_plugins", "mcp": "scan_mcp"}.get(surface)
+    config = _external_scanner_config()
+    if not key or not _config_bool(config.get(key), default=False):
+        return None
+    try:
+        timeout = max(1, int(config.get("scan_timeout_seconds", SCAN_TIMEOUT_SECONDS)))
+    except (TypeError, ValueError):
+        timeout = SCAN_TIMEOUT_SECONDS
+    report = _run_skillspector(path, timeout, baseline=_configured_baseline(config))
+    allowed, reason = should_allow_tier1(report, config=config)
+    return report, allowed, reason
 
 
 def format_tier1_report(report: Tier1Report, limit: int = 10) -> str:

--- a/tools/skillevaluator_scan.py
+++ b/tools/skillevaluator_scan.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""Advisory NVIDIA SkillEvaluator Tier 1 scan for skill installs — alongside (never instead of) skills_guard,
-the enforcement layer. Contract: warn, don't block (the upstream PII scanner false-positives on
-``git@github.com`` / ``op://``); prompt only for secrets-class criticals (``--force`` / non-interactive proceed
-with a loud warning); a missing/crashing/timed-out/unparseable scanner is a no-op. Toggle
-``skills.tier1_advisory`` (default on). Binary: ``uv tool install --python 3.13
-"skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git@v0.1.0"``."""
+"""External second-opinion scanning for Hermes install surfaces.
+
+The native Hermes guards remain the primary enforcement layer. SkillEvaluator
+provides deterministic hygiene checks and SkillSpector provides static security
+analysis without LLM calls. The default policy is report-only; operators may
+enable blocking for unsuppressed high/critical SkillSpector findings. Scanner
+failure remains fail-open unless ``fail_on_incomplete`` is explicitly enabled.
+"""
 
 from __future__ import annotations
 
@@ -20,6 +22,7 @@ from typing import List
 logger = logging.getLogger(__name__)
 
 SCANNER_BIN = "skillevaluator"
+SKILLSPECTOR_BIN = "skillspector"
 # Keyless, deterministic checks (schema/quality are index-pipeline hygiene, not install-time signal). `security`
 # invokes NVIDIA SkillSpector (static rules, no LLM); when absent it reports status="incomplete".
 TIER1_CHECKS = "pii,unicode,lint,license,security"
@@ -39,6 +42,7 @@ class Tier1Finding:
     file: str = ""
     line: int = 0
     suggestion: str = ""
+    scanner: str = "skillevaluator"
 
     @property
     def is_secrets_class(self) -> bool:
@@ -46,6 +50,19 @@ class Tier1Finding:
 
     def location(self) -> str:
         return f"{self.file}:{self.line}" if self.file and self.line else self.file or "?"
+
+    # Plugin dashboard compatibility: native plugin findings use these names.
+    @property
+    def pattern_id(self) -> str:
+        return self.check
+
+    @property
+    def category(self) -> str:
+        return self.validator
+
+    @property
+    def description(self) -> str:
+        return self.message
 
 
 @dataclass
@@ -55,6 +72,13 @@ class Tier1Report:
     findings: List[Tier1Finding] = field(default_factory=list)
     incomplete_checks: List[str] = field(default_factory=list)
     error: str = ""                 # why the scan is unavailable (debug only)
+    scanner: str = "skillevaluator"
+    risk_score: float = 0.0
+    risk_severity: str = ""
+    recommendation: str = ""
+    analysis_complete: bool = True
+    llm_used: bool = False
+    suppressed_count: int = 0
 
     @property
     def advisory_findings(self) -> List[Tier1Finding]:
@@ -74,6 +98,51 @@ def tier1_advisory_enabled() -> bool:
         return value.strip().lower() not in ("false", "0", "no", "off") if isinstance(value, str) else bool(value)
     except Exception:
         return True
+
+
+def _external_scanner_config() -> dict:
+    try:
+        from hermes_cli.config import load_config
+        security = load_config().get("security") or {}
+        scanner = security.get("external_scanner") or {} if isinstance(security, dict) else {}
+        return scanner if isinstance(scanner, dict) else {}
+    except Exception:
+        return {}
+
+
+def external_surface_enabled(surface: str) -> bool:
+    """Whether direct external scanning is enabled for a non-skill surface."""
+    key = {"plugins": "scan_plugins", "mcp": "scan_mcp"}.get(surface, "")
+    if not key:
+        return False
+    value = _external_scanner_config().get(key, False)
+    return value.strip().lower() not in ("false", "0", "no", "off") if isinstance(value, str) else bool(value)
+
+
+def should_allow_tier1(report: Tier1Report) -> tuple[bool, str]:
+    """Evaluate operator policy while keeping report-only as the safe default.
+
+    ``block_high`` blocks only unsuppressed high/critical findings. SkillSpector
+    applies the configured baseline before this point. Missing or incomplete
+    scanners remain advisory unless ``fail_on_incomplete`` is explicitly true.
+    """
+    config = _external_scanner_config()
+    mode = str(config.get("mode") or "report").strip().lower()
+    fail_on_incomplete = bool(config.get("fail_on_incomplete", False))
+    if mode != "block_high":
+        return True, "External scanner is report-only"
+    if not report.available:
+        return (False, "External scanner unavailable (fail-closed)") if fail_on_incomplete else (
+            True, "External scanner unavailable; advisory policy continues")
+    if report.incomplete_checks or not report.analysis_complete:
+        if fail_on_incomplete:
+            return False, "External scanner analysis incomplete (fail-closed)"
+    blocking = [f for f in report.findings
+                if f.scanner == "skillspector" and f.severity in {"high", "critical"}]
+    if blocking:
+        levels = ", ".join(sorted({f.severity for f in blocking}))
+        return False, f"External scanner found {len(blocking)} high/critical finding(s): {levels}"
+    return True, "No unsuppressed high/critical external findings"
 
 
 def _parse_report(report: dict) -> Tier1Report:
@@ -97,27 +166,143 @@ def _parse_report(report: dict) -> Tier1Report:
                        incomplete_checks=incomplete)
 
 
+def _parse_skillspector_report(report: dict) -> Tier1Report:
+    """Parse SkillSpector's native JSON without normalizing its risk metadata.
+
+    SkillEvaluator v0.1.0 rejects SkillSpector v2.11.0 reports where a clean
+    static-only scan has ``risk_severity=low`` and ``recommendation=caution``.
+    That consistency check must not erase the underlying static evidence, so
+    this parser is the compatibility fallback.
+    """
+    risk = report.get("risk_assessment") or {}
+    metadata = report.get("metadata") or report.get("scan_metadata") or {}
+    completeness = report.get("analysis_completeness") or {}
+    complete = bool(completeness.get("is_complete", metadata.get("analysis_complete", False)))
+    findings: List[Tier1Finding] = []
+    for issue in report.get("issues", []) or []:
+        if not isinstance(issue, dict):
+            continue
+        location = issue.get("location") or {}
+        if not isinstance(location, dict):
+            location = {}
+        title = str(issue.get("finding") or issue.get("title") or "")
+        description = str(issue.get("explanation") or issue.get("description") or "")
+        message = f"{title}: {description}".strip(": ")[:200]
+        findings.append(Tier1Finding(
+            check=str(issue.get("id") or issue.get("rule_id") or issue.get("check_name") or ""),
+            validator=str(issue.get("category") or "SkillSpector security"),
+            severity=str(issue.get("severity") or "info").lower(),
+            message=message,
+            file=str(location.get("path") or location.get("file") or issue.get("file_path") or ""),
+            line=int(location.get("start_line") or location.get("line") or issue.get("line_number") or 0),
+            suggestion=str(issue.get("remediation") or issue.get("recommendation") or issue.get("suggestion") or "")[:200],
+            scanner="skillspector",
+        ))
+    return Tier1Report(
+        available=True,
+        passed=not findings,
+        findings=findings,
+        incomplete_checks=[] if complete else ["SkillSpector security"],
+        scanner="skillspector",
+        risk_score=float(risk.get("score", risk.get("risk_score")) or 0.0),
+        risk_severity=str(risk.get("severity", risk.get("risk_severity")) or "").lower(),
+        recommendation=str(risk.get("recommendation") or "").lower(),
+        analysis_complete=complete,
+        llm_used=bool(metadata.get("llm_used", False) or metadata.get("inference_usage")),
+        suppressed_count=int(report.get("suppressed_count", metadata.get("suppressed_count")) or 0),
+    )
+
+
+def _configured_baseline() -> str:
+    """Return the operator-controlled SkillSpector baseline path, if configured."""
+    try:
+        from hermes_cli.config import load_config
+        security = load_config().get("security") or {}
+        scanner = security.get("external_scanner") or {} if isinstance(security, dict) else {}
+        value = scanner.get("baseline", "") if isinstance(scanner, dict) else ""
+        return str(value).strip()
+    except Exception:
+        return ""
+
+
+def _run_skillspector(skill_dir: Path, timeout: int) -> Tier1Report:
+    unavailable = lambda why: Tier1Report(available=False, error=why, scanner="skillspector")  # noqa: E731
+    if shutil.which(SKILLSPECTOR_BIN) is None:
+        return unavailable("SkillSpector not on PATH")
+    with tempfile.TemporaryDirectory(prefix="skillspector-static-") as outdir:
+        report_file = Path(outdir) / "report.json"
+        cmd = [SKILLSPECTOR_BIN, "scan", str(skill_dir), "--no-llm", "--format", "json",
+               "--output", str(report_file)]
+        baseline = _configured_baseline()
+        if baseline:
+            cmd.extend(["--baseline", baseline, "--show-suppressed"])
+        try:
+            subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace",
+                           stdin=subprocess.DEVNULL, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            return unavailable(f"scan timed out after {timeout}s")
+        except OSError as exc:
+            return unavailable(f"scanner failed to launch: {exc}")
+        if not report_file.is_file():
+            return unavailable("scanner produced no JSON report")
+        try:
+            parsed = json.loads(report_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            return unavailable(f"unparseable report: {exc}")
+        return _parse_skillspector_report(parsed) if isinstance(parsed, dict) else unavailable(
+            "unexpected report shape")
+
+
+def _merge_security_report(base: Tier1Report, security: Tier1Report) -> Tier1Report:
+    """Merge a native SkillSpector result into SkillEvaluator's partial report."""
+    incomplete = [name for name in base.incomplete_checks if name != "Security Scan"]
+    incomplete.extend(name for name in security.incomplete_checks if name not in incomplete)
+    findings = [*base.findings, *security.findings]
+    return Tier1Report(
+        available=base.available or security.available,
+        passed=base.passed and security.passed and not findings,
+        findings=findings,
+        incomplete_checks=incomplete,
+        error="; ".join(part for part in (base.error, security.error) if part),
+        scanner="skillevaluator+skillspector",
+        risk_score=security.risk_score,
+        risk_severity=security.risk_severity,
+        recommendation=security.recommendation,
+        analysis_complete=security.analysis_complete,
+        llm_used=security.llm_used,
+        suppressed_count=security.suppressed_count,
+    )
+
+
 def run_tier1_scan(skill_dir: Path, timeout: int = SCAN_TIMEOUT_SECONDS) -> Tier1Report:
     """Run SkillEvaluator Tier 1 over one skill dir; any failure returns ``available=False``, never raises."""
     unavailable = lambda why: Tier1Report(available=False, error=why)  # noqa: E731
     if shutil.which(SCANNER_BIN) is None:
-        return unavailable("scanner not on PATH")
+        return _run_skillspector(skill_dir, timeout)
     with tempfile.TemporaryDirectory(prefix="se-tier1-") as outdir:
         try:
             subprocess.run([SCANNER_BIN, "validate", str(skill_dir), "--checks", TIER1_CHECKS, "--no-dedup",
                             "-r", "json", "-o", outdir], capture_output=True, text=True, encoding="utf-8", errors="replace",
                            stdin=subprocess.DEVNULL, timeout=timeout)
         except subprocess.TimeoutExpired:
-            return unavailable(f"scan timed out after {timeout}s")
+            return _run_skillspector(skill_dir, timeout)
         except OSError as exc:
-            return unavailable(f"scanner failed to launch: {exc}")
+            fallback = _run_skillspector(skill_dir, timeout)
+            return fallback if fallback.available else unavailable(f"scanner failed to launch: {exc}")
         if not (reports := sorted(Path(outdir).glob("skillevaluator-output-*.json"))):
-            return unavailable("scanner produced no JSON report")
+            return _run_skillspector(skill_dir, timeout)
         try:
             parsed = json.loads(reports[-1].read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as exc:
             return unavailable(f"unparseable report: {exc}")
-        return _parse_report(parsed) if isinstance(parsed, dict) else unavailable("unexpected report shape")
+        if not isinstance(parsed, dict):
+            return unavailable("unexpected report shape")
+        report = _parse_report(parsed)
+        if "Security Scan" in report.incomplete_checks:
+            security = _run_skillspector(skill_dir, timeout)
+            if security.available:
+                return _merge_security_report(report, security)
+        return report
 
 
 def format_tier1_report(report: Tier1Report, limit: int = 10) -> str:
@@ -125,9 +310,18 @@ def format_tier1_report(report: Tier1Report, limit: int = 10) -> str:
     if not report.available:
         return ""
     lines: List[str] = []
+    if "skillspector" in report.scanner:
+        lines.append(
+            "SkillSpector static: "
+            f"risk={report.risk_severity or 'unknown'} score={report.risk_score:g} "
+            f"recommendation={report.recommendation or 'unknown'} "
+            f"complete={'yes' if report.analysis_complete else 'no'} "
+            f"suppressed={report.suppressed_count}"
+        )
     if not report.findings:
-        lines.append("SkillEvaluator Tier 1: no findings from completed checks." if report.incomplete_checks
-                     else "SkillEvaluator Tier 1: no findings.")
+        label = "External static scan" if report.scanner == "skillspector" else "SkillEvaluator Tier 1"
+        lines.append(f"{label}: no findings from completed checks." if report.incomplete_checks
+                     else f"{label}: no findings.")
     else:
         lines.append(f"SkillEvaluator Tier 1 (advisory): {len(report.findings)} finding(s) — informational, "
                      "verify before relying on this skill.")

--- a/tools/skillevaluator_scan.py
+++ b/tools/skillevaluator_scan.py
@@ -160,7 +160,8 @@ def _parse_report(report: dict) -> Tier1Report:
         findings.extend(Tier1Finding(
             check=str(f.get("check_name", "")), validator=validator, severity=str(f.get("severity", "info")).lower(),
             message=str(f.get("message", ""))[:200], file=str(f.get("file_path", "")),
-            line=int(f.get("line_number") or 0), suggestion=str(f.get("suggestion", ""))[:200])
+            line=int(f.get("line_number") or 0), suggestion=str(f.get("suggestion", ""))[:200],
+            scanner="skillspector" if validator.casefold() == "security scan" else "skillevaluator")
             for f in res.get("findings", []) or [] if isinstance(f, dict))
     return Tier1Report(available=True, passed=not failed and not findings, findings=findings,
                        incomplete_checks=incomplete)
@@ -215,14 +216,7 @@ def _parse_skillspector_report(report: dict) -> Tier1Report:
 
 def _configured_baseline() -> str:
     """Return the operator-controlled SkillSpector baseline path, if configured."""
-    try:
-        from hermes_cli.config import load_config
-        security = load_config().get("security") or {}
-        scanner = security.get("external_scanner") or {} if isinstance(security, dict) else {}
-        value = scanner.get("baseline", "") if isinstance(scanner, dict) else ""
-        return str(value).strip()
-    except Exception:
-        return ""
+    return str(_external_scanner_config().get("baseline", "")).strip()
 
 
 def _run_skillspector(skill_dir: Path, timeout: int) -> Tier1Report:
@@ -285,7 +279,7 @@ def run_tier1_scan(skill_dir: Path, timeout: int = SCAN_TIMEOUT_SECONDS) -> Tier
                             "-r", "json", "-o", outdir], capture_output=True, text=True, encoding="utf-8", errors="replace",
                            stdin=subprocess.DEVNULL, timeout=timeout)
         except subprocess.TimeoutExpired:
-            return _run_skillspector(skill_dir, timeout)
+            return unavailable(f"scan timed out after {timeout}s")
         except OSError as exc:
             fallback = _run_skillspector(skill_dir, timeout)
             return fallback if fallback.available else unavailable(f"scanner failed to launch: {exc}")


### PR DESCRIPTION
## Summary

- add a bounded external security-scan adapter around NVIDIA SkillEvaluator and SkillSpector
- run SkillEvaluator hygiene checks and direct SkillSpector security exactly once within one total timeout budget
- preserve raw severity, recommendation, completeness, suppression, and scanner provenance
- keep the default policy report-only; optional `block_high` blocks unsuppressed high/critical SkillSpector findings
- extend opt-in second-opinion scanning to skill quarantine, plugin installs, MCP manifests, and MCP source before bootstrap
- keep Hermes' native guards primary and external scanner failures fail-open unless explicitly configured otherwise

## Review hardening

- fixed SkillEvaluator `Security Scan` provenance so high/critical findings cannot bypass `block_high`
- removed the incompatible nested SkillEvaluator security invocation for SkillSpector 2.11
- use one deadline and reserve most of the budget for the security scan
- deduplicate merged findings defensively
- centralize non-skill surface evaluation and config parsing
- normalize boolean config values, including false-like strings
- use operator-controlled baselines only

## Policy defaults

```yaml
security:
  external_scanner:
    mode: report
    fail_on_incomplete: false
    scan_plugins: false
    scan_mcp: false
    baseline: ""
    scan_timeout_seconds: 120
```

The CLI/dashboard can opt into plugin and MCP scans. LLM analysis is never enabled by this integration.

## Verification

- `210 passed, 4 skipped` across scanner, plugin guard, MCP catalog, and config suites
- Ruff passed on all changed Python files
- Python compile and `git diff --check` passed
- exercised real local SkillSpector 2.11 paths for a pinned Ponytail skill, curated plugin bundle, and an MCP manifest tree

The complete repository suite still requires the project's optional test/runtime dependency set; a bare temporary pytest environment cannot collect modules such as `aiohttp`.
