### PR TITLE
Fix: MCP OAuth start_flow mislabels real errors as timeout

### DIFF
--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -199,10 +199,20 @@ def start_flow(
             time.sleep(0.1)
         if not auth_url:
             raise TimeoutError("Timed out waiting for MCP authorization URL")
-    except Exception:
+    except TimeoutError:
+        # Genuinely never got a URL within url_timeout: the "timed out" label is accurate here.
         flow.mark_error("Timed out waiting for MCP authorization URL")
         _shutdown_listener(rec)
         raise
+    except Exception as exc:
+        # Any other failure (e.g. the RuntimeError raised above when the flow's own
+        # status went to "error", carrying the real reason from snap.get("error"))
+        # must not be relabeled as a timeout — that discards the actual cause and
+        # misleads the caller/UI into thinking the user simply ran out of time.
+        flow.mark_error(str(exc) or "MCP OAuth flow failed before authorization")
+        _shutdown_listener(rec)
+        raise
+
     # ``flow`` mirrors the provider-OAuth discriminator: open a URL then poll (no user_code).
     return {"session_id": session_id, "auth_url": auth_url, "flow": "pkce"}
 


### PR DESCRIPTION
## Bug

In `tui_gateway/mcp_oauth_sessions.py`, `start_flow()` wraps its wait loop in a broad `except Exception:` that unconditionally overwrites the real error message with a hardcoded string:

```python
except Exception:
    flow.mark_error("Timed out waiting for MCP authorization URL")
    _shutdown_listener(rec)
    raise
```

However, the loop can also raise a `RuntimeError` carrying the *actual* failure reason from `snap.get("error")` when `snap.get("status") == "error"` — this is a genuine flow error, not a timeout. That distinct, useful error message gets discarded and replaced with the generic timeout string, which is then surfaced to the desktop/TUI client via `poll_flow`'s `error_message` field. Users see "Timed out waiting for MCP authorization URL" even when the real problem was something else entirely (e.g. a provider registration failure), making the bug much harder to diagnose.

## Fix

Split the exception handling so only a genuine `TimeoutError` (raised when the deadline is reached with no URL) gets the timeout label. Any other exception preserves and surfaces its real message:

```python
except TimeoutError:
    flow.mark_error("Timed out waiting for MCP authorization URL")
    _shutdown_listener(rec)
    raise
except Exception as exc:
    flow.mark_error(str(exc) or "MCP OAuth flow failed before authorization")
    _shutdown_listener(rec)
    raise
```

No other behavior changes.

Closes #105251