### PR TITLE
feat(agent): JIT Micro-Tool Synthesizer & Dynamic Security Sandbox

### DIFF
--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -118,7 +118,19 @@ class ClientLifecycleMixin:
             from tools.computer_use.tool import release_computer_use_session
             release_computer_use_session(task_id)
 
-        for step in (kill_processes, lambda: cleanup_vm(task_id), lambda: cleanup_browser(task_id), release_computer_use):
+        def release_jit_tools() -> None:
+            from agent.jit_tool_synthesizer import cleanup_session_jit_tools
+            owning_session_id = getattr(self, "session_id", None)
+            task_session_map = getattr(self, "_task_to_session", None)
+            mapped_session_id = task_session_map.get(task_id) if isinstance(task_session_map, dict) else None
+
+            cleaned_sessions = set()
+            for sid in (owning_session_id, mapped_session_id, task_id):
+                if sid and sid not in cleaned_sessions:
+                    cleanup_session_jit_tools(sid)
+                    cleaned_sessions.add(sid)
+
+        for step in (kill_processes, lambda: cleanup_vm(task_id), lambda: cleanup_browser(task_id), release_computer_use, release_jit_tools):
             _quietly(step)
 
     def _client_log_context(self) -> str:

--- a/agent/jit_tool_synthesizer.py
+++ b/agent/jit_tool_synthesizer.py
@@ -10,14 +10,18 @@ import ast
 import base64
 import datetime
 import hashlib
-import importlib
+import io
 import json
 import logging
 import math
 import os
 import re
+import subprocess
 import sys
+import threading
 import time
+import uuid
+import weakref
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
@@ -54,15 +58,63 @@ DISALLOWED_CALLS = frozenset({
     "delattr",
 })
 
+FRAME_TRAVERSAL_ATTRIBUTES = frozenset({
+    "f_back",
+    "f_builtins",
+    "f_globals",
+    "f_locals",
+    "f_code",
+    "f_lasti",
+    "f_lineno",
+    "f_trace",
+    "f_trace_lines",
+    "f_trace_opcodes",
+    "gi_frame",
+    "gi_code",
+    "gi_running",
+    "gi_yieldfrom",
+    "cr_frame",
+    "cr_code",
+    "cr_running",
+    "cr_await",
+    "ag_frame",
+    "ag_code",
+    "ag_running",
+    "ag_await",
+    "tb_frame",
+    "tb_next",
+    "tb_lasti",
+    "tb_lineno",
+    "co_code",
+    "co_consts",
+    "co_names",
+    "co_varnames",
+    "co_freevars",
+    "co_cellvars",
+})
+
 DISALLOWED_ATTRIBUTES = frozenset({
+    "__builtins__",
+    "__dict__",
+    "__class__",
     "__subclasses__",
     "__bases__",
     "__mro__",
     "__globals__",
     "__code__",
+    "__closure__",
+    "__func__",
+    "__self__",
+    "__module__",
+    "__loader__",
+    "__spec__",
+    "__package__",
+    "__reduce__",
+    "__reduce_ex__",
+    "__import__",
 })
 
-CURRENT_POLICY_VERSION = 2
+CURRENT_POLICY_VERSION = 4
 
 
 class JITSecurityViolation(Exception):
@@ -71,7 +123,7 @@ class JITSecurityViolation(Exception):
 
 
 class JITCompilationError(Exception):
-    """Raised when synthesized tool code fails compilation or fuzzing."""
+    """Raised when synthesized tool code fails compilation, fuzzing, or execution."""
     pass
 
 
@@ -122,6 +174,15 @@ class SynthesizedToolSpec:
         )
 
 
+@dataclass
+class RegistrationReceipt:
+    """Exact CAS registration receipt capturing registered slot state."""
+    name: str
+    scope: Optional[str]
+    entry: Any
+    previous: Optional[Any]
+
+
 class JITSandboxSecurityGuard(ast.NodeVisitor):
     """Inspects tool AST for positive capability compliance and security invariants."""
 
