### PR TITLE
fix(gateway): honor /model in GATEWAY_PROXY_URL sidecar

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2414,6 +2414,25 @@ class GatewayTurnMixin:
             logger.debug("Proxy: could not set up stream consumer: %s", _sc_err)
             return None
 
+    def _proxy_request_model_fields(self, session_key: Optional[str]) -> Dict[str, str]:
+        """Per-request model/provider for GATEWAY_PROXY_URL mode.
+
+        Host ``/v1/chat/completions`` treats ``hermes-agent`` as the virtual default. A sidecar
+        ``/model`` override must send BOTH fields: ``provider`` is always honored, but a bare
+        ``model`` is ignored unless ``direct_model_requests`` is on.
+        """
+        body = {"model": "hermes-agent"}
+        override = (getattr(self, "_session_model_overrides", {}) or {}).get(session_key or "")
+        if not isinstance(override, dict):
+            return body
+        model = str(override.get("model") or "").strip()
+        provider = str(override.get("provider") or "").strip()
+        if model:
+            body["model"] = model
+        if provider:
+            body["provider"] = provider
+        return body
+
     async def _run_agent_via_proxy(
         self, message: str, context_prompt: str, history: List[Dict[str, Any]],
         source: "SessionSource", session_id: str, session_key: str = None,
@@ -2472,7 +2491,9 @@ class GatewayTurnMixin:
             headers["Authorization"] = f"Bearer {proxy_key}"
         if session_id:
             headers["X-Hermes-Session-Id"] = session_id
-        body = {"model": "hermes-agent", "messages": api_messages, "stream": True}
+        # Default virtual model = host gateway default. A sidecar /model override must send BOTH
+        # model and provider: api_server ignores a bare model unless direct_model_requests is on.
+        body = {**self._proxy_request_model_fields(session_key), "messages": api_messages, "stream": True}
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
         _stream_consumer = self._proxy_stream_consumer(source, event_message_id, _thread_metadata, _run_still_current)

--- a/gateway/slash_commands_model.py
+++ b/gateway/slash_commands_model.py
@@ -507,6 +507,11 @@ class GatewayModelCommandsMixin:
         )
         ctx.read_config()
         ctx.apply_override(self._session_model_overrides.get(session_key, {}))
+        # Proxy-mode sidecars (Matrix E2EE container, etc.) have no providers catalog.
+        # Local switch_model would raise Unknown provider; the host honors model+provider
+        # on the proxied /v1/chat/completions body instead.
+        if self._get_proxy_url():
+            return await self._handle_proxied_model_command(ctx, request)
         if not request.target and not request.explicit_provider:
             return await self._model_listing_reply(event, ctx, profile_home)
         result, error = await self._perform_model_switch(ctx, request.target, request.explicit_provider, source)
@@ -516,6 +521,68 @@ class GatewayModelCommandsMixin:
         if guard_fired:
             return guard_reply
         return await self._commit_model_switch(result, ctx, source=source)
