### PR TITLE
fix(google-chat): include quoted message context

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -921,9 +921,15 @@ class GoogleChatAdapter(BasePlatformAdapter):
             user_id=(sender_email or sender_name), user_name=sender.get("displayName") or sender_email or sender_name,
             thread_id=session_thread_id, user_id_alt=(sender_name or None),
         )
+        quote_metadata = msg.get("quotedMessageMetadata")
+        quote_snapshot = quote_metadata.get("quotedMessageSnapshot") if isinstance(quote_metadata, dict) else {}
+        quoted_message_id = quote_metadata.get("name") if isinstance(quote_metadata, dict) else None
+        quoted_text = quote_snapshot.get("text") if isinstance(quote_snapshot, dict) else None
         return MessageEvent(
             text=text, message_type=message_type, source=source, raw_message=msg, message_id=msg.get("name") or None,
             media_urls=media_urls, media_types=media_types,
+            reply_to_message_id=quoted_message_id if isinstance(quoted_message_id, str) and quoted_message_id else None,
+            reply_to_text=quoted_text if isinstance(quoted_text, str) and quoted_text else None,
         )
 
     async def _download_attachment(self, attachment: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -655,6 +655,21 @@ class TestExtractMessagePayload:
 
 class TestBuildMessageEvent:
     @pytest.mark.asyncio
+    async def test_quoted_message_snapshot_becomes_reply_context(self, adapter):
+        env = _make_chat_envelope(text="What did you ask me here?")
+        msg = env["chat"]["messagePayload"]["message"]
+        msg["quotedMessageMetadata"] = {
+            "name": "spaces/S/messages/QUOTED_MESSAGE",
+            "quotedMessageSnapshot": {"text": "What question should I answer?"},
+        }
+
+        event = await adapter._build_message_event(msg, env)
+
+        assert event is not None
+        assert event.reply_to_message_id == "spaces/S/messages/QUOTED_MESSAGE"
+        assert event.reply_to_text == "What question should I answer?"
+
+    @pytest.mark.asyncio
     async def test_dm_first_message_in_thread_is_main_flow(self, adapter):
         """Google Chat DMs spawn a fresh thread per top-level user
         message in the input box. The FIRST message in any new thread


### PR DESCRIPTION
## Summary
- Map Google Chat quoted-message metadata to Hermes reply-context fields.
- Preserve the quoted message resource name and text so a reply can refer to the exact quoted bubble.

## Test plan
- `scripts/run_tests.sh tests/gateway/test_google_chat.py -q`
- `scripts/run_tests.sh tests/gateway/test_reply_to_injection.py -q`

## Scope
This is provider-native Google Chat parsing only; it adds no credentials, routing policy, or deployment-specific configuration.