### PR TITLE
fix(plugins): recover tool calls after a hung policy guard

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1156,7 +1156,7 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
         # also stale, the callback is quarantined until plugins are reloaded.
         self._hook_running_callbacks: Dict[tuple, Tuple[object, float]] = {}
         self._hook_timeout_suppressed_until: Dict[tuple, float] = {}
-        self._hook_stale_retries: Set[tuple] = set()
+        self._hook_abandoned_tokens: Dict[tuple, Set[object]] = {}
         self._hook_quarantined_callbacks: Set[tuple] = set()
         self._hook_timeout_lock = threading.Lock()
         self._hook_timeout_suppression_seconds = _HOOK_TIMEOUT_SUPPRESSION_SECONDS

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1151,9 +1151,10 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
         self._event_queue: queue.Queue[Any] = queue.Queue(maxsize=_EVENT_PENDING_CAP)
         self._event_worker: Optional[threading.Thread] = None
         self._emit_depth = threading.local()
-        # In-flight / recently-timed-out hook callbacks keyed by (hook_name, id(cb)) so a stuck
-        # policy hook cannot spawn a new abandoned thread on every fire.
-        self._hook_running_callbacks: Dict[tuple, object] = {}
+        # In-flight / recently-timed-out hook callbacks keyed by (hook_name, id(cb)). Each value is
+        # (identity token, start time), allowing bounded retries without letting a stuck policy hook
+        # spawn a new abandoned thread on every fire.
+        self._hook_running_callbacks: Dict[tuple, Tuple[object, float]] = {}
         self._hook_timeout_suppressed_until: Dict[tuple, float] = {}
         self._hook_timeout_lock = threading.Lock()
         self._hook_timeout_suppression_seconds = _HOOK_TIMEOUT_SUPPRESSION_SECONDS

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1152,10 +1152,12 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
         self._event_worker: Optional[threading.Thread] = None
         self._emit_depth = threading.local()
         # In-flight / recently-timed-out hook callbacks keyed by (hook_name, id(cb)). Each value is
-        # (identity token, start time), allowing bounded retries without letting a stuck policy hook
-        # spawn a new abandoned thread on every fire.
+        # (identity token, start time). A stale worker gets one replacement; if that replacement is
+        # also stale, the callback is quarantined until plugins are reloaded.
         self._hook_running_callbacks: Dict[tuple, Tuple[object, float]] = {}
         self._hook_timeout_suppressed_until: Dict[tuple, float] = {}
+        self._hook_stale_retries: Set[tuple] = set()
+        self._hook_quarantined_callbacks: Set[tuple] = set()
         self._hook_timeout_lock = threading.Lock()
         self._hook_timeout_suppression_seconds = _HOOK_TIMEOUT_SUPPRESSION_SECONDS
         # Ledger per plugin (ownership) plus global order (reverse teardown across plugins). Process-

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -212,6 +212,11 @@ class PluginDispatchMixin:
             now = time.monotonic()
             suppressed_until = self._hook_timeout_suppressed_until.get(callback_key)
             running = self._hook_running_callbacks.get(callback_key)
+            if callback_key in self._hook_quarantined_callbacks:
+                logger.error(
+                    "Hook '%s' callback %s remains quarantined after repeated hung workers; "
+                    "reload plugins to retry", hook_name, callback_name)
+                return _HOOK_SKIPPED
             if suppressed_until is not None and suppressed_until > now:
                 logger.warning(
                     "Hook '%s' callback %s skipped during timeout suppression", hook_name, callback_name)
@@ -225,11 +230,19 @@ class PluginDispatchMixin:
                         "Hook '%s' callback %s skipped while still running (age %.1fs)",
                         hook_name, callback_name, running_age)
                     return _HOOK_SKIPPED
+                if callback_key in self._hook_stale_retries:
+                    self._hook_quarantined_callbacks.add(callback_key)
+                    logger.error(
+                        "Hook '%s' callback %s replacement remained running for %.1fs; "
+                        "quarantining until plugins are reloaded",
+                        hook_name, callback_name, running_age)
+                    return _HOOK_SKIPPED
                 logger.error(
                     "Hook '%s' callback %s remained running for %.1fs; abandoning stale worker "
                     "token and retrying", hook_name, callback_name, running_age)
                 if self._hook_running_callbacks.get(callback_key) == (running_token, running_since):
                     self._hook_running_callbacks.pop(callback_key, None)