+
+    async def _handle_proxied_model_command(self, ctx: _ModelSwitchContext, request) -> str:
+        """``/model`` on a GATEWAY_PROXY_URL sidecar: store a session override, don't resolve locally.
+
+        The sidecar config has no ``providers:`` catalog (Matrix E2EE split). ``switch_model``
+        would raise ``Unknown provider``. The next proxied turn sends model+provider on the
+        host ``/v1/chat/completions`` body (see ``_proxy_request_model_fields``).
+        """
+        from hermes_cli.model_switch import format_model_for_display
+
+        if not request.target and not request.explicit_provider:
+            current = ctx.current_model or "host default"
+            provider = ctx.current_provider or "hermes-agent"
+            return (
+                f"Current model: `{current}` ({provider})\n\n"
+                "This gateway is in proxy mode — the model catalog lives on the host agent. "
+                "Typed switches are forwarded on the next turn.\n\n"
+                "Switch: `/model <name> --provider <slug>`\n"
+                "Example: `/model cf-turbo-q8-dual --provider ollama`"
+            )
+        if not request.target:
+            return "❌ Proxy mode requires a model name: `/model <name> --provider <slug>`"
+        if not request.explicit_provider:
+            return (
+                "❌ Proxy mode requires `--provider <slug>` "
+                "(this sidecar has no local provider catalog)."
+            )
+        override = {
+            "model": request.target,
+            "provider": request.explicit_provider,
+            "api_key": "",
+            "base_url": "",
+            "api_mode": "",
+            "request_overrides": {},
+            "capabilities": {},
+        }
+        if not hasattr(self, "_session_model_overrides") or self._session_model_overrides is None:
+            self._session_model_overrides = {}
+        self._session_model_overrides[ctx.session_key] = override
+        if not hasattr(self, "_pending_model_notes"):
+            self._pending_model_notes = {}
+        self._pending_model_notes[ctx.session_key] = (
+            f"[Note: model was just switched from {format_model_for_display(ctx.current_model)} to "
+            f"{format_model_for_display(request.target)} via {request.explicit_provider}. "
+            f"{'This override applies to the next turn only. ' if ctx.one_turn else ''}"
+            f"Adjust your self-identification accordingly.]"
+        )
+        if ctx.one_turn:
+            if not hasattr(self, "_pending_one_turn_model_restores"):
+                self._pending_one_turn_model_restores = {}
+            self._pending_one_turn_model_restores[ctx.session_key] = (
+                ctx.restore_snapshot or {"had_override": False, "override": None}
+            )
+        lines = [
+            t("gateway.model.switched", model=format_model_for_display(request.target)),
+            t("gateway.model.provider_label", provider=request.explicit_provider),
+        ]
+        if ctx.one_turn:
+            lines.append("    (next turn only — restores after one response)")
+        else:
+            lines.append(t("gateway.model.session_only_hint"))
+        return "\n".join(lines)
 
     # -------------------------------------------------- /codex-runtime, /personality
 

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -218,9 +218,47 @@ class TestRunAgentViaProxy:
 
         # Verify streaming is requested
         assert session.captured_json["stream"] is True
+        assert session.captured_json["model"] == "hermes-agent"
+        assert "provider" not in session.captured_json
 
         # Verify response was assembled
         assert result["final_response"] == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_forwards_session_model_override(self, monkeypatch):
