### PR TITLE
fix(honcho): fence dialectic prefetch against session-switch races

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -112,6 +112,12 @@ class HonchoMemoryProvider(DialecticMixin, MemoryProvider):
         self._recall_mode = "hybrid"  # "context", "tools", or "hybrid"
         self._recall_sync = False
         self._recall_generation = object()
+        # Session-identity fence for the async dialectic prefetch (queue_prefetch/_spawn_dialectic).
+        # Unlike _recall_generation (bumped every turn for the synchronous recall_sync path),
+        # this must survive turn boundaries — a dialectic result fired on turn N is meant to be
+        # consumed on turn N+1..N+k — so it is bumped only on real session-identity changes
+        # (initialize/on_session_switch/shutdown), never on_turn_start.
+        self._dialectic_generation = object()
         self._recall_sync_thread: Optional[threading.Thread] = None
         self._recall_sync_lock = threading.Lock()
         # Base context cache — refreshed on context_cadence, not frozen.
@@ -133,6 +139,7 @@ class HonchoMemoryProvider(DialecticMixin, MemoryProvider):
         # result was fired at, and consecutive empty dialectic returns (drives backoff).
         self._prefetch_thread_started_at: float = 0.0
         self._prefetch_result_fired_at: int = -999
+        self._prefetch_result_generation: object | None = None
         self._dialectic_empty_streak: int = 0
 
         # Tools-only mode may defer session initialization until a tool call.
