### PR TITLE
fix(cron): prefer shared Git Bash resolver for .sh jobs on Windows

### DIFF
--- a/cron/scheduler_script.py
+++ b/cron/scheduler_script.py
@@ -298,8 +298,15 @@ def _script_argv(path: Path) -> tuple[Optional[list[str]], dict[str, str], Optio
     shebang is deliberately NOT honoured (small, auditable surface): ``.sh``/``.bash`` → bash,
     else ``sys.executable`` (Windows uv-venv overlay gets the .pth bootstrap)."""
     if path.suffix.lower() in {".sh", ".bash"}:
-        # which() finds Git Bash on Windows; None there → clear error instead of a "[WinError 2]".
-        _bash = shutil.which("bash") or ("/bin/bash" if os.path.isfile("/bin/bash") else None)
+        # Prefer the shared Windows-aware resolver: bare shutil.which("bash")
+        # can return WSL's bash on Windows, which fails on Windows paths
+        # (#46332). tools/environments/local.py already documents this.
+        try:
+            from tools.environments.local import _find_bash
+            _bash = _find_bash()
+        except Exception:
+            _bash = None
+        _bash = _bash or shutil.which("bash") or ("/bin/bash" if os.path.isfile("/bin/bash") else None)
         if _bash is None:
             return None, {}, (
                 f"Cannot run .sh/.bash script {path.name!r}: bash not found on PATH. "

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -809,3 +809,41 @@ class TestScriptTimeoutTreeKill:
                     psutil.Process(gpid).kill()
                 except psutil.NoSuchProcess:
                     pass
+
+
+def test_script_argv_prefers_shared_bash_resolver_over_which(monkeypatch):
+    # Contract: _script_argv must prefer tools/environments/local._find_bash()
+    # over bare shutil.which("bash"), which can return WSL's bash on Windows
+    # (#46332 — WSL bash fails on Windows paths with exit 127).
+    from pathlib import Path
+
+    from cron import scheduler_script as sched_script
+    import tools.environments.local as local_env
+
+    monkeypatch.setattr(local_env, "_find_bash", lambda: "C:/Git/bin/bash.exe")
+    monkeypatch.setattr(
+        sched_script.shutil, "which", lambda *a, **k: "C:/Windows/System32/bash.EXE"
+    )
+    argv, _, err = sched_script._script_argv(Path("job.sh"))
+    assert err is None
+    assert argv[0] == "C:/Git/bin/bash.exe"
+
+
+def test_script_argv_falls_back_to_which_when_resolver_fails(monkeypatch):
+    # Contract: when the shared resolver raises (no Git Bash), _script_argv
+    # keeps the previous behaviour instead of failing closed.
+    from pathlib import Path
+
+    from cron import scheduler_script as sched_script
+    import tools.environments.local as local_env
+
+    def _boom():
+        raise RuntimeError("no git bash")
+
+    monkeypatch.setattr(local_env, "_find_bash", _boom)
+    monkeypatch.setattr(
+        sched_script.shutil, "which", lambda *a, **k: "/usr/bin/bash"
+    )
+    argv, _, err = sched_script._script_argv(Path("job.sh"))
+    assert err is None
+    assert argv[0] == "/usr/bin/bash"


### PR DESCRIPTION
Closes #46332 (alternative to #103066, #99470, #77532, #61629, #52204, #72697, #46364, #66769 — happy to close mine if one of those lands first).

## Root cause
`cron/scheduler_script.py::_script_argv` resolves bash via bare `shutil.which("bash")`. In scheduler child environments where System32 precedes Git on PATH, this returns WSL's `C:\WINDOWS\system32\bash.EXE`, which cannot run Windows paths at all — every `.sh` cron job then fails with exit 127 (`/bin/bash: C:Users...: No such file or directory`).

## Live evidence (OOLEAN fleet, Windows 11 native, 2026-09-07)
cron_incidents sequence on one host: green ticks 16:41–17:02, then exit-127 failures 17:13/17:19/17:24/17:25/17:31 — same scripts, same host, only PATH ordering differed. `shutil.which("bash")` in the ticker child env returned the System32 WSL launcher while Git Bash was installed and healthy.

## Fix (8 lines)
Route through the existing shared resolver `tools/environments/local.py::_find_bash()` (portable Git first, Git-for-Windows dirs, PATH last, WSL excluded — its own docstring already warns `shutil.which may return WSL's bash, which fails silently on Windows paths`). Fallback to the previous `which()` chain preserved when the resolver raises, so non-Windows behavior and no-Git-Bash behavior are unchanged. Same late-import pattern `scheduler_script.py` already uses for `build_subprocess_env`.

## Tests
Two contract tests in `tests/cron/test_cron_script.py` (platform-independent, no sys.platform faking): resolver preferred over which; which used when resolver raises. File: 33 passed, 2 skipped (pre-existing skips) on win32.