### PR TITLE
fix(desktop): stop successful Windows updates reporting exit 8

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -50,7 +50,8 @@ param(
     [switch]$NoMarkerCleanup,
     [switch]$SelfTestUi,
     [switch]$SelfTestPipeDrain,
-    [switch]$SelfTestMarker
+    [switch]$SelfTestMarker,
+    [switch]$SelfTestWorkingDirectory
 )
 
 if (-not $SelfTestUi -and -not $SelfTestPipeDrain -and -not $InstallRoot) {
@@ -1178,9 +1179,34 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     return @{ Code = $code; Output = $all; TreeQuiesced = (-not $stalled -or $proc.HasExited); StartedAfterJobAssignment = $true }
 }
 
+function Set-InstallRootCurrentDirectory([string]$Root) {
+    $resolved = [System.IO.Path]::GetFullPath($Root)
+    [Environment]::CurrentDirectory = $resolved
+    return $resolved
+}
+
 $finalCode = 1
 $finalMsg = "update did not complete"
 $script:TreeSafeToFinalize = $true
+
+# -SelfTestWorkingDirectory: prove StartAssigned inherits InstallRoot --------
+if ($SelfTestWorkingDirectory) {
+    try {
+        $resolvedInstallRoot = Set-InstallRootCurrentDirectory $InstallRoot
+    } catch {
+        Write-Host "WORKING-DIRECTORY SELF-TEST: FAIL cannot enter the install root ($InstallRoot)"
+        exit 3
+    }
+    $probeExe = Join-Path $PSHOME "powershell.exe"
+    $probe = Invoke-HermesStep $probeExe @("-NoProfile", "-Command", "[Environment]::CurrentDirectory") "cwd"
+    $observed = $probe.Output.Trim()
+    if ($probe.Code -ne 0 -or -not [string]::Equals($observed, $resolvedInstallRoot, [StringComparison]::OrdinalIgnoreCase)) {
+        Write-Host "WORKING-DIRECTORY SELF-TEST: FAIL expected=$resolvedInstallRoot observed=$observed code=$($probe.Code)"
+        exit 1
+    }
+    Write-Host "WORKING-DIRECTORY SELF-TEST: PASS $observed"
+    exit 0
+}
 
 # ── -SelfTestUi: drive the shim to both terminal states, no update ─────────
 # Manual QA for the Edge shell without a checkout or a real update. Exits
@@ -1442,6 +1468,20 @@ try {
         $finalCode = 0
         $finalMsg = "marker self-test complete"
         exit 0
+    }
+
+    # StartAssigned passes a null CreateProcess currentDirectory, so children
+    # inherit the hand-off process directory rather than PowerShell's $PWD.
+    # Desktop launches us from HERMES_HOME; pin the process directory to the
+    # checkout before any update child can resolve files against the wrong tree.
+    try {
+        $resolvedInstallRoot = Set-InstallRootCurrentDirectory $InstallRoot
+        Write-HandoffLog "process cwd set to install root: $resolvedInstallRoot"
+    } catch {
+        $finalCode = 3
+        $finalMsg = "Update aborted: cannot enter the install root ($InstallRoot). Nothing was changed."
+        Write-HandoffLog $finalMsg
+        exit $finalCode
     }
 
     # Check only the interpreter here: dependency recovery belongs to update.

