### PR TITLE
fix(cron): classify tool guardrail halts as failed jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1858,6 +1858,8 @@ def _final_response_from_result(result: dict, job_id: str, job_name: str, AIAgen
     # Raise so the except handler below builds the proper failure tuple. (issue #17855)
     turn_exit_reason = str(result.get("turn_exit_reason") or "")
     final_response_text = (result.get("final_response") or "").strip()
+    if turn_exit_reason == "guardrail_halt":
+        raise RuntimeError(final_response_text or "agent stopped at a tool-call guardrail")
     max_iteration_summary = (
         result.get("failed") is not True
         and result.get("completed") is False

--- a/tests/cron/test_scheduler_completion_verification.py
+++ b/tests/cron/test_scheduler_completion_verification.py
@@ -151,3 +151,14 @@ def test_classification_probe_failure_keeps_historical_reason(monkeypatch, tmp_p
 
     reasons = [reason for _sid, reason in instances[0].ended]
     assert reasons == ["cron_complete"]
+
+
+@pytest.mark.parametrize("reason,failed", [("guardrail_halt", True), ("text_response", False)])
+def test_guardrail_halt_is_not_a_successful_briefing(reason, failed):
+    result = {"turn_exit_reason": reason, "completed": True, "failed": False,
+              "final_response": "Stopped web_search after repeated failures" if failed else "A real briefing"}
+    if failed:
+        with pytest.raises(RuntimeError, match="Stopped web_search"):
+            cron_scheduler._final_response_from_result(result, "briefing", "Briefing", _FakeCronAgent)
+    else:
+        assert cron_scheduler._final_response_from_result(result, "briefing", "Briefing", _FakeCronAgent) == "A real briefing"


### PR DESCRIPTION
A scheduled agent run can return `turn_exit_reason=guardrail_halt` with explanatory final text and otherwise successful flags. Cron currently treats that text as a completed briefing, so users receive a halted-tool explanation while the job is recorded as successful.

Route this exit reason through the existing failure lane. Normal text responses retain their existing behavior; failure recording and delivery use the scheduler’s existing machinery.

Validation: all 5 cases in `tests/cron/test_scheduler_completion_verification.py` passed through `scripts/run_tests.sh` on macOS, including after applying the patch to current upstream main. Independent code review verified the guardrail producer and failure-delivery caller.
