### PR TITLE
config: preserve comments when saving config.yaml

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -30,7 +30,7 @@ from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul
 from hermes_cli.secret_prompt import masked_secret_prompt
 # Re-export from hermes_constants — canonical definition lives there.
 from hermes_constants import get_hermes_home, get_process_hermes_home  # noqa: F401
-from utils import atomic_replace, atomic_yaml_write, fast_safe_load
+from utils import atomic_replace, atomic_roundtrip_yaml_save, atomic_yaml_write, fast_safe_load
 
 logger = logging.getLogger(__name__)
 
@@ -2340,7 +2340,14 @@ def save_config(
             effective_preserve_keys = _explicit_config_paths(_raw_for_paths) | set(preserve_keys or ())
             normalized = _strip_default_values(normalized, DEFAULT_CONFIG, preserve_keys=effective_preserve_keys)
 
-        atomic_yaml_write(config_path, normalized, extra_content=_commented_sections_for_save(normalized))
+        if os.path.exists(config_path):
+            # Round-trip so hand-written comments survive. config.yaml is where the rationale for
+            # deliberate settings lives, and a migration rewrites the WHOLE file through this
+            # function -- with the PyYAML dumper that silently erases every comment in it.
+            # New files still go through atomic_yaml_write so the commented example blocks land.
+            atomic_roundtrip_yaml_save(config_path, normalized)
+        else:
+            atomic_yaml_write(config_path, normalized, extra_content=_commented_sections_for_save(normalized))
         _secure_file(config_path)
         _RAW_CONFIG_CACHE.pop(str(config_path), None)
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)


### PR DESCRIPTION
## Problem

`save_config()` writes through `atomic_yaml_write()` — the PyYAML dumper — which
reconstructs the file from the parsed dict and cannot represent comments.

Every migration step persists via `_persist_migration()` → `save_config()`, and each
rewrites the **whole** file. So one `hermes update` that crosses a migration boundary
erases every comment in the user's `config.yaml` and in every `profiles/*/config.yaml`,
silently and with no warning.

This bit me on a real install: a v40 → v41 migration changed nothing but
`_config_version` and took ~75 lines of rationale with it — why `max_tokens` and
`context_length` are set where they are, which toolsets are disabled and why, and a
header note recording that an earlier v31 → v32 step had silently rewritten
`verify_on_stop: true` → `false`. That last one is the reason this is worth fixing:
the comments explaining which settings a past migration quietly reverted are exactly
the comments the next migration deletes, so the next accidental revert is that much
harder to spot.

## Fix

Route existing files through `utils.atomic_roundtrip_yaml_save()`, which already exists
for precisely this — its docstring reads *"Comment-safe replacement for
`yaml.safe_dump(cfg, f)`"*. It:

- is covered by `tests/test_utils_atomic_roundtrip_yaml_save.py`
- handles the YAML 1.1 `on/off/yes/no` re-quoting trap
- uses the same explicit-absence delete semantics `save_config` needs
- is already used by `tui_gateway/server.py`

It just was never wired into this path.

New files keep going through `atomic_yaml_write` so the commented example blocks from
`_commented_sections_for_save()` still land on a fresh install; on later saves the
round-trip writer preserves them like any other comment.

## Verification

A config carrying a top-of-file block, a standalone comment and a trailing inline
comment keeps all three across a `save_config()` that bumps `_config_version`, values
unchanged:

```
# TOP-OF-FILE NOTE: keep _config_version in sync; the v31->v32 migration
# rewrites verify_on_stop on any config stamped below v32.
model:
  default: deepseek-v4-flash
  # 16384: a wiki page must leave write_file in ONE turn; a tool call
  # truncated mid-arguments cannot be continued.
  max_tokens: 16384
agent:
  verify_on_stop: true      # deliberate: unattended work gets checked
_config_version: 41
```

Test suites run: `test_utils_atomic_roundtrip_yaml_save`,
`test_yaml_indent_consistency_31999`, `test_atomic_replace_symlinks` (39 passed,
4 skipped); `test_sibling_config_migration`, `test_personality_single_owner`,
`test_journal_mode_config`, `test_update_autostash` (74 passed). Gateway/integration
collection errors in this environment are pre-existing (`ModuleNotFoundError: aiohttp`,
reproduced on a clean tree).

## Note for reviewers

Draft because the `os.path.exists()` branch is the piece worth a second opinion —
whether a fresh install should also go through the round-trip writer with the example
blocks prepended, rather than keeping two write paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NykuJQJvXH18ZTAC3eUNx
