### PR TITLE
fix(telegram): keep iOS New Chat shares replyable

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1131,8 +1131,14 @@ def _live_route_metadata(t: _TargetDelivery) -> tuple[Optional[str], dict, dict]
         and looks_like_telegram_private_chat_id(str(t.chat_id))
         and _looks_like_int(str(thread_id))
     )
-    if is_ambiguous_telegram_topic and _is_channel_dm_topic(
-        t.runtime_adapter, t.chat_id, t.loop, job["id"]):
+    is_origin_direct_topic = (
+        t.origin_target
+        and t.origin.get("thread_id_kind") == "direct_messages_topic"
+    )
+    if is_origin_direct_topic or (
+        is_ambiguous_telegram_topic
+        and _is_channel_dm_topic(t.runtime_adapter, t.chat_id, t.loop, job["id"])
+    ):
         # Channel DM topic: direct_messages_topic_id, no bare thread_id; media mirrors text.
         # See #22773.
         route_thread_id = None

--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1387,10 +1387,12 @@ def _standalone_send(
     job = t.job
     shutdown_msg = f"delivery to {t.where} skipped — interpreter is shutting down"
 
+    thread_id_kind = t.origin.get("thread_id_kind") if t.origin_target else None
+
     def _send():
         return _send_to_platform(
             t.platform, t.pconfig, t.chat_id, content, thread_id=t.thread_id,
-            media_files=media_files)
+            thread_id_kind=thread_id_kind, media_files=media_files)
 
     def _warned(msg: str) -> tuple[None, str]:
         logger.warning("Job '%s': %s", job["id"], msg)

--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -181,6 +181,7 @@ present (may be `null`); the rest are included only when set.
 | `user_name` | string\|null | yes | Author display name. |
 | `thread_id` | string\|null | yes | Thread/forum-topic id when in a thread. Session-key discriminator. |
 | `chat_topic` | string\|null | yes | Channel topic/description (Discord, Slack). |
+| `thread_id_kind` | string | no | Native routing primitive carried by `thread_id`; currently `direct_messages_topic` selects Telegram's `direct_messages_topic_id` send field. |
 | `user_id_alt` | string | no | Platform-specific stable alt id (Signal UUID, Feishu union_id). |
 | `chat_id_alt` | string | no | Alternate chat id (e.g. Signal group internal id). |
 | `scope_id` | string | no | Platform-neutral **scope** discriminator: Discord guild / Slack workspace / Matrix server. **REQUIRED for Discord/Slack scope isolation.** Session-key discriminator. (Canonical name as of the D-Q2.5 wire migration.) |

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -99,12 +99,20 @@ def _float_env(name: str, default: float) -> float:
 
 
 def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) -> dict | None:
-    """Platform-aware thread metadata for adapter sends. Telegram DM topics route with
-    ``message_thread_id`` + a reply anchor; anchorless synthetic/resumed sends fall back to
-    ``direct_messages_topic_id`` when supported."""
+    """Platform-aware thread metadata for adapter sends. Telegram forum-style DM topics route
+    with ``message_thread_id`` + a reply anchor; native direct-message topics route with
+    ``direct_messages_topic_id``."""
     thread_id = getattr(source, "thread_id", None)
     platform = _platform_name(getattr(source, "platform", None))
-    metadata = {"thread_id": thread_id} if thread_id is not None else {}
+    is_telegram_direct_topic = (
+        platform == "telegram"
+        and getattr(source, "thread_id_kind", None) == "direct_messages_topic"
+    )
+    metadata = (
+        {"direct_messages_topic_id": thread_id}
+        if is_telegram_direct_topic and thread_id is not None
+        else ({"thread_id": thread_id} if thread_id is not None else {})
+    )
     # Slack workspace identity is routing state: carry it so a multi-workspace Socket Mode
     # gateway never falls back to its primary WebClient.
     scope_id = getattr(source, "scope_id", None) if platform == "slack" else None
@@ -112,7 +120,11 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         metadata["slack_team_id"] = str(scope_id)
     if not metadata:
         return None
-    if platform == "telegram" and getattr(source, "chat_type", None) == "dm":
+    if (
+        platform == "telegram"
+        and getattr(source, "chat_type", None) == "dm"
+        and not is_telegram_direct_topic
+    ):
         metadata["telegram_dm_topic_reply_fallback"] = True
         if str(thread_id) not in {"", "1"}:
             metadata["direct_messages_topic_id"] = str(thread_id)
