### PR TITLE
fix(tui): prevent background completion queue starvation

### DIFF
--- a/tests/tui_gateway/test_notification_queue_routing.py
+++ b/tests/tui_gateway/test_notification_queue_routing.py
@@ -1,0 +1,128 @@
+"""Regression coverage for session-targeted background completion dequeue."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Callable
+
+from tools.process_registry import _NotificationQueue, process_registry
+from tui_gateway import server
+
+
+class _StopAfterOnePoll:
+    def __init__(self) -> None:
+        self._checks = 0
+
+    def is_set(self) -> bool:
+        self._checks += 1
+        return self._checks > 1
+
+
+class _InstrumentedQueue:
+    def __init__(self, events: list[dict]) -> None:
+        self.events = list(events)
+        self.get_calls = 0
+        self.matching_calls = 0
+
+    def get(self, timeout: float | None = None) -> dict:
+        self.get_calls += 1
+        raise queue.Empty
+
+    def get_matching(
+        self,
+        predicate: Callable[[dict], bool],
+        timeout: float | None = None,
+    ) -> dict:
+        self.matching_calls += 1
+        for index, event in enumerate(self.events):
+            if predicate(event):
+                return self.events.pop(index)
+        raise queue.Empty
+
+    def get_nowait(self) -> dict:
+        if not self.events:
+            raise queue.Empty
+        return self.events.pop(0)
+
+    def put(self, event: dict) -> None:
+        self.events.append(event)
+
+    def empty(self) -> bool:
+        return not self.events
+
+
+def _session(session_key: str) -> dict:
+    return {
+        "session_key": session_key,
+        "history_lock": threading.Lock(),
+        "running": False,
+        "_finalized": False,
+    }
+
+
+def test_notification_queue_removes_only_the_matching_event() -> None:
+    routed_queue = _NotificationQueue()
+    foreign = {"session_key": "foreign"}
+    owned = {"session_key": "owned"}
+    routed_queue.put(foreign)
+    routed_queue.put(owned)
+
+    assert (
+        routed_queue.get_matching(
+            lambda event: event.get("session_key") == "owned", timeout=0
+        )
+        is owned
+    )
+    assert routed_queue.get_nowait() is foreign
+
+
+def test_notification_poller_dequeues_its_event_without_rotating_foreign_event(
+    monkeypatch,
+) -> None:
+    foreign = {
+        "type": "completion",
+        "session_id": "proc-foreign",
+        "session_key": "foreign-key",
+        "command": "sleep 1",
+        "exit_code": 0,
+        "output": "foreign",
+    }
+    owned = {
+        "type": "completion",
+        "session_id": "proc-owned",
+        "session_key": "owned-key",
+        "command": "sleep 1",
+        "exit_code": 0,
+        "output": "owned",
+    }
+    routed_queue = _InstrumentedQueue([foreign, owned])
+    owner = _session("owned-key")
+    other = _session("foreign-key")
+    delivered: list[str] = []
+
+    monkeypatch.setattr(process_registry, "completion_queue", routed_queue)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text, **_kwargs: delivered.append(text),
+    )
+    server._sessions.update({"owner-sid": owner, "foreign-sid": other})
+    process_registry._completion_consumed.discard("proc-owned")
+
+    try:
+        getattr(server, "_notification_poller_loop")(
+            _StopAfterOnePoll(), "owner-sid", owner
+        )
+
+        assert routed_queue.matching_calls == 1
+        assert routed_queue.get_calls == 0
+        assert len(delivered) == 1
+        assert "proc-owned completed normally" in delivered[0]
+        assert routed_queue.events == [foreign]
+    finally:
+        server._sessions.pop("owner-sid", None)
+        server._sessions.pop("foreign-sid", None)
+        process_registry._completion_consumed.discard("proc-owned")

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import platform
+import queue
 import shlex
 import signal
 import subprocess
@@ -26,7 +27,7 @@ _IS_LINUX = platform.system() == "Linux"
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from hermes_cli.config import get_hermes_home
 
@@ -34,6 +35,41 @@ from agent.redact import redact_sensitive_text
 from tools.process_registry_notifications import format_process_notification
 
 logger = logging.getLogger(__name__)
+
+
+class _NotificationQueue(queue.Queue):
+    """Queue supporting non-destructive dequeue by ownership predicate."""
+
+    def get_matching(
+        self,
+        predicate: Callable[[Any], bool],
+        timeout: float | None = None,
+    ) -> Any:
+        """Remove the first matching item without rotating unrelated events."""
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            with self.mutex:
+                candidates = tuple(self.queue)
+            for candidate in candidates:
+                try:
+                    matches = predicate(candidate)
+                except Exception:
+                    matches = False
+                if not matches:
+                    continue
+                with self.not_empty:
+                    for index, current in enumerate(self.queue):
+                        if current is candidate:
+                            del self.queue[index]
+                            self.not_full.notify()
+                            return current
+            if timeout == 0:
+                raise queue.Empty
+            remaining = None if deadline is None else deadline - time.monotonic()
+            if remaining is not None and remaining <= 0:
+                raise queue.Empty
+            with self.not_empty:
+                self.not_empty.wait(remaining)
 
 # Crash-recovery checkpoint (gateway only)
 CHECKPOINT_PATH = get_hermes_home() / "processes.json"
@@ -401,8 +437,7 @@ class ProcessRegistry:
         self.pending_watchers: List[Dict[str, Any]] = []
         # Unified queue for all background events (distinguished by "type"); the CLI
         # process_loop and the gateway drain it after each agent turn to trigger new turns.
-        import queue as _queue_mod
-        self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
+        self.completion_queue: _NotificationQueue = _NotificationQueue()
         # Rehydrate durable delegation completions once, at registry startup.
         try:
             from tools.async_delegation import restore_undelivered_completions

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -473,7 +473,20 @@ def _notification_poller_loop(stop_event: threading.Event, sid: str, session: di
             last_kanban_poll = now
             _notif_poll_kanban(sid, session)
         try:
-            evt = queue.get(timeout=0.5)
+            # Every live session has a poller on this shared queue. A destructive
+            # get lets unrelated pollers repeatedly steal/requeue an owner's event;
+            # targeted dequeue leaves it in place until its owner wakes.
+            get_matching = getattr(queue, "get_matching", None)
+            evt = (
+                get_matching(
+                    lambda candidate: not _notification_event_belongs_elsewhere(
+                        sid, session, candidate
+                    ),
+                    timeout=0.5,
+                )
+                if callable(get_matching)
+                else queue.get(timeout=0.5)
+            )
         except Exception:
             continue
         handle(evt, None)


### PR DESCRIPTION
## Summary

Desktop-remote sessions run one notification poller per live session over a shared completion queue. A poller previously used destructive `get()`, so unrelated sessions could repeatedly dequeue and requeue another session's completion, delaying or starving the owning session. This change adds ownership-targeted dequeue so foreign events remain in place and the correct session receives completion promptly.

---

## Changes

- `tools/process_registry.py`: add a queue implementation that removes the first event matching an ownership predicate without rotating unrelated events.
- `tui_gateway/session_notifications.py`: make each session poller dequeue only events it may own, retaining compatibility with plain queues used by tests.
- `tests/tui_gateway/test_notification_queue_routing.py`: add two regressions covering selective queue removal and end-to-end poller routing.

## How to Test

```bash
python -m pytest tests/tui_gateway/test_notification_queue_routing.py tests/tui_gateway/test_kanban_notify_poller.py tests/tui_gateway/test_heartbeat_tui_tick.py tests/tui_gateway/test_loop_command.py -q
# 31 passed

python -m pytest tests/test_tui_gateway_server.py -k 'notification_poller or completion_ownership' -q
# 13 passed, 624 deselected

python -m pytest tests/tools/test_process_registry.py -k 'drain_notifications' -q
# 3 passed, 104 deselected

ruff check tools/process_registry.py tui_gateway/session_notifications.py tests/tui_gateway/test_notification_queue_routing.py
# All checks passed!
```

The canonical `scripts/run_tests.sh` entrypoint could not launch per-file subprocesses in the Termux sandbox (`PermissionError(13)`), so no full-suite pass is claimed. A broader direct process-registry run also hit existing Termux live-signal/systemd assumptions; the focused notification and drain tests above pass.

## Checklist

- [x] Focused regressions pass
- [x] Regression demonstrated failure before the fix
- [x] Follows Conventional Commits
- [x] Changes scoped to completion routing only
- [x] Cross-platform footgun check passes
- [x] No configuration or public API changes

## Risk & Impact

Low. Existing queue producers and non-TUI consumers retain standard `Queue` behavior; only TUI/Desktop pollers use selective dequeue. Plain queue substitutes keep the legacy fallback path.

Overlap: #90954 preserves notifications whose owner is no longer live. This PR addresses a distinct live-session starvation path where unrelated pollers rotate an event before its owner can claim it.

Type: Bug fix

Closes #105043
