### PR TITLE
fix(kanban): make active PR respawn guard state-aware

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -8,6 +8,7 @@ late-bound via ``_kb`` (import-cycle breaking) so monkeypatching
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import re
 import signal
@@ -66,10 +67,75 @@ DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 300  # 5 minutes
 # Within this window a GitHub PR URL in a comment blocks re-spawn.
 _RESPAWN_GUARD_PR_WINDOW = 86400  # 24 hours
 
-_RESPAWN_GUARD_PR_URL_RE = re.compile(
-    r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+",
+# The active-PR guard is content based, so resolve the referenced PR before
+# deferring a task. A short in-process cache keeps the dispatcher from running
+# one GitHub lookup per task on every tick. Failed lookups are cached as
+# unknown and fail closed (unknown still means "guard").
+_GITHUB_PR_URL_RE = re.compile(
+    r"https?://github\.com/([^/\s]+)/([^/\s]+)/pull/(\d+)",
     re.IGNORECASE,
 )
+_GITHUB_PR_STATE_CACHE_TTL = 300  # 5 minutes
+_github_pr_state_cache: dict[tuple[str, str], tuple[float, Optional[str]]] = {}
+
+
+def _github_pr_state(repo: str, number: str) -> Optional[str]:
+    """Return a GitHub PR state, or ``None`` when it cannot be resolved.
+
+    ``gh`` is intentionally an optional runtime dependency. Missing ``gh``,
+    missing authentication, a network failure, malformed output, or an
+    unexpected state all resolve to ``None``; the caller fails closed and
+    preserves the original duplicate-PR protection. Only ``MERGED`` and
+    ``CLOSED`` are considered inactive.
+    """
+    key = (repo.lower(), number)
+    now = time.time()
+    cached = _github_pr_state_cache.get(key)
+    if cached is not None and now - cached[0] < _GITHUB_PR_STATE_CACHE_TTL:
+        return cached[1]
+
+    state: Optional[str] = None
+    try:
+        completed = subprocess.run(
+            ["gh", "pr", "view", number, "--repo", repo, "--json", "state"],
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if completed.returncode == 0:
+            payload = json.loads(completed.stdout or "{}")
+            if isinstance(payload, dict):
+                candidate = payload.get("state")
+                if isinstance(candidate, str):
+                    state = candidate.strip().upper() or None
+    except (OSError, subprocess.SubprocessError, ValueError, TypeError):
+        # Best effort only: unknown state must not weaken the guard.
+        state = None
+
+    _github_pr_state_cache[key] = (now, state)
+    return state
+
+
+def _has_active_pr_comment(
+    conn: sqlite3.Connection, task_id: str, cutoff: int,
+) -> bool:
+    """Return whether a recent comment references an open/unknown GitHub PR."""
+    comments = conn.execute(
+        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        (task_id, cutoff),
+    ).fetchall()
+    for comment in comments:
+        body = comment["body"]
+        if not body:
+            continue
+        for match in _GITHUB_PR_URL_RE.finditer(body):
+            repo = f"{match.group(1)}/{match.group(2)}"
+            state = _github_pr_state(repo, match.group(3))
+            if state not in {"MERGED", "CLOSED"}:
+                return True
+    return False
 
 
 @dataclass
@@ -1203,14 +1269,14 @@ def check_respawn_guard(
         if not requeued_after:
             return "recent_success"
 
-    # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # 4. A recent GitHub PR comment only guards while the referenced PR is
+    #    still active. Historical audit/evidence comments commonly retain URLs
+    #    after the PR was merged or closed; those must not strand a task.
+    #    Unknown state fails closed so an unavailable `gh` or GitHub outage
+    #    preserves the original duplicate-PR protection.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    if _has_active_pr_comment(conn, task_id, pr_cutoff):
+        return "active_pr"
 
     return None
 

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -15,6 +15,7 @@ import signal
 import sqlite3
 import subprocess
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from dataclasses import field
@@ -68,18 +69,66 @@ DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 300  # 5 minutes
 _RESPAWN_GUARD_PR_WINDOW = 86400  # 24 hours
 
 # The active-PR guard is content based, so resolve the referenced PR before
-# deferring a task. A short in-process cache keeps the dispatcher from running
-# one GitHub lookup per task on every tick. Failed lookups are cached as
-# unknown and fail closed (unknown still means "guard").
+# deferring a task. Bound both the per-task and per-dispatch lookup work: a
+# large or adversarial comment set must not hold the dispatcher indefinitely.
+_GITHUB_PR_LOOKUPS_PER_TASK = 8
+_GITHUB_PR_LOOKUPS_PER_DISPATCH = 32
+_GITHUB_PR_LOOKUP_TIMEOUT_SECONDS = 2.0
+_GITHUB_PR_LOOKUP_TOTAL_BUDGET_SECONDS = 10.0
+_GITHUB_PR_COMMENT_SCAN_LIMIT = 64
+_GITHUB_PR_COMMENT_BODY_LIMIT = 64 * 1024
+_GITHUB_PR_STATE_CACHE_TTL = 300  # 5 minutes
+_GITHUB_PR_STATE_CACHE_MAX_ENTRIES = 256
 _GITHUB_PR_URL_RE = re.compile(
     r"https?://github\.com/([^/\s]+)/([^/\s]+)/pull/(\d+)",
     re.IGNORECASE,
 )
-_GITHUB_PR_STATE_CACHE_TTL = 300  # 5 minutes
+# Use monotonic timestamps so wall-clock changes cannot extend cache entries.
+# Only active/unknown states are cached. Caching MERGED/CLOSED could allow a
+# reopened PR to bypass the duplicate-work guard.
 _github_pr_state_cache: dict[tuple[str, str], tuple[float, Optional[str]]] = {}
+_github_pr_state_cache_lock = threading.Lock()
+_RESPAWN_GUARD_RESUME_EVENT_KINDS = (
+    "claimed", "completed", "spawned", "status", "promoted", "unblocked",
+    "reclaimed", "blocked", "changes_requested",
+)
 
 
-def _github_pr_state(repo: str, number: str) -> Optional[str]:
+def _should_emit_respawn_guard_event(
+    conn: sqlite3.Connection, task_id: str, reason: str,
+) -> bool:
+    """Return whether ``reason`` changed since the last guard event.
+
+    Repeated dispatcher ticks must not append an unbounded event row for the
+    same unchanged guard. A lifecycle event resets the sequence and permits a
+    fresh guard event when the task is deferred again.
+    """
+    last_guard = conn.execute(
+        "SELECT id, payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'respawn_guarded' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if last_guard is None:
+        return True
+    last_resume = conn.execute(
+        "SELECT id FROM task_events "
+        "WHERE task_id = ? AND kind IN (" + ",".join("?" for _ in _RESPAWN_GUARD_RESUME_EVENT_KINDS) + ") "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id, *_RESPAWN_GUARD_RESUME_EVENT_KINDS),
+    ).fetchone()
+    if last_resume is not None and last_resume["id"] > last_guard["id"]:
+        return True
+    try:
+        payload = json.loads(last_guard["payload"] or "{}")
+    except (TypeError, ValueError):
+        payload = {}
+    return not isinstance(payload, dict) or payload.get("reason") != reason
+
+
+def _github_pr_state(
+    repo: str, number: str, *, timeout: float = 10.0,
+) -> Optional[str]:
     """Return a GitHub PR state, or ``None`` when it cannot be resolved.
 
     ``gh`` is intentionally an optional runtime dependency. Missing ``gh``,
@@ -89,8 +138,9 @@ def _github_pr_state(repo: str, number: str) -> Optional[str]:
     ``CLOSED`` are considered inactive.
     """
     key = (repo.lower(), number)
-    now = time.time()
-    cached = _github_pr_state_cache.get(key)
+    now = time.monotonic()
+    with _github_pr_state_cache_lock:
+        cached = _github_pr_state_cache.get(key)
     if cached is not None and now - cached[0] < _GITHUB_PR_STATE_CACHE_TTL:
         return cached[1]
 
@@ -101,7 +151,7 @@ def _github_pr_state(repo: str, number: str) -> Optional[str]:
             capture_output=True,
             stdin=subprocess.DEVNULL,
             text=True,
-            timeout=10,
+            timeout=timeout,
             check=False,
         )
         if completed.returncode == 0:
@@ -114,25 +164,78 @@ def _github_pr_state(repo: str, number: str) -> Optional[str]:
         # Best effort only: unknown state must not weaken the guard.
         state = None
 
-    _github_pr_state_cache[key] = (now, state)
+    # Do not cache inactive states: a PR can be reopened, and an inactive
+    # result must never be reused to permit duplicate work. Active/unknown
+    # values are conservative if reused across an auth/context change.
+    if state in {"MERGED", "CLOSED"}:
+        with _github_pr_state_cache_lock:
+            _github_pr_state_cache.pop(key, None)
+    else:
+        with _github_pr_state_cache_lock:
+            if (
+                key not in _github_pr_state_cache
+                and len(_github_pr_state_cache) >= _GITHUB_PR_STATE_CACHE_MAX_ENTRIES
+            ):
+                oldest_key = min(
+                    _github_pr_state_cache,
+                    key=lambda item: _github_pr_state_cache[item][0],
+                )
+                _github_pr_state_cache.pop(oldest_key, None)
+            _github_pr_state_cache[key] = (now, state)
     return state
 
 
 def _has_active_pr_comment(
-    conn: sqlite3.Connection, task_id: str, cutoff: int,
+    conn: sqlite3.Connection,
+    task_id: str,
+    cutoff: int,
+    *,
+    lookup_budget: Optional[list[int]] = None,
+    lookup_deadline: Optional[float] = None,
 ) -> bool:
-    """Return whether a recent comment references an open/unknown GitHub PR."""
+    """Return whether a recent comment references an open/unknown GitHub PR.
+
+    The comment scan is bounded as well as the subprocess work. If a task has
+    more comments or a larger body than the scan limits, the guard fails closed
+    without materializing or regex-scanning the unbounded remainder.
+    """
     comments = conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, cutoff),
+        "SELECT substr(body, 1, ?) AS body, length(body) AS body_length "
+        "FROM task_comments WHERE task_id = ? AND created_at >= ? "
+        "ORDER BY created_at DESC LIMIT ?",
+        (
+            _GITHUB_PR_COMMENT_BODY_LIMIT,
+            task_id,
+            cutoff,
+            _GITHUB_PR_COMMENT_SCAN_LIMIT + 1,
+        ),
     ).fetchall()