+                    self._hook_stale_retries.add(callback_key)
             if suppressed_until is not None:
                 self._hook_timeout_suppressed_until.pop(callback_key, None)
             self._hook_running_callbacks[callback_key] = (token, started_at)
@@ -244,6 +257,7 @@ class PluginDispatchMixin:
                 running = self._hook_running_callbacks.get(callback_key)
                 if running is not None and running[0] is token:
                     self._hook_running_callbacks.pop(callback_key, None)
+                    self._hook_stale_retries.discard(callback_key)
 
         def _runner() -> None:
             try:

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -181,13 +181,14 @@ class PluginDispatchMixin:
         timeout = _resolve_hook_callback_timeout()
         use_timeout = _hook_uses_callback_timeout(hook_name, timeout)
         fail_closed = hook_name in _HOOK_TIMEOUT_FAIL_CLOSED_HOOKS
+        policy_unavailable = False
         for cb in self._hooks.get(hook_name, []):
             try:
                 if use_timeout:
                     ret = self._run_hook_callback_bounded(hook_name, cb, kwargs, timeout)
                     if ret is _HOOK_SKIPPED:
                         if fail_closed:  # policy hook: fail closed with a block directive
-                            results.append({"action": "block", "message": _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE})
+                            policy_unavailable = True
                         continue
                 else:
                     ret = self._invoke_hook_callback(cb, kwargs)
@@ -196,6 +197,8 @@ class PluginDispatchMixin:
             except Exception as exc:
                 logger.warning(
                     "Hook '%s' callback %s raised: %s", hook_name, getattr(cb, "__name__", repr(cb)), exc)
+        if policy_unavailable:
+            results.insert(0, {"action": "block", "message": _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE})
         return results
 
     def _run_hook_callback_bounded(

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -207,17 +207,32 @@ class PluginDispatchMixin:
         callback_name = getattr(cb, "__name__", repr(cb))
         callback_key = (hook_name, id(cb))
         token = object()
+        started_at = time.monotonic()
         with self._hook_timeout_lock:
+            now = time.monotonic()
             suppressed_until = self._hook_timeout_suppressed_until.get(callback_key)
-            running = callback_key in self._hook_running_callbacks
-            if (suppressed_until is not None and suppressed_until > time.monotonic()) or running:
+            running = self._hook_running_callbacks.get(callback_key)
+            if suppressed_until is not None and suppressed_until > now:
                 logger.warning(
-                    "Hook '%s' callback %s skipped after previous "
-                    "timeout or while still running", hook_name, callback_name)
+                    "Hook '%s' callback %s skipped during timeout suppression", hook_name, callback_name)
                 return _HOOK_SKIPPED
+            if running is not None:
+                running_token, running_since = running
+                running_age = max(0.0, now - running_since)
+                stale_after = timeout + self._hook_timeout_suppression_seconds
+                if running_age < stale_after:
+                    logger.warning(
+                        "Hook '%s' callback %s skipped while still running (age %.1fs)",
+                        hook_name, callback_name, running_age)
+                    return _HOOK_SKIPPED
+                logger.error(
+                    "Hook '%s' callback %s remained running for %.1fs; abandoning stale worker "
+                    "token and retrying", hook_name, callback_name, running_age)
+                if self._hook_running_callbacks.get(callback_key) == (running_token, running_since):
+                    self._hook_running_callbacks.pop(callback_key, None)
             if suppressed_until is not None:
                 self._hook_timeout_suppressed_until.pop(callback_key, None)
-            self._hook_running_callbacks[callback_key] = token
+            self._hook_running_callbacks[callback_key] = (token, started_at)
 
         context = contextvars.copy_context()
         done = threading.Event()
@@ -226,7 +241,8 @@ class PluginDispatchMixin:
 
         def _release_token() -> None:
             with self._hook_timeout_lock:
