### PR TITLE
feat(feishu): one-card lifecycle UX for Lark agents

### DIFF
--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -391,11 +391,13 @@ class GatewayBusySessionMixin:
 
     async def _send_busy_reply(self, event: MessageEvent, adapter, content: str, *, plain_anchor: bool = False) -> None:
         """Send a busy-path reply anchored to the event (thread metadata included)."""
+        from gateway.run import _interim_metadata
+
         reply_anchor = self._reply_anchor_for_event(event)
         await adapter._send_with_retry(
             chat_id=event.source.chat_id, content=content,
             reply_to=reply_anchor if plain_anchor else self._busy_reply_to(event, reply_anchor),
-            metadata=self._thread_metadata_for_source(event.source, reply_anchor),
+            metadata=_interim_metadata(self._thread_metadata_for_source(event.source, reply_anchor)),
         )
 
     async def _send_busy_drain_notice(self, event: MessageEvent, session_key: str, effective_mode: str) -> None:

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2764,7 +2764,7 @@ class GatewayTurnMixin:
         for status / approval / stream sends (Feishu topics need the triggering message id via the
         reply API, so carry it as a fallback). Slack and Buzz honour the user's reply_in_thread
         opt-out: never synthesise a thread for progress, or every later reply inherits it."""
-        from gateway.run import _non_conversational_metadata, _resolve_progress_thread_id
+        from gateway.run import _interim_metadata, _non_conversational_metadata, _resolve_progress_thread_id
         is_buzz = str(getattr(source.platform, "value", source.platform) or "").lower() == "buzz"
         _progress_reply_in_thread = True
         _adapter = self._adapter_for_source(source) if source.platform == Platform.SLACK or is_buzz else None
@@ -2792,12 +2792,12 @@ class GatewayTurnMixin:
             and not source.thread_id
             else None
         )
-        _progress_metadata = _non_conversational_metadata(
+        _progress_metadata = _interim_metadata(_non_conversational_metadata(
             self._thread_metadata_for_progress(
                 source, event_message_id, _progress_thread_id, _relay_prospective_thread_id,
             ),
             platform=source.platform,
-        )
+        ))
         if _native_slack_task_cards:
             # chat.startStream in channels requires the recipient team/user pair; harmless elsewhere.
             _progress_metadata = dict(_progress_metadata or {})

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -93,6 +93,14 @@ from utils import atomic_json_write, env_float, env_int
 
 from gateway.platforms._shared import get_scoped_secret as _get_scoped_secret
 
+from plugins.platforms.feishu.lifecycle_card import (
+    FINAL_STATES as _LIFECYCLE_FINAL_STATES,
+    LifecycleCard,
+    make_title as _lifecycle_make_title,
+    split_entry_ref as _lifecycle_split_entry_ref,
+    strip_mentions as _lifecycle_strip_mentions,
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -178,16 +186,17 @@ async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> byt
 
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
 
-# Feishu reactions render as prominent badges, unlike Discord/Telegram's
-# small footer emoji — a success badge on every message would add noise, so
-# we only mark start (Typing) and failure (CrossMark); the reply itself is
-# the success signal.
-_FEISHU_REACTION_IN_PROGRESS = "Typing"
+# Reactions on the user's message are the zero-cost status channel:
+# OnIt while working, DONE/CrossMark terminal — readable from a phone
+# lock screen without opening the thread.
+_FEISHU_REACTION_IN_PROGRESS = "OnIt"
+_FEISHU_REACTION_SUCCESS = "DONE"
 _FEISHU_REACTION_FAILURE = "CrossMark"
 # Bound on the (message_id → reaction_id) handle cache. Happy-path entries
 # drain on completion; the cap is a safeguard against unbounded growth from
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
+_LIFECYCLE_TITLE_TIMEOUT_SECONDS = 20.0
 _FEISHU_MESSAGE_TEXT_CACHE_SIZE = 512       # LRU cap for reply-context message text lookups
 
 # QR onboarding constants
@@ -311,6 +320,9 @@ class FeishuAdapterSettings:
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
     allow_all_dm: bool = False  # resolved per-profile so multiplexed adapters honor their own .env
+    group_thread_replies: bool = True
+    lifecycle_cards_enabled: bool = True
+    reaction_routing_enabled: bool = False
 
 
 @dataclass
@@ -332,7 +344,10 @@ class FeishuBatchState:
 
 # --- Admission: policy types ---
 
-RejectReason = Literal["self_echo", "self_ids_unknown", "bots_disabled", "bot_not_mentioned", "group_policy_rejected"]
+RejectReason = Literal[
+    "self_echo", "self_ids_unknown", "bots_disabled", "bot_not_mentioned",
+    "group_policy_rejected", "dm_policy_rejected",
+]
 
 
 def _is_bot_sender(sender: Any) -> bool:
@@ -1252,6 +1267,12 @@ class FeishuAdapter(BasePlatformAdapter):
         self._update_prompt_counter = itertools.count(1)
         # Reaction deletion needs the opaque reaction_id from create, cached per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
+        # ponytail: one lifecycle card per chat_id — concurrent runs in
+        # different topics of the same group degrade to separate messages.
+        self._lifecycle_cards: Dict[str, LifecycleCard] = {}
+        self._lifecycle_card_chats: Dict[str, str] = {}  # card message_id → card key
+        self._lifecycle_title_tasks: set = set()
+        self._lifecycle_lock = asyncio.Lock()
         self._load_seen_message_ids()
 
     @staticmethod
@@ -1326,6 +1347,13 @@ class FeishuAdapter(BasePlatformAdapter):
             default_group_policy=str(extra.get("default_group_policy", "")).strip().lower(),
             group_rules=group_rules, allow_bots=allow_bots, allow_all_dm=allow_all_dm,
             require_mention=_to_boolean(extra.get("require_mention", _get_scoped_secret("FEISHU_REQUIRE_MENTION", "true"))),
+            group_thread_replies=_to_boolean(extra.get("group_thread_replies", True)),
+            lifecycle_cards_enabled=_to_boolean(
+                extra.get("lifecycle_cards", _get_scoped_secret("FEISHU_LIFECYCLE_CARDS", "true"))
+            ),
+            reaction_routing_enabled=_to_boolean(
+                extra.get("reaction_routing", _get_scoped_secret("FEISHU_REACTION_ROUTING", "false"))
+            ),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1335,6 +1363,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._allowed_group_users = set(settings.allowed_group_users)
         self._admins = set(settings.admins)
         self._default_group_policy = settings.default_group_policy or settings.group_policy
+
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -1561,8 +1590,19 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        if self._lifecycle_cards_enabled and (metadata or {}).get("_interim_send"):
+            result = await self._lifecycle_interim_send(chat_id, content, reply_to, metadata)
+            if result is not None:
+                return result
+
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+
+        absorbed = await self._lifecycle_absorb_final(
+            chat_id, formatted, reply_to=reply_to, metadata=metadata, chunk_count=len(chunks)
+        )
+        if absorbed is not None:
+            return absorbed
         # Decide markdown-vs-text once for the whole message: a chunk of a long
         # markdown reply may be plain prose that fails the per-chunk regex and would
         # otherwise render as literal ``**bold`` / fences while other chunks render.
@@ -1610,6 +1650,10 @@ class FeishuAdapter(BasePlatformAdapter):
         """Edit a previously sent Feishu text/post message."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
+
+        base_id, entry_idx = _lifecycle_split_entry_ref(message_id)
+        if entry_idx is not None:
+            return await self._lifecycle_edit_entry(base_id, entry_idx, content)
 
         content = self.format_message(content)
 
@@ -1876,10 +1920,15 @@ class FeishuAdapter(BasePlatformAdapter):
                 logger.warning("[Feishu] Failed to get chat info for %s: [%s] %s", chat_id, code, msg)
                 return fallback
             data = getattr(response, "data", None)
