### PR TITLE
fix(state): prevent deleted sessions from being resurrected

### DIFF
--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -274,11 +274,17 @@ class SessionSessionsMixin:
         chat_id: str = None, chat_type: str = None, thread_id: str = None,
         parent_session_id: str = None, cwd: str = None, profile_name: Optional[str] = None,
         git_repo_root: str = None, origin_json: str = None, display_name: str = None,
+        ensure_exists: bool = True,
     ) -> None:
         """Upsert a session row, never overwriting what an earlier writer set (the gateway creates a
         bare row before create_session carries the real model/prompt). chat_id/thread_id scope gateway
         /resume (IDOR). Children backfill from the parent; a missing profile_name is stamped with THIS
         store's own (NULL reads as unowned).
+
+        ``ensure_exists=False`` is the fail-closed sibling used by per-turn writers that need to
+        backfill model/billing columns on the active session, but MUST NOT resurrect a session row the
+        user just deleted — a stale token delta landing after ``delete_session()`` would otherwise mint a
+        phantom ``source='unknown'`` row with no transcript and no chat context.
 
         When ``parent_session_id`` is set (compression fork, delegate/subagent spawn, branch continuation)
         and this row's own ``cwd``/``git_repo_root``/ ``git_branch``/``profile_name`` are still NULL after
@@ -304,6 +310,11 @@ class SessionSessionsMixin:
         if not (profile_name or "").strip():
             profile_name = self._own_profile_name()
         def _do(conn):
+            if not ensure_exists and conn.execute(
+                    "SELECT 1 FROM sessions WHERE id = ?", (session_id,)).fetchone() is None:
+                # Row was deleted (or never created — caller's choice). A stale per-turn writer must
+                # not resurrect the row as a phantom source='unknown' record.
+                return
             system_prompt_hash = self._store_system_prompt(conn, system_prompt)
             conn.execute(
                 """INSERT INTO sessions (

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -284,8 +284,10 @@ class SessionUsageMixin:
         where the cached agent holds cumulative totals)."""
         usage = {k: v for k, v in locals().items() if k in _MODEL_USAGE_FIELDS}
         # Ensure the row exists: under concurrent load create_session() may have failed on
-        # locking, and the UPDATE would silently affect 0 rows.
-        self._insert_session_row(session_id, "unknown", model=model)
+        # locking, and the UPDATE would silently affect 0 rows. ``ensure_exists=False`` keeps
+        # a stale async delta from resurrecting a session the user just deleted as a phantom
+        # ``source='unknown'`` row with no transcript.
+        self._insert_session_row(session_id, "unknown", model=model, ensure_exists=False)
         sql = _TOKEN_UPDATE_ABSOLUTE_SQL if absolute else _TOKEN_UPDATE_DELTA_SQL
         has_usage = bool(input_tokens or output_tokens or cache_read_tokens or cache_write_tokens or reasoning_tokens
                          or api_call_count or estimated_cost_usd)
@@ -312,7 +314,13 @@ class SessionUsageMixin:
             row = conn.execute(
                 "SELECT model, billing_provider, api_call_count FROM sessions WHERE id = ?", (session_id,),
             ).fetchone()
-            existing = dict(row) if row is not None else {}
+            if row is None:
+                # Session row was deleted between the ensure_exists check and the UPDATE.
+                # A stale per-turn delta must not resurrect it; the matching session_model_usage
+                # INSERT below would also fail its FK constraint. Drop the delta silently —
+                # accounting loss is logged, never raised into a turn (mirrors #23270).
+                return
+            existing = dict(row)
             # create_session records the requested route before any API call. If that fails
             # and fallback succeeds, the first accounted usage is the authoritative route;
             # after that keep the row as is (one row cannot represent mixed usage).
@@ -380,9 +388,19 @@ class SessionUsageMixin:
         if not session_id or not task:
             return
         usage["api_call_count"] = 1 if api_call_count is None else int(api_call_count)
-        # FK to sessions.id: same INSERT OR IGNORE guard as update_token_counts.
-        self._insert_session_row(session_id, "unknown")
-        self._execute_write(lambda conn: self._record_model_usage(conn, session_id, task=task, **usage))
+        # FK to sessions.id: same ensure_exists=False guard as update_token_counts — a stale
+        # async delta must not resurrect a session the user just deleted as a phantom
+        # source='unknown' row with no transcript.
+        self._insert_session_row(session_id, "unknown", ensure_exists=False)
+        def _do(conn):
+            if conn.execute(
+                    "SELECT 1 FROM sessions WHERE id = ?", (session_id,)).fetchone() is None:
+                # Session was deleted between the ensure_exists check and the INSERT.
+                # Bail before the FK trip on session_model_usage; the per-call delta is
+                # silently dropped (accounting loss is logged, never raised into a turn).
+                return
+            self._record_model_usage(conn, session_id, task=task, **usage)
+        self._execute_write(_do)
 
     def usage_totals(self, *, min_message_count: int = 1, include_archived: bool = False) -> Dict[str, float]:
         """Tokens and spend across the whole store (one scan), so the sidebar total does not

--- a/tests/agent/test_async_token_accounting.py
+++ b/tests/agent/test_async_token_accounting.py
@@ -9,6 +9,8 @@ thread while preserving update_token_counts() semantics exactly:
 3. flush_token_counts() gives readers read-your-writes (get_session and
    friends call it), and turn finalize / close() drain the queue.
 4. A failing apply is logged by the writer and never raises into a turn.
