### PR TITLE
fix(gateway): provision linger for system-service users

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2961,16 +2961,18 @@ def _ensure_linger_enabled(username: str | None = None) -> None:
     if is_termux() or not is_linux():
         return
 
+    explicit_username = username is not None
     if username is None:
         import getpass
         username = getpass.getuser()
-        linger_enabled, linger_detail = get_systemd_linger_status()
-    else:
-        linger_enabled, linger_detail = get_systemd_linger_status(username)
     if Path(f"/var/lib/systemd/linger/{username}").exists():
         print("✓ Systemd linger is enabled (service survives logout)")
         return
 
+    if explicit_username:
+        linger_enabled, linger_detail = get_systemd_linger_status(username)
+    else:
+        linger_enabled, linger_detail = get_systemd_linger_status()
     if linger_enabled is True:
         print("✓ Systemd linger is enabled (service survives logout)")
         return

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2483,8 +2483,13 @@ def ensure_gateway_service(context: str = "setup") -> bool:
     return False
 
 
-def get_systemd_linger_status() -> tuple[bool | None, str]:
-    """Linger status for the current user: ``(True, "")``, ``(False, "")``, or ``(None, detail)`` when unknown."""
+def get_systemd_linger_status(username: str | None = None) -> tuple[bool | None, str]:
+    """Linger status for *username* or the current user when omitted.
+
+    System-scope gateway installation runs as root but the service runs as a
+    configured target user, so querying the caller would validate the wrong
+    user manager.
+    """
     if is_termux():
         return None, "not supported in Termux"
     if not is_linux():
@@ -2492,7 +2497,8 @@ def get_systemd_linger_status() -> tuple[bool | None, str]:
     if not shutil.which("loginctl"):
         return None, "loginctl not found"
 
-    username = os.getenv("USER") or os.getenv("LOGNAME")
+    if username is None:
+        username = os.getenv("USER") or os.getenv("LOGNAME")
     if not username:
         try:
             import pwd
@@ -2950,18 +2956,21 @@ def _print_linger_enable_warning(username: str, detail: str | None = None) -> No
     print()
 
 
-def _ensure_linger_enabled() -> None:
-    """Enable linger when possible so the user gateway survives logout."""
+def _ensure_linger_enabled(username: str | None = None) -> None:
+    """Enable linger for *username* or the current user when possible."""
     if is_termux() or not is_linux():
         return
 
-    import getpass
-    username = getpass.getuser()
+    if username is None:
+        import getpass
+        username = getpass.getuser()
+        linger_enabled, linger_detail = get_systemd_linger_status()
+    else:
+        linger_enabled, linger_detail = get_systemd_linger_status(username)
     if Path(f"/var/lib/systemd/linger/{username}").exists():
         print("✓ Systemd linger is enabled (service survives logout)")
         return
 
-    linger_enabled, linger_detail = get_systemd_linger_status()
     if linger_enabled is True:
         print("✓ Systemd linger is enabled (service survives logout)")
         return
@@ -2981,6 +2990,18 @@ def _ensure_linger_enabled() -> None:
         print("✓ Linger enabled — gateway will persist after logout")
         return
     _print_linger_enable_warning(username, _completed_process_detail(result) or linger_detail)
+
+
+def _ensure_system_service_linger(unit_path: Path) -> None:
+    """Prepare the configured non-root service user for a user-scope worker bus.
+
+    Root/system-slice gateways use the system manager instead; only the
+    non-root system-service topology needs a persistent user manager for
+    ``systemd-run --user --scope``.
+    """
+    username = _read_systemd_user_from_unit(unit_path)
+    if username and username != "root":
+        _ensure_linger_enabled(username)
 
 
 def _select_systemd_scope(system: bool = False) -> bool:
