### PR TITLE
fix(codex): preserve Hermes settings and native session context

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -5,6 +5,7 @@ AIAgent first: ``run_codex_app_server_turn`` drives one ``codex app-server`` sub
 from __future__ import annotations
 
 import contextvars
+import hashlib
 import json
 import logging
 import os
@@ -379,9 +380,45 @@ def _consume_user_interrupt(agent, active: bool = True) -> tuple[bool, Any]:
     return interrupted, message
 
 
-def _ensure_codex_session(agent) -> None:
-    """Lazily spawn one CodexAppServerSession per AIAgent (reused across turns, closed by the _cleanup hook)."""
+def _codex_session_meta_key(session_id: str) -> str:
+    return f"codex_session:{session_id}"
+
+
+def invalidate_codex_session(agent) -> None:
+    """A turn in another runtime makes its Hermes transcript authoritative again."""
     if getattr(agent, "_codex_session", None) is not None:
+        _close_codex_session(agent)
+    db = getattr(agent, "_session_db", None)
+    session_id = getattr(agent, "session_id", None)
+    if db is not None and session_id:
+        key = _codex_session_meta_key(session_id)
+        if db.get_meta(key):
+            db.set_meta(key, "")
+
+
+def _codex_history_items(agent, messages: List[Dict[str, Any]]) -> list[dict]:
+    """Import plaintext history without replaying another runtime's encrypted state."""
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+    from agent.turn_context import build_api_messages
+
+    wire_messages, _ = build_api_messages(
+        agent, messages, current_turn_user_idx=-1, ext_prefetch_cache="", plugin_user_context="",
+        moa_config=None, active_system_prompt="",
+    )
+    items = _chat_messages_to_responses_input(wire_messages, replay_encrypted_reasoning=False)
+    for item in items:
+        if item.get("role") in {"user", "assistant"}:
+            item["type"] = "message"
+            if isinstance(item.get("content"), str):
+                part_type = "output_text" if item["role"] == "assistant" else "input_text"
+                item["content"] = [{"type": part_type, "text": item["content"]}]
+    return items
+
+
+def _ensure_codex_session(agent, *, instructions: str | None = None, history=None, history_end=None) -> None:
+    """Lazily spawn one CodexAppServerSession per AIAgent (reused across turns, closed by the _cleanup hook)."""
+    session = getattr(agent, "_codex_session", None)
+    if session is not None and getattr(session, "_instructions", None) == instructions:
         return
     from agent.runtime_cwd import resolve_agent_cwd
     from agent.transports.codex_app_server_session import CodexAppServerSession, _ServerRequestRouting
@@ -403,11 +440,35 @@ def _ensure_codex_session(agent) -> None:
     # _emit_interim_assistant_message). Without this, Discord/Telegram users see no live tool-progress or
     # interim commentary while codex_app_server is running — only the final answer (#33200). Supersedes the
     # narrower item/started-only bridge from #38835.
+    db = getattr(agent, "_session_db", None)
+    session_id = getattr(agent, "session_id", None)
+    meta_key = _codex_session_meta_key(session_id) if session_id else None
+    fingerprint = hashlib.sha256((instructions or "").encode("utf-8")).hexdigest()
+    if session is not None:
+        thread_id = session.ensure_started()
+        refresh_instructions = True
+        # A loaded thread ignores resume overrides. Cold resume updates the canonical
+        # instructions used after native compaction; injection updates retained history.
+        _close_codex_session(agent)
+    else:
+        state = json.loads(db.get_meta(meta_key) or "{}") if db is not None and session_id else {}
+        thread_id = state.get("thread_id")
+        refresh_instructions = bool(thread_id and state.get("instructions_hash") != fingerprint)
+    history_items = None
+    if not thread_id and history:
+        history_end = len(history) - 1 if history_end is None else history_end
+        history_items = _codex_history_items(agent, history[:history_end])
     agent._codex_session = CodexAppServerSession(
         cwd=getattr(agent, "session_cwd", None) or str(resolve_agent_cwd()), approval_callback=approval_callback,
         request_routing=_ServerRequestRouting(auto_approve_exec=auto_approve_requests, auto_approve_apply_patch=auto_approve_requests),
         on_event=make_codex_app_server_event_bridge(agent),
+        model=agent.model, instructions=instructions, thread_id=thread_id,
+        history=history_items, refresh_instructions=refresh_instructions,
     )
+    # Persist the link before the first tool can run. A failed write must stop the turn.
+    thread_id = agent._codex_session.ensure_started()
+    if db is not None and session_id:
+        db.set_meta(meta_key, json.dumps({"thread_id": thread_id, "instructions_hash": fingerprint}))
 
 
 def _persist_projected_messages(agent, turn, messages: List[Dict[str, Any]]) -> None:
@@ -468,7 +529,9 @@ def _finish_codex_turn(agent, turn, messages: List[Dict[str, Any]], *, original_
 
 
 def run_codex_app_server_turn(agent, *, user_message: str, original_user_message: Any, messages: List[Dict[str, Any]],
-                              effective_task_id: str, should_review_memory: bool = False) -> Dict[str, Any]:
+                              effective_task_id: str, should_review_memory: bool = False,
+                              api_messages: List[Dict[str, Any]] | None = None,
+                              instructions: str | None = None, current_turn_user_idx: int | None = None) -> Dict[str, Any]:
     """Hand the turn to a ``codex app-server`` subprocess and project its events into ``messages``.
     Returns the chat_completions result shape. The user message is ALREADY in ``messages`` — never append it again."""
     # Defense in depth for compression.checkpoint_required: agent init refuses the combination, but
