### PR TITLE
fix(tui): reap session-persistent kernels when a TUI-owned session ends

### DIFF
--- a/tests/tui_gateway/test_session_finalize_reaps_kernels.py
+++ b/tests/tui_gateway/test_session_finalize_reaps_kernels.py
@@ -1,0 +1,108 @@
+"""Session finalize must clear the owner's approval/kernel state (TUI-owned only).
+
+The gateway's /stop and /new paths call ``approval.clear_session`` so a finished
+conversation cannot leak a session-persistent execute_code kernel (see #88637).
+A TUI/Desktop session that ends via ``_finalize_session`` took no such path —
+kernels survived until the NEXT execute_code in the process ran the lazy idle
+sweep, orphaning one live interpreter per finished conversation.
+
+Contract: when the TUI owns the session lifecycle, finalize clears approval
+state (killing that owner's kernels) with the session's own key; when another
+backend (gateway) owns the lease, finalize must NOT clear it — a viewer tab
+must never kill the gateway's kernels.
+"""
+
+import threading
+
+from tui_gateway import server
+
+
+def _session(session_key: str) -> dict:
+    return {
+        "active_session_lease": None,
+        "agent": None,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": None,
+        "session_key": session_key,
+        "slash_worker": None,
+        "source": "desktop",
+    }
+
+
+def _install_stubs(monkeypatch, *, db_source: str | None = "desktop"):
+    """Stub out finalize's external work; keep the lifecycle-guard + db-source logic real."""
+    cleared: list[str] = []
+
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "tools.approval.clear_session",
+        lambda key: cleared.append(key),
+    )
+
+    class _FakeDB:
+        def __init__(self, source: str | None):
+            self.source = source
+
+        def get_session(self, target: str) -> dict | None:
+            if self.source is None:
+                return None
+            return {"id": target, "source": self.source}
+
+        def end_session(self, *_a, **_k):
+            pass
+
+    import contextlib
+
+    @contextlib.contextmanager
+    def _profile_db(_session: dict):
+        yield _FakeDB(db_source)
+
+    monkeypatch.setattr(server, "_session_db", _profile_db)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    return cleared
+
+
+def test_tui_owned_finalize_clears_approval_state_for_its_owner(monkeypatch):
+    cleared = _install_stubs(monkeypatch, db_source="desktop")
+
+    server._finalize_session(
+        _session("20260907_120000_abcdef"), end_reason="ws_orphan_reap"
+    )
+
+    assert cleared == ["20260907_120000_abcdef"]
+
+
+def test_user_close_also_clears_approval_state(monkeypatch):
+    cleared = _install_stubs(monkeypatch, db_source="desktop")
+
+    server._finalize_session(
+        _session("20260907_120000_abcdef"), end_reason="tui_close"
+    )
+
+    assert cleared == ["20260907_120000_abcdef"]
+
+
+def test_viewer_finalize_does_not_clear_gateway_owned_session(monkeypatch):
+    """A gateway-originated session (TUI is a viewer) must keep its kernels."""
+    cleared = _install_stubs(monkeypatch, db_source="telegram")
+
+    server._finalize_session(
+        _session("20260907_120000_abcdef"), end_reason="tui_shutdown"
+    )
+
+    assert cleared == []
+
+
+def test_finalize_without_db_row_still_clears_when_tui_owns(monkeypatch):
+    cleared = _install_stubs(monkeypatch, db_source=None)
+
+    server._finalize_session(
+        _session("20260907_120000_abcdef"), end_reason="idle_timeout"
+    )
+
+    assert cleared == ["20260907_120000_abcdef"]

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -260,6 +260,15 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
         interrupt_for_session(
             session_key=str(session_key or "") if _tui_owns_lifecycle else "",
             origin_ui_session_id=_lifecycle_own_sid(session), reason=end_reason)
+    # Session-persistent code kernels (execute_code) share this owner key and must die at the same boundary —
+    # the gateway's /stop and /new paths already clear_session() (approval.py), but a TUI/Desktop session that
+    # ends here otherwise leaves its kernels alive until the NEXT execute_code in this process triggers the
+    # lazy idle sweep, orphaning a live interpreter per finished conversation. Only when the TUI owns the
+    # lifecycle: a viewer tab over a gateway-owned session must not kill the gateway's kernels.
+    if _tui_owns_lifecycle and session_key:
+        with contextlib.suppress(Exception):
+            from tools.approval import clear_session
+            clear_session(str(session_key))
     # Close the slash-worker in this single ``_finalized``-guarded chokepoint (a direct caller can't leak it); idempotent.
     with contextlib.suppress(Exception):
         if worker := session.get("slash_worker"):


### PR DESCRIPTION
## What does this PR do?

A TUI/Desktop conversation that ends via `_finalize_session` never cleared its approval-session state, so session-persistent `execute_code` kernels (owner = approval session key, #88637) stayed alive until the *next* `execute_code` in the same process ran the lazy idle sweep in `_acquire_kernel`. Each finished conversation could orphan a live interpreter + tmpdir.

The gateway's `/stop` and `/new` paths already call `approval.clear_session` (`approval.py:264`), which calls `shutdown_kernels_for_owner` — killing the session's kernels at the same boundary. This PR aligns the TUI path: when the TUI owns the session lifecycle (not a viewer tab over a gateway-owned session), call `clear_session(session_key)` on finalize.

## Related Issue

Fixes #105213

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/session_lifecycle.py`: `_finalize_session` — clear approval session state when `_tui_owns_lifecycle` and a session key exists (+9 lines)
- `tests/tui_gateway/test_session_finalize_reaps_kernels.py`: new — 4 tests: TUI-owned reap on automatic reason + user close, viewer-over-gateway session NOT reaped, no-DB-row still reaps

## How to Test

1. `scripts/run_tests.sh tests/tui_gateway/test_session_finalize_reaps_kernels.py`
2. Regression proof (sabotage): with the fix disabled, 3 of 4 tests fail; viewer-safety test stays green in both states.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (via `scripts/run_tests.sh`; session-lifecycle files 61/61, full `tests/tui_gateway/` 1058 pass)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring added at the call site)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the fix runs on the shared TUI/Desktop Python backend (process/watchdog code untouched; `clear_session` already ships cross-platform in `approval.py`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool changes)