-                if self._hook_running_callbacks.get(callback_key) is token:
+                running = self._hook_running_callbacks.get(callback_key)
+                if running is not None and running[0] is token:
                     self._hook_running_callbacks.pop(callback_key, None)
 
         def _runner() -> None:

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -230,7 +230,7 @@ class PluginDispatchMixin:
                         "Hook '%s' callback %s skipped while still running (age %.1fs)",
                         hook_name, callback_name, running_age)
                     return _HOOK_SKIPPED
-                if callback_key in self._hook_stale_retries:
+                if self._hook_abandoned_tokens.get(callback_key):
                     self._hook_quarantined_callbacks.add(callback_key)
                     logger.error(
                         "Hook '%s' callback %s replacement remained running for %.1fs; "
@@ -242,7 +242,7 @@ class PluginDispatchMixin:
                     "token and retrying", hook_name, callback_name, running_age)
                 if self._hook_running_callbacks.get(callback_key) == (running_token, running_since):
                     self._hook_running_callbacks.pop(callback_key, None)
-                    self._hook_stale_retries.add(callback_key)
+                    self._hook_abandoned_tokens.setdefault(callback_key, set()).add(running_token)
             if suppressed_until is not None:
                 self._hook_timeout_suppressed_until.pop(callback_key, None)
             self._hook_running_callbacks[callback_key] = (token, started_at)
@@ -257,7 +257,11 @@ class PluginDispatchMixin:
                 running = self._hook_running_callbacks.get(callback_key)
                 if running is not None and running[0] is token:
                     self._hook_running_callbacks.pop(callback_key, None)
-                    self._hook_stale_retries.discard(callback_key)
+                abandoned = self._hook_abandoned_tokens.get(callback_key)
+                if abandoned is not None:
+                    abandoned.discard(token)
+                    if not abandoned:
+                        self._hook_abandoned_tokens.pop(callback_key, None)
 
         def _runner() -> None:
             try:

--- a/hermes_cli/plugins_ledger.py
+++ b/hermes_cli/plugins_ledger.py
@@ -298,6 +298,6 @@ class PluginLedgerMixin:
         with self._hook_timeout_lock:
             self._hook_running_callbacks.clear()
             self._hook_timeout_suppressed_until.clear()
-            self._hook_stale_retries.clear()
+            self._hook_abandoned_tokens.clear()
             self._hook_quarantined_callbacks.clear()
         self._discovered = False

--- a/hermes_cli/plugins_ledger.py
+++ b/hermes_cli/plugins_ledger.py
@@ -298,4 +298,6 @@ class PluginLedgerMixin:
         with self._hook_timeout_lock:
             self._hook_running_callbacks.clear()
             self._hook_timeout_suppressed_until.clear()
+            self._hook_stale_retries.clear()
+            self._hook_quarantined_callbacks.clear()
         self._discovered = False

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1193,27 +1193,44 @@ class TestForceReloadSymmetry:
         now = 0.0
         monkeypatch.setattr(dispatch_mod.time, "monotonic", lambda: now)
 
-        release_first = threading.Event()
+        releases = [threading.Event(), threading.Event()]
+        first_finished = threading.Event()
         starts = []
 
         def policy(**_kwargs):
-            starts.append(len(starts) + 1)
-            if len(starts) == 1:
-                release_first.wait(timeout=10.0)
+            generation = len(starts)
+            starts.append(generation + 1)
+            if generation == 0:
+                releases[0].wait(timeout=10.0)
+                first_finished.set()
+            elif generation == 2:
+                releases[1].wait(timeout=10.0)
             return None
 
         mgr = PluginManager()
         mgr._hooks["pre_tool_call"] = [policy]
 
-        assert mgr.invoke_hook("pre_tool_call") == [
-            {"action": "block", "message": _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE}
-        ]
+        blocked = [{"action": "block", "message": _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE}]
+        try:
+            assert mgr.invoke_hook("pre_tool_call") == blocked
 
