### PR TITLE
fix(desktop): separate the composer status stack's sections

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -297,8 +297,15 @@ export function ComposerStatusStack({ onSubmit, queue, sessionId }: ComposerStat
             scrolledUp ? 'opacity-30 group-hover/composer:opacity-100' : 'opacity-100'
           )}
         >
+          {/* Each section is its own framed sibling, separated by one hairline
+              (styles.css, `[data-status-section]`). Without the seam two
+              adjacent sections read as a single block: the billing wall runs
+              into session control, and a plugin's status line looks like a
+              footnote of the group above it rather than its own status. */}
           {sections.map(section => (
-            <div key={section.key}>{section.node}</div>
+            <div data-status-section="" key={section.key}>
+              {section.node}
+            </div>
           ))}
         </div>
       )}

--- a/apps/desktop/src/app/chat/composer/status-stack/section-frames.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/section-frames.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { $todosBySession } from '@/store/todos'
+
+import { ComposerStatusStack } from './index'
+
+/**
+ * Sections in the stack are framed siblings: each is wrapped in its own
+ * `[data-status-section]` element, which is the hook the seam rule in
+ * styles.css hangs a hairline on. Without the wrapper, two adjacent sections
+ * paint as one block and the lower one reads as a footnote of the one above.
+ */
+describe('ComposerStatusStack section frames', () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        disconnect() {}
+        observe() {}
+      }
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+    $todosBySession.set({})
+  })
+
+  const renderStack = (queue: React.ReactNode = null) =>
+    render(
+      <MemoryRouter>
+        <ComposerStatusStack queue={queue} sessionId="session-1" />
+      </MemoryRouter>
+    )
+
+  it('frames every rendered section separately', () => {
+    $todosBySession.set({
+      'session-1': [{ content: 'Wire the status stack', id: '1', status: 'in_progress' }]
+    })
+
+    const view = renderStack(<div data-testid="queue-section">Queued</div>)
+
+    expect(view.container.querySelectorAll('[data-status-section]').length).toBe(2)
+  })
+
+  it('keeps each section inside its own frame, so a seam always has one owner per side', () => {
+    $todosBySession.set({
+      'session-1': [{ content: 'Wire the status stack', id: '1', status: 'in_progress' }]
+    })
+
+    const view = renderStack(<div data-testid="queue-section">Queued</div>)
+    const todo = view.container.querySelector('[data-testid="queue-section"]')
+    const todoFrame = todo?.closest('[data-status-section]')
+    const otherFrame = [...view.container.querySelectorAll('[data-status-section]')].find(f => f !== todoFrame)
+
+    expect(todoFrame).toBeTruthy()
+    expect(otherFrame).toBeTruthy()
+    expect(otherFrame?.contains(todo as Node)).toBe(false)
+  })
+
+  it('frames a lone section too, so one section and many share the same shape', () => {
+    const view = renderStack(<div data-testid="queue-section">Queued</div>)
+
+    expect(view.container.querySelectorAll('[data-status-section]').length).toBe(1)
+  })
+})

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1700,6 +1700,19 @@ body.guest-pointer-lock :is(webview, iframe) {
   padding-inline: 5px;
 }
 
+/* Status-stack section seams. Each section in the stack (billing wall, session
+   control, subagents, background, previews, the queue) is a framed sibling;
+   one hairline between them is what keeps two adjacent sections from reading
+   as a single block.
+
+   `:not(:empty)` on BOTH sides is load-bearing: a section can render null (a
+   contribution slot with no active plugin, an empty preview block) and still
+   leave its wrapper in the DOM, so a plain `* + *` rule would draw a seam with
+   nothing on one side of it. */
+[data-slot='composer-status-stack'] [data-status-section]:not(:empty) ~ [data-status-section]:not(:empty) {
+  border-top: 1px solid var(--ui-stroke-tertiary);
+}
+
 /* Popped-out (floating) composer: compact width + an even 5px transparent grab
    platform. The higher-specificity selector resets the base rule's padding-bottom
    so the inset is equal on all four sides (not 5px sides / shell-pad bottom). */


### PR DESCRIPTION
## The problem

The composer status stack renders every section — billing wall, session control,
subagent/background groups, previews, the queue — as siblings inside one card
with nothing between them:

```tsx
{sections.map(section => (
  <div key={section.key}>{section.node}</div>
))}
```

With one section up that looks deliberate. With two, they fuse into a single
block and the lower one reads as a footnote of the one above rather than as its
own status. The component's own docstring already describes the sections as
"separated by light dividers" — they never were.

## The fix

Wrap each section in its own frame (`[data-status-section]`) and draw one
hairline between adjacent non-empty frames, using the app's existing
`--ui-stroke-tertiary` seam token.

`:not(:empty)` on both sides is load-bearing: a section can render null (an
empty preview block) and still leave its wrapper in the DOM, so a plain
`* + *` rule would draw a seam with nothing on one side of it.

13 lines of CSS and a wrapper element. No new colours, spacing or chrome.

## Before / after

A subagent group and a background group up at the same time, same session,
same viewport:

![before and after](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/assets/status-stack-seams/img/main-before-after.png)

![seam zoom](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/assets/status-stack-seams/img/main-seam-zoom.png)

## Testing

- `section-frames.test.tsx` — 3 invariant tests on the frame contract (every
  rendered section is framed; each section's content sits in exactly one frame;
  a lone section is framed too, so one and many share a shape). Proven **red on
  base** (3 failed), green with the fix.
- Full `ui` + `electron` vitest projects: **897 files / 9474 tests pass**.
- `tsc --noEmit` clean, `eslint --max-warnings 0` clean, prettier clean on the
  touched `.tsx` (`styles.css` already fails `prettier --check` on unmodified
  `main`, so it is left alone rather than reformatted in this PR).
- Verified in a headless Electron rig with both groups live: AFTER reports two
  framed sections with `0px` border on the first and a `1.11px` hairline on the
  second; the identical scene on base reports no frames at all.
