### PR TITLE
fix(whatsapp): match self-chat on LID exclusively when the account has one

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -609,7 +609,9 @@ async function startSocket() {
           const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
           const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
           const chatNumber = chatId.replace(/@.*/, '');
-          const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
+          // Meta AI prompts arrive on the legacy PN identity even when a LID exists.
+          // Matching both identities ingests those prompts and can trigger response loops.
+          const isSelfChat = myLid ? chatNumber === myLid : (myNumber && chatNumber === myNumber);
           emitDebugEvent({
             stage: 'self_chat_check',
             matched: !!isSelfChat,

--- a/scripts/whatsapp-bridge/bridge.selfchat.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.selfchat.test.mjs
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { registerHooks } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { after, before, test } from 'node:test';
+
+const handlers = new Map();
+const routes = new Map();
+const ready = Promise.withResolvers();
+const socket = {
+  user: {},
+  ev: {
+    on(name, handler) {
+      handlers.set(name, handler);
+      if (name === 'messages.upsert') ready.resolve();
+    },
+  },
+};
+const fixtureKey = Symbol.for('hermes.whatsapp.selfchat.test');
+const originalEnv = Object.fromEntries(
+  ['HOME', 'HERMES_HOME', 'WHATSAPP_MODE'].map(key => [key, process.env[key]]),
+);
+let home;
+let hooks;
+
+before(async () => {
+  home = mkdtempSync(path.join(tmpdir(), 'hermes-whatsapp-selfchat-'));
+  Object.assign(process.env, { HOME: home, HERMES_HOME: home, WHATSAPP_MODE: 'self-chat' });
+  globalThis[fixtureKey] = { socket, routes };
+
+  // Replace external transports only: run the real bridge intake and /messages
+  // handler without a WhatsApp connection, HTTP listener, or installed credentials.
+  const fixture = 'const fixture = globalThis[Symbol.for("hermes.whatsapp.selfchat.test")];';
+  const stubs = new Map([
+    ['@whiskeysockets/baileys', `${fixture}
+      export const makeWASocket = () => fixture.socket;
+      export const useMultiFileAuthState = async () => ({ state: {}, saveCreds() {} });
+      export const fetchLatestBaileysVersion = async () => ({ version: [2, 3000, 0] });
+      export const DisconnectReason = {};
+      export const jidNormalizedUser = id => id;
+      export function downloadMediaMessage() { throw new Error('Unexpected media download'); }
+      export function getAggregateVotesInPollMessage() { throw new Error('Unexpected poll'); }
+      export function decryptPollVote() { throw new Error('Unexpected poll'); }
+      export function getKeyAuthor() { throw new Error('Unexpected poll'); }
+    `],
+    ['express', `${fixture}
+      function express() {
+        return {
+          use() {},
+          get(route, handler) { fixture.routes.set(route, handler); },
+          post() {},
+          listen(port, host, callback) { callback(); },
+        };
+      }
+      express.json = () => () => {};
+      export default express;
+    `],
+    ['@hapi/boom', 'export class Boom extends Error {}'],
+    ['pino', 'export default () => ({})'],
+    ['qrcode-terminal', 'export default {}'],
+  ]);
+  hooks = registerHooks({
+    resolve(specifier, context, nextResolve) {
+      if (stubs.has(specifier)) {
+        return { url: `data:text/javascript,${encodeURIComponent(stubs.get(specifier))}`, shortCircuit: true };
+      }
+      return nextResolve(specifier, context);
+    },
+  });
+  await import('./bridge.js');
+  await ready.promise;
+});
+
+after(() => {
+  hooks?.deregister();
+  delete globalThis[fixtureKey];
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  if (home) rmSync(home, { recursive: true, force: true });
+});
+
+const pn = '15551234567';
+const lid = '67427329167522';
+for (const type of ['notify', 'append']) {
+  for (const [name, accountLid, chatId, accepted] of [
+    ['LID self-chat', `${lid}:10@lid`, `${lid}@lid`, true],
+    // Meta AI prompts use the legacy PN identity even when the account has a LID.
+    ['Meta AI on PN with LID', `${lid}:10@lid`, `${pn}@s.whatsapp.net`, false],
+    ['legacy PN self-chat without LID', undefined, `${pn}@s.whatsapp.net`, true],
+    ['legacy PN self-chat with empty LID', '', `${pn}@s.whatsapp.net`, true],
+    ['third-party PN with LID', `${lid}:10@lid`, '15559876543@s.whatsapp.net', false],
+    ['third-party LID', `${lid}:10@lid`, '88888888888888@lid', false],
+    ['third-party PN without LID', undefined, '15559876543@s.whatsapp.net', false],
+  ]) {
+    test(`${type}: ${name} ${accepted ? 'reaches' : 'never reaches'} the gateway queue`, async () => {
+      socket.user = { id: `${pn}:10@s.whatsapp.net`, lid: accountLid };
+      const messageId = `${type}-${name}`;
+      await handlers.get('messages.upsert')({
+        type,
+        messages: [{
+          key: { id: messageId, remoteJid: chatId, fromMe: true },
+          message: { conversation: 'Please handle this request' },
+          messageTimestamp: 123,
+        }],
+      });
+
+      let queued;
+      routes.get('/messages')({}, { json: messages => { queued = messages; } });
+      assert.deepEqual(queued.map(event => event.messageId), accepted ? [messageId] : []);
+      if (accepted) {
+        assert.equal(queued[0].chatId, chatId);
+        assert.equal(queued[0].body, 'Please handle this request');
+      }
+    });
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Under `WHATSAPP_MODE=self-chat`, self-chat detection compared the incoming chatId loosely against BOTH the account's LID and its legacy phone-number JID (#103281). Meta AI interactions surface under the account's legacy PN identity, so the OR-match classified them as self-chat — prompts the user sent to Meta AI were ingested as agent turns, causing response loops and unintended outbound API activity.

When the account exposes a LID, self-chat now matches the LID exclusively; the PN comparison only applies to legacy accounts with no LID, which keeps them working. The classification lives in the WhatsApp bridge (`scripts/whatsapp-bridge/bridge.js`), where the account identities are known.

## Related Issue

Fixes #103281

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/whatsapp-bridge/bridge.js` — `isSelfChat = myLid ? chatNumber === myLid : (myNumber && chatNumber === myNumber)` with a comment naming the Meta AI loop the loose OR caused
- `scripts/whatsapp-bridge/bridge.selfchat.test.mjs` (new) — 7-shape matrix: LID self-chat, Meta-AI-on-PN-with-LID (the bug), legacy PN self-chat with/without LID, third-party PN/LID variants

## How to Test

1. `node --test scripts/whatsapp-bridge/bridge.selfchat.test.mjs` → all green (the Meta-AI shape fails before the fix)
2. Manual: with a LID-bearing account in self-chat mode, send a prompt to Meta AI — the gateway no longer ingests it; a message to your own LID chat still reaches the agent

## Checklist

### Code
- [x] Contributing Guide read; Conventional Commits followed
- [x] Searched for duplicate PRs
- [x] Only changes related to this fix
- [x] Relevant tests pass; tests added
- [x] Tested on Linux (Node test runner; Python platform suite green apart from pre-existing missing-extra failures)

### Documentation & Housekeeping
- [x] N/A
