### PR TITLE
fix(qqbot): recognize Tencent-prefixed SILK_V3 header in magic-byte detection

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1110,8 +1110,13 @@ class QQAdapter(BasePlatformAdapter):
         self._unlink_quiet(src_path)
         return result
 
+    # SILK magic: plain "#!SILK_V3"/"#!SILK" plus the Tencent-prefixed
+    # "\x02#!SILK_V3" header that QQ voice notes actually carry. pilk treats any
+    # 0x02-prefixed file as Tencent format (it reads 1 byte then seeks 10), so a
+    # single b"\x02" prefix covers both the real "\x02#" header and the legacy
+    # "\x02!" marker.
     _MAGIC_EXTS = (
-        (b"#!SILK", ".silk"), (b"\x02!", ".silk"), (b"RIFF", ".wav"), (b"fLaC", ".flac"),
+        (b"#!SILK", ".silk"), (b"\x02", ".silk"), (b"RIFF", ".wav"), (b"fLaC", ".flac"),
         (b"\xff\xfb", ".mp3"), (b"\xff\xf3", ".mp3"), (b"\xff\xf2", ".mp3"),
         (b"\x30\x26\xb2\x75", ".ogg"), (b"\x4f\x67\x67\x53", ".ogg"))
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -174,6 +174,111 @@ class TestVoiceAttachmentTempCleanup:
 
 
 # ---------------------------------------------------------------------------
