### PR TITLE
fix(agent): session-scoped tool-surface snapshot — cold resume no longer breaks prompt cache (#103579)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2301,6 +2301,55 @@ def init_agent(
     _enforce_minimum_context(agent)
     _warn_nonagentic_hermes_model(agent)
     _inject_context_engine_tools(agent)
+
+    # ── Cold-resume tool-surface snapshot (#103579 族) ──
+    # agent.tools is the API request's top-level tools[], sitting between system
+    # prompt and messages in the cache prefix: any byte drift breaks the prefix
+    # right after the system prompt (observed hit residue == system-prompt
+    # tokens). Cold resume reassembles tools from the live registry (plugin
+    # registration order / check_fn pass-through / MCP connection state), so the
+    # bytes can differ from the previous process. Snapshot the final surface on
+    # first build (agent_tools table, content-addressed like system_prompts);
+    # reuse it unconditionally when the config fingerprint (model + toolsets)
+    # matches; rebuild + update on config change / no snapshot. Subagents keep
+    # their own build (no durable session, no cross-process prefix reuse).
+    if (
+        session_db is not None
+        and getattr(agent, "session_id", None)
+        and getattr(agent, "_delegate_depth", 0) == 0
+    ):
+        try:
+            from agent.tool_surface_snapshot import (
+                _tools_hash,
+                resolve_tool_surface,
+                tool_surface_fingerprint,
+            )
+
+            agent.tools = resolve_tool_surface(
+                session_db,
+                agent.session_id,
+                agent.model,
+                enabled_toolsets,
+                disabled_toolsets,
+                agent.tools,
+            )
+            agent.valid_tool_names = {
+                t.get("function", {}).get("name")
+                for t in agent.tools
+                if isinstance(t, dict) and t.get("function")
+            }
+            # Stash the built snapshot's hash/fingerprint on the agent: the
+            # sessions row may not exist yet (row creation is deferred to the
+            # first turn), so store_agent_tools' UPDATE hits 0 rows and the link
+            # is lost unless row creation (_ensure_db_session) carries it —
+            # mirroring how system_prompt travels with create_session.
+            agent._tool_surface_hash = _tools_hash(agent.tools)
+            agent._tool_surface_fingerprint = tool_surface_fingerprint(
+                agent.model, enabled_toolsets, disabled_toolsets
+            )
+        except Exception as exc:  # pragma: no cover — snapshot is a best-effort optimization
+            _ra().logger.warning("Tool-surface snapshot apply failed: %s", exc)
+
     _init_usage_state(agent)
     _configure_ollama_num_ctx(agent, _model_cfg, _config_context_length)
     _emit_compression_summary(agent, cs)

--- a/agent/tool_surface_snapshot.py
+++ b/agent/tool_surface_snapshot.py
@@ -1,0 +1,121 @@
+"""Cold-resume tool-surface snapshot — prompt-cache prefix stability (#103579 族).
+
+Background (observed 2026-09-07 22:11:57, session 20260907_220529_5021de):
+  ``agent.tools`` (the API-level ``tools[]`` array, located between the system
+  prompt and the messages in the cache prefix) is rebuilt on every agent
+  initialization by :func:`model_tools.get_tool_definitions`, whose output
+  depends on the *registry state at build time*: the ``tool_search`` bridge
+  description embeds the runtime deferrable set (``Search {N} additional
+  tools`` + a full catalog listing), and the deferrable set follows plugin
+  registration order / check_fn pass-through / MCP connection state. After a
+  dashboard/gateway restart the cold-resumed agent therefore produces a
+  different ``tools[]`` byte sequence than the previous process, and the
+  prompt-cache prefix breaks right after the system prompt (observed hit
+  residue == system-prompt tokens only, e.g. 14,592 for this host).
+
+Fix semantics (content-addressed, mirroring the ``system_prompts`` table):
+  * After a session's first build, store the final ``agent.tools`` bytes in
+    the ``agent_tools`` table (hash = content hash of the tool surface);
+    ``sessions`` records the ``tools_hash`` reference plus a
+    ``tools_fingerprint`` derived from the **user-visible configuration only**
+    (model + enabled/disabled toolsets).
+  * Cold resume: fingerprint match → reuse the snapshot bytes unconditionally,
+    ignoring the current registry (plugin registration order / check_fn
+    pass-through / MCP connection state must not change the bytes);
+    fingerprint mismatch or no snapshot → build live and store a new snapshot.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, List, Optional
+
+
+def tool_surface_fingerprint(
+    model: Optional[str],
+    enabled_toolsets: Optional[List[str]],
+    disabled_toolsets: Optional[List[str]],
+) -> str:
+    """Fingerprint = f(user-visible configuration), **excluding** runtime registry state.
+
+    This is the crux of the fix: only a model/toolset change invalidates the
+    snapshot; plugin registration order, check_fn pass-through, and MCP
+    connection state changes must never invalidate it.
+    """
+    payload = {
+        "model": model or "",
+        "enabled": sorted(enabled_toolsets or []),
+        "disabled": sorted(disabled_toolsets or []),
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _tools_hash(tools: List[Dict[str, Any]]) -> str:
+    """Content hash of a tool-surface list (``agent_tools`` primary key)."""
+    blob = json.dumps(tools, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def load_snapshot(
+    session_db, session_id: str, fingerprint: str
+) -> Optional[List[Dict[str, Any]]]:
+    """Return the stored tool-surface bytes if the snapshot matches, else None.
+
+    Match = sessions.tools_fingerprint == *fingerprint* (config unchanged) AND
+    the referenced agent_tools row exists.
+    """
+    if session_db is None or not session_id:
+        return None
+    try:
+        session = session_db.get_session(session_id)
+        if not session:
+            return None
+        if session.get("tools_fingerprint") != fingerprint:
+            return None
+        tools_hash = session.get("tools_hash")
+        if not tools_hash:
+            return None
+        return session_db.load_agent_tools(tools_hash)
+    except Exception as exc:  # pragma: no cover — snapshot failure must not block agent build
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Tool-surface snapshot load failed (%s); falling back to live build", exc
+        )
+        return None
+
+
+def store_snapshot(
+    session_db, session_id: str, fingerprint: str, tools: List[Dict[str, Any]]
+) -> str:
+    """Store the snapshot and link the session; returns the content hash."""
+    if session_db is None or not session_id:
+        return _tools_hash(tools)
+    try:
+        return session_db.store_agent_tools(session_id, fingerprint, tools)
+    except Exception as exc:  # pragma: no cover — snapshot failure must not block agent build
+        import logging
+
+        logging.getLogger(__name__).info(
+            "Tool-surface snapshot store skipped: %s", exc
+        )
+        return _tools_hash(tools)
+
+
+def resolve_tool_surface(
+    session_db,
+    session_id: str,
+    model: Optional[str],
+    enabled_toolsets: Optional[List[str]],
+    disabled_toolsets: Optional[List[str]],
+    built_tools: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return the agent's final tool surface: snapshot on match, else store + use live build."""
+    fp = tool_surface_fingerprint(model, enabled_toolsets, disabled_toolsets)
+    cached = load_snapshot(session_db, session_id, fp)
+    if cached is not None:
+        return cached
+    store_snapshot(session_db, session_id, fp, built_tools)
+    return built_tools

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -391,6 +391,68 @@ class SessionDB(
             "SELECT 1 FROM sessions WHERE sessions.system_prompt_hash = system_prompts.hash)"
         )
 
+    # ── Agent tool-surface snapshot (#103579 族) ──
+    # Content-addressed storage mirrored on system_prompts: agent_tools(hash, tools)
+    # + sessions.tools_hash reference + sessions.tools_fingerprint (config-only
+    # fingerprint). On cold resume a matching fingerprint lets the agent reuse the
+    # exact tools[] bytes built when the session was created, so the prompt-cache
+    # prefix (system prompt → tools[] → messages) survives across restarts —
+    # plugin registration order / check_fn pass-through must not change the bytes.
+
+    def load_agent_tools(self, tools_hash: str) -> Optional[List[Dict[str, Any]]]:
+        """Return the tool-surface snapshot bytes by content hash (exact, no re-sort)."""
+        if not tools_hash:
+            return None
+        try:
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT tools FROM agent_tools WHERE hash = ?",
+                    (tools_hash,),
+                ).fetchone()
+        except sqlite3.DatabaseError:
+            return None
+        if row is None or not row[0]:
+            return None
+        try:
+            parsed = json.loads(row[0])
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(parsed, list):
+            return None
+        return parsed
+
+    def store_agent_tools(
+        self,
+        session_id: str,
+        fingerprint: str,
+        tools: List[Dict[str, Any]],
+    ) -> str:
+        """Write a tool-surface snapshot (content-addressed) and link the session row.
+
+        Returns the content hash; snapshot failures only degrade to no-store, never
+        block agent building, so this method never raises.
+        """
+        from agent.tool_surface_snapshot import _tools_hash
+
+        tools_json = json.dumps(tools, sort_keys=True, separators=(",", ":"))
+        tools_hash = _tools_hash(tools)
+
+        def _do(conn) -> None:
+            conn.execute(
+                "INSERT OR IGNORE INTO agent_tools (hash, tools) VALUES (?, ?)",
+                (tools_hash, tools_json),
+            )
+            conn.execute(
+                "UPDATE sessions SET tools_hash = ?, tools_fingerprint = ? WHERE id = ?",
+                (tools_hash, fingerprint, session_id),
+            )
+
+        try:
+            self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+        except Exception:  # pragma: no cover — snapshot is a best-effort optimization
+            logger.warning("agent_tools snapshot store failed for %s", session_id, exc_info=True)
+        return tools_hash
+
     @staticmethod
     def _session_row_dict(row: sqlite3.Row) -> Dict[str, Any]:
         data = dict(row)

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -276,6 +276,11 @@ CREATE TABLE IF NOT EXISTS system_prompts (
     prompt TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS agent_tools (
+    hash TEXT PRIMARY KEY,
+    tools TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,
     source TEXT NOT NULL,
@@ -291,6 +296,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     model_config TEXT,
     system_prompt TEXT,
     system_prompt_hash TEXT,
+    tools_hash TEXT,
+    tools_fingerprint TEXT,
     parent_session_id TEXT,
     started_at REAL NOT NULL,
     ended_at REAL,

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -202,7 +202,7 @@ _SAME_KEY_NAMESPACE_SQL = (
 _UPSERT_KEEP_EXISTING_SQL = ",\n".join(
     f"                       {col} = COALESCE(sessions.{col}, excluded.{col})" for col in (
         "session_key", "chat_id", "chat_type", "thread_id", "parent_session_id", "cwd", "profile_name",
-        "git_repo_root", "origin_json", "display_name",
+        "git_repo_root", "origin_json", "display_name", "tools_hash", "tools_fingerprint",
     )
 )
 
@@ -274,6 +274,7 @@ class SessionSessionsMixin:
         chat_id: str = None, chat_type: str = None, thread_id: str = None,
         parent_session_id: str = None, cwd: str = None, profile_name: Optional[str] = None,
         git_repo_root: str = None, origin_json: str = None, display_name: str = None,
+        tools_hash: str = None, tools_fingerprint: str = None,
     ) -> None:
         """Upsert a session row, never overwriting what an earlier writer set (the gateway creates a
         bare row before create_session carries the real model/prompt). chat_id/thread_id scope gateway
@@ -310,9 +311,9 @@ class SessionSessionsMixin:
                    id, source, user_id, session_key, chat_id, chat_type, thread_id,
                    model, model_config, system_prompt, system_prompt_hash,
                    parent_session_id, cwd, profile_name, git_repo_root,
-                   origin_json, display_name, started_at
+                   origin_json, display_name, started_at, tools_hash, tools_fingerprint
                 )
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(id) DO UPDATE SET
                        model = COALESCE(sessions.model, excluded.model),
                        model_config = CASE
@@ -349,7 +350,7 @@ class SessionSessionsMixin:
                     session_id, source, user_id, session_key, chat_id, chat_type, thread_id, model,
                     json.dumps(model_config) if model_config else None, system_prompt_hash,
                     parent_session_id, cwd, profile_name, git_repo_root, origin_json, display_name,
-                    time.time(),
+                    time.time(), tools_hash, tools_fingerprint,
                 ),
             )
             if system_prompt_hash is not None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -343,6 +343,15 @@ class AIAgent(
                 display_name=getattr(self, "_chat_name", None) or getattr(self, "_user_name", None),
                 origin_json=_gateway_origin_json(self), parent_session_id=self._parent_session_id,
                 cwd=_launch_cwd_for_session(source), profile_name=profile_for_session,
+                # Tool-surface snapshot link: the snapshot was stored during agent
+                # build, BEFORE this row existed (row creation is deferred to the
+                # first turn), so store_agent_tools' UPDATE hit 0 rows and the link
+                # was silently lost. The link must travel with row creation (mirrors
+                # system_prompt_hash) — otherwise sessions.tools_hash stays NULL and
+                # a cold resume rebuilds tools[] from the live registry, breaking
+                # the prompt-cache prefix.
+                tools_hash=getattr(self, "_tool_surface_hash", None),
+                tools_fingerprint=getattr(self, "_tool_surface_fingerprint", None),
             )
             self._session_db_created = True
         except Exception as e:

--- a/tests/agent/test_tool_surface_snapshot.py
+++ b/tests/agent/test_tool_surface_snapshot.py
@@ -1,0 +1,303 @@
+"""Cold-resume tool-surface snapshot tests — TDD cases for the #103579 族 fix.
+
+Background (observed 2026-09-07 22:11:57, session 20260907_220529_5021de):
+  After a dashboard/gateway restart the cold-resumed agent rebuilds its tool
+  surface via ``assemble_tool_defs`` from the *live registry state*, so the
+  ``tools[]`` bytes change with the deferrable set (the ``tool_search`` bridge
+  description embeds "Search {N} additional tools" + a catalog listing) →
+  the cache prefix breaks right after the system prompt (observed hit residue
+  == system-prompt tokens, 14,592 in this environment).
+
+Fix: **session-scoped tool-surface snapshot** — after a session's first build
+store the final ``agent.tools`` bytes in state.db (``agent_tools`` table,
+content-addressed, linked via ``sessions.tools_hash`` /
+``sessions.tools_fingerprint``); on cold resume decide by fingerprint:
+  * fingerprint match (model/toolsets unchanged) → reuse the snapshot bytes
+    unconditionally (byte-stable, ignores the live registry) → cache prefix
+    stays stable across restarts
+  * fingerprint mismatch / no snapshot → build live and store a new snapshot
+
+The fingerprint covers only **user-visible configuration** (model +
+enabled/disabled toolsets), never runtime registry state — that is the crux:
+plugin registration order / check_fn pass-through / MCP connection state
+changes must NOT trigger a rebuild.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _td(name: str, description: str = "") -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+_SNAPSHOT_TOOLS = [_td("terminal", "Run shell commands."), _td("read_file", "Read a file.")]
+
+
+def _tmp_session_db(tmp_path):
+    """Build an isolated SessionDB (never touches the production state.db)."""
+    from hermes_state import SessionDB
+
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+class TestFingerprint:
+    """Fingerprint = f(user-visible configuration) contract."""
+
+    def test_stable_for_same_input(self):
+        from agent.tool_surface_snapshot import tool_surface_fingerprint
+
+        fp1 = tool_surface_fingerprint("deepseek-v4", ["cli"], [])
+        fp2 = tool_surface_fingerprint("deepseek-v4", ["cli"], [])
+        assert fp1 == fp2
+
+    def test_changes_with_model(self):
+        from agent.tool_surface_snapshot import tool_surface_fingerprint
+
+        assert tool_surface_fingerprint("model-a", ["cli"], []) != tool_surface_fingerprint(
+            "model-b", ["cli"], []
+        )
+
+    def test_changes_with_toolsets(self):
+        from agent.tool_surface_snapshot import tool_surface_fingerprint
+
+        assert tool_surface_fingerprint("m", ["cli"], []) != tool_surface_fingerprint(
+            "m", ["cli", "coding"], []
+        )
+        assert tool_surface_fingerprint("m", ["cli"], []) != tool_surface_fingerprint(
+            "m", ["cli"], ["web"]
+        )
+
+    def test_order_insensitive(self):
+        """toolsets participate as sets (enabled/disabled), not ordered lists."""
+        from agent.tool_surface_snapshot import tool_surface_fingerprint
+
+        assert tool_surface_fingerprint("m", ["a", "b"], []) == tool_surface_fingerprint(
+            "m", ["b", "a"], []
+        )
+
+
+class TestSnapshotStore:
+    """DB round-trip: stored bytes must come back exactly (byte-fidelity contract)."""
+
+    def test_roundtrip(self, tmp_path):
+        from agent.tool_surface_snapshot import load_snapshot, store_snapshot
+
+        db = _tmp_session_db(tmp_path)
+        db.create_session("sid-test", "cli", model="m")
+        tools = _SNAPSHOT_TOOLS
+        h = store_snapshot(db, "sid-test", "FP-1", tools)
+        assert isinstance(h, str) and len(h) == 64
+        loaded = load_snapshot(db, "sid-test", "FP-1")
+        assert loaded is not None
+        assert json.dumps(loaded, sort_keys=True) == json.dumps(tools, sort_keys=True)
+
+    def test_reload_with_new_db_instance(self, tmp_path):
+        """Simulate a restart: a new SessionDB instance reads the same DB identically."""
+        from agent.tool_surface_snapshot import load_snapshot, store_snapshot
+
+        db1 = _tmp_session_db(tmp_path)
+        db1.create_session("sid-restart", "cli", model="m")
+        store_snapshot(db1, "sid-restart", "FP-1", _SNAPSHOT_TOOLS)
+
+        db2 = _tmp_session_db(tmp_path)
+        loaded = load_snapshot(db2, "sid-restart", "FP-1")
+        assert loaded is not None
+        assert json.dumps(loaded, sort_keys=True) == json.dumps(_SNAPSHOT_TOOLS, sort_keys=True)
+
+
+class TestColdResume:
+    """Capture cases (FAIL before the fix / PASS after) — cold-resume byte stability."""
+
+    def test_load_returns_none_for_unknown_session(self, tmp_path):
+        from agent.tool_surface_snapshot import load_snapshot
+
+        db = _tmp_session_db(tmp_path)
+        assert load_snapshot(db, "sid-unknown", "FP-1") is None
+
+    def test_load_returns_none_on_fingerprint_mismatch(self, tmp_path):
+        """User changed config (model/toolsets) → fingerprint mismatch → rebuild."""
+        from agent.tool_surface_snapshot import load_snapshot, store_snapshot
+
+        db = _tmp_session_db(tmp_path)
+        db.create_session("sid-fp", "cli", model="m")
+        store_snapshot(db, "sid-fp", "FP-OLD", _SNAPSHOT_TOOLS)
+        assert load_snapshot(db, "sid-fp", "FP-NEW") is None
+
+    def test_registry_changes_do_not_invalidate_snapshot(self, tmp_path, monkeypatch):
+        """★ Core capture case: registry-state changes on cold resume must not alter bytes.
+
+        Bug scenario (22:11:57): plugin registration order / check_fn pass-through
+        differs from the previous process → assembled bytes differ → prefix break.
+        Snapshot semantics: when the fingerprint matches (config unchanged) the
+        stored bytes must be returned regardless of live registry state.
+        """
+        from agent.tool_surface_snapshot import load_snapshot, store_snapshot
+
+        db = _tmp_session_db(tmp_path)
+        db.create_session("sid-resume", "cli", model="m")
+        # First build: full tool surface (incl. 2 plugin tools)
+        original = _SNAPSHOT_TOOLS + [
+            _td("feishu_doc_read", "Read a Feishu doc."),
+            _td("video_analyze", "Analyze a video."),
+        ]
+        store_snapshot(db, "sid-resume", "FP-1", original)
+
+        # Simulate a restart where the registry lost 2 plugin tools (check_fn
+        # not passed / not registered) — a live assemble would produce different
+        # bytes; the snapshot must still return the original bytes.
+        loaded = load_snapshot(db, "sid-resume", "FP-1")
+        assert loaded is not None
+        assert json.dumps(loaded, sort_keys=True) == json.dumps(original, sort_keys=True), (
+            "Bug: cold resume changed the tool surface — snapshot must be used "
+            "regardless of live registry state when the config fingerprint matches"
+        )
+
+    def test_store_overwrites_newer_fingerprint(self, tmp_path):
+        """After a config change the rebuild must let the new fingerprint take over."""
+        from agent.tool_surface_snapshot import load_snapshot, store_snapshot
+
+        db = _tmp_session_db(tmp_path)
+        db.create_session("sid-evolve", "cli", model="m")
+        store_snapshot(db, "sid-evolve", "FP-1", _SNAPSHOT_TOOLS)
+        store_snapshot(
+            db,
+            "sid-evolve",
+            "FP-2",
+            _SNAPSHOT_TOOLS + [_td("new_tool", "New.")],
+        )
+        assert load_snapshot(db, "sid-evolve", "FP-1") is None
+        assert load_snapshot(db, "sid-evolve", "FP-2") is not None
+
+
+class TestNewSessionBuildLink:
+    """Capture cases (FAIL before the fix) — new-session row creation must link the snapshot.
+
+    Incident (2026-09-07, session 20260907_231241_8d9da0): a new session's agent
+    build happens BEFORE the sessions row is created (row creation is deferred to
+    the first turn of run_conversation). During build,
+    resolve_tool_surface → store_snapshot runs ``UPDATE sessions SET
+    tools_hash=... WHERE id=?`` — the row doesn't exist, so the UPDATE hits 0
+    rows (SQLite is silent), the snapshot is stored but the link is silently
+    lost → sessions.tools_hash stays NULL → a cold resume has no snapshot to
+    reuse → the tool-surface bytes can drift across restarts (the #103579 族
+    fix would be defeated).
+
+    system_prompt has no such problem: ``_ensure_db_session`` passes
+    system_prompt to create_session (writing system_prompts + linking the hash).
+    The tools snapshot is missing exactly that symmetric link.
+    """
+
+    def test_create_session_persists_tools_link(self, tmp_path):
+        """DB contract: create_session must accept tools_hash/tools_fingerprint.
+
+        This is the storage-layer support for "carry the snapshot link at row
+        creation" (isomorphic to system_prompt_hash); before the fix,
+        _insert_session_row raised TypeError on unknown kwargs.
+        """
+        from agent.tool_surface_snapshot import _tools_hash
+
+        db = _tmp_session_db(tmp_path)
+        h = _tools_hash(_SNAPSHOT_TOOLS)
+        db.create_session(
+            "sid-tools-link",
+            "cli",
+            model="m",
+            tools_hash=h,
+            tools_fingerprint="FP-1",
+        )
+        row = db.get_session("sid-tools-link")
+        assert row.get("tools_hash") == h, (
+            "Bug: create_session dropped tools_hash — the session row must "
+            "carry the built tool-surface snapshot link so a cold resume can "
+            "reuse it"
+        )
+        assert row.get("tools_fingerprint") == "FP-1", (
+            "Bug: create_session dropped tools_fingerprint — fingerprint is "
+            "required to decide whether the snapshot is still valid"
+        )
+
+    def test_store_before_row_creation_leaves_snapshot_row_but_no_link(
+        self, tmp_path
+    ):
+        """Guard: store before the row exists (new-session build semantics) must not
+        raise, and the agent_tools row is persisted — only the sessions link is
+        missing (snapshot body intact)."""
+        from agent.tool_surface_snapshot import load_snapshot, store_snapshot
+
+        db = _tmp_session_db(tmp_path)
+        # Build time: no session row yet (deferred); store only writes agent_tools
+        store_snapshot(db, "sid-late", "FP-1", _SNAPSHOT_TOOLS)
+        # Row still absent: UPDATE of 0 rows was silently swallowed (no exception)
+        # — pre-fix behavior, do not assert success.
+        row = db.get_session("sid-late")
+        assert row is None or row.get("tools_hash") is None
+
+    def test_ensure_db_session_links_built_tool_surface(self, tmp_path):
+        """★ Core capture case: after the first turn creates the row
+        (_ensure_db_session), the sessions row must carry the build-time
+        snapshot's tools_hash/tools_fingerprint.
+
+        Bug scenario (23:12:41): during build the store's UPDATE hit 0 rows; row
+        creation (first turn of run_conversation) did not carry the snapshot link
+        → tools_hash stayed NULL forever → cold resume had no snapshot to reuse.
+        system_prompt travels the same path; the tools snapshot lacked the
+        symmetric piece.
+        """
+        from types import SimpleNamespace
+
+        from run_agent import AIAgent
+
+        db = _tmp_session_db(tmp_path)
+        # Minimal agent stand-in: only the attributes _ensure_db_session reads
+        # (building a real AIAgent pulls full tool registration/MCP discovery).
+        fake = SimpleNamespace(
+            _persist_disabled=False,
+            _session_db_created=False,
+            _session_db=db,
+            platform="desktop",
+            session_id="sid-newbuild",
+            _session_init_model_config=None,
+            _cached_system_prompt="system prompt",
+            _parent_session_id=None,
+            model="m",
+            # After the fix: init_agent's snapshot block stashes the build-time
+            # hash/fingerprint here.
+            _tool_surface_hash="dummy-snapshot-hash",
+            _tool_surface_fingerprint="FP-NEW",
+        )
+        # Upstream _ensure_db_session delegates model_config to this method.
+        fake._session_row_model_config = lambda: None
+        # Simulate the first-turn row creation call from run_conversation
+        AIAgent._ensure_db_session(fake)
+
+        row = db.get_session("sid-newbuild")
+        assert row.get("tools_hash") == "dummy-snapshot-hash", (
+            "Bug: new-session row creation dropped the built tool-surface "
+            "snapshot link — the snapshot was stored before the row existed "
+            "(UPDATE 0 rows, silent), so without this link a cold resume "
+            "rebuilds tools[] from the live registry and can break the "
+            "prefix cache (tools_hash must travel with row creation, same as "
+            "system_prompt_hash)"
+        )
+        assert row.get("tools_fingerprint") == "FP-NEW", (
+            "Bug: tools_fingerprint missing on new-session row — without it "
+            "a resume cannot decide whether the stored snapshot is still valid"
+        )

--- a/tests/tools/test_cold_resume_tool_surface_stability.py
+++ b/tests/tools/test_cold_resume_tool_surface_stability.py
@@ -1,0 +1,187 @@
+"""Cold-resume tool-surface byte stability — regression guard for the #103579 族 fix.
+
+Background (observed 2026-09-07, session 20260907_220529_5021de):
+  A dashboard/gateway restart cold-resumes a rebuilt agent whose tool surface
+  is reassembled by ``assemble_tool_defs``. The ``tool_search`` bridge
+  description embeds the **runtime deferrable set** (plugin/MCP tools that pass
+  check_fn) as a deferred_count + full catalog listing (name + description),
+  so:
+
+    same config, same plugin set — if the deferrable set at *build time*
+    differs from the previous process (plugin registration order / check_fn
+    pass-through / async platform tool registration), the tool-surface bytes
+    differ → the API request's tools[] differs → the cache prefix breaks right
+    after the system prompt (hit residue == system-prompt, 14,592 tokens
+    measured in this environment).
+
+  The earlier fix (bdc21cb777) froze the tool-surface inheritance for
+  **bg-review forks** only; the main-thread cold resume had no snapshot
+  mechanism — "rebuild every time" — hence "first turn after a restart breaks,
+  next turn recovers".
+
+Test layers:
+  * Mechanism (PASS, proves existence): different deferrable sets → different
+    bytes; same set twice → identical bytes (no randomness).
+  * Contract layer (documentation): byte changes with the deferrable set are
+    by design — that is why the snapshot exists. The byte-stability contract
+    lives at the agent layer, carried by
+    ``tests/agent/test_tool_surface_snapshot.py`` (config fingerprint
+    unchanged → cold resume must reuse the session-snapshot bytes regardless
+    of registry state).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, Dict, List
+
+import pytest
+
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _td(name: str, description: str = "", properties: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Mini OpenAI-format tool definition."""
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {"type": "object", "properties": properties or {}},
+        },
+    }
+
+
+_CORE = _td("terminal", "Run shell commands.")
+_CORE2 = _td("read_file", "Read a file.")
+
+_PLUGIN_A = _td("feishu_doc_read", "Read the full content of a Feishu/Lark document as plain text.")
+_PLUGIN_B = _td("feishu_drive_add_comment", "Add a new whole-document comment on a Feishu document.")
+_PLUGIN_C = _td("feishu_drive_list_comments", "List all comments in a comment thread on a Feishu document.")
+_PLUGIN_D = _td("video_analyze", "Analyze a video from a URL or local file path.")
+
+
+def _assemble(tool_defs: List[Dict[str, Any]], context_length: int = 1_000_000) -> List[Dict[str, Any]]:
+    from tools.tool_search import ToolSearchConfig, assemble_tool_defs
+
+    cfg = ToolSearchConfig.from_raw(None)  # enabled=auto — activates when deferrables exist
+    result = assemble_tool_defs(tool_defs, context_length=context_length, config=cfg)
+    return result.tool_defs
+
+
+def _register_mcp_tool(name: str, description: str, toolset: str = "mcp-cold-resume") -> None:
+    """Register a plugin/MCP tool in the global registry so classify_tools
+    treats it as deferrable (is_deferrable_tool_name queries registry.get_entry)."""
+    from tools.registry import registry
+
+    registry.register(
+        name=name,
+        handler=lambda args, **kw: "{}",
+        schema=_td(name, description)["function"],
+        toolset=toolset,
+    )
+
+
+def _tool_search_desc(tool_defs: List[Dict[str, Any]]) -> str:
+    for td in tool_defs:
+        fn = td.get("function") or {}
+        if fn.get("name") == "tool_search":
+            return fn.get("description", "")
+    raise AssertionError("tool_search bridge missing from assembled output")
+
+
+# Plugin/MCP tool names (unique prefix per test to avoid global-registry pollution)
+_P = "coldresume"
+
+
+class TestMechanism:
+    """Mechanism layer: tool-surface bytes are a function of the deferrable set."""
+
+    def test_deferred_catalog_embedded_in_bridge_description(self):
+        """The bridge description must embed deferred_count + catalog (current design)."""
+        from tools.registry import discover_builtin_tools
+
+        discover_builtin_tools()
+        names = [f"{_P}_n{i}" for i in range(4)]
+        for i, n in enumerate(names):
+            _register_mcp_tool(n, f"Plugin tool {i}.")
+        tool_defs = [_CORE, _CORE2] + [_td(n, f"Plugin tool {i}.") for i, n in enumerate(names)]
+        result = _assemble(tool_defs)
+        desc = _tool_search_desc(result)
+        assert "Search 4 additional tools" in desc
+        for n in names:
+            assert n in desc, f"catalog listing must mention {n}"
+
+    def test_partial_set_produces_different_bytes(self):
+        """Same plugin set, different registration/check_fn pass-through (4→2) → different bytes."""
+        from tools.registry import discover_builtin_tools
+
+        discover_builtin_tools()
+        full_names = [f"{_P}_full_{i}" for i in range(4)]
+        for i, n in enumerate(full_names):
+            _register_mcp_tool(n, f"Full tool {i}.")
+        full = [_CORE, _CORE2] + [_td(n, f"Full tool {i}.") for i, n in enumerate(full_names)]
+        partial = [_CORE, _CORE2] + [_td(n, f"Full tool {i}.") for i, n in enumerate(full_names[:2])]
+        sa = json.dumps(_assemble(full), ensure_ascii=False, sort_keys=True)
+        sb = json.dumps(_assemble(partial), ensure_ascii=False, sort_keys=True)
+        assert sa != sb, "different deferred sets must produce different wire bytes (bug carrier)"
+
+    def test_same_set_same_bytes(self):
+        """Repeating an identical set must produce byte-identical output (no random sort/race)."""
+        from tools.registry import discover_builtin_tools
+
+        discover_builtin_tools()
+        names = [f"{_P}_stable_{i}" for i in range(3)]
+        for i, n in enumerate(names):
+            _register_mcp_tool(n, f"Stable tool {i}.")
+        tool_defs = [_CORE, _CORE2] + [_td(n, f"Stable tool {i}.") for i, n in enumerate(names)]
+        s1 = json.dumps(_assemble(tool_defs), ensure_ascii=False, sort_keys=True)
+        s2 = json.dumps(_assemble(tool_defs), ensure_ascii=False, sort_keys=True)
+        assert s1 == s2
+
+
+class TestByteStabilityContract:
+    """Contract layer (documentation): assemble-layer bytes changing with the
+    deferrable set is by design.
+
+    That is exactly why the snapshot exists — the byte-stability contract moved
+    up to the agent layer and is carried by
+    ``tests/agent/test_tool_surface_snapshot.py``:
+    config fingerprint (model/toolsets) unchanged → cold resume must reuse the
+    session-snapshot bytes regardless of registry/check_fn state
+    (test_registry_changes_do_not_invalidate_snapshot). This class no longer
+    asserts assemble-layer byte stability (that would be the wrong contract).
+    """
+
+    def test_bytes_change_with_deferred_set(self):
+        """Bytes change with the set = the necessity of the snapshot (if stable, no fix needed)."""
+        from tools.registry import discover_builtin_tools
+
+        discover_builtin_tools()
+        names = [f"{_P}_need_{i}" for i in range(4)]
+        for i, n in enumerate(names):
+            _register_mcp_tool(n, f"Need tool {i}.")
+        full = [_CORE, _CORE2] + [_td(n, f"Need tool {i}.") for i, n in enumerate(names)]
+        partial = [_CORE, _CORE2] + [_td(n, f"Need tool {i}.") for i, n in enumerate(names[:2])]
+        sa = json.dumps(_assemble(full), ensure_ascii=False, sort_keys=True)
+        sb = json.dumps(_assemble(partial), ensure_ascii=False, sort_keys=True)
+        assert sa != sb
+
+    def test_registration_order_does_not_change_bytes(self):
+        """Registration order does not affect bytes (the break driver is the set, not order)."""
+        from tools.registry import discover_builtin_tools
+
+        discover_builtin_tools()
+        names = [f"{_P}_order2_{i}" for i in range(4)]
+        for i, n in enumerate(names):
+            _register_mcp_tool(n, f"Order tool {i}.")
+        a = [_CORE, _CORE2] + [_td(n, f"Order tool {i}.") for i, n in enumerate(names)]
+        b = [_CORE, _CORE2] + [_td(n, f"Order tool {i}.") for i, n in reversed(list(enumerate(names)))]
+        sa = json.dumps(_assemble(a), ensure_ascii=False, sort_keys=True)
+        sb = json.dumps(_assemble(b), ensure_ascii=False, sort_keys=True)
+        assert sa == sb


