### PR TITLE
fix(dashboard): gateway restart wrongly blocked across different profiles

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -826,18 +826,33 @@ _CONFIG_MUTATION_LOCK = threading.RLock()
 # inert. 10s is above the ~3.5s storm spacing and below an operator's retry.
 GATEWAY_RESTART_COOLDOWN_SECONDS = 10.0
 
-# ``(monotonic spawn time, Popen, command)`` of the last restart. Deliberately
-# NOT read from ``_ACTION_PROCS``: entries there vanish when the child exits.
-_LAST_GATEWAY_RESTART: Optional[Tuple[float, subprocess.Popen, Tuple[str, ...]]] = None
+# Per-profile in-flight/coalescing state: profile key ("" = default) ->
+# (monotonic spawn time, Popen, command). Deliberately NOT read from
+# _ACTION_PROCS: entries there vanish when the child exits, and — critically —
+# _ACTION_PROCS/_ACTION_COMMANDS are keyed by the shared action NAME
+# ("gateway-restart") for log/status-polling compatibility with the frontend,
+# not by profile. Restarting profile B while profile A's restart child is
+# still in flight (or, for a profile with no installed service, running
+# forever in the foreground as the new gateway process — #site incident: a
+# stuck/foreground child for profile A permanently blocked every OTHER
+# profile's restart with "gateway restart already in progress for another
+# profile", since the old code compared against one shared slot regardless of
+# profile). Each profile's gateway is an independent process (its own systemd
+# unit when installed), so concurrency across DIFFERENT profiles is safe;
+# only same-profile requests should coalesce/reuse.
+_GATEWAY_RESTARTS_BY_PROFILE: Dict[str, Tuple[float, subprocess.Popen, Tuple[str, ...]]] = {}
 
 
 def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Popen, bool]:
-    """Spawn ``hermes gateway restart``, reusing an in-flight or recent restart.
+    """Spawn ``hermes gateway restart``, reusing an in-flight or recent restart
+    FOR THE SAME PROFILE ONLY. Different profiles never block each other —
+    each is an independent gateway process (own systemd unit when installed).
 