+            # chat_mode is the shape field ("group"/"p2p"); chat_type is the
+            # visibility field ("private"/"public") and misclassifies private
+            # groups as non-groups. Prefer chat_mode, fall back to chat_type.
+            raw_chat_mode = str(getattr(data, "chat_mode", "") or "").strip().lower()
             raw_chat_type = str(getattr(data, "chat_type", "") or "").strip().lower()
             info = {
                 "chat_id": chat_id, "name": str(getattr(data, "name", None) or chat_id),
-                "type": self._map_chat_type(raw_chat_type), "raw_type": raw_chat_type or None,
+                "type": self._map_chat_type(raw_chat_mode or raw_chat_type),
+                "raw_type": raw_chat_type or None, "raw_mode": raw_chat_mode or None,
             }
             self._chat_info_cache[chat_id] = info
             return dict(info)
@@ -2268,7 +2317,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""
-        if not self._client:
+        if not self._client or not getattr(self, "_reaction_routing_enabled", False):
             return
         event = getattr(data, "event", None)
         message_id = str(getattr(event, "message_id", "") or "")
@@ -2393,6 +2442,241 @@ class FeishuAdapter(BasePlatformAdapter):
         async with chat_lock:
             await self.handle_message(event)
 
+    # =========================================================================
+    # Lifecycle status card — one interactive card per turn, patched in place
+    # =========================================================================
+
+    @staticmethod
+    def _lifecycle_card_key(chat_id: str, anchor: str) -> str:
+        return f"{chat_id}\x00{anchor}"
+
+    def _register_lifecycle_card(self, key: str, card: LifecycleCard) -> None:
+        prev = self._lifecycle_cards.get(key)
+        if prev and prev.message_id:
+            self._lifecycle_card_chats.pop(prev.message_id, None)
+        card.key = key
+        self._lifecycle_cards[key] = card
+
+    def _drop_lifecycle_card(self, key: str) -> Optional[LifecycleCard]:
+        card = self._lifecycle_cards.pop(key, None)
+        if card and card.message_id:
+            self._lifecycle_card_chats.pop(card.message_id, None)
+        return card
+
+    def _resolve_lifecycle_card(
+        self, chat_id: str, reply_to: Optional[str], *, strict: bool
+    ) -> Optional[LifecycleCard]:
+        """Find the open card belonging to the turn that ``reply_to`` anchors.
+
+        Cards are per turn, so a chat can hold several at once when a second
+        question arrives mid-run. ``strict`` (used for final answers) demands
+        a real anchor match; progress updates accept the newest open card so a
+        status line without an anchor still lands somewhere sane.
+        """
+        open_cards = [
+            card
+            for card in self._lifecycle_cards.values()
+            if card.chat_id == chat_id
+            and card.state not in _LIFECYCLE_FINAL_STATES
+            and not card.answer_absorbed
+        ]
+        for card in open_cards:
+            if card.matches_anchor(reply_to):
+                return card
+        if strict or not open_cards:
+            return None
+        # ponytail: newest-wins when the send carries no anchor; per-turn
+        # routing would need the turn id plumbed through the send path.
+        return open_cards[-1]
+
+    async def _patch_lifecycle_card(self, card: LifecycleCard) -> bool:
+        if not self._client or not card.message_id:
+            return False
+        try:
+            from lark_oapi.api.im.v1 import (
+                PatchMessageRequest,
+                PatchMessageRequestBody,
+            )
+            body = (
+                PatchMessageRequestBody.builder()
+                .content(json.dumps(card.build_card(), ensure_ascii=False))
+                .build()
+            )
+            request = (
+                PatchMessageRequest.builder()
+                .message_id(card.message_id)
+                .request_body(body)
+                .build()
+            )
+            response = await self._run_blocking(self._client.im.v1.message.patch, request)
+            if self._response_succeeded(response):
+                return True
+            logger.debug(
+                "[Feishu] Lifecycle card patch rejected for %s: code=%s msg=%s",
+                card.message_id,
+                getattr(response, "code", None),
+                getattr(response, "msg", None),
+            )
+        except Exception:
+            logger.warning(
+                "[Feishu] Lifecycle card patch raised for %s", card.message_id, exc_info=True
+            )
+        return False
+
+    async def _lifecycle_interim_send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[SendResult]:
+        """Fold an interim status send into the chat's lifecycle card.
+
+        Returns None when the card path is unavailable so the caller falls
+        back to a normal message — no status update is ever silently lost.
+        """
+        async with self._lifecycle_lock:
+            card = self._resolve_lifecycle_card(chat_id, reply_to, strict=False)
+            if card is None:
+                card = LifecycleCard(chat_id=chat_id, anchor_message_id=reply_to or "")
+                self._register_lifecycle_card(
+                    self._lifecycle_card_key(chat_id, reply_to or f"anon{id(card):x}"), card
+                )
+            entry_idx = card.add_entry(self.format_message(content))
+            if not card.message_id:
+                if not await self._lifecycle_send_card(card, reply_to, metadata):
+                    return None
+            else:
+                if not await self._patch_lifecycle_card(card):
+                    self._drop_lifecycle_card(card.key)
+                    return None
+            return SendResult(
+                success=True,
+                message_id=f"{card.message_id}#e{entry_idx}",
+            )
+
+    def _spawn_lifecycle_title(self, card: LifecycleCard, prompt: str) -> None:
+        """Upgrade the card's raw-prompt title to a generated one, in the background.
+
+        The auxiliary titler takes seconds, so the card ships with the trimmed
+        prompt and is patched when (if) a better title arrives.
+        """
+        if not prompt.strip():
+            return
+        task = asyncio.create_task(self._apply_lifecycle_title(card, prompt))
+        self._lifecycle_title_tasks.add(task)
+        task.add_done_callback(self._lifecycle_title_tasks.discard)
+
+    async def _apply_lifecycle_title(self, card: LifecycleCard, prompt: str) -> None:
+        try:
+            from agent.title_generator import generate_title
+
+            title = await asyncio.to_thread(
+                generate_title, prompt, _LIFECYCLE_TITLE_TIMEOUT_SECONDS
+            )
+        except Exception:
+            logger.debug("[Feishu] Lifecycle card titling failed", exc_info=True)
+            return
+        if not title:
+            return
+        async with self._lifecycle_lock:
+            if self._lifecycle_cards.get(card.key) is not card:
+                return
+            card.title = _lifecycle_make_title(title)
+            if card.message_id:
+                await self._patch_lifecycle_card(card)
+
+    async def _lifecycle_send_card(
+        self,
+        card: LifecycleCard,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> bool:
+        """Post the card for the first time and record its message id."""
+        try:
+            response = await self._feishu_send_with_retry(
+                chat_id=card.chat_id,
+                msg_type="interactive",
+                payload=json.dumps(card.build_card(), ensure_ascii=False),
+                reply_to=card.anchor_message_id or reply_to,
+                metadata=metadata,
+            )
+        except Exception as exc:
+            logger.warning("[Feishu] Lifecycle card send failed: %s", exc)
+            return False
+        result = self._finalize_send_result(response, "lifecycle card send failed")
+        if not result.success or not result.message_id:
+            return False
+        card.message_id = str(result.message_id)
+        self._lifecycle_card_chats[card.message_id] = card.key
+        return True
+
+    async def _lifecycle_edit_entry(
+        self, base_message_id: str, entry_idx: int, content: str
+    ) -> SendResult:
+        async with self._lifecycle_lock:
+            card_key = self._lifecycle_card_chats.get(base_message_id)
+            card = self._lifecycle_cards.get(card_key) if card_key else None
+            if not card or card.message_id != base_message_id:
+                return SendResult(success=False, error="lifecycle card no longer active")
+            card.update_entry(entry_idx, self.format_message(content))
+            ok = await self._patch_lifecycle_card(card)
+            if ok:
+                return SendResult(success=True, message_id=f"{base_message_id}#e{entry_idx}")
+            return SendResult(success=False, error="lifecycle card patch failed")
+
+    async def _lifecycle_absorb_final(
+        self,
+        chat_id: str,
+        formatted: str,
+        *,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+        chunk_count: int,
+    ) -> Optional[SendResult]:
+        """Deliver a single-chunk final answer by patching the open card to done."""
+        if not self._lifecycle_cards_enabled or chunk_count != 1:
+            return None
+        if (metadata or {}).get("_interim_send"):
+            return None
+        async with self._lifecycle_lock:
+            card = self._resolve_lifecycle_card(chat_id, reply_to, strict=True)
+            if not card:
+                return None
+            card.finalize("done", answer=formatted)
+            if card.message_id:
+                delivered = await self._patch_lifecycle_card(card)
+            else:
+                # Turn finished before any status update had to be shown, so
+                # no card exists yet — post the answer as the card itself.
+                delivered = await self._lifecycle_send_card(card, reply_to, metadata)
+            if delivered:
+                return SendResult(success=True, message_id=card.message_id)
+            card.state = "working"
+            card.answer = ""
+            card.answer_absorbed = False
+            return None
+
+    async def _lifecycle_close(
+        self, chat_id: str, anchor: str, outcome: "ProcessingOutcome"
+    ) -> None:
+        if not chat_id:
+            return
+        async with self._lifecycle_lock:
+            card = self._drop_lifecycle_card(self._lifecycle_card_key(chat_id, anchor))
+            if not card or not card.message_id or card.answer_absorbed:
+                return
+            if outcome is ProcessingOutcome.SUCCESS:
+                card.add_entry("✅ Done — reply below")
+                card.finalize("done")
+            elif outcome is ProcessingOutcome.CANCELLED:
+                card.add_entry("⏹ Cancelled")
+                card.finalize("cancelled")
+            else:
+                card.add_entry("❌ Run failed")
+                card.finalize("failed")
+            await self._patch_lifecycle_card(card)
+
     # --- Processing status reactions ---
     def _reactions_enabled(self) -> bool:
         return os.getenv("FEISHU_REACTIONS", "true").strip().lower() not in {"false", "0", "no"}
@@ -2436,6 +2720,21 @@ class FeishuAdapter(BasePlatformAdapter):
         return data is not None
 
     async def on_processing_start(self, event: MessageEvent) -> None:
+        chat_id = str(getattr(getattr(event, "source", None), "chat_id", "") or "")
+        if self._lifecycle_cards_enabled and chat_id:
+            async with self._lifecycle_lock:
+                prompt = _lifecycle_strip_mentions(getattr(event, "text", "") or "")
+                card = LifecycleCard(
+                    chat_id=chat_id,
+                    title=_lifecycle_make_title(prompt),
+                    requester=str(getattr(event, "user_name", "") or ""),
+                    anchor_message_id=str(event.message_id or ""),
+                    thread_anchor_id=str(getattr(event, "reply_to_message_id", "") or ""),
+                )
+                self._register_lifecycle_card(
+                    self._lifecycle_card_key(chat_id, str(event.message_id or "")), card
+                )
+                self._spawn_lifecycle_title(card, prompt)
         message_id = event.message_id
         if not self._reactions_enabled() or not message_id or message_id in self._pending_processing_reactions:
             return
@@ -2448,18 +2747,29 @@ class FeishuAdapter(BasePlatformAdapter):
                 cache.popitem(last=False)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
+        if self._lifecycle_cards_enabled:
+            try:
+                await self._lifecycle_close(
+                    str(getattr(getattr(event, "source", None), "chat_id", "") or ""),
+                    str(getattr(event, "message_id", "") or ""),
+                    outcome,
+                )
+            except Exception:
+                logger.debug("[Feishu] Lifecycle card close failed", exc_info=True)
         message_id = event.message_id
         if not self._reactions_enabled() or not message_id:
             return
         start_reaction_id = self._pending_processing_reactions.get(message_id)
         if start_reaction_id:
             if not await self._remove_reaction(message_id, start_reaction_id):
-                # Don't stack a second badge on a Typing we couldn't remove (UI would read as both
+                # Don't stack a second badge on an OnIt we couldn't remove (UI would read as both
                 # "working" and "done/failed"); keep the handle so LRU eventually evicts it.
                 return
             self._pending_processing_reactions.pop(message_id, None)
         if outcome is ProcessingOutcome.FAILURE:
             await self._add_reaction(message_id, _FEISHU_REACTION_FAILURE)
+        elif outcome is ProcessingOutcome.SUCCESS:
+            await self._add_reaction(message_id, _FEISHU_REACTION_SUCCESS)
 
     # --- Webhook server and security ---
     def _record_webhook_anomaly(self, remote_ip: str, status: str) -> None:
@@ -3270,6 +3580,9 @@ class FeishuAdapter(BasePlatformAdapter):
             if mode == "mentions" and not require_mention and not self._mentions_self(message):
                 return "bot_not_mentioned"
         if not is_group:
+            # Groups-only bot: drop every DM before a turn/working bubble starts.
+            if os.getenv("FEISHU_DM_POLICY", "").strip().lower() == "disabled":
+                return "dm_policy_rejected"
             # _allow_all_dm is snapshotted per-profile in _load_settings: _admit runs on the
             # lark_oapi WS thread with no secret scope, so a bare os.getenv would read the
             # default profile's value.
@@ -3595,9 +3908,16 @@ class FeishuAdapter(BasePlatformAdapter):
     ) -> Any:
         thread_id = (metadata or {}).get("thread_id")
         effective_reply_to = reply_to or ((metadata or {}).get("reply_to_message_id") if thread_id else None)
