### PR TITLE
fix(gateway): delete the streaming preview the consumer abandoned once the final lands

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1569,6 +1569,10 @@ class SendResult:
     # Extra ids (send order) when a payload was split; ``message_id`` is then the LAST id so
     # later edits target the newest chunk.
     continuation_message_ids: tuple = ()
+    # True when only a PREFIX of the requested text landed (the base plain-text fallback caps at
+    # 3500 chars). ``success`` still means the reader got a reply; a consumer that needs the
+    # COMPLETE text (the post-delivery ``delivered`` stamp) must check this too.
+    truncated: bool = False
     # SEND_ERROR_KINDS member (failures only) via :func:`classify_send_error`, so consumers
     # branch without substring-matching ``error``.
     error_kind: Optional[str] = None
@@ -3236,9 +3240,14 @@ class BasePlatformAdapter(ABC):
         # rate-limited error never reaches here: it classifies as network above and the
         # loop only breaks on a non-transient, non-rate-limited error.
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
-        fallback_result = await _send(f"(Response formatting failed, plain text:)\n\n{content[:3500]}")
+        fallback_text = content[:3500]
+        fallback_result = await _send(f"(Response formatting failed, plain text:)\n\n{fallback_text}")
         if not fallback_result.success:
             logger.error("[%s] Fallback send also failed: %s", self.name, fallback_result.error)
+        elif len(fallback_text) < len(content):
+            # Only a prefix landed. Success stands (the reader got a reply), but nothing may treat
+            # this as the complete text having arrived.
+            fallback_result.truncated = True
         return fallback_result
 
     @staticmethod
@@ -3886,10 +3895,20 @@ class BasePlatformAdapter(ABC):
             text_content=text_content, images=images, media_files=media_files,
             local_files=local_files, force_document_attachments=force_document, pre_extract=pre_extract)
 
