### PR TITLE
feat(gateway): streaming TTS playback in Discord voice + Breeze provider

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3272,19 +3272,40 @@ class GatewayTurnMixin:
         if _agent.model != _cfg_model and not self._is_intentional_model_switch(session_key, _agent.model):
             self._evict_cached_agent(session_key)
 
+    @staticmethod
+    def _streaming_tts_should_abort_on_turn_end(stts: Any) -> bool:
+        """Abort a still-running consumer only when it never produced audio.
+
+        Audible streams must keep synthesising after the text send — aborting them
+        (the #60671 leak-hardening) clips Discord playback the moment the turn
+        ends. Silent streams still abort so whole-file TTS can fall back.
+        """
+        return bool(
+            stts is not None
+            and not getattr(stts, "done", True)
+            and not getattr(stts, "suppress_whole_file", False)
+        )
+
     async def _run_agent_finalize_streaming_tts(self, turn_ctx: TurnContext, adapter: Any) -> None:
         """Finalize the streaming-TTS consumer on the outer event-loop thread (covers early returns
-        from run_sync). On drain timeout abort to free the task — audible streams keep whole-file
-        suppression, silent streams stay eligible for the whole-file fallback."""
+        from run_sync). ``finish()`` ends the text feed; remaining PCM keeps playing after this
+        turn returns. Abort on drain timeout only if nothing was audible (whole-file fallback)."""
         _stts = turn_ctx.streaming_tts_consumer_holder[0]
         if _stts is None:
             return
         _stts.finish()
+        # Already speaking: don't block the Discord text send, and don't abort remaining clauses.
+        if _stts.suppress_whole_file:
+            if adapter is not None:
+                _mark_turn = getattr(adapter, "_mark_streaming_tts_completed_turn", None)
+                if callable(_mark_turn):
+                    _mark_turn(turn_ctx.session_key, turn_ctx.run_generation)
+            return
         try:
             await _stts.wait_complete(timeout=10.0)
         except Exception as _stts_done_err:
             logger.debug("streaming TTS wait_complete error: %s", _stts_done_err)
-        if not _stts.done:
+        if self._streaming_tts_should_abort_on_turn_end(_stts):
             _stts.abort("streaming TTS finalisation timeout")
             await _stts.wait_complete(timeout=2.0)
         if _stts.suppress_whole_file and adapter is not None:
@@ -3531,10 +3552,11 @@ class GatewayTurnMixin:
             else:
                 await self._await_stream_task(stream_task)
 
-        # Abort + bounded wait for streaming TTS: covers paths where normal finalisation was skipped.
+        # Abort only silent in-flight streaming TTS (never-audible → whole-file fallback).
+        # An audible stream is detached: finish() already ended the text feed, and remaining
+        # PCM must play out after the Discord message posts. See local Breeze Discord cut-out.
         _stts_finally = turn_ctx.streaming_tts_consumer_holder[0]
-        # See #60671.
-        if _stts_finally is not None and not _stts_finally.done:
+        if self._streaming_tts_should_abort_on_turn_end(_stts_finally):
             _stts_finally.abort("cleanup")
             with suppress(Exception):
                 await _stts_finally.wait_complete(timeout=2.0)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1054,6 +1054,16 @@ DEFAULT_CONFIG = {
             "voice": "default",
             # optional "base_url" key overrides DEEPINFRA_BASE_URL for TTS only
         },
+        "breeze": {
+            # Local streaming server (breeze-tts); streaming only, pin via streaming.provider: breeze
+            "base_url": "http://127.0.0.1:7860",  # or $BREEZE_TTS_URL
+            "ref_audio": "",  # optional voice-clone reference clip (needs ref_text too)
+            "ref_text": "",   # transcript of ref_audio (Breeze needs both or neither)
+            "instruction": "Speak clearly and naturally.",
+            "cfg_scale": 1.0,
+            "seed": 42,
+            "busy_timeout": 20.0,  # seconds to wait out a 409 (server synthesises one request at a time)
+        },
     },
 
     "stt": {

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3561,6 +3561,170 @@ class DiscordAdapter(BasePlatformAdapter):
         mixers = getattr(self, "_voice_mixers", None)
         return bool(mixers) and mixers.get(guild_id) is not None
 
+    # ------------------------------------------------------------------
+    # Streaming TTS (#60671) — play clauses as the LLM generates them.
+    #
+    # The gateway's StreamingTTSConsumer chunks the reply into clauses,
+    # synthesises each via a StreamingTTSProvider (e.g. Breeze), and calls
+    # these methods to push PCM onto the voice channel while the model is
+    # still writing.  We back the stream with the continuous VoiceMixer: one
+    # StreamingMixerChild per turn, fed resampled PCM, ducking the ambient bed
+    # for the life of the turn and swelling it back on completion.  Requires an
+    # installed mixer (voice-fx enabled); otherwise we decline and the gateway
+    # keeps the whole-file auto-TTS path.
+    # ------------------------------------------------------------------
+
+    def _voice_guild_for_chat(self, chat_id: str) -> Optional[int]:
+        """Return the guild whose voice channel is bound to *chat_id*, or None.
+
+        Only returns a guild that is both connected and running the continuous
+        mixer — the streaming path has no legacy fallback of its own.
+        """
+        bindings = getattr(self, "_voice_text_channels", None) or {}
+        for gid, text_ch_id in bindings.items():
+            if str(text_ch_id) == str(chat_id) and self.is_in_voice_channel(gid) \
+                    and self.voice_mixer_active(gid):
+                return gid
+        return None
+
+    def supports_streaming_tts(self, chat_id: str, audio_format: "AudioFormat") -> bool:
+        return self._voice_guild_for_chat(chat_id) is not None
+
+    def _guild_bound_to_chat(self, chat_id: str) -> Optional[int]:
+        """Guild whose voice channel is bound to *chat_id* (binding only).
+
+        Unlike :meth:`_voice_guild_for_chat` this does not require the mixer to
+        be active — used by stop paths that must find the stream to cancel even
+        as things are being torn down.
+        """
+        bindings = getattr(self, "_voice_text_channels", None) or {}
+        for gid, text_ch_id in bindings.items():
+            if str(text_ch_id) == str(chat_id):
+                return gid
+        return None
+
+    def _supersede_stream_handle(self, guild_id: int, *, hard: bool) -> None:
+        """Stop the guild's current streaming reply, if any.
+
+        A reply's audio plays out (its mixer child) after the consumer that fed
+        it has finished, so a new reply — or a barge-in — must stop the old one
+        or two replies overlap. ``hard`` cuts immediately (barge-in / new
+        reply); it also flags the old handle aborted so a still-running
+        background consumer for it stops synthesising.
+        """
+        handles = getattr(self, "_voice_stream_handles", None)
+        if not handles:
+            return
+        prior = handles.get(guild_id)
+        if prior is None:
+            return
+        prior.aborted = True
+        child = getattr(prior, "child", None)
+        if child is not None and not child.finished:
+            if hard:
+                child.clear_and_close()
+            else:
+                child.close()
+        handles.pop(guild_id, None)
+
+    def stop_streaming_speech(self, chat_id: str) -> None:
+        """Immediately stop any streaming reply playing for *chat_id* (barge-in)."""
+        guild_id = self._guild_bound_to_chat(chat_id)
+        if guild_id is not None:
+            self._supersede_stream_handle(guild_id, hard=True)
+
+    async def begin_streaming_tts(
+        self,
+        chat_id: str,
+        audio_format: "AudioFormat",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> "Optional[StreamingTTSHandle]":
+        guild_id = self._voice_guild_for_chat(chat_id)
+        if guild_id is None:
+            return None
+        try:
+            from .voice_mixer import PcmResamplerTo48Stereo
+        except ImportError:
+            from voice_mixer import PcmResamplerTo48Stereo
+        from gateway.platforms.base import StreamingTTSHandle
+
+        # A new reply supersedes any prior one still playing/synthesising for
+        # this guild, so replies never overlap.
+        self._supersede_stream_handle(guild_id, hard=True)
+
+        handle = StreamingTTSHandle(chat_id=chat_id, audio_format=audio_format)
+        # Extra per-turn state on the handle (dataclass, not slotted).
+        handle.guild_id = guild_id
+        handle.child = None  # created lazily on the first audible chunk
+        handle.resampler = PcmResamplerTo48Stereo(
+            audio_format.sample_rate, audio_format.channels
+        )
+        stream_handles = getattr(self, "_voice_stream_handles", None)
+        if stream_handles is None:
+            stream_handles = {}
+            self._voice_stream_handles = stream_handles
+        stream_handles[guild_id] = handle
+        # Playback is activity — don't let the idle timer disconnect mid-reply.
+        self._cancel_voice_timeout(guild_id)
+        return handle
+
+    async def write_streaming_tts(self, handle: "StreamingTTSHandle", chunk: bytes) -> None:
+        if handle is None or getattr(handle, "aborted", False) or not chunk:
+            return
+        mixer = getattr(self, "_voice_mixers", {}).get(getattr(handle, "guild_id", None))
+        if mixer is None:
+            return
+        pcm48 = handle.resampler.feed(chunk)
+        if not pcm48:
+            return
+        if handle.child is None:
+            # First audible PCM: install the streaming child now (not at begin)
+            # so the ambient bed keeps playing normally until the reply actually
+            # has audio — the duck coincides with speech, not the wait for it.
+            speech_gain = float(self._voice_fx_cfg.get("speech_gain", 1.0))
+            handle.child = mixer.play_stream(gain=speech_gain)
+            lead = self._lead_silence_bytes()
+            if lead:
+                handle.child.feed(lead)
+        handle.child.feed(pcm48)
+
+    async def finish_streaming_tts(
+        self, handle: "StreamingTTSHandle", *, interrupted: bool = False
+    ) -> None:
+        if handle is None:
+            return
+        # Close so the child drains its buffer and the ambient swells back once
+        # the last clause finishes playing. The resampler's tail (one carried
+        # source sample) is dropped — well under a millisecond, inaudible.
+        child = getattr(handle, "child", None)
+        if child is not None:
+            child.close()
+        gid = getattr(handle, "guild_id", None)
+        if gid is not None:
+            self._reset_voice_timeout(gid)
+
+    async def abort_streaming_tts(
+        self, handle: "StreamingTTSHandle", error: Optional[str] = None
+    ) -> None:
+        if handle is None:
+            return
+        handle.aborted = True
+        child = getattr(handle, "child", None)
+        if child is not None:
+            # Graceful by default: an end-of-turn finalisation timeout or a
+            # cleanup abort lets already-synthesised audio in the buffer play
+            # out rather than clipping the reply mid-word (the mixer child drains
+            # independently of the now-stopped consumer task). The live barge-in
+            # path is stop_streaming_speech() (a hard cut); the "barge" check
+            # here is a defensive fallback for an abort reason that names one.
+            if "barge" in (error or "").lower():
+                child.clear_and_close()
+            else:
+                child.close()
+        gid = getattr(handle, "guild_id", None)
+        if gid is not None:
+            self._reset_voice_timeout(gid)
+
     async def join_voice_channel(self, channel, *, text_channel_id: int = None, source: dict = None) -> bool:
         """Join a voice channel; returns True on success. ``text_channel_id`` stores the
         transcription-routing binding so programmatic joins work without ``/voice join``."""

--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -75,6 +75,164 @@ class MixerChild:
         return samples
 
 
+class StreamingMixerChild:
+    """A speech child fed incrementally instead of from a fixed buffer.
+
+    Holds a growable byte buffer of 48 kHz / stereo / s16le PCM (Discord-native
+    frame format).  :meth:`feed` appends bytes from the asyncio loop thread;
+    :meth:`read_frame` is drained one 20 ms frame at a time from discord.py's
+    sender thread.  The two are guarded by a lock.
+
+    Underrun policy: while the buffer is empty and the child is **not** closed
+    (synthesis of the next clause hasn't caught up), :meth:`read_frame` returns
+    a silence frame so the child stays live and keeps the ambient ducked — the
+    gap is a quiet beat, not the end of speech.  Once :meth:`close` is called
+    and the buffer drains, the child finishes and the mixer drops it (releasing
+    the duck).
+    """
+
+    __slots__ = (
+        "name", "_buf", "_lock", "gain", "is_speech",
+        "_closed", "_finished", "fade_frames", "_fade_done",
+    )
+
+    def __init__(self, name: str, *, gain: float = 1.0, fade_in_ms: int = 40):
+        self.name = name
+        self._buf = bytearray()
+        self._lock = threading.Lock()
+        self.gain = float(gain)
+        self.is_speech = True
+        self._closed = False
+        self._finished = False
+        self.fade_frames = max(0, fade_in_ms // FRAME_LENGTH_MS)
+        self._fade_done = 0
+
+    @property
+    def finished(self) -> bool:
+        return self._finished
+
+    def feed(self, pcm: bytes) -> None:
+        """Append 48 kHz stereo s16le PCM bytes (thread-safe)."""
+        if not pcm:
+            return
+        with self._lock:
+            self._buf.extend(pcm)
+
+    def close(self) -> None:
+        """Signal end-of-turn: drain what's buffered, then finish."""
+        with self._lock:
+            self._closed = True
+
+    def clear_and_close(self) -> None:
+        """Drop any buffered audio and finish immediately (barge-in/abort).
+
+        Unlike :meth:`close` (which lets the buffer drain first), this stops the
+        child at once so a barge-in cuts speech mid-word instead of playing one
+        more frame.  The mixer drops it on the next :meth:`read_frame`.
+        """
+        with self._lock:
+            self._buf.clear()
+            self._closed = True
+            self._finished = True
+
+    def read_frame(self) -> "Optional[np.ndarray]":
+        """Return the next 20 ms frame, a silence frame on underrun, or None."""
+        if self._finished:
+            return None
+
+        underrun = False
+        with self._lock:
+            if len(self._buf) >= FRAME_SIZE:
+                chunk = bytes(self._buf[:FRAME_SIZE])
+                del self._buf[:FRAME_SIZE]
+            elif self._closed:
+                if self._buf:
+                    # Final partial frame — pad to a whole frame, then finish.
+                    chunk = bytes(self._buf) + b"\x00" * (FRAME_SIZE - len(self._buf))
+                    self._buf.clear()
+                    self._finished = True
+                else:
+                    self._finished = True
+                    return None
+            else:
+                underrun = True
+                chunk = None
+
+        np = _require_numpy()
+        if underrun:
+            # Keep the child alive without advancing the fade-in ramp.
+            return np.zeros(SAMPLES_PER_FRAME * CHANNELS, dtype=np.float32)
+
+        samples = np.frombuffer(chunk, dtype=np.int16).astype(np.float32)
+        gain = self.gain
+        if self.fade_frames and self._fade_done < self.fade_frames:
+            self._fade_done += 1
+            gain *= self._fade_done / self.fade_frames
+        if gain != 1.0:
+            samples = samples * gain
+        return samples
+
+
+class PcmResamplerTo48Stereo:
+    """Stateful resampler: source-rate mono/stereo s16le → 48 kHz stereo s16le.
+
+    Streaming TTS providers emit PCM at their own rate (Breeze: 24 kHz mono);
+    the mixer is Discord-native 48 kHz stereo.  This converts each incoming
+    chunk, carrying a byte remainder (a sample split across chunk boundaries)
+    and the last source sample (for gap-free linear interpolation across
+    chunks) so back-to-back ``feed`` calls join without a click.
+    """
+
+    __slots__ = ("src_rate", "src_channels", "_rem", "_carry")
+
+    def __init__(self, src_rate: int, src_channels: int = 1):
+        self.src_rate = int(src_rate)
+        self.src_channels = max(1, int(src_channels))
+        self._rem = b""
+        self._carry: "Optional[float]" = None
+
+    def feed(self, pcm: bytes) -> bytes:
+        if not pcm:
+            return b""
+        np = _require_numpy()
+        data = self._rem + pcm
+        frame_bytes = 2 * self.src_channels
+        n = (len(data) // frame_bytes) * frame_bytes
+        self._rem = data[n:]
+        if n == 0:
+            return b""
+
+        arr = np.frombuffer(data[:n], dtype=np.int16).astype(np.float32)
+        if self.src_channels > 1:
+            arr = arr.reshape(-1, self.src_channels).mean(axis=1)
+
+        # Prepend the carried tail so the segment starts where the last ended.
+        if self._carry is not None:
+            arr = np.concatenate(([np.float32(self._carry)], arr))
+        if len(arr) < 2:
+            self._carry = float(arr[-1])
+            return b""
+
+        if self.src_rate == 48000:
+            out = arr[1:] if self._carry is not None else arr
+        else:
+            ratio = 48000.0 / self.src_rate
+            out_n = int((len(arr) - 1) * ratio)
+            if out_n <= 0:
+                self._carry = float(arr[-1])
+                return b""
+            xs = np.arange(out_n, dtype=np.float32) / ratio
+            idx = np.floor(xs).astype(np.int64)
+            frac = xs - idx
+            idx = np.clip(idx, 0, len(arr) - 2)
+            out = arr[idx] * (1.0 - frac) + arr[idx + 1] * frac
+
+        self._carry = float(arr[-1])
+        stereo = np.repeat(out[:, None], CHANNELS, axis=1).reshape(-1)
+        np.clip(stereo, -32768, 32767, out=stereo)
+        return stereo.astype(np.int16).tobytes()
+
+
 class VoiceMixer(discord.AudioSource):
     """Continuous ``discord.AudioSource`` mixing N children: :meth:`set_ambient` installs the
     looping idle bed, :meth:`play_speech` layers a one-shot clip over it (ducking the bed).
@@ -117,6 +275,32 @@ class VoiceMixer(discord.AudioSource):
             self._duck_release_left = 0
             if self._ambient is not None:
                 self._ambient.gain = self._duck_gain
+
+    def play_stream(self, *, gain: Optional[float] = None,
+                    fade_in_ms: int = 40) -> "StreamingMixerChild":
+        """Install a continuously-fed speech child and return it.
+
+        Unlike :meth:`play_speech` (which takes a complete clip), the returned
+        child is fed incrementally via :meth:`StreamingMixerChild.feed` as PCM
+        arrives from a streaming TTS provider.  It ducks the ambient bed for as
+        long as it is installed and, on buffer underrun, emits silence (rather
+        than finishing) so a mid-turn gap between clauses is a brief quiet beat
+        under the ambient rather than the stream ending.  Call
+        :meth:`StreamingMixerChild.close` at end-of-turn so it drains and
+        releases the duck.
+        """
+        child = StreamingMixerChild(
+            "speech-stream",
+            gain=self._speech_gain if gain is None else float(gain),
+            fade_in_ms=fade_in_ms,
+        )
+        with self._lock:
+            self._speech.append(child)
+            self._speech_active = True
+            self._duck_release_left = 0
+            if self._ambient is not None:
+                self._ambient.gain = self._duck_gain
+        return child
 
     @property
     def speech_active(self) -> bool:

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -163,3 +163,237 @@ class TestPlayAckInVoice:
         assert await adapter.play_ack_in_voice(111) is False
 
 
+# =====================================================================
+# Streaming TTS: mixer child + resampler (#60671)
+# =====================================================================
+
+class TestStreamingMixerChild:
+    def _full_frame(self, value=0x10):
+        # One 20ms frame of a constant loud-ish sample.
+        return (value.to_bytes(2, "little", signed=False)) * (
+            vm.SAMPLES_PER_FRAME * vm.CHANNELS
+        )
+
+    def test_delivers_buffered_frames_then_silence_on_underrun(self):
+        child = vm.StreamingMixerChild("s", gain=1.0, fade_in_ms=0)
+        child.feed(self._full_frame() * 3)
+        for _ in range(3):
+            frame = child.read_frame()
+            assert frame is not None and frame.shape[0] == vm.SAMPLES_PER_FRAME * vm.CHANNELS
+            assert frame.any()  # real audio
+        # Buffer drained but not closed → silence frame keeps the child alive.
+        under = child.read_frame()
+        assert under is not None and not under.any()
+        assert child.finished is False
+
+    def test_finishes_after_close_and_drain(self):
+        child = vm.StreamingMixerChild("s", fade_in_ms=0)
+        child.feed(self._full_frame())
+        assert child.read_frame() is not None       # the one real frame
+        child.close()
+        assert child.read_frame() is None            # drained + closed → done
+        assert child.finished is True
+
+    def test_close_pads_final_partial_frame(self):
+        child = vm.StreamingMixerChild("s", fade_in_ms=0)
+        child.feed(b"\x01\x02" * 10)  # less than a full frame
+        child.close()
+        frame = child.read_frame()
+        assert frame is not None and frame.shape[0] == vm.SAMPLES_PER_FRAME * vm.CHANNELS
+        assert child.read_frame() is None
+        assert child.finished is True
+
+    def test_clear_and_close_drops_buffer_immediately(self):
+        child = vm.StreamingMixerChild("s", fade_in_ms=0)
+        child.feed(self._full_frame() * 5)
+        child.clear_and_close()
+        assert child.read_frame() is None
+        assert child.finished is True
+
+    def test_play_stream_ducks_ambient_and_returns_child(self):
+        mx = vm.VoiceMixer()
+        mx.set_ambient(vm.synth_ambient_pcm(1.0))
+        child = mx.play_stream(gain=1.0)
+        assert isinstance(child, vm.StreamingMixerChild)
+        assert mx.speech_active is True
+        # The mixer read loop drops the child and releases the duck once it
+        # finishes (empty + closed).
+        child.close()
+        for _ in range(3):
+            mx.read()
+        assert mx.speech_active is False
+
+
+class TestPcmResampler:
+    def test_24k_mono_to_48k_stereo_doubles_and_widens(self):
+        # 0.5s of 24k mono -> ~0.5s of 48k stereo.
+        n = 12000
+        mono = (np.sin(np.arange(n) / 5.0) * 8000).astype(np.int16).tobytes()
+        rs = vm.PcmResamplerTo48Stereo(24000, 1)
+        out = rs.feed(mono)
+        out_frames = len(out) // 2 // vm.CHANNELS
+        assert abs(out_frames - 24000) < 50  # ~2x samples, stereo
+
+    def test_carries_odd_byte_remainder_across_chunks(self):
+        n = 4000
+        mono = (np.arange(n) % 100 - 50).astype(np.int16).tobytes()
+        rs_split = vm.PcmResamplerTo48Stereo(24000, 1)
+        # Feed in deliberately sample-splitting sizes (odd byte counts).
+        out_split = b""
+        for i in range(0, len(mono), 777):
+            out_split += rs_split.feed(mono[i:i + 777])
+        rs_whole = vm.PcmResamplerTo48Stereo(24000, 1)
+        out_whole = rs_whole.feed(mono)
+        # Same total audio regardless of how it was chunked (within rounding).
+        assert abs(len(out_split) - len(out_whole)) <= 8
+
+    def test_48k_stereo_passthrough_is_lossless_length(self):
+        frames = 960 * 3
+        stereo = (np.arange(frames * 2) % 200 - 100).astype(np.int16).tobytes()
+        rs = vm.PcmResamplerTo48Stereo(48000, 2)
+        out = rs.feed(stereo)
+        # Passthrough consumes one carried sample of latency; near-identical.
+        assert abs(len(out) - len(stereo)) <= 8
+
+
+# =====================================================================
+# Streaming TTS: adapter contract (#60671)
+# =====================================================================
+
+def _voice_adapter_with_mixer(guild_id=111, chat_id="900"):
+    """An adapter wired to a live mixer + connected VC for streaming tests."""
+    adapter = _make_adapter()
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    adapter._voice_clients[guild_id] = vc
+    adapter._voice_mixers[guild_id] = vm.VoiceMixer()
+    adapter._voice_text_channels[guild_id] = int(chat_id)
+    adapter._cancel_voice_timeout = MagicMock()
+    adapter._reset_voice_timeout = MagicMock()
+    return adapter, guild_id, chat_id
+
+
+class TestAdapterStreamingTTS:
+    def test_supports_only_when_mixer_bound_to_chat(self):
+        from gateway.platforms.base import AudioFormat
+        adapter, gid, chat_id = _voice_adapter_with_mixer()
+        assert adapter.supports_streaming_tts(chat_id, AudioFormat()) is True
+        # Unknown chat, or a chat with no mixer, is declined.
+        assert adapter.supports_streaming_tts("does-not-exist", AudioFormat()) is False
+
+    @pytest.mark.asyncio
+    async def test_begin_write_finish_flows_pcm_into_mixer(self):
+        from gateway.platforms.base import AudioFormat
+        adapter, gid, chat_id = _voice_adapter_with_mixer()
+        fmt = AudioFormat(sample_rate=24000, channels=1)
+
+        handle = await adapter.begin_streaming_tts(chat_id, fmt)
+        assert handle is not None
+        adapter._cancel_voice_timeout.assert_called_once_with(gid)
+        # No child yet — ambient must not duck until real audio arrives.
+        assert handle.child is None
+        assert adapter._voice_mixers[gid].speech_active is False
+
+        # Feed ~0.2s of 24k mono; a child appears and the ambient ducks.
+        mono = (np.sin(np.arange(4800) / 4.0) * 8000).astype(np.int16).tobytes()
+        await adapter.write_streaming_tts(handle, mono)
+        assert handle.child is not None
+        assert adapter._voice_mixers[gid].speech_active is True
+
+        # Drain frames off the mixer — we should hear real (non-silent) audio.
+        speechy = 0
+        for _ in range(20):
+            frame = np.frombuffer(adapter._voice_mixers[gid].read(), dtype=np.int16)
+            if np.abs(frame).mean() > 100:
+                speechy += 1
+        assert speechy > 0
+
+        await adapter.finish_streaming_tts(handle)
+        adapter._reset_voice_timeout.assert_called_with(gid)
+        # close() marks end-of-turn but the child only finishes once its buffer
+        # drains through read_frame() — it must not have finished mid-buffer.
+        assert handle.child.finished is False
+        while handle.child.read_frame() is not None:
+            pass
+        assert handle.child.finished is True
+
+    @pytest.mark.asyncio
+    async def test_new_reply_supersedes_prior_stream(self):
+        # A long reply plays out in the background after its turn; when the next
+        # reply begins it must stop the old one so they don't overlap.
+        from gateway.platforms.base import AudioFormat
+        adapter, gid, chat_id = _voice_adapter_with_mixer()
+        fmt = AudioFormat(sample_rate=24000, channels=1)
+        h1 = await adapter.begin_streaming_tts(chat_id, fmt)
+        mono = (np.ones(4800) * 5000).astype(np.int16).tobytes()
+        await adapter.write_streaming_tts(h1, mono)
+        assert h1.child is not None and not h1.child.finished
+
+        h2 = await adapter.begin_streaming_tts(chat_id, fmt)  # next reply
+        # Prior reply is superseded: flagged aborted and its audio cut.
+        assert h1.aborted is True
+        assert h1.child.finished is True
+        # The new reply is now the tracked stream for the guild.
+        assert adapter._voice_stream_handles[gid] is h2
+
+    @pytest.mark.asyncio
+    async def test_stop_streaming_speech_cuts_current(self):
+        from gateway.platforms.base import AudioFormat
+        adapter, gid, chat_id = _voice_adapter_with_mixer()
+        h = await adapter.begin_streaming_tts(chat_id, AudioFormat(sample_rate=24000, channels=1))
+        mono = (np.ones(4800) * 5000).astype(np.int16).tobytes()
+        await adapter.write_streaming_tts(h, mono)
+        adapter.stop_streaming_speech(chat_id)   # barge-in
+        assert h.aborted is True
+        assert h.child.finished is True
+        assert gid not in adapter._voice_stream_handles
+
+    def test_stop_streaming_speech_unknown_chat_is_noop(self):
+        adapter, gid, chat_id = _voice_adapter_with_mixer()
+        adapter.stop_streaming_speech("no-such-chat")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_begin_declines_without_mixer(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        adapter._voice_text_channels = {}
+        assert await adapter.begin_streaming_tts("nope", AudioFormat()) is None
+
+    @pytest.mark.asyncio
+    async def test_bargein_abort_clears_child_immediately(self):
+        from gateway.platforms.base import AudioFormat
+        adapter, gid, chat_id = _voice_adapter_with_mixer()
+        handle = await adapter.begin_streaming_tts(chat_id, AudioFormat(sample_rate=24000, channels=1))
+        mono = (np.ones(4800) * 5000).astype(np.int16).tobytes()
+        await adapter.write_streaming_tts(handle, mono)
+        # Barge-in: cut immediately, dropping buffered audio.
+        await adapter.abort_streaming_tts(handle, error="barge-in")
+        assert handle.aborted is True
+        assert handle.child.finished is True
+        # A late write after abort is dropped, not raised.
+        await adapter.write_streaming_tts(handle, mono)
+
+    @pytest.mark.asyncio
+    async def test_graceful_abort_drains_buffered_audio(self):
+        # A finalisation-timeout / cleanup abort must NOT discard already-
+        # synthesised audio — it should play out (child.close(), not clear).
+        from gateway.platforms.base import AudioFormat
+        adapter, gid, chat_id = _voice_adapter_with_mixer()
+        handle = await adapter.begin_streaming_tts(chat_id, AudioFormat(sample_rate=24000, channels=1))
+        # Buffer ~0.3s of audio (several frames).
+        mono = (np.ones(7200) * 5000).astype(np.int16).tobytes()
+        await adapter.write_streaming_tts(handle, mono)
+        await adapter.abort_streaming_tts(handle, error="streaming TTS finalisation timeout")
+        assert handle.aborted is True
+        # Not finished yet — buffered audio still there to play out.
+        assert handle.child.finished is False
+        drained = 0
+        for _ in range(200):
+            frame = handle.child.read_frame()
+            if frame is None:
+                break
+            drained += 1
+        assert drained > 0            # buffered audio played out
+        assert handle.child.finished is True
+
+

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -289,15 +289,16 @@ class TestConsumerLifecycle:
         _run_test(run)
 
 
-    def test_post_audio_timeout_keeps_suppression_then_aborts(self):
-        """After audible audio, a finalisation timeout aborts the consumer.
+    def test_post_audio_timeout_keeps_suppression_without_abort(self):
+        """After audible audio, a short wait_complete timeout must not abort.
 
-        The outer gateway loop calls abort() on timeout so no unowned
-        consumer task lingers.  Suppression is preserved so the gateway
-        does not replay from the beginning.  Updated for #60671
-        hardening: the outer loop now aborts instead of leaving the
-        consumer to complete later in the background.
+        Discord posts the text reply as soon as the LLM turn ends, while Breeze
+        may still be synthesising remaining clauses. Aborting here clips the
+        in-progress mixer child. Suppression stays set so whole-file TTS does
+        not replay from the start; the consumer finishes in the background.
         """
+        from gateway.run_turn import GatewayTurnMixin
+
         async def run(loop):
             adapter = FakeVoiceAdapter()
             streamer = BlockingSecondChunkStreamer()
@@ -318,15 +319,15 @@ class TestConsumerLifecycle:
             assert consumer.suppress_whole_file is True
             assert adapter.written_chunks == [b"chunk-1-0"]
 
-            # The outer loop now aborts on timeout after audible audio
-            # instead of leaving the consumer running in the background.
-            consumer.abort("streaming TTS finalisation timeout")
-            await consumer.wait_complete(timeout=2.0)
-
-            # The consumer is aborted, not completed.
-            assert consumer.completed is False
-            assert consumer._aborted is True
+            assert GatewayTurnMixin._streaming_tts_should_abort_on_turn_end(consumer) is False
+            assert consumer._aborted is False
+            assert consumer.done is False
             assert consumer.suppress_whole_file is True
+
+            streamer.allow_remaining_chunks.set()
+            await consumer.wait_complete(timeout=5.0)
+            assert consumer._aborted is False
+            assert consumer.completed is True
 
         _run_test(run)
 
@@ -600,14 +601,16 @@ class TestAdapterFinishFailure:
 
 
 # ---------------------------------------------------------------------------
-# Post-audio timeout: clean abort, no later background completion (#60671)
+# Post-audio timeout: detach audible streams so remaining PCM plays out after the text send. Silent streams still abort (#60671 leak path).
 # ---------------------------------------------------------------------------
 
 
-class TestPostAudioTimeoutAbort:
-    """On finalisation timeout after audible audio, abort the consumer."""
+class TestPostAudioTimeoutDetach:
+    """On finalisation timeout after audible audio, detach — do not abort."""
 
-    def test_timeout_after_audible_aborts_and_preserves_suppression(self):
+    def test_timeout_after_audible_does_not_abort(self):
+        from gateway.run_turn import GatewayTurnMixin
+
         async def run(loop):
             adapter = FakeVoiceAdapter()
             streamer = BlockingSecondChunkStreamer()
@@ -624,20 +627,30 @@ class TestPostAudioTimeoutAbort:
             assert consumer.audible is True
             assert consumer.suppress_whole_file is True
 
-            # Timeout: the consumer should be aborted, not left running.
             completed = await consumer.wait_complete(timeout=0.01)
             assert completed is False
             assert consumer.suppress_whole_file is True
+            assert GatewayTurnMixin._streaming_tts_should_abort_on_turn_end(consumer) is False
+            assert consumer._aborted is False
 
-            # Simulate the outer loop's abort-on-timeout behaviour.
-            consumer.abort("streaming TTS finalisation timeout")
-            await asyncio.sleep(0.05)
-
-            # The consumer must not complete later in the background.
-            assert consumer.completed is False
-            assert consumer._aborted is True
+            streamer.allow_remaining_chunks.set()
+            await consumer.wait_complete(timeout=5.0)
+            assert consumer.completed is True
+            assert consumer._aborted is False
 
         _run_test(run)
+
+    def test_silent_unfinished_consumer_is_aborted(self):
+        from types import SimpleNamespace
+        from gateway.run_turn import GatewayTurnMixin
+
+        silent = SimpleNamespace(done=False, suppress_whole_file=False)
+        audible = SimpleNamespace(done=False, suppress_whole_file=True)
+        finished = SimpleNamespace(done=True, suppress_whole_file=True)
+        assert GatewayTurnMixin._streaming_tts_should_abort_on_turn_end(silent) is True
+        assert GatewayTurnMixin._streaming_tts_should_abort_on_turn_end(audible) is False
+        assert GatewayTurnMixin._streaming_tts_should_abort_on_turn_end(finished) is False
+        assert GatewayTurnMixin._streaming_tts_should_abort_on_turn_end(None) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tts_streaming_breeze.py
+++ b/tests/tools/test_tts_streaming_breeze.py
@@ -1,0 +1,187 @@
+"""Tests for the Breeze local streaming-TTS provider.
+
+Breeze is a self-hosted warm-GPU server (``breeze-tts``) that serves chunked
+``audio/pcm`` from ``POST /v1/audio/speech``. These tests exercise the provider
+in isolation — registration/resolution, health-gated availability, the chunked
+read path, multipart-vs-urlencoded body selection, and the 409 busy-retry —
+with the network fully mocked, so they run without a live server.
+"""
+
+import io
+import urllib.error
+
+import pytest
+
+import tools.tts_streaming as ts
+
+
+class _FakeResp:
+    """Minimal urlopen() response: context manager + chunked ``read(n)``."""
+
+    def __init__(self, chunks, headers=None):
+        self._buf = io.BytesIO(b"".join(chunks))
+        self.headers = headers or {}
+
+    def read(self, n=-1):
+        return self._buf.read(n)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _breeze(section=None):
+    return ts.BreezeStreamer(tts_config={}, section=section or {})
+
+
+# ---------------------------------------------------------------------------
+# Registration / resolution
+# ---------------------------------------------------------------------------
+
+def test_breeze_is_registered():
+    assert ts._REGISTRY.get("breeze") is ts.BreezeStreamer
+
+
+def test_pinned_breeze_resolves_when_healthy(monkeypatch):
+    monkeypatch.setattr(ts, "_breeze_health", lambda url: (True, 24000))
+    prov = ts.resolve_streaming_provider({"streaming": {"provider": "breeze"}})
+    assert isinstance(prov, ts.BreezeStreamer)
+
+
+def test_pinned_breeze_declines_when_unreachable(monkeypatch):
+    monkeypatch.setattr(ts, "_breeze_health", lambda url: (False, None))
+    prov = ts.resolve_streaming_provider({"streaming": {"provider": "breeze"}})
+    assert prov is None
+
+
+def test_breeze_not_in_auto_priority():
+    # ``auto`` walks cloud providers only; a local box shouldn't be picked for
+    # everyone who opts into "best available".
+    assert "breeze" not in ts._PROVIDER_PRIORITY
+
+
+# ---------------------------------------------------------------------------
+# Availability (health-gated)
+# ---------------------------------------------------------------------------
+
+def test_available_reflects_health(monkeypatch):
+    monkeypatch.setattr(ts, "_breeze_base_url", lambda: "http://x")
+    monkeypatch.setattr(ts, "_breeze_health", lambda url: (True, 24000))
+    assert ts.BreezeStreamer.available() is True
+    monkeypatch.setattr(ts, "_breeze_health", lambda url: (False, None))
+    assert ts.BreezeStreamer.available() is False
+
+
+def test_sample_rate_adopts_server_when_unset(monkeypatch):
+    monkeypatch.setattr(ts, "_breeze_health", lambda url: (True, 16000))
+    s = _breeze({"base_url": "http://x"})
+    assert s.sample_rate == 16000
+
+
+def test_sample_rate_config_overrides_server(monkeypatch):
+    monkeypatch.setattr(ts, "_breeze_health", lambda url: (True, 16000))
+    s = _breeze({"base_url": "http://x", "sample_rate": 48000})
+    assert s.sample_rate == 48000
+
+
+# ---------------------------------------------------------------------------
+# Streaming
+# ---------------------------------------------------------------------------
+
+def test_stream_yields_pcm_chunks(monkeypatch):
+    captured = {}
+
+    def _fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["ctype"] = req.headers.get("Content-type")
+        captured["body"] = req.data
+        return _FakeResp([b"\x01\x02" * 100, b"\x03\x04" * 100])
+
+    monkeypatch.setattr(ts, "_breeze_health", lambda url: (True, 24000))
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+    s = _breeze({"base_url": "http://breeze:7860"})
+    out = b"".join(s.stream("Hello there."))
+
+    assert len(out) == 400
+    assert captured["url"] == "http://breeze:7860/v1/audio/speech"
+    # No ref_audio configured → form-urlencoded, text carried in the body.
+    assert captured["ctype"] == "application/x-www-form-urlencoded"
+    assert b"Hello" in captured["body"]
+
+
+def test_stream_uses_multipart_with_ref_audio(monkeypatch, tmp_path):
+    ref = tmp_path / "ref.wav"
+    ref.write_bytes(b"RIFFfake")
+    captured = {}
+
+    def _fake_urlopen(req, timeout=None):
+        captured["ctype"] = req.headers.get("Content-type")
+        captured["body"] = req.data
+        return _FakeResp([b"\x00\x00" * 10])
+
+    monkeypatch.setattr(ts, "_breeze_health", lambda url: (True, 24000))
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+    s = _breeze({
+        "base_url": "http://breeze:7860",
+        "ref_audio": str(ref),
+        "ref_text": "reference transcript",
+    })
+    list(s.stream("Clone my voice."))
+
+    assert captured["ctype"].startswith("multipart/form-data; boundary=")
+    assert b'name="ref_audio"' in captured["body"]
+    assert b"reference transcript" in captured["body"]
+    assert b"RIFFfake" in captured["body"]
+
+
+def test_ref_audio_without_ref_text_falls_back_to_urlencoded(monkeypatch, tmp_path):
+    # Breeze rejects one without the other; we send text-only rather than error.
+    ref = tmp_path / "ref.wav"
+    ref.write_bytes(b"RIFFfake")
+    captured = {}
+
+    def _fake_urlopen(req, timeout=None):
+        captured["ctype"] = req.headers.get("Content-type")
+        return _FakeResp([b"\x00\x00"])
+
+    monkeypatch.setattr(ts, "_breeze_health", lambda url: (True, 24000))
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+    s = _breeze({"base_url": "http://x", "ref_audio": str(ref)})  # no ref_text
+    list(s.stream("Hi."))
+    assert captured["ctype"] == "application/x-www-form-urlencoded"
+
+
+def test_stream_retries_on_409_busy(monkeypatch):
+    calls = {"n": 0}
+
+    def _fake_urlopen(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise urllib.error.HTTPError(req.full_url, 409, "busy", {}, None)
+        return _FakeResp([b"\x07\x08" * 50])
+
+    monkeypatch.setattr(ts, "_breeze_health", lambda url: (True, 24000))
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+
+    s = _breeze({"base_url": "http://x"})
+    out = b"".join(s.stream("Retry me."))
+    assert calls["n"] == 2
+    assert len(out) == 100
+
+
+def test_stream_raises_when_unreachable(monkeypatch):
+    def _fake_urlopen(req, timeout=None):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(ts, "_breeze_health", lambda url: (True, 24000))
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+    s = _breeze({"base_url": "http://x"})
+    with pytest.raises(RuntimeError, match="unreachable"):
+        list(s.stream("Nobody home."))

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -338,3 +338,234 @@ class XAIStreamer(StreamingTTSProvider):
                 if exc.__class__.__name__ != "ConnectionClosed":
                     logger.warning("xAI WS receive failed: %s", exc)
                 return
+
+
+# ---------------------------------------------------------------------------
+# Breeze — local warm-GPU streaming server (self-hosted, no cloud key)
+# ---------------------------------------------------------------------------
+
+DEFAULT_BREEZE_BASE_URL = "http://127.0.0.1:7860"
+
+# Cache the /health probe briefly so ``available()`` (called during every
+# provider resolution) doesn't hit the loopback socket on a hot path.
+_BREEZE_HEALTH_TTL = 5.0
+_breeze_health_cache: dict[str, tuple[float, bool, Optional[int]]] = {}
+_breeze_health_lock = None  # lazily set to a threading.Lock in _breeze_health
+
+
+def _breeze_base_url() -> str:
+    """Resolve the Breeze server base URL: config > env > localhost default."""
+    try:
+        section = (_load_tts_config().get("breeze") or {})
+        configured = str(section.get("base_url") or "").strip()
+        if configured:
+            return configured.rstrip("/")
+    except Exception:
+        pass
+    return (get_env_value("BREEZE_TTS_URL") or DEFAULT_BREEZE_BASE_URL).rstrip("/")
+
+
+def _breeze_health(base_url: str) -> tuple[bool, Optional[int]]:
+    """Return ``(reachable, sample_rate)`` for the Breeze server at *base_url*.
+
+    Cached for ``_BREEZE_HEALTH_TTL`` seconds per URL. Never raises — an
+    unreachable or malformed server reports ``(False, None)`` so the resolver
+    quietly falls back to the whole-file path.
+    """
+    global _breeze_health_lock
+    import threading as _threading
+    import time as _time
+
+    if _breeze_health_lock is None:
+        _breeze_health_lock = _threading.Lock()
+
+    now = _time.monotonic()
+    with _breeze_health_lock:
+        cached = _breeze_health_cache.get(base_url)
+        if cached is not None and (now - cached[0]) < _BREEZE_HEALTH_TTL:
+            return cached[1], cached[2]
+
+    ok, sr = False, None
+    try:
+        import json as _json
+        import urllib.request as _urlreq
+
+        with _urlreq.urlopen(f"{base_url}/health", timeout=1.5) as resp:
+            payload = _json.loads(resp.read().decode("utf-8") or "{}")
+        ok = str(payload.get("status") or "").lower() == "ok"
+        try:
+            sr = int(payload.get("sample_rate")) if payload.get("sample_rate") else None
+        except (TypeError, ValueError):
+            sr = None
+    except Exception as exc:
+        logger.debug("Breeze health check failed for %s: %s", base_url, exc)
+
+    with _breeze_health_lock:
+        _breeze_health_cache[base_url] = (now, ok, sr)
+    return ok, sr
+
+
+@register("breeze")
+class BreezeStreamer(StreamingTTSProvider):
+    """Local Breeze TTS 2 warm streaming server → s16le mono PCM.
+
+    Breeze serves chunked ``audio/pcm`` from ``POST /v1/audio/speech`` (see the
+    ``breeze-tts`` project: https://github.com/breezeblue-ai/breeze-tts). It runs
+    *below* real-time (~0.7x on a GB10), so we
+    buffer each clause to completion before yielding it: the consumer then hands
+    the adapter a gap-free clause instead of risking a within-word underrun.
+    The latency win comes from sentence-level pipelining upstream
+    (:class:`SentenceChunker`) — synthesis of the next clause overlaps playback
+    of the current one — not from sub-clause streaming, which this server is too
+    slow to sustain against a real-time sink.
+
+    Config (``tts.breeze`` in config.yaml)::
+
+        tts:
+          breeze:
+            base_url: http://127.0.0.1:7860   # or $BREEZE_TTS_URL
+            ref_audio: /path/to/reference.mp3  # optional voice-clone reference
+            ref_text: "Transcript of the reference clip."
+            instruction: "Speak clearly and naturally."
+            cfg_scale: 1.0
+            seed: 42
+          streaming:
+            provider: breeze                  # pin (base provider may differ)
+
+    ``ref_audio`` + ``ref_text`` must be supplied together (Breeze rejects one
+    without the other); omit both for the server's default speaker.
+    """
+
+    sample_rate = 24000  # refined from the server's X-Sample-Rate at init
+
+    _BOUNDARY = "----HermesBreezeStreamerBoundary"
+
+    def __init__(self, tts_config: Dict, section: Dict):
+        super().__init__(tts_config, section)
+        self.base_url = str(section.get("base_url") or _breeze_base_url()).rstrip("/")
+        self.instruction = str(section.get("instruction") or "Speak clearly and naturally.")
+        self.cfg_scale = section.get("cfg_scale", 1.0)
+        self.seed = section.get("seed", 42)
+        self.ref_audio = str(section.get("ref_audio") or "").strip()
+        self.ref_text = str(section.get("ref_text") or "").strip()
+        # Breeze serves one synthesis at a time (HTTP 409 while busy). Verbal
+        # acks, the whole-file fallback, and overlapping turns can hold the lock,
+        # so a clause request may need to wait. Poll until it frees rather than
+        # dropping the clause — up to ``busy_timeout`` seconds.
+        try:
+            self.busy_timeout = float(section.get("busy_timeout", 20.0))
+        except (TypeError, ValueError):
+            self.busy_timeout = 20.0
+        # Prefer an explicitly configured rate; otherwise adopt the server's.
+        configured_sr = section.get("sample_rate")
+        if configured_sr:
+            try:
+                self.sample_rate = int(configured_sr)
+            except (TypeError, ValueError):
+                pass
+        else:
+            _ok, sr = _breeze_health(self.base_url)
+            if sr:
+                self.sample_rate = sr
+
+    @staticmethod
+    def available() -> bool:
+        ok, _sr = _breeze_health(_breeze_base_url())
+        return ok
+
+    def stream(self, text: str) -> Iterator[bytes]:
+        yield from _capped(self._request(text), "Breeze streaming TTS")
+
+    # -- HTTP ------------------------------------------------------------
+
+    def _request_form(self) -> tuple[str, Dict[str, str]]:
+        """Return ``(mode, fields)`` for the speech request.
+
+        ``mode`` is ``"multipart"`` when a readable ``ref_audio`` is configured
+        (voice clone), else ``"urlencoded"`` (text-only). ``fields["text"]`` is
+        left ``None`` here and filled per-request in :meth:`_request`.
+        """
+        import os as _os
+
+        fields = {
+            "text": None,  # filled per-request in _request
+            "instruction": self.instruction,
+            "cfg_scale": str(self.cfg_scale),
+            "seed": str(self.seed),
+        }
+        if self.ref_audio and self.ref_text and _os.path.isfile(self.ref_audio):
+            fields["ref_text"] = self.ref_text
+            return "multipart", fields
+        return "urlencoded", fields
+
+    def _request(self, text: str) -> Iterator[bytes]:
+        import time as _time
+        import urllib.error as _urlerr
+        import urllib.parse as _urlparse
+        import urllib.request as _urlreq
+
+        mode, fields = self._request_form()
+        fields = dict(fields)
+        fields["text"] = text
+        url = f"{self.base_url}/v1/audio/speech"
+
+        if mode == "multipart":
+            data, content_type = self._multipart(fields)
+        else:
+            data = _urlparse.urlencode(fields).encode("utf-8")
+            content_type = "application/x-www-form-urlencoded"
+
+        # The server synthesises one request at a time (HTTP 409 while busy).
+        # Poll until it frees rather than dropping the clause. The 409 is raised
+        # by urlopen() before any body arrives (the lock is taken server-side at
+        # request start), so retrying before the first chunk never re-emits
+        # already-yielded audio.
+        deadline = _time.monotonic() + self.busy_timeout
+        while True:
+            req = _urlreq.Request(
+                url, data=data, method="POST",
+                headers={"Content-Type": content_type},
+            )
+            try:
+                with _urlreq.urlopen(req, timeout=180) as resp:
+                    while True:
+                        chunk = resp.read(16384)
+                        if not chunk:
+                            return
+                        yield chunk
+                return
+            except _urlerr.HTTPError as exc:
+                if exc.code == 409 and _time.monotonic() < deadline:
+                    _time.sleep(0.4)
+                    continue
+                raise
+            except _urlerr.URLError as exc:
+                raise RuntimeError(
+                    f"Breeze server unreachable at {self.base_url}: {exc}"
+                ) from exc
+
+    def _multipart(self, fields: Dict[str, str]) -> tuple[bytes, str]:
+        import os as _os
+
+        boundary = self._BOUNDARY
+        chunks: List[bytes] = []
+        for key, value in fields.items():
+            chunks.append(f"--{boundary}\r\n".encode())
+            chunks.append(
+                f'Content-Disposition: form-data; name="{key}"\r\n\r\n'.encode()
+            )
+            chunks.append(str(value).encode("utf-8") + b"\r\n")
+
+        with open(self.ref_audio, "rb") as fh:
+            ref_bytes = fh.read()
+        filename = _os.path.basename(self.ref_audio)
+        ctype = "audio/mpeg" if filename.lower().endswith(".mp3") else "audio/wav"
+        chunks.append(f"--{boundary}\r\n".encode())
+        chunks.append(
+            f'Content-Disposition: form-data; name="ref_audio"; '
+            f'filename="{filename}"\r\n'.encode()
+        )
+        chunks.append(f"Content-Type: {ctype}\r\n\r\n".encode())
+        chunks.append(ref_bytes + b"\r\n")
+        chunks.append(f"--{boundary}--\r\n".encode())
+        return b"".join(chunks), f"multipart/form-data; boundary={boundary}"


### PR DESCRIPTION
## What does this PR do?

Discord becomes the first platform adapter to implement the streaming-TTS
interface (#60671), so spoken replies play **clause-by-clause as the model
generates them** instead of waiting for the whole file to synthesise. This
cuts perceived latency in voice channels from "wait for the full reply" to
"start hearing it almost immediately."

Three pieces make that work end-to-end:

- **Discord playback** — a per-turn `StreamingMixerChild` feeds resampled PCM
  into the continuous voice mixer, ducking the ambient bed for the life of the
  turn and swelling it back when the reply finishes. A new reply or a barge-in
  supersedes the prior stream, so replies never overlap.
- **Gateway finalisation fix** — end-of-turn finalisation no longer aborts an
  *audible* consumer. The text reply posts while the remaining clauses keep
  playing out; only silent streams still abort (so whole-file TTS can fall
  back). Without this, Discord playback was clipped the instant the turn ended.
- **Breeze provider** — a self-hosted, warm-GPU streaming TTS provider wired
  through the existing streaming-provider registry (health-gated, pinned-only,
  409 busy-retry, optional voice-clone reference audio). Stdlib only — no new
  dependencies.

The finalisation fix is only reachable through a streaming-capable adapter, so
it ships alongside the adapter that exercises it rather than as a standalone
change.

## Related Issue

Related to #60671 — the streaming-TTS base interface and consumer already on
`main`. This PR adds the first adapter to use them plus a local provider.

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/discord/adapter.py` — implement the streaming-TTS adapter
  surface (`supports_streaming_tts`, `begin`/`write`/`finish`/`abort`,
  `stop_streaming_speech`); duck/swell the ambient bed; supersede an in-flight
  stream on a new reply or barge-in.
- `plugins/platforms/discord/voice_mixer.py` — add `StreamingMixerChild`
  (incrementally fed; emits silence on underrun so a mid-turn gap is a quiet
  beat, not the end of speech) and `PcmResamplerTo48Stereo` (source rate/mono →
  48 kHz stereo, gap-free across chunk boundaries); `VoiceMixer.play_stream`.
- `gateway/run_turn.py` — audible streams detach at turn end instead of being
  aborted; only silent streams still abort. Fixes the mid-word clipping.
- `tools/tts_streaming.py` — add the `breeze` streaming provider
  (`@register("breeze")`): health-gated `available()`, pinned-only (absent from
  the `auto` priority list), 409 busy-retry, optional multipart voice-clone
  request. Stdlib `urllib`/`json`/`threading` only.
- `hermes_cli/config_defaults.py` — document the `tts.breeze` provider block.
- `tests/gateway/test_discord_voice_mixer.py`,
  `tests/tools/test_tts_streaming_breeze.py`,
  `tests/gateway/test_streaming_tts_consumer.py` — cover mixer child drain,
  resampler geometry, detach-not-abort finalisation, and the Breeze request
  paths.

## How to Test

1. `pytest tests/gateway/test_discord_voice_mixer.py tests/tools/test_tts_streaming_breeze.py tests/gateway/test_streaming_tts_consumer.py -q` — all pass.
2. Stand up a local Breeze server: clone
   [breeze-tts](https://github.com/breezeblue-ai/breeze-tts), install deps,
   download the Breeze TTS 2 checkpoint, and start the single-concurrency
   streaming API:
   `python -m breeze_infer.api <checkpoint-dir> --host 0.0.0.0 --port 7860`
   (add `--fast-all` for the CUDA-graph path). Confirm `GET /health` responds.
3. Point Hermes at it in `config.yaml` — Breeze is streaming-only and not in the
   `auto` ladder, so the provider must be pinned:
   ```yaml
   tts:
     breeze:
       base_url: http://127.0.0.1:7860   # or $BREEZE_TTS_URL
     streaming:
       provider: breeze
   ```
   Optional voice clone: set `ref_audio` + `ref_text` together (both or neither).
4. Join a Discord voice channel and start a turn — the reply should begin
   speaking within about a clause of generation, ducking the ambient bed. If the
   server is down, Hermes skips Breeze rather than auto-selecting it.
5. Interrupt mid-reply (barge-in) and start a new turn — the prior stream stops
   and the new one plays without overlap; the tail of a normal reply is no
   longer clipped when the text posts.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux 6.17)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — config block documented in `config_defaults.py`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (the example documents only the `deepinfra` exemplar; other providers inherit from `DEFAULT_CONFIG`, and Breeze is streaming-only, not a plain `tts.provider` choice)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib only, no platform-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

<!-- Optional: add a short clip or gateway log showing the streamed reply if useful. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
