### PR TITLE
fix(gemini): native adapter drops video_url parts, so video_analyze silently analyzes nothing

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -172,10 +172,17 @@ def _coerce_content_to_text(content: Any) -> str:
     return "" if content is None else str(content)
 
 
-def _inline_data_part(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """``inlineData`` part for an ``image_url`` item carrying a ``data:`` URL; None otherwise."""
-    url = (item.get("image_url") or {}).get("url") or ""
-    if item.get("type") != "image_url" or not isinstance(url, str) or not url.startswith("data:"):
+def _inline_data_part(item: Dict[str, Any], *, allow_video: bool = False) -> Optional[Dict[str, Any]]:
+    """``inlineData`` part for an ``image_url`` (and, when *allow_video*, ``video_url``) item
+    carrying a ``data:`` URL; None otherwise. ``video_analyze`` ships whole videos as OpenAI
+    ``video_url`` data URLs, which Gemini's native API accepts as ``inlineData``. Tool results
+    keep videos disabled: the API rejects video in ``functionResponse.parts``."""
+    is_video = item.get("type") == "video_url"
+    if is_video and not allow_video:
+        return None
+    block_key = "video_url" if is_video else "image_url"
+    url = (item.get(block_key) or {}).get("url") or ""
+    if item.get("type") not in (("image_url", "video_url") if allow_video else ("image_url",)) or not isinstance(url, str) or not url.startswith("data:"):
         return None
     try:
         header, encoded = url.split(",", 1)
@@ -185,16 +192,16 @@ def _inline_data_part(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         return None
 
 
-def _multimodal_part(item: Any) -> Optional[Dict[str, Any]]:
+def _multimodal_part(item: Any, *, allow_video: bool = False) -> Optional[Dict[str, Any]]:
     text = _text_of(item)
     if text or isinstance(item, str):
         return {"text": text}
-    return _inline_data_part(item) if isinstance(item, dict) else None
+    return _inline_data_part(item, allow_video=allow_video) if isinstance(item, dict) else None
 
 
-def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
+def _extract_multimodal_parts(content: Any, *, allow_video: bool = False) -> List[Dict[str, Any]]:
     if isinstance(content, list):
-        return [p for p in map(_multimodal_part, content) if p]
+        return [p for p in (_multimodal_part(item, allow_video=allow_video) for item in content) if p]
     text = _coerce_content_to_text(content)
     return [{"text": text}] if text else []
 
@@ -315,7 +322,7 @@ def _build_gemini_contents(
             part = _translate_tool_result_to_gemini(msg, tool_name_by_call_id, include_tool_call_ids, is_gemini3=is_gemini3)
             contents.append({"role": "user", "parts": [part]})
             continue
-        parts = _extract_multimodal_parts(msg.get("content"))
+        parts = _extract_multimodal_parts(msg.get("content"), allow_video=True)
         tool_calls = msg.get("tool_calls") or []
         for tool_call in (tc for tc in tool_calls if isinstance(tc, dict)) if isinstance(tool_calls, list) else ():
             tool_name = str((tool_call.get("function") or {}).get("name") or "")

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -644,6 +644,47 @@ def test_gemini_2x_does_not_embed_image_parts():
     assert "parts" not in fr
 
 
+def test_user_video_url_part_becomes_inline_data():
+    """video_analyze's OpenAI ``video_url`` data URL reaches Gemini as inlineData.
+
+    Before the fix the part was dropped in translation and the model received a
+    text-only prompt, answering "no video attached" with HTTP 200 — a silent miss.
+    """
+    from agent.gemini_native_adapter import build_gemini_request
+
+    video_url = {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,AAAAIGZ0eXA="}}
+    request = build_gemini_request(
+        messages=[{"role": "user", "content": [{"type": "text", "text": "describe"}, video_url]}],
+        model="gemini-3.6-flash",
+    )
+    parts = request["contents"][0]["parts"]
+    assert len(parts) == 2, "video part must survive translation"
+    assert parts[1]["inlineData"]["mimeType"] == "video/mp4"
+    assert parts[1]["inlineData"]["data"]
+
+
+def test_video_not_embedded_in_function_response_parts():
+    """Gemini rejects inlineData videos in functionResponse.parts — tool results stay images-only."""
+    from agent.gemini_native_adapter import build_gemini_request
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "video_analyze", "arguments": "{}"}}],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "name": "video_analyze",
+            "content": [{"type": "video_url", "video_url": {"url": "data:video/mp4;base64,AAAA"}}],
+        },
+    ]
+    request = build_gemini_request(messages=messages, model="gemini-3.6-flash", tools=[], tool_choice=None)
+    fr = request["contents"][1]["parts"][0]["functionResponse"]
+    assert "parts" not in fr
+
+
 def test_text_only_tool_result_has_no_parts():
     """Text-only Gemini 3.x tool result does not add empty parts."""
     from agent.gemini_native_adapter import build_gemini_request


### PR DESCRIPTION
## Problem

`video_analyze` base64-encodes the video into an OpenAI-style `video_url` content part and calls the auxiliary client. When the vision backend resolves to a **native** Gemini endpoint (`generativelanguage.googleapis.com/v1beta`, i.e. the default `provider: gemini` with no `/openai` base_url), `GeminiNativeClient` translates the request via `build_gemini_request` — and `_inline_data_part` only recognized `image_url` items. The video part was dropped in translation with no error.

Observed end-to-end (Hermes 0.21.0, gemini-3.6-flash):

```json
{ "success": true,
  "analysis": "It looks like you didn't attach or link a video—please provide the video or a link to it..." }
```

HTTP 200, `success: true`, and a confident hallucinated answer. Nothing in logs hints the video never left the machine.

## Fix

Convert `video_url` data-URL parts to `inlineData` for user/assistant content parts — the native `generateContent` API accepts inline videos (verified against `gemini-3.6-flash`: a test mp4 with a sine tone came back describing both the visuals and the audio track).

`_inline_data_part` gains an `allow_video` keyword that `_extract_multimodal_parts` threads through. Only the message-content path passes `allow_video=True`: **tool results keep videos excluded**, because the API rejects `inlineData` videos inside `functionResponse.parts` (verified 400) — images embedded there behave exactly as before.

## Why not the /openai compat path

It rejects the part outright (`400 Invalid content part type: video_url`), so native inlineData is the only route for `video_analyze` on this provider.

## Tests

- `test_user_video_url_part_becomes_inline_data` — regression for the silent drop
- `test_video_not_embedded_in_function_response_parts` — tool-result videos stay excluded
- Full `tests/agent/test_gemini_native_adapter.py`: 30 passed, 16 passed in `tests/tools/test_video_analyze.py`. (One pre-existing failure, `test_async_native_client_streams_without_requiring_async_iterator_from_sync_client`, fails identically on clean `origin/main` — unrelated.)