+        reply_in_thread = bool(thread_id)
+        if not reply_in_thread and effective_reply_to and self._group_thread_replies:
+            # A top-level group reply has no thread_id yet — opt it into a topic
+            # thread instead of an inline quote. DMs stay inline (no thread concept).
+            chat_info = self._chat_info_cache.get(chat_id) or await self.get_chat_info(chat_id)
+            if chat_info.get("type") in ("group", "forum"):
+                reply_in_thread = True
         if effective_reply_to:
             body = self._build_reply_message_body(
-                content=payload, msg_type=msg_type, reply_in_thread=bool(thread_id), uuid_value=str(uuid.uuid4()),
+                content=payload, msg_type=msg_type, reply_in_thread=reply_in_thread, uuid_value=str(uuid.uuid4()),
             )
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)

--- a/plugins/platforms/feishu/lifecycle_card.py
+++ b/plugins/platforms/feishu/lifecycle_card.py
@@ -1,0 +1,231 @@
+"""Per-turn lifecycle status card: one Feishu interactive card, patched in place.
+
+Interim gateway sends (heartbeats, tool progress, busy/redirect acks, mid-turn
+commentary) become entries on a single card instead of separate messages.
+Entries are addressed as ``<card_message_id>#e<idx>`` so gateway edit loops
+(heartbeat, tool-progress accumulate) keep editing their own entry in place.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+ENTRY_SEP = "#e"
+
+_ENTRY_CAP = 14
+_ENTRY_TEXT_CAP = 700
+_ENTRY_TAIL_LINES = 8
+_BODY_CHAR_BUDGET = 7000
+_TITLE_CAP = 80
+
+_STATE_STYLE = {
+    "working": ("⏳", "blue"),
+    "done": ("✅", "green"),
+    "failed": ("❌", "red"),
+    "cancelled": ("⏹", "grey"),
+}
+
+FINAL_STATES = frozenset({"done", "failed", "cancelled"})
+
+
+def split_entry_ref(message_id: str) -> Tuple[str, Optional[int]]:
+    if message_id and ENTRY_SEP in message_id:
+        base, _, idx = message_id.rpartition(ENTRY_SEP)
+        if base and idx.isdigit():
+            return base, int(idx)
+    return message_id, None
+
+
+def _clip(text: str) -> str:
+    lines = [ln for ln in str(text).strip().splitlines() if ln.strip()]
+    if len(lines) > _ENTRY_TAIL_LINES:
+        lines = ["…"] + lines[-_ENTRY_TAIL_LINES:]
+    clipped = "\n".join(lines)
+    if len(clipped) > _ENTRY_TEXT_CAP:
+        clipped = "…" + clipped[-_ENTRY_TEXT_CAP:]
+    return clipped
+
+
+_MENTION_BLOCK_RE = re.compile(r"\[Mentioned:([^\]]*)\]")
+_MENTION_TOKEN_RE = re.compile(r"@\S+")
+_INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
+_HEADING_RE = re.compile(r"^#{1,6}\s+(.+)$")
+_TABLE_ROW_RE = re.compile(r"^\s*\|.*\|\s*$")
+_TABLE_SEP_RE = re.compile(r"^\s*\|(?:\s*:?-+:?\s*\|)+\s*$")
+
+
+def _table_cells(row: str) -> str:
+    return " · ".join(c for c in (c.strip() for c in row.strip().strip("|").split("|")) if c)
+
+
+def to_lark_md(text: str) -> str:
+    # Lark's card markdown renders `inline code`, #-headings and pipe tables
+    # literally — remap to bold / bullet rows, leaving fenced blocks untouched.
+    out: list[str] = []
+    in_fence = False
+    in_table = False
+    lines = str(text).splitlines()
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            in_table = False
+            out.append(line)
+            continue
+        if in_fence:
+            out.append(line)
+            continue
+        if _TABLE_ROW_RE.match(line):
+            if in_table:
+                if not _TABLE_SEP_RE.match(line):
+                    row = _INLINE_CODE_RE.sub(r"**\1**", _table_cells(line))
+                    if row:
+                        out.append(f"- {row}")
+                continue
+            if i + 1 < len(lines) and _TABLE_SEP_RE.match(lines[i + 1]):
+                in_table = True
+                header = _INLINE_CODE_RE.sub(r"**\1**", _table_cells(line))
+                if header:
+                    out.append(f"**{header}**")
+                continue
+        else:
+            in_table = False
+        line = _HEADING_RE.sub(r"**\1**", line)
+        line = _INLINE_CODE_RE.sub(r"**\1**", line)
+        out.append(line)
+    return "\n".join(out)
+
+
+def strip_mentions(text: str) -> str:
+    names: list[str] = []
+
+    def _collect_names(match: "re.Match[str]") -> str:
+        for part in match.group(1).split(","):
+            name = part.split("(open_id=")[0].strip()
+            if name:
+                names.append(name)
+        return " "
+
+    cleaned = _MENTION_BLOCK_RE.sub(_collect_names, str(text or "")).replace("\\", "")
+    for name in names:
+        cleaned = cleaned.replace(f"@{name}", " ")
+    cleaned = _MENTION_TOKEN_RE.sub(" ", cleaned)
+    return " ".join(cleaned.split())
+
+
+def make_title(text: str) -> str:
+    collapsed = strip_mentions(text)
+    if len(collapsed) > _TITLE_CAP:
+        collapsed = collapsed[: _TITLE_CAP - 1] + "…"
+    return collapsed
+
+
+@dataclass
+class _Entry:
+    text: str
+    updated_ts: float
+
+
+@dataclass
+class LifecycleCard:
+    chat_id: str
+    key: str = ""
+    title: str = ""
+    requester: str = ""
+    anchor_message_id: str = ""
+    thread_anchor_id: str = ""
+    message_id: str = ""
+    state: str = "working"
+    answer: str = ""
+    answer_absorbed: bool = False
+    entries: Dict[int, _Entry] = field(default_factory=dict)
+    started_ts: float = field(default_factory=time.time)
+    _next_idx: int = 0
+
+    def matches_anchor(self, reply_to: Optional[str]) -> bool:
+        # In Lark threads the gateway anchors the final reply to the thread
+        # root, not the triggering mention — accept either.
+        return bool(reply_to) and reply_to in {
+            a for a in (self.anchor_message_id, self.thread_anchor_id) if a
+        }
+
+    def add_entry(self, content: str) -> int:
+        idx = self._next_idx
+        self._next_idx += 1
+        self.entries[idx] = _Entry(_clip(content), time.time())
+        if len(self.entries) > _ENTRY_CAP:
+            # Evict the stalest entry so live-edited entries (heartbeat,
+            # tool progress) survive even though they were created first.
+            stalest = min(
+                (i for i in self.entries if i != idx),
+                key=lambda i: self.entries[i].updated_ts,
+            )
+            del self.entries[stalest]
+        return idx
+
+    def update_entry(self, idx: int, content: str) -> None:
+        # Upsert: an evicted entry that the gateway keeps editing (heartbeat,
+        # tool progress) is resurrected rather than silently dropped.
+        self.entries[idx] = _Entry(_clip(content), time.time())
+
+    def finalize(self, state: str, answer: str = "") -> None:
+        self.state = state
+        if answer:
+            self.answer = answer
+            self.answer_absorbed = True
+
+    def _elapsed(self) -> str:
+        seconds = max(0, int(time.time() - self.started_ts))
+        if seconds < 60:
+            return f"{seconds}s"
+        return f"{seconds // 60}m {seconds % 60:02d}s"
+
+    def _body(self) -> str:
+        parts: list[str] = []
+        budget = _BODY_CHAR_BUDGET
+        for idx in sorted(self.entries, reverse=True):
+            text = self.entries[idx].text
+            if not text:
+                continue
+            if budget - len(text) < 0:
+                parts.append("…")
+                break
+            parts.append(text)
+            budget -= len(text)
+        parts.reverse()
+        return "\n".join(parts)
+
+    def build_card(self) -> dict:
+        emoji, template = _STATE_STYLE.get(self.state, _STATE_STYLE["working"])
+        title = f"{emoji} {self.title}".strip() if self.title else f"{emoji} Working"
+        elements: list[dict] = []
+        if self.answer:
+            elements.append({"tag": "markdown", "content": to_lark_md(self.answer)})
+        else:
+            body = self._body()
+            if body:
+                elements.append({"tag": "markdown", "content": to_lark_md(body)})
+        if elements:
+            elements.append({"tag": "hr"})
+        footer_bits = []
+        if self.requester:
+            footer_bits.append(f"requested by {self.requester}")
+        footer_bits.append(self._elapsed())
+        if self.answer and self.entries:
+            footer_bits.append(f"{len(self.entries)} status updates")
+        elements.append(
+            {
+                "tag": "note",
+                "elements": [{"tag": "plain_text", "content": " · ".join(footer_bits)}],
+            }
+        )
+        return {
+            "config": {"wide_screen_mode": True, "update_multi": True},
+            "header": {
+                "title": {"tag": "plain_text", "content": title[:100]},
+                "template": template,
+            },
+            "elements": elements,
+        }

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1249,6 +1249,180 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
+    def _make_reply_capturing_adapter(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+        return adapter, captured
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_top_level_group_reply_upgrades_to_thread(self):
+        """A top-level group mention reply (no thread_id) should open a topic thread."""
+        adapter, captured = self._make_reply_capturing_adapter()
+        adapter._chat_info_cache["oc_chat"] = {"chat_id": "oc_chat", "name": "Team", "type": "group"}
+
+        result = asyncio.run(
+            adapter._send_raw_message(
+                chat_id="oc_chat",
+                msg_type="text",
+                payload="hi",
+                reply_to="om_parent",
+                metadata=None,
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_dm_reply_stays_inline(self):
+        """DM (p2p) replies keep the existing inline quoted-reply behavior."""
+        adapter, captured = self._make_reply_capturing_adapter()
+        adapter._chat_info_cache["oc_chat"] = {"chat_id": "oc_chat", "name": "DM", "type": "dm"}
+
+        result = asyncio.run(
+            adapter._send_raw_message(
+                chat_id="oc_chat",
+                msg_type="text",
+                payload="hi",
+                reply_to="om_parent",
+                metadata=None,
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertFalse(captured["request"].request_body.reply_in_thread)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_in_thread_inbound_reply_stays_thread_reply(self):
+        """A reply to an already-in-thread message keeps reply_in_thread=True."""
+        adapter, captured = self._make_reply_capturing_adapter()
+        adapter._chat_info_cache["oc_chat"] = {"chat_id": "oc_chat", "name": "Team", "type": "group"}
+
+        result = asyncio.run(
+            adapter._send_raw_message(
+                chat_id="oc_chat",
+                msg_type="text",
+                payload="hi",
+                reply_to=None,
+                metadata={"thread_id": "omt_1", "reply_to_message_id": "om_last"},
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_group_thread_replies_disabled_keeps_inline_reply(self):
+        """group_thread_replies=False opts out of the topic-thread upgrade."""
+        adapter, captured = self._make_reply_capturing_adapter()
+        adapter._group_thread_replies = False
+        adapter._chat_info_cache["oc_chat"] = {"chat_id": "oc_chat", "name": "Team", "type": "group"}
+
+        result = asyncio.run(
+            adapter._send_raw_message(
+                chat_id="oc_chat",
+                msg_type="text",
+                payload="hi",
+                reply_to="om_parent",
+                metadata=None,
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertFalse(captured["request"].request_body.reply_in_thread)
+
+    def _make_chat_info_adapter(self, response_data):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(chat=SimpleNamespace(
+                get=lambda request: SimpleNamespace(
+                    success=lambda: True,
+                    data=response_data,
+                ),
+            )))
+        )
+        return adapter
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_chat_info_private_group_classified_as_group(self):
+        """Regression for #53107: GET /im/v1/chats/:id returns
+        chat_mode="group" (shape) and chat_type="private" (visibility)
+        for a private group.  The adapter used to read only chat_type,
+        mapping every private group to "dm", which suppressed the
+        group thread-reply upgrade.  chat_mode must win.
+        """
+        adapter = self._make_chat_info_adapter(SimpleNamespace(
+            name="test_sample_group",
+            chat_mode="group",
+            chat_type="private",
+        ))
+
+        info = asyncio.run(adapter.get_chat_info("oc_1f2e3d4c5b6a7988776655443322110"))
+
+        self.assertEqual(info["type"], "group")
+        self.assertEqual(info["raw_mode"], "group")
+        self.assertEqual(info["raw_type"], "private")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_chat_info_p2p_chat_classified_as_dm(self):
+        """p2p chats (chat_mode="p2p") must still classify as "dm" so
+        quoted inline replies keep working in direct messages.
+        """
+        adapter = self._make_chat_info_adapter(SimpleNamespace(
+            name="Some User",
+            chat_mode="p2p",
+            chat_type="p2p",
+        ))
+
+        info = asyncio.run(adapter.get_chat_info("oc_dm"))
+
+        self.assertEqual(info["type"], "dm")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_chat_info_private_group_chat_info_feeds_thread_upgrade(self):
+        """End-to-end regression for #53107: with a private group's real
+        API payload in the cache, a top-level mention reply must upgrade
+        to a topic thread (reply_in_thread=True).
+        """
+        adapter, captured = self._make_reply_capturing_adapter()
+        adapter._chat_info_cache["oc_chat"] = {
+            "chat_id": "oc_chat",
+            "name": "Team",
+            "type": "group",
+            "raw_type": "private",
+            "raw_mode": "group",
+        }
+
+        result = asyncio.run(
+            adapter._send_raw_message(
+                chat_id="oc_chat",
+                msg_type="text",
+                payload="hi",
+                reply_to="om_parent",
+                metadata=None,
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertTrue(captured["request"].request_body.reply_in_thread)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_post_for_every_chunk_of_multi_chunk_markdown(self):
@@ -1715,6 +1889,62 @@ class TestDedupTTL(unittest.TestCase):
         self.assertEqual(writes[-1], ["om_a", "om_b"])
 
 
+class TestDmPolicyDisabled(unittest.TestCase):
+    """FEISHU_DM_POLICY=disabled drops DMs while groups still admit."""
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_DM_POLICY": "disabled",
+            "FEISHU_ALLOWED_USERS": "ou_allowed",
+            "FEISHU_GROUP_POLICY": "allowlist",
+        },
+        clear=True,
+    )
+    def test_disabled_rejects_allowlisted_dm(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        sender = SimpleNamespace(
+            sender_type="user",
+            sender_id=SimpleNamespace(open_id="ou_allowed", user_id=None, union_id=None),
+        )
+        message = SimpleNamespace(chat_type="p2p", chat_id="oc_dm", mentions=[], content="")
+        self.assertEqual(adapter._admit(sender, message), "dm_policy_rejected")
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_DM_POLICY": "disabled",
+            "FEISHU_ALLOWED_USERS": "ou_allowed",
+            "FEISHU_GROUP_POLICY": "allowlist",
+        },
+        clear=True,
+    )
+    def test_disabled_still_admits_allowlisted_group(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(content='{"text":"@_all hi"}', mentions=[])
+        allowed_sender = SimpleNamespace(open_id="ou_allowed", user_id=None)
+        self.assertTrue(_admits_group(adapter, message, allowed_sender, ""))
+
+    @patch.dict(os.environ, {"FEISHU_ALLOWED_USERS": "ou_allowed"}, clear=True)
+    def test_allowlisted_dm_admitted_when_policy_unset(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        sender = SimpleNamespace(
+            sender_type="user",
+            sender_id=SimpleNamespace(open_id="ou_allowed", user_id=None, union_id=None),
+        )
+        message = SimpleNamespace(chat_type="p2p", chat_id="oc_dm", mentions=[], content="")
+        self.assertIsNone(adapter._admit(sender, message))
+
+
 class TestGroupMentionAtAll(unittest.TestCase):
     """Tests for @_all (Feishu @everyone) group mention routing."""
 
@@ -1842,7 +2072,7 @@ class TestBotNameResolution(unittest.TestCase):
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestProcessingReactions(unittest.TestCase):
-    """Typing on start → removed on SUCCESS, swapped for CrossMark on FAILURE,
+    """OnIt on start → swapped for DONE on SUCCESS, CrossMark on FAILURE,
     removed (no replacement) on CANCELLED."""
 
     @staticmethod
