### PR TITLE
fix(cron): discover user bus for scoped workers

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3154,7 +3154,10 @@ def _launch_external_cron_worker(job: dict) -> bool:
 
     from agent.secret_scope import is_multiplex_active
     from tools.environments.local import build_subprocess_env
-    from tools.process_registry import restart_safe_gateway_child_argv
+    from tools.process_registry import (
+        restart_safe_gateway_child_argv,
+        restart_safe_gateway_child_env,
+    )
 
     multiplex_active = is_multiplex_active()
     scoped_command = restart_safe_gateway_child_argv(
@@ -3196,6 +3199,7 @@ def _launch_external_cron_worker(job: dict) -> bool:
         inherit_profile_home=True,
         extra={"HERMES_HOME": str(_get_hermes_home().resolve())},
     )
+    worker_env = restart_safe_gateway_child_env(worker_env)
     try:
         process = subprocess.Popen(
             scoped_command,

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -2257,7 +2257,11 @@ def _default_spawn(task: Task, workspace: str, *, board: Optional[str] = None) -
     # A worker spawned by a managed systemd gateway must leave the gateway's
     # cgroup before startup; otherwise restarting the service kills the worker
     # that is performing the handoff.
-    cmd = _restart_safe_worker_argv(task, cmd)
+    scoped_cmd = _restart_safe_worker_argv(task, cmd)
+    if scoped_cmd is not cmd:
+        from tools.process_registry import restart_safe_gateway_child_env
+        env = restart_safe_gateway_child_env(env)
+    cmd = scoped_cmd
     log_f = _open_worker_log(task, board)
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2375,6 +2375,48 @@ class TestSystemdCgroupIsolation:
             value.startswith("OOMPolicy=") for value in probe_argv if isinstance(value, str)
         ), probe_argv
 
