### PR TITLE
fix(dashboard): recognize sleep/resume idle in loop-heartbeat drift

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1298,7 +1298,11 @@ def _on_server_started(
     def _loop_heartbeat(expected: float) -> None:
         now = _hb_loop.time()
         drift = now - expected
-        if drift > _hb_stall_threshold:
+        # Sleep/resume: drift >> expected -> idle log + reanchor, not GIL stall.
+        # Real stalls (seconds-scale) surface correctly.
+        if drift > _hb_interval * 10:
+            _log.info("event loop idle %.1fs during sleep", drift)
+        elif drift > _hb_stall_threshold:
             _log.warning("event loop stalled %.1fs (GIL pressure suspected)", drift)
         _hb_loop.call_later(_hb_interval, _loop_heartbeat, now + _hb_interval)
 


### PR DESCRIPTION
## Problem

The loop-heartbeat watchdog (`hermes_cli/web_server.py:1298-1307`) attributes the entire sleep window to a "GIL stall" on resume. Six sleep windows verified (System event log Id 42/1) matched reported drift durations 1:1 to the second — see #105074 for full details.

This defeats the watchdog's stated purpose ("a stalled-loop WS drop is diagnosable from the log"): real seconds-scale stalls are drowned by resume artifacts.

## Fix

Mirrors the pattern from PR #100214 (power_management.py):

- Drift far exceeding tick interval (`drift > _hb_interval * 10`) → `INFO` line `event loop idle Ns during sleep` (instead of false `WARNING`).
- Real stalls (seconds-scale, e.g. #83208's 83.9s) still surface correctly via the existing `elif drift > _hb_stall_threshold` branch.

Minimal, cross-platform, no new deps.

## Testing

- AST parse + minimal smoke test pass.
- Full sleep/resume verification is on the reporter (Windows 11).

Fixes #105074.