### PR TITLE
fix(skills): keep github reference curl examples off the exfil_curl pattern

### DIFF
--- a/skills/software-development/github/references/auth.md
+++ b/skills/software-development/github/references/auth.md
@@ -210,7 +210,8 @@ Note: on Windows winget installs, gh lands at `/c/Program Files/GitHub CLI` — 
 > ```bash
 > # $TOKEN = the access token from the device flow above (never echo it)
 > mkdir -p ~/.config/gh
-> LOGIN=$(curl -s -H "Authorization: token $TOKEN" https://api.github.com/user \
+> GH_AUTH="Authorization: token $TOKEN"
+> LOGIN=$(curl -s -H "$GH_AUTH" https://api.github.com/user \
 >   | sed 's/.*"login": *"\([^"]*\)".*/\1/')
 > printf 'github.com:\n    users:\n        %s:\n            oauth_token: %s\n    git_protocol: https\n    oauth_token: %s\n    user: %s\n' \
 >   "$LOGIN" "$TOKEN" "$TOKEN" "$LOGIN" > ~/.config/gh/hosts.yml
@@ -253,7 +254,8 @@ When `gh` is not available, you can still access the full GitHub API using `curl
 export GITHUB_TOKEN="<token>"
 
 # Then use in curl calls:
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
+GH_AUTH="Authorization: token $GITHUB_TOKEN"
+curl -s -H "$GH_AUTH" \
   https://api.github.com/user
 ```
 

--- a/skills/software-development/github/references/ci-troubleshooting.md
+++ b/skills/software-development/github/references/ci-troubleshooting.md
@@ -9,7 +9,8 @@ Common CI failure patterns and how to diagnose them from the logs.
 gh run view <RUN_ID> --log-failed
 
 # With curl — download and extract
-curl -sL -H "Authorization: token $GITHUB_TOKEN" \
+GH_AUTH="Authorization: token $GITHUB_TOKEN"
+curl -sL -H "$GH_AUTH" \
   https://api.github.com/repos/$GH_OWNER/$GH_REPO/actions/runs/<RUN_ID>/logs \
   -o /tmp/ci-logs.zip && unzip -o /tmp/ci-logs.zip -d /tmp/ci-logs
 ```

--- a/skills/software-development/github/references/code-review.md
+++ b/skills/software-development/github/references/code-review.md
@@ -342,11 +342,12 @@ gh pr checks 123
 PR_NUMBER=123
 
 # PR details (title, author, description, branch)
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
+GH_AUTH="Authorization: token $GITHUB_TOKEN"
+curl -s -H "$GH_AUTH" \
   https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER
 
 # Changed files with line counts
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
+curl -s -H "$GH_AUTH" \
   https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER/files
 ```
 
@@ -404,7 +405,8 @@ gh pr review $PR_NUMBER --request-changes --body "Found a few issues — see inl
 
 **With curl — atomic review with multiple inline comments:**
 ```bash
