### PR TITLE
fix: preserve Slack update routing, flat DMs, and MCP schema maps

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2777,6 +2777,10 @@ class GatewayTurnMixin:
                     _progress_reply_in_thread = bool(
                         _mode_fn() if callable(_mode_fn) else _adapter.config.extra.get("reply_in_thread", True)
                     )
+                    _dm_threads_fn = getattr(_adapter, "_dm_top_level_threads_as_sessions", None)
+                    if (source.chat_id.startswith("D") and callable(_dm_threads_fn)
+                            and not _dm_threads_fn()):
+                        _progress_reply_in_thread = False
             except Exception:
                 _progress_reply_in_thread = True
         _progress_thread_id = _resolve_progress_thread_id(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3906,6 +3906,13 @@ class SlackAdapter(BasePlatformAdapter):
             return None
         edited = updated_message.get("edited")
         edited_ts = str(edited.get("ts") or "") if isinstance(edited, dict) else ""
+        # Unfurls and reply-count updates also emit message_changed. They must not
+        # replay an old request after restart has cleared the in-memory claims.
+        if not edited_ts:
+            return None
+        previous_message = event.get("previous_message")
+        if isinstance(previous_message, dict) and previous_message.get("edited") == edited:
+            return None
         outer_event_ts = str(event.get("ts") or "")
         changed_event_ts = (
             str(event.get("event_ts") or edited_ts or "")

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3908,10 +3908,13 @@ class SlackAdapter(BasePlatformAdapter):
         edited_ts = str(edited.get("ts") or "") if isinstance(edited, dict) else ""
         # Unfurls and reply-count updates also emit message_changed. They must not
         # replay an old request after restart has cleared the in-memory claims.
-        if not edited_ts:
-            return None
         previous_message = event.get("previous_message")
-        if isinstance(previous_message, dict) and previous_message.get("edited") == edited:
+        if isinstance(previous_message, dict):
+            # Native stream updates can change content without an edited marker.
+            if all(previous_message.get(key) == updated_message.get(key)
+                   for key in ("text", "blocks")):
+                return None
+        elif not edited_ts:
             return None
         outer_event_ts = str(event.get("ts") or "")
         changed_event_ts = (

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1885,7 +1885,7 @@ class SlackAdapter(BasePlatformAdapter):
     def _native_task_card_key(
         self, chat_id: str, reply_to: Optional[str], metadata: Optional[Dict[str, Any]]
     ) -> Optional[Tuple[str, str, str]]:
-        thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
         if not thread_ts:
             return None
         return self._workspace_thread_key(
@@ -2042,7 +2042,7 @@ class SlackAdapter(BasePlatformAdapter):
                 # "(empty)" final responses are filtered upstream), the assistant thread status must not
                 # stay stuck on "is thinking..." (#24117).
                 return SendResult(success=True)
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
             last_result = await self._post_chunks(chat_id, team_id, content, formatted, thread_ts)
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -2142,7 +2142,7 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="chat_id and user_id are required")
         try:
             formatted = self.format_message(content)
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
             kwargs = {"channel": chat_id, "user": user_id, "text": formatted, "mrkdwn": True}
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
@@ -2166,7 +2166,7 @@ class SlackAdapter(BasePlatformAdapter):
         during long retry loops. The first call posts and the message ts is remembered; subsequent calls
         with the same (channel, thread, status_key) edit that message in place via ``chat.update``.
         """
-        thread_ts = self._resolve_thread_ts(None, metadata) or ""
+        thread_ts = self._resolve_thread_ts(None, metadata, chat_id=chat_id) or ""
         key = (str(chat_id), str(thread_ts), str(status_key))
         cached_id = self._status_message_ids.get(key)
         if cached_id is not None:
@@ -2327,7 +2327,7 @@ class SlackAdapter(BasePlatformAdapter):
         """``chat.startStream`` for the first frame and register the stream. Streams must anchor to
         a thread_ts (the gateway sets metadata.thread_id even for top-level messages, so a miss is
         rare). Channels require recipient team/user; harmless for DMs."""
-        thread_ts = self._resolve_thread_ts(None, metadata)
+        thread_ts = self._resolve_thread_ts(None, metadata, chat_id=chat_id)
         if not thread_ts:
             return SendResult(success=False, error="no thread_ts for native stream")
         start_kwargs: Dict[str, Any] = {"channel": chat_id, "thread_ts": thread_ts}
@@ -2413,7 +2413,7 @@ class SlackAdapter(BasePlatformAdapter):
             # Same synthetic-thread guard as sending: with reply_in_thread=false thread_id is the
             # message's own ts, and setStatus on it would open an assistant thread prematurely.
             thread_ts = self._resolve_thread_ts(
-                reply_to=metadata.get("message_id"), metadata=metadata)
+                reply_to=metadata.get("message_id"), metadata=metadata, chat_id=chat_id)
         if not thread_ts:
             return  # Can only set status in a thread context
         team_id = self._metadata_team_id(metadata) or self._channel_team.get(chat_id, "")
@@ -2579,10 +2579,16 @@ class SlackAdapter(BasePlatformAdapter):
         return False
 
     def _resolve_thread_ts(
-        self, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None
+        self, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None,
+        *, chat_id: str = "",
     ) -> Optional[str]:
         """thread_ts for an API call: metadata thread_id (parent ts) over reply_to (may be a child
         ts). With ``reply_in_thread: false`` top-level messages get flat replies."""
+        # A shared DM session must not hide replies under each triggering message.
+        # Explicit DM threads still carry their parent in metadata.
+        if chat_id.startswith("D") and not self._dm_top_level_threads_as_sessions():
+            md = metadata or {}
+            return md.get("thread_id") or md.get("thread_ts") or None
         # Inbound sets metadata.thread_id to the message's own ts for top-level messages
         # (session keying), so thread_id == reply_to means a synthetic thread → reply flat.
         if not self.config.extra.get("reply_in_thread", True):
@@ -2628,7 +2634,7 @@ class SlackAdapter(BasePlatformAdapter):
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")
         chat_id = await self._dm_target(chat_id, metadata)
-        thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
         return await self._upload_with_retry(
             chat_id, file_path, os.path.basename(file_path), caption, thread_ts, metadata)
 
@@ -2643,7 +2649,7 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=not_found_error)
         chat_id = await self._dm_target(chat_id, metadata)
         try:
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
             label = f"{kind.capitalize()} upload"
             return await self._upload_with_retry(
                 chat_id, file_path, filename, caption, thread_ts, metadata, label)
@@ -2671,7 +2677,7 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception:
             await super().send_multiple_images(chat_id, images, metadata, human_delay)
             return
-        thread_ts = self._resolve_thread_ts(None, metadata)
+        thread_ts = self._resolve_thread_ts(None, metadata, chat_id=chat_id)
         CHUNK = 10
         chunks = [images[i : i + CHUNK] for i in range(0, len(images), CHUNK)]
         for chunk_idx, chunk in enumerate(chunks):
@@ -3164,8 +3170,8 @@ class SlackAdapter(BasePlatformAdapter):
                 event_hooks={"response": [_ssrf_redirect_guard]}) as client:
                 response = await client.get(image_url)
                 response.raise_for_status()
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
             chat_id = await self._dm_target(chat_id, metadata)
+            thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
             return await self._upload_with_retry(
                 chat_id, None, "image.png", caption, thread_ts, metadata, content=response.content,
                 attempts=1)
@@ -4554,7 +4560,7 @@ class SlackAdapter(BasePlatformAdapter):
         kwargs: Dict[str, Any] = {
             "channel": chat_id, "text": text,
             "blocks": sanitize_blocks(blocks) if sanitize else blocks}
-        thread_ts = self._resolve_thread_ts(None, metadata)
+        thread_ts = self._resolve_thread_ts(None, metadata, chat_id=chat_id)
         if thread_ts:
             kwargs["thread_ts"] = thread_ts
         team_id = self._metadata_team_id(metadata) if team_scoped else None

--- a/tests/gateway/test_slack_native_streaming.py
+++ b/tests/gateway/test_slack_native_streaming.py
@@ -228,3 +228,52 @@ class TestDisconnectCleanup:
         await adapter.disconnect()
         client.chat_stopStream.assert_awaited()
         assert not adapter._active_streams
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("chat_id", "thread_id", "dm_threads", "expected_thread"),
+    [
+        ("D1", None, False, None),
+        ("D1", "111.000", False, "111.000"),
+        ("D1", "222.000", True, "222.000"),
+        ("C1", "111.000", False, "111.000"),
+        ("C1", "222.000", False, "222.000"),
+    ],
+)
+async def test_flat_dm_session_setting_controls_progress_and_final_delivery(
+    chat_id, thread_id, dm_threads, expected_thread,
+):
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    adapter, client = _make_adapter({
+        "dm_top_level_threads_as_sessions": dm_threads, "reply_in_thread": True,
+    })
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda source: adapter
+    source = SessionSource(
+        platform=Platform.SLACK, chat_id=chat_id,
+        chat_type="dm" if chat_id.startswith("D") else "group",
+        thread_id=thread_id, user_id="U123",
+    )
+    progress_metadata, progress_reply_to, status_metadata = runner._run_agent_progress_threading(
+        source, "222.000", False,
+    )
+    assert (status_metadata or {}).get("thread_id") == expected_thread
+    progress = await adapter.send(chat_id, "Working", progress_reply_to, progress_metadata)
+    final = await adapter.send(
+        chat_id, "Done", "222.000", runner._thread_metadata_for_source(source, "222.000"),
+    )
+    assert progress.success and final.success
+    assert [call.kwargs.get("thread_ts") for call in client.chat_postMessage.await_args_list] == [
+        expected_thread, expected_thread,
+    ]
+    draft = await adapter.send_draft(chat_id, 42, "Draft", metadata=status_metadata)
+    if expected_thread is None:
+        assert not draft.success  # The consumer uses flat post/edit streaming instead.
+        client.chat_startStream.assert_not_awaited()
+    else:
+        assert draft.success
+        assert client.chat_startStream.await_args.kwargs["thread_ts"] == expected_thread

--- a/tests/gateway/test_slack_unfurl_duplicate_turn.py
+++ b/tests/gateway/test_slack_unfurl_duplicate_turn.py
@@ -321,3 +321,46 @@ def test_root_metadata_update_after_restart_does_not_replay_request(previously_e
     asyncio.run(adapter._handle_slack_message(update, _body()))
 
     assert delivered == [], "root metadata update replayed an old user request after restart"
+
+
+@pytest.mark.parametrize("mention_surface", ["text", "blocks"])
+@pytest.mark.parametrize("sender_policy", ["peer", "blocked", "self"])
+def test_bot_final_update_can_add_a_mention_without_edited_metadata(
+    mention_surface, sender_policy,
+):
+    delivered = []
+    adapter = _make_adapter(delivered)
+    adapter.config.extra["allow_bots"] = "none" if sender_policy == "blocked" else "mentions"
+    adapter._resolve_user_name = AsyncMock(return_value="peer bot")
+    original = _original_event()
+    original.update(text="Working", bot_id="B_PEER", subtype="bot_message")
+    original["user"] = adapter._bot_user_id if sender_policy == "self" else "U_PEER"
+    final = dict(original)
+    mention = f"<@{adapter._bot_user_id}> please continue"
+    if mention_surface == "text":
+        final["text"] = mention
+    else:
+        final["blocks"] = [{"type": "rich_text", "elements": [
+            {"type": "rich_text_section", "elements": [
+                {"type": "user", "user_id": adapter._bot_user_id},
+                {"type": "text", "text": " please continue"},
+            ]},
+        ]}]
+    update = {
+        "type": "message", "subtype": "message_changed", "channel": CHANNEL,
+        "channel_type": "channel", "team": TEAM, "ts": UNFURL_EVENT_TS,
+        "event_ts": UNFURL_EVENT_TS, "message": final, "previous_message": original,
+    }
+
+    async def scenario():
+        await adapter._handle_slack_message(original, _body())
+        await adapter._handle_slack_message(update, _body())
+        await adapter._handle_slack_message(update, _body())
+
+    asyncio.run(scenario())
+    if sender_policy == "peer":
+        assert len(delivered) == 1
+        assert "please continue" in delivered[0].text
+        assert delivered[0].message_id == ORIGINAL_TS
+    else:
+        assert delivered == []

--- a/tests/gateway/test_slack_unfurl_duplicate_turn.py
+++ b/tests/gateway/test_slack_unfurl_duplicate_turn.py
@@ -303,3 +303,21 @@ class TestClaimReleasedOnFailure:
 
         asyncio.run(scenario())
         assert len(delivered) == 1
+
+
+@pytest.mark.parametrize("previously_edited", [False, True])
+def test_root_metadata_update_after_restart_does_not_replay_request(previously_edited):
+    """A fresh adapter must not route old root text when Slack updates its metadata."""
+    delivered = []
+    adapter = _make_adapter(delivered)
+    adapter._resolve_user_name = AsyncMock(return_value="test user")
+    update = _unfurl_event()
+    update["message"]["thread_ts"] = ORIGINAL_TS
+    update["message"]["reply_count"] = 2
+    if previously_edited:
+        update["message"]["edited"] = {"user": USER, "ts": "1787365410.000000"}
+    update["previous_message"] = dict(update["message"], reply_count=1)
+
+    asyncio.run(adapter._handle_slack_message(update, _body()))
+
+    assert delivered == [], "root metadata update replayed an old user request after restart"

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -468,6 +468,33 @@ class TestLifecycleConfig:
 # ---------------------------------------------------------------------------
 
 class TestSchemaConversion:
+    @pytest.mark.parametrize("field_name", ["properties", "required"])
+    def test_nested_keyword_named_fields_remain_valid_schemas(self, field_name):
+        from jsonschema import Draft202012Validator
+        from tools.mcp_tool_schema import _convert_mcp_schema
+
+        raw = {
+            "type": "object",
+            "properties": {
+                "pages": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {field_name: {"type": "object"}},
+                        "required": [field_name],
+                    },
+                },
+            },
+        }
+        Draft202012Validator.check_schema(raw)
+        converted = _convert_mcp_schema(
+            "notion", _make_mcp_tool(name="create_pages", input_schema=raw)
+        )["parameters"]
+        Draft202012Validator.check_schema(converted)
+        fields = converted["properties"]["pages"]["items"]["properties"]
+        assert set(fields) == {field_name}
+        assert fields[field_name]["properties"] == {}
+
     def test_converts_mcp_tool_to_hermes_schema(self):
         from tools.mcp_tool_schema import _convert_mcp_schema
 

--- a/tools/mcp_tool_schema.py
+++ b/tools/mcp_tool_schema.py
@@ -73,7 +73,14 @@ def _repair_object_shape(node):
         return [_repair_object_shape(item) for item in node]
     if not isinstance(node, dict):
         return node
-    repaired = {k: _repair_object_shape(v) for k, v in node.items()}
+    # These dictionaries name schemas; a field named "properties" or "required"
+    # must not make its containing name map look like an object schema itself.
+    schema_maps = {"properties", "patternProperties", "$defs", "definitions", "dependentSchemas"}
+    repaired = {
+        k: {name: _repair_object_shape(schema) for name, schema in v.items()}
+        if k in schema_maps and isinstance(v, dict) else _repair_object_shape(v)
+        for k, v in node.items()
+    }
     if not repaired.get("type") and ("properties" in repaired or "required" in repaired):
         repaired["type"] = "object"
     if repaired.get("type") == "object":


### PR DESCRIPTION
Slack message updates can replay an old request, miss a newly added peer mention, or hide replies beneath separate DM messages. MCP schema repair can also corrupt valid schemas whose field names match JSON Schema keywords.

- Ignore Slack metadata-only updates after a gateway restart clears in-memory message claims. Compare previous/current text and blocks before routing a changed message.
- Preserve native stream updates that add a peer mention without an `edited` marker. Existing sender authorization, bot policy, and duplicate suppression still apply.
- Honor `dm_top_level_threads_as_sessions: false` for outbound DM progress and replies as well as inbound sessions. Top-level DMs stay in the main timeline through the existing post/edit fallback; explicit DM threads, channel threads, and default DM behavior remain unchanged. No new setting is needed, and `reply_in_thread: true` still applies to channels.
- Repair schemas inside property-name maps without treating the maps themselves as schemas. Nested fields named `properties` or `required` retain valid object schemas.

Validation:

- 625 tests passed with no failures or skips across 35 Slack, gateway progress, and MCP test files, using `scripts/run_tests.sh` with the native Slack SDK installed.
- Restart regressions cover unchanged roots with and without historical edit metadata. Stream regressions cover text/rich-text mentions, duplicate updates, blocked bots, and self-authored posts.
- DM regressions run the real gateway progress routing and adapter delivery path against a fake Slack transport, checking flat top-level DMs and preserved explicit/default thread targets.
- MCP regressions validate converted schemas with the JSON Schema validator for nested keyword-named fields.
- `git diff --check` passed.
- Live Slack acceptance passed for root replay suppression, separate channel conversations, and native peer handoff. Live acceptance of the flat-DM behavior is pending.

This branch starts from upstream main and contains only these four native fix commits.
