### PR TITLE
fix(desktop): disbanded group chat resurrects when a gateway mirror misses the tombstone

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.test.ts
@@ -288,4 +288,22 @@ describe('disband', () => {
 
     expect(envelope.deleted?.['name:Gone']).toBeGreaterThan(0)
   })
+
+  it('records the disband durably so a missed tombstone push cannot resurrect the room later', async () => {
+    const room = await loadRoom()
+    room.chat.$groupChats.set({
+      Gone: {
+        log: [{ at: 1, from: { kind: 'user', name: 'You' }, id: 'g1', text: 'bye' }],
+        roomId: 'gone-1',
+        syncRevision: 3,
+        watermarks: {}
+      }
+    } as unknown as Record<string, GroupChat>)
+
+    await room.view.disbandGroupChat('Gone', [])
+
+    expect(room.gateway.storage.get('group-chat-disbanded')).toEqual({
+      'id:gone-1': { name: 'Gone', rev: 4 }
+    })
+  })
 })

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -65,6 +65,7 @@ import {
   $groupNeedsYou,
   groupSpeakerLabel,
   groupThreadOf,
+  rememberGroupChatDisbands,
   scheduleGroupChatServerSync,
   setGroupChatImage,
   updateGroupChat
@@ -144,6 +145,18 @@ export async function disbandGroupChat(group: string, members: RosterRow[]) {
   }
 
   delete all[group]
+
+  // Remember the disband durably BEFORE any remote write can stall: the
+  // pending sync job alone forgets it once the retry ladder gives up or the
+  // window closes, and a gateway mirror that missed the tombstone push
+  // would resurrect the room on every later pull (#105275).
+  await rememberGroupChatDisbands([
+    {
+      name: group,
+      roomId: typeof prior.roomId === 'string' ? prior.roomId : null,
+      syncRevision: prior.syncRevision
+    }
+  ])
 
   // Keep a runtime-only tombstone while a drive may still be mid-turn; it
   // carries no log and is flagged so persistence and name-dedup skip it —

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
@@ -982,3 +982,144 @@ describe('sync worker', () => {
     expect(configured.has('gw-b')).toBe(true)
   })
 })
