### PR TITLE
fix(auxiliary): preserve compression reasoning effort and Responses usage details

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1852,6 +1852,7 @@ def _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_c
             proactive_prune_min_reclaim_tokens=cs.proactive_prune_min_reclaim,
             min_tail_user_messages=cs.min_tail_users, tail_mode=cs.tail_mode,
             custom_providers=_custom_providers,
+            reasoning_config=getattr(agent, "reasoning_config", None),
         )
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
     if callable(_bind_session_state):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1083,6 +1083,26 @@ def _parse_codex_final_response(final: Any) -> Tuple[List[str], List[Any], Any]:
         usage = SimpleNamespace(
             prompt_tokens=_u("input_tokens"), completion_tokens=_u("output_tokens"),
             total_tokens=_u("total_tokens"))
+        # Preserve the Responses detail buckets when adapting to Chat usage names —
+        # normalize_usage reads prompt_tokens_details/completion_tokens_details on the
+        # chat shape, so dropping them miscounts cached input as fresh input and hides
+        # reasoning tokens from every auxiliary consumer (session accounting, cache hit
+        # telemetry). Unset vs explicit null stays distinguishable: a dict (or object)
+        # is copied verbatim, an SDK-unset field is left absent, an explicit None is set.
+        for source_field, target_field in (
+            ("input_tokens_details", "prompt_tokens_details"),
+            ("output_tokens_details", "completion_tokens_details"),
+        ):
+            if isinstance(resp_usage, dict):
+                if source_field in resp_usage:
+                    setattr(usage, target_field, resp_usage[source_field])
+            else:
+                fields_set = getattr(resp_usage, "model_fields_set", None)
+                if (
+                    (fields_set is None or source_field in fields_set)
+                    and hasattr(resp_usage, source_field)
+                ):
+                    setattr(usage, target_field, getattr(resp_usage, source_field))
     return text_parts, tool_calls_raw, usage
 
 
@@ -1376,6 +1396,11 @@ class _CodexCompletionsAdapter:
             if isinstance(service_tier, str) and service_tier.strip() and not is_xai:
                 resp_kwargs["service_tier"] = service_tier.strip()
             reasoning_cfg = extra_body.get("reasoning")
+            if not isinstance(reasoning_cfg, dict) and kwargs.get("reasoning_effort") is not None:
+                # Provider profiles project session/task reasoning onto this top-level
+                # chat kwarg (custom/Ollama/vLLM style); honor it across the Responses
+                # bridge exactly like an explicit extra_body.reasoning dict.
+                reasoning_cfg = {"effort": kwargs["reasoning_effort"]}
             # ``enabled: False`` leaves reasoning/include unset (Codex still thinks by default).
             if isinstance(reasoning_cfg, dict) and reasoning_cfg.get("enabled") is not False:
                 # Truthy-only: Codex 400s on e.g. {"effort": null}, so falsy → default. Shared
