### PR TITLE
fix(mcp): park-entry WARNINGs fire once per episode, not per self-probe cycle (#105190)

### DIFF
--- a/tests/tools/test_mcp_reconnect_log_hygiene.py
+++ b/tests/tools/test_mcp_reconnect_log_hygiene.py
@@ -9,15 +9,45 @@ in 63h). Now:
   (connected→degraded, degraded→parked, parked→revived);
 - backoff sleeps get ±20% jitter so herds of servers don't retry in
   lockstep.
+
+#105190 extends the same contract across self-probe cycles: a parked server
+that stays dead wakes every ``_PARKED_RETRY_INTERVAL`` (#57129) and used to
+re-log the SAME park WARNING on every cycle (4,615 identical lines in 3 weeks
+on the reporting host). Now each park entry warns exactly once per episode
+(an episode ends when a revival proves healthy); repeats stay DEBUG with the
+message text unchanged, so the retry cadence remains diagnosable.
 """
 
 import asyncio
 import logging
+import time
+from types import SimpleNamespace
 
 import pytest
 
 from tools.mcp_tool import MCPServerTask
 from tools.mcp_tool_common import _jittered
+
+# Captured at import, before any test patches asyncio.sleep: the pump helper below
+# needs the REAL sleep so event-loop timers keep elapsing while we poll.
+_REAL_SLEEP = asyncio.sleep
+
+
+async def _pump_until(predicate, timeout: float = 4.0) -> bool:
+    """Advance the event loop with real (tiny) sleeps until ``predicate()`` is true.
+
+    Polling with ``sleep(0)`` yields control but never advances the loop clock, so
+    timer-based waits — the parked self-probe ``asyncio.wait(timeout=...)`` among
+    them — cannot fire; on a slow shared runner the poll loop exhausts its
+    iterations before a single 10ms park interval elapses (CI flake on #105190).
+    Bounding by wall clock instead of iteration count keeps that deterministic.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        await _REAL_SLEEP(0.001)
+        if predicate():
+            return True
+    return predicate()
 
 
 # ── Jitter ───────────────────────────────────────────────────────────────────
@@ -27,7 +57,6 @@ class TestJitter:
         for _ in range(200):
             v = _jittered(10.0)
             assert 8.0 <= v <= 12.0
-
 
     def test_jitter_varies(self):
         values = {_jittered(10.0) for _ in range(50)}
@@ -175,3 +204,491 @@ def test_initial_retry_attempts_log_debug(monkeypatch, tmp_path, caplog):
         and "connecting → parked" in r.getMessage()
     ]
     assert len(park_warnings) == 1
+
+
+# ── Park-warning deduplication across self-probe cycles (#105190) ────────────
+#
+# A parked server wakes every _PARKED_RETRY_INTERVAL for a self-probe (#57129).
+# A still-dead server re-enters run(), re-exhausts the park-entry ladder, and
+# used to re-log the SAME park WARNING on every cycle. Contract: each park
+# entry warns exactly once per episode (an episode ends at a proven-healthy
+# revival); repeats stay DEBUG with the message text unchanged.
+
+
+def _auth_error(status_code: int = 401):
+    """The repo's own OAuth error type — verifies as auth → permanent under
+    both ``_classify_mcp_failure`` and ``_is_auth_error`` (a bare 401/403
+    ``.response`` feeds the classifier but not the auth matcher)."""
+    from tools.mcp_oauth import OAuthNonInteractiveError
+
+    err = OAuthNonInteractiveError(f"{status_code} auth rejected")
+    err.response = SimpleNamespace(status_code=status_code)  # httpx-shaped marker for the classifier
+    return err
+
+
+@pytest.mark.no_isolate
+def test_parked_initial_failure_warns_once_across_self_probe_cycles(monkeypatch, tmp_path, caplog):
+    """Layer 1: initial-connect ladder exhaustion. The 'connecting → parked'
+    WARNING fires once; later self-probe re-parks log DEBUG, not WARNING."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_MAX_INITIAL_CONNECT_RETRIES", 2)
+    # Keep the parked self-probe cadence tiny so several cycles fit in the test.
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.01)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {"transport_calls": 0, "parked": 0}
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["parked"] += 1
+                self._registered_tool_names = []
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                raise ConnectionError("backend down")
+
+        task = _Task("deadstart")
+        task._registered_tool_names = ["deadstart__tool"]
+
+        with caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+            run_task = asyncio.ensure_future(task.run({"command": "x"}))
+            assert await _pump_until(lambda: state["parked"] >= 3), (
+                f"scenario never exercised repeated park cycles "
+                f"(parks={state['parked']}, transport_calls={state['transport_calls']})"
+            )
+
+        assert state["parked"] >= 3
+
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=15)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())
+
+    warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "connecting → parked" in r.getMessage()
+    ]
+    assert len(warnings) == 1, (
+        f"expected exactly 1 'connecting → parked' WARNING across {state['parked']} parks, "
+        f"got {len(warnings)}"
+    )
+    # Repeats must remain observable at DEBUG with the message text unchanged —
+    # the issue asks that diagnosis still show the cadence.
+    debug_repeats = [
+        r for r in caplog.records
+        if r.levelno == logging.DEBUG and "connecting → parked" in r.getMessage()
+    ]
+    assert debug_repeats, "repeated parks vanished from logs entirely (no DEBUG records)"
+
+
+@pytest.mark.no_isolate
+def test_parked_permanent_initial_failure_warns_once(monkeypatch, tmp_path, caplog):
+    """Layer 2: permanent initial failure (auth 401/403). The actionable
+    're-authenticate with `hermes mcp login`' guidance must not repeat forever
+    while credentials stay bad."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.01)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {"transport_calls": 0, "parked": 0}
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["parked"] += 1
+                self._registered_tool_names = []
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                raise _auth_error(401)
+
+        task = _Task("locked")
+
+        with caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+            run_task = asyncio.ensure_future(task.run({"command": "x"}))
+            assert await _pump_until(lambda: state["parked"] >= 3), (
+                f"scenario never exercised repeated park cycles (parks={state['parked']})"
+            )
+
+        assert state["parked"] >= 3
+
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=15)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())
+
+    warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "connecting → parked" in r.getMessage()
+    ]
+    assert len(warnings) == 1, (
+        f"expected exactly 1 permanent 'connecting → parked' WARNING, got {len(warnings)}"
+    )
+    assert any("hermes mcp login" in r.getMessage() for r in warnings), (
+        "permanent auth park must carry the re-authenticate guidance"
+    )
+
+
+@pytest.mark.no_isolate
+def test_parked_flapping_session_warns_once_per_episode(monkeypatch, tmp_path, caplog):
+    """Layers 3+5: a server that connects, never proves healthy, and drops
+    (rapid-drop budget / reconnect ladder exhausted) re-parks every self-probe
+    cycle; each episode warns once. Also the revival edge: after the backend
+    recovers and the session proves healthy, the NEXT park is a new episode
+    and warns again."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_MAX_RECONNECT_RETRIES", 1)
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.01)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {
+        "transport_calls": 0,
+        "parked": 0,
+        "backend_up": False,
+    }
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["parked"] += 1
+                self._registered_tool_names = []
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                if not state["backend_up"]:
+                    # Handshake succeeds then drops: unproven, charged, parks
+                    # via the rapid-drop budget or the reconnect ladder.
+                    self.session = object()
+                    self._ready.set()
+                    self._ever_connected = True
+                    self.session = None
+                    raise RuntimeError("handshake then drop")
+                # Backend recovered: establish a session that proves healthy.
+                self.session = object()
+                self._ready.set()
+                self._ever_connected = True
+                self._mark_session_proven()
+                return await self._wait_for_lifecycle_event()
+
+        task = _Task("flapper")
+        task._registered_tool_names = ["flapper__tool"]
+
+        with caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+            run_task = asyncio.ensure_future(task.run({"command": "x"}))
+            # Phase 1: park + several dead self-probe cycles.
+            assert await _pump_until(lambda: state["parked"] >= 3), (
+                f"never parked repeatedly (parks={state['parked']})"
+            )
+
+            phase1_warnings = [
+                r for r in caplog.records
+                if r.levelno == logging.WARNING
+                and ("degraded → parked" in r.getMessage() or "connected → parked" in r.getMessage())
+            ]
+            assert len(phase1_warnings) == 1, (
+                f"expected exactly 1 park WARNING in episode 1, got {len(phase1_warnings)}: "
+                + str([r.getMessage()[:90] for r in phase1_warnings])
+            )
+
+            # Phase 2: backend recovers; the self-probe revives the session.
+            state["backend_up"] = True
+            assert await _pump_until(lambda: task._session_proven), (
+                "parked server never revived to a proven session"
+            )
+
+            # Phase 3: backend dies again — a NEW park episode must warn again.
+            state["backend_up"] = False
+            task._reconnect_event.set()  # end the lifecycle wait
+            assert await _pump_until(lambda: state["parked"] >= 4), (
+                f"never re-parked after revival (parks={state['parked']})"
+            )
+
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=15)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())
+
+    park_warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING
+        and ("degraded → parked" in r.getMessage() or "connected → parked" in r.getMessage())
+    ]
+    revived = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "revived" in r.getMessage()
+    ]
+    # Episode 1 (many parks) + episode 2 (fresh park after revival) = 2 WARNINGs.
+    assert len(park_warnings) == 2, (
+        f"expected exactly 2 park WARNINGs (one per episode), got {len(park_warnings)}: "
+        + str([r.getMessage()[:90] for r in park_warnings])
+    )
+    assert revived, "revival WARNING missing — episode boundary never crossed"
+
+
+@pytest.mark.no_isolate
+def test_parked_permanent_error_on_proven_session_warns_once(monkeypatch, tmp_path, caplog):
+    """Layer 4: permanent error on a proven session (connected → parked) also
+    re-logged every self-probe cycle while the server stays dead."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_MAX_RECONNECT_RETRIES", 1)
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.01)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {"transport_calls": 0, "parked": 0}
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["parked"] += 1
+                self._registered_tool_names = []
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                if state["transport_calls"] == 1:
+                    # First connect succeeds and proves healthy...
+                    self.session = object()
+                    self._ready.set()
+                    self._ever_connected = True
+                    self._mark_session_proven()
+                    # ...then the next transport call hits a permanent error.
+                    raise _auth_error(403)
+                # Self-probe cycles: still permanently dead.
+                raise _auth_error(403)
+
+        task = _Task("revoked")
+        task._registered_tool_names = ["revoked__tool"]
+
+        with caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+            run_task = asyncio.ensure_future(task.run({"command": "x"}))
+            assert await _pump_until(lambda: state["parked"] >= 3), (
+                f"scenario never exercised repeated park cycles (parks={state['parked']})"
+            )
+
+        assert state["parked"] >= 3
+
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=15)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())
+
+    warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "connected → parked" in r.getMessage()
+    ]
+    assert len(warnings) == 1, (
+        f"expected exactly 1 'connected → parked' WARNING, got {len(warnings)}"
+    )
+
+
+@pytest.mark.no_isolate
+def test_park_failure_mode_change_still_warns(monkeypatch, tmp_path, caplog):
+    """Layer 7: when the failure mode changes mid-episode (transient
+    ConnectError → permanent 401 with re-auth guidance), the new, different
+    park message is a new signal and must still WARN, not be suppressed as a
+    repeat."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_MAX_RECONNECT_RETRIES", 1)
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.01)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {"transport_calls": 0, "parked": 0}
+
+    def _perm_403():
+        return _auth_error(403)
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["parked"] += 1
+                self._registered_tool_names = []
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                if state["parked"] >= 2:
+                    # Mid-episode switch: credentials revoked after the first park.
+                    raise _perm_403()
+                if state["transport_calls"] == 1:
+                    self.session = object()
+                    self._ready.set()
+                    self._ever_connected = True
+                    self.session = None
+                raise ConnectionError("transient network blip")
+
+        task = _Task("shifting")
+        task._registered_tool_names = ["shifting__tool"]
+
+        with caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+            run_task = asyncio.ensure_future(task.run({"command": "x"}))
+            assert await _pump_until(lambda: state["parked"] >= 4), (
+                f"scenario never exercised repeated park cycles (parks={state['parked']})"
+            )
+
+        assert state["parked"] >= 4
+
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=15)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())
+
+    degraded_warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "degraded → parked" in r.getMessage()
+    ]
+    connected_park_warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "connected → parked" in r.getMessage()
+    ]
+    # First episode: one transient 'degraded → parked'. Then the failure mode
+    # changed to permanent — that different park message must still surface.
+    assert len(degraded_warnings) == 1, (
+        f"expected exactly 1 'degraded → parked' WARNING, got {len(degraded_warnings)}"
+    )
+    assert connected_park_warnings, (
+        "permanent failure-mode change mid-episode was suppressed — the new "
+        "park message must still WARN"
+    )
+
+
+@pytest.mark.no_isolate
+def test_park_repeat_log_keeps_message_text(monkeypatch, tmp_path, caplog):
+    """Layer 8: the DEBUG repeat keeps the full park message (server name,
+    attempt count, state transition, root cause) so the cadence remains
+    diagnosable — only the level drops, nothing else."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_MAX_INITIAL_CONNECT_RETRIES", 1)
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.01)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {"transport_calls": 0, "parked": 0}
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["parked"] += 1
+                self._registered_tool_names = []
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                raise ConnectionError("backend down")
+
+        task = _Task("verbatim")
+        task._registered_tool_names = ["verbatim__tool"]
+
+        with caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+            run_task = asyncio.ensure_future(task.run({"command": "x"}))
+            assert await _pump_until(lambda: state["parked"] >= 3), (
+                f"scenario never exercised repeated park cycles (parks={state['parked']})"
+            )
+
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=15)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())
+
+    all_park_lines = [
+        r for r in caplog.records if "connecting → parked" in r.getMessage()
+    ]
+    assert len(all_park_lines) >= 2, "expected a WARNING + at least one DEBUG repeat"
+    warning_lines = [r for r in all_park_lines if r.levelno == logging.WARNING]
+    debug_lines = [r for r in all_park_lines if r.levelno == logging.DEBUG]
+    assert len(warning_lines) == 1
+    assert debug_lines
+    # The rendered message text is IDENTICAL — only the level changed.
+    assert warning_lines[0].getMessage() == debug_lines[0].getMessage()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -314,7 +314,7 @@ class MCPServerTask(MCPServerRunMixin, MCPServerTransportMixin, MCPServerHealthM
         "_auth_type", "_refresh_lock", "_rpc_lock", "_pending_refresh_tasks", "_pending_call_context",
         "_lifecycle_started_at", "_last_tool_call_at", "_idle_timeout_seconds", "_max_lifetime_seconds",
         "_recycled_reason", "initialize_result", "_ping_unsupported", "_list_cache_meta",
-        "_reconnect_retries", "_session_proven", "_was_parked", "_inflight_tasks", "_reconnecting",
+        "_reconnect_retries", "_session_proven", "_was_parked", "_park_warned_keys", "_inflight_tasks", "_reconnecting",
         "_suspect_reason", "_teardown_race", "_permanent_grace_used", "_stdio_child_pids",
         "_ever_connected")
 
