### PR TITLE
Add Vivaldi to supported Chromium browsers for real-profile browsing

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -105,6 +105,15 @@ _BROWSERS = (
         ("/usr/bin/microsoft-edge", "/usr/bin/microsoft-edge-stable",
          "/opt/microsoft/msedge/microsoft-edge", "/opt/microsoft/msedge/msedge"),
         "microsoft-edge", linux_exec=("microsoft-edge", "microsoft-edge-stable")),
+    _Browser(
+        "vivaldi", "/Applications/Vivaldi.app/Contents/MacOS/Vivaldi",
+        ("Vivaldi",), ("vivaldi.exe", "vivaldi"),
+        (("Vivaldi", "Application", "vivaldi.exe"),),
+        ("Vivaldi", "User Data"),
+        ("vivaldi", "vivaldi-stable"),
+        ("/usr/bin/vivaldi", "/usr/bin/vivaldi-stable",
+         "/opt/vivaldi/vivaldi", "/opt/vivaldi/vivaldi-stable"),
+        "vivaldi", linux_exec=("vivaldi", "vivaldi-stable")),
 )
 _BROWSER_BY_KEY = {b.key: b for b in _BROWSERS}
 
@@ -140,7 +149,13 @@ _LINUX_DESKTOP_MAP = (
     # ORDER MATTERS: ``brave-origin.desktop`` contains the bare ``brave`` fragment,
     # so the substring scan must hit the Origin entry first (#95549).
     ("brave-origin", "brave-origin"), ("brave", "brave"),
-    ("microsoft-edge", "edge"), ("com.microsoft.edge", "edge"), ("msedge", "edge"))
+    ("microsoft-edge", "edge"), ("com.microsoft.edge", "edge"), ("msedge", "edge"),
+    # Vivaldi: same Chromium core, but a fully distinct install identity
+    # (Vivaldi Technologies product path, ``com.vivaldi.Vivaldi`` bundle id) so
+    # it side-by-side installs with any other Chromium browser — its profile
+    # is under ``~/.config/vivaldi/`` and must never be conflated with
+    # Chromium's ``~/.config/chromium/`` profile (wrong-principal, #95549).
+    ("vivaldi", "vivaldi"), ("com.vivaldi.vivaldi", "vivaldi"))
 
 _LINUX_CHANNEL_FRAGMENTS = (
     "google-chrome-beta", "google-chrome-unstable", "google-chrome-canary",
@@ -162,7 +177,8 @@ _LINUX_SNAP_PROFILE_PARTS = {
 _DARWIN_BUNDLE_MAP = (
     ("com.google.chrome", "chrome"), ("com.microsoft.edgemac", "edge"),
     ("com.brave.browser", "brave"), ("com.brave.browser.origin", "brave-origin"),
-    ("org.chromium.chromium", "chromium"))
+    ("org.chromium.chromium", "chromium"),
+    ("com.vivaldi.vivaldi", "vivaldi"))
 
 _DARWIN_CHANNEL_BUNDLES = (
     "com.google.chrome.beta", "com.google.chrome.dev", "com.google.chrome.canary",

--- a/tests/hermes_cli/test_browser_connect_default_chromium.py
+++ b/tests/hermes_cli/test_browser_connect_default_chromium.py
@@ -6,6 +6,8 @@ caught here rather than in a user's browser session.
 """
 from unittest.mock import patch
 
+import os
+
 import pytest
 
 import hermes_cli.browser_connect as bc
@@ -152,6 +154,34 @@ class TestLinuxProfileDir:
     def test_native_path_when_nothing_exists(self, tmp_path, monkeypatch):
         self._env(monkeypatch, tmp_path)
         assert bc.real_profile_data_dir("chromium", "Linux") == str(tmp_path / ".config" / "chromium")
+
+    def test_vivaldi_native_path_when_nothing_exists(self, tmp_path, monkeypatch):
+        self._env(monkeypatch, tmp_path)
+        assert bc.real_profile_data_dir("vivaldi", "Linux") == str(tmp_path / ".config" / "vivaldi")
+
+    def test_vivaldi_darwin_path(self):
+        assert bc.real_profile_data_dir("vivaldi", "Darwin") == os.path.join(
+            os.path.expanduser("~"), "Library", "Application Support", "Vivaldi"
+        )
+
+    def test_vivaldi_windows_path(self, monkeypatch):
+        monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\j7\AppData\Local")
+        assert bc.real_profile_data_dir("vivaldi", "Windows") == r"C:\Users\j7\AppData\Local\Vivaldi\User Data"
+
+    def test_vivaldi_desktop_file_resolves(self):
+        # Both the .desktop filename and the Flatpak bundle id should resolve
+        # to the vivaldi key (not chromium, not brave).
+        for desktop in ("vivaldi-stable.desktop", "com.vivaldi.vivaldi.desktop"):
+            result = None
+            for fragment, key in bc._LINUX_DESKTOP_MAP:
+                if fragment in desktop:
+                    result = key
+                    break
+            assert result == "vivaldi", f"{desktop!r} resolved to {result!r}"
+
+    def test_vivaldi_chromium_executable(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda n: "/usr/bin/vivaldi" if n == "vivaldi" else None)
+        assert bc.chromium_executable("vivaldi") == "/usr/bin/vivaldi"
 
     def test_snap_chromium_profile_is_found(self, tmp_path, monkeypatch):
         self._env(monkeypatch, tmp_path)


### PR DESCRIPTION
## Summary

Vivaldi is a Chromium-family browser from Vivaldi Technologies with the same Chromium core as Chrome/Edge/Brave, but a fully distinct install identity:
- macOS bundle id: `com.vivaldi.Vivaldi` (also `com.vivaldi.vivaldi` via Snap/AUR installs)
- Linux profile dir: `~/.config/vivaldi/` (NOT under `chromium`)
- Linux xdg default: `vivaldi-stable.desktop` (or `com.vivaldi.vivaldi.desktop` Flatpak)
- Linux binary paths: `/usr/bin/vivaldi`, `/usr/bin/vivaldi-stable`, `/opt/vivaldi/vivaldi`, `/opt/vivaldi/vivaldi-stable`

Users with Vivaldi as their default browser hit `"your default browser is not a supported Chromium browser"` when `browser.use_real_profile: true` is on, even though the docs explicitly call this the consent-gated path for "use your own logins."

A previous PR (#105209, closed) targeted the pre-refactor `_CHROMIUM_BROWSERS` / `_LINUX_BROWSER_GROUPS` structure; this one targets the current unified `_Browser` record model.

## What changes

Adds Vivaldi to the three lookup sites in `hermes_cli/browser_connect.py`:

1. **`_BROWSERS` tuple** — new `_Browser("vivaldi", ...)` record (matches the Edge entry's shape, including the `linux_exec=("vivaldi", "vivaldi-stable")` override since the Linux binary name diverges from the `.desktop` filename)
2. **`_LINUX_DESKTOP_MAP`** — xdg `default-web-browser` fragment matching (`vivaldi` + `com.vivaldi.vivaldi`, ordered after `chromium` to avoid substring collisions)
3. **`_DARWIN_BUNDLE_MAP`** — macOS LaunchServices bundle id (`com.vivaldi.vivaldi`)

## Tests

5 new test cases in `TestLinuxProfileDir` (after the existing chromium test):
- `test_vivaldi_native_path_when_nothing_exists` — verifies `~/.config/vivaldi` is the native default
- `test_vivaldi_darwin_path` — verifies `~/Library/Application Support/Vivaldi`
- `test_vivaldi_windows_path` — verifies `%LOCALAPPDATA%\Vivaldi\User Data`
- `test_vivaldi_desktop_file_resolves` — verifies both `vivaldi-stable.desktop` and `com.vivaldi.vivaldi.desktop` resolve to the `vivaldi` key (not `chromium`, not `brave`)
- `test_vivaldi_chromium_executable` — verifies the binary name resolver finds `/usr/bin/vivaldi`

All 36 pre-existing tests still pass. Total: 36 → 41.

## Why no `_LINUX_FLATPAK_IDS` / `_LINUX_SNAP_PROFILE_PARTS` entry

Vivaldi doesn't ship a Flatpak or Snap today. If they add either later, the resolver table already has Brave and Chromium as the template — follow that pattern. Leaving the entry absent is the correct fail-closed behavior until then.

## Provenance

Discovered while wiring up Vivaldi for an X/Twitter fetch use case on a Linux laptop with `browser.use_real_profile: true`. The error message currently names the supported list (Chrome/Edge/Brave/Brave Origin/Chromium) but omits Vivaldi, which is the third-most-popular Chromium-family browser by install base.

## Verification

```bash
python3 -m pytest tests/hermes_cli/test_browser_connect_default_chromium.py
# 41 passed

python3 -c "
import sys; sys.path.insert(0, '/path/to/hermes-agent')
from hermes_cli import browser_connect as bc
print(bc.chromium_executable('vivaldi'))                     # /usr/bin/vivaldi
print(bc.real_profile_data_dir('vivaldi', 'Linux'))         # /home/j7/.config/vivaldi
print(bc.real_profile_data_dir('vivaldi', 'Darwin'))        # ~/Library/Application Support/Vivaldi
print('vivaldi' in bc._BROWSER_BY_KEY)                       # True
"
```