### PR TITLE
feat(stt): expose session context to command providers

### DIFF
--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1399,10 +1399,11 @@ class GatewayInboundMixin:
                 logger.debug("%s echo failed (non-fatal): %s", log_context, echo_exc)
 
     async def _enrich_inbound_voice(
-        self, event: MessageEvent, source: SessionSource, message_text: str, audio_paths: list[str]
+        self, event: MessageEvent, source: SessionSource, session_id: str,
+        message_text: str, audio_paths: list[str],
     ) -> str:
         message_text, _successful_transcripts = await self._enrich_message_with_transcription(
-            message_text, audio_paths,
+            message_text, audio_paths, session_id=session_id,
         )
         # Echo each successful transcript back immediately when configured so users can verify STT
         # quality in real time. On transcription failure do NOT send a hardcoded notice: that
@@ -1615,7 +1616,9 @@ class GatewayInboundMixin:
         if image_paths:
             message_text = await self._enrich_inbound_images(source, session_key, message_text, image_paths)
         if audio_paths:
-            message_text = await self._enrich_inbound_voice(event, source, message_text, audio_paths)
+            message_text = await self._enrich_inbound_voice(
+                event, source, session_key, message_text, audio_paths,
+            )
         message_text = self._prepend_inbound_media_file_notes(message_text, audio_file_paths, video_paths)
         message_text = self._prepend_inbound_document_notes(event, message_text)
         if "@" in message_text:
@@ -1914,9 +1917,14 @@ class GatewayInboundMixin:
         agent_path = to_agent_visible_cache_path(os.path.abspath(path))
         return f"[voice message could not be transcribed automatically; the audio is available at: {agent_path}]"
 
-    async def _transcribe_one_clip(self, path: str, transcribe_audio, transcribe_audio_local_fallback) -> Tuple[Optional[str], str]:
+    async def _transcribe_one_clip(
+        self, path: str, transcribe_audio, transcribe_audio_local_fallback,
+        session_id: Optional[str] = None,
+    ) -> Tuple[Optional[str], str]:
         """``(transcript_or_None, note)`` for one clip via configured STT with local fallback."""
-        result = await asyncio.to_thread(transcribe_audio, path, None, "gateway")
+        result = await asyncio.to_thread(
+            transcribe_audio, path, None, "gateway", session_id=session_id,
+        )
         if not result.get("success"):
             fallback = await asyncio.to_thread(transcribe_audio_local_fallback, path)
             if fallback.get("success"):
