### PR TITLE
fix(feishu): let unauthorized DMs reach the gateway's unauthorized_dm_behavior

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2638,6 +2638,15 @@ class FeishuAdapter(BasePlatformAdapter):
             return
 
         reason = self._admit(sender, message)
+        if reason == "dm_policy_rejected" and self._should_forward_unauthorized_dm():
+            # The gateway owns the unauthorized-DM reply (pairing code or a
+            # configured decline). Dropping here would make Feishu the only
+            # platform where ``unauthorized_dm_behavior`` never fires. Gateway
+            # auth still fail-closes agent access for the unknown sender.
+            logger.debug(
+                "[Feishu] forwarding unauthorized DM to gateway intake (unauthorized_dm_behavior)"
+            )
+            reason = None
         if reason is not None:
             logger.debug("[Feishu] dropping inbound event: %s", reason)
             return
@@ -4416,6 +4425,37 @@ class FeishuAdapter(BasePlatformAdapter):
         if rule and rule.require_mention is not None:
             return rule.require_mention
         return self._require_mention
+
+    def _should_forward_unauthorized_dm(self) -> bool:
+        """Return True when an allowlist-rejected DM must still reach the gateway.
+
+        ``_admit`` drops DMs from senders outside ``FEISHU_ALLOWED_USERS`` before
+        any event is built, so the gateway's ``unauthorized_dm_behavior`` never
+        runs for Feishu: a ``pair`` or ``decline`` configuration is silently
+        ignored while every other platform honors it. Mirror the Telegram
+        intake rule (``_should_pass_unauthorized_dm_for_pairing``): resolve the
+        effective behavior through the gateway runner when one is attached,
+        else fall back to the adapter's own ``extra.unauthorized_dm_behavior``.
+        Only ``ignore`` keeps the pre-event drop.
+        """
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        behavior_fn = getattr(runner, "_get_unauthorized_dm_behavior", None)
+        behavior = ""
+        if callable(behavior_fn):
+            try:
+                behavior = str(
+                    behavior_fn(Platform.FEISHU, profile=self._owner_profile) or ""
+                ).strip().lower()
+            except Exception:
+                logger.debug(
+                    "[Feishu] Failed to resolve unauthorized DM behavior; "
+                    "falling back to adapter-local override",
+                    exc_info=True,
+                )
+        if not behavior:
+            extra = getattr(getattr(self, "config", None), "extra", None) or {}
+            behavior = str(extra.get("unauthorized_dm_behavior", "")).strip().lower()
+        return bool(behavior) and behavior != "ignore"
 
     # --- Group policy ---------------------------------------------------------
 

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -566,3 +567,103 @@ def test_handle_message_event_data_forwards_sender_when_admitted():
     assert captured.get("sender_id") is sender.sender_id
     assert captured.get("is_bot") is True
     assert captured.get("message_id") == "om_bot_ok"
