### PR TITLE
fix(desktop): resolve gateway media downloads via their session's owning connection

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -13,6 +13,7 @@ export interface ArtifactRecord {
   label: string
   sessionId: string
   profile?: string
+  connectionId?: string
   sessionTitle: string
   timestamp: number
 }
@@ -410,6 +411,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         label: artifactLabel(value),
         sessionId: session.id,
         profile: session.profile,
+        connectionId: session.connection_id,
         sessionTitle: title,
         timestamp: artifactTimestamp(message, session)
       })

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -281,7 +281,11 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
         // Tilde/relative hrefs have no file URL form. Keep them gateway-owned:
         // expanding them on the client would target the wrong home or cwd.
         if (isRemoteGateway() && isArtifactFilePath(artifact.value)) {
-          await downloadGatewayMediaFile(artifact.value, { sessionId: artifact.sessionId, profile: artifact.profile })
+          await downloadGatewayMediaFile(artifact.value, {
+            sessionId: artifact.sessionId,
+            connectionId: artifact.connectionId,
+            profile: artifact.profile
+          })
 
           return
         }

--- a/apps/desktop/src/components/assistant-ui/markdown-text.download-scope.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.download-scope.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
+import { $connection } from '@/store/session'
+import { $sessionTiles } from '@/store/session-states'
+
+import { MarkdownImage } from './markdown-text'
+
+const TILE_SESSION_ID = 'tile-session'
+const IMAGE_PATH = '/tile/work/photo.png'
+
+/** Minimal tile view — only the fields the media components read. */
+function tileView(): SessionView {
+  return {
+    ...({} as SessionView),
+    $cwd: atom('/tile/work'),
+    $storedId: atom<null | string>(TILE_SESSION_ID),
+    kind: 'tile'
+  }
+}
+
+// Regression: an image (or audio/video) rendered inline in a chat message can
+// live in a background session tile pinned to a DIFFERENT connection than
+// whichever one this window currently shows. The "Open image"/"Open <kind>
+// file" fallback shown after a failed inline load must retry the download
+// against THAT session's owning connection, not the ambient `$connection`
+// (478d772f2c threaded sessionId/profile through the Artifacts page only —
+// this call site, useOpenMediaFile, had no origin at all).
+describe('MarkdownImage failed-load download connection scoping', () => {
+  const saveGatewayFile = vi.fn(async (_request: Record<string, unknown>) => ({
+    path: '/local/downloads/photo.png',
+    saved: true
+  }))
+
+  const api = vi.fn().mockRejectedValue(new Error('boom'))
+  let originalDesktop: typeof window.hermesDesktop
+
+  beforeEach(() => {
+    saveGatewayFile.mockClear()
+    api.mockClear()
+    originalDesktop = window.hermesDesktop
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: { api, saveGatewayFile } })
+    // The window is currently showing a DIFFERENT connection than the one
+    // that owns the tile's session.
+    $connection.set({ connectionId: 'ambient-conn', mode: 'remote', profile: 'ambient-profile' } as never)
+    $sessionTiles.set([
+      { ownerRoute: { connectionId: 'homelab-ssh', profile: 'writer' }, storedSessionId: TILE_SESSION_ID }
+    ] as never)
+  })
+
+  afterEach(() => {
+    cleanup()
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: originalDesktop })
+    $connection.set(null)
+    $sessionTiles.set([])
+  })
+
+  it('retries the download through the tile owning connection, not the ambient one', async () => {
+    render(
+      <SessionViewProvider value={tileView()}>
+        <MarkdownImage alt="pic" src={IMAGE_PATH} />
+      </SessionViewProvider>
+    )
+
+    const button = await screen.findByRole('button', { name: 'Open image' })
+
+    fireEvent.click(button)
+
+    await waitFor(() => expect(saveGatewayFile).toHaveBeenCalledTimes(1))
+    expect(saveGatewayFile).toHaveBeenCalledWith({
+      connectionId: 'homelab-ssh',
+      path: IMAGE_PATH,
+      profile: 'writer',
+      sessionId: TILE_SESSION_ID,
+      suggestedName: 'photo.png'
+    })
+  })
+
+  it('falls back to the ambient connection for the primary (untiled) view', async () => {
+    render(<MarkdownImage alt="pic" src={IMAGE_PATH} />)
+
+    const button = await screen.findByRole('button', { name: 'Open image' })
+
+    fireEvent.click(button)
+
+    await waitFor(() => expect(saveGatewayFile).toHaveBeenCalledTimes(1))
+    expect(saveGatewayFile.mock.calls[0]?.[0]).toMatchObject({
+      connectionId: 'ambient-conn',
+      profile: 'ambient-profile'
+    })
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -10,6 +10,7 @@ import {
 import type { code as streamdownCode } from '@streamdown/code'
 import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
 
+import { useSessionView } from '@/app/chat/session-view'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
@@ -31,11 +32,13 @@ import {
   mediaName,
   mediaPathFromMarkdownHref,
   resolveMediaDisplaySrc,
-  resolveMediaPlaybackSrc
+  resolveMediaPlaybackSrc,
+  sessionDownloadOrigin
 } from '@/lib/media'
 import { previewTargetFromMarkdownHref } from '@/lib/preview-targets'
 import { sessionRefFromMarkdownHref } from '@/lib/session-refs'
 import { cn } from '@/lib/utils'
+import { knownOwnerForSession } from '@/store/session-states'
 
 import { ArtifactCard } from './artifact-card'
 import { SessionRefLink } from './directive-text'
@@ -105,11 +108,22 @@ function preprocessWithTailRepair(text: string): string {
 
 function useOpenMediaFile(path: string) {
   const [openFailed, setOpenFailed] = useState(false)
+  const sessionView = useSessionView()
 
   const open = () => {
     if (window.hermesDesktop && isRemoteGateway()) {
       setOpenFailed(false)
-      void downloadGatewayMediaFile(path).catch(() => setOpenFailed(true))
+
+      // This media lives in one session's transcript, which can be a
+      // background tile pinned to a different connection than whichever one
+      // is currently in focus — resolve against THAT session's owner rather
+      // than the ambient ($connection) one.
+      const storedSessionId = sessionView.$storedId.get()
+
+      void downloadGatewayMediaFile(
+        path,
+        sessionDownloadOrigin(storedSessionId, knownOwnerForSession(storedSessionId))
+      ).catch(() => setOpenFailed(true))
     } else {
       openExternalLink(mediaExternalUrl(path))
     }

--- a/apps/desktop/src/components/chat/preview-attachment.test.tsx
+++ b/apps/desktop/src/components/chat/preview-attachment.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
+import { $connection } from '@/store/session'
+import { $sessionTiles } from '@/store/session-states'
+
+import { PreviewAttachment } from './preview-attachment'
+
+const TILE_SESSION_ID = 'tile-session'
+
+/** Minimal tile view — only the fields PreviewAttachment reads. */
+function tileView(): SessionView {
+  return {
+    ...({} as SessionView),
+    $cwd: atom('/tile/work'),
+    $storedId: atom<null | string>(TILE_SESSION_ID),
+    kind: 'tile'
+  }
+}
+
+describe('PreviewAttachment download connection scoping', () => {
+  const saveGatewayFile = vi.fn(async (_request: Record<string, unknown>) => ({
+    path: '/local/downloads/report.md',
+    saved: true
+  }))
+
+  let originalDesktop: typeof window.hermesDesktop
+
+  beforeEach(() => {
+    saveGatewayFile.mockClear()
+    originalDesktop = window.hermesDesktop
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: { saveGatewayFile } })
+    // The window is currently showing a DIFFERENT connection than the one
+    // that owns the tile's session — this is the case a background tile can
+    // legitimately be in (#478d772f2c only threaded profile/sessionId, never
+    // connectionId).
+    $connection.set({ connectionId: 'ambient-conn', mode: 'remote', profile: 'ambient-profile' } as never)
+    $sessionTiles.set([
+      { ownerRoute: { connectionId: 'homelab-ssh', profile: 'writer' }, storedSessionId: TILE_SESSION_ID }
+    ] as never)
+  })
+
+  afterEach(() => {
+    cleanup()
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: originalDesktop })
+    $connection.set(null)
+    $sessionTiles.set([])
+  })
+
+  it('downloads through the session tile owning connection, not the ambient one', async () => {
+    render(
+      <SessionViewProvider value={tileView()}>
+        <PreviewAttachment target="/tile/work/report.md" />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download' }))
+
+    await waitFor(() => expect(saveGatewayFile).toHaveBeenCalledTimes(1))
+    expect(saveGatewayFile).toHaveBeenCalledWith({
+      connectionId: 'homelab-ssh',
+      path: '/tile/work/report.md',
+      profile: 'writer',
+      sessionId: TILE_SESSION_ID,
+      suggestedName: 'report.md'
+    })
+  })
+
+  it('still downloads through the ambient connection for the primary (untiled) view', async () => {
+    render(<PreviewAttachment target="/primary/work/report.md" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download' }))
+
+    await waitFor(() => expect(saveGatewayFile).toHaveBeenCalledTimes(1))
+    expect(saveGatewayFile.mock.calls[0]?.[0]).toMatchObject({
+      connectionId: 'ambient-conn',
+      profile: 'ambient-profile'
+    })
+  })
+})

--- a/apps/desktop/src/components/chat/preview-attachment.tsx
+++ b/apps/desktop/src/components/chat/preview-attachment.tsx
@@ -5,16 +5,18 @@ import { useSessionView } from '@/app/chat/session-view'
 import { useI18n } from '@/i18n'
 import { Download, MonitorPlay } from '@/lib/icons'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
-import { downloadGatewayMediaFile } from '@/lib/media'
+import { downloadGatewayMediaFile, sessionDownloadOrigin } from '@/lib/media'
 import { previewName } from '@/lib/preview-targets'
 import { notifyError } from '@/store/notifications'
 import { $previewTabSources, closePreviewForSource, openPreview, type PreviewRecordSource } from '@/store/preview'
+import { knownOwnerForSession } from '@/store/session-states'
 
 export function PreviewAttachment({ source = 'manual', target }: { source?: PreviewRecordSource; target: string }) {
   const { t } = useI18n()
+  const sessionView = useSessionView()
   // This link lives in one session's transcript; resolve it against THAT
   // session's cwd, not the primary chat's.
-  const cwd = useStore(useSessionView().$cwd)
+  const cwd = useStore(sessionView.$cwd)
   const openSources = useStore($previewTabSources)
   const [opening, setOpening] = useState(false)
   const [downloading, setDownloading] = useState(false)
@@ -107,8 +109,16 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
     try {
       // Works in both modes: the Electron main process fetches the bytes
       // through the session's backend connection (local gateway or remote)
-      // and prompts for a save location.
-      const result = await downloadGatewayMediaFile(target)
+      // and prompts for a save location. Resolve THAT session's owning
+      // connection (same ladder as the cwd above) — this attachment can live
+      // in a background tile pinned to a different connection than whichever
+      // one is currently in focus.
+      const storedSessionId = sessionView.$storedId.get()
+
+      const result = await downloadGatewayMediaFile(
+        target,
+        sessionDownloadOrigin(storedSessionId, knownOwnerForSession(storedSessionId))
+      )
 
       if (mountedRef.current && result.saved) {
         setDownloaded(true)

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -11,7 +11,8 @@ import {
   mediaExternalUrl,
   mediaGatewayStreamUrl,
   resolveMediaDisplaySrc,
-  resolveMediaPlaybackSrc
+  resolveMediaPlaybackSrc,
+  sessionDownloadOrigin
 } from './media'
 
 describe('isRemoteGateway', () => {
@@ -266,5 +267,61 @@ describe('downloadGatewayMediaFile', () => {
     await expect(downloadGatewayMediaFile('/Users/me/project/report.md')).rejects.toThrow(
       'Desktop file download bridge'
     )
+  })
+
+  // Regression: a chat message (or an Artifacts-page row) can belong to a
+  // session pinned to a DIFFERENT connection than whichever one this window
+  // currently shows. `origin.connectionId` must win over the ambient
+  // `$connection` — mirroring how `origin.profile` already does — instead of
+  // every download riding whatever the foreground tab happens to be.
+  it('routes the download to the origin connection, not the ambient one', async () => {
+    await downloadGatewayMediaFile('/Users/me/project/report.md', {
+      connectionId: 'homelab-ssh',
+      profile: 'writer-profile',
+      sessionId: 'session-42'
+    })
+
+    expect(saveGatewayFile).toHaveBeenCalledWith({
+      connectionId: 'homelab-ssh',
+      path: '/Users/me/project/report.md',
+      profile: 'writer-profile',
+      sessionId: 'session-42',
+      suggestedName: 'report.md'
+    })
+  })
+
+  it('falls back to the ambient connection when origin carries no connectionId', async () => {
+    await downloadGatewayMediaFile('/Users/me/project/report.md', { sessionId: 'session-42' })
+
+    expect(saveGatewayFile).toHaveBeenCalledWith({
+      connectionId: 'work-ssh',
+      path: '/Users/me/project/report.md',
+      profile: 'docker-gw',
+      sessionId: 'session-42',
+      suggestedName: 'report.md'
+    })
+  })
+})
+
+describe('sessionDownloadOrigin', () => {
+  it('returns undefined with no session id', () => {
+    expect(sessionDownloadOrigin(null, { connectionId: 'homelab-ssh', profile: 'writer' })).toBeUndefined()
+    expect(sessionDownloadOrigin(undefined, undefined)).toBeUndefined()
+  })
+
+  it('carries the owner route connectionId/profile alongside the session id', () => {
+    expect(sessionDownloadOrigin('session-42', { connectionId: 'homelab-ssh', profile: 'writer' })).toEqual({
+      connectionId: 'homelab-ssh',
+      profile: 'writer',
+      sessionId: 'session-42'
+    })
+  })
+
+  it('passes only the session id through for a bare-profile (non-route) owner', () => {
+    expect(sessionDownloadOrigin('session-42', 'writer')).toEqual({ sessionId: 'session-42' })
+  })
+
+  it('passes only the session id through for an unresolved owner', () => {
+    expect(sessionDownloadOrigin('session-42', undefined)).toEqual({ sessionId: 'session-42' })
   })
 })

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -1,6 +1,7 @@
 import { readDesktopFileDataUrl } from '@/lib/desktop-fs'
 import { capitalize } from '@/lib/text'
 import { $connection } from '@/store/session'
+import { isSessionOwnerRoute, type SessionOwnerScope } from '@/store/session-request-router'
 
 export type MediaKind = 'audio' | 'image' | 'video' | 'file'
 
@@ -202,6 +203,29 @@ export async function gatewayMediaDataUrl(path: string): Promise<string> {
   return readDesktopFileDataUrl(filePathFromMediaPath(path))
 }
 
+// Build a download `origin` from a session's resolved owner (tile route,
+// open-time hint, or connection-tagged row — see session-states.ts's
+// `knownOwnerForSession`). A background session tile can be pinned to a
+// DIFFERENT registered connection than whichever one the window currently
+// shows, so the owner's connectionId/profile must ride along explicitly
+// instead of downloadGatewayMediaFile falling back to the ambient `$connection`.
+// A bare-profile (non-route) owner or an unresolved owner still passes the
+// sessionId through and lets the ambient fallback apply, matching a locally
+// owned or not-yet-known session.
+export function sessionDownloadOrigin(
+  sessionId: null | string | undefined,
+  owner: SessionOwnerScope
+): { sessionId: string; connectionId?: string; profile?: string } | undefined {
+  if (!sessionId) {
+    return undefined
+  }
+
+  return {
+    sessionId,
+    ...(isSessionOwnerRoute(owner) ? { connectionId: owner.connectionId, profile: owner.profile } : {})
+  }
+}
+
 // Remote-mode replacement for opening gateway-local file paths with file://.
 // The file lives on the gateway, so ask the Electron main process to fetch the
 // bytes through the authenticated backend connection and save them locally. This
@@ -209,7 +233,7 @@ export async function gatewayMediaDataUrl(path: string): Promise<string> {
 // used by preview endpoints.
 export async function downloadGatewayMediaFile(
   path: string,
-  origin?: { sessionId: string; profile?: string }
+  origin?: { sessionId: string; connectionId?: string; profile?: string }
 ): Promise<{ canceled?: boolean; path?: string; saved: boolean }> {
   // URI conversion belongs to the gateway OS, not the renderer's URL parser.
   const file = path
@@ -220,7 +244,7 @@ export async function downloadGatewayMediaFile(
   }
 
   return window.hermesDesktop.saveGatewayFile({
-    connectionId: conn?.connectionId,
+    connectionId: origin?.connectionId ?? conn?.connectionId,
     path: file,
     profile: origin?.profile ?? conn?.profile,
     ...(origin ? { sessionId: origin.sessionId } : {}),


### PR DESCRIPTION
## What does this PR do?

Fixes gateway media downloads landing on the wrong backend connection when the session a download originates from is owned by a *different* registered connection than whichever one the window currently shows.

## Root cause

`478d772f2c` ("fix(desktop): resolve artifact downloads in their originating session", merged earlier today from #104963) added an `origin: { sessionId, profile }` parameter to `downloadGatewayMediaFile()` in `apps/desktop/src/lib/media.ts` and threaded `profile` through correctly for the Artifacts page — but the function body still read `connectionId` exclusively from the ambient `$connection` atom, which `store/session.ts` itself documents as "presentation-oriented" (whichever connection tab the user currently has in focus), never a routing authority.

Since a user can have multiple registered gateway connections, and a chat message rendered in a background session tile (or an Artifacts row) can legitimately belong to a different connection than the one currently focused, this could send the download request to the wrong backend (wrong `baseUrl`/auth) while still carrying the right `sessionId` — a failed/404 download at best.

Three more call sites passed **no** origin at all (predating or missed by `478d772f2c`):
- `apps/desktop/src/components/assistant-ui/markdown-text.tsx`'s `useOpenMediaFile` (the "Open image"/"Open audio/video file" fallback shown after a failed inline load)
- `apps/desktop/src/components/chat/preview-attachment.tsx`'s download button — notably, this same file *already* scopes correctly for a different concern (`useSessionView().$cwd`, with a comment explaining why: "this link lives in one session's transcript; resolve it against THAT session's cwd, not the primary chat's") — the download button a few lines below just never got the same treatment.

## The fix

- `media.ts`: `downloadGatewayMediaFile`'s `origin` now accepts `connectionId`, used ahead of the ambient connection — mirroring the existing `profile` override (`origin?.connectionId ?? conn?.connectionId`). Added `sessionDownloadOrigin()`, a small helper that builds an origin from a session's resolved owner (`SessionOwnerScope`, e.g. from `knownOwnerForSession`/`tileOwnerRoute`'s ladder), passing only `sessionId` through when the owner is a bare profile or unresolved (matching the pre-existing local/ambient fallback).
- `artifact-utils.ts` / `artifacts/index.tsx`: `ArtifactRecord` now carries the session's `connection_id` (already stamped onto `SessionInfo` by `stampRowsWithOwningConnection` at fetch time) and threads it into the download call.
- `preview-attachment.tsx` and `markdown-text.tsx`'s `useOpenMediaFile`: both now resolve the rendering session's real owner via `useSessionView().$storedId` + `knownOwnerForSession()` — the same non-hook, sync owner-resolution ladder `session-tile.tsx`/`isSessionRemote()` already use for RPC routing and the upload-side byte-vs-path decision (`isSessionRemote`, salvaged via #95081) — instead of inventing a new mechanism.

### Scope note: `store/file-actions.ts`'s `downloadRemoteFile`

Investigated and **left unscoped**. This is the workspace Files/review-tree panel's download action. Unlike the chat-message call sites above, it has no session concept at all — it has no `sessionId` parameter, and every sibling operation in the same module (`readDesktopDir`, `readDesktopFileText`, `remoteFsApi`, etc.) is *already*, consistently ambient-connection-only by design: the panel renders the active workspace (`$currentCwd`), not a per-tile session. Scoping only the download call there would introduce a new inconsistency with its own siblings rather than fix a real gap.

## Tests

- `media.remote.test.ts`: two new cases on `downloadGatewayMediaFile` (origin connectionId wins over ambient; falls back to ambient when origin carries none) + four new cases on `sessionDownloadOrigin`.
- `components/chat/preview-attachment.test.tsx` (new file): renders `PreviewAttachment` under a tile `SessionView` pinned (via `$sessionTiles`) to a connection different from the ambient `$connection`, clicks Download, asserts `saveGatewayFile` receives the tile's connection — plus a control case for the untiled primary view still using ambient.
- `components/assistant-ui/markdown-text.download-scope.test.tsx` (new file): same tile-vs-ambient distinction, exercised through `MarkdownImage`'s failed-load "Open image" fallback (`useOpenMediaFile`).

### Mutation-verify

Reverted just the one-line fix in `media.ts` (`connectionId: conn?.connectionId` instead of `origin?.connectionId ?? conn?.connectionId`) with everything else in place — all 3 new "uses the origin connection" assertions failed with the exact pre-fix symptom (ambient connectionId used instead of the origin's), while the untiled/ambient-fallback tests kept passing. Restored the fix and all tests pass again.

```
npx vitest run src/lib/media.remote.test.ts src/app/artifacts/remote-open.test.tsx \
  src/components/chat/preview-attachment.test.tsx src/components/assistant-ui/markdown-text.download-scope.test.tsx \
  src/components/assistant-ui/markdown-text.media.test.tsx src/components/assistant-ui/markdown-text.media-md.test.tsx \
  src/components/assistant-ui/markdown-text.filelinks.test.tsx src/components/assistant-ui/markdown-text.session.test.tsx \
  src/components/assistant-ui/markdown-text.artifacts.test.tsx src/store/file-actions.test.ts
# 10 files, 56 tests passed

npx tsc -p tsconfig.json --noEmit          # clean
npx tsc -p tsconfig.electron.json --noEmit # clean
npx eslint <touched files>                 # clean
```

## Competitor check

Searched `gh pr list` (all states) for: "artifact download connection", "downloadGatewayMediaFile", "session tile connection scope", "preview attachment download", "478d772f2c", "104123", plus a `created:>=2026-09-07` sweep on "media"/"download"/"artifact". Nothing addresses this specific `connectionId` gap or the three call sites above.

Notable adjacent-but-non-overlapping PRs re-checked by reading their actual diffs:
- #104963 (merged as `478d772f2c` earlier today) is the PR this fix's residual gap is *in* — not a competitor.
- #94833 (open) and #101750 (open): both about `mediaExternalUrl`/media resolution *ladder* order (OAuth-gated fallback; local-vs-gateway artifact origin) — different functions, no connectionId involved.
- #104131 (open) and #104850 (closed): both about `~/`/relative-path *URL classification* (`Invalid external URL`, `classifyOpenTarget`) for the same issue #104123 that #104963 also targeted — touches some of the same files (`artifact-utils.ts`, `index.tsx`, `media.ts`) but a disjoint concern (path classification, not connection resolution); textually adjacent, not a semantic conflict.
- #94672 (closed, salvaged via #95081, merged as `71d804d00`): the upload-side analog of this exact bug class (`image.attach` byte-vs-path decision using ambient `$connection` instead of the session's own connection) — confirms `knownOwnerForSession`/`isSessionRemote`'s ladder is the established, maintainer-accepted pattern this PR reuses on the download side.
- #105139 (open): Desktop profile-switch/gateway-selection bug — no file overlap.
