### PR TITLE
fix(telegram): keep iOS New Chat shares replyable in their topic

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1131,8 +1131,14 @@ def _live_route_metadata(t: _TargetDelivery) -> tuple[Optional[str], dict, dict]
         and looks_like_telegram_private_chat_id(str(t.chat_id))
         and _looks_like_int(str(thread_id))
     )
-    if is_ambiguous_telegram_topic and _is_channel_dm_topic(
-        t.runtime_adapter, t.chat_id, t.loop, job["id"]):
+    is_origin_direct_topic = (
+        t.origin_target
+        and t.origin.get("thread_id_kind") == "direct_messages_topic"
+    )
+    if is_origin_direct_topic or (
+        is_ambiguous_telegram_topic
+        and _is_channel_dm_topic(t.runtime_adapter, t.chat_id, t.loop, job["id"])
+    ):
         # Channel DM topic: direct_messages_topic_id, no bare thread_id; media mirrors text.
         # See #22773.
         route_thread_id = None

--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -181,6 +181,7 @@ present (may be `null`); the rest are included only when set.
 | `user_name` | string\|null | yes | Author display name. |
 | `thread_id` | string\|null | yes | Thread/forum-topic id when in a thread. Session-key discriminator. |
 | `chat_topic` | string\|null | yes | Channel topic/description (Discord, Slack). |
+| `thread_id_kind` | string | no | Native routing primitive carried by `thread_id`; currently `direct_messages_topic` selects Telegram's `direct_messages_topic_id` send field. |
 | `user_id_alt` | string | no | Platform-specific stable alt id (Signal UUID, Feishu union_id). |
 | `chat_id_alt` | string | no | Alternate chat id (e.g. Signal group internal id). |
 | `scope_id` | string | no | Platform-neutral **scope** discriminator: Discord guild / Slack workspace / Matrix server. **REQUIRED for Discord/Slack scope isolation.** Session-key discriminator. (Canonical name as of the D-Q2.5 wire migration.) |

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -99,12 +99,20 @@ def _float_env(name: str, default: float) -> float:
 
 
 def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) -> dict | None:
-    """Platform-aware thread metadata for adapter sends. Telegram DM topics route with
-    ``message_thread_id`` + a reply anchor; anchorless synthetic/resumed sends fall back to
-    ``direct_messages_topic_id`` when supported."""
+    """Platform-aware thread metadata for adapter sends. Telegram forum-style DM topics route
+    with ``message_thread_id`` + a reply anchor; native direct-message topics route with
+    ``direct_messages_topic_id``."""
     thread_id = getattr(source, "thread_id", None)
     platform = _platform_name(getattr(source, "platform", None))
-    metadata = {"thread_id": thread_id} if thread_id is not None else {}
+    is_telegram_direct_topic = (
+        platform == "telegram"
+        and getattr(source, "thread_id_kind", None) == "direct_messages_topic"
+    )
+    metadata = (
+        {"direct_messages_topic_id": thread_id}
+        if is_telegram_direct_topic and thread_id is not None
+        else ({"thread_id": thread_id} if thread_id is not None else {})
+    )
     # Slack workspace identity is routing state: carry it so a multi-workspace Socket Mode
     # gateway never falls back to its primary WebClient.
     scope_id = getattr(source, "scope_id", None) if platform == "slack" else None
@@ -112,7 +120,11 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         metadata["slack_team_id"] = str(scope_id)
     if not metadata:
         return None
-    if platform == "telegram" and getattr(source, "chat_type", None) == "dm":
+    if (
+        platform == "telegram"
+        and getattr(source, "chat_type", None) == "dm"
+        and not is_telegram_direct_topic
+    ):
         metadata["telegram_dm_topic_reply_fallback"] = True
         if str(thread_id) not in {"", "1"}:
             metadata["direct_messages_topic_id"] = str(thread_id)