-    async def _fire_post_delivery_callback(self, session_key: str, interrupt_event: asyncio.Event) -> None:
+    async def _fire_post_delivery_callback(
+            self, session_key: str, interrupt_event: asyncio.Event, *, delivered: bool = False) -> None:
         """Run the one-shot post-delivery callback (bounded, errors swallowed). The generation is
         read HERE — stamped on the interrupt event DURING the handler await; an earlier snapshot
-        would let stale runs fire a fresher run's callbacks."""
+        would let stale runs fire a fresher run's callbacks.
+
+        ``delivered`` (the COMPLETE final text reached the user: its own send, or riding along as a
+        TTS caption; bare audio and a truncated plain-text fallback do not count) is stamped on the
+        same event first. The hook fires unconditionally
+        because its lifecycle consumers (goal continuation, background review release) must run either
+        way; a callback that would remove the reader's only text copy of the reply (abandoned-preview
+        cleanup) reads the stamp and stands down when the text did not land."""
+        with contextlib.suppress(Exception):
+            interrupt_event._hermes_final_delivered = bool(delivered)
         _post_cb = self.pop_post_delivery_callback(
             session_key, generation=getattr(interrupt_event, "_hermes_run_generation", None))
         if callable(_post_cb):
@@ -3925,12 +3944,24 @@ class BasePlatformAdapter(ABC):
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
         delivery_attempted = delivery_succeeded = False  # feeds the processing-complete hook
+        # The COMPLETE final text reached the user (own send, or as a TTS caption). Kept apart from the
+        # aggregate: a voice reply can land its audio while the text send fails, and a truncated
+        # plain-text fallback is a success that carried only a prefix. Neither may read as "text
+        # delivered" to the post-delivery stamp.
+        text_delivered = False
+        post_delivery_fired = False
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
             if result is not None:
                 delivery_attempted = True
                 delivery_succeeded = delivery_succeeded or bool(getattr(result, "success", False))
+
+        def _record_text_delivery(result):
+            nonlocal text_delivered
+            _record_delivery(result)
+            text_delivered = text_delivered or (
+                bool(getattr(result, "success", False)) and not getattr(result, "truncated", False))
         # Reuse the interrupt event handle_message() installed; new Event only if removed externally.
         interrupt_event = self._active_sessions.get(session_key) or asyncio.Event()
         self._active_sessions[session_key] = interrupt_event
@@ -3972,10 +4003,12 @@ class BasePlatformAdapter(ABC):
                 if not _tts_paths and _tts_requested_path is not None:
                     with contextlib.suppress(OSError):
                         os.remove(_tts_requested_path)
+                # _play_tts_file returns True only when the COMPLETE text rode along as the caption.
+                text_delivered = text_delivered or _tts_caption_delivered
                 if text_content and not _tts_caption_delivered:
                     await self._send_final_text(
                         event, session_key, text_content, _final_thread_metadata,
-                        is_ephemeral_response, _ephemeral_ttl, _record_delivery)
+                        is_ephemeral_response, _ephemeral_ttl, _record_text_delivery)
                 await self._deliver_attachments(
                     event, extracted, _final_thread_metadata,
                     anything_sent=delivery_attempted or _tts_caption_delivered)
@@ -3995,6 +4028,13 @@ class BasePlatformAdapter(ABC):
                 logger.debug("[%s] Processing queued follow-up message", self.name)
                 self._clear_session_guard(session_key)
                 await self._stop_typing_refresh(event.source.chat_id, typing_task, metadata=_thread_metadata)
+                # Fire the post-delivery callback BEFORE handing the session over: the follow-up turn
+                # shares this interrupt Event and re-stamps its run generation as soon as it starts, so a
+                # callback popped from ``finally`` could be the NEXT turn's, fired with THIS turn's
+                # delivery outcome (a preview cleanup would then delete a reply still in flight).
+                await self._fire_post_delivery_callback(
+                    session_key, interrupt_event, delivered=text_delivered)
+                post_delivery_fired = True
                 self._spawn_drain_task(pending_event, session_key)
                 return  # Drain task owns the session now.
         except asyncio.CancelledError:
@@ -4014,7 +4054,9 @@ class BasePlatformAdapter(ABC):
             # Stop typing BEFORE the post-delivery callback: a stuck callback must not keep it
             # alive.
             await self._stop_typing_refresh(event.source.chat_id, typing_task, metadata=_thread_metadata)
-            await self._fire_post_delivery_callback(session_key, interrupt_event)
+            if not post_delivery_fired:
+                await self._fire_post_delivery_callback(
+                    session_key, interrupt_event, delivered=text_delivered)
             # Callback work or a late refresh may have recreated typing — one final bounded stop.
             await self._stop_typing_refresh(
                 event.source.chat_id, None, metadata=_thread_metadata, stop_attempts=1)

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3673,6 +3673,69 @@ class GatewayTurnMixin:
                 "possible duplicate send (see wecom ack-timeout RCA).",
                 _sk, _streamed, _previewed, _content_delivered, _transformed, len(_final),
             )
+            self._run_agent_schedule_abandoned_preview_cleanup(_sc, source, turn_ctx, _content_delivered)
+
+    def _run_agent_schedule_abandoned_preview_cleanup(
+        self, stream_consumer: Any, source: SessionSource, turn_ctx: TurnContext,
+        content_delivered: bool) -> None:
+        """Delete previews the consumer abandoned when the gateway had to send the final itself.
+
+        The consumer deletes the previews it replaces on its own fresh-final and fallback paths. This
+        branch is the one where the consumer gave up and the GATEWAY sends the replacement instead, and
+        nothing cleaned up behind it: a preview frozen mid-render, because its edits were refused inside
+        a flood window, stayed in the chat above the complete reply showing raw MarkdownV2 markers and
+        the streaming cursor.
+
+        Three guards keep this from ever removing the reader's only copy of the answer. Skipped when the
+        stream did deliver the content (those previews ARE the reply). The ids come from the consumer's
+        segment-only seam, so finalized earlier segments survive. And the delete runs from the
+        post-delivery callback, which base.py fires from ``finally`` whether or not the final send
+        succeeded: the callback reads the outcome base.py stamps on the session event and stands down
+        after a failed send, rather than deleting the preview with no replacement in the chat."""
+        from gateway.run import safe_schedule_threadsafe
+        session_key = turn_ctx.session_key
+        if content_delivered or not session_key or stream_consumer is None:
+            return
+        ids_fn = getattr(stream_consumer, "abandoned_preview_ids", None)
+        delete_fn = getattr(stream_consumer, "delete_abandoned_previews", None)
+        if not callable(ids_fn) or not callable(delete_fn):
+            return
+        cleanup_adapter = self._adapter_for_source(source)
+        if cleanup_adapter is None or not hasattr(cleanup_adapter, "register_post_delivery_callback"):
+            return
+        try:
+            stale_ids = set(ids_fn())
+        except Exception as exc:
+            logger.debug("Abandoned preview id lookup failed: %s", exc)
+            return
+        if not stale_ids:
+            return
+        _loop_snapshot = asyncio.get_running_loop()
+
+        def _cleanup_abandoned_previews() -> None:
+            # Stamped by base.py right before the hook fires. Missing or False means the replacement
+            # never reached the reader, and the frozen preview is all they have: keep it.
+            _active = getattr(cleanup_adapter, "_active_sessions", {}).get(session_key)
+            if not getattr(_active, "_hermes_final_delivered", False):
+                logger.debug(
+                    "Abandoned preview cleanup skipped for session %s: final send did not land.", session_key)
+                return
+
+            async def _delete_all() -> None:
+                with suppress(Exception):
+                    await delete_fn(stale_ids)
+            with suppress(Exception):
+                safe_schedule_threadsafe(
+                    _delete_all(), _loop_snapshot, logger=logger,
+                    log_message="Abandoned preview cleanup scheduling error",
+                )
+
+        try:
+            cleanup_adapter.register_post_delivery_callback(
+                session_key, _cleanup_abandoned_previews, generation=turn_ctx.run_generation,
+            )
+        except Exception as exc:
+            logger.debug("Abandoned preview cleanup registration failed: %s", exc)
 
     def _run_agent_schedule_bubble_cleanup(self, response: Any, _cleanup_adapter: Any, turn_ctx: TurnContext) -> None:
         """Schedule deletion of tracked temporary progress bubbles after the final response lands.