@@ -347,6 +347,9 @@ class MCPServerTask(MCPServerRunMixin, MCPServerTransportMixin, MCPServerHealthM
         self._ever_connected: bool = False
         # True from park until proven healthy again; logs the revival once.
         self._was_parked: bool = False
+        # Park transitions already WARNed this episode (#105190); cleared with
+        # _was_parked when a revival proves the session healthy.
+        self._park_warned_keys: set = set()
         # In-flight RPC tasks so a deliberate teardown fails them fast; _reconnecting is True
         # during that teardown so _track_inflight_rpc turns the cancel into a retryable error.
         # In-flight RPC bookkeeping (#48069 salvage): user-visible requests registered while running so a

--- a/tools/mcp_tool_health.py
+++ b/tools/mcp_tool_health.py
@@ -205,6 +205,7 @@ class MCPServerHealthMixin:
         self._reconnect_retries = 0
         if self._was_parked:
             self._was_parked = False
+            self._park_warned_keys.clear()
             logger.warning("MCP server '%s': revived — session healthy again after "
                            "parking (state: parked → connected)", self.name)
         # A proven fresh transport clears the one-time permanent-failure grace and any race bookkeeping.

--- a/tools/mcp_tool_server_run.py
+++ b/tools/mcp_tool_server_run.py
@@ -144,6 +144,27 @@ class MCPServerRunMixin:
                      "rebuilding transport.", self.name, revival_reason)
         return False
 
