### PR TITLE
fix(tools): stop requiring and echoing an auxiliary question in native vision_analyze

### DIFF
--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -122,7 +122,6 @@ class TestBuildNativeVisionToolResult:
     def test_envelope_shape(self):
         env = _build_native_vision_tool_result(
             image_url="/tmp/foo.png",
-            question="what does it say?",
             image_data_url="data:image/png;base64,XYZ",
             image_size_bytes=1024,
         )
@@ -132,13 +131,14 @@ class TestBuildNativeVisionToolResult:
         assert env["content"][0]["type"] == "text"
         assert env["content"][1]["type"] == "image_url"
         assert env["content"][1]["image_url"]["url"] == "data:image/png;base64,XYZ"
-        assert "what does it say?" in env["content"][0]["text"]
+        assert "Image loaded" in env["content"][0]["text"]
         assert "Image attached natively" in env["text_summary"]
 
-    def test_no_question_omits_question_section(self):
+    def test_envelope_never_echoes_a_question(self):
+        """The original request is already in the conversation; pixels must not
+        carry a restatement of it."""
         env = _build_native_vision_tool_result(
             image_url="/tmp/foo.png",
-            question="",
             image_data_url="data:image/png;base64,XYZ",
             image_size_bytes=512,
         )
@@ -155,7 +155,7 @@ class TestVisionAnalyzeNative:
         img = tmp_path / "test.png"
         img.write_bytes(_TINY_PNG)
         result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(img), "what is this?")
+            _vision_analyze_native(str(img))
         )
         assert isinstance(result, dict)
         assert result.get("_multimodal") is True
@@ -183,7 +183,7 @@ class TestVisionAnalyzeNative:
                 image.load()
 
         result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(truncated), "describe")
+            _vision_analyze_native(str(truncated))
         )
 
         assert isinstance(result, str), "corrupt image must not return a multimodal envelope"
@@ -223,7 +223,7 @@ class TestVisionAnalyzeNative:
                     frame.load()
 
         result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(truncated), "describe")
+            _vision_analyze_native(str(truncated))
         )
 
         assert isinstance(result, str), "corrupt animation must not return a multimodal envelope"
@@ -248,7 +248,7 @@ class TestVisionAnalyzeNative:
         loaded_frames = _track_validated_frame_loads(monkeypatch)
 
         result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(animation), "describe")
+            _vision_analyze_native(str(animation))
         )
 
         assert isinstance(result, str)
@@ -275,7 +275,7 @@ class TestVisionAnalyzeNative:
         loaded_frames = _track_validated_frame_loads(monkeypatch)
 
         result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(animation), "describe")
+            _vision_analyze_native(str(animation))
         )
 
         assert isinstance(result, str)
@@ -290,7 +290,7 @@ class TestVisionAnalyzeNative:
         img = tmp_path / "t.png"
         img.write_bytes(_TINY_PNG)
         result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(f"file://{img}", "?")
+            _vision_analyze_native(f"file://{img}")
         )
         assert isinstance(result, dict)
         assert result.get("_multimodal") is True
@@ -300,7 +300,7 @@ class TestVisionAnalyzeNative:
         img = tmp_path / "bad.png"
         img.write_bytes(_CORRUPT_PNG)
         result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(img), "what is this?")
+            _vision_analyze_native(str(img))
         )
         assert isinstance(result, str)
         parsed = json.loads(result)
@@ -331,7 +331,7 @@ class TestVisionAnalyzeNative:
         assert big.stat().st_size * 4 // 3 > 5 * 1024 * 1024, "test image not big enough"
 
         result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(big), "describe")
+            _vision_analyze_native(str(big))
         )
         assert isinstance(result, dict) and result.get("_multimodal") is True
         url = next(

--- a/tests/tools/test_vision_region.py
+++ b/tests/tools/test_vision_region.py
@@ -96,7 +96,7 @@ class TestNativePathRegion:
 
         src = _make_png(tmp_path / "img.png", 100, 50)
         result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(src), "zoom", region=[10, 10, 60, 40])
