### PR TITLE
fix(desktop): recognize Chromium family browsers in Windows updater (#105268)

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -124,9 +124,14 @@ function Get-UiHtmlPath {
 function Get-DefaultBrowserExe {
     # The OS default browser, read from the UserChoice ProgId that the
     # Windows Settings app writes (https first, http as fallback). Only
-    # Chromium-family browsers (ChromeHTML / MSEdgeHTM) support the
-    # --app + --user-data-dir combo the shim relies on; any other
-    # default browser returns $null and degrades to the WinForms card.
+    # Chromium-family browsers support the --app + --user-data-dir combo
+    # the shim relies on. Any non-Chromium default (Firefox, Safari, etc.)
+    # returns $null and degrades to the WinForms card.
+    #
+    # Checks for known Chromium ProgIds by prefix (ChromeHTML / MSEdgeHTM /
+    # BraveHTML / ChromiumHTM / BraveOHTML / VivaldiHTM / OperaStableHTM).
+    # Channel builds (Beta/Dev/Canary) deliberately return $null and degrade
+    # to the safe fallback (#95549: don't drive the wrong profile).
     $progId = $null
     foreach ($proto in @("https", "http")) {
         try {
@@ -135,12 +140,40 @@ function Get-DefaultBrowserExe {
         if ($progId) { break }
     }
     if (-not $progId) { return $null }
-    $family = switch ($progId) {
-        "ChromeHTML" { "Google\Chrome\Application\chrome.exe" }
-        "MSEdgeHTM"  { "Microsoft\Edge\Application\msedge.exe" }
-        default      { $null }
+
+    # Stable Chromium family prefixes and their install trees. Case-insensitive.
+    $chromiumFamilies = @(
+        @{ prefix = "ChromeHTML"; install = @("Google", "Chrome", "Application", "chrome.exe") }
+        @{ prefix = "MSEdgeHTM"; install = @("Microsoft", "Edge", "Application", "msedge.exe") }
+        @{ prefix = "BraveHTML"; install = @("BraveSoftware", "Brave-Browser", "Application", "brave.exe") }
+        @{ prefix = "BraveOHTML"; install = @("BraveSoftware", "Brave-Origin", "Application", "brave.exe") }
+        @{ prefix = "ChromiumHTM"; install = @("Chromium", "Application", "chrome.exe") }
+        @{ prefix = "VivaldiHTM"; install = @("Vivaldi", "Application", "vivaldi.exe") }
+        @{ prefix = "OperaStableHTM"; install = @("Opera", "launcher.exe") }
+    )
+
+    # Channel build prefixes deliberately rejected (β/dev/canary):
+    $channelProgIds = @("ChromeBHTML", "ChromeDHTML", "ChromeSSHTML", "ChromeCanaryHTML",
+                        "MSEdgeBHTML", "MSEdgeDHTML", "MSEdgeCHTML",
+                        "BraveBetaHTML", "BraveNightlyHTML",
+                        "BraveOBHTML", "BraveODHTML", "BraveOSHTM",
+                        "ChromiumBHTML", "ChromiumDHTML",
+                        "VivaldiBetaHTM", "VivaldiSnapshotHTM",
+                        "OperaBetaHTM", "OperaDevHTM")
+    $lowerProgId = $progId.ToLowerInvariant()
+    foreach ($chan in $channelProgIds) {
+        if ($lowerProgId -eq $chan.ToLowerInvariant()) { return $null }
+    }
+
+    $family = $null
+    foreach ($entry in $chromiumFamilies) {
+        if ($lowerProgId.StartsWith($entry.prefix.ToLowerInvariant())) {
+            $family = $entry.install
+            break
+        }
     }
     if (-not $family) { return $null }
+
     # Exact path from the ProgId's open command first, then standard roots.
     try {
         $cmd = (Get-ItemProperty -Path "Registry::HKEY_CLASSES_ROOT\$progId\shell\open\command" -ErrorAction Stop).'(default)'
@@ -151,7 +184,7 @@ function Get-DefaultBrowserExe {
     } catch {}
     foreach ($root in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, $env:LOCALAPPDATA)) {
         if (-not $root) { continue }
-        $p = Join-Path $root $family
+        $p = Join-Path $root (Join-Path -Path $family[0..($family.Length - 2)] -ChildPath $family[-1])
         if (Test-Path -LiteralPath $p) { return $p }
     }
     return $null

--- a/tests/test_desktop_update_windows_chromium_family.py
+++ b/tests/test_desktop_update_windows_chromium_family.py
@@ -1,0 +1,81 @@
+"""Regression: Windows desktop updater must recognize Chromium family browsers.
+
+The update shim (scripts/desktop-update/windows.ps1) displays its progress window
+via ui.html in a chromeless browser window launched with --app --user-data-dir.
+That requires a Chromium-family default browser (Chrome/Edge/Brave/Chromium/Vivaldi/Opera);
+any other default (Firefox, Safari) gracefully degrades to the WinForms card.
+
+Before this fix, Get-DefaultBrowserExe hardcoded two ProgId entries (ChromeHTML,
+MSEdgeHTM) and returned $null for every other ProgId — including other Chromium
+family browsers like Brave (BraveHTML) or Vivaldi (VivaldiHTM). That forced them
+to the WinForms fallback, where the card became a frozen grey ghost window with
+leaked PowerShell console (#105268).
+
+The fix extends the recognition to all known stable Chromium ProgIds while
+explicitly blocking channel builds (Beta/Dev/Canary) to fail closed and
+avoid driving the wrong profile (#95549).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def test_chromium_family_progid_map_is_stable_complete() -> None:
+    source = WINDOWS_PS1.read_text(encoding="utf-8").replace("\r\n", "\n")
+
+    stable_progids = {
+        "ChromeHTML": ("Google", "Chrome"),
+        "MSEdgeHTM": ("Microsoft", "Edge"),
+        "BraveHTML": ("BraveSoftware", "Brave-Browser"),
+        "BraveOHTML": ("BraveSoftware", "Brave-Origin"),
+        "ChromiumHTM": ("Chromium",),
+        "VivaldiHTM": ("Vivaldi",),
+        "OperaStableHTM": ("Opera",),
+    }
+
+    for progid_prefix, path_parts in stable_progids.items():
+        # Each stable Chromium ProgId prefix must appear as a literal in a hashtable
+        # entry paired with its product path segments.
+        assert (
+            f'prefix = "{progid_prefix}"' in source
+        ), f"Desktop update script must recognize stable Chromium ProgId {progid_prefix} ({path_parts} install)."
+        for segment in path_parts:
+            assert (
+                segment in source
+            ), f"Desktop update script must carry the {segment} install tree segment for {progid_prefix}."
+
+
+def test_channel_builds_explicitly_rejected() -> None:
+    source = WINDOWS_PS1.read_text(encoding="utf-8").replace("\r\n", "\n")
+
+    # Channel prefixes must be in the explicit-reject list so they fail closed
+    # instead of resolving to the stable family (#95549).
+    channel_progids = [
+        "ChromeBHTML",
+        "ChromeDHTML",
+        "ChromeSSHTML",
+        "ChromeCanaryHTML",
+        "MSEdgeBHTML",
+        "MSEdgeDHTML",
+        "MSEdgeCHTML",
+        "BraveBetaHTML",
+        "BraveNightlyHTML",
+        "BraveOBHTML",
+        "BraveODHTML",
+        "BraveOSHTM",
+        "ChromiumBHTML",
+        "ChromiumDHTML",
+        "VivaldiBetaHTM",
+        "VivaldiSnapshotHTM",
+        "OperaBetaHTM",
+        "OperaDevHTM",
+    ]
+
+    for chan in channel_progids:
+        assert (
+            f'"{chan}"' in source
+        ), f"Desktop update script must explicitly reject channel ProgId {chan} to avoid driving the wrong profile."


### PR DESCRIPTION
**Summary**

Extends `Get-DefaultBrowserExe` in `scripts/desktop-update/windows.ps1` to recognize all stable Chromium-family browsers by ProgId prefix (Brave / Chromium / Vivaldi / Opera alongside Chrome / Edge), fixing the frozen grey "ghost" window and leaked PowerShell console on Windows when a Chromium alternative is the system default.

**Root cause**

Before this fix, the function hardcoded a `switch` that accepted only `ChromeHTML` (Chrome) and `MSEdgeHTM` (Edge). Any other Chromium browser (for example, Brave with `BraveHTML` or Vivaldi with `VivaldiHTM`) returned `$null` and forced the WinForms fallback card. The WinForms card is pumped only via `DoEvents` while the main thread runs the update pipeline — so it never renders, and Windows DWM composites it into a frozen grey window with the default icon. At the same time, the PowerShell console becomes visible on the taskbar.

**Fix**

The function now checks for known stable Chromium ProgId prefixes via case-insensitive `StartsWith` match and looks up their install trees from a table. Channel builds (Beta / Dev / Canary) are explicitly rejected and return `$null` to fail closed instead of driving the wrong profile (#95549 invariant). The rest of the resolution path (read from the ProgId's `shell\open\command` first, then fallback to standard roots) is unchanged.

**Testing**

- Regression guard: `tests/test_desktop_update_windows_chromium_family.py` verifies the stable Chromium ProgId map and channel reject list are complete (source-level assertions, with CRLF normalization matching the existing desktop-update test pattern).
- Local test run on macOS (tests are cross-platform source-level checks, not runtime Windows invocations):
  - New regression test: **2 passed**
  - Full desktop-update Windows suite: **12 passed, 6 skipped** (skipped = `windows_only` marker, expected on non-Windows)

**Fixes #105268**