### PR TITLE
fix(gateway): bound compression fallback and preserve queued turns

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -412,6 +412,13 @@ class CompressionCommitFence:
             raise ValueError("total compression ceiling must be positive")
         self._deadline = time.monotonic() + seconds
 
+    def set_precommit_deadline_monotonic(self, deadline: float) -> None:
+        """Arm one absolute pre-commit deadline shared across route attempts."""
+        deadline = float(deadline)
+        if deadline <= 0:
+            raise ValueError("compression deadline must be positive")
+        self._deadline = deadline
+
     def touch_progress(self) -> None:
         """Record forward progress (a streamed token); a bare float store is atomic, so no lock."""
         self._last_progress = time.monotonic()
@@ -814,7 +821,7 @@ def resolve_compression_fallback_route() -> Optional[dict]:
 
 def _retry_compression_on_fallback_chain(
     *, worker: Callable[[CompressionCommitFence], Tuple[list, str]], messages: list,
-    system_prompt_fallback: Any, idle_timeout_seconds: float, total_ceiling_seconds: float,
+    system_prompt_fallback: Any, idle_timeout_seconds: float, precommit_deadline_monotonic: float,
     on_commit_overrun: Optional[Callable[[float, float], None]] = None,
     on_timeout_cause: Optional[Callable[[bool, bool], None]] = None, telemetry_agent: Any = None,
     new_fence: Optional[Callable[[], CompressionCommitFence]] = None,
@@ -824,10 +831,8 @@ def _retry_compression_on_fallback_chain(
     before. The entry's ``timeout`` sets the idle window. Re-runs the whole worker, so pre-compression
     callbacks must be idempotent.
 
-    The retry is bounded the same way the primary was: silence for one idle window ends it, while a fallback
-    that is streaming keeps its ceiling. The entry's own ``timeout`` (when declared) sets that idle window,
-    so a fallback tuned for a slower-but-healthy backend is not held to a deadline the stalled primary
-    defined (#62452 semantics, applied to the stall path).
+    The retry spends only the primary's remaining pre-commit budget. Its route timeout still defines the
+    idle window, clamped to the shared monotonic deadline so a stalled primary cannot mint a second ceiling.
     Known limitation (accepted, #96634 review): the retry re-runs the COMPLETE worker, which repeats
     memory/plugin pre-compression callbacks. Built-in callbacks are idempotent (re-reads and overwrites of
     attempt-scoped state); third-party plugin callbacks are advised to be. Splitting the worker to resume
@@ -837,6 +842,9 @@ def _retry_compression_on_fallback_chain(
     # the same event anyway, but starting one at all makes /stop look ignored.
     hard_cancel = getattr(telemetry_agent, "_hard_interrupt_requested", None)
     if callable(getattr(hard_cancel, "is_set", None)) and hard_cancel.is_set():
+        return None
+    if time.monotonic() >= precommit_deadline_monotonic:
+        logger.info("Skipping compression stall fallback: the shared pre-commit ceiling is exhausted")
         return None
     route = resolve_compression_fallback_route()
     if route is None:
@@ -860,20 +868,26 @@ def _retry_compression_on_fallback_chain(
             "hard-interrupt admission will read the aborted attempt's fence rather than the retry's commit boundary"
         )
         retry_fence = CompressionCommitFence()
-    idle = float(route.get("timeout") or idle_timeout_seconds)
-    ceiling = max(float(total_ceiling_seconds), idle)
+    remaining_ceiling = precommit_deadline_monotonic - time.monotonic()
+    if remaining_ceiling <= 0:
+        retry_fence.revoke_commit_admission()
+        logger.info("Skipping compression stall fallback: its setup exhausted the shared pre-commit ceiling")
+        return None
+    idle = min(float(route.get("timeout") or idle_timeout_seconds), remaining_ceiling)
     logger.warning(
         "Context compression stalled on the configured summary route — "
-        "retrying once on %s (%s) before continuing without compression", route["label"], route["model"],
+        "retrying once on %s (%s) within %.1fs of shared pre-commit budget before continuing without "
+        "compression", route["label"], route["model"], remaining_ceiling,
     )
     try:
         from agent.context_compressor import pin_summary_route
         with pin_summary_route(route):
             result_msgs, result_prompt = run_compress_context_with_progress_timeout(
                 worker=worker, messages=messages, system_prompt_fallback=system_prompt_fallback,
-                idle_timeout_seconds=idle, total_ceiling_seconds=ceiling, on_commit_overrun=on_commit_overrun,
+                idle_timeout_seconds=idle, total_ceiling_seconds=remaining_ceiling,
+                on_commit_overrun=on_commit_overrun,
                 on_timeout_cause=on_timeout_cause, fence=retry_fence, telemetry_agent=telemetry_agent,
-                stall_fallback=False,
+                stall_fallback=False, precommit_deadline_monotonic=precommit_deadline_monotonic,
             )
     except Exception:
         # The primary already failed; a failing fallback must degrade, never
@@ -997,6 +1011,7 @@ def run_compress_context_with_progress_timeout(
     on_commit_overrun: Optional[Callable[[float, float], None]] = None,
     fence: Optional[CompressionCommitFence] = None, telemetry_agent: Any = None, stall_fallback: bool = True,
     new_fence: Optional[Callable[[], CompressionCommitFence]] = None,
+    precommit_deadline_monotonic: Optional[float] = None,
 ) -> Tuple[list, str]:
     """Run ``worker(fence)`` under a sync progress-aware (idle + ceiling) timeout.
     Budgets bound the PRE-commit phase only: an admitted commit always completes (overrun logged, surfaced
@@ -1011,10 +1026,20 @@ def run_compress_context_with_progress_timeout(
     def _resolve_fallback_prompt() -> str:
         return system_prompt_fallback() if callable(system_prompt_fallback) else system_prompt_fallback
 
-    ceiling = max(float(total_ceiling_seconds), float(idle_timeout_seconds))
-    idle = float(idle_timeout_seconds)
+    requested_ceiling = max(float(total_ceiling_seconds), float(idle_timeout_seconds))
+    wait_started = time.monotonic()
+    if precommit_deadline_monotonic is None:
+        precommit_deadline_monotonic = wait_started + requested_ceiling
+    else:
+        precommit_deadline_monotonic = float(precommit_deadline_monotonic)
+    ceiling = min(requested_ceiling, precommit_deadline_monotonic - wait_started)
+    if ceiling <= 0:
+        if fence is not None:
+            fence.revoke_commit_admission()
+        return messages, _resolve_fallback_prompt()
+    idle = min(float(idle_timeout_seconds), ceiling)
     fence = fence if fence is not None else CompressionCommitFence()
-    fence.set_total_ceiling_seconds(ceiling)
+    fence.set_precommit_deadline_monotonic(precommit_deadline_monotonic)
     # Sync mirror of gateway hygiene's run_in_executor + wait_for loop: offload,
     # poll idle budget + ceiling, fence-cancel on timeout so no late commit lands.
     from tools.thread_context import propagate_context_to_thread
@@ -1058,7 +1083,6 @@ def run_compress_context_with_progress_timeout(
         _release_compression_admission()
         raise
     future.add_done_callback(_release_compression_admission)
-    wait_started = time.monotonic()
     # EVERY host unwind must revoke commit admission or a detached worker could
     # later mutate durable state; handled_exit marks paths that settle it themselves
     handled_exit = False
@@ -1110,7 +1134,8 @@ def run_compress_context_with_progress_timeout(
         if stall_fallback:
             recovered = _retry_compression_on_fallback_chain(
                 worker=worker, messages=messages, system_prompt_fallback=system_prompt_fallback,
-                idle_timeout_seconds=idle, total_ceiling_seconds=ceiling, on_commit_overrun=on_commit_overrun,
+                idle_timeout_seconds=idle, precommit_deadline_monotonic=precommit_deadline_monotonic,
+                on_commit_overrun=on_commit_overrun,
                 on_timeout_cause=on_timeout_cause, telemetry_agent=telemetry_agent, new_fence=new_fence,
             )
             if recovered is not None:

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3281,6 +3281,16 @@ class GatewayTurnMixin:
         pending = None
         if result and adapter and session_key:
             pending_event = _dequeue_pending_event(adapter, session_key)
+            if result.get("compression_exhausted") and pending_event is not None:
+                # The outer handler owns the reset. Preserve the exact event in the head slot so the
+                # adapter's post-handler drain starts it against the fresh session; do not promote or
+                # prepare native media on the exhausted session.
+                adapter._pending_messages[session_key] = pending_event
+                logger.info(
+                    "Deferring queued follow-up for session %s until after its compression-exhausted reset",
+                    session_key,
+                )
+                return None, None
             # /queue overflow: promote the next queued event into the consumed "next-up" slot so the
             # recursive drain sees it (keeps FIFO order; a mid-chain /queue can't jump the queue).
             pending_event = self._promote_queued_event(session_key, adapter, pending_event)

--- a/tests/agent/test_compression_stall_fallback_78981.py
+++ b/tests/agent/test_compression_stall_fallback_78981.py
@@ -107,7 +107,7 @@ def _run(worker, *, chain, timeouts, messages, idle=0.05, ceiling=0.2):
 # ---------------------------------------------------------------------------
 
 
-def test_stalled_summary_attempts_configured_fallback_chain():
+def test_fallback_recovers_inside_remaining_shared_ceiling():
     original = [{"role": "user", "content": "keep-me"}]
     compressed = [{"role": "user", "content": "summary of earlier turns"}]
     worker = _StalledSummaryWorker(compressed)
@@ -115,7 +115,11 @@ def test_stalled_summary_attempts_configured_fallback_chain():
 
     try:
         msgs, prompt = _run(
-            worker, chain=[CHAIN_ENTRY], timeouts=timeouts, messages=original
+            worker,
+            chain=[CHAIN_ENTRY],
+            timeouts=timeouts,
+            messages=original,
+            ceiling=2.0,
         )
     finally:
         worker.release.set()
@@ -126,6 +130,9 @@ def test_stalled_summary_attempts_configured_fallback_chain():
     assert pinned is not None, "the retry must carry the configured fallback route"
     assert pinned["provider"] == "custom"
     assert pinned["model"] == "backup-summarizer"
+    assert worker.fences[1].deadline_monotonic == worker.fences[0].deadline_monotonic, (
+        "primary and fallback must use the same absolute pre-commit deadline"
+    )
     assert msgs == compressed, "the fallback attempt's compression must be published"
     assert prompt == "summarized-prompt"
     assert not timeouts, "no continue-without-compression degrade after a recovery"
@@ -225,9 +232,35 @@ def test_fallback_that_also_stalls_degrades_after_one_attempt():
         worker.release.set()
 
     assert worker.attempts == 2, "the fallback is attempted once, not in a loop"
+    assert worker.fences[1].deadline_monotonic == worker.fences[0].deadline_monotonic, (
+        "the fallback must not mint a second total ceiling"
+    )
     assert msgs is original, "no messages may be dropped when both routes stall"
     assert prompt == "degraded-prompt"
     assert len(timeouts) == 1, "the degrade must be reported exactly once"
+
+
+def test_total_ceiling_exhaustion_does_not_start_fallback():
+    original = [{"role": "user", "content": "keep-me"}]
+    worker = _StalledSummaryWorker([{"role": "user", "content": "unused"}])
+    timeouts = []
+
+    try:
+        msgs, prompt = _run(
+            worker,
+            chain=[dict(CHAIN_ENTRY, timeout=0.05)],
+            timeouts=timeouts,
+            messages=original,
+            idle=0.05,
+            ceiling=0.05,
+        )
+    finally:
+        worker.release.set()
+
+    assert worker.attempts == 1, "an exhausted shared budget cannot fund a retry"
+    assert msgs is original
+    assert prompt == "degraded-prompt"
+    assert len(timeouts) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_queued_native_image_session_key.py
+++ b/tests/gateway/test_queued_native_image_session_key.py
@@ -65,6 +65,18 @@ class CaptureQueuedNativeImageAgent:
         }
 
 
+class CompressionExhaustedAgent(CaptureQueuedNativeImageAgent):
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls.append(message)
+        return {
+            "final_response": "context exhausted",
+            "messages": [{"role": "user", "content": "oversized"}],
+            "api_calls": 1,
+            "failed": True,
+            "compression_exhausted": True,
+        }
+
+
 def _make_runner(adapter):
     gateway_run = importlib.import_module("gateway.run")
     runner = object.__new__(gateway_run.GatewayRunner)
@@ -149,3 +161,77 @@ async def test_queued_followup_uses_pending_event_session_key_for_native_images(
     assert queued_message[0]["type"] == "text"
     assert queued_message[0]["text"].startswith("describe this")
     assert any(part.get("type") == "image_url" for part in queued_message)
+
+
+@pytest.mark.asyncio
+async def test_compression_exhaustion_defers_queued_event_for_fresh_session(
+    monkeypatch, tmp_path
+):
+    CompressionExhaustedAgent.calls = []
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CompressionExhaustedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    adapter = CaptureAdapter()
+    runner = _make_runner(adapter)
+    session_key = "agent:main:telegram:group:-1001"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+    )
+    pending_source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+    pending_event = MessageEvent(
+        text="answer this after reset",
+        message_type=MessageType.PHOTO,
+        source=pending_source,
+        media_urls=[str(tmp_path / "queued-image.png")],
+        media_types=["image/png"],
+        raw_message={"native": "metadata"},
+        message_id="queued-after-exhaustion",
+        platform_update_id=4242,
+    )
+    overflow_event = MessageEvent(
+        text="second in fifo",
+        message_type=MessageType.TEXT,
+        source=pending_source,
+        message_id="queued-second",
+    )
+    runner._enqueue_fifo(session_key, pending_event, adapter)
+    runner._enqueue_fifo(session_key, overflow_event, adapter)
+
+    result = await runner._run_agent(
+        message="oversized turn",
+        context_prompt="",
+        history=[{"role": "user", "content": "old context"}],
+        source=source,
+        session_id="bloated-session",
+        session_key=session_key,
+    )
+
+    assert result["compression_exhausted"] is True
+    assert len(CompressionExhaustedAgent.calls) == 1, (
+        "the queued turn must not recurse into the exhausted session"
+    )
+    assert adapter._pending_messages[session_key] is pending_event, (
+        "the exact native event must survive for the post-reset adapter drain"
+    )
+    assert runner._queued_events[session_key] == [overflow_event], (
+        "deferral must not promote or reorder later FIFO events"
+    )


### PR DESCRIPTION
## Summary
- share one absolute pre-commit deadline across primary and fallback compression
- skip or clamp fallback work when the original compression budget is exhausted
- defer queued native MessageEvents until the compression-exhausted reset installs a fresh session
- preserve FIFO order and native event metadata

## Regression
A Telegram question arrived while context compression was stalled. The primary compressor and fallback each consumed a full ceiling, and a queued question could recurse into the still-exhausted session before the outer reset.

The added behavior tests reproduced four failures before the fix: deadline mismatch on recovery and double-stall, a second attempt after the total budget was spent, and queued execution against the bloated session.

## Verification
- canonical scripts/run_tests.sh with retries disabled: 67 passed across 8 focused compression/gateway files
- Ruff: passed
- git diff --check: passed

No provider, model, job, Telegram, session configuration, or cooldown changes.