### PR TITLE
fix(tools): keep delivering remaining Telegram chunks after a timeout

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1821,3 +1821,82 @@ class TestSendTelegramThreadNotFoundRetry:
         finally:
             if media_path and os.path.exists(media_path):
                 os.unlink(media_path)
+
+
+class TestSendTelegramTimeoutChunkContinue:
+    """Timed-out text chunks must not abandon the rest of the sequence (#47229).
+
+    A timed-out chunk is ambiguous (it may already be delivered) so it is never
+    retried, but the chunks after it were never sent and carry no duplication
+    risk — they must still be delivered, with a partial-delivery warning."""
+
+    @staticmethod
+    def _three_chunk_message():
+        # >2x4096 UTF-16 units -> three text chunks.
+        return "x" * 9000
+
+    def test_timeout_mid_sequence_delivers_remaining_chunks(self):
+        """Chunk 2 of 3 times out: chunks 1 and 3 still deliver; result is a
+        partial success naming the skipped chunk."""
+        sent = []
+
+        async def fake_retry(bot, *, chat_id, text, parse_mode, **kwargs):
+            sent.append(text)
+            if len(sent) == 2:
+                raise Exception("Timed out")
+            return SimpleNamespace(message_id=len(sent))
+
+        async def run_test():
+            with patch("tools.send_message_senders._send_telegram_message_with_retry", fake_retry):
+                return await _send_telegram("fake-token", "-100123", self._three_chunk_message())
+
+        result = asyncio.run(run_test())
+        assert result["success"] is True, result
+        assert len(sent) == 3, f"expected all 3 chunks attempted, got {len(sent)}"
+        assert result["message_id"] == "3"
+        partial_warnings = [w for w in result.get("warnings", []) if "delivery partial" in w.lower()]
+        assert partial_warnings, f"expected a partial-delivery warning, got {result.get('warnings')}"
+        assert "2/3" in partial_warnings[0]
+        assert "chunk(s) 2" in partial_warnings[0]
+
+    def test_non_timeout_error_still_fails_whole_send(self):
+        """Non-timeout errors keep the original fail-fast behaviour: no
+        per-chunk skip, nothing delivered after the failing chunk."""
+        sent = []
+
+        async def fake_retry(bot, *, chat_id, text, parse_mode, **kwargs):
+            sent.append(text)
+            if len(sent) == 2:
+                raise Exception("Connection reset by peer")
+            return SimpleNamespace(message_id=len(sent))
+
+        async def run_test():
+            with patch("tools.send_message_senders._send_telegram_message_with_retry", fake_retry):
+                return await _send_telegram("fake-token", "-100123", self._three_chunk_message())
+
+        result = asyncio.run(run_test())
+        assert result.get("success") is not True, result
+        assert "error" in result
+        assert len(sent) == 2, f"send should stop at the failing chunk, got {len(sent)} attempts"
+
+    def test_all_chunks_timeout_reports_unknown_state(self):
+        """When every chunk times out the error must say delivery state is
+        unknown — not the misleading 'No deliverable text'."""
+        sent = []
+
+        async def fake_retry(bot, *, chat_id, text, parse_mode, **kwargs):
+            sent.append(text)
+            raise Exception("Timed out")
+
+        async def run_test():
+            with patch("tools.send_message_senders._send_telegram_message_with_retry", fake_retry):
+                return await _send_telegram("fake-token", "-100123", self._three_chunk_message())
+
+        result = asyncio.run(run_test())
+        assert result.get("success") is not True, result
+        assert "error" in result
+        assert "timed out" in result["error"].lower()
+        assert "unknown" in result["error"].lower()
+        assert "no deliverable" not in result["error"].lower()
+        # All three chunks were still attempted (each one is ambiguous).
+        assert len(sent) == 3

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1900,3 +1900,110 @@ class TestSendTelegramTimeoutChunkContinue:
         assert "no deliverable" not in result["error"].lower()
         # All three chunks were still attempted (each one is ambiguous).
         assert len(sent) == 3
