### PR TITLE
fix(stt): preserve auto-detection in the discovered Whisper CLI backend

### DIFF
--- a/tests/tools/test_stt_discovered_cli_language.py
+++ b/tests/tools/test_stt_discovered_cli_language.py
@@ -1,0 +1,118 @@
+"""Language choices survive the fallback to Hermes-generated Whisper CLI calls."""
+
+import json
+import os
+from pathlib import Path
+import shlex
+import sys
+import wave
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def cli_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
+    monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
+    from tools import transcription_tools as tt
+
+    monkeypatch.setattr(tt, "_HAS_FASTER_WHISPER", False)
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: False)
+    audio = tmp_path / "voice clip;not-a-command.wav"
+    with wave.open(str(audio), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(16000)
+        handle.writeframes(b"\0\0" * 1600)
+    return tmp_path, audio
+
+
+def dispatch(home, audio, stt):
+    from tools import transcription_tools as tt
+
+    (home / "config.yaml").write_text(yaml.safe_dump({"stt": stt}), encoding="utf-8")
+    cfg = tt._load_stt_config()
+    provider = tt._get_provider(cfg)
+    assert provider == "local_command"
+    result = tt._dispatch_stt_provider(str(audio), provider, cfg)
+    assert result["success"], result
+    return json.loads(result["transcript"])
+
+
+@pytest.mark.parametrize("global_lang,local_lang,env_lang,hook_lang,provider,expected", [
+    ("", "", None, None, "local", None),
+    ("", "", None, None, "local_command", None),
+    ("en", "", None, None, "local", "en"),
+    ("en", "zh", None, None, "local", "zh"),
+    ("", "", "zh", None, "local", "zh"),
+    ("en", "", "zh", None, "local", "en"),
+    ("en", "zh", None, "ja", "local", "ja"),
+], ids=["auto-fallback", "auto-explicit-cli", "global-en", "local-zh", "env-zh",
+        "config-over-env", "hook-over-config"])
+def test_discovered_cli_language(
+    cli_home, monkeypatch, global_lang, local_lang, env_lang, hook_lang, provider, expected
+):
+    home, audio = cli_home
+    binary = str(home / "Whisper Tools" / "whisper")
+    monkeypatch.setattr("tools.transcription_local._find_whisper_binary", lambda: binary)
+    if env_lang:
+        monkeypatch.setenv("HERMES_LOCAL_STT_LANGUAGE", env_lang)
+    if hook_lang:
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *a, **kw: [{"language": hook_lang}])
+
+    def capture(argv, **kwargs):
+        assert argv[0] == binary
+        assert argv[1] == str(audio)
+        language = argv[argv.index("--language") + 1] if "--language" in argv else None
+        out = Path(argv[argv.index("--output_dir") + 1]) / "transcript.txt"
+        out.write_text(json.dumps({"language": language}), encoding="utf-8")
+
+    monkeypatch.setattr("tools.transcription_local._run_quiet", capture)
+    output = dispatch(home, audio, {"provider": provider, "language": global_lang,
+                                    "local": {"model": "base", "language": local_lang}})
+    assert output["language"] == expected
+
+
+@pytest.mark.parametrize("template_lang,expected", [("{language}", "en"), ("auto", "auto")])
+def test_custom_template_keeps_its_existing_language_behavior(cli_home, monkeypatch, template_lang, expected):
+    home, audio = cli_home
+    template = f"custom-asr {{input_path}} --output_dir {{output_dir}} --language {template_lang}"
+    monkeypatch.setenv("HERMES_LOCAL_STT_COMMAND", template)
+
+    def capture(argv, **kwargs):
+        assert argv[0] == "custom-asr"
+        assert argv[1] == str(audio)
+        out = Path(argv[argv.index("--output_dir") + 1]) / "transcript.txt"
+        out.write_text(json.dumps({"language": argv[argv.index("--language") + 1]}), encoding="utf-8")
+
+    monkeypatch.setattr("tools.transcription_local._run_quiet", capture)
+    output = dispatch(home, audio, {"provider": "local", "language": "", "local": {"language": ""}})
+    assert output["language"] == expected
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Executable shebang fixture requires POSIX")
+@pytest.mark.parametrize("language", ["", "zh"])
+def test_discovered_cli_executes_with_expected_language(cli_home, monkeypatch, language):
+    home, audio = cli_home
+    binary = home / "Whisper Tools" / "whisper"
+    binary.parent.mkdir()
+    binary.write_text(
+        f"#!/bin/sh\nexec {shlex.quote(sys.executable)} -c "
+        + shlex.quote(
+            "import json,sys; from pathlib import Path; a=sys.argv[1:]; "
+            "lang=a[a.index('--language')+1] if '--language' in a else None; "
+            "out=Path(a[a.index('--output_dir')+1])/'fixture.txt'; "
+            "out.write_text(json.dumps({'language':lang,'input':a[0]}))"
+        ) + ' "$@"\n', encoding="utf-8"
+    )
+    binary.chmod(0o700)
+    monkeypatch.setenv("PATH", str(binary.parent) + os.pathsep + os.environ.get("PATH", ""))
+    from tools.transcription_audio import _find_whisper_binary
+
+    assert Path(_find_whisper_binary()).resolve() == binary
+    output = dispatch(home, audio, {"provider": "local", "language": language, "local": {"language": ""}})
+    assert output["language"] == (language or None)
+    assert output["input"] == str(audio)

