### PR TITLE
fix(oneshot): honor agent.max_turns in -z runs

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -381,6 +381,16 @@ def _run_agent(
 
     skills_prompt = _build_preloaded_skills_prompt(skills)
 
+    # The chat and cron paths both forward the configured cap; oneshot never did, so a set
+    # agent.max_turns was ignored. resolve_turn_limit() honors none/unlimited (sys.maxsize) and
+    # explicit 0 / null, so an unset cap stays unlimited.
+    from hermes_cli.config import resolve_turn_limit
+
+    max_turns = (cfg.get("agent") or {}).get("max_turns")
+    if max_turns is None:
+        max_turns = cfg.get("max_turns")
+    max_iterations = resolve_turn_limit(max_turns)
+
     session_db = _create_session_db_for_oneshot()
     # The try spans agent construction (not just ``chat``) so the store is always closed, even when
     # ``AIAgent(...)`` raises — the one-shot exit path hard-exits via os._exit and skips finalizers.
@@ -400,6 +410,7 @@ def _run_agent(
             credential_pool=runtime.get("credential_pool"),
             fallback_model=get_fallback_chain(cfg) or None,
             ephemeral_system_prompt=skills_prompt,
+            max_iterations=max_iterations,
             # The only interactive callback wired: no user sits at a terminal. Sudo prompts gate on
             # HERMES_INTERACTIVE (never set), hook approval via HERMES_ACCEPT_HOOKS=1, dangerous
             # commands via HERMES_YOLO_MODE=1, skill secret capture degrades gracefully.

--- a/tests/hermes_cli/test_oneshot_max_turns.py
+++ b/tests/hermes_cli/test_oneshot_max_turns.py
@@ -1,0 +1,78 @@
+"""Oneshot (-z) must forward the configured turn cap, like the chat and cron paths do.
+
+``_run_agent`` builds its AIAgent directly and passed no ``max_iterations``, so a configured
+``agent.max_turns`` was ignored and every -z run went unbounded. An unset cap stays unlimited,
+which is the schema default the gateway and cron also resolve to.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+import hermes_cli.oneshot as oneshot
+
+
+def _build_agent(monkeypatch, cfg) -> dict:
+    """Run ``_run_agent`` against stubs and return the kwargs AIAgent was constructed with."""
+    import hermes_cli.config
+    import hermes_cli.mcp_startup
+    import hermes_cli.runtime_provider
+    import hermes_cli.tools_config
+    import run_agent
+
+    monkeypatch.setattr(hermes_cli.config, "load_config", lambda *a, **k: cfg)
+    monkeypatch.setattr(
+        hermes_cli.runtime_provider, "resolve_runtime_provider", lambda **k: {"provider": "openai"}
+    )
+    monkeypatch.setattr(hermes_cli.tools_config, "_get_platform_tools", lambda *a, **k: set())
+    monkeypatch.setattr(
+        hermes_cli.mcp_startup, "ensure_mcp_discovery_before_agent_build", lambda **k: None
+    )
+    monkeypatch.setattr(oneshot, "get_fallback_chain", lambda *a, **k: [])
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.setattr(oneshot, "_close_agent", lambda *a, **k: None)
+
+    seen = {}
+
+    def _fake_agent(**kwargs):
+        seen.update(kwargs)
+        return types.SimpleNamespace(
+            run_conversation=lambda _prompt: {"final_response": "ok"},
+            suppress_status_output=False,
+            stream_delta_callback=None,
+            tool_gen_callback=None,
+        )
+
+    monkeypatch.setattr(run_agent, "AIAgent", _fake_agent)
+
+    oneshot._run_agent("hi")
+    return seen
+
+
+def test_max_turns_becomes_max_iterations(monkeypatch):
+    seen = _build_agent(monkeypatch, {"model": {"default": "gpt-5"}, "agent": {"max_turns": 7}})
+    assert seen["max_iterations"] == 7
+
+
+def test_legacy_root_level_max_turns_still_applies(monkeypatch):
+    """The root-level key is never migrated on disk; cron keeps the same fallback."""
+    seen = _build_agent(monkeypatch, {"model": {"default": "gpt-5"}, "max_turns": 5})
+    assert seen["max_iterations"] == 5
+
+
+@pytest.mark.parametrize("cfg_agent", [{}, {"max_turns": None}])
+def test_unset_max_turns_stays_unlimited(monkeypatch, cfg_agent):
+    """null = unlimited is the documented schema default (caps truncated runs mid-task)."""
+    seen = _build_agent(monkeypatch, {"model": {"default": "gpt-5"}, "agent": cfg_agent})
+    assert seen["max_iterations"] == sys.maxsize
+
+
+@pytest.mark.parametrize("spelling", ["none", "unlimited", 0])
+def test_unlimited_spellings_stay_unbounded(monkeypatch, spelling):
+    seen = _build_agent(
+        monkeypatch, {"model": {"default": "gpt-5"}, "agent": {"max_turns": spelling}}
+    )
+    assert seen["max_iterations"] == sys.maxsize

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -151,6 +151,7 @@ def _stub_plugin_discovery(monkeypatch):
 
 def test_oneshot_wires_session_db_for_recall(monkeypatch):
     """hermes -z bypasses HermesCLI, but recall still needs SessionDB."""
+    from hermes_cli.config import resolve_turn_limit
     from hermes_cli.oneshot import _run_agent
 
     captured = {}
@@ -182,7 +183,11 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.config",
-        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}}),
+        mod(
+            "hermes_cli.config",
+            load_config=lambda: {"model": {"default": "m"}},
+            resolve_turn_limit=resolve_turn_limit,
+        ),
     )
     monkeypatch.setitem(
         sys.modules,


### PR DESCRIPTION
## What does this PR do?

`hermes -z` builds its `AIAgent` directly in `hermes_cli/oneshot.py::_run_agent` and never passes `max_iterations`, so a configured `agent.max_turns` is silently ignored and every one-shot run gets the constructor default (`sys.maxsize`). You can see it in the session record: `model_config.max_iterations: 9223372036854775807` even with `agent.max_turns: 600` in config. Chat (`cli.py::_init_turn_limits` → `max_iterations=self.max_turns`) and cron (`cron/scheduler.py`) both forward the cap; one-shot was the only entry point that dropped it.

This resolves the cap the same way cron does — `agent.max_turns`, then the legacy root-level `max_turns`, through `hermes_cli.config.resolve_turn_limit` so the `none`/`unlimited`/`0` spellings keep meaning unlimited — and passes it as `max_iterations`. An unset cap stays unlimited, which is the documented schema default (`config_defaults.py`: `max_turns: null` = unlimited) and what cron and the gateway already resolve to, so nobody's existing `-z` scripts change behaviour. Only a value the user actually set now takes effect.

Deliberately not touched here: the reasoning half of the same wiring gap (`reasoning_config`), which already has #70022 / #70023 / #82773 / #85164.

## Related Issue

Fixes #105243

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/oneshot.py`: resolve `agent.max_turns` (root-level fallback) via `resolve_turn_limit` and forward it as `max_iterations` to `AIAgent`.
- `tests/hermes_cli/test_oneshot_max_turns.py` (new): set value forwarded, legacy root-level key forwarded, absent/null stays `sys.maxsize`, `none`/`unlimited`/`0` stay `sys.maxsize`.
- `tests/hermes_cli/test_tui_resume_flow.py`: `test_oneshot_wires_session_db_for_recall` stubs the whole `hermes_cli.config` module, so the stub now also exposes `resolve_turn_limit`.

## How to Test

1. `hermes config set agent.max_turns 600`
2. `hermes -z "Reply with OK." --usage-file /tmp/usage.json`
3. Inspect the session's `model_config` (`hermes sessions export --session-id <id> --format jsonl -`): before this change `max_iterations` is `9223372036854775807`, after it is `600`. With the key unset it stays `9223372036854775807` both before and after.
4. `pytest tests/hermes_cli/test_oneshot_max_turns.py tests/hermes_cli/test_tui_resume_flow.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the `hermes_cli` oneshot/TUI-resume/MCP-discovery/turn-limit/argparse scopes (113 passed) plus config/setup/gateway-env-bridge scopes (170 passed, 4 skipped), not the full tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.3.1 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