@@ -477,9 +540,22 @@ def run_codex_app_server_turn(agent, *, user_message: str, original_user_message
         from agent.conversation_compression import _checkpoint_blocked
         raise _checkpoint_blocked("codex_app_server owns the authoritative thread and compacts it "
                                   "without a truthful pre-compaction transcript boundary")
-    _ensure_codex_session(agent)
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        from agent.fast_mode import BOUNDED_MODES, effective_request_overrides
+
+        wire_messages = api_messages if api_messages is not None else messages
+        _ensure_codex_session(agent, instructions=instructions, history=messages, history_end=current_turn_user_idx)
+        if getattr(agent, "_interrupt_requested", False):
+            agent._codex_session.request_interrupt()
+        reasoning = getattr(agent, "reasoning_config", None) or {}
+        service_tier = getattr(agent, "service_tier", None)
+        if service_tier in BOUNDED_MODES:
+            service_tier = effective_request_overrides(agent).get("service_tier")
+        turn = agent._codex_session.run_turn(
+            user_input=wire_messages[-1].get("content", user_message) if wire_messages else user_message,
+            model=agent.model, effort="none" if reasoning.get("enabled") is False else reasoning.get("effort"),
+            service_tier=service_tier or "default",
+        )
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         _close_codex_session(agent)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1475,12 +1475,24 @@ def run_conversation(
     # Opt-in runtime: api_mode == codex_app_server hands the whole turn to the codex
     # app-server subprocess (see agent/transports/codex_app_server_session.py).
     if agent.api_mode == "codex_app_server":
+        from agent.turn_context import build_api_messages
+
+        api_messages, instructions = build_api_messages(
+            agent, [s.messages[s.current_turn_user_idx]], current_turn_user_idx=0,
+            ext_prefetch_cache=s._ext_prefetch_cache, plugin_user_context=s._plugin_user_context,
+            moa_config=s.moa_config, active_system_prompt=s.active_system_prompt,
+        )
         return agent._run_codex_app_server_turn(
             user_message=s.user_message, original_user_message=s.original_user_message,
             messages=s.messages, effective_task_id=s.effective_task_id,
             should_review_memory=s._should_review_memory,
+            api_messages=api_messages, instructions=instructions,
+            current_turn_user_idx=s.current_turn_user_idx,
         )
 
+    from agent.codex_runtime import invalidate_codex_session
+
+    invalidate_codex_session(agent)
     while (s.api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         if _run_phase(begin_iteration, agent, s).action == "break":
             break

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -155,6 +155,9 @@ class CodexAppServerSession:
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
+        model: Optional[str] = None, instructions: Optional[str] = None,
+        thread_id: Optional[str] = None, history: Optional[list[dict]] = None,
+        refresh_instructions: bool = False,
     ) -> None:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
@@ -166,6 +169,11 @@ class CodexAppServerSession:
         self._on_event = on_event  # Display hook (kawaii spinner ticks etc.)
         self._routing = request_routing or _ServerRequestRouting()
         self._client_factory = client_factory or CodexAppServerClient
+        self._model = model
+        self._instructions = instructions
+        self._resume_thread_id = thread_id
+        self._history = history
+        self._refresh_instructions = refresh_instructions
 
         self._client: Optional[CodexAppServerClient] = None
         self._thread_id: Optional[str] = None
@@ -186,16 +194,39 @@ class CodexAppServerSession:
         self._client.initialize(client_name="hermes", client_title="Hermes Agent", client_version=_get_hermes_version())
         # Permissions are NOT sent on thread/start: codex gates ``thread/start.permissions``
         # behind experimentalApi + a matching ``[permissions]`` table in ~/.codex/config.toml.
-        result = self._client.request("thread/start", {"cwd": self._cwd}, timeout=15)
+        params: dict[str, Any] = {"cwd": self._cwd}
+        if self._model:
+            params["model"] = self._model
+        if self._instructions is not None:
+            params["developerInstructions"] = (
+                "These Hermes instructions replace all earlier Hermes instructions, "
+                "including any that are no longer listed:\n\n" + self._instructions
+            )
+        method = "thread/start"
+        if self._resume_thread_id:
+            method = "thread/resume"
+            params.update(threadId=self._resume_thread_id, excludeTurns=True)
+        result = self._client.request(method, params, timeout=15)
         # Different codex versions serialize the id under thread.id / sessionId / threadId.
         thread_obj = result.get("thread") or {}
         thread_id = thread_obj.get("id") or thread_obj.get("sessionId") or result.get("sessionId") or result.get("threadId")
         if not thread_id:
             raise CodexAppServerError(
-                code=-32603, message=f"codex thread/start returned no thread id (payload keys: {sorted(result.keys())})",
+                code=-32603, message=f"codex {method} returned no thread id (payload keys: {sorted(result.keys())})",
             )
+        if self._resume_thread_id and thread_id != self._resume_thread_id:
+            raise CodexAppServerError(code=-32603, message="codex resumed a different thread")
+        if not self._resume_thread_id and self._history:
+            self._client.request("thread/inject_items", {"threadId": thread_id, "items": self._history}, timeout=15)
+        if self._refresh_instructions and self._instructions is not None:
+            self._client.request("thread/inject_items", {"threadId": thread_id, "items": [{
+                "type": "message", "role": "developer",
+                "content": [{"type": "input_text", "text": params["developerInstructions"]}],
+            }]}, timeout=15)
         self._thread_id = thread_id
-        logger.info("codex app-server thread started: id=%s profile=%s cwd=%s", thread_id[:8], self._permission_profile, self._cwd)
+        self._resume_thread_id = thread_id
+        self._history = None
+        logger.info("codex app-server thread ready: id=%s sandbox=%s cwd=%s", thread_id[:8], result.get("sandbox"), self._cwd)
         return thread_id
 
     def close(self) -> None:
@@ -326,6 +357,8 @@ class CodexAppServerSession:
     def run_turn(
         self, user_input: Any, *, turn_timeout: float = 600.0,
         notification_poll_timeout: float = 0.25, post_tool_quiet_timeout: float = 90.0,
+        model: Optional[str] = None, effort: Optional[str] = None,
+        service_tier: Optional[str] = None,
     ) -> TurnResult:
         """Send a user message and block until turn/completed, bridging approvals and projecting items.
 
@@ -344,11 +377,14 @@ class CodexAppServerSession:
                 result.interrupted = True
             else:
                 result.submitted_user_text = _coerce_turn_input_text(user_input)
-                ts = self._request_for(
-                    result, "turn/start",
-                    {"threadId": self._thread_id, "input": [{"type": "text", "text": result.submitted_user_text}]},
-                    "turn/start",
-                )
+                params: dict[str, Any] = {"threadId": self._thread_id, "input": [{"type": "text", "text": result.submitted_user_text}]}
+                for key, value in (("model", model), ("effort", effort)):
+                    if value is not None:
+                        params[key] = value
+                if service_tier is not None:
+                    # Codex 0.125 uses fast/flex/null; null explicitly clears a previous override.
+                    params["serviceTier"] = {"default": None, "priority": "fast"}.get(service_tier, service_tier)
+                ts = self._request_for(result, "turn/start", params, "turn/start")
                 if ts is not None:
                     self._run_started_turn(result, ts, turn_timeout, notification_poll_timeout, post_tool_quiet_timeout)
         self._interrupt_event.clear()
@@ -575,7 +611,7 @@ class CodexAppServerSession:
     _SERVER_REQUEST_HANDLERS: dict[str, Callable[..., dict]] = {
         "item/commandExecution/requestApproval": lambda self, p: {"decision": self._decide_exec_approval(p)},
         "item/fileChange/requestApproval": lambda self, p: {"decision": self._decide_apply_patch_approval(p)},
-        "item/permissions/requestApproval": lambda self, p: {"decision": "decline"},
+        "item/permissions/requestApproval": lambda self, p: {"permissions": {}, "scope": "turn"},
         "mcpServer/elicitation/request": _respond_elicitation,
     }
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -96,7 +96,7 @@ _HOST_MANDATED_API_MODES = {
 }
 
 # codex_app_server is opt-in: hand the whole turn to a `codex app-server` subprocess (Codex's own
-# tool runtime), gated on `model.openai_runtime == "codex_app_server"` AND provider in {openai, openai-codex}.
+# tool runtime), gated on `model.openai_runtime == "codex_app_server"` and an OpenAI/Codex provider.
 _VALID_API_MODES = {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}
 
 
@@ -226,9 +226,9 @@ def _api_key_provider_api_mode(provider: str, model_cfg: Dict[str, Any], api_key
 
 
 def _maybe_apply_codex_app_server_runtime(*, provider: str, api_mode: str, model_cfg: Optional[Dict[str, Any]]) -> str:
-    """Opt-in rewrite to "codex_app_server" via ``model.openai_runtime``; only ``openai`` /
-    ``openai-codex`` are eligible. No-op when unset, "auto", or empty."""
-    if model_cfg and provider in {"openai", "openai-codex"} and str(model_cfg.get("openai_runtime") or "").strip().lower() == "codex_app_server":
+    """Opt-in rewrite to "codex_app_server" for OpenAI API/Codex providers.
+    No-op when ``model.openai_runtime`` is unset, "auto", or empty."""
+    if model_cfg and provider in {"openai", "openai-api", "openai-codex"} and str(model_cfg.get("openai_runtime") or "").strip().lower() == "codex_app_server":
         return "codex_app_server"
     return api_mode
 
@@ -240,8 +240,10 @@ _NO_ANTHROPIC_CREDENTIALS_MSG = ("No Anthropic credentials found. Set ANTHROPIC_
                                  "run 'claude setup-token', or authenticate with 'claude /login'.")
 
 
-def _runtime(provider: str, api_mode: str, base_url: Any, api_key: Any, **extra: Any) -> Dict[str, Any]:
+def _runtime(provider: str, api_mode: str, base_url: Any, api_key: Any, *,
+             model_cfg: Optional[Dict[str, Any]] = None, **extra: Any) -> Dict[str, Any]:
     """Build a resolved-runtime dict; ``extra`` carries source/requested_provider/provider-specific keys."""
+    api_mode = _maybe_apply_codex_app_server_runtime(provider=provider, api_mode=api_mode, model_cfg=model_cfg)
     return {"provider": provider, "api_mode": api_mode, "base_url": base_url, "api_key": api_key, **extra}
 
 
@@ -463,8 +465,7 @@ def _resolve_runtime_from_pool_entry(*, provider: str, entry: PooledCredential, 
     api_mode, base_url = _pool_entry_mode_and_url(provider, entry, model_cfg, _effective_model(model_cfg, target_model),
                                                   _pool_entry_base_url(entry).rstrip("/"))
     base_url = _finalize_base_url(provider, api_mode, base_url)
-    api_mode = _maybe_apply_codex_app_server_runtime(provider=provider, api_mode=api_mode, model_cfg=model_cfg)
-    return _runtime(provider, api_mode, base_url, _pool_entry_api_key(entry), source=getattr(entry, "source", "pool"),
+    return _runtime(provider, api_mode, base_url, _pool_entry_api_key(entry), model_cfg=model_cfg, source=getattr(entry, "source", "pool"),
                     credential_pool=pool, requested_provider=requested_provider)
 
 
@@ -541,7 +542,7 @@ def _creds_fallback(api_key, explicit_base_url, base_url, expiry, expiry_key, re
 def _explicit_codex(requested_provider, model_cfg, api_key, explicit_base_url, target_model):
     api_key, base_url, last_refresh = _creds_fallback(api_key, explicit_base_url, explicit_base_url or DEFAULT_CODEX_BASE_URL,
                                                       None, "last_refresh", resolve_codex_runtime_credentials)
-    return _runtime("openai-codex", "codex_responses", base_url, api_key, source="explicit", last_refresh=last_refresh,
+    return _runtime("openai-codex", "codex_responses", base_url, api_key, model_cfg=model_cfg, source="explicit", last_refresh=last_refresh,
                     requested_provider=requested_provider)
 
 
@@ -584,7 +585,7 @@ def _explicit_api_key_provider(provider, pconfig, requested_provider, model_cfg,
     api_mode = _api_key_provider_api_mode(provider, model_cfg, api_key, base_url, target_model or model_cfg.get("default", ""),
                                           opencode_by_model=False)
     api_key = _actual_local_key(provider, api_key, base_url)
-    return _runtime(provider, api_mode, base_url.rstrip("/"), api_key, source="explicit", requested_provider=requested_provider)
+    return _runtime(provider, api_mode, base_url.rstrip("/"), api_key, model_cfg=model_cfg, source="explicit", requested_provider=requested_provider)
 
 
 # Providers with a dedicated explicit-credential builder; everything else goes through the
@@ -655,7 +656,7 @@ def _resolve_oauth_runtime(provider, requested_provider, model_cfg, target_model
         return None
     api_mode = spec.api_mode(_effective_model(model_cfg, target_model)) if callable(spec.api_mode) else spec.api_mode
     return _runtime(provider, api_mode, (creds.get("base_url") or "").rstrip("/") or spec.default_base_url,
-                    creds.get("api_key", ""), source=creds.get("source", spec.default_source),
+                    creds.get("api_key", ""), model_cfg=model_cfg, source=creds.get("source", spec.default_source),
                     **{spec.expiry_key: creds.get(spec.expiry_key)}, requested_provider=requested_provider)
 
 
@@ -718,7 +719,7 @@ def _api_key_provider_runtime(provider, pconfig, requested_provider, model_cfg, 
                                           target_model or model_cfg.get("default", ""), opencode_by_model=True)
     base_url = _finalize_base_url(provider, api_mode, base_url)
     api_key = _actual_local_key(provider, creds.get("api_key", ""), base_url)
-    return _runtime(provider, api_mode, base_url, api_key, source=creds.get("source", "env"), requested_provider=requested_provider)
+    return _runtime(provider, api_mode, base_url, api_key, model_cfg=model_cfg, source=creds.get("source", "env"), requested_provider=requested_provider)
 
 
 # ── the resolution ladder ──────────────────────────────────────────────────────────────────

--- a/run_agent.py
+++ b/run_agent.py
@@ -385,6 +385,10 @@ class AIAgent(
         With ``previous_messages`` / ``old_session_id`` / ``carry_over_context`` the context engine gets the
         full transition lifecycle instead of a bare reset.
         """
+        if getattr(self, "_codex_session", None) is not None:
+            from agent.codex_runtime import _close_codex_session
+
+            _close_codex_session(self)
         for counter in (
             "session_total_tokens", "session_input_tokens", "session_output_tokens", "session_prompt_tokens",
             "session_completion_tokens", "session_cache_read_tokens", "session_cache_write_tokens",

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -329,6 +329,9 @@ class TestBridgeWiredInRuntime:
             def __init__(self, **kwargs):
                 captured.update(kwargs)
 
+            def ensure_started(self):
+                return "th1"
+
             def run_turn(self, user_input, **_):
                 from agent.transports.codex_app_server_session import TurnResult
                 return TurnResult(
@@ -350,6 +353,7 @@ class TestBridgeWiredInRuntime:
         # Minimal stub agent — the runtime only touches a handful of
         # attributes and we mock the heavy ones to keep the test fast.
         agent = SimpleNamespace(
+            model="gpt-5.4",
             session_cwd=None,
             _codex_session=None,
             tool_progress_callback=MagicMock(),
@@ -373,7 +377,7 @@ class TestBridgeWiredInRuntime:
             _session_db=None,
         )
 
-        codex_runtime.run_codex_app_server_turn(
+        result = codex_runtime.run_codex_app_server_turn(
             agent,
             user_message="hi",
             original_user_message="hi",
@@ -381,6 +385,7 @@ class TestBridgeWiredInRuntime:
             effective_task_id="t",
         )
 
+        assert result["completed"]
         assert "on_event" in captured, (
             "run_codex_app_server_turn must pass on_event=<bridge> to the "
             "session — without it the gateway sees no live progress (#33200)"

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -49,7 +49,7 @@ def _make_turn():
 def _make_agent(session_db=None, session_id="sess-codex"):
     agent = MagicMock()
     # Pre-seed the session so run_codex_app_server_turn skips the spawn block.
-    agent._codex_session = MagicMock()
+    agent._codex_session = MagicMock(_instructions=None)
     agent._codex_session.run_turn.return_value = _make_turn()
     agent.tool_progress_callback = None
     agent._iters_since_skill = 0
@@ -128,7 +128,7 @@ def test_codex_turn_persists_each_message_exactly_once():
             session_id=sid,
         )
         agent._session_db_created = True
-        agent._codex_session = MagicMock()
+        agent._codex_session = MagicMock(_instructions=None)
         agent._codex_session.run_turn.return_value = _make_turn()
         agent.tool_progress_callback = None
 
@@ -147,6 +147,7 @@ def test_codex_turn_persists_each_message_exactly_once():
             messages=messages,
             effective_task_id="task-1",
         )
+        assert result["completed"] is True
         assert result["agent_persisted"] is True
 
         rows = db.get_messages(sid, include_inactive=True)

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -7,7 +7,10 @@ covered by a separate live test gated on `codex --version`.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
+import yaml
 
 from hermes_cli.runtime_provider import (
     _VALID_API_MODES,
@@ -87,6 +90,84 @@ class TestMaybeApplyCodexAppServerRuntime:
         assert got == "anthropic_messages", (
             f"provider={provider!r} should not be rerouted to codex_app_server"
         )
+
+
+@pytest.mark.parametrize(
+    "provider,credential_source",
+    [
+        ("openai-api", "explicit"),
+        ("openai-codex", "explicit"),
+        ("openai-codex", "singleton"),
+        ("openai-api", "environment"),
+        ("openai-api", "pool"),
+        ("openai-codex", "pool"),
+    ],
+)
+@pytest.mark.parametrize(
+    "setting,expected_mode",
+    [("auto", "codex_responses"), ("codex_app_server", "codex_app_server")],
+)
+def test_saved_runtime_applies_to_every_credential_source(
+    tmp_path, monkeypatch, provider, credential_source, setting, expected_mode
+):
+    from hermes_cli import runtime_provider as rp
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+        "model": {"provider": provider, "default": "gpt-test", "openai_runtime": setting},
+    }), encoding="utf-8")
+    base_url = (
+        "https://api.openai.com/v1" if provider == "openai-api"
+        else "https://chatgpt.com/backend-api/codex"
+    )
+    api_key = "test-only-api-key"
+    entry = SimpleNamespace(access_token=api_key, base_url=base_url, source="test-pool")
+    pool = SimpleNamespace(provider=provider, has_credentials=lambda: True, select=lambda: entry)
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: pool if credential_source == "pool" else None)
+    kwargs = {}
+    if credential_source == "explicit":
+        kwargs["explicit_api_key"] = api_key
+    elif credential_source == "environment":
+        monkeypatch.setenv("OPENAI_API_KEY", api_key)
+    elif credential_source == "singleton":
+        monkeypatch.setattr(rp, "resolve_codex_runtime_credentials", lambda: {
+            "api_key": api_key, "base_url": base_url,
+            "source": "hermes-auth-store", "last_refresh": None,
+        })
+
+    resolved = rp.resolve_runtime_provider(requested=provider, **kwargs)
+
+    assert resolved["provider"] == provider
+    assert resolved["api_mode"] == expected_mode
+    assert resolved["base_url"] == base_url
+    assert resolved["api_key"] == api_key
+
+
+@pytest.mark.parametrize(
+    "provider,base_url,expected_mode",
+    [
+        ("anthropic", "https://api.anthropic.com", "anthropic_messages"),
+        ("custom", "https://api.openai.com/v1", "codex_responses"),
+    ],
+)
+def test_saved_runtime_does_not_reroute_other_providers(
+    tmp_path, monkeypatch, provider, base_url, expected_mode
+):
+    from hermes_cli import runtime_provider as rp
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+        "model": {"provider": provider, "default": "test-model", "openai_runtime": "codex_app_server"},
+    }), encoding="utf-8")
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: None)
+
+    resolved = rp.resolve_runtime_provider(
+        requested=provider, explicit_api_key="test-only-api-key", explicit_base_url=base_url,
+    )
+
+    assert resolved["provider"] == provider
+    assert resolved["api_mode"] == expected_mode
+    assert resolved["base_url"] == base_url
 
 
 class TestCodexAppServerModule:

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -30,6 +30,7 @@ class FakeClient:
         self.codex_bin = codex_bin
         self.codex_home = codex_home
         self.requests: list[tuple[str, dict]] = []
