### PR TITLE
Desktop task panel follows the todo_list rename; subagent progress survives tool_progress off

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -23,7 +23,7 @@ import {
   generatedImageEchoSources,
   stripGeneratedImageEchoes
 } from '@/lib/generated-images'
-import { nextTodosFromToolEvent, parseTodoRevision } from '@/lib/todos'
+import { isTodoToolName, nextTodosFromToolEvent, parseTodoRevision } from '@/lib/todos'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { isDiskFullErrorMessage, notifyError } from '@/store/notifications'
 import { broadcastSessionsChanged } from '@/store/session-sync'
@@ -461,7 +461,7 @@ export function useMessageStream({
 
       // The composer status stack owns todo display now (no inline panel) —
       // mirror every todo state the tool reports into its session store.
-      if (payload?.name === 'todo') {
+      if (payload && isTodoToolName(payload.name)) {
         const todos = nextTodosFromToolEvent($todosBySession.get()[sessionId] ?? [], payload)
 
         if (todos) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
@@ -71,3 +71,31 @@ describe('useMessageStream turn-end todo cleanup', () => {
     expect($todosBySession.get()[SID]?.[0]?.id).toBe('live')
   })
 })
+
+describe('useMessageStream todo tool naming', () => {
+  afterEach(() => {
+    cleanup()
+    clearSessionTodos(SID)
+  })
+
+  // The backend renamed the tool to `todo_list` (core-tool deferral); the
+  // composer status stack must follow the wire name, not only the legacy alias.
+  it('feeds the task panel from a tool.complete named todo_list', () => {
+    mountStream()
+
+    act(() =>
+      stream.handleEvent({
+        payload: {
+          args: {},
+          name: 'todo_list',
+          result: { revision: 2, todos: [todo('wire', 'in_progress')] },
+          tool_id: 'c1'
+        },
+        session_id: SID,
+        type: 'tool.complete'
+      })
+    )
+
+    expect($todosBySession.get()[SID]?.[0]?.id).toBe('wire')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts
@@ -25,7 +25,8 @@ describe('completionErrorText', () => {
 describe('toTodoPayload', () => {
   it('routes named todo and anonymous todos-bearing events to the todo stream', () => {
     expect(toTodoPayload(payload({ name: 'todo' }))?.tool_id).toBe('todo-live')
-    expect(toTodoPayload(payload({ todos: [] }))?.name).toBe('todo')
+    expect(toTodoPayload(payload({ todos: [] }))?.name).toBe('todo_list')
+    expect(toTodoPayload(payload({ name: 'todo_list' }))?.tool_id).toBe('todo-live')
     expect(toTodoPayload(payload({ name: 'web_search' }))).toBeUndefined()
     expect(toTodoPayload(undefined)).toBeUndefined()
   })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
@@ -1,5 +1,6 @@
 import type { GatewayEventPayload } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
+import { isTodoToolName } from '@/lib/todos'
 
 import type { ClientSessionState } from '../../../types'
 
@@ -142,9 +143,9 @@ export function toTodoPayload(payload: GatewayEventPayload | undefined): Gateway
     return undefined
   }
 
-  const isTodo = payload.name === 'todo' || (!payload.name && Object.hasOwn(payload, 'todos'))
+  const isTodo = isTodoToolName(payload.name) || (!payload.name && Object.hasOwn(payload, 'todos'))
 
-  return isTodo ? { ...payload, name: 'todo', tool_id: payload.tool_id || 'todo-live' } : undefined
+  return isTodo ? { ...payload, name: 'todo_list', tool_id: payload.tool_id || 'todo-live' } : undefined
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -22,6 +22,7 @@ import { SCAFFOLD_LABEL_CLASS, SCAFFOLD_META_CLASS, ScaffoldRow } from '@/compon
 import { useI18n } from '@/i18n'
 import { generatedImageFromResult } from '@/lib/generated-images'
 import { separateGluedReasoningBlocks } from '@/lib/reasoning-blocks'
+import { isTodoToolName } from '@/lib/todos'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { $reasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
@@ -64,7 +65,7 @@ const DelegateToolPart: FC<TimelineToolCallProps> = props => {
 
 const ChainToolFallback: FC<TimelineToolCallProps> = props => {
   // todo parts are hoisted to a dedicated panel above the message content.
-  if (props.toolName === 'todo') {
+  if (isTodoToolName(props.toolName)) {
     return null
   }
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -348,6 +348,7 @@ const DEFAULT_COUNT_NOUN_BY_TOOL: Record<string, string> = {
   search_files: 'result',
   session_search_recall: 'result',
   todo: 'todo',
+  todo_list: 'todo',
   web_search: 'result'
 }
 

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -1,5 +1,5 @@
 import { firstStringField, normalize } from '@/lib/text'
-import { parseTodos } from '@/lib/todos'
+import { isTodoToolName, parseTodos } from '@/lib/todos'
 import type { SessionMessage } from '@/types/hermes'
 
 import type { ChatMessage, ChatMessagePart, GatewayEventPayload } from './types'
@@ -231,7 +231,7 @@ function carryTodos(payload: GatewayEventPayload | undefined, ...prev: unknown[]
     return next === null ? undefined : { todos: next }
   }
 
-  if (payload?.name !== 'todo') {
+  if (!isTodoToolName(payload?.name)) {
     return undefined
   }
 

--- a/apps/desktop/src/lib/todos.ts
+++ b/apps/desktop/src/lib/todos.ts
@@ -18,6 +18,10 @@ export interface TodoPatch {
 
 const STATUSES: readonly TodoStatus[] = ['pending', 'in_progress', 'completed', 'cancelled']
 
+/** The task tool is `todo_list` on the wire since the core-tool rename; `todo`
+ *  survives as the legacy alias in stored transcripts and older backends. */
+export const isTodoToolName = (name: unknown): boolean => name === 'todo_list' || name === 'todo'
+
 const isRecord = (v: unknown): v is Record<string, unknown> => Boolean(v && typeof v === 'object' && !Array.isArray(v))
 const isStatus = (v: unknown): v is TodoStatus => (STATUSES as readonly string[]).includes(v as string)
 
@@ -240,7 +244,7 @@ export function todosFromMessageContent(content: unknown): null | TodoItem[] {
   let latest: null | TodoItem[] = null
 
   for (const part of content) {
-    if (!isRecord(part) || part.type !== 'tool-call' || part.toolName !== 'todo') {
+    if (!isRecord(part) || part.type !== 'tool-call' || !isTodoToolName(part.toolName)) {
       continue
     }
 

--- a/apps/desktop/src/lib/tool-render-class.ts
+++ b/apps/desktop/src/lib/tool-render-class.ts
@@ -39,7 +39,7 @@ export function isCardTool(toolName: string): boolean {
 // dedicated panel above the message content, and a reaction's UI is the emoji
 // landing on the bubble. Both still render when they FAIL, which is a bounded
 // error row either way.
-const SILENT_TOOL_NAMES = new Set(['react_to_message', 'todo'])
+const SILENT_TOOL_NAMES = new Set(['react_to_message', 'todo', 'todo_list'])
 
 export function isSilentTool(toolName: string): boolean {
   return SILENT_TOOL_NAMES.has(toolName)

--- a/tests/tui_gateway/test_todo_state_events.py
+++ b/tests/tui_gateway/test_todo_state_events.py
@@ -98,3 +98,18 @@ def test_empty_list_at_nonzero_revision_is_a_real_clear():
     state = server._normalize_todo_state({"todos": [], "revision": 2})
 
     assert state == {"todos": [], "revision": 2}
+
+
+def test_subagent_lifecycle_bypasses_tool_progress_off(monkeypatch):
+    """Subagent rows feed the Desktop status stack / TUI spawn tree — application state, not
+    tool-progress chrome — so display.tool_progress=off must not swallow them."""
+    sid = "subagent-progress-off"
+    events = []
+    monkeypatch.setitem(server._sessions, sid, {"agent": None, "tool_progress_mode": "off"})
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda _sid: False)
+    monkeypatch.setattr(server, "_emit", lambda event, event_sid, payload=None: events.append(event))
+
+    server._on_tool_progress(sid, "subagent.start", "delegate_task", "goal", None, goal="goal", subagent_id="s1")
+    server._on_tool_progress(sid, "reasoning.available", "_thinking", "hmm", None)
+
+    assert events == ["subagent.start"]

--- a/tui_gateway/tool_progress.py
+++ b/tui_gateway/tool_progress.py
@@ -358,10 +358,14 @@ def _on_tool_progress(
     sid: str, event_type: str, name: str | None = None, preview: str | None = None,
     _args: dict | None = None, **_kwargs,
 ):
-    if not _tool_progress_enabled(sid) or (event_type == "tool.started" and name):
+    if event_type == "tool.started" and name:
         return
+    # Subagent lifecycle is application state (Desktop status stack, TUI spawn tree), not
+    # tool-progress chrome: it must survive display.tool_progress=off like todo.updated does.
     if event_type.startswith("subagent."):
         return _progress_subagent(sid, name, preview, _kwargs, event_type)
+    if not _tool_progress_enabled(sid):
+        return
     handler, requires = _PROGRESS_HANDLERS.get(event_type, (None, None))
     if handler is not None and (requires is None or {"name": name, "preview": preview}[requires]):
         handler(sid, name, preview, _kwargs)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2055,6 +2055,8 @@ In the CLI, cycle through these modes with `/verbose`. To use `/verbose` in mess
 
 Tool progress requires a gateway adapter that can display progress updates safely. Platforms without message editing support, including Signal, suppress tool-progress bubbles even if `/verbose` saves a non-`off` mode.
 
+`off` hides tool-call *chrome* only. Application state that has its own surface in the Desktop app and TUI — the task list (`todo_list`), subagent progress, clarify questions, and MCP consent cards — keeps flowing regardless of this setting.
+
 ### Focus view (`/focus`, CLI + TUI)
 
 `display.focus_view: true` enables **focus view** — a reduced-output display mode for when you want the answer, not the play-by-play. It is a thin layer over the same `tool_progress` machinery rather than a second suppression path:


### PR DESCRIPTION
Desktop's task panel works again with the renamed `todo_list` tool, and hiding tool-call chrome (`display.tool_progress: off`) no longer hides subagent progress.

Community report (Discord): with `display.tool_progress: false`, "todos are broken" — the task panel never populates and the list vanishes when the turn ends. Investigation found two independent defects, one per surface.

## Changes

- **Desktop** (`apps/desktop`): the core-tool rename shipped `todo_list` on the wire (`todo` kept as a legacy alias). The renderer still matched the literal `todo` in seven places — live tool.start/complete mirror into the composer status stack, todo-stream router, args carry-over, transcript hoist, silent-tool class, count noun, stored-history hydration. Live updates rendered as ordinary tool rows and the panel stayed empty; reopening a chat never restored a finished list. One predicate `isTodoToolName` (`lib/todos.ts`) now owns the wire/legacy pair and every site reads it.
- **tui_gateway** (`tool_progress.py::_on_tool_progress`): `subagent.*` was dropped by the tool-progress gate. Subagent lifecycle is application state (Desktop status stack, TUI spawn tree), same class as `todo.updated`, clarify and MCP consent cards, which already bypass the gate. The gate now covers only optional chrome (reasoning previews, MoA rows, `tool.generating`).
- Docs: `display.tool_progress: off` scope clarified in `website/docs/user-guide/configuration.md`.

Root cause in one sentence: the backend rename (#97979) never reached the Desktop renderer's hard-coded tool name, and the gateway's progress gate sat in front of subagent events it should not own.

## Validation

| Check | Before | After |
|---|---|---|
| Live probe: real `AIAgent` + real `tui_gateway._agent_cbs`, `tool_progress: off`, mock provider calls `todo_list` | wire emits `tool.complete`, `todo.updated` | same (backend was already correct) |
| Live probe: real `_build_child_progress_callback` relay, `tool_progress: off` | `[]` | `['subagent.start', 'subagent.complete']` |
| Desktop `useMessageStream` fed `tool.complete{name:'todo_list'}` | `$todosBySession[sid]` undefined | populated |
| Desktop `latestSessionTodos` over a stored `todo_list` call | `null` | list restored |
| `apps/desktop` vitest (`src/lib src/app/session src/components/assistant-ui` + todo/composer stores) | — | 233 files / 2564 passed |
| `tests/tui_gateway/test_todo_state_events.py` + siblings | — | 16 passed |

Tests added: 1 vitest (`todo_list` named completion feeds the panel), 1 pytest (`subagent.start` survives progress off, `reasoning.available` still gated).

Not addressed here (separate class): the report's "unfinished lists are cleared at turn end and not restored on reopen" is the deliberate stale-active guard in `store/todos.ts`; #99644 (@royalaid) proposes durable Todo persistence and is the place for that discussion.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa97d3a/bS0CjPPGPCxUAu-EKd3P1_GGsWMPWx.png)