-    Concurrent children race each other on the kill-and-start path, so a live
-    child is reused; requests within ``GATEWAY_RESTART_COOLDOWN_SECONDS`` for the
-    same profile coalesce onto the last spawn too (#89034). Orphaned gateways
-    are reaped first so the fresh one doesn't stack a duplicate (#77276).
+    Concurrent children for the SAME profile race each other on the
+    kill-and-start path, so a live child is reused; requests within
+    ``GATEWAY_RESTART_COOLDOWN_SECONDS`` for the same profile coalesce onto
+    the last spawn too (#89034). Orphaned gateways are reaped first so the
+    fresh one doesn't stack a duplicate (#77276).
     Returns ``(proc, reused)``.
     """
     try:
@@ -847,32 +862,30 @@ def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Po
     except Exception:
         pass  # best-effort — don't block the restart on a reap failure
 
-    global _LAST_GATEWAY_RESTART
-
+    profile_key = (profile or "").strip()
     subcommand = _gateway_mod._gateway_subcommand(profile, "restart")
-    existing = _gateway_mod._ACTION_PROCS.get("gateway-restart")
-    if existing is not None and existing.poll() is None:
-        existing_command = _gateway_mod._ACTION_COMMANDS.get("gateway-restart")
-        if existing_command is None or existing_command == tuple(subcommand):
-            return existing, True
-        raise RuntimeError("gateway restart already in progress for another profile")
 
-    recent = _LAST_GATEWAY_RESTART
+    recent = _GATEWAY_RESTARTS_BY_PROFILE.get(profile_key)
     if recent is not None:
         spawned_at, recent_proc, recent_command = recent
-        age = time.monotonic() - spawned_at if recent_command == tuple(subcommand) else None
-        if age is not None and age < GATEWAY_RESTART_COOLDOWN_SECONDS:
+        if recent_proc.poll() is None:
+            # Still running: same profile always reuses the live handle,
+            # regardless of age (mirrors the previous same-command reuse path).
+            return recent_proc, True
+        age = time.monotonic() - spawned_at
+        if age < GATEWAY_RESTART_COOLDOWN_SECONDS:
             _log.info(
-                "Coalescing gateway restart: one was started %.1fs ago "
-                "(pid %s) and the gateway may still be coming back; not "
-                "spawning another (#89034).",
+                "Coalescing gateway restart for profile %r: one was started "
+                "%.1fs ago (pid %s) and the gateway may still be coming back; "
+                "not spawning another (#89034).",
+                profile_key or "default",
                 age,
                 getattr(recent_proc, "pid", "?"),
             )
             return recent_proc, True
 
     proc = _gateway_mod._spawn_hermes_action(subcommand, "gateway-restart")
-    _LAST_GATEWAY_RESTART = (time.monotonic(), proc, tuple(subcommand))
+    _GATEWAY_RESTARTS_BY_PROFILE[profile_key] = (time.monotonic(), proc, tuple(subcommand))
     return proc, False
 
 

--- a/tests/hermes_cli/test_spawn_gateway_restart_cooldown.py
+++ b/tests/hermes_cli/test_spawn_gateway_restart_cooldown.py
@@ -18,12 +18,12 @@ import hermes_cli.web_server_gateway as _web_server_gateway
 
 @pytest.fixture(autouse=True)
 def reset_restart_cooldown():
-    """Keep the module-level cooldown state out of neighbouring tests."""
+    """Keep the module-level per-profile cooldown state out of neighbouring tests."""
     import hermes_cli.web_server as web_server
 
-    web_server._LAST_GATEWAY_RESTART = None
+    web_server._GATEWAY_RESTARTS_BY_PROFILE.clear()
     yield
-    web_server._LAST_GATEWAY_RESTART = None
+    web_server._GATEWAY_RESTARTS_BY_PROFILE.clear()
 
 
 def _exited_proc(pid: int = 4242) -> MagicMock:
@@ -191,10 +191,8 @@ class TestExistingBehaviourIsPreserved:
         live.pid = 7
 
         with patch(
-            "hermes_cli.web_server_gateway._ACTION_PROCS", {"gateway-restart": live}
-        ), patch(
-            "hermes_cli.web_server_gateway._ACTION_COMMANDS",
-            {"gateway-restart": ("gateway", "restart")},
+            "hermes_cli.web_server._GATEWAY_RESTARTS_BY_PROFILE",
+            {"": (50.0, live, ("gateway", "restart"))},
         ), patch(
             "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
         ):
@@ -202,28 +200,4 @@ class TestExistingBehaviourIsPreserved:
 
         assert proc is live
         assert reused is True
-        mock_spawn.assert_not_called()
-
-    @patch(
-        "hermes_cli.web_server_gateway._gateway_subcommand",
-        return_value=["gateway", "restart"],
-    )
-    @patch("hermes_cli.web_server_gateway._spawn_hermes_action")
-    def test_live_child_for_another_profile_still_raises(self, mock_spawn, mock_subcmd):
-        from hermes_cli.web_server import _spawn_gateway_restart
-
-        live = MagicMock(spec=subprocess.Popen)
-        live.poll.return_value = None
-
-        with patch(
-            "hermes_cli.web_server_gateway._ACTION_PROCS", {"gateway-restart": live}
-        ), patch(
-            "hermes_cli.web_server_gateway._ACTION_COMMANDS",
-            {"gateway-restart": ("-p", "coder", "gateway", "restart")},
-        ), patch(
-            "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
-        ):
-            with pytest.raises(RuntimeError, match="another profile"):
-                _spawn_gateway_restart()
-
         mock_spawn.assert_not_called()

--- a/tests/hermes_cli/test_spawn_gateway_restart_reap.py
+++ b/tests/hermes_cli/test_spawn_gateway_restart_reap.py
@@ -17,9 +17,9 @@ def reset_restart_cooldown():
     """
     import hermes_cli.web_server as web_server
 
-    web_server._LAST_GATEWAY_RESTART = None
+    web_server._GATEWAY_RESTARTS_BY_PROFILE.clear()
     yield
-    web_server._LAST_GATEWAY_RESTART = None
+    web_server._GATEWAY_RESTARTS_BY_PROFILE.clear()
 
 
 class TestSpawnGatewayRestartReapsOrphans:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -940,6 +940,7 @@ function SidebarSystemActions({
   const navigate = useNavigate();
   const { activeAction, isBusy, isRunning, pendingAction, runAction } =
     useSystemActions();
+  const { profile: scopedProfile } = useProfileScope();
   const canUpdateHermes = status?.can_update_hermes === true;
   const [restartConfirmOpen, setRestartConfirmOpen] = useState(false);
   const [updateConfirmOpen, setUpdateConfirmOpen] = useState(false);
@@ -1076,15 +1077,19 @@ function SidebarSystemActions({
       cancelLabel={t.common.cancel}
       confirmLabel={t.status.restartGateway}
       description={
-        t.status.restartGatewayConfirmMessage ??
-        "This restarts the Hermes gateway process. Connected channels and active sessions will reconnect afterward."
+        scopedProfile
+          ? `This restarts the gateway for profile "${scopedProfile}" — not the dashboard's own default gateway. Connected channels and active sessions for that profile will reconnect afterward.`
+          : (t.status.restartGatewayConfirmMessage ??
+            "This restarts the Hermes gateway process. Connected channels and active sessions will reconnect afterward.")
       }
       loading={pendingAction === "restart"}
       onCancel={() => setRestartConfirmOpen(false)}
       onConfirm={confirmRestart}
       open={restartConfirmOpen}
       title={
-        t.status.restartGatewayConfirmTitle ?? `${t.status.restartGateway}?`
+        scopedProfile
+          ? `Restart gateway for profile "${scopedProfile}"?`
+          : (t.status.restartGatewayConfirmTitle ?? `${t.status.restartGateway}?`)
       }
     />
 

--- a/web/src/contexts/ProfileProvider.tsx
+++ b/web/src/contexts/ProfileProvider.tsx
@@ -32,17 +32,44 @@ import { ProfileContext } from "@/contexts/profile-context";
  * pages. We now sync the switcher when the sticky active profile differs from
  * the dashboard process on load, and ProfilesPage updates the switcher when
  * you click "Set as active".
+ *
+ * Persistence: the selection is mirrored to localStorage so a bare page
+ * reload / re-navigation without `?profile=` in the URL does NOT silently
+ * fall back to the dashboard's own profile. Without this, a destructive
+ * action (gateway restart) fired right after a reload could target the
+ * wrong profile's gateway while the switcher still visually showed the
+ * intended one moments before the reload (#profile-scope-restart-footgun).
  */
+const MANAGEMENT_PROFILE_STORAGE_KEY = "hermes.dashboard.managementProfile";
+
+function readStoredProfile(): string {
+  try {
+    return localStorage.getItem(MANAGEMENT_PROFILE_STORAGE_KEY) ?? "";
+  } catch {
+    return ""; // localStorage unavailable (private mode, disabled storage): fall back to URL/default
+  }
+}
+
+function writeStoredProfile(name: string): void {
+  try {
+    if (name) localStorage.setItem(MANAGEMENT_PROFILE_STORAGE_KEY, name);
+    else localStorage.removeItem(MANAGEMENT_PROFILE_STORAGE_KEY);
+  } catch {
+    // best-effort only — persistence is a convenience, never a hard requirement
+  }
+}
+
 export function ProfileProvider({ children }: { children: ReactNode }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { pathname } = useLocation();
   const [profiles, setProfiles] = useState<string[]>([]);
   const [currentProfile, setCurrentProfile] = useState("default");
 
-  // Initial value comes from the URL (deep link / refresh / unified-launch
-  // preselect); afterwards state leads and the URL follows.
+  // Precedence: explicit URL param (deep link / in-app nav) > last stored
+  // selection (survives reload) > "" (dashboard's own profile). Afterwards
+  // state leads and the URL follows.
   const [profile, setProfileState] = useState(
-    () => searchParams.get("profile") ?? "",
+    () => searchParams.get("profile") ?? readStoredProfile(),
   );
 
   // Mirror into the api module synchronously on every render where it
@@ -57,6 +84,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     if (urlProfile !== null && urlProfile !== profile) {
       setManagementProfile(urlProfile);
       setProfileState(urlProfile);
+      writeStoredProfile(urlProfile);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlProfile]);
@@ -92,13 +120,17 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
         const active = info.active || "default";
         setCurrentProfile(current);
 
-        // Deep links (?profile=) win. Otherwise align the switcher with the
-        // sticky active profile so Chat and management pages match what the
-        // Profiles page shows as "active" (machine dashboard runs as
-        // `current`, usually default).
-        if (urlProfile === null && active !== current) {
+        // Deep links (?profile=) win, and so does a profile already restored
+        // from localStorage (the user's last explicit choice for this
+        // browser) — otherwise a returning user editing profile B would get
+        // silently bounced back to the sticky "active" profile on every
+        // reload. Only align to "active" when neither is present, matching
+        // the original cold-start behavior for browsers with no prior
+        // selection.
+        if (urlProfile === null && !profile && active !== current) {
           setManagementProfile(active);
           setProfileState(active);
+          writeStoredProfile(active);
         }
       })
       .catch(() => {});
@@ -113,6 +145,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     (name: string) => {
       setManagementProfile(name);
       setProfileState(name);
+      writeStoredProfile(name);
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -35,6 +35,7 @@ import type {
 } from "@/lib/api";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { usePageHeader } from "@/contexts/usePageHeader";
+import { useProfileScope } from "@/contexts/useProfileScope";
 import { cn, themedBody } from "@/lib/utils";
 
 // State → badge mapping. The backend emits a small, fixed vocabulary plus
@@ -138,6 +139,7 @@ export default function ChannelsPage() {
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
   const { setEnd } = usePageHeader();
+  const { profile: scopedProfile } = useProfileScope();
 
   // Config modal state
   const [editing, setEditing] = useState<MessagingPlatform | null>(null);
@@ -281,6 +283,11 @@ export default function ChannelsPage() {
         size="sm"
         onClick={handleRestart}
         disabled={restarting}
+        title={
+          scopedProfile
+            ? `Restarts the gateway for profile "${scopedProfile}"`
+            : undefined
+        }
         prefix={restarting ? <Spinner /> : <RotateCw className="h-4 w-4" />}
       >
         {restarting ? "Restarting…" : "Restart gateway"}
@@ -288,7 +295,7 @@ export default function ChannelsPage() {
     );
     return () => setEnd(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setEnd, restarting]);
+  }, [setEnd, restarting, scopedProfile]);
 
   const configured = useMemo(
     () => platforms.filter((p) => p.configured).length,
@@ -315,6 +322,7 @@ export default function ChannelsPage() {
               <AlertTriangle className="h-4 w-4 shrink-0 text-warning" />
               <span>
                 Changes are saved. Restart the gateway for them to take effect.
+                {scopedProfile && ` This restarts the gateway for profile "${scopedProfile}".`}
               </span>
             </div>
             <Button

--- a/web/src/pages/WebhooksPage.tsx
+++ b/web/src/pages/WebhooksPage.tsx
@@ -26,6 +26,7 @@ import { Card, CardContent } from "@nous-research/ui/ui/components/card";
 import { Input } from "@nous-research/ui/ui/components/input";
 import { Label } from "@nous-research/ui/ui/components/label";
 import { usePageHeader } from "@/contexts/usePageHeader";
+import { useProfileScope } from "@/contexts/useProfileScope";
 import { cn, themedBody } from "@/lib/utils";
 
 interface CreatedWebhook {
@@ -66,6 +67,7 @@ export default function WebhooksPage() {
   const [restarting, setRestarting] = useState(false);
   const { toast, showToast } = useToast();
   const { setEnd } = usePageHeader();
+  const { profile: scopedProfile } = useProfileScope();
 
   // New subscription modal state
   const [createModalOpen, setCreateModalOpen] = useState(false);
@@ -504,6 +506,7 @@ export default function WebhooksPage() {
               <span>
                 {restartError ??
                   "Webhooks are enabled, but the gateway still needs a restart before the receiver can come online."}
+                {scopedProfile && ` This restarts the gateway for profile "${scopedProfile}".`}
               </span>
             </div>
             <Button


### PR DESCRIPTION
## Problem

`_spawn_gateway_restart()` in `hermes_cli/web_server.py` coalesced/rejected concurrent restart requests by comparing against ONE shared in-flight slot regardless of which profile the request was for -- keyed off `_ACTION_PROCS["gateway-restart"]`, an action NAME shared by every profile's restart action for log/status-polling purposes, not a profile-scoped key.

This broke multi-profile installs concretely: a profile with no installed systemd/launchd service falls through to the CLI's foreground restart path (stop the old process, then run as the new gateway in the foreground, which never returns on its own -- it IS the new gateway process). That long-lived child stayed recorded in the one shared slot forever, so restarting ANY OTHER profile afterward hit:

```
500: {"detail":"Failed to restart gateway: gateway restart already in progress for another profile"}
```

...even though the two profiles are completely independent gateway processes with no real conflict between them.

Live-reproduced on a 3-profile install (3 named profiles + default): restarting profile B failed with the above every time profile A's restart child was still the running gateway (which, for a profile with no installed service, is effectively always).

## Fix

Track in-flight/recent restarts in a new dict keyed by profile name (`_GATEWAY_RESTARTS_BY_PROFILE`), so only requests for the SAME profile ever coalesce, reuse the live handle, or wait out the `GATEWAY_RESTART_COOLDOWN_SECONDS` window (#89034 behavior, preserved). Different profiles never block each other, matching how independent their gateway processes actually are. The `RuntimeError("gateway restart already in progress for another profile")` branch is removed entirely -- it was the manifestation of comparing across profiles in the first place, not a real safety guard (two different profiles restarting concurrently is always safe; they are different processes, different systemd units when installed, different tokens/credentials).

## Tests

- Updated `tests/hermes_cli/test_spawn_gateway_restart_cooldown.py` and `test_spawn_gateway_restart_reap.py`: the two fixtures that reset `_LAST_GATEWAY_RESTART` now clear `_GATEWAY_RESTARTS_BY_PROFILE` instead.
- Removed `test_live_child_for_another_profile_still_raises`, which asserted the buggy cross-profile blocking behavior this commit removes.
- `test_a_different_profile_is_never_coalesced` (already present in the suite, previously passing almost by coincidence since it never hit the removed branch) is the correct-behavior counterpart and continues to pass.
- All 8 tests in both files pass locally (`pytest tests/hermes_cli/test_spawn_gateway_restart_cooldown.py tests/hermes_cli/test_spawn_gateway_restart_reap.py -v`).
- Manually verified end-to-end on the live 3-profile installation: installed systemd services for all 3 profiles (which independently also fixes the underlying "foreground restart never exits" issue for those profiles), confirmed each restarts independently without cross-profile blocking.

This is a companion fix to #105282 (profile-scope persistence in the dashboard frontend); that PR made sure the dashboard sends the *correct* `?profile=`, this one makes sure the backend doesn't then block one profile's legitimate restart because of another profile's still-running child.