+
+    def test_first_chunk_timeout_delivers_remaining(self):
+        """Chunk 1 of 3 times out: chunks 2 and 3 still deliver."""
+        sent = []
+
+        async def fake_retry(bot, *, chat_id, text, parse_mode, **kwargs):
+            sent.append(text)
+            if len(sent) == 1:
+                raise Exception("Timed out")
+            return SimpleNamespace(message_id=len(sent))
+
+        async def run_test():
+            with patch("tools.send_message_senders._send_telegram_message_with_retry", fake_retry):
+                return await _send_telegram("fake-token", "-100123", self._three_chunk_message())
+
+        result = asyncio.run(run_test())
+        assert result["success"] is True, result
+        assert len(sent) == 3, f"expected all 3 chunks attempted, got {len(sent)}"
+        assert result["message_id"] == "3"
+        partial_warnings = [w for w in result.get("warnings", []) if "delivery partial" in w.lower()]
+        assert partial_warnings, f"expected a partial-delivery warning, got {result.get('warnings')}"
+        assert "chunk(s) 1" in partial_warnings[0]
+
+    def test_last_chunk_timeout_delivers_prior(self):
+        """Chunk 3 of 3 times out: chunks 1 and 2 still deliver."""
+        sent = []
+
+        async def fake_retry(bot, *, chat_id, text, parse_mode, **kwargs):
+            sent.append(text)
+            if len(sent) == 3:
+                raise Exception("Timed out")
+            return SimpleNamespace(message_id=len(sent))
+
+        async def run_test():
+            with patch("tools.send_message_senders._send_telegram_message_with_retry", fake_retry):
+                return await _send_telegram("fake-token", "-100123", self._three_chunk_message())
+
+        result = asyncio.run(run_test())
+        assert result["success"] is True, result
+        assert len(sent) == 3, f"expected all 3 chunks attempted, got {len(sent)}"
+        assert result["message_id"] == "2"
+        partial_warnings = [w for w in result.get("warnings", []) if "delivery partial" in w.lower()]
+        assert partial_warnings, f"expected a partial-delivery warning, got {result.get('warnings')}"
+        assert "chunk(s) 3" in partial_warnings[0]
+
+    def test_single_chunk_timeout_reports_unknown(self):
+        """A single-chunk message that times out must report unknown state."""
+        sent = []
+
+        async def fake_retry(bot, *, chat_id, text, parse_mode, **kwargs):
+            sent.append(text)
+            raise Exception("Timed out")
+
+        async def run_test():
+            with patch("tools.send_message_senders._send_telegram_message_with_retry", fake_retry):
+                return await _send_telegram("fake-token", "-100123", "hello")
+
+        result = asyncio.run(run_test())
+        assert result.get("success") is not True, result
+        assert "error" in result
+        assert "timed out" in result["error"].lower()
+        assert "unknown" in result["error"].lower()
+        assert "no deliverable" not in result["error"].lower()
+        assert len(sent) == 1
+
+    def test_multiple_non_consecutive_timeouts(self):
+        """Chunks 1 and 3 time out, chunk 2 delivers — partial success."""
+        sent = []
+
+        async def fake_retry(bot, *, chat_id, text, parse_mode, **kwargs):
+            sent.append(text)
+            if len(sent) in (1, 3):
+                raise Exception("Timed out")
+            return SimpleNamespace(message_id=len(sent))
+
+        async def run_test():
+            with patch("tools.send_message_senders._send_telegram_message_with_retry", fake_retry):
+                return await _send_telegram("fake-token", "-100123", self._three_chunk_message())
+
+        result = asyncio.run(run_test())
+        assert result["success"] is True, result
+        assert len(sent) == 3, f"expected all 3 chunks attempted, got {len(sent)}"
+        assert result["message_id"] == "2"
+        partial_warnings = [w for w in result.get("warnings", []) if "delivery partial" in w.lower()]
+        assert partial_warnings, f"expected a partial-delivery warning, got {result.get('warnings')}"
+        assert "chunk(s) 1, 3" in partial_warnings[0]
+
+    def test_timeout_then_non_timeout_error_propagates(self):
+        """Chunk 1 times out, chunk 2 raises non-timeout → error propagates."""
+        sent = []
+
+        async def fake_retry(bot, *, chat_id, text, parse_mode, **kwargs):
+            sent.append(text)
+            if len(sent) == 1:
+                raise Exception("Timed out")
+            if len(sent) == 2:
+                raise Exception("Connection reset by peer")
+            return SimpleNamespace(message_id=len(sent))
+
+        async def run_test():
+            with patch("tools.send_message_senders._send_telegram_message_with_retry", fake_retry):
+                return await _send_telegram("fake-token", "-100123", self._three_chunk_message())
+
+        result = asyncio.run(run_test())
+        assert result.get("success") is not True, result
+        assert "error" in result
+        assert len(sent) == 2, f"send should stop at the non-timeout error, got {len(sent)} attempts"