@@ -1941,7 +1949,7 @@ class GatewayInboundMixin:
         return transcript, f'"{transcript}"'
 
     async def _enrich_message_with_transcription(
-        self, user_text: str, audio_paths: List[str]
+        self, user_text: str, audio_paths: List[str], session_id: Optional[str] = None,
     ) -> tuple[str, List[str]]:
         """Transcribe voice clips with the configured STT provider and prepend the transcripts →
         ``(enriched_text, successful_transcripts)``; the transcripts (input order; empty if every clip
@@ -1972,6 +1980,7 @@ class GatewayInboundMixin:
                 logger.debug("Transcribing user voice: %s", path)
                 transcript, note = await self._transcribe_one_clip(
                     path, transcribe_audio, transcribe_audio_local_fallback,
+                    session_id=session_id,
                 )
                 if transcript is not None:
                     successful_transcripts.append(transcript)
@@ -2003,7 +2012,9 @@ class GatewayInboundMixin:
         if not audio_paths:
             return user_text if user_text is not None else (getattr(event, "text", None) or None), []
         text = user_text if user_text is not None else (getattr(event, "text", "") or "")
-        enriched_text, successful_transcripts = await self._enrich_message_with_transcription(text, audio_paths)
+        enriched_text, successful_transcripts = await self._enrich_message_with_transcription(
+            text, audio_paths, session_id=self._session_key_for_source(event.source),
+        )
         event._gateway_pending_stt_text = enriched_text
         event._gateway_pending_stt_transcripts = list(successful_transcripts)
         return enriched_text, successful_transcripts

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -254,7 +254,7 @@ class TestBusySessionAck:
         await runner._handle_active_session_busy_message(event, sk)
 
         runner._enrich_message_with_transcription.assert_awaited_once_with(
-            "", ["/tmp/follow-up.ogg"]
+            "", ["/tmp/follow-up.ogg"], session_id=sk
         )
         agent.steer.assert_called_once_with('"yönü teknik mimariye çevir"')
         agent.interrupt.assert_not_called()

--- a/tests/gateway/test_telegram_audio_vs_voice.py
+++ b/tests/gateway/test_telegram_audio_vs_voice.py
@@ -72,9 +72,12 @@ async def test_voice_message_still_transcribed():
             event=event,
             source=source,
             history=[],
+            session_key="telegram:session-123",
         )
 
-    mock_transcribe.assert_called_once_with("/tmp/voice.ogg", None, "gateway")
+    mock_transcribe.assert_called_once_with(
+        "/tmp/voice.ogg", None, "gateway", session_id="telegram:session-123"
+    )
     # The transcript passes through as a plain quoted line — no "voice message"
     # meta-commentary in the LLM-visible prompt.
     assert "hello world" in result

--- a/tests/gateway/test_telegram_voice_v0_regressions.py
+++ b/tests/gateway/test_telegram_voice_v0_regressions.py
@@ -163,7 +163,12 @@ async def test_pending_voice_interrupt_reuses_transcript_and_echo():
     assert interrupt_text == '"hello once"'
     assert drain_text == interrupt_text
     assert drain_transcripts == interrupt_transcripts == ["hello once"]
-    mock_transcribe.assert_called_once_with("/tmp/telegram-voice.ogg", None, "gateway")
+    mock_transcribe.assert_called_once_with(
+        "/tmp/telegram-voice.ogg",
+        None,
+        "gateway",
+        session_id="telegram:dm:12345",
+    )
     adapter.send.assert_awaited_once_with(
         "12345",
         '🎙️ "hello once"',
@@ -216,7 +221,12 @@ async def test_monitor_to_drain_transcribes_and_echoes_pending_voice_once(
 
     assert result["final_response"] == "follow-up complete"
     assert _PendingVoiceAgent.messages == ["initial turn", '"hello once"']
-    mock_transcribe.assert_called_once_with("/tmp/telegram-pending-voice.ogg", None, "gateway")
+    mock_transcribe.assert_called_once_with(
+        "/tmp/telegram-pending-voice.ogg",
+        None,
+        "gateway",
+        session_id="telegram:dm:12345",
+    )
     assert adapter.sent == [("12345", '🎙️ "hello once"', None)]
 
 

--- a/tests/tools/test_transcription_command_providers.py
+++ b/tests/tools/test_transcription_command_providers.py
@@ -258,6 +258,21 @@ class TestTranscribeAudioDispatchToCommandProvider:
         assert result["transcript"] == "dispatched via command"
         assert result["provider"] == "fake-cli"
 
+    def test_session_id_placeholder_renders_known_and_unknown_values(self, tmp_path):
+        audio = _make_silent_wav(tmp_path / "audio.wav")
+        payload = "import sys; open(sys.argv[2], 'w').write('session=' + sys.argv[1])"
+        cfg = self._config_with_command_provider(
+            "fake-cli",
+            f'"{sys.executable}" -c "{payload}" {{session_id}} {{output_path}}',
+        )
+
+        with patch("tools.transcription_tools._load_stt_config", return_value=cfg):
+            known = transcribe_audio(str(audio), session_id="telegram:chat:topic")
+            unknown = transcribe_audio(str(audio))
+
+        assert known["transcript"] == "session=telegram:chat:topic"
+        assert unknown["transcript"] == "session="
+
 
     def test_unknown_provider_no_command_falls_through_to_error(self, tmp_path):
         audio = _make_silent_wav(tmp_path / "audio.wav")

--- a/tools/transcription_command.py
+++ b/tools/transcription_command.py
@@ -67,11 +67,12 @@ def _read_command_stt_output(output_path: Path, stdout: str, fmt: str) -> str:
 def _transcribe_command_stt(
     file_path: str, provider_name: str, config: Dict[str, Any], stt_config: Dict[str, Any],
     model_override: Optional[str] = None, language_override: Optional[str] = None,
-    prompt: Optional[str] = None) -> Dict[str, Any]:
+    prompt: Optional[str] = None, session_id: Optional[str] = None,
+) -> Dict[str, Any]:
     """Transcribe via a user-declared ``stt.providers.<name>: type: command``. Placeholders
     (shell-quote-aware; ``{{``/``}}`` stay literal): ``{input_path}``, ``{output_path}`` (transcript
     file), ``{output_dir}``, ``{format}`` txt/json/srt/vtt, ``{language}`` (default ``en``),