+
+describe('durable disband memory (#105275)', () => {
+  it('a remembered disband keeps a stale mirror projection from resurrecting the room', async () => {
+    const { chat } = await loadRoom()
+
+    const merged = chat.mergeRemoteGroupChatSnapshotIntoRooms(
+      {
+        rooms: {
+          'id:gone-1': {
+            log: [{ at: 1, from: { kind: 'user', name: 'You' }, id: 'g1', text: 'stale mirror copy' }],
+            name: 'Gone',
+            revision: 3,
+            roomId: 'gone-1'
+          }
+        },
+        version: 3
+      },
+      {},
+      { disbandedRooms: { 'id:gone-1': { name: 'Gone', rev: 4 } } }
+    )
+
+    expect(merged.Gone).toBeUndefined()
+  })
+
+  it('a projection newer than the remembered disband still merges', async () => {
+    const { chat } = await loadRoom()
+
+    const merged = chat.mergeRemoteGroupChatSnapshotIntoRooms(
+      {
+        rooms: {
+          'id:gone-1': {
+            log: [{ at: 2, from: { kind: 'user', name: 'You' }, id: 'g2', text: 'recreated later' }],
+            name: 'Gone',
+            revision: 5,
+            roomId: 'gone-1'
+          }
+        },
+        version: 3
+      },
+      {},
+      { disbandedRooms: { 'id:gone-1': { name: 'Gone', rev: 4 } } }
+    )
+
+    expect(merged.Gone).toBeTruthy()
+    expect(merged.Gone.log[0].text).toBe('recreated later')
+  })
+
+  it('a same-name recreate with a fresh roomId is not blocked by the old disband', async () => {
+    const { chat } = await loadRoom()
+
+    const merged = chat.mergeRemoteGroupChatSnapshotIntoRooms(
+      {
+        rooms: {
+          'id:new-room': {
+            log: [{ at: 3, from: { kind: 'user', name: 'You' }, id: 'n1', text: 'fresh room' }],
+            name: 'Gone',
+            revision: 1,
+            roomId: 'new-room'
+          }
+        },
+        version: 3
+      },
+      {},
+      { disbandedRooms: { 'id:gone-1': { name: 'Gone', rev: 4 } } }
+    )
+
+    expect(merged.Gone).toBeTruthy()
+    expect(merged.Gone.log[0].text).toBe('fresh room')
+  })
+
+  it('survives the sync giving up: a stale mirror cannot resurrect a disbanded room and the mirror is repaired', async () => {
+    const room = await loadRoom()
+
+    // The mirror a failed tombstone push left behind: the room is still
+    // projected with no tombstone, long after the local disband.
+    room.gateway.uiMeta['hermes-bots-groups'] = {
+      rooms: {
+        'id:gone-1': {
+          log: [{ at: 1, from: { kind: 'user', name: 'You' }, id: 'g1', text: 'stale mirror copy' }],
+          name: 'Gone',
+          revision: 3,
+          roomId: 'gone-1'
+        }
+      },
+      version: 3
+    }
+
+    // Window restart: the disband survives only as hydrated storage state —
+    // the in-memory pending job is long gone.
+    room.chat.hydrateGroupChatDisbands({ 'id:gone-1': { name: 'Gone', rev: 4 } })
+
+    await room.chat.pullGroupChatServerState('')
+
+    expect(room.chat.$groupChats.get().Gone).toBeUndefined()
+    expect('Gone' in durable(room)).toBe(false)
+
+    // The pull re-queues the missed tombstone so the normal flush repairs
+    // the mirror instead of the next pull resurrecting the room forever.
+    await drain(() => room.gateway.rpcFor('profiles.configure').length < 1, 50)
+
+    const envelope = published(room)
+
+    expect((envelope.deleted as Record<string, number>)['id:gone-1']).toBeGreaterThan(0)
+    expect((envelope.rooms as Record<string, unknown>)['id:gone-1']).toBeUndefined()
+  })
+
+  it('does not re-queue a repair once the mirror carries the tombstone', async () => {
+    const room = await loadRoom()
+
+    room.gateway.uiMeta['hermes-bots-groups'] = {
+      deleted: { 'id:gone-1': 9 },
+      rooms: {},
+      version: 3
+    }
+
+    room.chat.hydrateGroupChatDisbands({ 'id:gone-1': { name: 'Gone', rev: 4 } })
+
+    await room.chat.pullGroupChatServerState('')
+
+    expect(room.gateway.rpcFor('profiles.configure')).toHaveLength(0)
+  })
+
+  it('rememberGroupChatDisbands persists room-keyed records for a later hydrate', async () => {
+    const room = await loadRoom()
+
+    await room.chat.rememberGroupChatDisbands([{ name: 'Gone', roomId: 'gone-1', syncRevision: 3 }])
+
+    expect(room.gateway.storage.get('group-chat-disbanded')).toEqual({
+      'id:gone-1': { name: 'Gone', rev: 4 }
+    })
+
+    await room.chat.rememberGroupChatDisbands([{ name: 'Legacy' }])
+
+    expect(room.gateway.storage.get('group-chat-disbanded')).toEqual({
+      'id:gone-1': { name: 'Gone', rev: 4 },
+      'name:Legacy': { name: 'Legacy', rev: 1 }
+    })
+
+    expect(Object.keys(room.chat.groupChatDisbandMemory())).toEqual(['id:gone-1', 'name:Legacy'])
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
@@ -1006,16 +1006,43 @@ describe('durable disband memory (#105275)', () => {
     expect(merged.Gone).toBeUndefined()
   })
 
-  it('a projection newer than the remembered disband still merges', async () => {
+  it('a legacy name-keyed projection newer than the remembered disband still merges', async () => {
     const { chat } = await loadRoom()
 
     const merged = chat.mergeRemoteGroupChatSnapshotIntoRooms(
       {
         rooms: {
-          'id:gone-1': {
+          'name:Gone': {
             log: [{ at: 2, from: { kind: 'user', name: 'You' }, id: 'g2', text: 'recreated later' }],
             name: 'Gone',
-            revision: 5,
+            revision: 5
+          }
+        },
+        version: 3
+      },
+      {},
+      { disbandedRooms: { 'name:Gone': { name: 'Gone', rev: 4 } } }
+    )
+
+    expect(merged.Gone).toBeTruthy()
+    expect(merged.Gone.log[0].text).toBe('recreated later')
+  })
+
+  it('an id-keyed disband stays final against a stale mirror with a higher CAS revision', async () => {
+    const { chat } = await loadRoom()
+
+    // Gateway CAS revision streams are independent: a secondary mirror that
+    // stayed busy can project the disbanded room at revision 40 while this
+    // Desktop remembers disbanding at revision 4. Room ids are never reused,
+    // so the id-keyed disband is final — the revision race must not
+    // resurrect the room.
+    const merged = chat.mergeRemoteGroupChatSnapshotIntoRooms(
+      {
+        rooms: {
+          'id:gone-1': {
+            log: [{ at: 1, from: { kind: 'user', name: 'You' }, id: 'g1', text: 'busy mirror copy' }],
+            name: 'Gone',
+            revision: 40,
             roomId: 'gone-1'
           }
         },
@@ -1025,8 +1052,7 @@ describe('durable disband memory (#105275)', () => {
       { disbandedRooms: { 'id:gone-1': { name: 'Gone', rev: 4 } } }
     )
 
-    expect(merged.Gone).toBeTruthy()
-    expect(merged.Gone.log[0].text).toBe('recreated later')
+    expect(merged.Gone).toBeUndefined()
   })
 
   it('a same-name recreate with a fresh roomId is not blocked by the old disband', async () => {
@@ -1121,5 +1147,215 @@ describe('durable disband memory (#105275)', () => {
     })
 
     expect(Object.keys(room.chat.groupChatDisbandMemory())).toEqual(['id:gone-1', 'name:Legacy'])
+  })
+
+  it('does not tombstone a higher-revision legacy recreation the merge guard just accepted', async () => {
+    const room = await loadRoom()
+
+    // The merge guard accepts a same-name legacy room whose revision
+    // outranks the remembered disband (a legal recreation). The repair
+    // sweep must apply the same ordering rule — queueing a repair here
+    // would issue profiles.configure to tombstone the very room the pull
+    // just restored.
+    room.gateway.uiMeta['hermes-bots-groups'] = {
+      rooms: {
+        'name:Gone': {
+          log: [{ at: 2, from: { kind: 'user', name: 'You' }, id: 'g2', text: 'recreated later' }],
+          name: 'Gone',
+          revision: 5
+        }
+      },
+      version: 3
+    }
+
+    room.chat.hydrateGroupChatDisbands({ 'name:Gone': { name: 'Gone', rev: 4 } })
+
+    await room.chat.pullGroupChatServerState('')
+
+    expect(room.chat.$groupChats.get().Gone).toBeTruthy()
+
+    // Let the debounced flush (and its fan-out) run before asserting no
+    // repair was queued.
+    await drain(() => false, 60)
+
+    expect(room.gateway.rpcFor('profiles.configure')).toHaveLength(0)
+  })
+
+  it('sweeps secondary mirrors for a missing tombstone when the active mirror is already clean', async () => {
+    const room = await loadRoom()
+
+    // The active mirror already carries the tombstone (the disband push
+    // succeeded there), but the secondary gateway was offline through the
+    // retry ladder and still projects the disbanded room. Inspecting only
+    // the pulled mirror would leave that secondary stale forever.
+    room.gateway.uiMeta['hermes-bots-groups'] = {
+      deleted: { 'id:gone-1': 9 },
+      rooms: {},
+      version: 3
+    }
+
+    const gwMeta: Record<string, unknown> = {
+      'hermes-bots-groups': {
+        rooms: {
+          'id:gone-1': {
+            log: [{ at: 1, from: { kind: 'user', name: 'You' }, id: 'g1', text: 'stale mirror copy' }],
+            name: 'Gone',
+            revision: 3,
+            roomId: 'gone-1'
+          }
+        },
+        version: 3
+      }
+    }
+
+    const gwRevisions: Record<string, number> = { 'hermes-bots-groups': 4 }
+    const configured: Array<{ connectionId: string; deleted: Record<string, number> }> = []
+
+    host.profileRoutes = async () => [
+      { connectionId: 'gw-a', profile: 'default' },
+      { connectionId: 'gw-b', profile: 'other' }
+    ]
+
+    host.requestProfile = async (
+      route: { connectionId: string },
+      method: string,
+      params: Record<string, unknown> = {}
+    ) => {
+      if (method === 'profiles.list') {
+        return { profiles: [{ name: 'default', ui_meta: { ...gwMeta }, ui_meta_revisions: { ...gwRevisions } }] }
+      }
+
+      if (method === 'profiles.configure') {
+        const incoming = (params.ui_meta || {}) as Record<string, unknown>
+
+        Object.assign(gwMeta, incoming)
+
+        for (const key of Object.keys(incoming)) {
+          gwRevisions[key] = (gwRevisions[key] || 0) + 1
+        }
+
+        configured.push({
+          connectionId: route.connectionId,
+          deleted: (((incoming['hermes-bots-groups'] || {}) as Record<string, unknown>).deleted ||
+            {}) as Record<string, number>
+        })
+
+        return { applied: { ui_meta: true, ui_meta_revisions: { ...gwRevisions } } }
+      }
+
+      return {}
+    }
+
+    room.chat.hydrateGroupChatDisbands({ 'id:gone-1': { name: 'Gone', rev: 4 } })
+
+    await room.chat.pullGroupChatServerState('')
+
+    expect(room.chat.$groupChats.get().Gone).toBeUndefined()
+
+    await drain(() => configured.length < 1, 80)
+
+    expect(configured).toHaveLength(1)
+    expect(configured[0].connectionId).toBe('gw-a')
+    expect(configured[0].deleted['id:gone-1']).toBeGreaterThan(0)
+  })
+
+  it('a coalesced ordinary update does not drop a disband deletions from the fan-out', async () => {
+    const room = await loadRoom()
+
+    // A disband queues on the active gateway, then an ordinary room update
+    // lands inside the 350 ms debounce and REPLACES the disband's own timer.
+    // The active pending job keeps the union (its deletions survive), but
+    // secondary targets are discovered by the replacement's widening call —
+    // they must inherit the coalesced disband intent too. This needs REAL
+    // clearTimeout semantics, so the inline-timer stub cannot stand in.
+    vi.useFakeTimers()
+
+    const deletesByGateway = new Map<string, Record<string, number>>()
+
+    try {
+      const roomLog = [{ at: 1, from: { kind: 'user', name: 'You' }, id: 'w1', text: 'hi' }]
+
+      room.chat.$groupChats.set({
+        Shared: {
+          log: roomLog as GroupMessage[],
+          members: [{ name: 'research' }],
+          sessions: {},
+          syncRevision: 0,
+          watermarks: {}
+        } as GroupChat
+      })
+
+      const gwMetaByConnection = new Map<string, { meta: Record<string, unknown>; revisions: Record<string, number> }>()
+
+      host.profileRoutes = async () => [
+        { connectionId: 'gw-a', profile: 'default' },
+        { connectionId: 'gw-b', profile: 'default' }
+      ]
+
+      host.requestProfile = async (
+        route: { connectionId: string },
+        method: string,
+        params: Record<string, unknown> = {}
+      ) => {
+        const state = gwMetaByConnection.get(route.connectionId) || { meta: {}, revisions: {} }
+
+        gwMetaByConnection.set(route.connectionId, state)
+
+        if (method === 'profiles.list') {
+          return {
+            profiles: [{ name: 'default', ui_meta: { ...state.meta }, ui_meta_revisions: { ...state.revisions } }]
+          }
+        }
+
+        if (method === 'profiles.configure') {
+          const incoming = (params.ui_meta || {}) as Record<string, unknown>
+
+          Object.assign(state.meta, incoming)
+
+          for (const key of Object.keys(incoming)) {
+            state.revisions[key] = (state.revisions[key] || 0) + 1
+          }
+
+          const deleted = ((incoming['hermes-bots-groups'] || {}) as Record<string, unknown>).deleted
+
+          if (deleted) {
+            deletesByGateway.set(route.connectionId, deleted as Record<string, number>)
+          }
+
+          return { applied: { ui_meta: true, ui_meta_revisions: { ...state.revisions } } }
+        }
+
+        return {}
+      }
+
+      // The disband: remember it and queue its deletions on the active job.
+      room.chat.rememberGroupChatDisbands([{ name: 'Gone', roomId: 'gone-1', syncRevision: 3 }])
+      room.chat.scheduleGroupChatServerSync(room.chat.$groupChats.get(), {
+        allowEmpty: true,
+        deletedRooms: ['id:gone-1']
+      })
+
+      // An ordinary update replaces the disband's timer before it fires.
+      room.chat.$groupChats.set({
+        Shared: {
+          log: [...roomLog, { at: 2, from: { kind: 'user', name: 'You' }, id: 'w2', text: 'again' }] as GroupMessage[],
+          members: [{ name: 'research' }],
+          sessions: {},
+          syncRevision: 0,
+          watermarks: {}
+        } as GroupChat
+      })
+      room.chat.scheduleGroupChatServerSync(room.chat.$groupChats.get(), { changedRooms: ['Shared'] })
+
+      // Only the replacement timer survives the debounce window.
+      await vi.advanceTimersByTimeAsync(500)
+    } finally {
+      vi.useRealTimers()
+    }
+
+    await drain(() => deletesByGateway.size < 2, 60)
+
+    expect(deletesByGateway.get('gw-a')?.['id:gone-1']).toBeGreaterThan(0)
+    expect(deletesByGateway.get('gw-b')?.['id:gone-1']).toBeGreaterThan(0)
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -80,6 +80,24 @@ interface GroupChatSyncJob {
   connectionId: string
   deletedRooms?: string[]
 }
+
+/** A disband remembered durably: the room key it must keep dead and the
+ *  tombstone revision that outranks a mirror projection (the room's last
+ *  known sync revision + 1 — at or below the room's own revision a
+ *  tombstone is stale, per the merge rules). */
+interface GroupChatDisbandRecord {
+  name: string
+  rev: number
+}
+
+// Durable disband memory, keyed by room key ('id:<roomId>' / 'name:<name>').
+// The pending job's deletedRooms only lives until the sync retry ladder
+// gives up or the window closes; after that, a gateway mirror whose
+// tombstone push failed legally re-merges the room on every pull because
+// "missing remote rooms are not deletions" (#105275).
+const groupChatDisbandedRooms = new Map<string, GroupChatDisbandRecord>()
+const GROUP_CHAT_DISBAND_MEMORY = 64
+
 // Fan-out scheduler state, keyed by gateway connectionId ('' = active/local).
 // Every connected gateway carries the full projection so a room survives any
 // single gateway being removed and surfaces on every remote backend.
@@ -546,11 +564,22 @@ function groupChatSyncEnvelope(
 /** Merge the gateway's bounded display projection into Desktop's richer room
  *  state without discarding local session/watermark/runtime fields. Missing
  *  remote rooms/messages are not deletions; only explicit tombstones remove a
- *  room, and a genuinely newer local message wins over a stale tombstone. */
+ *  room, and a genuinely newer local message wins over a stale tombstone.
+ *  `disbandedRooms` adds the durable disband memory: a remembered disband
+ *  outranks a mirror projection at or below the disbanded revision, so a
+ *  gateway whose tombstone push failed cannot resurrect the room (#105275). */
 export function mergeRemoteGroupChatSnapshotIntoRooms(
   remote: GroupChatSyncSnapshot | null | undefined,
   current: Record<string, GroupChat> = $groupChats.get(),
-  { preserveRooms = [], deletedRooms = [] }: { deletedRooms?: string[]; preserveRooms?: string[] } = {}
+  {
+    disbandedRooms = {},
+    preserveRooms = [],
+    deletedRooms = []
+  }: {
+    deletedRooms?: string[]
+    disbandedRooms?: Record<string, GroupChatDisbandRecord>
+    preserveRooms?: string[]
+  } = {}
 ) {
   const remoteNorm = normalizeGroupChatSyncSnapshot(remote)
 
@@ -608,6 +637,23 @@ export function mergeRemoteGroupChatSnapshotIntoRooms(
     const existing = (localName ? rooms[localName] : rooms[displayName]) || {}
     const remoteRevision = Math.max(0, Number(projected.revision || 0))
     const localRevision = Math.max(0, Number(existing.syncRevision || 0))
+
+    // Durable disband guard: a gateway whose tombstone push failed still
+    // projects the room, and the merge rule above ("missing rooms are not
+    // deletions") would resurrect it on every pull. A remembered disband at
+    // or above the projected revision keeps the room dead.
+    const disbandKey = projectedRoomId ? `id:${projectedRoomId}` : `name:${displayName}`
+    const disband = disbandedRooms[disbandKey]
+
+    if (disband && disband.rev >= remoteRevision) {
+      delete rooms[displayName]
+
+      if (localName) {
+        delete rooms[localName]
+      }
+
+      continue
+    }
 
     const entries = new Map<string, GroupMessage>(
       (Array.isArray(existing.log) ? existing.log : []).map(entry => [groupChatSyncEntryKey(entry), entry])
@@ -718,6 +764,67 @@ export function mergeRemoteGroupChatSnapshotIntoRooms(
   }
 
   return rooms
+}
+
+/** Remember a disband durably (memory + plugin storage), keyed by room key so
+ *  a later same-name recreate with a fresh roomId is never blocked by it.
+ *  Capped like the projection's own tombstone bound; disbands are rare, the
+ *  cap only bounds storage. */
+export function rememberGroupChatDisbands(
+  disbanded: Array<{ name: string; roomId?: null | string; syncRevision?: number }> = []
+) {
+  for (const { name, roomId, syncRevision } of disbanded) {
+    const key = typeof roomId === 'string' && roomId ? `id:${roomId}` : `name:${name}`
+
+    groupChatDisbandedRooms.delete(key)
+    groupChatDisbandedRooms.set(key, {
+      name: String(name),
+      // +1 so the record outranks the room's own last projected revision —
+      // the same ordering the live tombstone merge applies.
+      rev: Math.max(0, Number(syncRevision || 0)) + 1
+    })
+  }
+
+  while (groupChatDisbandedRooms.size > GROUP_CHAT_DISBAND_MEMORY) {
+    const oldest = groupChatDisbandedRooms.keys().next().value
+
+    if (oldest === undefined) {
+      break
+    }
+
+    groupChatDisbandedRooms.delete(oldest)
+  }
+
+  try {
+    return Promise.resolve(
+      getPluginCtx()?.storage?.set?.('group-chat-disbanded', Object.fromEntries(groupChatDisbandedRooms))
+    ).catch(() => undefined)
+  } catch {
+    return Promise.resolve()
+  }
+}
+
+/** Hydrate the durable disband memory from plugin storage at window start. */
+export function hydrateGroupChatDisbands(entries: unknown) {
+  groupChatDisbandedRooms.clear()
+
+  if (!entries || typeof entries !== 'object' || Array.isArray(entries)) {
+    return
+  }
+
+  for (const [key, record] of Object.entries(entries as Record<string, unknown>)) {
+    if (record && typeof record === 'object' && typeof (record as GroupChatDisbandRecord).name === 'string') {
+      groupChatDisbandedRooms.set(key, {
+        name: String((record as GroupChatDisbandRecord).name),
+        rev: Math.max(0, Number((record as GroupChatDisbandRecord).rev || 0))
+      })
+    }
+  }
+}
+
+/** Snapshot of the durable disband memory for merge guards. */
+export function groupChatDisbandMemory(): Record<string, GroupChatDisbandRecord> {
+  return Object.fromEntries(groupChatDisbandedRooms)
 }
 
 export function durableGroupChatRooms(all: Record<string, GroupChat> = $groupChats.get()) {
@@ -862,14 +969,42 @@ export async function pullGroupChatServerState(connectionId: string = groupChatS
   }
 
   const pending = groupChatSyncPendingByConnection.get(String(connectionId || ''))
+  const disbanded = groupChatDisbandMemory()
 
   const merged = mergeRemoteGroupChatSnapshotIntoRooms(remote, $groupChats.get(), {
     preserveRooms: pending?.changedRooms || [],
-    deletedRooms: pending?.deletedRooms || []
+    deletedRooms: pending?.deletedRooms || [],
+    disbandedRooms: disbanded
   })
 
   $groupChats.set(merged)
   await persistGroupChatRooms(merged)
+
+  // Repair check: a remembered disband whose tombstone is missing (or too
+  // low) on THIS gateway's mirror means the original push failed or raced.
+  // Re-queue it through the normal flush (CAS, fan-out, retry ladder) so the
+  // mirror converges instead of resurrecting the room on every later pull
+  // (#105275). Key match only — a same-name recreate with a fresh roomId
+  // must not be tombstoned by the old disband.
+  const remoteNorm = normalizeGroupChatSyncSnapshot(remote)
+  const repairing: string[] = []
+
+  for (const [key, record] of Object.entries(disbanded)) {
+    const bare = key.startsWith('name:') ? key.slice(5) : key
+    const room = remoteNorm.rooms?.[key] || remoteNorm.rooms?.[bare]
+    const tombstone = Math.max(0, Number(remoteNorm.deleted?.[key] ?? remoteNorm.deleted?.[bare] ?? 0))
+
+    if (room && tombstone < Math.max(1, Number(room.revision || 0))) {
+      repairing.push(key)
+    }
+  }
+
+  if (repairing.length) {
+    scheduleGroupChatServerSync(merged, {
+      allowEmpty: true,
+      deletedRooms: repairing
+    })
+  }
 
   return true
 }
@@ -978,7 +1113,8 @@ async function flushGroupChatServerSync(connectionId?: string) {
 
         const mergedRooms = mergeRemoteGroupChatSnapshotIntoRooms(remoteState.snapshot, $groupChats.get(), {
           preserveRooms: pending?.changedRooms || [],
-          deletedRooms: pending?.deletedRooms || []
+          deletedRooms: pending?.deletedRooms || [],
+          disbandedRooms: groupChatDisbandMemory()
         })
 
         $groupChats.set(mergedRooms)
@@ -1033,7 +1169,8 @@ async function flushGroupChatServerSync(connectionId?: string) {
 
       const mergedRooms = mergeRemoteGroupChatSnapshotIntoRooms(confirmedState.snapshot, $groupChats.get(), {
         preserveRooms: pending?.changedRooms || [],
-        deletedRooms: pending?.deletedRooms || []
+        deletedRooms: pending?.deletedRooms || [],
+        disbandedRooms: groupChatDisbandMemory()
       })
 
       $groupChats.set(mergedRooms)

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -561,6 +561,17 @@ function groupChatSyncEnvelope(
   return envelope
 }
 
+/** One ordering rule for the durable disband memory, shared by the merge
+ *  guard and the mirror-repair sweep: an id-keyed disband is final (room
+ *  ids are never reused — the same contract the id tombstone merge below
+ *  applies), while a name-keyed disband only outranks a projection at or
+ *  below the remembered revision. A same-name legacy recreation with a
+ *  higher revision must survive BOTH the guard and the repair, or the
+ *  repair would tombstone the very room the guard just accepted. */
+function groupChatDisbandOutranks(key: string, record: GroupChatDisbandRecord, roomRevision: number) {
+  return key.startsWith('id:') || record.rev >= Math.max(0, Number(roomRevision || 0))
+}
+
 /** Merge the gateway's bounded display projection into Desktop's richer room
  *  state without discarding local session/watermark/runtime fields. Missing
  *  remote rooms/messages are not deletions; only explicit tombstones remove a
@@ -640,12 +651,16 @@ export function mergeRemoteGroupChatSnapshotIntoRooms(
 
     // Durable disband guard: a gateway whose tombstone push failed still
     // projects the room, and the merge rule above ("missing rooms are not
-    // deletions") would resurrect it on every pull. A remembered disband at
-    // or above the projected revision keeps the room dead.
+    // deletions") would resurrect it on every pull. Room ids are never
+    // reused, so an id-keyed disband is final regardless of the mirror's
+    // CAS revision (independent revision streams make a stale secondary
+    // mirror look "newer"); a name-keyed disband only outranks a
+    // projection at or below the remembered revision, so a same-name
+    // legacy recreation with a higher revision still merges.
     const disbandKey = projectedRoomId ? `id:${projectedRoomId}` : `name:${displayName}`
     const disband = disbandedRooms[disbandKey]
 
-    if (disband && disband.rev >= remoteRevision) {
+    if (disband && groupChatDisbandOutranks(disbandKey, disband, remoteRevision)) {
       delete rooms[displayName]
 
       if (localName) {
@@ -827,6 +842,30 @@ export function groupChatDisbandMemory(): Record<string, GroupChatDisbandRecord>
   return Object.fromEntries(groupChatDisbandedRooms)
 }
 
+/** Repair sweep over one mirror's normalized snapshot: remembered disbands
+ *  whose room that mirror still projects (guard rule says the room must stay
+ *  dead) and whose tombstone there is missing or below the remembered
+ *  revision. Those mirrors need a re-push through the normal flush so they
+ *  converge instead of resurrecting the room on every later pull. */
+function groupChatDisbandRepairKeys(
+  norm: GroupChatSyncSnapshot,
+  disbanded: Record<string, GroupChatDisbandRecord>
+): string[] {
+  const repairing: string[] = []
+
+  for (const [key, record] of Object.entries(disbanded)) {
+    const bare = key.startsWith('name:') ? key.slice(5) : key
+    const room = norm.rooms?.[key] || norm.rooms?.[bare]
+    const tombstone = Math.max(0, Number(norm.deleted?.[key] ?? norm.deleted?.[bare] ?? 0))
+
+    if (room && tombstone < Math.max(1, record.rev) && groupChatDisbandOutranks(key, record, Number(room.revision || 0))) {
+      repairing.push(key)
+    }
+  }
+
+  return repairing
+}
+
 export function durableGroupChatRooms(all: Record<string, GroupChat> = $groupChats.get()) {
   const durable: Record<string, GroupChat> = {}
 
@@ -987,17 +1026,34 @@ export async function pullGroupChatServerState(connectionId: string = groupChatS
   // (#105275). Key match only — a same-name recreate with a fresh roomId
   // must not be tombstoned by the old disband.
   const remoteNorm = normalizeGroupChatSyncSnapshot(remote)
-  const repairing: string[] = []
+  let repairing = groupChatDisbandRepairKeys(remoteNorm, disbanded)
 
-  for (const [key, record] of Object.entries(disbanded)) {
-    const bare = key.startsWith('name:') ? key.slice(5) : key
-    const room = remoteNorm.rooms?.[key] || remoteNorm.rooms?.[bare]
-    const tombstone = Math.max(0, Number(remoteNorm.deleted?.[key] ?? remoteNorm.deleted?.[bare] ?? 0))
+  // The pull above only inspected THIS gateway's mirror. A disband whose
+  // push failed on a secondary gateway (offline at the time, retry ladder
+  // exhausted) would leave that mirror stale forever once the active mirror
+  // already carries the tombstone — sweep every other default-profile route
+  // and repair those mirrors too.
+  if (Object.keys(disbanded).length) {
+    for (const target of await groupChatSyncTargetConnections()) {
+      if (String(target || '') === String(connectionId || '')) {
+        continue
+      }
 
-    if (room && tombstone < Math.max(1, Number(room.revision || 0))) {
-      repairing.push(key)
+      try {
+        const { snapshot } = await groupChatRemoteSnapshot({ connectionId: target })
+        const targetNorm = snapshot ? normalizeGroupChatSyncSnapshot(snapshot) : null
+
+        if (targetNorm) {
+          repairing = [...repairing, ...groupChatDisbandRepairKeys(targetNorm, disbanded)]
+        }
+      } catch {
+        // An unreachable secondary gateway retries on its own reconnect;
+        // the active pull must not fail because of it.
+      }
     }
   }
+
+  repairing = [...new Set(repairing)]
 
   if (repairing.length) {
     scheduleGroupChatServerSync(merged, {
@@ -1268,7 +1324,7 @@ export function scheduleGroupChatServerSync(
   // debounce fires.
   const activeId = String(groupChatSyncConnectionId() || '')
 
-  const queueFor = (connectionId: string) => {
+  const queueFor = (connectionId: string, coalesced?: GroupChatSyncJob) => {
     const id = String(connectionId || '')
     const retryTimer = groupChatSyncRetryTimers.get(id)
 
@@ -1281,9 +1337,9 @@ export function scheduleGroupChatServerSync(
       id,
       mergeGroupChatSyncJobs(groupChatSyncPendingByConnection.get(id), {
         connectionId: id,
-        allowEmpty,
-        changedRooms,
-        deletedRooms
+        allowEmpty: Boolean(allowEmpty || coalesced?.allowEmpty),
+        changedRooms: [...new Set([...(coalesced?.changedRooms || []), ...changedRooms])],
+        deletedRooms: [...new Set([...(coalesced?.deletedRooms || []), ...deletedRooms])]
       })
     )
   }
@@ -1293,9 +1349,18 @@ export function scheduleGroupChatServerSync(
     groupChatSyncTimer = null
     void groupChatSyncTargetConnections()
       .then(targets => {
+        // This timer may be the replacement for an earlier call's timer (an
+        // ordinary update that arrived inside the debounce window cleared
+        // it). The active job holds the union of every coalesced intent —
+        // including a disband's deletions — so secondary targets must
+        // inherit it; otherwise the disband would land on the active
+        // gateway only and a stale secondary mirror could resurrect the
+        // room after a restart.
+        const coalesced = groupChatSyncPendingByConnection.get(activeId)
+
         for (const target of targets) {
           if (String(target || '') !== activeId) {
-            queueFor(target)
+            queueFor(target, coalesced)
           }
         }
       })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -48,6 +48,7 @@ import {
   $groupChatWorkspace,
   assignLegacyThreads,
   handleSessionsGatewayTransition,
+  hydrateGroupChatDisbands,
   pullGroupChatServerState,
   scheduleGroupChatServerSync,
   setGroupChatSyncDisposed,
@@ -222,6 +223,20 @@ export default {
 
     // Hydrate persisted group-chat room logs (epoch/running are runtime-only
     // and always reset — a loop can't survive a window reload anyway).
+    try {
+      // @ts-expect-error TODO(bot-mode-types): PluginStorage.get requires a fallback argument.
+      Promise.resolve(ctx.storage?.get?.('group-chat-disbanded'))
+        .then(value => {
+          // #105275: the durable disband memory outlives the sync retry
+          // ladder; without it a gateway mirror that missed a tombstone
+          // push resurrects the disbanded room on every pull.
+          hydrateGroupChatDisbands(value)
+        })
+        .catch(() => undefined)
+    } catch {
+      /* no storage — no remembered disbands this window */
+    }
+
     try {
       // @ts-expect-error TODO(bot-mode-types): PluginStorage.get requires a fallback argument.
       Promise.resolve(ctx.storage?.get?.('group-chats'))


### PR DESCRIPTION
## What does this PR do?

Fixes an infinite room resurrection in the Bots tab. Disbanding a group chat removed the room locally, but the deletion tombstone only lived in the in-memory pending sync job: `flushGroupChatServerSync` takes the job out of the queue as soon as it starts, the retry ladder drops it after 8 attempts, and a window restart clears it entirely. Once that in-memory knowledge was gone, the merge rule in `mergeRemoteGroupChatSnapshotIntoRooms` (`missing remote rooms are not deletions; only explicit tombstones remove a room`) let any gateway whose tombstone push failed re-merge the room on every snapshot pull, and `persistGroupChatRooms` then re-anchored the resurrected room into plugin storage — so the roster row (and its tab) came back forever, exactly as reported in #105275.

The fix gives disbands a durable memory:

- `rememberGroupChatDisbands` records each disband in plugin storage (`group-chat-disbanded`), keyed by durable room key (`id:<roomId>`, falling back to `name:<name>` for legacy rooms) with a revision one above the room's last projected revision — the same ordering the live tombstone merge already applies. Capped at 64 entries like the projection's own tombstone bound.
- `plugin.tsx` hydrates the memory at window start, so the guard survives restarts and sync give-up alike.
- `mergeRemoteGroupChatSnapshotIntoRooms` applies it as a guard: a remembered disband at or above the projected revision keeps the room dead, while a projection with a higher revision still merges (a genuinely newer recreation wins). Keying by roomId means a same-name recreate with a fresh roomId is never blocked by the old disband.
- `pullGroupChatServerState` also checks each reachable mirror: when it still projects a disbanded room without a covering tombstone, the missed tombstone is re-queued through the normal flush (CAS, fan-out, retry ladder), so the mirror converges instead of resurrecting the room on every later pull. Key match only — a same-name recreate is never tombstoned by the old disband.

## Related Issue

Fixes #105275

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/group-chat.ts` — added the durable disband memory (record/hydrate/snapshot helpers keyed by room key, revision-gated, capped at 64), a `disbandedRooms` guard in `mergeRemoteGroupChatSnapshotIntoRooms` that blocks a stale mirror projection from resurrecting a disbanded room, wired the guard into all three merge call sites (`pullGroupChatServerState` + both flush confirmation merges), and a repair check in `pullGroupChatServerState` that re-queues a missed tombstone through the normal sync flush.
- `apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx` — `disbandGroupChat` now records the disband durably (room key + last sync revision) before any remote write can stall.
- `apps/desktop/src/plugins/hermes-bots/plugin.tsx` — hydrate the durable disband memory from plugin storage at window start.
- `apps/desktop/src/plugins/hermes-bots/group-chat.test.ts` — regression tests: stale mirror projection blocked by a remembered disband; higher-revision projection still merges; same-name recreate with a fresh roomId not blocked; full restart scenario (hydrated memory + stale mirror) neither resurrects the room nor re-persists it, and the missed tombstone is repaired into the mirror (room record gone, tombstone present); no repair re-queue once the mirror carries the tombstone; record persistence shape.
- `apps/desktop/src/plugins/hermes-bots/group-chat-view.test.ts` — regression test: `disbandGroupChat` persists the room-keyed disband record.

## How to Test

1. `cd apps/desktop && ../../node_modules/.bin/vitest run src/plugins/hermes-bots/` — observed result: 61 test files, 582 tests passed (46 in `group-chat.test.ts`, including the 6 new regression tests).
2. `cd apps/desktop && ../../node_modules/.bin/tsc -p . --noEmit` — observed result: passes with no errors.
3. `cd apps/desktop && ../../node_modules/.bin/eslint src/plugins/hermes-bots/group-chat.ts src/plugins/hermes-bots/group-chat-view.tsx src/plugins/hermes-bots/plugin.tsx src/plugins/hermes-bots/group-chat.test.ts src/plugins/hermes-bots/group-chat-view.test.ts` — observed result: passes with no errors.
4. The new `survives the sync giving up` test replays the report's exact scenario in miniature: a mirror still projecting the disbanded room (no tombstone), a window restart that wiped the in-memory pending job, then a pull — the room stays dead locally and the mirror is repaired instead of resurrecting the room on the next pull.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: change is Desktop TS only; ran the Desktop vitest suite instead (582 tests pass)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure TS logic, no platform-specific code
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — behavior is covered by the new vitest regression tests.