### PR TITLE
fix(cli): preserve comments in whole-document config.yaml writes

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -30,7 +30,7 @@ from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul
 from hermes_cli.secret_prompt import masked_secret_prompt
 # Re-export from hermes_constants — canonical definition lives there.
 from hermes_constants import get_hermes_home, get_process_hermes_home  # noqa: F401
-from utils import atomic_replace, atomic_yaml_write, fast_safe_load
+from utils import atomic_replace, atomic_roundtrip_yaml_save, atomic_yaml_write, fast_safe_load
 
 logger = logging.getLogger(__name__)
 
@@ -1983,8 +1983,26 @@ def require_readable_config_before_write(config_path: Optional[Path] = None) -> 
 
 
 def atomic_config_write(config_path: Path, data: Any, **kwargs: Any) -> None:
-    """Fail-closed atomic write for ``config.yaml`` (``require_readable_config_before_write`` first)."""
+    """Fail-closed atomic write for ``config.yaml`` (``require_readable_config_before_write`` first).
+
+    Existing files go through ruamel round-trip mode so hand-written comments survive. Every writer
+    here re-serialises the WHOLE document, and the PyYAML dumper cannot represent comments, so a
+    single migration or gateway config write silently erases the user's rationale for non-default
+    settings (#92554). New files keep the PyYAML path so ``extra_content`` example blocks still
+    land on a fresh install.
+
+    ``hermes config set`` is deliberately NOT routed here -- #72581 fixes that path with a
+    narrower before/after diff apply.
+    """
     require_readable_config_before_write(config_path)
+    if isinstance(data, dict) and os.path.exists(config_path):
+        try:
+            atomic_roundtrip_yaml_save(config_path, data)
+            return
+        except ImportError:
+            # ruamel is declared in pyproject, but #29655 reports installs without it.
+            # Losing comments beats refusing to write the config at all.
+            logger.warning("ruamel.yaml unavailable; config comments will not be preserved")
     atomic_yaml_write(config_path, data, **kwargs)
 
 
