### PR TITLE
fix(usage): consume provider-reported usage.cost as actual spend

### DIFF
--- a/agent/turn_usage.py
+++ b/agent/turn_usage.py
@@ -253,7 +253,11 @@ def record_response_usage(
                 cache_read_tokens=canonical_usage.cache_read_tokens,
                 cache_write_tokens=canonical_usage.cache_write_tokens,
                 reasoning_tokens=canonical_usage.reasoning_tokens,
-                estimated_cost_usd=_cost_delta,
+                # A provider-reported cost (status="actual") is real spend, not an
+                # estimate: accumulate it into actual_cost_usd (None keeps the
+                # stored column value untouched).
+                estimated_cost_usd=_cost_delta if cost_result.status != "actual" else None,
+                actual_cost_usd=_cost_delta if cost_result.status == "actual" else None,
                 cost_status=cost_result.status,
                 cost_source=cost_result.source,
                 billing_provider=agent.provider,

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -577,20 +577,36 @@ def _unknown_cost(source: CostSource, *notes: str) -> CostResult:
     return CostResult(amount_usd=None, status="unknown", source=source, label="n/a", notes=notes)
 
 
+_PROVIDER_REPORTED_COST_KEYS: tuple[tuple[str, ...], ...] = (
+    ("cost_details", "upstream_inference_cost"),
+    ("cost",),
+)
+
+
 def _provider_reported_cost(usage: CanonicalUsage) -> Optional[Decimal]:
-    """A finite, non-negative cost the provider reported inline in raw usage
-    (OpenRouter's ``usage.cost``, passed through unchanged by OpenAI-compatible
-    proxies such as LiteLLM). None when the payload carries no such field."""
+    """A finite, non-negative cost the provider reported inline in raw usage.
+    ``cost_details.upstream_inference_cost`` (Nous portal) wins over
+    ``usage.cost``: on that route ``usage.cost`` is a flat stub unrelated to
+    the billed amount, while the nested field carries the true per-call cost.
+    OpenRouter's ``usage.cost`` (passed through unchanged by OpenAI-compatible
+    proxies such as LiteLLM) remains the fallback. None when the payload
+    carries no usable field."""
     raw = usage.raw_usage if isinstance(usage.raw_usage, dict) else None
     if raw is None:
         return None
-    cost = raw.get("cost")
-    if isinstance(cost, bool) or not isinstance(cost, (int, float)):
-        return None
-    cost = float(cost)
-    if not math.isfinite(cost) or cost < 0:
-        return None
-    return Decimal(str(cost))
+    for path in _PROVIDER_REPORTED_COST_KEYS:
+        value: Any = raw
+        for key in path:
+            value = value.get(key) if isinstance(value, dict) else None
+            if value is None:
+                break
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            continue
+        cost = float(value)
+        if not math.isfinite(cost) or cost < 0:
+            continue
+        return Decimal(str(cost))
+    return None
 
 
 def estimate_usage_cost(

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import re
 from dataclasses import dataclass, fields
 from datetime import datetime, timezone
@@ -26,24 +27,27 @@ _SUBCENT_THRESHOLD = Decimal("0.01")
 _INCLUDED_NOTE = "subscription-included; no provider invoice for usage"
 
 
-def format_cost_label(amount: Decimal) -> str:
+def format_cost_label(amount: Decimal, *, approx: bool = True) -> str:
     """Cost display label: zero → "$0.00"; sub-cent → "~$0.0046" (4 dp, or
     "~$<0.0001" when it rounds to 0.0000 so the label never reads as zero);
     else "~$1.23". Shared by per-response labels and insights cost buckets.
+    ``approx=False`` drops the "~" for amounts the provider actually billed
+    (status="actual"), not estimated.
 
     This fixes #79220 where sub-cent per-turn costs on cheap models (DeepSeek, etc.) rendered as "$0.00"
     despite amount_usd carrying full Decimal precision.
     """
+    prefix = "~$" if approx else "$"
     if amount == _ZERO:
         return "$0.00"
     if amount < _SUBCENT_THRESHOLD:
-        label = f"~${amount:.4f}"
+        label = f"{prefix}{amount:.4f}"
         # Compare the rendered label: a naive `< 0.00005` threshold misses
         # the exact boundary under ROUND_HALF_EVEN.
         # A positive amount that rounds to 0.0000 at 4 dp would render "~$0.0000" — a zero-looking label,
         # the exact #79220 dishonesty.
-        return label if label != "~$0.0000" else "~$<0.0001"
-    return f"~${amount:.2f}"
+        return label if label != f"{prefix}0.0000" else f"{prefix}<0.0001"
+    return f"{prefix}{amount:.2f}"
 
 CostStatus = Literal["actual", "estimated", "included", "unknown"]
 CostSource = Literal[
@@ -490,6 +494,29 @@ _CHAT_USAGE_SHAPE = (
 )
 
 
+def _raw_usage_dict(response_usage: Any) -> Optional[dict[str, Any]]:
+    """Best-effort dict snapshot of a raw usage payload (pydantic model,
+    mapping, or plain attribute object), so cost pricing can read provider
+    extensions such as OpenRouter's ``usage.cost`` that never fit the
+    canonical token buckets."""
+    if isinstance(response_usage, dict):
+        return dict(response_usage)
+    for dump_name in ("model_dump", "dict"):
+        method = getattr(response_usage, dump_name, None)
+        if callable(method):
+            try:
+                dumped = method()
+            except Exception:  # pragma: no cover - defensive
+                dumped = None
+            if isinstance(dumped, dict):
+                return dict(dumped)
+    try:
+        plain = vars(response_usage)
+    except TypeError:  # no __dict__ (e.g. slotted/C-extension objects)
+        return None
+    return dict(plain) if plain else None
+
+
 def normalize_usage(
     response_usage: Any, *, provider: Optional[str] = None, api_mode: Optional[str] = None
 ) -> CanonicalUsage:
@@ -542,11 +569,28 @@ def normalize_usage(
     return CanonicalUsage(
         input_tokens=input_tokens, output_tokens=output_tokens, cache_read_tokens=cache_read_tokens,
         cache_write_tokens=cache_write_tokens, reasoning_tokens=reasoning_tokens,
+        raw_usage=_raw_usage_dict(u),
     )
 
 
 def _unknown_cost(source: CostSource, *notes: str) -> CostResult:
     return CostResult(amount_usd=None, status="unknown", source=source, label="n/a", notes=notes)
+
+
+def _provider_reported_cost(usage: CanonicalUsage) -> Optional[Decimal]:
+    """A finite, non-negative cost the provider reported inline in raw usage
+    (OpenRouter's ``usage.cost``, passed through unchanged by OpenAI-compatible
+    proxies such as LiteLLM). None when the payload carries no such field."""
+    raw = usage.raw_usage if isinstance(usage.raw_usage, dict) else None
+    if raw is None:
+        return None
+    cost = raw.get("cost")
+    if isinstance(cost, bool) or not isinstance(cost, (int, float)):
+        return None
+    cost = float(cost)
+    if not math.isfinite(cost) or cost < 0:
+        return None
+    return Decimal(str(cost))
 
 
 def estimate_usage_cost(
@@ -558,6 +602,17 @@ def estimate_usage_cost(
         return CostResult(
             amount_usd=_ZERO, status="included", source="none", label="included",
             pricing_version="included-route", notes=(_INCLUDED_NOTE,),
+        )
+
+    # A cost the provider reported on the wire is the amount actually billed
+    # (cache-read discounts already applied) — strictly better than any table
+    # estimate, so it wins whenever present. Otherwise fall through to the
+    # pricing-table estimate as before.
+    reported = _provider_reported_cost(usage)
+    if reported is not None:
+        return CostResult(
+            amount_usd=reported, status="actual", source="provider_cost_api",
+            label=format_cost_label(reported, approx=False),
         )
 
     entry = get_pricing_entry(model_name, provider=provider, base_url=base_url, api_key=api_key)

--- a/tests/agent/test_turn_usage_log_line.py
+++ b/tests/agent/test_turn_usage_log_line.py
@@ -64,3 +64,38 @@ def test_forensics_parser_reads_the_new_fields(tmp_path):
     assert [c["n"] for c in calls] == [3, 4]
     assert calls[0]["write"] == 28604 and calls[0]["id"] == "gen-1788636728-qMa1" and calls[0]["upstream"] == "Claude Platform on AWS"
     assert "write" not in calls[1] and "id" not in calls[1]
+
+
+class _StubSessionDB:
+    def __init__(self):
+        self.queued = []
+
+    def queue_token_counts(self, session_id, **kwargs):
+        self.queued.append((session_id, kwargs))
+
+
+def test_provider_reported_cost_persisted_as_actual_delta(tmp_path, monkeypatch):
+    """A provider-reported usage.cost prices the call as status="actual" and the
+    delta is accumulated into actual_cost_usd, not estimated_cost_usd (#105215)."""
+    a = _agent(tmp_path, monkeypatch)
+    try:
+        stub = _StubSessionDB()
+        a._session_db = stub
+        a._session_db_created = True
+        usage = SimpleNamespace(prompt_tokens=100, completion_tokens=7, total_tokens=107,
+                                prompt_tokens_details=SimpleNamespace(cached_tokens=0, cache_write_tokens=0),
+                                completion_tokens_details=None, cost=0.00002510375)
+        from agent import turn_usage
+        turn_usage.record_response_usage(
+            a, SimpleNamespace(usage=usage), messages=[{"role": "user", "content": "hi"}],
+            api_call_count=1, api_duration=0.2, compression_attempts=0, max_compression_attempts=3)
+        assert a.session_cost_status == "actual"
+        assert a.session_cost_source == "provider_cost_api"
+        assert abs(a.session_estimated_cost_usd - 0.00002510375) < 1e-12
+        (sid, kw), = stub.queued
+        assert sid == "t"
+        assert kw["cost_status"] == "actual"
+        assert abs(kw["actual_cost_usd"] - 0.00002510375) < 1e-15
+        assert kw["estimated_cost_usd"] is None
+    finally:
+        a.close()

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1007,6 +1007,43 @@ def test_estimate_usage_cost_prefers_provider_reported_cost():
     assert cents.label == "$1.23"
 
 
+def test_estimate_usage_cost_prefers_upstream_inference_cost_over_stub():
+    """cost_details.upstream_inference_cost is the true billed amount on the
+    Nous portal (#108936): it must win over usage.cost, which that route
+    reports as a flat 5e-05 stub regardless of token count."""
+    usage = CanonicalUsage(
+        input_tokens=171, output_tokens=500,
+        raw_usage={"cost": 0.00005, "cost_details": {"upstream_inference_cost": 0.06338552}},
+    )
+    result = estimate_usage_cost("deepseek/deepseek-v4-flash-0731", usage, provider="custom")
+    assert result.status == "actual"
+    assert result.source == "provider_cost_api"
+    assert result.amount_usd == Decimal("0.06338552")
+
+
+def test_estimate_usage_cost_falls_back_to_usage_cost_without_details():
+    """Routes without a usable cost_details block (OpenRouter / LiteLLM) keep
+    the plain usage.cost preference; a malformed nested field must not hijack
+    pricing (#108936)."""
+    usage = CanonicalUsage(
+        input_tokens=19, output_tokens=100,
+        raw_usage={"cost": 0.00002510375, "cost_details": "oops"},
+    )
+    result = estimate_usage_cost("openrouter/z-ai/glm-5.3-flash", usage, provider="custom")
+    assert result.status == "actual"
+    assert result.amount_usd == Decimal("0.00002510375")
+
+    for bad_details in ({"upstream_inference_cost": -1}, {"upstream_inference_cost": float("nan")},
+                        {"upstream_inference_cost": True}):
+        usage = CanonicalUsage(
+            input_tokens=19, output_tokens=100,
+            raw_usage={"cost": 0.00002510375, "cost_details": bad_details},
+        )
+        result = estimate_usage_cost("openrouter/z-ai/glm-5.3-flash", usage, provider="custom")
+        assert result.status == "actual", f"cost_details={bad_details!r}"
+        assert result.amount_usd == Decimal("0.00002510375")
+
+
 def test_estimate_usage_cost_ignores_malformed_reported_cost():
     """Missing / non-numeric / NaN / negative / boolean costs must not hijack
     pricing: the turn falls back to the pricing-table estimate as before."""

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -962,3 +962,82 @@ def test_flat_entries_unaffected_by_tier_machinery():
     )
     # 250k * $0.25/M + 10k * $1.50/M
     assert result.amount_usd == Decimal("0.0775")
+
+
+# ---------------------------------------------------------------------------
+# Provider-reported usage.cost (OpenRouter / OpenAI-compatible proxies)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_usage_preserves_raw_usage_payload():
+    """normalize_usage must carry the raw payload in raw_usage (#105215):
+    dict, pydantic-style and plain-attribute usage objects all keep their
+    provider extension fields available for cost pricing."""
+    payload = {"prompt_tokens": 100, "completion_tokens": 20, "cost": 0.00002510375}
+    assert normalize_usage(payload).raw_usage == payload
+
+    ns = SimpleNamespace(prompt_tokens=100, completion_tokens=20, cost=0.00002510375)
+    assert normalize_usage(ns).raw_usage == {"prompt_tokens": 100, "completion_tokens": 20,
+                                             "cost": 0.00002510375}
+
+    class _PydanticLike:
+        def model_dump(self):
+            return {"prompt_tokens": 100, "completion_tokens": 20, "cost": 0.5}
+
+    assert normalize_usage(_PydanticLike()).raw_usage["cost"] == 0.5
+
+
+def test_estimate_usage_cost_prefers_provider_reported_cost():
+    """A cost the provider reported on the wire is the amount actually billed
+    (#105215): it wins over any pricing-table estimate and produces the first
+    non-test producer of status="actual"."""
+    usage = CanonicalUsage(input_tokens=19, output_tokens=100, raw_usage={"cost": 0.00002510375})
+    result = estimate_usage_cost("openrouter/z-ai/glm-5.3-flash", usage, provider="custom")
+    assert result.status == "actual"
+    assert result.source == "provider_cost_api"
+    assert result.amount_usd == Decimal("0.00002510375")
+    # an actual billed amount is not an estimate: no "~" in the label
+    assert result.label == "$<0.0001"
+
+    cents = estimate_usage_cost(
+        "openrouter/z-ai/glm-5.3-flash",
+        CanonicalUsage(input_tokens=1, raw_usage={"cost": 1.234}),
+        provider="custom",
+    )
+    assert cents.label == "$1.23"
+
+
+def test_estimate_usage_cost_ignores_malformed_reported_cost():
+    """Missing / non-numeric / NaN / negative / boolean costs must not hijack
+    pricing: the turn falls back to the pricing-table estimate as before."""
+    for bad in (None, "oops", float("nan"), float("inf"), -1, True):
+        usage = CanonicalUsage(input_tokens=1, raw_usage={"cost": bad})
+        result = estimate_usage_cost(
+            "gemini-3.1-flash-lite", usage, provider="google"
+        )
+        assert result.status == "estimated", f"cost={bad!r}"
+        assert result.amount_usd == Decimal("0.00000025")  # 1 * $0.25/M
+
+    # no raw payload at all: table estimate still applies
+    plain = estimate_usage_cost(
+        "gemini-3.1-flash-lite", CanonicalUsage(input_tokens=1), provider="google"
+    )
+    assert plain.status == "estimated"
+
+
+def test_estimate_usage_cost_subscription_route_stays_included():
+    """A subscription-included route keeps its explicit billing declaration:
+    a stray provider-reported cost must not turn it into billable spend."""
+    usage = CanonicalUsage(input_tokens=1000, output_tokens=500, raw_usage={"cost": 0.02})
+    result = estimate_usage_cost("gpt-5.4-mini", usage, provider="openai-codex")
+    assert result.status == "included"
+    assert result.amount_usd == Decimal("0")
+
+
+def test_format_cost_label_exact_mode_drops_tilde():
+    """approx=False renders provider-billed amounts without the estimate mark,
+    keeping the sub-cent and zero guards."""
+    assert format_cost_label(Decimal("0.004640"), approx=False) == "$0.0046"
+    assert format_cost_label(Decimal("0.00004"), approx=False) == "$<0.0001"
+    assert format_cost_label(Decimal("1.23"), approx=False) == "$1.23"
+    assert format_cost_label(Decimal("0"), approx=False) == "$0.00"


### PR DESCRIPTION
## What does this PR do?

When a profile runs against an OpenAI-compatible proxy (e.g. LiteLLM in front of OpenRouter), the final streaming chunk carries the amount actually billed as `usage.cost` — but Hermes dropped it. `normalize_usage()` built the canonical struct from token buckets only, and `estimate_usage_cost()` priced exclusively from the pricing table, so proxied routes ended every turn as `cost_status: unknown` at `$0.00` even though the number was right there on the wire (`CostStatus["actual"]` had no producer outside tests).

This PR:

- carries the raw usage payload through `normalize_usage()` in `CanonicalUsage.raw_usage` (dict, pydantic, or plain-attribute payloads all snapshot to a dict);
- makes `estimate_usage_cost()` prefer a finite, non-negative provider-reported cost (`status="actual"`, `source="provider_cost_api"`) over any pricing-table estimate, falling back to the table as before when absent or malformed (missing/NaN/infinite/negative/bool are ignored);
- keeps `subscription_included` routes authoritative: an explicit subscription declaration still wins over a stray reported cost;
- accumulates an `actual` delta into `actual_cost_usd` (not `estimated_cost_usd`) in the per-call token-delta queue, so the existing insights residual reconciliation (`actual_cost_usd` vs per-model totals) can finally see real spend;
- renders actual amounts without the `~` estimate mark via `format_cost_label(..., approx=False)` (sub-cent and zero guards preserved).

This also benefits the direct OpenRouter path, where `_openrouter_pricing_entry` currently re-derives a price the response already reported.

Note vs #76187: that PR adds the same preference at the call site but only for routes it can identify as OpenRouter (`openrouter.ai` host / `provider == "openrouter"`), so the proxied case from the issue (custom base_url in front of OpenRouter) still falls through to estimation. This PR moves the preference into the pricing pipeline itself (`normalize_usage` + `estimate_usage_cost`), which covers any OpenAI-compatible endpoint that reports `usage.cost` — OpenRouter direct, LiteLLM/other proxies, or native support from other providers — with no route sniffing.

## Related Issue

Fixes #105215

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/usage_pricing.py`
  - `normalize_usage()` now fills `CanonicalUsage.raw_usage` with a best-effort dict snapshot of the raw payload (new `_raw_usage_dict()` helper), so provider extension fields survive normalization.
  - New `_provider_reported_cost()` helper: guarded read of the provider-reported cost (finite, non-negative, numeric-only; bool/NaN/inf/negative/string → skipped) — prefers `raw_usage["cost_details"]["upstream_inference_cost"]` (the real per-call billed amount on the Nous portal, where plain `usage.cost` is a flat 5e-05 stub, #108936) and falls back to `raw_usage["cost"]` (OpenRouter / LiteLLM).
  - `estimate_usage_cost()` prefers the provider-reported cost (status `actual`, source `provider_cost_api`) after the `subscription_included` check and before the pricing-table lookup; table estimate remains the fallback.
  - `format_cost_label()` gains `approx: bool = True`; `approx=False` drops the `~` for billed amounts while keeping the #79220 sub-cent/zero guards.
- `agent/turn_usage.py`
  - The per-call `queue_token_counts` delta now routes `status="actual"` spend into `actual_cost_usd` and leaves `estimated_cost_usd` untouched (None keeps the stored column value).
- `tests/agent/test_usage_pricing.py`
  - Regression tests: raw payload preservation (dict/SimpleNamespace/pydantic-like), reported-cost preference and label, malformed-cost guards with table-estimate fallback, subscription route staying `included`, `approx=False` label formats.
- `tests/agent/test_turn_usage_log_line.py`
  - End-to-end `record_response_usage` test: a usage payload carrying `cost` prices the call as `actual`/`provider_cost_api` and the delta lands in `actual_cost_usd` with `estimated_cost_usd` None.

## How to Test

1. `pytest tests/agent/test_usage_pricing.py tests/agent/test_turn_usage_log_line.py -q` → Observed result: 59 passed.
2. Wider accounting surface: `pytest tests/agent/test_billing_usage.py tests/agent/test_account_usage.py tests/agent/test_codex_usage_attribution.py tests/agent/test_meta_usage_cache_reporting.py tests/agent/test_context_engine_on_turn_complete_usage.py tests/agent/test_background_review_usage.py tests/agent/test_async_token_accounting.py tests/agent/test_insights.py -q` → Observed result: 107 passed.
3. Live repro from the issue: point a profile at any OpenAI-compatible endpoint that returns `usage.cost` (OpenRouter direct or through LiteLLM), run one turn, read `session_model_usage` → tokens unchanged, `cost_status` should now be `actual`, `cost_source` `provider_cost_api`, and `actual_cost_usd` non-zero instead of `unknown`/`none`/`$0.00`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