@@ -4071,7 +4083,8 @@ class BasePlatformAdapter(ABC):
     def build_source(
         self, chat_id: str, chat_name: Optional[str] = None, chat_type: str = "dm",
         user_id: Optional[str] = None, user_name: Optional[str] = None,
-        thread_id: Optional[str] = None, chat_topic: Optional[str] = None,
+        thread_id: Optional[str] = None, thread_id_kind: Optional[str] = None,
+        chat_topic: Optional[str] = None,
         user_id_alt: Optional[str] = None, chat_id_alt: Optional[str] = None, is_bot: bool = False,
         scope_id: Optional[str] = None, guild_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None, message_id: Optional[str] = None,
@@ -4084,6 +4097,7 @@ class BasePlatformAdapter(ABC):
         fields = dict(
             platform=self.platform, chat_id=str(chat_id), chat_name=chat_name, chat_type=chat_type,
             user_id=_opt(user_id), user_name=user_name, thread_id=_opt(thread_id),
+            thread_id_kind=_opt(thread_id_kind),
             chat_topic=(chat_topic or "").strip() or None, user_id_alt=user_id_alt,
             chat_id_alt=chat_id_alt, is_bot=is_bot, scope_id=_opt(scope_id),
             guild_id=_opt(guild_id), parent_chat_id=_opt(parent_chat_id),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4084,6 +4084,7 @@ class GatewayRunner(
             chat_type=str(context.source.chat_type) if context.source.chat_type else "",
             chat_name=context.source.chat_name or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
+            thread_id_kind=str(context.source.thread_id_kind) if context.source.thread_id_kind else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_id_alt=str(context.source.user_id_alt) if context.source.user_id_alt else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -71,6 +71,8 @@ class SessionSource:
     user_id: Optional[str] = None
     user_name: Optional[str] = None
     thread_id: Optional[str] = None  # forum topics, Discord threads, etc.
+    # Distinguishes native routing primitives that share the generic thread_id session-key slot.
+    thread_id_kind: Optional[str] = None
     chat_topic: Optional[str] = None  # channel topic/description (Discord, Slack)
     user_id_alt: Optional[str] = None  # platform-specific stable alt ID (Signal UUID, Feishu union_id)
     chat_id_alt: Optional[str] = None  # Signal group internal ID
@@ -122,7 +124,7 @@ class SessionSource:
     # Wire layout (order matters for byte-stable JSON): always-present, then truthy-only
     # optionals around the dual-written scope pair.
     _ALWAYS_FIELDS = ("chat_id", "chat_name", "chat_type", "user_id", "user_name", "thread_id", "chat_topic")
-    _OPTIONAL_PRE_SCOPE = ("user_id_alt", "chat_id_alt")
+    _OPTIONAL_PRE_SCOPE = ("thread_id_kind", "user_id_alt", "chat_id_alt")
     _OPTIONAL_POST_SCOPE = ("parent_chat_id", "message_id", "profile")
     _OPTIONAL_TAIL = ("auto_thread_initial_name", "prospective_thread_id")
 

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -33,13 +33,15 @@ def session_context_engaged() -> bool:
 # * CRON_SESSION: tri-state — _UNSET = legacy env fallback; "1" = cron; "" = non-cron, masks env.
 _SESSION_VARS = (
     _SESSION_PLATFORM, _SESSION_SOURCE, _SESSION_CHAT_ID, _SESSION_CHAT_TYPE,
-    _SESSION_CHAT_NAME, _SESSION_THREAD_ID, _SESSION_USER_ID, _SESSION_USER_ID_ALT,
+    _SESSION_CHAT_NAME, _SESSION_THREAD_ID, _SESSION_THREAD_ID_KIND,
+    _SESSION_USER_ID, _SESSION_USER_ID_ALT,
     _SESSION_USER_NAME, _SESSION_SCOPE_ID, _SESSION_KEY, _SESSION_ID,
     _SESSION_UI_SESSION_ID, _SESSION_MESSAGE_ID, _SESSION_PROFILE,
     _BROWSER_CONTROL_PRINCIPAL, _BROWSER_CONTROL_TRANSPORT_FAMILY, _CRON_SESSION,
 ) = tuple(ContextVar(name, default=_UNSET) for name in (
     "HERMES_SESSION_PLATFORM", "HERMES_SESSION_SOURCE", "HERMES_SESSION_CHAT_ID",
     "HERMES_SESSION_CHAT_TYPE", "HERMES_SESSION_CHAT_NAME", "HERMES_SESSION_THREAD_ID",
+    "HERMES_SESSION_THREAD_ID_KIND",
     "HERMES_SESSION_USER_ID", "HERMES_SESSION_USER_ID_ALT", "HERMES_SESSION_USER_NAME",
     "HERMES_SESSION_SCOPE_ID", "HERMES_SESSION_KEY", "HERMES_SESSION_ID",
     "HERMES_UI_SESSION_ID", "HERMES_SESSION_MESSAGE_ID", "HERMES_SESSION_PROFILE",
@@ -103,7 +105,8 @@ def scoped_current_session_id(session_id: str | None = None) -> Iterator[None]:
 
 def set_session_vars(
     platform: str = "", source: str = "", chat_id: str = "", chat_type: str = "",
-    chat_name: str = "", thread_id: str = "", user_id: str = "", user_id_alt: str = "",
+    chat_name: str = "", thread_id: str = "", thread_id_kind: str = "",
+    user_id: str = "", user_id_alt: str = "",
     user_name: str = "", scope_id: str = "", session_key: str = "", session_id: str = "",
     message_id: str = "", profile: str = "", browser_control_principal: str = "",
     browser_control_transport_family: str = "", cwd: str = "", async_delivery: bool = True,
@@ -115,7 +118,7 @@ def set_session_vars(
     global _session_context_engaged
     _session_context_engaged = True
     values = (
-        platform, source, chat_id, chat_type, chat_name, thread_id, user_id, user_id_alt,
+        platform, source, chat_id, chat_type, chat_name, thread_id, thread_id_kind, user_id, user_id_alt,
         user_name, scope_id, session_key, session_id, ui_session_id, message_id, profile,
         browser_control_principal, browser_control_transport_family, cron_session,
     )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -797,18 +797,24 @@ class TelegramAdapter(BasePlatformAdapter):
                 if not user_name:
                     user_name = str(getattr(sender_chat, "title", "") or "").strip() or None
         chat_id = str(getattr(chat, "id", "")).strip() or user_id
+        direct_topic = getattr(message, "direct_messages_topic", None)
+        direct_topic_id = getattr(direct_topic, "topic_id", None)
         thread_id_raw = getattr(message, "message_thread_id", None)
         is_topic_message = bool(getattr(message, "is_topic_message", False))
         is_forum_group = getattr(chat, "is_forum", False) is True
         chat_type = self._normalize_chat_type(
             getattr(chat, "type", "dm"), is_forum=thread_id_raw is not None and (is_topic_message or is_forum_group))
         thread_id = None
-        if thread_id_raw is not None and (
+        if direct_topic_id is not None:
+            thread_id = str(direct_topic_id)
+        elif thread_id_raw is not None and (
             (chat_type == "forum" and (is_topic_message or is_forum_group)) or (chat_type == "dm" and is_topic_message)):
             thread_id = str(thread_id_raw)
         return SessionSource(
             platform=Platform.TELEGRAM, chat_id=chat_id or "", chat_type=chat_type, user_id=user_id,
-            user_name=user_name, thread_id=thread_id, is_bot=is_bot)
+            user_name=user_name, thread_id=thread_id,
+            thread_id_kind="direct_messages_topic" if direct_topic_id is not None else None,
+            is_bot=is_bot)
 
     def _source_from_reaction_for_auth(self, update):
         """SessionSource for a ``message_reaction`` update's actor (``user`` or ``actor_chat``).
@@ -5139,6 +5145,10 @@ class TelegramAdapter(BasePlatformAdapter):
         a routing id. Gating, skill binding and outbound routing must all agree on this value."""
         chat = getattr(message, "chat", None)
         chat_type = cls._chat_type_str(chat)
+        direct_topic = getattr(message, "direct_messages_topic", None)
+        direct_topic_id = getattr(direct_topic, "topic_id", None)
+        if direct_topic_id is not None:
+            return str(direct_topic_id)
         raw = getattr(message, "message_thread_id", None)
         is_topic_message = bool(getattr(message, "is_topic_message", False))
         is_group = chat_type in ("group", "supergroup")
@@ -6288,6 +6298,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # (message_thread_id=None) normalize to the General-topic id so replies route back to General
         # (#22423).
         thread_id_str = self._effective_message_thread_id(message)
+        thread_id_kind = (
+            "direct_messages_topic"
+            if getattr(getattr(message, "direct_messages_topic", None), "topic_id", None) is not None
+            else None
+        )
         chat_topic, topic_skill = self._resolve_topic_binding(message, chat_type, thread_id_str)
         has_full_name = hasattr(chat, "full_name")
         if user:
@@ -6299,7 +6314,8 @@ class TelegramAdapter(BasePlatformAdapter):
         source = self.build_source(
             chat_id=str(chat.id), chat_name=chat.title or (chat.full_name if has_full_name else None), chat_type=chat_type,
             user_id=(str(user.id) if user else (str(chat.id) if chat_type in {"dm", "channel"} else None)),
-            user_name=user_name, thread_id=thread_id_str, chat_topic=chat_topic, message_id=str(message.message_id),
+            user_name=user_name, thread_id=thread_id_str, thread_id_kind=thread_id_kind,
+            chat_topic=chat_topic, message_id=str(message.message_id),
             is_bot=bool(getattr(user, "is_bot", False)) if user else False)
         reply_to_id, reply_to_text = self._reply_context(message)
         from gateway.platforms.base import resolve_channel_prompt  # per-channel/topic ephemeral prompt

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -797,8 +797,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 if not user_name:
                     user_name = str(getattr(sender_chat, "title", "") or "").strip() or None
         chat_id = str(getattr(chat, "id", "")).strip() or user_id
-        direct_topic = getattr(message, "direct_messages_topic", None)
-        direct_topic_id = getattr(direct_topic, "topic_id", None)
+        direct_topic_id = self._direct_messages_topic_id(message)
         thread_id_raw = getattr(message, "message_thread_id", None)
         is_topic_message = bool(getattr(message, "is_topic_message", False))
         is_forum_group = getattr(chat, "is_forum", False) is True
@@ -5138,6 +5137,26 @@ class TelegramAdapter(BasePlatformAdapter):
         chat = getattr(message, "chat", None)
         return bool(chat) and self._chat_type_str(chat) in {"group", "supergroup"}
 
+    @staticmethod
+    def _direct_messages_topic_id(message: Message) -> Optional[str]:
+        """Return Telegram's native direct-message topic id when the payload has one.
+
+        PTB message test doubles often synthesize missing attributes as ``MagicMock``
+        instances. Only Bot API-shaped integer ids (or their serialized decimal form)
+        are valid; accepting arbitrary truthy objects would turn unrelated messages into
+        malformed topic routes.
+        """
+        direct_topic = getattr(message, "direct_messages_topic", None)
+        topic_id = getattr(direct_topic, "topic_id", None)
+        if isinstance(topic_id, bool):
+            return None
+        if isinstance(topic_id, int):
+            return str(topic_id)
+        if isinstance(topic_id, str):
+            value = topic_id.strip()
+            return value if value.isdecimal() else None
+        return None
+
     @classmethod
     def _effective_message_thread_id(cls, message: Message) -> Optional[str]:
         """Routable thread id: forum General-topic messages arrive with ``message_thread_id=None`` but
@@ -5145,10 +5164,9 @@ class TelegramAdapter(BasePlatformAdapter):
         a routing id. Gating, skill binding and outbound routing must all agree on this value."""
         chat = getattr(message, "chat", None)
         chat_type = cls._chat_type_str(chat)
-        direct_topic = getattr(message, "direct_messages_topic", None)
-        direct_topic_id = getattr(direct_topic, "topic_id", None)
+        direct_topic_id = cls._direct_messages_topic_id(message)
         if direct_topic_id is not None:
-            return str(direct_topic_id)
+            return direct_topic_id
         raw = getattr(message, "message_thread_id", None)
         is_topic_message = bool(getattr(message, "is_topic_message", False))
         is_group = chat_type in ("group", "supergroup")
@@ -6298,11 +6316,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # (message_thread_id=None) normalize to the General-topic id so replies route back to General
         # (#22423).
         thread_id_str = self._effective_message_thread_id(message)
-        thread_id_kind = (
-            "direct_messages_topic"
-            if getattr(getattr(message, "direct_messages_topic", None), "topic_id", None) is not None
-            else None
-        )
+        thread_id_kind = "direct_messages_topic" if self._direct_messages_topic_id(message) is not None else None
         chat_topic, topic_skill = self._resolve_topic_binding(message, chat_type, thread_id_str)
         has_full_name = hasattr(chat, "full_name")
         if user:

--- a/tests/cron/test_cron_origin_synthetic_thread.py
+++ b/tests/cron/test_cron_origin_synthetic_thread.py
@@ -14,8 +14,11 @@ durable thread. A genuine in-thread creation has thread_id == the parent
 thread's id != the triggering message's own id, and must keep its thread.
 """
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
+from cron.scheduler_delivery import _live_route_metadata
+from gateway.config import Platform
 from tools.cronjob_tools import _origin_from_env
 
 
@@ -80,3 +83,36 @@ class TestSlackSyntheticThreadCapture:
             origin = _origin_from_env()
         assert origin is not None
         assert origin["thread_id"] == "1755040000.000100"
+
+
+def test_telegram_direct_topic_origin_keeps_native_cron_route():
+    env = {
+        "HERMES_SESSION_PLATFORM": "telegram",
+        "HERMES_SESSION_CHAT_ID": "775566675",
+        "HERMES_SESSION_THREAD_ID": "270453",
+        "HERMES_SESSION_THREAD_ID_KIND": "direct_messages_topic",
+    }
+    with _session_env(env):
+        origin = _origin_from_env()
+
+    assert origin is not None
+    assert origin["thread_id_kind"] == "direct_messages_topic"
+    delivery = SimpleNamespace(
+        job={"id": "job-1"},
+        platform=Platform.TELEGRAM,
+        platform_name="telegram",
+        chat_id="775566675",
+        thread_id="270453",
+        runtime_adapter=SimpleNamespace(),
+        loop=None,
+        notify_delivery=True,
+        origin=origin,
+        origin_target=True,
+    )
+
+    route_thread_id, route_metadata, media_metadata = _live_route_metadata(delivery)
+
+    assert route_thread_id is None
+    assert route_metadata["direct_messages_topic_id"] == "270453"
+    assert "thread_id" not in route_metadata
+    assert media_metadata["direct_messages_topic_id"] == "270453"

--- a/tests/cron/test_cron_origin_synthetic_thread.py
+++ b/tests/cron/test_cron_origin_synthetic_thread.py
@@ -17,8 +17,9 @@ thread's id != the triggering message's own id, and must keep its thread.
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from cron.scheduler_delivery import _live_route_metadata
+from cron.scheduler_delivery import _live_route_metadata, _standalone_send
 from gateway.config import Platform
+from tools.send_message_senders import _telegram_thread_kwargs
 from tools.cronjob_tools import _origin_from_env
 
 
@@ -116,3 +117,33 @@ def test_telegram_direct_topic_origin_keeps_native_cron_route():
     assert route_metadata["direct_messages_topic_id"] == "270453"
     assert "thread_id" not in route_metadata
     assert media_metadata["direct_messages_topic_id"] == "270453"
+
+
+def test_telegram_direct_topic_standalone_route_keeps_native_parameter(monkeypatch):
+    calls = {}
+
+    async def fake_send_to_platform(*args, **kwargs):
+        calls.update(kwargs)
+        return {"success": True}
+
+    monkeypatch.setattr("tools.send_message_tool._send_to_platform", fake_send_to_platform)
+    target = SimpleNamespace(
+        job={"id": "job-1"},
+        where="telegram:775566675",
+        platform=Platform.TELEGRAM,
+        pconfig=SimpleNamespace(),
+        chat_id="775566675",
+        thread_id="270453",
+        origin={"thread_id_kind": "direct_messages_topic"},
+        origin_target=True,
+        is_relay=False,
+    )
+
+    result, error = _standalone_send(target, "cron follow-up", [])
+
+    assert result == {"success": True}
+    assert error is None
+    assert calls["thread_id_kind"] == "direct_messages_topic"
+    assert _telegram_thread_kwargs("270453", "direct_messages_topic") == {
+        "direct_messages_topic_id": 270453,
+    }

--- a/tests/gateway/relay/test_contract_doc_conformance.py
+++ b/tests/gateway/relay/test_contract_doc_conformance.py
@@ -114,6 +114,7 @@ def _session_source_wire_keys() -> set[str]:
         user_id="u",
         user_name="un",
         thread_id="t",
+        thread_id_kind="direct_messages_topic",
         chat_topic="topic",
         user_id_alt="ua",
         chat_id_alt="ca",

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -20,6 +20,7 @@ from gateway.config import PlatformConfig, Platform
 from gateway.platforms.base import (
     SendResult,
     _reply_anchor_for_event,
+    _thread_metadata_for_event,
     _thread_metadata_for_source,
 )
 from gateway.platforms.event import MessageEvent, MessageType
@@ -227,6 +228,40 @@ def test_forum_general_topic_without_message_thread_id_keeps_thread_context():
     assert event.source.chat_id == "-100123"
     assert event.source.chat_type == "group"
     assert event.source.thread_id == "1"
+
+
+def test_direct_messages_topic_routes_session_and_reply_by_topic_id():
+    """New Chat shares expose direct_messages_topic, not message_thread_id."""
+    import plugins.platforms.telegram.adapter as telegram_mod
+
+    adapter = _make_adapter()
+    message = SimpleNamespace(
+        text="shared https://example.com",
+        caption=None,
+        chat=SimpleNamespace(
+            id=775566675,
+            type=telegram_mod.ChatType.PRIVATE,
+            is_forum=False,
+            title=None,
+            full_name="Alice",
+        ),
+        from_user=SimpleNamespace(id=775566675, full_name="Alice", is_bot=False),
+        message_thread_id=None,
+        direct_messages_topic=SimpleNamespace(topic_id=270453),
+        is_topic_message=False,
+        reply_to_message=None,
+        message_id=270454,
+        date=None,
+    )
+
+    event = adapter._build_message_event(message, msg_type=MessageType.TEXT)
+
+    assert event.source.thread_id == "270453"
+    assert event.source.thread_id_kind == "direct_messages_topic"
+    assert build_session_key(event.source) == "agent:main:telegram:dm:775566675:270453"
+    assert _thread_metadata_for_event(event) == {
+        "direct_messages_topic_id": "270453",
+    }
 
 
 @pytest.mark.asyncio

--- a/tools/cronjob_job_args.py
+++ b/tools/cronjob_job_args.py
@@ -34,6 +34,7 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
     return {
         "platform": origin_platform, "chat_id": origin_chat_id,
         "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None, "thread_id": thread_id,
+        "thread_id_kind": get_session_env("HERMES_SESSION_THREAD_ID_KIND") or None,
         # Lets a delivery mirror resolve the participant's session in per-user-isolated groups.
         "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
         # Workspace/server scope (Slack team, Discord guild...): Slack session keys embed it,

--- a/tools/send_message_senders.py
+++ b/tools/send_message_senders.py
@@ -121,9 +121,15 @@ def _telegram_bot(token):
     return Bot(token=token)
 
 
-def _telegram_thread_kwargs(thread_id):
-    """Topic id -> ``message_thread_id`` kwargs. Forum "General" is thread "1" inbound but
-    the Bot API rejects message_thread_id=1, so it maps to no thread — same as the adapter."""
+def _telegram_thread_kwargs(thread_id, thread_id_kind=None):
+    """Topic routing kwargs for standalone Telegram sends.
+
+    Native direct-message topics use ``direct_messages_topic_id``; forum-style
+    topics use ``message_thread_id``. Keeping the routing kind explicit prevents
+    a native topic id from being sent through the forum-topic parameter.
+    """
+    if thread_id_kind == "direct_messages_topic":
+        return {"direct_messages_topic_id": int(thread_id)}
     if thread_id is None:
         return {}
     try:
@@ -236,7 +242,8 @@ def _telegram_format(message):
         return message, ParseMode.MARKDOWN_V2, False  # formatting unavailable: send as-is
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False,
+                         force_document=False, thread_id_kind=None):
     """One-shot Telegram Bot API send; parse failures fall back to plain text."""
     try:
         formatted, send_parse_mode, _has_html = _telegram_format(message)
@@ -247,7 +254,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         # See #13206.
         int_chat_id = normalize_telegram_chat_id(chat_id)
         media_files = media_files or []
-        thread_kwargs = _telegram_thread_kwargs(thread_id)
+        thread_kwargs = _telegram_thread_kwargs(thread_id, thread_id_kind)
         # disable_web_page_preview is only valid for send_message, not media sends.
         text_kwargs = {**thread_kwargs, **({"disable_web_page_preview": True} if disable_link_previews else {})}
         last_msg, warnings, _tg_caption = None, [], None

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -469,7 +469,8 @@ _TEXT_SENDERS = {
 _MEDIA_PLATFORMS_NOTE = "telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack"
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None,
+                            force_document=False, args=None, thread_id_kind=None):
     """Route to the platform sender, chunking long text with the adapters' splitter. Order matters:
     Weixin first (its native helper must not be blocked by unrelated optional imports such as
     lark-oapi), Telegram (chunks itself), plugin standalone media, native chunked, generic text."""
@@ -481,7 +482,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # Telegram chunks internally on the *formatted* text (escaping inflates length).
     if platform == Platform.TELEGRAM:
         return await _send_telegram(
-            pconfig.token, chat_id, message, media_files=media_files, thread_id=thread_id, force_document=force_document,
+            pconfig.token, chat_id, message, media_files=media_files, thread_id=thread_id,
+            thread_id_kind=thread_id_kind, force_document=force_document,
             disable_link_previews=bool(getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews")))
     from gateway.platforms.base import BasePlatformAdapter
     max_len = _platform_max_length(platform)


### PR DESCRIPTION
## Summary

Carry forward and harden the verified root fix for #105206. Telegram iOS Share -> New Chat messages can carry a native `Message.direct_messages_topic.topic_id` while omitting `message_thread_id`. Hermes now preserves that identity through session routing, immediate replies, cron origin capture, live cron delivery, and standalone fallback delivery.

## Delivery receipt

- PR: https://github.com/NousResearch/hermes-agent/pull/105265
- Base: `main` at `e9bccc90a5e314ddf6dd4bd3772d50cb40027275`
- Head: `85e18d06b5a69a03b1e52ca6a943ab99e2e0770a`

## User-visible problem

An iOS Chrome share sent to a Telegram bot through New Chat was processed, but Hermes created a root-DM session with no usable topic identity. The resulting reply and cron destination could not be continued from the Telegram surface that initiated the request.

## Premise validation

The issue report did not include a raw Telegram update, so I built a deterministic PTB-shaped reproduction against the current `origin/main` base (`e9bccc90a5e314ddf6dd4bd3772d50cb40027275`). The regression test failed on the unfixed code:

```text
scripts/run_tests.sh tests/gateway/test_telegram_thread_fallback.py -k direct_messages_topic -q
1 failed, 20 deselected
AssertionError: assert None == '270453'
```

The failing line was the normalized `SessionSource.thread_id`: the adapter ignored `direct_messages_topic.topic_id` and only considered `message_thread_id`.

## Root cause

1. Telegram's native direct-message topic field was present on the inbound message, but `_effective_message_thread_id()` did not read it.
2. `_build_message_event()` therefore emitted `SessionSource.thread_id=None`; the session key collapsed to the root private chat.
3. Without a routing-kind discriminator, the generic thread id could not later distinguish Telegram's native `direct_messages_topic_id` from a forum-style `message_thread_id`.
4. Session persistence and session ContextVars did not carry that discriminator into cron origin state.
5. The live cron route had no explicit native-topic branch, and the standalone fallback always converted a numeric id into `message_thread_id`.
6. The first candidate implementation (closed PR #105232) fixed the main propagation path but its broad test run exposed a sibling defect: missing optional PTB attributes on `MagicMock` fixtures became a truthy mock topic id and raised `ValueError`. This PR retains the root fix and hardens the shared extractor instead of treating that candidate as green.

## Fix

- Preserve native direct-message topic ids as the generic session discriminator plus additive `thread_id_kind=direct_messages_topic`.
- Serialize the kind in `SessionSource`, propagate it through session ContextVars, and capture it in cron origins.
- Route native topics with `direct_messages_topic_id`; keep forum topics on `message_thread_id` and preserve ordinary unthreaded DMs.
- Validate native topic ids as integer/decimal values so absent or malformed optional PTB attributes cannot create bogus routes.
- Carry the routing kind through both live cron delivery and standalone fallback delivery, including media metadata parity.

## Scope and complexity

The new extraction and routing decisions are constant-time (`O(1)`) and allocate only bounded metadata for the current event (`O(1)` auxiliary space). No database schema migration, network round trip, retry loop, or unbounded cache was added. Existing forum-topic, ordinary-DM, and legacy serialized `SessionSource` behavior remains compatible because the new wire field is optional.

## Related work / duplicate handling

A mechanism search found closed PR #105232, whose root diagnosis and propagation direction match this issue. This is a carry-forward/hardening PR, not an unrelated parallel implementation: it preserves the verified contribution, fixes the regression that caused that PR's CI failure, and adds coverage for the standalone sibling path. The prior PR remains untouched.

## Tests

Focused regression and affected routing/session suites:

```text
scripts/run_tests.sh tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_telegram_documents.py tests/cron/test_cron_origin_synthetic_thread.py tests/gateway/test_session_context_inheritance.py tests/gateway/test_session.py tests/gateway/test_session_env.py tests/gateway/relay/test_contract_doc_conformance.py -q
7 files, 121 tests passed, 0 failed
```

Sibling standalone sender, scheduler, and send-message suites:

```text
scripts/run_tests.sh tests/tools/test_send_message_tool.py tests/tools/test_send_message_telegram_proxy.py tests/cron/test_scheduler.py tests/cron/test_cron_live_delivery_confirmation.py tests/cron/test_cron_multiplex_shared_route_delivery.py -q
5 files, 141 tests passed, 0 failed, 1 skipped
```

Lint:

```text
uv run ruff check cron/scheduler_delivery.py gateway/platforms/base.py gateway/run.py gateway/session.py gateway/session_context.py plugins/platforms/telegram/adapter.py tools/cronjob_job_args.py tools/send_message_senders.py tools/send_message_tool.py tests/cron/test_cron_origin_synthetic_thread.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/relay/test_contract_doc_conformance.py
All checks passed!
```

The new standalone regression was also proven RED before the fallback propagation change (`KeyError: 'thread_id_kind'`) and GREEN afterward.

## Verification status

- Local focused verification: complete and green as listed above.
- Post-PR three-round gate: 3 consecutive green rounds. Each round ran the 12-file canonical test scope (`262 passed, 0 failed, 1 skipped`) plus the concurrent stress harness (`64,000 events`, `32 workers`, `2,000 iterations/worker`).
- Stress observations: elapsed time `0.656s / 0.657s / 0.683s`; p95 worker time `0.127s / 0.149s / 0.175s`; peak traced allocations `107,101 / 114,430 / 109,333` bytes. This is an in-process deterministic routing harness, not a Telegram provider-capacity benchmark.
- Full repository suite attempt: the canonical wrapper was started on the final head and stopped at `14,258/~39,795` discovered test progress (`15,868` passed, `157` failed) after unrelated/environment failures accumulated. It is not reported as green. The failures included missing optional `acp` imports, Windows UTF-8/path-display assumptions, and unrelated timing/race tests. A clean `origin/main` baseline reproduced the `test_command_token_source.py` UnicodeDecodeError failures (`4 failed, 25 passed`); `test_coding_context.py` passed sequentially on that baseline.
- Remote CI readback at the final head: 24 SUCCESS, 13 SKIPPED, 1 NEUTRAL (`osv-scanner`), 0 failing or pending checks; PR state OPEN with merge state CLEAN.
- No real Telegram credentials, private chat ids, message bodies, or raw user payloads were used or committed.

## Graphify navigation

Used the existing knowledge graph before editing:

- `graphify query 'message_thread_id'`
- `graphify query 'DM topic'`
- `graphify explain 'TelegramAdapter'`
- `graphify explain 'tests/gateway/test_dm_topics.py'`
- `graphify path 'TelegramAdapter' 'GatewayTopicThreadsMixin'`

A post-edit `graphify update . --no-cluster` was attempted in the isolated worktree but timed out before producing a new index; this does not suppress any product test result.

## Files changed

- `plugins/platforms/telegram/adapter.py`
- `gateway/session.py`
- `gateway/platforms/base.py`
- `gateway/session_context.py`
- `gateway/run.py`
- `tools/cronjob_job_args.py`
- `cron/scheduler_delivery.py`
- `tools/send_message_senders.py`
- `tools/send_message_tool.py`
- `docs/relay-connector-contract.md`
- `tests/gateway/test_telegram_thread_fallback.py`
- `tests/cron/test_cron_origin_synthetic_thread.py`
- `tests/gateway/relay/test_contract_doc_conformance.py`

Closes #105206