+5. A deleted session is not resurrected as a phantom source='unknown' row
+   when a stale async delta lands after the deletion.
 """
 
 import sqlite3
@@ -552,3 +554,107 @@ class TestCoalesceFieldContract:
             f"coalescing field lists reference kwargs update_token_counts "
             f"no longer accepts: {sorted(phantom)}"
         )
+
+
+# =========================================================================
+# Deleted-session resurrection guard
+# =========================================================================
+
+
+class TestDeletedSessionResurrection:
+    """A queued/sync token delta must NOT bring a deleted session back as a
+    phantom ``source='unknown'`` row with no transcript. The async writer
+    routinely processes deltas enqueued before the user deleted the session
+    (e.g. ``/new`` discarding an empty session right after a turn finished
+    its token accounting). The per-call sync path (``record_auxiliary_usage``
+    for vision/compression/title) has the same exposure.
+    """
+
+    def test_queued_token_delta_does_not_resurrect_deleted_session(
+            self, tmp_path, monkeypatch):
+        """Slow the writer so a delete can race its apply."""
+        db = SessionDB(db_path=tmp_path / "resurrect-async.db")
+        try:
+            db.create_session("s-deleted", source="cli")
+            db.end_session("s-deleted", "test_done")
+
+            original_apply = db._apply_token_batch
+
+            def slow_apply(batch):
+                time.sleep(0.5)
+                return original_apply(batch)
+
+            monkeypatch.setattr(db, "_apply_token_batch", slow_apply)
+
+            db.queue_token_counts(
+                "s-deleted", input_tokens=100, output_tokens=50, api_call_count=1,
+                model="anthropic/claude-opus-4.6", billing_provider="auto",
+            )
+
+            assert db.delete_session("s-deleted") is True
+            assert db.get_session("s-deleted") is None
+
+            time.sleep(1.0)
+
+            resurrected = db.get_session("s-deleted")
+            assert resurrected is None, (
+                "BUG: async token writer resurrected a deleted session as a "
+                f"phantom row. source={resurrected.get('source')!r}, "
+                f"model={resurrected.get('model')!r}"
+            )
+        finally:
+            db.close()
+
+    def test_sync_update_token_counts_does_not_resurrect_deleted_session(self, db):
+        db.create_session("s-deleted", source="cli")
+        db.end_session("s-deleted", "test_done")
+        assert db.delete_session("s-deleted") is True
+        assert db.get_session("s-deleted") is None
+
+        db.update_token_counts(
+            "s-deleted", input_tokens=200, output_tokens=75, api_call_count=1,
+            model="anthropic/claude-opus-4.6", billing_provider="auto",
+        )
+
+        assert db.get_session("s-deleted") is None, (
+            "BUG: update_token_counts resurrected a deleted session."
+        )
+
+    def test_record_auxiliary_usage_does_not_resurrect_deleted_session(self, db):
+        """Auxiliary usage (vision, compression, title) shares the same
+        session-row UPSERT and the same FK pressure on session_model_usage.
+        A stale aux call for a deleted session must be silently dropped."""
+        db.create_session("s-deleted", source="cli")
+        db.end_session("s-deleted", "test_done")
+        assert db.delete_session("s-deleted") is True
+
+        db.record_auxiliary_usage(
+            "s-deleted", task="vision",
+            model="anthropic/claude-opus-4.6", billing_provider="auto",
+            input_tokens=50, output_tokens=10, api_call_count=1,
+        )
+
+        assert db.get_session("s-deleted") is None, (
+            "BUG: record_auxiliary_usage resurrected a deleted session."
+        )
+
+    def test_existing_token_writes_still_succeed_when_session_is_live(self, db):
+        """Regression guard: ``ensure_exists=False`` must not break the
+        normal accounting path on a live session (the row was created
+        earlier and the UPDATE is the authoritative accounting write)."""
+        db.create_session("s-live", source="cli", model="anthropic/claude-opus-4.6")
+
+        db.queue_token_counts(
+            "s-live", input_tokens=100, output_tokens=50, api_call_count=1,
+            model="anthropic/claude-opus-4.6", billing_provider="auto",
+        )
+        assert db.flush_token_counts()
+
+        totals = _totals(db, "s-live")
+        assert totals["input_tokens"] == 100
+        assert totals["output_tokens"] == 50
+        assert totals["api_call_count"] == 1
+        # Per-model attribution must still record the route.
+        usage = _model_usage(db, "s-live")
+        assert usage and usage[0]["model"] == "anthropic/claude-opus-4.6"
+        assert usage[0]["input_tokens"] == 100


### PR DESCRIPTION
## Summary

Prevent stale token/auxiliary accounting writes from resurrecting sessions that have already been deleted.

### Bug

`_insert_session_row()` is an idempotent UPSERT used by session creation and accounting paths. When a stale per-turn accounting write arrived after `delete_session()`, the accounting path could recreate the session with `source='unknown'`.

This produced phantom empty sessions that could appear in session listings and `/resume`.

### Fix

* Add `ensure_exists=False` to `_insert_session_row()` for fail-closed accounting writes.
* Make token accounting return when the session no longer exists.
* Make auxiliary usage check session existence before the `session_model_usage` FK insert.
* Preserve the existing `ensure_exists=True` behavior for legitimate session creation.
* Add regression coverage for deleted-session resurrection and normal live-session accounting.

The existence checks and writes run through `_execute_write()` / `BEGIN IMMEDIATE`, so deletion cannot interleave between the final existence check and the usage write.

### Tests

* `uv run pytest -q tests/agent/test_async_token_accounting.py`

  * 19 passed
* `uv run pytest -q tests/state/ tests/hermes_state/`

  * 481 passed, 2 skipped
  
  