@@ -187,6 +194,7 @@ class HonchoMemoryProvider(DialecticMixin, MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         """Configure recall settings and start (or defer) Honcho session creation."""
         self._recall_generation = object()
+        self._dialectic_generation = object()
         try:
             agent_context, platform = kwargs.get("agent_context", ""), kwargs.get("platform", "cli")
             if agent_context in {"cron", "flush"} or platform == "cron":
@@ -558,6 +566,7 @@ class HonchoMemoryProvider(DialecticMixin, MemoryProvider):
     def on_session_switch(self, new_session_id: str, **kwargs) -> None:
         """Discard in-flight recall even when the configured backend session is pinned."""
         self._recall_generation = object()
+        self._dialectic_generation = object()
 
     # ----- Writes -----
 
@@ -807,6 +816,7 @@ class HonchoMemoryProvider(DialecticMixin, MemoryProvider):
 
     def shutdown(self) -> None:
         self._recall_generation = object()
+        self._dialectic_generation = object()
         for t in (self._prefetch_thread, self._sync_thread, self._memwrite_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)

--- a/plugins/memory/honcho/dialectic.py
+++ b/plugins/memory/honcho/dialectic.py
@@ -67,18 +67,31 @@ class DialecticMixin:
     ) -> threading.Thread:
         """Start a background dialectic run that publishes into the pending-result slot. Only a
         non-empty result advances ``_last_dialectic_turn`` (so empty returns retry next turn) and
-        resets the empty streak; failures widen the backoff."""
+        resets the empty streak; failures widen the backoff.
+
+        ``_dialectic_generation`` is captured before the HTTP call(s) start and re-checked before
+        any shared state is touched, so a session switch (``on_session_switch``/``initialize``/
+        ``shutdown``) that lands while this thread is still in flight makes its result inert —
+        it can never be published into (and later consumed by) a different session, even when the
+        configured backend session key is pinned across the switch."""
+        generation = self._dialectic_generation
+
         def _run() -> None:
             try:
                 r = self._run_dialectic_depth(query, use_query_rewrite=use_query_rewrite)
             except Exception as exc:
                 logger.debug("Honcho %s failed: %s", log_label, exc)
-                self._note_dialectic_failure(exc)
+                if generation is self._dialectic_generation:
+                    self._note_dialectic_failure(exc)
+                return
+            if generation is not self._dialectic_generation:
+                logger.debug("Honcho %s result discarded: session changed while the fetch was in flight", log_label)
                 return
             if r and r.strip():
                 with self._prefetch_lock:
                     self._prefetch_result = r
                     self._prefetch_result_fired_at = fired_at
+                    self._prefetch_result_generation = generation
                 self._last_dialectic_turn = fired_at
                 self._dialectic_empty_streak = 0
             else:
@@ -91,10 +104,16 @@ class DialecticMixin:
         return thread
 
     def _consume_pending_dialectic(self) -> str:
-        """Pop the pending dialectic result, or "" when none is ready or it is stale."""
+        """Pop the pending dialectic result, or "" when none is ready, it is stale, or it was
+        fired for a session generation that no longer matches (a session switch happened after
+        it was published but before it was consumed)."""
         with self._prefetch_lock:
-            dialectic_result, fired_at = self._prefetch_result, self._prefetch_result_fired_at
-            self._prefetch_result, self._prefetch_result_fired_at = "", -999
+            dialectic_result, fired_at, generation = (
+                self._prefetch_result, self._prefetch_result_fired_at, self._prefetch_result_generation)
+            self._prefetch_result, self._prefetch_result_fired_at, self._prefetch_result_generation = "", -999, None
+        if dialectic_result and generation is not None and generation is not self._dialectic_generation:
+            logger.debug("Honcho pending dialectic discarded: session changed since it was fired")
+            return ""
         stale_limit = self._dialectic_cadence * self._STALE_RESULT_MULTIPLIER
         if dialectic_result and fired_at >= 0 and (self._turn_count - fired_at) > stale_limit:
             logger.debug("Honcho pending dialectic discarded as stale: fired_at=%d, turn=%d, limit=%d",

--- a/tests/honcho_plugin/test_dialectic.py
+++ b/tests/honcho_plugin/test_dialectic.py
@@ -1,0 +1,133 @@
+"""Session-identity fencing for the async dialectic prefetch (_spawn_dialectic /
+_consume_pending_dialectic) — the sibling of recall_sync.py's _recall_generation fence,
+but scoped to session-identity changes only (never per-turn) since dialectic results are
+meant to survive across turn boundaries."""
+import threading
+import time
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.client import HonchoClientConfig
+
+
+class DialecticManager:
+    """Fake session manager whose dialectic_query() can be held open with a barrier."""
+
+    def __init__(self):
+        self.calls = []
+
+    def dialectic_query(self, session, prompt, **kwargs):
+        self.calls.append((session, prompt, kwargs))
+        return f"dialectic-result-for:{session}"
+
+
+def make_provider(**options):
+    provider = HonchoMemoryProvider()
+    cfg = HonchoClientConfig(timeout=5, **options)
+    provider._config = cfg
+    provider._manager = DialecticManager()
+    provider._session_key = "session-a"
+    provider._session_initialized = True
+    for name in ("recall_mode", "injection_frequency", "context_cadence",
+                 "dialectic_cadence", "dialectic_depth", "dialectic_depth_levels", "reasoning_heuristic"):
+        setattr(provider, f"_{name}", getattr(cfg, name))
+    return provider
+
+
+def test_session_switch_during_fetch_prevents_publish_and_cross_session_leak():
+    """A dialectic fetch fired for session A must not land in _prefetch_result (and
+    therefore must never be consumable by session B) if on_session_switch fires while
+    the background HTTP call is still in flight."""
+    provider = make_provider()
+    entered, release = threading.Event(), threading.Event()
+
+    def blocked(session, prompt, **kwargs):
+        entered.set()
+        assert release.wait(3), "test setup: release was never signalled"
+        return f"LEAKED CONTENT FROM {session}"
+
+    provider._manager.dialectic_query = blocked
+    provider.on_turn_start(1, "Plan the garden")
+    thread = provider._spawn_dialectic(
+        "Plan the garden", thread_name="test-dialectic", fired_at=1, log_label="test prefetch")
+    assert entered.wait(2)
+
+    # Session switch lands while the fetch above is still blocked mid-flight — this is the
+    # exact race: honcho_sync's queue_prefetch() fired a background dialectic thread, then a
+    # /new, /branch, /resume, or compression-triggered session switch happened before it returned.
+    provider.on_session_switch("session-b")
+    provider._session_key = "session-b"
+    provider._turn_count = 1  # new session, its own turn 1 (turn numbers can repeat)
+
+    release.set()
+    thread.join(timeout=3)
+    assert not thread.is_alive()
+
+    # The stale session-A result must never have been published into shared state...
+    assert provider._prefetch_result == ""
+    assert provider._prefetch_result_fired_at == -999
+    assert provider._prefetch_result_generation is None
+    # ...so session B's own consume call gets nothing, never session A's leaked content.
+    assert provider._consume_pending_dialectic() == ""
+
+
+def test_session_switch_between_publish_and_consume_discards_result():
+    """Even if a result already landed in _prefetch_result before the switch (publish raced
+    ahead of on_session_switch), _consume_pending_dialectic must still reject it once the
+    generation has moved on — the switch may occur in the gap between publish and consume."""
+    provider = make_provider()
+    provider.on_turn_start(1, "Plan the garden")
+    thread = provider._spawn_dialectic(
+        "Plan the garden", thread_name="test-dialectic", fired_at=1, log_label="test prefetch")
+    thread.join(timeout=3)
+    assert provider._prefetch_result == "dialectic-result-for:session-a"
+
+    # Now the session switches before anyone calls _consume_pending_dialectic() for it.
+    provider.on_session_switch("session-b")
+    provider._session_key = "session-b"
+    provider._turn_count = 1
+
+    assert provider._consume_pending_dialectic() == ""
+
+
+def test_normal_cross_turn_consumption_is_not_broken_by_the_fence():
+    """Regression guard for the fence itself: a dialectic result fired on turn N, with no
+    session switch, must still be consumable on a later turn within the same session — the
+    fence must key off session-identity events only, never off on_turn_start."""
+    provider = make_provider()
+    provider.on_turn_start(1, "Plan the garden")
+    thread = provider._spawn_dialectic(
+        "Plan the garden", thread_name="test-dialectic", fired_at=1, log_label="test prefetch")
+    thread.join(timeout=3)
+    assert provider._prefetch_result == "dialectic-result-for:session-a"
+
+    # Turn advances within the SAME session (no session switch) — result must still be usable.
+    provider.on_turn_start(2, "Debug the compiler")
+    assert provider._consume_pending_dialectic() == "dialectic-result-for:session-a"
+
+
+def test_note_dialectic_failure_not_counted_against_new_session():
+    """A late failure from an abandoned (pre-switch) dialectic fetch must not widen the
+    NEW session's empty-streak backoff."""
+    provider = make_provider()
+    entered, release = threading.Event(), threading.Event()
+
+    def blocked_then_raise(session, prompt, **kwargs):
+        entered.set()
+        assert release.wait(3)
+        raise RuntimeError("simulated backend failure for the old session")
+
+    provider._manager.dialectic_query = blocked_then_raise
+    provider.on_turn_start(1, "Plan the garden")
+    thread = provider._spawn_dialectic(
+        "Plan the garden", thread_name="test-dialectic", fired_at=1, log_label="test prefetch")
+    assert entered.wait(2)
+
+    provider.on_session_switch("session-b")
+    provider._session_key = "session-b"
+    streak_before = provider._dialectic_empty_streak
+
+    release.set()
+    thread.join(timeout=3)
+    assert not thread.is_alive()
+
+    assert provider._dialectic_empty_streak == streak_before


