### PR TITLE
fix(desktop): settle managed SSH updates before the local updater handoff

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -153,6 +153,7 @@ import {
   updateEligibility,
   upsertConnection
 } from './connection-registry'
+import type { RegistryConnection } from './connection-registry'
 import type { RosterProfileMetadata } from './connection-registry'
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
@@ -391,6 +392,7 @@ import {
 } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
+import { updateConnectionsBeforeLocal } from './update-order'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import {
   collectRelaunchArgs,
@@ -3953,6 +3955,15 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
   updateInFlight = true
 
   try {
+    // The local handoff asks the window to exit and the update scripts only
+    // wait so long for that PID — never start that deadline while quit would
+    // still be gated on a managed SSH update or its recovery transaction
+    // (before-quit joins the same operations; the updater must not race them).
+    await waitForManagedUpdateOperations(() => [
+      ...managedConnectionUpdates.values(),
+      ...managedConnectionRecoveries.values()
+    ])
+
     const updater = resolveUpdaterBinary()
 
     if (!updater && !IS_WINDOWS) {
@@ -8158,7 +8169,6 @@ interface GatewayFileSaveContext {
 }
 
 interface GatewayFileSavePayload {
-  sessionId?: string
   connectionId?: unknown
   path?: unknown
   profile?: unknown
@@ -8199,10 +8209,8 @@ async function saveGatewayFile(payload: GatewayFileSavePayload = {}) {
   const fallbackName = path.basename(filePath) || suggested || 'download'
   const ctx = { suggested, fallbackName }
 
-  const requestPaths = gatewayFileRequestPaths(
-    filePath,
-    requestPath => gatewayFileRequestPath(connection, connectionId, profile, requestPath),
-    payload.sessionId
+  const requestPaths = gatewayFileRequestPaths(filePath, requestPath =>
+    gatewayFileRequestPath(connection, connectionId, profile, requestPath)
   )
 
   const url = `${connection.baseUrl}${requestPaths.download}`
@@ -15880,18 +15888,20 @@ ipcMain.handle('hermes:connections:update-all', async (_event, payload) => {
     Array.isArray((payload as any)?.excludeIds) ? (payload as any).excludeIds.map((id: unknown) => String(id)) : []
   )
 
-  const results = await Promise.all(
-    registry.connections
-      .filter(connection => !excludeIds.has(connection.id))
-      .map(async connection => {
-        const base = { connectionId: connection.id, label: connection.label, kind: connection.kind }
-        const eligibility = updateEligibility(connection)
+  // Remote entries settle before the local handoff runs: the local updater
+  // waits on the window PID exiting, so a still-running managed SSH update
+  // would eat into (or outlive) that deadline. Order of results is preserved.
+  const results = await updateConnectionsBeforeLocal(
+    registry.connections.filter(connection => !excludeIds.has(connection.id)),
+    async (connection: RegistryConnection) => {
+      const base = { connectionId: connection.id, label: connection.label, kind: connection.kind }
+      const eligibility = updateEligibility(connection)
 
-        if (!eligibility.eligible) {
+      if (!eligibility.eligible) {
           return { ...base, ok: false, skipped: true, reason: eligibility.reason }
-        }
+      }
 
-        try {
+      try {
           if (connection.kind === 'local') {
             // The app-managed runtime updates through the same pipeline as the
             // Settings → Updates button (marker + venv gate + relaunch flow).
@@ -15933,10 +15943,10 @@ ipcMain.handle('hermes:connections:update-all', async (_event, payload) => {
           }
 
           return { ...base, ok: true, detail: body?.message || 'update started' }
-        } catch (error: any) {
-          return { ...base, ok: false, error: String(error?.message || error) }
-        }
-      })
+      } catch (error: any) {
+        return { ...base, ok: false, error: String(error?.message || error) }
+      }
+    }
   )
 
   return { ok: true, results }

--- a/apps/desktop/electron/update-order.test.ts
+++ b/apps/desktop/electron/update-order.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { updateConnectionsBeforeLocal } from './update-order'
+
+test('a local handoff waits for remote updates that outlive its exit deadline', async () => {
+  let finishRemote: () => void = () => {}
+
+  const remote = new Promise<void>(resolve => {
+    finishRemote = resolve
+  })
+
+  const started: string[] = []
+  const connections = [{ kind: 'local' }, { kind: 'ssh' }, { kind: 'remote' }]
+
+  const result = updateConnectionsBeforeLocal(connections, async connection => {
+    started.push(connection.kind)
+
+    if (connection.kind === 'ssh') {
+      await remote
+    }
+
+    return connection.kind
+  })
+
+  await Promise.resolve()
+  await Promise.resolve()
+  const startedBeforeRemoteCompletion = [...started]
+  finishRemote()
+  assert.deepEqual(await result, ['local', 'ssh', 'remote'])
+  assert.deepEqual(startedBeforeRemoteCompletion, ['ssh', 'remote'])
+  assert.deepEqual(started, ['ssh', 'remote', 'local'])
+})
+
+test('an empty selection does nothing and a local-only selection runs once', async () => {
+  let calls = 0
+  const update = async () => ++calls
+  assert.deepEqual(await updateConnectionsBeforeLocal([], update), [])
+  assert.deepEqual(await updateConnectionsBeforeLocal([{ kind: 'local' }], update), [1])
+})
+
+test('remote updates still run concurrently with each other', async () => {
+  let running = 0
+  let maxRunning = 0
+
+  const results = await updateConnectionsBeforeLocal(
+    [{ kind: 'ssh' }, { kind: 'remote' }, { kind: 'ssh' }],
+    async connection => {
+      running += 1
+      maxRunning = Math.max(maxRunning, running)
+      await new Promise(resolve => setTimeout(resolve, 5))
+      running -= 1
+
+      return connection.kind
+    }
+  )
+
+  assert.deepEqual(results, ['ssh', 'remote', 'ssh'])
+  assert.equal(maxRunning, 3)
+})

--- a/apps/desktop/electron/update-order.ts
+++ b/apps/desktop/electron/update-order.ts
@@ -1,0 +1,22 @@
+/**
+ * A local update hands control to a detached updater that waits for the
+ * Desktop window to exit, so every remote update transaction must settle
+ * first — otherwise a managed SSH update can outlive the local updater's
+ * exit deadline and abort the whole update.
+ */
+export async function updateConnectionsBeforeLocal<T extends { kind: string }, R>(
+  connections: T[],
+  update: (connection: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(connections.length)
+  const indexed = connections.map((connection, index) => ({ connection, index }))
+
+  const run = async ({ connection, index }: (typeof indexed)[number]) => {
+    results[index] = await update(connection)
+  }
+
+  await Promise.all(indexed.filter(({ connection }) => connection.kind !== 'local').map(run))
+  await Promise.all(indexed.filter(({ connection }) => connection.kind === 'local').map(run))
+
+  return results
+}


### PR DESCRIPTION
## Summary
A local Desktop update hands control to a detached updater whose scripts wait **30s** for the window PID to exit. Two paths let a managed SSH update run concurrently with that deadline:

- `applyUpdates()` spawned the detached updater without first joining `managedConnectionUpdates` / `managedConnectionRecoveries` — the same transactions `before-quit` deliberately waits on via `waitForManagedUpdateOperations()`. A live remote update could outlive the local handoff's exit deadline and abort the update (`Update aborted: the Hermes window (pid …) did not exit within 30s`).
- The `hermes:connections:update-all` handler fanned **all** entries — local included — through one `Promise.all`, dispatching the exit-requiring local update alongside remote transactions.

Fix:
1. `applyUpdates()` now joins managed update/recovery transactions at the top, before `resolveUpdaterBinary()`. No bypass of the PID safety check; nothing is terminated to meet the deadline.
2. A small pure helper `updateConnectionsBeforeLocal` (`electron/update-order.ts`) sequences the handler **remote-first / local-last** while keeping remotes concurrent with each other and preserving the result order.

## Testing
- `npx tsc --build tsconfig.electron.json` — clean.
- `npx vitest run electron/update-order.test.ts --project electron` — 3 passed (ordering, empty/local-only, remote concurrency; mutation-verified RED on inverted sequencing).
- `npx vitest run electron/managed-ssh-update.test.ts electron/update-handoff-marker.test.ts electron/update-marker.test.ts electron/updater-process.test.ts --project electron` — 74 passed, 1 skipped; the single failure (`POSIX managed launcher`, `127 !== 0`) reproduces identically on clean `main` via `git stash -u` — pre-existing, unrelated to this diff.
- eslint on touched files — clean.

Fixes #105108

(report analysis, RCA and patch sketch credited to the issue author)