### PR TITLE
fix(local): read total RAM in-process so a failed subprocess cannot zero the UMA budget

### DIFF
--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -61,8 +61,30 @@ def _stdout(*argv: str) -> str:
     ).stdout
 
 
+def _sysconf_bytes(pages_name: str) -> int:
+    """``pages * page size`` via os.sysconf — in-process: no PATH, no fork, nothing to time out.
+    0 where the platform lacks the name. Apple's libc answers SC_PHYS_PAGES from hw.memsize, the
+    same figure the sysctl fallback below shells out for."""
+    sysconf = getattr(os, "sysconf", None)
+    if sysconf is None:
+        return 0
+    with suppress(OSError, ValueError):
+        pages, page = sysconf(pages_name), sysconf("SC_PAGE_SIZE")
+        if pages > 0 and page > 0:
+            return pages * page
+    return 0
+
+
 def _ram_bytes() -> tuple[int, int]:
-    """(total, available) physical memory, cross-platform stdlib."""
+    """(total, available) physical memory, cross-platform stdlib.
+
+    Total is read in-process first. On unified-memory machines the whole budget derives from it,
+    so a zero total does not degrade — every catalog row reads "too big for this machine" — and
+    it must not hinge on a child process: a spawn failure or an empty pipe under the packaged
+    desktop backend is a bad reading of the machine, not a small machine. Subprocesses remain as
+    the fallback and for the available figure; one that fails or hangs after the total was read
+    costs only the available figure.
+    """
     try:
         import ctypes
 
@@ -78,15 +100,17 @@ def _ram_bytes() -> tuple[int, int]:
         return stat.ullTotalPhys, stat.ullAvailPhys
     except (AttributeError, OSError):
         pass
+    total = _sysconf_bytes("SC_PHYS_PAGES")
     try:
         if sys.platform == "darwin":
             # macOS getconf has no _PHYS_PAGES/_AVPHYS_PAGES (exit 64) — the POSIX branch would
             # return (0, 0) and every model would read unavailable. sysctl is the platform truth.
-            total = int(_stdout("/usr/sbin/sysctl", "-n", "hw.memsize").strip() or 0)
+            if total <= 0:
+                total = int(_stdout("/usr/sbin/sysctl", "-n", "hw.memsize").strip() or 0)
             if total <= 0:
                 return 0, 0
             avail = total // 2  # conservative fallback
-            with suppress(OSError, ValueError):
+            with suppress(OSError, ValueError, subprocess.TimeoutExpired):
                 out = _stdout("/usr/bin/vm_stat")
                 page_m = re.search(r"page size of (\d+)", out)
                 page = int(page_m.group(1)) if page_m else 16384
@@ -99,14 +123,13 @@ def _ram_bytes() -> tuple[int, int]:
                     avail = pages * page
             return total, avail
         # POSIX
