### PR TITLE
fix(tools): parse a real digest in post-write verification

### DIFF
--- a/tests/tools/test_write_verification.py
+++ b/tests/tools/test_write_verification.py
@@ -71,3 +71,112 @@ class TestWriteVerification:
         assert "error" not in r
         assert f.read_text() == "content lands anyway\n"
         assert "verified" not in r or r.get("verified") is None
+
+
+class TestDigestParsing:
+    """The executor merges stderr into `output` (process_registry spawns with
+    stderr=subprocess.STDOUT), so shell noise can precede sha256sum's line. The
+    verifier must find the real digest and must never turn noise into a
+    'content mismatch' on a write that persisted. Regression for the
+    shell-init/getcwd false mismatch."""
+
+    NOISE = (
+        "shell-init: error retrieving current directory: getcwd: cannot access "
+        "parent directories: Operation not permitted\n"
+        "chdir: error retrieving current directory: getcwd: cannot access "
+        "parent directories: Operation not permitted\n"
+    )
+
+    @staticmethod
+    def _exec_with_noise(noise, digest_for):
+        """Patch _exec so sha256sum returns `noise` followed by a digest line.
+
+        `digest_for` maps the on-disk bytes to the digest to report, so a test
+        can emit either the correct digest or a wrong-but-valid one.
+        """
+        import tools.file_operations as fo
+        real_exec = fo.ShellFileOperations._exec
+
+        def fake_exec(self, cmd, **kw):
+            if "sha256sum" in cmd:
+                real = real_exec(self, cmd, **kw)
+                digest = digest_for(real.stdout)
+                body = f"{digest}  /path\n" if digest else ""
+                return fo.ExecuteResult(stdout=noise + body, exit_code=0)
+            return real_exec(self, cmd, **kw)
+
+        return mock_patch.object(fo.ShellFileOperations, "_exec", fake_exec)
+
+    def test_warning_before_digest_still_verifies(self, workdir):
+        # The actual bug: noise + correct digest was read as a mismatch.
+        import tools.file_operations as fo
+        f = workdir / "noisy.md"
+        content = "# heading\n\nbody text\n"
+        expected = fo.hashlib.sha256(content.encode()).hexdigest()
+
+        with self._exec_with_noise(self.NOISE, lambda _out: expected):
+            r = json.loads(write_file_tool(str(f), content, task_id="t-wv3"))
+
+        assert "error" not in r, r.get("error")
+        assert r.get("verified") is True
+        assert r.get("bytes_written") == len(content.encode())
+        assert f.read_text() == content
+
+    def test_warning_plus_wrong_digest_is_still_a_hard_error(self, workdir):
+        # Noise must not become a blanket excuse: a genuinely wrong digest is
+        # still a mismatch.
+        import tools.file_operations as fo
+        f = workdir / "wrong.md"
+        wrong = fo.hashlib.sha256(b"something else entirely").hexdigest()
+
+        with self._exec_with_noise(self.NOISE, lambda _out: wrong):
+            r = json.loads(write_file_tool(str(f), "real content\n", task_id="t-wv4"))
+
+        assert "error" in r
+        assert "did not persist" in r["error"]
+
+    def test_noise_without_any_digest_is_unverified_not_mismatch(self, workdir):
+        # No parseable digest -> verification unavailable. The write stands and
+        # no mismatch is fabricated.
+        f = workdir / "nodigest.md"
+        content = "content lands\n"
+
+        with self._exec_with_noise(self.NOISE, lambda _out: None):
+            r = json.loads(write_file_tool(str(f), content, task_id="t-wv5"))
+
+        assert "error" not in r, r.get("error")
+        assert r.get("verified") is None
+        assert f.read_text() == content
+
+
+class TestParseSha256Digest:
+    """Unit coverage for the parser itself."""
+
+    def test_plain_output(self):
+        from tools.file_operations import _parse_sha256_digest
+        d = "a" * 64
+        assert _parse_sha256_digest(f"{d}  /tmp/f") == d
+
+    def test_prepended_noise(self):
+        from tools.file_operations import _parse_sha256_digest
+        d = "3a1363c0" + "b" * 56
+        out = "shell-init: error retrieving current directory\n" + f"{d}  /tmp/f\n"
+        assert _parse_sha256_digest(out) == d
+
+    def test_uppercase_digest_normalized(self):
+        from tools.file_operations import _parse_sha256_digest
+        assert _parse_sha256_digest(("A" * 64) + "  /tmp/f") == "a" * 64
+
+    def test_no_digest_returns_none(self):
+        from tools.file_operations import _parse_sha256_digest
+        assert _parse_sha256_digest("shell-init: error\nchdir: error\n") is None
+        assert _parse_sha256_digest("") is None
+
+    def test_too_short_or_too_long_hex_rejected(self):
+        from tools.file_operations import _parse_sha256_digest
+        assert _parse_sha256_digest(("a" * 63) + "  /tmp/f") is None
+        assert _parse_sha256_digest(("a" * 65) + "  /tmp/f") is None
+
+    def test_hex_not_at_line_start_ignored(self):
+        from tools.file_operations import _parse_sha256_digest
+        assert _parse_sha256_digest("warning: token " + ("a" * 64) + "\n") is None

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -167,6 +167,28 @@ def _split_segments(output: str, sentinel: str) -> list[str]:
     return output.split(sentinel + "\n")
 
 