@@ -3084,10 +3105,14 @@ def systemd_install(
             refresh_systemd_unit_if_needed(system=system)
             if enable_on_startup:
                 _run_systemctl(["enable", get_service_name()], system=system, check=True, timeout=30)
+            if system:
+                _ensure_system_service_linger(unit_path)
             print(f"✓ {scope_label.capitalize()} service definition updated")
             return
         print(f"Service already installed at: {unit_path}")
         print("Use --force to reinstall")
+        if system:
+            _ensure_system_service_linger(unit_path)
         return
 
     unit_path.parent.mkdir(parents=True, exist_ok=True)
@@ -3114,6 +3139,7 @@ def systemd_install(
         configured_user = _read_systemd_user_from_unit(unit_path)
         if configured_user:
             print(f"Configured to run as: {configured_user}")
+            _ensure_system_service_linger(unit_path)
     else:
         _ensure_linger_enabled()
 

--- a/tests/hermes_cli/test_gateway_linger.py
+++ b/tests/hermes_cli/test_gateway_linger.py
@@ -2,6 +2,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 import hermes_cli.gateway as gateway
 
 
@@ -65,6 +67,25 @@ class TestEnsureLingerEnabled:
         assert "sudo loginctl enable-linger testuser" in out
         assert "Permission denied" in out
 
+    def test_loginctl_target_user_enables_target_linger(self, monkeypatch):
+        monkeypatch.setattr(gateway, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway, "Path", lambda _path: SimpleNamespace(exists=lambda: False))
+        monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda username: (False, ""))
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/loginctl")
+
+        run_calls = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+        gateway._ensure_linger_enabled("alice")
+
+        assert run_calls == [["loginctl", "enable-linger", "alice"]]
+
 
 def test_systemd_install_calls_linger_helper(monkeypatch, tmp_path, capsys):
     unit_path = tmp_path / "systemd" / "user" / "hermes-gateway.service"
@@ -100,3 +121,48 @@ def test_systemd_install_calls_linger_helper(monkeypatch, tmp_path, capsys):
     ]
     assert helper_calls == [True]
     assert "User service installed and enabled" in out
+
+
+def test_systemd_install_targets_linger_at_system_service_user(monkeypatch, tmp_path):
+    unit_path = tmp_path / "systemd" / "hermes-gateway.service"
+    helper_calls = []
+
+    monkeypatch.setattr(gateway, "_require_root_for_system_service", lambda action: None)
+    monkeypatch.setattr(gateway, "has_legacy_hermes_units", lambda: False)
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
+    monkeypatch.setattr(
+        gateway,
+        "generate_systemd_unit",
+        lambda system=False, run_as_user=None: "[Service]\nUser=alice\n",
+    )
+    monkeypatch.setattr(gateway, "_run_systemctl", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway, "_ensure_linger_enabled", lambda username=None: helper_calls.append(username))
+    monkeypatch.setattr(gateway, "print_systemd_scope_conflict_warning", lambda: None)
+    monkeypatch.setattr(gateway, "print_legacy_unit_warning", lambda: None)
+
+    gateway.systemd_install(system=True, run_as_user="alice")
+
+    assert helper_calls == ["alice"]
+
+
+@pytest.mark.parametrize("unit_is_current", [True, False])
+def test_existing_system_install_targets_linger_at_configured_user(
+    monkeypatch, tmp_path, unit_is_current
+):
+    unit_path = tmp_path / "systemd" / "hermes-gateway.service"
+    unit_path.parent.mkdir(parents=True)
+    unit_path.write_text("[Service]\nUser=alice\n", encoding="utf-8")
+    helper_calls = []
+
+    monkeypatch.setattr(gateway, "_require_root_for_system_service", lambda action: None)
+    monkeypatch.setattr(gateway, "has_legacy_hermes_units", lambda: False)
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
+    monkeypatch.setattr(gateway, "_sync_hermes_home_from_systemd_unit", lambda system=False: None)
+    monkeypatch.setattr(gateway, "systemd_unit_is_current", lambda system=False: unit_is_current)
+    monkeypatch.setattr(gateway, "refresh_systemd_unit_if_needed", lambda system=False: None)
+    monkeypatch.setattr(gateway, "_run_systemctl", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway, "_ensure_linger_enabled", lambda username=None: helper_calls.append(username))
+
+    gateway.systemd_install(system=True, run_as_user="alice")
+
+    assert helper_calls == ["alice"]


### PR DESCRIPTION
## Summary

Complements #104893 and the canonical runtime fix in #105037. This is a focused installation/lifecycle fix, not a carry-forward and not a superseding implementation.

A system-level gateway service is installed by root but runs as a configured non-root user. The canonical runtime implementation adopts the target user's D-Bus environment at gateway boot when the user manager already exists. The remaining gap is that the system-service install path never enables linger for that target user: a fresh or existing system unit can therefore start without a persistent user manager, leaving `systemd-run --user --scope` unavailable.

## Root cause and boundary

`systemd_install(system=True, run_as_user=<user>)` already knows the target `User=` value and runs with the root authority required to install the system unit. Before this change:

- `_ensure_linger_enabled()` only resolved the current CLI user;
- the system-install branch printed the configured user but did not prepare that user's linger state;
- an already-current system unit returned without any lifecycle preparation;
- a repaired system unit also returned without preparing the target user's user manager.

That left the runtime fix in #105037 dependent on a manual `loginctl enable-linger <gateway-user>` step for new and existing system-service installations.

This PR supplies that missing prerequisite. It does not attempt to create a bus from the gateway process, change worker isolation policy, or downgrade the restart-safe handoff.

## Implementation

`hermes_cli/gateway.py`:

