### PR TITLE
fix(memory): count agent retrievals in holographic retrieval_count

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -210,17 +210,37 @@ class HolographicMemoryProvider(MemoryProvider):
 
     def _entity_query(self, method: str, a: dict) -> str:
         """'probe' / 'related': single-entity retriever queries."""
-        return _results(getattr(self._retriever, method)(a["entity"], category=a.get("category"), limit=_limit(a)))
+        results = getattr(self._retriever, method)(a["entity"], category=a.get("category"), limit=_limit(a))
+        return _results(self._track_retrieval(results))
+
+    def _track_retrieval(self, results: list) -> list:
+        """Bump retrieval_count for facts returned by an explicit agent retrieval.
+
+        Advisory bookkeeping: a failing bump must never break the retrieval result
+        (the counter is usage telemetry, not a retrieval dependency). Auto-prefetch
+        calls retriever.search() directly and bypasses this, so it is intentionally
+        not counted; contradict/list return diagnostics/browse data and are not
+        retrieval recalls."""
+        if not self._store:  # never called before initialize(); guard mirrors system_prompt_block
+            return results
+        try:
+            ids = list(dict.fromkeys(r.get("fact_id") for r in results if r.get("fact_id")))
+            if ids:
+                self._store.bump_retrieval(ids)
+        except Exception as exc:
+            logger.warning("retrieval_count bump failed (advisory, retrieval unaffected): %s", exc, exc_info=True)
+        return results
 
     _TOOL_HANDLERS = {
         "fact_store": _tool_handler({
             "add": lambda self, a: json.dumps({"fact_id": self._store.add_fact(
                 a["content"], category=a.get("category", "general"), tags=a.get("tags", "")), "status": "added"}),
-            "search": lambda self, a: _results(self._retriever.search(
-                a["query"], category=a.get("category"), min_trust=float(a.get("min_trust", self._min_trust)), limit=_limit(a))),
+            "search": lambda self, a: _results(self._track_retrieval(self._retriever.search(
+                a["query"], category=a.get("category"), min_trust=float(a.get("min_trust", self._min_trust)), limit=_limit(a)))),
             "probe": lambda self, a: self._entity_query("probe", a),
             "related": lambda self, a: self._entity_query("related", a),
-            "reason": lambda self, a: _results(self._retriever.reason(a["entities"], category=a.get("category"), limit=_limit(a)))
+            "reason": lambda self, a: _results(self._track_retrieval(self._retriever.reason(
+                a["entities"], category=a.get("category"), limit=_limit(a))))
             if a.get("entities") else tool_error("reason requires 'entities' list"),
             "contradict": lambda self, a: _results(self._retriever.contradict(category=a.get("category"), limit=_limit(a))),
             "update": lambda self, a: json.dumps({"updated": self._store.update_fact(

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -198,6 +198,28 @@ class MemoryStore:
                    "ORDER BY trust_score DESC LIMIT ?")
             return [dict(r) for r in self._conn.execute(sql, params).fetchall()]
 
+    def bump_retrieval(self, fact_ids: list[int]) -> None:
+        """Increment retrieval_count for the given facts (advisory usage telemetry).
+
+        Called from the tool-handler layer after explicit agent retrievals. Counting lives
+        here, on the shared connection under the shared lock, so it cannot race sibling
+        store instances (main agent + subagents share one connection per DB).
+        """
+        if not fact_ids:
+            return
+        # Batch the UPDATE so an oversized id list can never hit SQLite's
+        # "too many SQL variables" limit (the advisory path must stay safe
+        # for any input size; the caller does not cap limit itself).
+        batch_size = 500
+        with self._lock:
+            for i in range(0, len(fact_ids), batch_size):
+                batch = list(fact_ids[i:i + batch_size])
+                placeholders = ",".join("?" * len(batch))
+                self._write(
+                    f"UPDATE facts SET retrieval_count = retrieval_count + 1 WHERE fact_id IN ({placeholders})",
+                    batch,
+                )
+
     def record_feedback(self, fact_id: int, helpful: bool) -> dict:
         """Adjust trust asymmetrically: helpful -> +0.05 and helpful_count += 1; unhelpful -> -0.10.
         Returns {fact_id, old_trust, new_trust, helpful_count}. Raises KeyError if fact_id is unknown."""

--- a/tests/plugins/memory/test_holographic_retrieval_count.py
+++ b/tests/plugins/memory/test_holographic_retrieval_count.py
@@ -1,0 +1,139 @@
+"""End-to-end tests for retrieval_count tracking on the fact_store tool path.
+
+Issue #78801: retrieval_count was never incremented when the agent retrieved
+facts, because every read path (FactRetriever search/probe/related/reason)
+only SELECTed and the one UPDATE in the codebase (the old store.search_facts)
+had zero callers. The memory janitor therefore flagged healthy facts as
+"stale / never retrieved".
+
+Fix shape: a locked MemoryStore.bump_retrieval(ids) helper, called from the
+tool-handler layer (HolographicMemoryProvider._track_retrieval) after each
+successful agent retrieval. Counting at the handler boundary means:
+
+- search/probe/related/reason count, regardless of internal numpy/HRR or FTS5
+  fallback paths,
+- auto-prefetch (which calls retriever.search() directly) is intentionally
+  NOT counted,
+- contradict/list (diagnostics/browse) are intentionally NOT counted,
+- a failing bump never breaks the retrieval result (advisory telemetry).
+
+These tests drive the real handle_tool_call dispatch and assert exact
+retrieval_count values in the DB.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+pytest.importorskip("numpy")  # retrieval module imports numpy indirectly
+
+from plugins.memory.holographic import HolographicMemoryProvider
+
+
+@pytest.fixture
+def provider(tmp_path):
+    """Provider with a fresh DB and a few facts, initialized like a real session."""
+    db_path = tmp_path / "memory_store.db"
+    prov = HolographicMemoryProvider(config={"db_path": str(db_path), "hrr_dim": 64})
+    prov.initialize("test-session")
+    prov.handle_tool_call("fact_store", {"action": "add", "content": "The deployment rollback failed because of stale migration state.", "category": "project"})
+    prov.handle_tool_call("fact_store", {"action": "add", "content": "Compaction settings tuned to 0.85 threshold.", "category": "tool"})
+    prov.handle_tool_call("fact_store", {"action": "add", "content": "Jordan Miller and Alex Smith pair on database tuning.", "category": "project"})
+    yield prov
+    prov.shutdown()
+
+
+def _counts(prov) -> dict:
+    """fact_id -> retrieval_count straight from the DB."""
+    return {r["fact_id"]: r["retrieval_count"] for r in prov._store.list_facts()}
+
+
+def _ids(prov, raw: str) -> list[int]:
+    return [r["fact_id"] for r in json.loads(raw)["results"]]
+
+
+class TestRetrievalCountToolPath:
+    def test_add_does_not_bump(self, provider):
+        counts = _counts(provider)
+        assert set(counts.values()) == {0}
+
+    def test_search_bumps_returned_facts_exactly_once(self, provider):
+        raw = provider.handle_tool_call("fact_store", {"action": "search", "query": "deployment rollback"})
+        returned = _ids(provider, raw)
+        assert returned, "search should return the deployment fact"
+        counts = _counts(provider)
+        for fact_id in returned:
+            assert counts[fact_id] == 1
+        # the other facts were not returned, so they stay at zero
+        for fact_id, count in counts.items():
+            if fact_id not in returned:
+                assert count == 0
+
+    def test_repeated_search_accumulates(self, provider):
+        provider.handle_tool_call("fact_store", {"action": "search", "query": "deployment"})
+        provider.handle_tool_call("fact_store", {"action": "search", "query": "deployment"})
+        returned = _ids(provider, provider.handle_tool_call("fact_store", {"action": "search", "query": "deployment"}))
+        counts = _counts(provider)
+        for fact_id in returned:
+            assert counts[fact_id] == 3
+
+    def test_probe_bumps(self, provider):
+        raw = provider.handle_tool_call("fact_store", {"action": "probe", "entity": "Jordan Miller"})
+        returned = _ids(provider, raw)
+        assert returned
+        counts = _counts(provider)
+        for fact_id in returned:
+            assert counts[fact_id] == 1
+
+    def test_related_bumps(self, provider):
+        raw = provider.handle_tool_call("fact_store", {"action": "related", "entity": "Jordan Miller"})
+        returned = _ids(provider, raw)
+        assert returned
+        counts = _counts(provider)
+        for fact_id in returned:
+            assert counts[fact_id] == 1
+
+    def test_reason_bumps(self, provider):
+        raw = provider.handle_tool_call("fact_store", {"action": "reason", "entities": ["Jordan Miller", "Alex Smith"]})
+        returned = _ids(provider, raw)
+        assert returned
+        counts = _counts(provider)
+        for fact_id in returned:
+            assert counts[fact_id] == 1
+
+    def test_list_does_not_bump(self, provider):
+        provider.handle_tool_call("fact_store", {"action": "list"})
+        assert set(_counts(provider).values()) == {0}
+
+    def test_prefetch_does_not_bump(self, provider):
+        provider.prefetch("deployment rollback")
+        assert set(_counts(provider).values()) == {0}
+
+    def test_empty_search_is_a_noop(self, provider):
+        provider.handle_tool_call("fact_store", {"action": "search", "query": "zzz-no-match-zzz"})
+        assert set(_counts(provider).values()) == {0}
+
+    def test_contradict_does_not_bump(self, provider):
+        provider.handle_tool_call("fact_store", {"action": "contradict"})
+        assert set(_counts(provider).values()) == {0}
+
+    def test_failing_bump_never_breaks_retrieval(self, provider, monkeypatch):
+        """Advisory contract: even a hard bump failure must leave the result intact."""
+        def boom(fact_ids):
+            raise sqlite3.Error("simulated store failure")
+
+        monkeypatch.setattr(provider._store, "bump_retrieval", boom)
+        raw = provider.handle_tool_call("fact_store", {"action": "search", "query": "deployment rollback"})
+        returned = _ids(provider, raw)
+        assert returned, "search result must survive a failed counter bump"
+
+    def test_bump_survives_oversized_id_list(self, provider):
+        """The batched UPDATE must handle id lists beyond SQLite's variable limit."""
+        fact_id = _ids(provider, provider.handle_tool_call(
+            "fact_store", {"action": "search", "query": "deployment rollback"}))[0]
+        provider._store.bump_retrieval(list(range(10, 1210)) + [fact_id])  # mostly nonexistent ids
+        counts = _counts(provider)
+        assert counts[fact_id] == 2  # one from search, one from the direct bump


### PR DESCRIPTION
## What does this PR do?

Fixes #78801 — `retrieval_count` in the holographic memory store was never
incremented when the agent retrieved facts. Every read path
(`FactRetriever.search/probe/related/reason`) only SELECTs; the single UPDATE
that used to exist (`store.search_facts`) was removed during the handler
refactor, so the field is dead weight today: the memory janitor flags healthy
facts as "never retrieved" and `fact_feedback` is the only working signal.

This PR counts retrievals at the **tool-handler boundary** via a locked store
helper, covering all four retrieval actions in one place — the shape the issue
discussion converged on (independently verified by two community members on
local deployments, 2026-09-02/03), delivered here on current main with tests.

## Related Issue

Fixes #78801

Also addresses the root cause described in #17899 (whose `search_facts`-based
description predates the handler refactor). The earlier open PRs (#35152,
#39664, #55729, #73644, #73901, #78864, #99087, #103073) target pre-refactor
code paths that no longer exist on main.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/memory/holographic/store.py` — new `MemoryStore.bump_retrieval(fact_ids)`:
  batched, parameterized `UPDATE facts SET retrieval_count = retrieval_count + 1`
  on the shared connection under the shared write lock (same serialization
  contract as every other store write). Empty-list guard included.
- `plugins/memory/holographic/__init__.py` — new
  `HolographicMemoryProvider._track_retrieval(results)`: bumps exactly the
  fact ids a retrieval returned (deduplicated), then returns the results
  untouched. Wired into the `search`, `probe`, `related`, and `reason`
  handlers. The bump is **advisory**: a failing UPDATE can never break the
  retrieval result.
- `tests/plugins/memory/test_holographic_retrieval_count.py` — new end-to-end
  tests driving the real `handle_tool_call` dispatch with exact counter
  asserts (see How to Test).

### Scope decisions (explicit)

| Path | Counted? | Why |
|---|---|---|
| `search` / `probe` / `related` / `reason` | ✅ | The agent-facing retrieval actions from #78801 |
| auto-`prefetch()` | ❌ | Calls `retriever.search()` directly, bypasses the handler — automatic context fill, not an explicit agent retrieval (conservative choice from the issue's design note) |
| `contradict` | ❌ | Memory-hygiene diagnostics; returns nested `fact_a`/`fact_b` pairs, not a recall result |
| `list` | ❌ | CRUD browsing, not retrieval |

Counting at the handler (not inside the retriever) makes the counter
independent of the internal numpy/HRR vs. FTS5 fallback split: whichever path
produced the result, the facts the agent actually received are the ones that
count.

## How to Test

1. Reproduce: `fact_store action=search query=<anything>` on current main —
   `retrieval_count` stays 0 for every returned fact.
2. With this PR, the same call increments `retrieval_count` by exactly 1 for
   each returned fact; repeated calls accumulate; non-returned facts stay at 0.
3. Run the focused suite:

   `pytest tests/plugins/memory/test_holographic_retrieval_count.py -q` → 12 passed

   `pytest tests/plugins/memory/test_holographic_*.py tests/plugins/test_holographic_vector_storage.py -q` → 74 passed (no regressions)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the focused holographic suite passes fully (74 tests, via the project's own `scripts/run_tests.sh` runner); a full local run is noisy on this machine because a live Hermes install shares it (gateway/port collisions), so I rely on this PR's CI for the full-suite verdict.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
