### PR TITLE
feat(desktop): edit delegation models and fallback policy

### DIFF
--- a/apps/desktop/src/api/config.ts
+++ b/apps/desktop/src/api/config.ts
@@ -83,9 +83,13 @@ export function getHermesConfigDefaults(): Promise<HermesConfigRecord> {
   })
 }
 
-export function getHermesConfigSchema(profile?: null | string): Promise<ConfigSchemaResponse> {
-  return hermesApi<ConfigSchemaResponse>({
-    ...profileScoped(profile),
+export type ConfigSchemaWithCapabilities = ConfigSchemaResponse & {
+  capabilities?: { delegation_fallbacks?: boolean }
+}
+
+export function getHermesConfigSchema(profile?: ProfileScope): Promise<ConfigSchemaWithCapabilities> {
+  return hermesApi<ConfigSchemaWithCapabilities>({
+    ...capabilityScoped(profile),
     path: '/api/config/schema'
   })
 }

--- a/apps/desktop/src/api/models-scope.test.ts
+++ b/apps/desktop/src/api/models-scope.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { setApiRequestConnection, setApiRequestProfile } from './client'
+import { getHermesConfigSchema, saveHermesConfigRecord } from './config'
+import { getGlobalModelOptions } from './models'
+
+afterEach(() => {
+  setApiRequestConnection(null)
+  setApiRequestProfile(null)
+  vi.unstubAllGlobals()
+})
+
+describe('model options owner scope', () => {
+  it('uses the same explicit owner for capability checks and delegation writes', async () => {
+    const api = vi.fn().mockResolvedValue({ ok: true, fields: {} })
+    vi.stubGlobal('window', { hermesDesktop: { api } })
+    setApiRequestConnection('ambient-gateway')
+    setApiRequestProfile('ambient-profile')
+    const scope = { connectionId: 'local', profile: 'worker-profile' }
+    await getHermesConfigSchema(scope)
+    await saveHermesConfigRecord({ delegation: { fallback_providers: [] } }, scope)
+    expect(api.mock.calls[0][0]).toMatchObject({ path: '/api/config/schema', ...scope })
+    expect(api.mock.calls[1][0]).toMatchObject({ path: '/api/config', method: 'PUT', ...scope })
+  })
+
+  it('pins the catalog to the same connection and profile as the configuration', async () => {
+    const api = vi.fn().mockResolvedValue({ providers: [] })
+    vi.stubGlobal('window', { hermesDesktop: { api } })
+    setApiRequestConnection('ambient-gateway')
+    setApiRequestProfile('ambient-profile')
+    await getGlobalModelOptions(undefined, { connectionId: 'worker-gateway', profile: 'worker-profile' })
+    expect(api).toHaveBeenCalledWith(expect.objectContaining({ connectionId: 'worker-gateway', profile: 'worker-profile' }))
+  })
+
+  it('preserves legacy profile-only callers', async () => {
+    const api = vi.fn().mockResolvedValue({ providers: [] })
+    vi.stubGlobal('window', { hermesDesktop: { api } })
+    setApiRequestConnection('ambient-gateway')
+    await getGlobalModelOptions(undefined, 'worker-profile')
+    expect(api).toHaveBeenCalledWith(expect.objectContaining({ connectionId: 'ambient-gateway', profile: 'worker-profile' }))
+  })
+})

--- a/apps/desktop/src/api/models.ts
+++ b/apps/desktop/src/api/models.ts
@@ -31,7 +31,7 @@ export function getGlobalModelOptions(
     includeUnconfigured?: boolean
     explicitOnly?: boolean
   },
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<ModelOptionsResponse> {
   const params = new URLSearchParams()
 
@@ -48,7 +48,7 @@ export function getGlobalModelOptions(
   }
 
   return hermesApi<ModelOptionsResponse>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: params.size > 0 ? `/api/model/options?${params.toString()}` : '/api/model/options',
     timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -32,6 +32,7 @@ import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
 import { PanelEmpty } from '../overlays/panel'
 
 import { ConfigField } from './config-field'
+import { DelegationModelSettings } from './delegation-model-settings'
 import {
   clearsEnabledToolsets,
   diffConfig,
@@ -285,7 +286,8 @@ function ConfigSettingsInner({
       return
     }
 
-    const element = document.getElementById(`setting-field-${targetField}`)
+    const resolvedField = targetField === 'delegation.provider' ? 'delegation.model' : targetField
+    const element = document.getElementById(`setting-field-${resolvedField}`)
 
     if (!element) {
       return
@@ -377,7 +379,9 @@ function ConfigSettingsInner({
     return <SettingsSkeleton sections={[{ rows: 6 }]} />
   }
 
-  const visibleFields = activeSectionId === 'voice' ? fields.filter(([key]) => voiceFieldVisible(key, config)) : fields
+  const visibleFields = fields.filter(([key]) =>
+    key !== 'delegation.provider' && (activeSectionId !== 'voice' || voiceFieldVisible(key, config))
+  )
 
   return (
     <SettingsContent>
@@ -387,6 +391,7 @@ function ConfigSettingsInner({
       {activeSectionId === 'model' && (
         <div className="mb-6">
           <ModelSettings onMainModelChanged={onMainModelChanged} scopeProfile={scopeProfile} />
+          <DelegationModelSettings scopeProfile={scopeProfile} />
         </div>
       )}
       {/* Device-local desktop prefs (not config.yaml) — they live here since
@@ -420,7 +425,9 @@ function ConfigSettingsInner({
         <div className="grid gap-1">
           {visibleFields.map(([key, field]) => (
             <div className="scroll-mt-6 rounded-lg" id={`setting-field-${key}`} key={key}>
-              <ConfigField
+              {key === 'delegation.model' ? (
+                <DelegationModelSettings scopeProfile={scopeProfile} />
+              ) : <ConfigField
                 descriptionExtra={
                   key === 'memory.provider' && isExternalMemoryProvider(getNested(config, key)) ? (
                     <MemoryConnect profile={scopeProfile} provider={String(getNested(config, key))} />
@@ -436,7 +443,7 @@ function ConfigSettingsInner({
                 schema={field}
                 schemaKey={key}
                 value={getNested(config, key)}
-              />
+              />}
               {key === 'memory.provider' && isExternalMemoryProvider(getNested(config, key)) ? (
                 <ProviderConfigPanel
                   key={String(getNested(config, key))}

--- a/apps/desktop/src/app/settings/delegation-model-provider-field.test.tsx
+++ b/apps/desktop/src/app/settings/delegation-model-provider-field.test.tsx
@@ -1,0 +1,75 @@
+/** Interaction contracts adapted from webtecnica's #67523, including model-only drafts. */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { DelegationModelProviderField } from './delegation-model-provider-field'
+import { delegationModelsCopy } from './delegation-models-copy'
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+afterEach(cleanup)
+
+const copy = delegationModelsCopy('en')
+
+const providers = [
+  { slug: 'provider-a', name: 'Provider A', authenticated: true, models: ['model-a', 'model-b'] },
+  { slug: 'custom:worker', name: 'Custom worker', authenticated: true, models: [] }
+]
+
+function Harness({ initial = { provider: '', model: '' }, onChange = vi.fn() }) {
+  const [pair, setPair] = useState(initial)
+
+  return <DelegationModelProviderField {...pair} copy={copy} onChange={(next, changed) => {
+    setPair(next)
+    onChange(next, changed)
+  }} providers={providers} />
+}
+
+describe('guided delegation picker', () => {
+  it('represents full inheritance without emitting a write on mount', () => {
+    const onChange = vi.fn()
+    render(<Harness onChange={onChange} />)
+    expect(screen.getByText(copy.mainProvider)).toBeTruthy()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('keeps a model-only override visible and editable', async () => {
+    const onChange = vi.fn()
+    render(<Harness initial={{ provider: '', model: 'inherited-provider-model' }} onChange={onChange} />)
+    const model = screen.getByRole('textbox', { name: copy.model })
+    expect((model as HTMLInputElement).value).toBe('inherited-provider-model')
+    fireEvent.change(model, { target: { value: 'inherited-provider-model-next' } })
+    expect(onChange).toHaveBeenLastCalledWith({ provider: '', model: 'inherited-provider-model-next' }, false)
+  })
+
+  it('uses the provider catalog and emits the selected pair to the local draft', async () => {
+    const onChange = vi.fn()
+    render(<Harness onChange={onChange} />)
+    fireEvent.click(screen.getByRole('combobox', { name: copy.provider }))
+    fireEvent.click(screen.getByRole('option', { name: 'Provider A' }))
+    fireEvent.click(screen.getByRole('combobox', { name: copy.model }))
+    fireEvent.click(screen.getByRole('option', { name: 'model-b' }))
+    expect(onChange).toHaveBeenLastCalledWith({ provider: 'provider-a', model: 'model-b' }, false)
+  })
+
+  it('allows models not in a provider catalog', async () => {
+    const onChange = vi.fn()
+    render(<Harness initial={{ provider: 'provider-a', model: 'model-a' }} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('combobox', { name: copy.model }))
+    fireEvent.click(screen.getByRole('option', { name: copy.customModel }))
+    fireEvent.change(screen.getByRole('textbox', { name: copy.model }), { target: { value: 'private/model:tag' } })
+    expect(onChange).toHaveBeenLastCalledWith({ provider: 'provider-a', model: 'private/model:tag' }, false)
+  })
+
+  it('resyncs controlled values when the owner changes', () => {
+    const props = { copy, providers, onChange: vi.fn() }
+    const view = render(<DelegationModelProviderField {...props} model="first" provider="" />)
+    view.rerender(<DelegationModelProviderField {...props} model="second" provider="custom:worker" />)
+    expect((screen.getByRole('textbox', { name: copy.model }) as HTMLInputElement).value).toBe('second')
+    expect(props.onChange).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/settings/delegation-model-provider-field.tsx
+++ b/apps/desktop/src/app/settings/delegation-model-provider-field.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react'
+
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import type { ModelOptionProvider } from '@/hermes'
+import { cn } from '@/lib/utils'
+
+import { CONTROL_TEXT, EMPTY_SELECT_VALUE } from './constants'
+import type { DelegationModelsCopy } from './delegation-models-copy'
+import type { DelegationModelProviderValue } from './delegation-models-state'
+
+const INHERIT_VALUE = '__inherit__'
+const DIRECT_VALUE = '__direct__'
+const CUSTOM_VALUE = '__custom_model__'
+
+/**
+ * Adapted from webtecnica's #67523 guided provider/model picker (fd6e822f).
+ * Catalog ownership is now profile-scoped in the parent. Intermediate pairs
+ * are local drafts, never autosaves. Blank provider + explicit model remains
+ * representable, including without a catalog (#67347's model-only reservation).
+ */
+export function DelegationModelProviderField({
+  allowInherit = true,
+  copy,
+  directEndpoint = false,
+  labelPrefix = '',
+  model,
+  onChange,
+  parentProvider = '',
+  provider,
+  providers
+}: {
+  allowInherit?: boolean
+  copy: DelegationModelsCopy
+  directEndpoint?: boolean
+  labelPrefix?: string
+  model: string
+  onChange: (next: DelegationModelProviderValue, providerChanged: boolean) => void
+  parentProvider?: string
+  provider: string
+  providers: readonly ModelOptionProvider[]
+}) {
+  const [manualModel, setManualModel] = useState(false)
+  const selectedProviderRow = providers.find(p => p.slug === (provider || parentProvider))
+  const catalog = directEndpoint ? [] : (selectedProviderRow?.models ?? [])
+  const modelItems = model && !catalog.includes(model) ? [model, ...catalog] : catalog
+  const modelFreeText = manualModel || catalog.length === 0 || (!!model && !catalog.includes(model))
+  const knownProvider = providers.some(p => p.slug === provider)
+
+  return (
+    <div className="grid w-full gap-2 sm:grid-cols-2">
+      {providers.length === 0 ? (
+        <Input
+          aria-label={`${labelPrefix}${copy.provider}`}
+          className={CONTROL_TEXT}
+          onChange={event => onChange({ model: '', provider: event.target.value }, true)}
+          placeholder={allowInherit ? copy.mainProvider : copy.provider}
+          value={provider}
+        />
+      ) : (
+        <Select
+          onValueChange={value => {
+            if (value === DIRECT_VALUE) {
+              return
+            }
+
+            setManualModel(false)
+            onChange({ model: '', provider: value === INHERIT_VALUE ? '' : value }, true)
+          }}
+          value={directEndpoint ? DIRECT_VALUE : provider || (allowInherit ? INHERIT_VALUE : EMPTY_SELECT_VALUE)}
+        >
+          <SelectTrigger aria-label={`${labelPrefix}${copy.provider}`} className={cn('w-full', CONTROL_TEXT)}>
+            <SelectValue placeholder={copy.provider} />
+          </SelectTrigger>
+          <SelectContent>
+            {directEndpoint && <SelectItem value={DIRECT_VALUE}>{copy.direct}</SelectItem>}
+            {allowInherit && <SelectItem value={INHERIT_VALUE}>{copy.mainProvider}</SelectItem>}
+            {provider && !knownProvider && <SelectItem value={provider}>{provider}</SelectItem>}
+            {providers.filter(p => p.slug).map(p => (
+              <SelectItem key={p.slug} value={p.slug}>
+                {p.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+      {modelFreeText ? (
+        <Input
+          aria-label={`${labelPrefix}${copy.model}`}
+          className={CONTROL_TEXT}
+          onChange={event => onChange({ model: event.target.value, provider }, false)}
+          placeholder={allowInherit && !provider && !directEndpoint ? copy.mainModel : copy.customModel}
+          value={model}
+        />
+      ) : (
+        <Select
+          onValueChange={nextModel => {
+            if (nextModel === CUSTOM_VALUE) {
+              setManualModel(true)
+            } else {
+              onChange({ model: nextModel === INHERIT_VALUE ? '' : nextModel, provider }, false)
+            }
+          }}
+          value={model || (allowInherit && !provider ? INHERIT_VALUE : EMPTY_SELECT_VALUE)}
+        >
+          <SelectTrigger aria-label={`${labelPrefix}${copy.model}`} className={cn('w-full', CONTROL_TEXT)}>
+            <SelectValue placeholder={copy.model} />
+          </SelectTrigger>
+          <SelectContent>
+            {allowInherit && !provider && <SelectItem value={INHERIT_VALUE}>{copy.mainModel}</SelectItem>}
+            {modelItems.map(item => (
+              <SelectItem key={item} value={item}>
+                {item}
+              </SelectItem>
+            ))}
+            <SelectItem value={CUSTOM_VALUE}>{copy.customModel}</SelectItem>
+          </SelectContent>
+        </Select>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/app/settings/delegation-model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/delegation-model-settings.test.tsx
@@ -1,0 +1,247 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type ProfileScope, profileScopeKey, setApiRequestConnection, setApiRequestProfile } from '@/api/client'
+import { $activeGatewayProfile } from '@/store/profile'
+
+import { DelegationModelSettings } from './delegation-model-settings'
+import { delegationModelsCopy } from './delegation-models-copy'
+
+const server = vi.hoisted(() => ({
+  get: vi.fn(),
+  options: vi.fn(),
+  records: {} as Record<string, Record<string, unknown>>,
+  save: vi.fn(),
+  schema: vi.fn()
+}))
+
+vi.mock('@/hermes', async () => ({
+  ...(await import('@/api/client')),
+  getGlobalModelOptions: (...args: unknown[]) => server.options(...args),
+  getHermesConfigSchema: (...args: unknown[]) => server.schema(...args),
+  getHermesConfigRecord: (...args: unknown[]) => server.get(...args),
+  saveHermesConfigRecord: (...args: unknown[]) => server.save(...args)
+}))
+vi.mock('@/lib/query-client', () => ({
+  queryClient: { invalidateQueries: vi.fn() },
+  writeCache: () => () => {}
+}))
+vi.mock('@/store/gateway', async () => ({ $gateway: (await import('nanostores')).atom(null) }))
+vi.mock('@/store/profile', async () => ({ $activeGatewayProfile: (await import('nanostores')).atom<string | null>('alpha') }))
+
+const copy = delegationModelsCopy('en')
+const main = { default: 'head-model', provider: 'head' }
+const click = (element: Element) => fireEvent.click(element)
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+beforeEach(() => {
+  vi.clearAllMocks()
+  setApiRequestConnection('gateway-a')
+  setApiRequestProfile('alpha')
+  $activeGatewayProfile.set('alpha')
+  server.records = {
+    'gateway-a::alpha': {
+      delegation: { max_iterations: 17 },
+      fallback_providers: [{ model: 'head-backup', provider: 'head' }],
+      model: main
+    },
+    'gateway-a::beta': { delegation: { model: 'beta-worker', provider: '' }, model: main }
+  }
+  server.get.mockImplementation(async (scope: ProfileScope) => structuredClone(server.records[profileScopeKey(scope)]))
+  server.schema.mockResolvedValue({ capabilities: { delegation_fallbacks: true }, fields: {} })
+  server.options.mockResolvedValue({
+    providers: [{ authenticated: true, models: ['worker-one', 'worker-two'], name: 'Worker provider', slug: 'worker' }]
+  })
+  server.save.mockImplementation(async (patch: { delegation: Record<string, unknown> }, scope: ProfileScope) => {
+    const key = profileScopeKey(scope)
+    const previous = server.records[key]
+
+    server.records[key] = { ...previous, delegation: { ...(previous.delegation as object), ...patch.delegation } }
+
+    return { ok: true }
+  })
+})
+afterEach(() => {
+  cleanup()
+  setApiRequestConnection(null)
+  setApiRequestProfile(null)
+  $activeGatewayProfile.set('default')
+})
+
+async function open(profile: string | null = 'alpha') {
+  const client = new QueryClient({ defaultOptions: { queries: { gcTime: 0, retry: false } } })
+
+  const ui = (next: string | null) => (
+    <QueryClientProvider client={client}>
+      <DelegationModelSettings scopeProfile={next ?? undefined} />
+    </QueryClientProvider>
+  )
+
+  const view = render(ui(profile))
+
+  await screen.findByRole('combobox', { name: copy.provider })
+
+  return { client, ui, user: { click }, view }
+}
+
+async function chooseWorker(user: { click: typeof click }) {
+  await user.click(screen.getByRole('combobox', { name: copy.provider }))
+  await user.click(screen.getByRole('option', { name: 'Worker provider' }))
+  expect(server.save).not.toHaveBeenCalled()
+  expect((screen.getByRole('button', { name: copy.apply }) as HTMLButtonElement).disabled).toBe(true)
+  await user.click(screen.getByRole('combobox', { name: copy.model }))
+  await user.click(screen.getByRole('option', { name: 'worker-two' }))
+}
+
+describe('Models screen delegation persistence', () => {
+  it('does not expose unused fallback controls on an older backend, even with saved keys', async () => {
+    server.schema.mockResolvedValue({ fields: {} })
+    server.records['gateway-a::alpha'].delegation = {
+      fallback_providers: [{ model: 'worker-one', provider: 'worker' }]
+    }
+    const client = new QueryClient({ defaultOptions: { queries: { gcTime: 0, retry: false } } })
+
+    render(
+      <QueryClientProvider client={client}>
+        <DelegationModelSettings scopeProfile="alpha" />
+      </QueryClientProvider>
+    )
+    await screen.findByText(copy.unsupported)
+    expect(screen.queryByRole('combobox')).toBeNull()
+    expect(server.save).not.toHaveBeenCalled()
+    expect(server.options).not.toHaveBeenCalled()
+    expect(server.schema).toHaveBeenCalledWith({ connectionId: 'gateway-a', profile: 'alpha' })
+  })
+
+  it('saves one complete pair to the catalog owner and confirms it without touching the main model', async () => {
+    const { user } = await open()
+
+    await chooseWorker(user)
+    expect(server.save).not.toHaveBeenCalled()
+    await user.click(screen.getByRole('button', { name: copy.apply }))
+    await waitFor(() => expect(server.save).toHaveBeenCalledTimes(1))
+    expect(server.save.mock.calls[0]).toEqual([
+      {
+        delegation: {
+          api_key: '',
+          api_mode: '',
+          base_url: '',
+          model: 'worker-two',
+          provider: 'worker',
+          request_overrides: null
+        }
+      },
+      { connectionId: 'gateway-a', profile: 'alpha' }
+    ])
+    expect(server.options).toHaveBeenCalledWith(undefined, { connectionId: 'gateway-a', profile: 'alpha' })
+    await waitFor(() => expect((screen.getByRole('button', { name: copy.apply }) as HTMLButtonElement).disabled).toBe(true))
+    expect(server.records['gateway-a::alpha'].model).toEqual(main)
+    expect(server.records['gateway-a::alpha'].delegation).toMatchObject({ max_iterations: 17 })
+    expect(server.records['gateway-a::alpha'].fallback_providers).toEqual([{ model: 'head-backup', provider: 'head' }])
+  })
+
+  it.each(['gateway-a', 'local'])('saves an implicit default profile on %s', async connectionId => {
+    setApiRequestConnection(connectionId === 'local' ? null : connectionId)
+    setApiRequestProfile(null)
+    $activeGatewayProfile.set('default')
+    const key = `${connectionId}::default`
+
+    server.records[key] = { delegation: { max_iterations: 17 }, model: main }
+    const { user } = await open(null)
+
+    await chooseWorker(user)
+    await user.click(screen.getByRole('button', { name: copy.apply }))
+    await waitFor(() => expect(server.save).toHaveBeenCalledTimes(1))
+    expect(server.save.mock.calls[0][1]).toEqual({ connectionId, profile: 'default' })
+    expect(server.options).toHaveBeenCalledWith(undefined, { connectionId, profile: 'default' })
+    await waitFor(() => expect((screen.getByRole('button', { name: copy.apply }) as HTMLButtonElement).disabled).toBe(true))
+    expect(server.records[key].delegation).toMatchObject({
+      max_iterations: 17,
+      model: 'worker-two',
+      provider: 'worker'
+    })
+    expect(server.records[key].model).toEqual(main)
+  })
+
+  it('retains edits and allows retry after a failed write', async () => {
+    const { user } = await open()
+
+    await chooseWorker(user)
+    server.save.mockRejectedValueOnce(new Error('offline'))
+    await user.click(screen.getByRole('button', { name: copy.apply }))
+    await screen.findByText(copy.failed)
+    expect(screen.getByRole('combobox', { name: copy.model }).textContent).toContain('worker-two')
+    expect((screen.getByRole('button', { name: copy.apply }) as HTMLButtonElement).disabled).toBe(false)
+    await user.click(screen.getByRole('button', { name: copy.apply }))
+    await waitFor(() => expect(server.save).toHaveBeenCalledTimes(2))
+  })
+
+  it('resets drafts on a profile switch, even when no prior write occurred', async () => {
+    const { ui, user, view } = await open()
+
+    await chooseWorker(user)
+    view.rerender(ui('beta'))
+    await waitFor(() =>
+      expect((screen.getByRole('textbox', { name: copy.model }) as HTMLInputElement).value).toBe('beta-worker')
+    )
+    expect(server.save).not.toHaveBeenCalled()
+    expect(server.options).toHaveBeenCalledWith(undefined, { connectionId: 'gateway-a', profile: 'beta' })
+  })
+
+  it('does not apply an old save completion to the newly selected profile', async () => {
+    const { ui, user, view } = await open()
+
+    await chooseWorker(user)
+    let finish!: (value: { ok: boolean }) => void
+
+    server.save.mockImplementationOnce(() => new Promise(resolve => { finish = resolve }))
+    await user.click(screen.getByRole('button', { name: copy.apply }))
+    await waitFor(() => expect(server.save).toHaveBeenCalledTimes(1))
+    const alphaReads = server.get.mock.calls.filter(([scope]) => scope.profile === 'alpha').length
+
+    view.rerender(ui('beta'))
+    await waitFor(() =>
+      expect((screen.getByRole('textbox', { name: copy.model }) as HTMLInputElement).value).toBe('beta-worker')
+    )
+    finish({ ok: true })
+    await waitFor(() => expect(screen.getByRole('textbox', { name: copy.model })).toBeTruthy())
+    expect(server.get.mock.calls.filter(([scope]) => scope.profile === 'alpha')).toHaveLength(alphaReads)
+    expect(server.records['gateway-a::beta'].delegation).toEqual({ model: 'beta-worker', provider: '' })
+  })
+
+  it('preserves endpoint and credential-reference metadata through a reorder', async () => {
+    const first = { base_url: 'https://one.invalid/v1', key_env: 'ONE_KEY', model: 'worker-one', provider: 'worker' }
+    const second = { base_url: 'https://two.invalid/v1', key_env: 'TWO_KEY', model: 'worker-two', provider: 'worker' }
+
+    server.records['gateway-a::alpha'].delegation = { fallback_providers: [first, second] }
+    const { user } = await open()
+
+    await user.click(screen.getByRole('button', { name: `${copy.up} 2` }))
+    expect(server.save).not.toHaveBeenCalled()
+    await user.click(screen.getByRole('button', { name: copy.apply }))
+    await waitFor(() => expect(server.save).toHaveBeenCalledTimes(1))
+    expect(server.save.mock.calls[0][0]).toEqual({
+      delegation: {
+        fallback_chain: null,
+        fallback_model: null,
+        fallback_providers: [second, first]
+      }
+    })
+  })
+
+  it('detects a competing config update rather than silently overwriting it', async () => {
+    const { client, user } = await open()
+
+    await chooseWorker(user)
+    server.records['gateway-a::alpha'].delegation = { model: 'newer-external-choice', provider: '' }
+    await client.invalidateQueries()
+    await screen.findByText(copy.conflict)
+    expect((screen.getByRole('button', { name: copy.apply }) as HTMLButtonElement).disabled).toBe(true)
+    expect(server.save).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/settings/delegation-model-settings.tsx
+++ b/apps/desktop/src/app/settings/delegation-model-settings.tsx
@@ -1,0 +1,425 @@
+import { useStore } from '@nanostores/react'
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import { getApiRequestConnection, type ProfileScope, profileScopeKey } from '@/api/client'
+import { Button } from '@/components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { getGlobalModelOptions, getHermesConfigSchema, saveHermesConfigRecord } from '@/hermes'
+import { useI18n } from '@/i18n'
+import { $gateway } from '@/store/gateway'
+import { $activeGatewayProfile } from '@/store/profile'
+import type { HermesConfigRecord, ModelOptionProvider } from '@/types/hermes'
+
+import { useHermesConfigRecord } from '../hooks/use-config-record'
+
+import { DelegationModelProviderField } from './delegation-model-provider-field'
+import { delegationModelsCopy, type DelegationModelsCopy } from './delegation-models-copy'
+import {
+  asRecord,
+  delegationDraftChanged,
+  delegationDraftValid,
+  type DelegationFallbackMode,
+  delegationModelsPatch,
+  moveDelegationFallback,
+  readDelegationModels,
+  updateDelegationFallback
+} from './delegation-models-state'
+
+export function DelegationModelSettings({ scopeProfile }: { scopeProfile?: string }) {
+  const gateway = useStore($gateway)
+  const activeProfile = useStore($activeGatewayProfile)
+  const { locale } = useI18n()
+  const copy = delegationModelsCopy(locale)
+
+  // Pin reads, catalog, write AND read-back to the same owner. Even the local
+  // pool needs an explicit tag: omission can select a remote registry primary.
+  const scope = useMemo(
+    () => ({
+      profile: scopeProfile ?? activeProfile ?? 'default',
+      connectionId: getApiRequestConnection() ?? 'local'
+    }),
+    // gateway is the change signal for the ambient connection getter.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeProfile, gateway, scopeProfile]
+  )
+
+  const config = useHermesConfigRecord(scope)
+
+  const schema = useQuery({
+    queryFn: () => getHermesConfigSchema(scope),
+    queryKey: ['delegation-model-capabilities', profileScopeKey(scope)],
+    retry: 1
+  })
+
+  const supported = schema.data?.capabilities?.delegation_fallbacks === true
+
+  const catalog = useQuery({
+    enabled: supported,
+    queryFn: () => getGlobalModelOptions(undefined, scope),
+    queryKey: ['delegation-model-options', profileScopeKey(scope)],
+    retry: 1
+  })
+
+  if (!config.data || !schema.data) {
+    const failed = config.isError || schema.isError
+
+    return (
+      <section aria-label={copy.title} className="my-6 grid gap-2">
+        <h3 className="text-sm font-medium">{copy.title}</h3>
+        <p className="text-xs text-muted-foreground">{failed ? copy.loadFailed : copy.loading}</p>
+        {failed && (
+          <Button
+            onClick={() => {
+              void config.refetch()
+              void schema.refetch()
+            }}
+            size="sm"
+          >
+            {copy.refresh}
+          </Button>
+        )}
+      </section>
+    )
+  }
+
+  if (!supported) {
+    return (
+      <section aria-label={copy.title} className="my-6 grid gap-2">
+        <h3 className="text-sm font-medium">{copy.title}</h3>
+        <p className="text-xs text-muted-foreground">{schema.isError ? copy.loadFailed : copy.unsupported}</p>
+        <Button onClick={() => void schema.refetch()} size="sm">
+          {copy.refresh}
+        </Button>
+      </section>
+    )
+  }
+
+  return (
+    <DelegationModelEditor
+      config={config.data}
+      copy={copy}
+      currentOwner={() =>
+        (getApiRequestConnection() ?? 'local') === scope.connectionId &&
+        (scopeProfile != null || ($activeGatewayProfile.get() ?? 'default') === scope.profile)
+      }
+      key={profileScopeKey(scope)}
+      offline={catalog.isError}
+      providers={catalog.data?.providers ?? []}
+      reload={async () => {
+        const next = await config.refetch()
+
+        if (next.isError || !next.data) {
+          throw new Error('Delegation config read-back failed')
+        }
+
+        return next.data
+      }}
+      retryCatalog={() => void catalog.refetch()}
+      retrySchema={() => void schema.refetch()}
+      runtimeReady={!schema.isError && !schema.isFetching}
+      schemaFailed={schema.isError}
+      scope={scope}
+    />
+  )
+}
+
+/** Local draft is not a saved setting: the full pair/chain commits only on Apply. */
+function DelegationModelEditor({
+  config,
+  copy,
+  currentOwner,
+  offline,
+  providers,
+  reload,
+  retryCatalog,
+  retrySchema,
+  runtimeReady,
+  schemaFailed,
+  scope
+}: {
+  config: HermesConfigRecord
+  copy: DelegationModelsCopy
+  currentOwner: () => boolean
+  offline: boolean
+  providers: readonly ModelOptionProvider[]
+  reload: () => Promise<HermesConfigRecord>
+  retryCatalog: () => void
+  retrySchema: () => void
+  runtimeReady: boolean
+  schemaFailed: boolean
+  scope: ProfileScope
+}) {
+  const [baseline, setBaseline] = useState(() => asRecord(config.delegation))
+  const [draft, setDraft] = useState(() => readDelegationModels(config.delegation))
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(false)
+  const alive = useRef(true)
+  const dirty = delegationDraftChanged(draft, baseline)
+  const valid = delegationDraftValid(draft, baseline)
+  const sourceSignature = JSON.stringify(asRecord(config.delegation))
+  const baselineSignature = JSON.stringify(baseline)
+  const conflict = sourceSignature !== baselineSignature && dirty && !saving
+  const directEndpoint = !draft.clearEndpoint && !!baseline.base_url
+
+  // eslint-disable-next-line no-restricted-syntax -- lifetime guard, not an atom mirror
+  useEffect(() => {
+    alive.current = true
+
+    return () => {
+      alive.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!dirty && !saving && sourceSignature !== baselineSignature) {
+      const next = JSON.parse(sourceSignature) as Record<string, unknown>
+
+      setBaseline(next)
+      setDraft(readDelegationModels(next))
+    }
+  }, [baselineSignature, dirty, saving, sourceSignature])
+
+  const reset = () => {
+    setBaseline(asRecord(config.delegation))
+    setDraft(readDelegationModels(config.delegation))
+    setError(false)
+  }
+
+  const apply = async () => {
+    if (!valid || !dirty || saving || conflict || !runtimeReady || !currentOwner()) {
+      return
+    }
+
+    const patch = delegationModelsPatch(baseline, draft)
+
+    setSaving(true)
+    setError(false)
+
+    try {
+      const result = await saveHermesConfigRecord({ delegation: patch }, scope)
+
+      if (!alive.current || !currentOwner()) {
+        return
+      }
+
+      if (!result.ok) {
+        throw new Error('Delegation config save failed')
+      }
+
+      const confirmed = await reload()
+
+      if (!alive.current || !currentOwner()) {
+        return
+      }
+
+      const stored = asRecord(confirmed.delegation)
+
+      // An ACK alone does not prove the selected pair/chain survived persistence.
+      const mismatch = Object.entries(patch).some(([key, value]) =>
+        value == null ? stored[key] != null : JSON.stringify(stored[key]) !== JSON.stringify(value)
+      )
+
+      if (mismatch) {
+        throw new Error('Delegation config read-back mismatch')
+      }
+
+      setBaseline(stored)
+      setDraft(readDelegationModels(stored))
+    } catch {
+      if (alive.current && currentOwner()) {
+        setError(true)
+      }
+    } finally {
+      if (alive.current && currentOwner()) {
+        setSaving(false)
+      }
+    }
+  }
+
+  return (
+    <section aria-label={copy.title} className="my-6 grid gap-3">
+      <div>
+        <h3 className="text-sm font-medium">{copy.title}</h3>
+        <p className="mt-1 text-xs text-muted-foreground">{copy.description}</p>
+      </div>
+      {schemaFailed && (
+        <p className="text-xs text-muted-foreground" role="alert">
+          {copy.loadFailed}
+          <Button onClick={retrySchema} size="sm" variant="textStrong">
+            {copy.refresh}
+          </Button>
+        </p>
+      )}
+      {offline && (
+        <p className="text-xs text-muted-foreground" role="status">
+          {copy.offline}
+          <Button onClick={retryCatalog} size="sm" variant="textStrong">
+            {copy.refresh}
+          </Button>
+        </p>
+      )}
+      {!offline && providers.length === 0 && <p className="text-xs text-muted-foreground">{copy.noProviders}</p>}
+      <fieldset className="grid min-w-0 gap-3" disabled={saving}>
+        {directEndpoint && <p className="text-xs text-muted-foreground">{copy.directHint}</p>}
+        <DelegationModelProviderField
+          copy={copy}
+          directEndpoint={directEndpoint}
+          model={draft.model}
+          onChange={(pair, providerChanged) => {
+            if (!saving) {
+              setDraft(previous => ({ ...previous, ...pair, clearEndpoint: previous.clearEndpoint || providerChanged }))
+            }
+          }}
+          parentProvider={String(asRecord(config.model).provider ?? '')}
+          provider={draft.provider}
+          providers={providers}
+        />
+        <div>
+          <Button
+            onClick={() => setDraft(previous => ({ ...previous, clearEndpoint: true, model: '', provider: '' }))}
+            size="sm"
+            variant="textStrong"
+          >
+            {copy.mainModel}
+          </Button>
+        </div>
+        <Select
+          onValueChange={mode => {
+            if (!saving) {
+              setDraft(previous => ({ ...previous, mode: mode as DelegationFallbackMode }))
+            }
+          }}
+          value={draft.mode}
+        >
+          <SelectTrigger aria-label={copy.policy}>
+            <SelectValue placeholder={copy.policy} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="auto">{copy.auto}</SelectItem>
+            <SelectItem value="inherit">{copy.inherit}</SelectItem>
+            <SelectItem value="none">{copy.none}</SelectItem>
+            <SelectItem value="custom">{copy.custom}</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          {draft.mode === 'auto'
+            ? copy.autoHint
+            : draft.mode === 'inherit'
+              ? copy.inheritHint
+              : draft.mode === 'custom'
+                ? copy.customHint
+                : draft.mode === 'none'
+                  ? copy.none
+                  : copy.invalid}
+        </p>
+        {draft.mode === 'custom' && (
+          <div className="grid gap-3">
+            {draft.rows.map((row, index) => (
+              <div className="grid gap-2" key={index}>
+                <DelegationModelProviderField
+                  allowInherit={false}
+                  copy={copy}
+                  labelPrefix={`${index + 1}. `}
+                  model={row.model}
+                  onChange={(pair, providerChanged) => {
+                    if (!saving) {
+                      setDraft(previous => ({
+                        ...previous,
+                        rows: previous.rows.map((entry, i) =>
+                          i === index ? updateDelegationFallback(entry, pair, providerChanged) : entry
+                        )
+                      }))
+                    }
+                  }}
+                  provider={row.provider}
+                  providers={providers}
+                />
+                <div className="flex gap-1">
+                  <Button
+                    aria-label={`${copy.up} ${index + 1}`}
+                    disabled={index === 0}
+                    onClick={() =>
+                      setDraft(previous => ({
+                        ...previous,
+                        rows: moveDelegationFallback(previous.rows, index, -1)
+                      }))
+                    }
+                    size="sm"
+                    variant="ghost"
+                  >
+                    ↑
+                  </Button>
+                  <Button
+                    aria-label={`${copy.down} ${index + 1}`}
+                    disabled={index === draft.rows.length - 1}
+                    onClick={() =>
+                      setDraft(previous => ({
+                        ...previous,
+                        rows: moveDelegationFallback(previous.rows, index, 1)
+                      }))
+                    }
+                    size="sm"
+                    variant="ghost"
+                  >
+                    ↓
+                  </Button>
+                  <Button
+                    aria-label={`${copy.remove} ${index + 1}`}
+                    onClick={() =>
+                      setDraft(previous => ({
+                        ...previous,
+                        rows: previous.rows.filter((_, i) => i !== index)
+                      }))
+                    }
+                    size="sm"
+                    variant="ghost"
+                  >
+                    {copy.remove}
+                  </Button>
+                </div>
+              </div>
+            ))}
+            <div>
+              <Button
+                onClick={() =>
+                  setDraft(previous => ({
+                    ...previous,
+                    rows: [...previous.rows, { model: '', provider: '' }]
+                  }))
+                }
+                size="sm"
+                variant="textStrong"
+              >
+                {copy.add}
+              </Button>
+            </div>
+          </div>
+        )}
+        {!valid && (
+          <p className="text-xs text-muted-foreground" role="status">
+            {copy.invalid}
+          </p>
+        )}
+        {conflict && (
+          <p className="text-xs text-muted-foreground" role="alert">
+            {copy.conflict}
+          </p>
+        )}
+        {error && (
+          <p className="text-xs text-destructive" role="alert">
+            {copy.failed}
+          </p>
+        )}
+        <div className="flex gap-2">
+          <Button disabled={!dirty || !valid || conflict || saving || !runtimeReady} onClick={() => void apply()} size="sm">
+            {saving ? copy.saving : copy.apply}
+          </Button>
+          <Button disabled={!dirty && !conflict} onClick={reset} size="sm" variant="ghost">
+            {conflict ? copy.refresh : copy.reset}
+          </Button>
+        </div>
+      </fieldset>
+    </section>
+  )
+}

--- a/apps/desktop/src/app/settings/delegation-models-copy.ts
+++ b/apps/desktop/src/app/settings/delegation-models-copy.ts
@@ -1,0 +1,109 @@
+/** Feature-local copy keeps this bounded integration out of the large locale owners. */
+const en = {
+  title: 'Delegation models',
+  loading: 'Loading delegation settings…',
+  unsupported: 'Update this gateway’s Hermes runtime to configure delegation fallbacks here. Existing settings remain unchanged.',
+  description: 'Default model and ordered backups for newly delegated work. Your main conversation is unchanged.',
+  provider: 'Delegation provider',
+  model: 'Delegation model',
+  mainProvider: 'Use main provider',
+  mainModel: 'Use main model',
+  direct: 'Existing direct endpoint',
+  directHint: 'A direct endpoint override is active. Choosing a provider replaces its endpoint and authentication overrides.',
+  customModel: 'Custom model ID…',
+  policy: 'Delegation fallback behavior',
+  auto: 'Default behavior',
+  autoHint: 'Inherit the main backups only when no delegation model or provider is pinned.',
+  inherit: 'Use main fallbacks',
+  inheritHint: 'Explicitly share the main conversation’s fallback chain, even with a delegation model selected.',
+  none: 'No fallbacks',
+  custom: 'Choose delegation fallbacks',
+  customHint: 'Try these provider/model pairs in order. Each backup keeps its own route and credentials.',
+  add: 'Add delegation fallback',
+  remove: 'Remove fallback',
+  up: 'Move fallback earlier',
+  down: 'Move fallback later',
+  apply: 'Apply delegation settings',
+  reset: 'Discard edits',
+  refresh: 'Reload settings',
+  saving: 'Saving…',
+  failed: 'Could not save and confirm these settings. Your edits are retained; retry after checking the connection.',
+  loadFailed: 'Could not load delegation settings.',
+  offline: 'The model catalog is unavailable. Enter provider and model IDs manually, or retry.',
+  conflict: 'Delegation settings changed elsewhere. Reload before applying to avoid overwriting newer settings.',
+  invalid: 'Complete every provider/model pair and choose a fallback behavior before applying.',
+  noProviders: 'No model catalog is available for this profile. You can enter IDs manually.'
+}
+
+export type DelegationModelsCopy = typeof en
+
+const zh: DelegationModelsCopy = {
+  loading: '正在加载委派设置…',
+  unsupported: '请更新此网关的 Hermes 运行时以在此配置委派备用模型。现有设置保持不变。',
+  title: '委派模型', description: '为新委派任务设置默认模型和有序备用模型。主对话保持不变。',
+  provider: '委派提供商', model: '委派模型', mainProvider: '使用主提供商', mainModel: '使用主模型',
+  direct: '现有直接端点', directHint: '直接端点覆盖已启用。选择提供商将替换其端点和身份验证覆盖。',
+  customModel: '自定义模型 ID…', policy: '委派备用行为', auto: '默认行为',
+  autoHint: '仅在未指定委派模型或提供商时继承主备用链。', inherit: '使用主备用链',
+  inheritHint: '明确共享主对话的备用链，即使已选择委派模型。', none: '不使用备用模型', custom: '选择委派备用模型',
+  customHint: '按顺序尝试这些提供商和模型。每个备用模型保留自己的路由和凭据。',
+  add: '添加委派备用模型', remove: '删除备用模型', up: '提前尝试', down: '推后尝试',
+  apply: '应用委派设置', reset: '放弃编辑', refresh: '重新加载设置', saving: '正在保存…',
+  failed: '无法保存并确认设置。编辑已保留；请检查连接后重试。', loadFailed: '无法加载委派设置。',
+  offline: '模型目录不可用。请手动输入提供商和模型 ID，或重试。', conflict: '委派设置已在其他位置更改。请重新加载后再应用。',
+  invalid: '应用前请填写完整的提供商和模型，并选择备用行为。', noProviders: '此配置没有可用的模型目录。可以手动输入 ID。'
+}
+
+const zhHant: DelegationModelsCopy = {
+  loading: '正在載入委派設定…',
+  unsupported: '請更新此閘道的 Hermes 執行環境，以在此設定委派備用模型。現有設定保持不變。',
+  title: '委派模型', description: '為新委派工作設定預設模型及有序備用模型。主對話保持不變。',
+  provider: '委派供應商', model: '委派模型', mainProvider: '使用主供應商', mainModel: '使用主模型',
+  direct: '現有直接端點', directHint: '直接端點覆寫已啟用。選擇供應商將取代其端點和驗證覆寫。',
+  customModel: '自訂模型 ID…', policy: '委派備用行為', auto: '預設行為',
+  autoHint: '僅在未指定委派模型或供應商時繼承主備用鏈。', inherit: '使用主備用鏈',
+  inheritHint: '明確共用主對話的備用鏈，即使已選擇委派模型。', none: '不使用備用模型', custom: '選擇委派備用模型',
+  customHint: '依序嘗試這些供應商和模型。每個備用模型保留自己的路由和憑證。',
+  add: '新增委派備用模型', remove: '刪除備用模型', up: '提前嘗試', down: '延後嘗試',
+  apply: '套用委派設定', reset: '捨棄編輯', refresh: '重新載入設定', saving: '儲存中…',
+  failed: '無法儲存並確認設定。編輯已保留；請檢查連線後重試。', loadFailed: '無法載入委派設定。',
+  offline: '模型目錄無法使用。請手動輸入供應商和模型 ID，或重試。', conflict: '委派設定已在其他位置變更。請重新載入後再套用。',
+  invalid: '套用前請填妥供應商和模型，並選擇備用行為。', noProviders: '此設定檔沒有可用的模型目錄。可手動輸入 ID。'
+}
+
+const ja: DelegationModelsCopy = {
+  loading: '委任設定を読み込み中…',
+  unsupported: '委任の代替モデルを設定するには、このゲートウェイの Hermes を更新してください。既存の設定は変更されません。',
+  title: '委任モデル', description: '新しい委任タスクの既定モデルと順序付き代替モデルを設定します。メイン会話は変更されません。',
+  provider: '委任プロバイダー', model: '委任モデル', mainProvider: 'メインプロバイダーを使用', mainModel: 'メインモデルを使用',
+  direct: '既存の直接エンドポイント', directHint: '直接エンドポイントが設定されています。プロバイダーの選択でエンドポイントと認証の上書き設定が置き換わります。',
+  customModel: 'カスタムモデル ID…', policy: '委任のフォールバック動作', auto: '既定の動作',
+  autoHint: '委任モデルもプロバイダーも指定されていない場合のみ、メインの代替モデルを継承します。', inherit: 'メインの代替モデルを使用',
+  inheritHint: '委任モデルが選択されていても、メイン会話の代替モデルを明示的に共有します。', none: '代替モデルなし', custom: '委任の代替モデルを選択',
+  customHint: 'これらのプロバイダーとモデルを順番に試します。各代替モデルのルートと認証情報は維持されます。',
+  add: '委任の代替モデルを追加', remove: '代替モデルを削除', up: '順序を上げる', down: '順序を下げる',
+  apply: '委任設定を適用', reset: '編集を破棄', refresh: '設定を再読み込み', saving: '保存中…',
+  failed: '設定を保存して確認できませんでした。編集は保持されています。接続を確認して再試行してください。', loadFailed: '委任設定を読み込めませんでした。',
+  offline: 'モデル一覧を取得できません。プロバイダーとモデル ID を手入力するか、再試行してください。', conflict: '委任設定が別の場所で変更されました。適用前に再読み込みしてください。',
+  invalid: 'プロバイダーとモデルをすべて入力し、代替動作を選択してください。', noProviders: 'このプロファイルにはモデル一覧がありません。ID を手入力できます。'
+}
+
+const ar: DelegationModelsCopy = {
+  loading: 'جارٍ تحميل إعدادات التفويض…',
+  unsupported: 'حدّث بيئة Hermes لهذه البوابة لإعداد بدائل التفويض هنا. تبقى الإعدادات الحالية دون تغيير.',
+  title: 'نماذج التفويض', description: 'النموذج الافتراضي والبدائل المرتبة للمهام المفوضة الجديدة. لا تتغير المحادثة الرئيسية.',
+  provider: 'مزود التفويض', model: 'نموذج التفويض', mainProvider: 'استخدام المزود الرئيسي', mainModel: 'استخدام النموذج الرئيسي',
+  direct: 'نقطة الاتصال المباشرة الحالية', directHint: 'يوجد تجاوز لنقطة الاتصال المباشرة. اختيار مزود يستبدل تجاوزات الاتصال والمصادقة.',
+  customModel: 'معرّف نموذج مخصص…', policy: 'سلوك بدائل التفويض', auto: 'السلوك الافتراضي',
+  autoHint: 'توريث البدائل الرئيسية فقط عندما لا يكون نموذج التفويض أو مزوده محددًا.', inherit: 'استخدام البدائل الرئيسية',
+  inheritHint: 'مشاركة سلسلة البدائل الرئيسية صراحةً، حتى مع اختيار نموذج للتفويض.', none: 'بدون بدائل', custom: 'اختيار بدائل التفويض',
+  customHint: 'تجربة أزواج المزود والنموذج بالترتيب. يحتفظ كل بديل بمساره وبيانات اعتماده.',
+  add: 'إضافة بديل للتفويض', remove: 'إزالة البديل', up: 'تقديم البديل', down: 'تأخير البديل',
+  apply: 'تطبيق إعدادات التفويض', reset: 'تجاهل التعديلات', refresh: 'إعادة تحميل الإعدادات', saving: 'جارٍ الحفظ…',
+  failed: 'تعذر حفظ الإعدادات وتأكيدها. تم الاحتفاظ بالتعديلات؛ تحقق من الاتصال وأعد المحاولة.', loadFailed: 'تعذر تحميل إعدادات التفويض.',
+  offline: 'دليل النماذج غير متاح. أدخل معرّفات المزود والنموذج يدويًا، أو أعد المحاولة.', conflict: 'تغيرت إعدادات التفويض في مكان آخر. أعد التحميل قبل التطبيق.',
+  invalid: 'أكمل جميع أزواج المزود والنموذج واختر سلوك البدائل قبل التطبيق.', noProviders: 'لا يوجد دليل نماذج لهذا الملف. يمكنك إدخال المعرّفات يدويًا.'
+}
+
+const copies: Record<string, DelegationModelsCopy> = { en, zh, 'zh-Hant': zhHant, 'zh-hant': zhHant, ja, ar }
+export const delegationModelsCopy = (locale: string): DelegationModelsCopy => copies[locale] ?? en

--- a/apps/desktop/src/app/settings/delegation-models-state.test.ts
+++ b/apps/desktop/src/app/settings/delegation-models-state.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  delegationDraftValid, delegationModelsPatch, moveDelegationFallback,
+  readDelegationModels, updateDelegationFallback
+} from './delegation-models-state'
+
+const worker = {
+  provider: 'custom:worker', model: 'worker/model', base_url: 'https://worker.invalid/v1',
+  key_env: 'WORKER_KEY', api_mode: 'chat_completions', request_overrides: { extra_body: { tier: 'batch' } }
+}
+
+describe('delegation model settings contract', () => {
+  it('round trips inherited state without any config write', () => {
+    expect(delegationModelsPatch({}, readDelegationModels({}))).toEqual({})
+  })
+
+  it('preserves a model-only override and its inherited provider', () => {
+    const baseline = { model: 'worker/model', provider: '' }
+    expect(readDelegationModels(baseline)).toMatchObject(baseline)
+    expect(delegationDraftValid(readDelegationModels(baseline), baseline)).toBe(true)
+  })
+
+  it('never commits a newly half-filled provider/model selection', () => {
+    const draft = { ...readDelegationModels({}), provider: 'custom:new' }
+    expect(delegationDraftValid(draft, {})).toBe(false)
+    expect(() => delegationModelsPatch({}, draft)).toThrow()
+  })
+
+  it('commits both route fields atomically, not a hardcoded choice', () => {
+    const draft = { ...readDelegationModels({}), provider: 'custom:any', model: 'arbitrary/model:tag' }
+    expect(delegationModelsPatch({}, draft)).toEqual({ provider: draft.provider, model: draft.model })
+  })
+
+  it('never rewrites the primary conversation or unrelated delegation settings', () => {
+    const baseline = { model: 'old', provider: 'custom:old', max_iterations: 17, reasoning_effort: 'high' }
+    const patch = delegationModelsPatch(baseline, { ...readDelegationModels(baseline), model: 'new' })
+    expect(patch).toEqual({ provider: 'custom:old', model: 'new' })
+    expect(baseline.max_iterations).toBe(17)
+    expect(baseline.reasoning_effort).toBe('high')
+  })
+
+  it('resets direct endpoint authority only after explicit provider selection', () => {
+    const baseline = { model: 'old', provider: '', base_url: 'https://direct.invalid/v1', api_key: 'private-key' }
+    const modelOnly = { ...readDelegationModels(baseline), model: 'new' }
+    expect(delegationModelsPatch(baseline, modelOnly)).toEqual({ model: 'new', provider: '' })
+    expect(delegationModelsPatch(baseline, { ...modelOnly, clearEndpoint: true })).toMatchObject({
+      base_url: '', api_key: '', api_mode: '', request_overrides: null
+    })
+  })
+
+  it('keeps canonical empty distinct from absence and suppresses legacy aliases', () => {
+    expect(readDelegationModels({}).mode).toBe('auto')
+    expect(readDelegationModels({ fallback_providers: [], fallback_model: worker }).mode).toBe('none')
+    expect(readDelegationModels({ fallback_chain: [worker] }).rows).toEqual([worker])
+  })
+
+  it('requires an explicit opt-in before a pinned model shares main backups', () => {
+    const baseline = { provider: 'custom:worker', model: 'pinned' }
+    expect(readDelegationModels(baseline).mode).toBe('auto')
+    expect(delegationModelsPatch(baseline, { ...readDelegationModels(baseline), mode: 'inherit' })).toEqual({
+      fallback_providers: 'inherit', fallback_chain: null, fallback_model: null
+    })
+  })
+
+  it('preserves endpoint and credential metadata when reordering backups', () => {
+    const other = { ...worker, provider: 'custom:backup', model: 'backup' }
+    const baseline = { fallback_providers: [worker, other] }
+    const rows = moveDelegationFallback(readDelegationModels(baseline).rows, 1, -1)
+    expect(delegationModelsPatch(baseline, { ...readDelegationModels(baseline), rows }).fallback_providers).toEqual([other, worker])
+    expect(baseline.fallback_providers).toEqual([worker, other])
+  })
+
+  it('drops old auth only for a row whose provider is deliberately replaced', () => {
+    const next = { provider: 'custom:another', model: '' }
+    expect(updateDelegationFallback(worker, next, true)).toEqual(next)
+    expect(updateDelegationFallback(worker, { provider: worker.provider, model: 'next' }, false)).toMatchObject({
+      model: 'next', base_url: worker.base_url, key_env: worker.key_env, request_overrides: worker.request_overrides
+    })
+  })
+
+  it('does not discard valid rows when an added backup is incomplete', () => {
+    const baseline = { fallback_providers: [worker] }
+    const draft = { ...readDelegationModels(baseline), rows: [worker, { provider: '', model: '' }] }
+    expect(delegationDraftValid(draft, baseline)).toBe(false)
+    expect(() => delegationModelsPatch(baseline, draft)).toThrow()
+    expect(baseline.fallback_providers).toEqual([worker])
+  })
+
+  it('does not silently normalize malformed declarations into inheritance', () => {
+    const invalid = readDelegationModels({ fallback_providers: ['broken'] })
+    expect(invalid.mode).toBe('invalid')
+    expect(delegationDraftValid(invalid, {})).toBe(false)
+  })
+
+  it('clears aliases on explicit reset so an old backup cannot reappear', () => {
+    const baseline = { fallback_chain: [worker] }
+    const draft = { ...readDelegationModels(baseline), mode: 'auto' as const }
+    expect(delegationModelsPatch(baseline, draft)).toEqual({
+      fallback_providers: null, fallback_chain: null, fallback_model: null
+    })
+  })
+
+  it('keeps no-op reorders referentially stable', () => {
+    const rows = [worker]
+    expect(moveDelegationFallback(rows, 0, -1)).toBe(rows)
+    expect(moveDelegationFallback(rows, 0, 1)).toBe(rows)
+  })
+})

--- a/apps/desktop/src/app/settings/delegation-models-state.ts
+++ b/apps/desktop/src/app/settings/delegation-models-state.ts
@@ -1,0 +1,127 @@
+/** Config-only state for the #67523 picker + #80479 fallback-matrix integration. */
+export interface DelegationModelProviderValue {
+  provider: string
+  model: string
+}
+
+export interface DelegationFallbackEntry extends DelegationModelProviderValue {
+  [key: string]: unknown
+}
+
+export type DelegationFallbackMode = 'auto' | 'inherit' | 'none' | 'custom' | 'invalid'
+
+export interface DelegationModelsDraft extends DelegationModelProviderValue {
+  mode: DelegationFallbackMode
+  rows: DelegationFallbackEntry[]
+  clearEndpoint: boolean
+}
+
+export const asRecord = (value: unknown): Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+
+const text = (value: unknown) => (typeof value === 'string' ? value : '')
+
+export const pairComplete = (pair: DelegationModelProviderValue): boolean =>
+  !!pair.provider.trim() && !!pair.model.trim()
+
+export function readDelegationModels(value: unknown): DelegationModelsDraft {
+  const config = asRecord(value)
+  const raw = config.fallback_providers ?? config.fallback_chain ?? config.fallback_model
+  const entries = Array.isArray(raw) ? raw : raw !== null && typeof raw === 'object' ? [raw] : []
+  let mode: DelegationFallbackMode = 'invalid'
+
+  if (raw == null) {
+    mode = 'auto'
+  } else if (typeof raw === 'string' && ['inherit', 'parent'].includes(raw.trim().toLowerCase())) {
+    mode = 'inherit'
+  } else if (Array.isArray(raw) && raw.length === 0) {
+    mode = 'none'
+  } else if (entries.length && entries.every(entry => {
+    const row = asRecord(entry)
+
+    return pairComplete({ provider: text(row.provider), model: text(row.model) })
+  })) {
+    mode = 'custom'
+  }
+
+  return {
+    provider: text(config.provider),
+    model: text(config.model),
+    mode,
+    rows: mode === 'custom' ? entries.map(entry => ({ ...asRecord(entry) } as DelegationFallbackEntry)) : [],
+    clearEndpoint: false
+  }
+}
+
+export function delegationDraftValid(draft: DelegationModelsDraft, baseline: unknown): boolean {
+  const original = readDelegationModels(baseline)
+  const routeChanged = draft.clearEndpoint || draft.provider !== original.provider || draft.model !== original.model
+
+  // Preserve an existing provider-default selection, but never persist the
+  // temporary provider/new-empty-model state during a new selection (#67523).
+  if (routeChanged && draft.provider.trim() && !draft.model.trim()) {
+    return false
+  }
+
+  return draft.mode !== 'invalid' && (draft.mode !== 'custom' || (draft.rows.length > 0 && draft.rows.every(pairComplete)))
+}
+
+export function delegationModelsPatch(baseline: unknown, draft: DelegationModelsDraft): Record<string, unknown> {
+  if (!delegationDraftValid(draft, baseline)) {
+    throw new Error('Incomplete delegation selection')
+  }
+
+  const original = readDelegationModels(baseline)
+  const patch: Record<string, unknown> = {}
+
+  if (draft.clearEndpoint || draft.provider !== original.provider || draft.model !== original.model) {
+    patch.provider = draft.provider.trim()
+    patch.model = draft.model.trim()
+  }
+
+  if (draft.clearEndpoint) {
+    // Provider selection means its configured route, not a stale direct URL
+    // and credential left by a previous override. Model-only edits retain it.
+    patch.base_url = ''
+    patch.api_key = ''
+    patch.api_mode = ''
+    patch.request_overrides = null
+  }
+
+  if (draft.mode !== original.mode || JSON.stringify(draft.rows) !== JSON.stringify(original.rows)) {
+    patch.fallback_providers = draft.mode === 'auto' ? null
+      : draft.mode === 'inherit' ? 'inherit'
+        : draft.mode === 'none' ? []
+          : draft.rows.map(entry => ({ ...entry, provider: entry.provider.trim(), model: entry.model.trim() }))
+    // A deliberate reset must not reanimate a legacy alias (#101017).
+    patch.fallback_chain = null
+    patch.fallback_model = null
+  }
+
+  return patch
+}
+
+export function delegationDraftChanged(draft: DelegationModelsDraft, baseline: unknown): boolean {
+  return JSON.stringify(draft) !== JSON.stringify(readDelegationModels(baseline))
+}
+
+/** Provider changes drop only that row's old endpoint/auth; model edits and moves preserve it. */
+export function updateDelegationFallback(
+  row: DelegationFallbackEntry, pair: DelegationModelProviderValue, providerChanged: boolean
+): DelegationFallbackEntry {
+  return providerChanged ? { ...pair } : { ...row, ...pair }
+}
+
+export function moveDelegationFallback(rows: DelegationFallbackEntry[], index: number, delta: number): DelegationFallbackEntry[] {
+  const target = index + delta
+
+  if (index < 0 || index >= rows.length || target < 0 || target >= rows.length) {
+    return rows
+  }
+
+  const next = [...rows]
+
+  ;[next[index], next[target]] = [next[target], next[index]]
+
+  return next
+}

--- a/hermes_cli/web_routers/config_env.py
+++ b/hermes_cli/web_routers/config_env.py
@@ -96,7 +96,12 @@ async def get_schema(profile: Optional[str] = None):
     # start still show up, scoped to the requested profile's config.
     with _config_profile_scope(profile):
         fields = _schema_with_dynamic_provider_options()
-    return {"fields": fields, "category_order": _CATEGORY_ORDER}
+    # Runtime support, not editable config: old backends also persist unknown
+    # keys, so presence of delegation.fallback_providers cannot prove support.
+    return {
+        "fields": fields, "category_order": _CATEGORY_ORDER,
+        "capabilities": {"delegation_fallbacks": True},
+    }
 
 
 @config_router.get("/api/egress/status")

--- a/tests/hermes_cli/test_delegation_config_capability.py
+++ b/tests/hermes_cli/test_delegation_config_capability.py
@@ -1,0 +1,30 @@
+"""The Models card negotiates runtime support, not a user-editable config key."""
+
+from contextlib import contextmanager
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_schema_advertises_delegation_runtime_support_in_requested_profile(monkeypatch):
+    from hermes_cli.web_routers import config_env
+
+    scopes = []
+
+    @contextmanager
+    def scoped(profile):
+        scopes.append(profile)
+        yield
+
+    fields = {"delegation.model": {"type": "string"}}
+    monkeypatch.setattr(config_env, "_config_profile_scope", scoped)
+    monkeypatch.setattr(config_env, "_schema_with_dynamic_provider_options", lambda: fields)
+    app = FastAPI()
+    app.include_router(config_env.config_router)
+    with TestClient(app) as client:
+        response = client.get("/api/config/schema", params={"profile": "worker-profile"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["capabilities"]["delegation_fallbacks"] is True
+    assert payload["fields"] == fields
+    assert scopes == ["worker-profile"]

--- a/website/docs/user-guide/features/delegation-models.md
+++ b/website/docs/user-guide/features/delegation-models.md
@@ -1,0 +1,124 @@
+---
+title: Delegation Models and Backups
+description: Choose persistent delegation defaults and a separate ordered fallback chain in Desktop.
+---
+
+# Delegation models and backups
+
+In **Desktop → Settings → Models → Delegation models**, choose a default
+provider and model for newly delegated work, followed by the backups to try
+when a model request reaches the existing provider-recovery path.
+
+The selectors use the same provider/model catalog as the other model controls.
+A model ID not in the catalog can be entered manually. Leaving the provider
+blank means **Use main provider**; a non-empty model with a blank provider is
+an independent model-only override. **Use main model** resets both fields.
+The picker persists empty strings for inheritance, not a literal `auto` model.
+
+Choose **Apply delegation settings** after completing the selection. Provider
+changes and incomplete fallback rows remain local drafts until then. The save
+writes only the changed `delegation` keys and verifies them by reading the same
+profile back. Changing a delegation setting does not change the primary
+conversation's model or top-level fallback chain. Existing delegated workers
+are not rerouted; the defaults apply when new children are constructed.
+
+The settings profile selector controls the configuration being edited. Its
+provider catalog, configuration read, save, and read-back use the same gateway
+and profile scope. A profile switch discards uncommitted drafts. A failed save
+retains edits for retry; an external delegation-config change requires an
+explicit reload before applying a stale draft.
+
+## Fallback behavior
+
+| Selection | Stored value | Behavior |
+| --- | --- | --- |
+| Default behavior | Key absent or `null` | Unpinned children inherit the parent's chain. Explicit provider, endpoint, or model-only pins do not silently inherit it. |
+| Use main fallbacks | `"inherit"` | Explicitly share the parent's chain, including with a pinned delegation model. |
+| No fallbacks | `[]` | Disable fallback for delegated children. |
+| Choose delegation fallbacks | List of provider/model entries | Use precisely this ordered, delegation-scoped chain, including with a pin. |
+
+Add, remove, or move backup rows on the same screen. Each row keeps its route
+metadata when moved or when only its model changes. Replacing a row's provider
+clears that row's old endpoint/credential overrides, so the old route cannot
+silently win over the new provider.
+
+The selected default is a persistent preference, not a source-code constant.
+Recovery uses the existing child `AIAgent` fallback machinery; this feature
+adds neither a second retry loop nor automatic rewrites of your saved default.
+The runtime fallback contract is owned by merged
+[#105347](https://github.com/NousResearch/hermes-agent/pull/105347); the Desktop
+editor only projects and persists that contract.
+Failure classification, retry budgets, and terminal errors remain those of the
+existing provider recovery system. Failure to resolve the initial delegation
+credentials still fails preflight; a fallback chain does not override that
+preflight authorization/transport check.
+
+## Configuration
+
+The same settings can be stored in the selected profile's `config.yaml`:
+
+```yaml
+delegation:
+  provider: custom:workers
+  model: worker-primary
+  fallback_providers:
+    - provider: custom:worker-backup
+      model: worker-backup
+    - provider: custom:local-worker
+      model: local-worker
+```
+
+Provider names and model IDs above are examples for configured custom
+providers, not built-in model defaults. Entries use the shared top-level
+fallback entry format, including optional `base_url`, `key_env`, `api_mode`,
+and other supported route metadata. Credentials continue to resolve through
+the provider and profile's existing credential machinery.
+
+Canonical `delegation.fallback_providers` takes precedence. For read
+compatibility, `delegation.fallback_chain` and then
+`delegation.fallback_model` are consulted only when the canonical value is
+absent or `null`. A canonical `[]` never resurrects an alias. The explicit
+`"parent"` string is accepted as an alias for `"inherit"`. Editing fallback
+behavior in Desktop writes the canonical key and clears the old aliases, so
+resetting to default cannot bring an old backup back accidentally.
+
+A malformed declaration is not partially applied: it warns and retains the
+pin-aware default from the existing fallback-matrix work. Thus a pinned child
+gets no implicit parent chain on a configuration error. The editor requires a
+valid policy and complete backup pairs before applying.
+
+## Existing direct endpoints
+
+A pre-existing `delegation.base_url` override is shown as **Existing direct
+endpoint** rather than mislabelled as the main provider. Editing only its model
+preserves the endpoint. Choosing a provider or **Use main model** explicitly
+clears the old delegation endpoint, inline credential, wire-mode, and request
+overrides so that the selected provider's configuration becomes authoritative.
+Other delegation settings, including reasoning effort and iteration limits,
+are preserved. The old Advanced delegation-model row opens the same scoped editor instead
+of retaining a second, stale pair of raw inputs. The Models page adds a
+discoverable control rather than moving runtime behavior into the renderer.
+
+The control checks the selected backend's config-schema capability before
+allowing edits. An older backend without delegation-scoped fallback support
+shows an update notice instead of saving inert settings. Existing settings
+are unchanged. An unavailable capability response shows a retry, not a false
+unsupported verdict. A successful config save alone does not establish runtime
+support: older backends can persist unknown keys without using them.
+
+## Contribution lineage
+
+This integration adapts webtecnica's [guided Desktop picker, #67523](https://github.com/NousResearch/hermes-agent/pull/67523)
+and projects the runtime contract now owned by kshitijk4poor's merged
+[#105347](https://github.com/NousResearch/hermes-agent/pull/105347). That runtime
+work salvaged Ayush Nangia's [pin × config matrix, #80479](https://github.com/NousResearch/hermes-agent/pull/80479),
+including spfcraze's model-only-pin correction, and builds on Ayush Nangia's
+#65052, Axl Ibiza's #80421, wz-heng's #80438, and Teknium's #80465 pin
+protection. Explicit parent inheritance follows devatnull's #81072; alias
+compatibility follows TurgutKural's #101017 without adopting its conflicting
+empty-list default. Reports and product requirements came from DavidMetcalfe
+(#67347), mlahatte (#65038), and ScotterMonk (#94629).
+
+The separate Dashboard part of #67347/#67557 is not implemented by this
+Desktop integration. Original PRs retain their discussion, authorship, and
+review reservations; this document does not declare them merged or closed.


### PR DESCRIPTION
## What does this PR do?

Rebuilds #105250 directly on current `main` (`267a6b79c8e0d8e0456d27948a80b79fea8f63d2`) as the **Desktop projection** of the delegation runtime contract merged in #105347.

This carrier retains the unique Desktop Models/profile editor and its authoritative persistence semantics:

- profile-scoped delegation provider/model selection, including model-only overrides
- ordered delegation fallback policies: default, explicit parent inheritance, none, or a declared chain
- local atomic drafts with incomplete selections blocked from saving
- same-owner catalog, capability, config read, save, and exact read-back across `{connectionId, profile}`
- stale external-change refusal, failed-save retry, and stale completion rejection after profile/gateway changes
- direct-endpoint metadata preservation until the provider is deliberately replaced
- capability negotiation so older backends do not accept inert fallback controls

It deliberately removes the duplicate runtime fallback implementation from the old branch. Runtime fallback ownership remains in current main via merged #105347. This PR changes neither the primary conversation model nor the top-level fallback chain.

## Related issues

- Refs #94629 (the open feature this Desktop editor surfaces)
- Runtime defect #65038 was settled by merged #105347 (2026-09-07); this PR is its Desktop projection, not the runtime fix
- Part of #67347
- Builds on merged #105347
- The separate Dashboard work remains in #67557

## Type of change

- [x] New feature
- [x] Documentation
- [x] Tests
- [ ] Breaking change

## Ownership boundary after #105347

| Concern | Owner |
| --- | --- |
| Delegation runtime resolution and pin-aware fallback semantics | #105347 / current main |
| Desktop Models editor, profile-scoped persistence, and read-back | This PR |
| Dashboard UI | #67557 |
| Generic primary-model fallback picker | #92942 |

## Persistence and read-back contract

The editor binds the provider catalog, capability schema, configuration read, write, and verification read-back to one explicit `{connectionId, profile}` owner.

Selections remain local until **Apply delegation settings**. A successful PUT is not accepted as proof of persistence: the editor reads the same owner back and requires the saved delegation patch to match. Failed saves retain the draft for retry. If the backing delegation configuration changes while a draft is open, Apply is blocked until the user reloads. Responses from an earlier profile, gateway, or request generation are ignored.

Provider changes clear only stale delegation endpoint/auth routing fields. Model-only changes and fallback reorders preserve route metadata. Resetting fallback behavior writes the canonical key and clears legacy aliases so an old fallback cannot reappear.

## Fallback matrix

| Selection | Stored value | Runtime meaning (owned by #105347) |
| --- | --- | --- |
| Default behavior | absent or `null` | Unpinned children inherit the parent chain; pinned children do not silently inherit |
| Use main fallbacks | `"inherit"` | Explicitly share the parent chain, including for a pinned child |
| No fallbacks | `[]` | Disable delegated-child fallbacks |
| Choose delegation fallbacks | ordered entries | Use exactly the declared delegation-scoped chain |

Canonical `delegation.fallback_providers` wins. Legacy `fallback_chain` and `fallback_model` are read only when the canonical value is absent/null. `"parent"` remains a read-compatible alias for `"inherit"`.

## Files changed

- `apps/desktop/src/api/config.ts`
- `apps/desktop/src/api/models-scope.test.ts`
- `apps/desktop/src/api/models.ts`
- `apps/desktop/src/app/settings/config-settings.tsx`
- `apps/desktop/src/app/settings/delegation-model-provider-field.test.tsx`
- `apps/desktop/src/app/settings/delegation-model-provider-field.tsx`
- `apps/desktop/src/app/settings/delegation-model-settings.test.tsx`
- `apps/desktop/src/app/settings/delegation-model-settings.tsx`
- `apps/desktop/src/app/settings/delegation-models-copy.ts`
- `apps/desktop/src/app/settings/delegation-models-state.test.ts`
- `apps/desktop/src/app/settings/delegation-models-state.ts`
- `hermes_cli/web_routers/config_env.py`
- `tests/hermes_cli/test_delegation_config_capability.py`
- `website/docs/user-guide/features/delegation-models.md`

## Collision and landing order

- #105347 is already merged and owns runtime behavior; this rebuild has zero runtime-file overlap.
- #67523's guided picker is superseded by this integrated Desktop carrier, with its source and authorship credited below.
- #67557 and #92942 are disjoint from this rebuilt file list.
- This PR should land before #106640 (overlap: `apps/desktop/src/api/config.ts`) and #106742 (overlap: `apps/desktop/src/app/settings/config-settings.tsx`); those branches should rebase afterward.

## Local verification

- Focused Desktop tests: **31/31 passed**
- Desktop TypeScript typecheck: **passed**
- Changed-file ESLint: **passed**
- Full Desktop lint: **0 errors** (158 pre-existing warnings)
- Broad Desktop suite: **7,431 passed; 2 failed**
  - both failures are in `src/store/voice-prefs.test.ts`
  - both reproduce unchanged on pristine current main `6f3e630`
  - neither file nor behavior is touched here
- Python capability test: **1/1 passed**
- Ruff on changed Python files: **passed**
- Windows-footgun diff audit: **passed**
- Contributor attribution audit: **repo-wide audit reports 4 pre-existing unmapped contributors on current main** (`Leanolf+212****0991@…`, `evan-bradford@…`, `stiraspo@…`, `witcheer.eth@…`) — none authored this PR's commit; this commit's lineage is covered by existing mappings plus its `Co-authored-by` trailers (webtecnica, Ayush Nangia). Repo-wide mapping repair is a separate main-level task, not owned by this PR.
- `git diff --check`: **passed**

Exact head: `cbe9fa581ac28191eae5bc986c550b95cf712e3a`. GitHub currently reports no workflow runs for this SHA. The three workflows created for the immediately preceding rebuilt head were stopped before jobs began with `action_required`; a NousResearch maintainer must approve the external-contributor workflows before exact-head CI evidence can run.

## Contribution lineage

This integration adapts webtecnica's guided Desktop picker in #67523 and projects the runtime contract now owned by kshitijk4poor's merged #105347. That runtime work salvaged Ayush Nangia's pin/config matrix in #80479, including spfcraze's model-only-pin correction, and builds on #65052, Axl Ibiza's #80421, wz-heng's #80438, Teknium's #80465, devatnull's #81072, and TurgutKural's #101017. Product reports and requirements came from DavidMetcalfe (#67347), mlahatte (#65038), and ScotterMonk (#94629).

Original PRs retain their discussion, authorship, and review reservations.