### PR TITLE
fix(agent): send x-opencode-session on max-iterations summary requests

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2057,7 +2057,16 @@ def _iteration_summary_chat_kwargs(agent, api_messages: list) -> dict:
                 extra_body["plugins"] = [{"id": "pareto-router", "min_coding_score": _ps}]
     if extra_body:
         summary_kwargs["extra_body"] = extra_body
-    return summary_kwargs
+    # The OpenCode relay pins per-conversation routing by x-opencode-session; without
+    # the header the summary call is rejected with 400 MissingSessionID (#105132).
+    from agent.opencode_affinity import merge_opencode_session_headers
+
+    return merge_opencode_session_headers(
+        summary_kwargs,
+        getattr(agent, "provider", None),
+        getattr(agent, "base_url", None),
+        getattr(agent, "session_id", None),
+    )
 
 
 def _summary_text(agent, response, **normalize_kwargs) -> str:
@@ -2079,6 +2088,17 @@ def _anthropic_summary_attempt(agent, api_messages: list, api_request_id: str):
             reasoning_config=agent.reasoning_config, is_oauth=agent._is_anthropic_oauth,
             preserve_dots=agent._anthropic_preserve_dots(), base_url=getattr(agent, "_anthropic_base_url", None))
         ant_kw = _merge_nous_portal_messages_extra_body(agent, ant_kw)
+        # The OpenCode relay pins per-conversation routing by x-opencode-session; without
+        # the header the summary call is rejected with 400 MissingSessionID (#105132).
+        from agent.opencode_affinity import merge_opencode_session_headers
+
+        ant_kw = merge_opencode_session_headers(
+            ant_kw,
+            getattr(agent, "provider", None),
+            getattr(agent, "_anthropic_base_url", None)
+            or getattr(agent, "base_url", None),
+            getattr(agent, "session_id", None),
+        )
         response = _managed_summary_call(agent, api_request_id, ant_kw, agent._anthropic_messages_create, retry_count=retry_count)
         return _summary_text(agent, response, strip_tool_prefix=agent._is_anthropic_oauth)
     return _attempt

--- a/tests/agent/test_opencode_session_affinity.py
+++ b/tests/agent/test_opencode_session_affinity.py
@@ -60,3 +60,35 @@ def test_auxiliary_calls_share_the_main_turn_session_key():
         assert "x-opencode-session" not in (other.get("extra_headers") or {})
     finally:
         aux._RUNTIME_MAIN_CONTEXT.reset(token)
+
+
+def test_max_iterations_summary_carries_session_header_on_chat():
+    from agent import chat_completion_helpers as cch
+
+    agent = _agent("opencode-go", "glm-5", "https://opencode.ai/zen/go/v1")
+    kwargs = cch._iteration_summary_chat_kwargs(agent, _MSGS)
+    assert kwargs["extra_headers"]["x-opencode-session"] == "sess-affinity-1"
+
+    other = _agent("openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1")
+    assert "x-opencode-session" not in (cch._iteration_summary_chat_kwargs(other, _MSGS).get("extra_headers") or {})
+
+
+def test_max_iterations_summary_carries_session_header_on_anthropic(monkeypatch):
+    from agent import chat_completion_helpers as cch
+
+    agent = _agent("opencode-go", "minimax-m2.7", "https://opencode.ai/zen/go/v1", "anthropic_messages")
+    captured = {}
+
+    def _capture(agent_, request_id, request, callback, *, retry_count):
+        captured.update(request)
+        return object()
+
+    monkeypatch.setattr(cch, "_managed_summary_call", _capture)
+    monkeypatch.setattr(cch, "_summary_text", lambda *args, **kwargs: "ok")
+    cch._anthropic_summary_attempt(agent, _MSGS, "req-summary")(0)
+    assert captured["extra_headers"]["x-opencode-session"] == "sess-affinity-1"
+
+    other = _agent("openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1", "anthropic_messages")
+    captured.clear()
+    cch._anthropic_summary_attempt(other, _MSGS, "req-summary")(0)
+    assert "x-opencode-session" not in (captured.get("extra_headers") or {})


### PR DESCRIPTION
## Summary

The max-iterations safety-net summary (`handle_max_iterations()`) builds its request kwargs through two raw builders that bypass the `x-opencode-session` merge every other in-turn request goes through, so the OpenCode Go/Zen relay rejects the summary call with `400 MissingSessionID` and the user gets "I reached the maximum iterations but couldn't summarize" instead of a graceful wrap-up.

- `_anthropic_summary_attempt` called `transport.build_kwargs()` directly — now merges `merge_opencode_session_headers(...)` after `_merge_nous_portal_messages_extra_body`, resolving the base URL from `_anthropic_base_url` first (the anthropic-mode transport may pin its own endpoint).
- `_chat_summary_attempt` returned `_iteration_summary_chat_kwargs()` raw — now the merge happens right at that return. Non-OpenCode targets are a no-op (`merge_opencode_session_headers` returns kwargs untouched).
- `_codex_summary_attempt` already routed through `agent._build_api_kwargs()` → `build_api_kwargs()` (the wrapped one), so no change there.
- The merge is additive (`setdefault` into any existing `extra_headers`), so the adapter's beta headers keep winning.

Fixes #105132

## Testing

- `env -u HERMES_YOLO_MODE .venv/bin/python -m pytest tests/agent/test_opencode_session_affinity.py -q` → **8 passed** (5 pre-existing + 2 new regression tests, one per raw builder, both asserting the header lands in kwargs and that non-OpenCode targets stay untouched)
- Sabotage run: reverting the two merges makes exactly the two new tests fail (`2 failed, 6 passed`), restoring them goes back to green
- `ruff check` clean on both files; `ruff format --diff` raises no complaints on any touched line
