### PR TITLE
fix(serve): register config shell hooks in the per-profile backend

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2522,6 +2522,22 @@ def cmd_dashboard(args):
 
     apply_nofile_soft_limit()
 
+    # `serve` reaches neither main()'s dispatch (intercepted by
+    # _try_fast_serve_launch) nor _prepare_agent_startup (not in
+    # _AGENT_COMMANDS), so config-owned shell hooks never registered in the
+    # Desktop's per-seat backend and every fail_closed guard was inert for
+    # room turns. Register here: named-profile routing above has resolved, so
+    # HERMES_HOME is the seat's, and --stop/--status already exited. Mirrors
+    # gateway/run_startup.py; idempotent per (home, event, matcher, command),
+    # and accept_hooks=False lets hooks_auto_accept / the allowlist decide.
+    try:
+        from agent.shell_hooks import register_from_config
+        from hermes_cli.config import load_config
+
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.debug("shell-hook registration failed at serve startup", exc_info=True)
+
     _ssh_session_token = _read_ssh_session_token_file(_token_file) if _token_file else None
     _mcp_discovery_after_bind = _dashboard_prepare_runtime(args, _headless_backend)
 

--- a/tests/hermes_cli/test_dashboard_registers_shell_hooks.py
+++ b/tests/hermes_cli/test_dashboard_registers_shell_hooks.py
@@ -1,0 +1,67 @@
+"""``hermes serve`` / ``hermes dashboard`` must register config-owned shell hooks.
+
+``serve`` reaches neither ``main()``'s dispatch (``_try_fast_serve_launch`` calls
+``cmd_dashboard`` directly) nor ``_prepare_agent_startup`` (``serve`` is not in
+``_AGENT_COMMANDS``), so before this fix every ``hooks:`` entry in ``config.yaml``
+was silently inert in that process while the same entries worked under
+``hermes chat``. Desktop starts one ``serve`` backend per profile, so a hook
+configured as a safety or policy boundary did not run for any turn served there.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _Stop(Exception):
+    """Sentinel: end cmd_dashboard right after the registration point."""
+
+
+def _ns(**kw):
+    defaults = dict(
+        port=9119, host="127.0.0.1", no_open=False, insecure=False,
+        stop=False, status=False, headless_backend=True,
+        ssh_session_token_file=None,
+    )
+    defaults.update(kw)
+    return argparse.Namespace(**defaults)
+
+
+def _run_cmd_dashboard(register_mock, load_config_mock):
+    """Call cmd_dashboard with everything around the registration point stubbed."""
+    from hermes_cli.main import cmd_dashboard
+
+    with patch("hermes_cli.main._dashboard_lifecycle_flags"), \
+         patch("hermes_cli.main._dashboard_validate_serve_args", return_value=None), \
+         patch("hermes_cli.main._dashboard_sanitize_desktop_env"), \
+         patch("hermes_cli.main._route_named_profile_dashboard"), \
+         patch("hermes_cli.resource_limits.apply_nofile_soft_limit"), \
+         patch("hermes_cli.config.load_config", load_config_mock), \
+         patch("agent.shell_hooks.register_from_config", register_mock), \
+         patch("hermes_cli.main._dashboard_prepare_runtime", side_effect=_Stop):
+        with pytest.raises(_Stop):
+            cmd_dashboard(_ns())
+
+
+def test_serve_registers_configured_shell_hooks():
+    register = MagicMock(return_value=[])
+    load_config = MagicMock(return_value={"hooks": {"pre_tool_call": [{"command": "x"}]}})
+    _run_cmd_dashboard(register, load_config)
+    assert register.call_count == 1, "serve must register config shell hooks exactly once"
+    cfg = register.call_args.args[0]
+    assert cfg == {"hooks": {"pre_tool_call": [{"command": "x"}]}}
+    # accept_hooks=False defers to hooks_auto_accept / the per-profile allowlist
+    # rather than prompting on a headless backend.
+    assert register.call_args.kwargs.get("accept_hooks") is False
+
+
+def test_registration_failure_does_not_break_serve():
+    """A broken hooks block must not take the backend down with it."""
+    register = MagicMock(side_effect=RuntimeError("bad hooks block"))
+    load_config = MagicMock(return_value={})
+    # _Stop still propagates, i.e. startup continued past the registration point.
+    _run_cmd_dashboard(register, load_config)
+    assert register.call_count == 1


### PR DESCRIPTION
## What does this PR do?

`hermes serve` never registers the `hooks:` block from `config.yaml`, so every configured `pre_tool_call` hook is inert in that process — while the same hook works normally under `hermes chat`.

Two independent causes, either one sufficient:

1. **`serve` bypasses `main()`'s dispatch.** `_try_fast_serve_launch()` (`hermes_cli/main.py`) intercepts `argv[0] == "serve"`, builds a narrow parser and calls `cmd_dashboard()` directly, so `_prepare_agent_startup()` is never reached.
2. **The gate excludes it anyway.** On the slow path `_prepare_agent_startup()` returns early unless `args.command in _AGENT_COMMANDS or _agent_subcommand_selected(args)`. `_AGENT_COMMANDS` is `{None, "chat", "acp", "rl"}`; `_AGENT_SUBCOMMANDS` covers `cron run/tick`, `gateway run` and `mcp serve`. Neither admits `serve`.

The web layer only *inspects* hooks — `web_routers/ops.py` uses `iter_configured_hooks`, `allowlist_entry_for`, `_record_approval`, `revoke` — and never registers them. The only registration sites are `hermes_cli/main.py` (agent commands), `cli.py`, and `gateway/run_startup.py`.

**Why this is easy to miss:** nothing fails loudly. The hook simply never runs, `hermes hooks list` still reports it configured and `✓ allowed`, and there is no `not allowlisted` warning to notice. It matters most where a hook is used as a policy or safety boundary, because the desktop app starts one `serve` backend per profile and serves its turns from there.

**The fix** registers in `cmd_dashboard()`, after named-profile routing has resolved (so `HERMES_HOME` is the target profile's) and after `--stop` / `--status` have had their chance to exit. It mirrors `gateway/run_startup.py`. `register_from_config()` is idempotent per `(home, event, matcher, command)`, and `accept_hooks=False` defers to `hooks_auto_accept` and the per-profile allowlist rather than prompting on a headless backend. Registration failure is swallowed to debug, as on the other startup paths, so a malformed `hooks:` block cannot take the backend down.

Adding `"serve"` to `_AGENT_COMMANDS` would also work, but it drags in plugin and inline MCP discovery that the web server already performs, so it is the worse option.

## Related Issue

No existing issue found; happy to open one if you'd prefer it tracked that way.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — register config shell hooks in `cmd_dashboard()` after `apply_nofile_soft_limit()` (16 lines, comment included).
- `tests/hermes_cli/test_dashboard_registers_shell_hooks.py` — new regression test.

## How to Test

Reproduction on `main` without the change:

1. Add a `pre_tool_call` hook to a profile's `config.yaml` (any command; `hooks_auto_accept: true` to skip the prompt).
2. Confirm it is picked up: `hermes hooks list` shows it as `✓ allowed`.
3. Start that profile's backend the way Desktop does: `hermes --profile <name> serve --host 127.0.0.1 --port 0`.
4. Grep the profile's `logs/agent.log` for `shell hook registered` — **nothing**, and no `not allowlisted` warning either. Run a turn and the hook never fires.
5. Compare with `hermes chat` in the same profile, where the same hook registers and fires.

With the change, step 4 logs one `shell hook registered` line per configured hook.

Automated:

```
pytest tests/hermes_cli/test_dashboard_registers_shell_hooks.py -q
```

Both tests fail without the one-line change and pass with it. The first asserts the call happens exactly once with `accept_hooks=False`; the second asserts a raising registration does not stop startup.

Also verified manually on Windows against a real Desktop-spawned backend: after the change it logs its `shell hook registered` lines on restart, where two restarts of the same backend immediately before logged none.