+
+
+# --- Unauthorized DM → gateway unauthorized_dm_behavior --------------------
+
+
+def _unauthorized_dm_event(message_id: str = "om_stranger") -> Any:
+    return SimpleNamespace(
+        event=SimpleNamespace(
+            sender=make_sender(open_id="ou_stranger"),
+            message=make_message(message_id=message_id, chat_type="p2p"),
+        )
+    )
+
+
+def _allowlisted_adapter(monkeypatch, *, behavior: str | None, via_runner: bool = True):
+    """Adapter with FEISHU_ALLOWED_USERS set; the stranger is not on it."""
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    adapter = make_adapter_skeleton()
+    install_dedup_state(adapter)
+    adapter._allowed_group_users = frozenset({"ou_owner"})
+    adapter._owner_profile = None
+    adapter.config = SimpleNamespace(extra={})
+    adapter._message_handler = None
+    if behavior is not None:
+        if via_runner:
+            runner = SimpleNamespace()
+            runner._get_unauthorized_dm_behavior = lambda platform, *, profile=None: behavior
+
+            class _Handler:
+                __self__ = runner
+
+            adapter._message_handler = _Handler()
+        else:
+            adapter.config = SimpleNamespace(extra={"unauthorized_dm_behavior": behavior})
+    captured: dict = {}
+
+    async def _fake_process_inbound_message(**kwargs):
+        captured.update(kwargs)
+
+    adapter._process_inbound_message = _fake_process_inbound_message
+    return adapter, captured
+
+
+@pytest.mark.parametrize("behavior", ["pair", "decline"])
+def test_unauthorized_dm_forwarded_when_gateway_would_reply(monkeypatch, behavior):
+    """Allowlist-rejected DM reaches gateway intake so unauthorized_dm_behavior runs."""
+    import asyncio
+
+    adapter, captured = _allowlisted_adapter(monkeypatch, behavior=behavior)
+    asyncio.run(adapter._handle_message_event_data(_unauthorized_dm_event()))
+    assert captured.get("message_id") == "om_stranger"
+    assert captured.get("chat_type") == "p2p"
+
+
+def test_unauthorized_dm_dropped_when_behavior_is_ignore(monkeypatch):
+    import asyncio
+
+    adapter, captured = _allowlisted_adapter(monkeypatch, behavior="ignore")
+    asyncio.run(adapter._handle_message_event_data(_unauthorized_dm_event()))
+    assert captured == {}
+
+
+def test_unauthorized_dm_dropped_without_gateway_or_override(monkeypatch):
+    """No runner and no per-platform override → keep the fail-closed drop."""
+    import asyncio
+
+    adapter, captured = _allowlisted_adapter(monkeypatch, behavior=None)
+    asyncio.run(adapter._handle_message_event_data(_unauthorized_dm_event()))
+    assert captured == {}
+
+
+def test_unauthorized_dm_honors_adapter_extra_override_without_runner(monkeypatch):
+    import asyncio
+
+    adapter, captured = _allowlisted_adapter(monkeypatch, behavior="pair", via_runner=False)
+    asyncio.run(adapter._handle_message_event_data(_unauthorized_dm_event()))
+    assert captured.get("message_id") == "om_stranger"
+
+
+def test_unauthorized_dm_forward_does_not_widen_group_gate(monkeypatch):
+    """Forwarding is DM-only: a stranger's group message stays rejected."""
+    import asyncio
+
+    adapter, captured = _allowlisted_adapter(monkeypatch, behavior="pair")
+    data = SimpleNamespace(
+        event=SimpleNamespace(
+            sender=make_sender(open_id="ou_stranger"),
+            message=make_message(message_id="om_group", chat_type="group", chat_id="oc_g"),
+        )
+    )
+    asyncio.run(adapter._handle_message_event_data(data))
+    assert captured == {}
+
+
+def test_admit_still_reports_dm_policy_rejected_for_stranger(monkeypatch):
+    """The admission verdict itself is unchanged; only the drop site consults the gateway."""
+    adapter, _ = _allowlisted_adapter(monkeypatch, behavior="pair")
+    verdict = adapter._admit(make_sender(open_id="ou_stranger"), make_message(chat_type="p2p"))
+    assert verdict == "dm_policy_rejected"

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -189,6 +189,14 @@ FEISHU_ALLOWED_USERS=ou_xxx,ou_yyy
 
 If you leave the allowlist empty, anyone who can reach the bot may be able to use it. In group chats, the allowlist is checked against the sender's open_id before the message is processed.
 
