### PR TITLE
fix(gateway): onboarding mark_seen writes to the profile config it reads

### DIFF
--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -581,7 +581,7 @@ class GatewayBusySessionMixin:
         demoted_for_subagents: bool, demoted_for_compression: bool,
     ) -> str:
         from gateway.run import (
-            _AGENT_PENDING_SENTINEL, _hermes_home, _load_gateway_config, _platform_config_key
+            _AGENT_PENDING_SENTINEL, _gateway_config_home, _hermes_home, _load_gateway_config, _platform_config_key
         )
         from gateway.display_config import resolve_display_setting
 
@@ -638,7 +638,7 @@ class GatewayBusySessionMixin:
                     else "interrupt"
                 )
                 message = f"{message}\n\n{busy_input_hint_gateway(_hint_mode)}"
-                mark_seen(_hermes_home / "config.yaml", BUSY_INPUT_FLAG)
+                mark_seen(_gateway_config_home() / "config.yaml", BUSY_INPUT_FLAG)
         except Exception as _onb_err:
             logger.debug("Failed to apply busy-input onboarding hint: %s", _onb_err)
         return message

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1235,7 +1235,7 @@ class GatewayTurnMixin:
         """First-ever-message onboarding note + one-time 'no home channel' prompt (both only when
         the session has no history). Delivered on the user message (sidecar), NOT the ephemeral
         system prompt: present-on-turn-1/absent-on-turn-2 was a guaranteed prompt diff + rebuild."""
-        from gateway.run import _hermes_home, _home_target_env_var, _load_gateway_config
+        from gateway.run import _gateway_config_home, _hermes_home, _home_target_env_var, _load_gateway_config
         if history:
             return
         if not await self.async_session_store.has_any_sessions():
@@ -1254,7 +1254,7 @@ class GatewayTurnMixin:
                 _onb_cfg = _load_gateway_config()
                 if profile_build_mode(_onb_cfg) == "ask" and not is_seen(_onb_cfg, PROFILE_BUILD_FLAG):
                     turn_sidecar_notes.append(profile_build_directive().strip())
-                    mark_seen(_hermes_home / "config.yaml", PROFILE_BUILD_FLAG)
+                    mark_seen(_gateway_config_home() / "config.yaml", PROFILE_BUILD_FLAG)
                 else:
                     turn_sidecar_notes.append(_intro_note)
             except Exception as _pb_err:

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -174,7 +174,7 @@ class TurnRunner:
     def _progress_onboarding_hint(self, kwargs: dict) -> None:
         """First-touch onboarding: the first time a tool exceeds _LONG_TOOL_THRESHOLD_S while
         streaming every tool (progress_mode == "all"), append a one-time /verbose hint."""
-        from gateway.run import _hermes_home, _load_gateway_config
+        from gateway.run import _gateway_config_home, _hermes_home, _load_gateway_config
         ctx = self._ctx
         try:
             if (kwargs.get("duration") or 0) >= ctx._LONG_TOOL_THRESHOLD_S and ctx.progress_mode == "all":
@@ -184,7 +184,7 @@ class TurnRunner:
                 if gate_on and not is_seen(cfg, TOOL_PROGRESS_FLAG):
                     ctx.long_tool_hint_fired[0] = True
                     ctx.progress_queue.put(tool_progress_hint_gateway())
-                    mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
+                    mark_seen(_gateway_config_home() / "config.yaml", TOOL_PROGRESS_FLAG)
         except Exception as err:
             logger.debug("tool-progress onboarding hint failed: %s", err)
 


### PR DESCRIPTION
One-time onboarding hints (`busy_input_prompt`, `tool_progress_prompt`, `profile_build_offered`) re-fire forever on non-default profiles — the "This notice won't appear again" line shows every time.

## Root cause
Under multiplex profiles `_load_gateway_config()` reads via `_gateway_config_home()` (live override), but the three gateway `mark_seen` call sites (`run_busy.py`, `run_turn_runner.py`, `run_turn.py`) wrote to module-level `_hermes_home` captured at boot. Read and write addressed different config.yaml files, so `is_seen` never found the flag.

## Fix
Route all three call sites through `_gateway_config_home()` — the same resolver the read path already uses. CLI call sites (`cli_stream_mixin`, `cli_tui_mixin`) keep `_hermes_home` since the CLI runs single-profile per process.

## Verification
- `scripts/run_tests.sh tests/gateway/test_busy_session_ack.py` — 11/11
- `scripts/run_tests.sh tests/agent/test_onboarding.py` — 22/22
- Real-import E2E: booted under default home, installed the profile override, asserted the flag lands in the overridden profile's config (the failing case pre-fix)
- Rebased on current main