### PR TITLE
fix(dashboard): skip the model-metadata probe against a pinned local endpoint

### DIFF
--- a/hermes_cli/web_routers/models.py
+++ b/hermes_cli/web_routers/models.py
@@ -63,15 +63,32 @@ def get_model_info(profile: Optional[str] = None):
         if not model_name:
             return dict(_EMPTY_MODEL_INFO, provider=provider)
 
-        try:
-            from agent.model_metadata import get_model_context_length
-            # config_context_length=None: ignore the override — we want the auto value
-            auto_ctx = get_model_context_length(model=model_name, base_url=base_url, provider=provider,
-                                                config_context_length=None)
-        except Exception:
-            auto_ctx = 0
-
         config_ctx_int = config_ctx if isinstance(config_ctx, int) and config_ctx > 0 else 0
+
+        # An explicit model.context_length against a local endpoint makes the probe pure
+        # cost. Local bridges and proxies commonly implement only the generation route
+        # (e.g. POST /v1/messages), so discovery fails against them and surfaces
+        # provider-down / cooldown noise in the dashboard while generation is healthy.
+        # With an override configured the probe cannot report anything the operator has
+        # not already stated. is_local_endpoint() is this module's own predicate, so
+        # loopback, container DNS, RFC-1918 and Tailscale all resolve consistently.
+        auto_ctx = 0
+        probe_skipped = False
+        if config_ctx_int > 0 and base_url:
+            try:
+                from agent.model_metadata import is_local_endpoint
+                probe_skipped = is_local_endpoint(base_url)
+            except Exception:
+                probe_skipped = False
+
+        if not probe_skipped:
+            try:
+                from agent.model_metadata import get_model_context_length
+                # config_context_length=None: ignore the override — we want the auto value
+                auto_ctx = get_model_context_length(model=model_name, base_url=base_url, provider=provider,
+                                                    config_context_length=None)
+            except Exception:
+                auto_ctx = 0
 
         caps = {}
         try:

--- a/tests/hermes_cli/test_model_info_probe_skip.py
+++ b/tests/hermes_cli/test_model_info_probe_skip.py
@@ -1,0 +1,84 @@
+"""``/api/model/info`` must not probe model metadata against a pinned local endpoint.
+
+The probe is pure cost there: with ``model.context_length`` already set by the
+operator it cannot report anything new, and local bridges/proxies commonly serve
+only the generation route, so discovery fails and surfaces as provider-down noise.
+"""
+
+
+def _record_probe(monkeypatch):
+    """Replace the metadata probe with a recorder.
+
+    ``get_model_info`` imports the symbol inside the call, so patching the
+    attribute on the module is what the route actually resolves.
+    """
+    calls = []
+    import agent.model_metadata as _mm
+
+    def _fake(**kwargs):
+        calls.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(_mm, "get_model_context_length", _fake)
+    return calls
+
+
+class TestModelInfoProbeSkip:
+    def test_pinned_local_endpoint_does_not_probe(self, monkeypatch):
+        from hermes_cli.config import save_config
+        from hermes_cli.web_routers.models import get_model_info
+
+        calls = _record_probe(monkeypatch)
+        save_config({
+            "model": {
+                "default": "llama3.2",
+                "provider": "ollama-local",
+                "base_url": "http://localhost:11434/v1",
+                "context_length": 200000,
+            }
+        })
+
+        info = get_model_info()
+
+        assert calls == [], "the probe ran against a pinned local endpoint"
+        assert info["config_context_length"] == 200000
+        assert info["effective_context_length"] == 200000
+
+    def test_remote_endpoint_still_probes(self, monkeypatch):
+        """Control. Without it the test above still passes if the probe is
+        deleted outright, which would prove nothing about the skip."""
+        from hermes_cli.config import save_config
+        from hermes_cli.web_routers.models import get_model_info
+
+        calls = _record_probe(monkeypatch)
+        save_config({
+            "model": {
+                "default": "google/gemini-2.5-flash",
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "context_length": 200000,
+            }
+        })
+
+        get_model_info()
+
+        assert len(calls) == 1, "a remote endpoint must still be probed"
+
+    def test_local_endpoint_without_override_still_probes(self, monkeypatch):
+        """Second control: local alone is not enough. Without an operator-stated
+        context_length the probe is the only source of the value, so it must run."""
+        from hermes_cli.config import save_config
+        from hermes_cli.web_routers.models import get_model_info
+
+        calls = _record_probe(monkeypatch)
+        save_config({
+            "model": {
+                "default": "llama3.2",
+                "provider": "ollama-local",
+                "base_url": "http://localhost:11434/v1",
+            }
+        })
+
+        get_model_info()
+
+        assert len(calls) == 1, "a local endpoint without an override must still be probed"


### PR DESCRIPTION
### Problem

`get_model_info` always probes the provider for model metadata, even when the operator has already pinned `model.context_length` in the config. Against a local endpoint that is pure cost: local bridges and proxies commonly implement only the generation route (e.g. `POST /v1/messages`) and return 404/405 for the discovery routes. The probe fails, and the dashboard surfaces provider-down / cooldown noise while generation is perfectly healthy.

With an explicit override configured, the probe cannot report anything the operator has not already stated — so the failure is noise with no upside.

### Fix

Skip the metadata probe when **both** conditions hold:

1. `model.context_length` is set to a positive integer (the operator stated the value), and
2. `base_url` points at a local endpoint.

Everything else is untouched: remote providers still probe, and a config without an override still probes even against a local endpoint.

### Why `is_local_endpoint`

The "is it local?" test uses `agent.model_metadata.is_local_endpoint` — this repo's own predicate — rather than a hand-written hostname list. It already covers loopback, container DNS, RFC-1918 and Tailscale ranges, so this path resolves consistently with the rest of the codebase and inherits any future change to that definition. The import is inside the branch and wrapped, so an import failure degrades to "probe anyway" (the current behaviour), never to an error.

### The change is the first hunk only

The diff renders two hunks. Only the first is proposed. The second, on `_MOA_PRESET_FIELDS`, is an artifact of the merge base: this branch is based on a commit that predates your removal of `max_tokens` / `reference_max_tokens` from that tuple, so GitHub shows the removal again. Measured against `main` as it stands today, `grep -c max_tokens` on that file returns 0. Both sides removed the same two entries, so the merge resolves to your current state and GitHub reports the branch as mergeable. Nothing in `_MOA_PRESET_FIELDS` is being proposed here — happy to rebase onto current `main` if you would rather review a single-hunk diff.

### Scope

One file, `hermes_cli/web_routers/models.py`. No new dependency, no config key, no behaviour change for any provider that is not both local **and** explicitly pinned.
