### PR TITLE
fix(gateway): gate clarify wait on resumable transport capability

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1895,6 +1895,11 @@ class BasePlatformAdapter(ABC):
     # answer, and an acknowledgement would silently abandon the task (#57056). Read generically via
     # ``getattr(adapter, "interactive_resume", True)`` — no per-platform branching at the call site.
     interactive_resume: bool = True
+    # Whether a reply on this chat_id can resolve a clarify_tool wait registered against it.
+    # One-shot event platforms (webhook: each delivery keys a brand-new, independent session) have
+    # no path back to a pending clarify_id, so the wait can never resolve — only a wasted timeout.
+    # Read generically via ``getattr(adapter, "supports_interactive_clarify", True)`` (#105097).
+    supports_interactive_clarify: bool = True
     # Back-reference to the running ``GatewayRunner`` (set by gateway/run.py); ``build_source``
     # resolves the inbound profile via ``runner._profile_name_for_source``.
     gateway_runner = None  # type: ignore[assignment]

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -152,6 +152,9 @@ class WebhookAdapter(BasePlatformAdapter):
     # The startup auto-resume turn must instruct the model to FINISH the interrupted work instead of
     # emitting an interactive acknowledgement that abandons the task (#57056).
     interactive_resume: bool = False
+    # Each delivery keys an independent session_chat_id (route+delivery_id): a reply arrives as an
+    # unrelated new session, never as a message this adapter can route back to a pending clarify_id.
+    supports_interactive_clarify: bool = False
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WEBHOOK)

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1173,10 +1173,17 @@ class TurnRunner:
         timeout. Returns the response string, or a sentinel when none arrived."""
         from gateway.run import _clarify_send_then_wait
         from tools import clarify_gateway as clarify_mod
+        from tools.clarify_tool import TIMEOUT_RESPONSE
         import uuid
         ctx = self._ctx
         if not ctx._status_adapter:
             return ""
+        # No path back to a pending clarify_id on this transport (e.g. webhook: every delivery is
+        # an independent one-shot session): skip the unresumable wait rather than registering one
+        # that can only ever time out. Same sentinel a real timeout returns, so the agent proceeds
+        # exactly as it already does when nobody answers in time (#105097).
+        if not getattr(ctx._status_adapter, "supports_interactive_clarify", True):
+            return TIMEOUT_RESPONSE
         session_key = ctx.session_key or ""
         clarify_id = uuid.uuid4().hex[:10]
         choices = list(choices) if choices else None

--- a/tests/gateway/test_clarify_webhook_capability_gate.py
+++ b/tests/gateway/test_clarify_webhook_capability_gate.py
@@ -1,0 +1,95 @@
+"""Gate interactive clarification on resumable-transport capability (#105097).
+
+A webhook route keys every delivery as an independent one-shot session
+(``webhook:{route}:{delivery_id}``) — a reply arrives as a brand-new,
+unrelated session, never as a message this adapter can route back to a
+pending ``clarify_id``. Registering the wait anyway (the old behavior)
+can only ever time out: wasted latency for a result nobody could deliver.
+
+``_clarify_callback_sync`` must check the adapter's
+``supports_interactive_clarify`` capability BEFORE registering a wait or
+sending the prompt, and short-circuit with the same sentinel a real
+timeout returns so the agent proceeds exactly as it already does when
+nobody answers in time. Interactive adapters (default True) must be
+unaffected.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.run_turn_runner import TurnRunner
+from gateway.turn_context import TurnContext
+from tools.clarify_tool import TIMEOUT_RESPONSE
+
+
+def _make_runner(adapter):
+    ctx = TurnContext(_status_adapter=adapter, session_key="webhook:orders:abc123")
+    return TurnRunner(MagicMock(), ctx)
+
+
+class _NonResumableAdapter:
+    """Stand-in for WebhookAdapter: capability explicitly False."""
+
+    supports_interactive_clarify = False
+
+
+class _InteractiveAdapter:
+    """Stand-in for a normal chat adapter: no ``supports_interactive_clarify``
+    override -> the callback's ``getattr(..., True)`` default applies, same
+    as every existing interactive platform (Slack, Telegram, Discord, ...)."""
+
+    def __init__(self):
+        self.send_clarify = MagicMock()
+        self.pause_typing_for_chat = MagicMock()
+        self.resume_typing_for_chat = MagicMock()
+
+
+def test_non_resumable_adapter_skips_wait_and_returns_timeout_sentinel(monkeypatch):
+    runner = _make_runner(_NonResumableAdapter())
+
+    register = MagicMock()
+    monkeypatch.setattr("tools.clarify_gateway.register", register)
+    schedule = MagicMock()
+    monkeypatch.setattr(runner, "_schedule", schedule)
+
+    result = runner._clarify_callback_sync("What's the target env?", None)
+
+    assert result == TIMEOUT_RESPONSE
+    register.assert_not_called()
+    schedule.assert_not_called()
+
+
+def test_interactive_adapter_still_registers_and_waits(monkeypatch):
+    runner = _make_runner(_InteractiveAdapter())
+
+    register = MagicMock()
+    monkeypatch.setattr("tools.clarify_gateway.register", register)
+    monkeypatch.setattr(runner, "_schedule", MagicMock(return_value="fut"))
+    monkeypatch.setattr(runner, "_close_native_stream_boundary", MagicMock())
+    monkeypatch.setattr(runner, "_stream_consumer", MagicMock(return_value=None))
+    monkeypatch.setattr(
+        "gateway.run._clarify_send_then_wait",
+        MagicMock(return_value="user picked B"),
+    )
+
+    result = runner._clarify_callback_sync("Pick one", ["A", "B"])
+
+    assert result == "user picked B"
+    register.assert_called_once()
+
+
+@pytest.mark.parametrize("adapter_cls", [_NonResumableAdapter, _InteractiveAdapter])
+def test_capability_defaults_true_on_base_adapter(adapter_cls):
+    """Sanity: only the non-resumable stand-in opts out; the interactive one
+    relies on BasePlatformAdapter's True default, proving the gate is additive."""
+    from gateway.platforms.base import BasePlatformAdapter
+
+    if adapter_cls is _InteractiveAdapter:
+        assert BasePlatformAdapter.supports_interactive_clarify is True
+
+
+def test_webhook_adapter_opts_out_of_interactive_clarify():
+    from gateway.platforms.webhook import WebhookAdapter
+
+    assert WebhookAdapter.supports_interactive_clarify is False


### PR DESCRIPTION
## What does this PR do?

Gates `clarify_tool`'s interactive wait on whether the current transport can
actually resolve it. `gateway/platforms/webhook.py::_dispatch_agent_run` keys
every delivery on its own `webhook:{route_name}:{delivery_id}` session — a
distinct, independent session per delivery. When the agent calls
`clarify_tool` on such a turn, `TurnRunner._clarify_callback_sync`
(`gateway/run_turn_runner.py`) registered a pending clarify entry, rendered
the question via the adapter's default `send_clarify` (plain text +
`mark_awaiting_text`), and blocked the agent thread waiting on that
`clarify_id`. But a real-world reply to a one-shot webhook route arrives as a
brand-new HTTP delivery with a brand-new `delivery_id` — a different session
entirely — so `gateway/platforms/base.py`'s clarify text-intercept (which
only fires for a message on the *same*, still-active `session_key`) never
sees it. The wait could only ever resolve by hitting its full configured
timeout (`clarify_mod.get_clarify_timeout()`, default 10 minutes), burning
that time for a result nobody could deliver.

