### PR TITLE
fix(plugins): preserve inherited core toolsets when toggling plugins

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1767,9 +1767,15 @@ def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
         if isinstance(ts_list, list) and enable != (toolset_key in ts_list):
             (ts_list.append if enable else ts_list.remove)(toolset_key)
             changed = True
-    # Enabling with no platform lists yet: seed "cli" at minimum.
+    # A new CLI selection replaces, rather than extends, the inherited default.
+    # Keep the composite so enabling a plugin does not discard core tools, and
+    # disabling it later leaves the default instead of an explicit empty list.
+    # Existing lists (including []) above remain deliberate user selections.
+
     if enable and not changed and not platform_toolsets:
-        platform_toolsets["cli"] = [toolset_key]
+        from hermes_cli.tools_config import PLATFORMS
+
+        platform_toolsets["cli"] = [PLATFORMS["cli"]["default_toolset"], toolset_key]
         changed = True
     if changed:
         save_config(config)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -504,28 +504,26 @@ def _explicit_toolsets(
     explicitly_configured: bool) -> Set[str]:
     """Enabled set when the saved list names configurable/plugin keys directly (subset inference over
     ``hermes-cli`` would re-enable disabled toolsets). A mixed list (``[hermes-cli, spotify]``) still expands the
-    composite; _DEFAULT_OFF_TOOLSETS applies to that implicit expansion only."""
-    from toolsets import resolve_toolset, TOOLSETS
+    composite through the same resolver as inherited defaults, including credential-enabled tools."""
+    from toolsets import TOOLSETS
 
     enabled = {ts for ts in toolset_names if ts in explicit_known_keys and _toolset_allowed_for_platform(ts, platform)}
-    composite_tools = {
-        t for ts_name in toolset_names if ts_name not in explicit_known_keys and ts_name in TOOLSETS
-        for t in resolve_toolset(ts_name)}
-    if composite_tools:
-        enabled |= _configurable_subset_of(composite_tools, platform) - _default_off_toolsets(platform, explicitly_configured)
+    composites = [ts for ts in toolset_names if ts not in explicit_known_keys and ts in TOOLSETS]
+    if composites:
+        enabled |= _composite_toolsets(composites, platform, explicitly_configured)
     _enable_recently_shipped_toolsets(enabled, config, platform)
     return enabled
 
 
 def _composite_toolsets(toolset_names: List[str], platform: str, explicitly_configured: bool) -> Set[str]:
-    """Enabled set inferred from composite names by reverse-mapping tool names (only while no explicit list is
-    saved). ``x_search`` is not in any composite, so inject it when xAI creds exist and exempt it from default-off."""
+    """Expand composites, whether inherited or mixed with explicit plugin/toolset entries.
+    Credential defaults extend real composites, never empty or unresolvable selections."""
     from toolsets import resolve_toolset
 
     all_tool_names = {t for ts_name in toolset_names for t in resolve_toolset(ts_name)}
     enabled = _configurable_subset_of(all_tool_names, platform)
     default_off = _default_off_toolsets(platform, explicitly_configured)
-    if _toolset_allowed_for_platform("x_search", platform) and _xai_credentials_present():
+    if all_tool_names and _toolset_allowed_for_platform("x_search", platform) and _xai_credentials_present():
         enabled.add("x_search")
         default_off.discard("x_search")
     return enabled - default_off

--- a/tests/hermes_cli/test_plugin_toolset_toggle.py
+++ b/tests/hermes_cli/test_plugin_toolset_toggle.py
@@ -1,0 +1,118 @@
+"""Plugin toggles must not replace inherited core tools with a plugin-only list."""
+
+import pytest
+
+from hermes_cli import config as config_module
+from hermes_cli import plugins_cmd
+from hermes_cli.tools_config import _get_platform_tools
+
+
+@pytest.fixture
+def plugin_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.mark.parametrize("initial", [{}, {"platform_toolsets": {}}, {"platform_toolsets": None}])
+def test_enable_preserves_inherited_core_tools(plugin_home, initial):
+    config_module.save_config(initial)
+    before = _get_platform_tools(config_module.load_config(), "cli")
+    assert {"terminal", "file", "web"} <= before
+    assert "spotify" not in before
+
+    plugins_cmd._toggle_plugin_toolset("spotify", enable=True)
+
+    saved = config_module.read_raw_config()
+    after = _get_platform_tools(config_module.load_config(), "cli")
+    assert before <= after
+    assert "spotify" in after
+    assert "spotify" in saved["platform_toolsets"]["cli"]
+
+    plugins_cmd._toggle_plugin_toolset("spotify", enable=False)
+    assert _get_platform_tools(config_module.load_config(), "cli") == before
+    assert "spotify" not in config_module.read_raw_config()["platform_toolsets"]["cli"]
+
+
+@pytest.mark.parametrize("selection", [[], ["file"], ["hermes-cli"], ["file", "no_mcp"]])
+def test_dashboard_round_trip_preserves_explicit_selections(plugin_home, selection):
+    config_module.save_config({
+        "platform_toolsets": {"cli": selection, "telegram": ["web"], "discord": []},
+        "agent": {"disabled_toolsets": ["memory"]},
+    })
+    before = config_module.read_raw_config()
+    tools_before = _get_platform_tools(config_module.load_config(), "cli")
+
+    result = plugins_cmd.dashboard_set_agent_plugin_enabled("spotify", enabled=True)
+    assert result == {"ok": True, "name": "spotify", "unchanged": False}
+    enabled = config_module.read_raw_config()
+    for platform, original in before["platform_toolsets"].items():
+        assert enabled["platform_toolsets"][platform] == [*original, "spotify"]
+    assert "spotify" in enabled["plugins"]["enabled"]
+    assert "spotify" not in enabled["plugins"].get("disabled", [])
+    assert "spotify" in _get_platform_tools(config_module.load_config(), "cli")
+    assert enabled["agent"] == before["agent"]
+
+    assert plugins_cmd.dashboard_set_agent_plugin_enabled("spotify", enabled=True)["unchanged"]
+    assert config_module.read_raw_config() == enabled
+    result = plugins_cmd.dashboard_set_agent_plugin_enabled("spotify", enabled=False)
+    assert result == {"ok": True, "name": "spotify", "unchanged": False}
+    disabled = config_module.read_raw_config()
+    assert disabled["platform_toolsets"] == before["platform_toolsets"]
+    assert "spotify" in disabled["plugins"]["disabled"]
+    assert "spotify" not in disabled["plugins"]["enabled"]
+    assert _get_platform_tools(config_module.load_config(), "cli") == tools_before
+    assert disabled["agent"] == before["agent"]
+    assert plugins_cmd.dashboard_set_agent_plugin_enabled("spotify", enabled=False)["unchanged"]
+    assert config_module.read_raw_config() == disabled
+
+
+@pytest.mark.parametrize("initial", [{}, {"platform_toolsets": {}}, {"platform_toolsets": {"cli": []}}])
+def test_disable_does_not_invent_a_selection(plugin_home, initial):
+    config_module.save_config(initial)
+    before = config_module.read_raw_config()
+    tools_before = _get_platform_tools(config_module.load_config(), "cli")
+    plugins_cmd._toggle_plugin_toolset("spotify", enable=False)
+    assert config_module.read_raw_config() == before
+    assert _get_platform_tools(config_module.load_config(), "cli") == tools_before
+
+
+def test_dashboard_inherited_round_trip_preserves_core_defaults(plugin_home):
+    config_module.save_config({"agent": {"disabled_toolsets": ["memory"]}})
+    before = _get_platform_tools(config_module.load_config(), "cli")
+    for enabled in (True, False, True, False):
+        assert plugins_cmd.dashboard_set_agent_plugin_enabled("spotify", enabled=enabled)["ok"]
+        selected = _get_platform_tools(config_module.load_config(), "cli")
+        assert before <= selected
+        assert ("spotify" in selected) is enabled
+        assert "memory" not in selected
+        saved = config_module.read_raw_config()
+        assert ("spotify" in saved["plugins"]["enabled"]) is enabled
+        assert ("spotify" in saved["plugins"]["disabled"]) is not enabled
+
+
+def test_disabling_explicit_plugin_only_selection_keeps_empty_list(plugin_home):
+    config_module.save_config({"platform_toolsets": {"cli": ["spotify"]}})
+    plugins_cmd._toggle_plugin_toolset("spotify", enable=False)
+    # There is no provenance proving this was the historical broken writer.
+    # Do not silently turn an explicit plugin-only choice into core defaults.
+    assert config_module.read_raw_config()["platform_toolsets"]["cli"] == []
+    assert "terminal" not in _get_platform_tools(config_module.load_config(), "cli")
+
+
+def test_other_platform_selection_does_not_materialize_inherited_cli(plugin_home):
+    config_module.save_config({"platform_toolsets": {"telegram": ["file"]}})
+    before = _get_platform_tools(config_module.load_config(), "cli")
+    for enabled in (True, False):
+        plugins_cmd._toggle_plugin_toolset("spotify", enable=enabled)
+        saved = config_module.read_raw_config()["platform_toolsets"]
+        assert "cli" not in saved
+        assert saved["telegram"] == (["file", "spotify"] if enabled else ["file"])
+        assert before <= _get_platform_tools(config_module.load_config(), "cli")
+
+
+def test_plugin_without_tools_leaves_toolset_config_untouched(plugin_home):
+    config_module.save_config({"platform_toolsets": {"cli": []}})
+    before = config_module.read_raw_config()
+    for enabled in (True, False):
+        plugins_cmd._toggle_plugin_toolset("nonexistent-no-tools-plugin", enable=enabled)
+        assert config_module.read_raw_config() == before

--- a/tests/hermes_cli/test_plugin_toolset_toggle.py
+++ b/tests/hermes_cli/test_plugin_toolset_toggle.py
@@ -116,3 +116,34 @@ def test_plugin_without_tools_leaves_toolset_config_untouched(plugin_home):
     for enabled in (True, False):
         plugins_cmd._toggle_plugin_toolset("nonexistent-no-tools-plugin", enable=enabled)
         assert config_module.read_raw_config() == before
+
+
+@pytest.mark.parametrize("credentials", [False, True])
+@pytest.mark.parametrize("initial", [{}, {"platform_toolsets": {"cli": ["hermes-cli"]}}])
+def test_plugin_round_trip_preserves_credential_defaults(plugin_home, monkeypatch, credentials, initial):
+    # Only exercise the offline credential-presence check, never an xAI request.
+    if credentials:
+        monkeypatch.setenv("XAI_API_KEY", "nonfunctional-test-fixture")
+    config_module.save_config(initial)
+    before = _get_platform_tools(config_module.load_config(), "cli")
+    assert ("x_search" in before) is credentials
+    for enabled in (True, False, True, False):
+        assert plugins_cmd.dashboard_set_agent_plugin_enabled("spotify", enabled=enabled)["ok"]
+        selected = _get_platform_tools(config_module.load_config(), "cli")
+        assert selected - {"spotify"} == before
+        assert ("spotify" in selected) is enabled
+
+
+@pytest.mark.parametrize("initial", [
+    {"platform_toolsets": {"cli": []}},
+    {"platform_toolsets": {"cli": ["file"]}},
+    {"agent": {"disabled_toolsets": ["x_search"]}},
+    {"platform_toolsets": {"cli": ["hermes-cli"]}, "agent": {"disabled_toolsets": ["x_search"]}},
+])
+def test_plugin_round_trip_respects_x_search_opt_out(plugin_home, monkeypatch, initial):
+    monkeypatch.setenv("XAI_API_KEY", "nonfunctional-test-fixture")
+    config_module.save_config(initial)
+    assert "x_search" not in _get_platform_tools(config_module.load_config(), "cli")
+    for enabled in (True, False):
+        assert plugins_cmd.dashboard_set_agent_plugin_enabled("spotify", enabled=enabled)["ok"]
+        assert "x_search" not in _get_platform_tools(config_module.load_config(), "cli")


### PR DESCRIPTION
## What does this PR do?

Fixes the shared backend plugin-toggle writer used by Desktop plugin settings and the dashboard. When no platform toolset override exists, enabling a tool-providing plugin currently persists a plugin-only CLI selection. That explicit list replaces inherited core defaults; disabling the plugin afterward leaves an explicit empty list.

Seed the new CLI selection with the canonical default composite plus the plugin toolset instead. Disabling then leaves the default composite intact. Existing explicit selections, including intentionally empty and plugin-only lists, keep their existing semantics. This does not migrate or reinterpret existing empty selections.

## Type of Change

- [x] Bug fix
- [x] Regression tests

## Changes Made

- `hermes_cli/plugins_cmd.py`: retain `PLATFORMS["cli"]["default_toolset"]` when creating the first CLI selection.
- `tests/hermes_cli/test_plugin_toolset_toggle.py`: exercise real plugin discovery and config IO under temporary `HERMES_HOME`, inherited defaults, explicit selections, multiple platforms, repeated round trips, idempotence, disabled-toolset exclusions, and no-tool no-ops.

## How to Test

1. In an isolated profile with no `platform_toolsets` override, enable a loaded tool-providing plugin through plugin settings.
2. Verify that core tools remain selected alongside the plugin.
3. Disable the plugin and verify the inherited core tools remain.
4. Repeat with an explicit limited selection and with `cli: []`; the round trip must restore the original explicit selection without adding core defaults.

Automated verification after applying the fix to current upstream `main`:

```sh
scripts/run_tests.sh tests/hermes_cli/test_plugin_toolset_toggle.py tests/test_plugins_manage_profile_scope.py tests/tui_gateway/test_plugins_manage_install.py tests/tui_gateway/test_gui_surface_toolsets.py tests/test_toolsets.py tests/hermes_cli/test_toolset_validation.py
```

Result: **68 passed, 0 failed**, including 14 new regression cases. The inherited-default regression was observed failing before the fix during development. `git diff --check` passed.

Manual verification during development used a real isolated Electron dev desktop and a harmless local fixture plugin, not a mocked renderer. Actual settings switches and persisted configuration were read back:

| Initial selection | Enabled | Disabled |
| --- | --- | --- |
| Inherited | Default composite + fixture | Default composite |
| Explicit file-only | File + fixture | File-only |
| Explicit empty | Fixture-only | Empty |

The manual desktop verification was performed before updating the branch to current upstream; the Python suite above was rerun afterward. No claim is made that the full repository suite or remote CI has passed.

## Scope and privacy

Only the shared writer and generic tests are included. No user configuration, logs, credentials, local paths, profile identifiers, or incident artifacts are included. This PR establishes the reproducible mutation defect, not attribution of any historical configuration change.

## Follow-up: credential-enabled toolsets

Mixed composite/plugin selections now use the same composite resolver as inherited defaults. This preserves credential-enabled `x_search` across plugin enable/disable round trips, without enabling it for an explicitly empty or limited selection. Global disabled-toolset exclusions still apply last.

Verification on `44a78430e4c`:

- New regression coverage was RED before the follow-up: **19 passed, 3 failed**.
- Updated targeted suite listed above: **76 passed, 0 failed** (retries disabled).
- Extended tool configuration, MCP, gateway, and X-search suites: **704 passed, 1 failed, 6 skipped**. The unrelated failure, `test_model_options_preserves_canonical_custom_row_after_agent_init`, reproduces on untouched original PR head with the same provider-list assertion. It is not changed here.
- Real isolated Electron Settings verification: **12 states**, covering before/enabled/disabled for inherited defaults, file-only, empty, and globally disabled X search. Actual switch clicks, persisted YAML readback, and real backend `tools.show` / `toolsets.list` confirm selection preservation and opt-outs. No model prompts or X-search requests. The final matrix was rerun after suppressing ambient provider credential discovery in the test rig. This verifies selection, not hot plugin unloading.
- Independent bounded review found no correctness blockers; Ruff and `git diff --check` passed.
- Source diff, commit messages and this description were scrubbed for private paths, credentials and local identifiers. Rig logs and screenshots remain private and are not included in the PR.
