### PR TITLE
fix(api-server): ship session unread flag through the client projection

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2674,7 +2674,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             "message_count", "tool_call_count", "input_tokens", "output_tokens",
             "cache_read_tokens", "cache_write_tokens", "reasoning_tokens", "estimated_cost_usd",
             "actual_cost_usd", "api_call_count", "parent_session_id", "last_active", "preview",
-            "_lineage_root_id", "pinned", "archived", "hidden")
+            "_lineage_root_id", "pinned", "archived", "hidden", "unread")
         payload = {key: session.get(key) for key in safe_keys if key in session}
         # SQLite stores the flags as 0/1.
         payload.update(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2752,6 +2752,29 @@ class TestSessionDbOffEventLoop:
             assert data["session"]["model"] is None
 
 
+class TestSessionResponsePreservesSharedReadState:
+    """``_session_response`` is the single client-facing projection for the
+    session API surface (list / get / create / PATCH). The API server already
+    ACCEPTS ``unread`` on PATCH (it calls ``db.set_session_read``), so dropping
+    it on the way back out breaks the shared read-state contract with every
+    non-desktop client: they can write the watermark but never read it, so they
+    fall back to device-local unread heuristics and disagree with Desktop.
+    """
+
+    def test_projection_preserves_unread(self):
+        """Whatever ``list_sessions_rich`` computes (it stamps ``unread`` on
+        every row via ``session_unread``) must survive the safe-keys projection,
+        for both a read (False) and an unread (True) row."""
+        for unread in (False, True):
+            row = {
+                "id": "s1", "source": "api_server", "title": "chat",
+                "message_count": 3, "last_active": 1234.5,
+                "pinned": 0, "archived": 0, "hidden": 0, "unread": unread,
+            }
+            payload = APIServerAdapter._session_response(row)
+            assert payload["unread"] is unread
+
+
 # ---------------------------------------------------------------------------
 # _api_key_passes_startup_guard — fail-closed on an unverifiable key
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The API server's session surface accepts `unread` on `PATCH /api/sessions/{id}` (it calls `db.set_session_read`), and `list_sessions_rich` stamps the computed flag onto every row via `session_unread` — but `_session_response`, the single client-facing projection used by **list / get / create / PATCH**, rebuilt each row from a hardcoded safe-keys allowlist that omitted `unread`.

Net effect: any non-desktop client (e.g. the iOS mobile app) can **write** the shared read watermark but never **read** it back. It falls back to device-local unread heuristics (message-count vs local seen-count), so a session opened and read on one client shows a stale unread dot on another while Desktop — whose backend path does return `unread` — shows it read.

Live repro (gateway `api_server`, GET /api/sessions): a session with `last_read_at = NULL` (server rule: untracked = read) returns a row with **no `unread` field at all**, despite `list_sessions_rich` having computed `unread: False` for it.

## Fix

One-word change: add `"unread"` to the `safe_keys` tuple in `_session_response`. The value is a real JSON boolean computed server-side by `session_unread` (not a raw SQLite 0/1), so no extra coercion is needed — unlike `pinned`/`archived`/`hidden`, which come straight from the column.

## Test

New invariant test `TestSessionResponsePreservesSharedReadState::test_projection_preserves_unread`: a row carrying `unread` (both `False` and `True`) must keep it through the projection. Verified red on base (KeyError at the projection) and green with the fix:

```
RED (base):   FAILED ...::test_projection_preserves_unread — 1 failed
GREEN (fix):  1 passed
```

The remainder of `tests/gateway/test_api_server.py` behaves identically with and without the change locally (the async-marked tests require the `pytest-asyncio` dev extra, which CI installs).
