### PR TITLE
fix(title): never title a session from an async-delegation-completion marker

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -152,8 +152,18 @@ def _summarize_user_message(user_message: str) -> str:
     return strip_control_wrappers(user_message if described is None else described)
 
 
-def is_titleable_user_message(user_message: str) -> bool:
-    """False for machine-authored openers and turns that reduce to nothing once scaffolding is stripped."""
+def is_titleable_user_message(user_message: str, display_kind: Optional[str] = None) -> bool:
+    """False for machine-authored openers and turns that reduce to nothing once scaffolding is stripped.
+
+    ``display_kind`` is the persisted timeline tag of the message (``model_switch``,
+    ``personality_switch``, ``async_delegation_complete``, ``internal_notification``, ...) when the
+    caller has the full message dict, not just its text. ANY tag disqualifies the turn — mirrors
+    ``ContextCompressor._is_actionable_user_turn``'s generic ``display_kind`` exclusion instead of
+    growing ``_MACHINE_PREFIXES`` with one literal string per new marker (a marker that changes its
+    wording, or a marker whose text simply isn't in the list yet, would otherwise leak straight into
+    the session title)."""
+    if display_kind:
+        return False
     return (isinstance(user_message, str) and bool(user_message.strip()) and not user_message.lstrip().startswith(_MACHINE_PREFIXES)
             and bool(_summarize_user_message(user_message).strip()))
 
@@ -333,12 +343,13 @@ def _persist_session_title(session_db, session_id, title, *, source, dedupe=True
         return _set(deduped)
 
 
-def apply_instant_title(session_db, session_id: str, user_message: str, title_callback: Optional[TitleCallback] = None) -> Optional[str]:
+def apply_instant_title(session_db, session_id: str, user_message: str, title_callback: Optional[TitleCallback] = None,
+                         *, display_kind: Optional[str] = None) -> Optional[str]:
     """Write the derived title inline. Returns it, or None (no usable text, or a ``derived``+ title exists). Never raises."""
     if not session_db or not session_id:
         return None
     try:
-        title = derive_title(user_message) if is_titleable_user_message(user_message) else None
+        title = derive_title(user_message) if is_titleable_user_message(user_message, display_kind=display_kind) else None
         persisted = _persist_session_title(session_db, session_id, title, source="derived", dedupe=False) if title else None
         if persisted:
             _notify_title(title_callback, persisted, "derived", "Instant-title")
@@ -402,7 +413,10 @@ def _is_real_user_turn(message: Any) -> bool:
     if not isinstance(message, dict) or message.get("role") != "user":
         return False
     content = message.get("content")
-    return is_titleable_user_message(content if isinstance(content, str) else flatten_message_text(content))
+    return is_titleable_user_message(
+        content if isinstance(content, str) else flatten_message_text(content),
+        display_kind=message.get("display_kind"),
+    )
 
 
 def _session_is_untitled(session_db, session_id: str) -> bool:
@@ -424,19 +438,27 @@ def maybe_auto_title(
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
     runtime_validator: Optional[RuntimeValidator] = None,
+    *,
+    display_kind: Optional[str] = None,
 ) -> None:
-    """Instant inline title, then a daemon-thread upgrade. Call at the START of a turn, before the model."""
+    """Instant inline title, then a daemon-thread upgrade. Call at the START of a turn, before the model.
+
+    ``display_kind`` is the current turn's persisted timeline tag, when the caller has the full
+    message dict (see ``is_titleable_user_message``); a synthetic marker never becomes the title.
+    """
     if not session_db or not session_id or not user_message:
         return
     # History may be pre- or post-message. Skip only when BOTH past the opening turn AND named: count alone
     # left a machinery-opened session nameless; title alone never titles on an old store.
     user_msg_count = sum(1 for m in (conversation_history or []) if _is_real_user_turn(m))
-    if (user_msg_count > 1 and not _session_is_untitled(session_db, session_id)) or not is_titleable_user_message(user_message):
+    if (user_msg_count > 1 and not _session_is_untitled(session_db, session_id)) or not is_titleable_user_message(
+        user_message, display_kind=display_kind
+    ):
         return
     if not _auto_title_enabled():  # config read after the cheap guards so the file isn't touched every turn
         logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
         return
-    apply_instant_title(session_db, session_id, user_message, title_callback)
+    apply_instant_title(session_db, session_id, user_message, title_callback, display_kind=display_kind)
     threading.Thread(
         target=auto_title_session,
         args=(session_db, session_id, user_message),

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -152,11 +152,15 @@ def _maybe_title_session_at_turn_start(agent: Any, messages: List[Any]) -> None:
         from agent.message_content import flatten_message_text
         from agent.title_generator import maybe_auto_title
 
-        # Turn's user message as text; image-only turns yield "" and are skipped.
-        user_text = ""
+        # Turn's user message as text; image-only turns yield "" and are skipped. display_kind
+        # (model-switch / personality-switch / async-delegation-complete / internal-notification /
+        # ...) travels with it so a synthetic marker turn is never fed to the titler as if a person
+        # typed it (see is_titleable_user_message's display_kind guard).
+        user_text, display_kind = "", None
         for msg in reversed(messages or []):
             if isinstance(msg, dict) and msg.get("role") == "user":
                 user_text = flatten_message_text(msg.get("content")).strip()
+                display_kind = msg.get("display_kind")
                 break
         if not user_text:
             return
@@ -189,6 +193,7 @@ def _maybe_title_session_at_turn_start(agent: Any, messages: List[Any]) -> None:
                 getattr(agent, "model", None) == main_runtime["model"]
                 and getattr(agent, "provider", None) == main_runtime["provider"]
             ),
+            display_kind=display_kind,
         )
     except Exception:
         logger.debug("Turn-start auto-title dispatch failed", exc_info=True)

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -598,3 +598,99 @@ class TestModelSwitchMarkerNotTitleable:
         assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
             "南京市秦淮区 小时级天气预报"
         )
