### PR TITLE
fix(google-chat): load WIF external_account credential configs

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -224,10 +224,42 @@ class _SACredentialError(Exception):
         self.kind, self.detail = kind, detail
 
 
+def _credentials_from_info(info: Dict[str, Any]) -> Any:
+    """Build credentials from a parsed Google credential JSON dict.
+
+    Official quickstart keys are ``type: service_account``. WIF / ADC configs
+    are ``type: external_account``. Calling ``from_service_account_info`` on a
+    WIF file raises ``MalformedError: missing fields client_email, token_uri``.
+    """
+    if not isinstance(info, dict):
+        raise _SACredentialError("file_invalid", ValueError("credential JSON must be an object"))
+    cred_type = info.get("type")
+    if cred_type == "service_account":
+        if service_account is None:
+            raise _SACredentialError("adc_no_auth")
+        return service_account.Credentials.from_service_account_info(info, scopes=_CHAT_SCOPES)
+    if cred_type == "external_account":
+        try:
+            import google.auth as google_auth
+        except ImportError as exc:
+            raise _SACredentialError("adc_no_auth") from exc
+        loader = getattr(google_auth, "load_credentials_from_dict", None)
+        if loader is None:
+            raise _SACredentialError("unsupported_type")
+        credentials, _project = loader(info, scopes=_CHAT_SCOPES)
+        logger.info("[GoogleChat] Loaded external_account (WIF) credentials")
+        return credentials
+    raise _SACredentialError("unsupported_type")
+
+
 def _load_sa_credentials_from(sa_value: Optional[str]) -> Any:
-    """Build SA credentials from a path / inline JSON, or fall back to ADC.
+    """Build credentials from a path / inline JSON, or fall back to ADC.
+
+    Accepts ``type: service_account`` (downloaded key) and
+    ``type: external_account`` (Workload Identity Federation / ADC config).
     Raises ``_SACredentialError`` with kind in {inline_invalid, not_found,
-    file_invalid, adc_foreign, adc_no_auth, adc_failed}."""
+    file_invalid, unsupported_type, adc_foreign, adc_no_auth, adc_failed}.
+    """
     if sa_value:
         if sa_value.lstrip().startswith("{"):
             try:
@@ -242,7 +274,7 @@ def _load_sa_credentials_from(sa_value: Optional[str]) -> Any:
                     info = json.load(fh)
             except json.JSONDecodeError as exc:
                 raise _SACredentialError("file_invalid", exc) from exc
-        return service_account.Credentials.from_service_account_info(info, scopes=_CHAT_SCOPES)
+        return _credentials_from_info(info)
     # No explicit SA — ADC (Cloud Run / GCE workload identity, or gcloud ADC login).
     if _adc_would_borrow_foreign_credentials():
         raise _SACredentialError("adc_foreign")
@@ -321,6 +353,8 @@ _SA_ERROR_MESSAGES = {
                     "GOOGLE_APPLICATION_CREDENTIALS, or install google-auth to use Application Default Credentials."),
     "adc_failed": ("No Service Account credentials configured and Application Default Credentials are unavailable. Set "
                    "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON or run ``gcloud auth application-default login``. ADC error: {exc}"),
+    "unsupported_type": ("Google credential JSON type is not supported. Use type 'service_account' "
+                         "(downloaded SA key) or 'external_account' (Workload Identity Federation / ADC config)."),
 }
 
 
@@ -416,14 +450,18 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
     # -- configuration -------------------------------------------------------
     def _load_sa_credentials(self) -> Any:
-        """SA credentials: ``extra['service_account_json']`` → GOOGLE_APPLICATION_CREDENTIALS → ADC.
+        """Credentials: extra JSON → GOOGLE_CHAT_SERVICE_ACCOUNT_JSON → GOOGLE_APPLICATION_CREDENTIALS → ADC.
 