### PR DESCRIPTION
## What does this PR do?

Fences the async dialectic prefetch (`_spawn_dialectic` / `_consume_pending_dialectic` in `plugins/memory/honcho/dialectic.py`) against session-switch races, mirroring the `_recall_generation` mechanism `99f7d2b4df` ("fix(honcho): isolate recall generations and reject unscoped fallback") already added for the synchronous `recall_sync.py` path — but adapted so it doesn't break the dialectic layer's cross-turn design.

### The bug

`99f7d2b4df` added `_recall_generation`, bumped on `initialize()`, `on_turn_start()`, `on_session_switch()`, and `shutdown()`, and wired it into `recall_sync.py`'s `prefetch_sync()`. That path is only active when `recallSync: true` is configured.

The **default** path (`recallSync: false`, the normal hybrid/context mode) uses a completely different, fire-and-forget mechanism in `dialectic.py`:

- `queue_prefetch()` calls `_spawn_dialectic()` at the end of a turn, which starts a background thread that eventually writes into `self._prefetch_result` (a single shared slot on the provider instance) once the Honcho `dialectic_query()` HTTP call(s) return.
- A later turn's `prefetch()` calls `_consume_pending_dialectic()`, which pops that slot and injects it into the model's context, subject only to a turn-count staleness check (`(self._turn_count - fired_at) > dialectic_cadence * 2`).

