### PR TITLE
fix(cron): unify manual run execution semantics

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2182,7 +2182,12 @@ def _record_run_outcome(
         job["run_claim"] = None
 
 
-def _advance_after_run(job: Dict[str, Any], now: str) -> None:
+def _advance_after_run(
+    job: Dict[str, Any],
+    now: str,
+    *,
+    preserve_paused_next_run_at: Any = _MISSING,
+) -> None:
     """Bump ``repeat.completed`` and recompute ``next_run_at``; retire the record as a terminal
     completion when the repeat limit is reached or a one-shot has no further run."""
     # If no next run, decide whether this is terminal completion (one-shot) or a transient failure
@@ -2193,6 +2198,12 @@ def _advance_after_run(job: Dict[str, Any], now: str) -> None:
     # One-shot dispatch-limit guard (issue #38758): a finite one-shot claimed via claim_dispatch() but whose
     # tick died before mark_job_run could remove it will have completed >= times while still looking due
     # (last_run_at was never written, so the recovery helper re-armed it). Remove it instead of re-firing.
+    preserve_paused_recurring = (
+        preserve_paused_next_run_at is not _MISSING
+        and kind in {"cron", "interval"}
+        and job.get("enabled") is False
+        and job.get("state") == "paused"
+    )
     repeat = job.get("repeat")
     if repeat:
         times = repeat.get("times")
@@ -2203,11 +2214,15 @@ def _advance_after_run(job: Dict[str, Any], now: str) -> None:
         if not (kind == "once" and finite and completed > 0):
             completed += 1
             repeat["completed"] = completed
-        if finite and completed >= times:
+        if finite and completed >= times and not preserve_paused_recurring:
             # Limit reached: retain a terminal record instead of popping it, so the status just
             # written stays inspectable in `cronjob list`; the retention sweep prunes it later.
             _complete_job_record(job)
             return
+
+    if preserve_paused_recurring:
+        job["next_run_at"] = copy.deepcopy(preserve_paused_next_run_at)
+        return
 
     job["next_run_at"] = compute_next_run(job["schedule"], now)
     if job["next_run_at"] is not None:
@@ -2237,6 +2252,7 @@ def mark_job_run(
     status: Optional[str] = None,
     *,
     expected_fire_owner: Optional[str] = None,
+    require_unclaimed: bool = False,
 ) -> bool:
     """Mark a job as run: update last_run_at/last_status, bump completed, recompute next_run_at,
     and retire the record as a terminal completion when the repeat limit is reached.
@@ -2245,6 +2261,8 @@ def mark_job_run(
     ``last_status = "delivery_failed"`` (never "ok") while ``failure_streak`` is left alone. An
     explicit ``status`` (e.g. "blocked_config") overrides the derived value. False when the fence
     can't be taken, the job is missing, or ``expected_fire_owner`` no longer holds the fire claim.
+    ``require_unclaimed`` is the complementary fence for delayed recovery bookkeeping: it
+    refuses to mutate a job if any newer fire owner has claimed it.
     """
     def apply(jobs, _i, job):
         if expected_fire_owner is not None:
@@ -2254,9 +2272,25 @@ def mark_job_run(
                     "mark_job_run: job_id %s fire claim owner changed; discarding stale completion",
                     job_id)
                 return False
+        elif require_unclaimed and isinstance(job.get("fire_claim"), dict):
+            logger.warning(
+                "mark_job_run: job_id %s gained a fire claim; discarding stale unclaimed update",
+                job_id,
+            )
+            return False
+        fire_claim = job.get("fire_claim")
+        preserve_paused_next_run_at = _MISSING
+        if isinstance(fire_claim, dict) and "preserve_paused_next_run_at" in fire_claim:
+            preserve_paused_next_run_at = copy.deepcopy(
+                fire_claim["preserve_paused_next_run_at"]
+            )
         now = _hermes_now().isoformat()
         _record_run_outcome(job, success, error, delivery_error, status, now)
-        _advance_after_run(job, now)
+        _advance_after_run(
+            job,
+            now,
+            preserve_paused_next_run_at=preserve_paused_next_run_at,
+        )
         save_jobs(jobs)
         return True
 
@@ -2523,6 +2557,11 @@ def claim_job_for_fire(
     def apply(jobs, _i, job):
         if is_terminal_job(job) and not _is_recoverable_error_job(job):
             return False
+        repeat = job.get("repeat") or {}
+        times = repeat.get("times")
+        completed = repeat.get("completed", 0)
+        if times is not None and times > 0 and completed >= times:
+            return False
         # Both enabled and pause markers must clear — a half-paused record must not claim. ``force``
         # bypasses that gate. ``preserve_paused`` is deliberately narrower: only a consistent
         # disabled+paused record keeps its scheduling state during this one manual occurrence.
@@ -2549,8 +2588,17 @@ def claim_job_for_fire(
             _activate_job_record(job)
         # Per-acquisition token: a process may legitimately reclaim its own stale lease, and the
         # previous runner must not heartbeat the new claim merely because hostname + PID match.
-        job["fire_claim"] = {"at": now.isoformat(), "by": f"{_machine_id()}:{uuid.uuid4().hex}"}
-        if job.get("schedule", {}).get("kind") in {"cron", "interval"}:
+        kind = job.get("schedule", {}).get("kind")
+        fire_claim: Dict[str, Any] = {
+            "at": now.isoformat(),
+            "by": f"{_machine_id()}:{uuid.uuid4().hex}",
+        }
+        if keep_paused and kind in {"cron", "interval"}:
+            fire_claim["preserve_paused_next_run_at"] = copy.deepcopy(
+                job.get("next_run_at")
+            )
+        job["fire_claim"] = fire_claim
+        if kind in {"cron", "interval"} and not keep_paused:
             nxt = compute_next_run(job["schedule"], now.isoformat())
             if nxt:
                 job["next_run_at"] = nxt

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import copy
+import hmac
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 import json
@@ -2482,14 +2483,40 @@ def _machine_id() -> str:
     return f"{host}:{os.getpid()}"
 
 
+def release_fire_claim(job_id: str, *, expected_owner: str) -> bool:
+    """Release an unstarted fire claim without recording a run.
+
+    The owner fence prevents a failed dispatcher from clearing a replacement claim.
+    No schedule, repeat, or terminal-status field is changed.
+    """
+    owner = str(expected_owner or "").strip()
+    if not owner:
+        return False
+
+    def apply(jobs, _i, job):
+        claim = job.get("fire_claim")
+        if not isinstance(claim, dict):
+            return False
+        current_owner = str(claim.get("by") or "")
+        if not current_owner or not hmac.compare_digest(current_owner, owner):
+            return False
+        job["fire_claim"] = None
+        save_jobs(jobs)
+        return True
+
+    return _with_job(job_id, apply, False)
+
+
 def claim_job_for_fire(
-    job_id: str, *, claim_ttl_seconds: int = FIRE_CLAIM_TTL_SECONDS, force: bool = False, return_job: bool = False,
+    job_id: str, *, claim_ttl_seconds: int = FIRE_CLAIM_TTL_SECONDS, force: bool = False,
+    preserve_paused: bool = False, return_job: bool = False,
 ) -> Union[bool, Dict[str, Any]]:
     """Atomically claim a job for one external 'fire' (multi-machine at-most-once); True iff THIS
     caller won (``CronScheduler.fire_due``: exactly one of N replicas runs a job). Under the
-    fence + file lock: reject missing/terminal/paused jobs unless ``force`` (explicit manual
-    fire, which also resumes the job atomically; external callbacks must leave it false so a
-    stale callback cannot resurrect a paused job). Lose if a claim younger than
+    fence + file lock: reject missing/terminal/paused jobs unless ``force``. Forced fires activate
+    the job atomically by default; an explicit manual run may set ``preserve_paused`` to execute a
+    properly paused job once without enabling its future schedule. External callbacks leave both
+    flags false so a stale callback cannot resurrect a paused job. Lose if a claim younger than
     ``claim_ttl_seconds`` exists (the TTL lets another fire reclaim after a crash; mark_job_run
     clears the claim). Otherwise stamp ``fire_claim`` and, for recurring jobs, advance
     ``next_run_at`` so a stale re-delivery cannot re-fire."""
@@ -2497,9 +2524,13 @@ def claim_job_for_fire(
         if is_terminal_job(job) and not _is_recoverable_error_job(job):
             return False
         # Both enabled and pause markers must clear — a half-paused record must not claim. ``force``
-        # (Trigger-now on a paused job) bypasses the gate and atomically resumes the job below.
+        # bypasses that gate. ``preserve_paused`` is deliberately narrower: only a consistent
+        # disabled+paused record keeps its scheduling state during this one manual occurrence.
         if not force and not is_job_runnable(job):
             return False
+        keep_paused = (
+            force and preserve_paused and job.get("enabled") is False and job.get("state") == "paused"
+        )
         now = _hermes_now()
         if _claim_is_live(job.get("fire_claim"), now, claim_ttl_seconds):
             return False  # someone holds a fresh claim
@@ -2514,7 +2545,7 @@ def claim_job_for_fire(
                     job["next_run_at"] = nxt
                     save_jobs(jobs)
             return False
-        if force:
+        if force and not keep_paused:
             _activate_job_record(job)
         # Per-acquisition token: a process may legitimately reclaim its own stale lease, and the
         # previous runner must not heartbeat the new claim merely because hostname + PID match.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -509,6 +509,7 @@ def _is_cron_silence_response(text: str) -> bool:
 _parallel_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _parallel_pool_max_workers: Optional[int] = None
 _running_job_ids: set = set()
+_running_reservation_tokens: dict[str, object] = {}
 _running_fire_owners: dict[str, dict[object, tuple[Optional[str], Path]]] = {}
 # Parent gateway threads synchronously waiting on restart-safe scope workers.
 # Shutdown must not misclassify these as ownerless in-process runs: the tool
@@ -582,7 +583,7 @@ def get_running_job_ids() -> "frozenset[str]":
         return frozenset(_running_job_ids | _running_fire_owners.keys())
 
 
-def try_register_running_job(job_id: str) -> bool:
+def try_register_running_job(job_id: str, *, reservation_token: Optional[object] = None) -> bool:
     """Atomically add ``job_id`` to the in-flight set; False (caller must skip) if already mid-run.
     Single dedupe owner for ticker + manual runs (the fire claim's 300s TTL is outlived by real
     jobs). Callers MUST pair success with ``release_running_job`` in a ``finally``.
@@ -595,9 +596,13 @@ def try_register_running_job(job_id: str) -> bool:
     and ``mark_running_jobs_interrupted``.
     """
     with _running_lock:
-        if job_id in _running_job_ids:
+        if job_id in _running_job_ids or job_id in _running_fire_owners:
             return False
         _running_job_ids.add(job_id)
+        if reservation_token is None:
+            _running_reservation_tokens.pop(job_id, None)
+        else:
+            _running_reservation_tokens[job_id] = reservation_token
         # Same critical section as the add: no window where an in-flight id lacks an age the sweep
         # can bound. Sentinel is replaced by the real future once ``pool.submit`` returns.
         _running_since[job_id] = time.time()
@@ -605,12 +610,22 @@ def try_register_running_job(job_id: str) -> bool:
         return True
 
 
-def release_running_job(job_id: str) -> None:
-    """Remove ``job_id`` from the in-flight running set (idempotent)."""
+def release_running_job(
+    job_id: str, *, expected_reservation_token: Optional[object] = None,
+) -> bool:
+    """Remove ``job_id`` from the in-flight set unless a newer reservation owns it."""
     with _running_lock:
+        current_token = _running_reservation_tokens.get(job_id)
+        if expected_reservation_token is None:
+            if current_token is not None:
+                return False
+        elif current_token != expected_reservation_token:
+            return False
         _running_job_ids.discard(job_id)
         _running_since.pop(job_id, None)
         _running_futures.pop(job_id, None)
+        _running_reservation_tokens.pop(job_id, None)
+        return True
 
 
 def _inflight_min_allowance_minutes() -> float:
@@ -777,11 +792,36 @@ def _record_stale_release(job: dict, job_id: str, age: float, allowance: float, 
             name, job_id)
         return
     try:
-        mark_job_run(
-            job_id, False,
+        fire_claim = job.get("fire_claim")
+        expected_owner = (
+            fire_claim.get("by") if isinstance(fire_claim, dict) else None
+        )
+        stale_error = (
             f"Stale in-flight claim force-released after {age / 60:.1f}m "
             f"(allowance {allowance / 60:.1f}m); previous run never released "
-            f"the scheduler in-flight guard")
+            f"the scheduler in-flight guard"
+        )
+        if expected_owner:
+            updated = mark_job_run(
+                job_id,
+                False,
+                stale_error,
+                expected_fire_owner=expected_owner,
+            )
+        else:
+            updated = mark_job_run(
+                job_id,
+                False,
+                stale_error,
+                require_unclaimed=True,
+            )
+        if not updated:
+            logger.info(
+                "cron.inflight.forced_release.status_skipped job='%s' id=%s — "
+                "a newer durable fire owner now holds the job",
+                name,
+                job_id,
+            )
     except Exception as e:
         logger.warning("Could not record forced release for job %s: %s", job_id, e)
 
@@ -841,6 +881,7 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
             _running_job_ids.discard(job_id)
             _running_since.pop(job_id, None)
             _running_futures.pop(job_id, None)
+            _running_reservation_tokens.pop(job_id, None)
             _forced_release_count += 1
             stale.append((job_id, age, allowance, fut, reason))
 
@@ -3639,6 +3680,7 @@ def _submit_with_guard(job: dict, pool: concurrent.futures.ThreadPoolExecutor, p
     Running-set membership is released in the worker's finally."""
     job_id = job["id"]
     job_label = job.get("name", job_id)
+    reservation_token = object()
 
     def _clear_run_claim_best_effort() -> None:
         """Best-effort claim cleanup on dispatch-failure paths. Only one-shots carry a run_claim;
@@ -3679,7 +3721,7 @@ def _submit_with_guard(job: dict, pool: concurrent.futures.ThreadPoolExecutor, p
         _not_dispatched_shutdown()
         _clear_run_claim_best_effort()
         return None
-    if not try_register_running_job(job_id):
+    if not try_register_running_job(job_id, reservation_token=reservation_token):
         logger.info("Job '%s' already running — skipping", job_label)
         return None
     # Record the attempt before dispatch; recovery marks abandoned rows unknown (no retry).
@@ -3690,7 +3732,7 @@ def _submit_with_guard(job: dict, pool: concurrent.futures.ThreadPoolExecutor, p
         _ctx = contextvars.copy_context()
     except Exception as execution_err:
         # Release the claim so the next tick retries instead of wedging "already running".
-        release_running_job(job_id)
+        release_running_job(job_id, expected_reservation_token=reservation_token)
         _clear_run_claim_best_effort()
         logger.exception(
             "Job '%s' not dispatched: execution creation failed: %s", job_label, execution_err)
@@ -3700,12 +3742,14 @@ def _submit_with_guard(job: dict, pool: concurrent.futures.ThreadPoolExecutor, p
         try:
             return ctx.run(process_job, j)
         finally:
-            release_running_job(j["id"])
+            release_running_job(
+                j["id"], expected_reservation_token=reservation_token
+            )
 
     try:
         fut = pool.submit(_run_and_release)
     except Exception as submit_err:
-        release_running_job(job_id)
+        release_running_job(job_id, expected_reservation_token=reservation_token)
         _clear_run_claim_best_effort()
         finish_execution(
             execution["id"], success=False, error=f"Executor dispatch failed: {submit_err}")
@@ -3716,7 +3760,7 @@ def _submit_with_guard(job: dict, pool: concurrent.futures.ThreadPoolExecutor, p
         return None
 
     with _running_lock:
-        if job_id in _running_job_ids:
+        if _running_reservation_tokens.get(job_id) is reservation_token:
             _running_futures[job_id] = fut
     return fut
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -909,6 +909,19 @@ def _admit_api_agent_request(handler):
     return _wrapped
 
 
+def _track_pending_api_work(handler):
+    """Reserve API work before the handler's first await without duplicating auth policy."""
+    @wraps(handler)
+    async def _wrapped(self, request, *args, **kwargs):
+        with _reserve_pending_api_work(self) as reservation:
+            token = _api_agent_request_reservation.set(reservation)
+            try:
+                return await handler(self, request, *args, **kwargs)
+            finally:
+                _api_agent_request_reservation.reset(token)
+    return _wrapped
+
+
 def _release_pending_api_work(adapter, reservation: dict[str, bool]) -> None:
     """Release a pending-work reservation exactly once."""
     if reservation["active"]:
@@ -3403,11 +3416,13 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         """POST /api/jobs/{job_id}/resume — resume a paused cron job."""
         return await self._job_lookup_or_mutate(request, _cron_resume, notify=True)
 
+    @_track_pending_api_work
     async def _handle_run_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/run — trigger immediate execution."""
         job_id, err = self._cron_request_guard(request, need_job_id=True, check_draining=True)
         if err:
             return err
+        assert web is not None
         # Optional transient per-run context (standalone `hermes cron run` /
         # cronjob(action='run', prompt=...)) — same cap + scan as a stored prompt.
         extra_prompt = body = None
@@ -3427,29 +3442,116 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             _run_claimed_job,
         )
 
-        with _reserve_pending_api_work(self) as reservation:
-            claimed_job, claim_error = await asyncio.to_thread(
+        with nullcontext(_api_agent_request_reservation.get()) as reservation:
+            assert reservation is not None
+            limited = self._concurrency_limited_response()
+            if limited is not None:
+                return limited
+            claim_coroutine = asyncio.to_thread(
                 _claim_for_manual_run, job_id, "relay manual run"
             )
+            try:
+                claim_task = asyncio.create_task(claim_coroutine)
+            except Exception as exc:
+                claim_coroutine.close()
+                logger.error("Manual cron claim task creation failed for job %s: %s", job_id, exc)
+                return web.json_response(
+                    {"error": f"Manual run claim unavailable: {exc}"}, status=503
+                )
+            try:
+                claimed_job, claim_error = await asyncio.shield(claim_task)
+            except asyncio.CancelledError:
+                reservation["detached"] = True
+
+                def _finish_cancelled_claim(done_task):
+                    try:
+                        detached_job, detached_error = done_task.result()
+                        if detached_error is None and isinstance(detached_job, dict):
+                            _release_manual_run_reservation(detached_job)
+                    except BaseException:
+                        logger.debug(
+                            "Cancelled manual cron claim cleanup failed for %s",
+                            job_id,
+                            exc_info=True,
+                        )
+                    finally:
+                        _release_pending_api_work(self, reservation)
+
+                claim_task.add_done_callback(_finish_cancelled_claim)
+                self._track_background_task(claim_task, tolerate_missing=True)
+                raise
             if claim_error is not None:
                 reason = str(claim_error.get("error") or "Manual run was not accepted.")
                 status = 404 if "no longer exists" in reason else 409
                 return web.json_response({"error": reason}, status=status)
             assert claimed_job is not None
 
+            worker_state = {"phase": "queued"}
+            worker_state_lock = threading.Lock()
+            event_loop = asyncio.get_running_loop()
+
+            def _release_pending_from_worker() -> None:
+                try:
+                    event_loop.call_soon_threadsafe(
+                        _release_pending_api_work, self, reservation
+                    )
+                except RuntimeError:
+                    # The loop is already closed, so no event-loop callback can race this fallback.
+                    _release_pending_api_work(self, reservation)
+
+            def _cancel_unstarted_worker() -> bool:
+                """Atomically win the handoff only if no executor worker owns it yet."""
+                with worker_state_lock:
+                    if worker_state["phase"] != "queued":
+                        return False
+                    worker_state["phase"] = "cancelled_before_start"
+                    return True
+
+            def _run_reserved_worker():
+                try:
+                    with worker_state_lock:
+                        if worker_state["phase"] != "queued":
+                            return {
+                                "claimed": True,
+                                "executed": False,
+                                "success": False,
+                                "error": "Manual run was cancelled before execution started.",
+                            }
+                        worker_state["phase"] = "started"
+                    return _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
+                finally:
+                    _release_pending_from_worker()
+
             async def _run_reserved_job():
                 try:
-                    return await asyncio.to_thread(
-                        _run_claimed_job, claimed_job, extra_prompt=extra_prompt
-                    )
+                    return await asyncio.to_thread(_run_reserved_worker)
                 except Exception as exc:
-                    _release_manual_run_reservation(claimed_job)
+                    if _cancel_unstarted_worker():
+                        _release_manual_run_reservation(claimed_job)
                     logger.error("Manual cron run executor failed for job %s: %s", job_id, exc)
                     return {"claimed": True, "executed": False, "success": False, "error": str(exc)}
 
-            task = asyncio.create_task(_run_reserved_job())
+            coroutine = _run_reserved_job()
+            try:
+                task = asyncio.create_task(coroutine)
+            except Exception as exc:
+                coroutine.close()
+                _release_manual_run_reservation(claimed_job)
+                logger.error("Manual cron run task creation failed for job %s: %s", job_id, exc)
+                return web.json_response(
+                    {"error": f"Manual run executor unavailable: {exc}"}, status=503
+                )
             reservation["detached"] = True
-            task.add_done_callback(lambda _task: _release_pending_api_work(self, reservation))
+
+            def _finish_manual_run_task(done_task):
+                if done_task.cancelled():
+                    if _cancel_unstarted_worker():
+                        _release_manual_run_reservation(claimed_job)
+                        _release_pending_api_work(self, reservation)
+                    return
+                _release_pending_api_work(self, reservation)
+
+            task.add_done_callback(_finish_manual_run_task)
             self._track_background_task(task, tolerate_missing=True)
             return web.json_response({"status": "accepted", "job_id": job_id}, status=202)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3421,8 +3421,37 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                 if prompt_err:
                     return prompt_err
                 extra_prompt = extra_prompt or None
-        return self._job_response(
-            lambda jid: _cron_trigger(jid, extra_prompt=extra_prompt), job_id, notify=False)
+        from tools.cronjob_tools import (
+            _claim_for_manual_run,
+            _release_manual_run_reservation,
+            _run_claimed_job,
+        )
+
+        with _reserve_pending_api_work(self) as reservation:
+            claimed_job, claim_error = await asyncio.to_thread(
+                _claim_for_manual_run, job_id, "relay manual run"
+            )
+            if claim_error is not None:
+                reason = str(claim_error.get("error") or "Manual run was not accepted.")
+                status = 404 if "no longer exists" in reason else 409
+                return web.json_response({"error": reason}, status=status)
+            assert claimed_job is not None
+
+            async def _run_reserved_job():
+                try:
+                    return await asyncio.to_thread(
+                        _run_claimed_job, claimed_job, extra_prompt=extra_prompt
+                    )
+                except Exception as exc:
+                    _release_manual_run_reservation(claimed_job)
+                    logger.error("Manual cron run executor failed for job %s: %s", job_id, exc)
+                    return {"claimed": True, "executed": False, "success": False, "error": str(exc)}
+
+            task = asyncio.create_task(_run_reserved_job())
+            reservation["detached"] = True
+            task.add_done_callback(lambda _task: _release_pending_api_work(self, reservation))
+            self._track_background_task(task, tolerate_missing=True)
+            return web.json_response({"status": "accepted", "job_id": job_id}, status=202)
 
     async def _handle_cron_fire(self, request: "web.Request") -> "web.Response":
         """POST /api/cron/fire — Chronos fire webhook (NAS -> agent), authenticated by a

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1757,7 +1757,7 @@ def _forward_command(name: str, module: str, attr: str, *, forward_return: bool 
 
     Imports at CALL time so fast paths never pay for it and
     ``patch("<module>.<attr>")`` keeps intercepting. ``forward_return``
-    surfaces the return code to ``main()`` (only kanban/project propagate).
+    surfaces the return code to ``main()`` for commands whose handlers own exit status.
     """
 
     def _cmd(args):
@@ -1776,7 +1776,7 @@ cmd_login = _forward_command("cmd_login", "hermes_cli.auth", "login_command", do
 cmd_logout = _forward_command("cmd_logout", "hermes_cli.auth", "logout_command", doc='Clear provider authentication.')
 cmd_auth = _forward_command("cmd_auth", "hermes_cli.auth_commands", "auth_command", doc='Manage pooled credentials.')
 cmd_status = _forward_command("cmd_status", "hermes_cli.status", "show_status", doc='Show status of all components.')
-cmd_cron = _forward_command("cmd_cron", "hermes_cli.cron", "cron_command", doc='Cron job management.')
+cmd_cron = _forward_command("cmd_cron", "hermes_cli.cron", "cron_command", forward_return=True, doc='Cron job management.')
 cmd_webhook = _forward_command("cmd_webhook", "hermes_cli.webhook", "webhook_command", doc='Webhook subscription management.')
 cmd_kanban = _forward_command("cmd_kanban", "hermes_cli.kanban", "kanban_command", forward_return=True, doc='Multi-profile collaboration board.')
 cmd_project = _forward_command("cmd_project", "hermes_cli.projects_cmd", "projects_command", forward_return=True, doc='Manage projects (named, multi-folder workspaces).')

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -76,6 +76,105 @@ def test_forced_claim_atomically_resumes_paused_job(temp_home):
     assert claimed["fire_claim"] is not None
 
 
+@pytest.mark.parametrize("null_next_run", [False, True], ids=["non-null", "null"])
+@pytest.mark.parametrize("success", [True, False], ids=["success", "failure"])
+def test_preserve_paused_claim_and_terminal_mark_keep_exact_next_run(
+    temp_home, null_next_run, success
+):
+    """A one-off paused recurring run must not re-arm or perturb its paused schedule."""
+    import cron.jobs as jobs
+
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="paused-preserve")
+    jobs.pause_job(job["id"])
+    if null_next_run:
+        records = jobs.load_jobs()
+        records[0]["next_run_at"] = None
+        jobs.save_jobs(records)
+    before = jobs.get_job(job["id"])
+    assert before is not None
+    expected_next_run = before.get("next_run_at")
+
+    claimed = jobs.claim_job_for_fire(
+        job["id"], force=True, preserve_paused=True, return_job=True
+    )
+    assert isinstance(claimed, dict)
+    owner = claimed["fire_claim"]["by"]
+    persisted_claim = jobs.get_job(job["id"])
+    assert persisted_claim is not None
+    assert persisted_claim["next_run_at"] == expected_next_run
+
+    assert jobs.mark_job_run(
+        job["id"], success=success, expected_fire_owner=owner
+    ) is True
+    after = jobs.get_job(job["id"])
+    assert after is not None
+    assert after["next_run_at"] == expected_next_run
+    assert after["state"] == "paused"
+    assert after["enabled"] is False
+    assert after["last_status"] == ("ok" if success else "error")
+    assert after["repeat"]["completed"] == 1
+
+
+def test_preserve_paused_one_shot_still_terminalizes_after_manual_run(temp_home):
+    """Pause preservation must not keep a consumed finite one-shot runnable."""
+    import cron.jobs as jobs
+
+    job = jobs.create_job(
+        prompt="x",
+        schedule="in 30m",
+        name="paused-once",
+        repeat=1,
+    )
+    jobs.pause_job(job["id"])
+
+    claimed = jobs.claim_job_for_fire(
+        job["id"], force=True, preserve_paused=True, return_job=True
+    )
+    assert isinstance(claimed, dict)
+    owner = claimed["fire_claim"]["by"]
+    assert jobs.mark_job_run(
+        job["id"], success=True, expected_fire_owner=owner
+    ) is True
+
+    after = jobs.get_job(job["id"])
+    assert after is not None
+    assert after["state"] == "completed"
+    assert after["enabled"] is False
+    assert after["next_run_at"] is None
+    assert after["fire_claim"] is None
+    assert after["repeat"]["completed"] == 1
+
+
+def test_finite_paused_recurring_manual_run_preserves_pause_at_repeat_limit(temp_home):
+    """A manual occurrence must not retire a paused recurring schedule."""
+    import cron.jobs as jobs
+
+    job = jobs.create_job(
+        prompt="x", schedule="every 5m", name="paused-finite", repeat=1
+    )
+    jobs.pause_job(job["id"])
+    before = jobs.get_job(job["id"])
+    assert before is not None
+
+    claimed = jobs.claim_job_for_fire(
+        job["id"], force=True, preserve_paused=True, return_job=True
+    )
+    assert isinstance(claimed, dict)
+    owner = claimed["fire_claim"]["by"]
+    assert jobs.mark_job_run(
+        job["id"], success=True, expected_fire_owner=owner
+    ) is True
+
+    after = jobs.get_job(job["id"])
+    assert after is not None
+    for key in ("enabled", "state", "paused_at", "next_run_at"):
+        assert after[key] == before[key]
+    assert after["repeat"] == {"times": 1, "completed": 1}
+    assert jobs.claim_job_for_fire(
+        job["id"], force=True, preserve_paused=True, return_job=True
+    ) is False
+
+
 def test_release_fire_claim_is_owner_fenced_and_state_neutral(temp_home):
     """Abort may clear only its own fire claim without recording an occurrence."""
     import cron.jobs as jobs

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -76,6 +76,30 @@ def test_forced_claim_atomically_resumes_paused_job(temp_home):
     assert claimed["fire_claim"] is not None
 
 
+def test_release_fire_claim_is_owner_fenced_and_state_neutral(temp_home):
+    """Abort may clear only its own fire claim without recording an occurrence."""
+    import cron.jobs as jobs
+
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="release")
+    jobs.pause_job(job["id"])
+    assert jobs.claim_job_for_fire(job["id"], force=True, preserve_paused=True) is True
+    claimed = jobs.get_job(job["id"])
+    assert claimed is not None
+    owner = claimed["fire_claim"]["by"]
+
+    assert jobs.release_fire_claim(job["id"], expected_owner="other-owner") is False
+    still_claimed = jobs.get_job(job["id"])
+    assert still_claimed is not None
+    assert still_claimed["fire_claim"]["by"] == owner
+    assert jobs.release_fire_claim(job["id"], expected_owner=owner) is True
+    released = jobs.get_job(job["id"])
+    assert released is not None
+    assert released["fire_claim"] is None
+    assert released["state"] == "paused"
+    assert released["enabled"] is False
+    assert released["repeat"]["completed"] == 0
+
+
 def test_stale_claim_is_reclaimable(temp_home, monkeypatch):
     """A claim older than the TTL is overwritten — the fire isn't stuck forever
     if the winning machine crashed before mark_job_run cleared the claim."""

--- a/tests/cron/test_cron_relay_run_forward.py
+++ b/tests/cron/test_cron_relay_run_forward.py
@@ -54,6 +54,13 @@ class TestForwardRelayFrontedRun:
             out = json.loads(cronjob_tools._forward_relay_fronted_run({"id": "j1"}))
         assert out["success"] is True
         assert out["forwarded_to_gateway"] is True
+        assert out["job"]["claimed"] is True
+        assert out["job"]["executed"] is False
+        assert out["job"]["execution_pending"] is True
+        assert out["job"]["execution_success"] is None
+        assert out["job"]["execution_mode"] == "background"
+        from hermes_cli.cron import _run_outcome
+        assert _run_outcome(out["job"]) == "Running in background."
 
     def test_errors_when_gateway_unreachable(self):
         with patch.object(

--- a/tests/cron/test_ticker_stall_60703.py
+++ b/tests/cron/test_ticker_stall_60703.py
@@ -11,8 +11,7 @@ Three fixes under test:
    ``fire_claim``/``run_claim`` stamped in the FUTURE (clock/TZ skew across a
    restart) is treated as stale/overwritable, not eternally fresh.
 
-3. ``_execute_job_now`` no longer mislabels paused/disabled/missing jobs as
-   "already being fired".
+3. ``_execute_job_now`` no longer mislabels a missing job as "already being fired".
 """
 
 import json
@@ -149,18 +148,6 @@ class TestFutureDatedClaims:
 
 
 class TestHonestRunSkipMessages:
-    def test_paused_job_not_reported_as_already_firing(self):
-        from tools.cronjob_tools import _execute_job_now
-
-        job = create_job(name="paused job", schedule="0 7 * * *", prompt="x")
-        from cron.jobs import pause_job
-
-        pause_job(job["id"])
-        res = _execute_job_now(get_job(job["id"]))
-        assert res["claimed"] is False
-        assert "paused" in (res["error"] or "").lower()
-        assert "already being fired" not in (res["error"] or "").lower()
-
     def test_missing_job_not_reported_as_already_firing(self):
         from tools.cronjob_tools import _execute_job_now
 

--- a/tests/cron/test_ticker_stall_60703.py
+++ b/tests/cron/test_ticker_stall_60703.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import pytest
 
 import cron.jobs as jobs_mod
+import cron.scheduler as scheduler_mod
 from cron.jobs import (
     _jobs_lock,
     claim_job_for_fire,
@@ -154,3 +155,148 @@ class TestHonestRunSkipMessages:
         res = _execute_job_now({"id": "does-not-exist-123"})
         assert res["claimed"] is False
         assert "no longer exists" in (res["error"] or "").lower()
+
+
+class TestManualRunLocalOwnership:
+    def test_live_fire_owner_blocks_replacement_local_reservation(self):
+        """A swept pre-execution guard must not admit a replacement while its body is live."""
+        job_id = "manual-owner-still-live"
+        execution_token = object()
+        with scheduler_mod._running_lock:
+            scheduler_mod._running_job_ids.discard(job_id)
+            scheduler_mod._running_fire_owners[job_id] = {
+                execution_token: ("store-owner-a", Path.cwd())
+            }
+        try:
+            assert scheduler_mod.try_register_running_job(job_id) is False
+        finally:
+            with scheduler_mod._running_lock:
+                scheduler_mod._running_fire_owners.pop(job_id, None)
+            scheduler_mod.release_running_job(job_id)
+
+    def test_old_owner_cannot_release_replacement_reservation(self):
+        """A delayed finally from owner A must not remove owner B's local dedupe guard."""
+        job_id = "manual-owner-replaced"
+        owner_a = "reservation-a"
+        owner_b = "reservation-b"
+        try:
+            assert scheduler_mod.try_register_running_job(
+                job_id, reservation_token=owner_a
+            )
+            assert scheduler_mod.release_running_job(
+                job_id, expected_reservation_token=owner_a
+            )
+            assert scheduler_mod.try_register_running_job(
+                job_id, reservation_token=owner_b
+            )
+
+            assert scheduler_mod.release_running_job(
+                job_id, expected_reservation_token=owner_a
+            ) is False
+            assert job_id in scheduler_mod.get_running_job_ids()
+        finally:
+            scheduler_mod.release_running_job(
+                job_id, expected_reservation_token=owner_b
+            )
+
+    def test_stale_ticker_finally_cannot_release_replacement_manual_reservation(
+        self, monkeypatch
+    ):
+        """A swept ticker worker must not remove a newer manual owner when it starts late."""
+
+        class FakeFuture:
+            def done(self):
+                return False
+
+        class DeferredPool:
+            submitted = None
+
+            def submit(self, fn):
+                self.submitted = fn
+                return FakeFuture()
+
+        job_id = "ticker-owner-replaced"
+        manual_owner = "manual-owner-b"
+        pool = DeferredPool()
+        ran = []
+        monkeypatch.setattr(
+            scheduler_mod,
+            "create_execution",
+            lambda *_args, **_kwargs: {"id": "execution-a"},
+        )
+        try:
+            assert scheduler_mod._submit_with_guard(
+                {"id": job_id, "name": job_id, "schedule": {"kind": "interval", "minutes": 5}},
+                pool,
+                lambda _job: ran.append("ticker-a"),
+            ) is not None
+            with scheduler_mod._running_lock:
+                ticker_owner = scheduler_mod._running_reservation_tokens.get(job_id)
+            assert scheduler_mod.release_running_job(
+                job_id, expected_reservation_token=ticker_owner
+            )
+            assert scheduler_mod.try_register_running_job(
+                job_id, reservation_token=manual_owner
+            )
+            assert scheduler_mod.release_running_job(job_id) is False
+            assert job_id in scheduler_mod.get_running_job_ids()
+
+            assert pool.submitted is not None
+            pool.submitted()
+            assert ran == ["ticker-a"]
+            assert job_id in scheduler_mod.get_running_job_ids()
+        finally:
+            scheduler_mod.release_running_job(
+                job_id, expected_reservation_token=manual_owner
+            )
+
+    def test_late_stale_ticker_record_cannot_clear_manual_store_claim(
+        self, monkeypatch
+    ):
+        """Stale telemetry is store-fenced after local sweep admits manual owner B."""
+        from tools.cronjob_tools import (
+            _claim_for_manual_run,
+            _release_manual_run_reservation,
+        )
+
+        class DoneFuture:
+            def done(self):
+                return True
+
+        job = create_job(name="durable aba", schedule="every 5m", prompt="x")
+        job_id = job["id"]
+        ticker_owner = object()
+        delayed = []
+        original_record = scheduler_mod._record_stale_release
+        assert scheduler_mod.try_register_running_job(
+            job_id, reservation_token=ticker_owner
+        )
+        with scheduler_mod._running_lock:
+            scheduler_mod._running_since[job_id] = time.time() - 7200
+            scheduler_mod._running_futures[job_id] = DoneFuture()
+        monkeypatch.setattr(
+            scheduler_mod,
+            "_record_stale_release",
+            lambda *args: delayed.append(args),
+        )
+        claimed_job = None
+        try:
+            assert scheduler_mod.sweep_stale_inflight([get_job(job_id)]) == [job_id]
+            assert len(delayed) == 1
+            claimed_job, err = _claim_for_manual_run(job_id, "durable ABA test")
+            assert err is None
+            assert claimed_job is not None
+            fire_owner = claimed_job["fire_claim"]["by"]
+
+            original_record(*delayed[0])
+
+            after = get_job(job_id)
+            assert after is not None
+            assert after["fire_claim"]["by"] == fire_owner
+            assert after["repeat"]["completed"] == 0
+        finally:
+            if claimed_job is not None:
+                _release_manual_run_reservation(claimed_job)
+            scheduler_mod.release_running_job(
+                job_id, expected_reservation_token=ticker_owner
+            )

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -12,6 +12,7 @@ Covers:
 
 import asyncio
 import logging
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -322,9 +323,96 @@ class TestResumeJob:
 
 class TestRunJob:
     @pytest.mark.asyncio
+    async def test_run_job_honors_concurrency_cap_before_claim(self, adapter):
+        app = _create_app(adapter)
+        adapter._max_concurrent_runs = 1
+        adapter._inflight_agent_runs = 1
+
+        with patch("tools.cronjob_tools._claim_for_manual_run") as claim:
+            async with TestClient(TestServer(app)) as cli:
+                with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                    resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+
+        assert resp.status == 429
+        claim.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_job_is_tracked_while_request_body_is_read(self, adapter):
+        body_read_started = asyncio.Event()
+        release_body_read = asyncio.Event()
+
+        async def request_json():
+            body_read_started.set()
+            await release_body_read.wait()
+            return {}
+
+        request = SimpleNamespace(
+            match_info={"job_id": VALID_JOB_ID},
+            json=request_json,
+        )
+        claim_error = {"claimed": False, "success": False, "error": "stop"}
+        task = None
+        try:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                "tools.cronjob_tools._claim_for_manual_run",
+                return_value=(None, claim_error),
+            ):
+                task = asyncio.create_task(adapter._handle_run_job(request))
+                await body_read_started.wait()
+                assert adapter._pending_agent_requests == 1
+                assert adapter.active_agent_work_count() == 1
+                release_body_read.set()
+                response = await task
+
+            assert response.status == 409
+            assert adapter._pending_agent_requests == 0
+            assert adapter.active_agent_work_count() == 0
+        finally:
+            release_body_read.set()
+            if task is not None and not task.done():
+                task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_run_requests_atomically_share_the_cap(self, adapter):
+        import threading
+
+        app = _create_app(adapter)
+        adapter._max_concurrent_runs = 1
+        first_claim_started = threading.Event()
+        release_first_claim = threading.Event()
+        claimed_job = {**SAMPLE_JOB, "fire_claim": {"by": "manual-owner"}}
+
+        def blocking_claim(job_id, source):
+            first_claim_started.set()
+            assert release_first_claim.wait(2.0)
+            return claimed_job, None
+
+        with (
+            patch(
+                "tools.cronjob_tools._claim_for_manual_run",
+                side_effect=blocking_claim,
+            ) as claim,
+            patch("tools.cronjob_tools._run_claimed_job", return_value=True),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                    first = asyncio.create_task(
+                        cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+                    )
+                    assert await asyncio.to_thread(first_claim_started.wait, 2.0)
+                    second = await cli.post("/api/jobs/112233445566/run")
+                    release_first_claim.set()
+                    first_response = await first
+
+        assert first_response.status == 202
+        assert second.status == 429
+        assert claim.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_run_job(self, adapter):
         """POST /api/jobs/{id}/run reserves the manual run before returning 202."""
         app = _create_app(adapter)
+        adapter._max_concurrent_runs = 1
         claimed_job = {**SAMPLE_JOB, "fire_claim": {"by": "manual-owner"}}
 
         async def immediate_to_thread(fn, *args, **kwargs):
@@ -343,6 +431,292 @@ class TestRunJob:
 
         claim.assert_called_once_with(VALID_JOB_ID, "relay manual run")
         run.assert_called_once_with(claimed_job, extra_prompt=None)
+
+    @pytest.mark.asyncio
+    async def test_relay_run_reconciles_provider_after_terminal_persistence(self, adapter):
+        app = _create_app(adapter)
+        claimed_job = {**SAMPLE_JOB, "fire_claim": {"by": "manual-owner"}}
+        order = []
+
+        with patch(
+            "tools.cronjob_tools._claim_for_manual_run", return_value=(claimed_job, None)
+        ), patch(
+            "cron.scheduler.run_one_job", side_effect=lambda *_a, **_kw: order.append("run") or True
+        ), patch(
+            "tools.cronjob_tools.get_job", return_value={"last_status": "ok", "last_error": None}
+        ), patch(
+            "tools.cronjob_tools._notify_provider_jobs_changed_safe",
+            side_effect=lambda: order.append("notify"),
+        ) as notify:
+            async with TestClient(TestServer(app)) as cli:
+                with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                    resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+                    assert resp.status == 202
+                    for _ in range(100):
+                        if not adapter._background_tasks:
+                            break
+                        await asyncio.sleep(0.01)
+
+        assert order == ["run", "notify"]
+        notify.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_cancel_while_claim_thread_runs_releases_returned_reservation(self, adapter):
+        """Request cancellation must clean a claim that its shielded thread wins later."""
+        claimed_job = {
+            **SAMPLE_JOB,
+            "fire_claim": {"by": "manual-owner"},
+            "_manual_reservation_token": "local-owner",
+        }
+        claim_started = threading.Event()
+        allow_claim_return = threading.Event()
+        abort_finished = threading.Event()
+
+        async def request_json():
+            return {}
+
+        request = SimpleNamespace(
+            match_info={"job_id": VALID_JOB_ID},
+            json=request_json,
+        )
+
+        def delayed_claim(*_args, **_kwargs):
+            claim_started.set()
+            assert allow_claim_return.wait(timeout=2.0)
+            return claimed_job, None
+
+        def record_abort(_job):
+            abort_finished.set()
+
+        handler_task = None
+        try:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                "tools.cronjob_tools._claim_for_manual_run", side_effect=delayed_claim
+            ), patch(
+                "tools.cronjob_tools._release_manual_run_reservation", side_effect=record_abort
+            ) as abort, patch("tools.cronjob_tools._run_claimed_job") as run:
+                handler_task = asyncio.create_task(adapter._handle_run_job(request))
+                assert await asyncio.to_thread(claim_started.wait, 1.0)
+                handler_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await handler_task
+
+                assert not abort_finished.is_set()
+                allow_claim_return.set()
+                assert await asyncio.to_thread(abort_finished.wait, 1.0)
+
+            abort.assert_called_once_with(claimed_job)
+            run.assert_not_called()
+        finally:
+            allow_claim_return.set()
+            if handler_task is not None and not handler_task.done():
+                handler_task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_cancel_before_reserved_coroutine_starts_releases_claim(self, adapter):
+        """A task cancelled before its first step never submitted a worker and must abort."""
+        claimed_job = {
+            **SAMPLE_JOB,
+            "fire_claim": {"by": "manual-owner"},
+            "_manual_reservation_token": "local-owner",
+        }
+
+        async def request_json():
+            return {}
+
+        request = SimpleNamespace(
+            match_info={"job_id": VALID_JOB_ID},
+            json=request_json,
+        )
+        loop = asyncio.get_running_loop()
+        real_create_task = loop.create_task
+        created = []
+
+        def create_then_cancel(coro, *, name=None, context=None):
+            kwargs = {"name": name}
+            if context is not None:
+                kwargs["context"] = context
+            task = real_create_task(coro, **kwargs)
+            created.append(task)
+            if len(created) == 2:
+                task.cancel()
+            return task
+
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            "tools.cronjob_tools._claim_for_manual_run", return_value=(claimed_job, None)
+        ), patch("tools.cronjob_tools._release_manual_run_reservation") as abort, patch.object(
+            loop, "create_task", side_effect=create_then_cancel
+        ):
+            response = await adapter._handle_run_job(request)
+            assert response.status == 202
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        assert len(created) == 2
+        assert created[0].done() and not created[0].cancelled()
+        assert created[1].cancelled()
+        abort.assert_called_once_with(claimed_job)
+
+    @pytest.mark.asyncio
+    async def test_cancel_after_executor_submission_before_worker_start_releases_claim(
+        self, adapter
+    ):
+        """A queued executor item cancelled before worker entry must abort its claim."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        claimed_job = {
+            **SAMPLE_JOB,
+            "fire_claim": {"by": "manual-owner"},
+            "_manual_reservation_token": "local-owner",
+        }
+        executor_queued = asyncio.Event()
+        release_blocker = threading.Event()
+        to_thread_calls = 0
+        executor = ThreadPoolExecutor(max_workers=1)
+        blocker = executor.submit(release_blocker.wait)
+
+        async def request_json():
+            return {}
+
+        request = SimpleNamespace(
+            match_info={"job_id": VALID_JOB_ID},
+            json=request_json,
+        )
+
+        async def saturate_second_to_thread(fn, *args, **kwargs):
+            nonlocal to_thread_calls
+            to_thread_calls += 1
+            if to_thread_calls == 1:
+                return fn(*args, **kwargs)
+            queued = executor.submit(fn, *args, **kwargs)
+            executor_queued.set()
+            return await asyncio.wrap_future(queued)
+
+        task = None
+        try:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                "tools.cronjob_tools._claim_for_manual_run", return_value=(claimed_job, None)
+            ), patch("tools.cronjob_tools._release_manual_run_reservation") as abort, patch(
+                "tools.cronjob_tools._run_claimed_job"
+            ) as run, patch("asyncio.to_thread", side_effect=saturate_second_to_thread):
+                response = await adapter._handle_run_job(request)
+                assert response.status == 202
+                await executor_queued.wait()
+                task = next(iter(adapter._background_tasks))
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+                await asyncio.sleep(0)
+
+            assert to_thread_calls == 2
+            abort.assert_called_once_with(claimed_job)
+            run.assert_not_called()
+        finally:
+            release_blocker.set()
+            blocker.result(timeout=1.0)
+            executor.shutdown(wait=True)
+
+    @pytest.mark.asyncio
+    async def test_task_creation_failure_releases_claim_and_returns_503(self, adapter):
+        claimed_job = {
+            **SAMPLE_JOB,
+            "fire_claim": {"by": "manual-owner"},
+            "_manual_reservation_token": "local-owner",
+        }
+
+        async def request_json():
+            return {}
+
+        request = SimpleNamespace(
+            match_info={"job_id": VALID_JOB_ID},
+            json=request_json,
+        )
+        real_create_task = asyncio.create_task
+        create_count = 0
+
+        def fail_executor_task(coro):
+            nonlocal create_count
+            create_count += 1
+            if create_count == 1:
+                return real_create_task(coro)
+            raise RuntimeError("task registry unavailable")
+
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            "tools.cronjob_tools._claim_for_manual_run", return_value=(claimed_job, None)
+        ), patch("tools.cronjob_tools._release_manual_run_reservation") as abort, patch(
+            "asyncio.create_task", side_effect=fail_executor_task
+        ):
+            response = await adapter._handle_run_job(request)
+
+        assert response.status == 503
+        assert "task registry unavailable" in response.text
+        abort.assert_called_once_with(claimed_job)
+
+    @pytest.mark.asyncio
+    async def test_cancelled_api_waiter_keeps_guard_until_worker_finishes(self, adapter):
+        """Cancelling the asyncio waiter must not unlock a still-running to_thread worker."""
+        from cron.scheduler import (
+            get_running_job_ids,
+            release_running_job,
+            try_register_running_job,
+        )
+
+        app = _create_app(adapter)
+        adapter._max_concurrent_runs = 1
+        token = "api-cancel-owner"
+        claimed_job = {
+            **SAMPLE_JOB,
+            "fire_claim": {"by": "manual-owner"},
+            "_manual_reservation_token": token,
+        }
+        worker_started = threading.Event()
+        allow_worker_finish = threading.Event()
+        worker_finished = threading.Event()
+
+        def claim(*_args, **_kwargs):
+            assert try_register_running_job(VALID_JOB_ID, reservation_token=token)
+            return claimed_job, None
+
+        def run(*_args, **_kwargs):
+            worker_started.set()
+            assert allow_worker_finish.wait(timeout=2.0)
+            release_running_job(VALID_JOB_ID, expected_reservation_token=token)
+            worker_finished.set()
+            return {"claimed": True, "executed": True, "success": True, "error": None}
+
+        task = None
+        try:
+            with patch("tools.cronjob_tools._claim_for_manual_run", side_effect=claim) as claim_mock, patch(
+                "tools.cronjob_tools._run_claimed_job", side_effect=run
+            ):
+                async with TestClient(TestServer(app)) as cli:
+                    with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                        resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+                        assert resp.status == 202
+                        assert await asyncio.to_thread(worker_started.wait, 1.0)
+                        task = next(iter(adapter._background_tasks))
+                        task.cancel()
+                        with pytest.raises(asyncio.CancelledError):
+                            await task
+
+                        assert VALID_JOB_ID in get_running_job_ids()
+                        assert adapter.active_agent_work_count() == 1
+                        second = await cli.post("/api/jobs/112233445566/run")
+                        assert second.status == 429
+                        assert claim_mock.call_count == 1
+                        allow_worker_finish.set()
+                        assert await asyncio.to_thread(worker_finished.wait, 1.0)
+                        for _ in range(100):
+                            if adapter.active_agent_work_count() == 0:
+                                break
+                            await asyncio.sleep(0.01)
+                        assert adapter.active_agent_work_count() == 0
+                        assert VALID_JOB_ID not in get_running_job_ids()
+        finally:
+            allow_worker_finish.set()
+            if task is not None and not task.done():
+                task.cancel()
+            release_running_job(VALID_JOB_ID, expected_reservation_token=token)
 
     @pytest.mark.asyncio
     async def test_run_job_releases_reservation_if_executor_cannot_start(self, adapter):

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -10,6 +10,7 @@ Covers:
 - Cron module unavailability (501 when _CRON_AVAILABLE is False)
 """
 
+import asyncio
 import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -322,71 +323,125 @@ class TestResumeJob:
 class TestRunJob:
     @pytest.mark.asyncio
     async def test_run_job(self, adapter):
-        """POST /api/jobs/{id}/run returns triggered job."""
+        """POST /api/jobs/{id}/run reserves the manual run before returning 202."""
         app = _create_app(adapter)
-        triggered_job = {**SAMPLE_JOB, "last_run": "2025-01-01T00:00:00Z"}
-        mock_trigger = MagicMock(return_value=triggered_job)
-        async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_trigger", mock_trigger
-            ):
-                resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
-                assert resp.status == 200
-                data = await resp.json()
-                assert data["job"] == triggered_job
-                mock_trigger.assert_called_once_with(VALID_JOB_ID, extra_prompt=None)
+        claimed_job = {**SAMPLE_JOB, "fire_claim": {"by": "manual-owner"}}
+
+        async def immediate_to_thread(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        with patch("tools.cronjob_tools._claim_for_manual_run", return_value=(claimed_job, None)) as claim, patch(
+            "tools.cronjob_tools._run_claimed_job", return_value={"claimed": True, "executed": True, "success": True, "error": None}
+        ) as run, patch("asyncio.to_thread", side_effect=immediate_to_thread):
+            async with TestClient(TestServer(app)) as cli:
+                with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                    resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+                    assert resp.status == 202
+                    data = await resp.json()
+                    assert data == {"status": "accepted", "job_id": VALID_JOB_ID}
+                    await asyncio.sleep(0)
+
+        claim.assert_called_once_with(VALID_JOB_ID, "relay manual run")
+        run.assert_called_once_with(claimed_job, extra_prompt=None)
+
+    @pytest.mark.asyncio
+    async def test_run_job_releases_reservation_if_executor_cannot_start(self, adapter):
+        app = _create_app(adapter)
+        claimed_job = {**SAMPLE_JOB, "fire_claim": {"by": "manual-owner"}}
+
+        with patch("tools.cronjob_tools._claim_for_manual_run", return_value=(claimed_job, None)) as claim, patch(
+            "tools.cronjob_tools._release_manual_run_reservation"
+        ) as abort:
+            async def fail_runner_to_thread(fn, *args, **kwargs):
+                if fn is claim:
+                    return claimed_job, None
+                raise RuntimeError("executor unavailable")
+
+            with patch("asyncio.to_thread", side_effect=fail_runner_to_thread):
+                async with TestClient(TestServer(app)) as cli:
+                    with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                        resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+                        assert resp.status == 202
+                        await asyncio.sleep(0)
+                        await asyncio.sleep(0)
+
+        abort.assert_called_once_with(claimed_job)
+
+    @pytest.mark.asyncio
+    async def test_run_job_returns_claim_conflict_reason(self, adapter):
+        app = _create_app(adapter)
+        claim_error = {
+            "claimed": False,
+            "success": False,
+            "error": "Job is already running",
+        }
+
+        async def immediate_to_thread(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        with patch(
+            "tools.cronjob_tools._claim_for_manual_run",
+            return_value=(None, claim_error),
+        ), patch("asyncio.to_thread", side_effect=immediate_to_thread):
+            async with TestClient(TestServer(app)) as cli:
+                with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                    resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+                    assert resp.status == 409
+                    assert await resp.json() == {"error": "Job is already running"}
 
     @pytest.mark.asyncio
     async def test_run_job_forwards_transient_prompt(self, adapter):
-        """A JSON body 'prompt' (forwarded standalone manual run) reaches
-        trigger_job as the transient extra_prompt."""
+        """A JSON body prompt reaches the detached manual execution only."""
         app = _create_app(adapter)
-        mock_trigger = MagicMock(return_value=SAMPLE_JOB)
-        async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_trigger", mock_trigger
-            ):
-                resp = await cli.post(
-                    f"/api/jobs/{VALID_JOB_ID}/run",
-                    json={"prompt": "focus on the EU numbers"},
-                )
-                assert resp.status == 200
-                mock_trigger.assert_called_once_with(
-                    VALID_JOB_ID, extra_prompt="focus on the EU numbers"
-                )
+        claimed_job = {**SAMPLE_JOB, "fire_claim": {"by": "manual-owner"}}
+
+        async def immediate_to_thread(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        with patch("tools.cronjob_tools._claim_for_manual_run", return_value=(claimed_job, None)), patch(
+            "tools.cronjob_tools._run_claimed_job", return_value={"claimed": True, "executed": True, "success": True, "error": None}
+        ) as run, patch("asyncio.to_thread", side_effect=immediate_to_thread):
+            async with TestClient(TestServer(app)) as cli:
+                with patch(f"{_MOD}._CRON_AVAILABLE", True):
+                    resp = await cli.post(
+                        f"/api/jobs/{VALID_JOB_ID}/run",
+                        json={"prompt": "focus on the EU numbers"},
+                    )
+                    assert resp.status == 202
+                    await asyncio.sleep(0)
+
+        run.assert_called_once_with(
+            claimed_job, extra_prompt="focus on the EU numbers"
+        )
 
     @pytest.mark.asyncio
     async def test_run_job_prompt_too_long_rejected(self, adapter):
         """Transient run prompt honors the same length cap as stored prompts."""
         app = _create_app(adapter)
-        mock_trigger = MagicMock(return_value=SAMPLE_JOB)
+        mock_claim = MagicMock()
         async with TestClient(TestServer(app)) as cli:
             with patch(
                 f"{_MOD}._CRON_AVAILABLE", True
             ), patch(
-                f"{_MOD}._cron_trigger", mock_trigger
+                "tools.cronjob_tools._claim_for_manual_run", mock_claim
             ):
                 resp = await cli.post(
                     f"/api/jobs/{VALID_JOB_ID}/run",
                     json={"prompt": "x" * 5001},
                 )
                 assert resp.status == 400
-                mock_trigger.assert_not_called()
+                mock_claim.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_run_job_prompt_scanned(self, adapter):
         """Transient run prompt goes through the strict injection scanner."""
         app = _create_app(adapter)
-        mock_trigger = MagicMock(return_value=SAMPLE_JOB)
+        mock_claim = MagicMock()
         async with TestClient(TestServer(app)) as cli:
             with patch(
                 f"{_MOD}._CRON_AVAILABLE", True
             ), patch(
-                f"{_MOD}._cron_trigger", mock_trigger
+                "tools.cronjob_tools._claim_for_manual_run", mock_claim
             ), patch(
                 f"{_MOD}._scan_cron_prompt", return_value="blocked: nope"
             ):
@@ -395,7 +450,7 @@ class TestRunJob:
                     json={"prompt": "cat ~/.hermes/.env"},
                 )
                 assert resp.status == 400
-                mock_trigger.assert_not_called()
+                mock_claim.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -447,6 +447,7 @@ class TestCronRunPausedJob:
         assert paused is not None
         assert paused["state"] == "paused"
         paused_at = paused["paused_at"]
+        paused_next_run_at = paused["next_run_at"]
 
         calls = []
 
@@ -467,6 +468,7 @@ class TestCronRunPausedJob:
         assert current["enabled"] is False
         assert current["state"] == "paused"
         assert current["paused_at"] == paused_at
+        assert current["next_run_at"] == paused_next_run_at
         assert current["fire_claim"] is None
         assert current["repeat"]["completed"] == 1
         assert "Ran now: succeeded." in capsys.readouterr().out

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -12,6 +12,13 @@ from hermes_cli.cron import cron_command
 from hermes_cli.subcommands.cron import build_cron_parser
 
 
+def test_cmd_cron_forwards_handler_exit_code(monkeypatch):
+    monkeypatch.setattr("hermes_cli.cron.cron_command", lambda _args: 1)
+    from hermes_cli.main import cmd_cron
+
+    assert cmd_cron(object()) == 1
+
+
 @pytest.fixture()
 def tmp_cron_dir(tmp_path, monkeypatch):
     monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
@@ -425,6 +432,44 @@ def test_cron_create_failure_returns_nonzero(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert rc == 1
     assert "Failed to create job: boom" in out
+
+
+class TestCronRunPausedJob:
+    def test_manual_run_executes_paused_job_without_resuming_it(
+        self, tmp_cron_dir, monkeypatch, capsys
+    ):
+        """An explicit CLI run claims a paused job but leaves its schedule paused."""
+        from cron.jobs import mark_job_run, pause_job
+
+        job = create_job(prompt="Manual report", schedule="every 1h", name="Paused report")
+        pause_job(job["id"])
+        paused = get_job(job["id"])
+        assert paused is not None
+        assert paused["state"] == "paused"
+        paused_at = paused["paused_at"]
+
+        calls = []
+
+        def complete_run(claimed_job, **kwargs):
+            calls.append((claimed_job, kwargs))
+            owner = claimed_job["fire_claim"]["by"]
+            assert mark_job_run(job["id"], success=True, expected_fire_owner=owner) is True
+            return True
+
+        monkeypatch.setattr("cron.scheduler.run_one_job", complete_run)
+
+        rc = cron_command(Namespace(cron_command="run", job_id=job["id"]))
+
+        current = get_job(job["id"])
+        assert rc == 0
+        assert len(calls) == 1
+        assert current is not None
+        assert current["enabled"] is False
+        assert current["state"] == "paused"
+        assert current["paused_at"] == paused_at
+        assert current["fire_claim"] is None
+        assert current["repeat"]["completed"] == 1
+        assert "Ran now: succeeded." in capsys.readouterr().out
 
 
 class TestCronRunBackgroundDispatch:

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -331,7 +331,10 @@ class TestCronjobRunToolIntegration:
                 out = json.loads(cronjob(action="run", job_id="job-bg-12"))
 
         assert out["success"] is True
-        assert out["job"]["executed"] is True
+        assert out["job"]["claimed"] is True
+        assert out["job"]["executed"] is False
+        assert out["job"]["execution_success"] is None
+        assert out["job"]["execution_pending"] is True
         assert out["job"]["execution_mode"] == "background"
         assert out["job"]["delegation_id"]
         assert "background" in out["note"]

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -79,7 +79,7 @@ class TestBackgroundDispatch:
             assert res["claimed"] is True
             assert res["dispatched"] is True
             assert res["delegation_id"]
-            m_claim.assert_called_once_with("job-bg-01", return_job=True)
+            m_claim.assert_called_once_with("job-bg-01", force=True, preserve_paused=True, return_job=True)
             # The job actually starts on the daemon executor.
             assert run_started.wait(timeout=5.0), "job never started in background"
         finally:
@@ -153,16 +153,16 @@ class TestBackgroundDispatch:
         assert "provider exploded" in (found.get("error") or "")
 
     def test_claim_lost_reports_immediately_without_dispatch(self):
-        """Paused/already-firing jobs report in the tool response, not as a
-        delayed completion event."""
+        """An already-firing job reports in the tool response, not as a delayed event."""
+        held = {**_JOB, "enabled": False, "state": "paused", "fire_claim": {"by": "other-owner"}}
         with _bound_session_key():
             with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
-                 patch("tools.cronjob_tools.get_job",
-                       return_value={**_JOB, "enabled": False}), \
+                 patch("tools.cronjob_tools.get_job", return_value=held), \
                  patch("tools.async_delegation.dispatch_async_delegation") as m_disp:
                 res = _try_dispatch_background_run(_job('job-bg-04'))
+        assert res is not None
         assert res["claimed"] is False
-        assert "paused/disabled" in res["error"]
+        assert "already running" in res["error"]
         m_disp.assert_not_called()
 
 
@@ -181,18 +181,57 @@ class TestSyncFallbacks:
         assert res is None
 
     def test_pool_at_capacity_runs_inline(self):
-        """A rejected dispatch must not strand the already-taken claim."""
+        """A rejected dispatch must not strand or detach the already-taken claim."""
+        claimed = {
+            **_job("job-bg-07"),
+            "enabled": True,
+            "state": "scheduled",
+            "fire_claim": {"by": "bg-owner"},
+        }
         with _bound_session_key():
-            with patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
-                 patch("tools.async_delegation.dispatch_async_delegation",
-                       return_value={"status": "rejected", "error": "capacity"}), \
-                 patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
-                 patch("tools.cronjob_tools.get_job",
-                       return_value={"last_status": "ok", "last_error": None}):
-                res = _try_dispatch_background_run(_job('job-bg-07'))
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire", return_value=claimed
+            ), patch(
+                "tools.async_delegation.dispatch_async_delegation",
+                return_value={"status": "rejected", "error": "capacity"},
+            ), patch(
+                "cron.scheduler.run_one_job", return_value=True
+            ) as m_run, patch(
+                "tools.cronjob_tools.get_job",
+                return_value={"last_status": "ok", "last_error": None},
+            ):
+                res = _try_dispatch_background_run(_job("job-bg-07"))
         assert res["dispatched"] is False
         assert res["success"] is True
-        m_run.assert_called_once()   # ran inline on this thread
+        m_run.assert_called_once_with(
+            claimed, adapters=None, loop=None, extra_prompt=None
+        )
+
+    def test_dispatch_exception_runs_claimed_job_inline(self):
+        claimed = {
+            **_job("job-bg-exception"),
+            "fire_claim": {"by": "bg-owner"},
+        }
+        with _bound_session_key():
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire", return_value=claimed
+            ), patch(
+                "tools.async_delegation.dispatch_async_delegation",
+                side_effect=RuntimeError("dispatcher unavailable"),
+            ), patch(
+                "cron.scheduler.run_one_job", return_value=True
+            ) as m_run, patch(
+                "tools.cronjob_tools.get_job",
+                return_value={"last_status": "ok", "last_error": None},
+            ):
+                res = _try_dispatch_background_run(_job("job-bg-exception"))
+
+        assert res is not None
+        assert res["dispatched"] is False
+        assert res["success"] is True
+        m_run.assert_called_once_with(
+            claimed, adapters=None, loop=None, extra_prompt=None
+        )
 
 
 class TestInFlightDedupe:
@@ -200,25 +239,8 @@ class TestInFlightDedupe:
     (salvaged from #53395 by @izumi0uu): the fire claim's 300s TTL is
     routinely outlived by real jobs, so the claim alone can't prevent it."""
 
-    def test_run_claimed_job_skips_when_already_running(self):
-        """The authoritative guard: _run_claimed_job refuses to fire a job
-        whose id is already registered in the scheduler running set."""
-        from cron import scheduler as sched
-        from tools.cronjob_tools import _run_claimed_job
-
-        assert sched.try_register_running_job("job-bg-08")   # simulate ticker mid-run
-        try:
-            with patch("cron.scheduler.run_one_job") as m_run:
-                res = _run_claimed_job(_job('job-bg-08'))
-            assert res["success"] is False
-            assert "already running" in res["error"]
-            m_run.assert_not_called()
-        finally:
-            sched.release_running_job("job-bg-08")
-
-    def test_run_claimed_job_registers_and_releases(self):
-        """A normal run holds the registration for run_one_job's duration and
-        releases it after — visible to get_running_job_ids mid-run."""
+    def test_run_claimed_job_uses_and_releases_prior_reservation(self):
+        """The runner sees the reservation acquired before store CAS and releases it after."""
         from cron import scheduler as sched
         from tools.cronjob_tools import _run_claimed_job
 
@@ -228,6 +250,7 @@ class TestInFlightDedupe:
             seen_during_run["registered"] = "job-bg-09" in sched.get_running_job_ids()
             return True
 
+        assert sched.try_register_running_job("job-bg-09")
         with patch("cron.scheduler.run_one_job", side_effect=probe_run), \
              patch("tools.cronjob_tools.get_job",
                    return_value={"last_status": "ok", "last_error": None}):
@@ -326,5 +349,5 @@ class TestCronjobRunToolIntegration:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-bg-13", return_job=True)
+        m_claim.assert_called_once_with("job-bg-13", force=True, preserve_paused=True, return_job=True)
         m_run.assert_called_once()

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -29,14 +29,51 @@ class TestCronjobRunExecutesImmediately:
     def test_abort_manual_run_releases_store_and_local_reservations(self):
         from tools.cronjob_tools import _release_manual_run_reservation
 
-        claimed = {"id": "job-abort", "fire_claim": {"by": "owner-abort"}}
+        claimed = {
+            "id": "job-abort",
+            "fire_claim": {"by": "owner-abort"},
+            "_manual_reservation_token": "local-owner-abort",
+        }
         with patch("cron.jobs.release_fire_claim", return_value=True) as release_store, patch(
             "cron.scheduler.release_running_job"
-        ) as release_local:
+        ) as release_local, patch(
+            "tools.cronjob_tools._notify_provider_jobs_changed_safe"
+        ) as notify:
             _release_manual_run_reservation(claimed)
 
         release_store.assert_called_once_with("job-abort", expected_owner="owner-abort")
-        release_local.assert_called_once_with("job-abort")
+        release_local.assert_called_once_with(
+            "job-abort", expected_reservation_token="local-owner-abort"
+        )
+        notify.assert_called_once_with()
+
+    def test_delayed_old_abort_does_not_release_replacement_local_reservation(self):
+        from cron.scheduler import (
+            get_running_job_ids,
+            release_running_job,
+            try_register_running_job,
+        )
+        from tools.cronjob_tools import _release_manual_run_reservation
+
+        job_id = "job-delayed-old-abort"
+        old_claimed = {
+            "id": job_id,
+            "fire_claim": {"by": "store-owner-old"},
+            "_manual_reservation_token": "local-owner-old",
+        }
+        try:
+            assert try_register_running_job(job_id, reservation_token="local-owner-old")
+            assert release_running_job(
+                job_id, expected_reservation_token="local-owner-old"
+            )
+            assert try_register_running_job(job_id, reservation_token="local-owner-new")
+
+            with patch("cron.jobs.release_fire_claim", return_value=False):
+                _release_manual_run_reservation(old_claimed)
+
+            assert job_id in get_running_job_ids()
+        finally:
+            release_running_job(job_id, expected_reservation_token="local-owner-new")
 
     def test_running_guard_rejects_before_store_claim(self):
         from tools.cronjob_tools import _claim_for_manual_run
@@ -51,6 +88,21 @@ class TestCronjobRunExecutesImmediately:
         assert err["claimed"] is False
         assert "already running" in err["error"]
         m_claim.assert_not_called()
+
+    def test_claim_binds_same_unique_token_to_local_guard_and_claimed_snapshot(self):
+        from tools.cronjob_tools import _claim_for_manual_run
+
+        claimed_from_store = {**_JOB, "fire_claim": {"by": "store-owner"}}
+        with patch("cron.scheduler.try_register_running_job", return_value=True) as register, patch(
+            "tools.cronjob_tools.claim_job_for_fire", return_value=claimed_from_store
+        ):
+            claimed, err = _claim_for_manual_run("job-run-1", "unit test")
+
+        assert err is None
+        assert claimed is not None
+        token = claimed.get("_manual_reservation_token")
+        assert isinstance(token, str) and token
+        register.assert_called_once_with("job-run-1", reservation_token=token)
 
     def test_run_action_claims_and_fires_via_run_one_job(self):
         """action='run' must claim the job then fire it through run_one_job."""

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -26,6 +26,32 @@ _JOB = {"id": "job-run-1", "name": "manual run", "prompt": "hi",
 
 
 class TestCronjobRunExecutesImmediately:
+    def test_abort_manual_run_releases_store_and_local_reservations(self):
+        from tools.cronjob_tools import _release_manual_run_reservation
+
+        claimed = {"id": "job-abort", "fire_claim": {"by": "owner-abort"}}
+        with patch("cron.jobs.release_fire_claim", return_value=True) as release_store, patch(
+            "cron.scheduler.release_running_job"
+        ) as release_local:
+            _release_manual_run_reservation(claimed)
+
+        release_store.assert_called_once_with("job-abort", expected_owner="owner-abort")
+        release_local.assert_called_once_with("job-abort")
+
+    def test_running_guard_rejects_before_store_claim(self):
+        from tools.cronjob_tools import _claim_for_manual_run
+
+        with patch("cron.scheduler.try_register_running_job", return_value=False), patch(
+            "tools.cronjob_tools.claim_job_for_fire"
+        ) as m_claim:
+            claimed, err = _claim_for_manual_run("job-run-1", "unit test")
+
+        assert claimed is None
+        assert err is not None
+        assert err["claimed"] is False
+        assert "already running" in err["error"]
+        m_claim.assert_not_called()
+
     def test_run_action_claims_and_fires_via_run_one_job(self):
         """action='run' must claim the job then fire it through run_one_job."""
         ran = {"job": "after-run", "last_status": "ok", "last_error": None}
@@ -39,7 +65,7 @@ class TestCronjobRunExecutesImmediately:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-run-1", return_job=True)
+        m_claim.assert_called_once_with("job-run-1", force=True, preserve_paused=True, return_job=True)
         m_run.assert_called_once_with(claimed, adapters=None, loop=None, extra_prompt=None)
 
     def test_run_reconciles_external_provider_after_claimed_execution(self):
@@ -74,7 +100,7 @@ class TestCronjobRunExecutesImmediately:
         claimed = {**_JOB, "fire_claim": {"by": "manual-owner"}}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
              patch("tools.cronjob_tools.claim_job_for_fire", return_value=claimed), \
-             patch("cron.scheduler.run_one_job", side_effect=RuntimeError("boom")), \
+             patch("cron.scheduler.run_one_job", return_value=False), \
              patch("tools.cronjob_tools.mark_job_run"), \
              patch("tools.cronjob_tools.get_job", return_value=failed), \
              patch("tools.cronjob_tools._notify_provider_jobs_changed_safe") as m_notify:
@@ -93,7 +119,7 @@ class TestCronjobRunExecutesImmediately:
              patch("tools.cronjob_tools._notify_provider_jobs_changed_safe") as m_notify:
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
 
-        assert out["success"] is True
+        assert out["success"] is False
         assert out["job"]["executed"] is False
         assert out["job"]["execution_success"] is False
         assert "execution_skipped" in out["job"]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -7,6 +7,7 @@ import logging
 import sys
 import threading
 import time
+import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -135,9 +136,18 @@ def _forward_relay_fronted_run(job: Dict[str, Any], extra_prompt: Optional[str] 
     except Exception:
         resp = None
     if resp is not None and resp.status_code < 300:
+        pending_job = _refreshed_job_view(job["id"])
+        pending_job.update({
+            "claimed": True,
+            "executed": False,
+            "execution_pending": True,
+            "execution_success": None,
+            "execution_mode": "background",
+        })
         return _dumps({
             "success": True,
             "forwarded_to_gateway": True,
+            "job": pending_job,
             "note": (
                 "This job targets a relay-fronted platform; it was dispatched "
                 "to the running gateway, whose live relay adapter owns that "
@@ -174,6 +184,7 @@ def _manual_run_delivery_note(deliver: str, refreshed: Dict[str, Any]) -> str:
 _ALREADY_RUNNING_ERROR = (
     "Job is already running (a scheduler tick or another "
     "manual run is executing it); not started again.")
+_MANUAL_RESERVATION_TOKEN_KEY = "_manual_reservation_token"
 
 
 def _claim_for_manual_run(job_id: str, log_label: str):
@@ -185,15 +196,18 @@ def _claim_for_manual_run(job_id: str, log_label: str):
     """
     from cron.scheduler import release_running_job, try_register_running_job
 
-    if not try_register_running_job(job_id):
+    reservation_token = uuid.uuid4().hex
+    if not try_register_running_job(job_id, reservation_token=reservation_token):
         return None, {"claimed": False, "success": False, "error": _ALREADY_RUNNING_ERROR}
     try:
         claimed_job = claim_job_for_fire(
             job_id, force=True, preserve_paused=True, return_job=True
         )
         if isinstance(claimed_job, dict):
+            claimed_job = dict(claimed_job)
+            claimed_job[_MANUAL_RESERVATION_TOKEN_KEY] = reservation_token
             return claimed_job, None
-        release_running_job(job_id)
+        release_running_job(job_id, expected_reservation_token=reservation_token)
         refreshed = get_job(job_id)
         if refreshed is None:
             reason = "Job no longer exists; nothing to run."
@@ -203,7 +217,7 @@ def _claim_for_manual_run(job_id: str, log_label: str):
             reason = "Job could not be claimed for this manual run."
         return None, {"claimed": False, "success": False, "error": reason}
     except Exception as e:
-        release_running_job(job_id)
+        release_running_job(job_id, expected_reservation_token=reservation_token)
         logger.error("Failed to claim cron job %s for %s: %s", job_id, log_label, e)
         return None, {"claimed": False, "success": False, "error": str(e)}
 
@@ -270,11 +284,14 @@ def _run_heartbeat(job_name: str):
             thread.join(timeout=_CRON_RUN_HEARTBEAT_INTERVAL + 1)
 
 
-def _release_manual_run_reservation(job: Dict[str, Any]) -> None:
+def _release_manual_run_reservation(
+    job: Dict[str, Any], *, notify_provider: bool = True
+) -> None:
     """Best-effort abort for a claimed manual run whose executor never started."""
     job_id = str(job.get("id") or "")
     claim = job.get("fire_claim")
     owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
+    reservation_token = job.get(_MANUAL_RESERVATION_TOKEN_KEY)
     if owner:
         try:
             from cron.jobs import release_fire_claim
@@ -285,9 +302,17 @@ def _release_manual_run_reservation(job: Dict[str, Any]) -> None:
     try:
         from cron.scheduler import release_running_job
 
-        release_running_job(job_id)
+        if reservation_token is None:
+            release_running_job(job_id)
+        else:
+            release_running_job(
+                job_id, expected_reservation_token=reservation_token
+            )
     except Exception:
         logger.debug("Could not release local manual-run reservation for %s", job_id, exc_info=True)
+    finally:
+        if notify_provider:
+            _notify_provider_jobs_changed_safe()
 
 
 def _run_claimed_job(job: Dict[str, Any], extra_prompt: Optional[str] = None) -> Dict[str, Any]:
@@ -297,6 +322,9 @@ def _run_claimed_job(job: Dict[str, Any], extra_prompt: Optional[str] = None) ->
     body entry.
     """
     job_id = job["id"]
+    reservation_token = job.get(_MANUAL_RESERVATION_TOKEN_KEY)
+    execution_job = dict(job)
+    execution_job.pop(_MANUAL_RESERVATION_TOKEN_KEY, None)
     _registered = True
     execution_started = False
     claim = job.get("fire_claim")
@@ -318,17 +346,25 @@ def _run_claimed_job(job: Dict[str, Any], extra_prompt: Optional[str] = None) ->
         adapters = getattr(runner, "adapters", None) if runner is not None else None
         gateway_loop = getattr(runner, "_gateway_loop", None) if runner is not None else None
         try:
-            # run_one_job records last_run_at/last_status via mark_job_run; `job` is the
-            # owner-bearing claimed snapshot, so terminal writes stay fenced by that owner.
+            # run_one_job records last_run_at/last_status via mark_job_run; ``execution_job`` is the
+            # owner-bearing claimed snapshot with the local-only reservation token removed, so
+            # terminal writes stay fenced without leaking that token into worker payloads.
             with _run_heartbeat(str(job.get("name") or job_id)):
                 execution_started = True
-                processed = run_one_job(job, adapters=adapters, loop=gateway_loop, extra_prompt=extra_prompt)
+                processed = run_one_job(
+                    execution_job, adapters=adapters, loop=gateway_loop, extra_prompt=extra_prompt
+                )
         finally:
             _registered = False
-            release_running_job(job_id)
+            if reservation_token is None:
+                release_running_job(job_id)
+            else:
+                release_running_job(
+                    job_id, expected_reservation_token=reservation_token
+                )
         refreshed = get_job(job_id) or {}
         execution = None
-        execution_id = job.get("execution_id")
+        execution_id = execution_job.get("execution_id")
         if execution_id:
             from cron.executions import get_execution
 
@@ -355,7 +391,7 @@ def _run_claimed_job(job: Dict[str, Any], extra_prompt: Optional[str] = None) ->
     except Exception as e:
         logger.error("Failed to execute cron job %s immediately: %s", job_id, e)
         if not execution_started:
-            _release_manual_run_reservation(job)
+            _release_manual_run_reservation(job, notify_provider=False)
             _registered = False
         else:
             if _registered:
@@ -363,7 +399,12 @@ def _run_claimed_job(job: Dict[str, Any], extra_prompt: Optional[str] = None) ->
                 with contextlib.suppress(Exception):
                     from cron.scheduler import release_running_job
 
-                    release_running_job(job_id)
+                    if reservation_token is None:
+                        release_running_job(job_id)
+                    else:
+                        release_running_job(
+                            job_id, expected_reservation_token=reservation_token
+                        )
             with contextlib.suppress(Exception):
                 mark_job_run(job_id, False, str(e), expected_fire_owner=fire_owner)
         return {
@@ -372,6 +413,8 @@ def _run_claimed_job(job: Dict[str, Any], extra_prompt: Optional[str] = None) ->
             "success": False,
             "error": str(e),
         }
+    finally:
+        _notify_provider_jobs_changed_safe()
 
 
 def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[str]:
@@ -686,7 +729,10 @@ def _action_run(job: Dict[str, Any], a: Dict[str, Any]) -> str:
     if bg is not None and bg.get("dispatched"):
         _notify_provider_jobs_changed_safe()
         result = _refreshed_job_view(job_id)
-        result["executed"] = True
+        result["claimed"] = True
+        result["executed"] = False
+        result["execution_success"] = None
+        result["execution_pending"] = True
         result["execution_mode"] = "background"
         result["delegation_id"] = bg.get("delegation_id")
         return _dumps({
@@ -706,14 +752,10 @@ def _action_run(job: Dict[str, Any], a: Dict[str, Any]) -> str:
         if forwarded is not None:
             return forwarded
         exec_result = _execute_job_now(job, extra_prompt=extra_prompt)
-    # A claimed direct run advances next_run_at and may race an external provider's
-    # one-shot for the same occurrence; a lost consumed fire cannot re-arm itself, so
-    # reconcile after the run has persisted its final state.
     claimed = exec_result.get("claimed", False)
     executed = bool(exec_result.get("executed", False))
-    if claimed:
-        _notify_provider_jobs_changed_safe()
     result = _refreshed_job_view(job_id)
+    result["claimed"] = claimed
     result["executed"] = executed
     result["execution_success"] = exec_result.get("success", False)
     if not executed:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -32,7 +32,6 @@ from cron.jobs import (
     AmbiguousJobReference,
     claim_job_for_fire,
     get_job,
-    is_job_runnable,
     list_jobs,
     mark_job_run,
     parse_schedule,
@@ -178,34 +177,45 @@ _ALREADY_RUNNING_ERROR = (
 
 
 def _claim_for_manual_run(job_id: str, log_label: str):
-    """At-most-once claim shared by the sync and background run paths: ``(claimed_job, None)`` or
-    ``(None, error_dict)`` in the ``_execute_job_now`` shape. A lost claim is labelled precisely —
-    claim_job_for_fire also returns False for paused/disabled/missing jobs, not just in-flight ones."""
+    """Reserve one manual run in-process, then take the cross-process store claim.
+
+    The local running-set reservation is deliberately first: a second manual run in the same
+    process must not steal an expired store claim from the run already in flight. On success the
+    reservation is transferred to ``_run_claimed_job``, which releases it in ``finally``.
+    """
+    from cron.scheduler import release_running_job, try_register_running_job
+
+    if not try_register_running_job(job_id):
+        return None, {"claimed": False, "success": False, "error": _ALREADY_RUNNING_ERROR}
     try:
-        claimed_job = claim_job_for_fire(job_id, return_job=True)
+        claimed_job = claim_job_for_fire(
+            job_id, force=True, preserve_paused=True, return_job=True
+        )
         if isinstance(claimed_job, dict):
             return claimed_job, None
+        release_running_job(job_id)
         refreshed = get_job(job_id)
         if refreshed is None:
             reason = "Job no longer exists; nothing to run."
-        elif not is_job_runnable(refreshed):
-            reason = "Job is paused/disabled; resume it before running."
+        elif isinstance(refreshed.get("fire_claim"), dict):
+            reason = _ALREADY_RUNNING_ERROR
         else:
-            reason = "Job is already being fired by the scheduler; not run again."
+            reason = "Job could not be claimed for this manual run."
         return None, {"claimed": False, "success": False, "error": reason}
     except Exception as e:
+        release_running_job(job_id)
         logger.error("Failed to claim cron job %s for %s: %s", job_id, log_label, e)
-        with contextlib.suppress(Exception):
-            mark_job_run(job_id, False, str(e))
-        return None, {"claimed": True, "success": False, "error": str(e)}
+        return None, {"claimed": False, "success": False, "error": str(e)}
 
 
 def _execute_job_now(job: Dict[str, Any], extra_prompt: Optional[str] = None) -> Dict[str, Any]:
-    """Run a job now, outside the scheduler tick: claim via ``claim_job_for_fire`` (the ticker's
-    CAS, so a concurrent tick cannot double-fire and next_run_at advances), then fire through
-    the shared ``run_one_job`` body. Returns {"claimed", "success", "error"}."""
+    """Run a job now outside the scheduler tick through the unified manual reservation and
+    owner-fenced runner. Returns distinct ``claimed``, ``executed``, ``success``, and ``error`` fields."""
     claimed_job, err = _claim_for_manual_run(job["id"], "immediate run")
-    return err if err is not None else _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
+    if err is not None:
+        return err
+    assert claimed_job is not None
+    return _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
 
 
 @contextlib.contextmanager
@@ -260,28 +270,42 @@ def _run_heartbeat(job_name: str):
             thread.join(timeout=_CRON_RUN_HEARTBEAT_INTERVAL + 1)
 
 
-def _run_claimed_job(job: Dict[str, Any], extra_prompt: Optional[str] = None) -> Dict[str, Any]:
-    """Fire an already-claimed job through the shared ``run_one_job`` body (split from
-    ``_execute_job_now`` so the background path can claim synchronously and hand the run
-    to a worker). Returns {"claimed": True, "success": bool, "error": ...}."""
-    job_id = job["id"]
-    _registered = False
-    fire_owner = None
+def _release_manual_run_reservation(job: Dict[str, Any]) -> None:
+    """Best-effort abort for a claimed manual run whose executor never started."""
+    job_id = str(job.get("id") or "")
+    claim = job.get("fire_claim")
+    owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
+    if owner:
+        try:
+            from cron.jobs import release_fire_claim
+
+            release_fire_claim(job_id, expected_owner=owner)
+        except Exception:
+            logger.debug("Could not release manual fire claim for %s", job_id, exc_info=True)
     try:
-        from cron.scheduler import release_running_job, run_one_job, try_register_running_job
+        from cron.scheduler import release_running_job
 
-        # In-flight dedupe: the fire claim's TTL is routinely outlived by real jobs, so
-        # register in the scheduler's shared running set (same guard the ticker uses;
-        # also visible to the gateway shutdown drain).
-        # In-flight dedupe (idea from #53395 by @izumi0uu): the fire claim's TTL (300s) is routinely
-        # outlived by real jobs, so it alone cannot stop a manual run from double-firing a job the ticker
-        # (or another manual run) is still executing.
-        if not try_register_running_job(job_id):
-            return {"claimed": True, "success": False, "error": _ALREADY_RUNNING_ERROR}
-        _registered = True
+        release_running_job(job_id)
+    except Exception:
+        logger.debug("Could not release local manual-run reservation for %s", job_id, exc_info=True)
 
-        claim = job.get("fire_claim")
-        fire_owner = str(claim.get("by") or "") if isinstance(claim, dict) else None
+
+def _run_claimed_job(job: Dict[str, Any], extra_prompt: Optional[str] = None) -> Dict[str, Any]:
+    """Execute a claimed manual-run reservation and release its local guard in ``finally``.
+
+    Returns distinct ``claimed`` and ``executed`` fields so callers never equate reservation with
+    body entry.
+    """
+    job_id = job["id"]
+    _registered = True
+    execution_started = False
+    claim = job.get("fire_claim")
+    fire_owner = str(claim.get("by") or "") if isinstance(claim, dict) else None
+    try:
+        from cron.scheduler import release_running_job, run_one_job
+
+        # ``_claim_for_manual_run`` acquired the process-local reservation before the store CAS.
+        # Ownership is transferred here and released exactly once in the execution ``finally``.
 
         # Inside the gateway process deliver on the loop that owns clients such as
         # Matrix/aiohttp (a standalone asyncio.run() loop breaks them).
@@ -297,6 +321,7 @@ def _run_claimed_job(job: Dict[str, Any], extra_prompt: Optional[str] = None) ->
             # run_one_job records last_run_at/last_status via mark_job_run; `job` is the
             # owner-bearing claimed snapshot, so terminal writes stay fenced by that owner.
             with _run_heartbeat(str(job.get("name") or job_id)):
+                execution_started = True
                 processed = run_one_job(job, adapters=adapters, loop=gateway_loop, extra_prompt=extra_prompt)
         finally:
             _registered = False
@@ -321,18 +346,32 @@ def _run_claimed_job(job: Dict[str, Any], extra_prompt: Optional[str] = None) ->
         if execution is not None and execution.get("status") != "completed":
             ok = False
             run_error = execution.get("error") or f"execution ended in {execution.get('status') or 'unknown'} state"
-        return {"claimed": True, "success": bool(processed and ok), "error": run_error}
+        return {
+            "claimed": True,
+            "executed": execution_started,
+            "success": bool(processed and ok),
+            "error": run_error,
+        }
     except Exception as e:
         logger.error("Failed to execute cron job %s immediately: %s", job_id, e)
-        if _registered:
-            # Raised before the run's own release (e.g. heartbeat setup): don't leave the
-            # job marked in-flight. Only release registrations WE took — a bare discard
-            # could erase a ticker-owned entry.
+        if not execution_started:
+            _release_manual_run_reservation(job)
+            _registered = False
+        else:
+            if _registered:
+                # Raised after body entry but before the normal release.
+                with contextlib.suppress(Exception):
+                    from cron.scheduler import release_running_job
+
+                    release_running_job(job_id)
             with contextlib.suppress(Exception):
-                release_running_job(job_id)
-        with contextlib.suppress(Exception):
-            mark_job_run(job_id, False, str(e), expected_fire_owner=fire_owner)
-        return {"claimed": True, "success": False, "error": str(e)}
+                mark_job_run(job_id, False, str(e), expected_fire_owner=fire_owner)
+        return {
+            "claimed": True,
+            "executed": execution_started,
+            "success": False,
+            "error": str(e),
+        }
 
 
 def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[str]:
@@ -453,6 +492,7 @@ def _try_dispatch_background_run(
         if err["claimed"]:
             err["dispatched"] = False
         return err
+    assert claimed_job is not None
 
     origin_ui_session_id = ""
     try:
@@ -486,14 +526,23 @@ def _try_dispatch_background_run(
         res = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
         return _manual_run_completion(res, job_id, job_name, deliver, started_at)
 
-    dispatch = dispatch_async_delegation(
-        goal=f"Manual run of cron job '{job_name}' ({job_id})",
-        context=("Triggered via cronjob(action='run'). The job executed in its own "
-                 "fresh cron session; this block reports its outcome."),
-        toolsets=None, role="cron_run", model=job.get("model"), session_key=session_key,
-        parent_session_id=str(session_id) if session_id else None, runner=_runner,
-        origin_ui_session_id=origin_ui_session_id, origin_session_id=origin_session_id,
-        max_async_children=max_async)
+    try:
+        dispatch = dispatch_async_delegation(
+            goal=f"Manual run of cron job '{job_name}' ({job_id})",
+            context=("Triggered via cronjob(action='run'). The job executed in its own "
+                     "fresh cron session; this block reports its outcome."),
+            toolsets=None, role="cron_run", model=job.get("model"), session_key=session_key,
+            parent_session_id=str(session_id) if session_id else None, runner=_runner,
+            origin_ui_session_id=origin_ui_session_id, origin_session_id=origin_session_id,
+            max_async_children=max_async)
+    except Exception as exc:
+        logger.warning(
+            "cronjob run: background dispatch failed (%s); running job '%s' inline.",
+            exc, job_name,
+        )
+        result = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
+        result["dispatched"] = False
+        return result
     if dispatch.get("status") == "dispatched":
         return {"claimed": True, "dispatched": True, "delegation_id": dispatch.get("delegation_id")}
 
@@ -501,7 +550,7 @@ def _try_dispatch_background_run(
     logger.info(
         "cronjob run: background pool unavailable (%s); running job '%s' inline.",
         dispatch.get("error", "rejected"), job_name)
-    result = _run_claimed_job(job, extra_prompt=extra_prompt)
+    result = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
     result["dispatched"] = False
     return result
 
@@ -661,17 +710,22 @@ def _action_run(job: Dict[str, Any], a: Dict[str, Any]) -> str:
     # one-shot for the same occurrence; a lost consumed fire cannot re-arm itself, so
     # reconcile after the run has persisted its final state.
     claimed = exec_result.get("claimed", False)
+    executed = bool(exec_result.get("executed", False))
     if claimed:
         _notify_provider_jobs_changed_safe()
     result = _refreshed_job_view(job_id)
-    result["executed"] = claimed
+    result["executed"] = executed
     result["execution_success"] = exec_result.get("success", False)
-    if not claimed:
+    if not executed:
         result["execution_skipped"] = exec_result.get("error") or (
-            "Already being fired by the scheduler; not run again.")
+            "Execution did not start; not run again.")
     elif exec_result.get("error"):
         result["execution_error"] = exec_result["error"]
-    return _dumps({"success": True, "job": result})
+    succeeded = bool(exec_result.get("success", False))
+    payload = {"success": succeeded, "job": result}
+    if not succeeded:
+        payload["error"] = exec_result.get("error") or "Manual run failed."
+    return _dumps(payload)
 
 
 def _pick(updates: Dict[str, Any], job: Dict[str, Any], key: str) -> Any:


### PR DESCRIPTION
## Summary

- give explicit manual cron runs one owner-fenced reservation/execution contract across CLI, tool, background delegation, direct API, relay, and ticker interactions
- run a paused job exactly once without resuming or mutating its `enabled`, `state`, `paused_at`, or `next_run_at` scheduling fields
- keep local and durable ownership fenced across cancellation, stale sweeps, delayed callbacks, future assignment, and worker completion
- distinguish claim acceptance, pending execution, body entry, and execution success so CLI/API/background results cannot report false success
- reconcile provider state only after terminal persistence or a fenced pre-body abort

## Problem

`hermes cron run <id>` used the ordinary scheduler claim for a paused job. It printed `Triggered job` and returned zero, but created no claim, execution, or output. A naive forced claim also changed pause scheduling and left races across the different manual-run entry points.

The fix also closes related ABA and cancellation windows discovered during fail-closed review:

- a stale local owner cannot release a replacement reservation
- a swept ticker owner cannot overwrite a replacement future or release a replacement manual guard
- delayed stale-run telemetry cannot clear or mutate a newer durable `fire_claim`
- cancellation while a claim thread is running cannot orphan its late result
- cancellation before an executor worker starts releases the exact reservation
- cancellation after a sync worker starts retains both cron and API/drain guards until that worker actually finishes
- a slow API request body is tracked before its first await, and concurrent run admission obeys the configured cap atomically

## Result

A paused recurring manual run creates one real occurrence and preserves `enabled=false`, `state=paused`, `paused_at`, and the exact prior `next_run_at`, including `null`. A finite paused recurring job stays paused at its repeat limit but cannot be claimed again. A finite one-shot runs once and becomes `completed`.

Background and relay acceptance report `claimed=true`, `execution_pending=true`, `executed=false`, and `execution_success=null`; they do not pretend the execution body already ran. Rejected or failed synchronous runs return a nonzero CLI status and do not print a false success.

## Test plan

- Affected contract suite: `245 passed, 0 failed`.
- API admission/drain suite: `165 passed, 0 failed`.
- Broad cron suite: `1231 passed, 1 failed, 4 skipped`.
  - The sole failure is the pre-existing macOS permission test `test_ensure_hermes_home_sets_0700` (`0755` observed vs `0700` expected); it reproduces on the clean initial PR commit.
- Isolated no-agent fixture: one execution, one artifact, claim cleared, repeat incremented once, exact pause schedule preserved.
- Detached installed-base port: `245 passed, 0 failed`; Ruff and `git diff --check` pass.
- Independent fail-closed review of complete diff SHA-256 `13d67a9fce7cd28d52d7d5ae7ab75de6cf1c98ef453db657f717206c25cf4abe`: `passed=true`, `contract_met=true`, `all_historical_blockers_resolved=true`; focused reviewer suite `141/141`.
- The candidate cleanly merge-trees with upstream `main` at `2237be355906fbe6065ce1815711eee52b2d646e`.