-    ``{model}`` (empty when unset)."""
+    ``{model}`` and ``{session_id}`` (empty when unset)."""
     from tools.transcription_tools import _resolve_stt_language
     if prompt:
         _log_prompt_unsupported(f"Command STT provider '{provider_name}'")
@@ -95,6 +96,7 @@ def _transcribe_command_stt(
                 "input_path": str(audio.resolve()), "output_path": str(output_path),
                 "output_dir": str(output_path.parent), "format": output_format,
                 "language": str(language), "model": str(model_override or config.get("model") or ""),
+                "session_id": str(session_id or ""),
             })
             logger.info("Transcribing %s via command STT provider '%s'...", audio.name, provider_name)
             result = _run_command_stt(command, timeout, env_passthrough=_command_stt_env_passthrough(config))

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -402,10 +402,12 @@ def _read_block_error(file_path: str) -> Optional[Dict[str, Any]]:
 
 
 def _transcribe_prepared_audio(
-    file_path: str, model: Optional[str] = None, source: Optional[str] = None) -> Dict[str, Any]:
+    file_path: str, model: Optional[str] = None, source: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
     """Transcribe a validated audio file with the configured STT provider. ``model`` overrides the
     config default; ``source`` is a caller-surface label (``"gateway"``, ``"voice_mode"``) forwarded
-    to the ``pre_transcription`` hook only."""
+    to the ``pre_transcription`` hook; ``session_id`` is available to command-provider templates."""
     # Validate before provider resolution so invalid files can't trigger provider setup
     # or lazy installation; the remote-upload size cap applies to non-local only.
     error = _read_block_error(file_path) or _validate_audio_file(file_path, enforce_size_limit=False)
@@ -432,7 +434,9 @@ def _transcribe_prepared_audio(
             file_path = trimmed
             trim_cleanup_dir = os.path.dirname(trimmed)
     try:
-        return _dispatch_stt_provider(file_path, provider, stt_config, model, source)
+        return _dispatch_stt_provider(
+            file_path, provider, stt_config, model, source, session_id=session_id,
+        )
     finally:
         if trim_cleanup_dir:
             shutil.rmtree(trim_cleanup_dir, ignore_errors=True)
@@ -463,7 +467,8 @@ def _builtin_model_name(provider: str, stt_config: Dict[str, Any], model: Option
 
 def _dispatch_stt_provider(
     file_path: str, provider: str, stt_config: Dict[str, Any], model: Optional[str] = None,
-    source: Optional[str] = None) -> Dict[str, Any]:
+    source: Optional[str] = None, session_id: Optional[str] = None,
+) -> Dict[str, Any]:
     """Route *file_path* to the handler for *provider* (built-in > command > plugin)."""
     # Static ``stt.prompt`` is the base; hook results mutate on top (last hook to set a field wins).
     prompt = stt_config.get("prompt")
@@ -487,7 +492,8 @@ def _dispatch_stt_provider(
     command_provider_config = _resolve_command_stt_provider_config(provider, stt_config)
     if command_provider_config is not None:
         return _transcribe_command_stt(file_path, provider, command_provider_config, stt_config,
-                                       model_override=model, language_override=language, prompt=prompt)
+                                       model_override=model, language_override=language, prompt=prompt,
+                                       session_id=session_id)
     # Plugin backend: reads ``stt.<provider>`` like built-ins; the ``model`` argument overrides it.
     plugin_result = _dispatch_to_plugin_provider(
         file_path, provider, stt_config, model=model or _get_stt_section(stt_config, provider).get("model"),
@@ -516,9 +522,12 @@ def _no_provider_error(provider: str, stt_config: Dict[str, Any]) -> Dict[str, A
 
 
 def transcribe_audio(
-    file_path: str, model: Optional[str] = None, source: Optional[str] = None) -> Dict[str, Any]:
+    file_path: str, model: Optional[str] = None, source: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
     """Validate, preprocess supported inputs, and dispatch transcription. ``source`` is a caller-surface
