### PR TITLE
fix(tui): land async attachments on the live composer, not the snapshot

### DIFF
--- a/ui-tui/src/__tests__/useComposerState.test.ts
+++ b/ui-tui/src/__tests__/useComposerState.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { looksLikeDroppedPath } from '../app/useComposerState.js'
+import { appendedText, looksLikeDroppedPath } from '../app/useComposerState.js'
 
 describe('looksLikeDroppedPath', () => {
   it('recognizes macOS screenshot temp paths and file URIs', () => {
@@ -55,5 +55,23 @@ describe('looksLikeDroppedPath', () => {
     expect(looksLikeDroppedPath('/usr/bin/test')).toBe(true)
     expect(looksLikeDroppedPath('/tmp/file.txt')).toBe(true)
     expect(looksLikeDroppedPath('/etc/hosts')).toBe(true) // has second /
+  })
+})
+
+describe('appendedText', () => {
+  it('takes only what the attach added', () => {
+    expect(appendedText('/paste', { cursor: 20, value: '/paste [[ Image 1 ]]' })).toBe('[[ Image 1 ]]')
+  })
+
+  it('keeps the remainder the gateway sent along with the token', () => {
+    expect(appendedText('', { cursor: 26, value: '[[ Image 1 ]] a screenshot' })).toBe('[[ Image 1 ]] a screenshot')
+  })
+
+  it('is empty when the attach found nothing', () => {
+    expect(appendedText('/paste', null)).toBe('')
+  })
+
+  it('is empty when the result no longer extends the snapshot', () => {
+    expect(appendedText('/paste', { cursor: 5, value: 'other' })).toBe('')
   })
 })

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -65,6 +65,21 @@ function insertAtCursor(value: string, cursor: number, text: string): { cursor: 
 }
 
 /**
+ * The text an async attach appended to the composer.
+ *
+ * `attach` runs against a snapshot taken before its await, so its result cannot
+ * be written back verbatim — by the time it resolves the composer may have been
+ * cleared or typed into. Only what it added is still meaningful.
+ */
+export function appendedText(start: string, result: ComposerPasteResult | null): string {
+  if (!result?.value.startsWith(start)) {
+    return ''
+  }
+
+  return result.value.slice(start.length).trim()
+}
+
+/**
  * Quick client-side heuristic to detect text that looks like a dropped file path.
  * When this returns true the composer sends RPC calls to the server for actual
  * validation. Keep in sync with _detect_file_drop() in cli.py — see that
@@ -347,14 +362,22 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   /**
    * `/paste` and `/image` attach without a cursor of their own — the token
    * lands at the end of whatever is currently typed.
+   *
+   * Whatever is typed *when the attach resolves*, which is not what it started
+   * from: submitting a slash command clears the composer as soon as the command
+   * is dispatched, and typing carries on meanwhile. Replaying just the appended
+   * text keeps the token; writing the whole result back would restore the line
+   * that was cleared.
    */
   const appendAttachment = useCallback(
     (attach: (value: string, cursor: number) => Promise<ComposerPasteResult | null>) => {
-      const current = inputRef.current
+      const start = inputRef.current
 
-      void attach(current, current.length).then(next => {
-        if (next) {
-          setInput(next.value)
+      void attach(start, start.length).then(next => {
+        const appended = appendedText(start, next)
+
+        if (appended) {
+          setInput(prev => insertAtCursor(prev, prev.length, appended).value)
         }
       })
     },


### PR DESCRIPTION
Covers the `/paste` trigger from #25607. #25605 rebases async paste inside `textInput`, which handles the typing-during-paste case; the slash-command case runs through a different path and survives that fix, so this is complementary to it rather than an alternative.

Repro (Linux/Wayland, kitty):

1. Copy an image to the clipboard
2. Type `/paste`, press Enter

Composer ends up as `/paste [[ Image 1 ]]`. The image attaches fine — only the command text comes back after being cleared.

`appendAttachment` in `ui-tui/src/app/useComposerState.ts` snapshots the input, awaits the gateway, then writes the result back:

```ts
const current = inputRef.current

void attach(current, current.length).then(next => {
  if (next) {
    setInput(next.value)
  }
})
```

`useSubmission` dispatches the slash command and clears the composer three lines below the dispatch, which lands between the snapshot and the write, so the write restores `/paste`. `/image` goes through the same function.

The patch takes only the text the attach appended and re-inserts it into the live buffer with the same `insertAtCursor` the rest of the file uses, so the spacing comes out right whether the composer was cleared or typed into in the meantime. `setInput` already accepts an updater, so the write reads the ref at write time instead of a captured value.

`appendedText` is exported so the anchor check gets a unit test, the same way `rebaseAsyncPasteResult` is tested in #25605.

Checks in `ui-tui`: `npm test` (1750 passed, 3 skipped), `npm run typecheck`, and `eslint` on both touched files — all clean.