-        page = int(_stdout("getconf", "PAGE_SIZE") or 4096)
-        total = int(_stdout("getconf", "_PHYS_PAGES") or 0) * page
-        avail = total // 2  # conservative when _AVPHYS is unavailable
-        with suppress(OSError, ValueError):
-            avail = int(_stdout("getconf", "_AVPHYS_PAGES") or 0) * page or avail
-        return total, avail
-    except (OSError, ValueError):
-        return 0, 0
+        if total <= 0:
+            page = int(_stdout("getconf", "PAGE_SIZE") or 4096)
+            total = int(_stdout("getconf", "_PHYS_PAGES") or 0) * page
+        # SC_AVPHYS_PAGES is glibc's; elsewhere the name is unknown and half of total stands in.
+        return total, _sysconf_bytes("SC_AVPHYS_PAGES") or total // 2
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        return (total, total // 2) if total > 0 else (0, 0)
 
 
 # nvidia-smi lives at a fixed path under the driver install; PATH presence varies by session type

--- a/tests/hermes_cli/test_ram_probe.py
+++ b/tests/hermes_cli/test_ram_probe.py
@@ -1,0 +1,173 @@
+"""The RAM probe must not read a machine as memoryless because a child process misbehaved.
+
+On unified-memory machines the whole budget derives from total RAM, so a probe that answers 0
+does not degrade gracefully: every catalog row reads "too big for this machine" and a 128 GiB
+Mac is told it has no memory (#102619). Total therefore comes from os.sysconf in-process; the
+sysctl/getconf subprocesses remain only as the fallback and for the available figure."""
+
+from __future__ import annotations
+
+import ctypes
+import subprocess
+
+import hermes_cli.local_runtime.hardware as hw
+
+GIB = 1 << 30
+PAGE = 16384
+MAC_128 = 128 * GIB
+MAC_SYSCONF = {"SC_PHYS_PAGES": MAC_128 // PAGE, "SC_PAGE_SIZE": PAGE}
+
+VM_STAT = """Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                              123456.
+Pages active:                           3000000.
+Pages inactive:                         2000000.
+Pages speculative:                       100000.
+Pages throttled:                              0.
+Pages wired down:                        500000.
+Pages purgeable:                          50000.
+"Translation faults":                 999999999.
+Pages compressed:                        400000.
+"""
+VM_STAT_RECLAIMABLE = (123456 + 2000000 + 100000 + 50000) * PAGE
+
+
+def _sysconf(values: dict):
+    def fake(name):
+        if name not in values:
+            raise ValueError(f"unrecognized configuration name: {name}")
+        return values[name]
+    return fake
+
+
+def _host(monkeypatch, *, platform, sysconf, stdout=None):
+    """Pin the platform and stub every process boundary the probe can cross. Returns the argv of
+    each subprocess the probe attempted; ``stdout=None`` makes any attempt a failure."""
+    # Windows answers from GlobalMemoryStatusEx before any of this runs; take that path away so
+    # the POSIX branches are exercised on every CI runner.
+    monkeypatch.delattr(ctypes, "windll", raising=False)
+    monkeypatch.setattr(hw.sys, "platform", platform)
+    if sysconf is None:
+        monkeypatch.delattr(hw.os, "sysconf", raising=False)
+    else:
+        monkeypatch.setattr(hw.os, "sysconf", _sysconf(sysconf), raising=False)
+    calls: list[tuple[str, ...]] = []
+
+    def fake_stdout(*argv):
+        calls.append(argv)
+        assert stdout is not None, f"unexpected subprocess {argv}"
+        out = stdout(argv)
+        if isinstance(out, BaseException):
+            raise out
+        return out
+
+    monkeypatch.setattr(hw, "_stdout", fake_stdout)
+    return calls
+
+
+# ── macOS ────────────────────────────────────────────────────
+
+
+def test_darwin_total_is_read_in_process(monkeypatch):
+    """Only vm_stat (the available figure) is spawned; the total never waits on a child."""
+    calls = _host(monkeypatch, platform="darwin", sysconf=MAC_SYSCONF,
+                  stdout=lambda argv: VM_STAT if argv[0] == "/usr/bin/vm_stat" else "")
+    assert hw._ram_bytes() == (MAC_128, VM_STAT_RECLAIMABLE)
+    assert [c[0] for c in calls] == ["/usr/bin/vm_stat"]
+
+
+def test_darwin_empty_subprocess_output_keeps_the_total(monkeypatch):
+    """#102619's shape: a subprocess spawned by the packaged backend produced no output (the
+    sibling report #102616 shows exactly that for --version). The old probe turned an empty
+    sysctl pipe into total=0; now only the available figure degrades, to half."""
+    _host(monkeypatch, platform="darwin", sysconf=MAC_SYSCONF, stdout=lambda argv: "")
+    assert hw._ram_bytes() == (MAC_128, MAC_128 // 2)
+
+
+def test_darwin_spawn_failure_keeps_the_total(monkeypatch):
+    """fork/exec refused (EAGAIN under load, a stripped or sandboxed environment): the total
+    stands, the available figure degrades to half."""
+    _host(monkeypatch, platform="darwin", sysconf=MAC_SYSCONF,
+          stdout=lambda argv: BlockingIOError(11, "Resource temporarily unavailable"))
+    assert hw._ram_bytes() == (MAC_128, MAC_128 // 2)
+
+
+def test_darwin_hung_vm_stat_keeps_the_total(monkeypatch):
+    """vm_stat past its timeout must not take the reading (and the catalog endpoint) down."""
+    _host(monkeypatch, platform="darwin", sysconf=MAC_SYSCONF,
+          stdout=lambda argv: subprocess.TimeoutExpired(argv, 5))
+    assert hw._ram_bytes() == (MAC_128, MAC_128 // 2)
+
+
+def test_darwin_falls_back_to_sysctl_without_sysconf(monkeypatch):
+    calls = _host(monkeypatch, platform="darwin", sysconf=None,
+                  stdout=lambda argv: f"{MAC_128}\n" if argv[0] == "/usr/sbin/sysctl" else VM_STAT)
+    assert hw._ram_bytes() == (MAC_128, VM_STAT_RECLAIMABLE)
+    assert calls[0] == ("/usr/sbin/sysctl", "-n", "hw.memsize")
+
+
+def test_darwin_sysconf_answering_zero_falls_back_to_sysctl(monkeypatch):
+    """A libc that has the name but no answer (-1 / 0) is treated as absent, not as a 0-byte
+    machine."""
+    calls = _host(monkeypatch, platform="darwin",
+                  sysconf={"SC_PHYS_PAGES": -1, "SC_PAGE_SIZE": PAGE},
+                  stdout=lambda argv: f"{MAC_128}\n" if argv[0] == "/usr/sbin/sysctl" else VM_STAT)
+    assert hw._ram_bytes()[0] == MAC_128
+    assert calls[0][0] == "/usr/sbin/sysctl"
+
+
+# ── Linux / other POSIX ──────────────────────────────────────
+
+
+def test_linux_total_and_available_are_read_in_process(monkeypatch):
+    """glibc carries both names: no getconf fork at all (stdout=None fails on any attempt)."""
+    _host(monkeypatch, platform="linux", sysconf={
+        "SC_PHYS_PAGES": 64 * GIB // 4096, "SC_AVPHYS_PAGES": 20 * GIB // 4096, "SC_PAGE_SIZE": 4096})
+    assert hw._ram_bytes() == (64 * GIB, 20 * GIB)
+
+
+def test_posix_without_avphys_halves_the_total(monkeypatch):
+    """BSD-flavoured libc: SC_PHYS_PAGES only. Half of total stands in for available, as before."""
+    _host(monkeypatch, platform="freebsd14", sysconf={"SC_PHYS_PAGES": 32 * GIB // 4096, "SC_PAGE_SIZE": 4096})
+    assert hw._ram_bytes() == (32 * GIB, 16 * GIB)
+
+
+def test_linux_falls_back_to_getconf_without_sysconf(monkeypatch):
+    def getconf(argv):
+        return {"PAGE_SIZE": "4096\n", "_PHYS_PAGES": f"{64 * GIB // 4096}\n"}[argv[1]]
+
+    calls = _host(monkeypatch, platform="linux", sysconf=None, stdout=getconf)
+    assert hw._ram_bytes() == (64 * GIB, 32 * GIB)
+    assert [c[1] for c in calls] == ["PAGE_SIZE", "_PHYS_PAGES"]
+
+
+def test_nothing_answers_reads_unavailable(monkeypatch):
+    """Every source gone: (0, 0) remains the 'unknown machine' signal downstream code expects."""
+    _host(monkeypatch, platform="darwin", sysconf=None,
+          stdout=lambda argv: FileNotFoundError(2, "no such file"))
+    assert hw._ram_bytes() == (0, 0)
+
+
+def test_hung_fallback_reads_unavailable_instead_of_raising(monkeypatch):
+    """No sysconf and a hung sysctl: unavailable, not an exception out of probe_budget."""
+    _host(monkeypatch, platform="darwin", sysconf=None,
+          stdout=lambda argv: subprocess.TimeoutExpired(argv, 5))
+    assert hw._ram_bytes() == (0, 0)
+
+
+# ── the symptom, end to end ──────────────────────────────────
+
+
+def test_unified_mac_prices_the_catalog_from_the_in_process_total(monkeypatch):
+    """A 128 GiB Mac whose subprocesses return nothing must still budget the pool minus headroom
+    and price the 27B as resident — the row #102619 saw tagged 'Too big for this machine'."""
+    from hermes_cli.local_runtime import catalog
+
+    _host(monkeypatch, platform="darwin", sysconf=MAC_SYSCONF, stdout=lambda argv: "")
+    monkeypatch.setattr(hw, "_nvidia_vram", lambda: None)
+    monkeypatch.setattr(hw, "_device_pool_view", lambda: None)
+    budget = hw.probe_budget(planning=True)
+    assert budget.uma is True
+    assert budget.total_device_bytes == MAC_128
+    assert budget.usable_vram_bytes == int(MAC_128 * (1 - hw._UMA_HEADROOM_FRACTION))
+    choice = catalog.select_variant(catalog.catalog_by_id()["qwen3.8-27b"], budget)
+    assert choice is not None and choice.zero_spill


### PR DESCRIPTION
_Edited 2026-09-10: added hardware evidence for the macOS premise, and two overlapping PRs my original check missed (#102963, #102276). For Linux "available", #102963's `MemAvailable` is the better figure. See [comment](https://github.com/NousResearch/hermes-agent/pull/105312#issuecomment-5616618711)._

## What does this PR do?

On unified-memory machines (Apple Silicon, and any box without an NVIDIA device) the whole budget derives from total RAM: `probe_budget` returns `usable = 0.8 × ram_total`. `_ram_bytes()` obtained that total by spawning `/usr/sbin/sysctl` (macOS) or `getconf` (other POSIX), and any failure of that child — spawn error, empty pipe, non-numeric output — collapsed to `(0, 0)`. A zero total does not degrade gracefully: `usable` becomes 0, `select_variant` returns `None` for every entry, and each catalog row is tagged **Too big for this machine** with the detail "Needs more memory than this machine has". The machine is not small; the reading is bad.

That is the only way the code on `main` produces the row in #102619 (Qwen3.8 27B tagged too big on a 128 GB M5 Max). A correctly probed 128 GiB Mac budgets 102.4 GiB and prices that entry as resident at its full 256K window. On macOS the darwin branch has exactly two outcomes — the true `hw.memsize`, or 0 when the child fails or prints nothing — so the reporter's backend read 0. The sibling report from the same machine, #102616, shows a child spawned by the packaged desktop backend returning empty output for `llama-server --version`, so that environment does produce empty pipes; which failure hit `sysctl` (that, a transient fork failure under load, a stripped or sandboxed spawn) I cannot tell from here.

The fix reads the total in-process via `os.sysconf`, so a misbehaving child can no longer zero the budget. Apple's libc implements `_SC_PHYS_PAGES` as `hw.memsize / hw.pagesize` (Libc `gen/FreeBSD/sysconf.c`) — the same figure the sysctl call shells out for. No budget policy changes: headroom fractions, margins, planning/live semantics and the discrete paths are as before. Does not overlap #102993 (discrete host-RAM headroom, `overhead_bytes`) or #102562 (AMD sysfs probe); neither touches `_ram_bytes`. #102963 and #102276 do touch `_ram_bytes()` (Linux `MemAvailable`), and my original check missed them. The PRs agree on the total; for Linux "available", #102963's `MemAvailable` is the better figure, and this PR's tests conflict with it on Linux ([details](https://github.com/NousResearch/hermes-agent/pull/105312#issuecomment-5616618711)).

## Related Issue

Related to #102619 and #102616. Deliberately not marked `Fixes` until the reporter confirms `ram_total_bytes` reads 0 on their build (see How to Test); if it reads 128 GB there, the cause is elsewhere.

Sibling hardening in TurboFit's own probe: SouthpawIN/turbofit#32 (merged).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/local_runtime/hardware.py`
  - New `_sysconf_bytes()`: `os.sysconf("SC_PHYS_PAGES") × os.sysconf("SC_PAGE_SIZE")`, in-process — no PATH, no fork, nothing to time out. Returns 0 where the name is missing or the libc answers ≤ 0.
  - `_ram_bytes()` takes the total from that first. The `sysctl` / `getconf` subprocesses remain as the fallback when sysconf has no answer, and for the *available* figure (`vm_stat` on macOS; `SC_AVPHYS_PAGES` in-process on glibc, which also drops the `getconf _AVPHYS_PAGES` fork). A child that fails or hangs after the total was read — including `vm_stat` past its 5 s timeout, which previously escaped `probe_budget` and 500'd the catalog endpoint — now costs only the available figure (half of total, the existing conservative fallback); the total stands.
  - Windows path (`GlobalMemoryStatusEx`) untouched. `(0, 0)` remains the "unknown machine" signal when every source is gone.
- `tests/hermes_cli/test_ram_probe.py` (new, 12 tests) stubs every process boundary and the Windows path so all branches run on every CI runner:
  - total read in-process with only `vm_stat` spawned
  - empty subprocess output, a spawn failure (`EAGAIN`) and a hung `vm_stat` (`TimeoutExpired`) keep the total
  - fallback to `sysctl` / `getconf` when sysconf is absent or answers ≤ 0
  - glibc available figure in-process; BSD-flavoured libc halves; every source gone, or a hung fallback child, reads `(0, 0)` instead of raising
  - the symptom end to end: a 128 GiB Mac whose subprocesses return nothing budgets `0.8 × 128 GiB` and prices `qwen3.8-27b` as resident

## How to Test

1. `pytest tests/hermes_cli/test_ram_probe.py -q` — 12 pass, on any OS (the Windows path and every subprocess are stubbed).
2. On a Mac with 32 GB or more running Hermes Desktop: note the RAM figure under "This machine" and the pill on the Qwen3.8 27B row in Settings → Local Models. Then in `~/.hermes/hermes-agent`: `git fetch --depth 1 https://github.com/3x3xX3N0N/hermes-agent.git fix/ram-probe-in-process && git checkout -b fix/ram-probe-in-process FETCH_HEAD`, fully quit and relaunch Desktop (the backend runs from the checkout; no reinstall). Expected: real RAM under "This machine", green "Fits your GPU" on the 27B row.
3. Hard number: `~/.hermes/hermes-agent/venv/bin/python -c "from hermes_cli.local_runtime.hardware import _ram_bytes, probe_budget; print(_ram_bytes()); print(probe_budget(planning=True))"` — first value is RAM in bytes, `usable_vram_bytes` is 80% of it.

**This branch has not been run on Apple hardware, but its premise has been checked on a Mac.** On a Mac Studio M2 Max (macOS 26.5.2), `SC_PHYS_PAGES × SC_PAGE_SIZE` returned `34359738368` = `hw.memsize`, matching Apple's Libc source. @femtendo measured it on the TurboFit sibling ([results](https://github.com/SouthpawIN/turbofit/pull/32#issuecomment-5616306488)). `os.sysconf_names` carrying `SC_PAGE_SIZE`, `SC_PHYS_PAGES` and `SC_AVPHYS_PAGES` was verified on a real Linux host (WSL2, Gentoo). @LAMBODOG, if you can run this branch, `ram_total_bytes` from `GET /api/local-models/hardware` (or the "This machine" RAM figure) before and after would confirm it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#102993 and #102562 reviewed; neither touches `_ram_bytes`. Missed at first: #102963 and #102276, which do; see [comment](https://github.com/NousResearch/hermes-agent/pull/105312#issuecomment-5616618711))
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the local-runtime modules on a Windows host: 563 passed, 3 skipped; the 11 failures there (9 in `test_gateway_foreign_xdg_runtime.py` / `test_gateway_runtime_health.py`, one each in `test_dashboard_unified_launch.py` and `test_codex_runtime_plugin_migration.py`) fail identically with this file reverted to `main` (Linux systemd/XDG paths and a web build on a Windows box). `ruff check` (0.15.10) and `scripts/check-windows-footguns.py --all` clean.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (test suite). Not on macOS — see How to Test.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings; no docs page describes the probe
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows path untouched; macOS, glibc and BSD-flavoured libc each covered by a test
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

