### PR TITLE
feat(tts): tune the first streaming sentence independently of later batching

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1477,6 +1477,14 @@ platform_toolsets:
 # tts:
 #   provider: "gemini"
 #   speed: 1.0              # global speed multiplier (provider-specific overrides this)
+#   streaming:
+#     # Positive integer; default 20 preserves normal sentence batching.
+#     # Set to 1 to start a complete short opener (e.g. "Yes.") at its sentence
+#     # boundary. Only the first emitted sentence uses this threshold; later
+#     # sentences keep the 20-character minimum. Applies to the gateway, CLI
+#     # speaker pipeline, and speak-stream WebSocket. Does not change punctuation
+#     # detection; an idle/end-of-text flush also counts as the first emission.
+#     first_sentence_min_chars: 20
 #   gemini:
 #     model: "gemini-3.1-flash-tts-preview"
 #     voice: "Kore"

--- a/contributors/emails/francip@kortexa.ai
+++ b/contributors/emails/francip@kortexa.ai
@@ -1,0 +1,1 @@
+francip

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -34,7 +34,7 @@ class StreamingTTSConsumer:
         self._adapter, self._chat_id, self._loop, self._metadata = adapter, chat_id, loop, metadata
         # Resolved once; None => inactive, gateway falls back to whole-file TTS.
         self._streamer = resolve_streaming_provider(tts_config)
