### PR TITLE
fix(plugins): serialize plugin-module loads — concurrent build race silently drops providers (#47954)

### DIFF
--- a/plugins/plugin_loader.py
+++ b/plugins/plugin_loader.py
@@ -10,10 +10,30 @@ import importlib.machinery
 import importlib.util
 import logging
 import sys
+import threading
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple
 
 _PLUGINS_ROOT = Path(__file__).parent
+
+# ── Concurrent-load guards ──
+# load_plugin_module puts the module into sys.modules BEFORE exec_module runs
+# (so intra-plugin relative imports resolve). A concurrent caller can observe
+# the half-built module (__file__ present, register not yet defined), find no
+# provider, and return None — silently disabling that plugin for the agent.
+# Serialize loads per module name; the second caller waits for the in-flight
+# load and then reuses the fully evaluated module.
+_module_load_locks: dict = {}
+_module_load_locks_guard = threading.Lock()
+
+
+def _module_load_lock(module_name: str) -> threading.Lock:
+    with _module_load_locks_guard:
+        lock = _module_load_locks.get(module_name)
+        if lock is None:
+            lock = threading.Lock()
+            _module_load_locks[module_name] = lock
+        return lock
 
 
 def register_synthetic_package(name: str, search_locations: List[str]) -> None:
@@ -84,42 +104,48 @@ def load_plugin_module(module_name: str, plugin_dir: Path, *, parents: Tuple[str
     """Import ``plugin_dir/__init__.py`` as *module_name* (reusing sys.modules when loaded).
     Order matters: parents first (relative imports need them), then siblings as ``module_name.<stem>``
     (so ``from ._x import Y`` resolves), then the module. Finally child is bound onto parent and
-    siblings onto module — the shape normal imports produce, which monkeypatch relies on."""
+    siblings onto module — the shape normal imports produce, which monkeypatch relies on.
+    The per-module lock serializes check/create/exec: another thread can observe the module in
+    sys.modules BEFORE exec_module finishes (half-built), which would make callers that scan for
+    ``register``/subclasses find nothing and return None — silently disabling that plugin for the
+    agent (observed on concurrent agent builds as "Memory provider 'X' loaded but no provider
+    instance found")."""
     init_file = plugin_dir / "__init__.py"
     if not init_file.exists():
         return None
-    # A synthetic package shell has no __file__; only reuse modules loaded from disk.
-    cached = sys.modules.get(module_name)
-    if cached is not None and getattr(cached, "__file__", None):
-        return cached
-    for parent in parents:
-        parent_path = _PLUGINS_ROOT.joinpath(*parent.split(".")[1:])
-        if parent not in sys.modules and (parent_path / "__init__.py").exists():
-            _exec(_new_module(parent, parent_path / "__init__.py", [str(parent_path)]))
-    if synthetic_namespace:
-        register_synthetic_package(synthetic_namespace, [])
-    # Reserve the name before siblings exec so their relative imports resolve.
-    mod = _new_module(module_name, init_file, [str(plugin_dir)])
-    if mod is None:
-        return None
-    loaded_submodules = []
-    for sub_file in plugin_dir.glob("*.py"):
-        full_sub_name = f"{module_name}.{sub_file.stem}"
-        if sub_file.name == "__init__.py" or full_sub_name in sys.modules:
-            continue
-        sub_mod = _new_module(full_sub_name, sub_file)
-        if _exec(sub_mod, logger):
-            loaded_submodules.append((sub_file.stem, sub_mod))
-    if not _exec(mod, logger):
-        sys.modules.pop(module_name, None)
-        return None
-    parent_name, child_name = module_name.rsplit(".", 1)
-    parent_mod = sys.modules.get(parent_name)
-    if parent_mod is not None:
-        setattr(parent_mod, child_name, mod)
-    for sub_name, sub_mod in loaded_submodules:
-        setattr(mod, sub_name, sub_mod)
-    return mod
+    with _module_load_lock(module_name):
+        # A synthetic package shell has no __file__; only reuse modules loaded from disk.
+        cached = sys.modules.get(module_name)
+        if cached is not None and getattr(cached, "__file__", None):
+            return cached
+        for parent in parents:
+            parent_path = _PLUGINS_ROOT.joinpath(*parent.split(".")[1:])
+            if parent not in sys.modules and (parent_path / "__init__.py").exists():
+                _exec(_new_module(parent, parent_path / "__init__.py", [str(parent_path)]))
+        if synthetic_namespace:
+            register_synthetic_package(synthetic_namespace, [])
+        # Reserve the name before siblings exec so their relative imports resolve.
+        mod = _new_module(module_name, init_file, [str(plugin_dir)])
+        if mod is None:
+            return None
+        loaded_submodules = []
+        for sub_file in plugin_dir.glob("*.py"):
+            full_sub_name = f"{module_name}.{sub_file.stem}"
+            if sub_file.name == "__init__.py" or full_sub_name in sys.modules:
+                continue
+            sub_mod = _new_module(full_sub_name, sub_file)
+            if _exec(sub_mod, logger):
+                loaded_submodules.append((sub_file.stem, sub_mod))
+        if not _exec(mod, logger):
+            sys.modules.pop(module_name, None)
+            return None
+        parent_name, child_name = module_name.rsplit(".", 1)
+        parent_mod = sys.modules.get(parent_name)
+        if parent_mod is not None:
+            setattr(parent_mod, child_name, mod)
+        for sub_name, sub_mod in loaded_submodules:
+            setattr(mod, sub_name, sub_mod)
+        return mod
 
 
 class NoopPluginContext:

--- a/tests/plugins/test_plugin_loader_concurrent_load.py
+++ b/tests/plugins/test_plugin_loader_concurrent_load.py
@@ -1,0 +1,106 @@
+"""Concurrent plugin-module load guard — regression test for the startup race.
+
+Background (observed 2026-09-08, dashboard/gateway restart):
+  After a restart the process builds agents concurrently (one AIAgent per
+  session). Both call ``load_plugin_module`` for the same plugin module at the
+  same time. The loader puts the *unevaluated* module object into
+  ``sys.modules`` before ``exec_module`` runs (needed so intra-plugin relative
+  imports resolve), so the second caller can hit the half-built module in the
+  cache: ``__file__`` is already present but ``register`` is not defined yet →
+  the subclass scan finds nothing → the loader returns None → the provider/engine
+  is silently disabled for that agent (no recall, no memory tools/context
+  engine). Observed live: exactly one of two concurrent agent builds logged
+  "Memory provider 'X' loaded but no provider instance found" while the sibling
+  build 9ms later registered it successfully.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+# Import order stability: loading the loader package first leaves
+# ``plugins.memory`` unbound on the ``plugins`` package, which breaks string
+# monkeypatch targets ("plugins.memory._get_user_plugins_dir") in unrelated
+# tests that assume the attribute exists. Bind it explicitly.
+import plugins.memory  # noqa: F401  (side effect: binds plugins.memory)
+from plugins import plugin_loader
+
+# Slow plugin: sleeps during module evaluation (exec_module), keeping the
+# module in sys.modules as a half-built object long enough for a concurrent
+# caller to observe it.
+_SLOW_SOURCE = """\
+import time
+time.sleep(0.2)
+
+
+def register(ctx):
+    ctx.register_memory_provider(object())
+"""
+
+
+@pytest.fixture
+def slow_plugin(tmp_path):
+    plugin_dir = tmp_path / "slowplugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text(_SLOW_SOURCE, encoding="utf-8")
+    yield plugin_dir
+    sys.modules.pop("plugins.memory.slowplugin", None)
+
+
+def test_concurrent_load_slow_plugin(slow_plugin):
+    """Two concurrent loads of the same module must both get the evaluated module.
+
+    Before the fix the second loader can observe the half-built module
+    (sys.modules entry exists, exec_module still sleeping) → returns None.
+    With the fix the load is serialized per module, so the second caller waits
+    and then reuses the fully-evaluated module.
+    """
+    results: list = []
+    results_lock = threading.Lock()
+    module_name = "plugins.memory.slowplugin"
+
+    def _load():
+        got = plugin_loader.load_plugin_module(
+            module_name,
+            slow_plugin,
+            parents=("plugins", "plugins.memory"),
+            logger=logging.getLogger("test"),
+            synthetic_namespace="_hermes_user_memory",
+        )
+        # Record the register state IMMEDIATELY at return time: a half-built
+        # module is the SAME object the first loader finishes later, so a
+        # deferred check (after join) would see register defined and miss the
+        # race window entirely.
+        with results_lock:
+            results.append((got is not None, hasattr(got, "register") if got is not None else None))
+
+    t1 = threading.Thread(target=_load)
+    t2 = threading.Thread(target=_load)
+    t1.start()
+    # Deterministically wait until the half-built module is observable
+    # (sys.modules entry present, register not yet defined), THEN start t2.
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        mod = sys.modules.get(module_name)
+        if mod is not None and not hasattr(mod, "register"):
+            break
+        time.sleep(0.005)
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert len(results) == 2, f"loaders did not both finish: {results!r}"
+    assert all(ok and has_register for ok, has_register in results), (
+        "Bug: concurrent load returned a half-built module for one caller — "
+        "the module was in sys.modules but exec_module had not finished (no "
+        "register defined), and the caller reused it instead of waiting. Live "
+        "effect: the provider/engine is silently disabled for that agent "
+        "(observed 2026-09-08: 'Memory provider ... loaded but no provider "
+        "instance found' on one of two concurrent agent builds)."
+    )


### PR DESCRIPTION
## Summary

Fixes the **concurrent plugin-module load race** that silently disables a memory provider / cron provider / context engine on one of two simultaneous agent builds — the same class of bug tracked in #47954 ("race condition on startup").

### Symptoms observed

After a dashboard/gateway restart the process builds agents concurrently (one `AIAgent` per session). Both call `load_plugin_module` for the same plugin module at the same time. The loader puts the *unevaluated* module into `sys.modules` **before** `exec_module` runs (so intra-plugin relative imports resolve). A concurrent caller can then observe the half-built module: `__file__` is present but `register` is not defined yet → its `register(ctx)`/subclass scan finds nothing → the loader returns `None` → the plugin is silently disabled **for that agent**. Observed live on two concurrent agent builds:

```
Memory provider 'hindsight' loaded but no provider instance found   ← one build
Memory provider 'hindsight' registered (3 tools)                     ← sibling build, 9ms later
```

Result: the losing agent never recalls/retains memory (and misses the memory tools) until the process is restarted.

## Fix

`load_plugin_module` (shared by memory providers, cron providers, and context engines) now serializes the `check → create → siblings → exec` sequence under a **per-module-name lock**. The second caller waits for the in-flight load, then reuses the fully evaluated module. Locking is keyed per module name so unrelated plugins still load in parallel; the lock only guards the same-module case.

## Test

`tests/plugins/test_plugin_loader_concurrent_load.py`:
- A slow plugin module (sleeps during evaluation) plus two concurrent callers.
- Pre-fix: one caller gets the half-built module (no `register`), reproduced deterministically (the caller samples the module *at return time*, since the half-built object is the same object the first loader later finishes — a deferred check after join would miss the window).
- Post-fix: both callers get the complete module. Verified RED → GREEN.

## Verification

- New test: passes (was failing on the unfixed baseline).
- Regression: `tests/agent/test_memory_provider.py` (73), `tests/run_agent/test_memory_provider_init.py`, `tests/agent/test_memory_provider_unavailable_warning.py`, `tests/plugins/test_plugin_loader_concurrent_load.py` all pass together.
- ruff clean.

## Notes

Related to #47954 (same race reported for honcho); the loader change here covers memory/cron/context-engine plugin modules in one place. This is independent of the tool-surface snapshot work in #105211.
