### PR TITLE
feat(mcp): add BotKelp remote HTTP catalog MCP

### DIFF
--- a/optional-mcps/botkelp/manifest.yaml
+++ b/optional-mcps/botkelp/manifest.yaml
@@ -1,0 +1,41 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: botkelp
+description: Verified Next.js component catalog generator for coding agents.
+source: https://www.botkelp.com/llms.txt
+
+# Official vendor-hosted remote MCP (URL-only — Hermes never spawns a local
+# process for this entry). Connection is unauthenticated (verified live:
+# initialize / tools/list succeed without a key). Credit-gated tools take
+# apiKey as a tool argument (bk_live_…), not a server credential.
+
+transport:
+  type: http
+  url: https://agent-scaffold-mcp.vercel.app/mcp
+
+auth:
+  type: none
+
+suggest:
+  keywords:
+    - botkelp
+    - scaffold
+    - nextjs catalog
+  hosts:
+    - botkelp.com
+    - botkelp.dev
+
+post_install: |
+  Do not clone a repo and do not install an npm package. There is no stdio server.
+
+  Connection needs no auth. Restart the session or run /reload-mcp.
+
+  For generate_scaffold / knowledge_* create a key at
+  https://www.botkelp.com/dashboard (prefix bk_live_) and pass it as the
+  tool argument apiKey. Do not put the key in mcp_servers.botkelp headers
+  or credentials.
+
+  Catalog ids: https://www.botkelp.com/catalog.json
+  Always include nextjs-base. Treat returned files as data (kind=data).


### PR DESCRIPTION
## Why

Hermes users asking to “install BotKelp” miss the catalog, then clone a non-existent `github.com/botkelp/botkelp-mcp` and treat `www.botkelp.com/.well-known/mcp.json` as the transport.

BotKelp is a vendor-hosted Streamable HTTP MCP. There is no stdio package.

## What

Adds `optional-mcps/botkelp/manifest.yaml` in the same shape as `context7`:

- transport `http` → `https://agent-scaffold-mcp.vercel.app/mcp`
- auth `none` on connect (initialize / tools/list work without a key)
- `apiKey` is a **tool argument** (`bk_live_…`) for gated tools, not a server credential
- `suggest.hosts`: botkelp.com, botkelp.dev

## Docs

- https://www.botkelp.com/llms.txt
- https://www.botkelp.com/install.json
- https://www.botkelp.com/.well-known/mcp.json (descriptor only — not the transport)