+            _vision_analyze_native(str(src), region=[10, 10, 60, 40])
         )
         assert isinstance(result, dict) and result.get("_multimodal") is True
         url = next(
@@ -111,7 +111,7 @@ class TestNativePathRegion:
 
         src = _make_png(tmp_path / "img.png", 100, 50)
         result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(src), "full shot")
+            _vision_analyze_native(str(src))
         )
         assert isinstance(result, dict) and result.get("_multimodal") is True
         url = next(
@@ -128,7 +128,7 @@ class TestNativePathRegion:
 
         src = _make_png(tmp_path / "img.png", 100, 50)
         result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(src), "zoom", region=[500, 500, 600, 600])
+            _vision_analyze_native(str(src), region=[500, 500, 600, 600])
         )
         assert isinstance(result, str)
         payload = json.loads(result)
@@ -148,7 +148,7 @@ class TestNativePathRegion:
             big, format="PNG"
         )
         result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(big), "zoom", region=[0, 0, 200, 300])
+            _vision_analyze_native(str(big), region=[0, 0, 200, 300])
         )
         assert isinstance(result, dict) and result.get("_multimodal") is True
         url = next(
@@ -174,6 +174,15 @@ class TestSchemaAndHandler:
         # Description must document original-image pixel space.
         assert "original" in props["region"]["description"].lower()
 
+    def test_schema_question_is_optional(self):
+        """Native image loading must not force the main model to restate a
+        request it already has in context."""
+        from tools.vision_tools import VISION_ANALYZE_SCHEMA
+
+        required = VISION_ANALYZE_SCHEMA["parameters"]["required"]
+        assert required == ["image_url"]
+        assert "question" in VISION_ANALYZE_SCHEMA["parameters"]["properties"]
+
     def test_handler_passes_region_to_native_path(self, tmp_path, monkeypatch):
         from tools import vision_tools
         from tools.vision_tools import _handle_vision_analyze
@@ -181,7 +190,7 @@ class TestSchemaAndHandler:
         src = _make_png(tmp_path / "img.png", 100, 50)
         seen = {}
 
-        async def _fake_native(image_url, question, task_id=None, region=None):
+        async def _fake_native(image_url, task_id=None, region=None):
             seen["region"] = region
             return {"_multimodal": True, "content": []}
 

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -180,6 +180,43 @@ class TestHandleVisionAnalyze:
             config={"auxiliary": {"vision": {}}}, env_model="fallback-model",
         ) == "fallback-model"
 
+    @pytest.mark.asyncio
+    async def test_aux_prompt_with_question(self):
+        """A supplied question narrows the default describe-everything prompt."""
+        with ExitStack() as st:
+            mock_tool = st.enter_context(
+                patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock)
+            )
+            st.enter_context(patch(
+                "tools.vision_tools._should_use_native_vision_fast_path",
+                return_value=False,
+            ))
+            mock_tool.return_value = json.dumps({"result": "ok"})
+            await _handle_vision_analyze(
+                {"image_url": "https://example.com/img.png", "question": "how many cats?"}
+            )
+            prompt = mock_tool.call_args[0][1]
+        assert "following question" in prompt
+        assert "how many cats?" in prompt
+
+    @pytest.mark.asyncio
+    async def test_aux_prompt_without_question_is_complete(self):
+        """No dangling question section when the question is omitted."""
+        with ExitStack() as st:
+            mock_tool = st.enter_context(
+                patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock)
+            )
+            st.enter_context(patch(
+                "tools.vision_tools._should_use_native_vision_fast_path",
+                return_value=False,
+            ))
+            mock_tool.return_value = json.dumps({"result": "ok"})
+            await _handle_vision_analyze({"image_url": "https://example.com/img.png"})
+            prompt = mock_tool.call_args[0][1]
+        assert "following question" not in prompt
+        assert prompt.strip().endswith(".")
+        assert "Fully describe" in prompt
+
 
 # ---------------------------------------------------------------------------
 # Error logging with exc_info — verify tracebacks are logged
