### PR TITLE
feat(kanban): show timestamped current-attempt runtime budget

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3730,13 +3730,16 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     attachments, prior attempts, done-parent handoffs, the assignee's recent
     work, comments. Lists are tail-capped and fields char-capped
     (``_CTX_MAX_*``) so the prompt stays bounded on pathological boards."""
+    from hermes_cli.kanban_runtime_budget import format_runtime_budget, runtime_budget_snapshot
+
     task = get_task(conn, task_id)
     if not task:
         raise ValueError(f"unknown task {task_id}")
     # One clock reading so every relative age in this rendering agrees.
     now = int(time.time())
     lines: list[str] = []
-    _ctx_header(lines, task)
+    budget = runtime_budget_snapshot(conn, task_id, observed_at=now)
+    _ctx_header(lines, task, budget_line=format_runtime_budget(budget))
     _ctx_attachments(lines, list_attachments(conn, task_id))
     _ctx_prior_attempts(lines, conn, task_id, now)
     _ctx_parent_results(lines, conn, task_id, now)
@@ -3782,7 +3785,7 @@ def _ctx_tail(items: list, cap: int, noun: str) -> tuple[list, Optional[str]]:
     )
 
 
-def _ctx_header(lines: list[str], task: Task) -> None:
+def _ctx_header(lines: list[str], task: Task, *, budget_line: str = "") -> None:
     lines.append(f"# Kanban task {task.id}: {task.title}")
     lines.append("")
     lines.append(f"Assignee: {task.assignee or '(unassigned)'}")
@@ -3800,6 +3803,8 @@ def _ctx_header(lines: list[str], task: Task) -> None:
             lines.append(f"Terminal timeout: {effective_terminal_timeout}s")
     if task.branch_name:
         lines.append(f"Branch:   {task.branch_name}")
+    if budget_line:
+        lines.append(budget_line)
     lines.append("")
     if task.body and task.body.strip():
         lines.append("## Body")

--- a/hermes_cli/kanban_runtime_budget.py
+++ b/hermes_cli/kanban_runtime_budget.py
@@ -1,0 +1,86 @@
+"""Read-only, timestamped views of the existing per-attempt runtime limit.
+
+These snapshots neither renew claims nor authorize more work. The dispatcher
+still owns hard enforcement; other limits apply even without a per-task cap.
+"""
+
+from dataclasses import dataclass, replace
+import sqlite3
+import time
+
+
+@dataclass(frozen=True)
+class RuntimeBudget:
+    task_id: str
+    run_id: int | None
+    observed_at: int
+    state: str
+    limit_seconds: int | None = None
+    started_at: int | None = None
+    start_basis: str | None = None
+    deadline_at: int | None = None
+    elapsed_seconds: int | None = None
+    remaining_seconds: int | None = None
+    reason: str = ""
+
+
+def runtime_budget_snapshot(
+    conn: sqlite3.Connection, task_id: str, *, observed_at: int,
+) -> RuntimeBudget:
+    """Use one joined read and the caller's clock, never a new policy/default.
+
+    Match enforcement's current run start, task-start fallback and task cap.
+    A stale/cross-task run or invalid clock is reported unknown, not silently
+    presented as permission to continue. No board or runtime state is written.
+    """
+    row = conn.execute(
+        "SELECT t.status, t.current_run_id, t.max_runtime_seconds, t.started_at, "
+        "r.task_id, r.started_at, r.ended_at FROM tasks t "
+        "LEFT JOIN task_runs r ON r.id = t.current_run_id WHERE t.id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        raise ValueError(f"unknown task {task_id}")
+    status, run_id, limit, task_start, run_task, run_start, run_end = row
+    result = RuntimeBudget(task_id, run_id, observed_at, "unknown")
+    if status != "running":
+        return replace(result, state="not_running", reason="no running attempt")
+    if run_task is not None and (run_task != task_id or run_end is not None):
+        return replace(result, reason="current run binding is inconsistent")
+    if limit is None:
+        return replace(result, state="unbounded", reason="no per-task runtime cap; other limits still apply")
+    start = run_start if run_start is not None else task_start
+    if start is None:
+        return replace(result, reason="attempt start is unavailable")
+    try:
+        limit, start = int(limit), int(start)
+    except (TypeError, ValueError, OverflowError):
+        return replace(result, reason="invalid runtime cap or start")
+    basis = "current_run" if run_start is not None else "task_fallback"
+    result = replace(result, limit_seconds=limit, started_at=start, start_basis=basis)
+    if start > observed_at:
+        return replace(result, reason="observation clock precedes attempt start")
+    deadline = start + limit
+    return replace(
+        result, state="active" if observed_at < deadline else "exhausted",
+        deadline_at=deadline, elapsed_seconds=observed_at - start,
+        remaining_seconds=max(0, deadline - observed_at),
+    )
+
+
+def _utc(timestamp: int) -> str:
+    try:
+        return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(timestamp))
+    except (OverflowError, OSError, ValueError):
+        return f"{timestamp} Unix seconds"
+
+
+def format_runtime_budget(snapshot: RuntimeBudget) -> str:
+    """A snapshot label prevents old context from posing as a live countdown."""
+    prefix = (f"Runtime budget snapshot: observed={_utc(snapshot.observed_at)}; "
+              f"run={snapshot.run_id}; state={snapshot.state}")
+    if snapshot.remaining_seconds is None:
+        return f"{prefix}; {snapshot.reason}."
+    return (f"{prefix}; {snapshot.remaining_seconds}s remaining; "
+            f"deadline={_utc(snapshot.deadline_at)}; elapsed={snapshot.elapsed_seconds}s; "
+            f"cap={snapshot.limit_seconds}s; start_basis={snapshot.start_basis}.")

--- a/tests/hermes_cli/test_kanban_runtime_budget.py
+++ b/tests/hermes_cli/test_kanban_runtime_budget.py
@@ -1,0 +1,119 @@
+"""Budget displays are read-only snapshots of the existing attempt deadline."""
+
+import os
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+
+
+@pytest.fixture
+def attempt(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    with closing(kbc.connect()) as conn:
+        tid = kb.create_task(conn, title="Budget example", assignee="worker",
+                             body="Preserve the ordinary task body.",
+                             max_runtime_seconds=120)
+        assert kb.claim_task(conn, tid) is not None
+        run_id = kb.get_task(conn, tid).current_run_id
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET started_at=1000 WHERE id=?", (tid,))
+            conn.execute("UPDATE task_runs SET started_at=2000 WHERE id=?", (run_id,))
+        yield conn, tid, run_id
+
+
+@pytest.mark.parametrize(
+    "changes,state,remaining,basis",
+    [
+        ({}, "active", 70, "current_run"),
+        ({"now": 2120}, "exhausted", 0, "current_run"),
+        ({"now": 2150}, "exhausted", 0, "current_run"),
+        ({"cap": 0}, "exhausted", 0, "current_run"),
+        ({"cap": -1}, "exhausted", 0, "current_run"),
+        ({"cap": None}, "unbounded", None, None),
+        ({"status": "ready"}, "not_running", None, None),
+        ({"status": "done"}, "not_running", None, None),
+        ({"run": None, "task_start": 2000}, "active", 70, "task_fallback"),
+        ({"run": 999999, "task_start": 2000}, "active", 70, "task_fallback"),
+        ({"run": None, "task_start": None}, "unknown", None, None),
+        ({"run_start": "invalid"}, "unknown", None, None),
+        ({"cap": "invalid"}, "unknown", None, None),
+        ({"now": 1999}, "unknown", None, "current_run"),
+        ({"ended": 2020}, "unknown", None, None),
+        ({"foreign_run": True}, "unknown", None, None),
+    ],
+)
+def test_snapshot_matches_attempt_without_mutating(attempt, changes, state, remaining, basis):
+    from hermes_cli.kanban_runtime_budget import runtime_budget_snapshot
+
+    conn, tid, run_id = attempt
+    other_task = (kb.create_task(conn, title="Other fixture", assignee="worker")
+                  if changes.get("foreign_run") else None)
+    task_columns = {"cap": "max_runtime_seconds", "status": "status",
+                    "run": "current_run_id", "task_start": "started_at"}
+    with kb.write_txn(conn):
+        for key, column in task_columns.items():
+            if key in changes:
+                conn.execute(f"UPDATE tasks SET {column}=? WHERE id=?", (changes[key], tid))
+        if "run_start" in changes:
+            conn.execute("UPDATE task_runs SET started_at=? WHERE id=?", (changes["run_start"], run_id))
+        if "ended" in changes:
+            conn.execute("UPDATE task_runs SET ended_at=? WHERE id=?", (changes["ended"], run_id))
+        if changes.get("foreign_run"):
+            # Deliberately corrupt only the disposable fixture's run binding.
+            conn.execute("UPDATE task_runs SET task_id=? WHERE id=?", (other_task, run_id))
+    before = list(conn.iterdump())
+    snapshot = runtime_budget_snapshot(conn, tid, observed_at=changes.get("now", 2050))
+    assert snapshot.state == state
+    assert snapshot.remaining_seconds == remaining
+    assert snapshot.start_basis == basis
+    assert snapshot.task_id == tid
+    if state in {"active", "exhausted"}:
+        assert snapshot.deadline_at == snapshot.started_at + snapshot.limit_seconds
+        assert snapshot.elapsed_seconds == snapshot.observed_at - snapshot.started_at
+        assert remaining == max(0, snapshot.deadline_at - snapshot.observed_at)
+    assert list(conn.iterdump()) == before
+    with pytest.raises(ValueError, match="unknown task"):
+        runtime_budget_snapshot(conn, "missing-task", observed_at=2050)
+
+
+def test_context_snapshot_and_heartbeat_preserve_hard_cutoff(attempt, monkeypatch):
+    conn, tid, run_id = attempt
+    calls = []
+
+    def clock():
+        calls.append(2050)
+        return 2050
+
+    with monkeypatch.context() as frozen:
+        frozen.setattr(kb.time, "time", clock)
+        context = kb.build_worker_context(conn, tid)
+        assert len(calls) == 1
+    assert "Runtime budget snapshot:" in context
+    assert "70s remaining" in context
+    assert f"run={run_id}" in context
+    assert "1970-01-01T00:35:20Z" in context  # 2000 + 120, not original task start.
+    assert "Max runtime: 120s" in context
+    assert "Preserve the ordinary task body." in context
+
+    from hermes_cli.kanban_runtime_budget import runtime_budget_snapshot
+
+    before = runtime_budget_snapshot(conn, tid, observed_at=2050)
+    monkeypatch.setattr(kb.time, "time", lambda: 2050)
+    assert kb.heartbeat_claim(conn, tid, ttl_seconds=600)
+    assert runtime_budget_snapshot(conn, tid, observed_at=2050) == before
+    kbd._set_worker_pid(conn, tid, os.getpid())
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+    signals = []
+    assert kbd.enforce_max_runtime(conn, signal_fn=lambda *args: signals.append(args)) == []
+    assert signals == []
+    monkeypatch.setattr(kb.time, "time", lambda: before.deadline_at)
+    assert kbd.enforce_max_runtime(conn, signal_fn=lambda *args: signals.append(args)) == [tid]
+    assert signals
+    event = next(e for e in kb.list_events(conn, tid) if e.kind == "timed_out")
+    assert event.payload["elapsed_seconds"] == event.payload["limit_seconds"] == 120


### PR DESCRIPTION
## What does this PR do?

Adds a timestamped, read-only runtime-budget snapshot to Kanban worker context. The worker can see the current attempt's deadline and remaining seconds at context creation, instead of inferring a fresh retry's budget from historical task age.

This is a snapshot, not a continuously updating countdown or a new budget policy. It does not extend runtime, renew claims, change retries, or alter timeout enforcement.

## Related Issue

No closing issue. Related but distinct from #80320, which concerns iteration-exhaustion notifications and late finalizers; this change only exposes current-attempt wall-clock budget in worker context. Searched open and closed PRs/issues for runtime-budget and Kanban remaining-runtime overlap.

## Type of Change

- [x] New feature (additive context information)

## Changes Made

- New stdlib-only `hermes_cli/kanban_runtime_budget.py` derives a snapshot from existing task/current-run records, following the enforcer's start/cap calculation.
- Minimal `build_worker_context` / `_ctx_header` wiring reuses the existing observation clock and retains the task body.
- New tests cover retries, boundaries, invalid/missing timing, inconsistent run bindings, no database mutation, and unchanged hard cutoff after heartbeat renewal.
- No changes to dispatch, respawn guards, schemas, configuration, dependencies, or live installations.

## How to Test

On Linux, with the project test environment available:

```sh
scripts/run_tests.sh -j 1 --file-retries 0 tests/hermes_cli/test_kanban_runtime_budget.py tests/hermes_cli/test_kanban_core_functionality.py tests/plugins/test_kanban_attachments.py
```

Result: **50 passed, 0 failed** (17 new budget cases, 24 existing core tests, 9 attachment/context tests). The new context integration test failed on the unmodified base because the snapshot was absent. It passes on this candidate using real temporary SQLite fixtures and a frozen clock. Example: attempt start 2000, cap 120, observation 2050 yields 70 seconds remaining and deadline 2120; claim heartbeat does not move that deadline.

Independent cross-vendor source review approved the same source tree and separately exercised the new suite, existing database/context tests, attachment tests, and timeout-focused tests. This is not upstream maintainer approval.

## Checklist and limits

- [x] Contributing guide read; conventional commit; duplicate search performed; one focused change.
- [x] Regression tests added and selected tests passed on Linux.
- [x] `git diff --check` passed.
- [x] Cross-platform impact considered: stdlib SQL/arithmetic/formatting only, no new process or filesystem operations.
- [x] Configuration, schema, tool schemas and dependency documentation: not applicable.
- [ ] Full repository suite: not run.
- [ ] Ruff/lint: unavailable in the existing test environment; not installed for this patch.
- [ ] Manual live-worker deployment: intentionally not performed.

Residual limitation: budget derivation parallels the enforcer; the integration test pins their shared deadline boundary. Unknown inputs are labelled unknown, and no per-task cap is explicitly distinguished from freedom from all other limits.
