### PR TITLE
fix(install): pin Windows npm cwd so desktop pack does not read the launcher project

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -2,6 +2,10 @@
 
 * ``["npm", ...]`` — on Windows ``npm`` is ``npm.cmd``, a batch shim; ``Popen`` fails with
   WinError 193 because CreateProcessW can't run a ``.cmd`` without ``shell=True``/PATHEXT.
+* npm.cmd also ignores CreateProcess ``lpCurrentDirectory`` (Python's ``Popen(cwd=)``): it
+  inherits the process Win32 directory, which can stay at the folder Hermes was launched
+  from. :func:`pinned_win32_cwd` aligns that directory with the intended checkout, matching
+  ``Sync-Win32ProcessCwd`` in ``scripts/install.ps1``.
 * ``start_new_session=True`` — POSIX ``os.setsid()`` detach; silently ignored on Windows, whose
   equivalent is the ``CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW`` creationflags bundle.
 """
@@ -13,6 +17,8 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from typing import Mapping, Sequence
 
 __all__ = [
@@ -24,6 +30,8 @@ __all__ = [
     "windows_detach_flags_without_breakaway",
     "windows_hide_flags",
     "windows_detach_popen_kwargs",
+    "pinned_win32_cwd",
+    "npm_failure_is_wrong_cwd",
     "bounded_git_probe",
     "bounded_probe_run",
     "noninteractive_git_env",
@@ -111,6 +119,55 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
     """
     resolved = shutil.which(name)
     return [resolved or name, *argv]
+
+
+@contextmanager
+def pinned_win32_cwd(
+    cwd: str | os.PathLike[str] | None,
+    *,
+    is_windows: bool | None = None,
+    chdir: Callable[[str], object] | None = None,
+    getcwd: Callable[[], str] | None = None,
+) -> Iterator[None]:
+    """On Windows, set the process Win32 directory to *cwd* for the duration of the block.
+
+    ``Push-Location`` / ``os.chdir``-equivalent Python ``Popen(cwd=)`` does not pin ``npm.cmd``:
+    the batch shim inherits ``GetCurrentDirectory``, which can remain the directory Hermes was
+    launched from (e.g. ``D:\\Work``). npm then reads that folder's ``package.json``:
+
+      No workspaces found: --workspace=ui-tui --workspace=web
+      Missing script: "pack"
+
+    POSIX and a missing *cwd* are no-ops. *is_windows* / *chdir* / *getcwd* are injectable so
+    tests pass the Windows branch as data without faking ``sys.platform``.
+    """
+    if is_windows is None:
+        is_windows = IS_WINDOWS
+    if not is_windows or cwd is None:
+        yield
+        return
+    target = os.fspath(cwd)
+    if not target:
+        yield
+        return
+    _chdir = chdir or os.chdir
+    _getcwd = getcwd or os.getcwd
+    previous = _getcwd()
+    _chdir(target)
+    try:
+        yield
+    finally:
+        _chdir(previous)
+
+
+def npm_failure_is_wrong_cwd(output: str | None) -> bool:
+    """True when npm ran against the wrong ``package.json`` (launch cwd), not a missing Electron zip.
+
+    The installer and ``hermes desktop`` otherwise misdiagnose this as a blocked GitHub download
+    and retry npmmirror (#46785).
+    """
+    text = output or ""
+    return ('Missing script: "pack"' in text) or ("No workspaces found" in text)
 
 
 # Win32 CreationFlags — defined here because CREATE_NO_WINDOW / DETACHED_PROCESS aren't guaranteed

--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -1281,13 +1281,30 @@ def _run_desktop_pack_with_recovery(
     repeat the same slow failure.
     """
     from hermes_cli.main import PROJECT_ROOT
+    from hermes_cli._subprocess_compat import npm_failure_is_wrong_cwd
     def _staged_exe() -> Optional[Path]:
         return _desktop_packaged_executable_in(staging_dir) if staging_dir else None
 
     def _pack(run_env: dict) -> subprocess.CompletedProcess:
-        return subprocess.run(build_cmd, cwd=desktop_dir, env=run_env, check=False)
+        from hermes_cli._subprocess_compat import pinned_win32_cwd
+        with pinned_win32_cwd(desktop_dir):
+            result = subprocess.run(
+                build_cmd, cwd=desktop_dir, env=run_env, check=False,
+                stderr=subprocess.PIPE, text=True, encoding="utf-8", errors="replace",
+            )
+        if result.stderr:
+            sys.stderr.write(result.stderr)
+            sys.stderr.flush()
+        return result
+
+    def _pack_output(result: subprocess.CompletedProcess) -> str:
+        return f"{result.stdout or ''}\n{result.stderr or ''}"
 
     build_result = _pack(npm_build_env)
+    if build_result.returncode != 0 and npm_failure_is_wrong_cwd(_pack_output(build_result)):
+        print("  ⚠ npm ran against the wrong package.json (launch folder), not a "
+              "blocked Electron download. Skipping the npmmirror retry.")
+        return build_result
     if build_result.returncode != 0 and staging_dir is not None and _staged_exe() is None:
         # Corrupt cached Electron zip → partial unpack → ENOENT on rename. stdlib zipfile won't catch the
         # common concat-junk case, so purge and retry once; @electron/get SHASUM is the real gate. Gate on a
@@ -1313,6 +1330,10 @@ def _run_desktop_pack_with_recovery(
         and staging_dir is not None
         and not env.get("ELECTRON_MIRROR")
         and _staged_exe() is None):
+        if npm_failure_is_wrong_cwd(_pack_output(build_result)):
+            print("  ⚠ npm ran against the wrong package.json (launch folder), not a "
+                  "blocked Electron download. Skipping the npmmirror retry.")
+            return build_result
         print("  ⚠ Desktop build still failing; the Electron download from "
               "GitHub looks blocked. Re-downloading via a public mirror "
               "(npmmirror.com)... (set ELECTRON_MIRROR to use another mirror)")

--- a/hermes_cli/main_tui_launch.py
+++ b/hermes_cli/main_tui_launch.py
@@ -463,9 +463,11 @@ def _exit_on_npm_failure(result: subprocess.CompletedProcess, message: str, *, s
 
 def _run_tui_npm_build(npm: str, cwd: Path, failure_message: str) -> None:
     """``npm run build`` in *cwd*; exit with *failure_message* + output tail on failure."""
-    result = subprocess.run(
-        [npm, "run", "build"], cwd=str(cwd), capture_output=True, text=True, encoding="utf-8",
-        errors="replace", env=_npm_lifecycle_env())
+    from hermes_cli._subprocess_compat import pinned_win32_cwd
+    with pinned_win32_cwd(cwd):
+        result = subprocess.run(
+            [npm, "run", "build"], cwd=str(cwd), capture_output=True, text=True, encoding="utf-8",
+            errors="replace", env=_npm_lifecycle_env())
     _exit_on_npm_failure(result, failure_message, sep="")
 
 
@@ -494,13 +496,15 @@ def _install_tui_dependencies(tui_dir: Path, *, termux_startup: bool) -> None:
     ]
 
     def _run_tui_install() -> subprocess.CompletedProcess:
+        from hermes_cli._subprocess_compat import pinned_win32_cwd
         from hermes_constants import with_hermes_node_path
         # Managed tree first on PATH: if the EBADENGINE repair provisioned a
         # managed Node, npm's shebang/lifecycle scripts must resolve that node.
-        return subprocess.run(
-            npm_install_cmd, cwd=str(npm_cwd), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            text=True, encoding="utf-8", errors="replace",
-            env=_npm_lifecycle_env(with_hermes_node_path()))
+        with pinned_win32_cwd(npm_cwd):
+            return subprocess.run(
+                npm_install_cmd, cwd=str(npm_cwd), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                text=True, encoding="utf-8", errors="replace",
+                env=_npm_lifecycle_env(with_hermes_node_path()))
 
     result = _run_tui_install()
     if result.returncode != 0:

--- a/hermes_cli/main_web_build.py
+++ b/hermes_cli/main_web_build.py
@@ -225,10 +225,14 @@ def _run_with_idle_timeout(
     last_output_ts = _time.monotonic()
     lock = threading.Lock()
 
+    from hermes_cli._subprocess_compat import pinned_win32_cwd
+
     try:
-        proc = subprocess.Popen(
-            cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            text=True, encoding="utf-8", errors="replace", bufsize=1, env=env)
+        # npm.cmd inherits the Win32 process directory, not Popen(cwd=).
+        with pinned_win32_cwd(cwd):
+            proc = subprocess.Popen(
+                cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                text=True, encoding="utf-8", errors="replace", bufsize=1, env=env)
     except OSError as exc:
         # E.g. npm not on PATH between the which() check and now.
         return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(exc))
@@ -363,22 +367,26 @@ def _run_npm_watching_for_engine_failure(
     ``capture_output=False`` callers stream npm's progress live; tee stderr so it
     is both forwarded as it arrives and accumulated for the engine-repair check.
     """
-    if capture_output:
-        return subprocess.run(
-            cmd, cwd=cwd, env=env, capture_output=True, text=True, encoding="utf-8", errors="replace", check=False,
-        )
+    from hermes_cli._subprocess_compat import pinned_win32_cwd
 
-    captured: list[str] = []
-    with subprocess.Popen(
-        cmd, cwd=cwd, env=env, stderr=subprocess.PIPE, text=True, encoding="utf-8", errors="replace",
-    ) as proc:
-        if proc.stderr is not None:
-            for line in proc.stderr:
-                captured.append(line)
-                sys.stderr.write(line)
-            sys.stderr.flush()
-        returncode = proc.wait()
-    return subprocess.CompletedProcess(cmd, returncode, None, "".join(captured))
+    # npm.cmd inherits the Win32 process directory, not Popen(cwd=).
+    with pinned_win32_cwd(cwd):
+        if capture_output:
+            return subprocess.run(
+                cmd, cwd=cwd, env=env, capture_output=True, text=True, encoding="utf-8", errors="replace", check=False,
+            )
+
+        captured: list[str] = []
+        with subprocess.Popen(
+            cmd, cwd=cwd, env=env, stderr=subprocess.PIPE, text=True, encoding="utf-8", errors="replace",
+        ) as proc:
+            if proc.stderr is not None:
+                for line in proc.stderr:
+                    captured.append(line)
+                    sys.stderr.write(line)
+                sys.stderr.flush()
+            returncode = proc.wait()
+        return subprocess.CompletedProcess(cmd, returncode, None, "".join(captured))
 
 
 def _missing_web_build_tool(output: str) -> str | None:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3566,6 +3566,7 @@ function Install-NodeDeps {
             # via the returned exit code, which is reliable regardless of
             # stderr noise.
             $ErrorActionPreference = "Continue"
+            Sync-Win32ProcessCwd
             $code = _Invoke-NativeWithTimeout $npmPath "install --silent" `
                 $installDir $logPath $nodeDepsTimeoutSec
             $ErrorActionPreference = $prevEAP
@@ -3928,6 +3929,23 @@ function Clear-ElectronBuildCache {
 # Last-resort Electron mirror after GitHub download fails (#47266).
 $script:DesktopElectronFallbackMirror = "https://npmmirror.com/mirrors/electron/"
 
+function Sync-Win32ProcessCwd {
+    # Push-Location updates $PWD. npm.cmd inherits the Win32 process cwd,
+    # which can stay at the directory the installer was launched from
+    # (e.g. D:\Work). npm then reads that folder's package.json:
+    # "No workspaces found" / Missing script "pack".
+    $fsPath = (Get-Location -PSProvider FileSystem).ProviderPath
+    if ($fsPath) {
+        [System.IO.Directory]::SetCurrentDirectory($fsPath)
+    }
+}
+
+function Test-DesktopNpmFailureIsWrongCwd {
+    param([string]$NpmOutput)
+    if ([string]::IsNullOrWhiteSpace($NpmOutput)) { return $false }
+    return ($NpmOutput -match 'Missing script:\s*"pack"') -or ($NpmOutput -match 'No workspaces found')
+}
+
 # Electron package dir -- workspace-local nest first, then root hoist.
 function Get-ElectronDir {
     param([string]$InstallDir)
@@ -4079,6 +4097,7 @@ function Install-Desktop {
     # apps/* workspaces resolve.
     Write-Info "Installing desktop workspace dependencies (this includes Electron ~150MB, takes 1-3min)..."
     Push-Location $InstallDir
+    Sync-Win32ProcessCwd
     $prevEAP = $ErrorActionPreference
     try {
         $ErrorActionPreference = "Continue"
@@ -4196,6 +4215,7 @@ function Install-Desktop {
         Write-Warn "Could not resolve a git commit for the desktop stamp -- write-build-stamp will use its non-git fallback"
     }
     Push-Location $desktopDir
+    Sync-Win32ProcessCwd
     $prevEAP = $ErrorActionPreference
     $prevCSCAuto = $env:CSC_IDENTITY_AUTO_DISCOVERY
     $prevWinCscLink = $env:WIN_CSC_LINK
@@ -4208,34 +4228,42 @@ function Install-Desktop {
         & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
         $code = $LASTEXITCODE
         if ($code -ne 0) {
-            $purged = @()
-            $restored = $false
-            if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
-                $purged = @(Clear-ElectronBuildCache -DesktopDir $desktopDir)
-                $restored = Restore-ElectronDist -InstallDir $InstallDir
-            }
-            if ($restored) {
-                Write-Warn "Desktop build failed - refreshed the Electron download, retrying once:"
-                foreach ($p in $purged) { Write-Info "  - $p" }
-                & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
-                $code = $LASTEXITCODE
-            }
-        }
-        if ($code -ne 0 -and -not $env:ELECTRON_MIRROR) {
-            $mirror = $script:DesktopElectronFallbackMirror
-            Write-Warn "Desktop build still failing - the Electron download from GitHub looks blocked."
-            Write-Warn "Re-downloading Electron via a public mirror ($mirror), then rebuilding:"
-            Write-Info "  (set ELECTRON_MIRROR yourself to use a different/trusted mirror)"
-            if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
-                Restore-ElectronDist -InstallDir $InstallDir -Mirror $mirror | Out-Null
-            }
-            $prevMirror = $env:ELECTRON_MIRROR
-            $env:ELECTRON_MIRROR = $mirror
-            try {
-                & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
-                $code = $LASTEXITCODE
-            } finally {
-                $env:ELECTRON_MIRROR = $prevMirror
+            $errSoFar = Get-Content $buildLog -Raw -ErrorAction SilentlyContinue
+            if (Test-DesktopNpmFailureIsWrongCwd $errSoFar) {
+                Write-Warn "Desktop npm used the wrong package.json (cwd is not apps/desktop). Skipping Electron redownload."
+                Write-Info "  expected cwd: $desktopDir"
+            } else {
+                $purged = @()
+                $restored = $false
+                if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
+                    $purged = @(Clear-ElectronBuildCache -DesktopDir $desktopDir)
+                    $restored = Restore-ElectronDist -InstallDir $InstallDir
+                }
+                if ($restored) {
+                    Write-Warn "Desktop build failed - refreshed the Electron download, retrying once:"
+                    foreach ($p in $purged) { Write-Info "  - $p" }
+                    Sync-Win32ProcessCwd
+                    & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
+                    $code = $LASTEXITCODE
+                }
+                if ($code -ne 0 -and -not $env:ELECTRON_MIRROR) {
+                    $mirror = $script:DesktopElectronFallbackMirror
+                    Write-Warn "Desktop build still failing - the Electron download from GitHub looks blocked."
+                    Write-Warn "Re-downloading Electron via a public mirror ($mirror), then rebuilding:"
+                    Write-Info "  (set ELECTRON_MIRROR yourself to use a different/trusted mirror)"
+                    if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
+                        Restore-ElectronDist -InstallDir $InstallDir -Mirror $mirror | Out-Null
+                    }
+                    $prevMirror = $env:ELECTRON_MIRROR
+                    $env:ELECTRON_MIRROR = $mirror
+                    try {
+                        Sync-Win32ProcessCwd
+                        & $npmExe run pack 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $buildLog
+                        $code = $LASTEXITCODE
+                    } finally {
+                        $env:ELECTRON_MIRROR = $prevMirror
+                    }
+                }
             }
         }
         $ErrorActionPreference = $prevEAP

--- a/tests/hermes_cli/test_windows_npm_cwd.py
+++ b/tests/hermes_cli/test_windows_npm_cwd.py
@@ -1,0 +1,81 @@
+"""Windows npm.cmd must see the checkout directory, not the launch cwd.
+
+Launching ``hermes desktop`` / ``hermes dashboard`` from another project (e.g.
+D:\\Work) leaves the Win32 process directory there. Python's ``Popen(cwd=)``
+does not override it for ``npm.cmd``, so npm reads the wrong package.json
+(``Missing script: "pack"`` / ``No workspaces found``) and the desktop pack
+path misdiagnoses that as a blocked Electron download (#46785).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from hermes_cli._subprocess_compat import npm_failure_is_wrong_cwd, pinned_win32_cwd
+from hermes_cli import main_desktop
+
+
+def test_pinned_win32_cwd_chdirs_only_on_windows() -> None:
+    """The Windows branch chdirs into the checkout and restores; POSIX is a no-op."""
+    seen: list[str] = []
+
+    def chdir(path: str) -> None:
+        seen.append(path)
+
+    with pinned_win32_cwd(
+        r"C:\hermes\apps\desktop",
+        is_windows=True,
+        chdir=chdir,
+        getcwd=lambda: r"D:\Work",
+    ):
+        pass
+    assert seen == [r"C:\hermes\apps\desktop", r"D:\Work"]
+
+    seen.clear()
+    with pinned_win32_cwd("/tmp/desktop", is_windows=False, chdir=chdir, getcwd=lambda: "/"):
+        pass
+    assert seen == []
+
+
+def test_desktop_pack_skips_electron_mirror_on_wrong_package_json(
+    tmp_path: Path, monkeypatch, capsys,
+) -> None:
+    """A missing pack script is the wrong package.json, not GitHub blocking Electron."""
+    desktop_dir = tmp_path / "apps" / "desktop"
+    desktop_dir.mkdir(parents=True)
+    staging = desktop_dir / ".staging-pack"
+    staging.mkdir()
+    redownloads: list[object] = []
+    pack_envs: list[dict] = []
+
+    def fake_run(cmd, **kwargs):
+        pack_envs.append(dict(kwargs.get("env") or {}))
+        return subprocess.CompletedProcess(
+            cmd, 1, stdout="", stderr='npm error Missing script: "pack"\n',
+        )
+
+    monkeypatch.setattr(main_desktop.subprocess, "run", fake_run)
+    monkeypatch.setattr(main_desktop, "_desktop_packaged_executable_in", lambda *_a, **_k: None)
+    monkeypatch.setattr(main_desktop, "_electron_dist_ok", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        main_desktop,
+        "_redownload_electron_dist",
+        lambda *_a, **_k: redownloads.append(1) or False,
+    )
+    monkeypatch.setattr(main_desktop, "_purge_electron_build_cache", lambda *_a, **_k: [])
+    monkeypatch.setattr(main_desktop, "_stop_desktop_processes_locking_build", lambda *_a, **_k: [])
+
+    result = main_desktop._run_desktop_pack_with_recovery(
+        desktop_dir, ["npm.cmd", "run", "pack"], {}, {}, staging,
+    )
+
+    assert result.returncode == 1
+    assert len(pack_envs) == 1
+    assert redownloads == []
+    out = capsys.readouterr().out
+    assert "Skipping the npmmirror retry" in out
+    assert "Re-downloading via a public mirror" not in out
+    assert npm_failure_is_wrong_cwd(result.stderr)
+    assert npm_failure_is_wrong_cwd("npm error No workspaces found: --workspace=ui-tui --workspace=web")
+    assert not npm_failure_is_wrong_cwd("electron failed to download")

--- a/tests/test_install_ps1_desktop_npm_cwd.py
+++ b/tests/test_install_ps1_desktop_npm_cwd.py
@@ -1,0 +1,72 @@
+"""Install-Desktop must pin npm's Win32 cwd to the Hermes checkout.
+
+Launching Hermes-Setup.exe from another project (e.g. D:\\Work) leaves the
+process cwd there. Push-Location updates $PWD, but npm.cmd inherits
+[Environment]::CurrentDirectory, so it reads the wrong package.json:
+
+  No workspaces found: --workspace=ui-tui --workspace=web
+  Missing script: "pack"
+
+The installer then misdiagnoses that as a blocked Electron download and
+retries npmmirror (#46785).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+
+def _source() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def _function_body(source: str, name: str) -> str:
+    match = re.search(
+        rf"^function {re.escape(name)} \{{.*?^\}}", source, re.MULTILINE | re.DOTALL
+    )
+    assert match, f"could not extract function {name} from install.ps1"
+    return match.group(0)
+
+
+def test_install_desktop_syncs_win32_cwd_before_npm() -> None:
+    """npm.cmd children must see the checkout directory, not the launch cwd."""
+    source = _source()
+    sync = _function_body(source, "Sync-Win32ProcessCwd")
+    assert "[System.IO.Directory]::SetCurrentDirectory" in sync
+
+    desktop = _function_body(source, "Install-Desktop")
+    push_then_sync = re.search(
+        r"Push-Location \$InstallDir\s+.*?Sync-Win32ProcessCwd",
+        desktop,
+        re.DOTALL,
+    )
+    assert push_then_sync, "npm ci must run after Sync-Win32ProcessCwd at $InstallDir"
+    pack_sync = re.search(
+        r"Push-Location \$desktopDir\s+.*?Sync-Win32ProcessCwd",
+        desktop,
+        re.DOTALL,
+    )
+    assert pack_sync, "npm run pack must run after Sync-Win32ProcessCwd at $desktopDir"
+    ci_idx = desktop.find("Sync-Win32ProcessCwd")
+    pack_idx = desktop.find("& $npmExe run pack")
+    assert ci_idx != -1 and pack_idx != -1 and ci_idx < pack_idx
+
+
+def test_install_desktop_skips_electron_mirror_on_wrong_cwd() -> None:
+    """A missing pack script is the wrong package.json, not GitHub blocking Electron."""
+    source = _source()
+    detector = _function_body(source, "Test-DesktopNpmFailureIsWrongCwd")
+    assert "Missing script" in detector
+    assert "No workspaces found" in detector
+
+    desktop = _function_body(source, "Install-Desktop")
+    assert "Test-DesktopNpmFailureIsWrongCwd" in desktop
+    skip_gate = re.search(
+        r"if \(Test-DesktopNpmFailureIsWrongCwd \$errSoFar\) \{[\s\S]{0,400}?"
+        r"Skipping Electron redownload",
+        desktop,
+    )
+    assert skip_gate, "wrong-cwd npm output must skip the npmmirror retry"


### PR DESCRIPTION
## Summary
- Windows `npm.cmd` inherits the Win32 process directory, not `Push-Location` / Python `Popen(cwd=)`. Launching Setup, `hermes desktop`, or `hermes dashboard` from another folder (e.g. `D:\Work`) made npm read that project's `package.json`: `No workspaces found` and `Missing script: "pack"`.
- The installer and `hermes desktop` then retried npmmirror as if GitHub had blocked Electron. Pin the Win32 cwd to the Hermes checkout before npm (installer + CLI), and skip that Electron retry when the failure is the wrong package.json.

## Test plan
- [x] `scripts/run_tests.sh tests/test_install_ps1_desktop_npm_cwd.py tests/hermes_cli/test_windows_npm_cwd.py tests/hermes_cli/test_run_with_idle_timeout.py tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_web_ui_build.py tests/hermes_cli/test_cmd_update.py`
- [ ] On Windows: start Hermes-Setup from a directory that has its own `package.json` (not the Hermes checkout) and confirm desktop `npm run pack` runs under `...\hermes-agent\apps\desktop` instead of the launch folder
- [ ] On Windows: from that same launch folder, run `hermes desktop --force-build` and `hermes dashboard` and confirm npm uses the checkout, not the launch folder
- [ ] Confirm a real Electron download failure still prints the npmmirror retry
