### PR TITLE
fix(ntfy): enforce the message body limit in UTF-8 bytes (#105287)

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -25,7 +25,7 @@ except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.base import BasePlatformAdapter, SendResult, _custom_unit_to_cp
 from gateway.platforms.event import MessageEvent, MessageType
 from gateway.platforms._shared import get_scoped_secret as _get_scoped_secret
 
@@ -74,13 +74,26 @@ def _publish_headers(token: str, markdown: bool, *, auth_first: bool = True) -> 
     return headers
 
 
+def _utf8_len(s: str) -> int:
+    """UTF-8 bytes in *s* — ntfy's ``message-size-limit`` is a byte budget (Go's ``len()``
+    on the message), so a Cyrillic char costs two and an emoji four, unlike Python ``len()``."""
+    return len(s.encode("utf-8"))
+
+
 def _truncate_body(message: str, *, context: str) -> bytes:
-    """Apply the ntfy 4096-char limit, logging a warning (tagged ``context``) on truncation."""
-    if len(message) > MAX_MESSAGE_LENGTH:
+    """Apply the ntfy 4096-byte body limit, logging a warning (tagged ``context``) on truncation.
+
+    The cut lands on a character boundary so the published payload stays valid UTF-8."""
+    if _utf8_len(message) > MAX_MESSAGE_LENGTH:
+        cp = _custom_unit_to_cp(message, MAX_MESSAGE_LENGTH, _utf8_len)
         logger.warning(
-            "%s: truncating message from %d to %d chars (ntfy limit)",
-            context, len(message), MAX_MESSAGE_LENGTH)
-    return message[:MAX_MESSAGE_LENGTH].encode("utf-8")
+            "%s: truncating message from %d to %d bytes (ntfy limit)",
+            context,
+            _utf8_len(message),
+            _utf8_len(message[:cp]),
+        )
+        return message[:cp].encode("utf-8")
+    return message.encode("utf-8")
 
 
 def _response_message_id(resp) -> str:
@@ -119,6 +132,11 @@ class NtfyAdapter(BasePlatformAdapter):
     """ntfy adapter: HTTP-streaming subscription in, HTTP POST publish out."""
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    @property
+    def message_len_fn(self):
+        """ntfy enforces its 4096 limit in UTF-8 bytes, not Python characters."""
+        return _utf8_len
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config=config, platform=Platform("ntfy"))
@@ -289,11 +307,7 @@ class NtfyAdapter(BasePlatformAdapter):
         if not self._http_client:
             return SendResult(success=False, error="HTTP client not initialized")
         headers = _publish_headers(self._token, bool((self.config.extra or {}).get("markdown", False)))
-        if len(content) > self.MAX_MESSAGE_LENGTH:
-            logger.warning(
-                "[%s] Message truncated from %d to %d chars (ntfy limit)",
-                self.name, len(content), self.MAX_MESSAGE_LENGTH)
-        body = content[:self.MAX_MESSAGE_LENGTH].encode("utf-8")
+        body = _truncate_body(content, context=f"[{self.name}]")
         try:
             resp = await self._http_client.post(
                 f"{self._server}/{publish_topic}", content=body, headers=headers, timeout=15.0)
@@ -396,7 +410,7 @@ def register(ctx) -> None:
             "Use plain text by default — ntfy supports optional markdown "
             "(set markdown: true in config or NTFY_MARKDOWN=true). "
             "Keep responses concise; ntfy is a push notification service "
-            "with a 4096-character per-message limit."
+            "with a 4096-byte per-message limit."
         ))
 
 

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -483,12 +483,68 @@ class TestFatalErrorPropagation:
 
 
 class TestTruncateHelper:
-    """``_truncate_body`` is shared between adapter.send() (inline truncation
-    today, may migrate) and ``_standalone_send``. It must cap to
-    MAX_MESSAGE_LENGTH and return bytes."""
+    """``_truncate_body`` is shared between adapter.send() and ``_standalone_send``.
+    It must cap to MAX_MESSAGE_LENGTH UTF-8 bytes, return bytes, and never split
+    a multi-byte character."""
 
     def test_short_message_passes_through(self):
         assert _ntfy._truncate_body("hi", context="test") == b"hi"
