### PR TITLE
test(prompt): assert the context-read timeout with an event barrier, not a stopwatch

### DIFF
--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -5,7 +5,7 @@ import importlib
 import logging
 import os
 import sys
-import time
+import threading
 from pathlib import Path
 
 import pytest
@@ -1191,19 +1191,38 @@ class TestContextFileReadTimeout:
 
         original_read_text = Path.read_text
 
+        read_started = threading.Event()
+        release_read = threading.Event()
+        load_finished = threading.Event()
+        result_holder = {}
+
         def slow_read_text(self, *args, **kwargs):
             if self.name == ".hermes.md":
-                time.sleep(0.6)
+                read_started.set()
+                release_read.wait()
             return original_read_text(self, *args, **kwargs)
 
         monkeypatch.setattr(Path, "read_text", slow_read_text)
 
-        start = time.monotonic()
         with caplog.at_level(logging.WARNING, logger=pb_mod.__name__):
-            result = build_context_files_prompt(cwd=str(tmp_path))
-        elapsed = time.monotonic() - start
+            def load_context():
+                result_holder["result"] = build_context_files_prompt(cwd=str(tmp_path))
+                load_finished.set()
 
-        assert elapsed < 0.4, f"context load blocked for {elapsed:.2f}s"
+            worker = threading.Thread(target=load_context, daemon=True)
+            worker.start()
+            try:
+                assert read_started.wait(timeout=10.0), "slow context read did not start"
+                # The read stays blocked until release_read, so ANY completion proves the loader
+                # gave up on it. The bound is generous on purpose: it only has to exclude a hang,
+                # not measure latency, and a tight one flakes under load on a busy Windows host.
+                assert load_finished.wait(timeout=10.0), "context loader waited for the timed-out read"
+            finally:
+                release_read.set()
+                worker.join(timeout=2.0)
+
+        assert not worker.is_alive(), "context loader thread did not terminate"
+        result = result_holder["result"]
         assert "Agent fallback rules" in result
         assert "Hermes project rules" not in result
         assert "timed out" in caplog.text.lower()


### PR DESCRIPTION
Part of #105121 (defect 3 — the context-read timeout asserted by stopwatch). Defects 1 and 2 in that issue are #104688.

Split out of #104688 at @teknium1's request ("Please narrow/rebase **or split** that remaining test portability/reliability scope"). That review named two independent leftovers; this PR carries the first one, and #104688 now carries only the second (the `resolve_agent_cwd` patch seam plus the temporary `SessionDB` handle cleanup in `tests/run_agent/test_compression_persistence.py`). The prompt-ordering scope both once shared already landed on `main` via #104908.

One test file. No production code is touched.

## The problem

`TestContextFileReadTimeout::test_slow_hermes_md_is_skipped_and_agents_md_still_loads` proved that a slow context file is abandoned by timing the loader with a stopwatch:

```python
def slow_read_text(self, *args, **kwargs):
    if self.name == ".hermes.md":
        time.sleep(0.6)
    ...

start = time.monotonic()
result = build_context_files_prompt(cwd=str(tmp_path))
elapsed = time.monotonic() - start

assert elapsed < 0.4, f"context load blocked for {elapsed:.2f}s"
```

`0.4s` is not a property of the code under test. Inside that budget the loader must lose a thread hand-off, a real file read, and pytest's own logging capture — so a busy CI runner or a laptop under load fails a test whose subject never moved. It is loose in the other direction too: `0.4s` is 8× the `0.05s` timeout the test installs, so a regression that merely made the timeout sloppy would still pass.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[⏱️ Old: sleep 0.6s in read] -->|assert elapsed under 0.4s| B[⚡ Verdict from host scheduling]
    B --> C[🔥 Flaky under load]
    B --> D[🕳️ Blind to a sloppy timeout]
    E[🔒 New: read blocks on Event] -->|loader finishes at all| F[🚀 Verdict from the timeout itself]
    F --> G[✅ No timing window]
    F --> H[🧵 Worker joined and asserted dead]
```

## The change

The slow read now blocks on a `threading.Event` that only the test releases. The loader runs on a worker thread, so **any** completion of it proves it gave up on the still-blocked read — the verdict comes from the timeout, never from the clock. The read is released in a `finally`, the worker is joined, and the test asserts it terminated, so a leaked blocked thread cannot pass silently.

The two remaining `wait(timeout=10.0)` calls are hang bounds, not latency measurements, and are generous on purpose.

## Verification

The assertion still has teeth. Raising the installed timeout to `30.0s` so the loader genuinely waits for the read:

```
E   AssertionError: context loader waited for the timed-out read
1 failed in 10.55s
```

Unmodified, on Windows 11 / CPython 3.14:

```
tests/agent/test_prompt_builder.py .... 76 passed, 1 skipped
```

Green under `pytest-randomly`'s shuffled ordering as well. The old test also passes on this host — it is not failing today, and this is a flakiness fix rather than a bug fix: it removes the load-sensitive wall-clock budget instead of widening it.

 