--- a/gateway/stream_consumer_transport.py
+++ b/gateway/stream_consumer_transport.py
@@ -118,6 +118,27 @@ class StreamTransportMixin:
             except Exception as e:
                 logger.debug("%s preview cleanup failed (%s): %s", label, stale_id, e)
 
+    def abandoned_preview_ids(self) -> set:
+        """Previews a GATEWAY-sent final replaces after this consumer gave up on the current segment
+        (every edit refused, so nothing here delivered the answer). Public seam for the gateway's
+        abandoned-preview cleanup.
+
+        Only the single frozen bubble of a non-split segment is handed over. Segment-only, because
+        earlier segments are finalized preambles the reader already has. Single bubble, because
+        adapters cap a long final by message count or length and still report success (Discord keeps
+        the first N-1 chunks, WeCom and others cut at their limit): one bubble holds at most one
+        platform message of the reply's prefix, which any successful final send covers, while a split
+        chain or several bubbles could hold more than a capped final delivered."""
+        if self._turn_split_delivery:
+            return set()
+        stale = {sid for sid in self._stale_preview_ids(segment_only=True) if sid}
+        return stale if len(stale) == 1 else set()
+
+    async def delete_abandoned_previews(self, stale_ids) -> None:
+        """Best-effort delete of ``abandoned_preview_ids()`` once the replacement has landed.
+        ``retry_on_false``: the flood window that stranded the preview can refuse the delete too."""
+        await self._delete_previews(set(stale_ids), label="Abandoned preview", retry_on_false=True)
+
     def _resolve_draft_streaming(self) -> bool:
         """cfg.transport "draft"/"auto" → the adapter's supports_draft_streaming probe
         ("draft" logs the downgrade); "edit"/"off" → False."""

