### PR TITLE
fix(aux): report the real cause when marking an aux provider unhealthy

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2160,7 +2160,7 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
         logger.debug("Auxiliary client: OpenRouter pool exhausted, trying OPENROUTER_API_KEY")
     or_key = explicit_api_key or _scoped_key_env("OPENROUTER_API_KEY")
     if not or_key:
-        _mark_provider_unhealthy("openrouter", ttl=60)
+        _mark_provider_unhealthy("openrouter", ttl=60, reason="no credential configured")
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return _create_openai_client(
@@ -2195,13 +2195,13 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
         _remaining = nous_rate_limit_remaining()
         if _remaining is not None and _remaining > 0:
             logger.debug("Auxiliary: skipping Nous Portal (rate-limited, resets in %.0fs)", _remaining)
-            _mark_provider_unhealthy("nous", ttl=_remaining)
+            _mark_provider_unhealthy("nous", ttl=_remaining, reason="cross-session rate limit")
             return None, None
     nous = _read_nous_auth()
     runtime = _resolve_nous_runtime_api(force_refresh=False)
     if runtime is None and not nous:
         logger.warning("Auxiliary Nous client unavailable: no Nous authentication found (run: hermes auth).")
-        _mark_provider_unhealthy("nous", ttl=60)
+        _mark_provider_unhealthy("nous", ttl=60, reason="no authentication found")
         return None, None
     if runtime is None and nous:
         logger.debug("Auxiliary Nous: runtime JWT refresh failed; checking stored auth.json token.")
@@ -2236,7 +2236,7 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
                 "Auxiliary Nous client unavailable: no usable inference JWT found "
                 "(run: hermes auth add nous)."
             )
