### PR TITLE
fix(google-chat): preserve quoted reply context

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -921,9 +921,23 @@ class GoogleChatAdapter(BasePlatformAdapter):
             user_id=(sender_email or sender_name), user_name=sender.get("displayName") or sender_email or sender_name,
             thread_id=session_thread_id, user_id_alt=(sender_name or None),
         )
+        quote_metadata = msg.get("quotedMessageMetadata")
+        quote_snapshot = (
+            quote_metadata.get("quotedMessageSnapshot") if isinstance(quote_metadata, dict) else None
+        )
+        quoted_message_id = quote_metadata.get("name") if isinstance(quote_metadata, dict) else None
+        quoted_text = quote_snapshot.get("text") if isinstance(quote_snapshot, dict) else None
+        quoted_author = quote_snapshot.get("sender") if isinstance(quote_snapshot, dict) else None
         return MessageEvent(
             text=text, message_type=message_type, source=source, raw_message=msg, message_id=msg.get("name") or None,
             media_urls=media_urls, media_types=media_types,
+            reply_to_message_id=(
+                quoted_message_id
+                if isinstance(quoted_message_id, str) and quoted_message_id.strip()
+                else None
+            ),
+            reply_to_text=quoted_text.strip() if isinstance(quoted_text, str) and quoted_text.strip() else None,
+            reply_to_author_name=quoted_author.strip() if isinstance(quoted_author, str) and quoted_author.strip() else None,
         )
 
     async def _download_attachment(self, attachment: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -655,6 +655,67 @@ class TestExtractMessagePayload:
 
 class TestBuildMessageEvent:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("quoted_metadata", "expected_id", "expected_text", "expected_author"),
+        [
+            (
+                {
+                    "name": "spaces/S/messages/QUOTED_MESSAGE",
+                    "quotedMessageSnapshot": {
+                        "text": " What question should I answer? ",
+                        "sender": "Test User",
+                    },
+                },
+                "spaces/S/messages/QUOTED_MESSAGE",
+                "What question should I answer?",
+                "Test User",
+            ),
+            ("not-a-mapping", None, None, None),
+            ({"name": "spaces/S/messages/QUOTED_MESSAGE"}, "spaces/S/messages/QUOTED_MESSAGE", None, None),
+            (
+                {"name": "spaces/S/messages/QUOTED_MESSAGE", "quotedMessageSnapshot": "not-a-mapping"},
+                "spaces/S/messages/QUOTED_MESSAGE",
+                None,
+                None,
+            ),
+            (
+                {"name": " ", "quotedMessageSnapshot": {"text": " ", "sender": " "}},
+                None,
+                None,
+                None,
+            ),
+            (
+                {"name": 42, "quotedMessageSnapshot": {"text": "quoted", "sender": 7}},
+                None,
+                "quoted",
+                None,
+            ),
+        ],
+        ids=[
+            "documented-payload",
+            "malformed-metadata",
+            "missing-snapshot",
+            "malformed-snapshot",
+            "whitespace-fields",
+            "invalid-fields",
+        ],
+    )
+    async def test_quoted_message_metadata_populates_schema_safe_reply_context(
+        self, adapter, quoted_metadata, expected_id, expected_text, expected_author
+    ):
+        env = _make_chat_envelope(text="What did you ask me here?")
+        msg = env["chat"]["messagePayload"]["message"]
+        msg["quotedMessageMetadata"] = quoted_metadata
+
+        event = await adapter._build_message_event(msg, env)
+
+        assert event is not None
+        assert event.reply_to_message_id == expected_id
+        assert event.reply_to_text == expected_text
+        assert event.reply_to_author_name == expected_author
+        assert event.reply_to_is_own_message is False
+
+    @pytest.mark.asyncio
     async def test_dm_first_message_in_thread_is_main_flow(self, adapter):
         """Google Chat DMs spawn a fresh thread per top-level user
         message in the input box. The FIRST message in any new thread


### PR DESCRIPTION
## Summary
Rebases and supersedes #56614, preserving its schema-correct approach while resolving its conflict with current `main`.

- Map Google Chat quote metadata to the existing `MessageEvent.reply_to_message_id`, `reply_to_text`, and `reply_to_author_name` fields.
- Treat `quotedMessageSnapshot.sender` as the documented display-name string.
- Safely ignore non-mapping metadata/snapshots and invalid or whitespace-only fields.
- Leave `reply_to_is_own_message` false because quote snapshots do not provide a trustworthy bot resource ID.

## Basis and scope
This is based on #56614 and retains its focused adapter-level design. It deliberately does not use #56622's unused sender parsing or infer bot ownership from a display name.

## Test plan
- `scripts/run_tests.sh tests/gateway/test_google_chat.py tests/gateway/test_reply_to_injection.py -q`
  - 79 passed
- Added production-path coverage for documented payloads, absent/malformed metadata or snapshots, invalid field types, and whitespace-only fields.

Fixes #56607