### PR TITLE
fix(desktop): stop idle profile chats from exhausting backend slots

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1583,10 +1583,9 @@ function setPoolLimits(raw) {
   return { ...poolLimits }
 }
 
-// A backend touched within this window has a live renderer socket (the keepalive
-// pings every 60s for every open profile). LRU eviction must spare these — a
-// concurrent multi-profile session keeps several backends "fresh" at once, and
-// killing one to honor the soft cap would abort a running agent.
+// A backend streaming within this window must be spared from cap eviction. A
+// renderer keepalive only proves that its socket is open; treating that as work
+// made every profile ever opened permanently exempt from the cap (#105239).
 //
 // The window is intentionally MUCH wider than the 60s ping cadence:
 //   * 1 missed ping    = +60s of apparent silence
@@ -11515,6 +11514,7 @@ async function ensureBackend(profile, opts: { spawnPriority?: LocalBackendSpawnP
     token: null,
     connectionPromise: null,
     lastActiveAt: Date.now(),
+    lastStreamingAt: null,
     remoteBaseUrl: null,
     releaseLocalBackendSlot: null,
     localBackendSlotKey: null,
@@ -11690,6 +11690,7 @@ async function ensureRegistryBackend(
       token: null,
       connectionPromise: null,
       lastActiveAt: Date.now(),
+      lastStreamingAt: null,
       remoteBaseUrl: null,
       releaseLocalBackendSlot: null,
       localBackendSlotKey: null,
@@ -12381,12 +12382,16 @@ async function stopRegistryConnectionBackends(connectionId) {
 // Mark a pool profile as recently used so the idle reaper spares it. The
 // renderer calls this when it opens a profile's chat WS and periodically while
 // streaming, since the main process can't see the direct renderer↔backend WS.
-function touchPoolBackend(profile) {
+function touchPoolBackend(profile, options: { streaming?: boolean } = {}) {
   for (const key of poolTouchKeys(profile)) {
     const entry = backendPool.get(key)
 
     if (entry) {
       entry.lastActiveAt = Date.now()
+
+      if (options.streaming) {
+        entry.lastStreamingAt = entry.lastActiveAt
+      }
 
       return
     }
@@ -12394,9 +12399,10 @@ function touchPoolBackend(profile) {
 }
 
 // Evict least-recently-used SPAWNED pool backends until at most `keep` remain —
-// but only ever evict backends without a live renderer socket (stale beyond the
-// keepalive window). When every backend is actively kept alive we let the pool
-// exceed the soft cap rather than kill a running session. Process-less
+// but only ever evict backends without recent streaming activity. An open idle
+// renderer socket is eligible immediately, restoring the configured memory
+// bound; when every backend is streaming we wait rather than kill active work.
+// Process-less
 // descriptor entries (remote/cloud registry sources, per-profile remote
 // overrides — `entry.process === null`) are excluded from the cap entirely:
 // they hold no local process, so counting them used to let a roster refresh
@@ -15002,8 +15008,8 @@ function revalidateSuspectPoolAfterResume() {
   )
 }
 
-ipcMain.handle('hermes:backend:touch', async (_event, profile) => {
-  touchPoolBackend(profile)
+ipcMain.handle('hermes:backend:touch', async (_event, profile, options) => {
+  touchPoolBackend(profile, options)
 
   return { ok: true }
 })

--- a/apps/desktop/electron/pool-eviction.test.ts
+++ b/apps/desktop/electron/pool-eviction.test.ts
@@ -11,14 +11,18 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { selectPoolEvictions } from './pool-eviction'
+import { type PoolEvictionEntry, selectPoolEvictions } from './pool-eviction'
 
 const NOW = 1_000_000
 // Mirrors main.ts POOL_KEEPALIVE_FRESH_MS (4 minutes — see #95189).
 const FRESH_MS = 4 * 60_000
 
 /** A spawned local backend entry (has a child process). */
-const spawned = (idleMs: number) => ({ process: { pid: 123 }, lastActiveAt: NOW - idleMs })
+const spawned = (idleMs: number, streamedMs: number | null = null): PoolEvictionEntry => ({
+  process: { pid: 123 },
+  lastActiveAt: NOW - idleMs,
+  lastStreamingAt: streamedMs === null ? null : NOW - streamedMs
+})
 
 /** A process-less remote/cloud descriptor entry. */
 const descriptor = (idleMs: number) => ({ process: null, lastActiveAt: NOW - idleMs })
@@ -51,14 +55,35 @@ test('spawned backends over the cap are still LRU-evicted', () => {
   assert.deepEqual(selectPoolEvictions(entries, 2, NOW, FRESH_MS), ['a'])
 })
 
-test('fresh spawned backends are spared even over the cap', () => {
+test('recent renderer keepalives do not pin idle spawned backends over the cap', () => {
   const entries: [string, ReturnType<typeof spawned>][] = [
     ['a', spawned(1_000)],
     ['b', spawned(2_000)],
     ['c', spawned(3_000)]
   ]
 
-  // All within the keepalive window → the pool may exceed the soft cap.
+  // An open renderer socket is not evidence of a running turn. The two least
+  // recently used idle children must make room even though keepalive touched
+  // every socket moments ago.
+  assert.deepEqual(selectPoolEvictions(entries, 1, NOW, FRESH_MS), ['c', 'b'])
+})
+
+test('recent streaming activity protects a spawned backend from cap eviction', () => {
+  const entries: [string, ReturnType<typeof spawned>][] = [
+    ['streaming', spawned(3_000, 2_000)],
+    ['idle-a', spawned(2_000)],
+    ['idle-b', spawned(1_000)]
+  ]
+
+  assert.deepEqual(selectPoolEvictions(entries, 1, NOW, FRESH_MS), ['idle-a', 'idle-b'])
+})
+
+test('all-streaming pools stay over cap rather than terminate active work', () => {
+  const entries: [string, ReturnType<typeof spawned>][] = [
+    ['a', spawned(3_000, 2_000)],
+    ['b', spawned(2_000, 1_000)]
+  ]
+
   assert.deepEqual(selectPoolEvictions(entries, 1, NOW, FRESH_MS), [])
 })
 
@@ -100,7 +125,7 @@ test('descriptor-only pools never evict', () => {
 // without evicting an active backend. Truly stale backends (multiple lapses,
 // minutes idle) are still evicted as before.
 
-test('#95189: one missed keepalive ping must NOT make the most-recently-touched backend evictable', () => {
+test('#95189: one missed streaming ping must NOT make an active backend evictable', () => {
   // Renderer's keepalive cadence is 60s. With the old freshMs=90s window,
   // a backend last touched 95s ago — i.e. exactly ONE missed/delayed ping —
   // was eligible for LRU eviction even though it had been actively
@@ -112,8 +137,8 @@ test('#95189: one missed keepalive ping must NOT make the most-recently-touched 
   // extra cycle — killing an active backend is far worse than briefly
   // exceeding the soft cap.
   const entries: [string, ReturnType<typeof spawned>][] = [
-    ['active', spawned(95_000)], // 1 missed ping on a 60s cadence
-    ['fresher', spawned(2_000)] // touched recently — must NOT be evicted
+    ['active', spawned(95_000, 95_000)], // 1 missed ping on a 60s cadence
+    ['fresher', spawned(2_000, 2_000)] // streaming recently — must NOT be evicted
   ]
 
   // keep=1 → pool over cap by one. Active backend must be spared; the cap
@@ -122,7 +147,7 @@ test('#95189: one missed keepalive ping must NOT make the most-recently-touched 
   assert.deepEqual(selectPoolEvictions(entries, 1, NOW, FRESH_MS), [])
 })
 
-test('#95189: two missed keepalive pings (2-min IPC stall) must NOT evict an active backend', () => {
+test('#95189: two missed streaming pings (2-min IPC stall) must NOT evict an active backend', () => {
   // The reported symptom: gateways exited ~80–90s after start with a clean
   // disconnect (no stderr), recurring every ~2 min. Reproduce the boundary:
   // 125s of silence = just over two missed pings at 60s. A backend in this
@@ -132,9 +157,9 @@ test('#95189: two missed keepalive pings (2-min IPC stall) must NOT evict an act
   // The other entries are all FRESH (well within the keepalive window), so
   // no eviction is correct even before any cap considerations.
   const entries: [string, ReturnType<typeof spawned>][] = [
-    ['active', spawned(125_000)],
-    ['fresher', spawned(2_000)],
-    ['fresher-2', spawned(5_000)]
+    ['active', spawned(125_000, 125_000)],
+    ['fresher', spawned(2_000, 2_000)],
+    ['fresher-2', spawned(5_000, 5_000)]
   ]
 
   assert.deepEqual(selectPoolEvictions(entries, 1, NOW, FRESH_MS), [])
@@ -144,8 +169,8 @@ test('#95189: a backend genuinely idle for minutes IS evicted (#95189 long-windo
   // Sanity: the widening does NOT make the pool unbounded. 10 minutes of
   // silence (the documented POOL_IDLE_MS) is still fair game.
   const entries: [string, ReturnType<typeof spawned>][] = [
-    ['idle', spawned(10 * 60_000)],
-    ['fresh', spawned(5_000)]
+    ['idle', spawned(10 * 60_000, 10 * 60_000)],
+    ['fresh', spawned(5_000, 5_000)]
   ]
 
   // keep=1, idle is over the cap AND past the fresh window → evicted.

--- a/apps/desktop/electron/pool-eviction.ts
+++ b/apps/desktop/electron/pool-eviction.ts
@@ -16,15 +16,17 @@
 
 export interface PoolEvictionEntry {
   lastActiveAt?: null | number
+  lastStreamingAt?: null | number
   process?: unknown
 }
 
 /**
  * Pick which pool keys the LRU cap should evict so that at most `keep`
  * SPAWNED backends remain. Only entries with a live child process count
- * toward the cap or are eligible for cap eviction, and — as before — only
- * entries idle beyond `freshMs` may be evicted (an actively kept-alive pool
- * may exceed the soft cap rather than kill a running session).
+ * toward the cap or are eligible for cap eviction. A renderer keepalive only
+ * proves that a socket is open; only recent streaming activity protects a
+ * child from cap eviction. If every child is streaming, the pool may remain
+ * over cap rather than terminate active work.
  */
 export function selectPoolEvictions<K>(
   entries: Iterable<[K, PoolEvictionEntry]>,
@@ -39,7 +41,7 @@ export function selectPoolEvictions<K>(
   }
 
   const evictable = spawned
-    .filter(([, entry]) => now - (entry.lastActiveAt || 0) > freshMs)
+    .filter(([, entry]) => now - (entry.lastStreamingAt || 0) > freshMs)
     .sort((a, b) => (a[1].lastActiveAt || 0) - (b[1].lastActiveAt || 0))
 
   let removable = spawned.length - Math.max(0, keep)

--- a/apps/desktop/electron/pool-stop.test.ts
+++ b/apps/desktop/electron/pool-stop.test.ts
@@ -114,9 +114,10 @@ test('stopAll stops every pooled backend and resolves after all exits', async ()
 })
 
 test('a respawn can await the in-flight stop before reusing the key', async () => {
-  const { addChild, exitResolvers, stopper } = harness()
+  const { addChild, exitResolvers, pool, stopper } = harness()
   const child = addChild('selena')
   const order: string[] = []
+  const replacement: Child = { exited: false, killed: false }
 
   void stopper.stop('selena')
 
@@ -127,6 +128,7 @@ test('a respawn can await the in-flight stop before reusing the key', async () =
       await dying
     }
 
+    pool.set('selena', { process: replacement })
     order.push('spawn')
   })()
 
@@ -135,4 +137,5 @@ test('a respawn can await the in-flight stop before reusing the key', async () =
   await respawn
 
   assert.deepEqual(order, ['exit-signal', 'spawn'])
+  assert.equal(pool.get('selena')?.process, replacement)
 })

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -23,7 +23,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getConnectionFor: payload => ipcRenderer.invoke('hermes:connection:for', payload),
   getProfileRoutes: profiles => ipcRenderer.invoke('hermes:plugin-profile-routes', profiles),
   revalidateConnection: () => ipcRenderer.invoke('hermes:connection:revalidate'),
-  touchBackend: profile => ipcRenderer.invoke('hermes:backend:touch', profile),
+  touchBackend: (profile, options) => ipcRenderer.invoke('hermes:backend:touch', profile, options),
   getPoolLimits: () => ipcRenderer.invoke('hermes:pool-limits:get'),
   setPoolLimits: limits => ipcRenderer.invoke('hermes:pool-limits:set', limits),
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -79,7 +79,8 @@ import {
   openTileGatewayScopes,
   reconcileBusyStatesOnReconnect,
   recordSessionEventScope,
-  resetTileRuntimeBindings
+  resetTileRuntimeBindings,
+  workingSessionScopes
 } from '@/store/session-states'
 import { windowProfileOverride } from '@/store/windows'
 import type { RpcEvent } from '@/types/hermes'
@@ -944,10 +945,13 @@ export function useGatewayBoot({
 
     // Keep live pool backends alive while this window is open (the main process
     // can't observe the direct renderer↔backend WS). No-op for the primary.
-    const keepaliveTimer = setInterval(() => {
-      touchActiveGatewayBackend()
-      touchSecondaryGateways()
-    }, 60_000)
+    const touchKeptGatewayBackends = () => {
+      const streamingScopes = workingSessionScopes()
+      touchActiveGatewayBackend(streamingScopes)
+      touchSecondaryGateways(streamingScopes)
+    }
+
+    const keepaliveTimer = setInterval(touchKeptGatewayBackends, 60_000)
 
     // Bound concurrency cost to consumers: keep a background socket while its
     // profile has a running (working) or blocked (needs-input) session, OR an
@@ -982,7 +986,13 @@ export function useGatewayBoot({
       pruneSecondaryGateways(keep)
     }
 
-    const offWorking = $workingSessionIds.subscribe(() => recomputeKeptGateways())
+    const offWorking = $workingSessionIds.subscribe(() => {
+      recomputeKeptGateways()
+      // Protect a stream as soon as its busy state lands; waiting for the next
+      // minute heartbeat leaves a cap-eviction race at turn start.
+      touchKeptGatewayBackends()
+    })
+
     const offAttention = $attentionSessionIds.subscribe(() => recomputeKeptGateways())
     const offActiveSession = $activeSessionId.subscribe(() => recomputeKeptGateways())
     const offSessionTiles = $sessionTiles.subscribe(() => recomputeKeptGateways())

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -51,7 +51,7 @@ declare global {
       revalidateConnection: () => Promise<{ ok: boolean; rebuilt: boolean }>
       // Keepalive: mark a pool profile backend as recently used so the idle
       // reaper spares it while its chat is active.
-      touchBackend: (profile?: string | null) => Promise<{ ok: boolean }>
+      touchBackend: (profile?: string | null, options?: { streaming?: boolean }) => Promise<{ ok: boolean }>
       // Pool sizing (Settings → Advanced): device-local, live-applied by the
       // main process. get resolves the limits currently in force; set applies
       // (and persists) new ones, evicting/reaping to converge immediately.

--- a/apps/desktop/src/store/gateway-connection-scope.test.ts
+++ b/apps/desktop/src/store/gateway-connection-scope.test.ts
@@ -49,7 +49,8 @@ const {
   openGatewayForAgent,
   pruneSecondaryGateways,
   setPrimaryGateway,
-  setPrimaryGatewayConnectionId
+  setPrimaryGatewayConnectionId,
+  touchSecondaryGateways
 } = await import('./gateway')
 
 const { setApiRequestConnection } = await import('@/hermes')
@@ -129,6 +130,20 @@ describe('primary gateway registry scope', () => {
 })
 
 describe('pruneSecondaryGateways with registry-scoped entries', () => {
+  it('marks only running scopes as streaming in pool keepalives', async () => {
+    await openGatewayForAgent(null, 'research')
+    await openGatewayForAgent('homelab', 'worker')
+    await openGatewayForAgent('homelab', 'idle')
+    const touchBackend = window.hermesDesktop?.touchBackend as ReturnType<typeof vi.fn>
+    touchBackend.mockClear()
+
+    touchSecondaryGateways(new Set(['research', 'conn:homelab::worker']))
+
+    expect(touchBackend).toHaveBeenCalledWith('research', { streaming: true })
+    expect(touchBackend).toHaveBeenCalledWith('conn:homelab::worker', { streaming: true })
+    expect(touchBackend).toHaveBeenCalledWith('conn:homelab::idle', { streaming: false })
+  })
+
   it('keeps the previous source socket open when Sessions switches backends', async () => {
     await ensureGatewayForAgent('work', 'default')
     await ensureGatewayForAgent('homelab', 'default')

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1665,12 +1665,13 @@ export function openSecondaryCount(): number {
 
 // Keep the idle reaper from killing a backend we still need: ping every live
 // secondary. The active one is pinged separately (touchActiveGatewayBackend).
-export function touchSecondaryGateways(): void {
+export function touchSecondaryGateways(streamingScopes: ReadonlySet<string> = new Set()): void {
   const desktop = window.hermesDesktop
 
   for (const entry of g.secondaries.values()) {
     if (entry.wantOpen) {
-      void desktop?.touchBackend?.(entry.scope).catch(() => undefined)
+      const streaming = streamingScopes.has(entry.scope) || (!entry.connectionId && streamingScopes.has(entry.profile))
+      void desktop?.touchBackend?.(entry.scope, { streaming }).catch(() => undefined)
     }
   }
 }

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -1000,9 +1000,9 @@ export function requestProfileCreate(): void {
 // Keepalive ping for the active pool backend so the main-process idle reaper
 // (which can't see the direct renderer↔backend WS) spares it. No-op for the
 // primary/default backend, which is never pooled.
-export function touchActiveGatewayBackend(): void {
+export function touchActiveGatewayBackend(streamingScopes: ReadonlySet<string> = new Set()): void {
   // Always ping: the main process no-ops for non-pool (primary) backends, so we
   // don't need to know which profile is primary from here.
   const target = normalizeProfileKey($activeGatewayProfile.get())
-  void window.hermesDesktop?.touchBackend?.(target).catch(() => undefined)
+  void window.hermesDesktop?.touchBackend?.(target, { streaming: streamingScopes.has(target) }).catch(() => undefined)
 }

--- a/apps/desktop/src/store/session-states-scopes.test.ts
+++ b/apps/desktop/src/store/session-states-scopes.test.ts
@@ -9,7 +9,8 @@ import {
   liveSessionScopes,
   openTileGatewayScopes,
   publishSessionState,
-  recordSessionEventScope
+  recordSessionEventScope,
+  workingSessionScopes
 } from '@/store/session-states'
 
 /**
@@ -31,6 +32,15 @@ beforeEach(() => {
 })
 
 describe('liveSessionScopes', () => {
+  it('reports only actively working scopes for backend stream protection', () => {
+    recordSessionEventScope({ connectionId: 'homelab', profile: 'worker', session_id: 'running' })
+    recordSessionEventScope({ connectionId: 'homelab', profile: 'reviewer', session_id: 'blocked' })
+    publishSessionState('running', state({ busy: true }))
+    publishSessionState('blocked', state({ busy: false, needsInput: true }))
+
+    expect(workingSessionScopes()).toEqual(new Set(['conn:homelab::worker']))
+  })
+
   it('maps a registry-tagged busy session to its composite scope', () => {
     recordSessionEventScope({ connectionId: 'homelab', profile: 'default', session_id: 'rt-1' })
     publishSessionState('rt-1', state({ busy: true }))

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -153,6 +153,29 @@ export function liveSessionScopes(): Set<string> {
   return scopes
 }
 
+/** Backend scopes with a turn actively running. Needs-input sessions still
+ * retain their socket, but they are safe cap-eviction candidates because no
+ * stream is in flight and foregrounding transparently re-ensures the backend. */
+export function workingSessionScopes(): Set<string> {
+  const scopes = new Set<string>()
+
+  for (const [runtimeId, state] of Object.entries($sessionStates.get())) {
+    if (!state?.busy) {
+      continue
+    }
+
+    const owner = sessionOwnerByRuntimeId.get(runtimeId)
+
+    if (typeof owner === 'string') {
+      scopes.add(normalizeProfileKey(owner))
+    } else if (owner) {
+      scopes.add(registryBackendScopeKey(owner.connectionId, owner.profile))
+    }
+  }
+
+  return scopes
+}
+
 // ── Owner hold across the create → foreground gap ───────────────────────────
 // A routed session.create returns a stored id on the owner's socket, but the
 // surface that will PIN that socket (the selected primary thread, or a tile)


### PR DESCRIPTION
## What does this PR do?

Bounds resident Desktop profile backends even when many profile chats remain open. Renderer keepalives now distinguish a running turn from an idle socket, so the configured cap can evict pinned-but-idle children while recent streaming activity remains protected.

### Symptom

After many profile chats had been opened, their keepalive pings made every pooled backend look active. The pool could not choose an eviction candidate, retaining one full local backend per opened profile on affected builds; current main's newer spawn coordinator bounds process growth but foreground profile opens can still wait and time out behind idle pinned entries.

### Impact

Multi-profile Desktop installations can retain substantial memory in idle local `hermes serve` children, and a user opening another profile can be blocked even though existing children are idle and safe to replace.

### Bug Cause

**Trigger:** `apps/desktop/electron/pool-eviction.ts:41` / `selectPoolEvictions()` filters candidates using renderer socket keepalive freshness.

**Causal chain:**
1. Each open profile socket periodically calls `touchBackend()`.
2. Electron updates `lastActiveAt`, and cap eviction treats every recently touched child as non-evictable without knowing whether a turn is actually running.
3. Idle profile children remain pinned; once the hard spawn coordinator is full, a foreground ensure cannot obtain a slot.

**Why it is wrong:** An open renderer socket proves reachability, not an in-flight stream. Socket lifetime and work lifetime were conflated into one timestamp.

**Working sibling / contrast:** Renderer session state already distinguishes `busy` turns from needs-input and idle sessions, and the pool stopper already supports bounded teardown followed by same-key respawn.

**Ruled out:** This is not an orphan-process lifecycle failure. The affected entries remain owned by the live Electron backend pool, and the existing bounded pool stopper retains process handles through exit.

### Fix

Propagate busy-session ownership scopes through the existing keepalive IPC and record a separate `lastStreamingAt` timestamp in Electron. Cap selection now LRU-evicts non-streaming local children regardless of socket freshness, protects recently streaming children across missed pings, and preserves the existing wait-for-exit then respawn path.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/pool-eviction.ts` - base cap protection on recent streaming activity instead of socket keepalive freshness.
- `apps/desktop/electron/main.ts` and `electron/preload.ts` - carry streaming state through pool touches.
- `apps/desktop/src/store/session-states.ts` and gateway stores - derive exact backend scopes for running sessions and publish them immediately and periodically.
- Desktop unit tests - cover capped idle eviction, active-stream protection, exact scope attribution, and stop-then-respawn reuse.

## How to Test

1. Run the focused Electron pool tests.
2. Run the renderer scope and gateway keepalive tests.
3. Run Desktop type checking and linting.

```bash
cd apps/desktop
npx vitest run --project electron electron/pool-eviction.test.ts electron/pool-stop.test.ts
npx vitest run --project ui src/store/session-states-scopes.test.ts src/store/gateway-connection-scope.test.ts
npm run typecheck
npx eslint electron/pool-eviction.ts electron/pool-eviction.test.ts electron/pool-stop.test.ts electron/main.ts electron/preload.ts src/global.d.ts src/store/gateway.ts src/store/profile.ts src/store/session-states.ts src/store/session-states-scopes.test.ts src/store/gateway-connection-scope.test.ts src/app/gateway/hooks/use-gateway-boot.ts
```

Focused tests: 37 passed. Type checking and linting passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant project tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior and IPC types are documented in code
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no workflow changed
- [x] I've considered Windows and macOS impact; the change is platform-independent TypeScript pool policy
- [x] Tool descriptions/schemas update is N/A; no agent tool changed

## Screenshots / Logs

N/A - lifecycle policy change covered by focused invariant tests.