-        now = 60.2
-        assert mgr.invoke_hook("pre_tool_call") == []
-        assert starts == [1, 2]
-        assert "remained running for 60.2s; abandoning stale worker token and retrying" in caplog.text
-        release_first.set()
+            now = 60.2
+            assert mgr.invoke_hook("pre_tool_call") == []
+            assert starts == [1, 2]
+            assert "remained running for 60.2s; abandoning stale worker token and retrying" in caplog.text
+
+            assert mgr.invoke_hook("pre_tool_call") == blocked
+            now = 120.3
+            assert mgr.invoke_hook("pre_tool_call") == blocked
+            assert starts == [1, 2, 3]
+
+            releases[0].set()
+            assert first_finished.wait(timeout=2.0)
+            assert mgr.invoke_hook("pre_tool_call") == blocked
+            assert starts == [1, 2, 3]
+        finally:
+            for release in releases:
+                release.set()
 
     def test_pre_tool_call_quarantines_repeated_hung_workers(self, monkeypatch, caplog):
         """Repeated permanent hangs get one retry, then stay fail closed without more workers."""

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1215,6 +1215,54 @@ class TestForceReloadSymmetry:
         assert "remained running for 60.2s; abandoning stale worker token and retrying" in caplog.text
         release_first.set()
 
+    def test_pre_tool_call_quarantines_repeated_hung_workers(self, monkeypatch, caplog):
+        """Repeated permanent hangs get one retry, then stay fail closed without more workers."""
+        from hermes_cli.plugins import _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
+        import hermes_cli.plugins_dispatch as dispatch_mod
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 0.1
+        )
+        now = 0.0
+        monkeypatch.setattr(dispatch_mod.time, "monotonic", lambda: now)
+
+        releases = [threading.Event(), threading.Event()]
+        first_finished = threading.Event()
+        starts = []
+
+        def policy(**_kwargs):
+            generation = len(starts)
+            starts.append(generation + 1)
+            releases[generation].wait(timeout=10.0)
+            if generation == 0:
+                first_finished.set()
+            return None
+
+        mgr = PluginManager()
+        mgr._hooks["pre_tool_call"] = [policy]
+        blocked = [{"action": "block", "message": _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE}]
+
+        try:
+            assert mgr.invoke_hook("pre_tool_call") == blocked
+            now = 60.2
+            assert mgr.invoke_hook("pre_tool_call") == blocked
+            assert starts == [1, 2]
+
+            now = 120.3
+            assert mgr.invoke_hook("pre_tool_call") == blocked
+            now = 180.4
+            assert mgr.invoke_hook("pre_tool_call") == blocked
+            assert starts == [1, 2]
+            assert "quarantining until plugins are reloaded" in caplog.text
+
+            releases[0].set()
+            assert first_finished.wait(timeout=2.0)
+            assert mgr.invoke_hook("pre_tool_call") == blocked
+            assert starts == [1, 2]
+        finally:
+            for release in releases:
+                release.set()
+
     def test_pre_tool_call_worker_start_failure_fails_closed_without_sticking(
         self, monkeypatch
     ):

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1182,6 +1182,39 @@ class TestForceReloadSymmetry:
         assert msg2 == _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
         hold.set()
 
+    def test_pre_tool_call_retries_after_running_worker_becomes_stale(self, monkeypatch, caplog):
+        """A permanently hung policy worker must not block tools until restart."""
+        from hermes_cli.plugins import _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
+        import hermes_cli.plugins_dispatch as dispatch_mod
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 0.1
+        )
+        now = 0.0
+        monkeypatch.setattr(dispatch_mod.time, "monotonic", lambda: now)
+
+        release_first = threading.Event()
+        starts = []
+
+        def policy(**_kwargs):
+            starts.append(len(starts) + 1)
+            if len(starts) == 1:
+                release_first.wait(timeout=10.0)
+            return None
+
+        mgr = PluginManager()
+        mgr._hooks["pre_tool_call"] = [policy]
+
+        assert mgr.invoke_hook("pre_tool_call") == [
+            {"action": "block", "message": _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE}
+        ]
+
+        now = 60.2
+        assert mgr.invoke_hook("pre_tool_call") == []
+        assert starts == [1, 2]
+        assert "remained running for 60.2s; abandoning stale worker token and retrying" in caplog.text
+        release_first.set()
+
     def test_pre_tool_call_worker_start_failure_fails_closed_without_sticking(
         self, monkeypatch
     ):

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1182,6 +1182,44 @@ class TestForceReloadSymmetry:
         assert msg2 == _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
         hold.set()
 
