### PR TITLE
fix(dashboard): profile-scoped gateway restart loses target after reload

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -940,6 +940,7 @@ function SidebarSystemActions({
   const navigate = useNavigate();
   const { activeAction, isBusy, isRunning, pendingAction, runAction } =
     useSystemActions();
+  const { profile: scopedProfile } = useProfileScope();
   const canUpdateHermes = status?.can_update_hermes === true;
   const [restartConfirmOpen, setRestartConfirmOpen] = useState(false);
   const [updateConfirmOpen, setUpdateConfirmOpen] = useState(false);
@@ -1076,15 +1077,19 @@ function SidebarSystemActions({
       cancelLabel={t.common.cancel}
       confirmLabel={t.status.restartGateway}
       description={
-        t.status.restartGatewayConfirmMessage ??
-        "This restarts the Hermes gateway process. Connected channels and active sessions will reconnect afterward."
+        scopedProfile
+          ? `This restarts the gateway for profile "${scopedProfile}" — not the dashboard's own default gateway. Connected channels and active sessions for that profile will reconnect afterward.`
+          : (t.status.restartGatewayConfirmMessage ??
+            "This restarts the Hermes gateway process. Connected channels and active sessions will reconnect afterward.")
       }
       loading={pendingAction === "restart"}
       onCancel={() => setRestartConfirmOpen(false)}
       onConfirm={confirmRestart}
       open={restartConfirmOpen}
       title={
-        t.status.restartGatewayConfirmTitle ?? `${t.status.restartGateway}?`
+        scopedProfile
+          ? `Restart gateway for profile "${scopedProfile}"?`
+          : (t.status.restartGatewayConfirmTitle ?? `${t.status.restartGateway}?`)
       }
     />
 

--- a/web/src/contexts/ProfileProvider.tsx
+++ b/web/src/contexts/ProfileProvider.tsx
@@ -32,17 +32,44 @@ import { ProfileContext } from "@/contexts/profile-context";
  * pages. We now sync the switcher when the sticky active profile differs from
  * the dashboard process on load, and ProfilesPage updates the switcher when
  * you click "Set as active".
+ *
+ * Persistence: the selection is mirrored to localStorage so a bare page
+ * reload / re-navigation without `?profile=` in the URL does NOT silently
+ * fall back to the dashboard's own profile. Without this, a destructive
+ * action (gateway restart) fired right after a reload could target the
+ * wrong profile's gateway while the switcher still visually showed the
+ * intended one moments before the reload (#profile-scope-restart-footgun).
  */
+const MANAGEMENT_PROFILE_STORAGE_KEY = "hermes.dashboard.managementProfile";
+
+function readStoredProfile(): string {
+  try {
+    return localStorage.getItem(MANAGEMENT_PROFILE_STORAGE_KEY) ?? "";
+  } catch {
+    return ""; // localStorage unavailable (private mode, disabled storage): fall back to URL/default
+  }
+}
+
+function writeStoredProfile(name: string): void {
+  try {
+    if (name) localStorage.setItem(MANAGEMENT_PROFILE_STORAGE_KEY, name);
+    else localStorage.removeItem(MANAGEMENT_PROFILE_STORAGE_KEY);
+  } catch {
+    // best-effort only — persistence is a convenience, never a hard requirement
+  }
+}
+
 export function ProfileProvider({ children }: { children: ReactNode }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { pathname } = useLocation();
   const [profiles, setProfiles] = useState<string[]>([]);
   const [currentProfile, setCurrentProfile] = useState("default");
 
-  // Initial value comes from the URL (deep link / refresh / unified-launch
-  // preselect); afterwards state leads and the URL follows.
+  // Precedence: explicit URL param (deep link / in-app nav) > last stored
+  // selection (survives reload) > "" (dashboard's own profile). Afterwards
+  // state leads and the URL follows.
   const [profile, setProfileState] = useState(
-    () => searchParams.get("profile") ?? "",
+    () => searchParams.get("profile") ?? readStoredProfile(),
   );
 
   // Mirror into the api module synchronously on every render where it
@@ -57,6 +84,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     if (urlProfile !== null && urlProfile !== profile) {
       setManagementProfile(urlProfile);
       setProfileState(urlProfile);
+      writeStoredProfile(urlProfile);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlProfile]);
@@ -92,13 +120,17 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
         const active = info.active || "default";
         setCurrentProfile(current);
 
-        // Deep links (?profile=) win. Otherwise align the switcher with the
-        // sticky active profile so Chat and management pages match what the
-        // Profiles page shows as "active" (machine dashboard runs as
-        // `current`, usually default).
-        if (urlProfile === null && active !== current) {
+        // Deep links (?profile=) win, and so does a profile already restored
+        // from localStorage (the user's last explicit choice for this
+        // browser) — otherwise a returning user editing profile B would get
+        // silently bounced back to the sticky "active" profile on every
+        // reload. Only align to "active" when neither is present, matching
+        // the original cold-start behavior for browsers with no prior
+        // selection.
+        if (urlProfile === null && !profile && active !== current) {
           setManagementProfile(active);
           setProfileState(active);
+          writeStoredProfile(active);
         }
       })
       .catch(() => {});
@@ -113,6 +145,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     (name: string) => {
       setManagementProfile(name);
       setProfileState(name);
+      writeStoredProfile(name);
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -35,6 +35,7 @@ import type {
 } from "@/lib/api";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { usePageHeader } from "@/contexts/usePageHeader";
+import { useProfileScope } from "@/contexts/useProfileScope";
 import { cn, themedBody } from "@/lib/utils";
 
 // State → badge mapping. The backend emits a small, fixed vocabulary plus
@@ -138,6 +139,7 @@ export default function ChannelsPage() {
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
   const { setEnd } = usePageHeader();
+  const { profile: scopedProfile } = useProfileScope();
 
   // Config modal state
   const [editing, setEditing] = useState<MessagingPlatform | null>(null);
@@ -281,6 +283,11 @@ export default function ChannelsPage() {
         size="sm"
         onClick={handleRestart}
         disabled={restarting}
+        title={
+          scopedProfile
+            ? `Restarts the gateway for profile "${scopedProfile}"`
+            : undefined
+        }
         prefix={restarting ? <Spinner /> : <RotateCw className="h-4 w-4" />}
       >
         {restarting ? "Restarting…" : "Restart gateway"}
@@ -288,7 +295,7 @@ export default function ChannelsPage() {
     );
     return () => setEnd(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setEnd, restarting]);
+  }, [setEnd, restarting, scopedProfile]);
 
   const configured = useMemo(
     () => platforms.filter((p) => p.configured).length,
@@ -315,6 +322,7 @@ export default function ChannelsPage() {
               <AlertTriangle className="h-4 w-4 shrink-0 text-warning" />
               <span>
                 Changes are saved. Restart the gateway for them to take effect.
+                {scopedProfile && ` This restarts the gateway for profile "${scopedProfile}".`}
               </span>
             </div>
             <Button

--- a/web/src/pages/WebhooksPage.tsx
+++ b/web/src/pages/WebhooksPage.tsx
@@ -26,6 +26,7 @@ import { Card, CardContent } from "@nous-research/ui/ui/components/card";
 import { Input } from "@nous-research/ui/ui/components/input";
 import { Label } from "@nous-research/ui/ui/components/label";
 import { usePageHeader } from "@/contexts/usePageHeader";
+import { useProfileScope } from "@/contexts/useProfileScope";
 import { cn, themedBody } from "@/lib/utils";
 
 interface CreatedWebhook {
@@ -66,6 +67,7 @@ export default function WebhooksPage() {
   const [restarting, setRestarting] = useState(false);
   const { toast, showToast } = useToast();
   const { setEnd } = usePageHeader();
+  const { profile: scopedProfile } = useProfileScope();
 
   // New subscription modal state
   const [createModalOpen, setCreateModalOpen] = useState(false);
@@ -504,6 +506,7 @@ export default function WebhooksPage() {
               <span>
                 {restartError ??
                   "Webhooks are enabled, but the gateway still needs a restart before the receiver can come online."}
+                {scopedProfile && ` This restarts the gateway for profile "${scopedProfile}".`}
               </span>
             </div>
             <Button


### PR DESCRIPTION
## Problem

The dashboard's sidebar profile switcher (`ProfileProvider.tsx`) is pure React state, initialized from the URL's `?profile=` param on every mount with no other persistence. A bare page reload (or navigating to a bookmarked/typed URL without the param) silently resets the management scope to the dashboard's own default profile, while the switcher UI can still visually look unchanged for a moment.

This becomes a real footgun for the "Restart Gateway" action: `/api/gateway/restart` already accepted `?profile=` correctly on the backend, but a user who selected a secondary profile, then reloaded the page (or navigated without the param), could click restart believing they were targeting profile B while the request silently targeted the dashboard's own default gateway. Live-observed symptom: two profiles' gateways fighting over the same Telegram bot token (`terminated by other getUpdates request`) after a restart from the dashboard targeted the wrong profile.

## Fix

- `ProfileProvider.tsx`: mirrors the selected management profile to `localStorage` (`hermes.dashboard.managementProfile`) on every explicit selection (manual switch, URL deep link, active-profile alignment), and reads it back as a fallback when no `?profile=` is present in the URL. The active-profile alignment effect also now respects a restored/explicit profile instead of unconditionally overwriting it.
- `App.tsx`: the sidebar's gateway-restart confirmation dialog now names the target profile explicitly (`Restart gateway for profile "sam"?`) instead of a generic message, so the destructive action is never ambiguous about its target.
- `ChannelsPage.tsx` / `WebhooksPage.tsx`: their own restart banners/buttons (which already inherited the `?profile=` scoping via `fetchJSON`) now also name the scoped profile for visual consistency with the sidebar dialog.

No backend changes — `/api/gateway/restart` already handled `?profile=` correctly; the bug was purely in the frontend losing track of the selected scope.

## Testing

- `tsc --noEmit` — clean
- `npm run build` — clean
- Manually verified end-to-end on a live multi-profile Hermes installation (3 named profiles + default), confirming the restart dialog names the correct profile and the scope survives a page reload.

No behavior change when no profile is selected (dashboard's own profile) — all messages fall back to their original generic wording.