+Direct messages from senders outside the allowlist follow the gateway-wide `unauthorized_dm_behavior` setting (see [Security](../security.md#dm-pairing-system)). With an allowlist configured the default is `ignore` (silent drop). Set it to `pair` to offer a pairing code, or override it for Feishu only:
+
+```yaml
+platforms:
+  feishu:
+    unauthorized_dm_behavior: pair   # or ignore
+```
+
 ### Webhook Encryption Key
 
 When running in webhook mode, set an encryption key to enable signature verification of inbound webhook payloads:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
@@ -155,6 +155,14 @@ FEISHU_ALLOWED_USERS=ou_xxx,ou_yyy
 
 如果白名单为空，任何能访问机器人的人都可能使用它。在群聊中，消息处理前会根据发送者的 open_id 检查白名单。
 
+白名单之外的用户发来的单聊消息，遵循网关全局的 `unauthorized_dm_behavior` 设置（参见[安全](../security.md#dm-pairing-system)）。配置了白名单时默认值为 `ignore`（静默丢弃）；设为 `pair` 则回复配对码，也可以只为飞书单独覆盖：
+
+```yaml
+platforms:
+  feishu:
+    unauthorized_dm_behavior: pair   # 或 ignore
+```
+
 ### Webhook 加密密钥
 
 在 webhook 模式下运行时，设置加密密钥以启用入站 webhook payload 的签名验证：


### PR DESCRIPTION
## What does this PR do?

Makes `unauthorized_dm_behavior` actually apply to Feishu when `FEISHU_ALLOWED_USERS` is set.

Today `FeishuAdapter._admit()` returns `dm_policy_rejected` for any DM from a sender outside the allowlist, and `_handle_message_event_data()` drops it before a `MessageEvent` exists — so the gateway's unauthorized-DM path (pairing code, or the pending `decline` mode) never runs for Feishu. The per-platform `platforms.feishu.unauthorized_dm_behavior: pair` override is silently dead. Every other allowlisted platform forwards the DM so the gateway can answer (Telegram: `_should_pass_unauthorized_dm_for_pairing`).

The fix is at the drop site only: when the reason is `dm_policy_rejected`, resolve the effective behavior through the attached runner (`_get_unauthorized_dm_behavior(Platform.FEISHU, profile=...)`, profile-aware under multiplex), falling back to the adapter's own `config.extra.unauthorized_dm_behavior`. Only `ignore` keeps the pre-event drop. Because the allowlist-configured default resolves to `ignore` (#9337), nobody's current silent setup changes — this only turns on the behavior operators explicitly asked for. Gateway auth still fail-closes agent access for the unknown sender; group messages are untouched; the `_admit()` verdict itself is unchanged.

## Related Issue

Fixes #105156

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/feishu/adapter.py`
  - `_handle_message_event_data()`: forward instead of drop when `dm_policy_rejected` and `_should_forward_unauthorized_dm()` is true.
  - new `_should_forward_unauthorized_dm()` next to `_require_mention_for()`.
- `tests/gateway/test_feishu_bot_admission.py`: 7 new cases — `pair`/`decline` forwarded, `ignore` dropped, no-runner-no-override dropped (fail-closed preserved), adapter `extra` override honored without a runner, stranger's *group* message still rejected, `_admit()` verdict unchanged.
- `website/docs/user-guide/messaging/feishu.md` + zh-Hans mirror: one paragraph under *User Allowlist* pointing at `unauthorized_dm_behavior` and the per-platform override.

## How to Test

1. `.env`: `FEISHU_ALLOWED_USERS=ou_<owner>`; `config.yaml`: `platforms.feishu.unauthorized_dm_behavior: pair`.
2. DM the bot from a second Feishu account → pairing-code reply arrives; `hermes pairing approve feishu <code>` then admits that user.
3. Remove the override (or set `ignore`) → stranger DM is dropped as before (`[Feishu] dropping inbound event: dm_policy_rejected` at DEBUG).

Unit tests (RED on `main`, GREEN here):

```
.venv/bin/python -m pytest tests/gateway/test_feishu_bot_admission.py -q -o addopts=''
# main:   3 failed, 3 passed (new cases) — forwarded events never reach _process_inbound_message
# branch: 21 passed
```

Feishu suite on this branch: `test_feishu_bot_admission.py test_feishu.py test_feishu_bot_auth_bypass.py test_feishu_approval_buttons.py test_unauthorized_dm_behavior.py` → 130 passed, 4 failed. The same 4 fail identically on clean `origin/main` f709bd88b6 in this environment (three need `aiohttp` which the `feishu` extra doesn't pull in; `test_download_remote_document_blocks_connect_time_rebind` raises `httpcore.ConnectError` before the SSRF guard on this host). None touch the changed code; with `aiohttp` installed only the last one remains and it is unchanged by this PR.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] I searched for existing PRs — closest are #57215 (allowlist `*` wildcard) and #92865 (card-click admission); neither forwards unauthorized DMs to the gateway
- [x] Only changes related to this fix
- [ ] Full `pytest tests/ -q` — not run; targeted Feishu + unauthorized-DM suites run as above
- [x] Tests added
- [x] Tested on: macOS 26.6, Python 3.11.15, lark-oapi 1.6.8, websocket mode

### Documentation & Housekeeping

- [x] Docs updated (Feishu messaging page, en + zh-Hans)
- [x] `cli-config.yaml.example` — N/A (no new key; uses existing `unauthorized_dm_behavior`)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — N/A (pure Python, no OS calls)
- [x] Tool schemas — N/A
