### PR TITLE
feat(model): gpt-6-astra on Codex OAuth — curated catalog entry + opt-in -900k large-context variant

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1438,23 +1438,23 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 # Codex OAuth `context_window` values (what Codex enforces — lower than the direct API for the same
 # slugs). Fallback when the live probe fails; longest-key-first. gpt-5.3-codex-spark is listed so "gpt-5.3-codex" doesn't win.
 _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
-    "gpt-5.1-codex-max": 272_000, "gpt-5.1-codex-mini": 272_000, "gpt-5.3-codex": 272_000,
+    "gpt-6-astra": 272_000, "gpt-5.1-codex-max": 272_000, "gpt-5.1-codex-mini": 272_000, "gpt-5.3-codex": 272_000,
     "gpt-5.3-codex-spark": 128_000, "gpt-5.2-codex": 272_000, "gpt-5.4-mini": 272_000,
     "gpt-5.6-sol": 272_000, "gpt-5.6-terra": 272_000, "gpt-5.6-luna": 272_000, "gpt-daybreak-blue-latest": 272_000,
     "gpt-5.5": 272_000, "gpt-5.4": 272_000, "gpt-5.2": 272_000, "gpt-5": 272_000,
 }
 # Codex OAuth advertises 272K for these families but ACCEPTS ~900K+ (verified live; gpt-5.5 and
-# gpt-5.4-mini genuinely reject >272K). 900K keeps ≥11K margin. OPT-IN ONLY via explicit ``-900k``
-# picker variants (a 900K default burned subscription usage); the suffix is stripped before the wire.
+# gpt-5.4-mini genuinely reject >272K; gpt-6-astra: 917K accepted, 931K rejected). 900K keeps ≥11K margin.
+# OPT-IN ONLY via explicit ``-900k`` picker variants (a 900K default burned subscription usage); the suffix is stripped before the wire.
 # The bump fires ONLY when the resolved value is exactly the stale 272,000. ``gpt-5.6`` is a FAMILY
 # PREFIX (``-pro`` slugs aren't routable on Codex); ``gpt-5.4`` is EXACT because gpt-5.4-mini enforces 272K.
-_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES: Dict[str, int] = {"gpt-5.6": 900_000}  # sol / terra / luna
+_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES: Dict[str, int] = {"gpt-5.6": 900_000, "gpt-6-astra": 900_000}  # sol / terra / luna; astra (+ dated snapshots)
 _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {"gpt-5.4": 900_000, "gpt-daybreak-blue-latest": 900_000}
 _CODEX_OAUTH_STALE_ADVERTISED_CTX = 272_000  # the only advertised value the bump may override
 CODEX_CONTEXT_VARIANT_SUFFIX = "-900k"  # picker-only opt-in suffix; never sent on the wire
 # The ONLY bases eligible for ``-900k``: routable, live-verified. No family prefixing (it would synthesize
-# dead ``-pro`` variants); dated snapshots of the 5.6 bases are allowed. gpt-daybreak-blue-latest is a verified Sol alias.
-_CODEX_900K_SNAPSHOT_BASES = ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna")
+# dead ``-pro`` variants); dated snapshots of the 5.6/Astra bases are allowed. gpt-daybreak-blue-latest is a verified Sol alias.
+_CODEX_900K_SNAPSHOT_BASES = ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-6-astra")
 _CODEX_900K_ELIGIBLE_BASES = frozenset({*_CODEX_900K_SNAPSHOT_BASES, "gpt-5.4", "gpt-daybreak-blue-latest"})
 _CODEX_900K_SNAPSHOT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 # when using Codex with a ChatGPT account"), so listing them leaked dead picker choices. If
 # OpenAI re-enables any, live discovery (_fetch_models_from_api) picks them up automatically.
 DEFAULT_CODEX_MODELS: List[str] = [
+    "gpt-6-astra",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",
@@ -39,6 +40,7 @@ DEFAULT_CODEX_MODELS: List[str] = [
 # unsupported — that was wrong; restored here. Keep it in the curated fallback so Pro users still see Spark
 # in `/model` when live discovery is unavailable (offline first run, transient API failure).
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
+    ("gpt-6-astra", ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna")),
     ("gpt-5.6-sol", ("gpt-5.5", "gpt-5.4")),
     ("gpt-5.6-terra", ("gpt-5.5", "gpt-5.4")),
     ("gpt-5.6-luna", ("gpt-5.5", "gpt-5.4")),

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -534,6 +534,7 @@ class TestCodexOAuthContextLength:
             "gpt-5.6-sol-2026-07-09",  # dated snapshot via gpt-5.6 family prefix
             "gpt-5.4",
             "gpt-daybreak-blue-latest",  # Sol alias; exact verified slug
+            "gpt-6-astra",  # 917K accepted / 931K rejected live, Sep 2026
         ],
     )
     def test_900k_variant_slug_bumped_to_live_verified_900k(self, slug):
@@ -567,6 +568,7 @@ class TestCodexOAuthContextLength:
             "gpt-5.6-luna",
             "gpt-5.4",
             "gpt-daybreak-blue-latest",
+            "gpt-6-astra",
         ],
     )
     def test_base_slug_keeps_advertised_272k(self, slug):
@@ -691,6 +693,10 @@ class TestCodexOAuthContextLength:
         ("gpt-5.6-luna-900k",             True,  900_000, "gpt-5.6-luna"),
         ("gpt-5.4-900k",                  True,  900_000, "gpt-5.4"),
         ("gpt-daybreak-blue-latest-900k", True,  900_000, "gpt-daybreak-blue-latest"),
