### PR TITLE
feat(desktop): honour voice.auto_tts=false in the composer voice conversation

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -67,6 +67,7 @@ export function useComposerVoice({
   const ownsWakeIndicatorRef = useRef(false)
   const previousSessionIdRef = useRef(sessionId)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
+  const autoSpeak = useStore($autoSpeakReplies)
 
   // eslint-disable-next-line no-restricted-syntax -- session-id adopt token, not an atom mirror
   useEffect(() => {
@@ -160,6 +161,7 @@ export function useComposerVoice({
     onSubmit: submitVoiceTurn,
     onTranscribeAudio,
     pendingResponse: pendingTurnResponse,
+    speakReplies: autoSpeak,
     // Before the conversation opens the mic, wait for any in-flight wake.pause
     // to finish releasing the capture device (see wakePauseBarrierRef).
     beforeMicOpen: () => wakePauseBarrierRef.current ?? undefined

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { BargeMonitorCallbacks } from '@/lib/voice-barge-in'
+import { playSpeechText, startSpeechStream } from '@/lib/voice-playback'
 
 import type { MicRecording } from './use-mic-recorder'
 import { useVoiceConversation } from './use-voice-conversation'
@@ -75,7 +76,9 @@ interface HookProps {
   busy: boolean
 }
 
-function renderConversation(overrides: { onInterrupt?: () => void; transcript?: string } = {}) {
+function renderConversation(
+  overrides: { onInterrupt?: () => void; pendingResponse?: () => { id: string; pending: boolean; text: string } | null; speakReplies?: boolean; transcript?: string } = {}
+) {
   const onInterrupt = overrides.onInterrupt ?? vi.fn()
 
   // Mirrors the real app: submitting a turn makes the agent busy.
@@ -95,24 +98,27 @@ function renderConversation(overrides: { onInterrupt?: () => void; transcript?: 
     transcriptions++ === 0 ? 'kick off the task' : (overrides.transcript ?? 'and another thing')
   )
 
+  const consumePendingResponse = vi.fn()
+
   const hook = renderHook(
     ({ busy }: HookProps) =>
       useVoiceConversation({
         busy,
-        consumePendingResponse: vi.fn(),
+        consumePendingResponse,
         enabled: true,
         onInterrupt,
         onStopWord,
         onSubmit,
         onTranscribeAudio,
-        pendingResponse: () => null
+        pendingResponse: overrides.pendingResponse ?? (() => null),
+        speakReplies: overrides.speakReplies
       }),
     { initialProps: { busy: false } }
   )
 
   onBusyChange.current = busy => hook.rerender({ busy })
 
-  return { hook, onInterrupt, onStopWord, onSubmit, onTranscribeAudio }
+  return { consumePendingResponse, hook, onInterrupt, onStopWord, onSubmit, onTranscribeAudio }
 }
 
 /** Drive the hook into the generation phase (turn submitted, model working). */
@@ -262,5 +268,61 @@ describe('useVoiceConversation full-duplex barge-in', () => {
     hook.rerender({ busy: true })
 
     expect(monitorCalls.length).toBe(armed)
+  })
+})
+
+describe('useVoiceConversation spoken replies off', () => {
+  beforeEach(() => {
+    monitorCalls.length = 0
+    vi.clearAllMocks()
+    micHandle.start.mockResolvedValue(undefined)
+    micHandle.stop.mockResolvedValue(null)
+  })
+
+  afterEach(cleanup)
+
+  it('never plays the reply and re-listens once the turn completes', async () => {
+    const { hook } = renderConversation({
+      pendingResponse: () => ({ id: 'reply-1', pending: false, text: 'the answer' }),
+      speakReplies: false
+    })
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await enterThinking(hook)
+
+    await act(async () => {
+      hook.rerender({ busy: false })
+    })
+
+    await waitFor(() => expect(hook.result.current.status).not.toBe('thinking'))
+    expect(hook.result.current.status).not.toBe('speaking')
+    expect(startSpeechStream).not.toHaveBeenCalled()
+    expect(playSpeechText).not.toHaveBeenCalled()
+  })
+
+  it('still speaks the reply when spoken replies are on', async () => {
+    const { hook } = renderConversation({
+      pendingResponse: () => ({ id: 'reply-1', pending: false, text: 'the answer' }),
+      speakReplies: true
+    })
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+
+    micHandle.stop.mockResolvedValueOnce({
+      audio: new Blob(['q'], { type: 'audio/webm' }),
+      durationMs: 900,
+      heardSpeech: true
+    })
+
+    await act(async () => {
+      hook.result.current.stopTurn()
+    })
+
+    await waitFor(() => expect(startSpeechStream).toHaveBeenCalled())
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -36,6 +36,8 @@ interface VoiceConversationOptions {
   onTranscribeAudio?: (audio: Blob) => Promise<string>
   pendingResponse: () => PendingVoiceResponse | null
   consumePendingResponse: () => void
+  /** `voice.auto_tts` — false leaves the reply text-only, same as CLI voice mode. */
+  speakReplies?: boolean
   /** Awaited right before the mic is opened. Used to let the wake-word listener
    *  fully release the capture device first, so the two never contend. */
   beforeMicOpen?: () => Promise<void> | void
@@ -55,6 +57,7 @@ export function useVoiceConversation({
   onTranscribeAudio,
   pendingResponse,
   consumePendingResponse,
+  speakReplies = true,
   beforeMicOpen
 }: VoiceConversationOptions) {
   const { t } = useI18n()
@@ -693,7 +696,21 @@ export function useVoiceConversation({
       const response = pendingResponse()
 
       if (response) {
-        openLiveSpeech(response.id)
+        if (speakReplies) {
+          openLiveSpeech(response.id)
+
+          return
+        }
+
+        // Spoken replies off: nothing will ever play, so close the turn out
+        // here instead of waiting on playback and hand the mic straight back.
+        if (!busy && !response.pending) {
+          awaitingSpokenResponseRef.current = false
+          consumePendingResponse()
+          dropSpeechSession()
+          pendingStartRef.current = true
+          setStatus('idle')
+        }
 
         return
       }
@@ -717,7 +734,18 @@ export function useVoiceConversation({
     if (pendingStartRef.current) {
       void startListening()
     }
-  }, [busy, enabled, muted, ensureBargeMonitor, openLiveSpeech, pendingResponse, startListening, status])
+  }, [
+    busy,
+    consumePendingResponse,
+    enabled,
+    muted,
+    ensureBargeMonitor,
+    openLiveSpeech,
+    pendingResponse,
+    speakReplies,
+    startListening,
+    status
+  ])
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {


### PR DESCRIPTION
The composer's voice conversation starts TTS playback regardless of `voice.auto_tts`, so users who set it to `false` still get spoken replies.

This threads the setting through the composer voice hooks so `auto_tts=false` is respected.

Covered by `apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx`.