### PR TITLE
Add Vivaldi to supported Chromium browsers for real-profile browsing

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -94,6 +94,15 @@ _LINUX_BROWSER_GROUPS = (
             "/opt/microsoft/msedge/msedge",
         ),
     ),
+    (
+        ("vivaldi", "vivaldi-stable"),
+        (
+            "/usr/bin/vivaldi",
+            "/usr/bin/vivaldi-stable",
+            "/opt/vivaldi/vivaldi",
+            "/opt/vivaldi/vivaldi-stable",
+        ),
+    ),
 )
 
 _LINUX_BIN_NAMES = tuple(name for names, _ in _LINUX_BROWSER_GROUPS for name in names)
@@ -117,7 +126,7 @@ _LINUX_INSTALL_PATHS = tuple(path for _, paths in _LINUX_BROWSER_GROUPS for path
 # ``BraveOHTML`` ProgId, ``com.brave.Browser.origin`` bundle id) so it
 # side-by-side installs with regular Brave — its profile is NOT under
 # Brave-Browser and must never be conflated with the ``brave`` key.
-_CHROMIUM_BROWSERS = ("chrome", "edge", "brave", "chromium", "brave-origin")
+_CHROMIUM_BROWSERS = ("chrome", "edge", "brave", "chromium", "brave-origin", "vivaldi")
 
 # Windows UserChoice ProgId prefixes → canonical browser key. Matched
 # case-insensitively by prefix so version suffixes (e.g. ``ChromeHTML.X``)
@@ -167,6 +176,13 @@ _LINUX_DESKTOP_MAP = (
     ("microsoft-edge", "edge"),
     ("com.microsoft.edge", "edge"),
     ("msedge", "edge"),
+    # Vivaldi: same Chromium core, but a fully distinct install identity
+    # (Vivaldi Technologies product path, ``com.vivaldi.Vivaldi`` bundle id)
+    # so it side-by-side installs with any other Chromium browser — its
+    # profile is under ~/.config/vivaldi/ and must never be conflated with
+    # Chromium's ``~/.config/chromium/`` profile (wrong-principal).
+    ("vivaldi", "vivaldi"),
+    ("com.vivaldi.vivaldi", "vivaldi"),
 )
 
 # Non-stable Linux channel .desktop fragments — recognized, unsupported.
@@ -202,6 +218,7 @@ _DARWIN_BUNDLE_MAP = (
     # ever being read as plain ``com.brave.browser``.
     ("com.brave.browser.origin", "brave-origin"),
     ("org.chromium.chromium", "chromium"),
+    ("com.vivaldi.vivaldi", "vivaldi"),
 )
 
 # Non-stable macOS channel bundle ids — recognized, unsupported. Checked first.
@@ -247,6 +264,11 @@ def _real_profile_relparts(browser: str) -> tuple:
             ("BraveSoftware", "Brave-Origin"),
             ("BraveSoftware", "Brave-Origin", "User Data"),
             "BraveSoftware/Brave-Origin",
+        ),
+        "vivaldi": (
+            ("Vivaldi",),
+            ("Vivaldi", "User Data"),
+            "vivaldi",
         ),
     }[browser]
 
@@ -334,6 +356,7 @@ def chromium_executable(browser: str, system: str | None = None) -> str | None:
         "brave": ("brave-browser", "brave-browser-stable", "brave"),
         "brave-origin": ("brave-origin",),
         "edge": ("microsoft-edge", "microsoft-edge-stable"),
+        "vivaldi": ("vivaldi", "vivaldi-stable"),
     }[browser]
     for name in linux:
         found = shutil.which(name)