This adds a small adapter capability flag, following the exact precedent
already used for the same problem shape on this class
(`interactive_resume`, added for the startup auto-resume prompt):

- `BasePlatformAdapter.supports_interactive_clarify: bool = True` (default —
  every existing interactive adapter, Slack/Telegram/Discord/etc., is
  unaffected)
- `WebhookAdapter.supports_interactive_clarify = False` — every delivery is
  an independent one-shot session with no path back to a pending
  `clarify_id`
- `_clarify_callback_sync` checks
  `getattr(ctx._status_adapter, "supports_interactive_clarify", True)`
  *before* registering the clarify entry, sending the prompt, or blocking,
  and short-circuits with `tools.clarify_tool.TIMEOUT_RESPONSE` — the exact
  same sentinel a real timeout already returns today on every adapter, so
  the agent proceeds using its best judgement and can still surface the
  question in its own final reply, precisely as it already does whenever
  nobody answers an interactive clarify prompt in time.

An adapter with an explicit resolver (e.g. a plugin that owns its own
continuation contract) can still opt back in by setting
`supports_interactive_clarify = True` on its own subclass; this only flips
the default for the one adapter that structurally cannot resolve it
(one-shot, per-delivery sessions).

## Related Issue

Fixes #105097

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: add `BasePlatformAdapter.supports_interactive_clarify: bool = True`
- `gateway/platforms/webhook.py`: set `WebhookAdapter.supports_interactive_clarify = False`
- `gateway/run_turn_runner.py`: `_clarify_callback_sync` checks the capability before registering/sending/waiting, returning `TIMEOUT_RESPONSE` immediately when the adapter opts out
- `tests/gateway/test_clarify_webhook_capability_gate.py`: new regression tests

## How to Test

1. `python -m pytest tests/gateway/test_clarify_webhook_capability_gate.py -v` — 5 tests covering: a non-resumable adapter skips registration/send/wait and returns the timeout sentinel; an interactive adapter (no override) is unaffected and still registers + waits + returns the real answer; the two class-level defaults themselves.
2. Proved the regression: `git checkout HEAD~1 -- gateway/platforms/base.py gateway/platforms/webhook.py gateway/run_turn_runner.py`, reran the same test file — 3 of 5 fail (`AttributeError: no attribute 'supports_interactive_clarify'` / falls through to the old unconditional `send_clarify` call), then `git checkout HEAD -- ...` to restore the fix.
3. Ran the surrounding clarify/webhook suite for regressions: `pytest tests/gateway/test_clarify_webhook_capability_gate.py tests/gateway/test_clarify_send_timeout_ambiguity.py tests/gateway/test_clarify_active_session_bypass.py tests/gateway/test_clarify_thread_followup_not_swallowed.py tests/gateway/test_clarify_progress_leak.py tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_session_close.py tests/gateway/test_webhook_deliver_only.py tests/gateway/test_webhook_integration.py tests/tools/test_clarify_tool.py tests/tools/test_clarify_gateway.py -q` → **153 passed**.
4. `ruff check gateway/platforms/base.py gateway/platforms/webhook.py gateway/run_turn_runner.py tests/gateway/test_clarify_webhook_capability_gate.py` → **All checks passed!**

## What platforms you tested on

Linux (Ubuntu, CI runner). No platform-specific paths touched.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (searched `clarify`, `webhook`, `resumable`, `one-shot`; nothing addresses this specific gap)
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` on the affected area and related suites pass (153/153, see above)
- [x] I've added tests for my changes
- [ ] N/A — no config keys, docs, or tool schemas changed

## Disclosure

This fix was authored with AI assistance (an autonomous coding agent), with the
diff, tests, and this description reviewed before submission.