@@ -2535,7 +2560,7 @@ def _runtime_main_value(field: str) -> Any:
 def set_runtime_main(
     provider: str, model: str, *, requested_provider: str = "", base_url: str = "",
     api_key: Any = "", api_mode: str = "", auth_mode: str = "", session_id: str = "",
-    cache_scope: str = "",
+    cache_scope: str = "", reasoning_config: Optional[Dict[str, Any]] = None,
 ) -> contextvars.Token:
     """Record the current context's live main runtime for auxiliary routing.
 
@@ -2545,7 +2570,9 @@ def set_runtime_main(
 
     ``cache_scope`` is the rotation-stable logical cache scope (compression- lineage root —
     agent/prompt_cache_scope.py) resolved once per turn by turn_context; auxiliary Responses calls prefer it
-    over ``session_id`` for prompt_cache_key derivation (#79017).
+    over ``session_id`` for prompt_cache_key derivation (#79017). ``reasoning_config`` is the
+    session's live effort snapshot, deep-copied so a later in-session change cannot mutate an
+    in-flight auxiliary attempt that inherited it.
     """
     runtime = {
         "provider": (provider or "").strip().lower(),
@@ -2558,6 +2585,8 @@ def set_runtime_main(
         "session_id": (session_id or "").strip(),
         "cache_scope": (cache_scope or "").strip(),
     }
+    if isinstance(reasoning_config, dict):
+        runtime["reasoning_config"] = copy.deepcopy(reasoning_config)
     # Publish authoritative context before updating the locked mirrors.
     token = _RUNTIME_MAIN_CONTEXT.set(runtime)
     _publish_runtime_main_mirrors(tuple(runtime[field] for field in _MAIN_RUNTIME_FIELDS))
@@ -2583,6 +2612,16 @@ def scoped_runtime_main(main_runtime: Optional[Dict[str, Any]]):
         yield runtime
     finally:
         _RUNTIME_MAIN_CONTEXT.reset(token)
+
+
+def get_scoped_runtime_main() -> Dict[str, Any]:
+    """Snapshot only the caller's scoped runtime; never consult legacy mirrors or config.
+
+    Producers (the compressor's summary handoff) must not inherit another concurrent
+    session's endpoint or effort through the compat globals — the ContextVar is the only
+    source, normalized the same way ``scoped_runtime_main`` binds it.
+    """
+    return _normalize_main_runtime(_RUNTIME_MAIN_CONTEXT.get() or {})
 
 
 def clear_runtime_main() -> None:
@@ -2849,7 +2888,13 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
 
 
 _MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
-_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + ("requested_provider",)
+# ``session_id``/``cache_scope`` key the scoped-runtime handoff (compressor snapshot match,
+# prompt_cache_key derivation); ``reasoning_config`` carries the session's live effort snapshot
+# for tasks that inherit it (compression). Only dict reasoning configs survive normalization —
+# an absent/None effort must stay distinguishable from an explicit one downstream.
+_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + (
+    "requested_provider", "session_id", "cache_scope", "reasoning_config",
+)
 
 
 def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -2868,7 +2913,10 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     normalized: Dict[str, Any] = {}
     for field in _MAIN_RUNTIME_CONTEXT_FIELDS:
         value = main_runtime.get(field)
-        if field == "api_key" and callable(value) and not isinstance(value, str):
+        if field == "reasoning_config" and isinstance(value, dict):
+            # Deep copy: the snapshot must not mutate under a concurrent in-session effort change.
+            normalized[field] = copy.deepcopy(value)
+        elif field == "api_key" and callable(value) and not isinstance(value, str):
             normalized[field] = value
         elif isinstance(value, str) and value.strip():
             normalized[field] = value.strip()
@@ -6569,6 +6617,43 @@ _PreparedAuxRequest = NamedTuple("_PreparedAuxRequest", [
     ("effective_extra_body", Dict[str, Any]), ("base_info", str)])
 
 
+def _aux_route_pins_target(resolved_provider: Optional[str], resolved_model: Optional[str]) -> bool:
+    """Whether task config pinned an explicit provider/model for this call.
+
+    A pinned target (``auxiliary.<task>.provider/model``, a summary_model override, or a
+    per-call ``model=``) owns its own reasoning policy; only a route left to ``auto``
+    inherits the session's.
+    """
+    return (
+        str(resolved_provider or "").strip().lower() not in {"", "auto", "main"}
+        or bool(str(resolved_model or "").strip())
+    )
+
+
+def _aux_route_matches_main_runtime(
+    request_provider: Optional[str], final_model: Optional[str], base_url: str,
+    main_runtime: Dict[str, Any],
+) -> bool:
+    """Whether the concrete auxiliary route IS the session's main deployment.
+
+    Provider and model must match; base_url only disambiguates when both sides carry one
+    (default-OpenAI sessions have no explicit URL on either side). Deployment identity is
+    compared from normalized route fields — anything stricter would silently disable
+    inheritance for default routes.
+    """
+    def _norm(value: Any) -> str:
+        return str(value or "").strip().rstrip("/").lower()
+
+    route_provider = _normalize_aux_provider(
+        _fallback_provider_from_label(str(request_provider or "")))
+    if route_provider != _normalize_aux_provider(str(main_runtime.get("provider") or "")):
+        return False
+    if _norm(final_model) != _norm(main_runtime.get("model")):
+        return False
+    main_base, route_base = _norm(main_runtime.get("base_url")), _norm(base_url)
+    return not (main_base and route_base and main_base != route_base)
+
+
 def _prepare_aux_request(
     task: Optional[str], *, provider: Optional[str], model: Optional[str], base_url: Optional[str],
     api_key: Optional[str], main_runtime: Dict[str, Any], messages: list,
@@ -6614,6 +6699,23 @@ def _prepare_aux_request(
                          f" at {base_info}" if base_info and "openrouter" not in base_info else "")
     # Client's actual base_url so endpoint-specific temperature overrides work on
     # auto-detected routes (api.moonshot.ai vs api.kimi.com/coding).
+    # Session-effort inheritance for compression: when task routing left provider/model
+    # ownership to the live main runtime AND the resolved route is that session's
+    # deployment, the summary follows the owning session's effort snapshot. Explicit
+    # per-call ``reasoning_config`` and a task-config ``extra_body.reasoning`` both win
+    # over inheritance; a route that landed anywhere else owns its own effort and must
+    # not carry the session's (a cross-route model change drops it).
+    if (
+        task == "compression"
+        and reasoning_config is None
+        and "reasoning" not in effective_extra_body
+        and not _aux_route_pins_target(resolved_provider, resolved_model)
+        and _aux_route_matches_main_runtime(
+            request_provider, final_model, base_info or resolved_base_url or "", main_runtime)
+    ):
+        inherited = main_runtime.get("reasoning_config")
+        if isinstance(inherited, dict):
+            reasoning_config = copy.deepcopy(inherited)
     kwargs = _build_call_kwargs(
         request_provider, final_model, messages, temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,

--- a/agent/compression_facade.py
+++ b/agent/compression_facade.py
@@ -240,15 +240,25 @@ class CompressionFacadeMixin:
             missing_fence = object()
             previous_fence = vars(self).get("_active_compression_commit_fence", missing_fence)
             self._active_compression_commit_fence = active_fence
+        # Frozen per-attempt runtime snapshot: in-turn callers already have the turn's scope
+        # ambient, but out-of-turn entry points (/compact, gateway /compress) run with none —
+        # and the summarizer must see the session's CURRENT effort/model even when a
+        # fallback or /model switch changed it after turn_context published its snapshot.
+        # Deep-copied (incl. reasoning_config) so a mid-attempt change cannot mutate it.
+        from agent.auxiliary_client import scoped_runtime_main
+        from agent.prompt_cache_scope import resolve_prompt_cache_scope_safe
+        compression_runtime = self._current_main_runtime()
+        compression_runtime["cache_scope"] = resolve_prompt_cache_scope_safe(self) or ""
         try:
 
             def _run(fence=None, target_messages=None):
-                return compress_context(
-                    self, target_messages if target_messages is not None else messages, system_message,
-                    approx_tokens=approx_tokens, task_id=task_id, focus_topic=focus_topic, force=force,
-                    bypass_cooldown=bypass_cooldown,
-                    defer_context_engine_notification=(defer_context_engine_notification), commit_fence=fence,
-                )
+                with scoped_runtime_main(compression_runtime):
+                    return compress_context(
+                        self, target_messages if target_messages is not None else messages, system_message,
+                        approx_tokens=approx_tokens, task_id=task_id, focus_topic=focus_topic, force=force,
+                        bypass_cooldown=bypass_cooldown,
+                        defer_context_engine_notification=(defer_context_engine_notification), commit_fence=fence,
+                    )
 
             # Callers that already own a progress-aware wait (gateway session
             # hygiene) pass commit_fence and must not be double-wrapped.

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -65,8 +65,13 @@ _SUMMARY_ROUTE_PIN: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
     contextvars.ContextVar("hermes_summary_route_pin", default=None)
 )
 
-# ``timeout`` is included so a fallback entry keeps its own deadline.
-_PINNED_ROUTE_FIELDS: tuple[str, ...] = ("provider", "model", "base_url", "api_key", "api_mode", "timeout")
+# ``timeout`` is included so a fallback entry keeps its own deadline; ``reasoning_config``
+# so a pinned stall-fallback route carries its own effort instead of the stalled route's.
+_PINNED_ROUTE_FIELDS: tuple[str, ...] = ("provider", "model", "base_url", "api_key", "api_mode", "timeout", "reasoning_config")
+
+# update_model() sentinel distinguishing "caller left the effort unset" (keep/clear by route
+# change) from an explicit ``reasoning_config=None`` (clear on purpose).
+_REASONING_CONFIG_UNSET = object()
 
 
 @contextlib.contextmanager
@@ -2142,10 +2147,16 @@ class ContextCompressor(SummaryDispatchMixin, MicroCompactionMixin, ContextEngin
 
     def update_model(
         self, model: str, context_length: int, base_url: str = "", api_key: Any = "", provider: str = "",
-        api_mode: str = "", max_tokens: int | None = None,
+        api_mode: str = "", max_tokens: int | None = None, reasoning_config: Any = _REASONING_CONFIG_UNSET,
     ) -> None:
         """Update model info after a model switch or fallback activation."""
         runtime_changed = (model, provider, base_url, api_mode) != (self.model, self.provider, self.base_url, self.api_mode)
+        if reasoning_config is not _REASONING_CONFIG_UNSET:
+            self.reasoning_config = copy.deepcopy(reasoning_config)
+        elif runtime_changed:
+            # An omitted effort cannot carry the previous route's policy across a route
+            # change; a same-route context-window recalibration keeps the snapshot.
+            self.reasoning_config = None
         self.model, self.base_url, self.api_key, self.provider, self.api_mode = model, base_url, api_key, provider, api_mode
         self.context_length = context_length
         # Re-resolve from the raw config value so a switch away from an overridden model falls back correctly.
@@ -2265,8 +2276,13 @@ class ContextCompressor(SummaryDispatchMixin, MicroCompactionMixin, ContextEngin
         proactive_prune_tokens: int = 0, proactive_prune_min_result_chars: int = 8000,
         proactive_prune_min_reclaim_tokens: int = 4096, min_tail_user_messages: int = 1, tail_mode: str = "lean",
         custom_providers: list | None = None,
+        reasoning_config: Optional[Dict[str, Any]] = None,
     ):
         self.model, self.base_url, self.api_key, self.provider, self.api_mode = model, base_url, api_key, provider, api_mode
+        # Construction-time effort snapshot (deep copy: the caller's dict may keep mutating);
+        # agent-hosted compressors normally take the owning session's live snapshot via the
+        # scoped runtime instead — see _summary_main_runtime.
+        self.reasoning_config = copy.deepcopy(reasoning_config)
         # "lean" = small clamped tail + verbatim-user summary section; "legacy" = 0.20*window tail.
         self.tail_mode = tail_mode if tail_mode in ("legacy", "lean") else "lean"
         # Per-model context_length overrides live in custom_providers; without them deferred
@@ -3180,6 +3196,31 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         self.summary_model = ""  # empty = use main model
         self._clear_compression_failure_cooldown()  # no cooldown — retry immediately
 
+    def _summary_main_runtime(self) -> Dict[str, Any]:
+        """Runtime snapshot for the next summary call: the owning session's attempt
+        snapshot when it matches, else this compressor's construct/update snapshot.
+
+        A reused compressor can outlive a session effort/model switch. The host scopes a
+        fresh runtime (``scoped_runtime_main``) around each compression attempt, and that
+        ContextVar also isolates a detached pool worker from a later attempt. The session-id
+        match refuses a FOREIGN session's runtime even on the same deployment; standalone
+        compressors (no bound session) always use their own snapshot.
+        """
+        from agent.auxiliary_client import get_scoped_runtime_main
+
+        runtime = get_scoped_runtime_main()
+        session_id = getattr(self, "_session_id", "")
+        if session_id and runtime.get("session_id") == session_id:
+            return runtime
+        return {
+            "model": self.model,
+            "provider": self.provider,
+            "base_url": self.base_url,
+            "api_key": self.api_key,
+            "api_mode": self.api_mode,
+            "reasoning_config": copy.deepcopy(self.reasoning_config),
+        }
+
     def _call_summary_llm(self, prompt: str, prompt_started_at: float) -> str:
         """Issue the single aux summary call; return validated content text.
         Raises RuntimeError for empty content or a length-truncated (PARTIAL) summary so the failure
@@ -3188,10 +3229,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         _aux_route: Dict[str, str] = {}
         call_kwargs: Dict[str, Any] = {
             "task": "compression",
-            "main_runtime": {
-                "model": self.model, "provider": self.provider, "base_url": self.base_url, "api_key": self.api_key,
-                "api_mode": self.api_mode,
-            },
+            "main_runtime": self._summary_main_runtime(),
             "messages": [{"role": "user", "content": prompt}], "route_info": _aux_route,
             # NO max_tokens: Anthropic/NIM wires forward it and a hard cap truncates summaries
             # (thinking models burn it on reasoning). Timeout comes from call_llm config.

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3218,7 +3218,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             "base_url": self.base_url,
             "api_key": self.api_key,
             "api_mode": self.api_mode,
-            "reasoning_config": copy.deepcopy(self.reasoning_config),
+            "reasoning_config": copy.deepcopy(getattr(self, "reasoning_config", None)),
         }
 
     def _call_summary_llm(self, prompt: str, prompt_started_at: float) -> str:

--- a/agent/micro_compaction.py
+++ b/agent/micro_compaction.py
@@ -126,10 +126,10 @@ class MicroCompactionMixin:
         if self.summary_model:
             call_kwargs["model"] = self.summary_model
         if self.model:
-            call_kwargs.setdefault("main_runtime", {
-                "model": self.model, "provider": self.provider or "", "base_url": self.base_url or "",
-                "api_key": self.api_key or "", "api_mode": getattr(self, "api_mode", "") or "",
-            })
+            # Session-scoped snapshot (fresh effort, frozen for this pass) — see
+            # ContextCompressor._summary_main_runtime; never a bare route dict that
+            # silently drops the owning session's reasoning effort.
+            call_kwargs["main_runtime"] = self._summary_main_runtime()
 
         try:
             with aux_interrupt_protection():

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -386,6 +386,9 @@ def _publish_runtime_main(agent: Any) -> None:
                 "requested_provider", "base_url", "api_key", "api_mode", "auth_mode", "session_id"
             )},
             cache_scope=_cache_scope,
+            # Entry snapshot of the session's reasoning effort (deep-copied inside
+            # set_runtime_main); auxiliary compression inherits it for this turn.
+            reasoning_config=getattr(agent, "reasoning_config", None),
         )
 
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -280,7 +280,21 @@ def _micro_compact_after_turn(agent, messages, final_response, logger) -> None:
             and not getattr(agent, "_persist_disabled", False)
         ):
             _before = len(messages)
-            _compacted = _compressor._micro_compact(messages)
+            # A fallback or model switch may have changed the session's reasoning effort
+            # since turn_context published the turn's runtime snapshot; micro-compaction
+            # must summarize under the CURRENT runtime, not the entry snapshot. Best-effort:
+            # a stand-in agent without the facade method keeps baseline (unscoped) behavior.
+            _current_runtime = getattr(agent, "_current_main_runtime", None)
+            if callable(_current_runtime):
+                from agent.auxiliary_client import scoped_runtime_main
+                from agent.prompt_cache_scope import resolve_prompt_cache_scope_safe
+
+                micro_runtime = _current_runtime()
+                micro_runtime["cache_scope"] = resolve_prompt_cache_scope_safe(agent) or ""
+                with scoped_runtime_main(micro_runtime):
+                    _compacted = _compressor._micro_compact(messages)
+            else:
+                _compacted = _compressor._micro_compact(messages)
             # Defrag rewrites the newest MICRO marker in place and pops _db_persisted;
             # the compressor flags us to invalidate the flush-scan cursor, else the
             # rewritten row is identity-skipped (stale).

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -486,7 +486,7 @@ _CHAT_USAGE_SHAPE = (
     (("completion_tokens",), ("output_tokens",)),
     (("prompt_tokens_details", "cached_tokens"), ("cache_read_input_tokens",), ("prompt_cache_hit_tokens",), ("cached_tokens",)),
     (("prompt_tokens_details", "cache_write_tokens"), ("prompt_tokens_details", "cache_creation_input_tokens"),
-     ("cache_creation_input_tokens",), ("cache_write_tokens",)),
+     ("prompt_tokens_details", "cache_creation_tokens"), ("cache_creation_input_tokens",), ("cache_write_tokens",)),
 )
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -499,9 +499,20 @@ class AIAgent(
             detail = detail[:217].rstrip() + "..."
         self._emit_warning(f"⚠ Auxiliary {task} failed: {detail}")
 
-    def _current_main_runtime(self) -> Dict[str, str]:
-        """Return the live main runtime for session-scoped auxiliary routing."""
-        return {key: getattr(self, key, "") or "" for key in ("model", "provider", "base_url", "api_key", "api_mode", "auth_mode")}
+    def _current_main_runtime(self) -> Dict[str, Any]:
+        """Return the live main runtime for session-scoped auxiliary routing.
+
+        ``session_id`` keys the compressor's scoped-runtime handoff (a foreign session's
+        runtime must never be borrowed); ``reasoning_config`` is the session's live effort
+        snapshot, deep-copied so a later in-session change cannot mutate an in-flight
+        auxiliary attempt that inherited it.
+        """
+        runtime: Dict[str, Any] = {
+            key: getattr(self, key, "") or "" for key in ("model", "provider", "base_url", "api_key", "api_mode", "auth_mode")
+        }
+        runtime["session_id"] = getattr(self, "session_id", "") or ""
+        runtime["reasoning_config"] = copy.deepcopy(getattr(self, "reasoning_config", None))
+        return runtime
 
     _check_compression_model_feasibility = _forward("agent.conversation_compression", "check_compression_model_feasibility")
     _replay_compression_warning = _forward("agent.conversation_compression", "replay_compression_warning")

--- a/tests/agent/test_aux_codex_session_accounting.py
+++ b/tests/agent/test_aux_codex_session_accounting.py
@@ -1,0 +1,168 @@
+"""Synthetic Responses -> real compression/aux accounting -> a private SessionDB.
+
+The effort regression fixture replaces only HTTP transport and blocks sockets.
+Rates below are synthetic arithmetic fixtures, never claims about provider prices.
+"""
+import asyncio
+from decimal import Decimal
+import json
+
+import httpx
+import pytest
+
+import agent.auxiliary_client as aux
+from agent.aux_accounting import reset_accounting_context, set_accounting_context
+from agent.usage_pricing import PricingEntry, normalize_usage
+from hermes_state import SessionDB
+from tests.agent.test_compressor_runtime_handoff import MODEL, URL, compress, response_bytes, wire
+
+
+def _cache_details_reported(usage) -> bool:
+    """Cache-read telemetry is trustworthy iff the adapter carried input details with a
+    provider-REPORTED cached_tokens value; unset details, explicit null, or a details dict
+    without the key (SDK: cached_tokens=None) must not read as a real zero hit."""
+    details = getattr(usage, "prompt_tokens_details", None)
+    if details is None:
+        return False
+    value = details.get("cached_tokens") if isinstance(details, dict) else getattr(details, "cached_tokens", None)
+    return value is not None
+
+
+@pytest.fixture
+def accounting(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "usage.db")
+    db.create_session("usage-session", source="cli", model=MODEL)
+    # Main-loop totals are deliberately nonzero; auxiliary writes must not add to them.
+    db.update_token_counts("usage-session", input_tokens=10, output_tokens=2,
+                           model=MODEL, billing_provider="custom", api_call_count=1)
+    token = set_accounting_context(db, "usage-session")
+    rates = PricingEntry(input_cost_per_million=Decimal("2"),
+                         output_cost_per_million=Decimal("10"),
+                         cache_read_cost_per_million=Decimal("0.5"),
+                         cache_write_cost_per_million=Decimal("2.5"), source="official_docs_snapshot")
+    monkeypatch.setattr("agent.usage_pricing.get_pricing_entry", lambda *a, **k: rates)
+    yield db
+    reset_accounting_context(token)
+    db.close()
+
+
+def rows(db, task="compression"):
+    with db._lock:
+        return [dict(r) for r in db._conn.execute(
+            "SELECT * FROM session_model_usage WHERE session_id=? AND task=?",
+            ("usage-session", task))]
+
+
+def replace_usage(hook, usage, terminal=True):
+    def response(request, body):
+        events = [json.loads(part.split("data: ", 1)[1])
+                  for part in response_bytes(body).decode().strip().split("\n\n")]
+        for event in events:
+            if "response" in event:
+                event["response"]["usage"] = usage
+        if not terminal:
+            events = [event for event in events if event["type"] != "response.completed"]
+        data = "".join("data: " + json.dumps(event) + "\n\n" for event in events)
+        return httpx.Response(200, headers={"content-type": "text/event-stream"},
+                              content=data.encode(), request=request)
+    hook[0] = response
+
+
+CASES = [
+    pytest.param({"input_tokens": 1000, "input_tokens_details": {"cached_tokens": 600}}, 400, 600, 0, True, id="partial"),
+    pytest.param({"input_tokens": 1000, "input_tokens_details": {"cached_tokens": 1000}}, 0, 1000, 0, True, id="full"),
+    pytest.param({"input_tokens": 1000, "input_tokens_details": {"cached_tokens": 0}}, 1000, 0, 0, True, id="zero"),
+    pytest.param({"input_tokens": 0, "input_tokens_details": {"cached_tokens": 600}}, 0, 600, 0, True, id="input-zero"),
+    pytest.param({"input_tokens": None, "input_tokens_details": {"cached_tokens": 600}}, 0, 600, 0, True, id="input-null"),
+    pytest.param({"input_tokens_details": {"cached_tokens": 600}}, 0, 600, 0, True, id="input-missing"),
+    pytest.param({"input_tokens": 1000}, 1000, 0, 0, False, id="details-missing"),
+    pytest.param({"input_tokens": 1000, "input_tokens_details": None}, 1000, 0, 0, False, id="details-null"),
+    pytest.param({"input_tokens": 1000, "input_tokens_details": {}}, 1000, 0, 0, False, id="cache-missing"),
+    pytest.param({"input_tokens": 1000, "input_tokens_details": {"cached_tokens": 600, "cache_write_tokens": 100}}, 300, 600, 100, True, id="cache-write"),
+    pytest.param({"input_tokens": 1000, "input_tokens_details": {"cached_tokens": 600, "cache_creation_tokens": 100}}, 300, 600, 100, True, id="legacy-write"),
+]
+
+
+@pytest.mark.parametrize("fields,fresh,cached,written,known", CASES)
+def test_compression_persists_usage(wire, accounting, monkeypatch, fields, fresh, cached, written, known):
+    make, requests, _, hook = wire
+    seen = []
+    original = aux._CodexCompletionsAdapter.create
+    def observe(self, **kwargs):
+        result = original(self, **kwargs)
+        seen.append(result.usage)
+        return result
+    monkeypatch.setattr(aux._CodexCompletionsAdapter, "create", observe)
+    raw = {"output_tokens": 7, "total_tokens": 1007,
+           "output_tokens_details": {"reasoning_tokens": 3}, **fields}
+    replace_usage(hook, raw)
+    agent = make(sid="usage-session")
+    compressed, _ = compress(agent)
+    assert len(compressed) < 28 and len(requests) == 1
+    assert len(seen) == 1 and seen[0].total_tokens == raw["total_tokens"]
+    assert _cache_details_reported(seen[0]) == known
+    records = rows(accounting)
+    assert len(records) == 1
+    row = records[0]
+    assert (row["input_tokens"], row["cache_read_tokens"], row["cache_write_tokens"],
+            row["output_tokens"], row["reasoning_tokens"], row["api_call_count"]) == (fresh, cached, written, 7, 3, 1)
+    assert (row["model"], row["billing_provider"], row["billing_base_url"].rstrip("/")) == (MODEL, "custom", URL)
+    assert row["estimated_cost_usd"] == pytest.approx((fresh * 2 + cached * .5 + written * 2.5 + 7 * 10) / 1_000_000)
+    main = rows(accounting, "")[0]
+    assert (main["input_tokens"], main["output_tokens"], main["api_call_count"]) == (10, 2, 1)
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+def test_aux_call_preserves_totals_presence_and_single_accounting(wire, accounting, async_mode):
+    make, requests, _, hook = wire
+    raw = {"input_tokens": 1000, "input_tokens_details": {"cached_tokens": 600},
+           "output_tokens": 7, "output_tokens_details": {"reasoning_tokens": 3}, "total_tokens": 1007}
+    replace_usage(hook, raw)
+    agent = make(sid="usage-session")
+    args = dict(task="compression", messages=[{"role": "user", "content": "Synthetic."}],
+                main_runtime=agent._current_main_runtime())
+    result = asyncio.run(aux.async_call_llm(**args)) if async_mode else aux.call_llm(**args)
+    assert len(requests) == 1
+    assert (result.usage.prompt_tokens, result.usage.completion_tokens, result.usage.total_tokens) == (1000, 7, 1007)
+    canonical = normalize_usage(result.usage, api_mode="chat_completions", provider="custom")
+    assert (canonical.input_tokens, canonical.cache_read_tokens, canonical.output_tokens, canonical.reasoning_tokens) == (400, 600, 7, 3)
+    assert _cache_details_reported(result.usage)
+    assert rows(accounting)[0]["api_call_count"] == 1
+    assert rows(accounting)[0]["estimated_cost_usd"] == pytest.approx(.00117)
+
+
+def test_pooled_repeated_compression_accumulates_once(wire, accounting):
+    make, requests, _, _ = wire
+    agent = make(sid="usage-session")
+    for pooled in (False, True):
+        compressed, _ = compress(agent, pooled=pooled)
+        assert len(compressed) < 28
+    assert len(requests) == 2
+    row = rows(accounting)[0]
+    assert (row["input_tokens"], row["cache_read_tokens"], row["output_tokens"],
+            row["reasoning_tokens"], row["api_call_count"]) == (800, 1200, 14, 6, 2)
+    assert row["estimated_cost_usd"] == pytest.approx(.00234)
+
+
+@pytest.mark.parametrize("terminal", [False, True])
+def test_unknown_usage_never_creates_an_aux_row(wire, accounting, terminal):
+    make, requests, _, hook = wire
+    replace_usage(hook, None, terminal=terminal)
+    agent = make(sid="usage-session")
+    args = dict(task="compression", messages=[{"role": "user", "content": "Synthetic."}],
+                main_runtime=agent._current_main_runtime())
+    # The existing stream consumer permits truncated text, but its usage is unknown.
+    assert aux.call_llm(**args).usage is None
+    assert len(requests) == 1
+    assert rows(accounting) == []
+
+
+def test_empty_stream_fails_without_invented_usage(wire, accounting):
+    make, requests, _, hook = wire
+    hook[0] = lambda request, body: httpx.Response(
+        200, headers={"content-type": "text/event-stream"}, content=b"", request=request)
+    agent = make(sid="usage-session")
+    with pytest.raises(RuntimeError, match="terminal response"):
+        aux.call_llm(task="compression", messages=[{"role": "user", "content": "Synthetic."}],
+                     main_runtime=agent._current_main_runtime())
+    assert len(requests) == 1 and rows(accounting) == []

--- a/tests/agent/test_aux_codex_usage_provenance.py
+++ b/tests/agent/test_aux_codex_usage_provenance.py
@@ -1,0 +1,90 @@
+"""Preserve upstream cache/reasoning details through the actual auxiliary adapter."""
+import asyncio
+from types import SimpleNamespace as S
+import pytest
+from agent.auxiliary_client import _CodexCompletionsAdapter,_AsyncCompletionsAdapter
+from agent.usage_pricing import normalize_usage
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    import socket
+    def forbidden(*args,**kwargs):raise AssertionError('Network forbidden in telemetry regression tests')
+    monkeypatch.setattr(socket.socket,'connect',forbidden)
+
+def adapter(raw):
+    final=S(output=[S(type='message',content=[S(type='output_text',text='ok')])],usage=raw)
+    return _CodexCompletionsAdapter(S(base_url='http://127.0.0.1:18324/v1',responses=S(create=lambda **kw:final)),'gpt-6-astra')
+
+@pytest.mark.parametrize('as_dict',[True,False])
+@pytest.mark.parametrize('async_mode',[True,False])
+def test_actual_adapter_keeps_live_compression_usage(as_dict,async_mode):
+    # Actual Tokyo repeat #2 totals; a separate synthetic reasoning count checks its path.
+    raw={'input_tokens':6358,'output_tokens':23,'total_tokens':6381,
+         'input_tokens_details':{'cached_tokens':6144,'cache_write_tokens':0},
+         'output_tokens_details':{'reasoning_tokens':7}}
+    wrapped=adapter(raw if as_dict else S(**raw))
+    kwargs={'messages':[{'role':'user','content':'Synthetic completed calibration.'}]}
+    response=asyncio.run(_AsyncCompletionsAdapter(wrapped).create(**kwargs)) if async_mode else wrapped.create(**kwargs)
+    usage=normalize_usage(response.usage)
+    assert usage.cache_read_tokens==6144
+    assert usage.input_tokens==214 and usage.output_tokens==23 and usage.reasoning_tokens==7
+    assert response.usage.total_tokens==6381 and response.choices[0].message.content=='ok'
+    assert raw['input_tokens_details']['cached_tokens']==6144
+
+@pytest.mark.parametrize('as_dict',[True,False])
+@pytest.mark.parametrize('shape',['missing','null','zero'])
+def test_detail_presence_is_preserved(as_dict,shape):
+    raw={'input_tokens':12,'output_tokens':3,'total_tokens':15}
+    if shape!='missing':
+        raw['input_tokens_details']=None if shape=='null' else {'cached_tokens':0}
+        raw['output_tokens_details']=None if shape=='null' else {'reasoning_tokens':0}
+    usage=adapter(raw if as_dict else S(**raw)).create(messages=[{'role':'user','content':'Synthetic.'}]).usage
+    if shape=='missing':
+        assert not hasattr(usage,'prompt_tokens_details') and not hasattr(usage,'completion_tokens_details')
+    elif shape=='null':
+        assert usage.prompt_tokens_details is None and usage.completion_tokens_details is None
+    else:
+        assert usage.prompt_tokens_details=={'cached_tokens':0}
+        assert usage.completion_tokens_details=={'reasoning_tokens':0}
+
+def test_explicit_cache_write_remains_separate():
+    raw=S(input_tokens=6000,output_tokens=24,total_tokens=6024,
+          input_tokens_details=S(cached_tokens=4096,cache_write_tokens=128),
+          output_tokens_details=S(reasoning_tokens=3))
+    usage=normalize_usage(adapter(raw).create(messages=[{'role':'user','content':'Synthetic.'}]).usage)
+    assert (usage.input_tokens,usage.cache_read_tokens,usage.cache_write_tokens)==(1776,4096,128)
+
+def test_missing_usage_stays_missing():
+    assert adapter(None).create(messages=[{'role':'user','content':'Synthetic.'}]).usage is None
+
+@pytest.mark.parametrize('explicit_null',[False,True])
+def test_sdk_unset_is_distinct_from_explicit_null(explicit_null):
+    from openai.types.responses.response_usage import ResponseUsage
+    fields={'input_tokens':12,'output_tokens':3,'total_tokens':15}
+    if explicit_null:fields.update(input_tokens_details=None,output_tokens_details=None)
+    raw=ResponseUsage.model_construct(**fields)
+    result=adapter(raw).create(messages=[{'role':'user','content':'Synthetic.'}]).usage
+    if explicit_null:assert result.prompt_tokens_details is None
+    else:assert not hasattr(result,'prompt_tokens_details')
+
+@pytest.mark.parametrize('cached,output',[(3968,24),(6144,23)])
+def test_sdk_stream_preserves_actual_terminal_buckets(cached,output):
+    import json
+    import httpx
+    from openai import OpenAI
+    def handler(request):
+        assert request.url.host=='127.0.0.1'
+        item={'type':'message','id':'fixture-message','role':'assistant','status':'completed',
+              'content':[{'type':'output_text','text':'ok','annotations':[]}]}
+        usage={'input_tokens':6358,'input_tokens_details':{'cached_tokens':cached,'cache_write_tokens':0},
+               'output_tokens':output,'output_tokens_details':{'reasoning_tokens':0},'total_tokens':6358+output}
+        events=[{'type':'response.output_item.done','output_index':0,'item':item},
+                {'type':'response.completed','response':{'id':'fixture','object':'response','model':'gpt-6-astra',
+                   'status':'completed','output':[item],'usage':usage}}]
+        data=''.join('data: '+json.dumps(event)+'\n\n' for event in events)
+        return httpx.Response(200,headers={'content-type':'text/event-stream'},stream=httpx.ByteStream(data.encode()))
+    with OpenAI(api_key='synthetic',base_url='http://127.0.0.1:18324/v1',max_retries=0,
+                http_client=httpx.Client(transport=httpx.MockTransport(handler))) as client:
+        result=_CodexCompletionsAdapter(client,'gpt-6-astra').create(messages=[{'role':'user','content':'Synthetic.'}])
+        normalized=normalize_usage(result.usage)
+        assert (normalized.input_tokens,normalized.cache_read_tokens,normalized.output_tokens)==(6358-cached,cached,output)

--- a/tests/agent/test_compressor_runtime_handoff.py
+++ b/tests/agent/test_compressor_runtime_handoff.py
@@ -1,0 +1,336 @@
+"""Real compressor -> auxiliary router -> Responses SDK runtime handoff.
+
+Only the HTTP transport is synthetic. Route comparison, runtime construction,
+summary serialization, client creation and Responses adaptation execute normally.
+"""
+import asyncio
+import json
+import socket
+import threading
+
+import httpx
+import pytest
+import yaml
+
+import agent.auxiliary_client as aux
+from agent.context_compressor import ContextCompressor, pin_summary_route
+from agent.conversation_compression import CompressionCommitFence
+from run_agent import AIAgent
+
+
+MODEL = "gpt-5.6-session-fixture"
+URL = "http://127.0.0.1:1/v1"
+KEY = "synthetic-only-no-provider-access"
+SUMMARY = "## Goal\nSynthetic checkpoint.\n## Completed Actions\n" + (
+    "Verified the synthetic data and preserved the pending local task.\n" * 4
+)
+
+
+def reasoning(effort):
+    return None if effort is None else {"enabled": True, "effort": effort}
+
+
+def history():
+    return [
+        {"role": "user" if n % 2 == 0 else "assistant",
+         "content": f"Synthetic turn {n}: " + "local fixture context " * 180}
+        for n in range(28)
+    ]
+
+
+def response_bytes(body, text=SUMMARY):
+    output = [{"type": "message", "id": "msg_fixture", "role": "assistant",
+               "status": "completed", "content": [
+                   {"type": "output_text", "text": text, "annotations": []}]}]
+    response = {"id": "resp_fixture", "object": "response", "created_at": 1,
+                "model": body["model"], "status": "completed", "output": output,
+                "usage": {"input_tokens": 1000, "output_tokens": 7,
+                          "total_tokens": 1007,
+                          "input_tokens_details": {"cached_tokens": 600},
+                          "output_tokens_details": {"reasoning_tokens": 3}},
+                "error": None, "incomplete_details": None}
+    events = [
+        {"type": "response.created", "response": dict(response, status="in_progress", output=[])},
+        {"type": "response.output_text.delta", "output_index": 0, "content_index": 0,
+         "item_id": "msg_fixture", "delta": text},
+        {"type": "response.completed", "response": response},
+    ]
+    return "".join("event: " + e["type"] + "\ndata: " + json.dumps(e) + "\n\n"
+                   for e in events).encode()
+
+
+@pytest.fixture
+def wire(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DISABLE_LAZY_INSTALLS", "1")
+    monkeypatch.chdir(tmp_path)
+    cfg = {
+        "model": {"provider": "custom", "default": MODEL, "base_url": URL,
+                  "context_length": 65536},
+        "agent": {"reasoning_effort": "low"},
+        "context": {"engine": "compressor"},
+        "compression": {"enabled": True},
+        "auxiliary": {"compression": {"provider": "auto", "model": "", "timeout": 5},
+                      "title_generation": {"enabled": False},
+                      "background_review": {"enabled": False}},
+        "session": {"save_json": False},
+    }
+
+    def configure(task=None):
+        if task is not None:
+            cfg["auxiliary"]["compression"] = {"provider": "auto", "model": "", "timeout": 5, **task}
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg))
+
+    configure()
+    requests = []
+    hook = [None]
+    lock = threading.Lock()
+
+    def handle(_transport, request):
+        assert request.url.host == "127.0.0.1" and request.url.port == 1
+        assert request.url.path == "/v1/responses" and request.method == "POST"
+        body = json.loads(request.content)
+        with lock:
+            requests.append(body)
+        if hook[0]:
+            replacement = hook[0](request, body)
+            if replacement is not None:
+                return replacement
+        return httpx.Response(200, headers={"content-type": "text/event-stream"},
+                              content=response_bytes(body), request=request)
+
+    async def async_handle(transport, request):
+        return handle(transport, request)
+
+    def no_socket(*args, **kwargs):
+        raise AssertionError("Unexpected real network in synthetic compression test")
+
+    monkeypatch.setattr(httpx.HTTPTransport, "handle_request", handle)
+    monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", async_handle)
+    monkeypatch.setattr(socket.socket, "connect", no_socket)
+    aux.clear_runtime_main()
+    aux.shutdown_cached_clients()
+    agents = []
+
+    def make(effort="high", sid="session-fixture", **kwargs):
+        agent = AIAgent(
+            api_key=KEY, base_url=URL, provider="custom", model=MODEL,
+            api_mode="codex_responses", reasoning_config=reasoning(effort),
+            enabled_toolsets=[], quiet_mode=True, session_id=sid,
+            skip_context_files=True, skip_memory=True, skip_background_review=True,
+            save_trajectories=False, max_iterations=2,
+            **kwargs,
+        )
+        agent._cached_system_prompt = "Synthetic system."
+        agents.append(agent)
+        return agent
+
+    yield make, requests, configure, hook
+    for agent in agents:
+        agent.close()
+    aux.shutdown_cached_clients()
+    aux.clear_runtime_main()
+
+
+def compress(agent, pooled=False):
+    kw = {} if pooled else {"commit_fence": CompressionCommitFence()}
+    return agent._compress_context(history(), "Synthetic system.", force=True,
+                                   approx_tokens=30000, **kw)
+
+
+@pytest.mark.parametrize("pooled", [False, True])
+def test_current_session_effort_reaches_responses(wire, pooled):
+    make, requests, _, _ = wire
+    agent = make()
+    compressed, _ = compress(agent, pooled)
+    assert len(compressed) < 28
+    assert len(requests) == 1
+    assert requests[0]["reasoning"]["effort"] == "high"
+    assert requests[0]["stream"] is True
+    assert len(requests[0]["input"]) == 1
+    assert requests[0]["prompt_cache_key"]
+
+
+@pytest.mark.parametrize("effort,expected", [("low", "low"), (None, None), ("none", "none")])
+def test_reused_compressor_uses_current_effort(wire, effort, expected):
+    make, requests, _, _ = wire
+    agent = make()
+    compress(agent)
+    agent.reasoning_config = reasoning(effort)
+    compress(agent, pooled=True)
+    assert requests[0].get("reasoning", {}).get("effort") == "high"
+    assert requests[1].get("reasoning", {}).get("effort") == expected
+
+
+def test_disabled_session_reasoning_respected(wire):
+    make, requests, _, _ = wire
+    agent = make()
+    agent.reasoning_config = {"enabled": False}
+    compress(agent)
+    # The custom profile represents disabled reasoning as effort=none.
+    assert requests[0]["reasoning"]["effort"] == "none"
+
+
+@pytest.mark.parametrize("task", [{"reasoning_effort": "medium"},
+                                  {"extra_body": {"reasoning": {"effort": "medium"}}}])
+def test_auxiliary_override_keeps_ownership(wire, task):
+    make, requests, configure, _ = wire
+    configure(task)
+    compress(make())
+    assert requests[0]["reasoning"]["effort"] == "medium"
+
+
+def test_pinned_fallback_owns_effort(wire):
+    make, requests, _, _ = wire
+    agent = make()
+    with pin_summary_route({"provider": "custom", "model": "gpt-5.6-fallback-fixture",
+                            "base_url": URL, "api_key": KEY, "api_mode": "codex_responses",
+                            "reasoning_config": reasoning("medium")}):
+        compress(agent)
+    assert requests[0]["model"] == "gpt-5.6-fallback-fixture"
+    assert requests[0]["reasoning"]["effort"] == "medium"
+
+
+def test_runtime_snapshot_is_deep(wire):
+    make, _, _, _ = wire
+    agent = make()
+    agent.reasoning_config["nested"] = {"values": [1]}
+    frozen = agent._current_main_runtime()
+    agent.reasoning_config["nested"]["values"].append(2)
+    agent.reasoning_config["effort"] = "low"
+    assert frozen["reasoning_config"] == {"enabled": True, "effort": "high", "nested": {"values": [1]}}
+
+
+@pytest.mark.asyncio
+async def test_parallel_async_sessions_do_not_leak(wire):
+    make, requests, _, hook = wire
+    agents = [make(effort, f"session-{effort}") for effort in ("high", "low")]
+    barrier = threading.Barrier(2)
+    def rendezvous(*_):
+        barrier.wait(timeout=15)
+    hook[0] = rendezvous
+    await asyncio.gather(*(asyncio.to_thread(compress, agent) for agent in agents))
+    assert sorted(r["reasoning"]["effort"] for r in requests) == ["high", "low"]
+    assert len({r["prompt_cache_key"] for r in requests}) == 2
+
+
+def test_standalone_construct_update_and_clear(wire):
+    _, requests, _, _ = wire
+    config = reasoning("high")
+    c = ContextCompressor(MODEL, base_url=URL, provider="custom", api_key=KEY,
+                          api_mode="codex_responses", config_context_length=65536,
+                          quiet_mode=True, reasoning_config=config)
+    config["effort"] = "low"
+    assert c._generate_summary(history())
+    c.update_model(MODEL, 65536, URL, KEY, "custom", "codex_responses")
+    assert c._micro_summarize_one("Synthetic exchange")
+    changed = reasoning("medium")
+    c.update_model(MODEL, 65536, URL, KEY, "custom", "codex_responses", reasoning_config=changed)
+    changed["effort"] = "low"
+    assert c._generate_summary(history())
+    c.update_model("gpt-5.6-other-fixture", 65536, URL, KEY, "custom", "codex_responses")
+    assert c._generate_summary(history())
+    assert [r.get("reasoning", {}).get("effort") for r in requests] == ["high", "high", "medium", None]
+
+
+def test_foreign_session_runtime_not_borrowed(wire):
+    make, requests, _, _ = wire
+    own, foreign = make("high", "own"), make("low", "foreign")
+    with aux.scoped_runtime_main(foreign._current_main_runtime()):
+        assert own.context_compressor._generate_summary(history())
+    assert requests[0]["reasoning"]["effort"] == "high"
+
+
+def test_model_switch_current_runtime_overrides_compressor_snapshot(wire):
+    make, requests, _, _ = wire
+    agent = make()
+    agent.switch_model("gpt-5.6-other-fixture", "custom", api_key=KEY,
+                       base_url=URL, api_mode="codex_responses")
+    assert agent.reasoning_config == reasoning("low")
+    compress(agent)
+    assert (requests[0]["model"], requests[0]["reasoning"]["effort"]) == (agent.model, "low")
+
+
+def test_active_fallback_and_primary_restore_keep_their_own_effort(wire):
+    make, requests, _, _ = wire
+    agent = make(fallback_model={"provider": "custom", "model": "gpt-5.6-fallback-fixture",
+                                "base_url": URL, "api_key": KEY, "api_mode": "codex_responses"})
+    assert agent._try_activate_fallback()
+    # Upstream resolves the fallback effort from per-model/global config (low here), not
+    # from the fallback entry; the invariant is that compression follows the CURRENT
+    # agent effort instead of the compressor's stale construction snapshot (high).
+    assert agent.reasoning_config == reasoning("low")
+    compress(agent)
+    assert (requests[-1]["model"], requests[-1]["reasoning"]["effort"]) == ("gpt-5.6-fallback-fixture", "low")
+    agent._restore_primary_runtime()
+    # The init-time primary snapshot predates reasoning_config, so the restore keeps the
+    # agent's live value; the model itself must return to the primary route.
+    compress(agent)
+    assert (requests[-1]["model"], requests[-1]["reasoning"]["effort"]) == (MODEL, "low")
+
+
+def test_summary_retry_keeps_frozen_runtime(wire):
+    make, requests, _, hook = wire
+    agent = make()
+    compressor = agent.context_compressor
+    compressor.summary_model = "gpt-5.6-summary-fixture"
+
+    def first_empty(_request, body):
+        if len(requests) == 1:
+            agent.reasoning_config["effort"] = "low"
+            return httpx.Response(200, headers={"content-type": "text/event-stream"},
+                                  content=response_bytes(body, text=""))
+
+    hook[0] = first_empty
+    compress(agent)
+    assert [r["model"] for r in requests] == ["gpt-5.6-summary-fixture", MODEL]
+    assert requests[-1]["reasoning"]["effort"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_async_auxiliary_uses_real_responses_bridge(wire):
+    make, requests, _, _ = wire
+    agent = make()
+    response = await aux.async_call_llm(task="compression", messages=history()[:2],
+                                      main_runtime=agent._current_main_runtime())
+    assert response.choices[0].message.content
+    assert requests[0]["reasoning"]["effort"] == "high"
+
+
+def test_snapshot_update_explicit_none_and_nested_copy(wire):
+    make, requests, _, _ = wire
+    c = make().context_compressor
+    settings = {"effort": "low", "nested": {"values": [1]}}
+    c.update_model(MODEL, 65536, URL, KEY, "custom", "codex_responses", reasoning_config=settings)
+    settings["nested"]["values"].append(2)
+    assert c.reasoning_config["nested"]["values"] == [1]
+    c.update_model(MODEL, 65536, URL, KEY, "custom", "codex_responses", reasoning_config=None)
+    assert c._generate_summary(history())
+    assert "reasoning" not in requests[-1]
+
+
+def test_nested_disabled_override_wins_over_profile_effort(wire):
+    make, requests, configure, _ = wire
+    configure({"extra_body": {"reasoning": {"enabled": False}}})
+    compress(make())
+    assert "reasoning" not in requests[0]
+
+
+def test_turn_finalizer_micro_summary_uses_current_session(wire):
+    make, requests, _, hook = wire
+    agent = make()
+    c = agent.context_compressor
+    c._micro_compact_enabled = True
+    agent.compression_enabled = False
+
+    def after_main(_request, _body):
+        if len(requests) == 1:
+            # In-turn fallback/effort change occurs after turn_context's entry
+            # snapshot; finalization must publish the current agent runtime.
+            agent.reasoning_config = reasoning("low")
+
+    hook[0] = after_main
+    result = agent.run_conversation("Synthetic next turn", conversation_history=history())
+    assert result["completed"]
+    assert len(requests) == 2
+    assert [r["reasoning"]["effort"] for r in requests] == ["high", "low"]

--- a/tests/agent/test_portal_tags.py
+++ b/tests/agent/test_portal_tags.py
@@ -164,6 +164,9 @@ def test_compress_context_preserves_ambient_context(monkeypatch):
     monkeypatch.setattr(cc, "compress_context", _fake_compress)
 
     class _Agent:
+        def _current_main_runtime(self):
+            return {"session_id": "segment-after-compaction", "reasoning_config": None}
+
         def _conversation_root_id(self):
             # A rotated segment id must never win over the ambient root.
             return "segment-after-compaction"

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -145,6 +145,8 @@ def test_feasibility_check_passes_live_main_runtime():
     agent.base_url = "https://chatgpt.com/backend-api/codex"
     agent.api_key = "codex-token"
     agent.api_mode = "codex_responses"
+    agent.session_id = "feasibility-session"
+    agent.reasoning_config = {"effort": "high"}
 
     mock_client = MagicMock()
     mock_client.base_url = "https://chatgpt.com/backend-api/codex"
@@ -164,6 +166,8 @@ def test_feasibility_check_passes_live_main_runtime():
             "api_key": "codex-token",
             "api_mode": "codex_responses",
             "auth_mode": "",
+            "session_id": agent.session_id,
+            "reasoning_config": agent.reasoning_config,
         },
     )
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -37,6 +37,7 @@ from hermes_state import SessionDB
 def _make_mock_parent(depth=0):
     """Create a mock parent agent with the fields delegate_task expects."""
     parent = MagicMock()
+    parent.reasoning_config = None
     parent.base_url = "https://openrouter.ai/api/v1"
     parent.api_key="***"
     parent.provider = "openrouter"

--- a/tests/tools/test_delegate_batch_validation.py
+++ b/tests/tools/test_delegate_batch_validation.py
@@ -22,6 +22,7 @@ from tools.delegate_tool import delegate_task
 
 def _make_mock_parent(depth=0):
     parent = MagicMock()
+    parent.reasoning_config = None
     parent.base_url = "https://openrouter.ai/api/v1"
     parent.api_key = "test-key"
     parent.provider = "openrouter"


### PR DESCRIPTION
## What

Two auxiliary-path fixes, both reproduced on current `main`:

1. **Compression requests lose the session's reasoning effort.** `ContextCompressor` built `main_runtime` with only model/provider/base_url/api_key/api_mode, so summarization calls never carried the owning session's effort. Custom/OpenAI-chat style profiles also project effort onto a top-level `reasoning_effort` kwarg, which the Codex Responses adapter ignored (it only read `extra_body.reasoning`).

2. **Responses→Chat usage adapter drops detail buckets.** `_parse_codex_final_response` / `_CodexCompletionsAdapter` kept only prompt/completion/total tokens, discarding `input_tokens_details` / `output_tokens_details`. Chat-path `normalize_usage` then reads no cached tokens: auxiliary usage records cache 0 and full fresh input even when the Responses API reported cached tokens. The Chat shape also lacked the legacy `prompt_tokens_details.cache_creation_tokens` fallback the Codex shape already had.

## How

- `set_runtime_main` / `turn_context` publish a deep-copied `reasoning_config` snapshot; `ContextCompressor` keeps a construct/update snapshot (UNSET sentinel distinguishes "caller omitted" from explicit `None`; cross-route changes don't inherit the old route's effort), and `_summary_main_runtime()` resolves the owning session's scoped runtime — refusing a foreign session's runtime — falling back to the compressor's own snapshot.
- `compression_facade` and `turn_finalizer` scope each compression/micro-compaction attempt with a frozen per-attempt runtime, so out-of-turn entry points (`/compact`, gateway compress) and post-fallback switches still see the current effort.
- The adapter bridges `input_tokens_details`→`prompt_tokens_details` and `output_tokens_details`→`completion_tokens_details` (dict/object/None/unset all preserved), honors top-level `reasoning_effort` when `extra_body.reasoning` is absent, and `_CHAT_USAGE_SHAPE` gains the nested legacy cache-write candidate.

## Testing

- Baseline reproduces both bugs: effort test fails without the fix (compression request carries no reasoning config); 9 usage tests fail (cache_read recorded 0, details dropped, cache-write split missing).
- With the fix: 3 new test files (real compressor→auxiliary routing→Responses adapter→SDK chain against a socket-blocked fixture, plus SessionDB accounting), 53/53 pass; 58 existing upstream files covering every touched surface pass — **1,416 passed, 5 skipped, 0 failed** via the canonical runner.
- No dependency/manifest changes; `git diff --check` clean.

Fixes the same class of issue for auxiliary accounting that `normalize_usage` already handles for direct Chat consumers.