--- a/tests/gateway/test_abandoned_preview_cleanup.py
+++ b/tests/gateway/test_abandoned_preview_cleanup.py
@@ -1,0 +1,604 @@
+"""A preview the stream consumer abandoned is deleted once the gateway's own final lands.
+
+The consumer deletes the previews it replaces on its fresh-final and fallback paths. It does not
+own the case where it gives up entirely and the GATEWAY sends the final instead, and nothing
+cleaned up behind that: on 6 Sep 2026 four preview edits were refused inside a Telegram flood
+window (9s waits against a 5s inline cap, so each failed closed), the preview froze mid-render,
+and the complete 2888-character reply arrived six seconds later as a separate message. The reader
+was left with a truncated preview above the real answer, showing raw MarkdownV2 markers and the
+streaming cursor.
+
+Three guards keep the cleanup from ever removing the reader's only copy of the answer:
+
+* skipped when the stream did deliver the content (those previews ARE the reply);
+* segment-only ids, so finalized earlier segments (delivered preambles) survive;
+* the delete runs from the post-delivery callback, which fires whether or not the final send
+  succeeded, so it reads the outcome base.py stamps on the session event (did the final TEXT land,
+  by its own send or as a TTS caption; audio alone does not count) and stands down otherwise. That
+  stamp is bound to the finishing turn: a queued follow-up shares the session event, so the hook
+  fires before the drain hand-off rather than from ``finally``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway import run as run_mod
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource, build_session_key
+
+SESSION_KEY = "agent:main:telegram:dm:5230977008"
+CHAT = "5230977008"
+FINAL = "**No, the 9 euro is admission to the whole fair, not just the one-hour lesson.**"
+
+
+@pytest.fixture
+def scheduled(monkeypatch):
+    """Capture coroutines handed to safe_schedule_threadsafe so the test awaits them deterministically."""
+    captured: list = []
+    monkeypatch.setattr(run_mod, "safe_schedule_threadsafe",
+                        lambda coro, loop, **kw: captured.append(coro))
+    return captured
+
+
+def _consumer(*, stale=("901",), delivered=False, with_seam=True):
+    consumer = SimpleNamespace(
+        final_content_delivered=delivered,
+        message_id="901",
+        adapter=MagicMock(),
+    )
+    if with_seam:
+        consumer.abandoned_preview_ids = MagicMock(return_value=set(stale))
+        consumer.delete_abandoned_previews = AsyncMock()
+    return consumer
+
+
+def _session_event(*, delivered=True, stamped=True):
+    event = asyncio.Event()
+    if stamped:
+        event._hermes_final_delivered = delivered
+    return event
+
+
+def _adapter(*, with_hook=True, session_event=None):
+    adapter = SimpleNamespace()
+    if with_hook:
+        adapter.register_post_delivery_callback = MagicMock()
+    adapter._active_sessions = {}
+    if session_event is not None:
+        adapter._active_sessions[SESSION_KEY] = session_event
+    return adapter
+
+
+def _runner(adapter, *, streamed=False):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = MagicMock(return_value=adapter)
+    runner._run_agent_stream_confirmed_final_delivery = MagicMock(return_value=streamed)
+    return runner
+
+
+def _turn_ctx(consumer, session_key=SESSION_KEY):
+    return SimpleNamespace(
+        stream_consumer_holder=[consumer],
+        source=SimpleNamespace(chat_id=CHAT, thread_id=None, platform="telegram"),
+        session_key=session_key,
+        run_generation=3,
+    )
+
+
+async def _drive(runner, turn_ctx):
+    """Run the real decision function down to the abandoned-preview branch."""
+    from gateway.run import GatewayRunner
+
+    await GatewayRunner._run_agent_mark_streamed_delivery(
+        runner, {"final_response": FINAL}, turn_ctx)
+
+
+def _registered_callback(adapter):
+    adapter.register_post_delivery_callback.assert_called_once()
+    args, kwargs = adapter.register_post_delivery_callback.call_args
+    assert args[0] == SESSION_KEY
+    assert kwargs["generation"] == 3
+    return args[1]
+
+
+# ---------------------------------------------------------------------------
+# The branch registers the cleanup; a landed final lets it delete the stale previews.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_the_abandoned_preview_is_deleted_after_the_replacement_lands(scheduled):
+    consumer = _consumer()
+    adapter = _adapter(session_event=_session_event(delivered=True))
+    turn_ctx = _turn_ctx(consumer)
+
+    await _drive(_runner(adapter), turn_ctx)
+
+    callback = _registered_callback(adapter)
+    # Nothing is deleted until the callback fires: it fires after the final send.
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+    callback()
+    assert len(scheduled) == 1
+    await scheduled[0]
+
+    consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+
+
+@pytest.mark.asyncio
+async def test_nothing_is_deleted_inline_before_the_final_send(scheduled):
+    """The branch runs before the normal final send, so an inline delete could leave the reader with
+    neither the preview nor a replacement."""
+    consumer = _consumer()
+    adapter = _adapter(session_event=_session_event(delivered=True))
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    assert scheduled == []
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+@pytest.mark.parametrize("session_event", [
+    pytest.param(_session_event(delivered=False), id="final-send-failed"),
+    pytest.param(_session_event(stamped=False), id="no-stamp"),
+    pytest.param(None, id="no-active-session"),
+])
+@pytest.mark.asyncio
+async def test_a_final_that_did_not_land_keeps_the_preview(scheduled, session_event):
+    """The post-delivery hook fires from ``finally`` even when the final send failed. Without the
+    delivered stamp the frozen preview is all the reader has, so the callback must stand down."""
+    consumer = _consumer()
+    adapter = _adapter(session_event=session_event)
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+    _registered_callback(adapter)()
+
+    assert scheduled == []
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Guards.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_previews_that_hold_the_delivered_answer_are_kept():
+    """When the stream did deliver the content, those previews ARE the reply."""
+    from gateway.run import GatewayRunner
+
+    consumer = _consumer(delivered=True)
+    adapter = _adapter(session_event=_session_event(delivered=True))
+    turn_ctx = _turn_ctx(consumer)
+
+    GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(
+        _runner(adapter), consumer, turn_ctx.source, turn_ctx, True)
+
+    adapter.register_post_delivery_callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_consumer_with_no_previews_registers_nothing():
+    consumer = _consumer(stale=())
+    adapter = _adapter()
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    adapter.register_post_delivery_callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_consumer_without_the_cleanup_seam_is_ignored():
+    """Relay-style consumers without the transport mixin must not raise here."""
+    consumer = _consumer(with_seam=False)
+    adapter = _adapter()
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    adapter.register_post_delivery_callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_an_adapter_without_the_post_delivery_hook_is_ignored():
+    consumer = _consumer()
+    adapter = _adapter(with_hook=False)
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_registration_never_breaks_the_turn():
+    consumer = _consumer()
+    adapter = _adapter()
+    adapter.register_post_delivery_callback = MagicMock(side_effect=RuntimeError("adapter gone"))
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_refused_delete_never_propagates(scheduled):
+    """The cleanup is best effort: a delete that raises must not surface from the callback."""
+    consumer = _consumer()
+    consumer.delete_abandoned_previews = AsyncMock(side_effect=RuntimeError("flood"))
+    adapter = _adapter(session_event=_session_event(delivered=True))
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+    _registered_callback(adapter)()
+    await scheduled[0]
+
+    consumer.delete_abandoned_previews.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_a_stream_that_delivered_the_final_takes_the_suppression_path(scheduled):
+    """Sanity check on the branch we must NOT disturb: a confirmed streamed delivery suppresses the
+    normal send and registers no cleanup."""
+    consumer = _consumer()
+    adapter = _adapter(session_event=_session_event(delivered=True))
+    response = {"final_response": FINAL}
+
+    from gateway.run import GatewayRunner
+    await GatewayRunner._run_agent_mark_streamed_delivery(
+        _runner(adapter, streamed=True), response, _turn_ctx(consumer))
+
+    assert response.get("already_sent") is True
+    adapter.register_post_delivery_callback.assert_not_called()
+    assert scheduled == []
+
+
+# ---------------------------------------------------------------------------
+# The consumer's seam: segment-only ids, and the delete goes through the retrying helper.
+# ---------------------------------------------------------------------------
+
+def _real_consumer():
+    from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+    adapter = MagicMock(spec=BasePlatformAdapter)
+    adapter.delete_message = AsyncMock(return_value=True)
+    return GatewayStreamConsumer(adapter=adapter, chat_id=CHAT, config=StreamConsumerConfig())
+
+
+def test_finalized_earlier_segments_are_not_abandoned():
+    """A tool boundary finalizes the segment before it and resets the per-segment state, but the
+    turn-wide preview set keeps those ids. Handing that set over would delete delivered preambles
+    whose text is absent from the final answer."""
+    consumer = _real_consumer()
+
+    # Segment 1 streamed, landed and was finalized at a tool boundary.
+    consumer._message_id = "801"
+    consumer._preview_message_ids.add("801")
+    consumer._segment_preview_message_ids.add("801")
+    consumer._reset_segment_state()
+    assert consumer._message_id is None and "801" in consumer._preview_message_ids
+
+    # Segment 2 is the one the consumer gave up on.
+    consumer._message_id = "901"
+    consumer._preview_message_ids.add("901")
+    consumer._segment_preview_message_ids.add("901")
+
+    assert consumer.abandoned_preview_ids() == {"901"}
+
+
+def test_a_split_chain_is_never_handed_over():
+    """After an oversized split the sealed head chunks hold delivered text, and a long final may be
+    capped by the adapter (message count or length) while still reporting success. Nothing is deleted."""
+    consumer = _real_consumer()
+    consumer._message_id = "901"
+    consumer._preview_message_ids.add("901")
+    consumer._segment_preview_message_ids.add("901")
+    consumer._turn_split_delivery = True
+
+    assert consumer.abandoned_preview_ids() == set()
+
+
+def test_several_bubbles_in_one_segment_are_never_handed_over():
+    """Several bubbles can hold more text than a capped final delivered; only a single frozen bubble
+    is provably covered by any successful final send."""
+    consumer = _real_consumer()
+    consumer._message_id = "902"
+    for mid in ("901", "902"):
+        consumer._preview_message_ids.add(mid)
+        consumer._segment_preview_message_ids.add(mid)
+
+    assert consumer.abandoned_preview_ids() == set()
+
+
+def test_the_no_edit_sentinel_is_never_an_abandoned_preview():
+    consumer = _real_consumer()
+    consumer._message_id = "__no_edit__"
+
+    assert consumer.abandoned_preview_ids() == set()
+
+
+@pytest.mark.asyncio
+async def test_delete_abandoned_previews_requests_the_bounded_retry():
+    """Telegram reports a refused delete by returning False, and the flood window that stranded the
+    preview can refuse the delete too, so the existing bounded retry must be requested."""
+    consumer = _real_consumer()
+    consumer._delete_previews = AsyncMock()
+
+    await consumer.delete_abandoned_previews({"901", "902"})
+
+    consumer._delete_previews.assert_awaited_once_with(
+        {"901", "902"}, label="Abandoned preview", retry_on_false=True)
+
+
+# ---------------------------------------------------------------------------
+# End to end through the real background processor: the delete waits for a LANDED final.
+# ---------------------------------------------------------------------------
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+@pytest.mark.parametrize("final_landed", [True, False], ids=["final-landed", "final-refused"])
+@pytest.mark.asyncio
+async def test_end_to_end_the_delete_waits_for_a_landed_final(scheduled, final_landed):
+    from gateway.run import GatewayRunner
+
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="t", typing_indicator=False), Platform.TELEGRAM)
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(
+        success=final_landed, message_id="777" if final_landed else None,
+        error=None if final_landed else "Flood control exceeded. Retry in 9 seconds"))
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id=CHAT, chat_type="dm")
+    session_key = build_session_key(source)
+    session_event = asyncio.Event()
+    session_event._hermes_run_generation = 3
+    adapter._active_sessions[session_key] = session_event
+
+    consumer = _consumer()
+    turn_ctx = _turn_ctx(consumer, session_key=session_key)
+    runner = _runner(adapter)
+
+    async def _handler(_event):
+        # What run_turn does on the abandoned-preview branch, BEFORE base.py sends the final.
+        GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(
+            runner, consumer, source, turn_ctx, False)
+        return FINAL
+
+    adapter._message_handler = _handler
+    event = MessageEvent(text="hi", message_type=MessageType.TEXT, source=source, message_id="123")
+
+    await adapter._process_message_background(event, session_key)
+
+    adapter._send_with_retry.assert_awaited_once()
+    if final_landed:
+        assert len(scheduled) == 1
+        await scheduled[0]
+        consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+    else:
+        assert scheduled == []
+        consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Voice replies: only the TEXT landing counts.
+# ---------------------------------------------------------------------------
+
+async def _run_voice_turn(tmp_path, *, final_text, text_send_ok):
+    """A turn with auto-TTS on: the audio always lands; the text send outcome is the parameter."""
+    from gateway.run import GatewayRunner
+
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="t", typing_indicator=False), Platform.TELEGRAM)
+    audio = tmp_path / "reply.ogg"
+    audio.write_bytes(b"ogg")
+    adapter._wants_auto_tts = MagicMock(return_value=True)
+    adapter._synthesize_auto_tts = AsyncMock(return_value=([str(audio)], None))
+    adapter.play_tts = AsyncMock(return_value=SendResult(success=True, message_id="a1"))
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(
+        success=text_send_ok, message_id="777" if text_send_ok else None,
+        error=None if text_send_ok else "Flood control exceeded. Retry in 9 seconds"))
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id=CHAT, chat_type="dm")
+    session_key = build_session_key(source)
+    session_event = asyncio.Event()
+    session_event._hermes_run_generation = 3
+    adapter._active_sessions[session_key] = session_event
+
+    consumer = _consumer()
+    turn_ctx = _turn_ctx(consumer, session_key=session_key)
+    runner = _runner(adapter)
+
+    async def _handler(_event):
+        GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(
+            runner, consumer, source, turn_ctx, False)
+        return final_text
+
+    adapter._message_handler = _handler
+    event = MessageEvent(text="hi", message_type=MessageType.TEXT, source=source, message_id="123")
+    await adapter._process_message_background(event, session_key)
+    return adapter, consumer
+
+
+@pytest.mark.asyncio
+async def test_audio_that_landed_without_its_text_keeps_the_preview(scheduled, tmp_path):
+    """A reply over Telegram's caption limit sends the audio bare and the text separately. If that text
+    send is refused, the audio's success must not authorise deleting the reader's only text copy."""
+    adapter, consumer = await _run_voice_turn(
+        tmp_path, final_text="x" * 1500, text_send_ok=False)
+
+    adapter.play_tts.assert_awaited_once()
+    adapter._send_with_retry.assert_awaited_once()
+    assert scheduled == []
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_delivered_tts_caption_counts_as_the_text_landing(scheduled, tmp_path):
+    """A short reply rides along as the audio's caption and the text send is skipped: the reader has
+    the text, so the abandoned preview goes."""
+    adapter, consumer = await _run_voice_turn(tmp_path, final_text=FINAL, text_send_ok=True)
+
+    adapter.play_tts.assert_awaited_once()
+    adapter._send_with_retry.assert_not_awaited()
+    assert len(scheduled) == 1
+    await scheduled[0]
+    consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+
+
+# ---------------------------------------------------------------------------
+# Queued follow-up: the finishing turn fires ITS callback, with ITS outcome, before the hand-off.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_draining_turn_never_fires_the_next_turns_cleanup(scheduled):
+    """A follow-up queued mid-turn is drained by a new task that shares the session's interrupt Event
+    and re-stamps its run generation as soon as it starts. The finishing turn must pop and fire its own
+    callback before that hand-off; popped from ``finally`` instead, it could be the next turn's cleanup,
+    fired with this turn's delivery outcome while that turn's final send is still in flight."""
+    from gateway.run import GatewayRunner
+
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="t", typing_indicator=False), Platform.TELEGRAM)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id=CHAT, chat_type="dm")
+    session_key = build_session_key(source)
+    session_event = asyncio.Event()
+    session_event._hermes_run_generation = 1
+    adapter._active_sessions[session_key] = session_event
+    runner = _runner(adapter)
+
+    first_consumer, second_consumer = _consumer(stale=("901",)), _consumer(stale=("902",))
+    second_turn_started, release_second_send = asyncio.Event(), asyncio.Event()
+    event1 = MessageEvent(text="first", message_type=MessageType.TEXT, source=source, message_id="1")
+    event2 = MessageEvent(text="second", message_type=MessageType.TEXT, source=source, message_id="2")
+
+    sends: list = []
+
+    async def _send_with_retry(**kwargs):
+        sends.append(kwargs["content"])
+        if len(sends) == 1:
+            return SendResult(success=True, message_id="11")  # the first turn's final lands
+        await release_second_send.wait()  # the second turn's final stays in flight, then is refused
+        return SendResult(success=False, error="Flood control exceeded. Retry in 9 seconds")
+
+    adapter._send_with_retry = _send_with_retry
+
+    # The real typing stop awaits the platform; that yield is what lets the drain task run first.
+    real_stop = adapter._stop_typing_refresh
+
+    async def _yielding_stop(*args, **kwargs):
+        await asyncio.sleep(0)
+        return await real_stop(*args, **kwargs)
+
+    adapter._stop_typing_refresh = _yielding_stop
+
+    turns: list = []
+
+    async def _handler(event):
+        turns.append(event.message_id)
+        if len(turns) == 1:
+            adapter._pending_messages[session_key] = event2  # a follow-up arrives mid-turn
+            ctx = _turn_ctx(first_consumer, session_key=session_key)
+            ctx.run_generation = 1
+            GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(
+                runner, first_consumer, source, ctx, False)
+            return "first answer"
+        session_event._hermes_run_generation = 2  # what the gateway's generation binding does
+        ctx = _turn_ctx(second_consumer, session_key=session_key)
+        ctx.run_generation = 2
+        GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(
+            runner, second_consumer, source, ctx, False)
+        second_turn_started.set()
+        return "second answer"
+
+    adapter._message_handler = _handler
+
+    await adapter._process_message_background(event1, session_key)
+    await asyncio.wait_for(second_turn_started.wait(), 5)
+    await asyncio.sleep(0)
+
+    # The first turn's own cleanup fired, with the first turn's outcome ...
+    assert len(scheduled) == 1
+    await scheduled[0]
+    first_consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+    # ... and the second turn's did not while its final was still in flight.
+    second_consumer.delete_abandoned_previews.assert_not_awaited()
+
+    drain_task = adapter._session_tasks.get(session_key)
+    release_second_send.set()
+    if drain_task is not None:
+        await asyncio.wait_for(drain_task, 5)
+    assert turns == ["1", "2"]
+    # The second turn's final was refused, so its preview stays.
+    assert len(scheduled) == 1
+    second_consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# The plain-text fallback in _send_with_retry: a success that carried only a prefix is not delivery.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("final_text, expect_delete", [
+    pytest.param("x" * 4933, False, id="fallback-truncated-keeps-preview"),
+    pytest.param("y" * 800, True, id="fallback-complete-deletes-preview"),
+])
+@pytest.mark.asyncio
+async def test_a_truncated_plain_text_fallback_is_not_text_delivery(scheduled, final_text, expect_delete):
+    """After a formatting failure, ``_send_with_retry`` falls back to plain text capped at 3500 chars and
+    returns the fallback's success. For a long reply that is a prefix, and the frozen preview may hold
+    text the replacement does not, so it must stay. A complete fallback is the whole reply and the
+    preview goes."""
+    from gateway.run import GatewayRunner
+
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="t", typing_indicator=False), Platform.TELEGRAM)
+    adapter.send = AsyncMock(side_effect=[
+        SendResult(success=False, error="Bad Request: can't parse entities: unmatched '*'"),
+        SendResult(success=True, message_id="778"),
+    ])
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id=CHAT, chat_type="dm")
+    session_key = build_session_key(source)
+    session_event = asyncio.Event()
+    session_event._hermes_run_generation = 3
+    adapter._active_sessions[session_key] = session_event
+
+    consumer = _consumer()
+    turn_ctx = _turn_ctx(consumer, session_key=session_key)
+    runner = _runner(adapter)
+
+    async def _handler(_event):
+        GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(
+            runner, consumer, source, turn_ctx, False)
+        return final_text
+
+    adapter._message_handler = _handler
+    event = MessageEvent(text="hi", message_type=MessageType.TEXT, source=source, message_id="123")
+    await adapter._process_message_background(event, session_key)
+
+    # The real retry helper ran: the formatted send failed, the plain-text fallback landed.
+    assert adapter.send.await_count == 2
+    fallback_text = adapter.send.await_args_list[1].kwargs["content"]
+    assert fallback_text.startswith("(Response formatting failed, plain text:)")
+    assert (len(fallback_text) < len(final_text)) is (not expect_delete)
+
+    if expect_delete:
+        assert len(scheduled) == 1
+        await scheduled[0]
+        consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+    else:
+        assert scheduled == []
+        consumer.delete_abandoned_previews.assert_not_awaited()


### PR DESCRIPTION
A streaming preview that the consumer abandons is left in the chat when the gateway sends the final reply itself, so the reader sees a truncated message with raw MarkdownV2 markers and the streaming cursor sitting above the complete answer.

## What happens

The stream consumer deletes the previews it replaces. `_delete_previews` has four call sites and every one of them is inside the consumer, on a path where the consumer itself sends the replacement: the fresh-final path in `gateway/stream_consumer_transport.py`, and the partial, empty and silence-marker paths in `gateway/stream_consumer_fallback.py`.

There is a fifth case the consumer does not own. When its edits stop working entirely, control returns to `gateway/run_turn.py` and the **gateway** sends the final instead. That branch, the `elif _sc is not None:` arm of `_run_agent_mark_streamed_delivery`, is labelled a duplicate-risk diagnostic and only logs. Nothing cleans up behind it, so the abandoned preview stays.

## Observed

On a 1 GB deployment running the Telegram adapter, 6 September 2026:

```
16:02:10  [Telegram] Telegram flood control, waiting 9.0s      (x4)
16:02:16  Normal final-send NOT suppressed despite active stream consumer
          for session ...: streamed=False previewed=False content_delivered=...
16:02:16  [Telegram] Sending response (2888 chars) to ...
```

The four preview edits asked for a 9 second wait, which exceeds the adapter's 5 second inline cap, so each failed closed rather than sleeping. The preview froze mid-sentence. Six seconds later the complete 2888 character reply arrived as a separate message. Nothing was lost, but the frozen preview remained, and because a partial preview is rendered without MarkdownV2 its asterisks and heading markers were literal.

This pattern appears 6 times in that deployment's logs since 25 May, 4 of them in the last 8 days as traffic grew. It is cosmetic, never a lost reply.

`_delete_previews` already anticipates the neighbouring case: its docstring notes that "the same flood window that broke the finalize edit can reject this delete too, leaving the preview bubble next to the fresh final (#71047 Problem B)". This is the same class of problem on the one path that had no cleanup at all.

## The change

Three files, one small piece each.

**`gateway/stream_consumer_transport.py`**: two public methods on the transport mixin, `abandoned_preview_ids()` and `delete_abandoned_previews()`, so the gateway never reaches into consumer privates. The ids are the **current segment's only**. A tool boundary finalizes the segment before it and resets the per-segment state, but the turn-wide preview set keeps those ids; handing that set over would delete delivered preambles whose text is absent from the final answer. And only a **single frozen bubble of a non-split segment** is handed over. Adapters cap a long final by message count or length and still report success (Discord keeps the first N-1 chunks and replaces the rest with a notice, WeCom and others cut at their limit, none of them marks the result). One bubble holds at most one platform message of the reply's prefix, which any successful final send covers; a split chain or several bubbles could hold more than a capped final delivered, so those stay. The delete goes through the existing `_delete_previews` with `retry_on_false=True`, because Telegram reports a refused delete by returning False and the flood window that stranded the preview can refuse the delete too.

**`gateway/platforms/base.py`**: `_fire_post_delivery_callback` takes `delivered` and stamps it on the session's interrupt event before popping the callback, the same way the run generation already travels on that event. The value is a new `text_delivered` flag, kept apart from the aggregate `delivery_succeeded`: it is set only by the final text send itself, or by a TTS caption that carried the complete text. A voice reply can land its audio while the text send is refused, and that must not read as "text delivered". Nor may a truncated fallback: after a formatting failure `_send_with_retry` sends the first 3500 characters as plain text and returns that success, so `SendResult` gains a `truncated` flag the fallback sets when it cut the text, and the recorder ignores such results. The hook itself stays unconditional: goal continuation and the background-review release depend on it firing either way.

One ordering change on the pending-drain path. A follow-up queued mid-turn is drained by a new task that shares the session's interrupt event and re-stamps its run generation as soon as it starts. Popped from `finally` after the hand-off, the callback could be the *next* turn's, fired with *this* turn's outcome while the next final is still in flight. The hook is therefore fired before `_spawn_drain_task` on that branch, and `finally` skips it. Everywhere else the timing is unchanged.

**`gateway/run_turn.py`**: `_run_agent_schedule_abandoned_preview_cleanup`, a sibling of `_run_agent_schedule_bubble_cleanup` using the same post-delivery registration, called as the last statement of that `elif` arm.

Three guards keep this from ever removing the reader's only copy of the answer:

- It is **skipped when the stream delivered the content**. Those previews hold the answer.
- The ids are **segment-only**, as above.
- The delete is **deferred to the post-delivery callback and gated on the stamp**. The branch executes *before* the normal final send, and the post-delivery hook fires whether or not that send succeeded. Without the gate, a failed final send would have deleted the frozen preview while no replacement existed. The callback reads the stamp off the active-session event and stands down when it is missing or False.

A consumer without the transport mixin, an adapter without the post-delivery hook, an empty stale set, a failed registration and a refused delete are all no-ops.

## Tests

`tests/gateway/test_abandoned_preview_cleanup.py`, 24 cases. 18 fail without the change and the 6 pure guard tests pass there as no-ops.

- The branch registers the cleanup and nothing is deleted inline.
- A landed final lets the callback delete the stale previews.
- A final that did not land keeps the preview, parametrized over a False stamp, a missing stamp and a missing active session.
- Seam tests on the real `GatewayStreamConsumer`: after a segment break, `abandoned_preview_ids()` returns the new segment's bubble only; a split chain and a multi-bubble segment return nothing; the `__no_edit__` sentinel is never included.
- Two end-to-end cases drive the real `_process_message_background` with a `BasePlatformAdapter` subclass and a mocked `_send_with_retry`: success deletes, a refused send keeps the preview.
- Two voice cases through the same processor: audio that landed bare while the text send was refused keeps the preview; a delivered caption counts as the text landing and the preview goes.
- A two-turn drain case queues a follow-up mid-turn, blocks and then refuses the second turn's final send, and checks that the first turn fired only its own cleanup and the second turn's preview stayed.
- Two cases drive the real `_send_with_retry`: a formatting failure whose plain-text fallback truncates a long reply keeps the preview, and a complete fallback deletes it.
- The remaining cases pin that the guards stay no-ops and that a confirmed streamed delivery still suppresses the normal send.

Scope: this is the abandoned-preview path only. It does not change when a preview is created, when suppression fires, or the adapter's flood handling. Adapters that cap a send could set the new `SendResult.truncated` themselves in a follow-up, which would let the cleanup cover split chains too; this PR does not depend on that. One known cosmetic edge remains: Slack's rich-blocks final clips a heading over 150 characters in the rendered message while the fallback text keeps it, so deleting a preview that showed the raw heading loses that tail from the rendered view. The consumer's own fresh-final path has the same property, so it is left alone here.
