### PR TITLE
fix: create continuable Buzz threads for cron handoffs

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -966,6 +966,25 @@ class BuzzAdapter(BasePlatformAdapter):
             self._remember_event_meta(str(chat_id), result.message_id, self._self_pubkey, content)
         return result
 
+    async def create_handoff_thread(self, parent_chat_id: str, name: str) -> Optional[str]:
+        """Create a fresh Buzz thread root for a continuable cron handoff.
+
+        Buzz threads are NIP-10 reply trees rather than server-side objects.  A top-level
+        seed event therefore *is* the thread: return its verified event id so the cron
+        delivery can reply to it and seed the matching Hermes session.
+        """
+        if self._reply_to_mode == "off":
+            return None
+        seed = f"🧵 {(str(name or '').strip() or 'Hermes session')[:100]}"
+        result = await self.send(str(parent_chat_id), seed)
+        if not result.success or not result.message_id:
+            logger.warning(
+                "Buzz handoff thread: seed-post failed for channel %s: %s",
+                parent_chat_id, result.error or "missing event id",
+            )
+            return None
+        return str(result.message_id)
+
     def _reply_args(self, anchor: Optional[str]) -> List[str]:
         """``--reply-to`` CLI args for *anchor*, honoring ``reply_to_mode``."""
         reply_target = self._resolve_reply_anchor(anchor)

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -158,6 +158,31 @@ class TestBuzzAdapterInit:
         assert adapter.relay_url == "https://env.relay"
 
 
+class TestBuzzHandoffThread:
+    @pytest.mark.asyncio
+    async def test_creates_top_level_seed_and_returns_event_id(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        event_id = "c" * 64
+        cli.script("messages", "send", {"event_id": event_id, "accepted": True})
+        adapter._run_cli = cli
+
+        result = await adapter.create_handoff_thread(CHANNEL, "Hermes — interview")
+
+        assert result == event_id
+        args, content = cli.calls[-1]
+        assert args == ["messages", "send", "--channel", CHANNEL, "--content", "-"]
+        assert content == "🧵 Hermes — interview"
+
+    @pytest.mark.asyncio
+    async def test_disabled_threading_does_not_post_seed(self):
+        adapter = _make_adapter({"reply_in_thread": False})
+        adapter._run_cli = AsyncMock()
+
+        assert await adapter.create_handoff_thread(CHANNEL, "Hermes — interview") is None
+        adapter._run_cli.assert_not_awaited()
+
+
 # ── Multiplex secondary-profile scope (#98738) ─────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- implement `BuzzAdapter.create_handoff_thread()` for continuable cron deliveries
- create a top-level Buzz/NIP-10 seed event and return its verified event ID as the new thread root
- preserve the existing no-thread fallback when Buzz reply threading is disabled
- add focused success and disabled-threading tests

Fixes #105300.

## Why

Hermes core already opens fresh sessions for continuable cron jobs through the adapter hook. Buzz inherited the base no-op implementation, so scheduled conversation starters fell back to an existing thread and did not appear as new Buzz sessions.

## Testing

```text
scripts/run_tests.sh tests/gateway/test_buzz_adapter.py -q -k 'HandoffThread or TestBuzzAdapterInit'
4 passed, 0 failed
```

## Live verification

Verified against a hosted Buzz relay:

- created a new top-level root event;
- delivered the cron question as a reply to that root with the intended user `p`-tag;
- scheduler logged that the continuable thread was opened and seeded;
- `state.db` contained a distinct Buzz session keyed to the new root;
- the new session appeared in the Buzz UI.
