### PR TITLE
fix: complete pending fleet restarts from gateway restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6012,6 +6012,13 @@ def _restart_all(system: bool) -> None:
 
 def _cmd_restart(args):
     _refuse_from_inside_gateway("restart", "restart loops")
+    # The startup warning points users here after an interrupted update. That
+    # recovery must restart the whole tracked fleet before discharging its
+    # marker, rather than letting this profile-only command hide stale siblings.
+    from hermes_cli.update_cmd import _apply_pending_fleet_restart_catchup
+
+    if _apply_pending_fleet_restart_catchup():
+        return
     system = getattr(args, "system", False)
     restart_all = getattr(args, "all", False)
     if restart_all and _dispatch_all_via_service_manager_if_s6("restart"):

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -300,21 +300,22 @@ def _run_pending_fleet_restart() -> bool:
         return False
 
 
-def _apply_pending_fleet_restart_catchup() -> None:
+def _apply_pending_fleet_restart_catchup() -> bool:
     """On an already-up-to-date ``hermes update``, finish a skipped restart.
 
-    No-op when nothing is pending; exits 1 on incomplete catch-up so automation
-    does not treat the fleet as healthy.
+    Returns True when it handled a pending restart, False when no restart was
+    pending, and exits 1 on incomplete recovery so automation does not treat
+    the fleet as healthy.
     """
     from hermes_cli.update_cmd import _run_pending_fleet_restart
     if not _pending_fleet_restart_needed():
-        return
+        return False
     print()
     _warn_pending_fleet_restart()
     print("→ Running the pending fleet restart...")
     if _run_pending_fleet_restart():
         _clear_fleet_restart_pending_marker()
-        return
+        return True
     print("  ⚠ Fleet restart incomplete. Recover with: hermes gateway restart")
     sys.exit(1)
 

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -25,6 +25,7 @@ from hermes_cli import main as hermes_main
 import hermes_cli.main_web_build as main_web_build
 import hermes_cli.main_install_repair as main_install_repair
 from hermes_cli import update_cmd
+import hermes_cli.gateway as gateway_cli
 import hermes_cli.update_cmd_fleet as update_cmd_fleet
 import hermes_cli.update_cmd_deps as update_cmd_deps
 from hermes_cli.update_receipt import COMMAND_BOUNDARY_STOP_REASON
@@ -356,6 +357,39 @@ def test_run_pending_restart_true_when_no_gateways(monkeypatch, capsys):
     ])
     assert update_cmd._run_pending_fleet_restart() is True
     assert "Pending fleet restart completed" in capsys.readouterr().out
+
+
+def test_gateway_restart_uses_fleet_catchup_when_update_restart_is_pending(monkeypatch):
+    """The restart hint must recover every tracked gateway, not one profile."""
+    calls = []
+    monkeypatch.setattr(gateway_cli, "_refuse_from_inside_gateway", lambda *args: None)
+    monkeypatch.setattr(
+        update_cmd,
+        "_apply_pending_fleet_restart_catchup",
+        lambda: calls.append("catchup") or True,
+    )
+    monkeypatch.setattr(gateway_cli, "_service_backend", lambda: calls.append("direct-restart"))
+
+    gateway_cli._cmd_restart(SimpleNamespace(system=False, all=False))
+
+    assert calls == ["catchup"]
+
+
+def test_gateway_restart_uses_regular_path_when_no_update_restart_is_pending(monkeypatch):
+    """Ordinary restarts retain their existing one-profile behavior."""
+    calls = []
+    monkeypatch.setattr(gateway_cli, "_refuse_from_inside_gateway", lambda *args: None)
+    monkeypatch.setattr(update_cmd, "_apply_pending_fleet_restart_catchup", lambda: False)
+    monkeypatch.setattr(gateway_cli, "_installed_service_kind_for", lambda windows: "systemd")
+    monkeypatch.setattr(
+        gateway_cli,
+        "_service_call",
+        lambda kind, verb, system: calls.append((kind, verb, system)),
+    )
+
+    gateway_cli._cmd_restart(SimpleNamespace(system=False, all=False))
+
+    assert calls == [("systemd", "restart", False)]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Make `hermes gateway restart` complete a pending update restart through the existing fleet catch-up path.
- Preserve ordinary one-profile restart behavior when no update restart is pending.
- Return whether the catch-up routine handled a pending restart so the gateway command can avoid a second restart.

The startup warning already directs users to `hermes gateway restart`. Before this change, that command could restart only the active profile while leaving the fleet-wide marker in place. The fleet catch-up path restarts the tracked fleet and clears the marker only after successful recovery.

## Validation

- `uv run --frozen --extra dev python -m pytest tests\\hermes_cli\\test_update_fleet_restart_pending.py -k "gateway_restart_uses or marker_round_trip or pending_needed_when_marker_exists or already_up_to_date_runs_pending_restart_when_marker_present" -q`
- `uv run --frozen --extra dev ruff check hermes_cli\\gateway.py hermes_cli\\update_cmd_fleet.py tests\\hermes_cli\\test_update_fleet_restart_pending.py`
- `git diff --check`

The full pending-restart pair ran with 27 passed and 7 skipped, plus one unrelated Windows failure in `test_run_pending_restart_true_when_no_gateways`. That existing test does not mock the Windows service branch and attempts a real temporary gateway startup.
