### PR TITLE
fix(desktop): bound backend pool with hard cap for pinned tier (#105239)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12395,14 +12395,16 @@ function touchPoolBackend(profile) {
 
 // Evict least-recently-used SPAWNED pool backends until at most `keep` remain —
 // but only ever evict backends without a live renderer socket (stale beyond the
-// keepalive window). When every backend is actively kept alive we let the pool
-// exceed the soft cap rather than kill a running session. Process-less
-// descriptor entries (remote/cloud registry sources, per-profile remote
-// overrides — `entry.process === null`) are excluded from the cap entirely:
-// they hold no local process, so counting them used to let a roster refresh
-// across N registered remote connections LRU-evict a REAL local backend that
-// was merely idle past the keepalive window. Descriptors are still reclaimed
-// by the idle reaper.
+// keepalive window) under the soft cap. When every backend is actively kept
+// alive we let the pool exceed the soft cap rather than kill a running
+// session, but the hard cap (keep + 6, see pool-eviction.ts) bounds the
+// pinned tier so N-profile fleets cannot hold N resident serve processes
+// indefinitely (#105239). Process-less descriptor entries (remote/cloud
+// registry sources, per-profile remote overrides — `entry.process === null`)
+// are excluded from the cap entirely: they hold no local process, so
+// counting them used to let a roster refresh across N registered remote
+// connections LRU-evict a REAL local backend that was merely idle past the
+// keepalive window. Descriptors are still reclaimed by the idle reaper.
 function evictLruPoolBackends(keep) {
   const evictions = selectPoolEvictions(backendPool.entries(), Math.max(0, keep), Date.now(), POOL_KEEPALIVE_FRESH_MS)
 

--- a/apps/desktop/electron/pool-eviction.ts
+++ b/apps/desktop/electron/pool-eviction.ts
@@ -19,12 +19,26 @@ export interface PoolEvictionEntry {
   process?: unknown
 }
 
+// Hard-cap padding for keepalive-pinned backends. The soft cap (maxBackends)
+// spares keepalive-fresh entries unconditionally — when every backend is
+// actively kept alive the pool can exceed the soft cap rather than kill a
+// running session. Without a second tier this is unbounded: every profile
+// whose chat was ever opened keeps a resident serve process (~120 MB) until
+// app quit (issue #105239: 62 profiles → 126 processes, ~7.5 GB). The hard
+// cap bounds the pinned tier so the pool's memory footprint is always capped
+// regardless of how many profile chats have been opened over the app's
+// lifetime. Soft = maxBackends, hard = maxBackends + HARD_CAP_EXTRA.
+const HARD_CAP_EXTRA = 6
+
 /**
  * Pick which pool keys the LRU cap should evict so that at most `keep`
  * SPAWNED backends remain. Only entries with a live child process count
  * toward the cap or are eligible for cap eviction, and — as before — only
- * entries idle beyond `freshMs` may be evicted (an actively kept-alive pool
- * may exceed the soft cap rather than kill a running session).
+ * entries idle beyond `freshMs` may be evicted under the soft cap (an
+ * actively kept-alive pool may exceed the soft cap rather than kill a
+ * running session). When the pool exceeds the hard cap (keep + 6), even
+ * keepalive-fresh entries are evicted LRU so the resident set is bounded
+ * (fix for #105239).
  */
 export function selectPoolEvictions<K>(
   entries: Iterable<[K, PoolEvictionEntry]>,
@@ -52,6 +66,28 @@ export function selectPoolEvictions<K>(
 
     evictions.push(key)
     removable -= 1
+  }
+
+  // Hard cap: even keepalive-fresh backends are evicted LRU when the
+  // pinned tier grows beyond keep + HARD_CAP_EXTRA. Without this the pool
+  // is unbounded — every profile whose chat was ever opened stays pinned
+  // indefinitely via the 60s keepalive touch (#105239).
+  const hardKeep = Math.max(0, keep) + HARD_CAP_EXTRA
+  const remaining = spawned.length - evictions.length
+
+  if (remaining > hardKeep) {
+    const evictedSet = new Set(evictions)
+    const candidates = spawned
+      .filter(([key]) => !evictedSet.has(key))
+      .sort((a, b) => (a[1].lastActiveAt || 0) - (b[1].lastActiveAt || 0))
+
+    let need = remaining - hardKeep
+
+    for (const [key] of candidates) {
+      if (need <= 0) break
+      evictions.push(key)
+      need -= 1
+    }
   }
 
   return evictions


### PR DESCRIPTION
Fixes #105239

**Problem:** Desktop backend pool caps speculative prewarms (`maxBackends` default 3) and reaps idle after 10 min, but keepalive-touched backends are spared from both the LRU cap and the idle reaper unconditionally. Every profile whose chat was ever opened keeps a resident `python -m hermes_cli.main --profile <name> serve` process (~120 MB) until app quit. On a 62-profile fleet this grew to 126 processes / ~7.5 GB for hours idle, all direct children of Hermes.exe (not orphans).

**Fix:** Keep soft cap behavior (spare keepalive-fresh entries) but bound the pinned tier with a hard cap (`soft + 6` = 9 by default). `selectPoolEvictions` now: (1) evicts stale entries down to soft cap as before, (2) if the pool still exceeds hard cap, evicts the oldest entries LRU even if keepalive-fresh so the resident set is always bounded. `evictLruPoolBackends` documentation updated accordingly.

**Verification:** Existing `pool-eviction.test.ts` still green (8/8). Hard cap manually verified: 12 fresh backends with soft=3 hard=9 evicts 3 oldest; 9 fresh at hard cap is spared; mixed stale+fresh pools correctly prioritize stale before fresh.

No workflow changes. Touched files: `apps/desktop/electron/pool-eviction.ts`, `apps/desktop/electron/main.ts`