### PR TITLE
fix(desktop): fail loudly when a built renderer chunk is not valid ESM

### DIFF
--- a/apps/desktop/scripts/assert-dist-built.mjs
+++ b/apps/desktop/scripts/assert-dist-built.mjs
@@ -12,6 +12,7 @@
 // See issues #39484 (renderer blank page) and #41327 / #39472 (dashboard 404).
 
 import { existsSync, readFileSync, statSync, readdirSync } from "fs"
+import { spawnSync } from "child_process"
 import { join, resolve } from "path"
 import { isMain } from "./utils.mjs"
 
@@ -77,6 +78,52 @@ export function checkDistBuilt(distDir) {
     }
   }
 
+  // Parse-validate every emitted chunk as an ES module. Corrupted-silent-fail
+  // bundles (a dropped identifier token mid-file) produce invalid syntax that
+  // only explodes at module-evaluation time in Electron's renderer.
+  const chunkParse = verifyChunksParse(assetsDir)
+  if (!chunkParse.ok) {
+    return chunkParse
+  }
+
+  return { ok: true }
+}
+
+// Renderer chunks are emitted as ESM (`<script type="module">` in index.html).
+// A silent bundler failure can emit syntactically invalid chunks that parse fine
+// as CJS-ish text but throw on module evaluation in Electron — the app then
+// white-screens with `Uncaught SyntaxError` in the renderer console (observed
+// 2026-09: the update-produced bundle was missing a 10-byte identifier token,
+// `{$:n,}` vs `{categories:n,}`, leaving an invalid destructuring pattern).
+// Parse each emitted chunk as an ES module before packaging so a corrupted
+// build fails loudly and the update retry rebuilds instead of shipping it.
+function verifyChunksParse(assetsDir) {
+  const nodeBin = process.env.NODE ||
+    (process.execPath && process.execPath.endsWith("node") ? process.execPath : "node")
+  const chunks = readdirSync(assetsDir).filter(name => name.endsWith(".js"))
+  for (const name of chunks) {
+    const file = join(assetsDir, name)
+    const probe = spawnSync(nodeBin, ["--input-type=module", "--check"], {
+      input: readFileSync(file),
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 60_000,
+    })
+    if (probe.error) {
+      return {
+        ok: false,
+        error: `could not run node to syntax-check ${name}: ${probe.error.message}`,
+      }
+    }
+    if (probe.status !== 0) {
+      const detail = String(probe.stderr || "").trim().split("\n").slice(0, 4).join(" / ")
+      return {
+        ok: false,
+        error: `built chunk is not valid ES module syntax: ${name} — ${detail}. ` +
+          `A renderer chunk failed to parse, so packaging would ship an app that ` +
+          `white-screens with "Uncaught SyntaxError" on launch. Re-run the build.`,
+      }
+    }
+  }
   return { ok: true }
 }
 

--- a/apps/desktop/scripts/assert-dist-built.test.mjs
+++ b/apps/desktop/scripts/assert-dist-built.test.mjs
@@ -162,3 +162,36 @@ test('checkDistBuilt fails when the QueryClient context invariant is in multiple
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }
 })
+
+test('checkDistBuilt fails when a chunk is not valid ES module syntax', () => {
+  const { tempRoot, distDir } = makeDist(d => {
+    fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html>', 'utf8')
+    fs.mkdirSync(path.join(d, 'assets'))
+    // Invalid: destructuring pattern with a hole, like a bundle that lost an
+    // identifier token mid-minification (`{categories:n}` minus `categories`).
+    fs.writeFileSync(path.join(d, 'assets', 'index-abc123.js'), 'let {,:n}=x', 'utf8')
+    fs.writeFileSync(path.join(d, 'assets', 'vendor-def456.js'), 'export const ok = 1', 'utf8')
+  })
+  try {
+    const result = checkDistBuilt(distDir)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /not valid ES module syntax/)
+    assert.match(result.error, /index-abc123\.js/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkDistBuilt passes when every chunk parses as an ES module', () => {
+  const { tempRoot, distDir } = makeDist(d => {
+    fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html>', 'utf8')
+    fs.mkdirSync(path.join(d, 'assets'))
+    fs.writeFileSync(path.join(d, 'assets', 'index-abc123.js'), 'export const a = `x`', 'utf8')
+    fs.writeFileSync(path.join(d, 'assets', 'vendor-def456.js'), 'import.meta.url', 'utf8')
+  })
+  try {
+    assert.deepEqual(checkDistBuilt(distDir), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Why

Twice in one week (2026-09-02 and 2026-09-07, different HEADs), the in-app desktop update produced a renderer bundle that was syntactically invalid, while the build reported success. The app then white-screens with `Uncaught SyntaxError: Unexpected token ':'` on every launch; the update path reports success, so the user has no error and no recovery hint.

Byte-level proof (issue #105184): the broken bundle is the correct bundle minus exactly one identifier token — `let t=(0,$.c)(10),{:n,segmentTotal:r}=e` vs `{categories:n,...}` — a 10-byte silent output loss by the bundler/emit path. Re-injecting the token makes the broken file byte-for-byte identical to a fresh local rebuild. Nothing in the current pipeline validates that emitted JS parses.

## What this does

Extends `apps/desktop/scripts/assert-dist-built.mjs` (the existing build-time guard whose purpose is "refuse to package a broken renderer") with an emit-time ESM parse check of every `dist/assets/*.js` chunk via `node --input-type=module --check` (spawnSync, ~250 chunks in <2 s).

A corrupted bundle now fails `npm run build` loudly with the offending chunk name and the parse error. The desktop update path (`scripts/desktop-update/posix.sh`) already retries the build once on "Desktop build failed", and stage-and-swap keeps the previous working app if the retry also fails — so the failure mode changes from "silent white screen after update" to "update retries / honest failure with a named artifact".

## Testing

- `npx vitest run scripts/assert-dist-built.test.mjs` — 11 passed:
  - a chunk with invalid ESM syntax (a destructuring hole, matching the observed corruption) fails `checkDistBuilt` with `not valid ES module syntax: <chunk>`
  - valid chunks (template literals, `import.meta`) still pass; all 9 pre-existing guard tests unchanged and green
- The real corrupted bundle from the 2026-09-07 incident, run through the new check, is rejected with the same error line the Electron renderer reported (line 440)
- Full `npm run build && npm run pack` on a real install passes with the guard active (~250 chunks validated)

Fixes #105184