+        self.instructions_seen: list[str] = []
         self.notifications_responses: list[dict] = []
         self.responses: list[tuple[Any, dict]] = []
         self.error_responses: list[tuple[Any, int, str]] = []
@@ -186,6 +187,18 @@ class TestLifecycle:
 # ---- turn loop ----
 
 class TestRunTurn:
+    @pytest.mark.parametrize(("selected", "wire_value"), [
+        ("default", None), ("priority", "fast"), ("fast", "fast"), ("flex", "flex"),
+    ])
+    def test_service_tier_uses_values_supported_by_minimum_codex(self, selected, wire_value):
+        client = FakeClient()
+        client.queue_notification("turn/completed", turn={"id": "turn-fake-001", "status": "completed"})
+        result = make_session(client).run_turn("Continue.", service_tier=selected)
+
+        assert result.error is None
+        params = next(params for method, params in client.requests if method == "turn/start")
+        assert params["serviceTier"] == wire_value
+
     def test_simple_text_turn_returns_final_message(self):
         client = FakeClient()
         client.queue_notification("turn/started", threadId="t", turn={"id": "tu1"})
@@ -520,6 +533,23 @@ class TestCompactThread:
 # ---- approval bridge ----
 
 class TestServerRequestRouting:
+
+    def test_codex_runtime_permissions_denial_grants_nothing(self):
+        client = FakeClient()
+        session = make_session(client)
+        session.ensure_started()
+        session._handle_server_request({
+            "method": "item/permissions/requestApproval", "id": "permissions-1",
+            "params": {
+                "threadId": "thread-fake-001", "turnId": "turn-fake-001",
+                "itemId": "permissions-item", "cwd": "/tmp", "startedAtMs": 1,
+                "permissions": {"network": {"enabled": True}},
+            },
+        })
+
+        assert client.responses == [
+            ("permissions-1", {"permissions": {}, "scope": "turn"})
+        ]
 
 
 
