### PR TITLE
fix(tui): preserve MCP OAuth startup errors

### DIFF
--- a/tests/tui_gateway/test_mcp_oauth_client_callback.py
+++ b/tests/tui_gateway/test_mcp_oauth_client_callback.py
@@ -143,6 +143,31 @@ def test_start_flow_rejects_bad_client_redirect(monkeypatch):
     )
 
 
+def test_start_flow_preserves_worker_startup_error(monkeypatch):
+    monkeypatch.setattr(mcp_oauth_sessions, "_sessions", {})
+    flows = []
+
+    def worker(session_id, *_args):
+        flow = mcp_oauth_sessions._sessions[session_id]["flow"]
+        flows.append(flow)
+        flow.mark_error("dynamic client registration failed")
+        flow.mark_worker_done()
+
+    monkeypatch.setattr(mcp_oauth_sessions, "_worker", worker)
+
+    with pytest.raises(RuntimeError, match="dynamic client registration failed"):
+        mcp_oauth_sessions.start_flow(
+            str(get_hermes_home()),
+            "startup-error",
+            {"url": "https://mcp.example.com/mcp", "auth": "oauth"},
+            client_redirect_uri="http://127.0.0.1:8412/callback",
+            url_timeout=2,
+        )
+
+    assert flows
+    assert flows[0].snapshot()["error"] == "dynamic client registration failed"
+
+
 # ---------------------------------------------------------------------------
 # deliver_callback_flow: relay accept/reject semantics
 # ---------------------------------------------------------------------------

--- a/tests/tui_gateway/test_mcp_oauth_client_callback.py
+++ b/tests/tui_gateway/test_mcp_oauth_client_callback.py
@@ -168,6 +168,43 @@ def test_start_flow_preserves_worker_startup_error(monkeypatch):
     assert flows[0].snapshot()["error"] == "dynamic client registration failed"
 
 
+def test_start_flow_shutdown_preserves_original_error_if_mark_error_fails(monkeypatch):
+    monkeypatch.setattr(mcp_oauth_sessions, "_sessions", {})
+    shutdowns = []
+
+    def broken_mark_error(_message):
+        raise RuntimeError("mark_error failed")
+
+    def worker(session_id, *_args):
+        flow = mcp_oauth_sessions._sessions[session_id]["flow"]
+        flow.mark_error("dynamic client registration failed")
+        flow.mark_error = broken_mark_error
+        flow.mark_worker_done()
+
+    def shutdown(rec):
+        shutdowns.append(rec["session_id"])
+
+    monkeypatch.setattr(mcp_oauth_sessions, "_worker", worker)
+    monkeypatch.setattr(mcp_oauth_sessions, "_shutdown_listener", shutdown)
+
+    with pytest.raises(RuntimeError, match="dynamic client registration failed"):
+        mcp_oauth_sessions.start_flow(
+            str(get_hermes_home()),
+            "startup-error-cleanup",
+            {"url": "https://mcp.example.com/mcp", "auth": "oauth"},
+            client_redirect_uri="http://127.0.0.1:8412/callback",
+            url_timeout=2,
+        )
+
+    rec = next(
+        r
+        for r in mcp_oauth_sessions._sessions.values()
+        if r["server_name"] == "startup-error-cleanup"
+    )
+
+    assert shutdowns == [rec["session_id"]]
+
+
 # ---------------------------------------------------------------------------
 # deliver_callback_flow: relay accept/reject semantics
 # ---------------------------------------------------------------------------

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -199,8 +199,12 @@ def start_flow(
             time.sleep(0.1)
         if not auth_url:
             raise TimeoutError("Timed out waiting for MCP authorization URL")
-    except Exception:
+    except TimeoutError:
         flow.mark_error("Timed out waiting for MCP authorization URL")
+        _shutdown_listener(rec)
+        raise
+    except Exception as exc:
+        flow.mark_error(str(exc) or "MCP OAuth flow failed before authorization")
         _shutdown_listener(rec)
         raise
     # ``flow`` mirrors the provider-OAuth discriminator: open a URL then poll (no user_code).

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -34,6 +34,12 @@ def _shutdown_listener(rec: Dict[str, Any]) -> None:
     rec["httpd"] = None
 
 
+def _mark_error_and_shutdown(flow: Any, rec: Dict[str, Any], message: str) -> None:
+    with suppress(Exception):
+        flow.mark_error(message)
+    _shutdown_listener(rec)
+
+
 def _validate_client_redirect_uri(uri: str) -> str:
     """Accept only plain-http loopback URLs (RFC 8252) so the gateway can't pin an
     attacker-controlled redirect into a DCR registration."""
@@ -200,12 +206,10 @@ def start_flow(
         if not auth_url:
             raise TimeoutError("Timed out waiting for MCP authorization URL")
     except TimeoutError:
-        flow.mark_error("Timed out waiting for MCP authorization URL")
-        _shutdown_listener(rec)
+        _mark_error_and_shutdown(flow, rec, "Timed out waiting for MCP authorization URL")
         raise
     except Exception as exc:
-        flow.mark_error(str(exc) or "MCP OAuth flow failed before authorization")
-        _shutdown_listener(rec)
+        _mark_error_and_shutdown(flow, rec, str(exc) or "MCP OAuth flow failed before authorization")
         raise
     # ``flow`` mirrors the provider-OAuth discriminator: open a URL then poll (no user_code).
     return {"session_id": session_id, "auth_url": auth_url, "flow": "pkce"}


### PR DESCRIPTION
## What

Preserve the real MCP OAuth startup error in `tui_gateway.mcp_oauth_sessions.start_flow()` instead of overwriting every pre-authorization failure with the timeout message. Genuine authorization URL timeouts still report `Timed out waiting for MCP authorization URL`.

## Why

When the worker marks the flow as errored before publishing an authorization URL, the surrounding `except Exception` replaced that actionable error with a misleading timeout.

Fixes #105251.

## How to test

- `HERMES_PYTHON=$HOME/.hermes/venvs/hermes-agent-contrib/bin/python scripts/run_tests.sh tests/tui_gateway/test_mcp_oauth_client_callback.py -q`
- `python3 scripts/check-windows-footguns.py tui_gateway/mcp_oauth_sessions.py tests/tui_gateway/test_mcp_oauth_client_callback.py`

## Platforms tested

- macOS, Python 3.11.13