### PR TITLE
fix(desktop): keep a clarify request from pulling a scrolled-up reader to the bottom

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.scroll.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.scroll.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { clearClarifyRequest, sessionClarifyRequest } from '@/store/clarify'
+import { onScrollToBottomRequest, resetThreadScroll, setThreadAtBottom } from '@/store/thread-scroll'
+
+import { handleInputRequestEvent } from './input-requests'
+import type { GatewayEventContext } from './types'
+
+// A clarify.request for the ACTIVE session snaps the transcript to the bottom so
+// the question is seen. That snap must not fire while the reader has scrolled up
+// into history: they still get the floating jump control and a native
+// notification, so the question cannot go unnoticed, but their reading position
+// is theirs. Same rule the runStart guard applies to a new run.
+
+const SESSION = 'active-session'
+
+function context(overrides: Partial<GatewayEventContext> = {}): GatewayEventContext {
+  const payload = { choices: ['yes', 'no'], question: 'Continue?', request_id: 'req-1' }
+
+  return {
+    deps: {
+      activeSessionIdRef: { current: SESSION },
+      sessionInterrupted: () => false,
+      updateSessionState: (_sid, updater) => updater(createClientSessionState()),
+      upsertToolCall: vi.fn()
+    } as unknown as GatewayEventContext['deps'],
+    event: { payload, session_id: SESSION, type: 'clarify.request' },
+    explicitSid: SESSION,
+    fromActiveSource: () => true,
+    isActiveEvent: true,
+    occurredAt: 1_700_000_100,
+    payload: payload as GatewayEventContext['payload'],
+    scheduleConfigRefresh: vi.fn(),
+    sessionId: SESSION,
+    ...overrides
+  }
+}
+
+describe('clarify.request scroll guard', () => {
+  afterEach(() => {
+    resetThreadScroll()
+    clearClarifyRequest()
+  })
+
+  it('snaps to the bottom when the reader is already there', () => {
+    const scrolled = vi.fn()
+    const off = onScrollToBottomRequest(scrolled, SESSION)
+    setThreadAtBottom(true)
+
+    expect(handleInputRequestEvent(context())).toBe(true)
+    expect(scrolled).toHaveBeenCalledTimes(1)
+    off()
+  })
+
+  it('leaves a scrolled-up reader where they are', () => {
+    const scrolled = vi.fn()
+    const off = onScrollToBottomRequest(scrolled, SESSION)
+    setThreadAtBottom(false)
+
+    expect(handleInputRequestEvent(context())).toBe(true)
+    expect(scrolled).not.toHaveBeenCalled()
+    off()
+  })
+
+  it('never snaps for a background session, scrolled or not', () => {
+    const scrolled = vi.fn()
+    const off = onScrollToBottomRequest(scrolled, SESSION)
+    setThreadAtBottom(true)
+
+    expect(
+      handleInputRequestEvent(
+        context({ deps: { ...context().deps, activeSessionIdRef: { current: 'other' } } as GatewayEventContext['deps'] })
+      )
+    ).toBe(true)
+    expect(scrolled).not.toHaveBeenCalled()
+    off()
+  })
+
+  it('applies the same guard to a batch (multi-question) request', () => {
+    const scrolled = vi.fn()
+    const off = onScrollToBottomRequest(scrolled, SESSION)
+    const payload = {
+      questions: [
+        { choices: ['a', 'b'], qid: 'q0', question: 'First?' },
+        { choices: ['c', 'd'], qid: 'q1', question: 'Second?' }
+      ],
+      request_id: 'req-batch'
+    }
+    const batch = (): GatewayEventContext =>
+      context({ event: { payload, session_id: SESSION, type: 'clarify.request' }, payload: payload as GatewayEventContext['payload'] })
+
+    setThreadAtBottom(false)
+    expect(handleInputRequestEvent(batch())).toBe(true)
+    // Prove the batch branch ran, so the guard under test is the batch one.
+    expect(sessionClarifyRequest(SESSION).get()?.questions.length).toBe(2)
+    expect(scrolled).not.toHaveBeenCalled()
+
+    clearClarifyRequest()
+    setThreadAtBottom(true)
+    expect(handleInputRequestEvent(batch())).toBe(true)
+    expect(scrolled).toHaveBeenCalledTimes(1)
+    off()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -13,7 +13,7 @@ import { $gateway } from '@/store/gateway'
 import { setMcpSetupRequest } from '@/store/mcp-setup'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { receiveApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
-import { requestScrollToBottom } from '@/store/thread-scroll'
+import { $threadScrolledUp, requestScrollToBottom } from '@/store/thread-scroll'
 
 import type { GatewayEventContext } from './types'
 
@@ -23,6 +23,13 @@ import type { GatewayEventContext } from './types'
 export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, occurredAt } = ctx
   const { activeSessionIdRef, sessionInterrupted, updateSessionState, upsertToolCall } = deps
+
+  // A clarify request for the active session snaps the transcript to the
+  // bottom so the question is seen, unless the reader has scrolled up into
+  // history: same rule the runStart guard applies. They still get the floating
+  // jump control and a native notification, so the question cannot go unnoticed.
+  const shouldSnapToClarify = (sid: string): boolean =>
+    sid === activeSessionIdRef.current && !$threadScrolledUp.get()
 
   if (event.type === 'clarify.request') {
     // Surface the clarify tool's overlay. The Python side is blocked on
@@ -93,7 +100,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
           }
         })
 
-        if (sessionId === activeSessionIdRef.current) {
+        if (shouldSnapToClarify(sessionId)) {
           requestScrollToBottom(sessionId)
         }
       }
@@ -141,7 +148,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
           }
         })
 
-        if (sessionId === activeSessionIdRef.current) {
+        if (shouldSnapToClarify(sessionId)) {
           requestScrollToBottom(sessionId)
         }
       }


### PR DESCRIPTION
## What does this PR do?

An incoming `clarify.request` for the active session called `requestScrollToBottom` unconditionally. A reader who had scrolled up into a long response was yanked back to the bottom the moment the agent asked a question, and again on every replayed request.

This applies the rule the runStart snap already follows: consult `$threadScrolledUp` and leave a scrolled-up reader alone. They still get the floating jump-to-bottom control and the native notification, so the question cannot go unnoticed; what they keep is their place. Both call sites, single-question and batch, use one `shouldSnapToClarify` helper.

## Related Issue

No existing issue found for this symptom.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts`: guard both `requestScrollToBottom(sessionId)` calls on `!$threadScrolledUp.get()`.
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.scroll.test.ts` (new): at-bottom reader is snapped; scrolled-up reader is not; a background session is never snapped; the batch request takes the same guard.

## How to Test

1. `cd apps/desktop && npx vitest run src/app/session/hooks/use-message-stream/gateway-event/input-requests.scroll` — 4 pass.
2. Swap in upstream's `input-requests.ts`: the two scrolled-up cases fail, the other two pass.
3. Live: scroll up in a long response while the agent is working, then have it ask a clarifying question; the viewport stays put and the jump control appears.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 arm64

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — N/A
- [x] Tool descriptions/schemas — N/A