+    def test_pre_tool_call_timeout_block_precedes_earlier_approval(self, monkeypatch):
+        """An unavailable policy callback must dominate another callback's approval directive."""
+        from hermes_cli.plugins import (
+            _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE,
+            resolve_pre_tool_block,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 0.1
+        )
+        hold = threading.Event()
+        approval_calls = []
+
+        def approve(**_kwargs):
+            return {"action": "approve", "message": "operator approval required"}
+
+        def hung_policy(**_kwargs):
+            hold.wait(timeout=10.0)
+
+        mgr = PluginManager()
+        mgr._hooks["pre_tool_call"] = [approve, hung_policy]
+
+        import hermes_cli.plugins as plugins_mod
+
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+        monkeypatch.setattr(
+            "tools.approval.request_tool_approval",
+            lambda *_args, **_kwargs: approval_calls.append(1) or {"approved": True},
+        )
+
+        try:
+            assert resolve_pre_tool_block("web_search", {"query": "x"}) == (
+                _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
+            )
+            assert approval_calls == []
+        finally:
+            hold.set()
+
     def test_pre_tool_call_retries_after_running_worker_becomes_stale(self, monkeypatch, caplog):
         """A permanently hung policy worker must not block tools until restart."""
         from hermes_cli.plugins import _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE


### PR DESCRIPTION
## What does this PR do?

A permanently hung `pre_tool_call` plugin callback no longer blocks every later tool call until the Hermes process restarts. The dispatcher now treats a running worker as stale after the callback timeout plus the existing suppression window, retries the callback with a new identity token, and emits an error-level recovery log.

### Symptom

After one `pre_tool_call` callback exceeds its timeout and never returns, every later tool call is blocked with `pre_tool_call plugin callback timed out or is still running`.

### Impact

A single stuck policy plugin can deny all tool execution in a long-lived CLI, gateway, or embedded WebUI process until that process is restarted.

### Bug Cause

**Trigger:** `hermes_cli/plugins_dispatch.py:201` / `_run_hook_callback_bounded()` / a callback worker that remains alive after its timeout.

**Causal chain:**
1. A `pre_tool_call` callback exceeds `plugins.hook_callback_timeout` and its daemon worker never exits.
2. The worker retains its callback key in `_hook_running_callbacks`, while the dispatch path treats every presence of that key as permanently in flight.
3. Every later invocation returns `_HOOK_SKIPPED`, which correctly becomes a fail-closed block for policy hooks, but there is no retry or recovery path.

**Why it is wrong:** The running ledger stored only an identity token and had no age bound. The timeout suppression deadline expired, but the still-running condition could not expire.

**Working sibling / contrast:** A slow worker that eventually exits releases its token in `finally`, so calls recover after suppression. Only a worker that never exits retains the key indefinitely.

**Ruled out:** The fail-closed conversion is not the defect and remains unchanged. It correctly protects tool execution while a policy decision is unavailable.

### Fix

Store each callback worker's monotonic start time with its identity token. Calls continue to fail closed throughout the configured timeout and suppression interval. Once that bounded interval expires, the dispatcher abandons only the stale token, logs the worker age at error level, and retries with a new token. The abandoned worker cannot clear a replacement worker's state because cleanup still checks token identity.

## Related Issue

Closes #105223

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins.py` - track hook worker tokens with monotonic start times.
- `hermes_cli/plugins_dispatch.py` - bound still-running suppression, retry stale callbacks, and distinguish suppression/running/recovery logs.
- `tests/hermes_cli/test_plugins.py` - reproduce a permanently hung guard and assert fail-closed behavior followed by bounded recovery.

## How to Test

1. Register a `pre_tool_call` callback whose first invocation never returns and whose next invocation succeeds.
2. Confirm the first invocation times out and blocks the tool call.
3. Advance beyond the timeout plus suppression interval and confirm the callback is retried, the tool call proceeds, and the stale-worker recovery is logged.
4. Automated verification (77 passed):

```bash
scripts/run_tests.sh tests/hermes_cli/test_plugins.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant test file and all 77 tests pass
- [x] I've added a regression test for this bug
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A; the existing timeout configuration contract is unchanged
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] Cross-platform impact was considered; the fix uses Python monotonic time and thread synchronization already used by this path
- [x] Tool descriptions and schemas are N/A; no tool interface changed

## Screenshots / Logs

N/A; the regression test captures the stale-worker recovery log.