### PR DESCRIPTION
## Summary

Fixes the prompt-cache prefix break on **main-thread cold resume** (dashboard/gateway restart) — the fourth gap in the #103579 family: the previous fix (#103581, pool of PRs from other contributors) only froze bg-review fork inheritance; the main thread rebuilt `tools[]` from the live registry on every agent initialization.

`agent.tools` (API `tools[]`) sits between system prompt and messages in the cache prefix. Its bytes depend on the registry state **at build time** (the `tool_search` bridge embeds `Search {N} additional tools` + catalog listing, where N follows plugin registration order / check_fn pass-through / MCP connection state). On restart, cold resume builds different bytes → prefix breaks right after the system prompt (observed hit residue == system-prompt tokens, 14,592 in the reporter's env) → hundreds of K tokens of re-computation per restart, then recovery from the next turn.

## Fix

Session-scoped tool-surface snapshot, content-addressed and isomorphic to `system_prompts`:

- **`agent_tools(hash, tools)` table + `sessions.tools_hash` / `sessions.tools_fingerprint`** (declared in SCHEMA_SQL; the existing column reconciler adds them to existing DBs automatically — no manual migration).
- **`agent/tool_surface_snapshot.py`**: `tool_surface_fingerprint()` derived **only** from user-visible config (model + enabled/disabled toolsets) — never registry/check_fn runtime state (the crux: runtime changes must not invalidate the snapshot); `load_snapshot` / `store_snapshot` / `resolve_tool_surface` (fingerprint match → reuse bytes unconditionally; mismatch → build live + store).
- **`init_agent`** applies `resolve_tool_surface` after context-engine tool injection (`_delegate_depth == 0` only; subagents keep their own build) and stashes the resulting hash/fingerprint on the agent.
- **New-session build-order fix**: the sessions row is created lazily on the first turn, *after* the agent build ran `store_snapshot` — the UPDATE hit 0 rows and the link was silently lost (`sessions.tools_hash` stayed NULL, defeating the fix). `_ensure_db_session` now carries `tools_hash`/`tools_fingerprint` with row creation, mirroring `system_prompt_hash`.
- Best-effort everywhere (snapshot failures never block agent build).

## Tests

- `tests/agent/test_tool_surface_snapshot.py` (13): fingerprint contract, DB round-trip + cross-instance reuse (restart simulation), capture case `test_registry_changes_do_not_invalidate_snapshot`, fingerprint-mismatch rebuild, new-session link trio (incl. `test_ensure_db_session_links_built_tool_surface`).
- `tests/tools/test_cold_resume_tool_surface_stability.py` (5): mechanism pinning (deferred catalog in bridge description, set→bytes, order-insensitivity) + contract documentation.

## Verification

- New tests: 18/18 pass.
- Regression: `tests/hermes_state/` 300 passed, `tests/tools/test_tool_search.py` + run_agent memory/plugin-context-engine init 69 passed (one pre-existing unrelated FTS5 failure in `test_hermes_state.py` also fails on the untouched baseline).
- ruff clean.

## Notes

Overlaps with #103581 / #103937 (bg-review fork tool-surface parity) are complementary, not conflicting: this PR covers the main-thread cold-resume gap that those do not touch. Related: #103579 (head issue).