-        self._chunker = SentenceChunker()
+        self._chunker = SentenceChunker.from_config(tts_config)
         self._audio_format = audio_format or AudioFormat() if self._streamer is None else (
             AudioFormat(**{f: int(getattr(self._streamer, f, getattr(AudioFormat, f)))
                            for f in ("sample_rate", "channels", "sample_width")})

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -997,6 +997,10 @@ DEFAULT_CONFIG = {
         # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" |
         # "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
         "provider": "edge",
+        "streaming": {
+            # Lower only the first sentence's threshold; subsequent sentences still batch at 20.
+            "first_sentence_min_chars": 20,
+        },
         "edge": {
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
             "voice": "en-US-AriaNeural",

--- a/hermes_cli/web_routers/audio.py
+++ b/hermes_cli/web_routers/audio.py
@@ -371,16 +371,16 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
     loop = asyncio.get_running_loop()
 
     def _resolve():
-        from tools.tts_streaming import resolve_streaming_provider
+        from tools.tts_streaming import SentenceChunker, resolve_streaming_provider
         from tools.tts_tool import _get_provider, _load_tts_config, _resolve_max_text_length
         with _config_profile_scope(profile):
             cfg = _load_tts_config()
             streamer = resolve_streaming_provider(cfg)
             cap = _resolve_max_text_length(_get_provider(cfg), cfg) if streamer else 0
-        return streamer, cap
+        return streamer, cap, SentenceChunker.from_config(cfg)
 
     try:
-        streamer, cap = await loop.run_in_executor(None, _resolve)
+        streamer, cap, chunker = await loop.run_in_executor(None, _resolve)
     except Exception:
         _log.exception("speak-stream provider resolution failed")
         streamer, cap = None, 0
@@ -399,10 +399,7 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
     chunks: asyncio.Queue = asyncio.Queue()  # PCM out; None = synthesis done
 
     def _produce():
-        from tools.tts_streaming import SentenceChunker
         from tools.tts_text_normalize import _strip_markdown_for_tts
-
-        chunker = SentenceChunker()
 
         # The session stays open for a whole agent turn and no text arrives
         # during tool execution, so without an idle flush a narration line with

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -48,8 +48,12 @@ def test_profile_first_sentence_threshold_preserves_later_batching(value, tmp_pa
         consumer.start()
         consumer.finish()
         assert await consumer.wait_complete()
-        expected = (["Yes.", "OK. This is the longer sentence."] if tuned else
-                    ["Yes. OK. This is the longer sentence."])
+        if tuned:
+            expected = ["Yes.", "OK. This is the longer sentence."]
+        elif type(value) is int and value == 6:
+            expected = ["Yes. OK.", "This is the longer sentence."]
+        else:
+            expected = ["Yes. OK. This is the longer sentence."]
         assert calls == expected + ["Tail"]
         assert adapter.finish_count == 1
         assert consumer.completed and not consumer.partial

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -20,6 +20,43 @@ from gateway.streaming_tts_consumer import StreamingTTSConsumer
 from tools.tts_streaming import SentenceChunker
 
 
+@pytest.mark.parametrize("value", [None, 1, 6, 20, 0, -1, True, "1", 1.5, float("inf")])
+def test_profile_first_sentence_threshold_preserves_later_batching(value, tmp_path, monkeypatch):
+    import yaml
+    from tools.tts_tool import _load_tts_config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+        "tts": {"streaming": {"first_sentence_min_chars": value}},
+    }))
+    calls = []
+
+    class TrackingStreamer(FakeStreamer):
+        def stream(self, text):
+            calls.append(text)
+            yield from super().stream(text)
+
+    monkeypatch.setattr("tools.tts_streaming.resolve_streaming_provider", lambda cfg: TrackingStreamer())
+
+    async def run(loop):
+        adapter = FakeVoiceAdapter()
+        consumer = StreamingTTSConsumer(adapter, "chat", _load_tts_config(), loop)
+        consumer.on_delta("Yes. ")
+        tuned = type(value) is int and value == 1
+        assert consumer._queue.qsize() == (1 if tuned else 0)
+        consumer.on_delta("OK. This is the longer sentence. Tail")
+        consumer.start()
+        consumer.finish()
+        assert await consumer.wait_complete()
+        expected = (["Yes.", "OK. This is the longer sentence."] if tuned else
+                    ["Yes. OK. This is the longer sentence."])
+        assert calls == expected + ["Tail"]
+        assert adapter.finish_count == 1
+        assert consumer.completed and not consumer.partial
+
+    _run_test(run)
+
+
 # ---------------------------------------------------------------------------
 # Fakes
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server_speak_stream.py
+++ b/tests/hermes_cli/test_web_server_speak_stream.py
@@ -61,20 +61,26 @@ def _patch_provider(monkeypatch, streamer, cap=4000):
 
 
 
-def test_streams_pcm_frames_then_end(stream_client, monkeypatch):
+@pytest.mark.parametrize("first_min_chars", [None, 1])
+def test_streams_pcm_frames_then_end(stream_client, monkeypatch, first_min_chars):
     streamer = _FakeStreamer([b"\x01\x02\x03\x04", b"\x05\x06"])
     _patch_provider(monkeypatch, streamer)
+    config = {} if first_min_chars is None else {"streaming": {"first_sentence_min_chars": first_min_chars}}
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: config)
+    text = "Hello there." if first_min_chars is None else "Yes. OK. This is the next full sentence."
+    expected = [text] if first_min_chars is None else ["Yes.", "OK. This is the next full sentence."]
 
     with stream_client.websocket_connect(_url()) as conn:
         start = conn.receive_json()
         assert start == {"type": "start", "sample_rate": 24000, "channels": 1}
 
-        conn.send_text(json.dumps({"text": "Hello there.", "done": True}))
-        assert conn.receive_bytes() == b"\x01\x02\x03\x04"
-        assert conn.receive_bytes() == b"\x05\x06"
+        conn.send_text(json.dumps({"text": text, "done": True}))
+        for _ in expected:
+            assert conn.receive_bytes() == b"\x01\x02\x03\x04"
+            assert conn.receive_bytes() == b"\x05\x06"
         assert conn.receive_json() == {"type": "end"}
 
-    assert streamer.requests == ["Hello there."]
+    assert streamer.requests == expected
 
 
 
@@ -120,5 +126,4 @@ def test_split_text_respects_cap_and_preserves_content():
     joined = " ".join(pieces)
     for word in text.replace(".", "").split():
         assert word in joined
