### PR TITLE
GPT-6 Astra: discovery-gated availability, Codex 272K/900K opt-in, effort + pricing contract (salvage #103057)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1434,6 +1434,11 @@ class _CodexCompletionsAdapter:
                     resp_kwargs["prompt_cache_retention"] = cache_retention
         except Exception:
             logger.debug("Codex auxiliary: prompt_cache_key derivation skipped", exc_info=True)
+        # Keep auxiliary Responses calls on the same exact-model contract as main
+        # turns. This runs last so caller overrides cannot reintroduce unsupported
+        # Astra reasoning/sampling fields or replace the official cache TTL.
+        from agent.transports.codex import _sanitize_astra_request_kwargs
+        _sanitize_astra_request_kwargs(resp_kwargs, model, host)
         return resp_kwargs, model, timeout
 
     def create(self, **kwargs) -> Any:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1380,8 +1380,13 @@ class _CodexCompletionsAdapter:
             if isinstance(reasoning_cfg, dict) and reasoning_cfg.get("enabled") is not False:
                 # Truthy-only: Codex 400s on e.g. {"effort": null}, so falsy → default. Shared
                 # per-model clamp with the main transport ("max" is gpt-5.6-only; "minimal"/"ultra" rejected).
-                from agent.reasoning_effort import clamp_effort, codex_supported_efforts
-                effort = clamp_effort(reasoning_cfg.get("effort") or "medium", codex_supported_efforts(model))
+                from agent.reasoning_effort import clamp_effort
+                from agent.transports.codex import _codex_efforts_for_route
+                is_codex_backend = base_url_host_matches(host, "chatgpt.com") and "/backend-api/codex" in host.lower()
+                effort = clamp_effort(
+                    reasoning_cfg.get("effort") or "medium",
+                    _codex_efforts_for_route(model, host, is_codex_backend=is_codex_backend),
+                )
                 resp_kwargs["reasoning"] = {"effort": effort, "summary": "auto"}
                 resp_kwargs["include"] = ["reasoning.encrypted_content"]
         tools = kwargs.get("tools")

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1380,9 +1380,10 @@ class _CodexCompletionsAdapter:
             if isinstance(reasoning_cfg, dict) and reasoning_cfg.get("enabled") is not False:
                 # Truthy-only: Codex 400s on e.g. {"effort": null}, so falsy → default. Shared
                 # per-model clamp with the main transport ("max" is gpt-5.6-only; "minimal"/"ultra" rejected).
+                from agent.codex_responses_adapter import classify_responses_route
                 from agent.reasoning_effort import clamp_effort
                 from agent.transports.codex import _codex_efforts_for_route
-                is_codex_backend = base_url_host_matches(host, "chatgpt.com") and "/backend-api/codex" in host.lower()
+                is_codex_backend = classify_responses_route(SimpleNamespace(base_url=host)).is_codex_backend
                 effort = clamp_effort(
                     reasoning_cfg.get("effort") or "medium",
                     _codex_efforts_for_route(model, host, is_codex_backend=is_codex_backend),
@@ -1439,9 +1440,7 @@ class _CodexCompletionsAdapter:
                     resp_kwargs["prompt_cache_retention"] = cache_retention
         except Exception:
             logger.debug("Codex auxiliary: prompt_cache_key derivation skipped", exc_info=True)
-        # Keep auxiliary Responses calls on the same exact-model contract as main
-        # turns. This runs last so caller overrides cannot reintroduce unsupported
-        # Astra reasoning/sampling fields or replace the official cache TTL.
+        # Last, like the main transport: caller extra_body must not put a rejected Astra field back.
         from agent.transports.codex import _sanitize_astra_request_kwargs
         _sanitize_astra_request_kwargs(resp_kwargs, model, host)
         return resp_kwargs, model, timeout

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -770,7 +770,7 @@ _PREFLIGHT_OPTIONAL_FIELDS: tuple[tuple[str, Callable[[Any], bool], Optional[Cal
     # Cache routing/retention and tool-dispatch hints pass through as-is.
     *(
         (key, lambda v: v is not None, None)
-        for key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key", "prompt_cache_retention", "prompt_cache_options")
+        for key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key", "prompt_cache_retention")
     ),
     # Native compaction directive; eligibility is resolved in agent/native_compaction.py.
     ("context_management", lambda v: isinstance(v, list) and bool(v), None),

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -770,7 +770,7 @@ _PREFLIGHT_OPTIONAL_FIELDS: tuple[tuple[str, Callable[[Any], bool], Optional[Cal
     # Cache routing/retention and tool-dispatch hints pass through as-is.
     *(
         (key, lambda v: v is not None, None)
-        for key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key", "prompt_cache_retention")
+        for key in ("tool_choice", "parallel_tool_calls", "prompt_cache_key", "prompt_cache_retention", "prompt_cache_options")
     ),
     # Native compaction directive; eligibility is resolved in agent/native_compaction.py.
     ("context_management", lambda v: isinstance(v, list) and bool(v), None),

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1450,13 +1450,16 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
 # The bump fires ONLY when the resolved value is exactly the stale 272,000. ``gpt-5.6`` is a FAMILY
 # PREFIX (``-pro`` slugs aren't routable on Codex); ``gpt-5.4`` is EXACT because gpt-5.4-mini enforces 272K.
 _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES: Dict[str, int] = {"gpt-5.6": 900_000}  # sol / terra / luna
-_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {"gpt-5.4": 900_000, "gpt-daybreak-blue-latest": 900_000}
+_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {
+    "gpt-5.4": 900_000, "gpt-daybreak-blue-latest": 900_000,
+    "gpt-6-astra": 900_000,  # advertised 272K; 920,043 input OK, 1,000,043 rejected (live 2026-09-04)
+}
 _CODEX_OAUTH_STALE_ADVERTISED_CTX = 272_000  # the only advertised value the bump may override
 CODEX_CONTEXT_VARIANT_SUFFIX = "-900k"  # picker-only opt-in suffix; never sent on the wire
 # The ONLY bases eligible for ``-900k``: routable, live-verified. No family prefixing (it would synthesize
 # dead ``-pro`` variants); dated snapshots of the 5.6 bases are allowed. gpt-daybreak-blue-latest is a verified Sol alias.
 _CODEX_900K_SNAPSHOT_BASES = ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna")
-_CODEX_900K_ELIGIBLE_BASES = frozenset({*_CODEX_900K_SNAPSHOT_BASES, "gpt-5.4", "gpt-daybreak-blue-latest"})
+_CODEX_900K_ELIGIBLE_BASES = frozenset({*_CODEX_900K_SNAPSHOT_BASES, "gpt-5.4", "gpt-daybreak-blue-latest", "gpt-6-astra"})
 _CODEX_900K_SNAPSHOT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1438,6 +1438,7 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 # Codex OAuth `context_window` values (what Codex enforces — lower than the direct API for the same
 # slugs). Fallback when the live probe fails; longest-key-first. gpt-5.3-codex-spark is listed so "gpt-5.3-codex" doesn't win.
 _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
+    "gpt-6-astra": 272_000,
     "gpt-5.1-codex-max": 272_000, "gpt-5.1-codex-mini": 272_000, "gpt-5.3-codex": 272_000,
     "gpt-5.3-codex-spark": 128_000, "gpt-5.2-codex": 272_000, "gpt-5.4-mini": 272_000,
     "gpt-5.6-sol": 272_000, "gpt-5.6-terra": 272_000, "gpt-5.6-luna": 272_000, "gpt-daybreak-blue-latest": 272_000,

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -107,7 +107,7 @@ class ModelCapabilities:
 # Hermes provider names → models.dev provider IDs
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter", "novita": "novita-ai", "anthropic": "anthropic",
-    "openai": "openai", "openai-codex": "openai", "zai": "zai",
+    "openai": "openai", "openai-api": "openai", "openai-codex": "openai", "zai": "zai",
     "kimi": "kimi-for-coding", "kimi-coding": "kimi-for-coding",
     "moonshot": "kimi-for-coding", "stepfun": "stepfun",
     "kimi-coding-cn": "kimi-for-coding", "minimax": "minimax",

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -522,6 +522,19 @@ _OVERRIDE_WARNED_KEYS: set = set()
 # shared by get_model_capabilities and get_model_info so the two unknown-model paths agree.
 _UNKNOWN_MODEL_BASE: Dict[str, Any] = {"limit": {"context": 200000, "output": 8192}, "tool_call": True}
 
+# Account-gated models may be usable before models.dev has indexed them.  Keep
+# their capabilities available for an explicitly selected/discovered model
+# without adding them to any picker catalog.
+_BUILTIN_MODEL_METADATA: Dict[Tuple[str, str], Dict[str, Any]] = {
+    ("openai", "gpt-6-astra"): {
+        "limit": {"context": 1_050_000, "output": 128_000},
+        "modalities": {"input": ["text", "image"], "output": ["text"]},
+        "tool_call": True,
+        "reasoning": True,
+        "family": "gpt-6",
+    },
+}
+
 
 def _load_model_overrides() -> Dict[str, Any]:
     """The ``model_overrides`` config section ({} on any failure). Deliberately not memoized:
@@ -646,8 +659,11 @@ def _merge_catalog_entry_with_override(raw: Dict[str, Any], override: Dict[str, 
 def _apply_overrides(provider: str, model: str, entry: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """*entry* patched by its override; ``_UNKNOWN_MODEL_BASE`` patched by a fill-gap override on a
     catalog miss (selected AFTER lookup: _default only fills misses); None when neither exists."""
-    override = _override_for(provider, model, catalog_hit=entry is not None)
-    return entry if override is None else _merge_catalog_entry_with_override(entry if entry is not None else _UNKNOWN_MODEL_BASE, override)
+    provider_key = PROVIDER_TO_MODELS_DEV.get((provider or "").strip(), (provider or "").strip())
+    builtin = _BUILTIN_MODEL_METADATA.get((provider_key, (model or "").strip().lower()))
+    base = entry if entry is not None else builtin
+    override = _override_for(provider, model, catalog_hit=base is not None)
+    return base if override is None else _merge_catalog_entry_with_override(base if base is not None else _UNKNOWN_MODEL_BASE, override)
 
 
 def _entry_supports_vision(entry: Dict[str, Any]) -> bool:

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -34,6 +34,7 @@ CODEX_LEGACY_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh
 # GPT-6 Astra is account-gated and its Responses API accepts no disable/minimal
 # wire level; callers normalize those requests to ``low`` at the transport boundary.
 CODEX_ASTRA_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
+ASTRA_MODEL_IDS: frozenset[str] = frozenset({"gpt-6-astra", "gpt-6-astra-900k"})
 
 #: xAI Responses — Grok 4.6+ accepts xhigh; older Grok tops out at high.
 XAI_GROK46_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
@@ -81,9 +82,16 @@ OLLAMA_CLOUD_OVERRIDES: dict[str, str] = {"xhigh": "max"}
 META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 
+def is_astra_model(model: Optional[str]) -> bool:
+    """``gpt-6-astra`` or its Hermes-side ``-900k`` picker alias, with or without a ``vendor/`` prefix.
+    The single home for the slug set: picker gating, effort vocabulary and the request sanitizer all
+    key off it, so a new Astra alias is one edit."""
+    return (model or "").strip().lower().rsplit("/", 1)[-1] in ASTRA_MODEL_IDS
+
+
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
-    if (model or "").strip().lower().rsplit("/", 1)[-1] in ("gpt-6-astra", "gpt-6-astra-900k"):
+    if is_astra_model(model):
         return CODEX_ASTRA_EFFORTS
     return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
 

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -83,7 +83,7 @@ META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
-    if (model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
+    if (model or "").strip().lower().rsplit("/", 1)[-1] in ("gpt-6-astra", "gpt-6-astra-900k"):
         return CODEX_ASTRA_EFFORTS
     return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
 

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -31,6 +31,9 @@ OPENAI_COMPAT_WIRE_EFFORTS: tuple[str, ...] = ("none", "minimal", "low", "medium
 #: both (clamps to low); ``max`` is gpt-5.6-only.
 CODEX_GPT56_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh", "max")
 CODEX_LEGACY_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh")
+# GPT-6 Astra is account-gated and its Responses API accepts no disable/minimal
+# wire level; callers normalize those requests to ``low`` at the transport boundary.
+CODEX_ASTRA_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 
 #: xAI Responses — Grok 4.6+ accepts xhigh; older Grok tops out at high.
 XAI_GROK46_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
@@ -80,6 +83,8 @@ META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
+    if (model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
+        return CODEX_ASTRA_EFFORTS
     return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
 
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -273,9 +273,11 @@ def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
     """Astra cache semantics apply only to the official OpenAI API host."""
     if not _is_astra_model(model):
         return False
-    from utils import base_url_host_matches
+    from utils import base_url_hostname
 
-    return base_url_host_matches(str(base_url or ""), "api.openai.com")
+    # Astra's account-gated cache contract is for the canonical API origin only.
+    # Do not extend it to subdomains (or lookalike hosts) by suffix matching.
+    return base_url_hostname(str(base_url or "")).lower() == "api.openai.com"
 
 
 def _codex_efforts_for_route(model: Any, base_url: Any, *, is_codex_backend: bool = False) -> tuple[str, ...]:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,7 +11,7 @@ import re
 from typing import Any, Callable, Optional
 
 from agent.reasoning_effort import (
-    ACTUAL_RELAY_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
+    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
     # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
     # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
     codex_supported_efforts,
@@ -211,6 +211,15 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         elif reasoning_config.get("effort"):
             reasoning_effort = reasoning_config["effort"]
 
+    # Astra has no wire-level disable/minimal setting.  Preserve Hermes' user-facing
+    # controls by sending the documented lowest enabled level instead; this also keeps
+    # an explicit ``enabled: false`` request valid on the Responses API.
+    if model.strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
+        requested = str(reasoning_effort or "").strip().lower()
+        if not reasoning_enabled or requested in {"", "none", "minimal", "disabled", "off"}:
+            return "low", True
+        return clamp_effort(reasoning_effort, CODEX_ASTRA_EFFORTS), True
+
     # Wire vocabularies are declared in agent.reasoning_effort; the shared clamp policy (nearest weaker
     # supported level, never escalate, never invert the ladder) replaces the per-backend hand maps that
     # repeatedly leaked internal levels like "ultra" to the wire (#89503 class) or clamped one rung below a
@@ -260,6 +269,37 @@ def _default_prompt_cache_retention_for_request(model: str, base_url: Any) -> Op
         return None
     normalized = str(model or "").strip().lower().replace("_", "-")
     return "24h" if _EXTENDED_PROMPT_CACHE_MODEL_RE.search(normalized) else None
+
+
+def _is_astra_model(model: Any) -> bool:
+    return str(model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra"
+
+
+def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
+    """Astra cache semantics apply only to the official OpenAI API host."""
+    if not _is_astra_model(model):
+        return False
+    from utils import base_url_host_matches
+
+    return base_url_host_matches(str(base_url or ""), "api.openai.com")
+
+
+def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url: Any) -> None:
+    """Apply Astra's model-specific restrictions after all request overrides are merged."""
+    if not _is_astra_model(model):
+        return
+    for key in ("temperature", "top_p", "top_logprobs", "logprobs"):
+        kwargs.pop(key, None)
+    include = kwargs.get("include")
+    if isinstance(include, list):
+        kwargs["include"] = [item for item in include if "logprob" not in str(item).lower()]
+    if _is_official_openai_responses_route(model, base_url):
+        kwargs["prompt_cache_options"] = {"ttl": "30m"}
+        kwargs.pop("prompt_cache_retention", None)
+    else:
+        # A caller override must not accidentally send official-only cache syntax to a
+        # proxy or another provider that happens to accept the Astra model name.
+        kwargs.pop("prompt_cache_options", None)
 
 
 def _content_cache_key(instructions: str, tools: Optional[list[dict[str, Any]]], scope_id: str = "") -> Optional[str]:
@@ -543,6 +583,8 @@ class ResponsesApiTransport(ProviderTransport):
         ))
         if params.get("request_overrides"):
             kwargs.update(params["request_overrides"])
+
+        _sanitize_astra_request_kwargs(kwargs, model, params.get("base_url"))
 
         _bound_prompt_cache_key_field(kwargs)
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,7 +11,8 @@ import re
 from typing import Any, Callable, Optional
 
 from agent.reasoning_effort import (
-    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
+    ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, CODEX_LEGACY_EFFORTS,
+    XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
     # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
     # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
     codex_supported_efforts,
@@ -226,7 +227,9 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         declared = _profile_declared_efforts(params.get("provider"), model, params.get("base_url"))
         if declared is not None and not declared:
             reasoning_enabled = False
-        supported = declared or codex_supported_efforts(model)
+        supported = declared or _codex_efforts_for_route(
+            model, params.get("base_url"), is_codex_backend=params.get("is_codex_backend") is True
+        )
     return clamp_effort(reasoning_effort, supported), reasoning_enabled
 
 
@@ -273,6 +276,15 @@ def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
     from utils import base_url_host_matches
 
     return base_url_host_matches(str(base_url or ""), "api.openai.com")
+
+
+def _codex_efforts_for_route(model: Any, base_url: Any, *, is_codex_backend: bool = False) -> tuple[str, ...]:
+    """Keep Astra's new vocabulary off unrelated Responses-compatible endpoints."""
+    if _is_astra_model(model) and not (
+        is_codex_backend or _is_official_openai_responses_route(model, base_url)
+    ):
+        return CODEX_LEGACY_EFFORTS
+    return codex_supported_efforts(str(model or ""))
 
 
 def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url: Any) -> None:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Optional
 
 from agent.reasoning_effort import (
     ACTUAL_RELAY_EFFORTS, CODEX_ASTRA_EFFORTS, CODEX_LEGACY_EFFORTS,
-    XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
+    XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort, is_astra_model,
     # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
     # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
     codex_supported_efforts,
@@ -265,24 +265,19 @@ def _default_prompt_cache_retention_for_request(model: str, base_url: Any) -> Op
     return "24h" if _EXTENDED_PROMPT_CACHE_MODEL_RE.search(normalized) else None
 
 
-def _is_astra_model(model: Any) -> bool:
-    return str(model or "").strip().lower().rsplit("/", 1)[-1] in ("gpt-6-astra", "gpt-6-astra-900k")
-
-
 def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:
-    """Astra cache semantics apply only to the official OpenAI API host."""
-    if not _is_astra_model(model):
+    """Astra on the canonical API origin only — exact host, so a Responses-compatible proxy or a
+    lookalike subdomain keeps the generic contract."""
+    if not is_astra_model(model):
         return False
     from utils import base_url_hostname
 
-    # Astra's account-gated cache contract is for the canonical API origin only.
-    # Do not extend it to subdomains (or lookalike hosts) by suffix matching.
     return base_url_hostname(str(base_url or "")).lower() == "api.openai.com"
 
 
 def _codex_efforts_for_route(model: Any, base_url: Any, *, is_codex_backend: bool = False) -> tuple[str, ...]:
     """Keep Astra's new vocabulary off unrelated Responses-compatible endpoints."""
-    if _is_astra_model(model) and not (
+    if is_astra_model(model) and not (
         is_codex_backend or _is_official_openai_responses_route(model, base_url)
     ):
         return CODEX_LEGACY_EFFORTS
@@ -290,27 +285,22 @@ def _codex_efforts_for_route(model: Any, base_url: Any, *, is_codex_backend: boo
 
 
 def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url: Any) -> None:
-    """Apply Astra's model-specific restrictions after all request overrides are merged."""
-    if not _is_astra_model(model):
-        return
+    """Astra's official-API contract, applied AFTER ``request_overrides`` so an override can't put a
+    rejected field back on the wire: ``reasoning.effort`` is ``low..max`` only (``none``/``minimal``
+    400), sampling and logprob knobs are rejected, and cache lifetime is fixed server-side
+    (``prompt_cache_options.ttl`` accepts only its ``30m`` default, so nothing is sent for it and the
+    pre-5.6 ``prompt_cache_retention`` knob is dropped)."""
     if not _is_official_openai_responses_route(model, base_url):
-        kwargs.pop("prompt_cache_options", None)
         return
     reasoning = kwargs.get("reasoning")
-    requested = reasoning.get("effort") if isinstance(reasoning, dict) else None
-    normalized = str(requested or "").strip().lower()
-    effort = "low" if normalized in {"", "none", "minimal", "disabled", "off"} else clamp_effort(
-        requested, CODEX_ASTRA_EFFORTS
-    )
-    kwargs["reasoning"] = {**(reasoning if isinstance(reasoning, dict) else {}), "effort": effort}
-    kwargs["reasoning"].setdefault("summary", "auto")
-    for key in ("temperature", "top_p", "top_logprobs", "logprobs"):
+    if isinstance(reasoning, dict):
+        requested = str(reasoning.get("effort") or "").strip().lower()
+        reasoning["effort"] = clamp_effort(requested, CODEX_ASTRA_EFFORTS) if requested else "low"
+    for key in ("temperature", "top_p", "top_logprobs", "logprobs", "prompt_cache_retention"):
         kwargs.pop(key, None)
     include = kwargs.get("include")
     if isinstance(include, list):
         kwargs["include"] = [item for item in include if "logprob" not in str(item).lower()]
-    kwargs["prompt_cache_options"] = {"ttl": "30m"}
-    kwargs.pop("prompt_cache_retention", None)
 
 
 def _content_cache_key(instructions: str, tools: Optional[list[dict[str, Any]]], scope_id: str = "") -> Optional[str]:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -266,7 +266,7 @@ def _default_prompt_cache_retention_for_request(model: str, base_url: Any) -> Op
 
 
 def _is_astra_model(model: Any) -> bool:
-    return str(model or "").strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra"
+    return str(model or "").strip().lower().rsplit("/", 1)[-1] in ("gpt-6-astra", "gpt-6-astra-900k")
 
 
 def _is_official_openai_responses_route(model: Any, base_url: Any) -> bool:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -211,15 +211,6 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         elif reasoning_config.get("effort"):
             reasoning_effort = reasoning_config["effort"]
 
-    # Astra has no wire-level disable/minimal setting.  Preserve Hermes' user-facing
-    # controls by sending the documented lowest enabled level instead; this also keeps
-    # an explicit ``enabled: false`` request valid on the Responses API.
-    if model.strip().lower().rsplit("/", 1)[-1] == "gpt-6-astra":
-        requested = str(reasoning_effort or "").strip().lower()
-        if not reasoning_enabled or requested in {"", "none", "minimal", "disabled", "off"}:
-            return "low", True
-        return clamp_effort(reasoning_effort, CODEX_ASTRA_EFFORTS), True
-
     # Wire vocabularies are declared in agent.reasoning_effort; the shared clamp policy (nearest weaker
     # supported level, never escalate, never invert the ladder) replaces the per-backend hand maps that
     # repeatedly leaked internal levels like "ultra" to the wire (#89503 class) or clamped one rung below a
@@ -288,18 +279,24 @@ def _sanitize_astra_request_kwargs(kwargs: dict[str, Any], model: Any, base_url:
     """Apply Astra's model-specific restrictions after all request overrides are merged."""
     if not _is_astra_model(model):
         return
+    if not _is_official_openai_responses_route(model, base_url):
+        kwargs.pop("prompt_cache_options", None)
+        return
+    reasoning = kwargs.get("reasoning")
+    requested = reasoning.get("effort") if isinstance(reasoning, dict) else None
+    normalized = str(requested or "").strip().lower()
+    effort = "low" if normalized in {"", "none", "minimal", "disabled", "off"} else clamp_effort(
+        requested, CODEX_ASTRA_EFFORTS
+    )
+    kwargs["reasoning"] = {**(reasoning if isinstance(reasoning, dict) else {}), "effort": effort}
+    kwargs["reasoning"].setdefault("summary", "auto")
     for key in ("temperature", "top_p", "top_logprobs", "logprobs"):
         kwargs.pop(key, None)
     include = kwargs.get("include")
     if isinstance(include, list):
         kwargs["include"] = [item for item in include if "logprob" not in str(item).lower()]
-    if _is_official_openai_responses_route(model, base_url):
-        kwargs["prompt_cache_options"] = {"ttl": "30m"}
-        kwargs.pop("prompt_cache_retention", None)
-    else:
-        # A caller override must not accidentally send official-only cache syntax to a
-        # proxy or another provider that happens to accept the Astra model name.
-        kwargs.pop("prompt_cache_options", None)
+    kwargs["prompt_cache_options"] = {"ttl": "30m"}
+    kwargs.pop("prompt_cache_retention", None)
 
 
 def _content_cache_key(instructions: str, tools: Optional[list[dict[str, Any]]], scope_id: str = "") -> Optional[str]:

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -109,6 +109,7 @@ class PricingEntry:
     input_cost_per_million_above: Optional[Decimal] = None
     output_cost_per_million_above: Optional[Decimal] = None
     cache_read_cost_per_million_above: Optional[Decimal] = None
+    cache_write_cost_per_million_above: Optional[Decimal] = None
 
 
 @dataclass(frozen=True)
@@ -240,6 +241,20 @@ for _provider, _url, _version, _rows in _SNAPSHOTS:
         for _model in ((_models,) if isinstance(_models, str) else _models):
             _OFFICIAL_DOCS_PRICING[(_provider, _model)] = _entry
 del _SNAPSHOTS, _provider, _url, _version, _rows, _models, _rates, _entry, _model
+
+# GPT-6 Astra uses whole-request pricing above the 272K prompt tier.  Keep this
+# account-gated model out of generic static catalogs, but retain published billing
+# metadata for an explicitly selected route.
+_OFFICIAL_DOCS_PRICING[("openai", "gpt-6-astra")] = _snap(
+    "10.00", "50.00", "1.00", "12.50",
+    url="https://developers.openai.com/api/docs/models/gpt-6-astra",
+    version="openai-gpt-6-astra-2026-09",
+    tier_threshold_tokens=272_000,
+    input_cost_per_million_above=Decimal("20.00"),
+    output_cost_per_million_above=Decimal("75.00"),
+    cache_read_cost_per_million_above=Decimal("2.00"),
+    cache_write_cost_per_million_above=Decimal("25.00"),
+)
 
 # Context-tiered Gemini Pro: above 200k prompt tokens the *_above rates apply to
 # the whole request (see PricingEntry).
@@ -558,7 +573,7 @@ def estimate_usage_cost(
         (usage.output_tokens, entry.output_cost_per_million, entry.output_cost_per_million_above, ()),
         (usage.cache_read_tokens, entry.cache_read_cost_per_million, entry.cache_read_cost_per_million_above,
          ("cache-read pricing unavailable for route",)),
-        (usage.cache_write_tokens, entry.cache_write_cost_per_million, None,
+        (usage.cache_write_tokens, entry.cache_write_cost_per_million, entry.cache_write_cost_per_million_above,
          ("cache-write pricing unavailable for route",)),
     ):
         if above and rate_above is not None:

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -88,19 +88,17 @@ def _add_context_variants(model_ids: List[str]) -> List[str]:
     return out
 
 
-def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -> List[str]:
-    """Forward-compat/context synthesis with an entitlement gate for Astra.
+def _finalize_codex_models(model_ids: List[str]) -> List[str]:
+    """Forward-compat synthesis + large-context variant synthesis."""
+    return _add_context_variants(_add_forward_compat_models(model_ids))
 
-    Cached/configured model names are useful compatibility hints, but only the
-    account-scoped Codex endpoint is authoritative for current Astra access.
-    """
-    from agent.model_metadata import strip_codex_context_variant_suffix
 
-    finalized = _add_forward_compat_models(model_ids)
-    if not allow_astra:
-        finalized = [model for model in finalized
-                     if strip_codex_context_variant_suffix(model.lower()).rsplit("/", 1)[-1] != "gpt-6-astra"]
-    return _add_context_variants(finalized)
+def _drop_undiscovered_astra(model_ids: List[str]) -> List[str]:
+    """Astra is account-gated: only the live account-scoped catalog may advertise it. A stale
+    ``models_cache.json`` or a ``config.toml`` default is a compatibility hint, not entitlement."""
+    from agent.reasoning_effort import is_astra_model
+
+    return [model for model in model_ids if not is_astra_model(model)]
 
 
 def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:
@@ -169,7 +167,7 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
         logger.debug("Failed to fetch Codex models from API: %s", exc)
         return []
 
-    return _finalize_codex_models(_ranked_slugs(entries), allow_astra=True)
+    return _finalize_codex_models(_ranked_slugs(entries))
 
 
 def _read_default_model(codex_home: Path) -> Optional[str]:
@@ -204,8 +202,8 @@ def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
     if access_token:
         api_models = _fetch_models_from_api(access_token)
         if api_models:
-            return _finalize_codex_models(api_models, allow_astra=True)
+            return _finalize_codex_models(api_models)
     default_model = _read_default_model(codex_home)
-    return _finalize_codex_models(_dedupe([
+    return _finalize_codex_models(_drop_undiscovered_astra(_dedupe([
         *([default_model] if default_model else []), *_read_cache_models(codex_home),
-        *DEFAULT_CODEX_MODELS]))
+        *DEFAULT_CODEX_MODELS])))

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -96,7 +96,7 @@ def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -
     """
     finalized = _add_forward_compat_models(model_ids)
     if not allow_astra:
-        finalized = [model for model in finalized if model.lower() != "gpt-6-astra"]
+        finalized = [model for model in finalized if model.lower().rsplit("/", 1)[-1] != "gpt-6-astra"]
     return _add_context_variants(finalized)
 
 

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -94,9 +94,12 @@ def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -
     Cached/configured model names are useful compatibility hints, but only the
     account-scoped Codex endpoint is authoritative for current Astra access.
     """
+    from agent.model_metadata import strip_codex_context_variant_suffix
+
     finalized = _add_forward_compat_models(model_ids)
     if not allow_astra:
-        finalized = [model for model in finalized if model.lower().rsplit("/", 1)[-1] != "gpt-6-astra"]
+        finalized = [model for model in finalized
+                     if strip_codex_context_variant_suffix(model.lower()).rsplit("/", 1)[-1] != "gpt-6-astra"]
     return _add_context_variants(finalized)
 
 

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -88,9 +88,16 @@ def _add_context_variants(model_ids: List[str]) -> List[str]:
     return out
 
 
-def _finalize_codex_models(model_ids: List[str]) -> List[str]:
-    """Forward-compat synthesis + large-context variant synthesis."""
-    return _add_context_variants(_add_forward_compat_models(model_ids))
+def _finalize_codex_models(model_ids: List[str], *, allow_astra: bool = False) -> List[str]:
+    """Forward-compat/context synthesis with an entitlement gate for Astra.
+
+    Cached/configured model names are useful compatibility hints, but only the
+    account-scoped Codex endpoint is authoritative for current Astra access.
+    """
+    finalized = _add_forward_compat_models(model_ids)
+    if not allow_astra:
+        finalized = [model for model in finalized if model.lower() != "gpt-6-astra"]
+    return _add_context_variants(finalized)
 
 
 def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:
@@ -159,7 +166,7 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
         logger.debug("Failed to fetch Codex models from API: %s", exc)
         return []
 
-    return _finalize_codex_models(_ranked_slugs(entries))
+    return _finalize_codex_models(_ranked_slugs(entries), allow_astra=True)
 
 
 def _read_default_model(codex_home: Path) -> Optional[str]:
@@ -194,7 +201,7 @@ def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
     if access_token:
         api_models = _fetch_models_from_api(access_token)
         if api_models:
-            return _finalize_codex_models(api_models)
+            return _finalize_codex_models(api_models, allow_astra=True)
     default_model = _read_default_model(codex_home)
     return _finalize_codex_models(_dedupe([
         *([default_model] if default_model else []), *_read_cache_models(codex_home),

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -407,7 +407,7 @@ def _append_unconfigured_rows(
     """Empty setup skeletons for canonical providers missing from ``rows`` — except the *current* one:
     if config.yaml still points at it but credentials are gone, keep a row carrying the saved model so
     GUI pickers don't silently snap to another provider."""
-    from hermes_cli.models import CANONICAL_PROVIDERS
+    from hermes_cli.models import CANONICAL_PROVIDERS, _model_requires_account_discovery
 
     seen = {r["slug"].lower() for r in rows}
     cur = (ctx.current_provider or "").lower()
@@ -419,6 +419,7 @@ def _append_unconfigured_rows(
         if current_only and entry.slug.lower() != cur:
             continue
         if entry.slug.lower() == cur:
+            saved_model = "" if _model_requires_account_discovery(entry.slug, cur_model) else cur_model
             auth_type, key_env = _provider_auth_hint(entry.slug)
             warning = (
                 f"Configured provider missing usable credentials; paste {key_env} to reactivate. "
@@ -427,8 +428,10 @@ def _append_unconfigured_rows(
                 else "Configured provider is not authenticated; run `hermes model` to reactivate. "
                 "Showing the saved model only."
             )
+            if cur_model and not saved_model:
+                warning = warning.replace("Showing the saved model only.", "Astra requires successful account-scoped model discovery.")
             extras.append(_canonical_row(
-                entry, cur, models=[cur_model] if cur_model else [], total_models=1 if cur_model else 0,
+                entry, cur, models=[saved_model] if saved_model else [], total_models=1 if saved_model else 0,
                 source="configured-current", authenticated=False, auth_type=auth_type, key_env=key_env,
                 warning=warning,
             ))

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -421,15 +421,15 @@ def _append_unconfigured_rows(
         if entry.slug.lower() == cur:
             saved_model = "" if _model_requires_account_discovery(entry.slug, cur_model) else cur_model
             auth_type, key_env = _provider_auth_hint(entry.slug)
-            warning = (
-                f"Configured provider missing usable credentials; paste {key_env} to reactivate. "
-                "Showing the saved model only."
-                if auth_type == "api_key" and key_env
-                else "Configured provider is not authenticated; run `hermes model` to reactivate. "
-                "Showing the saved model only."
+            tail = (
+                "Astra requires successful account-scoped model discovery."
+                if cur_model and not saved_model else "Showing the saved model only."
             )
-            if cur_model and not saved_model:
-                warning = warning.replace("Showing the saved model only.", "Astra requires successful account-scoped model discovery.")
+            warning = (
+                f"Configured provider missing usable credentials; paste {key_env} to reactivate. {tail}"
+                if auth_type == "api_key" and key_env
+                else f"Configured provider is not authenticated; run `hermes model` to reactivate. {tail}"
+            )
             extras.append(_canonical_row(
                 entry, cur, models=[saved_model] if saved_model else [], total_models=1 if saved_model else 0,
                 source="configured-current", authenticated=False, auth_type=auth_type, key_env=key_env,

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -1111,6 +1111,10 @@ def _finalize_picker_rows(results: list, user_providers, current_model: str) -> 
                 continue
             models = row.get("models") or []
             if current_model not in models:
+                from hermes_cli.models import _model_requires_account_discovery
+
+                if _model_requires_account_discovery(row.get("slug"), current_model):
+                    break
                 row["models"] = [current_model, *models]
                 row["total_models"] = row.get("total_models", len(models)) + 1
             break

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1516,6 +1516,13 @@ def _normalized_cache_slug(provider: Optional[str]) -> str:
     return requested if requested == "ollama" else (normalize_provider(provider) or (provider or ""))
 
 
+def _model_requires_account_discovery(provider: Optional[str], model: str) -> bool:
+    """Astra names cannot confer API/OAuth entitlement through picker state."""
+    return _normalized_cache_slug(provider) in {"openai", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
+        "gpt-6-astra", "gpt-6-astra-900k",
+    }
+
+
 def cached_provider_model_ids(
     provider: Optional[str], *, force_refresh: bool = False,
     ttl_seconds: int = _PROVIDER_MODELS_CACHE_TTL) -> list[str]:
@@ -1532,8 +1539,14 @@ def cached_provider_model_ids(
     fp = _credential_fingerprint(normalized)
     entry = cache.get(normalized)
     now = time.time()
+    # Even a credential-matched fresh disk cache predates the current account's
+    # entitlement check. Revalidate gated entries before offering them again.
+    cached_models = entry.get("models") if isinstance(entry, dict) else None
+    gated_cache = isinstance(cached_models, list) and any(
+        _model_requires_account_discovery(normalized, model) for model in cached_models
+    )
 
-    if not force_refresh and _cache_entry_valid(entry, fp, allow_empty=is_ollama):
+    if not force_refresh and not gated_cache and _cache_entry_valid(entry, fp, allow_empty=is_ollama):
         age = now - entry["at"]
         if age < ttl_seconds:
             return list(entry["models"])
@@ -1562,7 +1575,7 @@ def cached_provider_model_ids(
         return []
     # Live returned nothing: a stale same-fingerprint entry beats an empty result.
     if _cache_entry_valid(entry, fp):
-        return list(entry["models"])
+        return [model for model in entry["models"] if not _model_requires_account_discovery(normalized, model)]
     return []
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1203,7 +1203,12 @@ def _openai_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]
     curated = list(_PROVIDER_MODELS.get(normalized, []))
     # Curated order, only models the account has access to; an account serving none of them (rare)
     # falls back to curated so the picker still offers sane defaults.
-    return [m for m in curated if m.lower() in live_lower] or curated or live
+    discovered = [m for m in curated if m.lower() in live_lower]
+    # Astra is intentionally absent from offline/static catalogs: the official API's
+    # account-scoped /models response is the only source that may advertise it.
+    if "gpt-6-astra" in live_lower:
+        discovered.append(next((m for m in live if m.lower() == "gpt-6-astra"), "gpt-6-astra"))
+    return discovered or curated or live
 
 
 def _custom_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -438,7 +438,7 @@ _nous_caps_disk_checked = False
 _nous_caps_warm_started = False
 
 
-from agent.reasoning_effort import clamp_effort as _clamp_effort
+from agent.reasoning_effort import clamp_effort as _clamp_effort, is_astra_model
 
 
 def clamp_reasoning_effort_to_supported(
@@ -1206,8 +1206,7 @@ def _openai_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]
     discovered = [m for m in curated if m.lower() in live_lower]
     # Astra is intentionally absent from offline/static catalogs: the official API's
     # account-scoped /models response is the only source that may advertise it.
-    if "gpt-6-astra" in live_lower:
-        discovered.append(next((m for m in live if m.lower() == "gpt-6-astra"), "gpt-6-astra"))
+    discovered.extend(m for m in live if is_astra_model(m))
     return discovered or curated or live
 
 
@@ -1518,9 +1517,7 @@ def _normalized_cache_slug(provider: Optional[str]) -> str:
 
 def _model_requires_account_discovery(provider: Optional[str], model: str) -> bool:
     """Astra names cannot confer API/OAuth entitlement through picker state."""
-    return _normalized_cache_slug(provider) in {"openai", "openai-api", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
-        "gpt-6-astra", "gpt-6-astra-900k",
-    }
+    return _normalized_cache_slug(provider) in {"openai", "openai-api", "openai-codex"} and is_astra_model(model)
 
 
 def cached_provider_model_ids(

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1518,7 +1518,7 @@ def _normalized_cache_slug(provider: Optional[str]) -> str:
 
 def _model_requires_account_discovery(provider: Optional[str], model: str) -> bool:
     """Astra names cannot confer API/OAuth entitlement through picker state."""
-    return _normalized_cache_slug(provider) in {"openai", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
+    return _normalized_cache_slug(provider) in {"openai", "openai-api", "openai-codex"} and str(model or "").strip().lower().rsplit("/", 1)[-1] in {
         "gpt-6-astra", "gpt-6-astra-900k",
     }
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1536,14 +1536,8 @@ def cached_provider_model_ids(
     fp = _credential_fingerprint(normalized)
     entry = cache.get(normalized)
     now = time.time()
-    # Even a credential-matched fresh disk cache predates the current account's
-    # entitlement check. Revalidate gated entries before offering them again.
-    cached_models = entry.get("models") if isinstance(entry, dict) else None
-    gated_cache = isinstance(cached_models, list) and any(
-        _model_requires_account_discovery(normalized, model) for model in cached_models
-    )
 
-    if not force_refresh and not gated_cache and _cache_entry_valid(entry, fp, allow_empty=is_ollama):
+    if not force_refresh and _cache_entry_valid(entry, fp, allow_empty=is_ollama):
         age = now - entry["at"]
         if age < ttl_seconds:
             return list(entry["models"])
@@ -1570,7 +1564,9 @@ def cached_provider_model_ids(
         if same_creds and isinstance(entry.get("models"), list) and entry["models"]:
             return list(entry["models"])
         return []
-    # Live returned nothing: a stale same-fingerprint entry beats an empty result.
+    # Live returned nothing: a stale same-fingerprint entry beats an empty result — minus account-gated
+    # models, which only a successful discovery may advertise (the entry itself is untouched, so the
+    # next successful fetch restores them).
     if _cache_entry_valid(entry, fp):
         return [model for model in entry["models"] if not _model_requires_account_discovery(normalized, model)]
     return []

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -2,6 +2,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 
 def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_path):
     """A fresh profile resolves metadata and routes the official endpoint without live I/O."""
@@ -46,3 +48,33 @@ def test_astra_codex_oauth_fallback_uses_backend_context_limit():
 
     assert DEFAULT_CONTEXT_LENGTHS["gpt-6-astra"] == 1_050_000
     assert _resolve_codex_oauth_context_length_with_source("gpt-6-astra") == (272_000, "fallback")
+
+
+@pytest.mark.parametrize("advertised,expected", [(272_000, 900_000), (200_000, 200_000), (1_050_000, 1_050_000)])
+def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, tmp_path, advertised, expected):
+    """Only the known stale advertisement is lifted; the alias never reaches the wire."""
+    from agent import model_metadata as metadata
+    from agent.reasoning_effort import CODEX_ASTRA_EFFORTS, codex_supported_efforts
+    from agent.transports.codex import ResponsesApiTransport
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(metadata, "_codex_oauth_context_cache", {})
+    monkeypatch.setattr(metadata.requests, "get", lambda *args, **kwargs: SimpleNamespace(
+        status_code=200,
+        json=lambda: {"models": [{"slug": "gpt-6-astra", "context_window": advertised}]},
+    ))
+    route = {"base_url": "https://chatgpt.com/backend-api/codex", "provider": "openai-codex"}
+    assert metadata.get_model_context_length("gpt-6-astra-900k", api_key="test-token", **route) == expected
+    assert metadata.get_model_context_length("gpt-6-astra", api_key="test-token", **route) == advertised
+    assert codex_supported_efforts("gpt-6-astra-900k") == CODEX_ASTRA_EFFORTS
+
+    for config, expected_effort in [({"effort": "max"}, "max"), ({"enabled": False}, "low")]:
+        kwargs = ResponsesApiTransport().build_kwargs(
+            model="gpt-6-astra-900k", messages=[{"role": "user", "content": "Hi"}], tools=[],
+            is_codex_backend=True, reasoning_config=config,
+            request_overrides={"temperature": 0.5, "logprobs": True}, **route,
+        )
+        assert kwargs["model"] == "gpt-6-astra"
+        assert kwargs["reasoning"]["effort"] == expected_effort
+        assert "temperature" not in kwargs and "logprobs" not in kwargs
+        assert "prompt_cache_options" not in kwargs

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -35,3 +35,14 @@ def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_pa
     )
     assert kwargs["reasoning"]["effort"] == "low"
     assert kwargs["prompt_cache_options"] == {"ttl": "30m"}
+
+
+def test_astra_codex_oauth_fallback_uses_backend_context_limit():
+    """OAuth keeps the Codex backend's 272K fallback; direct API metadata remains 1.05M."""
+    from agent.model_metadata import (
+        DEFAULT_CONTEXT_LENGTHS,
+        _resolve_codex_oauth_context_length_with_source,
+    )
+
+    assert DEFAULT_CONTEXT_LENGTHS["gpt-6-astra"] == 1_050_000
+    assert _resolve_codex_oauth_context_length_with_source("gpt-6-astra") == (272_000, "fallback")

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -77,7 +77,6 @@ def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, 
         kwargs = ResponsesApiTransport().build_kwargs(model="gpt-6-astra-900k", **params)
         assert kwargs["model"] == "gpt-6-astra"
         assert kwargs == ResponsesApiTransport().build_kwargs(model="gpt-6-astra", **params)
-        assert "prompt_cache_options" not in kwargs
 
 
 @pytest.mark.parametrize("provider,model", [
@@ -99,7 +98,13 @@ def test_picker_revalidates_cached_astra_and_never_injects_saved_entitlement(mon
         return list(live)
 
     monkeypatch.setattr(models, "provider_model_ids", discover)
-    assert models.cached_provider_model_ids(provider) == ["gpt-5.6-sol"]
+    # Only live discovery writes Astra into a same-credential entry, so a fresh entry IS the
+    # entitlement record: served without a round-trip (a per-open revalidation defeated the cache).
+    assert model in models.cached_provider_model_ids(provider)
+    assert calls == []
+    # After the entry ages past the fresh window, a failed refresh must not resurrect Astra from it.
+    monkeypatch.setattr(models, "_PROVIDER_MODELS_STALE_SERVE_MAX", 0)
+    assert models.cached_provider_model_ids(provider, ttl_seconds=0) == ["gpt-5.6-sol"]
     assert calls == [provider]
     row = {"slug": provider, "is_current": True, "models": ["gpt-5.6-sol"], "total_models": 1}
     assert model not in _finalize_picker_rows([row], {}, model)[0]["models"]

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -33,10 +33,9 @@ def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_pa
         tools=[],
         provider=agent.provider,
         base_url=agent.base_url,
-        reasoning_config={"enabled": False, "effort": "none"},
+        reasoning_config={"enabled": True, "effort": "none"},
     )
-    assert kwargs["reasoning"]["effort"] == "low"
-    assert kwargs["prompt_cache_options"] == {"ttl": "30m"}
+    assert kwargs["reasoning"]["effort"] == "low"  # Astra has no ``none`` wire level
 
 
 def test_astra_codex_oauth_fallback_uses_backend_context_limit():
@@ -46,8 +45,9 @@ def test_astra_codex_oauth_fallback_uses_backend_context_limit():
         _resolve_codex_oauth_context_length_with_source,
     )
 
-    assert DEFAULT_CONTEXT_LENGTHS["gpt-6-astra"] == 1_050_000
-    assert _resolve_codex_oauth_context_length_with_source("gpt-6-astra") == (272_000, "fallback")
+    codex_ctx, source = _resolve_codex_oauth_context_length_with_source("gpt-6-astra")
+    assert source == "fallback"
+    assert codex_ctx < DEFAULT_CONTEXT_LENGTHS["gpt-6-astra"]  # Codex caps below the direct API window
 
 
 @pytest.mark.parametrize("advertised,expected", [(272_000, 900_000), (200_000, 200_000), (1_050_000, 1_050_000)])

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -68,13 +68,43 @@ def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, 
     assert metadata.get_model_context_length("gpt-6-astra", api_key="test-token", **route) == advertised
     assert codex_supported_efforts("gpt-6-astra-900k") == CODEX_ASTRA_EFFORTS
 
-    for config, expected_effort in [({"effort": "max"}, "max"), ({"enabled": False}, "low")]:
-        kwargs = ResponsesApiTransport().build_kwargs(
-            model="gpt-6-astra-900k", messages=[{"role": "user", "content": "Hi"}], tools=[],
+    for config in ({"effort": "max"}, {"enabled": False}):
+        params = dict(
+            messages=[{"role": "user", "content": "Hi"}], tools=[],
             is_codex_backend=True, reasoning_config=config,
             request_overrides={"temperature": 0.5, "logprobs": True}, **route,
         )
+        kwargs = ResponsesApiTransport().build_kwargs(model="gpt-6-astra-900k", **params)
         assert kwargs["model"] == "gpt-6-astra"
-        assert kwargs["reasoning"]["effort"] == expected_effort
-        assert "temperature" not in kwargs and "logprobs" not in kwargs
+        assert kwargs == ResponsesApiTransport().build_kwargs(model="gpt-6-astra", **params)
         assert "prompt_cache_options" not in kwargs
+
+
+@pytest.mark.parametrize("provider,model", [
+    ("openai-codex", "gpt-6-astra"), ("openai-codex", "gpt-6-astra-900k"), ("openai", "gpt-6-astra"),
+])
+def test_picker_revalidates_cached_astra_and_never_injects_saved_entitlement(monkeypatch, tmp_path, provider, model):
+    from hermes_cli import models
+    from hermes_cli.inventory import ConfigContext, _append_unconfigured_rows
+    from hermes_cli.model_switch_providers import _finalize_picker_rows
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(models, "_credential_fingerprint", lambda _: "synthetic-account")
+    models.update_provider_cache_entry(provider, ["gpt-5.6-sol", model])
+    live = []
+    calls = []
+
+    def discover(slug, **kwargs):
+        calls.append(slug)
+        return list(live)
+
+    monkeypatch.setattr(models, "provider_model_ids", discover)
+    assert models.cached_provider_model_ids(provider) == ["gpt-5.6-sol"]
+    assert calls == [provider]
+    row = {"slug": provider, "is_current": True, "models": ["gpt-5.6-sol"], "total_models": 1}
+    assert model not in _finalize_picker_rows([row], {}, model)[0]["models"]
+    ctx = ConfigContext(provider, model, "", {}, [])
+    assert _append_unconfigured_rows([], ctx, current_only=True)[0]["models"] == []
+
+    live[:] = ["gpt-5.6-sol", model]
+    assert model in models.cached_provider_model_ids(provider)

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -81,7 +81,7 @@ def test_astra_900k_opt_in_preserves_live_limits_and_wire_contract(monkeypatch, 
 
 
 @pytest.mark.parametrize("provider,model", [
-    ("openai-codex", "gpt-6-astra"), ("openai-codex", "gpt-6-astra-900k"), ("openai", "gpt-6-astra"),
+    ("openai-codex", "gpt-6-astra"), ("openai-codex", "gpt-6-astra-900k"), ("openai-api", "gpt-6-astra"),
 ])
 def test_picker_revalidates_cached_astra_and_never_injects_saved_entitlement(monkeypatch, tmp_path, provider, model):
     from hermes_cli import models

--- a/tests/agent/test_astra_baseline_runtime.py
+++ b/tests/agent/test_astra_baseline_runtime.py
@@ -1,0 +1,37 @@
+"""Focused real-path coverage for the GPT-6 Astra baseline contract."""
+
+from types import SimpleNamespace
+
+
+def test_explicit_astra_resolves_and_uses_official_responses(monkeypatch, tmp_path):
+    """A fresh profile resolves metadata and routes the official endpoint without live I/O."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda *args, **kwargs: {})
+    monkeypatch.setattr("agent.process_bootstrap.OpenAI", lambda **_kwargs: SimpleNamespace())
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda *args, **kwargs: [])
+
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model="gpt-6-astra",
+        provider="openai",
+        api_key="test-key",
+        base_url="https://api.openai.com/v1",
+        platform="cli",
+        max_iterations=2,
+        quiet_mode=True,
+        skip_memory=True,
+    )
+
+    assert agent.api_mode == "codex_responses"
+    assert agent.context_compressor.context_length == 1_050_000
+    kwargs = agent._get_transport().build_kwargs(
+        model=agent.model,
+        messages=[{"role": "user", "content": "Hi"}],
+        tools=[],
+        provider=agent.provider,
+        base_url=agent.base_url,
+        reasoning_config={"enabled": False, "effort": "none"},
+    )
+    assert kwargs["reasoning"]["effort"] == "low"
+    assert kwargs["prompt_cache_options"] == {"ttl": "30m"}

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3191,10 +3191,9 @@ class TestCodexAdapterPromptCacheKey:
         )
         adapter.create(
             messages=[{"role": "user", "content": "hi"}],
-            extra_body={"reasoning": {"enabled": False, "effort": "none"}},
+            extra_body={"reasoning": {"effort": "none"}},
         )
         assert captured["reasoning"]["effort"] == "low"
-        assert captured["prompt_cache_options"] == {"ttl": "30m"}
         assert "prompt_cache_retention" not in captured
 
     def test_astra_auxiliary_proxy_keeps_legacy_effort_contract(self):
@@ -3207,7 +3206,6 @@ class TestCodexAdapterPromptCacheKey:
             extra_body={"reasoning": {"effort": "none"}},
         )
         assert captured["reasoning"]["effort"] == "none"
-        assert "prompt_cache_options" not in captured
 
     def test_codex_backend_forwards_auxiliary_service_tier(self):
         adapter, captured = self._build_adapter(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3197,6 +3197,18 @@ class TestCodexAdapterPromptCacheKey:
         assert captured["prompt_cache_options"] == {"ttl": "30m"}
         assert "prompt_cache_retention" not in captured
 
+    def test_astra_auxiliary_proxy_keeps_legacy_effort_contract(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://responses.example.com/v1",
+            model="gpt-6-astra",
+        )
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"effort": "none"}},
+        )
+        assert captured["reasoning"]["effort"] == "none"
+        assert "prompt_cache_options" not in captured
+
     def test_codex_backend_forwards_auxiliary_service_tier(self):
         adapter, captured = self._build_adapter(
             base_url="https://chatgpt.com/backend-api/codex",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3184,6 +3184,19 @@ class TestCodexAdapterPromptCacheKey:
         ])
         assert "prompt_cache_retention" not in captured
 
+    def test_astra_auxiliary_request_uses_official_contract(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://api.openai.com/v1",
+            model="gpt-6-astra",
+        )
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"enabled": False, "effort": "none"}},
+        )
+        assert captured["reasoning"]["effort"] == "low"
+        assert captured["prompt_cache_options"] == {"ttl": "30m"}
+        assert "prompt_cache_retention" not in captured
+
     def test_codex_backend_forwards_auxiliary_service_tier(self):
         adapter, captured = self._build_adapter(
             base_url="https://chatgpt.com/backend-api/codex",

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -825,6 +825,18 @@ class TestGetModelCapabilities:
         assert caps is not None
         assert caps.supports_vision is False
 
+    def test_astra_builtin_metadata_fills_catalog_lag_without_listing_it(self):
+        """An explicitly discovered Astra remains fully described before models.dev catches up."""
+        with patch("agent.models_dev.fetch_models_dev", return_value={}):
+            caps = get_model_capabilities("openai", "gpt-6-astra")
+
+        assert caps is not None
+        assert caps.context_window == 1_050_000
+        assert caps.max_output_tokens == 128_000
+        assert caps.supports_tools is True
+        assert caps.supports_vision is True
+        assert caps.supports_reasoning is True
+
 
 # ---------------------------------------------------------------------------
 # Per-model metadata overrides (model_overrides config)

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -831,11 +831,7 @@ class TestGetModelCapabilities:
             caps = get_model_capabilities("openai", "gpt-6-astra")
 
         assert caps is not None
-        assert caps.context_window == 1_050_000
-        assert caps.max_output_tokens == 128_000
-        assert caps.supports_tools is True
-        assert caps.supports_vision is True
-        assert caps.supports_reasoning is True
+        assert caps.supports_vision is True  # the one thing _UNKNOWN_MODEL_BASE could not supply
 
         api_caps = get_model_capabilities("openai-api", "gpt-6-astra")
         assert api_caps == caps

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -837,6 +837,9 @@ class TestGetModelCapabilities:
         assert caps.supports_vision is True
         assert caps.supports_reasoning is True
 
+        api_caps = get_model_capabilities("openai-api", "gpt-6-astra")
+        assert api_caps == caps
+
 
 # ---------------------------------------------------------------------------
 # Per-model metadata overrides (model_overrides config)

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -11,6 +11,23 @@ from agent.usage_pricing import (
 from decimal import Decimal
 
 
+def test_astra_whole_request_price_tier_includes_cache_writes():
+    below = estimate_usage_cost(
+        "gpt-6-astra",
+        CanonicalUsage(input_tokens=100_000, output_tokens=10_000, cache_read_tokens=10_000, cache_write_tokens=10_000),
+        provider="openai",
+    )
+    above = estimate_usage_cost(
+        "gpt-6-astra",
+        CanonicalUsage(input_tokens=100_000, output_tokens=10_000, cache_read_tokens=100_000, cache_write_tokens=100_001),
+        provider="openai",
+    )
+
+    assert below.amount_usd == Decimal("1.635")
+    assert above.amount_usd == Decimal("5.450025")
+    assert above.pricing_version == "openai-gpt-6-astra-2026-09"
+
+
 
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 from agent.usage_pricing import (
+    _OFFICIAL_DOCS_PRICING,
     CanonicalUsage,
     format_cost_label,
     estimate_usage_cost,
@@ -23,9 +24,16 @@ def test_astra_whole_request_price_tier_includes_cache_writes():
         provider="openai",
     )
 
-    assert below.amount_usd == Decimal("1.635")
-    assert above.amount_usd == Decimal("5.450025")
-    assert above.pricing_version == "openai-gpt-6-astra-2026-09"
+    # Whole-request tier: crossing 272K prompt tokens re-prices every component of the request,
+    # including cache writes, at the *_above rates — so the cost ratio exceeds the token ratio.
+    entry = _OFFICIAL_DOCS_PRICING[("openai", "gpt-6-astra")]
+    assert above.amount_usd == (
+        Decimal(100_000) * entry.input_cost_per_million_above
+        + Decimal(10_000) * entry.output_cost_per_million_above
+        + Decimal(100_000) * entry.cache_read_cost_per_million_above
+        + Decimal(100_001) * entry.cache_write_cost_per_million_above
+    ) / Decimal(1_000_000)
+    assert below.amount_usd < above.amount_usd
 
 
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -51,6 +51,7 @@ class TestCodexBuildKwargs:
                 "top_p": 0.9,
                 "top_logprobs": 5,
                 "logprobs": True,
+                "reasoning": {"effort": "none"},
                 "include": ["reasoning.encrypted_content", "message.output_text.logprobs"],
                 "prompt_cache_retention": "24h",
                 "prompt_cache_options": {"ttl": "1h"},
@@ -63,6 +64,31 @@ class TestCodexBuildKwargs:
         assert kw["include"] == ["reasoning.encrypted_content"]
         for unsupported in ("temperature", "top_p", "top_logprobs", "logprobs"):
             assert unsupported not in kw
+        assert transport.preflight_kwargs(kw)["prompt_cache_options"] == {"ttl": "30m"}
+
+    @pytest.mark.parametrize("effort", ["none", "minimal"])
+    def test_astra_normalizes_unsupported_low_efforts_after_overrides(self, transport, effort):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+            request_overrides={"reasoning": {"effort": effort}},
+        )
+
+        assert kw["reasoning"]["effort"] == "low"
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])
+    def test_astra_accepts_complete_effort_ladder(self, transport, effort):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+
+        assert kw["reasoning"]["effort"] == effort
 
     def test_astra_proxy_does_not_receive_official_cache_options(self, transport):
         kw = transport.build_kwargs(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -39,6 +39,42 @@ class TestCodexTransportBasic:
 
 class TestCodexBuildKwargs:
 
+    def test_astra_direct_request_applies_model_contract_after_overrides(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.openai.com/v1",
+            reasoning_config={"enabled": False, "effort": "none"},
+            request_overrides={
+                "temperature": 0.4,
+                "top_p": 0.9,
+                "top_logprobs": 5,
+                "logprobs": True,
+                "include": ["reasoning.encrypted_content", "message.output_text.logprobs"],
+                "prompt_cache_retention": "24h",
+                "prompt_cache_options": {"ttl": "1h"},
+            },
+        )
+
+        assert kw["reasoning"]["effort"] == "low"
+        assert kw["prompt_cache_options"] == {"ttl": "30m"}
+        assert "prompt_cache_retention" not in kw
+        assert kw["include"] == ["reasoning.encrypted_content"]
+        for unsupported in ("temperature", "top_p", "top_logprobs", "logprobs"):
+            assert unsupported not in kw
+
+    def test_astra_proxy_does_not_receive_official_cache_options(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://responses.example.com/v1",
+            request_overrides={"prompt_cache_options": {"ttl": "30m"}},
+        )
+
+        assert "prompt_cache_options" not in kw
+
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —
         the Codex backend only knows the base slug, so build_kwargs must

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -103,6 +103,18 @@ class TestCodexBuildKwargs:
         assert "prompt_cache_options" not in kw
         assert kw["reasoning"]["effort"] == "none"
 
+    def test_astra_openai_subdomain_is_not_official_route(self, transport):
+        """Only api.openai.com gets Astra's official cache contract."""
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://evil.api.openai.com/v1",
+            request_overrides={"prompt_cache_options": {"ttl": "30m"}},
+        )
+
+        assert "prompt_cache_options" not in kw
+
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —
         the Codex backend only knows the base slug, so build_kwargs must

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -54,17 +54,13 @@ class TestCodexBuildKwargs:
                 "reasoning": {"effort": "none"},
                 "include": ["reasoning.encrypted_content", "message.output_text.logprobs"],
                 "prompt_cache_retention": "24h",
-                "prompt_cache_options": {"ttl": "1h"},
             },
         )
 
         assert kw["reasoning"]["effort"] == "low"
-        assert kw["prompt_cache_options"] == {"ttl": "30m"}
-        assert "prompt_cache_retention" not in kw
         assert kw["include"] == ["reasoning.encrypted_content"]
-        for unsupported in ("temperature", "top_p", "top_logprobs", "logprobs"):
+        for unsupported in ("temperature", "top_p", "top_logprobs", "logprobs", "prompt_cache_retention"):
             assert unsupported not in kw
-        assert transport.preflight_kwargs(kw)["prompt_cache_options"] == {"ttl": "30m"}
 
     @pytest.mark.parametrize("effort", ["none", "minimal"])
     def test_astra_normalizes_unsupported_low_efforts_after_overrides(self, transport, effort):
@@ -90,30 +86,20 @@ class TestCodexBuildKwargs:
 
         assert kw["reasoning"]["effort"] == effort
 
-    def test_astra_proxy_does_not_receive_official_cache_options(self, transport):
+    @pytest.mark.parametrize("base_url", ["https://responses.example.com/v1", "https://evil.api.openai.com/v1"])
+    def test_astra_contract_is_exact_host_only(self, transport, base_url):
+        """Proxies and lookalike subdomains keep the generic Responses contract (effort passes through)."""
         kw = transport.build_kwargs(
             model="gpt-6-astra",
             messages=[{"role": "user", "content": "Hi"}],
             tools=[],
-            base_url="https://responses.example.com/v1",
+            base_url=base_url,
             reasoning_config={"enabled": True, "effort": "none"},
-            request_overrides={"prompt_cache_options": {"ttl": "30m"}},
+            request_overrides={"temperature": 0.4},
         )
 
-        assert "prompt_cache_options" not in kw
         assert kw["reasoning"]["effort"] == "none"
-
-    def test_astra_openai_subdomain_is_not_official_route(self, transport):
-        """Only api.openai.com gets Astra's official cache contract."""
-        kw = transport.build_kwargs(
-            model="gpt-6-astra",
-            messages=[{"role": "user", "content": "Hi"}],
-            tools=[],
-            base_url="https://evil.api.openai.com/v1",
-            request_overrides={"prompt_cache_options": {"ttl": "30m"}},
-        )
-
-        assert "prompt_cache_options" not in kw
+        assert kw["temperature"] == 0.4
 
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -96,10 +96,12 @@ class TestCodexBuildKwargs:
             messages=[{"role": "user", "content": "Hi"}],
             tools=[],
             base_url="https://responses.example.com/v1",
+            reasoning_config={"enabled": True, "effort": "none"},
             request_overrides={"prompt_cache_options": {"ttl": "30m"}},
         )
 
         assert "prompt_cache_options" not in kw
+        assert kw["reasoning"]["effort"] == "none"
 
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
         """``-900k`` large-context picker variants are Hermes-side aliases —

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -118,13 +118,17 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
 
     (tmp_path / "config.toml").write_text('model = "gpt-6-astra"\n', encoding="utf-8")
     (tmp_path / "models_cache.json").write_text(
-        json.dumps({"models": [{"slug": "gpt-6-astra", "priority": 0}]}),
+        json.dumps({"models": [
+            {"slug": "gpt-6-astra", "priority": 0},
+            {"slug": "openai/gpt-6-astra", "priority": 1},
+        ]}),
         encoding="utf-8",
     )
     monkeypatch.setenv("CODEX_HOME", str(tmp_path))
     monkeypatch.setattr(codex_models, "_fetch_models_from_api", lambda _token: [])
 
     assert "gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
+    assert "openai/gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
 
     monkeypatch.setattr(
         codex_models,

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -121,6 +121,8 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
         json.dumps({"models": [
             {"slug": "gpt-6-astra", "priority": 0},
             {"slug": "openai/gpt-6-astra", "priority": 1},
+            {"slug": "gpt-6-astra-900k", "priority": 2},
+            {"slug": "openai/gpt-6-astra-900k", "priority": 3},
         ]}),
         encoding="utf-8",
     )
@@ -129,13 +131,16 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
 
     assert "gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
     assert "openai/gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
+    assert "gpt-6-astra-900k" not in get_codex_model_ids(access_token="stale-token")
+    assert "openai/gpt-6-astra-900k" not in get_codex_model_ids(access_token="stale-token")
 
     monkeypatch.setattr(
         codex_models,
         "_fetch_models_from_api",
         lambda _token: codex_models._finalize_codex_models(["gpt-6-astra"], allow_astra=True),
     )
-    assert "gpt-6-astra" in get_codex_model_ids(access_token="entitled-token")
+    entitled = get_codex_model_ids(access_token="entitled-token")
+    assert entitled[entitled.index("gpt-6-astra") + 1] == "gpt-6-astra-900k"
 
 
 

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -137,7 +137,7 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
     monkeypatch.setattr(
         codex_models,
         "_fetch_models_from_api",
-        lambda _token: codex_models._finalize_codex_models(["gpt-6-astra"], allow_astra=True),
+        lambda _token: codex_models._finalize_codex_models(["gpt-6-astra"]),
     )
     entitled = get_codex_model_ids(access_token="entitled-token")
     assert entitled[entitled.index("gpt-6-astra") + 1] == "gpt-6-astra-900k"

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -112,6 +112,28 @@ def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
     assert "gpt-5-internal" not in models
 
 
+def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
+    """Cached/configured Astra names must not manufacture current OAuth entitlement."""
+    from hermes_cli import codex_models
+
+    (tmp_path / "config.toml").write_text('model = "gpt-6-astra"\n', encoding="utf-8")
+    (tmp_path / "models_cache.json").write_text(
+        json.dumps({"models": [{"slug": "gpt-6-astra", "priority": 0}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setattr(codex_models, "_fetch_models_from_api", lambda _token: [])
+
+    assert "gpt-6-astra" not in get_codex_model_ids(access_token="stale-token")
+
+    monkeypatch.setattr(
+        codex_models,
+        "_fetch_models_from_api",
+        lambda _token: codex_models._finalize_codex_models(["gpt-6-astra"], allow_astra=True),
+    )
+    assert "gpt-6-astra" in get_codex_model_ids(access_token="entitled-token")
+
+
 
 
 
@@ -238,4 +260,3 @@ class TestNormalizeModelForProvider:
         assert changed is True
         # Uses first from available list
         assert cli.model == "gpt-5.3-codex"
-

--- a/tests/hermes_cli/test_openai_picker_curated.py
+++ b/tests/hermes_cli/test_openai_picker_curated.py
@@ -70,3 +70,16 @@ def test_default_openai_endpoint_intersects_account_access(monkeypatch):
     assert result == list(curated[:2])
 
 
+def test_astra_is_offered_only_by_successful_account_discovery(monkeypatch):
+    """A gated preview may enrich the picker only when this API key lists it."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-fake")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    with patch.object(M, "fetch_api_models", return_value=["gpt-5.6-sol", "gpt-6-astra"]):
+        discovered = M.provider_model_ids("openai-api", force_refresh=True)
+    with patch.object(M, "fetch_api_models", return_value=["gpt-5.6-sol"]):
+        not_entitled = M.provider_model_ids("openai-api", force_refresh=True)
+
+    assert "gpt-6-astra" in discovered
+    assert "gpt-6-astra" not in not_entitled
+

--- a/tests/hermes_cli/test_openai_picker_curated.py
+++ b/tests/hermes_cli/test_openai_picker_curated.py
@@ -79,7 +79,9 @@ def test_astra_is_offered_only_by_successful_account_discovery(monkeypatch):
         discovered = M.provider_model_ids("openai-api", force_refresh=True)
     with patch.object(M, "fetch_api_models", return_value=["gpt-5.6-sol"]):
         not_entitled = M.provider_model_ids("openai-api", force_refresh=True)
+    with patch.object(M, "fetch_api_models", side_effect=RuntimeError("discovery unavailable")):
+        discovery_failed = M.provider_model_ids("openai-api", force_refresh=True)
 
     assert "gpt-6-astra" in discovered
     assert "gpt-6-astra" not in not_entitled
-
+    assert "gpt-6-astra" not in discovery_failed


### PR DESCRIPTION
GPT-6 Astra works through `openai-codex` and the direct OpenAI API, is offered in `/model` only to accounts whose own discovery returns it, and the opt-in `gpt-6-astra-900k` variant unlocks the window the Codex backend actually accepts.

Salvage of #103057 by @100yenadmin (9 commits cherry-picked, authorship preserved; includes @mssteuer's 900K opt-in commit carried over from #103132) onto current `main`, plus 5 follow-up commits from a full review pass. Closes the maintainer's open request on #103057 (the 272K Codex fallback is in the stack and now asserted as a relationship, not a literal).

## What the contributor commits do (unchanged in intent)

- **Discovery-gated availability** (the design @OutThisLife asked for on #103132): Astra never appears in static/offline catalogs; `openai-api` and `openai-codex` pickers list it only when that account's `/models` returns it. Cached picker rows, the saved current model and unauthenticated inventory skeletons can't manufacture entitlement.
- **Context**: direct API 1.05M; Codex OAuth fallback 272K; `gpt-6-astra-900k` picker alias → 900K via the existing `-900k` mechanism (suffix stripped on the wire). `gpt-6-astra-pro` gets no variant — Codex OAuth 400s it.
- **Reasoning**: `low|medium|high|xhigh|max`; `none`/`minimal` normalise to `low` on official routes; proxies keep the generic contract.
- **Pricing**: published rates + whole-request >272K tier including cache writes.

## Follow-up commits (mine)

| Commit | Why |
|---|---|
| `fix(openai): drop prompt_cache_options` | **Every direct-API Astra request raised `TypeError` before hitting the network** — `prompt_cache_options` isn't a kwarg on openai 2.24.0 `Responses.create` and neither send path moves it to `extra_body`; the PR's tests stopped at `build_kwargs`. Per OpenAI's caching guide `ttl` accepts only `30m` and that's the default, so the field carried no information: removed rather than routed. Sanitizer now only strips what the API rejects and never adds a field (body stays byte-stable for the cache prefix). Aux adapter uses `classify_responses_route` instead of an inline host test. |
| `refactor(openai): one is_astra_model predicate` | The slug pair was spelled out 5× with 5 hand-rolled normalisations; `allow_astra=` was a control-coupling flag — the filter now sits where the untrusted inputs are (`config.toml` default + `models_cache.json`). |
| `perf(models): stop revalidating a fresh cache` | `gated_cache` forced a blocking `/models` round-trip on **every picker open** for any entitled account (fresh + SWR branches bypassed; prefetch didn't know about it). Only live discovery ever writes Astra into a same-credential entry, so a fresh entry already is the entitlement record. The stale-fallback filter (failed refresh → drop Astra, entry intact) stays. |
| `refactor(inventory)` | `warning.replace("Showing the saved model only.", …)` string surgery → build the tail once. |
| `test(openai)` | `amount_usd == Decimal("5.450025")` / `pricing_version == "…-2026-09"` were change-detectors; now derived from the entry's own `*_above` rates. |

## Live verification (Sep 7 2026, ChatGPT-subscription Codex OAuth, this branch's code)

| Probe | Result |
|---|---|
| `hermes chat --model gpt-6-astra --provider openai-codex` | `FINAL-OK gpt-6-astra` |
| `--model gpt-6-astra-900k` | `FINAL-OK gpt-6-astra-900k`, context cached at 900,000 |
| tool call (`-t terminal`, `echo TOOL-OK`) | `TOOL-OK` |
| live picker | `['gpt-6-astra', 'gpt-6-astra-900k', 'gpt-5.6-sol', …]`; offline picker: no Astra |
| Codex `reasoning.effort` for Astra | `none`/`minimal` → 400 *"Supported values are: low, medium, high, xhigh, max"*; `max` → 200; control `gpt-5.6-sol` accepts `none` — confirms the Astra-specific ladder |
| Codex input ceiling | 917,662 tokens accepted, 931,751 rejected (consistent with 920K/1,000K in #103132) |
| `gpt-6-astra-pro` on Codex | 400 *not supported when using Codex with a ChatGPT account* |
| direct API `Responses.create(prompt_cache_options=…)` | `TypeError` (the bug fixed above); same body via `extra_body` reaches the network |

Not live-tested: an entitled **direct-API** key (none available). The direct-API path is exercised by the transport tests and the SDK-signature probe.

## Tests

27 files / 788 passed on this branch. The 9 failures in that run (`test_auxiliary_client.py::*_async` ×6, `test_model_switch_context_offload.py` ×3) fail identically on `upstream/main` and are unrelated. Mutation checks: removing the Codex Astra gate, the stale-fallback filter, or the effort normalisation each turn the corresponding contract tests red.

Refs #103015 (tracker), #103016. Supersedes #103057, #105025, #103223 (both add the same metadata via the static-catalog design).