--- a/tests/hermes_cli/test_browser_connect_default_chromium.py
+++ b/tests/hermes_cli/test_browser_connect_default_chromium.py
@@ -6,6 +6,8 @@ caught here rather than in a user's browser session.
 """
 from unittest.mock import patch
 
+import os
+
 import pytest
 
 import hermes_cli.browser_connect as bc
@@ -152,6 +154,30 @@ class TestLinuxProfileDir:
     def test_native_path_when_nothing_exists(self, tmp_path, monkeypatch):
         self._env(monkeypatch, tmp_path)
         assert bc.real_profile_data_dir("chromium", "Linux") == str(tmp_path / ".config" / "chromium")
+
+    def test_vivaldi_native_path_when_nothing_exists(self, tmp_path, monkeypatch):
+        self._env(monkeypatch, tmp_path)
+        assert bc.real_profile_data_dir("vivaldi", "Linux") == str(tmp_path / ".config" / "vivaldi")
+
+    def test_vivaldi_darwin_path(self):
+        assert bc.real_profile_data_dir("vivaldi", "Darwin") == os.path.join(
+            os.path.expanduser("~"), "Library", "Application Support", "Vivaldi"
+        )
+
+    def test_vivaldi_windows_path(self, monkeypatch):
+        monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\j7\AppData\Local")
+        assert bc.real_profile_data_dir("vivaldi", "Windows") == r"C:\Users\j7\AppData\Local\Vivaldi\User Data"
+
+    def test_vivaldi_desktop_file_resolves(self):
+        # Both the .desktop filename and the Flatpak bundle id should resolve
+        # to the vivaldi key (not chromium, not brave).
+        for desktop in ("vivaldi-stable.desktop", "com.vivaldi.vivaldi.desktop"):
+            result = None
+            for fragment, key in bc._LINUX_DESKTOP_MAP:
+                if fragment in desktop:
+                    result = key
+                    break
+            assert result == "vivaldi", f"{desktop!r} resolved to {result!r}"
 
     def test_snap_chromium_profile_is_found(self, tmp_path, monkeypatch):
         self._env(monkeypatch, tmp_path)


### PR DESCRIPTION
## Summary

Vivaldi is a Chromium-family browser from Vivaldi Technologies with the same Chromium core as Chrome/Edge/Brave, but a fully distinct install identity:
- macOS bundle id: `com.vivaldi.Vivaldi` (also `com.vivaldi.vivaldi` via Snap/aur installs)
- Linux profile dir: `~/.config/vivaldi/` (NOT under `chromium`)
- Linux xdg default: `vivaldi-stable.desktop` (or `com.vivaldi.vivaldi.desktop` Flatpak)
- Linux binary paths: `/usr/bin/vivaldi`, `/usr/bin/vivaldi-stable`, `/opt/vivaldi/vivaldi`, `/opt/vivaldi/vivaldi-stable`

Users with Vivaldi as their default browser hit `"your default browser is not a supported Chromium browser"` when `browser.use_real_profile: true` is on, even though the docs explicitly call this the consent-gated path for "use your own logins."

## What changes

Adds Vivaldi to all five lookup sites in `hermes_cli/browser_connect.py`:

1. **`_LINUX_BROWSER_GROUPS`** — binary path tuples (`/usr/bin/vivaldi`, `/usr/bin/vivaldi-stable`, `/opt/vivaldi/...`)
2. **`_CHROMIUM_BROWSERS`** — canonical key tuple (now `("chrome", "edge", "brave", "chromium", "brave-origin", "vivaldi")`)
3. **`_LINUX_DESKTOP_MAP`** — xdg `default-web-browser` fragment matching (`vivaldi` + `com.vivaldi.vivaldi`)
4. **`chromium_executable`** — local `linux` name lookup dict
5. **`_real_profile_relparts`** — per-OS profile-dir resolver table (mac support subdir, Windows User Data parts, Linux config name)
6. **`_DARWIN_BUNDLE_MAP`** — macOS LaunchServices bundle id (`com.vivaldi.vivaldi`)

## Tests

4 new test cases in `TestLinuxProfileDir`:
- `test_vivaldi_native_path_when_nothing_exists` — verifies `~/.config/vivaldi` is the native default
- `test_vivaldi_darwin_path` — verifies `~/Library/Application Support/Vivaldi`
- `test_vivaldi_windows_path` — verifies `%LOCALAPPDATA%\Vivaldi\User Data`
- `test_vivaldi_desktop_file_resolves` — verifies both `vivaldi-stable.desktop` and `com.vivaldi.vivaldi.desktop` resolve to the `vivaldi` key (not `chromium`, not `brave`)

All 36 pre-existing tests still pass. Total: 36 → 40.

## Why no `_LINUX_FLATPAK_IDS` / `_LINUX_SNAP_PROFILE_PARTS` entry

Vivaldi doesn't ship a Flatpak or Snap today. If they add either later, the resolver table already has Brave and Chromium as the template — follow that pattern. Leaving the entry absent is the correct fail-closed behavior until then.

## Provenance

Discovered while wiring up Vivaldi for the @painn_x X/Twitter fetch use case on a Linux laptop with `browser.use_real_profile: true`. The error message currently names the supported list (Chrome/Edge/Brave/Brave Origin/Chromium) but omits Vivaldi, which is the third-most-popular Chromium-family browser by install base.

## Verification

```bash
python3 -m pytest tests/hermes_cli/test_browser_connect_default_chromium.py
# 40 passed

python3 -c "
import sys; sys.path.insert(0, '/path/to/hermes-agent')
from hermes_cli import browser_connect as bc
print(bc.chromium_executable('vivaldi'))                     # /usr/bin/vivaldi
print(bc.real_profile_data_dir('vivaldi', 'Linux'))         # /home/j7/.config/vivaldi
print(bc.real_profile_data_dir('vivaldi', 'Darwin'))        # ~/Library/Application Support/Vivaldi
"
```