### PR TITLE
fix(tools): surface same-lineage FTS hits with owning-session metadata

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -19,6 +19,7 @@ from hermes_state import SessionDB
 from tools.registry import registry
 from tools.session_search_tool import (
     SESSION_SEARCH_SCHEMA,
+    _branch_copy_edge,
     _format_timestamp,
     _is_compacted_message,
     _resolve_to_parent,
@@ -328,7 +329,13 @@ class TestDiscoveryShape:
 
 class TestGatewayRestartLineageDiscovery:
     @pytest.fixture
-    def restarted_lineage(self, db):
+    def restarted_lineage(self, db, request):
+        """Gateway restart chain in production shape: each successor row carries the
+        ``_reset_from`` marker stamped atomically at CREATE time
+        (gateway/session_recovery.py ``_session_create_kwargs``); the predecessor's
+        end write is a separate best-effort and may be missing ("the old row remains
+        open"). ``request.param=False`` seeds the pre-marker bare-link shape."""
+        markers = getattr(request, "param", True)
         root, owner, current = (
             "20260812_gateway_root", "20260903_gateway_owner", "20260904_gateway_current",
         )
@@ -341,6 +348,7 @@ class TestGatewayRestartLineageDiscovery:
             db.create_session(
                 sid, source="telegram", parent_session_id=parent,
                 session_key="tg:restart:1",
+                model_config={"_reset_from": parent} if markers and parent else None,
             )
             started_at = datetime.fromisoformat(day).replace(tzinfo=timezone.utc).timestamp()
             db._conn.execute(
@@ -359,6 +367,10 @@ class TestGatewayRestartLineageDiscovery:
         db._conn.commit()
         return owner, current
 
+    # markers=True: production rows carry _reset_from; markers=False: pre-marker bare
+    # links. Both must behave identically for every end_reason — the marker decides
+    # the boundary, not the (optional, overwritable) end write.
+    @pytest.mark.parametrize("restarted_lineage", [True, False], indirect=True)
     @pytest.mark.parametrize("end_reason", [None, "compression", "session_reset"])
     def test_previous_owner_is_searchable_but_current_context_is_not(
         self, db, restarted_lineage, end_reason,
@@ -391,9 +403,34 @@ class TestGatewayRestartLineageDiscovery:
         assert result["success"] is True
         hit, = result["results"]
         assert hit["session_id"] == owner
+        # The tool formats timestamps in the host's local zone — compute the expected
+        # string the same way instead of hardcoding a zone-dependent literal.
+        expected_when = datetime.fromtimestamp(
+            datetime.fromisoformat("2026-09-03").replace(tzinfo=timezone.utc).timestamp()
+        ).strftime("%B %d, %Y at %I:%M %p")
         assert (hit["when"], hit["title"]) == (
-            "September 03, 2026 at 12:00 AM", "September gateway recovery",
+            expected_when, "September gateway recovery",
         )
+
+    def test_unended_restart_predecessor_hit_is_scrollable(self, db, restarted_lineage):
+        """PR-head gap: discovery surfaced the unended restart predecessor but scroll
+        rejected its anchor — "scroll never rejects a discovery result"."""
+        owner, current = restarted_lineage
+        disc = json.loads(session_search(
+            query="restartneedle", db=db, current_session_id=current, limit=1,
+        ))
+        assert disc["count"] == 1
+        hit = disc["results"][0]
+        scrolled = json.loads(session_search(
+            session_id=hit["session_id"],
+            around_message_id=hit["match_message_id"],
+            db=db,
+            current_session_id=current,
+        ))
+        assert scrolled["success"] is True
+        assert scrolled["mode"] == "scroll"
+        contents = " ".join(m.get("content") or "" for m in scrolled["messages"])
+        assert "restartneedle" in contents
 
 
 class TestDiscoverySort:
@@ -449,9 +486,15 @@ class TestScrollShape:
 
 
     def test_scroll_rejects_active_delegation_child_in_current_lineage(self, db):
+        """Production shape (run_agent.py source fallback): a delegate run can land
+        with source='cli', so the ``_delegate_from`` marker — not the source — is what
+        keeps live delegation children out of recall. A bare child row without a
+        marker is indistinguishable from a restart successor and must stay
+        scrollable (see TestGatewayRestartLineageDiscovery)."""
         db.create_session("s_current", source="cli")
         db.create_session(
-            "s_delegate", source="delegate", parent_session_id="s_current"
+            "s_delegate", source="cli", parent_session_id="s_current",
+            model_config={"_delegate_from": "s_current"},
         )
         mid = db.append_message(
             "s_delegate", role="assistant", content="live delegated result"
@@ -860,7 +903,10 @@ class TestLegacyRotationDiscovery:
 
 
 class TestSameLineageDiscovery:
-    """A shared parent link does not prove another session is live context."""
+    """A bare parent link proves nothing either way: with no marker and no branch end
+    write (pre-marker legacy rows) the predecessor is treated as NOT projected into
+    the caller's context — recall errs toward surfacing (#20856/#85756) — while the
+    current session's own rows stay excluded."""
 
     def test_unended_parent_surfaces_but_current_child_is_excluded(self, db):
         db.create_session("s_parent", source="cli")
@@ -1131,27 +1177,6 @@ class TestNewResetLineageDiscovery:
         ))
         assert result["count"] == 0
 
-    def test_branched_parent_surfaces_but_current_copy_is_excluded(self, db):
-        """Even copied content is filtered by its owning session, not its lineage."""
-        db.create_session("s_p", source="cli")
-        db.append_message(
-            "s_p", role="user", content="zephyr crystal cache design",
-        )
-        db.end_session("s_p", "branched")
-        db.create_session(
-            "s_q", source="cli", parent_session_id="s_p",
-            model_config={"_branched_from": "s_p"},
-        )
-        # /branch copies history into the child
-        db.append_message(
-            "s_q", role="user", content="zephyr crystal cache design",
-        )
-        result = json.loads(session_search(
-            query="zephyr crystal", db=db, current_session_id="s_q",
-        ))
-        sids = [r["session_id"] for r in result.get("results", [])]
-        assert sids == ["s_p"]
-
     def test_title_match_reset_parent_not_dropped(self, db):
         _seed_gateway_new_reset_chain(db)
         result = json.loads(session_search(
@@ -1221,4 +1246,297 @@ class TestNewResetLineageBrowse:
         result = json.loads(session_search(db=db, current_session_id="s_other"))
         sids = [r["session_id"] for r in result["results"]]
         assert "s_legacy_child" in sids
+
+
+# =========================================================================
+# Branch-copy boundary (review rework of #105147 / upstream #103184)
+#
+# /branch is the only writer that carries a transcript verbatim into a child
+# session row, and it stamps ``_branched_from`` atomically in the child's
+# INSERT. A predecessor whose transcript is already projected into the
+# caller's live context must STAY excluded from recall (the review's core
+# ask); reset/restart predecessors (empty child) and compression ancestors
+# (summary, not transcript) must surface. The marker — not the parent link,
+# not the end write — is the boundary in both directions.
+# =========================================================================
+
+def _seed_branch_copy(db, parent_id, child_id, needle, *, end_parent=None):
+    """Seed a /branch in production shape: the child row's INSERT stamps the
+    ``_branched_from`` marker atomically (gateway/slash_commands_session.py,
+    tui_gateway/methods_session.py, hermes_cli/cli_commands_mixin.py) and the
+    transcript is then copied verbatim; the gateway /branch path does NOT end
+    the parent row. Returns the parent's needle message id."""
+    db.create_session(parent_id, source="cli")
+    parent_mid = db.append_message(parent_id, role="user", content=needle)
+    if end_parent:
+        db.end_session(parent_id, end_parent)
+    db.create_session(child_id, source="cli", parent_session_id=parent_id,
+                      model_config={"_branched_from": parent_id})
+    db.append_message(child_id, role="user", content=needle)  # verbatim copy
+    db._conn.commit()
+    return parent_mid
+
+
+class TestBranchCopyExclusion:
+    """Negative controls: predecessors whose transcripts were verbatim-copied into
+    the current session stay excluded — restoring the semantic distinction the
+    pre-PR tests pinned (this flip-back is the review's purpose, not a regression
+    of the restart-chain fix below)."""
+
+    def test_branched_parent_still_excluded(self, db):
+        _seed_branch_copy(db, "s_p", "s_q", "zephyr crystal cache design")
+        result = json.loads(session_search(
+            query="zephyr crystal", db=db, current_session_id="s_q",
+        ))
+        sids = [r["session_id"] for r in result.get("results", [])]
+        assert "s_p" not in sids
+        assert result["count"] == 0
+
+    def test_branched_parent_still_excluded_after_re_end(self, db):
+        """A later end write on the parent (tui_shutdown and friends overwrite
+        end_reason — #20856) must not turn the copied transcript back into
+        recall; the marker is the boundary, not the end_reason."""
+        _seed_branch_copy(db, "s_p", "s_q", "zephyr crystal cache design")
+        db.end_session("s_p", "session_reset")
+        result = json.loads(session_search(
+            query="zephyr crystal", db=db, current_session_id="s_q",
+        ))
+        assert result["count"] == 0
+
+    def test_legacy_api_fork_parent_still_excluded(self, db):
+        """api_server fork: no marker, parent ended 'branched' before the child row
+        (the legacy arm). Seed the child's started_at from the parent's actual
+        ended_at + 1 — end_session stamps wall-clock now, so a fake small timestamp
+        would make the ordering arm false-negative."""
+        db.create_session("s_p", source="api_server")
+        db.append_message("s_p", role="user", content="zephyr crystal cache design")
+        db.end_session("s_p", "branched")
+        ended_at = db.get_session("s_p")["ended_at"]
+        db.create_session("s_q", source="api_server", parent_session_id="s_p")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?", (ended_at + 1, "s_q"),
+        )
+        db.append_message("s_q", role="user", content="zephyr crystal cache design")
+        db._conn.commit()
+        result = json.loads(session_search(
+            query="zephyr crystal", db=db, current_session_id="s_q",
+        ))
+        assert result["count"] == 0
+
+    def test_current_sessions_branch_descendant_excluded(self, db):
+        """Downward closure: the branch child of the CURRENT session holds a copy of
+        the caller's own transcript (ancestor-prefix copy), so it is a duplicate
+        source, not new recall."""
+        db.create_session("s_cur", source="cli")
+        db.append_message("s_cur", role="user", content="zephyr crystal cache design")
+        db.create_session("s_bc", source="cli", parent_session_id="s_cur",
+                          model_config={"_branched_from": "s_cur"})
+        db.append_message("s_bc", role="user", content="zephyr crystal cache design")
+        db._conn.commit()
+        result = json.loads(session_search(
+            query="zephyr crystal", db=db, current_session_id="s_cur",
+        ))
+        assert result["count"] == 0
+
+    def test_branch_of_branch_excludes_both_ancestors(self, db):
+        db.create_session("s_a", source="cli")
+        db.append_message("s_a", role="user", content="aurora spindle calibration")
+        db.create_session("s_b", source="cli", parent_session_id="s_a",
+                          model_config={"_branched_from": "s_a"})
+        db.append_message("s_b", role="user", content="aurora spindle calibration")
+        db.append_message("s_b", role="user", content="aurora beacon alignment")
+        db.create_session("s_c", source="cli", parent_session_id="s_b",
+                          model_config={"_branched_from": "s_b"})
+        db.append_message("s_c", role="user", content="aurora spindle calibration")
+        db._conn.commit()
+        result = json.loads(session_search(
+            query="aurora", db=db, current_session_id="s_c",
+        ))
+        assert [r["session_id"] for r in result.get("results", [])] == []
+
+    def test_scroll_into_branched_parent_anchor_is_rejected(self, db):
+        """Scroll duality: the branch parent's transcript is already in the child's
+        active context, so scrolling its anchor must be rejected — while reset
+        predecessors stay scrollable (test_unended_restart_predecessor_hit_is_scrollable)."""
+        parent_mid = _seed_branch_copy(db, "s_p", "s_q", "zephyr crystal cache design")
+        result = json.loads(session_search(
+            session_id="s_p", around_message_id=parent_mid, db=db,
+            current_session_id="s_q",
+        ))
+        assert result["success"] is False
+        assert "current session" in result.get("error", "").lower()
+
+    def test_branch_parent_title_suppressed_from_child_side(self, db):
+        db.create_session("s_p", source="cli")
+        db.append_message("s_p", role="user", content="plain work note")
+        db._conn.execute("UPDATE sessions SET title = ? WHERE id = ?",
+                         ("Zephyr Branch Origin Story", "s_p"))
+        db.create_session("s_q", source="cli", parent_session_id="s_p",
+                          model_config={"_branched_from": "s_p"})
+        db._conn.commit()
+        from_child = json.loads(session_search(
+            query="Zephyr Branch Origin Story", db=db, current_session_id="s_q",
+        ))
+        assert from_child["count"] == 0
+        # From outside the lineage the same title must still resolve.
+        from_outside = json.loads(session_search(
+            query="Zephyr Branch Origin Story", db=db,
+        ))
+        assert [r["session_id"] for r in from_outside["results"]] == ["s_p"]
+
+
+class TestContinuationProjectionDiscovery:
+    """Positive controls: only branch-copy edges keep a predecessor inside the
+    caller's live context; every continuation that does NOT carry the transcript
+    (reset, restart, compression) surfaces."""
+
+    def test_compression_continuation_with_inherited_marker_surfaces_parent(self, db):
+        """s_a --branch--> s_b --compression--> s_c. The compression continuation
+        inherits ``_branched_from=s_a`` verbatim while its parent is s_b: binding
+        the marker BY VALUE must not misread s_c as a branch child of s_b."""
+        db.create_session("s_a", source="cli")
+        db.append_message("s_a", role="user", content="velvet compass assembly")
+        db.create_session("s_b", source="cli", parent_session_id="s_a",
+                          model_config={"_branched_from": "s_a"})
+        db.append_message("s_b", role="user", content="velvet compass assembly")
+        db.append_message("s_b", role="user", content="harbor winch calibration")
+        db.end_session("s_b", "compression")
+        db.create_session("s_c", source="cli", parent_session_id="s_b",
+                          model_config={"_branched_from": "s_a"})
+        db.append_message("s_c", role="user", content="continue after summary")
+        db._conn.commit()
+        # s_b's own post-branch message crossed the edge only as a summary — it must
+        # be reachable from the continuation (existence-only marker matching would
+        # misread s_c as s_b's branch child and hide it).
+        from_sc = json.loads(session_search(
+            query="harbor winch", db=db, current_session_id="s_c",
+        ))
+        assert [r["session_id"] for r in from_sc["results"]] == ["s_b"]
+        # From s_b itself the branch edge to s_a still binds: s_a and s_b's own copy
+        # of it stay hidden.
+        from_sb = json.loads(session_search(
+            query="velvet compass", db=db, current_session_id="s_b",
+        ))
+        assert from_sb["count"] == 0
+
+    def test_reset_edge_cuts_the_projection(self, db):
+        """s_a --branch--> s_b, then a fresh reset child s_r of s_b: the branch
+        chain is reachable from s_r (the reset child carries no transcript) while
+        staying hidden from s_b (the branch child carries a copy)."""
+        db.create_session("s_a", source="cli")
+        db.append_message("s_a", role="user", content="solstice ledger audit")
+        db.create_session("s_b", source="cli", parent_session_id="s_a",
+                          model_config={"_branched_from": "s_a"})
+        db.append_message("s_b", role="user", content="solstice ledger audit")
+        db.append_message("s_b", role="user", content="harbor winch calibration")
+        db.create_session("s_r", source="cli", parent_session_id="s_b",
+                          model_config={"_reset_from": "s_b"})
+        db._conn.commit()
+        from_sr = json.loads(session_search(
+            query="solstice ledger", db=db, current_session_id="s_r",
+        ))
+        assert from_sr["count"] == 1
+        assert from_sr["results"][0]["session_id"] in {"s_a", "s_b"}
+        from_sb = json.loads(session_search(
+            query="solstice ledger", db=db, current_session_id="s_b",
+        ))
+        assert from_sb["count"] == 0
+
+    def test_branch_sibling_under_non_projected_ancestor_surfaces(self, db):
+        """The projection stops at the reset edge below s_p, so s_p AND its branch
+        child (an alternate future of s_p, not of the caller) are both reachable
+        from the reset child — and stay hidden from the branch sibling itself."""
+        db.create_session("s_p", source="cli")
+        db.append_message("s_p", role="user", content="solstice ledger audit")
+        db.create_session("s_sib", source="cli", parent_session_id="s_p",
+                          model_config={"_branched_from": "s_p"})
+        db.append_message("s_sib", role="user", content="solstice ledger audit")
+        db.create_session("s_r", source="cli", parent_session_id="s_p",
+                          model_config={"_reset_from": "s_p"})
+        db._conn.commit()
+        from_sr = json.loads(session_search(
+            query="solstice ledger", db=db, current_session_id="s_r",
+        ))
+        assert from_sr["count"] == 1
+        assert from_sr["results"][0]["session_id"] in {"s_p", "s_sib"}
+        from_sib = json.loads(session_search(
+            query="solstice ledger", db=db, current_session_id="s_sib",
+        ))
+        assert from_sib["count"] == 0
+
+    def test_delegate_marker_hides_cli_sourced_delegate_child_from_discovery(self, db):
+        """run_agent.py can stamp delegate runs source='cli' (fallback chain), so the
+        ``_delegate_from`` marker — not the source filter — hides the live
+        delegation run from discovery."""
+        db.create_session("s_current", source="cli")
+        db.create_session(
+            "s_delegate", source="cli", parent_session_id="s_current",
+            model_config={"_delegate_from": "s_current"},
+        )
+        db.append_message(
+            "s_delegate", role="assistant", content="quasar delegation trace results",
+        )
+        db._conn.commit()
+        result = json.loads(session_search(
+            query="quasar delegation", db=db, current_session_id="s_current",
+        ))
+        assert result["count"] == 0
+
+
+class TestBranchCopyEdge:
+    """Unit matrix for the pure edge classifier behind the live-context projection."""
+
+    def test_marker_bound_by_value_to_the_parent(self):
+        assert _branch_copy_edge(
+            {"model_config": {"_branched_from": "p1"}}, {"id": "p1"}) is True
+
+    def test_marker_survives_json_text_storage(self):
+        # sessions.model_config is stored as JSON text; get_session returns it unparsed.
+        assert _branch_copy_edge(
+            {"model_config": '{"_branched_from": "p1"}'}, {"id": "p1"}) is True
+
+    def test_inherited_marker_names_the_grandparent_not_this_edge(self):
+        # compression copies model_config onto the continuation row: the inherited
+        # value names s_a while the parent here is s_b — not a branch copy.
+        assert _branch_copy_edge(
+            {"model_config": {"_branched_from": "s_a"}, "started_at": 200.0},
+            {"id": "s_b"}) is False
+
+    def test_marker_pointing_at_an_unrelated_id(self):
+        assert _branch_copy_edge(
+            {"model_config": {"_branched_from": "someone-else"}}, {"id": "p1"}) is False
+
+    def test_legacy_branched_end_with_later_child_start(self):
+        # api_server fork shape: parent ended 'branched', child started afterwards.
+        assert _branch_copy_edge(
+            {"started_at": 101.0},
+            {"id": "p1", "end_reason": "branched", "ended_at": 100.0}) is True
+
+    def test_legacy_arm_requires_an_ended_at(self):
+        assert _branch_copy_edge(
+            {"started_at": 101.0},
+            {"id": "p1", "end_reason": "branched", "ended_at": None}) is False
+
+    def test_legacy_arm_requires_child_started_after_parent_ended(self):
+        assert _branch_copy_edge(
+            {"started_at": 99.0},
+            {"id": "p1", "end_reason": "branched", "ended_at": 100.0}) is False
+
+    def test_reset_marker_is_not_a_copy_edge(self):
+        assert _branch_copy_edge(
+            {"model_config": {"_reset_from": "p1"}, "started_at": 101.0},
+            {"id": "p1", "end_reason": "session_reset", "ended_at": 100.0}) is False
+
+    def test_delegate_marker_is_not_a_copy_edge(self):
+        assert _branch_copy_edge(
+            {"model_config": {"_delegate_from": "p1"}, "started_at": 101.0},
+            {"id": "p1"}) is False
+
+    def test_bare_parent_link_is_not_a_copy_edge(self):
+        assert _branch_copy_edge({"started_at": 101.0}, {"id": "p1"}) is False
+
+    def test_compression_ended_parent_is_not_a_copy_edge(self):
+        assert _branch_copy_edge(
+            {"started_at": 101.0},
+            {"id": "p1", "end_reason": "compression", "ended_at": 100.0}) is False
 

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -11,10 +11,12 @@ All run zero LLM calls.
 import inspect
 import json
 import time
+from datetime import datetime, timezone
 
 import pytest
 
 from hermes_state import SessionDB
+from tools.registry import registry
 from tools.session_search_tool import (
     SESSION_SEARCH_SCHEMA,
     _format_timestamp,
@@ -322,6 +324,76 @@ class TestDiscoveryShape:
         result = json.loads(session_search(query="modpack", db=db, current_session_id="s_newest"))
         sids = [r["session_id"] for r in result["results"]]
         assert "s_newest" not in sids
+
+
+class TestGatewayRestartLineageDiscovery:
+    @pytest.fixture
+    def restarted_lineage(self, db):
+        root, owner, current = (
+            "20260812_gateway_root", "20260903_gateway_owner", "20260904_gateway_current",
+        )
+        parent = None
+        for sid, day, title in (
+            (root, "2026-08-12", "MCP серверы Hermes"),
+            (owner, "2026-09-03", "September gateway recovery"),
+            (current, "2026-09-04", "Current gateway conversation"),
+        ):
+            db.create_session(
+                sid, source="telegram", parent_session_id=parent,
+                session_key="tg:restart:1",
+            )
+            started_at = datetime.fromisoformat(day).replace(tzinfo=timezone.utc).timestamp()
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+                (started_at, title, sid),
+            )
+            parent = sid
+        # A restart can create a successor without ever ending its predecessor.
+        for index in range(6):
+            db.append_message(
+                owner, role="user" if index % 2 == 0 else "assistant",
+                content=f"restartneedle recovery note {index}",
+                timestamp=datetime(2026, 9, 3, 12, index, tzinfo=timezone.utc).timestamp(),
+            )
+        db.append_message(current, role="user", content="currentneedle live context")
+        db._conn.commit()
+        return owner, current
+
+    @pytest.mark.parametrize("end_reason", [None, "compression", "session_reset"])
+    def test_previous_owner_is_searchable_but_current_context_is_not(
+        self, db, restarted_lineage, end_reason,
+    ):
+        owner, current = restarted_lineage
+        if end_reason is not None:
+            db.end_session(owner, end_reason)
+        result = json.loads(registry.dispatch(
+            "session_search", {"query": "restartneedle"},
+            db=db, current_session_id=current,
+        ))
+        assert result["success"] is True
+        assert [hit["session_id"] for hit in result["results"]] == [owner]
+        assert result["sessions_searched"] == result["count"] == 1
+        live = json.loads(registry.dispatch(
+            "session_search", {"query": "currentneedle"},
+            db=db, current_session_id=current,
+        ))
+        assert live["success"] is True
+        assert live["results"] == []
+
+    def test_metadata_describes_the_message_owner_not_the_lineage_root(
+        self, db, restarted_lineage,
+    ):
+        owner, _ = restarted_lineage
+        # Omit current_session_id so the visibility bug cannot mask the metadata bug.
+        result = json.loads(registry.dispatch(
+            "session_search", {"query": "restartneedle"}, db=db,
+        ))
+        assert result["success"] is True
+        hit, = result["results"]
+        assert hit["session_id"] == owner
+        assert (hit["when"], hit["title"]) == (
+            "September 03, 2026 at 12:00 AM", "September gateway recovery",
+        )
 
 
 class TestDiscoverySort:
@@ -679,8 +751,8 @@ class TestCompactionSummaryFiltering:
 # After compression (in-place compaction or legacy rotation), pre-compaction
 # content is no longer in the live context but MUST stay discoverable via
 # session_search. The old code skipped any FTS hit on the current session or
-# lineage, creating a "memory black hole". Delegation children must STAY
-# excluded — their content is still visible to the parent agent.
+# lineage, creating a "memory black hole". Live context is scoped to the
+# current session; hidden subagent sources remain excluded separately.
 # =========================================================================
 
 class TestResolveToParent:
@@ -787,14 +859,10 @@ class TestLegacyRotationDiscovery:
         assert "s_parent" in sids
 
 
-class TestDelegationExclusion:
-    """Delegation children (delegate_task) must STAY excluded — their content
-    is still visible to the parent agent. parent_session_id is set but the
-    parent does NOT have end_reason='compression'."""
+class TestSameLineageDiscovery:
+    """A shared parent link does not prove another session is live context."""
 
-    def test_delegation_parent_excluded_from_child(self, db):
-        """Child can see its own content but parent's live content stays
-        excluded (it's in context via delegation)."""
+    def test_unended_parent_surfaces_but_current_child_is_excluded(self, db):
         db.create_session("s_parent", source="cli")
         db.append_message("s_parent", role="user",
                           content="nebula deployment infrastructure setup")
@@ -808,7 +876,7 @@ class TestDelegationExclusion:
         result = json.loads(session_search(
             query="nebula deployment", db=db, current_session_id="s_child",
         ))
-        assert result["count"] == 0
+        assert [hit["session_id"] for hit in result["results"]] == ["s_parent"]
 
 
 # =========================================================================
@@ -931,7 +999,7 @@ class TestRewindExclusion:
 
 class TestLegacyContinuationPlusDelegation:
     """Regression: a delegation child created under a compression continuation
-    must stay excluded — its content is still live to the parent agent.
+    must stay excluded because subagent runs are not the user's history.
     Only the compression-ended ancestor's content should surface."""
 
     def test_compression_parent_surfaces_but_delegate_child_excluded(self, db):
@@ -955,7 +1023,7 @@ class TestLegacyContinuationPlusDelegation:
         db.create_session("s_current", source="cli", parent_session_id="s_p")
 
         # Delegation child under s_p (not compression-ended)
-        db.create_session("s_delegate", source="cli", parent_session_id="s_p")
+        db.create_session("s_delegate", source="subagent", parent_session_id="s_p")
         db.append_message("s_delegate", role="assistant",
                           content="delegated cosmic anomaly subtask results")
 
@@ -980,7 +1048,7 @@ class TestLegacyContinuationPlusDelegation:
 # current-lineage exclusion (which assumes same-root content is already in
 # context) goes blind: FTS hits in last-night's session are dropped, and
 # browse hides every recent interactive row because they all have a parent.
-# Delegation children (live parent, no end_reason) must stay excluded.
+# Hidden subagent sources must stay excluded independently of parent links.
 # =========================================================================
 
 def _seed_gateway_new_reset_chain(db, *, needle="ibuprofen night-dose protocol"):
@@ -1048,25 +1116,23 @@ class TestNewResetLineageDiscovery:
         assert result["count"] >= 1
         assert "s_cli_old" in [r["session_id"] for r in result["results"]]
 
-    def test_live_delegation_child_still_excluded(self, db):
-        """Unended parent+child (delegate_task) must stay hidden."""
+    def test_hidden_subagent_child_still_excluded(self, db):
+        """Source filtering must still hide subagent runs after lineage filtering changes."""
         db.create_session("s_parent", source="cli")
+        db.create_session(
+            "s_child", source="subagent", parent_session_id="s_parent",
+        )
         db.append_message(
-            "s_parent", role="user",
+            "s_child", role="user",
             content="nebula deployment infrastructure setup",
         )
-        db.create_session(
-            "s_child", source="cli", parent_session_id="s_parent",
-        )
         result = json.loads(session_search(
-            query="nebula deployment", db=db, current_session_id="s_child",
+            query="nebula deployment", db=db, current_session_id="s_parent",
         ))
         assert result["count"] == 0
 
-    def test_branched_parent_still_excluded(self, db):
-        """/branch verbatim-copies the transcript into the child, so the
-        parent's content IS the branch child's live context — it must not
-        surface as a same-lineage recall hit (unlike /new-reset parents)."""
+    def test_branched_parent_surfaces_but_current_copy_is_excluded(self, db):
+        """Even copied content is filtered by its owning session, not its lineage."""
         db.create_session("s_p", source="cli")
         db.append_message(
             "s_p", role="user", content="zephyr crystal cache design",
@@ -1084,7 +1150,7 @@ class TestNewResetLineageDiscovery:
             query="zephyr crystal", db=db, current_session_id="s_q",
         ))
         sids = [r["session_id"] for r in result.get("results", [])]
-        assert "s_p" not in sids
+        assert sids == ["s_p"]
 
     def test_title_match_reset_parent_not_dropped(self, db):
         _seed_gateway_new_reset_chain(db)

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -242,7 +242,8 @@ def _hydrate_hit(db, lineage_root: str, match_info: Dict[str, Any], result_detai
     except Exception as e:
         logging.warning("get_anchored_view failed for %s/%s: %s", hit_sid, msg_id, e, exc_info=True)
         return None
-    session_meta, full = _get_session_meta(db, lineage_root), result_detail == "full"
+    # A gateway lineage can span months; metadata must describe the matched session.
+    session_meta, full = _get_session_meta(db, hit_sid), result_detail == "full"
     return _discovery_entry(
         lineage_root, session_id=hit_sid,
         when=_format_timestamp(session_meta.get("started_at") or match_info.get("session_started")),
@@ -285,26 +286,16 @@ def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort
         seen_sessions[title_lineage] = {"_title_only": True}
     # Dedupe by lineage (lineage_root -> first surviving FTS row) up to `limit`. The raw
     # owning session_id stays on the row — only it pairs validly with the FTS match id.
-    # Current-lineage hits are skipped UNLESS the transcript left live context
-    # (compression-ended, /new-reset predecessor, or an in-place compacted row on the
-    # SAME session); a live delegation child (end_reason=None) stays excluded.
+    # Parent links do not prove live context: a restart can leave an old session
+    # unended after its successor starts. Only the current session's own live rows
+    # are excluded; explicit end handling and compaction archives remain valid.
     for r in raw_results:
         if len(seen_sessions) >= limit:
             break
         raw_sid, resolved_sid = r["session_id"], _resolve_lineage(db, r["session_id"])
-        # Skip the current session lineage — UNLESS the hit's transcript has left live context. Three
-        # sub-cases: Legacy compression rotation: the FTS hit lives in a session that itself ended with
-        # end_reason='compression'. That session's content has been replaced by a summary in the
-        # continuation child, so it must stay discoverable. /new-reset (and idle/daily/CLI new_session): the
-        # predecessor was ended without carrying any transcript into the child. Same lineage root, but the
-        # prior conversation is NOT in the active context — hiding it made gateway recall go blind after
-        # every /new (#85756). A live delegation child has end_reason=None, so it stays excluded. In-place
-        # compaction: the FTS hit lives on the SAME session_id as the current session, but the matched
-        # message row is an archived (active=0, compacted=1) row. The live-context load filters active=1, so
-        # that content is no longer in context — let it through.
         is_compacted_hit = _is_compacted_message(db, r.get("id"))
         if current_lineage_root and resolved_sid == current_lineage_root and not (
-                _session_left_live_context(db, raw_sid) or is_compacted_hit):
+                raw_sid != current_session_id or _session_left_live_context(db, raw_sid) or is_compacted_hit):
             continue
         if current_session_id and raw_sid == current_session_id and not is_compacted_hit:
             continue

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -6,6 +6,13 @@ FTS5 deduped by lineage, adaptive detail hydrates only the top result),
 SCROLL (``session_id`` + ``around_message_id``; ±window around the anchor),
 READ (``session_id`` alone; whole session or head/tail), BROWSE (no args).
 No LLM calls — every shape returns actual DB messages.
+
+Same-lineage visibility is bounded by continuation semantics, not parent links
+or end writes (both are unproven in either direction — #20856): only sessions
+whose transcripts are already projected into the caller's active context — the
+branch-copy closure around the current session, plus live delegate runs — are
+excluded; reset/restart predecessors and compression ancestors stay searchable.
+See ``_live_context_projection``.
 """
 
 import json
@@ -13,7 +20,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
-from hermes_state_common import _RESET_END_REASONS
+from hermes_state_sessions import _parse_model_config
 
 # Hidden from browsing/searching — integrations (HERMES_SESSION_SOURCE=tool), delegate
 # subagent runs, kanban workers are not the user's history.
@@ -34,10 +41,16 @@ _DISCOVER_SCAN_LIMIT = 300
 _DISCOVER_SEARCH_FIELDS = ("id", "session_id", "role", "snippet", "source", "model", "session_started")
 # Compaction handoff summaries (agent/context_compressor.py); excluded from bookends.
 _COMPACTION_PREFIXES = ("[CONTEXT COMPACTION", "[CONTEXT SUMMARY]:")
-# /new, /reset, idle/daily expiry and CLI /new ("new_session") end the predecessor WITHOUT
-# carrying its transcript forward — unlike compression continuations and live delegation
-# children. Derived from the gateway set so the two cannot drift.
-_FRESH_RESET_END_REASONS = frozenset(_RESET_END_REASONS) | {"new_session"}
+# Stable lineage markers in sessions.model_config, each written atomically in the child
+# row's CREATE INSERT — so a marker proves its edge's semantics even when the parent's
+# end write is missing or was later overwritten (#20856). Local to this file on purpose:
+# hermes_state keeps its SQL literals inline; do not widen these without the write sites.
+_BRANCHED_FROM_KEY = "_branched_from"  # /branch + api fork children: gateway/slash_commands_session.py, tui_gateway/methods_session.py + session_workdir.py, hermes_cli/cli_commands_mixin.py
+_RESET_FROM_KEY = "_reset_from"  # fresh starts (/new, /reset, idle/daily, restart promote): gateway/session_recovery.py _session_create_kwargs
+_DELEGATE_FROM_KEY = "_delegate_from"  # delegate subagent children: tools/delegate_tool.py (+ hermes_state_schema.py v16 backfill)
+# Soft cap on lineage nodes visited per projection; real branch chains are single digits,
+# so this only bounds pathological/corrupt graphs (the visited set is the cycle guard).
+_PROJECTION_NODE_CAP = 256
 
 
 def _quiet(fn, default, msg, *log_args, with_exc: bool = False):
@@ -113,13 +126,98 @@ def _same_lineage(db, a: str, b: str) -> bool:
     return bool(a_root and a_root == _resolve_lineage(db, b))
 
 
-def _session_left_live_context(db, session_id: str) -> bool:
-    """True when the transcript left everyone's live context: ``compression``
-    (summarised into the child) or a fresh reset (child starts empty). Live delegation
-    children (``end_reason is None``) and ``branched`` parents (copied verbatim into
-    the branch) ARE the current context, so they stay excluded from recall."""
-    end_reason = (session_id and _get_session_meta(db, session_id).get("end_reason")) or None
-    return end_reason == "compression" or end_reason in _FRESH_RESET_END_REASONS
+def _branch_copy_edge(child_meta: Dict[str, Any], parent_meta: Dict[str, Any]) -> bool:
+    """True when *child_meta*'s row started life as a verbatim copy of *parent_meta*'s
+    transcript (a /branch or api-fork child) — the only edge that carries a caller's
+    transcript into another row.
+
+    Marker arm binds BY VALUE (``_branched_from`` must equal the parent's id): compression
+    copies ``model_config`` onto its continuation row (hermes_state_compression.py
+    ``_publish_child_session_row``), so presence-only matching would misclassify every
+    compression continuation as a branch child (same binding as the
+    ``_is_explicit_fork_child_row`` precedent in hermes_state_messages.py). Legacy arm
+    mirrors the second disjunct of ``_BRANCH_CHILD_SQL`` (hermes_state_common.py) so
+    pre-marker api forks and old CLI branches stay covered — keep the two in sync.
+    Reset/restart edges, delegate edges, compression-ended parents and bare parent links
+    are all False."""
+    if _parse_model_config(child_meta.get("model_config")).get(_BRANCHED_FROM_KEY) == parent_meta.get("id"):
+        return True
+    return (parent_meta.get("end_reason") == "branched"
+            and parent_meta.get("ended_at") is not None
+            and (child_meta.get("started_at") or 0) >= parent_meta["ended_at"])
+
+
+def _live_context_projection(db, current_session_id: Optional[str]) -> tuple[frozenset[str], frozenset[str]]:
+    """``(projected, subagent_hidden)`` — the live-context boundary for *current_session_id*.
+
+    ``projected`` is the bidirectional closure of branch-copy edges around the current
+    session (itself included): every session whose transcript is already in the caller's
+    active context. /branch is the only writer that carries a transcript verbatim into a
+    child row, and it stamps ``_branched_from`` atomically in the child's INSERT; a
+    reset/restart/compression edge carries no transcript (empty child or a summary), so
+    the walk stops at the first non-copy edge and everything beyond it stays searchable.
+    ``subagent_hidden`` holds delegate-marked children of the visited walk (marker by
+    existence — the v16 migration also backfills ``'__orphaned__'``): a live delegation
+    run is its parent's own context, and its source can fall back to ``'cli'``
+    (run_agent.py), so the marker — not the source — is what hides it.
+
+    Cost: one indexed child-rows query (idx_sessions_parent) per visited node, computed
+    once per discover/title call — no per-scanned-row metadata lookups."""
+    if not current_session_id:
+        return frozenset(), frozenset()
+    projected = {current_session_id}
+    subagent_hidden = set()
+    metas: Dict[str, Dict[str, Any]] = {}
+
+    def _meta_of(sid: str) -> Dict[str, Any]:
+        if sid not in metas:
+            metas[sid] = _get_session_meta(db, sid)
+        return metas[sid]
+
+    def _child_rows(parent_id: str) -> List[Dict[str, Any]]:
+        def _query():
+            with db._lock:
+                return [dict(r) for r in db._conn.execute(
+                    "SELECT * FROM sessions WHERE parent_session_id = ?", (parent_id,)).fetchall()]
+        return _quiet(_query, [], "child-session lookup failed for %s", parent_id, with_exc=True) or []
+
+    # Upward: hop parent links while each edge is a branch copy; the first non-copy edge
+    # (reset, restart, compression, bare legacy link) ends the walk — nothing at or above
+    # it is in the caller's context.
+    visited = {current_session_id}
+    cur, boundary_id = current_session_id, None
+    while len(visited) < _PROJECTION_NODE_CAP:
+        cur_meta = _meta_of(cur)
+        parent_id = cur_meta.get("parent_session_id")
+        if not parent_id or parent_id in visited:
+            break
+        parent_meta = _meta_of(parent_id)
+        if not _branch_copy_edge(cur_meta, parent_meta):
+            boundary_id = parent_id  # delegate children of the boundary hide too
+            break
+        visited.add(parent_id)
+        projected.add(parent_id)
+        cur = parent_id
+    # Downward: branch descendants of every projected member also hold ancestor-prefix
+    # copies of the caller's transcript (same duplicate source), so they join the
+    # projection; the boundary predecessor's children only get the delegate sweep (its
+    # branch children are alternate futures of a session the caller replaced, not of the
+    # caller's own context).
+    stack = list(projected) + ([boundary_id] if boundary_id else [])
+    while stack:
+        node = stack.pop()
+        node_meta = _meta_of(node)
+        for child in _child_rows(node):
+            cid = child.get("id")
+            if not cid:
+                continue
+            if _parse_model_config(child.get("model_config")).get(_DELEGATE_FROM_KEY) is not None:
+                subagent_hidden.add(cid)
+            if (node in projected and cid not in projected
+                    and len(projected) < _PROJECTION_NODE_CAP and _branch_copy_edge(child, node_meta)):
+                projected.add(cid)
+                stack.append(cid)
+    return frozenset(projected), frozenset(subagent_hidden)
 
 
 def _get_message_storage_state(db, message_id) -> Optional[Dict[str, Any]]:
@@ -183,18 +281,21 @@ def _discovery_entry(lineage_root: Optional[str], **fields) -> Dict[str, Any]:
     return entry
 
 
-def _title_match_result(db, query: str, current_lineage_root: Optional[str]) -> Optional[Dict[str, Any]]:
-    """Discovery-shaped result when the query matches a session title, else None."""
+def _title_match_result(db, query: str, live_projection) -> Optional[Dict[str, Any]]:
+    """Discovery-shaped result when the query matches a session title, else None.
+    *live_projection* is the ``(projected, subagent_hidden)`` pair from
+    ``_live_context_projection`` for the caller's session: a title is suppressed only
+    when that very session is already in the caller's live context (a branch
+    predecessor); a reset/restart predecessor's title must surface."""
     title_query = query.strip().strip("`'\"")  # models often quote a remembered title
     session_id = title_query and _quiet(lambda: db.resolve_session_by_title(title_query), None,
                                         "resolve_session_by_title failed for %r", title_query)
     if not session_id:
         return None
-    lineage_root = _resolve_lineage(db, session_id)
-    # Same-lineage title hits are in-context only while the session is live;
-    # /new-reset and compression-ended parents are not.
-    if current_lineage_root and lineage_root == current_lineage_root and not _session_left_live_context(db, session_id):
+    projected, subagent_hidden = live_projection
+    if session_id in projected or session_id in subagent_hidden:
         return None
+    lineage_root = _resolve_lineage(db, session_id)
     session_meta = _quiet(lambda: db.get_session(lineage_root) or db.get_session(session_id), None,
                           "get_session failed for title match %s", session_id) or {}
     if session_meta.get("source") in _HIDDEN_SESSION_SOURCES:
@@ -262,8 +363,8 @@ def _hydrate_hit(db, lineage_root: str, match_info: Dict[str, Any], result_detai
 def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort: Optional[str],
               detail: str, current_session_id: str = None, link_profile: str = None) -> str:
     """Discovery shape: FTS5 plus adaptive or full result hydration."""
-    current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
+    live_projection = _live_context_projection(db, current_session_id)
+    title_result = _title_match_result(db, query, live_projection)
     raw_results, err = _loud(lambda: db.search_messages(
         query=query, role_filter=role_filter or ["user", "assistant"],
         exclude_sources=list(_HIDDEN_SESSION_SOURCES), limit=_DISCOVER_SCAN_LIMIT, offset=0, sort=sort,
@@ -286,18 +387,19 @@ def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort
         seen_sessions[title_lineage] = {"_title_only": True}
     # Dedupe by lineage (lineage_root -> first surviving FTS row) up to `limit`. The raw
     # owning session_id stays on the row — only it pairs validly with the FTS match id.
-    # Parent links do not prove live context: a restart can leave an old session
-    # unended after its successor starts. Only the current session's own live rows
-    # are excluded; explicit end handling and compaction archives remain valid.
+    # Live context is bounded by continuation semantics, not parent links or end writes:
+    # a hit is already in the caller's context only when its owning session sits inside
+    # the branch-copy closure around the current session, or is a live delegate run of
+    # the visited walk. Reset/restart predecessors without an end write, compression
+    # ancestors and branch siblings all stay searchable; compaction archives on the
+    # current session keep their exemption (archived rows are out-of-context history).
+    projected, subagent_hidden = live_projection
     for r in raw_results:
         if len(seen_sessions) >= limit:
             break
         raw_sid, resolved_sid = r["session_id"], _resolve_lineage(db, r["session_id"])
         is_compacted_hit = _is_compacted_message(db, r.get("id"))
-        if current_lineage_root and resolved_sid == current_lineage_root and not (
-                raw_sid != current_session_id or _session_left_live_context(db, raw_sid) or is_compacted_hit):
-            continue
-        if current_session_id and raw_sid == current_session_id and not is_compacted_hit:
+        if not is_compacted_hit and (raw_sid in projected or raw_sid in subagent_hidden):
             continue
         seen_sessions.setdefault(resolved_sid, {**r, "_lineage_root": resolved_sid})
     for lineage_root, match_info in seen_sessions.items():
@@ -431,12 +533,16 @@ def _clamp_int(value, default: int, lo: int, hi: int) -> int:
 
 def _anchor_in_live_context(db, anchor_state, anchor_sid: str, current_session_id: str) -> bool:
     """True when the scroll anchor is still in the caller's active context (reject).
-    Same-lineage history that LEFT live context (compacted rows, compression-ended
-    parents, /new-reset predecessors) passes, so scroll never rejects a discovery result.
-    Rewind/undo rows (active=0, compacted!=1) never count as out-of-context history."""
-    if not _same_lineage(db, anchor_sid, current_session_id) or _is_compacted_state(anchor_state):
+    History that LEFT the context passes — compaction archives (active=0/compacted=1)
+    and any session outside the branch-copy projection (reset/restart predecessors,
+    compression ancestors) — so scroll never rejects a discovery result. Rewind/undo
+    rows (active=0, compacted!=1) never count as out-of-context history."""
+    if _is_compacted_state(anchor_state):
         return False
-    return (anchor_state is not None and anchor_state["active"] == 0) or not _session_left_live_context(db, anchor_sid)
+    if anchor_state is not None and anchor_state["active"] == 0:
+        return True
+    projected, subagent_hidden = _live_context_projection(db, current_session_id)
+    return anchor_sid in projected or anchor_sid in subagent_hidden
 
 
 def _scroll(db, session_id: str, around_message_id: int, window: int = 5,


### PR DESCRIPTION
## What does this PR do?

`session_search` could return **0 results** while the FTS index held exact-phrase matches, and the results it did return carried wrong session metadata (#103184). Two interacting defects in the discovery pipeline of `tools/session_search_tool.py`:

1. The same-lineage filter treated UNENDED sessions as live context. In long-lived messaging-gateway linearies, every gateway reset creates a child whose predecessor's end-write does not always fire (`ended_at IS NULL`), so those sessions' FTS hits were silently dropped — no signal in the response. "Live" now means the CURRENT session: same-lineage hits owned by a different session surface even if that session's end-write never fired; compaction-archived and explicit-end handling are unchanged.
2. Result metadata hydrated from the lineage ROOT, not the matching session — September content was reported as "August 12 … <root title>" (the per-message timestamps inside the payload were correct, making the mismatch actively confusing). Entries now carry the OWNING session's when/title.

## Related Issue

Fixes #103184

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/session_search_tool.py` — current-session-only live skip; owning-session metadata hydration
- Regression tests: the issue's real-world shape (lineage root titled "MCP серверы Hermes", an unended September child, 6 FTS hits) — hits surface with their own metadata; current-session skipping and compression-end semantics unchanged

## How to Test

1. The two session_search test files fully green (58 passed; 4 failing before the fix)
2. Direct shape: search an exact phrase that lives in an unended sibling session of your lineage — results now include it with the sibling's date/title

## Checklist

### Code
- [x] Contributing Guide read; Conventional Commits followed
- [x] Searched for duplicate PRs
- [x] Only changes related to this fix
- [x] Relevant tests pass; tests added
- [x] Tested on Linux (Python 3.11)

### Documentation & Housekeeping
- [x] N/A