+        ("gpt-6-astra-900k",              True,  900_000, "gpt-6-astra"),
+        ("gpt-6-astra-2026-09-01-900k",   True,  900_000, "gpt-6-astra-2026-09-01"),
+        # Astra Pro is public-API only (Codex OAuth 400s it) — no variant
+        ("gpt-6-astra-pro-900k",          False, 272_000, "gpt-6-astra-pro-900k"),
         # dated snapshot of a routable 5.6 base
         ("gpt-5.6-sol-2026-07-09-900k",   True,  900_000, "gpt-5.6-sol-2026-07-09"),
         # vendor-namespaced variant (display/aux callers) resolves too

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -42,7 +42,7 @@ def test_picker_synthesizes_900k_variants_for_verified_slugs():
     in the list as the cheaper 272K default."""
     model_ids = get_codex_model_ids()  # offline curated path
 
-    for base in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4"):
+    for base in ("gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4"):
         assert base in model_ids
         assert f"{base}-900k" in model_ids
         assert model_ids.index(f"{base}-900k") == model_ids.index(base) + 1

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -243,16 +243,17 @@ hermes config set compression.codex_gpt55_autoraise_notice false
 
 ### Codex large-context `-900k` picker variants (opt-in)
 
-The ChatGPT Codex backend *advertises* a 272K window for the gpt-5.4 and
-gpt-5.6 (Sol/Terra/Luna) families, but actually accepts ~911K input tokens
-for ChatGPT-subscription accounts (live-verified Aug 2026). Hermes keeps the
+The ChatGPT Codex backend *advertises* a 272K window for the gpt-5.4,
+gpt-5.6 (Sol/Terra/Luna) and gpt-6-astra families, but actually accepts ~911K
+input tokens for ChatGPT-subscription accounts (live-verified Aug 2026;
+Astra: ~917K accepted, ~931K rejected, Sep 2026). Hermes keeps the
 **advertised 272K as the default** for the base slugs — a bigger window means
 more tokens per request and much faster subscription-usage burn, so the large
 window is strictly opt-in.
 
 To use the large window, pick the explicit `-900k` variant in `/model` (e.g.
-`gpt-5.6-sol-900k`, `gpt-5.6-terra-900k`, `gpt-5.6-luna-900k`,
-`gpt-5.4-900k`). These are Hermes-side aliases: the suffix is stripped before
+`gpt-6-astra-900k`, `gpt-5.6-sol-900k`, `gpt-5.6-terra-900k`,
+`gpt-5.6-luna-900k`, `gpt-5.4-900k`). These are Hermes-side aliases: the suffix is stripped before
 the model id is sent to the backend, and pricing/usage accounting treats them
 as the base model. Slugs that genuinely enforce 272K (gpt-5.5, gpt-5.4-mini)
 have no `-900k` variant.


### PR DESCRIPTION
## Symptom

`gpt-6-astra` is served by `chatgpt.com/backend-api/codex` (priority 1 in the live catalog, advertised `context_window: 272000`) and works through `--provider openai-codex`, but the Codex side of Hermes never registered it:

- not in `DEFAULT_CODEX_MODELS` / `_FORWARD_COMPAT_TEMPLATE_MODELS` → missing from `/model` when live discovery is unavailable
- not in `_CODEX_OAUTH_CONTEXT_FALLBACK` → offline resolution fell through to the **direct-API** `DEFAULT_CONTEXT_LENGTHS` entry (1,050,000), over-promising the Codex window ~4x
- not eligible for the existing opt-in `-900k` variant, so there was no way to use the window the backend actually accepts

## Live verification (Sep 2026, ChatGPT subscription, `responses.stream` against the official endpoint)

| input tokens | result |
|---|---|
| 282,382 | accepted |
| 894,142 | accepted |
| 903,550 | accepted |
| 917,662 | accepted |
| 931,751 | `Your input exceeds the context window of this model` |
| 950,566 | rejected |
| 1,025,862 | rejected |

Same shape as the gpt-5.6 Sol/Terra/Luna bases (advertised 272K, accepts ~911K+), so Astra joins the same mechanism rather than a new one. The true ceiling is ~920–930K, not the direct-API 1.05M — the existing 900K cap keeps ≥11K margin.

## Change

- `agent/model_metadata.py`: `gpt-6-astra` → `_CODEX_OAUTH_CONTEXT_FALLBACK` (272K), `_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES` (900K, prefix so dated snapshots qualify like 5.6), `_CODEX_900K_SNAPSHOT_BASES`
- `hermes_cli/codex_models.py`: curated fallback + forward-compat template (Astra surfaces when any 5.6 base is present)
- docs: `-900k` section lists Astra with the probe numbers

## Behaviour

- `gpt-6-astra` on Codex: 272K (live + offline), 85% compaction autoraise — unchanged for anyone already using it
- `gpt-6-astra-900k` on Codex: 900K, global compaction threshold, suffix stripped on the wire; verified end-to-end (`hermes chat --model gpt-6-astra-900k --provider openai-codex` → `ASTRA-900K-OK gpt-6-astra-900k`, context cached at 900,000)
- `gpt-6-astra-pro-900k`: rejected as an invalid alias (Astra Pro is public-API only; Codex OAuth 400s `-pro`)
- Nothing on OpenRouter/Nous/direct-API paths changes

## Tests

5 new parametrizations in the existing contract tests (`test_900k_eligibility_table`, `test_900k_variant_slug_bumped_to_live_verified_900k`, `test_base_slug_keeps_advertised_272k`, picker synthesis) — all red on `upstream/main`, green here. `test_model_catalog.py` unaffected (catalog is built from the OpenRouter/Nous lists, not the Codex catalog).