- `get_systemd_linger_status(username=None)` can query the configured target user instead of accidentally querying the root installer account.
- `_ensure_linger_enabled(username=None)` preserves the existing current-user behavior and accepts an explicit target user.
- `_ensure_system_service_linger(unit_path)` reads the installed `User=` value, skips root/system-manager services, and prepares linger for non-root system-service users.
- The helper runs for fresh installation, current existing units, and repair of stale units.
- Permission failures retain the existing actionable warning and do not silently claim that linger was enabled.

The install/repair path remains the only side-effect boundary. No cron tick, worker dispatch, or gateway hot path is changed.

## Relationship to existing work

- #105037 is the canonical runtime implementation: it adopts the user bus before cron and Kanban worker environment snapshots. This PR supplies the installation-time user-manager prerequisite it assumes; it does not copy its runtime patch.
- #103706 adds `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` to generated system units. That is complementary template work; this PR handles linger ownership and lifecycle preparation only.
- #12989 repairs linger for user-service repair paths. This PR covers the distinct system-service target-user path and deliberately preserves the user-service behavior.
- #1023 is historical work for headless user-service installation and explicitly left system-service mode out of scope. This PR addresses the system-service gap in the context of #104893 without carrying that PR forward.
- #103080 covers root/system-manager scopes. Root system services are intentionally skipped here; this PR targets the reported `User=<non-root>` topology.
- #102431 degrades to an unscoped worker and therefore changes the restart-safety contract; this PR does not adopt that behavior.

No effective patch from #105037 or #103706 is duplicated in this branch.

## Correctness and security invariants

- Only the root-authorized system-install path can request linger for the target user.
- The target username comes from the generated unit's `User=` field, not from the sudo caller's environment.
- Root/system-manager services do not receive an unnecessary user-linger side effect.
- Existing user-service installation behavior remains unchanged.
- `loginctl` is invoked at most once per install/repair operation when the target is not already enabled.
- A denied or unavailable `loginctl` operation produces the existing manual remediation instead of fabricating readiness.

## Algorithm and performance

The change reduces to one target-user lookup, one bounded `loginctl show-user` query, and at most one bounded `loginctl enable-linger` operation per installation or repair. It is `O(1)` in the number of jobs, workers, and gateway runtime duration, with `O(1)` auxiliary memory. No per-dispatch work, retry loop, database access, network access, or new registry is added.

A bounded synthetic install-helper stress run of 10,000 mocked target-user evaluations preserved the target username and command contract on every iteration. This is an install-path overhead test, not a systemd capacity benchmark; real systemd behavior is delegated to Linux CI.

## Verification

Focused complementary regression selection:

```text
HERMES_PYTHON=C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe scripts/run_tests.sh tests/hermes_cli/test_gateway_linger.py -k 'target_user or system_install_targets or existing_system_install'
```

Result on Windows 11: 3 focused pytest cases passed, 0 failed.

Additional local validation:

```text
scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway.py
```

Result: 35 passed, 0 failed, 6 skipped.

The non-Linux full linger file retains one pre-existing Windows/POSIX failure in `test_systemd_install_calls_linger_helper`; a clean `origin/main` baseline reproduces the same failure (`os.getuid()` reached from a user-systemd mock). The new complementary tests pass independently and the failure was not suppressed or removed.

Static validation passed:

- Ruff on the changed production and test files.
- `py_compile` on the changed Python files.
- `git diff --check`.

The canonical #105037 Linux CI run already exercised the runtime side of this pair with 45,480 tests passed and 0 failures. This PR adds the missing install-side contract and will run its own CI matrix after publication.

## Scope boundary

This PR does not:

- modify `systemd-run` worker argv;
- modify cron or Kanban dispatch;
- add a fallback that can be killed by a gateway restart;
- add `XDG_RUNTIME_DIR` or `DBUS_SESSION_BUS_ADDRESS` to the generated unit;
- change root/system-manager scope selection;
- add configuration or environment variables;
- close, supersede, or alter #105037.

## Delivery state

- Issue: #104893
- Complementary PR: https://github.com/NousResearch/hermes-agent/pull/105222
- Canonical runtime PR: #105037
- Complementary branch: `JoaoMarcos44:fix/104893-system-service-linger`
- Implementation commits: `0f1199ced064121c158e421da942cb05ba1a9404`, `718767e6e3d3500e434ef74e9d8977e7923b76fb`
- Base: `233757037df1f03f9fe1cfddc097acd5ad7f7510`
- CI history: the first run exposed one regression in the pre-existing linger test because the new target-aware status query ran before the existing file fast-path. Follow-up commit `718767e6e3d3500e434ef74e9d8977e7923b76fb` restores the fast-path order. The fresh final run completed with 38 checks: 24 success, 13 skipped, 1 neutral, 0 failures; the full Python test job passed.
- Original #105037 remains open and untouched.