@@ -351,7 +388,7 @@ class TestVisionSafetyGuards:
         secret = tmp_path / ".env"
         secret.write_text("OPENAI_API_KEY=sk-super-secret\n", encoding="utf-8")
 
-        result = json.loads(await _vision_analyze_native(str(secret), "extract text"))
+        result = json.loads(await _vision_analyze_native(str(secret)))
 
         assert result["success"] is False
         assert "secret-bearing environment file" in result["error"]
@@ -1090,7 +1127,7 @@ class TestVisionCpuBurstCap:
                     enc_inflight -= 1
             return "data:image/jpeg;base64,AAAA"
 
-        async def fake_native(image_url, question, task_id=None, **_kw):
+        async def fake_native(image_url, task_id=None, **_kw):
             nonlocal calls_inflight, calls_peak
             calls_inflight += 1
             calls_peak = max(calls_peak, calls_inflight)

--- a/tools/browser_tool_vision.py
+++ b/tools/browser_tool_vision.py
@@ -68,7 +68,7 @@ def _native_vision_result(
 
     data_url = _resize_image_for_vision(screenshot_path, mime_type="image/png", max_base64_bytes=_EMBED_TARGET_BYTES,
                                         max_dimension=_EMBED_MAX_DIMENSION, force_jpeg=True)
-    native_result = _build_native_vision_tool_result(image_url=str(screenshot_path), question=question,
+    native_result = _build_native_vision_tool_result(image_url=str(screenshot_path),
                                                      image_data_url=data_url,
                                                      image_size_bytes=screenshot_path.stat().st_size)
     meta = native_result.setdefault("meta", {})

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -477,16 +477,17 @@ def _should_use_native_vision_fast_path() -> bool:
 
 
 def _build_native_vision_tool_result(
-    image_url: str, question: str, image_data_url: str, image_size_bytes: int,
+    image_url: str,
+    image_data_url: str,
+    image_size_bytes: int,
     scale_note: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Multimodal tool-result envelope. The text part is intentionally minimal (the model already
-    has the question); ``text_summary`` is the fallback for providers without multimodal tool results."""
+    """Multimodal tool-result envelope. The text part is intentionally minimal — the original
+    request is already in the conversation, so the pixels carry no restatement of it; ``text_summary``
+    is the fallback for providers without multimodal tool results."""
     text_part = (
         "Image loaded into your context — you can see it natively now. "
         "Use your built-in vision to answer the user.")
-    if isinstance(question, str) and question.strip():
-        text_part += f"\n\nQuestion: {question.strip()}"
     if scale_note:
         text_part += f"\n\nNote: {scale_note}"
     return {
@@ -579,10 +580,13 @@ async def _resize_prepared(prepared: _PreparedImage, scale_info: dict, **kwargs)
 
 
 async def _vision_analyze_native(
-    image_url: str, question: str, task_id: Optional[str] = None, region: Optional[list] = None,
+    image_url: str,
+    task_id: Optional[str] = None,
+    region: Optional[list] = None,
 ) -> Any:
     """Fast path for vision-capable main models: a ``_multimodal`` envelope dict on success,
-    or a JSON error string (the normal tool-result contract) on failure."""
+    or a JSON error string (the normal tool-result contract) on failure. The original request
+    stays in the conversation; this only loads pixels."""
     if not isinstance(image_url, str) or not image_url.strip():
         return tool_error("image_url is required", success=False)
     prepared: Optional[_PreparedImage] = None
@@ -612,9 +616,13 @@ async def _vision_analyze_native(
             if len(image_data_url) > _MAX_BASE64_BYTES:
                 return tool_error(_too_large_message(image_data_url), success=False)
         return _build_native_vision_tool_result(
-            image_url=image_url, question=question, image_data_url=image_data_url,
+            image_url=image_url,
+            image_data_url=image_data_url,
             image_size_bytes=prepared.size_bytes,
-            scale_note=_build_scale_note(_scale_info or None, prepared.crop_offset or None))
+            scale_note=_build_scale_note(
+                _scale_info or None, prepared.crop_offset or None
+            ),
+        )
     except Exception as exc:
         logger.warning("Native vision fast path failed: %s", exc)
         return tool_error(f"Native vision failed: {exc}", success=False)
@@ -840,7 +848,10 @@ VISION_ANALYZE_SCHEMA = {
             },
             "question": {
                 "type": "string",
-                "description": "Your question or request about the image."
+                "description": (
+                    "Optional focus for the auxiliary-model route only; ignored when "
+                    "the image is loaded into your own context."
+                ),
             },
             "region": {
                 "type": "array",
@@ -853,11 +864,11 @@ VISION_ANALYZE_SCHEMA = {
                     "keeps full resolution. Load the full image first, then "
                     "re-call with a region to zoom into small text or fine "
                     "detail."
-                )
-            }
+                ),
+            },
         },