+    if len(comments) > _GITHUB_PR_COMMENT_SCAN_LIMIT:
+        return True
+    lookups = 0
     for comment in comments:
+        if int(comment["body_length"] or 0) > _GITHUB_PR_COMMENT_BODY_LIMIT:
+            return True
         body = comment["body"]
         if not body:
             continue
         for match in _GITHUB_PR_URL_RE.finditer(body):
+            if lookups >= _GITHUB_PR_LOOKUPS_PER_TASK:
+                return True
+            if lookup_budget is not None:
+                if not lookup_budget or lookup_budget[0] <= 0:
+                    return True
+                lookup_budget[0] -= 1
+            if lookup_deadline is not None:
+                remaining = lookup_deadline - time.monotonic()
+                if remaining <= 0:
+                    return True
+                timeout = min(_GITHUB_PR_LOOKUP_TIMEOUT_SECONDS, remaining)
+            else:
+                timeout = 10.0
+            lookups += 1
             repo = f"{match.group(1)}/{match.group(2)}"
-            state = _github_pr_state(repo, match.group(3))
+            state = _github_pr_state(repo, match.group(3), timeout=timeout)
             if state not in {"MERGED", "CLOSED"}:
                 return True
     return False
@@ -184,10 +287,6 @@ class DispatchResult:
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
     stale: list[str] = field(default_factory=list)
     """Task ids reclaimed for no heartbeat within ``dispatch_stale_timeout_seconds``."""
