### PR TITLE
fix(web): support native Vite config loading during updates

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -77,8 +77,8 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@hermes/shared": path.resolve(__dirname, "../apps/shared/src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
+      "@hermes/shared": path.resolve(import.meta.dirname, "../apps/shared/src"),
     },
     // When @nous-research/ui is symlinked via `file:../../design-language`,
     // Node's module resolution would pick up shared deps from
@@ -111,6 +111,8 @@ export default defineConfig({
     // imports in App.tsx create the route boundaries; these groups keep
     // shared node_modules out of every page chunk.
     rolldownOptions: {
+      // React Compiler dominates these short builds; keep correctness warnings enabled.
+      checks: { pluginTimings: false },
       output: {
         codeSplitting: {
           minSize: 20_000,


### PR DESCRIPTION
The dashboard's ESM Vite configuration uses `__dirname` for two aliases, which produces a compatibility warning during updates and prevents loading the configuration with `--configLoader native`. Resolve both aliases from `import.meta.dirname`.

Disable only Rolldown's plugin-timing diagnostic for the dashboard's short React Compiler builds. Keep React Compiler and the correctness diagnostics enabled. This changes diagnostic output; it does not claim a compilation-speed improvement.

Validation: `npm run build --workspace web -- --configLoader native` passed on the installed checkout and again after rebasing onto upstream `main` at `233757037df1f03f9fe1cfddc097acd5ad7f7510`. The installed build emitted neither warning. Root/web package manifests and lockfiles were unchanged between the two bases, so the rebased build reused the installed dependencies. `git diff --check` and a deterministic secret scan of the changed file passed.