+    def test_systemd_probe_derives_owned_user_bus_env_for_system_gateway(
+        self, registry, monkeypatch
+    ):
+        """A system service running as an unprivileged user has no login env,
+        but may still have a valid lingering user manager and D-Bus socket."""
+        import tools.process_registry as pr
+
+        runtime_dir = pr.Path(f"/tmp/hbus-{os.getpid()}-{time.time_ns()}")
+        runtime_dir.mkdir(mode=0o700)
+        bus_path = runtime_dir / "bus"
+        import socket
+
+        bus_socket = socket.socket(socket.AF_UNIX)
+        bus_socket.bind(str(bus_path))
+
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_default_user_runtime_dir", lambda: runtime_dir)
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        derived = pr._systemd_user_bus_env(
+            {"DBUS_SESSION_BUS_ADDRESS": "unix:path=/tmp/untrusted-bus"}
+        )
+        assert derived["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={bus_path}"
+        probe_kwargs = []
+
+        def fake_run(*args, **kwargs):
+            probe_kwargs.append(kwargs)
+            return subprocess.CompletedProcess(args=args[0], returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        assert pr._systemd_run_user_scope_available() is True
+        env = probe_kwargs[0]["env"]
+        assert env["XDG_RUNTIME_DIR"] == str(runtime_dir)
+        assert env["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={bus_path}"
+        assert "XDG_RUNTIME_DIR" not in os.environ
+        assert "DBUS_SESSION_BUS_ADDRESS" not in os.environ
+        bus_socket.close()
+        bus_path.unlink()
+        runtime_dir.rmdir()
+
     def test_systemd_scope_first_probe_is_serialized(self, monkeypatch):
         """Concurrent first-use callers must wait for one definitive probe.
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -12,6 +12,7 @@ import os
 import platform
 import shlex
 import signal
+import stat
 import subprocess
 import threading
 import time
@@ -136,6 +137,53 @@ def _systemd_scope_argv(binary: str, unit_name: str, *argv: str) -> List[str]:
     ]
 
 
+def _default_user_runtime_dir() -> Path:
+    """Return systemd's conventional per-user runtime directory."""
+    return Path(f"/run/user/{os.getuid()}")
+
+
+def _secure_user_runtime_dir(path: Path) -> bool:
+    """Accept only an absolute, owned, non-writable real directory."""
+    try:
+        metadata = path.lstat()
+        return (
+            path.is_absolute()
+            and stat.S_ISDIR(metadata.st_mode)
+            and metadata.st_uid == os.getuid()
+            and metadata.st_mode & 0o022 == 0
+        )
+    except OSError:
+        return False
+
+
+def _systemd_user_bus_env(base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    """Build an environment that can reach this user's lingering systemd manager.
+
+    System-level gateway units run as an unprivileged ``User=`` but normally do
+    not inherit login-session variables.  When the conventional runtime
+    directory is owned by this uid and its bus exists, derive the two standard
+    variables.  The returned copy must be passed explicitly to both the probe
+    and worker; global process state is intentionally left unchanged.
+    """
+    env = dict(os.environ if base_env is None else base_env)
+    configured = Path(env["XDG_RUNTIME_DIR"]) if env.get("XDG_RUNTIME_DIR") else None
+    runtime_dir = configured if configured and _secure_user_runtime_dir(configured) else _default_user_runtime_dir()
+    if not _secure_user_runtime_dir(runtime_dir):
+        return env
+
+    bus_path = runtime_dir / "bus"
+    try:
+        bus_metadata = bus_path.lstat()
+    except OSError:
+        return env
+    if not stat.S_ISSOCK(bus_metadata.st_mode) or bus_metadata.st_uid != os.getuid():
+        return env
+
+    env["XDG_RUNTIME_DIR"] = str(runtime_dir)
+    env["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path={bus_path}"
+    return env
+
+
 def _systemd_scope_cached() -> Optional[bool]:
     """Cached probe verdict, or None when a (re)probe is due. True is permanent; False
     expires after ``_SYSTEMD_SCOPE_FAILURE_TTL_SECONDS`` so a D-Bus blip isn't sticky."""
@@ -170,7 +218,10 @@ def _systemd_run_user_scope_available() -> bool:
                     # Unique unit avoids collisions; the timeout bounds D-Bus.
                     probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
                     result = subprocess.run(
-                        _systemd_scope_argv(binary, probe_unit, "/bin/true"), capture_output=True, timeout=3,
+                        _systemd_scope_argv(binary, probe_unit, "/bin/true"),
+                        capture_output=True,
+                        timeout=3,
+                        env=_systemd_user_bus_env(),
                     )
                     available = result.returncode == 0
                     if not available:
@@ -247,6 +298,11 @@ def restart_safe_gateway_child_argv(
     return scoped
 
 
+def restart_safe_gateway_child_env(env: Dict[str, str]) -> Dict[str, str]:
+    """Add validated user-bus routing to an explicitly scoped child env."""
+    return _systemd_user_bus_env(env)
+
+
 def _stop_systemd_unit(unit_name: str) -> bool:
     """Stop a transient systemd user scope by unit name.
     Reaps the *entire* cgroup — catching double-forked descendants reparented to init
@@ -262,8 +318,13 @@ def _stop_systemd_unit(unit_name: str) -> bool:
     if binary is None:
         return False
     try:
-        result = subprocess.run([binary, "--user", "stop", unit_name], capture_output=True, timeout=15,
-                                stdin=subprocess.DEVNULL)
+        result = subprocess.run(
+            [binary, "--user", "stop", unit_name],
+            capture_output=True,
+            timeout=15,
+            stdin=subprocess.DEVNULL,
+            env=_systemd_user_bus_env(),
+        )
         if result.returncode != 0:
             stderr = (result.stderr or b"").decode(errors="replace").strip()
             if any(marker in stderr.lower() for marker in ("not loaded", "not found", "does not exist")):
@@ -801,12 +862,14 @@ class ProcessRegistry:
             from winpty import PtyProcess as _PtyProcessCls
         else:
             from ptyprocess import PtyProcess as _PtyProcessCls
+        pty_argv = self._scope_argv(session, safe_command, session.id, "PTY")
         pty_env = self._spawn_env(env_vars)
+        if session.systemd_unit:
+            pty_env = _systemd_user_bus_env(pty_env)
         # A PTY is a real TTY, so pager-happy tools (git log/diff, man) WILL page and
         # hang waiting for `q` — default them to cat, honoring any pager the user set.
         pty_env.setdefault("GIT_PAGER", "cat")
         pty_env.setdefault("PAGER", "cat")
-        pty_argv = self._scope_argv(session, safe_command, session.id, "PTY")
         pty_proc = _PtyProcessCls.spawn(pty_argv, cwd=session.cwd, env=pty_env, dimensions=(30, 120))
         session.pid = pty_proc.pid
         session.host_start_time = self._safe_host_start_time(session.pid)
@@ -848,13 +911,16 @@ class ProcessRegistry:
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
         unit_suffix = f"{session.id}-pipe-fallback" if pty_scope_attempted else session.id
         spawn_argv = self._scope_argv(session, safe_command, unit_suffix, "Local")
+        spawn_env = self._spawn_env(env_vars)
+        if session.systemd_unit:
+            spawn_env = _systemd_user_bus_env(spawn_env)
         # start_new_session is REQUIRED with systemd-run --scope too: the scope does not
         # give the worker a new session, so from an interactive TUI the worker would
         # share the foreground process group and background spawns would stop the whole
         # session (observed as dead TUIs in state T). Cgroup isolation is unaffected —
         # the scope attaches to the invoked process, not the spawning session.
         proc = subprocess.Popen(
-            spawn_argv, text=True, cwd=session.cwd, env=self._spawn_env(env_vars), encoding="utf-8",
+            spawn_argv, text=True, cwd=session.cwd, env=spawn_env, encoding="utf-8",
             errors="replace", stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL,
             start_new_session=True, **_popen_kwargs)
         session.process = proc


### PR DESCRIPTION
## Summary

- derive a validated per-user systemd D-Bus environment for system-level gateways running as an unprivileged `User=`
- pass that environment explicitly to restart-safe cron, Kanban, PTY, pipe-worker, and scope-cleanup subprocesses
- reject foreign, symlinked, group/world-writable runtime directories and non-socket/foreign bus paths
- preserve fail-closed restart-safe worker dispatch while restoring it on headless hosts with a lingering user manager

## Root cause

A system-level gateway running as an unprivileged user does not inherit `XDG_RUNTIME_DIR` or `DBUS_SESSION_BUS_ADDRESS`. Even when `/run/user/<uid>/bus` and the lingering user manager are healthy, `systemd-run --user --scope` therefore fails before cron scripts start.

## Verification

- reproduced the original dispatch failure on a live system gateway
- live scope probe from an environment with both variables removed: exit code 0 after the fix
- `scripts/run_tests.sh tests/cron tests/tools/test_process_registry.py tests/hermes_cli/test_kanban_gateway_restart_handoff.py`
  - 1334 passed
  - 0 failed
  - 5 platform skips
- Ruff, Python compile, `git diff --check`, and `git fsck` passed
- independent security/logic review passed with no blocking findings
- live one-shot cron probe completed successfully after deployment

## Safety

The derived bus address is used only when the runtime directory is absolute, owned by the current UID, not group/world writable, and the bus entry is a current-UID Unix socket. The helper returns a copy and does not mutate global process state.