@@ -2340,7 +2358,7 @@ def save_config(
             effective_preserve_keys = _explicit_config_paths(_raw_for_paths) | set(preserve_keys or ())
             normalized = _strip_default_values(normalized, DEFAULT_CONFIG, preserve_keys=effective_preserve_keys)
 
-        atomic_yaml_write(config_path, normalized, extra_content=_commented_sections_for_save(normalized))
+        atomic_config_write(config_path, normalized, extra_content=_commented_sections_for_save(normalized))
         _secure_file(config_path)
         _RAW_CONFIG_CACHE.pop(str(config_path), None)
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -539,9 +539,12 @@ class TestSaveConfigAtomicity:
             config_path = tmp_path / "config.yaml"
             assert config_path.exists()
 
-            # Simulate a crash during yaml.dump by making atomic_yaml_write's
-            # yaml.dump raise after the temp file is created but before replace.
-            with patch("utils.yaml.dump", side_effect=OSError("disk full")):
+            # Simulate a crash during the dump, after the temp file is created but
+            # before replace. Both writers are patched: an existing config.yaml is
+            # written through ruamel round-trip mode to preserve comments, a new one
+            # through PyYAML, and either must leave the previous file intact.
+            with patch("utils.yaml.dump", side_effect=OSError("disk full")), \
+                    patch("ruamel.yaml.main.YAML.dump", side_effect=OSError("disk full")):
                 try:
                     config["model"] = "should-not-persist"
                     save_config(config)

--- a/tests/hermes_cli/test_config_write_preserves_comments.py
+++ b/tests/hermes_cli/test_config_write_preserves_comments.py
@@ -1,0 +1,85 @@
+"""Whole-document config.yaml writes must preserve hand-written comments (#92554).
+
+`save_config` and `atomic_config_write` re-serialise the entire document. With the PyYAML
+dumper that silently destroys the user's rationale for non-default settings, so existing
+files go through ruamel round-trip mode instead.
+
+`hermes config set` is covered separately by #72581 and is not exercised here.
+"""
+
+import textwrap
+
+import pytest
+import yaml
+
+CONFIG_WITH_COMMENTS = textwrap.dedent("""\
+    # TOP COMMENT — must survive
+    model:
+      provider: test
+      # why this ceiling: a page must leave write_file in ONE turn
+      max_tokens: 16384
+    agent:
+      verify_on_stop: true      # deliberate: unattended work gets checked
+    _config_version: 40
+    """)
+
+COMMENTS = ("TOP COMMENT", "must leave write_file in ONE turn", "deliberate: unattended work")
+
+
+@pytest.fixture
+def config_path(tmp_path, monkeypatch):
+    from hermes_cli import config as config_module
+
+    path = tmp_path / "config.yaml"
+    path.write_text(CONFIG_WITH_COMMENTS, encoding="utf-8")
+    monkeypatch.setattr(config_module, "get_config_path", lambda: path)
+    monkeypatch.setattr(config_module, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(config_module, "ensure_hermes_home", lambda: None)
+    monkeypatch.setattr(config_module, "is_managed", lambda: False)
+    config_module._RAW_CONFIG_CACHE.pop(str(path), None)
+    return path
+
+
+def _assert_comments_survive(path):
+    text = path.read_text(encoding="utf-8")
+    for comment in COMMENTS:
+        assert comment in text, f"comment lost: {comment!r}"
+
+
+def test_atomic_config_write_preserves_comments(config_path):
+    """The shared fail-closed writer (plugins enable, gateway slash commands, doctor)."""
+    from hermes_cli.config import atomic_config_write
+
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    data["_config_version"] = 41
+    atomic_config_write(config_path, data)
+
+    _assert_comments_survive(config_path)
+    assert yaml.safe_load(config_path.read_text(encoding="utf-8"))["_config_version"] == 41
+
+
+def test_save_config_preserves_comments_across_migration(config_path):
+    """A migration bumping _config_version must not erase the file's rationale."""
+    from hermes_cli import config as config_module
+
+    raw = config_module.read_raw_config()
+    raw["_config_version"] = 41
+    config_module.save_config(raw)
+
+    _assert_comments_survive(config_path)
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["_config_version"] == 41
+    assert saved["agent"]["verify_on_stop"] is True
+    assert saved["model"]["max_tokens"] == 16384
+
+
+def test_new_config_still_gets_example_blocks(tmp_path):
+    """A file that does not exist yet keeps the PyYAML path so extra_content lands."""
+    from hermes_cli.config import atomic_config_write
+
+    path = tmp_path / "fresh.yaml"
+    atomic_config_write(path, {"model": {"provider": "test"}}, extra_content="# ── Security ──\n")
+
+    text = path.read_text(encoding="utf-8")
+    assert "── Security ──" in text
+    assert yaml.safe_load(text)["model"]["provider"] == "test"


### PR DESCRIPTION
## What does this PR do?

`save_config()` and `atomic_config_write()` re-serialise the **entire** config document through
`atomic_yaml_write`, i.e. the PyYAML dumper, which cannot represent comments. Every migration step
persists via `_persist_migration()` → `save_config()`, so a single `hermes update` that crosses a
migration boundary destroys every comment in `config.yaml` and in each `profiles/*/config.yaml`.
The gateway slash commands, `hermes doctor` and the yuanbao platform hit the same thing through
`atomic_config_write()`.

Observed on a real install: a v40 → v41 migration changed nothing but `_config_version` (verified
by parsing both YAML trees) and took ~75 lines of rationale with it — including a header note
recording that an earlier v31 → v32 step had silently rewritten `verify_on_stop: true` → `false`.
Nothing errored and nothing was flagged. The comments explaining which settings a past migration
quietly reverted are exactly the comments the next migration deletes.

`utils.atomic_roundtrip_yaml_save()` already exists for this — its docstring reads *"Comment-safe
replacement for `yaml.safe_dump(cfg, f)`"*. It is covered by
`tests/test_utils_atomic_roundtrip_yaml_save.py`, handles the YAML 1.1 `on/off/yes/no` re-quoting
trap, uses the same explicit-absence delete semantics these callers need, and is already used by
`tui_gateway/server.py`. It was simply never wired into this path.

### Scope

Deliberately limited to the two **whole-document** writers, which no open PR touches. The
neighbouring paths are already claimed and are left alone:

| Path | Covered by |
|---|---|
| `save_config()` (migrations), `atomic_config_write()` (gateway, doctor) | **this PR** |
| `hermes config set` / `unset` (`_write_user_config`) | #72581 |
| `hermes plugins enable/disable` | #92652 |

No dependency on either: this uses `atomic_roundtrip_yaml_save`, already on main via #82630 — not
#72581's new `atomic_roundtrip_yaml_apply`. It applies and passes standalone.

## Related Issue

Refs #92554

(Not `Fixes` — #92554 also reproduces through `config set` and `plugins enable`, which #72581 and
#92652 handle. This closes the migration-path half.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — `atomic_config_write()` routes existing files through
  `atomic_roundtrip_yaml_save()`, with an `ImportError` fallback to the old writer (ruamel is
  declared in `pyproject.toml`, but #29655 reports installs without it; losing comments beats
  refusing to write). New files keep the PyYAML path so `extra_content` example blocks still land
  on a fresh install.
- `hermes_cli/config.py` — `save_config()` writes through `atomic_config_write()` rather than
  calling `atomic_yaml_write` directly, so both whole-document writers are fixed at one point.
- `tests/hermes_cli/test_config_write_preserves_comments.py` — new.
- `tests/hermes_cli/test_config.py` — `TestSaveConfigAtomicity::test_no_partial_write_on_crash`
  proved atomicity by making `utils.yaml.dump` raise *inside* the atomic write. An existing
  `config.yaml` now goes through ruamel, so that patch no longer fired and the write succeeded.
  Both dumpers are patched now; the assertion is unchanged and covers whichever writer runs.

## How to Test

1. Write a `config.yaml` carrying a top-of-file block, a standalone comment and a trailing inline
   comment, stamped `_config_version: 40`.
2. Run a `save_config()` that bumps `_config_version` to 41 (or `hermes update` across a migration).
3. Before: all comments gone, plus the stock `── Security ──` / `── Fallback Model ──` boilerplate
   appended. After: all three comments intact, `_config_version: 41`, values unchanged.

Automated: `scripts/run_tests.sh tests/hermes_cli/test_config_write_preserves_comments.py`

The three regression tests fail on `main` and pass with this change; the fourth asserts a fresh
install still gets its example blocks, and passes both ways.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate — see the scope table above
- [x] My PR contains **only** changes related to this fix (single commit, rebased onto current main)
- [ ] I've run `pytest tests/ -q` and all tests pass — see **Test environment** below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 13 (trixie), Linux 6.12.107, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on `atomic_config_write`)
- [x] `cli-config.yaml.example` — N/A, no config keys added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — `os.path.exists` + the existing `_atomic_write` helper;
      no new platform-specific behaviour
- [x] Tool descriptions/schemas — N/A

### Test environment

Targeted suites pass under `scripts/run_tests.sh`:
`test_config_write_preserves_comments`, `test_utils_atomic_roundtrip_yaml_save`,
`test_yaml_indent_consistency_31999`, `test_atomic_replace_symlinks`,
`test_sibling_config_migration`, `test_personality_single_owner`, `test_journal_mode_config`,
`test_update_autostash`.

`scripts/run_tests.sh tests/hermes_cli/` ran to completion: **9,133 passed, 9 failed** across
8,086 files. It surfaced the atomicity regression above, which is fixed here —
`tests/hermes_cli/test_config.py` and the new test file are now 124 passed, 4 skipped.

The remaining 8 failures are **all pre-existing**, verified by re-running each with
`hermes_cli/config.py` reverted to `origin/main` and getting byte-identical results:

| File | Failures |
|---|---|
| `test_dashboard_auth_gate.py` | 4 |
| `test_local_quickstart.py` | 2 |
| `test_session_recovery_lost_and_found.py` | 1 |
| `test_update_head_moved_gate.py` | 1 |

One caveat, flagged rather than silently ticking the box: the full 45,804-test suite does not
collect on this machine — 33 files fail on optional dependencies that are absent here (`aiohttp`,
`acp`, `xgrammar`), all unrelated to this change and reproducible on a clean tree. CI is the
authority on the full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cz3hvoZxo5YPa73kRhqrc
