### PR TITLE
fix(gateway): surface real MCP OAuth start_flow() errors instead of blanket timeout

### DIFF
--- a/tests/tui_gateway/test_mcp_oauth_start_flow_errors.py
+++ b/tests/tui_gateway/test_mcp_oauth_start_flow_errors.py
@@ -1,0 +1,96 @@
+"""start_flow() must surface the worker's real failure cause, not a blanket timeout.
+
+The polling loop distinguishes a worker error (RuntimeError with the flow's
+error) from a genuine deadline miss (TimeoutError); the error handlers around
+it must preserve that distinction in what poll_flow() later reports.
+"""
+
+import threading
+
+import pytest
+
+from tui_gateway import mcp_oauth_sessions as sessions
+
+
+def _start(home, server, **kwargs):
+    return sessions.start_flow(home, server, {"url": "https://mcp.example"}, **kwargs)
+
+
+def test_worker_failure_surfaces_real_error(tmp_path, monkeypatch):
+    finished = threading.Event()
+
+    def worker(session_id, *_args):
+        rec = sessions._sessions[session_id]
+        rec["flow"].mark_error("registration failed: invalid client metadata")
+        rec["flow"].mark_worker_done()
+        finished.set()
+
+    monkeypatch.setattr(sessions, "_worker", worker)
+    monkeypatch.setattr(sessions, "_sessions", {})
+    home = str(tmp_path / "home")
+    monkeypatch.setenv("HERMES_HOME", home)
+
+    with pytest.raises(RuntimeError, match="registration failed"):
+        _start(home, "reports")
+
+    sid = next(iter(sessions._sessions))
+    rec = sessions._sessions[sid]
+    assert finished.wait(5)
+    out = sessions.poll_flow(sid, "reports")
+    assert out["status"] == "error"
+    assert out["error_message"] == "registration failed: invalid client metadata"
+    assert "Timed out" not in out["error_message"]
+    assert rec["httpd"] is None
+
+
+def test_genuine_timeout_keeps_timeout_message(tmp_path, monkeypatch):
+    finished = threading.Event()
+    worker_exited = threading.Event()
+
+    def worker(session_id, *_args):
+        rec = sessions._sessions[session_id]
+        finished.wait(10)
+        rec["flow"].mark_worker_done()
+        worker_exited.set()
+
+    monkeypatch.setattr(sessions, "_worker", worker)
+    monkeypatch.setattr(sessions, "_sessions", {})
+    home = str(tmp_path / "home")
+    monkeypatch.setenv("HERMES_HOME", home)
+
+    try:
+        with pytest.raises(TimeoutError):
+            _start(home, "reports", url_timeout=0.3)
+
+        sid = next(iter(sessions._sessions))
+        rec = sessions._sessions[sid]
+        out = sessions.poll_flow(sid, "reports")
+        assert out["status"] == "error"
+        assert out["error_message"] == "Timed out waiting for MCP authorization URL"
+        assert rec["httpd"] is None
+    finally:
+        finished.set()
+        worker_exited.wait(5)
+
+
+def test_empty_worker_error_uses_fallback_message(tmp_path, monkeypatch):
+    finished = threading.Event()
+
+    def worker(session_id, *_args):
+        rec = sessions._sessions[session_id]
+        rec["flow"].mark_error("")
+        rec["flow"].mark_worker_done()
+        finished.set()
+
+    monkeypatch.setattr(sessions, "_worker", worker)
+    monkeypatch.setattr(sessions, "_sessions", {})
+    home = str(tmp_path / "home")
+    monkeypatch.setenv("HERMES_HOME", home)
+
+    with pytest.raises(RuntimeError, match="MCP OAuth flow failed"):
+        _start(home, "reports")
+
+    assert finished.wait(5)
+    sid = next(iter(sessions._sessions))
+    out = sessions.poll_flow(sid, "reports")
+    assert out["error_message"] == "MCP OAuth flow failed before authorization"

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -199,8 +199,12 @@ def start_flow(
             time.sleep(0.1)
         if not auth_url:
             raise TimeoutError("Timed out waiting for MCP authorization URL")
-    except Exception:
+    except TimeoutError:
         flow.mark_error("Timed out waiting for MCP authorization URL")
+        _shutdown_listener(rec)
+        raise
+    except Exception as exc:
+        flow.mark_error(str(exc) or "MCP OAuth flow failed before authorization")
         _shutdown_listener(rec)
         raise
     # ``flow`` mirrors the provider-OAuth discriminator: open a URL then poll (no user_code).


### PR DESCRIPTION
## Summary
- `start_flow()` in `tui_gateway/mcp_oauth_sessions.py` waited for the OAuth authorization URL and, on *any* failure, recorded the hardcoded `"Timed out waiting for MCP authorization URL"` — even when the polling loop had just raised a `RuntimeError` carrying the worker's real failure (registration rejection, unreachable OAuth server, unexpected exception). Every non-timeout MCP OAuth failure was therefore surfaced to `poll_flow()` callers (desktop/TUI) as a misleading timeout, discarding the actionable cause.
- Split the handler: `except TimeoutError:` keeps the genuine-timeout message; `except Exception as exc:` records `str(exc) or "MCP OAuth flow failed before authorization"`, so the real cause reaches the user.
- Regression tests in `tests/tui_gateway/test_mcp_oauth_start_flow_errors.py` cover both paths through the public `start_flow()`/`poll_flow()` seam: a worker error surfaces verbatim (not "Timed out"), a genuine timeout keeps the timeout message, and an empty worker error falls back to a descriptive message; the loopback listener is shut down in every case.

Fixes #105251

## Testing
- `pytest tests/tui_gateway/test_mcp_oauth_start_flow_errors.py tests/tui_gateway/test_mcp_oauth_cancel.py tests/tui_gateway/test_mcp_oauth_client_callback.py` → 28 passed (mutation check: reverting the split fails the two new error-path tests).
- `ruff check` clean on both files; `ruff format --diff` unchanged vs main (no new drift).