-        Priority: 1. Explicit ``extra['service_account_json']`` (path or inline JSON) 2. 3. Application
-        Default Credentials via ``google.auth.default()`` — works on Cloud Run / GCE / GKE with a workload
-        identity attached, or locally via ``gcloud auth application-default login``. Lets operators run the
-        gateway in GCP without managing SA key files. Pattern lifted from PR #14965.
+        The JSON may be ``type: service_account`` (downloaded key) or
+        ``type: external_account`` (WIF / ADC config). ADC via
+        ``google.auth.default()`` covers Cloud Run / GCE / GKE workload identity
+        and local ``gcloud auth application-default login``.
         """
-        sa_path = self.config.extra.get("service_account_json") or _get_scoped_secret("GOOGLE_APPLICATION_CREDENTIALS")
+        sa_path = (
+            self.config.extra.get("service_account_json")
+            or _get_scoped_secret("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
+            or _get_scoped_secret("GOOGLE_APPLICATION_CREDENTIALS")
+        )
         try:
             credentials = _load_sa_credentials_from(sa_path)
         except _SACredentialError as err:
@@ -1637,6 +1675,8 @@ _STANDALONE_SA_ERRORS = {
                     "not in this profile's secret scope"),
     "adc_no_auth": "no SA credentials configured and google-auth is not installed for ADC fallback",
     "adc_failed": "no SA credentials configured and Application Default Credentials are unavailable: {exc}",
+    "unsupported_type": ("credential JSON type is not supported; use type 'service_account' or "
+                         "'external_account'"),
 }
 
 

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1560,6 +1560,89 @@ class TestADCFallback:
         assert "google_chat_service_account_json" in msg
 
 
+class TestWifExternalAccountCredentials:
+    """WIF external_account files must not be parsed as SA keys."""
+
+    def _ensure_sa_module(self, monkeypatch):
+        sa_mod = _gc_mod.service_account or MagicMock()
+        monkeypatch.setattr(_gc_mod, "service_account", sa_mod)
+        return sa_mod
+
+    def _install_google_auth_package(self, monkeypatch, **attrs):
+        """Make `import google.auth` work even when tests stub google as MagicMock."""
+        google_pkg = types.ModuleType("google")
+        google_pkg.__path__ = []
+        auth_mod = types.ModuleType("google.auth")
+        for key, value in attrs.items():
+            setattr(auth_mod, key, value)
+        google_pkg.auth = auth_mod
+        monkeypatch.setitem(sys.modules, "google", google_pkg)
+        monkeypatch.setitem(sys.modules, "google.auth", auth_mod)
+        return auth_mod
+
+    def test_service_account_uses_sa_parser(self, monkeypatch):
+        fake = MagicMock(name="sa_creds")
+        sa_mod = self._ensure_sa_module(monkeypatch)
+        monkeypatch.setattr(
+            sa_mod.Credentials,
+            "from_service_account_info",
+            MagicMock(return_value=fake),
+        )
+        info = {
+            "type": "service_account",
+            "client_email": "bot@example.iam.gserviceaccount.com",
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
+        assert _gc_mod._credentials_from_info(info) is fake
+
+    def test_external_account_uses_wif_loader(self, monkeypatch):
+        fake = object()
+        loader = MagicMock(return_value=(fake, "proj"))
+        self._install_google_auth_package(monkeypatch, load_credentials_from_dict=loader)
+        sa_mod = self._ensure_sa_module(monkeypatch)
+        sa_parser = MagicMock(side_effect=AssertionError("SA parser must not run for WIF"))
+        monkeypatch.setattr(sa_mod.Credentials, "from_service_account_info", sa_parser)
+        info = {
+            "type": "external_account",
+            "audience": "//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/p",
+            "subject_token_type": "urn:ietf:params:oauth:token-type:mtls",
+            "token_url": "https://sts.googleapis.com/v1/token",
+            "credential_source": {"file": "/dev/null"},
+        }
+        assert _gc_mod._credentials_from_info(info) is fake
+        sa_parser.assert_not_called()
+        loader.assert_called_once()
+        args, kwargs = loader.call_args
+        assert args[0] is info
+        assert kwargs.get("scopes") == _gc_mod._CHAT_SCOPES
+
+    def test_unknown_type_explains_supported_formats(self):
+        with pytest.raises(_gc_mod._SACredentialError) as ei:
+            _gc_mod._credentials_from_info({"type": "authorized_user"})
+        assert ei.value.kind == "unsupported_type"
+
+    def test_load_sa_credentials_from_wif_file_does_not_use_sa_parser(
+        self, monkeypatch, tmp_path
+    ):
+        wif = tmp_path / "wif.json"
+        wif.write_text(json.dumps({
+            "type": "external_account",
+            "audience": "//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/p",
+            "subject_token_type": "urn:ietf:params:oauth:token-type:mtls",
+            "token_url": "https://sts.googleapis.com/v1/token",
+            "credential_source": {"file": "/dev/null"},
+        }), encoding="utf-8")
+        fake = object()
+        loader = MagicMock(return_value=(fake, None))
+        self._install_google_auth_package(monkeypatch, load_credentials_from_dict=loader)
+        sa_mod = self._ensure_sa_module(monkeypatch)
+        sa_parser = MagicMock(side_effect=AssertionError("SA parser must not run for WIF"))
+        monkeypatch.setattr(sa_mod.Credentials, "from_service_account_info", sa_parser)
+        assert _gc_mod._load_sa_credentials_from(str(wif)) is fake
+        sa_parser.assert_not_called()
+        loader.assert_called_once()
+
+
 class TestGoogleChatInteractiveSetup:
     def test_interactive_setup_uses_shared_cli_prompt_helpers(self, monkeypatch):
         """Google Chat setup should not import prompt helpers from config.py."""

--- a/website/docs/user-guide/messaging/google_chat.md
+++ b/website/docs/user-guide/messaging/google_chat.md
@@ -166,6 +166,24 @@ GOOGLE_CHAT_MAX_BYTES=16777216                  # 16 MiB — cap on in-flight me
 The project ID also falls back to `GOOGLE_CLOUD_PROJECT`, and the SA path falls
 back to `GOOGLE_APPLICATION_CREDENTIALS` — use whichever convention you prefer.
 
+Hermes accepts two Google credential JSON types at that path:
+
+- `type: service_account` — a downloaded service-account key (the official Chat quickstart).
+- `type: external_account` — a Workload Identity Federation / ADC config (no long-lived key).
+
+Do **not** point `GOOGLE_CHAT_SERVICE_ACCOUNT_JSON` at a WIF file and expect the
+service-account key parser to work. WIF configs have `audience` / `token_url`, not
+`client_email` / `token_uri`. Older Hermes always called
+`from_service_account_info` and failed with:
+
+```text
+Service account info was not in the expected format, missing fields client_email, token_uri.
+```
+
+Leave `GOOGLE_CHAT_SERVICE_ACCOUNT_JSON` unset when using WIF and set
+`GOOGLE_APPLICATION_CREDENTIALS` to the `external_account` cred-config instead.
+mTLS WIF from the Hermes venv also needs `pyOpenSSL`.
+
 Under a [multi-profile gateway](../multi-profile-gateways.md), every
 `GOOGLE_CHAT_*` setting is read from the routed profile's own `.env`; a
 secondary profile never inherits the default profile's project, subscription,
@@ -345,6 +363,13 @@ evicts only that user's cache. Users don't disrupt each other.
 3. Check `hermes gateway` logs for `[GoogleChat] Connected`. If you see
    `[GoogleChat] Config validation failed`, the error message tells you which
    env var to fix.
+
+**`Service account info was not in the expected format, missing fields client_email, token_uri`**
+
+The configured JSON is a WIF `external_account` file, but Hermes was parsing it
+as a downloaded service-account key. Point `GOOGLE_APPLICATION_CREDENTIALS` at
+the WIF cred-config and leave `GOOGLE_CHAT_SERVICE_ACCOUNT_JSON` unset, or use
+a real `type: service_account` key. Current Hermes loads both types.
 
 **Bot replies but an error message appears instead of the agent's answer.**
 


### PR DESCRIPTION
## What does this PR do?

Google Chat currently treats every credential JSON as a downloaded service-account key. That is wrong for Workload Identity Federation.

A WIF / ADC cred-config is `type: external_account`. It has `audience`, `token_url`, and a credential source. It does **not** have `client_email` or `token_uri`. The adapter still called `google.oauth2.service_account.Credentials.from_service_account_info(...)`, so gateway connect failed with:

```text
Service account info was not in the expected format, missing fields client_email, token_uri.
```

That error looks like "the format is not correct" in Google Chat / gateway health, even when IAM, Pub/Sub, and ADC are fine. Cron `deliver=google_chat` hit the same parser on the standalone send path.

This PR branches on JSON `type` in the shared loader used by both the live adapter and standalone send:

- `service_account` → existing SA key parser
- `external_account` → `google.auth.load_credentials_from_dict` with `chat.bot` + `pubsub` scopes
- anything else → a clear error naming those two types

It also honors `GOOGLE_CHAT_SERVICE_ACCOUNT_JSON` on the adapter path (standalone already did) and documents the two formats.

## Related Issue

No existing issue for this symptom. Closest related work is multiplex SA scoping (`#57674`, `#73445`), which did not add a WIF loader.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/google_chat/adapter.py` — `_credentials_from_info()`; `_load_sa_credentials_from()` no longer always uses `from_service_account_info`
- `tests/gateway/test_google_chat.py` — WIF vs SA parser tests
- `website/docs/user-guide/messaging/google_chat.md` — credential types + troubleshooting for the MalformedError

## How to Test

1. Point `GOOGLE_APPLICATION_CREDENTIALS` at a WIF `external_account` JSON (leave `GOOGLE_CHAT_SERVICE_ACCOUNT_JSON` unset).
2. Confirm `jq -r .type "$GOOGLE_APPLICATION_CREDENTIALS"` prints `external_account`.
3. Restart the gateway and look for:
   - `[GoogleChat] Loaded external_account (WIF) credentials`
   - `[GoogleChat] Connected; project=..., inbound=pubsub`
4. Regression: a real `type: service_account` key still connects.

Local proof on this change:

```text
PYTHONPATH=. python -m pytest tests/gateway/test_google_chat.py::TestWifExternalAccountCredentials tests/gateway/test_google_chat.py::TestADCFallback tests/gateway/test_google_chat.py::TestEnvConfigLoading::test_multiplex_scoped_profile_never_borrows_process_env -q
# 6 passed
```

Live WIF refresh + Pub/Sub `get_subscription` also succeeded against a real external_account config before this PR.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(google-chat): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the Google Chat credential tests above, not the full suite)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu/WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — English Google Chat guide
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — credential JSON type is platform-agnostic; mTLS WIF still needs `pyOpenSSL` in the Hermes venv
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before:

```text
[GoogleChat] Config validation failed: Service account info was not in the expected format, missing fields client_email, token_uri.
✗ google_chat failed to connect
```

After:

```text
[GoogleChat] Loaded external_account (WIF) credentials
[GoogleChat] Connected; project=..., inbound=pubsub
```