@@ -4157,7 +4169,8 @@ class BasePlatformAdapter(ABC):
     def build_source(
         self, chat_id: str, chat_name: Optional[str] = None, chat_type: str = "dm",
         user_id: Optional[str] = None, user_name: Optional[str] = None,
-        thread_id: Optional[str] = None, chat_topic: Optional[str] = None,
+        thread_id: Optional[str] = None, thread_id_kind: Optional[str] = None,
+        chat_topic: Optional[str] = None,
         user_id_alt: Optional[str] = None, chat_id_alt: Optional[str] = None, is_bot: bool = False,
         scope_id: Optional[str] = None, guild_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None, message_id: Optional[str] = None,
@@ -4170,6 +4183,7 @@ class BasePlatformAdapter(ABC):
         fields = dict(
             platform=self.platform, chat_id=str(chat_id), chat_name=chat_name, chat_type=chat_type,
             user_id=_opt(user_id), user_name=user_name, thread_id=_opt(thread_id),
+            thread_id_kind=_opt(thread_id_kind),
             chat_topic=(chat_topic or "").strip() or None, user_id_alt=user_id_alt,
             chat_id_alt=chat_id_alt, is_bot=is_bot, scope_id=_opt(scope_id),
             guild_id=_opt(guild_id), parent_chat_id=_opt(parent_chat_id),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4084,6 +4084,7 @@ class GatewayRunner(
             chat_type=str(context.source.chat_type) if context.source.chat_type else "",
             chat_name=context.source.chat_name or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
+            thread_id_kind=str(context.source.thread_id_kind) if context.source.thread_id_kind else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_id_alt=str(context.source.user_id_alt) if context.source.user_id_alt else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -71,6 +71,8 @@ class SessionSource:
     user_id: Optional[str] = None
     user_name: Optional[str] = None
     thread_id: Optional[str] = None  # forum topics, Discord threads, etc.
+    # Distinguishes native routing primitives that share the generic thread_id session-key slot.
+    thread_id_kind: Optional[str] = None
     chat_topic: Optional[str] = None  # channel topic/description (Discord, Slack)
     user_id_alt: Optional[str] = None  # platform-specific stable alt ID (Signal UUID, Feishu union_id)
     chat_id_alt: Optional[str] = None  # Signal group internal ID
@@ -122,7 +124,7 @@ class SessionSource:
     # Wire layout (order matters for byte-stable JSON): always-present, then truthy-only
     # optionals around the dual-written scope pair.
     _ALWAYS_FIELDS = ("chat_id", "chat_name", "chat_type", "user_id", "user_name", "thread_id", "chat_topic")
-    _OPTIONAL_PRE_SCOPE = ("user_id_alt", "chat_id_alt")
+    _OPTIONAL_PRE_SCOPE = ("thread_id_kind", "user_id_alt", "chat_id_alt")
     _OPTIONAL_POST_SCOPE = ("parent_chat_id", "message_id", "profile")
     _OPTIONAL_TAIL = ("auto_thread_initial_name", "prospective_thread_id")
 

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -33,13 +33,15 @@ def session_context_engaged() -> bool:
 # * CRON_SESSION: tri-state — _UNSET = legacy env fallback; "1" = cron; "" = non-cron, masks env.
 _SESSION_VARS = (
     _SESSION_PLATFORM, _SESSION_SOURCE, _SESSION_CHAT_ID, _SESSION_CHAT_TYPE,
-    _SESSION_CHAT_NAME, _SESSION_THREAD_ID, _SESSION_USER_ID, _SESSION_USER_ID_ALT,
+    _SESSION_CHAT_NAME, _SESSION_THREAD_ID, _SESSION_THREAD_ID_KIND,
+    _SESSION_USER_ID, _SESSION_USER_ID_ALT,
     _SESSION_USER_NAME, _SESSION_SCOPE_ID, _SESSION_KEY, _SESSION_ID,
     _SESSION_UI_SESSION_ID, _SESSION_MESSAGE_ID, _SESSION_PROFILE,
     _BROWSER_CONTROL_PRINCIPAL, _BROWSER_CONTROL_TRANSPORT_FAMILY, _CRON_SESSION,
 ) = tuple(ContextVar(name, default=_UNSET) for name in (
     "HERMES_SESSION_PLATFORM", "HERMES_SESSION_SOURCE", "HERMES_SESSION_CHAT_ID",
     "HERMES_SESSION_CHAT_TYPE", "HERMES_SESSION_CHAT_NAME", "HERMES_SESSION_THREAD_ID",
+    "HERMES_SESSION_THREAD_ID_KIND",
     "HERMES_SESSION_USER_ID", "HERMES_SESSION_USER_ID_ALT", "HERMES_SESSION_USER_NAME",
     "HERMES_SESSION_SCOPE_ID", "HERMES_SESSION_KEY", "HERMES_SESSION_ID",
     "HERMES_UI_SESSION_ID", "HERMES_SESSION_MESSAGE_ID", "HERMES_SESSION_PROFILE",
@@ -103,7 +105,8 @@ def scoped_current_session_id(session_id: str | None = None) -> Iterator[None]:
 
 def set_session_vars(
     platform: str = "", source: str = "", chat_id: str = "", chat_type: str = "",
-    chat_name: str = "", thread_id: str = "", user_id: str = "", user_id_alt: str = "",
+    chat_name: str = "", thread_id: str = "", thread_id_kind: str = "",
+    user_id: str = "", user_id_alt: str = "",
     user_name: str = "", scope_id: str = "", session_key: str = "", session_id: str = "",
     message_id: str = "", profile: str = "", browser_control_principal: str = "",
     browser_control_transport_family: str = "", cwd: str = "", async_delivery: bool = True,
@@ -115,7 +118,7 @@ def set_session_vars(
     global _session_context_engaged
     _session_context_engaged = True
     values = (
-        platform, source, chat_id, chat_type, chat_name, thread_id, user_id, user_id_alt,
+        platform, source, chat_id, chat_type, chat_name, thread_id, thread_id_kind, user_id, user_id_alt,
         user_name, scope_id, session_key, session_id, ui_session_id, message_id, profile,
         browser_control_principal, browser_control_transport_family, cron_session,
     )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -795,18 +795,24 @@ class TelegramAdapter(BasePlatformAdapter):
                 if not user_name:
                     user_name = str(getattr(sender_chat, "title", "") or "").strip() or None
         chat_id = str(getattr(chat, "id", "")).strip() or user_id
+        direct_topic = getattr(message, "direct_messages_topic", None)
+        direct_topic_id = getattr(direct_topic, "topic_id", None)
         thread_id_raw = getattr(message, "message_thread_id", None)
         is_topic_message = bool(getattr(message, "is_topic_message", False))
         is_forum_group = getattr(chat, "is_forum", False) is True
         chat_type = self._normalize_chat_type(
             getattr(chat, "type", "dm"), is_forum=thread_id_raw is not None and (is_topic_message or is_forum_group))
         thread_id = None
-        if thread_id_raw is not None and (
+        if direct_topic_id is not None:
+            thread_id = str(direct_topic_id)
+        elif thread_id_raw is not None and (
             (chat_type == "forum" and (is_topic_message or is_forum_group)) or (chat_type == "dm" and is_topic_message)):
             thread_id = str(thread_id_raw)
         return SessionSource(
             platform=Platform.TELEGRAM, chat_id=chat_id or "", chat_type=chat_type, user_id=user_id,
-            user_name=user_name, thread_id=thread_id, is_bot=is_bot)
+            user_name=user_name, thread_id=thread_id,
+            thread_id_kind="direct_messages_topic" if direct_topic_id is not None else None,
+            is_bot=is_bot)
 
     def _source_from_reaction_for_auth(self, update):
         """SessionSource for a ``message_reaction`` update's actor (``user`` or ``actor_chat``).
@@ -5137,6 +5143,10 @@ class TelegramAdapter(BasePlatformAdapter):
         a routing id. Gating, skill binding and outbound routing must all agree on this value."""
         chat = getattr(message, "chat", None)
         chat_type = cls._chat_type_str(chat)
+        direct_topic = getattr(message, "direct_messages_topic", None)
+        direct_topic_id = getattr(direct_topic, "topic_id", None)
+        if direct_topic_id is not None:
+            return str(direct_topic_id)
         raw = getattr(message, "message_thread_id", None)
         is_topic_message = bool(getattr(message, "is_topic_message", False))
         is_group = chat_type in ("group", "supergroup")
@@ -6286,6 +6296,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # (message_thread_id=None) normalize to the General-topic id so replies route back to General
         # (#22423).
         thread_id_str = self._effective_message_thread_id(message)
+        thread_id_kind = (
+            "direct_messages_topic"
+            if getattr(getattr(message, "direct_messages_topic", None), "topic_id", None) is not None
+            else None
+        )
         chat_topic, topic_skill = self._resolve_topic_binding(message, chat_type, thread_id_str)
         has_full_name = hasattr(chat, "full_name")
         if user:
@@ -6297,7 +6312,8 @@ class TelegramAdapter(BasePlatformAdapter):
         source = self.build_source(
             chat_id=str(chat.id), chat_name=chat.title or (chat.full_name if has_full_name else None), chat_type=chat_type,
             user_id=(str(user.id) if user else (str(chat.id) if chat_type in {"dm", "channel"} else None)),
-            user_name=user_name, thread_id=thread_id_str, chat_topic=chat_topic, message_id=str(message.message_id),
+            user_name=user_name, thread_id=thread_id_str, thread_id_kind=thread_id_kind,
+            chat_topic=chat_topic, message_id=str(message.message_id),
             is_bot=bool(getattr(user, "is_bot", False)) if user else False)
         reply_to_id, reply_to_text = self._reply_context(message)
         from gateway.platforms.base import resolve_channel_prompt  # per-channel/topic ephemeral prompt

--- a/tests/cron/test_cron_origin_synthetic_thread.py
+++ b/tests/cron/test_cron_origin_synthetic_thread.py
@@ -14,8 +14,11 @@ durable thread. A genuine in-thread creation has thread_id == the parent
 thread's id != the triggering message's own id, and must keep its thread.
 """
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
+from cron.scheduler_delivery import _live_route_metadata
+from gateway.config import Platform
 from tools.cronjob_tools import _origin_from_env
 
 
@@ -80,3 +83,36 @@ class TestSlackSyntheticThreadCapture:
             origin = _origin_from_env()
         assert origin is not None
         assert origin["thread_id"] == "1755040000.000100"
+
+
+def test_telegram_direct_topic_origin_keeps_native_cron_route():
+    env = {
+        "HERMES_SESSION_PLATFORM": "telegram",
+        "HERMES_SESSION_CHAT_ID": "775566675",
+        "HERMES_SESSION_THREAD_ID": "270453",
+        "HERMES_SESSION_THREAD_ID_KIND": "direct_messages_topic",
+    }
+    with _session_env(env):
+        origin = _origin_from_env()
+
+    assert origin is not None
+    assert origin["thread_id_kind"] == "direct_messages_topic"
+    delivery = SimpleNamespace(
+        job={"id": "job-1"},
+        platform=Platform.TELEGRAM,
+        platform_name="telegram",
+        chat_id="775566675",
+        thread_id="270453",
+        runtime_adapter=SimpleNamespace(),
+        loop=None,
+        notify_delivery=True,
+        origin=origin,
+        origin_target=True,
+    )
+
+    route_thread_id, route_metadata, media_metadata = _live_route_metadata(delivery)
+
+    assert route_thread_id is None
+    assert route_metadata["direct_messages_topic_id"] == "270453"
+    assert "thread_id" not in route_metadata
+    assert media_metadata["direct_messages_topic_id"] == "270453"

--- a/tests/gateway/relay/test_contract_doc_conformance.py
+++ b/tests/gateway/relay/test_contract_doc_conformance.py
@@ -114,6 +114,7 @@ def _session_source_wire_keys() -> set[str]:
         user_id="u",
         user_name="un",
         thread_id="t",
+        thread_id_kind="direct_messages_topic",
         chat_topic="topic",
         user_id_alt="ua",
         chat_id_alt="ca",

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -22,6 +22,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
     _reply_anchor_for_event,
+    _thread_metadata_for_event,
     _thread_metadata_for_source,
 )
 from gateway.session import build_session_key
@@ -228,6 +229,40 @@ def test_forum_general_topic_without_message_thread_id_keeps_thread_context():
     assert event.source.chat_id == "-100123"
     assert event.source.chat_type == "group"
     assert event.source.thread_id == "1"
+
+
+def test_direct_messages_topic_routes_session_and_reply_by_topic_id():
+    """New Chat shares expose direct_messages_topic, not message_thread_id."""
+    import plugins.platforms.telegram.adapter as telegram_mod
+
+    adapter = _make_adapter()
+    message = SimpleNamespace(
+        text="shared https://example.com",
+        caption=None,
+        chat=SimpleNamespace(
+            id=775566675,
+            type=telegram_mod.ChatType.PRIVATE,
+            is_forum=False,
+            title=None,
+            full_name="Alice",
+        ),
+        from_user=SimpleNamespace(id=775566675, full_name="Alice", is_bot=False),
+        message_thread_id=None,
+        direct_messages_topic=SimpleNamespace(topic_id=270453),
+        is_topic_message=False,
+        reply_to_message=None,
+        message_id=270454,
+        date=None,
+    )
+
+    event = adapter._build_message_event(message, msg_type=MessageType.TEXT)
+
+    assert event.source.thread_id == "270453"
+    assert event.source.thread_id_kind == "direct_messages_topic"
+    assert build_session_key(event.source) == "agent:main:telegram:dm:775566675:270453"
+    assert _thread_metadata_for_event(event) == {
+        "direct_messages_topic_id": "270453",
+    }
 
 
 @pytest.mark.asyncio

--- a/tools/cronjob_job_args.py
+++ b/tools/cronjob_job_args.py
@@ -34,6 +34,7 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
     return {
         "platform": origin_platform, "chat_id": origin_chat_id,
         "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None, "thread_id": thread_id,
+        "thread_id_kind": get_session_env("HERMES_SESSION_THREAD_ID_KIND") or None,
         # Lets a delivery mirror resolve the participant's session in per-user-isolated groups.
         "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
         # Workspace/server scope (Slack team, Discord guild...): Slack session keys embed it,


### PR DESCRIPTION
## What does this PR do?

An iOS share sent through Telegram's New Chat surface can now remain in its native direct-message topic, so Hermes replies and cron follow-ups do not fall back to an unreplyable root conversation. The fix preserves Telegram's `direct_messages_topic.topic_id` as session routing state and carries its routing kind through immediate delivery, persisted sources, and cron origins.

### Symptom

A webpage shared from iPhone Chrome into Telegram New Chat is processed by Hermes, but the resulting session has no topic id. Replies and a cron created in that turn consequently target the root chat instead of the visible New Chat topic.

### Impact

Affected users can see that Hermes executed the request but cannot continue the conversation in the Telegram surface that initiated it. Scheduled follow-ups also inherit the unusable root destination.

### Bug Cause

**Trigger:** `plugins/platforms/telegram/adapter.py:5134` / `TelegramAdapter._effective_message_thread_id()` when an inbound message has `direct_messages_topic.topic_id` but no `message_thread_id`.

**Causal chain:**
1. Telegram's New Chat share update carries its native topic identity in `Message.direct_messages_topic.topic_id`.
2. The adapter only reads `message_thread_id`, so it builds a `SessionSource` with `thread_id=None` and loses the routing primitive.
3. Session creation and cron origin capture then persist only the root chat, and later delivery cannot target the initiating topic.

**Why it is wrong:** `direct_messages_topic` is a first-class Bot API routing primitive and must be preserved separately from forum-style `message_thread_id`; flattening it changes both session identity and delivery destination.

**Working sibling / contrast:** Existing Telegram forum and private topic messages carry `message_thread_id`, so their session keys and outbound routing already retain the topic. Intentional plain DMs carry neither field and remain unchanged.

**Ruled out:** The request is not lost at Telegram intake: the reported turn and cron both execute. The controlled PTB-shaped regression also isolates the failure to topic-id extraction and routing propagation rather than agent execution.

### Fix

- Normalize `direct_messages_topic.topic_id` into the source's generic thread/session discriminator while retaining `thread_id_kind=direct_messages_topic` for native Bot API delivery.
- Serialize that additive routing-kind field and bridge it into session ContextVars so cron origin capture preserves it.
- Route immediate replies and origin cron deliveries with `direct_messages_topic_id`; existing forum-style topics continue to use `message_thread_id`, and plain DMs remain unthreaded.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py` - extract native direct-message topic ids for authorization and normalized inbound events.
- `gateway/session.py`, `gateway/platforms/base.py`, `gateway/session_context.py`, `gateway/run.py` - persist and propagate the additive thread routing kind and produce the correct immediate reply metadata.
- `tools/cronjob_job_args.py`, `cron/scheduler_delivery.py` - retain native direct-topic routing for cron jobs created from the conversation.
- `docs/relay-connector-contract.md` - document the additive SessionSource wire field.
- `tests/gateway/test_telegram_thread_fallback.py`, `tests/cron/test_cron_origin_synthetic_thread.py` - cover New Chat ingress/reply and cron inheritance.

## How to Test

1. Construct a PTB message with `direct_messages_topic.topic_id` and no `message_thread_id`; verify its session key includes the topic id and reply metadata uses `direct_messages_topic_id`.
2. Capture a cron origin from that source; verify live text and media delivery retain `direct_messages_topic_id` rather than falling back to a root or forum-style route.
3. Run the focused suites:

```bash
scripts/run_tests.sh tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_telegram_topic_mode.py tests/cron/test_cron_origin_synthetic_thread.py tests/gateway/test_session_context_inheritance.py tests/gateway/test_session.py tests/gateway/test_session_env.py tests/gateway/relay/test_contract_doc_conformance.py
uv run ruff check cron/scheduler_delivery.py gateway/platforms/base.py gateway/run.py gateway/session.py gateway/session_context.py plugins/platforms/telegram/adapter.py tools/cronjob_job_args.py tests/cron/test_cron_origin_synthetic_thread.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/relay/test_contract_doc_conformance.py
```

Result: 122 tests passed; Ruff passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because no configuration key changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no workflow changed
- [x] I've considered cross-platform impact; the change is platform-independent Python routing logic
- [x] Tool descriptions and schemas are N/A because no tool behavior changed

## Screenshots / Logs

N/A - this is a routing-state fix covered by deterministic PTB-shaped and cron delivery tests.