@@ -910,4 +940,3 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure() is None
         assert _classify_oauth_failure("") is None
         assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
-

--- a/tests/run_agent/test_codex_app_server_context.py
+++ b/tests/run_agent/test_codex_app_server_context.py
@@ -1,0 +1,478 @@
+"""Hermes context must survive the boundary to a native Codex thread."""
+
+import json
+import os
+from contextlib import ExitStack, closing
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent.memory_manager import MemoryManager
+from agent.memory_provider import MemoryProvider
+from agent.transports.codex_app_server import CodexAppServerError
+from hermes_state import SessionDB
+from run_agent import AIAgent
+from tests.agent.transports.test_codex_app_server_session import FakeClient
+
+
+@pytest.fixture
+def codex_runtime(tmp_path, monkeypatch):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(yaml.safe_dump({
+        "model": {"context_length": 256000},
+        "auxiliary": {"title_generation": {"enabled": False}},
+    }), encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    clients, failures, threads, canonical_instructions = [], {}, {}, {}
+
+    def client_factory(**kwargs):
+        client = FakeClient(**kwargs)
+        loaded_threads = set()
+        clients.append(client)
+        number = len(clients)
+
+        def request(method, params):
+            if method in failures:
+                raise CodexAppServerError(-32602, failures[method])
+            if method in {"thread/start", "thread/resume"}:
+                thread_id = params.get("threadId", f"codex-thread-{number}")
+                # Codex replays existing developer items even when resume supplies new instructions.
+                threads.setdefault(thread_id, params.get("developerInstructions", ""))
+                if thread_id not in loaded_threads:
+                    canonical_instructions[thread_id] = params.get("developerInstructions", "")
+                    loaded_threads.add(thread_id)
+                return {
+                    "thread": {"id": thread_id}, "cwd": str(tmp_path),
+                    "model": params.get("model", "codex-config-model"),
+                    "modelProvider": "openai", "approvalPolicy": "never",
+                    "approvalsReviewer": "user", "sandbox": {"type": "readOnly"},
+                }
+            if method == "turn/start":
+                client.instructions_seen.append(threads[params["threadId"]])
+                turn_id = f"turn-{number}-{len(client.requests)}"
+                scope = {"threadId": params["threadId"], "turnId": turn_id}
+                client.queue_notification("item/completed", **scope, item={
+                    "type": "userMessage", "id": f"user-{turn_id}", "content": params["input"],
+                })
+                client.queue_notification("item/completed", **scope, item={
+                    "type": "agentMessage", "id": f"answer-{turn_id}", "text": "Acknowledged.",
+                })
+                turn = {"id": turn_id, "items": [], "status": "completed", "error": None}
+                client.queue_notification("turn/completed", threadId=params["threadId"], turn=turn)
+                return {"turn": {**turn, "status": "inProgress"}}
+            if method == "thread/inject_items":
+                for item in params["items"]:
+                    if item.get("role") == "developer":
+                        threads[params["threadId"]] = "\n".join(part["text"] for part in item["content"])
+                return {}
+            if method == "thread/compact/start":
+                thread_id, turn_id = params["threadId"], f"compact-{number}"
+                threads[thread_id] = canonical_instructions[thread_id]
+                client.queue_notification("turn/started", threadId=thread_id, turn={"id": turn_id})
+                client.queue_notification("turn/completed", threadId=thread_id, turn={
+                    "id": turn_id, "status": "completed", "error": None,
+                })
+                return {}
+            raise AssertionError(f"Unexpected Codex RPC: {method}")
+
+        client._request_handler = request
+        return client
+
+    monkeypatch.setattr(
+        "agent.transports.codex_app_server_session.CodexAppServerClient", client_factory,
+    )
+    with ExitStack() as resources:
+        def make_agent(db, session_id="hermes-session", *, api_mode="codex_app_server", model="gpt-5.4", **kwargs):
+            agent = AIAgent(
+                api_key="test-key", base_url="https://stub.invalid", provider="openai",
+                api_mode=api_mode, model=model, enabled_toolsets=[],
+                quiet_mode=True, skip_context_files=True, skip_memory=True,
+                save_trajectories=False, session_db=db, session_id=session_id,
+                **kwargs,
+            )
+            setattr(agent, "_end_session_on_close", False)
+            resources.callback(agent.close)
+            return agent
+
+        yield make_agent, clients, failures
+
+
+def test_codex_runtime_selected_settings_reach_each_turn(codex_runtime, tmp_path):
+    make_agent, clients, _ = codex_runtime
+    with closing(SessionDB(tmp_path / "state.db")) as db:
+        agent = make_agent(db, reasoning_config={"enabled": True, "effort": "high"}, service_tier="fast")
+        first = agent.run_conversation("Explain the release checklist.")
+        agent.reasoning_config = {"enabled": True, "effort": "low"}
+        agent.service_tier = "default"
+        second = agent.run_conversation("Summarize the next step.", conversation_history=first["messages"])
+
+        assert first["completed"] and second["completed"]
+        starts = [params for method, params in clients[0].requests if method == "thread/start"]
+        turns = [params for method, params in clients[0].requests if method == "turn/start"]
+        assert len(starts) == 1
+        assert starts[0]["model"] == agent.model
+        assert [(p["model"], p["effort"], p["serviceTier"]) for p in turns] == [
+            (agent.model, "high", "fast"), (agent.model, "low", None),
+        ]
+        assert turns[0]["threadId"] == turns[1]["threadId"]
+        assert all("sandbox" not in p and "approvalPolicy" not in p for p in starts)
+        assert all("sandboxPolicy" not in p and "approvalPolicy" not in p for p in turns)
+        agent.close()
+
+
+def test_codex_runtime_instructions_and_turn_context_reach_codex(codex_runtime, tmp_path, monkeypatch):
+    class Memory(MemoryProvider):
+        name = "test-memory"
+
+        def is_available(self):
+            return True
+
+        def initialize(self, session_id, **kwargs):
+            pass
+
+        def get_tool_schemas(self):
+            return []
+
+        def prefetch(self, query, *, session_id=""):
+            return f"RECALL: {query}"
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda hook, **kw: (
+        [{"context": f"PLUGIN: {kw['user_message']}"}] if hook == "pre_llm_call" else []
+    ))
+    make_agent, clients, _ = codex_runtime
+    with closing(SessionDB(tmp_path / "state.db")) as db:
+        agent = make_agent(db, ephemeral_system_prompt="EPHEMERAL_POLICY")
+        agent._memory_manager = MemoryManager()
+        agent._memory_manager.add_provider(Memory())
+        first = agent.run_conversation("Inspect the first document.", system_message="STATIC_POLICY")
+        second = agent.run_conversation("Inspect the second document.", conversation_history=first["messages"])
+
+        assert first["completed"] and second["completed"]
+        starts = [params for method, params in clients[0].requests if method == "thread/start"]
+        turns = [params for method, params in clients[0].requests if method == "turn/start"]
+        assert len(starts) == 1
+        instructions = starts[0]["developerInstructions"]
+        assert "STATIC_POLICY" in instructions and "EPHEMERAL_POLICY" in instructions
+        assert "RECALL:" not in instructions and "PLUGIN:" not in instructions
+        for params, text in zip(turns, ["Inspect the first document.", "Inspect the second document."]):
+            sent = "\n".join(part["text"] for part in params["input"] if part["type"] == "text")
+            assert f"RECALL: {text}" in sent and f"PLUGIN: {text}" in sent
+        assert "Inspect the first document." not in turns[1]["input"][0]["text"]
+        users = [row["content"] for row in db.get_messages_as_conversation(agent.session_id) if row["role"] == "user"]
+        assert users == ["Inspect the first document.", "Inspect the second document."]
+        agent.close()
+
+
+def test_codex_runtime_reconstructs_native_thread_from_reopened_db(codex_runtime, tmp_path):
+    make_agent, clients, _ = codex_runtime
+    db_path = tmp_path / "state.db"
+    with closing(SessionDB(db_path)) as db:
+        first_agent = make_agent(db)
+        first = first_agent.run_conversation("Remember the marker: copper-orbit.")
+        assert first["completed"]
+        first_agent.close()
+    with closing(SessionDB(db_path)) as db:
+        resumed = make_agent(db)
+        history = db.get_messages_as_conversation(resumed.session_id)
+        second = resumed.run_conversation("What was the marker?", conversation_history=history)
+        separate = make_agent(db, session_id="hermes-new-session")
+        fresh = separate.run_conversation("Start a separate conversation.")
+
+        assert second["completed"] and fresh["completed"]
+        assert second["codex_thread_id"] == first["codex_thread_id"]
+        assert fresh["codex_thread_id"] != first["codex_thread_id"]
+        assert clients[1].requests[0][0] == "thread/resume"
+        assert clients[1].requests[0][1]["threadId"] == first["codex_thread_id"]
+        assert all(method not in {"thread/start", "thread/inject_items"} for method, _ in clients[1].requests)
+        assert clients[2].requests[0][0] == "thread/start"
+        users = [row["content"] for row in db.get_messages_as_conversation(resumed.session_id) if row["role"] == "user"]
+        assert users == ["Remember the marker: copper-orbit.", "What was the marker?"]
+        resumed.close()
+        separate.close()
+
+
+def test_codex_runtime_imports_legacy_history_once(codex_runtime, tmp_path):
+    make_agent, clients, _ = codex_runtime
+    history = [
+        {"role": "user", "content": "The marker is copper-orbit."},
+        {"role": "assistant", "content": "I will remember copper-orbit."},
+    ]
+    with closing(SessionDB(tmp_path / "state.db")) as db:
+        agent = make_agent(db)
+        first = agent.run_conversation("Repeat the marker.", conversation_history=history)
+        second = agent.run_conversation("Repeat it again.", conversation_history=first["messages"])
+
+        assert first["completed"] and second["completed"]
+        methods = [method for method, _ in clients[0].requests]
+        assert methods == ["thread/start", "thread/inject_items", "turn/start", "turn/start"]
+        imported = clients[0].requests[1][1]
+        assert imported["threadId"] == first["codex_thread_id"]
+        assert [
+            (item["type"], item["role"], [(part["type"], part["text"]) for part in item["content"]])
+            for item in imported["items"]
+        ] == [
+            ("message", "user", [("input_text", history[0]["content"])]),
+            ("message", "assistant", [("output_text", history[1]["content"])]),
+        ]
+        assert "Repeat the marker." not in json.dumps(imported["items"])
+        agent.close()
+
+
+@pytest.mark.parametrize("failed_method", ["thread/resume", "thread/inject_items"])
+def test_codex_runtime_context_restore_failure_stops_turn(codex_runtime, tmp_path, failed_method):
+    make_agent, clients, failures = codex_runtime
+    with closing(SessionDB(tmp_path / "state.db")) as db:
+        if failed_method == "thread/resume":
+            first_agent = make_agent(db)
+            first = first_agent.run_conversation("Remember copper-orbit.")
+            assert first["completed"]
+            history = db.get_messages_as_conversation(first_agent.session_id)
+            first_agent.close()
+        else:
+            history = [{"role": "user", "content": "Remember copper-orbit."}]
+        failures[failed_method] = "Stored context is unavailable"
+        agent = make_agent(db)
+        result = agent.run_conversation("Recall the earlier marker.", conversation_history=history)
+
+        assert result["completed"] is False
+        assert "Stored context is unavailable" in result["error"]
+        methods = [method for method, _ in clients[-1].requests]
+        assert methods[-1] == failed_method
+        assert "turn/start" not in methods
+        if failed_method == "thread/resume":
+            assert "thread/start" not in methods
+        agent.close()
+
+
+def test_codex_runtime_rebinds_after_reset(codex_runtime, tmp_path):
+    make_agent, clients, _ = codex_runtime
+    with closing(SessionDB(tmp_path / "state.db")) as db:
+        agent = make_agent(db)
+        original_session_id = agent.session_id
+        first = agent.run_conversation("Remember the private marker: copper-orbit.")
+        db.create_session(session_id="new-hermes-session", source="cli", model=agent.model)
+
+        agent.session_id = "new-hermes-session"
+        agent.reset_session_state(previous_messages=first["messages"], old_session_id=original_session_id)
+        fresh = agent.run_conversation("Begin an unrelated conversation.")
+        agent.session_id = original_session_id
+        agent.reset_session_state(previous_messages=fresh["messages"], old_session_id="new-hermes-session")
+        resumed = agent.run_conversation(
+            "Recall my private marker.", conversation_history=db.get_messages_as_conversation(original_session_id),
+        )
+
+        assert first["completed"] and fresh["completed"] and resumed["completed"]
+        assert fresh["codex_thread_id"] != first["codex_thread_id"]
+        assert resumed["codex_thread_id"] == first["codex_thread_id"]
+        resumes = [params for client in clients for method, params in client.requests if method == "thread/resume"]
+        assert any(params["threadId"] == first["codex_thread_id"] for params in resumes)
+        agent.close()
+
+
+@pytest.mark.parametrize("reconstruct", [False, True], ids=["warm", "reconstructed"])
+def test_codex_runtime_clearing_settings_resets_native_overrides(codex_runtime, tmp_path, reconstruct):
+    make_agent, clients, _ = codex_runtime
+    with closing(SessionDB(tmp_path / "state.db")) as db:
+        agent = make_agent(db, reasoning_config={"enabled": True, "effort": "high"}, service_tier="priority")
+        first = agent.run_conversation("Explain the release checklist.")
+        if reconstruct:
+            agent.close()
+            agent = make_agent(db, reasoning_config={"enabled": False}, service_tier=None)
+        else:
+            agent.reasoning_config = {"enabled": False}
+            agent.service_tier = None
+        second = agent.run_conversation(
+            "Summarize the next step.", conversation_history=db.get_messages_as_conversation(agent.session_id),
+        )
+
+        assert first["completed"] and second["completed"]
+        turns = [params for client in clients for method, params in client.requests if method == "turn/start"]
+        assert turns[0]["serviceTier"] == "fast" and turns[0]["effort"] == "high"
+        assert turns[1]["effort"] == "none"
+        assert turns[1]["serviceTier"] is None
+        assert second["codex_thread_id"] == first["codex_thread_id"]
+        agent.close()
+
+
+def test_codex_runtime_round_trip_imports_intervening_hermes_turn(codex_runtime, tmp_path, monkeypatch):
+    from openai.types.chat import ChatCompletion, ChatCompletionChunk
+
+    model_requests = []
+
+    def create(_client, **kwargs):
+        model_requests.append(kwargs)
+        common = {"id": "hermes-response", "created": 0, "model": kwargs["model"]}
+        reply = "Hermes recorded the intermediate marker: bronze-signal."
+        if kwargs.get("stream"):
+            return iter([
+                ChatCompletionChunk.model_validate({**common, "object": "chat.completion.chunk", "choices": [{
+                    "index": 0, "delta": {"role": "assistant", "content": reply}, "finish_reason": None,
+                }]}),
+                ChatCompletionChunk.model_validate({**common, "object": "chat.completion.chunk", "choices": [{
+                    "index": 0, "delta": {}, "finish_reason": "stop",
+                }]}),
+            ])
+        return ChatCompletion.model_validate({**common, "object": "chat.completion", "choices": [{
+            "index": 0, "message": {"role": "assistant", "content": reply}, "finish_reason": "stop",
+        }]})
+
+    monkeypatch.setattr("openai.resources.chat.completions.Completions.create", create)
+    make_agent, clients, _ = codex_runtime
+    with closing(SessionDB(tmp_path / "state.db")) as db:
+        first_agent = make_agent(db)
+        first = first_agent.run_conversation("Remember the first marker: copper-orbit.")
+        assert first["completed"]
+        first_agent.close()
+
+        normal = make_agent(db, api_mode="chat_completions", model="gpt-4.1")
+        middle = normal.run_conversation(
+            "The intermediate marker is bronze-signal.",
+            conversation_history=db.get_messages_as_conversation(normal.session_id),
+        )
+        assert middle["completed"]
+        assert middle["final_response"] == "Hermes recorded the intermediate marker: bronze-signal."
+        assert len(model_requests) == 1
+        assert "copper-orbit" in json.dumps(model_requests[0]["messages"])
+        normal.close()
+
+        resumed = make_agent(db)
+        last = resumed.run_conversation(
+            "Recall both markers.", conversation_history=db.get_messages_as_conversation(resumed.session_id),
+        )
+        assert last["completed"]
+        imported = [params["items"] for method, params in clients[-1].requests if method == "thread/inject_items"]
+        assert imported, "The native thread never received the intervening Hermes turn"
+        assert "The intermediate marker is bronze-signal." in json.dumps(imported)
+        assert middle["final_response"] in json.dumps(imported)
+        resumed.close()
+
+
+def test_codex_runtime_warm_turn_does_not_reencode_imported_history(codex_runtime, tmp_path, monkeypatch):
+    from agent import conversation_loop
+    from agent.turn_context import build_api_messages
+
+    make_agent, clients, _ = codex_runtime
+    with closing(SessionDB(tmp_path / "state.db")) as db:
+        agent = make_agent(db)
+        history = [
+            {"role": role, "content": f"Archived {role} message {index}."}
+            for index in range(128) for role in ("user", "assistant")
+        ]
+        first = agent.run_conversation("Continue the imported conversation.", conversation_history=history)
+        assert first["completed"]
+        cloned_messages = []
+        real_clone = conversation_loop._clone_message_for_send
+
+        def counted_clone(value):
+            if isinstance(value, dict) and value.get("role") in {"user", "assistant", "tool"}:
+                cloned_messages.append(value.get("content"))
+            return real_clone(value)
+
+        monkeypatch.setattr(conversation_loop, "_clone_message_for_send", counted_clone)
+        calibration = {"role": "user", "content": "Calibration input."}
+        build_api_messages(
+            agent, [calibration], current_turn_user_idx=0, ext_prefetch_cache="", plugin_user_context="",
+            moa_config=None, active_system_prompt=agent._cached_system_prompt,
+        )
+        assert cloned_messages == [calibration["content"]]
+        cloned_messages.clear()
+
+        last = agent.run_conversation("Process only this new input.", conversation_history=first["messages"])
+        assert last["completed"]
+        assert len(cloned_messages) <= 1, f"Re-encoded {len(cloned_messages)} messages for one new input"
+        assert clients[0].requests[-1][1]["input"] == [{"type": "text", "text": "Process only this new input."}]
+        agent.close()
+
+
+@pytest.mark.parametrize("reconstruct", [False, True], ids=["warm", "reconstructed"])
+def test_codex_runtime_changing_ephemeral_instructions_preserves_native_thread(codex_runtime, tmp_path, reconstruct):
+    make_agent, clients, _ = codex_runtime
+    with closing(SessionDB(tmp_path / "state.db")) as db:
+        agent = make_agent(db, ephemeral_system_prompt="EPHEMERAL_ALPHA")
+        first = agent.run_conversation("Start the review.", system_message="SESSION_POLICY")
+        history = first["messages"]
+        results = [first]
+        for instructions in ("EPHEMERAL_BETA", None, None):
+            if reconstruct:
+                agent.close()
+                agent = make_agent(db)
+            agent.ephemeral_system_prompt = instructions
+            result = agent.run_conversation("Continue the review.", conversation_history=history)
+            results.append(result)
+            history = result["messages"]
+            if instructions == "EPHEMERAL_BETA":
+                compacted = agent._codex_session.compact_thread()
+                assert compacted.error is None and not compacted.interrupted
+                result = agent.run_conversation("Continue after compaction.", conversation_history=history)
+                results.append(result)
+                history = result["messages"]
+
+        assert all(result["completed"] for result in results)
+        assert {result["codex_thread_id"] for result in results} == {first["codex_thread_id"]}
+        seen = [instructions for client in clients for instructions in client.instructions_seen]
+        assert "EPHEMERAL_ALPHA" in seen[0]
+        assert all("EPHEMERAL_BETA" in instructions and "EPHEMERAL_ALPHA" not in instructions for instructions in seen[1:3])
+        assert all("EPHEMERAL_" not in instructions for instructions in seen[3:])
+        assert all(agent._cached_system_prompt in instructions for instructions in seen)
+        updates = [params for client in clients for method, params in client.requests if method == "thread/inject_items"]
+        assert len(updates) == 2, "Unchanged instructions must not grow the native history"
+        assert all("replace" in params["items"][0]["content"][0]["text"].lower() for params in updates)
+        agent.close()
+
+
+def test_codex_runtime_instruction_update_failure_stops_turn(codex_runtime, tmp_path):
+    make_agent, clients, failures = codex_runtime
+    with closing(SessionDB(tmp_path / "state.db")) as db:
+        agent = make_agent(db, ephemeral_system_prompt="EPHEMERAL_ALPHA")
+        first = agent.run_conversation("Start the review.")
+        assert first["completed"]
+        failures["thread/inject_items"] = "Could not update instructions"
+        agent.ephemeral_system_prompt = "EPHEMERAL_BETA"
+        failed = agent.run_conversation("Continue the review.", conversation_history=first["messages"])
+
+        assert failed["completed"] is False
+        assert "Could not update instructions" in failed["error"]
+        assert sum(method == "turn/start" for client in clients for method, _ in client.requests) == 1
+        agent.close()
+
+
+def test_codex_runtime_hard_stop_survives_instruction_restart(codex_runtime, tmp_path, monkeypatch):
+    make_agent, clients, _ = codex_runtime
+    with closing(SessionDB(tmp_path / "state.db")) as db:
+        agent = make_agent(db, ephemeral_system_prompt="EPHEMERAL_ALPHA")
+        first = agent.run_conversation("Start the review.")
+        assert first["completed"]
+        close = clients[0].close
+
+        def stop_during_close():
+            agent.hard_interrupt()
+            close()
+
+        monkeypatch.setattr(clients[0], "close", stop_during_close)
+        agent.ephemeral_system_prompt = "EPHEMERAL_BETA"
+        stopped = agent.run_conversation("Continue the review.", conversation_history=first["messages"])
+
+        assert stopped["interrupted"] and not stopped["completed"]
+        assert sum(method == "turn/start" for client in clients for method, _ in client.requests) == 1
+        agent.close()
+
+
+@pytest.mark.parametrize(("mode", "window", "expected"), [
+    ("auto", 60, ["fast", "fast"]),
+    ("cold", 60, ["fast", None]),
+    ("auto", 0, [None, None]),
+])
+def test_codex_runtime_resolves_bounded_fast_mode(codex_runtime, tmp_path, mode, window, expected):
+    make_agent, clients, _ = codex_runtime
+    with closing(SessionDB(tmp_path / "state.db")) as db:
+        agent = make_agent(db, service_tier=mode)
+        agent.base_url = "https://api.openai.com/v1"
+        agent.fast_auto_seconds = window
+        first = agent.run_conversation("Start the review.")
+        second = agent.run_conversation("Continue the review.", conversation_history=first["messages"])
+
+        assert first["completed"] and second["completed"]
+        tiers = [params["serviceTier"] for client in clients for method, params in client.requests if method == "turn/start"]
+        assert tiers == expected
+        agent.close()

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -5,7 +5,7 @@ sidebar_label: Codex App-Server Runtime
 
 # Codex App-Server Runtime
 