--- a/tools/send_message_senders.py
+++ b/tools/send_message_senders.py
@@ -66,6 +66,14 @@ _TELEGRAM_TRANSIENT_MARKERS = ("bad gateway", "502", "too many requests", "429",
                                "gateway timeout", "504")
 
 
+def _is_telegram_timeout(exc: Exception) -> bool:
+    """``True`` for transport timeouts (e.g. python-telegram-bot's ``TimedOut``). A timed-out
+    send is ambiguous — it may already have been delivered — so it is never retried;
+    chunked sequences skip that chunk instead of abandoning the chunks after it (#47229)."""
+    text = str(exc).lower()
+    return "timed out" in text or "timeout" in text
+
+
 def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
     """Retry delay in seconds, or None when final: honours ``retry_after``; timeouts are
     never retried (the send may have gone through); 5xx/429 back off exponentially."""
@@ -76,7 +84,7 @@ def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
         except (TypeError, ValueError):
             return 1.0
     text = str(exc).lower()
-    if "timed out" in text or "timeout" in text:
+    if _is_telegram_timeout(exc):
         return None
     return float(2 ** attempt) if any(marker in text for marker in _TELEGRAM_TRANSIENT_MARKERS) else None
 
@@ -257,8 +265,24 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         if _cap is not None and utf16_len(formatted) <= _TELEGRAM_CAPTION_LIMIT:
             _tg_caption, formatted = formatted, ""  # suppress the separate text send below
         # Chunk *after* formatting, in UTF-16 units: escaping can push a raw-<4096 message over.
-        for chunk in BasePlatformAdapter.truncate_message(formatted, 4096, len_fn=utf16_len) if formatted.strip() else ():
-            last_msg = await _telegram_send_text_chunk(bot, int_chat_id, chunk, send_parse_mode, _has_html, text_kwargs)
+        chunks = list(BasePlatformAdapter.truncate_message(formatted, 4096, len_fn=utf16_len)) if formatted.strip() else []
+        timed_out_chunks = []
+        for chunk_index, chunk in enumerate(chunks, start=1):
+            try:
+                last_msg = await _telegram_send_text_chunk(bot, int_chat_id, chunk, send_parse_mode, _has_html, text_kwargs)
+            except Exception as exc:
+                # A timed-out chunk may already be delivered, so it is never retried — but the
+                # chunks after it were never sent and carry no duplication risk: skip only the
+                # ambiguous chunk and keep delivering the rest (#47229).
+                if not _is_telegram_timeout(exc):
+                    raise
+                timed_out_chunks.append(chunk_index)
+                logger.warning("Telegram chunk %d/%d timed out (may still have been delivered); delivering remaining chunks",
+                               chunk_index, len(chunks))
+        if timed_out_chunks:
+            warnings.append(f"Delivery partial: {len(chunks) - len(timed_out_chunks)}/{len(chunks)} text chunks "
+                            f"confirmed; chunk(s) {', '.join(str(i) for i in timed_out_chunks)} timed out and were "
+                            "skipped (they may still arrive out of order)")
         for media_path, is_voice in media_files:
             if not os.path.exists(media_path):
                 warnings.append(f"Media file not found, skipping: {media_path}")
@@ -281,6 +305,12 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 warnings.append(_sanitize_error_text(f"Failed to send media {media_path}: {e}"))
                 logger.error(warnings[-1])
         if last_msg is None:
+            if timed_out_chunks:
+                result = _error(f"Telegram send timed out on all {len(chunks)} text chunks "
+                                "(delivery state unknown; timed-out chunks are never retried)")
+                if warnings:
+                    result["warnings"] = warnings
+                return result
             return {"error": _NO_DELIVERABLE, **({"warnings": warnings} if warnings else {})}
         return _success("telegram", chat_id, warnings, message_id=str(last_msg.message_id))
     except ImportError:


### PR DESCRIPTION
## What does this PR do?

`_send_telegram` sends long messages as 4096-unit chunks in a bare loop. When chunk *N* of *M* hits a transport timeout, the loop `raise`s straight into the outer catch-all and the whole send is reported as failed — even though:

- chunks `1…N-1` are already delivered and stay in the channel;
- chunk *N* is ambiguous (it may have gone through) and is correctly **never retried** — the anti-duplication rule in `_telegram_retry_delay` is right;
- chunks `N+1…M` were **never sent** and carry **zero** duplication risk, yet they are silently abandoned.

So the never-retry-a-timeout guard quietly escalates from "don't resend this chunk" to "don't deliver the rest of the document" (sequencing analysis by @olopez25 in the issue). This PR keeps the guard intact and fixes the escalation: a timed-out chunk is skipped, the remaining chunks are still delivered, and the result carries a `Delivery partial` warning naming the confirmed and skipped chunks. When *every* text chunk times out, the error now says delivery state is unknown instead of the misleading `No deliverable text or media remained after processing MEDIA tags`. Non-timeout errors keep the original fail-fast behaviour, and the media loop's per-item tolerance is unchanged.

Timeout detection is extracted into `_is_telegram_timeout`, shared with `_telegram_retry_delay`, so the never-retry-a-timeout rule stays single-sourced instead of being duplicated as a second string match.

## Related Issue

Fixes #47229

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/send_message_senders.py`: extract `_is_telegram_timeout(exc)` and reuse it in `_telegram_retry_delay` (identical matching, no behaviour change there); wrap each text chunk send in `_send_telegram` with per-chunk handling — on timeout, log, record the skipped index, and continue with the remaining chunks; append a `Delivery partial: x/y text chunks confirmed; chunk(s) k timed out and were skipped (they may still arrive out of order)` warning; when all text chunks time out, return a `delivery state unknown` error instead of `NO_DELIVERABLE`.
- `tests/tools/test_send_message_tool.py`: add `TestSendTelegramTimeoutChunkContinue` — timeout mid-sequence still delivers the remaining chunks with a partial warning; non-timeout errors still fail the whole send; all-chunks-timeout reports unknown delivery state (not "No deliverable text").

## How to Test

1. `pytest tests/tools/test_send_message_tool.py -v` — Observed result: 50 passed (47 existing + 3 new), including `test_timeout_mid_sequence_delivers_remaining_chunks`, `test_non_timeout_error_still_fails_whole_send`, `test_all_chunks_timeout_reports_unknown_state`.
2. `pytest` on the full send-message domain (13 files: `test_send_message_*`, `test_*send_message_*`, `test_media_caption_split.py`) — Observed result: 128 passed.
3. `ruff check tools/send_message_senders.py tests/tools/test_send_message_tool.py` — Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full send-message/telegram domain suite: 128 passed; the repo-wide run is not feasible on this host, platform-suite gaps tracked in #105054)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behaviour documented via warnings text and test docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure-Python control flow, no platform-specific paths touched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (result payload only gains the existing `warnings` channel)

## For New Skills

N/A — not a skill.

## Screenshots / Logs

New test output:

```
tests/tools/test_send_message_tool.py::TestSendTelegramTimeoutChunkContinue::test_timeout_mid_sequence_delivers_remaining_chunks PASSED
tests/tools/test_send_message_tool.py::TestSendTelegramTimeoutChunkContinue::test_non_timeout_error_still_fails_whole_send PASSED
tests/tools/test_send_message_tool.py::TestSendTelegramTimeoutChunkContinue::test_all_chunks_timeout_reports_unknown_state PASSED
```