-
 

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -25,6 +25,33 @@ pytest.importorskip("numpy")
 
 
 class TestSentenceChunker:
+    @pytest.mark.parametrize("first_min_len", [None, 1, 6])
+    @pytest.mark.parametrize("split_at", range(6))
+    def test_first_threshold_ends_at_first_nonempty_emission(self, first_min_len, split_at):
+        c = ts.SentenceChunker(first_min_len=first_min_len)
+        assert c.feed("<think>private</think>") == []
+        assert c.flush() == []  # An empty flush must not consume the first-sentence override.
+        opener = "Yes. "
+        opening = c.feed(opener[:split_at]) + c.feed(opener[split_at:])
+        assert opening == ([opener] if first_min_len == 1 else [])
+        assert c.feed("OK. ") == []  # Later short sentences still batch normally.
+        rest = c.feed("This is the longer sentence. Tail")
+        assert rest == ["OK. This is the longer sentence. " if opening else
+                        "Yes. OK. This is the longer sentence. "]
+        assert c.flush() == ["Tail"]
+        assert c.flush() == []
+        assert "".join(opening + rest + ["Tail"]) == "Yes. OK. This is the longer sentence. Tail"
+
+        # Several sentences in one delta obey the same first-only rule.
+        batched = ts.SentenceChunker(first_min_len=first_min_len)
+        assert batched.feed("Yes. OK. This is the longer sentence. ") == opening + rest
+
+        # An idle flush of a nonempty tail counts as the first emitted sentence.
+        idle = ts.SentenceChunker(first_min_len=first_min_len)
+        assert idle.feed("Hi") == []
+        assert idle.flush() == ["Hi"]
+        assert idle.feed("OK. ") == []
+
     def test_cuts_sentence_the_moment_its_boundary_arrives(self):
         c = ts.SentenceChunker()
         assert c.feed("This is the first full") == []
@@ -461,7 +488,8 @@ def test_streamer_tempfile_fallback_after_reinit_exhausted(monkeypatch):
     sys.platform == "darwin",
     reason="macOS deliberately skips the sounddevice OutputStream path (PR #62601)",
 )
-def test_hybrid_first_sentence_streamed_individually(monkeypatch):
+@pytest.mark.parametrize("first_min_chars", [None, 1])
+def test_hybrid_first_sentence_streamed_individually(monkeypatch, first_min_chars):
     """The first sentence must get its own stream() call for low TTFA."""
     from tools import tts_tool
     from tools.tts_tool_speaker import stream_tts_to_speaker
@@ -480,7 +508,10 @@ def test_hybrid_first_sentence_streamed_individually(monkeypatch):
             yield b"\x00\x00" * 10
 
     sd, out = _sd_mock()