-Hermes can optionally hand `openai/*` and `openai-codex/*` turns to the [Codex CLI app-server](https://github.com/openai/codex) instead of running its own tool loop. When enabled, terminal commands, file edits, sandboxing, and MCP tool calls all execute inside Codex's runtime — Hermes becomes the shell around it (sessions DB, slash commands, gateway, memory and skill review).
+Hermes can optionally hand OpenAI API (`openai-api`, legacy `openai`) and Codex (`openai-codex`) turns to the [Codex CLI app-server](https://github.com/openai/codex) instead of running its own tool loop. When enabled, terminal commands, file edits, sandboxing, and MCP tool calls all execute inside Codex's runtime — Hermes becomes the shell around it (sessions DB, slash commands, gateway, memory and skill review).
 
 This is **opt-in only**. Default Hermes behavior is unchanged unless you flip the flag. Hermes never auto-routes you onto this runtime.
 
@@ -196,6 +196,28 @@ You can also set it manually in `~/.hermes/config.yaml`:
 model:
   openai_runtime: codex_app_server   # default is "auto" (= Hermes runtime)
 ```
+
+## Model settings and session context
+
+Hermes sends its selected model, reasoning effort, and service tier on each turn.
+Disabling reasoning sends `none`; the selected model must support that value.
+Unsupported settings return Codex's error. Codex's configuration continues to own
+authentication, sandboxing, and approval policy.
+For `/fast auto` and `/fast cold`, Hermes evaluates the window when the native turn
+starts; the selected tier applies to that whole Codex turn.
+
+Each saved Hermes session keeps a link to its native Codex conversation. Resuming
+the Hermes session after a restart restores that conversation; `/new` starts a
+separate one. Existing Hermes history is imported once when no native link exists.
+After a turn in the default runtime, returning to Codex imports the updated Hermes
+history, including the intervening turn. Unavailable native history stops the turn
+before model execution.
+
+Hermes system instructions and per-turn memory and plugin context reach Codex.
+Unchanged turns reuse the subprocess and send only the new input. Changing or
+clearing Hermes instructions restarts the subprocess, resumes the same native
+conversation, and appends one replacement instruction block. This extra startup
+also updates the instructions Codex restores after compaction.
 
 ## Self-improvement loop (memory + skill nudges)
 


### PR DESCRIPTION
## What does this PR do?

Codex app-server turns could omit Hermes instructions and settings, and reconstructing the Hermes agent started a new native conversation. The handoff now includes the selected model, reasoning effort, service tier, instructions, and prepared user input, and it restores the linked native conversation.

## Related Issue

Related work: #103352, #65599, #34788, #83269, and #41905. This overlaps their routing, model, and continuity fixes and adds instruction updates through native compaction, initial history import, runtime transitions, and regression/performance evidence.

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/runtime_provider.py`: apply the saved runtime selection through the shared provider factory, including direct, pooled, environment, and singleton OAuth credentials and the canonical `openai-api` provider.
- `agent/conversation_loop.py` and `agent/codex_runtime.py`: forward settings and prepared context, store the native link and instruction fingerprint in existing session metadata, import history once, and re-import intervening default-runtime turns.
- `agent/transports/codex_app_server_session.py`: use `fast` and explicit `null` for tier overrides so the wire remains compatible with Codex 0.125. Hermes's bounded fast policies are resolved before sending the turn.
- On instruction changes, cold-resume with the new canonical instructions and append one replacement block. Codex otherwise replays old developer items; updating both retained history and canonical instructions also preserves the change after compaction. Unchanged turns reuse the process.
- Preserve stops during a restart, close cached native sessions on Hermes session reset in `run_agent.py`, stop before model execution when context restoration fails, and return an empty permission grant with turn scope when declining escalation.
- Add regression coverage and update the runtime guide.

## How to Test

1. Run the focused handoff tests:

   ```sh
   scripts/run_tests.sh -j 4 --file-retries 0 tests/run_agent/test_codex_app_server_context.py tests/agent/transports/test_codex_app_server_session.py tests/agent/transports/test_codex_app_server_runtime.py -- -q -p no:cacheprovider
   ```

2. In an OpenAI/Codex test profile with the runtime enabled, remember a marker, restart Hermes, and resume the session. Verify the marker and native conversation survive. Exercise `/new`, instruction changes, compaction, and a native file edit.

Verified on macOS arm64, Python 3.12.13, and Codex CLI 0.153.4:

- Affected suite: 258 files, **2,921 passed, 0 failed, 4 existing gated skips**, using the canonical runner with retries disabled.
- Installed-checkout verification: **196 passed**. Real Codex checks passed for instructions, same-session recall, agent recreation, native file read/edit, and a separate process restart with `ultra` effort.
- Additional live checks passed for legacy tool-history import, changed/cleared instructions through native compaction, and clearing an inherited priority tier. Unsupported reasoning settings surface the native error.
- Ruff, compatibility-pointer checks, and the Windows portability checker passed. `ty` reports **no new diagnostics** against base; 142 existing diagnostics remain in the checked files.
- Independent branch review completed; all findings addressed. The full repository suite and live Telegram delivery were not run. Linux and Windows were not executed locally.

## Performance

Local warm-turn benchmark against `233757037df1f03f9fe1cfddc097acd5ad7f7510`: real `AIAgent.run_conversation` and SQLite, 24 interleaved samples per case, plus an identical-base process as a noise control. All **288 timed turns** completed with one external request and no errors or retries.

| Path | History messages | Base p50 | Patched p50 |
| --- | ---: | ---: | ---: |
| Codex, short | 16–62 | 2.480 ms | 2.492 ms |
| Codex, long | 1,008–1,054 | 5.708 ms | 5.554 ms |
| Hermes, short | 16–62 | 7.671 ms | 7.525 ms |
| Hermes, long | 1,008–1,054 | 74.097 ms | 73.556 ms |

No material warm-turn regression was observed; paired changes overlapped the identical-base control's noise. Added work stays constant: one current-message preparation for Codex, one metadata SELECT for default Hermes turns. There are no extra warm native RPCs, history conversions, or metadata writes.

External responses were faked at the Codex client/HTTP response boundary; HTTP serialization and SSE parsing remained real. This excludes startup, initial history import, instruction-change restarts, network latency, and model generation. Instruction changes require a subprocess restart; bounded fast windows are evaluated when the native turn starts.

## Checklist

- [x] Followed the contributing guidance for Python, runtime, and portability changes.
- [x] Conventional commit; only changes related to the runtime handoff.
- [x] Searched existing PRs and documented overlapping work above.
- [x] Added regression tests and completed affected-suite and live validation.
- [x] Updated relevant documentation; no new configuration keys or dependencies.
- [ ] Full repository test suite; the affected suite and its limits are recorded above.

## Screenshots / Logs

Screenshots of the real Codex smoke-test receipts:

Before

<img width="1080" height="780" alt="before-receipt" src="https://github.com/user-attachments/assets/bac8626f-27f7-4402-9550-caec073ed5fe" />

After

<img width="1080" height="780" alt="after-receipt" src="https://github.com/user-attachments/assets/2f8ac72c-4a34-43aa-8af4-3001295b3489" />
