### PR TITLE
fix(opencode): preserve custom provider identity for session affinity

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5953,7 +5953,19 @@ def _build_call_kwargs(
     # OpenCode relay session affinity — same key as the main turn so compression/title/vision
     # calls stay on the conversation's warm backend.
     from agent.opencode_affinity import merge_opencode_session_headers
-    return merge_opencode_session_headers(kwargs, provider, base_url, _runtime_main_value("session_id") or None)
+    route_provider = str(provider or "").strip().lower()
+    route_base_url = str(base_url or "").strip().rstrip("/")
+    main_provider = str(_runtime_main_value("provider") or "").strip().lower()
+    main_base_url = str(_runtime_main_value("base_url") or "").strip().rstrip("/")
+    requested_provider = (
+        _runtime_main_value("requested_provider")
+        if route_provider == main_provider and route_base_url == main_base_url
+        else None
+    )
+    return merge_opencode_session_headers(
+        kwargs, provider, base_url, _runtime_main_value("session_id") or None,
+        requested_provider=requested_provider,
+    )
 
 
 def _validate_llm_response(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1375,6 +1375,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         getattr(agent, "provider", None),
         getattr(agent, "base_url", None),
         getattr(agent, "session_id", None),
+        requested_provider=getattr(agent, "requested_provider", None),
     )
 
 

--- a/agent/opencode_affinity.py
+++ b/agent/opencode_affinity.py
@@ -22,16 +22,23 @@ from typing import Any, Optional
 OPENCODE_SESSION_HEADER = "x-opencode-session"
 
 
-def is_opencode_target(provider: Optional[str], base_url: Optional[str]) -> bool:
+def is_opencode_target(
+    provider: Optional[str],
+    base_url: Optional[str],
+    requested_provider: Optional[str] = None,
+) -> bool:
     """True when *provider* or *base_url* addresses the OpenCode relay.
 
-    Matches the built-in opencode-zen/go/free providers, custom
+    Matches the built-in opencode-zen/go/free providers, resolved or requested custom
     ``opencode-<family>-*`` providers, and any base_url hosted on opencode.ai.
     """
     try:
         from hermes_cli.models import opencode_provider_family
 
-        if opencode_provider_family(provider) is not None:
+        if any(
+            opencode_provider_family(candidate) is not None
+            for candidate in (provider, requested_provider)
+        ):
             return True
     except Exception:
         pass
@@ -47,9 +54,10 @@ def opencode_session_headers(
     provider: Optional[str],
     base_url: Optional[str],
     session_id: Optional[str] = None,
+    requested_provider: Optional[str] = None,
 ) -> dict[str, str]:
     """Return ``{"x-opencode-session": <key>}`` for OpenCode targets, else ``{}``."""
-    if not is_opencode_target(provider, base_url):
+    if not is_opencode_target(provider, base_url, requested_provider):
         return {}
     try:
         from agent.portal_tags import get_affinity_scope, get_conversation_context
@@ -80,13 +88,14 @@ def merge_opencode_session_headers(
     provider: Optional[str],
     base_url: Optional[str],
     session_id: Optional[str] = None,
+    requested_provider: Optional[str] = None,
 ) -> dict[str, Any]:
     """Merge the affinity header into ``kwargs["extra_headers"]`` (in place).
 
     Existing per-request headers win, so a caller-pinned value is preserved.
     Non-OpenCode targets are left untouched.
     """
-    headers = opencode_session_headers(provider, base_url, session_id)
+    headers = opencode_session_headers(provider, base_url, session_id, requested_provider)
     if headers:
         existing = kwargs.get("extra_headers")
         merged = dict(existing) if isinstance(existing, dict) else {}

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1886,7 +1886,7 @@ def opencode_provider_family(provider_id: Optional[str]) -> Optional[str]:
     """Resolve a provider id (canonical or prefixed) to its OpenCode family, or None.
 
     Returns ``"opencode-zen"`` or ``"opencode-go"`` for the built-in providers AND for custom providers
-    whose name extends a family slug (e.g. ``opencode-go-bridge`` pointing at
+    whose bare or ``custom:``-prefixed name extends a family slug (e.g. ``opencode-go-bridge`` pointing at
     ``https://opencode.ai/zen/go/v1``, issue #85589). Matching is case-insensitive. Custom family providers
     need the same per-model api_mode routing and /v1 base-url normalization as the built-ins — this
     predicate is the single owner of that family-membership question; do not re-implement it inline.
@@ -1894,7 +1894,11 @@ def opencode_provider_family(provider_id: Optional[str]) -> Optional[str]:
     raw = str(provider_id or "").strip().lower()
     if not raw:
         return None
-    canonical = normalize_provider(provider_id)
+    if raw.startswith("custom:"):
+        raw = raw.split(":", 1)[1].strip()
+        if not raw:
+            return None
+    canonical = normalize_provider(raw)
     if canonical in _OPENCODE_FAMILIES:
         return canonical
     return next((f for f in _OPENCODE_FAMILIES if raw.startswith(f)), None)

--- a/tests/agent/test_opencode_session_affinity.py
+++ b/tests/agent/test_opencode_session_affinity.py
@@ -11,7 +11,7 @@ from run_agent import AIAgent
 _MSGS = [{"role": "user", "content": "hi"}]
 
 
-def _agent(provider, model, base_url, api_mode=None):
+def _agent(provider, model, base_url, api_mode=None, requested_provider=None):
     agent = AIAgent(
         api_key="test-key",
         base_url=base_url,
@@ -21,6 +21,7 @@ def _agent(provider, model, base_url, api_mode=None):
         skip_context_files=True,
         skip_memory=True,
         session_id="sess-affinity-1",
+        requested_provider=requested_provider,
     )
     if api_mode:
         agent.api_mode = api_mode
@@ -49,6 +50,38 @@ def test_main_turn_sends_stable_session_header_on_every_transport(provider, mode
     assert "x-opencode-session" not in (build_api_kwargs(other, _MSGS).get("extra_headers") or {})
 
 
+@pytest.mark.parametrize("requested_provider", ["opencode-go-proxy", "custom:opencode-go-proxy"])
+def test_named_custom_opencode_gateway_uses_requested_provider_identity(
+    requested_provider, tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CUSTOM_OPENCODE_API_KEY", "test-key")
+    (hermes_home / "config.yaml").write_text(
+        """
+model:
+  provider: custom:opencode-go-proxy
+  default: glm-5
+providers:
+  opencode-go-proxy:
+    base_url: https://gateway.example/v1
+    key_env: CUSTOM_OPENCODE_API_KEY
+    transport: chat_completions
+"""
+    )
+
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    runtime = resolve_runtime_provider(requested=requested_provider, target_model="glm-5")
+    assert runtime["provider"] == "custom"
+    agent = _agent(
+        runtime["provider"], "glm-5", runtime["base_url"],
+        requested_provider=runtime["requested_provider"],
+    )
+    assert build_api_kwargs(agent, _MSGS)["extra_headers"]["x-opencode-session"] == "sess-affinity-1"
+
+
 def test_auxiliary_calls_share_the_main_turn_session_key():
     token = aux.set_runtime_main(
         "opencode-go", "glm-5", base_url="https://opencode.ai/zen/go/v1", session_id="sess-affinity-1"
@@ -58,5 +91,26 @@ def test_auxiliary_calls_share_the_main_turn_session_key():
         assert kwargs["extra_headers"]["x-opencode-session"] == "sess-affinity-1"
         other = aux._build_call_kwargs("openrouter", "x", _MSGS, base_url="https://openrouter.ai/api/v1")
         assert "x-opencode-session" not in (other.get("extra_headers") or {})
+    finally:
+        aux._RUNTIME_MAIN_CONTEXT.reset(token)
+
+
+def test_auxiliary_calls_inherit_named_custom_opencode_identity_only_on_main_route():
+    token = aux.set_runtime_main(
+        "custom", "glm-5",
+        requested_provider="custom:opencode-go-proxy",
+        base_url="https://gateway.example/v1",
+        session_id="sess-affinity-1",
+    )
+    try:
+        kwargs = aux._build_call_kwargs(
+            "custom", "glm-5", _MSGS, base_url="https://gateway.example/v1"
+        )
+        assert kwargs["extra_headers"]["x-opencode-session"] == "sess-affinity-1"
+
+        fallback = aux._build_call_kwargs(
+            "custom", "glm-5", _MSGS, base_url="https://fallback.example/v1"
+        )
+        assert "x-opencode-session" not in (fallback.get("extra_headers") or {})
     finally:
         aux._RUNTIME_MAIN_CONTEXT.reset(token)


### PR DESCRIPTION
## What does this PR do?

Named custom OpenCode-family providers lose their provider identity during runtime resolution.

`_resolve_named_custom_runtime()` correctly resolves these providers to `provider="custom"` and preserves the configured identity in `requested_provider`. However, the OpenCode session-affinity request path previously inspected only the resolved provider and `base_url`.

For a custom gateway whose hostname is outside `opencode.ai`, neither value identifies the route as OpenCode. Hermes therefore omitted `x-opencode-session`, even though the configured provider belongs to an existing OpenCode family.

This change carries the preserved `requested_provider` identity into the existing OpenCode affinity check. It does not introduce a new configuration option or change how the affinity value is generated.

## Related Issue

Related to #104449.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `hermes_cli/models.py` so `opencode_provider_family()` recognizes both bare and `custom:`-prefixed named custom provider identities.
- Pass `agent.requested_provider` through the main request affinity path.
- Let auxiliary requests inherit the main runtime's requested provider identity only when their resolved provider and base URL match the main route.
- Add regression coverage for bare and `custom:`-prefixed identities, main-turn requests, matching auxiliary requests, and unrelated fallback routes.

## Cache Behavior

The session-affinity key generation remains unchanged: host-declared affinity scope, then ambient conversation root, then physical session ID. The change only restores OpenCode-family detection after named custom providers have been normalized to `provider="custom"`.

Prompt content, cache scope, session IDs, gateway credentials, and explicit per-request header precedence are unchanged.

## Related Work

- Builds on the `x-opencode-session` affinity behavior introduced by #101864.
- Unlike #104566, this does not add generic configurable affinity headers or change the configuration schema.
- This is orthogonal to #105023, which handles fallback keys for out-of-turn auxiliary calls. No new fallback session key is introduced here.
- The named custom OpenCode-family runtime behavior originates from #85589.

## How to Test

1. Configure a named custom provider such as `custom:opencode-go-proxy` with a gateway URL outside `opencode.ai`.
2. Resolve it through `resolve_runtime_provider()` and build both main-turn and auxiliary request kwargs.
3. Run `scripts/run_tests.sh tests/agent/test_opencode_session_affinity.py`.
4. Confirm that main and matching auxiliary requests receive the same `x-opencode-session` value, while a different custom fallback route does not receive the header.

Validation:

- Full test suite: tests relevant to this change passed; the remaining failures were unrelated to this PR
- Windows 11 OpenCode session-affinity tests: 9 passed
- Windows 11, all 12 OpenCode-related test files: 90 passed
- WSL Debian 13 / Python 3.11 affinity regression suite: 9 passed
- Repository-wide Ruff check: passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass locally (all tests relevant to this change pass; remaining failures are unrelated to this PR)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — platform-independent request metadata
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable.