+
+    def test_ascii_boundary_truncates_to_limit(self):
+        truncated = _ntfy._truncate_body("x" * 5000, context="test")
+        assert len(truncated) == _ntfy.MAX_MESSAGE_LENGTH
+
+    def test_cyrillic_truncates_by_bytes_not_chars(self):
+        # 2049 two-byte chars = 4098 bytes: over the byte limit while under the
+        # old character guard — nothing was trimmed and nothing was logged.
+        body = _ntfy._truncate_body("я" * 2049, context="test")
+        assert len(body) <= _ntfy.MAX_MESSAGE_LENGTH
+        assert len(body) == 4096
+
+    def test_emoji_truncates_to_fourth_of_char_budget(self):
+        body = _ntfy._truncate_body("😀" * 4096, context="test")
+        assert len(body) <= _ntfy.MAX_MESSAGE_LENGTH
+        assert len(body) == 4096
+
+    def test_truncation_lands_on_character_boundary(self):
+        body = _ntfy._truncate_body("я" * 2049, context="test")
+        # 2048 chars × 2 bytes, no partial character in the published payload.
+        assert body.decode("utf-8") == "я" * 2048
+
+    def test_exactly_at_byte_limit_passes_through(self):
+        assert _ntfy._truncate_body("я" * 2048, context="test") == ("я" * 2048).encode(
+            "utf-8"
+        )
+
+
+class TestSendByteBudget:
+    """``send()`` publishes at most MAX_MESSAGE_LENGTH UTF-8 bytes."""
+
+    def _make_adapter(self, topic="hermes-in"):
+        return NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": topic}))
+
+    def test_send_truncates_multibyte_body(self):
+        adapter = self._make_adapter()
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "abc123"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        result = _run(adapter.send("hermes-in", "я" * 3000))
+        assert result.success is True
+        posted_body = mock_client.post.call_args[1]["content"]
+        assert len(posted_body) <= _ntfy.MAX_MESSAGE_LENGTH
+        posted_body.decode("utf-8")  # must stay valid UTF-8
+
+    def test_message_len_fn_counts_utf8_bytes(self):
+        adapter = self._make_adapter()
+        assert adapter.message_len_fn("я") == 2
+        assert adapter.message_len_fn("😀") == 4
+        assert adapter.message_len_fn("hi") == 2
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/ntfy.md
+++ b/website/docs/user-guide/messaging/ntfy.md
@@ -141,7 +141,7 @@ If you only want Hermes to *push* notifications to ntfy (cron summaries, alerts)
 
 ## Limits
 
-- **Message size**: ntfy caps message bodies at 4096 chars. Hermes truncates with a warning when this is exceeded.
+- **Message size**: ntfy caps message bodies at 4096 bytes (UTF-8; non-Latin text costs more than one byte per character). Hermes truncates on a character boundary with a warning when this is exceeded.
 - **No typing indicators**: the protocol doesn't expose one; `send_typing` is a no-op.
 - **No threads or attachments**: ntfy is plain push notifications. Long replies stay in the message body, no thread fanout.
 - **No native user identity**: see the identity-model section above.


### PR DESCRIPTION
## Summary

`_truncate_body()` sliced the outgoing body by Python characters and encoded to UTF-8 only afterwards, so non-Latin text shipped at 2-4x the ntfy `message-size-limit` (a byte budget — Go's `len()` on the message). The guard `len(message) > MAX_MESSAGE_LENGTH` also never fired in the interesting range: a 2049-char Cyrillic message is already 4098 bytes over the limit while nothing was trimmed and nothing was logged. `send()` repeated the same inline character slice.

Fixes #105287 in the pattern the codebase already uses for Telegram's UTF-16 unit counting:

- `_utf8_len()` + `_custom_unit_to_cp()` cap the body on a **byte** budget, cutting on a character boundary so the published payload stays valid UTF-8 (a naive byte slice would split a multi-byte character)
- `send()` now routes through `_truncate_body()` instead of its own inline slice — one truncation path, shared with `_standalone_send()`
- `message_len_fn` override makes router-level truncation count ntfy bodies in the same units the server enforces
- the registered platform hint and `website/docs/user-guide/messaging/ntfy.md` said "4096 chars"; both now say bytes

## Testing

- mutation-verified: reverting `_truncate_body` to the char-based slice fails `test_cyrillic_truncates_by_bytes_not_chars` immediately
- new cases next to the existing pass-through test: ASCII boundary, Cyrillic 2x, emoji 4x, exact-limit pass-through, character-boundary decode, `send()` multi-byte truncation, `message_len_fn` units
- `tests/gateway/test_ntfy_plugin.py` 39/39 pass; `tests/gateway -k "truncate or len_fn or message_len"` 55 pass, 2 skipped
- `ruff check` clean; `ruff format --diff` raises no complaints on the touched lines
