### PR TITLE
fix(agent): keep subagents out of the sidebar when the parent row is late

### DIFF
--- a/agent/session_persistence.py
+++ b/agent/session_persistence.py
@@ -381,6 +381,17 @@ class SessionPersistenceMixin:
         try:
             if not self._session_db_created:  # retry row creation if the earlier attempt failed transiently
                 self._ensure_db_session()
+                if (not self._session_db_created and self.platform == "subagent"
+                        and self._parent_session_id):
+                    # A missing parent must not discard a scratchpad transcript or turn it into a
+                    # sidebar conversation. Drop only the FK; keep the durable delegation marker.
+                    model_config = dict(self._session_row_model_config() or {})
+                    model_config["_delegate_from"] = self._parent_session_id
+                    self._session_db.ensure_session(
+                        self.session_id, source="tool", model=self.model,
+                        model_config=model_config, system_prompt=self._cached_system_prompt,
+                    )
+                    self._session_db_created = True
             batch_rows, batch_msgs = _db_flush_collect(self, messages, conversation_history)
             _db_flush_write(self, batch_rows, batch_msgs)
             # Markers are now the sole truth; reset the one-shot seed so no id() outlives this flush.

--- a/tests/tools/test_delegate_session_persistence.py
+++ b/tests/tools/test_delegate_session_persistence.py
@@ -1,0 +1,125 @@
+"""Delegation keeps late-parent and orphaned transcripts out of session pickers."""
+
+import json
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+from tools import delegate_tool
+
+
+@pytest.fixture
+def make_agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("agent.model_metadata.fetch_model_metadata", lambda *a, **kw: {})
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", lambda *a, **kw: 32768)
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda *a, **kw: [])
+    monkeypatch.setattr(delegate_tool, "_load_config", lambda: {})
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: {})
+    agents = []
+    with SessionDB(db_path=tmp_path / "state.db") as db:
+        def build(session_id, **kwargs):
+            agent = AIAgent(
+                api_key="test-key", base_url="http://127.0.0.1:1/v1", provider="openai",
+                api_mode="chat_completions", model="test-model", session_id=session_id,
+                session_db=db, quiet_mode=True, skip_context_files=True, skip_memory=True,
+                save_trajectories=False, enabled_toolsets=[], **kwargs,
+            )
+            agents.append(agent)
+            return agent
+
+        yield build
+        for agent in reversed(agents):
+            agent.close()
+
+
+@pytest.mark.parametrize("background", [False, True])
+@pytest.mark.parametrize("parent_write_recovers", [False, True])
+def test_dispatch_commits_parent_before_child_construction(
+    make_agent, monkeypatch, caplog, background, parent_write_recovers,
+):
+    parent = make_agent("late-parent", platform="cli")
+    db = parent._session_db
+    create_session = db.create_session
+    attempts = 0
+
+    def delayed_create(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1 or not parent_write_recovers:
+            raise sqlite3.OperationalError("database is locked")
+        return create_session(*args, **kwargs)
+
+    monkeypatch.setattr(db, "create_session", delayed_create)
+    parent._ensure_db_session()
+    assert db.get_session(parent.session_id) is None
+    caplog.clear()
+    children = []
+    construction_attempts = []
+    build_child = delegate_tool._build_child_agent
+
+    def observe_child(**kwargs):
+        construction_attempts.append(kwargs["task_index"])
+        # A separate handle proves COMMIT visibility, not just an in-transaction insert.
+        with SessionDB(db_path=db.db_path) as reader:
+            assert reader.get_session(parent.session_id) is not None
+        child = build_child(**kwargs)
+        children.append(child)
+        child._ensure_db_session()
+        row = child._session_db.get_session(child.session_id)
+        assert row["parent_session_id"] == parent.session_id
+        assert json.loads(row["model_config"])["_delegate_from"] == parent.session_id
+        return child
+
+    monkeypatch.setattr(delegate_tool, "_build_child_agent", observe_child)
+    # Stop at the batch boundary: construction and SQLite are real, model execution is not.
+    monkeypatch.setattr(delegate_tool, "_run_batch", lambda batch, background: '{"results": []}')
+    try:
+        result = json.loads(delegate_tool.delegate_task(
+            tasks=[{"goal": "Inspect the first module"}, {"goal": "Inspect the second module"}],
+            parent_agent=parent, background=background,
+        ))
+        if parent_write_recovers:
+            assert "error" not in result
+            assert len(children) == 2
+        else:
+            assert "error" in result
+            assert not construction_attempts
+        assert "FOREIGN KEY constraint failed" not in caplog.text
+    finally:
+        for child in children:
+            child.close()
+
+
+@pytest.mark.parametrize("has_marker", [False, True])
+@pytest.mark.parametrize("platform", ["cli", "subagent"])
+def test_subagent_flush_recovers_orphan_without_sidebar_leak(make_agent, has_marker, platform):
+    child = make_agent("orphan-child", platform=platform, parent_session_id="missing-parent")
+    if has_marker:
+        child._session_init_model_config["_delegate_from"] = "missing-parent"
+    initial_config = dict(child._session_init_model_config)
+    messages = [{"role": "user", "content": "scratchpad task"},
+                {"role": "assistant", "content": "scratchpad result"}]
+
+    db = child._session_db
+    flushed = child._flush_messages_to_session_db(messages, [])
+    if platform != "subagent":
+        assert flushed is False
+        assert db.get_session(child.session_id) is None
+        return
+    assert flushed is True
+    row = db.get_session(child.session_id)
+    assert row["parent_session_id"] is None
+    assert row["source"] == "tool"
+    assert json.loads(row["model_config"]) == {**initial_config, "_delegate_from": "missing-parent"}
+    assert child._session_init_model_config == initial_config
+    assert [(msg["role"], msg["content"]) for msg in db.get_messages(child.session_id)] == [
+        ("user", "scratchpad task"), ("assistant", "scratchpad result"),
+    ]
+    db.create_session("visible-parent", source="cli")
+    assert {row["id"] for row in db.list_sessions_rich()} == {"visible-parent"}
+    assert child.session_id in {row["id"] for row in db.list_sessions_rich(include_children=True)}
+    assert child._flush_messages_to_session_db(messages, []) is True
+    assert len(db.get_messages(child.session_id)) == 2

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -419,6 +419,13 @@ def delegate_task(
     if err:
         return tool_error(err)
 
+    # Children use independent DB handles, so their parent must be committed before construction.
+    # Turn-start creation is best-effort and may have failed while the parent continued running.
+    if getattr(parent_agent, "_session_db", None) is not None:
+        parent_agent._ensure_db_session()
+        if not parent_agent._session_db_created:
+            return tool_error("Cannot delegate until the parent session is persisted. Retry the delegation.")
+
     overall_start = time.monotonic()
     # Live transcripts: cache/delegation/live/<id>/task-<n>.log per task, a side channel with zero effect on message
     # content or prompt caching. Best-effort: on failure live_paths is empty and delegation proceeds.


### PR DESCRIPTION
## What does this PR do?

Subagents leaked into the Sessions sidebar when the parent session row was uncommitted (#103789): `delegate_task` spawns children referencing `parent_session_id` before the parent's `_ensure_db_session()` commits, the child insert fails with `FOREIGN KEY constraint failed`, and when the subagent finishes, the fallback persistence rescues its transcript with a BARE row — `parent_session_id=NULL`, `model_config=NULL` (stripping the `_delegate_from` marker), `source="unknown"`. The sidebar query then classifies every subagent run as a standalone conversation.

Both ends fixed:
1. The delegate path now ensures the parent session row is committed BEFORE children referencing it are created.
2. Belt-and-suspenders for every other FK-failure path: fallback recovery of a `platform="subagent"` run keeps the delegate marker (and the row hidden from the main picker), so unparented scratchpad sessions never surface even when the ordering fix doesn't apply.

## Related Issue

Fixes #103789

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Delegate dispatch ordering (parent row before child spawn) + fallback recovery preserving the subagent classification — see the diff for exact sites
- Regression tests for both parts (uncommitted-parent interleaving; fallback row classification + sidebar exclusion)

## How to Test

1. New tests green (8 passed; 6 failing before the fix) + wider regression 552 passed (1 pre-existing FTS expectation failure reproducible on unmodified main)
2. Manual shape: dispatch subagents during a flaky parent turn — the sidebar shows no orphan conversations afterwards

## Checklist

### Code
- [x] Contributing Guide read; Conventional Commits followed
- [x] Searched for duplicate PRs
- [x] Only changes related to this fix
- [x] Relevant tests pass; tests added
- [x] Tested on Linux (Python 3.11)

### Documentation & Housekeeping
- [x] N/A
