### PR TITLE
fix(gateway): prioritize managed Node in system units

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2707,21 +2707,26 @@ def _systemd_watchdog_seconds(hermes_home: str | Path | None = None) -> int:
 
 
 def _append_node_dir_for_service(path_entries: list[str], hermes_root: Path | None = None) -> None:
-    """Append the Node dir a service unit should use: managed ``<hermes_root>/node`` (profile-scoped)
-    first — a unit survives reboots, so baking a shell-PATH Node is permanent breakage — else PATH lookup."""
+    """Put the Node dirs a service unit should use first.
+
+    A unit survives reboots, so selecting a shell-PATH Node is permanent breakage.  ``node/bin``
+    can already be present from the generic service path builder; move it rather than merely
+    avoiding a duplicate, otherwise a legacy ``/usr/bin/node`` can still win.
+    """
     from hermes_constants import (hermes_managed_node_tree_present, iter_hermes_node_dirs)
     managed_node_present = hermes_managed_node_tree_present(hermes_root)
+    managed_entries = []
     for directory in iter_hermes_node_dirs(hermes_root) if managed_node_present else ():
-        entry = str(directory)
         try:
-            present = directory.is_dir()
+            if directory.is_dir():
+                managed_entries.append(str(directory))
         except OSError:
-            present = False
-        if present and entry not in path_entries:
-            path_entries.append(entry)
+            continue
 
     # With managed Node present, consulting the invoker's PATH would make a system unit depend on who ran sudo.
     if managed_node_present:
+        path_entries[:] = [entry for entry in path_entries if entry not in managed_entries]
+        path_entries[:0] = managed_entries
         return
 
     resolved_node = shutil.which("node")
@@ -2768,10 +2773,12 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         working_dir = str(hermes_home) if hermes_home else _remap_path_for_user(working_dir, home_dir)
         venv_dir = _remap_path_for_user(venv_dir, home_dir)
         path_entries = [_remap_path_for_user(p, home_dir) for p in path_entries]
-        # Managed Node for the TARGET user's tree, prepended so it outranks remapped shell-PATH entries.
+        # Managed Node for the TARGET user's tree must outrank every generic service entry.  In
+        # particular, node/bin is often already present from _build_service_path_dirs(); retaining
+        # that copy later in PATH lets an older /usr/bin/node win.
         _target_node_entries: list[str] = []
         _append_node_dir_for_service(_target_node_entries, Path(hermes_home) if hermes_home else None)
-        path_entries = [e for e in _target_node_entries if e not in path_entries] + path_entries
+        path_entries = _target_node_entries + [e for e in path_entries if e not in _target_node_entries]
         user_home = Path(home_dir)
         identity_lines = f"User={username}\nGroup={group_name}\n"
         env_lines = (

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1239,6 +1239,20 @@ class TestSystemUnitHermesHome:
 
         assert entries == ["/opt/external-node/bin"]
 
+    def test_managed_node_entries_outrank_an_existing_system_node_path(self, tmp_path):
+        """The managed bin dir must move ahead of an older node already in PATH."""
+        managed_root = tmp_path / ".hermes"
+        managed_bin = managed_root / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        node = managed_bin / "node"
+        node.write_text("#!/bin/sh\n")
+        node.chmod(0o755)
+        entries = ["/usr/bin", str(managed_bin), "/custom/bin", str(managed_root / "node")]
+
+        gateway_cli._append_node_dir_for_service(entries, managed_root)
+
+        assert entries == [str(managed_bin), str(managed_root / "node"), "/usr/bin", "/custom/bin"]
+
     def test_managed_node_makes_system_unit_independent_of_callers_path(
         self, monkeypatch, tmp_path
     ):
@@ -1273,6 +1287,36 @@ class TestSystemUnitHermesHome:
         assert root_unit == user_unit
         assert str(managed_bin) in root_unit
         assert "/root/bin" not in root_unit
+
+    def test_system_unit_prioritizes_target_managed_node_when_bin_is_already_generic(
+        self, monkeypatch, tmp_path
+    ):
+        """A generic node/bin entry must not leave an older system Node ahead of it."""
+        target_home = tmp_path / "home" / "alice"
+        target_hermes = target_home / ".hermes"
+        root_hermes = tmp_path / "root" / ".hermes"
+        managed_bin = target_hermes / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        node = managed_bin / "node"
+        node.write_text("#!/bin/sh\n")
+        node.chmod(0o755)
+        root_hermes.mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "root"))
+        monkeypatch.setenv("HERMES_HOME", str(root_hermes))
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", str(target_home)),
+        )
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: root_hermes)
+        monkeypatch.setattr(gateway_cli, "_build_service_path_dirs", lambda: ["/venv/bin", str(managed_bin)])
+        monkeypatch.setattr(gateway_cli, "_build_user_local_paths", lambda home, existing: ["/usr/bin"])
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+        path = next(line for line in unit.splitlines() if line.startswith('Environment="PATH=')).split("PATH=", 1)[1][:-1]
+
+        assert path.split(":")[:2] == [str(managed_bin), str(target_hermes / "node")]
 
     def test_node_path_lookup_remains_fallback_without_managed_node(
         self, monkeypatch, tmp_path


### PR DESCRIPTION
## Summary
- put the target user’s managed `node/bin` ahead of all generic service PATH entries
- prevent a pre-existing `node/bin` entry from being retained behind `/usr/bin`
- cover both direct path assembly and system-unit generation

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -k "managed_node or node_path_lookup"`
- generated system unit resolves `node` and `npm` to the managed Node 22 tree