+
+
+class TestDisplayKindMarkerNotTitleable:
+    """Regression: any ``display_kind``-tagged row must never become the session title.
+
+    ``tools/process_registry_notifications._format_batch_delegation`` re-injects a finished
+    background subagent fan-out as a nominal ``role="user"`` turn (the model needs it in the
+    conversation), persisted with ``display_kind="async_delegation_complete"`` — the same tag
+    ``agent.context_compressor._is_actionable_user_turn`` already excludes generically from
+    compaction anchoring. ``title_generator`` used to only check the raw persisted text against a
+    hand-maintained prefix list (``_MACHINE_PREFIXES``), which the delegation marker's
+    ``"[ASYNC DELEGATION BATCH COMPLETE — ..."`` text was never added to: a session left untitled
+    through its opening turn (e.g. the opener was itself a compaction handoff) that next receives a
+    delegation-completion notice would title itself off the raw bracketed marker text instead of
+    ever asking a person something.
+
+    ``is_titleable_user_message`` / ``apply_instant_title`` / ``maybe_auto_title`` now take an
+    optional ``display_kind`` and reject the turn outright when it is set, regardless of the text —
+    catching this marker (and ``personality_switch``, which had no prefix-list entry at all) without
+    growing the prefix list per new marker.
+    """
+
+    DELEGATION_MARKER = (
+        "[ASYNC DELEGATION BATCH COMPLETE — deleg-42]\n"
+        "A background fan-out unit you dispatched earlier — 2 subagent(s) — has finished; "
+        "its consolidated results are below."
+    )
+
+    def test_marker_text_alone_would_be_titleable(self):
+        """Sanity check: nothing about the raw text itself disqualifies it — only the tag does."""
+        from agent.title_generator import is_titleable_user_message
+
+        assert is_titleable_user_message(self.DELEGATION_MARKER) is True
+
+    def test_marker_with_display_kind_is_not_titleable(self):
+        from agent.title_generator import is_titleable_user_message
+
+        assert is_titleable_user_message(self.DELEGATION_MARKER, display_kind="async_delegation_complete") is False
+
+    def test_any_display_kind_tag_disqualifies_a_turn(self):
+        """Generic guard: not just this one marker's name — the personality-switch marker (which
+        has no _MACHINE_PREFIXES entry at all) is caught the same way."""
+        from agent.title_generator import is_titleable_user_message
+
+        assert is_titleable_user_message("[System: The user has changed the assistant's personality...]",
+                                          display_kind="personality_switch") is False
+        assert is_titleable_user_message("ordinary question", display_kind="internal_notification") is False
+
+    def test_real_user_turn_excludes_tagged_rows_from_the_turn_count(self):
+        from agent.title_generator import _is_real_user_turn
+
+        assert _is_real_user_turn(
+            {"role": "user", "content": self.DELEGATION_MARKER, "display_kind": "async_delegation_complete"}
+        ) is False
+
+    def test_instant_title_skips_a_tagged_marker(self):
+        from agent.title_generator import apply_instant_title
+
+        db = MagicMock()
+        db.get_session_title_source.return_value = None
+
+        assert apply_instant_title(db, "sess-1", self.DELEGATION_MARKER, display_kind="async_delegation_complete") is None
+
+    def test_maybe_auto_title_skips_a_tagged_marker_as_the_opening_turn(self):
+        """A session still untitled by the time a delegation-completion turn arrives must not be
+        named off it — end-to-end through the real entry point (mirrors
+        test_leaves_an_already_titled_session_alone_on_later_turns's real-SessionDB style)."""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(Path(tmp) / "state.db")
+            db.create_session(session_id="sess-1", source="cli")
+            with patch("agent.title_generator.auto_title_session") as mock_auto:
+                maybe_auto_title(db, "sess-1", self.DELEGATION_MARKER, [], display_kind="async_delegation_complete")
+            assert db.get_session_title("sess-1") is None
+            mock_auto.assert_not_called()
+
+    def test_real_question_after_a_tagged_marker_still_titles(self):
+        """The marker must not consume the session's one titling opportunity (same bug shape as
+        test_real_question_after_marker_still_titles for the model-switch marker)."""
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        db.get_session_title_source.return_value = None
+        history = [
+            {"role": "user", "content": self.DELEGATION_MARKER, "display_kind": "async_delegation_complete"},
+            {"role": "user", "content": "what's the weather in Nanjing"},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            import threading
+
+            called = threading.Event()
+            mock_auto.side_effect = lambda *a, **k: called.set()
+            maybe_auto_title(db, "sess-1", "what's the weather in Nanjing", history)
+            assert called.wait(timeout=10), "auto_title never ran after the tagged marker"

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -495,3 +495,36 @@ def test_prologue_does_not_title_machine_driven_runs(platform):
     overwritten or never read.
     """
     assert not _title_turn(platform).called
+
+
+def test_prologue_threads_display_kind_of_the_turns_user_message():
+    """The current turn's ``display_kind`` (async-delegation-complete / model-switch /
+    personality-switch / internal-notification / ...) travels with the extracted text into
+    ``maybe_auto_title``, so a synthetic marker turn is recognisable as non-titleable at the real
+    entry point (agent.title_generator.is_titleable_user_message's display_kind guard) and not just
+    when its raw text happens to match a hand-maintained prefix list."""
+    from agent import turn_context
+
+    with patch("agent.title_generator.maybe_auto_title") as titler:
+        turn_context._maybe_title_session_at_turn_start(
+            _TitlingAgent("cli"),
+            [{
+                "role": "user",
+                "content": "[ASYNC DELEGATION BATCH COMPLETE — deleg-1]\nresults below",
+                "display_kind": "async_delegation_complete",
+            }],
+        )
+    assert titler.called
+    assert titler.call_args.kwargs["display_kind"] == "async_delegation_complete"
+
+
+def test_prologue_passes_no_display_kind_for_an_ordinary_message():
+    from agent import turn_context
+
+    with patch("agent.title_generator.maybe_auto_title") as titler:
+        turn_context._maybe_title_session_at_turn_start(
+            _TitlingAgent("cli"),
+            [{"role": "user", "content": "Fix the login button"}],
+        )
+    assert titler.called
+    assert titler.call_args.kwargs["display_kind"] is None


### PR DESCRIPTION
## What does this PR do?

`tools/process_registry_notifications.py` re-injects a finished background subagent fan-out (a
`delegate_task` batch) as a nominal `role="user"` turn — the model needs it in the conversation to
act on it. It's persisted with `display_kind="async_delegation_complete"` (see e.g.
`tui_gateway/session_notifications.py::_notif_dispatch_event`, `hermes_cli/cli_chat_turn_mixin.py`),
the same tag `agent/context_compressor.py`'s `_is_actionable_user_turn` already excludes generically
from compaction anchoring ("`display_kind` rows ... are not human input").

`agent/title_generator.py` never got the same treatment: it only checks the raw persisted text
against a hand-maintained prefix list (`_MACHINE_PREFIXES`, currently covering compaction handoffs
and the model-switch marker), and the delegation marker's text
(`"[ASYNC DELEGATION BATCH COMPLETE — <id>]\n..."`, built by
`tools/process_registry_notifications.py::_format_batch_delegation` /
`_format_async_delegation`) was never added to it.

**Reachability is narrow** (verified directly, not assumed): the auto-titling gate's own
precondition means this only bites a session that is *still untitled* by the time an async
delegation completion turn arrives — e.g. the opener was itself a compaction handoff, or the model
declined to produce a title on turn one — **and** the very next real turn happens to be this
synthetic notification. When it does fire, the session title becomes the raw bracketed marker text
instead of a person's actual question. Not a common path, but the failure is unambiguous when it
happens.

## Fix

Rather than adding one more literal string to `_MACHINE_PREFIXES` (which only protects against this
one exact marker shape, and drifts the moment the wording changes), `is_titleable_user_message` /
`_is_real_user_turn` / `apply_instant_title` / `maybe_auto_title` now take an optional
`display_kind` and reject the turn outright when it's set — mirroring
`ContextCompressor._is_actionable_user_turn`'s existing generic `display_kind` guard instead of
growing a per-marker prefix list.

This was the more robust option here specifically because the call site
(`agent/turn_context.py::_maybe_title_session_at_turn_start`) already holds the full message dict
when it extracts the turn's text — it just wasn't threading `display_kind` through. That function
now captures `msg.get("display_kind")` alongside the text and passes it to `maybe_auto_title`.

**Side effect (transparently noted):** this generic guard also happens to close a gap for
`display_kind="personality_switch"` — the personality-pivot marker
(`tui_gateway/agent_callbacks.py::_apply_personality_to_session`) had **no** `_MACHINE_PREFIXES`
entry at all, so it was titleable before this change too. Open PR #82559 addresses that same gap
narrowly (adds the marker's literal text to `_MACHINE_PREFIXES`), against an older shape of
`_apply_personality_to_session` (it lived in `tui_gateway/server.py` at that PR's base, before
moving to `tui_gateway/agent_callbacks.py`). This PR does not touch that PR's target lines and
should merge independently either way; whichever lands first makes the other's specific fix
redundant (not conflicting) for the personality-switch case.

## Testing

- `tests/agent/test_title_generator.py`: new `TestDisplayKindMarkerNotTitleable` class (7 tests) —
  `is_titleable_user_message`/`_is_real_user_turn`/`apply_instant_title`/`maybe_auto_title` all
  reject the async-delegation-completion marker when tagged, a second test proves ANY
  `display_kind` (including `personality_switch`, `internal_notification`) disqualifies a turn, and
  a "real question after the marker still titles" regression mirrors the existing
  model-switch-marker test.
- `tests/agent/test_turn_context.py`: 2 new tests proving
  `_maybe_title_session_at_turn_start` extracts `display_kind` off the turn's message dict and
  threads it into `maybe_auto_title` (and passes `None` for an ordinary message).
- Mutation-verified: reverted both source files via patch-file (not `git stash`), confirmed all 7
  new title_generator tests + both new turn_context tests fail for the right reason (5 with
  assertion/behavior failures, 2 with `TypeError: unexpected keyword argument 'display_kind'`),
  then reapplied and confirmed all 65 tests in both files pass again.
- `tests/agent/test_title_generator.py` + `tests/agent/test_turn_context.py` full run: 65 passed.
- `ruff check` clean on all 4 changed files.

## Competitor check

Searched `gh pr list --repo NousResearch/hermes-agent --search "..."` across all states for
`"title async delegation"`, `"is_titleable_user_message"`, `"async_delegation_complete title"` —
no PR targets the async-delegation-completion marker in title generation. The only overlapping PR
is #82559 (personality-switch marker only, different mechanism, noted above).

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Tests added, mutation-verified
