### PR TITLE
fix(feishu): gate reaction routing by the chat's admission rules

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3043,6 +3043,21 @@ class FeishuAdapter(BasePlatformAdapter):
         action = "added" if "created" in event_type else "removed"
         synthetic_text = f"reaction:{action}:{emoji_type}"
 
+        # Reactions become agent turns, so they must clear the same
+        # admission gate as a text message from this operator in this chat:
+        # DM allowlist, group policy (allowlist / admin_only / disabled /
+        # per-chat rules) and bot-sender policy. Without this, anyone who
+        # can see a bot message in a group can wake the agent by reacting,
+        # even under FEISHU_GROUP_POLICY=allowlist. A reaction has no
+        # mention payload, so mention gating is not applied.
+        reject = self._admit_reaction(user_id_obj, chat_id=chat_id, chat_type=chat_type_raw)
+        if reject is not None:
+            logger.debug(
+                "[Feishu] dropping reaction %s:%s on %s: %s",
+                action, emoji_type, message_id, reject,
+            )
+            return
+
         sender_profile = await self._resolve_sender_profile(user_id_obj)
         chat_info = await self.get_chat_info(chat_id)
         source = self.build_source(
@@ -4416,6 +4431,36 @@ class FeishuAdapter(BasePlatformAdapter):
         if rule and rule.require_mention is not None:
             return rule.require_mention
         return self._require_mention
+
+    def _admit_reaction(
+        self, user_id_obj: Any, *, chat_id: str, chat_type: str
+    ) -> Optional[RejectReason]:
+        """Admission for a reaction that would become a synthetic agent turn.
+
+        DMs go through ``_admit`` unchanged (allowlist / allow-all / pairing
+        intake). Groups apply self-echo and ``_allow_group_message`` (global
+        policy, per-chat ``group_rules``, admins) but skip the mention
+        requirement, because a reaction carries no @ payload.
+        """
+        sender = SimpleNamespace(sender_type="user", sender_id=user_id_obj)
+        message = SimpleNamespace(
+            chat_type=chat_type or "p2p",
+            chat_id=chat_id,
+            mentions=None,
+            content="",
+            message_type="text",
+        )
+        is_group = message.chat_type != "p2p"
+        if not is_group:
+            return self._admit(sender, message)
+        # Group: apply policy without the mention requirement.
+        sender_ids = _sender_identity(sender)
+        self_ids = frozenset(v for v in (self._bot_open_id, self._bot_user_id) if v)
+        if self_ids and sender_ids & self_ids:
+            return "self_echo"
+        if not self._allow_group_message(user_id_obj, chat_id, is_bot=False):
+            return "group_policy_rejected"
+        return None
 
     # --- Group policy ---------------------------------------------------------
 

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -566,3 +566,124 @@ def test_handle_message_event_data_forwards_sender_when_admitted():
     assert captured.get("sender_id") is sender.sender_id
     assert captured.get("is_bot") is True
     assert captured.get("message_id") == "om_bot_ok"
+
+
+# --- Reaction routing must clear the same admission gate -------------------
+
+
+def _reaction_adapter(**kwargs):
+    """Adapter whose GET-message lookup says the reacted-to message is ours."""
+    adapter = make_adapter_skeleton(**kwargs)
+    adapter._app_id = "cli_self_app"
+    adapter._client = SimpleNamespace(
+        im=SimpleNamespace(
+            v1=SimpleNamespace(
+                message=SimpleNamespace(
+                    get=lambda _req: SimpleNamespace(
+                        success=lambda: True,
+                        data=SimpleNamespace(
+                            items=[
+                                SimpleNamespace(
+                                    sender=SimpleNamespace(id="cli_self_app"),
+                                    chat_id=adapter._reaction_chat_id,
+                                    chat_type=adapter._reaction_chat_type,
+                                )
+                            ]
+                        ),
+                    )
+                )
+            )
+        )
+    )
+    adapter._build_get_message_request = lambda _mid: object()
+
+    async def _run_blocking(func, *args):
+        return func(*args)
+
+    adapter._run_blocking = _run_blocking
+
+    async def _resolve_sender_profile(user_id_obj, *, is_bot=False):
+        return {"user_id": getattr(user_id_obj, "open_id", None), "user_name": "U", "user_id_alt": None}
+
+    adapter._resolve_sender_profile = _resolve_sender_profile
+
+    async def _get_chat_info(_chat_id):
+        return {"name": "Chat", "type": None}
+
+    adapter.get_chat_info = _get_chat_info
+    adapter._resolve_channel_prompt = lambda *_a, **_k: None
+    adapter.build_source = lambda **kw: SimpleNamespace(**kw)
+    routed: list = []
+
+    async def _handle_message_with_guards(event):
+        routed.append(event)
+
+    adapter._handle_message_with_guards = _handle_message_with_guards
+    adapter._routed = routed
+    return adapter
+
+
+def _reaction_data(open_id: str):
+    return SimpleNamespace(
+        event=SimpleNamespace(
+            message_id="om_bot_msg",
+            operator_type="user",
+            user_id=SimpleNamespace(open_id=open_id, user_id=None, union_id=None),
+            reaction_type=SimpleNamespace(emoji_type="THUMBSUP"),
+        )
+    )
+
+
+def _run_reaction(adapter, open_id: str, *, chat_id: str, chat_type: str):
+    import asyncio
+
+    adapter._reaction_chat_id = chat_id
+    adapter._reaction_chat_type = chat_type
+    asyncio.run(adapter._handle_reaction_event("im.message.reaction.created_v1", _reaction_data(open_id)))
+    return adapter._routed
+
+
+def test_group_reaction_from_non_allowlisted_user_is_dropped(monkeypatch):
+    """FEISHU_GROUP_POLICY=allowlist must gate reactions like text (#bypass)."""
+    adapter = _reaction_adapter(group_policy="allowlist")
+    adapter._allowed_group_users = frozenset({"ou_owner"})
+    assert _run_reaction(adapter, "ou_stranger", chat_id="oc_g", chat_type="group") == []
+
+
+def test_group_reaction_from_allowlisted_user_is_routed(monkeypatch):
+    adapter = _reaction_adapter(group_policy="allowlist")
+    adapter._allowed_group_users = frozenset({"ou_owner"})
+    routed = _run_reaction(adapter, "ou_owner", chat_id="oc_g", chat_type="group")
+    assert len(routed) == 1
+    assert routed[0].text == "reaction:added:THUMBSUP"
+
+
+def test_group_reaction_ignores_mention_requirement(monkeypatch):
+    """require_mention applies to text; a reaction has no @ payload."""
+    adapter = _reaction_adapter(group_policy="open", require_mention=True)
+    routed = _run_reaction(adapter, "ou_anyone", chat_id="oc_g", chat_type="group")
+    assert len(routed) == 1
+
+
+def test_group_reaction_respects_per_chat_disabled_rule(monkeypatch):
+    from plugins.platforms.feishu.adapter import FeishuGroupRule
+
+    adapter = _reaction_adapter(group_policy="open")
+    adapter._group_rules = {"oc_locked": FeishuGroupRule(policy="disabled")}
+    assert _run_reaction(adapter, "ou_anyone", chat_id="oc_locked", chat_type="group") == []
+
+
+def test_dm_reaction_from_non_allowlisted_user_is_dropped(monkeypatch):
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    adapter = _reaction_adapter()
+    adapter._allowed_group_users = frozenset({"ou_owner"})
+    assert _run_reaction(adapter, "ou_stranger", chat_id="oc_dm", chat_type="p2p") == []
+
+
+def test_dm_reaction_from_allowlisted_user_is_routed(monkeypatch):
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    adapter = _reaction_adapter()
+    adapter._allowed_group_users = frozenset({"ou_owner"})
+    assert len(_run_reaction(adapter, "ou_owner", chat_id="oc_dm", chat_type="p2p")) == 1


### PR DESCRIPTION
## What does this PR do?

Makes Feishu reaction routing respect the same admission rules as text.

`_handle_reaction_event()` converts a user reaction on a bot message into a synthetic agent turn but never consulted `_admit()` / `_allow_group_message()`. Result: under the default `FEISHU_GROUP_POLICY=allowlist`, any group member can wake the agent by reacting even though their text is dropped; per-chat `group_rules` (`disabled`, `admin_only`, `blacklist`) and the DM allowlist are likewise not applied to reactions.

This adds `_admit_reaction()` and calls it before the operator API lookup:

- **DM**: reuses `_admit()` unchanged (allowlist / allow-all / pairing-mode intake).
- **Group**: self-echo check + `_allow_group_message()` (global policy, `group_rules`, `admins`). The mention requirement is deliberately *not* applied — a reaction has no @ payload, and requiring one would disable reaction routing for every `require_mention=true` group, which is the default.

Rejected reactions are dropped at DEBUG before `_resolve_sender_profile()` / `get_chat_info()`.

## Related Issue

Fixes #105157

Related, not a duplicate: #87086 adds a per-profile opt-out for reaction routing. This PR is about reactions honoring the *existing* allowlist/policy when routing is on; the two compose (both gates must pass).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `plugins/platforms/feishu/adapter.py`
  - `_handle_reaction_event()`: call `_admit_reaction()` after the "message is ours" check, before sender/chat lookups.
  - new `_admit_reaction()` next to `_require_mention_for()`.
- `tests/gateway/test_feishu_bot_admission.py`: 6 new cases — group allowlist drop / route, mention requirement not applied to reactions, per-chat `disabled` rule honored, DM allowlist drop / route. Uses a stubbed `im.v1.message.get` so no network.

## How to Test

1. `.env`: `FEISHU_ALLOWED_USERS=ou_<owner>`, `FEISHU_GROUP_POLICY=allowlist`.
2. Owner @-mentions the bot in a group; bot replies.
3. Non-allowlisted member reacts to the bot's reply → on `main`: `[Feishu] Routing reaction added:... as synthetic event` + an agent turn; on this branch: `[Feishu] dropping reaction added:...: group_policy_rejected` at DEBUG, no turn.
4. Owner reacts → routed as before.

Unit tests (RED on `main`, GREEN here):

```
.venv/bin/python -m pytest tests/gateway/test_feishu_bot_admission.py -k reaction -q -o addopts=''
# main:   3 failed, 3 passed — non-allowlisted / disabled-rule reactions are routed
# branch: 6 passed
```

Feishu suite on this branch: `test_feishu_bot_admission.py test_feishu.py test_feishu_bot_auth_bypass.py test_feishu_approval_buttons.py` → 116 passed, 4 failed; the same 4 fail identically on clean `origin/main` f709bd88b6 in this environment (three need `aiohttp`, which the `feishu` extra doesn't install; `test_download_remote_document_blocks_connect_time_rebind` raises `httpcore.ConnectError` before the SSRF guard on this host). None exercise the changed code.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs — #87086 (opt-out), #92865 (card clicks) are adjacent, not overlapping
- [x] Only changes related to this fix
- [ ] Full `pytest tests/ -q` — not run; targeted Feishu suites run as above
- [x] Tests added
- [x] Tested on: macOS 26.6, Python 3.11.15, lark-oapi 1.6.8, websocket mode

### Documentation & Housekeeping

- [x] Docs — N/A (no user-visible config change; behavior now matches the documented allowlist/policy semantics)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — N/A
- [x] Tool schemas — N/A