--- a/tools/transcription_local.py
+++ b/tools/transcription_local.py
@@ -28,13 +28,14 @@ from tools.transcription_common import (
 logger = logging.getLogger("tools.transcription_tools")
 
 
-def _get_local_command_template() -> Optional[str]:
+def _get_local_command_template(*, language: Optional[str] = None) -> Optional[str]:
     configured = os.getenv(LOCAL_STT_COMMAND_ENV, "").strip()
     if configured:
         return configured
     whisper_binary = _find_whisper_binary()
+    language_arg = " --language {language}" if language else ""
     return (f"{shlex.quote(whisper_binary)} {{input_path}} --model {{model}} --output_format txt "
-            "--output_dir {output_dir} --language {language}") if whisper_binary else None
+            f"--output_dir {{output_dir}}{language_arg}") if whisper_binary else None
 
 
 def _has_local_command() -> bool:
@@ -222,15 +223,14 @@ def _join_confident_segments(segments: Any, local_cfg: Dict[str, Any]) -> str:
 def _transcribe_local_command(
     file_path: str, model_name: str, *, language: Optional[str] = None, prompt: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Run the configured local STT command template and read back a .txt transcript."""
+    """Run local STT; discovered Whisper preserves auto-detection, custom templates keep their fallback."""
     from tools.transcription_tools import _resolve_stt_language
     if prompt:
         _log_prompt_unsupported("STT provider 'local_command'")
-    command_template = _get_local_command_template()
+    language = language or _resolve_stt_language("local")
+    command_template = _get_local_command_template(language=language)
     if not command_template:
         return _error_result(f"{LOCAL_STT_COMMAND_ENV} not configured and no local whisper binary was found")
-    # Language: hook override > stt.local.language > stt.language > env > "en".
-    language = language or _resolve_stt_language("local") or DEFAULT_LOCAL_STT_LANGUAGE
     normalized_model = _normalize_local_model(model_name)
     try:
         with tempfile.TemporaryDirectory(prefix="hermes-local-stt-") as output_dir:
@@ -239,7 +239,8 @@ def _transcribe_local_command(
                 return _error_result(prep_error)
             command = command_template.format(
                 input_path=shlex.quote(prepared_input), output_dir=shlex.quote(output_dir),
-                language=shlex.quote(language), model=shlex.quote(normalized_model))
+                # Only custom templates can still contain {language} when no hint was resolved.
+                language=shlex.quote(language or DEFAULT_LOCAL_STT_LANGUAGE), model=shlex.quote(normalized_model))
             # Scrub Hermes secrets from the child env (same policy as _run_command_stt).
             # Scrub Hermes secrets from the child env (sibling path to #56332 / _run_command_stt — this
             # local-whisper path previously inherited the full process environment).


### PR DESCRIPTION
## What does this PR do?

Preserves automatic language detection when Hermes falls back from faster-whisper to a discovered `whisper` executable.

With blank global/local language settings and no language environment override, the shared resolver returns `None`. The CLI handler then replaces it with `en` and generates `--language en`. The same configuration therefore auto-detects with faster-whisper but forces English through the CLI.

This patch omits `--language` from the generated command when no language is resolved. Explicit language choices still work. Custom `HERMES_LOCAL_STT_COMMAND` templates keep their existing interpolation and fallback behavior; named command providers and the global default are unchanged.

## Related Issue

Related to [#103182](https://github.com/NousResearch/hermes-agent/pull/103182), which changes the global default but explicitly leaves `local_command` unchanged. This issue also reproduces on that branch. This fix does not depend on it.

## Type of Change

- [x] Bug fix

## Changes Made

- `tools/transcription_local.py`: resolve the language before generating the template and include the language argument only when needed.
- `tests/tools/test_stt_discovered_cli_language.py`: add 11 cases covering auto-detection, explicit language precedence, custom-template compatibility, and path quoting. Two cases discover and execute a recorder fixture through the real subprocess path.

## How to Test

In an isolated environment where faster-whisper is unavailable and `whisper` is on PATH, leave both `HERMES_LOCAL_STT_COMMAND` and `HERMES_LOCAL_STT_LANGUAGE` unset and use:

```yaml
stt:
  provider: local
  language: ""
  local:
    language: ""
```

Transcribe audio and inspect the CLI arguments. Auto-detection should omit `--language`; setting the global language to `zh` should still produce `--language zh`.

```bash
python -m pytest tests/tools/test_stt_discovered_cli_language.py -q --tb=short
```

- Before: **3 failed, 8 passed**; all three failures observed unwanted English.
- After: **11 passed**.
- Broader checks: **185 passed, 1 pre-existing failure** on macOS 26.3 / Apple Silicon, Python 3.11.
- Ruff and `git diff --check`: passed.

<details>
<summary>Broader coverage and known failure</summary>

Each module ran in a separate process with a temporary home and no live credentials:

```text
tests/tools/test_transcription_tools.py
tests/tools/test_transcription.py
tests/tools/test_transcription_command_providers.py
tests/tools/test_stt_default_language.py
tests/tools/test_stt_language_resolution.py
tests/tools/test_stt_silence_hallucinations.py
tests/tools/test_pre_transcription_hook.py
tests/tools/test_stt_cloud_trim.py
tests/tools/test_transcription_plugin_dispatch.py
tests/gateway/test_stt_config.py
tests/gateway/test_stt_transcript_echo_config.py
```

`TestTranscribeLocalExtended.test_config_device_and_compute_type_passed_to_whisper` expects `float32`, but the existing Apple Silicon loader passes `int8`. The same failure reproduces on the unmodified relevant source and test files. It is not changed here.

The subprocess fixture records arguments; it does not run Whisper inference. No model downloads or provider API calls are required. The full repository suite, Linux, and Windows were not tested; the two executable-fixture tests skip Windows.

</details>

## Checklist

### Code

- [x] Read the contributing guide and searched related PRs.
- [x] Commit follows Conventional Commits.
- [x] Changes are limited to this fix and regression tests.
- [ ] Full `pytest tests/ -q` passes: not run; focused results disclosed above.
- [x] Added tests and verified on macOS / Apple Silicon.

### Documentation & Housekeeping

- [x] Updated the relevant function docstring.
- [x] Config example, architecture documentation, and tool schemas: N/A.
- [x] Considered cross-platform behavior; existing quoting and subprocess handling are retained.
- [x] No new dependencies or configuration keys.

## Screenshots / Logs

Captured with blank global/local language settings and no language environment override:

```text
Before: resolved language = None; CLI receives --language en
After:  resolved language = None; CLI receives no --language argument
```