-    label (``"gateway"``, ``"voice_mode"``) forwarded to the ``pre_transcription`` hook only."""
+    label (``"gateway"``, ``"voice_mode"``) forwarded to the ``pre_transcription`` hook;
+    ``session_id`` is available to command-provider templates."""
     # Secret-store refusal runs before ANY validation so the error names the real reason.
     blocked = _read_block_error(file_path)
     if blocked:
@@ -534,7 +543,9 @@ def transcribe_audio(
         return prep_error or _error_result("Audio preprocessing did not produce a file for transcription.")
     try:
         return (_validate_audio_file(prepared_path, enforce_size_limit=False)
-                or _transcribe_prepared_audio(prepared_path, model, source))
+                or _transcribe_prepared_audio(
+                    prepared_path, model, source, session_id=session_id,
+                ))
     finally:
         if cleanup_dir:
             shutil.rmtree(cleanup_dir, ignore_errors=True)

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -591,6 +591,7 @@ Your command template can reference these placeholders. Hermes substitutes them 
 | `{format}`        | Configured output format: `txt` / `json` / `srt` / `vtt`             |
 | `{language}`      | Configured language code (defaults to `en`)                          |
 | `{model}`         | `stt.providers.<name>.model`, empty when unset                       |
+| `{session_id}`    | Gateway conversation key, empty outside a known session              |
 
 Use `{{` and `}}` for literal braces (handy when embedding JSON snippets in the command).
 


### PR DESCRIPTION
## What does this PR do?

Command-based speech-to-text providers can now receive the gateway conversation key through a `{session_id}` command placeholder. This lets an external ASR command keep conversation-scoped context for terminology and homophone disambiguation without changing existing templates.

### Motivation

Gateway voice-message processing already resolves a stable session key, but the transcription call discarded it before command-provider rendering. Command providers therefore had no generic way to maintain per-conversation state.

### Behavior

When a gateway voice message is transcribed, `{session_id}` renders to its resolved gateway session key. Calls without a known session render an empty string. Templates that do not reference `{session_id}` retain their existing command text and behavior. Prompt passthrough and changes to built-in or plugin provider APIs are out of scope.

### Implementation

The gateway threads its resolved session key through `transcribe_audio()` to the command-provider renderer. Normal inbound voice messages and pending busy/clarify voice paths both preserve the key. Regression coverage verifies known and unknown placeholder values and the gateway handoff.

## Related Issue

Closes #105062

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/run_inbound.py` - preserve the resolved session key across normal and pending voice transcription paths.
- `tools/transcription_tools.py` - add the optional `session_id` transcription context and forward it during command-provider dispatch.
- `tools/transcription_command.py` - render `{session_id}`, defaulting to an empty string.
- `tests/` - cover command rendering and gateway session-key forwarding.
- `website/docs/user-guide/features/tts.md` - document the new placeholder.

## How to Test

1. Configure a command STT provider whose command includes `{session_id}` and send a gateway voice message.
2. Confirm the command receives the stable gateway conversation key; call `transcribe_audio()` without session context and confirm the placeholder is empty.
3. Run:

```bash
scripts/run_tests.sh tests/tools/test_transcription_command_providers.py -k session_id_placeholder
scripts/run_tests.sh tests/gateway/test_telegram_audio_vs_voice.py -k voice_message_still_transcribed
scripts/run_tests.sh tests/gateway/test_busy_session_ack.py -k steer_mode_transcribes_voice_before_injection
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the relevant repository tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation and docstrings
- [x] `cli-config.yaml.example` is N/A because no config key changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because architecture and workflows are unchanged
- [x] I've considered cross-platform impact; command rendering uses the existing platform-aware quoting helper
- [x] Tool descriptions and schemas are N/A because no model tool schema changed

## Screenshots / Logs

N/A - automated tests exercise the command output and gateway handoff directly.