+    def _park_log(self, key: str, msg: str, *args: object) -> None:
+        """Log a park-entry WARNING once per park episode and transition type (#105190).
+
+        A parked server that stays dead wakes every ``_PARKED_RETRY_INTERVAL``, re-enters the
+        park-entry ladder, and without a latch re-logs the SAME warning forever (4,615 identical
+        lines in 3 weeks on the reporting host). An episode runs from the first park until a
+        revival proves the session healthy — the window ``_was_parked`` already tracks (set in
+        ``_park``, cleared in ``_mark_session_proven``, which also clears the key set). ``key``
+        names the transition (site + failure class): an identical repeat drops to DEBUG with the
+        message text unchanged so the retry cadence stays diagnosable, while a DIFFERENT
+        transition mid-episode (e.g. transient blips giving way to a permanent 401 with
+        re-authenticate guidance) is new signal and still warns. The key set is bounded by the
+        fixed park-site vocabulary — a flapper alternating two failure shapes warns at most twice
+        per episode, never per cycle.
+        """
+        if self._was_parked and key in self._park_warned_keys:
+            logger.debug(msg, *args)
+        else:
+            logger.warning(msg, *args)
+            self._park_warned_keys.add(key)
+
     async def _prepare_run(self, config: dict) -> bool:
         """Bind config, build sampling/elicitation handlers, validate HTTP. False when the server
         must not start (bad remote URL / non-MCP endpoint: fail fast with ``_error`` set and
@@ -253,7 +274,8 @@ class MCPServerRunMixin:
         else:
             self._reconnect_retries += 1
             if self._reconnect_retries > _core._MAX_RECONNECT_RETRIES:
-                logger.warning(
+                self._park_log(
+                    "rapid_drop",
                     "MCP server '%s': %d consecutive reconnects without a healthy session (rapid-drop budget "
                     "exhausted), parking; will self-probe every %ds until it recovers (state: degraded → parked)",
                     self.name, _core._MAX_RECONNECT_RETRIES, _core._PARKED_RETRY_INTERVAL)
@@ -314,7 +336,8 @@ class MCPServerRunMixin:
             return await self._on_permanent_error(root, budget)
         self._reconnect_retries += 1
         if self._reconnect_retries > _core._MAX_RECONNECT_RETRIES:
-            logger.warning(
+            self._park_log(
+                "reconnect_ladder",
                 "MCP server '%s' failed after %d reconnection attempts, parking; will self-probe every %ds "
                 "until it recovers (state: degraded → parked): %s: %s",
                 self.name, _core._MAX_RECONNECT_RETRIES, _core._PARKED_RETRY_INTERVAL, type(root).__name__, root)
@@ -333,12 +356,14 @@ class MCPServerRunMixin:
             detail = (f"authentication, parking until credentials change; re-authenticate with "
                       f"`hermes mcp login {self.name}`" if _errors._is_auth_error(root)
                       else "connection with a permanent error, parking without retries")
-            logger.warning("MCP server '%s' failed initial %s (state: connecting → parked): %s: %s",
+            self._park_log(f"initial:{'auth' if _errors._is_auth_error(root) else 'permanent'}",
+                           "MCP server '%s' failed initial %s (state: connecting → parked): %s: %s",
                            self.name, detail, type(root).__name__, root)
             return await self._park_initial_failure(exc, "after permanent initial failure", budget)
         budget.initial_retries += 1
         if budget.initial_retries > _core._MAX_INITIAL_CONNECT_RETRIES:
-            logger.warning(
+            self._park_log(
+                "initial_ladder",
                 "MCP server '%s' failed initial connection after %d attempts, parking until a reconnect is "
                 "requested (state: connecting → parked): %s: %s",
                 self.name, _core._MAX_INITIAL_CONNECT_RETRIES, type(root).__name__, root)
@@ -366,7 +391,8 @@ class MCPServerRunMixin:
             await asyncio.sleep(_jittered(1.0))
             return not self._shutdown_event.is_set()
         # Deterministic failure on a working server: park now.
-        logger.warning(
+        self._park_log(
+            "permanent_error",
             "MCP server '%s' hit a permanent error, parking without retries; will self-probe every %ds "
             "(state: connected → parked): %s: %s", self.name, _core._PARKED_RETRY_INTERVAL, type(root).__name__, root)
         return await self._park_and_rearm("from parked state (permanent error)", budget)


### PR DESCRIPTION
## What

A parked MCP server that stays dead wakes every `_PARKED_RETRY_INTERVAL` for a self-probe (#57129). Still dead, it re-enters the park-entry ladder and re-logs the SAME park WARNING — forever. On the reporting host one dead parked server produced **4,615 identical parking WARNING lines in 3 weeks**, drowning the 48 genuine events around them.

Root cause (matches the diagnosis in the issue thread): `_was_parked` — the only park latch — is cleared exclusively in `_mark_session_proven()`, which is reachable only from keepalive-success / tool-call-success paths. A dead server never gets there, so nothing deduplicates the per-cycle park warnings.

## Fix

One shared `_park_log(key, msg, *args)` latch on `MCPServerRunMixin`; all **five** park-entry WARNING sites route through it:

- `_on_initial_connect_error` ladder-exhausted (the exact line from the report)
- `_on_initial_connect_error` permanent branch (auth 401/403 — the actionable `hermes mcp login` guidance was the worst repeat offender)
- `_on_transport_error` reconnect-ladder-exhausted
- `_on_permanent_error` proven-session
- `_on_clean_return` rapid-drop budget — a 5th site in the same class that the issue comment's 4-site diagnosis missed

Semantics:

- identical repeat within an episode → **DEBUG, message text unchanged** (the retry cadence stays diagnosable, per the issue's ask)
- a *different* transition mid-episode (e.g. transient blips giving way to a permanent 401 with re-auth guidance) is new signal → still **WARN**s (key = site + failure class)
- a proven-healthy revival clears the latch (alongside `_was_parked`), so the next park is a new episode and warns fresh

No intervals, retry counts, or revival behavior touched — pure log-emission change. The existing #65673/#66092 log-hygiene contract ("state transitions carry exactly one WARNING each") is preserved and extended across self-probe cycles.

## Verification

- **RED**: 6 new regression tests in `tests/tools/test_mcp_reconnect_log_hygiene.py` fail on unfixed `main` with the issue's exact symptom (3× the expected WARNING count across self-probe cycles)
- **GREEN**: 10/10 in the log-hygiene contract file (4 pre-existing + 6 new)
- Nearby suites (parked self-probe, death supervisor, reconnect retry-reset/signal): 39/39
- Broad MCP sweep at build time: 743 passed; 8 failures re-verified identical on clean `main` (OAuth device-flow/elicitation env tests, unrelated)
- Rebased onto current `main` at publish time; focused + nearby suites re-run green post-rebase

### Post-first-CI revision (test-harness only)

The first CI run caught a flake in one of the new tests: the scenario poll loops used `await sleep(0)` iteration counts, which advance the event loop **clock** zero — the parked self-probe `asyncio.wait(timeout=10ms)` could not elapse, so on a loaded shared runner the poll exhausted its iterations before enough park cycles accumulated (`parks=3` where `>=4` required). The captured CI log confirmed the production fix itself behaved exactly as designed (repeat → DEBUG, changed failure class → WARNING).

Revision: all six scenario poll loops now use a wall-clock-bounded `_pump_until(predicate, timeout)` helper that sleeps in real 1ms slices, so timer-based waits elapse deterministically regardless of runner speed. **No production code changed** — `tools/` is byte-identical to the first push. Focused file passed 4× consecutively locally; focused + nearby suites 49/49.

## Competitor analysis

None. The issue thread's promised PR (kokhlo, 16:52Z) never materialized — zero PRs by that author in the repo at publish time. Searched by issue number, branch pattern, and parking/log-flood/MCP-park keywords; no cross-referenced PRs on the issue timeline.

Closes #105190.

Auto-published by Moonsong via Path B automated pipeline.