-    respawn_guarded: list[tuple[str, str]] = field(default_factory=list)
-    """``(task_id, reason)`` skipped by the respawn guard: ``"blocker_auth"``
-    (quota/auth error — also auto-blocked), ``"recent_success"`` (completed run
-    within guard window), ``"active_pr"`` (GitHub PR URL in a recent comment)."""
     rate_limited: list[str] = field(default_factory=list)
     """Task ids whose workers bailed on a provider rate-limit / quota wall
     (EX_TEMPFAIL sentinel exit) and were released to ``ready`` WITHOUT counting
@@ -199,6 +298,10 @@ class DispatchResult:
     """Memory pressure that restricted this tick: ``"critical"`` (no new
     workers), ``"elevated"`` (at most one), ``None`` (no restriction).
     Reclaim/promotion bookkeeping still ran; deferred tasks stay queued."""
+    respawn_guarded: list[tuple[str, str]] = field(default_factory=list)
+    """``(task_id, reason)`` skipped by the respawn guard: ``"blocker_auth"``
+    (quota/auth error — also auto-blocked), ``"recent_success"`` (completed run
+    within guard window), ``"active_pr"`` (GitHub PR URL in a recent comment)."""
 
 
 # Bounded registry of recently-reaped worker exits, filled by the reap loop in
@@ -1189,7 +1292,12 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 
 
 def check_respawn_guard(
-    conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    lane: str = "ready",
+    pr_lookup_budget: Optional[list[int]] = None,
+    pr_lookup_deadline: Optional[float] = None,
 ) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
@@ -1285,7 +1393,13 @@ def check_respawn_guard(
     if latest_run is not None and latest_run["outcome"] == "changes_requested":
         return None
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    if _has_active_pr_comment(conn, task_id, pr_cutoff):
+    if _has_active_pr_comment(
+        conn,
+        task_id,
+        pr_cutoff,
+        lookup_budget=pr_lookup_budget,
+        lookup_deadline=pr_lookup_deadline,
+    ):
         return "active_pr"
 
     return None
@@ -1577,6 +1691,8 @@ def _dispatch_lane_task(
     spawn_fn,
     per_profile_cap: Optional[int],
     per_profile_running: dict[str, int],
+    pr_lookup_budget: Optional[list[int]] = None,
+    pr_lookup_deadline: Optional[float] = None,
 ) -> bool:
     """Guard, claim, resolve the workspace and spawn one ready/review row.
     Returns True when a spawn slot was consumed (real or ``dry_run``); every
