### PR TITLE
fix(gateway): run sync plugin command handlers off the event loop (#105279)

### DIFF
--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -984,9 +984,15 @@ class GatewayInboundMixin:
                 from hermes_cli.plugins import get_plugin_command_handler
                 plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
                 if plugin_handler:
-                    result = plugin_handler(event.get_command_args().strip())
-                    if asyncio.iscoroutine(result):
-                        result = await result
+                    user_args = event.get_command_args().strip()
+                    if asyncio.iscoroutinefunction(plugin_handler):
+                        result = await plugin_handler(user_args)
+                    else:
+                        # Sync handlers may do blocking I/O; running them on the loop
+                        # thread stalls every task (shutdown_watchdog probes included).
+                        result = await asyncio.to_thread(plugin_handler, user_args)
+                        if asyncio.iscoroutine(result):
+                            result = await result
                     return True, str(result) if result else None, command
             except Exception as e:
                 logger.warning("Plugin command dispatch failed: %s", e)

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -225,3 +225,38 @@ async def test_command_hook_rewrite_routes_to_plugin(monkeypatch):
     # First emit_collect fires on the original command; after rewrite the
     # dispatcher does NOT re-fire for the new command (one decision per turn).
     assert call_log == ["command:status"]
+
+
+@pytest.mark.asyncio
+async def test_sync_plugin_command_runs_off_loop_thread(monkeypatch):
+    """A sync plugin handler doing blocking I/O must run off the gateway loop thread,
+    else the loop stops answering shutdown_watchdog probes and is killed with exit 75."""
+    import threading
+    import time
+
+    import gateway.run as gateway_run
+    from hermes_cli import plugins as _plugins_mod
+
+    runner = _make_runner()
+    seen_threads = []
+
+    def _blocking_handler(args: str) -> str:
+        seen_threads.append(threading.current_thread().name)
+        time.sleep(0.15)
+        return f"sync {args}"
+
+    monkeypatch.setattr(
+        _plugins_mod,
+        "get_plugin_command_handler",
+        lambda name: _blocking_handler if name == "slow-api" else None,
+    )
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/slow-api arg"))
+
+    assert result == "sync arg"
+    assert seen_threads, "handler must have run"
+    # pytest-asyncio runs the loop on the main thread; the blocking handler must not.
+    assert seen_threads[0] != threading.main_thread().name


### PR DESCRIPTION
## Summary

Fixes #105279.

A **synchronous** plugin-registered slash-command handler ran **inline on the gateway's event-loop thread** (`gateway/run_inbound.py`, `_hm_dispatch_quick_and_plugin_commands`):

```python
result = plugin_handler(event.get_command_args().strip())
if asyncio.iscoroutine(result):
    result = await result
```

Only a handler that *returns* a coroutine was awaited; a plain `def` handler executed inline, so blocking I/O inside it (`requests.get(..., timeout=60)`) stalled the whole loop. The threaded liveness watchdog in `gateway/shutdown_watchdog.py` probes the loop via `call_soon_threadsafe` (3 × 30 s), gets no answers, and `os._exit(75)`s the gateway mid-handler.

The CLI/TUI path is unaffected: `tui_gateway/methods_tools.py` runs plugin commands on its RPC worker pool. It is specifically the gateway dispatch that ran third-party plugin code on the loop thread.

## Change

- `async def` handlers keep being awaited directly (no behavior change);
- sync handlers now run through `asyncio.to_thread`, so blocking I/O happens off the loop thread while the result path stays identical (`str(result) if result else None`).

## Testing

- New regression test `test_sync_plugin_command_runs_off_loop_thread`: registers a sync handler doing blocking I/O (`time.sleep`) and asserts it executed on a worker thread, not the loop thread. Fails on `main` (handler runs on `MainThread`), passes with the fix.
- `tests/gateway/` dispatch-related suites (unknown-command, slash-access, discord-slash, config, update-streaming, feishu): 93 passed.
- Mutation check: reverting just the `to_thread` routing makes the new test fail.

```diff
 gateway/run_inbound.py                | 12 +++++++++---
 tests/gateway/test_unknown_command.py | 35 +++++++++++++++++++++++++++++++++++
```