-            _mark_provider_unhealthy("nous", ttl=60)
+            _mark_provider_unhealthy("nous", ttl=60, reason="no usable inference JWT")
             return None, None
         base_url = str(
             (nous or {}).get("inference_base_url") or os.getenv("NOUS_INFERENCE_BASE_URL", _NOUS_DEFAULT_BASE_URL)
@@ -2886,6 +2886,7 @@ def _get_provider_chain() -> List[tuple]:
 _AUX_UNHEALTHY_TTL_SECONDS = 600  # 10 minutes
 _aux_unhealthy_until: Dict[Any, float] = {}
 _aux_unhealthy_logged_at: Dict[Any, float] = {}
+_aux_unhealthy_reason: Dict[Any, str] = {}
 # resolved_provider / explicit-config names → chain labels.
 _AUX_UNHEALTHY_LABEL_ALIASES = {
     "openrouter": "openrouter", "nous": "nous", "custom": "local/custom",
@@ -2903,8 +2904,10 @@ def _normalize_chain_label(provider: str) -> str:
 
 def _mark_provider_unhealthy(
     provider: str, ttl: Optional[float] = None, *, base_url: Optional[str] = None,
+    reason: str = "payment / credit error",
 ) -> None:
-    """Hide one provider endpoint until the TTL expires after a confirmed payment error."""
+    """Hide one provider endpoint until the TTL expires; ``reason`` states why (confirmed
+    payment error by default — callers marking for other causes pass their own reason)."""
     label = _normalize_chain_label(provider)
     if not label:
         return
@@ -2912,10 +2915,11 @@ def _mark_provider_unhealthy(
     ttl = _AUX_UNHEALTHY_TTL_SECONDS if ttl is None else ttl
     expires_at = time.time() + ttl
     _aux_unhealthy_until[key] = expires_at
+    _aux_unhealthy_reason[key] = reason
     logger.warning(
-        "Auxiliary: marking %s unhealthy for %ds (payment / credit error). "
+        "Auxiliary: marking %s unhealthy for %ds (%s). "
         "Subsequent auxiliary calls will skip it until %s.",
-        label, int(ttl), time.strftime("%H:%M:%S", time.localtime(expires_at)),
+        label, int(ttl), reason, time.strftime("%H:%M:%S", time.localtime(expires_at)),
     )
 
 
@@ -2930,6 +2934,7 @@ def _is_provider_unhealthy(label: str, base_url: Optional[str] = None) -> bool:
     if time.time() >= expires_at:
         _aux_unhealthy_until.pop(key, None)
         _aux_unhealthy_logged_at.pop(key, None)
+        _aux_unhealthy_reason.pop(key, None)
         return False
     return True
 
@@ -2943,9 +2948,10 @@ def _log_skip_unhealthy(
     if now - _aux_unhealthy_logged_at.get(key, 0.0) >= 60:
         _aux_unhealthy_logged_at[key] = now
         expires_at = _aux_unhealthy_until.get(key, now)
+        reason = _aux_unhealthy_reason.get(key, "payment / credit error")
         logger.info(
-            "Auxiliary %s: skipping %s (recently returned payment error, retry in %ds)",
-            task or "call", label, max(0, int(expires_at - now)),
+            "Auxiliary %s: skipping %s (%s, retry in %ds)",
+            task or "call", label, reason, max(0, int(expires_at - now)),
         )
 
 
@@ -2953,6 +2959,7 @@ def _reset_aux_unhealthy_cache() -> None:
     """Clear the unhealthy cache (tests / explicit user reset)."""
     _aux_unhealthy_until.clear()
     _aux_unhealthy_logged_at.clear()
+    _aux_unhealthy_reason.clear()
 
 
 def _contains_any(text: str, needles: Tuple[str, ...]) -> bool:
@@ -3654,7 +3661,8 @@ def _quarantine_fallback_candidate(
     base_url: str = "", tag: str = "",
 ) -> None:
     """Refresh unavailable or still 401s: token is dead. Quarantine the candidate so the caller moves on."""
-    _mark_provider_unhealthy(fb_provider or fb_label, base_url=base_url)
+    _mark_provider_unhealthy(fb_provider or fb_label, base_url=base_url,
+                             reason="stale/unrefreshable credential")
     logger.warning("Auxiliary %s%s: fallback candidate %s has a stale/unrefreshable "
                    "credential (%s) — skipping to next fallback", task or "call", tag, fb_label, fb_err)
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -77,9 +77,11 @@ def _clean_env(monkeypatch):
     import agent.auxiliary_client as _aux_mod
     _aux_mod._aux_unhealthy_until.clear()
     _aux_mod._aux_unhealthy_logged_at.clear()
+    _aux_mod._aux_unhealthy_reason.clear()
     yield
     _aux_mod._aux_unhealthy_until.clear()
     _aux_mod._aux_unhealthy_logged_at.clear()
+    _aux_mod._aux_unhealthy_reason.clear()
 
 
 @pytest.fixture
@@ -1150,6 +1152,57 @@ class TestOpenRouterPaidLaneGuard:
         assert not _is_free_model(None)
 
 
+class TestUnhealthyReasonReporting:
+    """Issue #105150: the unhealthy-mark WARNING must state the real cause.
+    "payment / credit error" is only for actual 402-class provider responses;
+    no-credential skips never make a request and must not claim one did."""
+
+    def test_no_credential_marks_unhealthy_without_payment_error(self, monkeypatch, caplog):
+        """No OpenRouter key + empty pool → the mark says 'no credential configured'."""
+        import logging
+
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly", return_value={"auxiliary": {}}), \
+             caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+            client, model = _try_openrouter()
+
+        assert client is None
+        assert model is None
+        marks = [r.getMessage() for r in caplog.records
+                 if "marking openrouter unhealthy" in r.getMessage()]
+        assert len(marks) == 1
+        assert "no credential configured" in marks[0]
+        assert "payment / credit error" not in marks[0]
+
+    def test_default_reason_keeps_payment_wording(self, caplog):
+        """Callers that don't pass a reason (real 402 path) keep the payment wording."""
+        import logging
+
+        import agent.auxiliary_client as _aux_mod
+        with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+            _aux_mod._mark_provider_unhealthy("openrouter", ttl=60)
+
+        marks = [r.getMessage() for r in caplog.records
+                 if "marking openrouter unhealthy" in r.getMessage()]
+        assert len(marks) == 1
+        assert "payment / credit error" in marks[0]
+
+    def test_skip_log_reports_recorded_reason(self, caplog):
+        """The per-minute skip INFO reports the recorded reason, not a payment claim."""
+        import logging
+
+        import agent.auxiliary_client as _aux_mod
+        _aux_mod._mark_provider_unhealthy("openrouter", ttl=90, reason="no credential configured")
+        with caplog.at_level(logging.INFO, logger="agent.auxiliary_client"):
+            _aux_mod._log_skip_unhealthy("openrouter", task="chat")
+
+        skips = [r.getMessage() for r in caplog.records
+                 if "skipping openrouter" in r.getMessage()]
+        assert len(skips) == 1
+        assert "no credential configured" in skips[0]
+        assert "payment error" not in skips[0]
+
+
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
 
@@ -1799,6 +1852,7 @@ class TestStaleFallbackCandidateSkip:
         assert mock_fb.call_args_list[1].kwargs.get("reason") == "stale fallback credential"
         mock_mark.assert_called_once_with(
             "anthropic", base_url="https://api.anthropic.com",
+            reason="stale/unrefreshable credential",
         )
         assert stale_fb.chat.completions.create.call_count == 1
         assert healthy_fb.chat.completions.create.call_count == 1


### PR DESCRIPTION
## What does this PR do?

`_mark_provider_unhealthy()` hardcodes `(payment / credit error)` in its WARNING, but only one of its seven call sites actually marks after a confirmed 402-class response. Every other caller marks for a different cause — worst case #105150: hosts with no OpenRouter credential get a scary `payment / credit error` WARNING on every aux probe, even though no request was ever made.

This PR adds a keyword-only `reason` parameter (default `payment / credit error`, so the real 402 path is unchanged) and passes the true cause at the five non-payment call sites:

- `_try_openrouter` with no pool entry and no `OPENROUTER_API_KEY` → `no credential configured`
- `_try_nous` cross-session rate guard → `cross-session rate limit`
- `_try_nous` with no stored auth → `no authentication found`
- `_try_nous` with no usable inference JWT → `no usable inference JWT`
- `_quarantine_fallback_candidate` for a stale/unrefreshable credential → `stale/unrefreshable credential`

The per-minute skip INFO in `_log_skip_unhealthy()` now reports the recorded reason instead of the hardcoded `recently returned payment error`, so a skip after a no-credential mark no longer claims a payment error either. TTL/caching behavior is unchanged everywhere.

## Related Issue

Fixes #105150

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: `_mark_provider_unhealthy()` gains keyword-only `reason` param used in the WARNING text and recorded in a new `_aux_unhealthy_reason` cache (cleared on expiry/reset); `_log_skip_unhealthy()` renders the recorded reason; the five non-payment call sites listed above pass their true cause; the real-402 call site keeps the default wording.
- `tests/agent/test_auxiliary_client.py`: new `TestUnhealthyReasonReporting` class covering the no-credential path (asserts the WARNING names the credential cause and never claims a payment error), the default payment wording for the 402 path, and the skip-INFO reason rendering; updated the `TestStaleFallbackCandidateSkip` assertion for the new kwarg; the `_clean_env` autouse fixture now also clears the reason cache.

## How to Test

1. On a host with no OpenRouter credential anywhere (no pool entry, `OPENROUTER_API_KEY` unset), trigger an aux resolution that probes the provider chain.
2. Observed result before this PR: `Auxiliary: marking openrouter unhealthy for 60s (payment / credit error). …` on every probe.
3. Observed result after this PR: `Auxiliary: marking openrouter unhealthy for 60s (no credential configured). …`; subsequent 60s skips log `skipping openrouter (no credential configured, retry in Ns)`. A real 402 response still logs `payment / credit error` (covered by `test_default_reason_keeps_payment_wording`).
4. `pytest tests/agent/test_auxiliary_client.py -q` — 205 passed (including the 3 new tests).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
# Before (host with no OpenRouter credential, no request made):
WARNING Auxiliary: marking openrouter unhealthy for 60s (payment / credit error). Subsequent auxiliary calls will skip it until 23:17:41.

# After:
WARNING Auxiliary: marking openrouter unhealthy for 60s (no credential configured). Subsequent auxiliary calls will skip it until 23:17:41.
INFO    Auxiliary chat: skipping openrouter (no credential configured, retry in 57s)
```