-        "required": ["image_url", "question"]
-    }
+        "required": ["image_url"],
+    },
 }
 
 
@@ -880,12 +891,16 @@ async def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> str:
     # encode/resize step, so multi-image fan-out keeps full request concurrency.
     if _should_use_native_vision_fast_path():
         logger.info("vision_analyze: native fast path")
-        return await _vision_analyze_native(image_url, question, task_id=task_id, region=region)
+        return await _vision_analyze_native(image_url, task_id=task_id, region=region)
 
-    # Legacy path: aux LLM describes the image and we return its text.
+    # Aux-model route: the optional question narrows an otherwise complete default prompt.
+    question = question.strip() if isinstance(question, str) else ""
     full_prompt = (
-        "Fully describe and explain everything about this image, then answer the "
-        f"following question:\n\n{question}")
+        "Fully describe and explain everything about this image."
+        if not question
+        else "Fully describe and explain everything about this image, then answer the "
+        f"following question:\n\n{question}"
+    )
     model = _configured_aux_model(("vision",), ("AUXILIARY_VISION_MODEL",))
     return await vision_analyze_tool(image_url, full_prompt, model, task_id=task_id, region=region)
 


### PR DESCRIPTION
## Summary

On the native image path, `vision_analyze` loads pixels into the main model's context, yet the schema still required the model to generate an auxiliary `question`, and the native tool result echoed that question back next to the pixels — the model was forced to restate a request already in context and then read its own restatement as tool-result text.

- `VISION_ANALYZE_SCHEMA`: `question` is now optional (`required: ["image_url"]`) and its description states it only focuses the auxiliary-model route.
- `_build_native_vision_tool_result` / `_vision_analyze_native`: the `question` parameter is gone — native results carry pixels, the scale note, and nothing else.
- Auxiliary route: an omitted question now yields a complete default prompt instead of a dangling `following question:` section.

`region` behaviour, prompt-cache stability, and the video tool (aux-only, keeps its required question) are unchanged.

## Tests

- `test_schema_question_is_optional` — required list is exactly `["image_url"]`.
- `test_envelope_never_echoes_a_question` — no `Question:` text in the native envelope.
- `test_aux_prompt_with_question` / `test_aux_prompt_without_question_is_complete` — prompt shape on both sides of the ternary.
- Updated direct `_vision_analyze_native` call sites and fakes that passed the old positional `question`.
- Mutation-red verified: restoring the echo, the old required list, or the dangling prompt each fails the new tests.

Local run: `82 passed` across `test_vision_tools.py`, `test_vision_native_fast_path.py`, `test_vision_region.py`, `test_auxiliary_config_bridge.py` (the two `TestVisionDispatchLoopSafety` failures are pre-existing on clean `main` — DNS on this host resolves example.com into a private range, URL guard blocks it).

Fixes #105151.