### PR TITLE
fix(skills): default curator.prune_builtins to false

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -121,8 +121,8 @@ def get_archive_after_days() -> int:
 
 
 def get_prune_builtins() -> bool:
-    """Bundled built-ins are curation candidates (ON by default); a suppression list keeps them archived across `hermes update` re-seeds. Hub skills are never pruned."""
-    return bool(_load_config().get("prune_builtins", True))
+    """Bundled pruning is opt-in: a suppression list keeps archives from being re-seeded by `hermes update`. Hub skills are never pruned."""
+    return bool(_load_config().get("prune_builtins", False))
 
 
 def get_consolidate() -> bool:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1353,10 +1353,10 @@ DEFAULT_CONFIG = {
         # LLM consolidation (umbrella-building) pass. OFF = deterministic inactivity prune only, no
         # aux-model cost. `hermes curator run --consolidate` overrides once.
         "consolidate": False,
-        # Also prune bundled built-ins (a suppression list stops `hermes update` restoring them);
+        # Opt-in: prune bundled built-ins (a suppression list stops `hermes update` restoring them);
         # hub-installed skills are NEVER pruned. A built-in's clock starts when the curator first
         # sees it, so never a mass-prune on the first run. false = keep all.
-        "prune_builtins": True,
+        "prune_builtins": False,
         # TTL purge of skills/.archive/: 0 = never; > 0 lets the explicit `hermes curator purge`
         # delete older archived skills (never automatic; logged in the ledger).
         "archive_ttl_days": 0,

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -69,6 +69,58 @@ def _write_skill(skills_dir: Path, name: str):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("config_text, expected", [
+    (None, False),
+    ("{}\n", False),
+    ("curator: {}\n", False),
+    ("curator: null\n", False),
+    ("curator:\n  prune_builtins: false\n", False),
+    ("curator:\n  prune_builtins: true\n", True),
+])
+def test_prune_builtins_config_requires_opt_in(tmp_path, monkeypatch, config_text, expected):
+    from agent import curator
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    if config_text is not None:
+        (tmp_path / "config.yaml").write_text(config_text, encoding="utf-8")
+
+    # Exercise the real loader: mocked defaults hide accidental destructive opt-ins.
+    assert curator.get_prune_builtins() is expected
+
+
+@pytest.mark.parametrize("opt_in", [None, False, True])
+def test_curator_archives_builtins_only_with_opt_in(tmp_path, monkeypatch, opt_in):
+    from agent import curator
+    from tools import skill_usage
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    if opt_in is not None:
+        (tmp_path / "config.yaml").write_text(
+            f"curator:\n  prune_builtins: {str(opt_in).lower()}\n", encoding="utf-8",
+        )
+    skills_dir = tmp_path / "skills"
+    name = "unused-builtin"
+    skill_dir = _write_skill(skills_dir, name)
+    (skills_dir / ".bundled_manifest").write_text(f"{name}:abc\n", encoding="utf-8")
+    record = skill_usage._empty_record()
+    record["last_used_at"] = (datetime.now(timezone.utc) - timedelta(days=500)).isoformat()
+    skill_usage.save_usage({name: record})
+
+    enabled = opt_in is True
+    assert skill_usage.is_curation_eligible(name) is enabled
+    assert (name in skill_usage.list_agent_created_skill_names()) is enabled
+    counts = curator.apply_automatic_transitions()
+
+    assert counts["archived"] == int(enabled)
+    assert skill_dir.exists() is not enabled
+    assert (name in skill_usage.read_suppressed_names()) is enabled
+    assert skill_usage.load_usage()[name]["state"] == (
+        skill_usage.STATE_ARCHIVED if enabled else skill_usage.STATE_ACTIVE
+    )
+
+
 
 
 

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -514,7 +514,7 @@ def test_adopt_refuses_skills_the_user_does_not_own(skills_home, monkeypatch, ki
     """Adoption writes a provenance claim, so it must refuse anything with an
     external owner rather than stamping a lie onto the record.
 
-    ``prune_builtins`` is forced ON here — the shipped default — because that
+    ``prune_builtins`` is explicitly enabled here because that
     is the configuration in which a bundled skill is otherwise curation-
     eligible. With it off, ``mark_agent_created``'s own eligibility gate would
     block the write and this test would pass without exercising adopt's guard

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -165,14 +165,14 @@ def _read_hub_installed_names() -> Set[str]:
 
 
 def _prune_builtins_enabled() -> bool:
-    """``curator.prune_builtins`` (default True); lazy config import keeps this module importable during update/sync."""
+    """``curator.prune_builtins`` is opt-in; lazy config import keeps this module importable during update/sync."""
     try:
         from hermes_cli.config import load_config
         cur = load_config().get("curator")
-        return bool(cur.get("prune_builtins", True)) if isinstance(cur, dict) else True
+        return bool(cur.get("prune_builtins", False)) if isinstance(cur, dict) else False
     except Exception as e:  # pragma: no cover — best-effort config read
         logger.debug("Failed to read curator.prune_builtins: %s", e)
-        return True
+        return False
 
 
 def read_suppressed_names() -> Set[str]:

--- a/website/docs/user-guide/features/curator.md
+++ b/website/docs/user-guide/features/curator.md
@@ -10,7 +10,7 @@ The curator is a background maintenance pass for **agent-created skills**. It tr
 
 It exists so that skills created via the [self-improvement loop](/user-guide/features/skills#agent-managed-skills-skill_manage-tool) don't pile up forever. Every time the agent solves a novel problem and saves a skill, that skill lands in `~/.hermes/skills/`. Without maintenance, you end up with dozens of narrow near-duplicates that pollute the catalog and waste tokens.
 
-By default (`prune_builtins: true`) the curator can archive **unused bundled built-in skills** (shipped with the repo) after `archive_after_days` of non-use, alongside the agent-created skills it primarily manages. Hub-installed skills (from [agentskills.io](https://agentskills.io)) are always off-limits. Set `curator.prune_builtins: false` to restore the old agent-created-only behavior, where bundled skills are never touched. The curator also **never auto-deletes** — the worst outcome is archival into `~/.hermes/skills/.archive/`, which is recoverable.
+By default (`prune_builtins: false`) the curator leaves **bundled built-in skills** (shipped with the repo) untouched. Set `curator.prune_builtins: true` to explicitly opt in to archiving unused bundled skills after `archive_after_days` of non-use, alongside the agent-created skills it primarily manages. This removes them from the active library, and a suppression list prevents `hermes update` from re-seeding them until they are explicitly restored. Hub-installed skills (from [agentskills.io](https://agentskills.io)) are always off-limits. The curator **never auto-deletes**; archived skills remain recoverable.
 
 Tracks [issue #7816](https://github.com/NousResearch/hermes-agent/issues/7816).
 
@@ -54,7 +54,7 @@ curator:
   stale_after_days: 30
   archive_after_days: 90
   consolidate: false           # LLM umbrella-building pass — opt-in (prune-only by default)
-  prune_builtins: true         # archive unused bundled built-in skills too (hub skills always exempt)
+  prune_builtins: false        # opt-in: archived built-ins are not re-seeded by hermes update
 ```
 
 To disable entirely, set `curator.enabled: false`. To keep the always-on pruning but opt into LLM consolidation, set `curator.consolidate: true`.
@@ -313,7 +313,7 @@ The flag is stored as `"pinned": true` on the skill's entry in `~/.hermes/skills
 
 Skills named in any cron job's `skills:` list are protected the same way for **auto-transitions** (the curator never stales/archives them while the reference remains), even when the job is paused or disabled. Prefer an explicit pin when you also want `skill_manage delete` blocked.
 
-Only **agent-created** skills can be pinned — `hermes curator pin` refuses on bundled and hub-installed skills with an explanatory message if you try. Hub-installed skills are never subject to curator mutation. Bundled built-in skills are only touched when `curator.prune_builtins: true` (the default), and even then only archived after `archive_after_days` of non-use — never patched, consolidated, or deleted. Set `curator.prune_builtins: false` to exempt bundled skills entirely.
+Only **agent-created** skills can be pinned — `hermes curator pin` refuses on bundled and hub-installed skills with an explanatory message if you try. Hub-installed skills are never subject to curator mutation. Bundled built-in skills are only touched when you explicitly set `curator.prune_builtins: true` (default: `false`), and even then only archived after `archive_after_days` of non-use — never patched, consolidated, or deleted. Set `curator.prune_builtins: false` to exempt bundled skills entirely.
 
 A small set of **protected built-ins** can be hardcoded as never-archivable and never-consolidatable, regardless of `curator.prune_builtins`, pin state, or LLM judgment. These back load-bearing UX, so silently archiving one would turn its slash command into an "Unknown command" error with no signal to you. (The set is currently empty — `plan`, its original member, graduated to a built-in `/plan` command with no skill on disk.) Protected built-ins are filtered out of the curator's candidate list entirely, so the consolidation pass never sees them.
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/curator.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/curator.md
@@ -10,7 +10,7 @@ Curator 是针对 **agent 创建的技能**的后台维护流程。它跟踪每�
 
 它的存在是为了防止通过[自我改进循环](/user-guide/features/skills#agent-managed-skills-skill_manage-tool)创建的技能无限堆积。每次 agent 解决新问题并保存技能时，该技能都会落入 `~/.hermes/skills/`。若没有维护，最终会出现数十个范围狭窄的近似重复项，污染技能目录并浪费 token（令牌）。
 
-默认情况下（`prune_builtins: true`），Curator 在 `archive_after_days` 天未使用后，可以归档**未使用的捆绑内置技能**（随仓库附带），与它主要管理的 agent 自创技能一并处理。通过 [agentskills.io](https://agentskills.io) 安装的 hub 技能始终不受影响。设置 `curator.prune_builtins: false` 可恢复旧的“仅 agent 自创”行为，此时捆绑技能绝不会被触碰。Curator 也**绝不自动删除**——最坏的结果是归档到 `~/.hermes/skills/.archive/`，这是可恢复的。
+默认情况下（`prune_builtins: false`），Curator 不会处理**捆绑内置技能**（随仓库附带）。只有显式设置 `curator.prune_builtins: true`，才会在 `archive_after_days` 天未使用后，将未使用的捆绑技能与 agent 自创技能一并归档。这会将技能移出可用列表，且在显式恢复前，抑制名单会阻止 `hermes update` 重新安装它们。通过 [agentskills.io](https://agentskills.io) 安装的 hub 技能始终不受影响。Curator **绝不自动删除**，归档技能仍可恢复。
 
 跟踪 [issue #7816](https://github.com/NousResearch/hermes-agent/issues/7816)。
 


### PR DESCRIPTION
## What does this PR do?

`curator.prune_builtins` defaulted to `true` (#103098), so bundled/upstream-owned skills entered the Curator lifecycle and could be marked stale + archived purely on inactivity — without the user opting in. Worse, the resulting `.curator_suppressed` marker blocks `hermes update` from re-seeding the skill: the loss persists across updates. The issue also notes the inconsistency: Curator otherwise treats bundled skills as upstream-owned and protects them from autonomous writes, and the bundled `plan` skill already needed explicit protection after a real archival incident.

The shipped default is now `false` — pruning bundled skills is an explicit opt-in. Persisted `true` values are honored; already-archived skills are not silently restored (recovery stays a user action). Follows the existing default-flip precedent in `hermes_cli/config_migrations.py` (changed default, no new migration).

## Related Issue

Fixes #103098

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/curator.py`, `hermes_cli/config_defaults.py` — default flipped to false (asserted through the real config-resolution path)
- `tests/agent/test_curator.py` — no-config default is False; explicit true still prunes; explicit false still skips
- Docs synced (`website/docs/user-guide/features/curator.md` + versioned copy, `tools/skill_usage.py` comment)

## How to Test

1. `.venv/bin/python -m pytest tests/agent/test_curator.py tests/tools/test_skill_usage.py -q` → 64 passed (5 failing before the fix)
2. Manual: fresh HERMES_HOME with no curator config — bundled skills never enter the lifecycle; setting `curator.prune_builtins: true` restores the old behavior

## Checklist

### Code
- [x] Contributing Guide read; Conventional Commits followed
- [x] Searched for duplicate PRs
- [x] Only changes related to this fix
- [x] Relevant tests pass; tests added
- [x] Tested on Linux (Python 3.11)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (curator docs reflect the opt-in default)