+_SHA256_LINE = re.compile(r"^([0-9a-fA-F]{64})(?:\s|$)", re.MULTILINE)
+
+
+def _parse_sha256_digest(output: str) -> Optional[str]:
+    """Extract the digest from ``sha256sum`` output, or None if there isn't one.
+
+    The executor merges stderr into the same stream as stdout (process_registry
+    spawns with ``stderr=subprocess.STDOUT``), and ``2>/dev/null`` on the command
+    does not help: shell-initialization diagnostics are emitted before the
+    command's own redirection applies. So this stream can legitimately start with
+    lines like ``shell-init: error retrieving current directory: getcwd: ...``.
+
+    Taking the first whitespace token of the stream therefore yielded
+    ``shell-init:`` as the "digest" and fabricated a hash mismatch on a write that
+    had in fact persisted correctly. Match a real 64-hex digest anchored at the
+    start of a line instead. Noise is prepended, and sha256sum prints one line per
+    file, so the last match is the digest line.
+    """
+    matches = _SHA256_LINE.findall(output or "")
+    return matches[-1].lower() if matches else None
+
+
 class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
     """File operations over any terminal backend exposing ``execute(command, cwd)``
     returning ``{"output": str, "returncode": int}``.
@@ -1193,7 +1215,12 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
         try:
             hash_result = self._exec(f"sha256sum {self._escape_shell_arg(path)} 2>/dev/null")
             if hash_result.exit_code == 0 and hash_result.stdout.strip():
-                disk_sha = hash_result.stdout.strip().split()[0]
+                disk_sha = _parse_sha256_digest(hash_result.stdout)
+                if disk_sha is None:
+                    # Unparsable output is "could not verify", never "mismatch".
+                    # Claiming a mismatch here would tell the model a good write
+                    # failed and send it into a retry loop. See _parse_sha256_digest.
+                    return None, None
                 if disk_sha != hashlib.sha256(content_bytes).hexdigest():
                     return False, WriteResult(error=(
                         f"Post-write verification failed for {path}: on-disk "


### PR DESCRIPTION
## What changed and why

`write_file`'s post-write verification reads the on-disk digest as the first
whitespace token of the `sha256sum` result:

```python
hash_result = self._exec(f"sha256sum {self._escape_shell_arg(path)} 2>/dev/null")
if hash_result.exit_code == 0 and hash_result.stdout.strip():
    disk_sha = hash_result.stdout.strip().split()[0]
```

That token is the digest only when the stream is clean, and it isn't guaranteed
to be. Two things combine:

1. `_exec` maps the backend's generic combined `output` field into a field
   *named* `stdout` (`tools/file_operations.py`), and the local executor spawns
   with `stderr=subprocess.STDOUT` (`tools/process_registry.py`). So stderr is
   interleaved into the value being parsed.
2. The `2>/dev/null` on the command does not protect against this. Shell
   *initialization* diagnostics are emitted before the command's own
   redirection applies, so they still reach the stream.

When anything precedes the digest line, `disk_sha` becomes that leading token,
never matches, and `write_file` returns

> Post-write verification failed for `<path>`: on-disk content hash differs from
> the intended write. The write did not persist correctly — re-read the file and
> retry.

with `bytes_written: 0` — for a file that is on disk, complete, and correct.

This is a follow-on to #57788. That issue was about the verifier fabricating
**success** (the old `wc -c` block substituting `len(content)` when it couldn't
confirm the write). The hash verifier that replaced it is correct in principle,
but it assumes a stderr-free channel the executor does not provide, so the same
code path can now fabricate **failure**.

The failure mode is worse than a spurious error message: the tool tells the
model a good write did not land, and the model's correct response is to write
it again. It also tracks the shell's environment rather than the content, which
makes it intermittent and easy to misdiagnose as a size or encoding bug.

## The fix

Match a real 64-hex digest anchored at a line start instead of taking the first
token. Noise is prepended and `sha256sum` prints one line per file, so the last
match is the digest line.

Unparsable output is now `verified: None` ("could not verify"), never a
mismatch — fabricating a mismatch is the actual harm. A wrong-but-valid digest
is still a hard error, so the check is not weakened.

A deeper fix would be to have `env.execute` return stdout and stderr separately
so a field named `stdout` means it. That is a broader change to the executor
contract; this PR keeps to the parsing bug, and the digest-format validation is
worth having regardless of how the stream is plumbed.

## How to test

Automated — `tests/tools/test_write_verification.py` gains 9 tests:

- `TestDigestParsing` — three behavioral cases through `write_file_tool` with
  `_exec` patched to emit realistic noise before the digest:
  - noise + correct digest → `verified: True`, no error *(fails without the fix)*
  - noise + wrong-but-valid digest → still a hard mismatch error
  - noise + no digest at all → `verified: None`, write stands *(fails without the fix)*
- `TestParseSha256Digest` — six unit cases: plain output, prepended noise,
  uppercase normalization, no digest, 63/65-hex rejection, and hex that isn't
  at a line start.

Reverting only the `tools/file_operations.py` change makes the two marked cases
fail with the original symptom.

Manual reproduction — any shell that emits startup noise triggers it. The
original sighting was a sandboxed macOS gateway whose tool shell started in a
directory it could not traverse, so bash prefixed every command with:

```
shell-init: error retrieving current directory: getcwd: cannot access parent directories: Operation not permitted
chdir: error retrieving current directory: getcwd: cannot access parent directories: Operation not permitted
```

Every `write_file` then failed verification while writing correctly. A simpler
equivalent is anything that writes to stderr from shell startup — e.g. an
`echo` in the profile/rc that the backend picks up.

## Platforms tested

macOS 26.6.2 (arm64), Python 3.11.16, `hermes-agent` 0.21.0.

`scripts/run_tests.sh` across the write/file-operation suites — 196 passed,
0 failed:

```
tests/tools/test_write_verification.py      tests/tools/test_write_approval.py
tests/tools/test_file_operations.py         tests/tools/test_write_deny.py
tests/tools/test_file_operations_edge_cases.py
tests/tools/test_file_write_safety.py       tests/tools/test_line_ending_preservation.py
tests/tools/test_write_file_syntax_gate.py
```

Not run on Linux or WSL2. The change is pure string parsing with no
platform-specific behavior, but the *trigger* is most visible on macOS, where
sandboxing makes an inaccessible-cwd shell easy to produce.

One note for reviewers on this host: a full-suite run shows unrelated
pre-existing failures, including two in `tests/tools/test_file_tools.py`
(`test_writes_content`, `test_replace_mode_calls_patch_replace`) that assert on
`/tmp/...` while macOS resolves it to `/private/tmp/...`. These reproduce on
an unmodified checkout and are untouched by this PR.

## Related issues

- #57788 — the same verifier fabricating success; this is its inverse.