--- a/tests/test_desktop_update_windows_cwd.py
+++ b/tests/test_desktop_update_windows_cwd.py
@@ -1,0 +1,74 @@
+"""Native regression coverage for the Windows Desktop handoff cwd."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.windows_only
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_UPDATE_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def _run_cwd_self_test(
+    install_root: Path,
+    launch_cwd: Path,
+    temp_dir: Path,
+) -> subprocess.CompletedProcess[str]:
+    powershell = shutil.which("powershell.exe")
+    assert powershell, "Windows updater tests require Windows PowerShell."
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["TEMP"] = str(temp_dir)
+    env["TMP"] = str(temp_dir)
+    return subprocess.run(
+        [
+            powershell,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(WINDOWS_UPDATE_PS1),
+            "-InstallRoot",
+            str(install_root),
+            "-SelfTestWorkingDirectory",
+            "-NoUi",
+        ],
+        cwd=launch_cwd,
+        env=env,
+        text=True,
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_handoff_children_run_from_install_root(tmp_path: Path) -> None:
+    install_root = tmp_path / "checkout"
+    launch_cwd = tmp_path / "profile-home"
+    install_root.mkdir()
+    launch_cwd.mkdir()
+
+    result = _run_cwd_self_test(install_root, launch_cwd, tmp_path / "temp")
+
+    assert result.returncode == 0, result.stdout
+    assert "WORKING-DIRECTORY SELF-TEST: PASS" in result.stdout
+
+
+def test_handoff_fails_closed_when_install_root_cannot_be_entered(tmp_path: Path) -> None:
+    install_root = tmp_path / "missing" / "checkout"
+    launch_cwd = tmp_path / "profile-home"
+    launch_cwd.mkdir()
+
+    result = _run_cwd_self_test(install_root, launch_cwd, tmp_path / "temp")
+
+    assert result.returncode == 3, result.stdout
+    assert "cannot enter the install root" in result.stdout


### PR DESCRIPTION
## What does this PR do?

Windows Desktop updates can complete the code and app rebuild successfully, then report `exit 8` because post-update verification searches for the packaged executable under `HERMES_HOME` instead of the checkout. This change pins the handoff process working directory to the validated install root before any update child starts, preserving truthful verification without weakening its fail-closed checks.

### Symptom

A Desktop-driven Windows update finishes `hermes update`, rebuilds the app, and restarts the gateway, but the Desktop reports `detached update FAILED (exit 8)` and says the updated runtime or Desktop build failed verification.

### Impact

Affected Windows Desktop users see a failed-update warning after a successful update and may retry or repair an installation whose rebuilt executable is present.

### Bug Cause

**Trigger:** `scripts/desktop-update/windows.ps1:1610` / post-update verification after a zero-exit update

**Causal chain:**
1. Electron starts the repo handoff with `cwd` set to `HERMES_HOME` while passing the checkout separately as `-InstallRoot`.
2. `HermesUpdateJob.StartAssigned` calls `CreateProcess` with a null current-directory argument, so update, rebuild, and verification children inherit the handoff process directory.
3. Verification passes `Path.cwd()` as the project root and looks for `apps/desktop/release` under `HERMES_HOME`, producing a false missing-executable failure and exit 8.

**Why it is wrong:** The verifier's argument is required to be the checkout root, but the Windows handoff never established that process-level working-directory invariant.

**Working sibling / contrast:** The POSIX handoff explicitly changes to `INSTALL_ROOT` before running update steps, so its children resolve the checkout correctly.

**Ruled out:** The packaged executable and bundle verifier are not the failing component; verification passes when given the checkout root, and the reported executable remained present in the checkout release directory.

### Fix

Set `[Environment]::CurrentDirectory` to the resolved install root before any updater child runs. If the directory cannot be entered, abort with exit 3 before mutation. A native Windows self-test launches the real `Invoke-HermesStep` path from an unrelated cwd and verifies that its child observes the install root; a second test covers the invalid-root refusal.

## Related Issue

Fixes #105145

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/desktop-update/windows.ps1` - establish the install-root process cwd and fail closed when it is unavailable.
- `tests/test_desktop_update_windows_cwd.py` - exercise inherited child cwd and invalid-root refusal on native Windows.

## How to Test

1. Launch the handoff working-directory self-test from a directory other than `-InstallRoot`; confirm the child reports the install root.
2. Run the self-test with a missing install root; confirm it exits 3 before update work.
3. Run the related Windows handoff and verifier tests:

```bash
scripts/run_tests.sh tests/test_desktop_update_windows_cwd.py tests/test_desktop_update_windows_timestamp.py tests/test_desktop_update_windows_retry_policy.py tests/test_desktop_update_windows_python_handoff.py tests/hermes_cli/test_desktop_update_verify.py
```

Result: 15 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - behavior and regression test only
- [x] `cli-config.yaml.example`: N/A - no configuration changes
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changes
- [x] Cross-platform impact considered - the change is confined to the Windows handoff; POSIX is unchanged
- [x] Tool descriptions/schemas: N/A - no tool changes

## Screenshots / Logs

N/A - the native regression test executes the Windows handoff child-launch path directly.
