### PR TITLE
fix(buzz): create continuable cron handoff threads

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -967,6 +967,15 @@ class BuzzAdapter(BasePlatformAdapter):
             self._remember_event_meta(str(chat_id), result.message_id, self._self_pubkey, content)
         return result
 
+    async def create_handoff_thread(self, parent_chat_id: str, name: str) -> Optional[str]:
+        """Create a Buzz thread by publishing its top-level seed event."""
+        try:
+            result = await self.send(parent_chat_id, name)
+        except Exception:
+            logger.warning("Buzz: failed to create handoff thread in %s", parent_chat_id, exc_info=True)
+            return None
+        return result.message_id if result.success else None
+
     def _reply_args(self, anchor: Optional[str]) -> List[str]:
         """``--reply-to`` CLI args for *anchor*, honoring ``reply_to_mode``."""
         reply_target = self._resolve_reply_anchor(anchor)

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -2148,6 +2148,37 @@ class TestThreadRoots:
 class TestBuzzAdapterSend:
 
     @pytest.mark.asyncio
+    async def test_create_handoff_thread_uses_top_level_seed_event_as_root(self):
+        """Continuable cron needs a new root, not a reply in the origin thread."""
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "fresh-root", "message": ""})
+        adapter._run_cli = cli
+
+        thread_id = await adapter.create_handoff_thread(CHANNEL, "Hermes — source interview")
+
+        assert thread_id == "fresh-root"
+        args, stdin_text = cli.calls[0]
+        assert "--reply-to" not in args
+        assert stdin_text == "Hermes — source interview"
+
+    @pytest.mark.asyncio
+    async def test_create_handoff_thread_returns_none_when_seed_publish_fails(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": False, "message": "rejected"})
+        adapter._run_cli = cli
+
+        assert await adapter.create_handoff_thread(CHANNEL, "new thread") is None
+
+    @pytest.mark.asyncio
+    async def test_create_handoff_thread_returns_none_when_seed_publish_raises(self):
+        adapter = _make_adapter()
+        adapter.send = AsyncMock(side_effect=RuntimeError("transport failed"))
+
+        assert await adapter.create_handoff_thread(CHANNEL, "new thread") is None
+
+    @pytest.mark.asyncio
     async def test_send_success_via_stdin(self):
         adapter = _make_adapter()
         adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}


### PR DESCRIPTION
## What does this PR do?

Adds the missing Buzz implementation of the platform handoff-thread hook used by continuable cron deliveries.

Buzz represents a thread by a top-level Nostr event plus replies anchored to that event. The adapter now publishes the handoff name through its existing verified `send()` path and returns the accepted event ID as the new thread root. Rejected publishes and runtime failures return `None`, preserving the base adapter contract and scheduler fallback behavior.

## Related Issue

Fixes #105294

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Implement `BuzzAdapter.create_handoff_thread()` using a top-level seed message.
- Return only the verified Buzz event ID from a successful receipt.
- Log and degrade to `None` on rejected receipts or runtime failures.
- Add regressions for top-level semantics, rejected publication, and raised transport errors.

## How to Test

1. `uv run pytest tests/gateway/test_buzz_adapter.py -q -k create_handoff_thread`
2. Configure a Buzz-delivered continuable cron job with `attach_to_session: true` and no origin thread ID.
3. Trigger it and confirm the title is a top-level root while the cron question replies to that root.

Live verification on a hosted Buzz relay created a fresh root, delivered the question under it, and seeded a distinct Hermes session.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS and a Linux-hosted Buzz gateway

Targeted result: `3 passed, 186 deselected`.

The complete Buzz adapter module reaches `188 passed`; one unrelated existing test fails while creating a path longer than macOS permits, before adapter code executes (`test_live_media_redacts_long_path_before_bounding`). A full repository run was also attempted but the local cross-platform suite has unrelated baseline failures outside this change.

### Documentation & Housekeeping

- [x] Documentation update — N/A; this implements an existing adapter contract
- [x] `cli-config.yaml.example` — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no architecture or workflow change
- [x] Cross-platform impact considered; implementation uses the existing async adapter path
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```text
...                                                                      [100%]
3 passed, 186 deselected in 0.35s
All checks passed!
```
