### PR TITLE
Cron re-pages every runner-suppressed repeat as a new incident

### DIFF
--- a/cron/incidents.py
+++ b/cron/incidents.py
@@ -39,6 +39,17 @@ _FAILURE_TYPE_ORDER = (
 MAX_ERROR_CHARS = 500
 _MAX_SIGNATURE_ERROR_CHARS = 200
 
+# Some script runners deliberately replace a repeated failure card with a short
+# stdout marker while preserving the non-zero exit. The outer cron scheduler sees
+# that marker as the error for this run. Its occurrence counter is telemetry, not
+# condition identity: signing it verbatim mints a fresh outer incident every tick
+# and defeats both the runner's dedup and cron's ack gate.
+_SUPPRESSED_DUPLICATE_OCCURRENCE_RE = re.compile(
+    r"(?P<prefix>suppressed:\s*duplicate of an open condition\s*\(occurrence\s*)"
+    r"\d+(?P<suffix>\))",
+    re.IGNORECASE,
+)
+
 _lock = threading.RLock()
 
 
@@ -90,8 +101,12 @@ def _transaction() -> Iterator[sqlite3.Connection]:
 
 
 def _normalize_error(error: str) -> str:
-    """Strip whitespace and lowercase before signing (dedup normalization)."""
-    return re.sub(r"\s+", " ", str(error or "")).strip().lower()
+    """Remove run-varying fields, then normalize whitespace/case for signing."""
+    text = str(error or "")
+    text = _SUPPRESSED_DUPLICATE_OCCURRENCE_RE.sub(
+        r"\g<prefix>N\g<suffix>", text
+    )
+    return re.sub(r"\s+", " ", text).strip().lower()
 
 
 def _redact_error(error: str) -> str:

--- a/tests/cron/test_cron_incidents.py
+++ b/tests/cron/test_cron_incidents.py
@@ -106,6 +106,38 @@ def test_same_signature_dedups_same_incident(monkeypatch, tmp_path):
     assert inc.get_incident(id1)["state"] == "detected"
 
 
+def test_runner_suppression_occurrence_dedups_same_outer_incident(monkeypatch, tmp_path):
+    """An inner runner's occurrence counter must not bypass outer cron dedup."""
+    inc = _point_db(monkeypatch, tmp_path)
+    error_2 = (
+        "Script exited with code 3\nstdout:\n"
+        "(suppressed: duplicate of an open condition (occurrence 2))"
+    )
+    error_43 = (
+        "Script exited with code 3\nstdout:\n"
+        "(suppressed: duplicate of an open condition (occurrence 43))"
+    )
+
+    id1, new1 = inc.upsert_incident("job-1", error_2)
+    id2, new2 = inc.upsert_incident("job-1", error_43)
+
+    assert id1 == id2
+    assert new1 is True
+    assert new2 is False
+    assert inc.count_incidents() == 1
+
+
+def test_unsuppressed_occurrence_text_still_mints_distinct_incidents(monkeypatch, tmp_path):
+    """Do not erase numbers from arbitrary failures that may carry real identity."""
+    inc = _point_db(monkeypatch, tmp_path)
+
+    id1, _ = inc.upsert_incident("job-1", "worker failed at occurrence 2")
+    id2, new2 = inc.upsert_incident("job-1", "worker failed at occurrence 43")
+
+    assert id1 != id2
+    assert new2 is True
+
+
 def test_error_change_mints_new_incident(monkeypatch, tmp_path):
     inc = _point_db(monkeypatch, tmp_path)
 


### PR DESCRIPTION
## What happened

A `no_agent` script can already deduplicate a persistent failure and emit only:

```text
(suppressed: duplicate of an open condition (occurrence N))
```

The outer cron scheduler still treats the runner's non-zero exit as a failure. Its durable incident signature included `N` verbatim, so every tick minted a new outer incident and re-delivered a failure card. In a measured five-minute job this produced 40 consecutive Telegram pages even though the inner runner was suppressing the same condition.

## Fix

Normalize only the occurrence counter in this explicit runner-suppression marker before signing the outer incident. Arbitrary occurrence numbers elsewhere remain distinct.

## Verification

- `scripts/run_tests.sh tests/cron/test_cron_incidents.py`
- 16 passed
- Added both directions: 2 vs 43 deduplicate for the suppression marker, while ordinary `worker failed at occurrence 2/43` messages remain distinct.