-HEAD_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+GH_AUTH="Authorization: token $GITHUB_TOKEN"
+HEAD_SHA=$(curl -s -H "$GH_AUTH" \
   https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER \
   | python -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
 

--- a/skills/software-development/github/references/github-api-cheatsheet.md
+++ b/skills/software-development/github/references/github-api-cheatsheet.md
@@ -130,13 +130,19 @@ Most list endpoints support:
 ## Rate Limits
 
 - Authenticated: 5,000 requests/hour
-- Check remaining: `curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/rate_limit`
+- Check remaining:
+
+  ```bash
+  GH_AUTH="Authorization: token $GITHUB_TOKEN"
+  curl -s -H "$GH_AUTH" https://api.github.com/rate_limit
+  ```
 
 ## Common curl Patterns
 
 ```bash
 # GET
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
+GH_AUTH="Authorization: token $GITHUB_TOKEN"
+curl -s -H "$GH_AUTH" \
   https://api.github.com/repos/$GH_OWNER/$GH_REPO
 
 # POST with JSON body

--- a/skills/software-development/github/references/pr-workflow.md
+++ b/skills/software-development/github/references/pr-workflow.md
@@ -344,9 +344,13 @@ git push -u origin HEAD
 
 ## Useful PR Commands Reference
 
+```bash
+GH_AUTH="Authorization: token $GITHUB_TOKEN"
+```
+
 | Action | gh | git + curl |
 |--------|-----|-----------|
-| List my PRs | `gh pr list --author @me` | `curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$OWNER/$REPO/pulls?state=open"` |
+| List my PRs | `gh pr list --author @me` | `curl -s -H "$GH_AUTH" "https://api.github.com/repos/$OWNER/$REPO/pulls?state=open"` |
 | View PR diff | `gh pr diff` | `git diff main...HEAD` (local) or `curl -H "Accept: application/vnd.github.diff" ...` |
 | Add comment | `gh pr comment N --body "..."` | `curl -X POST .../issues/N/comments -d '{"body":"..."}'` |
 | Request review | `gh pr edit N --add-reviewer user` | `curl -X POST .../pulls/N/requested_reviewers -d '{"reviewers":["user"]}'` |

--- a/skills/software-development/github/references/repo-management.md
+++ b/skills/software-development/github/references/repo-management.md
@@ -26,7 +26,8 @@ fi
 if [ "$AUTH" = "gh" ]; then
   GH_USER=$(gh api user --jq '.login')
 else
-  GH_USER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user | python -c "import sys,json; print(json.load(sys.stdin)['login'])")
+  GH_AUTH="Authorization: token $GITHUB_TOKEN"
+  GH_USER=$(curl -s -H "$GH_AUTH" https://api.github.com/user | python -c "import sys,json; print(json.load(sys.stdin)['login'])")
 fi
 ```
 

--- a/tests/skills/test_github_skill.py
+++ b/tests/skills/test_github_skill.py
@@ -9,7 +9,10 @@ disciplines now check the reference body.
 import re
 from pathlib import Path
 
+import pytest
 import yaml
+
+from tools.threat_patterns import scan_for_threats
 
 SKILL_DIR = (
     Path(__file__).resolve().parents[2]
@@ -45,6 +48,17 @@ def test_all_workflow_references_exist():
         "repo-management.md",
     ):
         assert (SKILL_DIR / "references" / ref).is_file(), f"missing reference: {ref}"
+
+
+# Other bundled skills have existing findings; keep this gate scoped to GitHub.
+@pytest.mark.parametrize(
+    "path",
+    [SKILL_PATH]
+    + sorted(path for path in (SKILL_DIR / "references").rglob("*") if path.is_file()),
+    ids=lambda path: str(path.relative_to(SKILL_DIR)),
+)
+def test_skill_documents_pass_context_threat_scan(path):
+    assert scan_for_threats(path.read_text(encoding="utf-8"), scope="context") == []
 
 
 def test_frontmatter_required_fields():


### PR DESCRIPTION
## What does this PR do?

Six `references/*.md` files of the bundled `software-development/github` skill carry the documented gh-less fallback — `curl -s -H "Authorization: token $GITHUB_TOKEN" …` — which matches the `exfil_curl` context pattern in `tools/threat_patterns.py` (#102473). The prompt builder therefore dropped each affected file from context with only a `logger.warning`, while `SKILL.md` routing loaded fine: the agent was told the reference exists and then could not read it. The scanner is NOT the regression and is NOT weakened — the bundled content is what the project's own loader refused to serve.

Both fixes from the issue:

1. The six references now use the convention the repo already established for `blocked-page-recovery` (#98489): the header goes into a plainly-named variable on its own line and only that variable stays on the `curl` line. Examples remain functional; the pattern no longer fires.
2. A regression gate (`tests/skills/test_github_skill.py`) walks the shipped github skill and asserts `scan_for_threats(text, scope="context") == []` for every SKILL.md and reference file — the next skill refactor cannot silently reintroduce this.

For maintainers — other pre-existing offenders found while scoping the gate (NOT fixed here, gate is scoped to the github skill accordingly): `skills/media/gif-search/SKILL.md` (4 hits), `skills/productivity/airtable/SKILL.md` (2 hits), `skills/web/blocked-page-recovery/SKILL.md:97`, `skills/autonomous-ai-agents/hermes-agent/references/themes.md:77`. A repo-wide gate would need those cleaned first.

Note: open PRs #100369 / #98512 edit some of these files for unrelated reasons — the edits here are line-local to minimize rebase friction.

## Related Issue

Fixes #102473

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `skills/software-development/github/references/{auth,ci-troubleshooting,code-review,github-api-cheatsheet,pr-workflow,repo-management}.md` — 12 sites reworded to the variable-header convention
- `tests/skills/test_github_skill.py` — context-scan gate over the shipped skill

## How to Test

1. `.venv/bin/python -m pytest tests/skills/test_github_skill.py -q` → green (fails on the 6 files before the rewording)
2. Direct: run `scan_for_threats(open(f).read(), scope="context")` over the skill's files — all empty

## Checklist

### Code
- [x] Contributing Guide read; Conventional Commits followed
- [x] Searched for duplicate PRs
- [x] Only changes related to this fix
- [x] Relevant tests pass; tests added
- [x] Tested on Linux (Python 3.11)

### Documentation & Housekeeping
- [x] N/A (bundled-skill content fix; no schema changes)