`_recall_generation` was never wired into this path at all. If a session switch (`/new`, `/branch`, `/resume`, or a compression-triggered switch — all of which call `MemoryManager.on_session_switch()` on the *same* provider instance, since the provider persists across the switch) happens while a dialectic background thread is still in flight, the thread's result is written into `self._prefetch_result` unconditionally when it completes — with no session-identity check. A subsequent turn for the *new* session then consumes it via `_consume_pending_dialectic()`, since the turn-count heuristic alone doesn't know the session changed. This leaks one session's dialectic recall content into a different session's context. (`on_session_switch()`'s own docstring — "Discard in-flight recall even when the configured backend session is pinned" — signals this was meant to be handled generically, but the wiring only reached `recall_sync.py`.)

Straight reuse of `_recall_generation` doesn't work here: it's bumped on *every* `on_turn_start()`, which is correct for `recall_sync.py`'s fully-synchronous, single-turn-scoped design, but would make every dialectic result "wrong generation" the instant the next turn starts — breaking the intended cross-turn persistence (a result fired on turn N is meant to be consumable on turn N+1..N+k).

### The fix

Adds a second, narrower token, `_dialectic_generation`, bumped only on real session-identity changes (`initialize()`, `on_session_switch()`, `shutdown()`) and deliberately **not** on `on_turn_start()`:

- `_spawn_dialectic()` captures `_dialectic_generation` before starting the background thread. Before publishing into `_prefetch_result` (or before counting a failure against the backoff streak), it re-checks the captured value against the live one and discards the result if they no longer match.
- The published result now also carries its generation (`_prefetch_result_generation`), and `_consume_pending_dialectic()` rejects it if the *current* generation has since moved on — this covers the narrower window where a result already landed before the switch, but is consumed after it.

### Test

`tests/honcho_plugin/test_dialectic.py` (new), mirroring the barrier/event technique `tests/honcho_plugin/test_recall_sync.py` already uses for `_recall_generation`:

- `test_session_switch_during_fetch_prevents_publish_and_cross_session_leak` — blocks the fake manager's `dialectic_query()` mid-flight, fires `on_session_switch()` while it's blocked, then releases it; asserts the result never reaches `_prefetch_result` and the new session's `_consume_pending_dialectic()` gets nothing.
- `test_session_switch_between_publish_and_consume_discards_result` — lets the fetch complete and publish normally, then switches session *before* anyone consumes it; asserts the consume call still discards it.
- `test_normal_cross_turn_consumption_is_not_broken_by_the_fence` — regression guard for the fence itself: with no session switch, a result fired on turn 1 must still be consumable after `on_turn_start(2, ...)`.
- `test_note_dialectic_failure_not_counted_against_new_session` — an abandoned pre-switch fetch that later raises must not widen the new session's empty-streak backoff.

**Mutation-verify**: reverted the fix in `plugins/memory/honcho/__init__.py` and `plugins/memory/honcho/dialectic.py` only (test file untouched) and reran — 3 of the 4 tests failed exactly as expected (the leak was reproduced, and the failure-isolation regressed); the 4th (normal cross-turn consumption) correctly passed both before and after, since it's a non-regression guard rather than a bug repro. Restored the fix and confirmed all 4 pass again.

Ran the full Honcho-related test suite (`tests/honcho_plugin/`, plus `tests/test_honcho_client_concurrency.py`, `tests/test_honcho_client_config.py`, `tests/test_honcho_session_context.py`, `tests/test_honcho_startup_fail_open.py`, `tests/plugins/memory/test_honcho_cli_peers.py`, `tests/plugins/memory/test_honcho_config_schema.py`): 349 passed, 16 pre-existing skips, 0 failures.

### Competitor check

Searched `gh pr list`/`gh issue list` across "honcho dialectic", "honcho recall generation", "dialectic session switch/race", "honcho session", "honcho generation", and related terms. No open or merged PR addresses this specific gap. The one open PR that also touches `dialectic.py`, #103889 ("honor the config keys that parsed and did nothing, bound and serialize the session manager, and stop minting peers"), only adds an `owner=self` kwarg to the same `spawn_context_thread()` call site (an unrelated thread-ownership/shutdown-tracking change) — trivial textual proximity, not a semantic conflict; it does not touch `_prefetch_result`, `_recall_generation`, or `on_session_switch` at all.