+        """A sidecar /model override must ride the proxy body as model+provider.
+
+        Host api_server ignores a bare model unless direct_model_requests is on;
+        provider is always honored. See Matrix E2EE sidecar split.
+        """
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.setenv("GATEWAY_PROXY_KEY", "test-key-123")
+        runner = _make_runner()
+        runner._session_model_overrides["matrix:room"] = {
+            "model": "cf-turbo-q8-dual",
+            "provider": "ollama",
+        }
+        source = _make_source()
+        resp = _FakeSSEResponse(
+            status=200,
+            sse_chunks=[b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n'],
+        )
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="session-abc",
+                        session_key="matrix:room",
+                    )
+
+        assert session.captured_json["model"] == "cf-turbo-q8-dual"
+        assert session.captured_json["provider"] == "ollama"
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_proxy_model_command.py
+++ b/tests/gateway/test_proxy_model_command.py
@@ -1,0 +1,108 @@
+"""Proxy-mode /model must not resolve against the sidecar catalog.
+
+The Matrix E2EE sidecar has GATEWAY_PROXY_URL and an empty providers: block.
+Local switch_model() raises Unknown provider 'Local'/'ollama'. The sidecar
+stores a session override; the next proxied turn sends model+provider to the host.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+def _event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.MATRIX,
+            chat_id="!room:server.org",
+            chat_type="dm",
+            user_id="@greg:nevfi",
+            user_name="greg",
+        ),
+    )
+
+
+def _runner(tmp_path, monkeypatch, *, proxy_url="http://host:8642"):
+    import gateway.run as gateway_run
+    from gateway.run import GatewayRunner
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"gateway": {"proxy_url": proxy_url}, "platforms": {"matrix": {"enabled": True}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setenv("GATEWAY_PROXY_URL", proxy_url)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hermes_home)
+
+    called = []
+
+    def _should_not_switch(**kwargs):
+        called.append(kwargs)
+        raise AssertionError("switch_model must not run on a proxy-mode sidecar")
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _should_not_switch)
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner.config = MagicMock()
+    runner.config.multiplex_profiles = False
+    runner._session_model_overrides = {}
+    runner._pending_one_turn_model_restores = {}
+    runner._switch_calls = called
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_proxy_model_switch_stores_override_without_local_resolve(tmp_path, monkeypatch):
+    runner = _runner(tmp_path, monkeypatch)
+    result = await runner._handle_model_command(
+        _event("/model cf-turbo-q8-dual --provider ollama")
+    )
+    assert runner._switch_calls == []
+    assert result is not None and "cf-turbo-q8-dual" in result
+    assert "ollama" in result
+    overrides = list(runner._session_model_overrides.values())
+    assert len(overrides) == 1
+    assert overrides[0]["model"] == "cf-turbo-q8-dual"
+    assert overrides[0]["provider"] == "ollama"
+
+
+@pytest.mark.asyncio
+async def test_proxy_model_switch_accepts_display_name_local(tmp_path, monkeypatch):
+    """The host catalog shows name Local for providers.local — users type that."""
+    runner = _runner(tmp_path, monkeypatch)
+    result = await runner._handle_model_command(
+        _event("/model cf-turbo-q8-dual --provider Local")
+    )
+    assert runner._switch_calls == []
+    assert result is not None and "Unknown provider" not in result
+    override = next(iter(runner._session_model_overrides.values()))
+    assert override["provider"] == "Local"
+
+
+@pytest.mark.asyncio
+async def test_proxy_model_requires_provider_flag(tmp_path, monkeypatch):
+    runner = _runner(tmp_path, monkeypatch)
+    result = await runner._handle_model_command(_event("/model cf-turbo-q8-dual"))
+    assert runner._switch_calls == []
+    assert result is not None and "--provider" in result
+    assert runner._session_model_overrides == {}
+
+
+@pytest.mark.asyncio
+async def test_proxy_model_bare_lists_usage(tmp_path, monkeypatch):
+    runner = _runner(tmp_path, monkeypatch)
+    result = await runner._handle_model_command(_event("/model"))
+    assert runner._switch_calls == []
+    assert result is not None and "proxy mode" in result.lower()
+    assert "--provider" in result


### PR DESCRIPTION
## Summary

Slash commands run on the **sidecar**, not through `GATEWAY_PROXY_URL`. In a Matrix E2EE sidecar + host brain split:

1. `/model` resolved against the sidecar's empty providers catalog → `Unknown provider 'Local'` / `'ollama'`
2. Even a successful local switch would not change inference — `_run_agent_via_proxy` always POSTed `model: hermes-agent` and never forwarded `provider`

Host `api_server` honors `provider` even when `direct_model_requests` is off; bare `model` alone is ignored unless that flag is set.

## Changes

- **Proxy `/model` path**: when `GATEWAY_PROXY_URL` is set, require `--provider`, store a session override `{model, provider}`, skip local `switch_model`
- **Proxy request body**: forward session override `model` + `provider` on `/v1/chat/completions` (default remains `hermes-agent` with no override)
- **Tests**: default body still omits provider; override is forwarded; listing / missing-provider / success cases for the proxied handler

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_proxy_mode.py tests/gateway/test_proxy_model_command.py`
- [x] Deployed on Nevermore Matrix sidecar (`hermes-matrix`); dual-login cleaned (`platforms.matrix.enabled: false` on host)
- [ ] Live Element: `!model cf-turbo-q8-dual --provider ollama` then a turn that hits the host