@@ -1909,43 +2139,43 @@ class TestProcessingReactions(unittest.TestCase):
 
     # ------------------------------------------------------------------ start
     @patch.dict(os.environ, {}, clear=True)
-    def test_start_adds_typing_and_caches_reaction_id(self):
+    def test_start_adds_onit_and_caches_reaction_id(self):
         adapter, tracker = self._build_adapter(next_reaction_id="r_typing")
         with self._patch_to_thread():
             self._run(adapter.on_processing_start(self._event()))
-        self.assertEqual(tracker.create_calls, ["Typing"])
+        self.assertEqual(tracker.create_calls, ["OnIt"])
         self.assertEqual(adapter._pending_processing_reactions["om_msg"], "r_typing")
 
 
     # --------------------------------------------------------------- complete
     @patch.dict(os.environ, {}, clear=True)
-    def test_success_removes_typing_and_adds_nothing(self):
+    def test_success_removes_onit_and_adds_done(self):
         adapter, tracker = self._build_adapter(next_reaction_id="r_typing")
         with self._patch_to_thread():
             self._run(adapter.on_processing_start(self._event()))
             self._run(
                 adapter.on_processing_complete(self._event(), ProcessingOutcome.SUCCESS)
             )
-        self.assertEqual(tracker.create_calls, ["Typing"])
+        self.assertEqual(tracker.create_calls, ["OnIt", "DONE"])
         self.assertEqual(tracker.delete_calls, ["r_typing"])
         self.assertNotIn("om_msg", adapter._pending_processing_reactions)
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_failure_removes_typing_then_adds_cross_mark(self):
+    def test_failure_removes_onit_then_adds_cross_mark(self):
         adapter, tracker = self._build_adapter(next_reaction_id="r_typing")
         with self._patch_to_thread():
             self._run(adapter.on_processing_start(self._event()))
             self._run(
                 adapter.on_processing_complete(self._event(), ProcessingOutcome.FAILURE)
             )