+# SILK magic-byte detection & conversion routing
+# ---------------------------------------------------------------------------
+
+# Real QQ voice note header produced by pilk with tencent=True:
+# 0x02 + "#!SILK_V3" (the second byte is '#'=0x23, not '!').
+_TENCENT_SILK_HEADER = b"\x02#!SILK_V3"
+
+
+class TestSilkMagicBytes:
+    def _guess(self, data):
+        from gateway.platforms.qqbot import QQAdapter
+
+        return QQAdapter._guess_ext_from_data(data)
+
+    def _looks_like_silk(self, data):
+        from gateway.platforms.qqbot import QQAdapter
+
+        return QQAdapter._looks_like_silk(data)
+
+    def test_tencent_prefixed_silk_v3_header_is_silk(self):
+        # Regression: a b"\x02!"-only check missed the real header, so no-.silk
+        # voice notes were classified .amr and sent to ffmpeg (no SILK decoder)
+        # instead of pilk → never transcribed.
+        data = _TENCENT_SILK_HEADER + b"\x1f\x00\x00"
+        assert self._guess(data) == ".silk"
+        assert self._looks_like_silk(data) is True
+
+    def test_legacy_tencent_marker_is_still_silk(self):
+        data = b"\x02!\x00\x00"
+        assert self._guess(data) == ".silk"
+        assert self._looks_like_silk(data) is True
+
+    def test_plain_silk_headers_are_silk(self):
+        assert self._guess(b"#!SILK_V3\x1f\x00") == ".silk"
+        assert self._guess(b"#!SILK") == ".silk"
+        assert self._looks_like_silk(b"#!SILK") is True
+
+    def test_non_silk_magic_bytes_unaffected(self):
+        assert self._guess(b"RIFF\x00\x00\x00WAVE") == ".wav"
+        assert self._guess(b"\xff\xfb\x90\x00") == ".mp3"
+        assert self._guess(b"\x00\x00\x00\x20payload") == ".amr"
+        assert self._looks_like_silk(b"RIFF\x00\x00\x00WAVE") is False
+
+    def test_unknown_bytes_default_to_amr(self):
+        assert self._guess(b"\x00\x01\x02garbage") == ".amr"
+        assert self._looks_like_silk(b"\x00\x01\x02garbage") is False
+
+
+class TestVoiceConversionRouting:
+    """A QQ voice note whose URL carries no audio extension must still reach the
+    pilk (SILK) path via magic-byte detection."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+
+        return QQAdapter(_make_config(**extra))
+
+    @pytest.mark.asyncio
+    async def test_tencent_silk_without_url_suffix_routes_to_pilk(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        # QQ Bot API can return voice URLs whose path has no ".silk" extension.
+        url = (
+            "https://cdn.qq.com/voice/2f5f43c0-9f4a-4b3f-8d0e-1a2b3c4d5e6f"
+            "?sign=abc&t=12345"
+        )
+        data = _TENCENT_SILK_HEADER + b"\x1f\x00" + b"\x00" * 64
+
+        async def fake_silk_to_wav(src_path, wav_path):
+            # Stand-in for pilk: write a tiny valid WAV and return its path.
+            import wave
+
+            with wave.open(wav_path, "w") as wf:
+                wf.setnchannels(1)
+                wf.setsampwidth(2)
+                wf.setframerate(16000)
+                wf.writeframes(b"\x00\x00" * 160)
+            return wav_path
+
+        ffmpeg_calls = []
+
+        async def fake_ffmpeg_to_wav(src_path, wav_path):
+            ffmpeg_calls.append(src_path)
+            return None
+
+        adapter._convert_silk_to_wav = fake_silk_to_wav
+        adapter._convert_ffmpeg_to_wav = fake_ffmpeg_to_wav
+        cached = {}
+
+        async def fake_cache(data_bytes, name):
+            cached["name"] = name
+            return "/cache/" + name
+
+        adapter._unlink_quiet = lambda *a, **k: None
+        with mock.patch(
+            "gateway.platforms.qqbot.adapter.cache_document_from_bytes_async",
+            fake_cache,
+        ):
+            result = await adapter._convert_audio_to_wav(data, url)
+
+        assert result == "/cache/qq_voice.wav"
+        assert cached.get("name") == "qq_voice.wav"
+        assert ffmpeg_calls == []  # SILK data never fell back to ffmpeg
+
+
+# ---------------------------------------------------------------------------
 # WebSocket proxy handling
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #105154 — QQ voice notes with the Tencent-prefixed SILK header (`\x02#!SILK_V3`) are never transcribed when the attachment URL lacks a `.silk` suffix.

## Root cause

`_MAGIC_EXTS` in `gateway/platforms/qqbot/adapter.py` matched SILK via `b"\x02!"` (0x02 + `!`), but real QQ voice notes produced by pilk (`tencent=True`) start with the 10-byte header `\x02#!SILK_V3` (second byte is `#` = 0x23). When the QQ Bot API returns a voice URL without a `.silk` extension, `_guess_ext_from_data()` classified the data as `.amr`, the note went to ffmpeg (no SILK decoder), conversion failed, and it was cached as an untranscribed attachment (`qq_voice.amr`).

## Fix

pilk treats **any** `\x02`-prefixed file as Tencent format (`get_duration()` reads 1 byte, then seeks 10), so a single `b"\x02"` prefix covers both the real `\x02#` header and the legacy `\x02!` marker:

```python
_MAGIC_EXTS = (
    (b"#!SILK", ".silk"), (b"\x02", ".silk"), (b"RIFF", ".wav"), (b"fLaC", ".flac"),
    ...
)
```

`_looks_like_silk()` delegates to `_guess_ext_from_data()`, so one entry fixes both call sites (including the no-suffix branch of `_convert_audio_to_wav()`).

## Tests

Adds 6 regression tests to `tests/gateway/test_qqbot.py`:

- `TestSilkMagicBytes` — real Tencent header (`\x02#!SILK_V3`) classifies as `.silk`; legacy `\x02!` still works; plain `#!SILK`/`#!SILK_V3` unchanged; RIFF/MP3/AMR unaffected; unknown bytes fall back to `.amr`.
- `TestVoiceConversionRouting` — end-to-end: a `.silk`-less voice URL with Tencent-header data reaches the pilk path, never falls back to ffmpeg, and caches as `qq_voice.wav`.

## Verification

- Applied on clean `origin/main` (`d9833c56`); `tests/gateway/test_qqbot.py` → **69 passed** (63 existing + 6 new).
- Without the fix, the 2 key regression tests fail and reproduce the reported symptom: `audio conversion failed ... (format=.amr)`, cache name `qq_voice.amr`.
- Real Tencent-prefixed SILK decodes through `pilk.silk_to_wav` to a valid 16 kHz mono WAV; no false positives on RIFF/MP3/AMR magic bytes.
