### PR TITLE
fix(dashboard): stop polling logs of deleted profiles

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -35,7 +35,10 @@ else:
     from logging.handlers import RotatingFileHandler  # noqa: E402
 
 
-from hermes_constants import get_config_path, get_hermes_home, mkdir_under_hermes_home
+from hermes_constants import (
+    get_config_path, get_hermes_home, mkdir_under_hermes_home,
+    named_profile_home, named_profile_is_deleted,
+)
 
 # setup_logging() is idempotent: a second call is a no-op unless ``force=True``.
 _logging_initialized = False
@@ -260,6 +263,7 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         from hermes_cli.config import is_managed
         self._managed = is_managed()
         super().__init__(*args, **kwargs)
+        self._profile_home = named_profile_home(self.baseFilename)
         self._record_stream_stat()
 
     def _chmod_if_managed(self):
@@ -312,19 +316,33 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
             self._reopen_stream(st)
 
     def emit(self, record: logging.LogRecord) -> None:
+        # FileHandler in append mode can reopen after close(); deletion must be terminal.
+        if self._closed:
+            return
+        if (
+            self._profile_home is not None
+            and (not self._profile_home.is_dir() or named_profile_is_deleted(self._profile_home))
+        ) or not Path(self.baseFilename).parent.is_dir():
+            self.close()
+            return
         # The kernel caches inode metadata, so this stat is sub-microsecond on a hot file.
         if self.stream is not None or os.path.exists(self.baseFilename):
             self._reopen_if_externally_rotated()
         super().emit(record)
 
     def handleError(self, record: logging.LogRecord) -> None:
-        """Suppress the known Windows ``concurrent-log-handler`` lock timeout.
+        """Retire deleted log directories and suppress the known Windows lock timeout.
 
         CLH's ``emit()`` routes that RuntimeError here, so this is the single point to
         silence it before stdlib prints to stderr (which the Desktop slash-worker
         captures into chat output).
         """
-        if not _is_windows_concurrent_log_lock_timeout(sys.exc_info()[1]):
+        error = sys.exc_info()[1]
+        if isinstance(error, FileNotFoundError) and not Path(self.baseFilename).parent.is_dir():
+            # Deletion can race the emit preflight; never re-arm the missing path.
+            self.close()
+            return
+        if not _is_windows_concurrent_log_lock_timeout(error):
             super().handleError(record)
 
     def _open(self):
@@ -372,6 +390,9 @@ class _ProfileRoutingFileHandler(logging.Handler):
         self._max_bytes = getattr(existing, "maxBytes", 0)
         self._backup_count = getattr(existing, "backupCount", 0)
         self._profile_handlers: dict[Path, _ManagedRotatingFileHandler] = {}
+        # Bounded by the startup home list; retain routing identity so stale records
+        # are dropped instead of falling back into another profile's log.
+        self._retired_homes: set[Path] = set()
         self._profile_handlers_lock = threading.RLock()
         self.setFormatter(existing.formatter)
         for log_filter in existing.filters:
@@ -385,8 +406,20 @@ class _ProfileRoutingFileHandler(logging.Handler):
             candidate = self._default_home
         return candidate if candidate in self._profile_homes else self._default_home
 
-    def _handler_for_home(self, home: Path) -> _ManagedRotatingFileHandler:
+    def _retire_home(self, home: Path) -> None:
         with self._profile_handlers_lock:
+            self._retired_homes.add(home)
+            handler = self._profile_handlers.pop(home, None)
+            if handler is not None:
+                handler.close()
+
+    def _handler_for_home(self, home: Path) -> Optional[_ManagedRotatingFileHandler]:
+        with self._profile_handlers_lock:
+            if home in self._retired_homes:
+                return None
+            if not home.is_dir() or named_profile_is_deleted(home):
+                self._retire_home(home)
+                return None
             if home not in self._profile_handlers:
                 self._profile_handlers[home] = _new_file_handler(
                     home / "logs" / self._filename, level=self.level, max_bytes=self._max_bytes,
@@ -396,7 +429,15 @@ class _ProfileRoutingFileHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         try:
-            self._handler_for_home(self._home_for_record(record)).handle(record)
+            home = self._home_for_record(record)
+            handler = self._handler_for_home(home)
+            if handler is not None:
+                handler.handle(record)
+                if handler._closed:
+                    self._retire_home(home)
+        except FileNotFoundError:
+            # The profile can disappear between the registration check and open().
+            self._retire_home(home)
         except Exception:
             self.handleError(record)
 

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -2,6 +2,7 @@
 import io
 import logging
 import os
+import shutil
 import stat
 import sys
 import threading
@@ -141,6 +142,113 @@ class TestSetupLogging:
         assert "profile-routed cron record" not in (
             hermes_home / "logs" / "agent.log"
         ).read_text()
+
+    @pytest.mark.linux_only
+    @pytest.mark.parametrize("routed", [False, True])
+    @pytest.mark.parametrize("removed", ["home", "logs", "tombstone"])
+    def test_deleted_profile_stops_log_retries(
+        self, hermes_home, monkeypatch, capsys, routed, removed,
+    ):
+        from hermes_constants import (
+            mark_named_profile_deleted, reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        profile_home = hermes_home / "profiles" / "worker"
+        profile_home.mkdir(parents=True)
+        hermes_logging.setup_logging(
+            hermes_home=hermes_home if routed else profile_home, mode="gui",
+        )
+        if routed:
+            assert hermes_logging.enable_profile_log_routing([hermes_home, profile_home])
+
+        logger = logging.getLogger("hermes_cli.web_server")
+
+        def emit_cycle():
+            token = set_hermes_home_override(profile_home)
+            try:
+                logger.warning("deleted-profile record")
+            finally:
+                reset_hermes_home_override(token)
+            hermes_logging.flush_log_queue()
+
+        emit_cycle()
+        handlers = [
+            h._profile_handlers[profile_home] if routed else h
+            for h in hermes_logging._queued_file_handlers
+        ]
+        streams = [h.stream for h in handlers]
+        if removed == "tombstone":
+            mark_named_profile_deleted(profile_home)
+        else:
+            # POSIX permits deletion while the dashboard still holds open log files.
+            shutil.rmtree(profile_home if removed == "home" else profile_home / "logs")
+
+        attempts = []
+        for handler in handlers:
+            original_open = handler._open
+
+            def tracked_open(original_open=original_open):
+                attempts.append(original_open)
+                return original_open()
+
+            monkeypatch.setattr(handler, "_open", tracked_open)
+
+        capsys.readouterr()
+        emit_cycle()
+        first_attempts = len(attempts)
+        emit_cycle()
+        emit_cycle()
+        assert len(attempts) == first_attempts, "later records retried the deleted log"
+        assert "--- Logging error ---" not in capsys.readouterr().err
+        assert all(stream.closed for stream in streams)
+        assert all(handler._closed for handler in handlers)
+        if routed:
+            assert all(
+                profile_home not in router._profile_handlers
+                for router in hermes_logging._queued_file_handlers
+            )
+            logger.warning("live-profile record")
+            hermes_logging.flush_log_queue()
+            live_log = (hermes_home / "logs" / "agent.log").read_text()
+            assert "live-profile record" in live_log
+            assert "deleted-profile record" not in live_log
+
+    @pytest.mark.parametrize("removed", ["home", "tombstone"])
+    def test_deleted_profile_is_not_registered_lazily(
+        self, hermes_home, capsys, removed,
+    ):
+        from hermes_constants import (
+            mark_named_profile_deleted, reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        profile_home = hermes_home / "profiles" / "worker"
+        profile_home.mkdir(parents=True)
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gui")
+        assert hermes_logging.enable_profile_log_routing([hermes_home, profile_home])
+        if removed == "tombstone":
+            mark_named_profile_deleted(profile_home)
+        else:
+            profile_home.rmdir()
+
+        # Reaching the constructor at all would retry a known-deleted profile on every record.
+        with patch.object(
+            hermes_logging, "_new_file_handler", wraps=hermes_logging._new_file_handler,
+        ) as create:
+            token = set_hermes_home_override(profile_home)
+            try:
+                for _ in range(3):
+                    logging.getLogger("hermes_cli.web_server").warning("stale profile poll")
+                    hermes_logging.flush_log_queue()
+            finally:
+                reset_hermes_home_override(token)
+            create.assert_not_called()
+        assert "--- Logging error ---" not in capsys.readouterr().err
+        assert all(
+            profile_home not in router._profile_handlers
+            for router in hermes_logging._queued_file_handlers
+        )
 
 
 
@@ -685,4 +793,3 @@ class TestAsyncQueueLogging:
             "agent.log" in getattr(h, "baseFilename", "")
             for h in hermes_logging._queued_file_handlers
         )
-


### PR DESCRIPTION
## What does this PR do?

After `hermes profile delete <name>`, a still-running dashboard kept trying to emit to the deleted profile's `logs/agent.log`: every ~10-20s a "--- Logging error --- / FileNotFoundError" cycle fired, and that error-handling loop itself was the leak's engine — memory grew from ~250MB to a 3.7GB peak over ~5.5h until the service went unresponsive (#103777).

The fix lands in `hermes_logging.py`'s per-profile handler layer, where the re-arm actually happened:

- A `FileNotFoundError` on emit whose target parent directory no longer exists now **closes the handler and never re-arms the missing path** (deletion can race the emit preflight).
- The routing handler retires the profile's registration when the profile disappears between the registration check and open — the polling loop stops instead of retrying forever.

Catching the exception per-iteration would not have been enough; the retries themselves were the leak.

## Related Issue

Fixes #103777

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_logging.py` — close-and-retire on missing profile log paths (both the emit preflight race and the registration race)
- `tests/test_hermes_logging.py` — regression: register a profile, delete its log tree, drive the cycle again — no re-open, no repeated error path, registry cleaned

## How to Test

1. `.venv/bin/python -m pytest tests/test_hermes_logging.py -q` → green
2. Manual shape of the issue: run the dashboard, `hermes profile delete <p>`, watch logs — the FileNotFoundError loop does not start; memory stays flat
3. Known local limitation (sandbox): two dashboard FastAPI test files hang under a no-network sandbox (AnyIO cross-thread waits) — they pass outside it; noted for transparency

## Checklist

### Code
- [x] Contributing Guide read; Conventional Commits followed
- [x] Searched for duplicate PRs
- [x] Only changes related to this fix
- [x] Relevant tests pass; tests added
- [x] Tested on Linux (Python 3.11)

### Documentation & Housekeeping
- [x] N/A