-        self.assertEqual(tracker.create_calls, ["Typing", "CrossMark"])
+        self.assertEqual(tracker.create_calls, ["OnIt", "CrossMark"])
         self.assertEqual(tracker.delete_calls, ["r_typing"])
 
 
     # ------------------------- delete failure: don't stack badges -----------
     @patch.dict(os.environ, {}, clear=True)
     def test_delete_failure_on_failure_outcome_skips_cross_mark(self):
-        # Removing Typing is best-effort — but if it fails, we must NOT
+        # Removing OnIt is best-effort — but if it fails, we must NOT
         # additionally add CrossMark, or the UI would show two contradictory
         # badges. The handle stays in the cache for LRU to clean up later.
         adapter, tracker = self._build_adapter(
@@ -1956,7 +2186,7 @@ class TestProcessingReactions(unittest.TestCase):
             self._run(
                 adapter.on_processing_complete(self._event(), ProcessingOutcome.FAILURE)
             )
-        self.assertEqual(tracker.create_calls, ["Typing"])  # CrossMark NOT added
+        self.assertEqual(tracker.create_calls, ["OnIt"])  # CrossMark NOT added
         self.assertEqual(tracker.delete_calls, ["r_typing"])  # delete was attempted
         self.assertEqual(
             adapter._pending_processing_reactions["om_msg"], "r_typing",

--- a/tests/gateway/test_feishu_lifecycle_card.py
+++ b/tests/gateway/test_feishu_lifecycle_card.py
@@ -1,0 +1,441 @@
+"""Lifecycle status card: one interactive card per turn, patched in place."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from gateway.platforms.base import ProcessingOutcome
+from plugins.platforms.feishu.lifecycle_card import (
+    LifecycleCard,
+    make_title,
+    split_entry_ref,
+    to_lark_md,
+)
+
+
+def _ok_response(message_id="om_card1"):
+    return SimpleNamespace(
+        success=lambda: True,
+        data=SimpleNamespace(message_id=message_id),
+        code=0,
+        msg="ok",
+    )
+
+
+CHAT_KEY = "oc_1\x00om_ask"
+
+
+def make_lifecycle_adapter():
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    adapter = object.__new__(FeishuAdapter)
+    adapter._client = SimpleNamespace(
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(patch=lambda req: _ok_response())))
+    )
+    adapter._lifecycle_cards = {}
+    adapter._lifecycle_card_chats = {}
+    adapter._lifecycle_title_tasks = set()
+    adapter._spawn_lifecycle_title = lambda *a, **k: None
+    adapter._lifecycle_lock = asyncio.Lock()
+    adapter._lifecycle_cards_enabled = True
+    adapter._sends = []
+    adapter._patches = []
+
+    async def _fake_send(**kwargs):
+        adapter._sends.append(kwargs)
+        return _ok_response()
+
+    async def _fake_run_blocking(fn, request):
+        adapter._patches.append(request)
+        return _ok_response()
+
+    adapter._feishu_send_with_retry = _fake_send
+    adapter._run_blocking = _fake_run_blocking
+    return adapter
+
+
+class TestCardModel:
+    def test_split_entry_ref(self):
+        assert split_entry_ref("om_x#e3") == ("om_x", 3)
+        assert split_entry_ref("om_x") == ("om_x", None)
+        assert split_entry_ref("om_x#enope") == ("om_x#enope", None)
+
+    def test_state_colors(self):
+        card = LifecycleCard(chat_id="oc_1", title="Check logs")
+        assert card.build_card()["header"]["template"] == "blue"
+        card.finalize("done")
+        assert card.build_card()["header"]["template"] == "green"
+        card.finalize("failed")
+        assert card.build_card()["header"]["template"] == "red"
+
+    def test_entry_cap_evicts_stalest_not_oldest(self):
+        card = LifecycleCard(chat_id="oc_1")
+        heartbeat_idx = card.add_entry("heartbeat v1")
+        for n in range(20):
+            card.update_entry(heartbeat_idx, f"heartbeat v{n}")
+            card.add_entry(f"noise {n}")
+        assert heartbeat_idx in card.entries
+        assert "heartbeat v19" in card.entries[heartbeat_idx].text
+
+    def test_entry_clips_to_tail(self):
+        card = LifecycleCard(chat_id="oc_1")
+        idx = card.add_entry("\n".join(f"line {n}" for n in range(50)))
+        text = card.entries[idx].text
+        assert text.startswith("…")
+        assert "line 49" in text
+        assert "line 0" not in text
+
+    def test_answer_replaces_body(self):
+        card = LifecycleCard(chat_id="oc_1", title="Q", requester="Test User")
+        card.add_entry("working on it")
+        card.finalize("done", answer="**TL;DR** all good")
+        built = card.build_card()
+        markdowns = [e for e in built["elements"] if e.get("tag") == "markdown"]
+        assert markdowns == [{"tag": "markdown", "content": "**TL;DR** all good"}]
+        note = built["elements"][-1]
+        assert note["tag"] == "note"
+        assert "requested by Test User" in note["elements"][0]["content"]
+
+    def test_make_title_collapses_and_caps(self):
+        assert make_title("  check   the\nlogs ") == "check the logs"
+        assert len(make_title("x" * 500)) <= 80
+
+    def test_make_title_strips_mention_markup(self):
+        raw = (
+            "[Mentioned: Test User (open_id=ou_1a2b3c4d)]\n\n"
+            "@test\\_bot @Test User\nUpdated, with notes"
+        )
+        assert make_title(raw) == "Updated, with notes"
+        assert make_title("@test\\_bot approve the MR then") == "approve the MR then"
+
+    def test_to_lark_md_remaps_unrenderable_syntax(self):
+        src = "## Cause\nfailing on `initiate_payment` (warn 5%)\n```py\nx = `raw`\n```\nafter"
+        assert to_lark_md(src) == (
+            "**Cause**\nfailing on **initiate_payment** (warn 5%)\n```py\nx = `raw`\n```\nafter"
+        )
+
+    def test_to_lark_md_flattens_pipe_tables(self):
+        src = (
+            "Noise:\n"
+            "| Count | Share | Signature |\n"
+            "|------:|------:|---|\n"
+            "| 156 | 53% | iText missing PDF image |\n"
+            "| 24 | | `Invoice` idempotent return |\n"
+            "after"
+        )
+        assert to_lark_md(src) == (
+            "Noise:\n"
+            "**Count · Share · Signature**\n"
+            "- 156 · 53% · iText missing PDF image\n"
+            "- 24 · **Invoice** idempotent return\n"
+            "after"
+        )
+
+    def test_to_lark_md_leaves_lone_pipe_line_alone(self):
+        assert to_lark_md("| just a pipe line |") == "| just a pipe line |"
+
+    def test_card_body_is_lark_md_with_divider_before_footer(self):
+        card = LifecycleCard(chat_id="oc_1", title="Q")
+        card.finalize("done", answer="see `errorCode`")
+        elements = card.build_card()["elements"]
+        assert elements[0] == {"tag": "markdown", "content": "see **errorCode**"}
+        assert elements[1] == {"tag": "hr"}
+        assert elements[-1]["tag"] == "note"
+
+    def test_matches_anchor_accepts_thread_root(self):
+        card = LifecycleCard(
+            chat_id="oc_1", anchor_message_id="om_ask", thread_anchor_id="om_root"
+        )
+        assert card.matches_anchor("om_ask")
+        assert card.matches_anchor("om_root")
+        assert not card.matches_anchor("om_other")
+        assert not card.matches_anchor("")
+        assert not LifecycleCard(chat_id="oc_1").matches_anchor("")
+
+
+class TestAdapterRouting:
+    def test_interim_creates_card_then_patches(self):
+        adapter = make_lifecycle_adapter()
+
+        async def scenario():
+            first = await adapter._lifecycle_interim_send("oc_1", "⏳ Working — 1 min", "om_ask", {})
+            second = await adapter._lifecycle_interim_send("oc_1", "↪ Redirected", "om_ask", {})
+            return first, second
+
+        first, second = asyncio.run(scenario())
+        assert first.success and first.message_id == "om_card1#e0"
+        assert second.success and second.message_id == "om_card1#e1"
+        assert len(adapter._sends) == 1
+        assert adapter._sends[0]["msg_type"] == "interactive"
+        assert len(adapter._patches) == 1
+
+    def test_edit_entry_updates_in_place(self):
+        adapter = make_lifecycle_adapter()
+
+        async def scenario():
+            sent = await adapter._lifecycle_interim_send("oc_1", "⏳ Working — 1 min", "om_ask", {})
+            edited = await adapter._lifecycle_edit_entry("om_card1", 0, "⏳ Working — 4 min")
+            return sent, edited
+
+        _, edited = asyncio.run(scenario())
+        assert edited.success
+        card = adapter._lifecycle_cards[CHAT_KEY]
+        assert "4 min" in card.entries[0].text
+        assert len(adapter._sends) == 1
+
+    def test_absorb_final_requires_anchor_match(self):
+        adapter = make_lifecycle_adapter()
+
+        async def scenario():
+            async with adapter._lifecycle_lock:
+                card = LifecycleCard(
+                    chat_id="oc_1",
+                    anchor_message_id="om_ask",
+                    thread_anchor_id="om_root",
+                )
+                card.message_id = "om_card1"
+                adapter._register_lifecycle_card(CHAT_KEY, card)
+                adapter._lifecycle_card_chats["om_card1"] = CHAT_KEY
+            wrong = await adapter._lifecycle_absorb_final(
+                "oc_1", "answer", reply_to="om_other", metadata=None, chunk_count=1
+            )
+            multi = await adapter._lifecycle_absorb_final(
+                "oc_1", "answer", reply_to="om_ask", metadata=None, chunk_count=2
+            )
+            thread = await adapter._lifecycle_absorb_final(
+                "oc_1", "answer", reply_to="om_root", metadata=None, chunk_count=1
+            )
+            return wrong, multi, thread
+
+        wrong, multi, right = asyncio.run(scenario())
+        assert wrong is None and multi is None
+        assert right.success and right.message_id == "om_card1"
+        card = adapter._lifecycle_cards[CHAT_KEY]
+        assert card.answer_absorbed and card.state == "done"
+        patched = json.loads(adapter._patches[-1].request_body.content)
+        assert patched["header"]["template"] == "green"
+
+    def test_close_marks_outcome_and_drops_state(self):
+        adapter = make_lifecycle_adapter()
+
+        async def scenario():
+            await adapter._lifecycle_interim_send("oc_1", "⏳ Working — 1 min", "om_ask", {})
+            await adapter._lifecycle_close("oc_1", "om_ask", ProcessingOutcome.FAILURE)
+
+        asyncio.run(scenario())
+        assert CHAT_KEY not in adapter._lifecycle_cards
+        assert not adapter._lifecycle_card_chats
+        patched = json.loads(adapter._patches[-1].request_body.content)
+        assert patched["header"]["template"] == "red"
+
+    def test_close_after_absorb_skips_extra_patch(self):
+        adapter = make_lifecycle_adapter()
+
+        async def scenario():
+            async with adapter._lifecycle_lock:
+                card = LifecycleCard(chat_id="oc_1", anchor_message_id="om_ask")
+                card.message_id = "om_card1"
+                adapter._register_lifecycle_card(CHAT_KEY, card)
+                adapter._lifecycle_card_chats["om_card1"] = CHAT_KEY
+            await adapter._lifecycle_absorb_final(
+                "oc_1", "answer", reply_to="om_ask", metadata=None, chunk_count=1
+            )
+            patch_count = len(adapter._patches)
+            await adapter._lifecycle_close("oc_1", "om_ask", ProcessingOutcome.SUCCESS)
+            return patch_count
+
+        patch_count = asyncio.run(scenario())
+        assert len(adapter._patches) == patch_count
+        assert CHAT_KEY not in adapter._lifecycle_cards
+
+    def test_failed_card_send_falls_back_to_none(self):
+        adapter = make_lifecycle_adapter()
+
+        async def _failing_send(**kwargs):
+            raise RuntimeError("boom")
+
+        adapter._feishu_send_with_retry = _failing_send
+        result = asyncio.run(adapter._lifecycle_interim_send("oc_1", "⏳ Working", "om_ask", {}))
+        assert result is None
+
+
+class TestConcurrentTurns:
+    """A second question sent mid-run is its own turn, so it gets its own
+    titled card — sharing one card stranded the slower turn (live 2026-09-01:
+    turn A's answer sealed the card, turn B fell out to a plain message)."""
+
+    @staticmethod
+    def _event(chat_id, message_id, text):
+        return SimpleNamespace(
+            source=SimpleNamespace(chat_id=chat_id),
+            message_id=message_id,
+            text=text,
+            user_name="Test User",
+            reply_to_message_id=None,
+        )
+
+    def _adapter(self):
+        adapter = make_lifecycle_adapter()
+        adapter._reactions_enabled = lambda: False
+        sends = iter(["om_cardA", "om_cardB"])
+
+        async def _fake_send(**kwargs):
+            adapter._sends.append(kwargs)
+            return _ok_response(next(sends))
+
+        adapter._feishu_send_with_retry = _fake_send
+        return adapter
+
+    def test_each_turn_gets_its_own_card(self):
+        adapter = self._adapter()
+
+        async def scenario():
+            await adapter.on_processing_start(self._event("oc_1", "om_a", "check PCS shutdown"))
+            await adapter.on_processing_start(self._event("oc_1", "om_b", "do what vivek says"))
+            a = await adapter._lifecycle_interim_send("oc_1", "reading", "om_a", {})
+            b = await adapter._lifecycle_interim_send("oc_1", "terminal", "om_b", {})
+            return a, b
+
+        a, b = asyncio.run(scenario())
+        assert a.message_id == "om_cardA#e0"
+        assert b.message_id == "om_cardB#e0"
+        titles = {c.title for c in adapter._lifecycle_cards.values()}
+        assert titles == {"check PCS shutdown", "do what vivek says"}
+
+    def test_first_answer_does_not_strand_the_other_turn(self):
+        adapter = self._adapter()
+
+        async def scenario():
+            await adapter.on_processing_start(self._event("oc_1", "om_a", "check PCS shutdown"))
+            await adapter.on_processing_start(self._event("oc_1", "om_b", "do what vivek says"))
+            await adapter._lifecycle_interim_send("oc_1", "reading", "om_a", {})
+            await adapter._lifecycle_interim_send("oc_1", "terminal", "om_b", {})
+            first = await adapter._lifecycle_absorb_final(
+                "oc_1", "answer A", reply_to="om_a", metadata=None, chunk_count=1
+            )
+            await adapter.on_processing_complete(
+                self._event("oc_1", "om_a", "check PCS shutdown"), ProcessingOutcome.SUCCESS
+            )
+            second = await adapter._lifecycle_absorb_final(
+                "oc_1", "answer B", reply_to="om_b", metadata=None, chunk_count=1
+            )
+            return first, second
+
+        first, second = asyncio.run(scenario())
+        assert first.message_id == "om_cardA"
+        assert second.message_id == "om_cardB", "turn B's answer must land in turn B's card"
+        assert len(adapter._sends) == 2, "no third, untitled card"
+        card_b = adapter._lifecycle_cards[adapter._lifecycle_card_key("oc_1", "om_b")]
+        assert card_b.answer == "answer B" and card_b.title == "do what vivek says"
+
+
+class TestFastTurnStillGetsACard:
+    """A turn that finishes before any status update (no tools, under the
+    heartbeat threshold) still lands in a card, not a plain message.
+    Live 2026-08-31 13:22: 38.2s / api_calls=2 posted as bare text."""
+
+    def test_answer_creates_the_card_when_no_progress_ran(self):
+        adapter = make_lifecycle_adapter()
+
+        async def scenario():
+            async with adapter._lifecycle_lock:
+                adapter._register_lifecycle_card(
+                    CHAT_KEY, LifecycleCard(chat_id="oc_1", anchor_message_id="om_ask")
+                )
+            return await adapter._lifecycle_absorb_final(
+                "oc_1", "the answer", reply_to="om_ask", metadata=None, chunk_count=1
+            )
+
+        result = asyncio.run(scenario())
+        assert result is not None and result.success
+        assert result.message_id == "om_card1"
+        assert len(adapter._sends) == 1
+        assert adapter._sends[0]["msg_type"] == "interactive"
+        payload = json.loads(adapter._sends[0]["payload"])
+        assert payload["header"]["template"] == "green"
+        assert "the answer" in payload["elements"][0]["content"]
+
+    def test_send_failure_leaves_the_card_reusable(self):
+        adapter = make_lifecycle_adapter()
+
+        async def _failing_send(**kwargs):
+            raise RuntimeError("boom")
+
+        adapter._feishu_send_with_retry = _failing_send
+
+        async def scenario():
+            async with adapter._lifecycle_lock:
+                adapter._register_lifecycle_card(
+                    CHAT_KEY, LifecycleCard(chat_id="oc_1", anchor_message_id="om_ask")
+                )
+            return await adapter._lifecycle_absorb_final(
+                "oc_1", "the answer", reply_to="om_ask", metadata=None, chunk_count=1
+            )
+
+        assert asyncio.run(scenario()) is None
+        card = adapter._lifecycle_cards[CHAT_KEY]
+        assert card.state == "working" and not card.answer_absorbed
+
+
+class TestGeneratedCardTitle:
+    """The card ships with the trimmed prompt, then upgrades to the auxiliary
+    titler's output — which takes seconds, so it must never block the turn."""
+
+    def test_generated_title_replaces_the_raw_prompt(self, monkeypatch):
+        import agent.title_generator as tg
+
+        adapter = make_lifecycle_adapter()
+        del adapter._spawn_lifecycle_title  # exercise the real one
+        monkeypatch.setattr(
+            tg, "generate_title", lambda *a, **k: "Count August pending by payment method"
+        )
+
+        async def scenario():
+            card = LifecycleCard(chat_id="oc_1", title="can you also show me how many of…")
+            async with adapter._lifecycle_lock:
+                adapter._register_lifecycle_card(CHAT_KEY, card)
+            await adapter._lifecycle_interim_send("oc_1", "working", "om_ask", {})
+            await adapter._apply_lifecycle_title(card, "can you also show me how many…")
+            return card
+
+        card = asyncio.run(scenario())
+        assert card.title == "Count August pending by payment method"
+        assert json.loads(adapter._sends[0]["payload"])["header"]["title"]["content"].startswith("⏳ can you")
+        assert len(adapter._patches) == 1
+
+    def test_title_is_dropped_when_the_card_was_replaced(self, monkeypatch):
+        import agent.title_generator as tg
+
+        adapter = make_lifecycle_adapter()
+        monkeypatch.setattr(tg, "generate_title", lambda *a, **k: "A better title")
+
+        async def scenario():
+            stale = LifecycleCard(chat_id="oc_1", title="old")
+            async with adapter._lifecycle_lock:
+                adapter._register_lifecycle_card(CHAT_KEY, LifecycleCard(chat_id="oc_1", title="live"))
+            await adapter._apply_lifecycle_title(stale, "prompt")
+            return stale, adapter._lifecycle_cards[CHAT_KEY]
+
+        stale, live = asyncio.run(scenario())
+        assert stale.title == "old" and live.title == "live"
+
+    def test_titler_failure_keeps_the_raw_prompt(self, monkeypatch):
+        import agent.title_generator as tg
+
+        adapter = make_lifecycle_adapter()
+
+        def _boom(*a, **k):
+            raise RuntimeError("no provider configured")
+
+        monkeypatch.setattr(tg, "generate_title", _boom)
+
+        async def scenario():
+            card = LifecycleCard(chat_id="oc_1", title="raw prompt")
+            async with adapter._lifecycle_lock:
+                adapter._register_lifecycle_card(CHAT_KEY, card)
+            await adapter._apply_lifecycle_title(card, "prompt")
+            return card
+
+        assert asyncio.run(scenario()).title == "raw prompt"

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -530,6 +530,7 @@ async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch
     expected_metadata = {
         "thread_id": "1234567890.000001",
         "message_id": "1234567890.000001",
+        "_interim_send": True,
     }
     assert adapter.sent[0]["metadata"] == expected_metadata
     assert all(call["metadata"] == expected_metadata for call in adapter.typing)

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -357,6 +357,7 @@ async def test_gateway_runner_busy_ack_replies_to_triggering_message_for_telegra
         "telegram_dm_topic_reply_fallback": True,
         "direct_messages_topic_id": "20197",
         "telegram_reply_to_message_id": "463",
+        "_interim_send": True,
     }
 
 


### PR DESCRIPTION
On Lark, a turn currently posts a new message for each status update, so an active chat fills with progress noise and the final answer is separated from the work that produced it.

This collapses a turn into a **single card that is patched in place**.

## What's here

- One card per turn, keyed by the turn's anchor
- Concurrent turns in a chat share a card instead of stranding each other
- The card is posted even when a turn finishes before any status update
- A short card title is generated with the auxiliary titler
- Reaction-routing is gated behind `reaction_routing`, **default off**, so existing behaviour is unchanged unless opted in
- `FEISHU_DM_POLICY=disabled` drops DMs while groups still admit

Lifecycle state is extracted into `plugins/platforms/feishu/lifecycle_card.py` rather than growing the adapter further.

## Tests

New `tests/gateway/test_feishu_lifecycle_card.py` (25 tests) covers card creation/patching, in-place edits, anchor matching on absorb, close/outcome, concurrent turns, and generated titles.

Note: three pre-existing failures in `tests/gateway/test_feishu.py` (`test_url_verification_requires_configured_verification_token`, `test_webhook_request_uses_same_message_dispatch_path`, `test_webhook_request_rejects_oversized_chunked_body_while_reading`) reproduce on an unmodified `main` in my environment and are unrelated to this change.

This has been running in production against a Lark workspace for several weeks.