### PR TITLE
fix(tui,profiles): treat ".hermes" dir name as default profile (#105228)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -178,8 +178,14 @@ def normalize_profile_name(name: str) -> str:
     stripped = name.strip()
     if not stripped:
         raise ValueError("profile name cannot be empty")
-    if stripped.casefold() == "default":
+    if stripped.casefold() in ("default", ".hermes"):
         return "default"
+    # Defensive: callers that derived a name via Path(profile_home).name get
+    # ".hermes" for the default home — treat it as the default profile.
+    if stripped.startswith("."):
+        maybe = stripped.lstrip(".").casefold()
+        if maybe in ("default", "hermes", ""):
+            return "default"
     return stripped.lower()
 
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -97,6 +97,32 @@ def _profile_session_db(profile_home):
         from hermes_state_registry import acquire
         return acquire(Path(profile_home) / "state.db"), True
     return _get_db(), False
+def _profile_name_for_home(profile_home) -> str | None:
+    """Map a profile_home Path to its profile id without yielding ".hermes".
+
+    Path("~/.hermes").name is ".hermes" — not a valid profile id.
+    named_profile_home distinguishes the default home (→ "default") from
+    a named profile (→ its dir name). See #105228.
+    """
+    try:
+        from hermes_constants import named_profile_home
+        named = named_profile_home(str(profile_home))
+        if named is not None:
+            return named.name
+        s = str(profile_home)
+        if s.endswith(".hermes") or s.endswith("/.hermes"):
+            return None
+        from pathlib import Path as _P
+        return _P(s).name
+    except Exception:
+        try:
+            from hermes_cli.profiles import normalize_profile_name
+            from pathlib import Path as _P
+            canon = normalize_profile_name(str(_P(str(profile_home)).name))
+            return None if canon == "default" else canon
+        except Exception:
+            return None
+
 
 
 def _release_db(db) -> None:
@@ -268,7 +294,7 @@ def _seed_branch_row(record: dict, key: str, parent_session_id: str, history: li
                 return
             _persist_branch(db, key, parent_session_id, _branch_title(db, parent_session_id), history,
                             source=source, cwd=record["cwd"],
-                            profile_name=(Path(profile_home).name if profile_home else None), compensate=True)
+                            profile_name=(_profile_name_for_home(profile_home) if profile_home else None), compensate=True)
             record["pending_title"] = None
     except Exception:
         logger.warning("seeded-branch persistence failed for %s; falling back to lazy row creation", key,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1974,6 +1974,34 @@ def _current_profile_name() -> str:
     return "default"
 
 
+def _profile_name_for_session(session: dict | None) -> str:
+    """Profile name for a live session's ``profile_home``.
+
+    The previous implementation used ``Path(profile_home).name`` which yields
+    ``".hermes"`` for the default home (``~/.hermes``). That string is not a
+    valid profile id and trips ``_response_profile_name`` / ``resolve_profile_env``
+    into ``Profile '.hermes' does not exist`` (#105228). Use ``named_profile_home``
+    to distinguish the default home (→ ``"default"``) from a real named profile.
+    """
+    if not isinstance(session, dict) or not session.get("profile_home"):
+        return _current_profile_name()
+    try:
+        from hermes_constants import named_profile_home
+        home = session.get("profile_home")
+        named = named_profile_home(home)
+        if named is not None:
+            return named.name
+        # ``named_profile_home`` returns None for the default home and for
+        # custom paths — both map to ``"default"`` for display.
+        return "default"
+    except Exception:
+        # Fallback: Path.name then normalize (handles ".hermes" → "default").
+        with contextlib.suppress(Exception):
+            from hermes_cli.profiles import normalize_profile_name
+            return normalize_profile_name(str(Path(str(session.get("profile_home"))).name))
+        return "default"
+
+
 # Monotonic GUI<->backend contract version: the desktop refuses a backend reporting less (or none) with a
 # one-click "update to align" prompt; bump whenever the desktop's backend contract changes. v2 file.attach;
 # v3 approvals.mode RPCs + session.info reconciliation; v4 session.create fast=false = explicit normal tier;
@@ -2053,9 +2081,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "stored_session_id": session_key or "", "desktop_contract": DESKTOP_BACKEND_CONTRACT,
         "version": "", "release_date": "", "update_behind": None, "update_command": "",
         "usage": _session_usage_snapshot(session),
-        "profile_name": (
-            _response_profile_name(Path(session["profile_home"]).name)
-            if isinstance(session, dict) and session.get("profile_home") else _current_profile_name()),
+        "profile_name": _profile_name_for_session(session),
     }
     with contextlib.suppress(Exception):
         from hermes_cli import __version__, __release_date__


### PR DESCRIPTION
Fixes #105228.

**Problem:** After `hermes update` in the default profile, Desktop shows
`agent init failed: Profile '.hermes' does not exist` and
`Resume failed: handler error: Profile '.hermes' does not exist`.

Root cause is two TUI sites that derived a profile name via
`Path(profile_home).name`. For the default home `~/.hermes` that yields
".hermes" — not a valid profile id — which then fails
`_profile_home(".hermes")`/ `resolve_profile_env(".hermes")` lookup and
surfaces as the reported error.

**Fix:**
- `hermes_cli/profiles.py:normalize_profile_name` now maps ".hermes"
  (case-insensitive, with defensive lstrip-"." handling) to "default".
- `tui_gateway/server.py:_session_info` no longer uses naive `Path.name`;
  new helper `_profile_name_for_session` uses
  `hermes_constants.named_profile_home` so the default home maps to
  "default" and named profiles map to their dir name.
- `tui_gateway/methods_session.py:_seed_branch_row` same fix via new
  `_profile_name_for_home` helper.

**Testing:** `python -m py_compile` on all three files; manual verification
that `normalize_profile_name(".hermes") == "default"` and
`named_profile_home("~/.hermes") is None` → "default"; named profiles
still resolve correctly; `tests/hermes_cli/test_profiles.py` (56 passed) and
`tests/hermes_cli/test_deleted_profile_tombstone.py` (16 passed) green.