-    q = _drain_queue(["This is the first complete sentence."])
+    text = "This is the first complete sentence." if first_min_chars is None else "Yes. OK. This is the next full sentence."
+    config = {} if first_min_chars is None else {"streaming": {"first_sentence_min_chars": first_min_chars}}
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: config)
+    q = _drain_queue([text])
     stop, done = threading.Event(), threading.Event()
 
     with patch("tools.tts_streaming.resolve_streaming_provider",
@@ -488,9 +519,8 @@ def test_hybrid_first_sentence_streamed_individually(monkeypatch):
          patch.object(tts_tool, "_import_sounddevice", return_value=sd):
         stream_tts_to_speaker(q, stop, done)
 
-    assert len(stream_calls) == 1, (
-        f"single sentence should trigger 1 stream() call, got {stream_calls}"
-    )
+    assert stream_calls == ([text] if first_min_chars is None else
+                            ["Yes.", "OK. This is the next full sentence."])
     assert done.is_set()
 
 

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -34,17 +34,20 @@ class TestSentenceChunker:
         opener = "Yes. "
         opening = c.feed(opener[:split_at]) + c.feed(opener[split_at:])
         assert opening == ([opener] if first_min_len == 1 else [])
-        assert c.feed("OK. ") == []  # Later short sentences still batch normally.
+        middle = c.feed("OK. ")
+        assert middle == (["Yes. OK. "] if first_min_len == 6 else [])
         rest = c.feed("This is the longer sentence. Tail")
-        assert rest == ["OK. This is the longer sentence. " if opening else
-                        "Yes. OK. This is the longer sentence. "]
+        expected_rest = {1: "OK. This is the longer sentence. ",
+                         6: "This is the longer sentence. "}.get(first_min_len,
+                         "Yes. OK. This is the longer sentence. ")
+        assert rest == [expected_rest]
         assert c.flush() == ["Tail"]
         assert c.flush() == []
-        assert "".join(opening + rest + ["Tail"]) == "Yes. OK. This is the longer sentence. Tail"
+        assert "".join(opening + middle + rest + ["Tail"]) == "Yes. OK. This is the longer sentence. Tail"
 
         # Several sentences in one delta obey the same first-only rule.
         batched = ts.SentenceChunker(first_min_len=first_min_len)
-        assert batched.feed("Yes. OK. This is the longer sentence. ") == opening + rest
+        assert batched.feed("Yes. OK. This is the longer sentence. ") == opening + middle + rest
 
         # An idle flush of a nonempty tail counts as the first emitted sentence.
         idle = ts.SentenceChunker(first_min_len=first_min_len)

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -66,11 +66,25 @@ _THINK_BLOCK_RE = re.compile(r"<think[\s>].*?</think>", flags=re.DOTALL)
 class SentenceChunker:
     """Incremental sentence cutter for LLM token deltas, shared by the speaker pipeline and the
     speak-stream WebSocket so every surface cuts speech identically. Strips ``<think>`` blocks (even
-    split across deltas) and merges fragments shorter than *min_len* into the following sentence."""
+    split across deltas) and merges fragments shorter than *min_len* into the following sentence.
+    *first_min_len* can release a short opener sooner without changing later batching."""
 
-    def __init__(self, min_len: int = 20):
+    def __init__(self, min_len: int = 20, *, first_min_len: Optional[int] = None):
         self.min_len = min_len
+        self._next_min_len = min_len if first_min_len is None else first_min_len
         self.buf = ""
+
+    @classmethod
+    def from_config(cls, tts_config: Dict) -> SentenceChunker:
+        """Use the same first-sentence setting on every streaming speech surface."""
+        streaming = tts_config.get("streaming")
+        value = streaming.get("first_sentence_min_chars") if isinstance(streaming, dict) else None
+        if value is None:
+            return cls()
+        if type(value) is not int or value < 1:
+            logger.warning("Invalid tts.streaming.first_sentence_min_chars; using the default")
+            return cls()
+        return cls(first_min_len=value)
 
     def feed(self, delta: str) -> List[str]:
         """Absorb *delta*; return every complete sentence now ready to speak."""
@@ -81,10 +95,11 @@ class SentenceChunker:
         start = 0  # skip boundaries that would leave the head too short
         while m := SENTENCE_BOUNDARY_RE.search(self.buf, start):
             head = self.buf[: m.end()]
-            if len(head.strip()) < self.min_len:
+            if len(head.strip()) < self._next_min_len:
                 start = m.end()
                 continue
             out.append(head)
+            self._next_min_len = self.min_len
             self.buf = self.buf[m.end():]
             start = 0
         return out
@@ -92,6 +107,8 @@ class SentenceChunker:
     def flush(self) -> List[str]:
         """Drain the tail (end-of-text or long-idle flush)."""
         tail, self.buf = _THINK_BLOCK_RE.sub("", self.buf).strip(), ""
+        if tail:
+            self._next_min_len = self.min_len
         return [tail] if tail else []
 
 

--- a/tools/tts_tool_speaker.py
+++ b/tools/tts_tool_speaker.py
@@ -302,7 +302,7 @@ def stream_tts_to_speaker(
                 stream_max_len = origin._resolve_max_text_length(
                     provider or origin._get_provider(tts_config), tts_config)
             playback = _StreamerPlayback(streamer, stop_event)
-        chunker = SentenceChunker()
+        chunker = SentenceChunker.from_config(tts_config)
         spoken_sentences: list[str] = []  # skip duplicate/near-duplicate sentences (LLM repetition)
 
         def _speak_sentence(sentence: str) -> None:


### PR DESCRIPTION
## Consolidated implementation

The first-emission-only control, shared gateway/CLI/speak-stream wiring, validation and tests have been incorporated into #96933 at `e7e13fae4f35c7a8c0b6e0d2f50ed3a491fbbc42`, after its author invited our contribution. Authorship is preserved. [Author confirmation](https://github.com/NousResearch/hermes-agent/pull/96933#issuecomment-5576519223).

The resulting Git tree is identical to our reviewed follow-up (`36a9bf00daeb47b62f2c3d97ca0d401689247d28`). The combined implementation retains the configurable whole-response `min_len`; an omitted/null first override inherits that value, and later emissions restore that configured minimum. Pure-CJK sentence splitting remains separate in #78477.

Closing this PR as **superseded by #96933**, not merged. Shared issue tracking is #96927. The combined PR is still open; no upstream release or production branch change is implied. The original implementation and validation record below are retained for reference.

---

## What does this PR do?

Adds `tts.streaming.first_sentence_min_chars` so a complete short opening sentence can reach streaming TTS without waiting for the next sentence. The default stays 20. Lowering it applies only until the first nonempty emission; subsequent sentences still use the existing 20-character minimum.

The gateway, CLI speaker pipeline, and speak-stream WebSocket all construct the shared chunker through the same validated configuration path. Positive integers are accepted; invalid values fall back to the existing default. Empty flushes do not consume the override; nonempty idle/end-of-text flushes do.

## Related issue

Original report: #105235. Shared tracking: #96927; combined implementation: #96933.

#96933 now includes the first-emission-only override, shared consumer wiring, validation and tests from our follow-up contribution. The previous implementation comparison no longer applies. Punctuation/CJK boundary handling remains separate in #78477.

## Changes

- Add first-emission state and a shared `SentenceChunker.from_config` constructor.
- Wire gateway, CLI speaker, and profile-scoped speak-stream resolution.
- Document the default and tuning in config defaults and the example config.
- Add two parameterized behavior tests for emission lifetime and profile-to-consumer propagation; extend existing CLI/WebSocket tests.

No new dependencies, environment variables, provider integrations, or platform-specific runtime behavior.

## Validation

- macOS arm64 / Python 3.11.15: 165 passed, 16 skipped across seven focused speech/voice files.
- Linux arm64 / Python 3.11.16: 77 passed across the three directly changed test files, including the mocked CLI speaker path skipped on macOS.
- Red on unmodified upstream `233757037d`: the configured short-opener gateway case stayed unqueued; the WebSocket returned a combined sentence; the first-threshold constructor cases failed because the option was absent.
- All tests used `scripts/run_tests.sh` with retries disabled, isolated profiles, and no physical playback.
- Windows-footgun check: clean (8 files). `git diff --check`: clean.
- Full repository suite and native Windows execution were not run.

A prior controlled replay through the real streaming provider showed about 0.89 s less time to first PCM in one warm paired short-opener case. This is not a promised saving for every response or a physical-speaker measurement.

## Try it

```sh
hermes config set tts.streaming.first_sentence_min_chars 1
```

With streaming speech enabled and a chunked provider selected, a response beginning `Yes. ` can start synthesis at that sentence boundary. Later short sentences continue to batch normally.

## Checklist

- [x] Contribution guidance read; existing issues and PRs searched and overlap documented.
- [x] Focused conventional commits; no deployment-specific configuration or fork bookkeeping.
- [x] Tests cover text order, delta splitting, first-only lifetime, flushing, invalid settings, and consumer wiring.
- [x] Configuration defaults and example updated; default behavior preserved.
- [x] Cross-platform impact reviewed; no OS-specific changes.