@@ -163,8 +224,49 @@ class JITSandboxSecurityGuard(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Attribute(self, node: ast.Attribute) -> None:
-        if node.attr in DISALLOWED_ATTRIBUTES:
-            self.violations.append(f"Disallowed attribute access: {node.attr}")
+        if (
+            node.attr.startswith("_")
+            or node.attr in FRAME_TRAVERSAL_ATTRIBUTES
+            or node.attr in DISALLOWED_ATTRIBUTES
+            or node.attr in {"sys", "os", "subprocess", "posix", "nt"}
+        ):
+            self.violations.append(f"Disallowed attribute access: '{node.attr}'")
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        # Detect subscript escapes like collections.__builtins__['open'] or f_builtins['op' + 'en']
+        slice_val = None
+        if isinstance(node.slice, ast.Constant) and isinstance(node.slice.value, str):
+            slice_val = node.slice.value
+        elif isinstance(node.slice, ast.BinOp):
+            def _eval_str_binop(op_node: ast.AST) -> Optional[str]:
+                if isinstance(op_node, ast.Constant) and isinstance(op_node.value, str):
+                    return op_node.value
+                if isinstance(op_node, ast.BinOp) and isinstance(op_node.op, ast.Add):
+                    l_val = _eval_str_binop(op_node.left)
+                    r_val = _eval_str_binop(op_node.right)
+                    if l_val is not None and r_val is not None:
+                        return l_val + r_val
+                return None
+            slice_val = _eval_str_binop(node.slice)
+        elif hasattr(ast, "Index") and isinstance(node.slice, getattr(ast, "Index", None)):
+            if isinstance(node.slice.value, ast.Constant) and isinstance(node.slice.value.value, str):
+                slice_val = node.slice.value.value
+
+        if isinstance(slice_val, str):
+            if (
+                slice_val.startswith("_")
+                or slice_val in FRAME_TRAVERSAL_ATTRIBUTES
+                or slice_val in {"open", "eval", "exec", "__import__", "compile", "globals", "locals", "sys", "os"}
+            ):
+                self.violations.append(f"Disallowed subscript access to sensitive key: '{slice_val}'")
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        # Prevent mutating attributes on external modules (e.g. json.REVIEW_SENTINEL = ...)
+        for target in node.targets:
+            if isinstance(target, ast.Attribute):
+                self.violations.append(f"Disallowed mutation of module or object attribute: '{target.attr}'")
         self.generic_visit(node)
 
 
@@ -184,96 +286,259 @@ def audit_tool_source(name: str, source_code: str) -> None:
         raise JITSecurityViolation(f"Security violations detected: {'; '.join(checker.violations)}")
 
 
-class JITSandboxExecutor:
-    """Isolated execution sandbox for validating and running synthesized micro-tools."""
+# Disposable isolated worker script for sandboxed execution
+_WORKER_CODE = """
+import json
+import sys
+import io
 
-    @staticmethod
-    def get_safe_builtins() -> Dict[str, Any]:
-        """Construct a restricted builtins dictionary with standard algorithmic utilities."""
+# Capture real stdout for clean JSON protocol response
+protocol_out = sys.stdout
+sys.stdout = io.StringIO()
+
+data = json.loads(sys.stdin.read())
+action = data.get("action", "execute")
+name = data["name"]
+source = data["source"]
+test_vectors = data.get("test_vectors", [])
+kwargs = data.get("kwargs", {})
+
+import builtins
+safe_names = [
+    "abs", "all", "any", "ascii", "bin", "bool", "bytearray", "bytes",
+    "chr", "complex", "dict", "divmod", "enumerate", "filter", "float",
+    "format", "frozenset", "hex", "int", "isinstance", "issubclass",
+    "iter", "len", "list", "map", "max", "min", "next", "oct", "ord",
+    "pow", "print", "range", "repr", "reversed", "round", "set", "slice",
+    "sorted", "str", "sum", "tuple", "zip",
+    "Exception", "ValueError", "TypeError", "KeyError", "IndexError",
+    "ZeroDivisionError", "ArithmeticError",
+]
+safe_builtins = {k: getattr(builtins, k) for k in safe_names if hasattr(builtins, k)}
+safe_builtins["True"] = True
+safe_builtins["False"] = False
+safe_builtins["None"] = None
+
+ALLOWED_MODULES = frozenset({
+    "math", "re", "json", "collections", "itertools", "datetime",
+    "hashlib", "urllib.parse", "decimal", "fractions", "string", "bisect", "heapq"
+})
+
+orig_import = builtins.__import__
+def safe_import(mod_name, globals=None, locals=None, fromlist=(), level=0):
+    base = mod_name.split(".")[0]
+    if base not in ALLOWED_MODULES and mod_name not in ALLOWED_MODULES:
+        raise ImportError(f"Import of '{mod_name}' is disallowed in JIT sandbox.")
+    return orig_import(mod_name, globals, locals, fromlist, level)
+
+safe_builtins["__import__"] = safe_import
+
+env = {"__builtins__": safe_builtins}
+
+import math, re, json as _json, collections, itertools, datetime, hashlib, urllib.parse, decimal, fractions, string, bisect, heapq
+for mod in [math, re, _json, collections, itertools, datetime, hashlib, urllib.parse, decimal, fractions, string, bisect, heapq]:
+    mod_alias = mod.__name__.split(".")[-1]
+    env[mod_alias] = mod
+    if hasattr(mod, "__builtins__"):
+        try:
+            delattr(mod, "__builtins__")
+        except Exception:
+            pass
+    for leak in ["sys", "_sys", "os", "_os"]:
+        if hasattr(mod, leak):
+            try:
+                delattr(mod, leak)
+            except Exception:
+                pass
+
+# Neutralize frame inspection and stack traversal in worker sys
+if hasattr(sys, "_getframe"):
+    try:
+        delattr(sys, "_getframe")
+    except Exception:
+        sys._getframe = None
+
+# Strip dangerous ambient execution/filesystem primitives from root builtins
+for bad in ["open", "breakpoint", "input", "exit", "quit"]:
+    if hasattr(builtins, bad):
+        try:
+            delattr(builtins, bad)
+        except Exception:
+            setattr(builtins, bad, None)
+
+try:
+    compiled = compile(source, f"<jit_{name}>", "exec")
+    exec(compiled, env)
+    fn = env.get(name)
+    if not callable(fn):
+        print(json.dumps({"status": "error", "error": f"Symbol '{name}' is not callable"}), file=protocol_out)
+        sys.exit(0)
+
+    if action == "fuzz":
+        for i, vec in enumerate(test_vectors):
+            args = vec.get("inputs", {})
+            expected = vec.get("expected")
+            res = fn(**args)
+            if expected is not None and res != expected:
+                print(json.dumps({"status": "error", "error": f"Test vector #{i + 1} failed: expected {expected!r}, got {res!r}"}), file=protocol_out)
+                sys.exit(0)
+        print(json.dumps({"status": "ok"}), file=protocol_out)
+    else:
+        res = fn(**kwargs)
+        print(json.dumps({"status": "ok", "result": res}, default=str), file=protocol_out)
+except Exception as exc:
+    print(json.dumps({"status": "error", "error": str(exc)}), file=protocol_out)
+"""
+
+
+class JITSandboxExecutor:
+    """Isolated execution sandbox for validating and running synthesized micro-tools in a subprocess worker."""
+
+    @classmethod
+    def get_safe_builtins(cls) -> Dict[str, Any]:
+        """Expose safe builtins dictionary for testing and inspection."""
+        import builtins
         safe_names = [
             "abs", "all", "any", "ascii", "bin", "bool", "bytearray", "bytes",
             "chr", "complex", "dict", "divmod", "enumerate", "filter", "float",
             "format", "frozenset", "hex", "int", "isinstance", "issubclass",
             "iter", "len", "list", "map", "max", "min", "next", "oct", "ord",
-            "pow", "range", "repr", "reversed", "round", "set", "slice",
+            "pow", "print", "range", "repr", "reversed", "round", "set", "slice",
             "sorted", "str", "sum", "tuple", "zip",
             "Exception", "ValueError", "TypeError", "KeyError", "IndexError",
             "ZeroDivisionError", "ArithmeticError",
         ]
-        import builtins
+        safe = {k: getattr(builtins, k) for k in safe_names if hasattr(builtins, k)}
+        safe["True"] = True
+        safe["False"] = False
+        safe["None"] = None
+
         orig_import = builtins.__import__
+        def safe_import(mod_name, globals=None, locals=None, fromlist=(), level=0):
+            base = mod_name.split(".")[0]
+            if base not in ALLOWED_MODULES and mod_name not in ALLOWED_MODULES:
+                raise ImportError(f"Import of '{mod_name}' is disallowed in JIT sandbox.")
+            return orig_import(mod_name, globals, locals, fromlist, level)
 
-        def safe_import(name: str, globals=None, locals=None, fromlist=(), level=0):
-            base = name.split(".")[0]
-            if base not in ALLOWED_MODULES and name not in ALLOWED_MODULES:
-                raise ImportError(
-                    f"Import of '{name}' is disallowed in JIT sandbox. "
-                    f"Only explicitly allowed modules are permitted: {sorted(ALLOWED_MODULES)}"
-                )
-            return orig_import(name, globals, locals, fromlist, level)
+        safe["__import__"] = safe_import
+        return safe
 
-        safe_builtins = {k: getattr(builtins, k) for k in safe_names if hasattr(builtins, k)}
-        safe_builtins["True"] = True
-        safe_builtins["False"] = False
-        safe_builtins["None"] = None
-        safe_builtins["__import__"] = safe_import
-        return safe_builtins
+    @classmethod
+    def execute_in_worker(
+        cls,
+        name: str,
+        source_code: str,
+        action: str = "execute",
+        kwargs: Optional[Dict[str, Any]] = None,
+        test_vectors: Optional[List[Dict[str, Any]]] = None,
+        timeout: float = 5.0,
+    ) -> Any:
+        """Execute tool or test vectors in a disposable isolated subprocess worker."""
+        payload = json.dumps({
+            "name": name,
+            "source": source_code,
+            "action": action,
+            "kwargs": kwargs or {},
+            "test_vectors": test_vectors or [],
+        })
+        try:
+            # -I: isolated mode (ignore env vars and user site)
+            # -s: don't add user site directory
+            proc = subprocess.run(
+                [sys.executable, "-I", "-s", "-c", _WORKER_CODE],
+                input=payload,
+                text=True,
+                capture_output=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise JITCompilationError(f"Execution timed out after {timeout}s") from exc
+        except Exception as exc:
+            raise JITCompilationError(f"Worker invocation error: {exc}") from exc
 
-    @staticmethod
-    def create_sandbox_env() -> Dict[str, Any]:
-        """Create an execution environment with safe standard libraries."""
-        import collections
-        import datetime
-        import hashlib
-        import itertools
-        import json
-        import math
-        import re
-        import urllib.parse
+        if proc.returncode != 0:
+            err = proc.stderr.strip() or f"Worker process exited with code {proc.returncode}"
+            raise JITCompilationError(f"Sandbox worker failure: {err}")
 
-        return {
-            "__builtins__": JITSandboxExecutor.get_safe_builtins(),
-            "math": math,
-            "re": re,
-            "json": json,
-            "collections": collections,
-            "itertools": itertools,
-            "datetime": datetime,
-            "hashlib": hashlib,
-            "urllib_parse": urllib.parse,
-        }
+        try:
+            resp = json.loads(proc.stdout.strip())
+        except Exception as exc:
+            raise JITCompilationError(f"Invalid worker response: {proc.stdout}") from exc
+
+        if resp.get("status") != "ok":
+            err_msg = resp.get("error", "Unknown execution failure")
+            raise JITCompilationError(err_msg)
+
+        return resp.get("result")
 
     @classmethod
     def compile_and_extract(cls, name: str, source_code: str) -> Callable:
-        """Compile source within the sandbox and extract the entry function."""
-        env = cls.create_sandbox_env()
-        try:
-            compiled = compile(source_code, f"<jit_tool_{name}>", "exec")
-            exec(compiled, env)
-        except Exception as exc:
-            raise JITCompilationError(f"Compilation/execution error: {exc}") from exc
+        """Return a callable interface that executes the tool in an isolated worker subprocess."""
+        tree = ast.parse(source_code)
+        param_names: List[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == name:
+                param_names = [arg.arg for arg in node.args.args]
+                break
 
-        fn = env.get(name)
-        if not callable(fn):
-            raise JITCompilationError(f"Extracted symbol '{name}' is not callable")
-        return fn
+        # Verify compilation and extraction in worker
+        cls.execute_in_worker(name, source_code, action="fuzz", test_vectors=[])
+
+        def runner(*args, **kwargs):
+            call_kwargs = dict(kwargs)
+            for param, val in zip(param_names, args):
+                call_kwargs[param] = val
+            return cls.execute_in_worker(name, source_code, action="execute", kwargs=call_kwargs)
+
+        runner._source_code = source_code
+        return runner
 
     @classmethod
-    def fuzz_test_tool(cls, name: str, fn: Callable, test_vectors: List[Dict[str, Any]]) -> None:
-        """Execute test vectors against the compiled function to verify behavioral stability."""
-        for i, vec in enumerate(test_vectors):
-            args = vec.get("inputs", {})
-            expected = vec.get("expected")
+    def fuzz_test_tool(cls, name: str, source_code_or_fn: Any, test_vectors: List[Dict[str, Any]]) -> None:
+        """Run fuzz test vectors in isolated worker to verify behavioral stability without host side effects."""
+        source_code = source_code_or_fn if isinstance(source_code_or_fn, str) else getattr(source_code_or_fn, "_source_code", None)
+        if source_code:
+            cls.execute_in_worker(name, source_code, action="fuzz", test_vectors=test_vectors)
+        else:
+            for i, vec in enumerate(test_vectors):
+                args = vec.get("inputs", {})
+                expected = vec.get("expected")
+                res = source_code_or_fn(**args)
+                if expected is not None and res != expected:
+                    raise JITCompilationError(f"Test vector #{i + 1} failed: expected {expected!r}, got {res!r}")
+
+
+_ACTIVE_SYNTHESIZERS: "weakref.WeakSet[JITToolSynthesizer]" = weakref.WeakSet()
+_SYNTH_LOCK = threading.RLock()
+
+
+def cleanup_session_jit_tools(session_id: str) -> int:
+    """Owner-finalization hook: revoke all ephemeral tools leased to session_id across active synthesizers."""
+    if not session_id:
+        return 0
+    total = 0
+    with _SYNTH_LOCK:
+        for synth in list(_ACTIVE_SYNTHESIZERS):
             try:
-                result = fn(**args)
-                if expected is not None and result != expected:
-                    raise JITCompilationError(
-                        f"Test vector #{i + 1} failed: expected {expected!r}, got {result!r}"
-                    )
+                total += synth.revoke_session_tools(session_id)
             except Exception as exc:
-                if isinstance(exc, JITCompilationError):
-                    raise
-                raise JITCompilationError(f"Test vector #{i + 1} raised error: {exc}") from exc
+                logger.debug("Error revoking session JIT tools for %s: %s", session_id, exc)
+    return total
+
+
+def _is_tool_entry_live_in_any_synthesizer(entry: Any, name: str, scope: Optional[str]) -> bool:
+    """Check if a previous JIT ToolEntry is still held active by any live synthesizer."""
+    with _SYNTH_LOCK:
+        for synth in list(_ACTIVE_SYNTHESIZERS):
+            for r in synth._receipts.values():
+                if r.entry is entry and r.name == name and r.scope == scope:
+                    return True
+            for k, s in synth._tools.items():
+                if s.name == name and s.scope == scope:
+                    rec = synth._receipts.get(k)
+                    if rec and rec.entry is entry:
+                        return True
+    return False
 
 
 class JITToolSynthesizer:
@@ -291,10 +556,45 @@ class JITToolSynthesizer:
         self.storage_dir.mkdir(parents=True, exist_ok=True)
         self.meta_file = self.storage_dir / "jit_manifest.json"
 
-        self._tools: Dict[str, SynthesizedToolSpec] = {}
-        self._compiled_callables: Dict[str, Callable] = {}
-        self._session_leases: Dict[str, Set[str]] = {}  # session_id -> set of tool names
+        # Qualified composite storage: (scope, session_id, name) -> spec
+        self._tools: Dict[Tuple[Optional[str], Optional[str], str], SynthesizedToolSpec] = {}
+        # Tracks exact registration receipts for compare-and-swap registry ownership
+        self._receipts: Dict[Tuple[Optional[str], Optional[str], str], RegistrationReceipt] = {}
+        # session_id -> set of qualified tool keys
+        self._session_leases: Dict[str, Set[Tuple[Optional[str], Optional[str], str]]] = {}
+
+        with _SYNTH_LOCK:
+            _ACTIVE_SYNTHESIZERS.add(self)
+
         self.load_persisted_tools()
+
+    def _make_key(self, scope: Optional[str], session_id: Optional[str], name: str) -> Tuple[Optional[str], Optional[str], str]:
+        return (scope or None, session_id or None, name)
+
+    def _find_key(self, name: str, session_id: Optional[str] = None, scope: Optional[str] = None) -> Optional[Tuple[Optional[str], Optional[str], str]]:
+        """Resolve a tool key prioritizing explicit session and scope."""
+        exact = self._make_key(scope, session_id, name)
+        if exact in self._tools:
+            return exact
+
+        candidates = [k for k in self._tools.keys() if k[2] == name]
+        if not candidates:
+            return None
+
+        if session_id is not None and scope is not None:
+            return None
+
+        if session_id is not None:
+            matches = [k for k in candidates if k[1] == session_id]
+            return matches[0] if matches else None
+
+        if scope is not None:
+            matches = [k for k in candidates if k[0] == scope]
+            return matches[0] if matches else None
+
+        if len(candidates) == 1:
+            return candidates[0]
+        return None
 
     def synthesize_and_register(
         self,
@@ -313,6 +613,9 @@ class JITToolSynthesizer:
         if not re.match(r"^[a-zA-Z0-9_]{3,64}$", name):
             return False, f"Invalid tool name: '{name}'. Must be alphanumeric/underscores (3-64 chars)."
 
+        if is_ephemeral and not session_id:
+            return False, "Ephemeral JIT tools require an explicit session_id owner to enforce lifecycle scoping."
+
         vectors = test_vectors or []
 
         # 1. AST Security Audit with strict positive allowlist
@@ -322,11 +625,13 @@ class JITToolSynthesizer:
             logger.warning("Security/Compilation check failed for JIT tool %s: %s", name, exc)
             return False, f"Audit failed: {exc}"
 
-        # 2. Compile & Fuzz
+        # 2. Compile & Fuzz inside disposable worker (zero host side-effects)
         try:
-            compiled_fn = JITSandboxExecutor.compile_and_extract(name, python_source)
             if vectors:
-                JITSandboxExecutor.fuzz_test_tool(name, compiled_fn, vectors)
+                JITSandboxExecutor.fuzz_test_tool(name, python_source, vectors)
+            else:
+                # Compile verification probe
+                JITSandboxExecutor.execute_in_worker(name, python_source, action="fuzz", test_vectors=[])
         except JITCompilationError as exc:
             logger.warning("Fuzzing/Execution error for JIT tool %s: %s", name, exc)
             return False, f"Fuzzing failed: {exc}"
@@ -351,18 +656,19 @@ class JITToolSynthesizer:
             policy_version=CURRENT_POLICY_VERSION,
         )
 
+        key = self._make_key(scope, session_id, name)
+
         # 5. Bind into Hermes Tool Registry if requested
         if register_with_global_registry:
-            ok, reg_msg = self._register_into_hermes_registry(spec, compiled_fn)
+            ok, reg_msg = self._register_into_hermes_registry(spec)
             if not ok:
                 return False, reg_msg
 
-        self._tools[name] = spec
-        self._compiled_callables[name] = compiled_fn
+        self._tools[key] = spec
 
         # Track session lease if scoped
         if session_id:
-            self._session_leases.setdefault(session_id, set()).add(name)
+            self._session_leases.setdefault(session_id, set()).add(key)
 
         # 6. Persist if non-ephemeral
         if not is_ephemeral:
@@ -393,19 +699,36 @@ class JITToolSynthesizer:
             pass
         return None
 
-    def _register_into_hermes_registry(self, spec: SynthesizedToolSpec, compiled_fn: Callable) -> Tuple[bool, str]:
-        """Register into tools.registry.registry dynamically with scope attribution."""
+    def _register_into_hermes_registry(self, spec: SynthesizedToolSpec) -> Tuple[bool, str]:
+        """Register into tools.registry.registry dynamically matching production calling convention."""
         try:
             from tools.registry import registry
 
-            def handler(**kwargs) -> str:
+            # Production calling convention: entry.handler(args, **kwargs)
+            # args is the dictionary of tool arguments supplied positionally by ToolRegistry.dispatch()
+            def handler(args: Any = None, **context) -> str:
                 spec.call_count += 1
+                call_args: Dict[str, Any] = {}
+                if isinstance(args, dict):
+                    call_args = dict(args)
+                elif args is None:
+                    call_args = {}
+                else:
+                    raise TypeError(f"Tool arguments must be a dictionary, got {type(args).__name__}")
+
+                caller_session_id = context.get("session_id")
+                if spec.session_id and caller_session_id and caller_session_id != spec.session_id:
+                    raise PermissionError(
+                        f"JIT tool '{spec.name}' is owned by session '{spec.session_id}', "
+                        f"cannot be dispatched by session '{caller_session_id}'."
+                    )
+
                 try:
-                    res = compiled_fn(**kwargs)
+                    res = self.execute_tool(spec.name, session_id=spec.session_id, scope=spec.scope, **call_args)
                     return json.dumps({"result": res}) if not isinstance(res, str) else res
                 except Exception as exc:
                     spec.last_error = str(exc)
-                    return json.dumps({"error": str(exc)})
+                    raise exc
 
             schema = {
                 "name": spec.name,
@@ -413,6 +736,10 @@ class JITToolSynthesizer:
                 "parameters": spec.parameters_schema,
             }
 
+            # 1. Snapshot slot before registration
+            prev_entry = registry.snapshot_registration(spec.name, scope=spec.scope)
+
+            # 2. Register tool
             registry.register(
                 name=spec.name,
                 toolset=spec.toolset,
@@ -421,43 +748,64 @@ class JITToolSynthesizer:
                 description=spec.description,
                 scope=spec.scope,
             )
+
+            # 3. Snapshot slot after registration to verify success
+            new_entry = registry.snapshot_registration(spec.name, scope=spec.scope)
+            if new_entry is None or new_entry is prev_entry or new_entry.handler != handler:
+                return False, f"Tool registration was rejected or not updated in ToolRegistry for '{spec.name}'"
+
+            # 4. Record registration receipt for CAS ownership
+            key = self._make_key(spec.scope, spec.session_id, spec.name)
+            self._receipts[key] = RegistrationReceipt(
+                name=spec.name,
+                scope=spec.scope,
+                entry=new_entry,
+                previous=prev_entry,
+            )
+
             return True, "Registered in ToolRegistry"
         except Exception as exc:
             logger.warning("Failed to bind into tools.registry.registry: %s", exc)
             return False, f"ToolRegistry binding error: {exc}"
 
-    def execute_tool(self, name: str, **kwargs) -> Any:
-        """Execute a synthesized tool with arguments."""
-        if name not in self._compiled_callables:
+    def execute_tool(self, name: str, session_id: Optional[str] = None, scope: Optional[str] = None, **kwargs) -> Any:
+        """Execute a synthesized tool in an isolated worker process."""
+        key = self._find_key(name, session_id=session_id, scope=scope)
+        if key is None or key not in self._tools:
             raise KeyError(f"JIT tool '{name}' is not registered.")
-        spec = self._tools[name]
+        spec = self._tools[key]
         spec.call_count += 1
-        return self._compiled_callables[name](**kwargs)
+        return JITSandboxExecutor.execute_in_worker(spec.name, spec.python_source, action="execute", kwargs=kwargs)
 
-    def deregister(self, name: str, scope: Optional[str] = None) -> bool:
-        """Safely remove a tool from memory and registry, strictly guarding foreign tools."""
-        if name not in self._tools:
+    def deregister(self, name: str, session_id: Optional[str] = None, scope: Optional[str] = None) -> bool:
+        """Safely remove a tool with compare-and-swap ownership protection."""
+        key = self._find_key(name, session_id=session_id, scope=scope)
+        if key is None or key not in self._tools:
             return False
 
-        spec = self._tools[name]
-        del self._tools[name]
-        self._compiled_callables.pop(name, None)
+        spec = self._tools.pop(key)
 
-        # Remove from session leases if tracked
         if spec.session_id and spec.session_id in self._session_leases:
-            self._session_leases[spec.session_id].discard(name)
+            self._session_leases[spec.session_id].discard(key)
 
-        target_scope = scope if scope is not None else spec.scope
-
-        try:
-            from tools.registry import registry
-            entry = registry.get_entry(name, scope=target_scope)
-            # CAS-style safety: only deregister if the entry belongs to jit_synthesized
-            if entry is not None and entry.toolset == "jit_synthesized":
-                if hasattr(registry, "deregister"):
-                    registry.deregister(name, scope=target_scope)
-        except Exception as exc:
-            logger.debug("Deregistration notice: %s", exc)
+        # Compare-and-swap registry cleanup:
+        # ONLY restore/remove if THIS instance actually registered this tool and holds its receipt!
+        receipt = self._receipts.pop(key, None)
+        if receipt is not None:
+            try:
+                from tools.registry import registry
+                prev = receipt.previous
+                if prev is not None and getattr(prev, "toolset", None) == "jit_synthesized":
+                    if not _is_tool_entry_live_in_any_synthesizer(prev, receipt.name, receipt.scope):
+                        prev = None
+                registry.restore_registration(
+                    name=receipt.name,
+                    current=receipt.entry,
+                    previous=prev,
+                    scope=receipt.scope,
+                )
+            except Exception as exc:
+                logger.debug("Deregistration notice for %s: %s", receipt.name, exc)
 
         if not spec.is_ephemeral:
             self.save_persisted_tools()
@@ -465,10 +813,10 @@ class JITToolSynthesizer:
 
     def revoke_session_tools(self, session_id: str) -> int:
         """Revoke and deregister all ephemeral tools leased to a finalized session."""
-        leased_names = list(self._session_leases.get(session_id, set()))
+        leased_keys = list(self._session_leases.get(session_id, set()))
         revoked_count = 0
-        for name in leased_names:
-            if self.deregister(name):
+        for key in leased_keys:
+            if self.deregister(key[2], session_id=key[1], scope=key[0]):
                 revoked_count += 1
         self._session_leases.pop(session_id, None)
         return revoked_count
@@ -477,19 +825,20 @@ class JITToolSynthesizer:
         """Remove all ephemeral tools across all sessions."""
         to_prune = [k for k, v in self._tools.items() if v.is_ephemeral]
         for k in to_prune:
-            self.deregister(k)
+            self.deregister(k[2], session_id=k[1], scope=k[0])
         return len(to_prune)
 
     def list_tools(self) -> List[SynthesizedToolSpec]:
         """Return all active synthesized tools."""
         return list(self._tools.values())
 
-    def get_tool(self, name: str) -> Optional[SynthesizedToolSpec]:
-        return self._tools.get(name)
+    def get_tool(self, name: str, session_id: Optional[str] = None, scope: Optional[str] = None) -> Optional[SynthesizedToolSpec]:
+        key = self._find_key(name, session_id=session_id, scope=scope)
+        return self._tools.get(key) if key else None
 
     def save_persisted_tools(self) -> None:
         """Persist non-ephemeral tools with source digest provenance to disk."""
-        non_ephemeral = {k: v.to_dict() for k, v in self._tools.items() if not v.is_ephemeral}
+        non_ephemeral = {k[2]: v.to_dict() for k, v in self._tools.items() if not v.is_ephemeral}
         try:
             self.meta_file.write_text(json.dumps(non_ephemeral, indent=2), encoding="utf-8")
         except Exception as exc:
@@ -512,7 +861,7 @@ class JITToolSynthesizer:
                     )
                     continue
 
-                # 2. Re-run current AST security policy audit (fail closed on tightened rules)
+                # 2. Re-run current AST security policy audit
                 try:
                     audit_tool_source(spec.name, spec.python_source)
                 except (JITSecurityViolation, JITCompilationError) as exc:
@@ -521,17 +870,16 @@ class JITToolSynthesizer:
                     )
                     continue
 
-                # 3. Re-compile and fuzz against stored test vectors
+                # 3. Re-fuzz in isolated worker
                 try:
-                    compiled = JITSandboxExecutor.compile_and_extract(spec.name, spec.python_source)
                     if spec.test_vectors:
-                        JITSandboxExecutor.fuzz_test_tool(spec.name, compiled, spec.test_vectors)
+                        JITSandboxExecutor.fuzz_test_tool(spec.name, spec.python_source, spec.test_vectors)
                 except Exception as exc:
                     logger.warning("Durable JIT tool '%s' failed compilation/fuzzing: %s", name, exc)
                     continue
 
-                self._tools[spec.name] = spec
-                self._compiled_callables[spec.name] = compiled
-                self._register_into_hermes_registry(spec, compiled)
+                key = self._make_key(spec.scope, spec.session_id, spec.name)
+                self._tools[key] = spec
+                self._register_into_hermes_registry(spec)
         except Exception as exc:
             logger.error("Failed to load persisted JIT tools: %s", exc)

--- a/agent/jit_tool_synthesizer.py
+++ b/agent/jit_tool_synthesizer.py
@@ -1,0 +1,537 @@
+"""Hermes JIT Micro-Tool Synthesizer & Dynamic Sandbox.
+
+Enables Hermes to autonomously synthesize, AST-audit, fuzz-test, and hot-reload
+domain-specific Python micro-tools directly into its runtime ToolRegistry on demand.
+"""
+
+from __future__ import annotations
+
+import ast
+import base64
+import datetime
+import hashlib
+import importlib
+import json
+import logging
+import math
+import os
+import re
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger("hermes.jit_tools")
+
+# Strict positive allowlist for JIT sandbox imports — all other imports are rejected
+ALLOWED_MODULES = frozenset({
+    "math",
+    "re",
+    "json",
+    "collections",
+    "itertools",
+    "datetime",
+    "hashlib",
+    "urllib.parse",
+    "decimal",
+    "fractions",
+    "string",
+    "bisect",
+    "heapq",
+})
+
+DISALLOWED_CALLS = frozenset({
+    "exec",
+    "eval",
+    "__import__",
+    "open",
+    "compile",
+    "globals",
+    "locals",
+    "getattr",
+    "setattr",
+    "delattr",
+})
+
+DISALLOWED_ATTRIBUTES = frozenset({
+    "__subclasses__",
+    "__bases__",
+    "__mro__",
+    "__globals__",
+    "__code__",
+})
+
+CURRENT_POLICY_VERSION = 2
+
+
+class JITSecurityViolation(Exception):
+    """Raised when synthesized tool code violates AST security policies."""
+    pass
+
+
+class JITCompilationError(Exception):
+    """Raised when synthesized tool code fails compilation or fuzzing."""
+    pass
+
+
+@dataclass
+class SynthesizedToolSpec:
+    """Specification and metadata for a dynamically synthesized tool."""
+    name: str
+    description: str
+    parameters_schema: Dict[str, Any]
+    python_source: str
+    toolset: str = "jit_synthesized"
+    author: str = "hermes_jit_synthesizer"
+    created_at: float = field(default_factory=time.time)
+    test_vectors: List[Dict[str, Any]] = field(default_factory=list)
+    is_ephemeral: bool = True
+    session_id: Optional[str] = None
+    scope: Optional[str] = None
+    source_digest: str = ""
+    policy_version: int = CURRENT_POLICY_VERSION
+    call_count: int = 0
+    last_error: Optional[str] = None
+
+    def __post_init__(self):
+        if not self.source_digest and self.python_source:
+            self.source_digest = hashlib.sha256(self.python_source.encode("utf-8")).hexdigest()
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SynthesizedToolSpec":
+        return cls(
+            name=str(data.get("name", "")),
+            description=str(data.get("description", "")),
+            parameters_schema=dict(data.get("parameters_schema", {})),
+            python_source=str(data.get("python_source", "")),
+            toolset=str(data.get("toolset", "jit_synthesized")),
+            author=str(data.get("author", "hermes_jit_synthesizer")),
+            created_at=float(data.get("created_at", time.time())),
+            test_vectors=list(data.get("test_vectors", [])),
+            is_ephemeral=bool(data.get("is_ephemeral", True)),
+            session_id=data.get("session_id"),
+            scope=data.get("scope"),
+            source_digest=str(data.get("source_digest", "")),
+            policy_version=int(data.get("policy_version", CURRENT_POLICY_VERSION)),
+            call_count=int(data.get("call_count", 0)),
+            last_error=data.get("last_error"),
+        )
+
+
+class JITSandboxSecurityGuard(ast.NodeVisitor):
+    """Inspects tool AST for positive capability compliance and security invariants."""
+
+    def __init__(self, target_function_name: str):
+        self.target_name = target_function_name
+        self.found_target = False
+        self.violations: List[str] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if node.name == self.target_name:
+            self.found_target = True
+        self.generic_visit(node)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            base_mod = alias.name.split(".")[0]
+            if base_mod not in ALLOWED_MODULES and alias.name not in ALLOWED_MODULES:
+                self.violations.append(
+                    f"Disallowed import: '{alias.name}'. Only explicitly allowed modules may be imported: {sorted(ALLOWED_MODULES)}"
+                )
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.module:
+            base_mod = node.module.split(".")[0]
+            if base_mod not in ALLOWED_MODULES and node.module not in ALLOWED_MODULES:
+                self.violations.append(
+                    f"Disallowed from-import: '{node.module}'. Only explicitly allowed modules may be imported: {sorted(ALLOWED_MODULES)}"
+                )
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if isinstance(node.func, ast.Name):
+            if node.func.id in DISALLOWED_CALLS:
+                self.violations.append(f"Disallowed function call: {node.func.id}()")
+        elif isinstance(node.func, ast.Attribute):
+            if node.func.attr in {"system", "popen", "spawn", "fork", "execv", "kill", "unlink", "remove", "rmdir"}:
+                self.violations.append(f"Disallowed host execution/filesystem call: {node.func.attr}()")
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if node.attr in DISALLOWED_ATTRIBUTES:
+            self.violations.append(f"Disallowed attribute access: {node.attr}")
+        self.generic_visit(node)
+
+
+def audit_tool_source(name: str, source_code: str) -> None:
+    """Audit tool source code against positive-capability AST security policy."""
+    try:
+        tree = ast.parse(source_code, filename=f"<jit_{name}>")
+    except SyntaxError as exc:
+        raise JITCompilationError(f"Syntax error in synthesized code: {exc}") from exc
+
+    checker = JITSandboxSecurityGuard(name)
+    checker.visit(tree)
+
+    if not checker.found_target:
+        raise JITSecurityViolation(f"Source does not define target entry function: '{name}'")
+    if checker.violations:
+        raise JITSecurityViolation(f"Security violations detected: {'; '.join(checker.violations)}")
+
+
+class JITSandboxExecutor:
+    """Isolated execution sandbox for validating and running synthesized micro-tools."""
+
+    @staticmethod
+    def get_safe_builtins() -> Dict[str, Any]:
+        """Construct a restricted builtins dictionary with standard algorithmic utilities."""
+        safe_names = [
+            "abs", "all", "any", "ascii", "bin", "bool", "bytearray", "bytes",
+            "chr", "complex", "dict", "divmod", "enumerate", "filter", "float",
+            "format", "frozenset", "hex", "int", "isinstance", "issubclass",
+            "iter", "len", "list", "map", "max", "min", "next", "oct", "ord",
+            "pow", "range", "repr", "reversed", "round", "set", "slice",
+            "sorted", "str", "sum", "tuple", "zip",
+            "Exception", "ValueError", "TypeError", "KeyError", "IndexError",
+            "ZeroDivisionError", "ArithmeticError",
+        ]
+        import builtins
+        orig_import = builtins.__import__
+
+        def safe_import(name: str, globals=None, locals=None, fromlist=(), level=0):
+            base = name.split(".")[0]
+            if base not in ALLOWED_MODULES and name not in ALLOWED_MODULES:
+                raise ImportError(
+                    f"Import of '{name}' is disallowed in JIT sandbox. "
+                    f"Only explicitly allowed modules are permitted: {sorted(ALLOWED_MODULES)}"
+                )
+            return orig_import(name, globals, locals, fromlist, level)
+
+        safe_builtins = {k: getattr(builtins, k) for k in safe_names if hasattr(builtins, k)}
+        safe_builtins["True"] = True
+        safe_builtins["False"] = False
+        safe_builtins["None"] = None
+        safe_builtins["__import__"] = safe_import
+        return safe_builtins
+
+    @staticmethod
+    def create_sandbox_env() -> Dict[str, Any]:
+        """Create an execution environment with safe standard libraries."""
+        import collections
+        import datetime
+        import hashlib
+        import itertools
+        import json
+        import math
+        import re
+        import urllib.parse
+
+        return {
+            "__builtins__": JITSandboxExecutor.get_safe_builtins(),
+            "math": math,
+            "re": re,
+            "json": json,
+            "collections": collections,
+            "itertools": itertools,
+            "datetime": datetime,
+            "hashlib": hashlib,
+            "urllib_parse": urllib.parse,
+        }
+
+    @classmethod
+    def compile_and_extract(cls, name: str, source_code: str) -> Callable:
+        """Compile source within the sandbox and extract the entry function."""
+        env = cls.create_sandbox_env()
+        try:
+            compiled = compile(source_code, f"<jit_tool_{name}>", "exec")
+            exec(compiled, env)
+        except Exception as exc:
+            raise JITCompilationError(f"Compilation/execution error: {exc}") from exc
+
+        fn = env.get(name)
+        if not callable(fn):
+            raise JITCompilationError(f"Extracted symbol '{name}' is not callable")
+        return fn
+
+    @classmethod
+    def fuzz_test_tool(cls, name: str, fn: Callable, test_vectors: List[Dict[str, Any]]) -> None:
+        """Execute test vectors against the compiled function to verify behavioral stability."""
+        for i, vec in enumerate(test_vectors):
+            args = vec.get("inputs", {})
+            expected = vec.get("expected")
+            try:
+                result = fn(**args)
+                if expected is not None and result != expected:
+                    raise JITCompilationError(
+                        f"Test vector #{i + 1} failed: expected {expected!r}, got {result!r}"
+                    )
+            except Exception as exc:
+                if isinstance(exc, JITCompilationError):
+                    raise
+                raise JITCompilationError(f"Test vector #{i + 1} raised error: {exc}") from exc
+
+
+class JITToolSynthesizer:
+    """High-level engine managing lifecycle, verification, scoped leases, and collision-safe registration."""
+
+    def __init__(self, storage_dir: Optional[Path] = None):
+        if storage_dir is None:
+            try:
+                from hermes_constants import get_hermes_home
+                storage_dir = Path(get_hermes_home()) / "jit_tools"
+            except Exception:
+                storage_dir = Path(os.path.expanduser("~/.hermes/jit_tools"))
+
+        self.storage_dir = storage_dir
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self.meta_file = self.storage_dir / "jit_manifest.json"
+
+        self._tools: Dict[str, SynthesizedToolSpec] = {}
+        self._compiled_callables: Dict[str, Callable] = {}
+        self._session_leases: Dict[str, Set[str]] = {}  # session_id -> set of tool names
+        self.load_persisted_tools()
+
+    def synthesize_and_register(
+        self,
+        name: str,
+        description: str,
+        parameters_schema: Dict[str, Any],
+        python_source: str,
+        test_vectors: Optional[List[Dict[str, Any]]] = None,
+        is_ephemeral: bool = True,
+        session_id: Optional[str] = None,
+        scope: Optional[str] = None,
+        register_with_global_registry: bool = True,
+    ) -> Tuple[bool, str]:
+        """Audit, compile, fuzz, and register a synthesized micro-tool with collision and ownership safety."""
+        name = name.strip()
+        if not re.match(r"^[a-zA-Z0-9_]{3,64}$", name):
+            return False, f"Invalid tool name: '{name}'. Must be alphanumeric/underscores (3-64 chars)."
+
+        vectors = test_vectors or []
+
+        # 1. AST Security Audit with strict positive allowlist
+        try:
+            audit_tool_source(name, python_source)
+        except (JITSecurityViolation, JITCompilationError) as exc:
+            logger.warning("Security/Compilation check failed for JIT tool %s: %s", name, exc)
+            return False, f"Audit failed: {exc}"
+
+        # 2. Compile & Fuzz
+        try:
+            compiled_fn = JITSandboxExecutor.compile_and_extract(name, python_source)
+            if vectors:
+                JITSandboxExecutor.fuzz_test_tool(name, compiled_fn, vectors)
+        except JITCompilationError as exc:
+            logger.warning("Fuzzing/Execution error for JIT tool %s: %s", name, exc)
+            return False, f"Fuzzing failed: {exc}"
+
+        # 3. Collision check against built-in or foreign tools
+        if register_with_global_registry:
+            collision_error = self._check_registry_collision(name, scope)
+            if collision_error:
+                return False, collision_error
+
+        # 4. Create Spec with SHA-256 digest provenance
+        spec = SynthesizedToolSpec(
+            name=name,
+            description=description,
+            parameters_schema=parameters_schema,
+            python_source=python_source,
+            toolset="jit_synthesized",
+            test_vectors=vectors,
+            is_ephemeral=is_ephemeral,
+            session_id=session_id,
+            scope=scope,
+            policy_version=CURRENT_POLICY_VERSION,
+        )
+
+        # 5. Bind into Hermes Tool Registry if requested
+        if register_with_global_registry:
+            ok, reg_msg = self._register_into_hermes_registry(spec, compiled_fn)
+            if not ok:
+                return False, reg_msg
+
+        self._tools[name] = spec
+        self._compiled_callables[name] = compiled_fn
+
+        # Track session lease if scoped
+        if session_id:
+            self._session_leases.setdefault(session_id, set()).add(name)
+
+        # 6. Persist if non-ephemeral
+        if not is_ephemeral:
+            self.save_persisted_tools()
+
+        logger.info("Successfully synthesized and registered JIT micro-tool '%s'", name)
+        return True, f"Successfully synthesized tool '{name}'"
+
+    def _check_registry_collision(self, name: str, scope: Optional[str] = None) -> Optional[str]:
+        """Verify that synthesizing *name* does not collide with a built-in or foreign toolset."""
+        try:
+            from tools.registry import registry
+            existing = registry.get_entry(name, scope=scope)
+            if existing is None:
+                try:
+                    from tools.registry import discover_builtin_tools
+                    discover_builtin_tools()
+                    existing = registry.get_entry(name, scope=scope)
+                except Exception:
+                    pass
+
+            if existing is not None and existing.toolset != "jit_synthesized":
+                return (
+                    f"Cannot synthesize tool '{name}': name collides with existing tool "
+                    f"in toolset '{existing.toolset}'. Synthesis rejected to protect host built-ins."
+                )
+        except Exception:
+            pass
+        return None
+
+    def _register_into_hermes_registry(self, spec: SynthesizedToolSpec, compiled_fn: Callable) -> Tuple[bool, str]:
+        """Register into tools.registry.registry dynamically with scope attribution."""
+        try:
+            from tools.registry import registry
+
+            def handler(**kwargs) -> str:
+                spec.call_count += 1
+                try:
+                    res = compiled_fn(**kwargs)
+                    return json.dumps({"result": res}) if not isinstance(res, str) else res
+                except Exception as exc:
+                    spec.last_error = str(exc)
+                    return json.dumps({"error": str(exc)})
+
+            schema = {
+                "name": spec.name,
+                "description": spec.description,
+                "parameters": spec.parameters_schema,
+            }
+
+            registry.register(
+                name=spec.name,
+                toolset=spec.toolset,
+                schema=schema,
+                handler=handler,
+                description=spec.description,
+                scope=spec.scope,
+            )
+            return True, "Registered in ToolRegistry"
+        except Exception as exc:
+            logger.warning("Failed to bind into tools.registry.registry: %s", exc)
+            return False, f"ToolRegistry binding error: {exc}"
+
+    def execute_tool(self, name: str, **kwargs) -> Any:
+        """Execute a synthesized tool with arguments."""
+        if name not in self._compiled_callables:
+            raise KeyError(f"JIT tool '{name}' is not registered.")
+        spec = self._tools[name]
+        spec.call_count += 1
+        return self._compiled_callables[name](**kwargs)
+
+    def deregister(self, name: str, scope: Optional[str] = None) -> bool:
+        """Safely remove a tool from memory and registry, strictly guarding foreign tools."""
+        if name not in self._tools:
+            return False
+
+        spec = self._tools[name]
+        del self._tools[name]
+        self._compiled_callables.pop(name, None)
+
+        # Remove from session leases if tracked
+        if spec.session_id and spec.session_id in self._session_leases:
+            self._session_leases[spec.session_id].discard(name)
+
+        target_scope = scope if scope is not None else spec.scope
+
+        try:
+            from tools.registry import registry
+            entry = registry.get_entry(name, scope=target_scope)
+            # CAS-style safety: only deregister if the entry belongs to jit_synthesized
+            if entry is not None and entry.toolset == "jit_synthesized":
+                if hasattr(registry, "deregister"):
+                    registry.deregister(name, scope=target_scope)
+        except Exception as exc:
+            logger.debug("Deregistration notice: %s", exc)
+
+        if not spec.is_ephemeral:
+            self.save_persisted_tools()
+        return True
+
+    def revoke_session_tools(self, session_id: str) -> int:
+        """Revoke and deregister all ephemeral tools leased to a finalized session."""
+        leased_names = list(self._session_leases.get(session_id, set()))
+        revoked_count = 0
+        for name in leased_names:
+            if self.deregister(name):
+                revoked_count += 1
+        self._session_leases.pop(session_id, None)
+        return revoked_count
+
+    def prune_ephemeral(self) -> int:
+        """Remove all ephemeral tools across all sessions."""
+        to_prune = [k for k, v in self._tools.items() if v.is_ephemeral]
+        for k in to_prune:
+            self.deregister(k)
+        return len(to_prune)
+
+    def list_tools(self) -> List[SynthesizedToolSpec]:
+        """Return all active synthesized tools."""
+        return list(self._tools.values())
+
+    def get_tool(self, name: str) -> Optional[SynthesizedToolSpec]:
+        return self._tools.get(name)
+
+    def save_persisted_tools(self) -> None:
+        """Persist non-ephemeral tools with source digest provenance to disk."""
+        non_ephemeral = {k: v.to_dict() for k, v in self._tools.items() if not v.is_ephemeral}
+        try:
+            self.meta_file.write_text(json.dumps(non_ephemeral, indent=2), encoding="utf-8")
+        except Exception as exc:
+            logger.error("Failed to save persisted JIT tools: %s", exc)
+
+    def load_persisted_tools(self) -> None:
+        """Restore non-ephemeral tools, enforcing full re-audit under current admission policy."""
+        if not self.meta_file.exists():
+            return
+        try:
+            data = json.loads(self.meta_file.read_text(encoding="utf-8"))
+            for name, spec_dict in data.items():
+                spec = SynthesizedToolSpec.from_dict(spec_dict)
+
+                # 1. Digest provenance check
+                expected_digest = hashlib.sha256(spec.python_source.encode("utf-8")).hexdigest()
+                if spec.source_digest and spec.source_digest != expected_digest:
+                    logger.warning(
+                        "Manifest digest mismatch for durable JIT tool '%s'; rejecting restore.", name
+                    )
+                    continue
+
+                # 2. Re-run current AST security policy audit (fail closed on tightened rules)
+                try:
+                    audit_tool_source(spec.name, spec.python_source)
+                except (JITSecurityViolation, JITCompilationError) as exc:
+                    logger.warning(
+                        "Durable JIT tool '%s' rejected by current security policy: %s", name, exc
+                    )
+                    continue
+
+                # 3. Re-compile and fuzz against stored test vectors
+                try:
+                    compiled = JITSandboxExecutor.compile_and_extract(spec.name, spec.python_source)
+                    if spec.test_vectors:
+                        JITSandboxExecutor.fuzz_test_tool(spec.name, compiled, spec.test_vectors)
+                except Exception as exc:
+                    logger.warning("Durable JIT tool '%s' failed compilation/fuzzing: %s", name, exc)
+                    continue
+
+                self._tools[spec.name] = spec
+                self._compiled_callables[spec.name] = compiled
+                self._register_into_hermes_registry(spec, compiled)
+        except Exception as exc:
+            logger.error("Failed to load persisted JIT tools: %s", exc)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3202,6 +3202,9 @@ def _build_cli_parser():
     from hermes_cli.subcommands.peer import build_peer_parser
     build_peer_parser(subparsers)
 
+    from hermes_cli.subcommands.jit_cmd import build_jit_parser
+    build_jit_parser(subparsers)
+
     from hermes_cli.portal_cli import add_parser as _add_portal_parser
     _add_portal_parser(subparsers)
 

--- a/hermes_cli/subcommands/jit_cmd.py
+++ b/hermes_cli/subcommands/jit_cmd.py
@@ -1,0 +1,94 @@
+"""``hermes jit`` — JIT Micro-Tool Synthesizer & Dynamic Sandbox.
+
+Manage, inspect, and test dynamically synthesized runtime micro-tools.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from agent.jit_tool_synthesizer import (
+    JITSandboxExecutor,
+    JITToolSynthesizer,
+)
+
+
+def jit_list(args: argparse.Namespace) -> int:
+    synth = JITToolSynthesizer()
+    tools = synth.list_tools()
+    if not tools:
+        print("No JIT micro-tools currently registered.")
+        return 0
+
+    print(f"{'TOOL NAME':<24} {'CALLS':<8} {'EPHEMERAL':<12} {'DESCRIPTION'}")
+    print("-" * 75)
+    for t in tools:
+        eph = "Yes" if t.is_ephemeral else "Durable"
+        desc = t.description[:40] + ("..." if len(t.description) > 40 else "")
+        print(f"{t.name:<24} {t.call_count:<8} {eph:<12} {desc}")
+    return 0
+
+
+def jit_test(args: argparse.Namespace) -> int:
+    synth = JITToolSynthesizer()
+    tool = synth.get_tool(args.name)
+    if not tool:
+        print(f"\033[31m[-] Tool '{args.name}' not found in JIT registry.\033[0m")
+        return 1
+
+    print(f"Testing JIT tool '{tool.name}' with {len(tool.test_vectors)} test vectors in sandbox...")
+    try:
+        compiled = JITSandboxExecutor.compile_and_extract(tool.name, tool.python_source)
+        if tool.test_vectors:
+            JITSandboxExecutor.fuzz_test_tool(tool.name, compiled, tool.test_vectors)
+        print(f"\033[32m[+] All test vectors passed successfully for '{tool.name}'!\033[0m")
+        return 0
+    except Exception as exc:
+        print(f"\033[31m[-] Sandbox test failed: {exc}\033[0m")
+        return 1
+
+
+def jit_prune(args: argparse.Namespace) -> int:
+    synth = JITToolSynthesizer()
+    count = synth.prune_ephemeral()
+    print(f"Pruned {count} ephemeral JIT micro-tools.")
+    return 0
+
+
+def jit_remove(args: argparse.Namespace) -> int:
+    synth = JITToolSynthesizer()
+    if synth.deregister(args.name):
+        print(f"\033[32mSuccessfully removed tool '{args.name}'.\033[0m")
+        return 0
+    else:
+        print(f"\033[31mTool '{args.name}' not found.\033[0m")
+        return 1
+
+
+def build_jit_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "jit",
+        help="JIT Micro-Tool Synthesizer & Dynamic Sandbox",
+        description="Inspect, test, and manage on-the-fly synthesized micro-tools.",
+    )
+    sub = parser.add_subparsers(dest="jit_action")
+
+    # list
+    p_list = sub.add_parser("list", help="List active synthesized JIT micro-tools")
+    p_list.set_defaults(func=jit_list)
+
+    # test
+    p_test = sub.add_parser("test", help="Test a synthesized tool against test vectors in sandbox")
+    p_test.add_argument("name", help="Name of the JIT tool")
+    p_test.set_defaults(func=jit_test)
+
+    # prune
+    p_prune = sub.add_parser("prune", help="Prune all ephemeral session-scoped JIT tools")
+    p_prune.set_defaults(func=jit_prune)
+
+    # remove
+    p_remove = sub.add_parser("remove", help="Deregister and remove a JIT tool")
+    p_remove.add_argument("name", help="Name of the JIT tool to remove")
+    p_remove.set_defaults(func=jit_remove)

--- a/tests/agent/test_jit_tools.py
+++ b/tests/agent/test_jit_tools.py
@@ -13,7 +13,9 @@ from agent.jit_tool_synthesizer import (
     JITSecurityViolation,
     JITToolSynthesizer,
     audit_tool_source,
+    cleanup_session_jit_tools,
 )
+from tools.registry import registry, ToolRegistry
 
 
 @pytest.fixture
@@ -164,27 +166,44 @@ def extract_tickers(text: str) -> list:
         python_source=src,
         test_vectors=vectors,
         is_ephemeral=True,
+        session_id="session-test-tickers",
     )
     assert ok
     assert "Successfully synthesized tool" in msg
 
     # Execute
-    res = synth.execute_tool("extract_tickers", text="Long $BTC and $ETH!")
+    res = synth.execute_tool("extract_tickers", session_id="session-test-tickers", text="Long $BTC and $ETH!")
     assert res == ["BTC", "ETH"]
 
-    tool_spec = synth.get_tool("extract_tickers")
+    tool_spec = synth.get_tool("extract_tickers", session_id="session-test-tickers")
     assert tool_spec is not None
     assert tool_spec.call_count == 1
     assert len(tool_spec.source_digest) == 64
 
+    synth.deregister("extract_tickers", session_id="session-test-tickers")
+
+
+def test_ephemeral_requires_session_id(temp_jit_dir):
+    synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
+    src = "def no_owner(): return 42"
+    ok, msg = synth.synthesize_and_register(
+        name="no_owner",
+        description="No owner tool",
+        parameters_schema={},
+        python_source=src,
+        is_ephemeral=True,
+        session_id=None,
+    )
+    assert not ok
+    assert "explicit session_id owner" in msg
+
 
 def test_collision_detection_protects_builtins(temp_jit_dir):
-    from tools.registry import registry
     registry.register(
         name="host_terminal",
         toolset="terminal",
         schema={"name": "host_terminal"},
-        handler=lambda: "real",
+        handler=lambda args=None, **kw: "real",
     )
 
     synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
@@ -196,10 +215,15 @@ def test_collision_detection_protects_builtins(temp_jit_dir):
         description="Fake terminal tool",
         parameters_schema={},
         python_source=src,
+        is_ephemeral=True,
+        session_id="sess-collision",
     )
-    # Built-in host_terminal already exists in ToolRegistry, so synthesis must be rejected
     assert not ok
     assert "collides with existing tool in toolset 'terminal'" in msg
+
+    # Cleanup test entry
+    entry = registry.snapshot_registration("host_terminal")
+    registry.restore_registration("host_terminal", current=entry, previous=None)
 
 
 def test_session_lease_and_scoped_revocation(temp_jit_dir):
@@ -215,12 +239,12 @@ def test_session_lease_and_scoped_revocation(temp_jit_dir):
         scope="profile-test",
     )
     assert ok
-    assert synth.get_tool("session_helper") is not None
+    assert synth.get_tool("session_helper", session_id="session-xyz-123", scope="profile-test") is not None
 
     # Revoking session-xyz-123 should cleanly deregister session_helper
     revoked = synth.revoke_session_tools("session-xyz-123")
     assert revoked == 1
-    assert synth.get_tool("session_helper") is None
+    assert synth.get_tool("session_helper", session_id="session-xyz-123", scope="profile-test") is None
 
 
 def test_durable_persistence_with_digest_and_reaudit(temp_jit_dir):
@@ -253,14 +277,432 @@ def math_cube(x: int) -> int:
     manifest_path.write_text(json.dumps(manifest_data), encoding="utf-8")
 
     synth3 = JITToolSynthesizer(storage_dir=temp_jit_dir)
-    # Must reject tampered tool
     assert synth3.get_tool("math_cube") is None
 
+    synth2.deregister("math_cube")
 
-def test_deregister_preserves_foreign_tools(temp_jit_dir):
+
+def test_deregister_preserves_foreign_and_newer_entries(temp_jit_dir):
     synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
-    src = "def custom_calc(a: int): return a + 5"
-    synth.synthesize_and_register("custom_calc", "Calculator", {}, src)
 
-    assert synth.deregister("custom_calc")
-    assert synth.get_tool("custom_calc") is None
+    # Install a foreign tool in registry
+    foreign_handler = lambda args=None, **kw: "foreign_result"
+    registry.register(
+        name="foreign_tool",
+        toolset="custom_plugin",
+        schema={"name": "foreign_tool"},
+        handler=foreign_handler,
+    )
+    foreign_entry = registry.snapshot_registration("foreign_tool")
+    assert foreign_entry is not None
+
+    # Synthesizer with no registry authority attempts deregister -> should fail and NOT touch registry
+    assert not synth.deregister("foreign_tool")
+    assert registry.snapshot_registration("foreign_tool") is foreign_entry
+
+    # Cleanup foreign entry
+    registry.restore_registration("foreign_tool", current=foreign_entry, previous=None)
+
+
+def test_host_builtins_subscript_escapes_blocked():
+    # collections.__builtins__['open'] bypass attempt
+    host_read_src = """
+import collections
+
+def host_read(p: str):
+    return collections.__builtins__['open'](p).read()
+"""
+    with pytest.raises(JITSecurityViolation) as exc_info:
+        audit_tool_source("host_read", host_read_src)
+    assert "Disallowed attribute access: '__builtins__'" in str(exc_info.value) or "Disallowed subscript access" in str(exc_info.value)
+
+    # collections.__builtins__['__import__'] bypass attempt
+    host_pid_src = """
+import collections
+
+def host_pid():
+    return collections.__builtins__['__import__']('os').getpid()
+"""
+    with pytest.raises(JITSecurityViolation) as exc_info:
+        audit_tool_source("host_pid", host_pid_src)
+    assert "Disallowed attribute access: '__builtins__'" in str(exc_info.value) or "Disallowed subscript access" in str(exc_info.value)
+
+
+def test_host_module_mutation_pre_effect_contained(temp_jit_dir):
+    import json as host_json
+    assert not hasattr(host_json, "REVIEW_SENTINEL")
+
+    # Attempt module-level mutation followed by a failing test vector
+    mutator_src = """
+import json
+json.REVIEW_SENTINEL = 'HOST_MUTATION'
+
+def mutator_tool() -> int:
+    return 1
+"""
+    synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
+
+    # 1. AST check catches attribute assignment
+    with pytest.raises(JITSecurityViolation) as exc_info:
+        audit_tool_source("mutator_tool", mutator_src)
+    assert "Disallowed mutation of module or object attribute: 'REVIEW_SENTINEL'" in str(exc_info.value)
+
+    # 2. Even directly testing fuzzing via worker subprocess isolates the mutation completely
+    with pytest.raises(JITCompilationError):
+        JITSandboxExecutor.fuzz_test_tool(
+            "mutator_tool",
+            mutator_src,
+            test_vectors=[{"inputs": {}, "expected": 999}],  # intentionally fail
+        )
+
+    # Assert host interpreter's json module was NEVER polluted
+    assert hasattr(host_json, "REVIEW_SENTINEL") is False
+
+
+def test_multi_session_same_name_independent_isolation(temp_jit_dir):
+    synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
+
+    src_a = "def shared_calc(x: int): return x * 2"
+    src_b = "def shared_calc(x: int): return x * 3"
+
+    ok_a, _ = synth.synthesize_and_register(
+        name="shared_calc",
+        description="Calc for session A",
+        parameters_schema={"type": "object", "properties": {"x": {"type": "integer"}}},
+        python_source=src_a,
+        session_id="session-A",
+        scope="profile-A",
+    )
+    assert ok_a
+
+    ok_b, _ = synth.synthesize_and_register(
+        name="shared_calc",
+        description="Calc for session B",
+        parameters_schema={"type": "object", "properties": {"x": {"type": "integer"}}},
+        python_source=src_b,
+        session_id="session-B",
+        scope="profile-B",
+    )
+    assert ok_b
+
+    # Verify both exist simultaneously in both scopes
+    entry_a = registry.snapshot_registration("shared_calc", scope="profile-A")
+    entry_b = registry.snapshot_registration("shared_calc", scope="profile-B")
+    assert entry_a is not None
+    assert entry_b is not None
+    assert entry_a is not entry_b
+
+    # Dispatch to both
+    res_a = registry.dispatch("shared_calc", {"x": 5}, scope="profile-A")
+    assert json.loads(res_a).get("result") == 10
+
+    res_b = registry.dispatch("shared_calc", {"x": 5}, scope="profile-B")
+    assert json.loads(res_b).get("result") == 15
+
+    # Revoke Session A
+    revoked = synth.revoke_session_tools("session-A")
+    assert revoked == 1
+
+    # Session A entry is gone from profile-A
+    assert registry.snapshot_registration("shared_calc", scope="profile-A") is None
+    assert synth.get_tool("shared_calc", session_id="session-A", scope="profile-A") is None
+
+    # Session B entry STILL EXISTS and functions in profile-B!
+    assert registry.snapshot_registration("shared_calc", scope="profile-B") is entry_b
+    assert synth.get_tool("shared_calc", session_id="session-B", scope="profile-B") is not None
+    res_b_after = registry.dispatch("shared_calc", {"x": 5}, scope="profile-B")
+    assert json.loads(res_b_after).get("result") == 15
+
+    # Cleanup Session B
+    synth.revoke_session_tools("session-B")
+    assert registry.snapshot_registration("shared_calc", scope="profile-B") is None
+
+
+def test_cas_registration_ownership_and_unregistered_isolation(temp_jit_dir):
+    synth_a = JITToolSynthesizer(storage_dir=temp_jit_dir)
+    synth_b = JITToolSynthesizer(storage_dir=temp_jit_dir)
+
+    src = "def token_tool(x: int): return x + 1"
+    # A registers globally
+    ok, _ = synth_a.synthesize_and_register(
+        name="token_tool",
+        description="A's tool",
+        parameters_schema={},
+        python_source=src,
+        is_ephemeral=True,
+        session_id="session-reg",
+        register_with_global_registry=True,
+    )
+    assert ok
+    reg_entry = registry.snapshot_registration("token_tool")
+    assert reg_entry is not None
+
+    # B synthesizes same tool with register_with_global_registry=False
+    ok_b, _ = synth_b.synthesize_and_register(
+        name="token_tool",
+        description="B's unregistered tool",
+        parameters_schema={},
+        python_source=src,
+        is_ephemeral=True,
+        session_id="session-unreg",
+        register_with_global_registry=False,
+    )
+    assert ok_b
+
+    # B deregisters -> must have NO teardown authority over registry slot
+    assert synth_b.deregister("token_tool", session_id="session-unreg")
+    assert registry.snapshot_registration("token_tool") is reg_entry  # Untouched!
+
+    # Now register a newer entry in the same toolset
+    newer_handler = lambda args=None, **kw: "newer"
+    registry.register(
+        name="token_tool",
+        toolset="jit_synthesized",
+        schema={"name": "token_tool"},
+        handler=newer_handler,
+    )
+    newer_entry = registry.snapshot_registration("token_tool")
+    assert newer_entry is not reg_entry
+
+    # A deregisters with its now-stale receipt -> CAS restore must NOT remove newer_entry
+    assert synth_a.deregister("token_tool", session_id="session-reg")
+    assert registry.snapshot_registration("token_tool") is newer_entry  # Preserved!
+
+    # Cleanup newer entry
+    registry.restore_registration("token_tool", current=newer_entry, previous=None)
+
+
+def test_tool_registry_dispatch_calling_convention(temp_jit_dir):
+    synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
+
+    src = """
+def times_ten(x: int) -> int:
+    if x == 0:
+        raise ValueError("x cannot be 0")
+    return x * 10
+"""
+    ok, _ = synth.synthesize_and_register(
+        name="times_ten",
+        description="Multiply by ten",
+        parameters_schema={"type": "object", "properties": {"x": {"type": "integer"}}},
+        python_source=src,
+        is_ephemeral=True,
+        session_id="dispatch-session",
+    )
+    assert ok
+
+    # Real ToolRegistry.dispatch passes (args_dict, **host_context_kwargs)
+    res_str = registry.dispatch(
+        "times_ten",
+        {"x": 4},
+        session_id="dispatch-session",
+        profile="default",
+        agent=None,
+    )
+    parsed = json.loads(res_str)
+    assert parsed.get("result") == 40
+
+    # Test error path through real ToolRegistry.dispatch
+    err_str = registry.dispatch(
+        "times_ten",
+        {"x": 0},
+        session_id="dispatch-session",
+        profile="default",
+        agent=None,
+    )
+    parsed_err = json.loads(err_str)
+    assert "error" in parsed_err
+    assert "x cannot be 0" in parsed_err["error"]
+
+    synth.deregister("times_ten", session_id="dispatch-session")
+
+
+def test_owner_finalization_cleans_ephemeral_tools(temp_jit_dir):
+    synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
+
+    src = "def finalized_tool(): return 'done'"
+    ok, _ = synth.synthesize_and_register(
+        name="finalized_tool",
+        description="Ephemeral tool for finalization",
+        parameters_schema={},
+        python_source=src,
+        is_ephemeral=True,
+        session_id="target-session-to-finalize",
+    )
+    assert ok
+    assert synth.get_tool("finalized_tool", session_id="target-session-to-finalize") is not None
+    assert registry.snapshot_registration("finalized_tool") is not None
+
+    # Invoke owner finalization hook (same hook called by agent.close())
+    count = cleanup_session_jit_tools("target-session-to-finalize")
+    assert count == 1
+    assert synth.get_tool("finalized_tool", session_id="target-session-to-finalize") is None
+    assert registry.snapshot_registration("finalized_tool") is None
+
+
+def test_computed_key_and_frame_traversal_host_effects_blocked():
+    """P0 regression: computed key and frame traversal via collections._sys must be rejected."""
+    traversal_code = """
+import collections
+
+def host_read(p: str):
+    return collections._sys._getframe().f_back.f_builtins["op" + "en"](p).read()
+"""
+    # 1. AST Security Audit rejection
+    with pytest.raises(JITSecurityViolation) as exc_info:
+        audit_tool_source("host_read", traversal_code)
+    err = str(exc_info.value)
+    assert "_sys" in err or "f_back" in err or "f_builtins" in err or "_getframe" in err
+
+    # 2. Worker runtime containment: even if bypassed to worker, module leaks are purged
+    with pytest.raises(JITCompilationError) as exc_worker:
+        JITSandboxExecutor.execute_in_worker(
+            "host_read",
+            traversal_code,
+            action="execute",
+            kwargs={"p": "pyproject.toml"},
+        )
+    assert "no attribute '_sys'" in str(exc_worker.value) or "NoneType" in str(exc_worker.value) or "open" in str(exc_worker.value)
+
+
+def test_same_scope_session_isolation_and_wrong_session_dispatch(temp_jit_dir):
+    """P1 regression: same-scope tools owned by different sessions enforce session caller authority."""
+    synth_a = JITToolSynthesizer(storage_dir=temp_jit_dir / "sa")
+    synth_b = JITToolSynthesizer(storage_dir=temp_jit_dir / "sb")
+
+    shared_scope = "common_profile_scope"
+
+    src_a = "def shared_calc(x: int): return x * 2"
+    src_b = "def shared_calc(x: int): return x * 10"
+
+    # Session A synthesizes in shared_scope
+    ok_a, _ = synth_a.synthesize_and_register(
+        name="shared_calc",
+        description="Calc A",
+        parameters_schema={"type": "object", "properties": {"x": {"type": "integer"}}},
+        python_source=src_a,
+        is_ephemeral=True,
+        session_id="session-AAA",
+        scope=shared_scope,
+    )
+    assert ok_a
+
+    # Dispatch as session-AAA succeeds
+    res_a = registry.dispatch("shared_calc", {"x": 3}, scope=shared_scope, session_id="session-AAA")
+    assert json.loads(res_a).get("result") == 6
+
+    # Session B registers in same scope
+    ok_b, _ = synth_b.synthesize_and_register(
+        name="shared_calc",
+        description="Calc B",
+        parameters_schema={"type": "object", "properties": {"x": {"type": "integer"}}},
+        python_source=src_b,
+        is_ephemeral=True,
+        session_id="session-BBB",
+        scope=shared_scope,
+    )
+    assert ok_b
+
+    # Dispatch with session-BBB succeeds
+    res_b = registry.dispatch("shared_calc", {"x": 3}, scope=shared_scope, session_id="session-BBB")
+    assert json.loads(res_b).get("result") == 30
+
+    # Wrong-session dispatch: session-AAA calling while session-BBB holds slot is rejected with PermissionError
+    err_dispatch = registry.dispatch("shared_calc", {"x": 3}, scope=shared_scope, session_id="session-AAA")
+    assert "PermissionError" in err_dispatch
+    assert "is owned by session 'session-BBB'" in err_dispatch
+
+    # Cleanup
+    synth_b.deregister("shared_calc", session_id="session-BBB", scope=shared_scope)
+    synth_a.deregister("shared_calc", session_id="session-AAA", scope=shared_scope)
+
+
+def test_cas_restoration_of_previous_live_owner_across_synthesizers(temp_jit_dir):
+    """P1 regression: newer JIT owner teardown restores still-live previous owner across synthesizers."""
+    synth_a = JITToolSynthesizer(storage_dir=temp_jit_dir / "ca")
+    synth_b = JITToolSynthesizer(storage_dir=temp_jit_dir / "cb")
+
+    scope = "cas_scope"
+
+    src_a = "def cascaded_tool(val: int): return val + 1"
+    src_b = "def cascaded_tool(val: int): return val + 100"
+
+    # Synth A registers tool
+    ok_a, _ = synth_a.synthesize_and_register(
+        name="cascaded_tool",
+        description="Tool A",
+        parameters_schema={"type": "object", "properties": {"val": {"type": "integer"}}},
+        python_source=src_a,
+        is_ephemeral=True,
+        session_id="session-owner-A",
+        scope=scope,
+    )
+    assert ok_a
+    entry_a = registry.snapshot_registration("cascaded_tool", scope=scope)
+    assert entry_a is not None
+
+    # Synth B registers tool under same name/scope (new owner)
+    ok_b, _ = synth_b.synthesize_and_register(
+        name="cascaded_tool",
+        description="Tool B",
+        parameters_schema={"type": "object", "properties": {"val": {"type": "integer"}}},
+        python_source=src_b,
+        is_ephemeral=True,
+        session_id="session-owner-B",
+        scope=scope,
+    )
+    assert ok_b
+    entry_b = registry.snapshot_registration("cascaded_tool", scope=scope)
+    assert entry_b is not None
+    assert entry_b is not entry_a
+
+    # Verify B's result
+    res_b = registry.dispatch("cascaded_tool", {"val": 5}, scope=scope, session_id="session-owner-B")
+    assert json.loads(res_b).get("result") == 105
+
+    # Synth B tears down -> MUST restore still-live Synth A's entry!
+    synth_b.deregister("cascaded_tool", session_id="session-owner-B", scope=scope)
+    restored_entry = registry.snapshot_registration("cascaded_tool", scope=scope)
+    assert restored_entry is entry_a
+
+    # Dispatch now executes Synth A's tool under session-owner-A
+    res_a = registry.dispatch("cascaded_tool", {"val": 5}, scope=scope, session_id="session-owner-A")
+    assert json.loads(res_a).get("result") == 6
+
+    # Synth A tears down -> cleans up registry slot completely
+    synth_a.deregister("cascaded_tool", session_id="session-owner-A", scope=scope)
+    assert registry.snapshot_registration("cascaded_tool", scope=scope) is None
+
+
+def test_close_task_resources_with_distinct_session_and_task_id(temp_jit_dir):
+    """P1 regression: client_lifecycle _close_task_resources cleans up session-owned JIT tools when task_id != session_id."""
+    from agent.client_lifecycle import ClientLifecycleMixin
+
+    class DummyLifecycleAgent(ClientLifecycleMixin):
+        def __init__(self, session_id: str):
+            self.session_id = session_id
+            self._process_owner_task_ids = ()
+
+    synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
+
+    src = "def lifecycle_tool(): return 'ok'"
+    ok, _ = synth.synthesize_and_register(
+        name="lifecycle_tool",
+        description="Lifecycle ephemeral tool",
+        parameters_schema={},
+        python_source=src,
+        is_ephemeral=True,
+        session_id="owning-session-777",
+    )
+    assert ok
+    assert synth.get_tool("lifecycle_tool", session_id="owning-session-777") is not None
+    assert registry.snapshot_registration("lifecycle_tool") is not None
+
+    # Agent has session_id = 'owning-session-777', closing a delegated task 'delegated-task-999'
+    agent = DummyLifecycleAgent(session_id="owning-session-777")
+    agent._close_task_resources(task_id="delegated-task-999")
+
+    # Ephemeral tool owned by 'owning-session-777' must be cleaned up
+    assert synth.get_tool("lifecycle_tool", session_id="owning-session-777") is None
+    assert registry.snapshot_registration("lifecycle_tool") is None
+

--- a/tests/agent/test_jit_tools.py
+++ b/tests/agent/test_jit_tools.py
@@ -1,0 +1,266 @@
+"""Tests for the Hermes JIT Micro-Tool Synthesizer & Dynamic Sandbox."""
+
+import hashlib
+import json
+from pathlib import Path
+import pytest
+
+from agent.jit_tool_synthesizer import (
+    ALLOWED_MODULES,
+    JITCompilationError,
+    JITSandboxExecutor,
+    JITSandboxSecurityGuard,
+    JITSecurityViolation,
+    JITToolSynthesizer,
+    audit_tool_source,
+)
+
+
+@pytest.fixture
+def temp_jit_dir(tmp_path):
+    jit_dir = tmp_path / "hermes_jit_tools"
+    jit_dir.mkdir(parents=True, exist_ok=True)
+    return jit_dir
+
+
+def test_security_audit_blocks_non_allowlisted_modules():
+    # Attempting to import os (not in allowlist) must be rejected
+    os_src = """
+import os
+
+def check_env(k: str):
+    return os.environ.get(k)
+"""
+    with pytest.raises(JITSecurityViolation) as exc_info:
+        audit_tool_source("check_env", os_src)
+    assert "Disallowed import: 'os'" in str(exc_info.value)
+
+    # Attempting to import pathlib
+    pathlib_src = """
+from pathlib import Path
+
+def read_secret(p: str):
+    return Path(p).read_text()
+"""
+    with pytest.raises(JITSecurityViolation) as exc_info:
+        audit_tool_source("read_secret", pathlib_src)
+    assert "Disallowed from-import: 'pathlib'" in str(exc_info.value)
+
+
+def test_adversarial_network_and_subprocess_escapes_blocked():
+    # Attempting urllib.request escape
+    net_src = """
+import urllib.request
+
+def exfiltrate(url: str):
+    return urllib.request.urlopen(url).read()
+"""
+    with pytest.raises(JITSecurityViolation) as exc_info:
+        audit_tool_source("exfiltrate", net_src)
+    assert "Disallowed import: 'urllib.request'" in str(exc_info.value)
+
+    # Subprocess escape
+    sub_src = """
+import subprocess
+
+def run_sh(cmd: str):
+    return subprocess.getoutput(cmd)
+"""
+    with pytest.raises(JITSecurityViolation) as exc_info:
+        audit_tool_source("run_sh", sub_src)
+    assert "Disallowed import: 'subprocess'" in str(exc_info.value)
+
+
+def test_security_audit_blocks_eval_exec():
+    malicious_src = """
+def eval_tool(code: str):
+    return eval(code)
+"""
+    with pytest.raises(JITSecurityViolation) as exc_info:
+        audit_tool_source("eval_tool", malicious_src)
+    assert "Disallowed function call: eval()" in str(exc_info.value)
+
+
+def test_security_audit_requires_target_function():
+    src = """
+def other_func():
+    return 42
+"""
+    with pytest.raises(JITSecurityViolation) as exc_info:
+        audit_tool_source("my_expected_tool", src)
+    assert "does not define target entry function: 'my_expected_tool'" in str(exc_info.value)
+
+
+def test_sandbox_safe_import_allows_only_allowlist():
+    safe_builtins = JITSandboxExecutor.get_safe_builtins()
+    importer = safe_builtins["__import__"]
+
+    # math is allowed
+    m = importer("math")
+    assert m.sqrt(16) == 4.0
+
+    # re is allowed
+    r = importer("re")
+    assert r.findall(r"\d+", "123") == ["123"]
+
+    # os is disallowed at runtime
+    with pytest.raises(ImportError) as exc_info:
+        importer("os")
+    assert "is disallowed in JIT sandbox" in str(exc_info.value)
+
+
+def test_sandbox_compilation_and_fuzzing_success():
+    src = """
+def compound_interest(principal: float, rate: float, periods: int) -> float:
+    return round(principal * ((1.0 + rate) ** periods), 2)
+"""
+    fn = JITSandboxExecutor.compile_and_extract("compound_interest", src)
+    assert callable(fn)
+    assert fn(1000.0, 0.05, 2) == 1102.50
+
+    vectors = [
+        {"inputs": {"principal": 100.0, "rate": 0.1, "periods": 1}, "expected": 110.0},
+        {"inputs": {"principal": 1000.0, "rate": 0.05, "periods": 2}, "expected": 1102.50},
+    ]
+    JITSandboxExecutor.fuzz_test_tool("compound_interest", fn, vectors)
+
+
+def test_sandbox_fuzzing_catches_runtime_mismatch():
+    buggy_src = """
+def add_numbers(a: int, b: int) -> int:
+    return a - b  # Bug intentionally injected
+"""
+    fn = JITSandboxExecutor.compile_and_extract("add_numbers", buggy_src)
+    vectors = [
+        {"inputs": {"a": 5, "b": 3}, "expected": 8},
+    ]
+    with pytest.raises(JITCompilationError) as exc_info:
+        JITSandboxExecutor.fuzz_test_tool("add_numbers", fn, vectors)
+    assert "expected 8, got 2" in str(exc_info.value)
+
+
+def test_synthesizer_register_and_execute(temp_jit_dir):
+    synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
+
+    src = """
+import re
+
+def extract_tickers(text: str) -> list:
+    return re.findall(r"\\$([A-Z]{1,5})\\b", text)
+"""
+    schema = {
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"],
+    }
+    vectors = [
+        {"inputs": {"text": "Buying $AAPL and $NVDA today"}, "expected": ["AAPL", "NVDA"]},
+    ]
+
+    ok, msg = synth.synthesize_and_register(
+        name="extract_tickers",
+        description="Extract cashtags from social posts",
+        parameters_schema=schema,
+        python_source=src,
+        test_vectors=vectors,
+        is_ephemeral=True,
+    )
+    assert ok
+    assert "Successfully synthesized tool" in msg
+
+    # Execute
+    res = synth.execute_tool("extract_tickers", text="Long $BTC and $ETH!")
+    assert res == ["BTC", "ETH"]
+
+    tool_spec = synth.get_tool("extract_tickers")
+    assert tool_spec is not None
+    assert tool_spec.call_count == 1
+    assert len(tool_spec.source_digest) == 64
+
+
+def test_collision_detection_protects_builtins(temp_jit_dir):
+    from tools.registry import registry
+    registry.register(
+        name="host_terminal",
+        toolset="terminal",
+        schema={"name": "host_terminal"},
+        handler=lambda: "real",
+    )
+
+    synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
+
+    # Attempt to synthesize a tool named 'host_terminal'
+    src = "def host_terminal(): return 'fake'"
+    ok, msg = synth.synthesize_and_register(
+        name="host_terminal",
+        description="Fake terminal tool",
+        parameters_schema={},
+        python_source=src,
+    )
+    # Built-in host_terminal already exists in ToolRegistry, so synthesis must be rejected
+    assert not ok
+    assert "collides with existing tool in toolset 'terminal'" in msg
+
+
+def test_session_lease_and_scoped_revocation(temp_jit_dir):
+    synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
+
+    src = "def session_helper(x: int): return x * 10"
+    ok, _ = synth.synthesize_and_register(
+        name="session_helper",
+        description="Helper for session A",
+        parameters_schema={},
+        python_source=src,
+        session_id="session-xyz-123",
+        scope="profile-test",
+    )
+    assert ok
+    assert synth.get_tool("session_helper") is not None
+
+    # Revoking session-xyz-123 should cleanly deregister session_helper
+    revoked = synth.revoke_session_tools("session-xyz-123")
+    assert revoked == 1
+    assert synth.get_tool("session_helper") is None
+
+
+def test_durable_persistence_with_digest_and_reaudit(temp_jit_dir):
+    synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
+
+    durable_src = """
+def math_cube(x: int) -> int:
+    return x ** 3
+"""
+    synth.synthesize_and_register(
+        name="math_cube",
+        description="Cube calculator",
+        parameters_schema={},
+        python_source=durable_src,
+        test_vectors=[{"inputs": {"x": 3}, "expected": 27}],
+        is_ephemeral=False,
+    )
+
+    # Re-instantiate from disk
+    synth2 = JITToolSynthesizer(storage_dir=temp_jit_dir)
+    restored = synth2.get_tool("math_cube")
+    assert restored is not None
+    assert restored.source_digest == hashlib.sha256(durable_src.encode("utf-8")).hexdigest()
+    assert synth2.execute_tool("math_cube", x=4) == 64
+
+    # Tamper test: corrupt source in manifest so digest fails
+    manifest_path = temp_jit_dir / "jit_manifest.json"
+    manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest_data["math_cube"]["source_digest"] = "corrupted_digest_hash_12345"
+    manifest_path.write_text(json.dumps(manifest_data), encoding="utf-8")
+
+    synth3 = JITToolSynthesizer(storage_dir=temp_jit_dir)
+    # Must reject tampered tool
+    assert synth3.get_tool("math_cube") is None
+
+
+def test_deregister_preserves_foreign_tools(temp_jit_dir):
+    synth = JITToolSynthesizer(storage_dir=temp_jit_dir)
+    src = "def custom_calc(a: int): return a + 5"
+    synth.synthesize_and_register("custom_calc", "Calculator", {}, src)
+
+    assert synth.deregister("custom_calc")
+    assert synth.get_tool("custom_calc") is None


### PR DESCRIPTION
## Overview

Introduces **Hermes JIT Micro-Tool Synthesizer & Dynamic Sandbox** (`agent/jit_tool_synthesizer.py`). 

When facing specialized calculations, AST rewrites, custom encodings, or domain-specific data structures with no pre-existing tool in the registry, Hermes can now synthesize typed micro-tools on the fly, static-audit their AST for security vulnerabilities, fuzz-test them against test vectors in an isolated sandbox, and hot-reload them directly into runtime `ToolRegistry`.

## Key Capabilities

1. **AST Security Audit & Static Analysis**:
   - Parses the AST of synthesized Python source before compilation.
   - Enforces strict security policy: disallows forbidden modules (`subprocess`, `ctypes`, `socket`, `pty`, `shutil`, etc.), unsafe OS calls (`system`, `popen`, `execv`), and prototype pollution / dangerous introspection attributes (`__subclasses__`, `__globals__`).

2. **Isolated Dynamic Execution Sandbox**:
   - Restricts execution environment with safe builtins and algorithmic standard libraries (`math`, `re`, `json`, `collections`, `itertools`, `hashlib`, `datetime`).
   - Dynamic `__import__` guard blocks unauthorized runtime loading.

3. **Pre-flight Fuzz Testing & Vector Verification**:
   - Runs synthesized tools against synthetic input/output test vectors and assertions inside the sandbox.
   - If logic errors, syntax bugs, or unexpected return shapes occur, registration fails immediately without polluting the agent state.

4. **Dynamic Hot-Plugging into ToolRegistry**:
   - Synthesized tools are dynamically wrapped and bound to `tools.registry.registry`, immediately exposing JSON Schemas to LLM planning.

5. **Lifecycle Management & Persistence**:
   - Ephemeral (session-scoped) vs durable (persisted to `~/.hermes/jit_tools/`) tool management.
   - CLI subcommands for inspection, manual fuzz-testing, and pruning:
     ```bash
     hermes jit list          # List active synthesized micro-tools
     hermes jit test <name>   # Fuzz-test tool against test vectors in sandbox
     hermes jit prune         # Prune ephemeral micro-tools
     hermes jit remove <name> # Deregister and delete tool
     ```

## Verification
- Comprehensive test suite in `tests/agent/test_jit_tools.py` with 10 passing unit tests covering AST security audits, disallowed imports/calls, sandbox fuzzing, test-vector mismatch catching, Hermes tool execution, persistence across restarts, and pruning.