### PR TITLE
fix(webhook): gate unsupported interactive clarification

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1895,6 +1895,10 @@ class BasePlatformAdapter(ABC):
     # answer, and an acknowledgement would silently abandon the task (#57056). Read generically via
     # ``getattr(adapter, "interactive_resume", True)`` — no per-platform branching at the call site.
     interactive_resume: bool = True
+    # Whether a clarify prompt can be answered back into the pending gateway turn. Ordinary
+    # ``send()`` success is not sufficient: one-shot transports must opt out, while a plugin
+    # that implements a resolver can explicitly opt back in.
+    supports_interactive_clarification: bool = True
     # Back-reference to the running ``GatewayRunner`` (set by gateway/run.py); ``build_source``
     # resolves the inbound profile via ``runner._profile_name_for_source``.
     gateway_runner = None  # type: ignore[assignment]

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -148,6 +148,9 @@ def _validate_svix_signature(body: bytes, secret: str, msg_id: str, timestamp: s
 class WebhookAdapter(BasePlatformAdapter):
     """Generic webhook receiver that triggers agent runs from HTTP POSTs."""
 
+    # Each delivery owns a distinct session, so a later webhook cannot resolve a pending clarify
+    # wait from the first delivery. Resolver-capable plugin subclasses may explicitly opt back in.
+    supports_interactive_clarification: bool = False
     # Event-triggered, no human present: startup auto-resume must FINISH the interrupted work, not ask "what next?".
     # The startup auto-resume turn must instruct the model to FINISH the interrupted work instead of
     # emitting an interactive acknowledgement that abandons the task (#57056).

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2078,6 +2078,11 @@ class GatewayTurnMixin:
         from agent.skill_utils import parse_config_string_list
         enabled = self._resolve_enabled_toolsets_for_source(user_config, source, platform_key)
         disabled = parse_config_string_list((user_config.get("agent") or {}).get("disabled_toolsets")) or None
+        adapter = self._adapter_for_source(source)
+        if adapter is not None and not getattr(adapter, "supports_interactive_clarification", True):
+            disabled = list(disabled or [])
+            if "clarify" not in disabled:
+                disabled.append("clarify")
         return enabled, disabled
 
     async def _run_background_task_inner(

--- a/tests/gateway/test_webhook_route_toolsets.py
+++ b/tests/gateway/test_webhook_route_toolsets.py
@@ -135,3 +135,30 @@ class TestGatewayResolveEnabledToolsetsForSource:
             gr, cfg, _Src("webhook:mon:d"), "webhook"
         )
         assert cfg["platform_toolsets"]["webhook"] == ["web"]
+
+
+class TestGatewayResolveDisabledToolsetsForSource:
+    def test_one_shot_webhook_disables_clarify_even_when_configured(self):
+        wa = _make_adapter({"mon": {"secret": "x", "toolsets": ["web", "clarify"]}})
+        gr = _make_runner(wa)
+
+        enabled, disabled = GatewayRunner._resolve_turn_toolsets(
+            gr, BASE_CONFIG, _Src("webhook:mon:d1"), "webhook"
+        )
+
+        assert "clarify" in enabled
+        assert "clarify" in disabled
+
+    def test_explicit_resumable_capability_preserves_clarify(self):
+        class ResumableWebhookAdapter(WebhookAdapter):
+            supports_interactive_clarification = True
+
+        wa = object.__new__(ResumableWebhookAdapter)
+        wa._routes = {"mon": {"secret": "x", "toolsets": ["web", "clarify"]}}
+        gr = _make_runner(wa)
+
+        _enabled, disabled = GatewayRunner._resolve_turn_toolsets(
+            gr, BASE_CONFIG, _Src("webhook:mon:d1"), "webhook"
+        )
+
+        assert not disabled or "clarify" not in disabled


### PR DESCRIPTION
## Summary

One-shot webhook deliveries use a distinct session per delivery, so the generic clarify fallback could register a pending interaction that no later webhook could resume. This change makes interactive clarification an explicit adapter capability and disables the `clarify` toolset for the built-in webhook adapter while allowing resolver-capable plugin subclasses to opt back in.

---

## Changes

- `gateway/platforms/base.py`: defines the transport capability contract, defaulting interactive adapters to supported.
- `gateway/platforms/webhook.py`: marks one-shot webhook sessions as unable to resume clarification.
- `gateway/run_turn.py`: adds `clarify` to per-turn disabled toolsets when the selected adapter lacks the capability.
- `tests/gateway/test_webhook_route_toolsets.py`: adds two regression tests covering one-shot gating and explicit resolver opt-in.

## How to Test

```bash
pytest tests/gateway/test_webhook_route_toolsets.py -q
# 14 passed

pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_session_close.py tests/gateway/test_webhook_offloop_delivery.py tests/gateway/test_webhook_route_toolsets.py tests/gateway/test_webhook_signature_rate_limit.py tests/gateway/test_webhook_dynamic_routes.py tests/gateway/test_webhook_integration.py tests/gateway/test_webhook_deliver_only.py -q
# 76 passed
```

## Checklist

- [x] Regression test failed before the fix
- [x] Targeted tests pass
- [x] Ruff check passes
- [x] Changes are scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] No profile paths or non-credential environment settings added

## Risk & Impact

Low. Existing interactive adapters retain the default capability, while only the one-shot webhook adapter opts out; resolver-capable plugin subclasses can explicitly opt back in.

Type: Bug fix

Closes #105097