@@ -1598,7 +1714,13 @@ def _dispatch_lane_task(
         if current >= per_profile_cap:
             result.skipped_per_profile_capped.append((task_id, assignee, current))
             return False
-    guard_reason = check_respawn_guard(conn, task_id, lane=lane)
+    guard_reason = check_respawn_guard(
+        conn,
+        task_id,
+        lane=lane,
+        pr_lookup_budget=pr_lookup_budget,
+        pr_lookup_deadline=pr_lookup_deadline,
+    )
     if guard_reason is not None:
         result.respawn_guarded.append((task_id, guard_reason))
         # Event so ``hermes kanban tail`` shows why the task looks stuck.
@@ -1608,9 +1730,16 @@ def _dispatch_lane_task(
         # the operator's intent ("default") was perfectly clear (#27145). Mutating the row (not just the
         # in-memory view) keeps diagnostics and the board state consistent: the task is now legitimately
         # owned by ``kanban.default_assignee``, not "unassigned but secretly routed".
-        if not dry_run:
+        if not dry_run and _should_emit_respawn_guard_event(conn, task_id, guard_reason):
+            guard_payload: dict[str, Any] = {"reason": guard_reason}
+            if guard_reason == "rate_limit_cooldown":
+                guard_payload["window_seconds"] = _kb._resolve_rate_limit_cooldown_seconds()
+            elif guard_reason == "recent_success":
+                guard_payload["window_seconds"] = _RESPAWN_GUARD_SUCCESS_WINDOW
+            elif guard_reason == "active_pr":
+                guard_payload["window_seconds"] = _RESPAWN_GUARD_PR_WINDOW
             with _kb.write_txn(conn):
-                _kb._append_event(conn, task_id, "respawn_guarded", {"reason": guard_reason})
+                _kb._append_event(conn, task_id, "respawn_guarded", guard_payload)
         return False
 
     def _count_spawn(name: str) -> None:
@@ -1883,10 +2012,14 @@ def _dispatch_once_locked(
             "GROUP BY assignee"
         ):
             per_profile_running[prow["assignee"]] = int(prow["n"])
+    pr_lookup_budget = [_GITHUB_PR_LOOKUPS_PER_DISPATCH]
+    pr_lookup_deadline = time.monotonic() + _GITHUB_PR_LOOKUP_TOTAL_BUDGET_SECONDS
     lane_kwargs: dict[str, Any] = dict(
         dry_run=dry_run, ttl_seconds=ttl_seconds, board=board,
         failure_limit=failure_limit, spawn_fn=spawn_fn,
         per_profile_cap=per_profile_cap, per_profile_running=per_profile_running,
+        pr_lookup_budget=pr_lookup_budget,
+        pr_lookup_deadline=pr_lookup_deadline,
     )
     default_assignee = _resolve_default_assignee(default_assignee)
     spawned = 0

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1220,7 +1220,10 @@ def check_respawn_guard(
     latest_run = conn.execute(
         "SELECT outcome, ended_at FROM task_runs "
         "WHERE task_id = ? AND ended_at IS NOT NULL "
-        "ORDER BY ended_at DESC LIMIT 1",
+        # id breaks the tie when two runs end within the same second (a
+        # review handoff + reviewer verdict routinely do) — without it the
+        # older run can shadow the newer verdict.
+        "ORDER BY ended_at DESC, id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
     if latest_run is not None and latest_run["outcome"] == "rate_limited":
@@ -1272,8 +1275,13 @@ def check_respawn_guard(
     # 4. A recent GitHub PR comment only guards while the referenced PR is
     #    still active. Historical audit/evidence comments commonly retain URLs
     #    after the PR was merged or closed; those must not strand a task.
+    #    A fresh changes_requested verdict is an explicit rework handoff to
+    #    the same implementer, so its existing PR must be reused rather than
+    #    blocked by the duplicate-work guard.
     #    Unknown state fails closed so an unavailable `gh` or GitHub outage
     #    preserves the original duplicate-PR protection.
+    if latest_run is not None and latest_run["outcome"] == "changes_requested":
+        return None
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     if _has_active_pr_comment(conn, task_id, pr_cutoff):
         return "active_pr"

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1201,8 +1201,10 @@ def check_respawn_guard(
     (quota/auth pattern; the breaker still trips eventually), then for the
     ready lane only ``"recent_success"`` (completed run within the window, unless
     a re-queue event arrived after it — a deliberate re-run) and ``"active_pr"``
-    (PR URL in a recent comment; re-spawning risks a duplicate PR). The review
-    lane skips the last two: they are the *inputs* to a review handoff. Stale /
+    (a recent PR URL whose GitHub state is ``OPEN`` or unknown; ``MERGED`` and
+    ``CLOSED`` references no longer guard). A latest ``changes_requested`` run
+    is an explicit rework handoff and bypasses the PR guard. The review lane
+    skips the last two: they are the *inputs* to a review handoff. Stale /
     dead claim locks are NOT a guard reason — the reclaim passes own those.
     """
     row = conn.execute(

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -661,35 +661,67 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
 
     # A recent guard event explains an otherwise stranded ready card. Ignore
     # stale guard history once a later lifecycle event shows the task resumed.
-    latest_guard = None
     latest_guard_index = -1
     for index, event in enumerate(events):
         if _event_kind(event) == "respawn_guarded":
-            latest_guard = event
             latest_guard_index = index
-    if latest_guard is not None:
-        resumed_kinds = {
-            "claimed", "completed", "spawned", "status", "promoted",
-            "unblocked", "reclaimed", "blocked",
+    resumed_kinds = {
+        "claimed", "completed", "spawned", "status", "promoted",
+        "unblocked", "reclaimed", "blocked", "changes_requested",
+    }
+    if latest_guard_index >= 0 and any(
+        _event_kind(event) in resumed_kinds
+        for event in events[latest_guard_index + 1:]
+    ):
+        latest_guard_index = -1
+    if latest_guard_index >= 0:
+        latest_guard = events[latest_guard_index]
+        guard_payload = _parse_payload(latest_guard)
+        guard_reason = guard_payload.get("reason", "unknown")
+        last_resume_index = max(
+            (
+                index for index, event in enumerate(events[:latest_guard_index])
+                if _event_kind(event) in resumed_kinds
+            ),
+            default=-1,
+        )
+        # Use the first event for the current reason after the last lifecycle
+        # event, so repeated historical guard rows cannot reset expiry.
+        guard_index = latest_guard_index
+        seen_current_reason = False
+        for index in range(last_resume_index + 1, latest_guard_index + 1):
+            event = events[index]
+            if _event_kind(event) != "respawn_guarded":
+                continue
+            if _parse_payload(event).get("reason", "unknown") == guard_reason:
+                if not seen_current_reason:
+                    guard_index = index
+                    seen_current_reason = True
+            else:
+                guard_index = latest_guard_index
+                seen_current_reason = False
+        guard_ts = _event_ts(events[guard_index])
+        guard_windows = {
+            "rate_limit_cooldown": 300,
+            "recent_success": 3600,
+            "active_pr": 86400,
         }
-        if not any(
-            _event_kind(event) in resumed_kinds
-            for event in events[latest_guard_index + 1:]
-        ):
-            guard_reason = _parse_payload(latest_guard).get("reason", "unknown")
-            guard_windows = {
-                "rate_limit_cooldown": 300,
-                "recent_success": 3600,
-                "active_pr": 86400,
-            }
+        configured_window = guard_payload.get("window_seconds")
+        if type(configured_window) is int and configured_window > 0:
+            window = configured_window
+        else:
+            # Only dispatcher-written integer windows are trusted. In
+            # particular, reject JSON Infinity/NaN and oversized floats rather
+            # than letting int() raise or silently create a bogus expiry.
+            window = guard_windows.get(guard_reason, 0)
+        guard_current = not window or guard_ts + window > int(now)
+        if guard_current:
             guard_descriptions = {
                 "rate_limit_cooldown": "a rate-limit cooldown is in effect",
                 "recent_success": "a run completed recently",
                 "active_pr": "a prior worker has an active GitHub PR",
                 "blocker_auth": "the last failure was a quota/auth blocker",
             }
-            guard_ts = _event_ts(latest_guard)
-            window = guard_windows.get(guard_reason, 0)
             remaining = max(0, guard_ts + window - int(now)) if window else 0
             if remaining:
                 expiry = (

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -659,6 +659,81 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     else:
         severity = "warning"
 
+    # A recent guard event explains an otherwise stranded ready card. Ignore
+    # stale guard history once a later lifecycle event shows the task resumed.
+    latest_guard = None
+    latest_guard_index = -1
+    for index, event in enumerate(events):
+        if _event_kind(event) == "respawn_guarded":
+            latest_guard = event
+            latest_guard_index = index
+    if latest_guard is not None:
+        resumed_kinds = {
+            "claimed", "completed", "spawned", "status", "promoted",
+            "unblocked", "reclaimed", "blocked",
+        }
+        if not any(
+            _event_kind(event) in resumed_kinds
+            for event in events[latest_guard_index + 1:]
+        ):
+            guard_reason = _parse_payload(latest_guard).get("reason", "unknown")
+            guard_windows = {
+                "rate_limit_cooldown": 300,
+                "recent_success": 3600,
+                "active_pr": 86400,
+            }
+            guard_descriptions = {
+                "rate_limit_cooldown": "a rate-limit cooldown is in effect",
+                "recent_success": "a run completed recently",
+                "active_pr": "a prior worker has an active GitHub PR",
+                "blocker_auth": "the last failure was a quota/auth blocker",
+            }
+            guard_ts = _event_ts(latest_guard)
+            window = guard_windows.get(guard_reason, 0)
+            remaining = max(0, guard_ts + window - int(now)) if window else 0
+            if remaining:
+                expiry = (
+                    f"; guard expires in ~{remaining / 3600:.1f}h"
+                    if remaining >= 3600
+                    else f"; guard expires in ~{max(1, remaining // 60)}m"
+                )
+            elif window:
+                expiry = "; guard window may have elapsed on the last tick"
+            else:
+                expiry = ""
+            task_id = _task_field(task, "id", "")
+            actions = [
+                _cli_hint(
+                    "Inspect dispatcher events",
+                    f"hermes kanban events {task_id}" if task_id else "hermes kanban diagnostics",
+                    suggested=True,
+                ),
+                DiagnosticAction(
+                    kind="reassign", label="Reassign to a different worker",
+                    payload={"current_assignee": assignee},
+                ),
+            ]
+            return [Diagnostic(
+                kind="stranded_in_ready", severity=severity,
+                title=f"Ready for {age_str}: deferred by respawn guard ({guard_reason})",
+                detail=(
+                    f"The dispatcher deferred this task for {age_str} because "
+                    f"{guard_descriptions.get(guard_reason, guard_reason)}{expiry}. "
+                    "This is intentional guard behavior, not a missing worker. "
+                    "Inspect the event history and resolve the guard condition before retrying."
+                ),
+                actions=actions,
+                first_seen_at=last_ready_ts, last_seen_at=guard_ts, count=1,
+                data={
+                    "ready_since": last_ready_ts,
+                    "age_seconds": int(age_seconds),
+                    "assignee": assignee,
+                    "threshold_seconds": int(threshold_seconds),
+                    "guard_reason": guard_reason,
+                    "guard_event_ts": guard_ts,
+                },
+            )]
+
     actions = [
         DiagnosticAction(kind="reassign", label="Reassign to a different worker",
                          payload={"current_assignee": assignee}),

--- a/hermes_cli/kanban_ops.py
+++ b/hermes_cli/kanban_ops.py
@@ -104,6 +104,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
+            "respawn_guarded": [
+                {"task_id": tid, "reason": reason}
+                for (tid, reason) in res.respawn_guarded
+            ],
             "auto_assigned_default": res.auto_assigned_default,
         }, ascii=True)
         return 0
@@ -136,6 +140,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
         )
+    if res.respawn_guarded:
+        details = ", ".join(
+            f"{task_id} ({reason})" for task_id, reason in res.respawn_guarded
+        )
+        print(f"Deferred (respawn guard): {details}")
     return 0
 
 

--- a/tests/hermes_cli/test_kanban_active_pr_guard_regression.py
+++ b/tests/hermes_cli/test_kanban_active_pr_guard_regression.py
@@ -1,0 +1,156 @@
+"""Regression tests for Kanban active-PR guard false positives."""
+from __future__ import annotations
+
+import argparse
+import json
+from contextlib import nullcontext
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+from hermes_cli import kanban_diagnostics as diagnostics
+from hermes_cli import kanban_ops
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _task_with_pr_comment(conn, *, title: str, url: str) -> str:
+    task_id = kb.create_task(conn, title=title, assignee="worker")
+    kb.add_comment(conn, task_id, author="worker", body=f"Evidence: {url}")
+    return task_id
+
+
+def test_merged_pr_comment_does_not_hold_ready_task(kanban_home, monkeypatch):
+    """A historical merged PR URL must not make a ready task unspawnable."""
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(
+            conn,
+            title="baseline gate",
+            url="https://github.com/example/repo/pull/88",
+        )
+
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return type("Completed", (), {"returncode": 0, "stdout": '{"state":"MERGED"}'})()
+
+        monkeypatch.setattr(kbd.subprocess, "run", fake_run)
+
+        assert kbd.check_respawn_guard(conn, task_id) is None
+        assert calls, "the guard must resolve the referenced PR state"
+        assert calls[0][0] == [
+            "gh", "pr", "view", "88", "--repo", "example/repo", "--json", "state"
+        ]
+
+
+def test_open_pr_comment_still_holds_ready_task(kanban_home, monkeypatch):
+    """An open PR URL remains a duplicate-work guard."""
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(
+            conn,
+            title="already PRed",
+            url="https://github.com/example/repo/pull/89",
+        )
+
+        monkeypatch.setattr(
+            kbd.subprocess,
+            "run",
+            lambda *args, **kwargs: type(
+                "Completed", (), {"returncode": 0, "stdout": '{"state":"OPEN"}'}
+            )(),
+        )
+
+        assert kbd.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_unresolved_pr_state_keeps_ready_task_guarded(kanban_home, monkeypatch):
+    """A lookup failure must fail closed rather than allow duplicate work."""
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(
+            conn,
+            title="unknown PR state",
+            url="https://github.com/example/repo/pull/90",
+        )
+
+        monkeypatch.setattr(
+            kbd.subprocess,
+            "run",
+            lambda *args, **kwargs: type(
+                "Completed", (), {"returncode": 1, "stdout": ""}
+            )(),
+        )
+
+        assert kbd.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_dispatch_json_and_text_expose_respawn_guarded():
+    """Operators must see why dispatch spawned zero workers."""
+    result = kbd.DispatchResult(respawn_guarded=[("t_demo", "active_pr")])
+    args = argparse.Namespace(
+        dry_run=False, max=None, failure_limit=2, json=True,
+    )
+    with (
+        patch("hermes_cli.config.load_config", return_value={"kanban": {}}),
+        patch.object(kbc, "connect_closing", return_value=nullcontext(object())),
+        patch.object(kbd, "dispatch_once", return_value=result),
+    ):
+        output = StringIO()
+        with patch("sys.stdout", output):
+            assert kanban_ops._cmd_dispatch(args) == 0
+    payload = json.loads(output.getvalue())
+    assert payload["respawn_guarded"] == [{"task_id": "t_demo", "reason": "active_pr"}]
+
+    args.json = False
+    with (
+        patch("hermes_cli.config.load_config", return_value={"kanban": {}}),
+        patch.object(kbc, "connect_closing", return_value=nullcontext(object())),
+        patch.object(kbd, "dispatch_once", return_value=result),
+    ):
+        output = StringIO()
+        with patch("sys.stdout", output):
+            assert kanban_ops._cmd_dispatch(args) == 0
+    assert "Deferred (respawn guard): t_demo (active_pr)" in output.getvalue()
+
+
+def test_ready_diagnostics_identify_respawn_guard(kanban_home):
+    """Diagnostics must distinguish a guarded ready card from a missing worker."""
+    now = 100_000
+    task = {
+        "id": "t_demo",
+        "status": "ready",
+        "assignee": "worker",
+        "claim_lock": None,
+        "created_at": now - 3600,
+    }
+    events = [
+        {"kind": "created", "created_at": now - 3600, "payload": None},
+        {
+            "kind": "respawn_guarded",
+            "created_at": now - 30,
+            "payload": '{"reason":"active_pr"}',
+        },
+    ]
+
+    stranded = [
+        item
+        for item in diagnostics.compute_task_diagnostics(task, events, [], now=now)
+        if item.kind == "stranded_in_ready"
+    ]
+    assert len(stranded) == 1
+    assert "respawn guard" in stranded[0].title.lower()
+    assert "active_pr" in stranded[0].title
+    assert stranded[0].data["guard_reason"] == "active_pr"

--- a/tests/hermes_cli/test_kanban_active_pr_guard_regression.py
+++ b/tests/hermes_cli/test_kanban_active_pr_guard_regression.py
@@ -170,6 +170,115 @@ def test_pr_state_lookup_failures_keep_ready_task_guarded(
         assert kbd.check_respawn_guard(conn, task_id) == "active_pr"
 
 
+def test_inactive_pr_state_is_not_cached_across_reopen(kanban_home, monkeypatch):
+    """A reopened PR must be checked again rather than using CLOSED cache data."""
+    calls = []
+    responses = iter([
+        '{"state":"CLOSED"}',
+        '{"state":"OPEN"}',
+    ])
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return type("Completed", (), {"returncode": 0, "stdout": next(responses)})()
+
+    monkeypatch.setattr(kbd.subprocess, "run", fake_run)
+    assert kbd._github_pr_state("example/repo", "96") == "CLOSED"
+    assert kbd._github_pr_state("example/repo", "96") == "OPEN"
+    assert len(calls) == 2
+
+
+def test_pr_lookup_budget_fails_closed_before_unbounded_gh_calls(
+    kanban_home, monkeypatch,
+):
+    """A comment backlog cannot consume an unbounded number of GH calls."""
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="many PR references", assignee="worker")
+        urls = " ".join(
+            f"https://github.com/example/repo/pull/{number}"
+            for number in range(100, 110)
+        )
+        kb.add_comment(conn, task_id, author="worker", body=urls)
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            return type(
+                "Completed", (), {"returncode": 0, "stdout": '{"state":"MERGED"}'}
+            )()
+
+        monkeypatch.setattr(kbd.subprocess, "run", fake_run)
+        assert kbd._has_active_pr_comment(
+            conn, task_id, 0, lookup_budget=[3],
+        ) is True
+        assert len(calls) == 3
+
+
+def test_pr_comment_scan_bounds_body_work(kanban_home, monkeypatch):
+    """Oversized comments fail closed without scanning their full body."""
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="oversized comment", assignee="worker")
+        kb.add_comment(conn, task_id, author="worker", body="x" * 70_000)
+        calls = []
+        monkeypatch.setattr(
+            kbd.subprocess,
+            "run",
+            lambda *args, **kwargs: calls.append(args) or None,
+        )
+        assert kbd._has_active_pr_comment(conn, task_id, 0, lookup_budget=[3]) is True
+        assert calls == []
+
+
+def test_pr_comment_scan_bounds_comment_count(kanban_home, monkeypatch):
+    """A noisy comment backlog fails closed before unbounded scanning."""
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="many comments", assignee="worker")
+        for index in range(70):
+            kb.add_comment(conn, task_id, author="worker", body=f"note {index}")
+        calls = []
+        monkeypatch.setattr(
+            kbd.subprocess,
+            "run",
+            lambda *args, **kwargs: calls.append(args) or None,
+        )
+        assert kbd._has_active_pr_comment(conn, task_id, 0, lookup_budget=[3]) is True
+        assert calls == []
+
+
+def test_pr_lookup_deadline_fails_closed_before_lookup(kanban_home, monkeypatch):
+    """An exhausted per-tick deadline must not start another GH subprocess."""
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(
+            conn,
+            title="expired lookup budget",
+            url="https://github.com/example/repo/pull/97",
+        )
+        calls = []
+        monkeypatch.setattr(
+            kbd.subprocess,
+            "run",
+            lambda *args, **kwargs: calls.append(args) or None,
+        )
+        assert kbd._has_active_pr_comment(
+            conn, task_id, 0, lookup_budget=[3], lookup_deadline=0,
+        ) is True
+        assert calls == []
+
+
+    """Repeated guarded ticks do not grow task_events without progress."""
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="deduplicated guard", assignee="worker")
+        with kb.write_txn(conn):
+            kb._append_event(conn, task_id, "respawn_guarded", {"reason": "active_pr"})
+        assert not kbd._should_emit_respawn_guard_event(conn, task_id, "active_pr")
+        with kb.write_txn(conn):
+            kb._append_event(conn, task_id, "commented", {"author": "worker"})
+        assert not kbd._should_emit_respawn_guard_event(conn, task_id, "active_pr")
+        with kb.write_txn(conn):
+            kb._append_event(conn, task_id, "status", {"status": "ready"})
+        assert kbd._should_emit_respawn_guard_event(conn, task_id, "active_pr")
+
+
 def test_dispatch_json_and_text_expose_respawn_guarded():
     """Operators must see why dispatch spawned zero workers."""
     result = kbd.DispatchResult(respawn_guarded=[("t_demo", "active_pr")])
@@ -228,6 +337,34 @@ def test_ready_diagnostics_identify_respawn_guard(kanban_home):
     assert "active_pr" in stranded[0].title
 
 
+def test_ready_diagnostics_reject_nonfinite_guard_window(kanban_home):
+    """Malformed persisted windows must not suppress the guard diagnostic."""
+    now = 100_000
+    task = {
+        "id": "t_demo",
+        "status": "ready",
+        "assignee": "worker",
+        "claim_lock": None,
+        "created_at": now - 3600,
+    }
+    events = [
+        {"kind": "created", "created_at": now - 3600, "payload": None},
+        {
+            "kind": "respawn_guarded",
+            "created_at": now - 30,
+            "payload": '{"reason":"active_pr","window_seconds":Infinity}',
+        },
+    ]
+
+    stranded = [
+        item
+        for item in diagnostics.compute_task_diagnostics(task, events, [], now=now)
+        if item.kind == "stranded_in_ready"
+    ]
+    assert len(stranded) == 1
+    assert "respawn guard" in stranded[0].title.lower()
+
+
 def test_ready_diagnostics_ignore_stale_respawn_guard_after_lifecycle_progress(
     kanban_home,
 ):
@@ -259,3 +396,39 @@ def test_ready_diagnostics_ignore_stale_respawn_guard_after_lifecycle_progress(
     assert "respawn guard" not in stranded[0].title.lower()
     assert "no worker" in stranded[0].title.lower()
     assert "guard_reason" not in stranded[0].data
+
+
+def test_ready_diagnostics_do_not_reset_guard_expiry_on_repeated_events(
+    kanban_home,
+):
+    """Repeated historical guard rows use the first event for expiry."""
+    now = 100_000
+    task = {
+        "id": "t_demo",
+        "status": "ready",
+        "assignee": "worker",
+        "claim_lock": None,
+        "created_at": now - 7200,
+    }
+    events = [
+        {"kind": "created", "created_at": now - 7200, "payload": None},
+        {
+            "kind": "respawn_guarded",
+            "created_at": now - 4000,
+            "payload": '{"reason":"recent_success"}',
+        },
+        {
+            "kind": "respawn_guarded",
+            "created_at": now - 1,
+            "payload": '{"reason":"recent_success"}',
+        },
+    ]
+
+    stranded = [
+        item
+        for item in diagnostics.compute_task_diagnostics(task, events, [], now=now)
+        if item.kind == "stranded_in_ready"
+    ]
+    assert len(stranded) == 1
+    assert "respawn guard" not in stranded[0].title.lower()
+    assert "no worker" in stranded[0].title.lower()

--- a/tests/hermes_cli/test_kanban_active_pr_guard_regression.py
+++ b/tests/hermes_cli/test_kanban_active_pr_guard_regression.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 from contextlib import nullcontext
 from io import StringIO
 from pathlib import Path
@@ -97,6 +98,78 @@ def test_unresolved_pr_state_keeps_ready_task_guarded(kanban_home, monkeypatch):
         assert kbd.check_respawn_guard(conn, task_id) == "active_pr"
 
 
+def test_malformed_pr_state_keeps_ready_task_guarded(kanban_home, monkeypatch):
+    """Malformed successful output must fail closed, not crash dispatch."""
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(
+            conn,
+            title="malformed PR state",
+            url="https://github.com/example/repo/pull/91",
+        )
+
+        monkeypatch.setattr(
+            kbd.subprocess,
+            "run",
+            lambda *args, **kwargs: type(
+                "Completed", (), {"returncode": 0, "stdout": "[]"}
+            )(),
+        )
+
+        assert kbd.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+@pytest.mark.parametrize(
+    "number, stdout",
+    [(92, '{"state":null}'), (93, '{"state":123}')],
+)
+def test_missing_or_non_string_pr_state_keeps_ready_task_guarded(
+    kanban_home, monkeypatch, number, stdout,
+):
+    """Missing or non-string state must fail closed."""
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(
+            conn,
+            title=f"invalid PR state {number}",
+            url=f"https://github.com/example/repo/pull/{number}",
+        )
+
+        monkeypatch.setattr(
+            kbd.subprocess,
+            "run",
+            lambda *args, **kwargs: type(
+                "Completed", (), {"returncode": 0, "stdout": stdout}
+            )(),
+        )
+
+        assert kbd.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+@pytest.mark.parametrize(
+    "number, failure",
+    [
+        (94, subprocess.TimeoutExpired(["gh"], timeout=10)),
+        (95, OSError("gh unavailable")),
+    ],
+)
+def test_pr_state_lookup_failures_keep_ready_task_guarded(
+    kanban_home, monkeypatch, number, failure,
+):
+    """Timeout and process errors must fail closed."""
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(
+            conn,
+            title=f"failed PR lookup {number}",
+            url=f"https://github.com/example/repo/pull/{number}",
+        )
+
+        def raise_failure(*args, **kwargs):
+            raise failure
+
+        monkeypatch.setattr(kbd.subprocess, "run", raise_failure)
+
+        assert kbd.check_respawn_guard(conn, task_id) == "active_pr"
+
+
 def test_dispatch_json_and_text_expose_respawn_guarded():
     """Operators must see why dispatch spawned zero workers."""
     result = kbd.DispatchResult(respawn_guarded=[("t_demo", "active_pr")])
@@ -153,4 +226,36 @@ def test_ready_diagnostics_identify_respawn_guard(kanban_home):
     assert len(stranded) == 1
     assert "respawn guard" in stranded[0].title.lower()
     assert "active_pr" in stranded[0].title
-    assert stranded[0].data["guard_reason"] == "active_pr"
+
+
+def test_ready_diagnostics_ignore_stale_respawn_guard_after_lifecycle_progress(
+    kanban_home,
+):
+    """A later spawn event must clear the earlier guard explanation."""
+    now = 100_000
+    task = {
+        "id": "t_demo",
+        "status": "ready",
+        "assignee": "worker",
+        "claim_lock": None,
+        "created_at": now - 3600,
+    }
+    events = [
+        {"kind": "created", "created_at": now - 3600, "payload": None},
+        {
+            "kind": "respawn_guarded",
+            "created_at": now - 300,
+            "payload": '{"reason":"active_pr"}',
+        },
+        {"kind": "spawned", "created_at": now - 60, "payload": None},
+    ]
+
+    stranded = [
+        item
+        for item in diagnostics.compute_task_diagnostics(task, events, [], now=now)
+        if item.kind == "stranded_in_ready"
+    ]
+    assert len(stranded) == 1
+    assert "respawn guard" not in stranded[0].title.lower()
+    assert "no worker" in stranded[0].title.lower()
+    assert "guard_reason" not in stranded[0].data

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -478,6 +478,68 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         ) == "rate_limit_cooldown"
 
 
+def test_active_pr_guard_released_after_changes_requested(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rework after ``request_changes`` must re-spawn the implementer.
+
+    The canonical review cycle is: worker opens PR -> ``request_review`` ->
+    reviewer ``request_changes`` -> task lands back in ``ready`` for the SAME
+    implementer, who must push to the EXISTING PR. The PR URL from the
+    handoff is still inside the 24h window, so without a bypass the
+    ``active_pr`` guard defers every tick and the card is stuck until the
+    window elapses (NousResearch/hermes-agent#91614). The guard's rationale
+    ("re-spawning risks a duplicate PR") is inverted here: the rework is
+    *supposed* to touch that PR. A later plain re-queue with no review
+    verdict keeps the guard (a duplicate-PR risk is still real there).
+    """
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *a, **k: {"kanban": {"review_dispatch": True}},
+    )
+
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="rework me", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        kb.add_comment(
+            conn, tid, author="worker",
+            body="Opened https://github.com/example/repo/pull/7 for review.",
+        )
+        assert kb.request_review(
+            conn, tid, summary="PR ready",
+            expected_run_id=claimed.current_run_id,
+        )
+        reviewer_run = kb.claim_review_task(conn, tid)
+        assert reviewer_run is not None
+        ok, implementer = kb.request_changes(
+            conn, tid, reason="fix wording",
+            expected_run_id=reviewer_run.current_run_id,
+        )
+        assert ok and implementer == "worker"
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "ready" and task.assignee == "worker"
+
+        # Rework lane: the changes_requested verdict releases the guard.
+        assert kbd.check_respawn_guard(conn, tid) is None
+        res = kbd.dispatch_once(conn, dry_run=True)
+        assert tid in [s[0] for s in res.spawned]
+        assert tid not in dict(res.respawn_guarded)
+
+        # Contrast: a task whose latest run is NOT a rework verdict stays guarded.
+        other = kb.create_task(conn, title="already PRed", assignee="worker")
+        kb.add_comment(
+            conn, other, author="worker",
+            body="Opened https://github.com/example/repo/pull/8 for review.",
+        )
+        assert kbd.check_respawn_guard(conn, other) == "active_pr"
+
+
 def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
     kanban_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -52,6 +52,13 @@ Declare PR work at creation with `--completion-contract OWNER/REPO` (or an exact
 accepts the same `completion_contract`. Use `local-only` for intentionally local
 work; existing and undeclared cards retain that default. Prose URLs are not policy.
 
+The dispatcher’s duplicate-PR respawn guard resolves recent GitHub PR references
+read-only with `gh pr view`. `OPEN` (or unknown) PR state continues to defer a
+ready task; `MERGED` and `CLOSED` references in audit/evidence comments do not
+strand it. State lookup failures fail closed. `hermes kanban dispatch --json`
+reports guard-deferred task IDs and reasons, and diagnostics identifies a
+current guard separately from an ordinary missing-worker condition.
+
 After publishing, pass `metadata.published_pr` to completion. The first matching
 URL binds the card permanently; retries cannot substitute a green sibling PR.
 CLI `show --json` and `kanban_show` expose the persisted contract.

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -57,7 +57,10 @@ read-only with `gh pr view`. `OPEN` (or unknown) PR state continues to defer a
 ready task; `MERGED` and `CLOSED` references in audit/evidence comments do not
 strand it. State lookup failures fail closed. `hermes kanban dispatch --json`
 reports guard-deferred task IDs and reasons, and diagnostics identifies a
-current guard separately from an ordinary missing-worker condition.
+current guard separately from an ordinary missing-worker condition. An explicit
+`changes_requested` review outcome is treated as a rework handoff so the
+existing PR can be reused. Lookups are bounded per task and dispatch tick;
+unknown state remains fail-closed.
 
 After publishing, pass `metadata.published_pr` to completion. The first matching
 URL binds the card permanently; retries cannot substitute a green sibling PR.


### PR DESCRIPTION
## Summary

- Make the Kanban `active_pr` respawn guard state-aware instead of treating every recent PR URL as an active handoff.
- Keep duplicate-work protection for open or unresolved PRs, while allowing merged/closed historical evidence URLs.
- Preserve the explicit `changes_requested` rework path and expose current `respawn_guarded` decisions in dispatch output and diagnostics.

This fixes ready tasks being stranded by audit comments that mention an already-merged PR (for example, a baseline PR URL).

## Implementation notes

- GitHub lookups use a bounded, argumentized `gh pr view ... --json state` subprocess.
- Missing `gh`, authentication/network failures, timeouts, nonzero exits, and malformed/unexpected responses fail closed.
- PR-state results are cached briefly to avoid repeating the lookup every dispatch tick.
- Diagnostics ignore stale guard events after later lifecycle progress.
- The `changes_requested` bypass preserves the existing PR for explicit review rework.

The `changes_requested` lifecycle commit was adapted from upstream PR #104629, preserving its original author attribution.

## Verification

- Focused Kanban tests: 40 passed.
- Full Kanban test selection: 56 files, 381 passed, 3 skipped, 0 failed.
- Ruff: passed.
- Python compilation: passed.
- `git diff --check`: passed.

## Deployment note

The hosted `/opt/hermes` runtime is platform-managed. This PR changes the durable source repository; the live gateway will use it only after the platform ships a runtime containing this revision.

No live Kanban task status, lock, worker, or gateway state was mutated by this change.
