### PR TITLE
fix(mcp-oauth): serialise refresh across processes; never clear tokens a sibling just rotated

### DIFF
--- a/tests/tools/test_mcp_oauth_cross_process_refresh.py
+++ b/tests/tools/test_mcp_oauth_cross_process_refresh.py
@@ -1,0 +1,150 @@
+"""Two Hermes processes (gateway + desktop backend, or gateway + CLI) share one MCP tokens file.
+An authorization server that ROTATES refresh tokens (single use, e.g. CoRecruit) rejects the
+second process's refresh with 400 when both try around the same expiry; the SDK then cleared
+tokens that the sibling had just validly written, and the server sat in "needs re-auth" until a
+human ran ``hermes mcp login`` again.
+
+These tests drive two provider instances against one storage the way two processes would, with a
+fake token endpoint that rotates the refresh token and rejects a reused one.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+async def _noop_redirect(_url: str) -> None:  # pragma: no cover
+    return None
+
+
+async def _noop_callback():  # pragma: no cover
+    return ("code", None)
+
+
+class _RotatingTokenServer:
+    """Refresh-token grant with rotation: the current refresh token is valid exactly once."""
+
+    def __init__(self, httpx, current_refresh: str):
+        self.httpx = httpx
+        self.valid_refresh = current_refresh
+        self.issued = 0
+        self.rejected = 0
+
+    def respond(self, request):
+        body = dict(pair.split("=", 1) for pair in request.content.decode().split("&"))
+        if body.get("grant_type") != "refresh_token" or body.get("refresh_token") != self.valid_refresh:
+            self.rejected += 1
+            return self.httpx.Response(400, json={"error": "invalid_grant"}, request=request)
+        self.issued += 1
+        self.valid_refresh = f"refresh_{self.issued}"
+        return self.httpx.Response(200, json={
+            "access_token": f"access_{self.issued}", "token_type": "Bearer", "expires_in": 900,
+            "refresh_token": self.valid_refresh, "scope": "admin",
+        }, request=request)
+
+
+async def _seed(tmp_path, monkeypatch):
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+    from pydantic import AnyHttpUrl, AnyUrl
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+    assert _HERMES_PROVIDER_CLS is not None
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+    storage = HermesTokenStorage("srv")
+    # Expired access token + refresh token: every provider that loads this must refresh first.
+    await storage.set_tokens(OAuthToken(access_token="access_0", token_type="Bearer", expires_in=0, refresh_token="refresh_0"))
+    await storage.set_client_info(OAuthClientInformationFull(
+        client_id="test-client", redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+        grant_types=["authorization_code", "refresh_token"], response_types=["code"], token_endpoint_auth_method="none"))
+    from mcp.shared.auth import OAuthMetadata
+    storage.save_oauth_metadata(OAuthMetadata(
+        issuer=AnyHttpUrl("https://as.example"), authorization_endpoint=AnyHttpUrl("https://as.example/authorize"),
+        token_endpoint=AnyHttpUrl("https://as.example/token"), response_types_supported=["code"],
+        grant_types_supported=["authorization_code", "refresh_token"]))
+
+    def build():
+        return _HERMES_PROVIDER_CLS(
+            server_name="srv", server_url="https://example.com/mcp",
+            client_metadata=OAuthClientMetadata(redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")], client_name="Hermes Agent"),
+            storage=HermesTokenStorage("srv"), redirect_handler=_noop_redirect, callback_handler=_noop_callback)
+    return storage, build
+
+
+async def _run_flow(provider, httpx, server):
+    """Drive one auth flow: answer token-endpoint requests with the rotating server, answer the
+    resource request with 200. Returns the Bearer token that was sent to the resource."""
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+    outgoing = await flow.__anext__()
+    sent_bearer = None
+    while True:
+        if outgoing.url.host == "as.example":
+            response = server.respond(outgoing)
+        else:
+            sent_bearer = outgoing.headers.get("Authorization")
+            response = httpx.Response(200, request=outgoing)
+        try:
+            outgoing = await flow.asend(response)
+        except StopAsyncIteration:
+            return sent_bearer
+
+
+@pytest.mark.asyncio
+async def test_second_process_adopts_siblings_rotated_tokens_instead_of_clearing(tmp_path, monkeypatch):
+    from tools.mcp_tool import sdk_httpx
+    httpx = sdk_httpx()
+    storage, build = await _seed(tmp_path, monkeypatch)
+    server = _RotatingTokenServer(httpx, "refresh_0")
+
+    gateway, desktop = build(), build()
+    # Both processes load the same expired pair into memory (each holds refresh_0).
+    await gateway._initialize()
+    await desktop._initialize()
+
+    # Process A refreshes: the server rotates to refresh_1 and A writes it to disk.
+    assert await _run_flow(gateway, httpx, server) == "Bearer access_1"
+    assert server.issued == 1
+
+    # Process B still holds refresh_0 in memory. Before the fix it POSTed refresh_0, got 400,
+    # cleared tokens and wiped the file. It must instead adopt A's pair from disk.
+    assert await _run_flow(desktop, httpx, server) == "Bearer access_1"
+    assert server.rejected == 0, "stale refresh token must never be sent when disk holds a newer pair"
+    assert server.issued == 1, "no second refresh needed: sibling's token is still valid"
+
+    persisted = await storage.get_tokens()
+    assert persisted is not None and persisted.refresh_token == "refresh_1", "tokens file must survive"
+
+
+@pytest.mark.asyncio
+async def test_rejected_refresh_prefers_disk_over_clearing(tmp_path, monkeypatch):
+    """If a stale refresh does reach the server (lock timed out, guard skipped), the 400 must not
+    destroy a newer pair on disk: adopt it and report success instead of forcing browser re-auth."""
+    from mcp.shared.auth import OAuthToken
+    from tools.mcp_tool import sdk_httpx
+    httpx = sdk_httpx()
+    storage, build = await _seed(tmp_path, monkeypatch)
+    provider = build()
+    await provider._initialize()  # memory: refresh_0 (expired access)
+
+    # Sibling process already rotated and wrote a fresh, valid pair to disk.
+    await storage.set_tokens(OAuthToken(access_token="access_1", token_type="Bearer", expires_in=900, refresh_token="refresh_1"))
+
+    rejected = httpx.Response(400, json={"error": "invalid_grant"}, request=httpx.Request("POST", "https://as.example/token"))
+    assert await provider._handle_refresh_response(rejected) is True, "newer pair on disk means the refresh outcome is success"
+    assert provider.context.current_tokens.access_token == "access_1"
+    assert provider.context.is_token_valid()
+    persisted = await storage.get_tokens()
+    assert persisted is not None and persisted.refresh_token == "refresh_1", "400 must not wipe the sibling's tokens"
+
+
+@pytest.mark.asyncio
+async def test_rejected_refresh_with_no_newer_disk_pair_still_clears(tmp_path, monkeypatch):
+    """The fallback only rescues a genuine sibling refresh; a dead grant still clears tokens."""
+    from tools.mcp_tool import sdk_httpx
+    httpx = sdk_httpx()
+    storage, build = await _seed(tmp_path, monkeypatch)
+    provider = build()
+    await provider._initialize()
+    rejected = httpx.Response(400, json={"error": "invalid_grant"}, request=httpx.Request("POST", "https://as.example/token"))
+    assert await provider._handle_refresh_response(rejected) is False
+    assert provider.context.current_tokens is None

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -8,6 +8,7 @@ than an await + refresh round-trip."""
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
 import threading
@@ -24,6 +25,64 @@ try:
     _SDK_BASES: tuple = (_SDKOAuthClientProvider,)
 except ImportError:  # pragma: no cover — SDK required in CI; module must still import
     _SDK_BASES = ()
+
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover — Windows: no cross-process refresh lock, behaviour unchanged
+    _fcntl = None
+
+# Longest a process waits for a sibling's in-flight refresh before proceeding unguarded.
+_REFRESH_LOCK_TIMEOUT_S = 20.0
+
+
+class _RefreshFileLock:
+    """Cross-process exclusive lock (``flock``) on ``<tokens>.json.lock``, held only for the
+    duration of one refresh-token exchange. Two Hermes processes (gateway + desktop backend,
+    or gateway + CLI) share one tokens file; an authorization server that ROTATES refresh
+    tokens (single use) rejects the second process's refresh with 400 when both race, and the
+    SDK then clears tokens that a sibling had just validly written. Serialising the exchange,
+    and re-reading disk once the lock is held, turns that race into a plain adopt-from-disk."""
+
+    def __init__(self, path: Path):
+        self._path = path
+        self._fh = None
+
+    @property
+    def held(self) -> bool:
+        return self._fh is not None
+
+    def _acquire_blocking(self, timeout: float) -> bool:
+        import time
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        fh = open(self._path, "a+")  # noqa: SIM115 — closed in release()
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                _fcntl.flock(fh.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+                self._fh = fh
+                return True
+            except OSError:
+                if time.monotonic() >= deadline:
+                    fh.close()
+                    return False
+                time.sleep(0.1)
+
+    async def acquire(self, timeout: float = _REFRESH_LOCK_TIMEOUT_S) -> bool:
+        if _fcntl is None or self._fh is not None:
+            return self._fh is not None
+        try:
+            return await asyncio.to_thread(self._acquire_blocking, timeout)
+        except OSError:
+            return False
+
+    def release(self) -> None:
+        fh, self._fh = self._fh, None
+        if fh is None:
+            return
+        with contextlib.suppress(OSError):
+            _fcntl.flock(fh.fileno(), _fcntl.LOCK_UN)
+        with contextlib.suppress(OSError):
+            fh.close()
 
 
 @dataclass
@@ -62,6 +121,7 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
         self._hermes_home = ""
         # A config-supplied client_id rejected as invalid_client means the *config* is wrong — only DCR clients auto-heal.
         self._hermes_preregistered = preregistered
+        self._hermes_refresh_lock: Optional[_RefreshFileLock] = None
 
     def _hermes_storage(self):
         """The context storage when it is a ``HermesTokenStorage``, else None."""
@@ -70,6 +130,74 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
 
     def _log_nonfatal(self, what: str, exc: BaseException) -> None:
         logger.debug("MCP OAuth '%s': %s failed (non-fatal): %s", self._hermes_server_name, what, exc)
+
+    # ── cross-process refresh serialisation ────────────────────────────────────────────
+
+    def _hermes_needs_refresh(self) -> bool:
+        ctx = self.context
+        return bool(ctx.current_tokens) and not ctx.is_token_valid() and ctx.can_refresh_token()
+
+    async def _hermes_reload_tokens_from_disk(self, *, other_than: str | None = None) -> bool:
+        """Re-read the tokens file and adopt it when it carries a refresh token different from the
+        one in memory and from ``other_than`` (a token just rejected), i.e. a sibling process
+        refreshed. True if a newer pair was adopted."""
+        storage = self._hermes_storage()
+        if storage is None:
+            return False
+        try:
+            disk = await storage.get_tokens()
+        except Exception as exc:  # pragma: no cover — corrupt/absent file already logged by storage
+            self._log_nonfatal("token reload from disk", exc)
+            return False
+        mem = getattr(self.context.current_tokens, "refresh_token", None)
+        if disk is None or not disk.refresh_token or disk.refresh_token in (mem, other_than):
+            return False
+        self.context.current_tokens = disk
+        if disk.expires_in is not None:
+            self.context.update_token_expiry(disk)
+        logger.info("MCP OAuth '%s': adopted tokens refreshed by another process", self._hermes_server_name)
+        return True
+
+    async def _hermes_guard_refresh(self) -> None:
+        """Called once tokens are loaded and a refresh looks necessary. Take the cross-process lock,
+        then re-check disk: if a sibling already refreshed, adopt its pair and release (no refresh
+        needed). Otherwise keep the lock until ``_handle_refresh_response`` runs."""
+        storage = self._hermes_storage()
+        if storage is None or _fcntl is None:
+            return
+        lock = getattr(self, "_hermes_refresh_lock", None)  # tests may build via __new__
+        if lock is None:
+            lock = self._hermes_refresh_lock = _RefreshFileLock(storage._tokens_path().with_suffix(".json.lock"))
+        if lock.held:
+            return
+        if not await lock.acquire():
+            logger.warning("MCP OAuth '%s': refresh lock busy for %.0fs, refreshing unguarded",
+                           self._hermes_server_name, _REFRESH_LOCK_TIMEOUT_S)
+            return
+        await self._hermes_reload_tokens_from_disk()
+        if not self._hermes_needs_refresh():
+            lock.release()
+
+    def _hermes_release_refresh_lock(self) -> None:
+        lock = getattr(self, "_hermes_refresh_lock", None)
+        if lock is not None and lock.held:
+            lock.release()
+
+    async def _handle_refresh_response(self, response) -> bool:
+        """On a rejected refresh, prefer a sibling's freshly written tokens over clearing ours: with
+        rotating refresh tokens a 400 usually means *our* copy went stale, not that the grant died."""
+        sent = getattr(self.context.current_tokens, "refresh_token", None)
+        try:
+            ok = await super()._handle_refresh_response(response)
+            if ok:
+                return True
+            if await self._hermes_reload_tokens_from_disk(other_than=sent):
+                logger.info("MCP OAuth '%s': refresh rejected (%s) but disk holds a newer pair; using it",
+                            self._hermes_server_name, getattr(response, "status_code", "?"))
+                return self.context.is_token_valid()
+            return False
+        finally:
+            self._hermes_release_refresh_lock()
 
     async def _initialize(self) -> None:
         """Load stored state, seed ``token_expiry_time``, restore/prefetch metadata. The SDK's
@@ -94,6 +222,11 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
                 await self._prefetch_oauth_metadata()
             except Exception as exc:  # pragma: no cover — the SDK's 401-branch discovery runs next request
                 self._log_nonfatal("pre-flight metadata discovery", exc)
+        if self._hermes_needs_refresh():
+            try:
+                await self._hermes_guard_refresh()
+            except Exception as exc:  # pragma: no cover — lock is an optimisation, never a blocker
+                self._log_nonfatal("refresh lock", exc)
 
     async def _prefetch_oauth_metadata(self) -> None:
         """Fetch PRM + ASM from the well-known endpoints before the first request, via the SDK's own URL
@@ -207,6 +340,10 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
             await get_manager().invalidate_if_disk_changed(self._hermes_server_name, hermes_home=self._hermes_home)
         except Exception as exc:  # pragma: no cover — defensive
             self._log_nonfatal("pre-flow disk-watch", exc)
+        # An initialised provider about to refresh must go through ``_initialize`` again so the
+        # cross-process refresh guard (lock + disk re-read) runs before the SDK builds the request.
+        if getattr(self, "_initialized", False) and self._hermes_needs_refresh():
+            self._initialized = False
         # Bridge the bidirectional generator by hand: a naive ``async for item in inner: yield
         # item`` DISCARDS the responses httpx sends back via ``asend``, and the SDK crashes on None.
         # Manually bridge the bidirectional generator protocol. httpx's auth_flow driver
@@ -256,6 +393,7 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
                 import anyio
                 with anyio.CancelScope(shield=True):
                     await self.context.lock.acquire()
+            self._hermes_release_refresh_lock()  # never hold the file lock past one flow
         if retry_after_concurrent_auth:
             yield request
             self._persist_oauth_metadata_if_changed()


### PR DESCRIPTION
## Problem

Two Hermes processes commonly share one `mcp-tokens/<server>.json`: the gateway (cron) plus the desktop app's `serve` backend, or the gateway plus an interactive CLI. Against an authorization server that **rotates refresh tokens** (single use), both processes reach expiry inside the same window and both POST the same refresh token. The second one gets `400`, and the SDK's `_handle_refresh_response` then calls `clear_tokens()`, which **wipes the tokens file the first process had just written seconds earlier**. The server sits in `needs_reauth` until a human runs `hermes mcp login` again.

Real-world trigger: CoRecruit's MCP issues 15-minute access tokens with rotating refresh tokens. On one install this produced eight `Token refresh failed: 400` events in a single day and forced re-auth twice. Log excerpt (gateway refresh succeeds at `:21.581`, desktop backend's stale refresh fails at `:21.824`, then discovery/re-auth):

```
19:42:21,581 INFO httpx2: POST .../v1/oauth2/token "HTTP/1.1 200 OK"
19:42:21,716 INFO httpx2: POST .../v1/mcp "HTTP/1.1 200 OK"
19:42:21,824 INFO httpx2: POST .../v1/oauth2/token "HTTP/1.1 400 Bad Request"
19:42:21,825 WARNING tools.mcp_oauth_manager: Token refresh failed: 400
19:42:21,932 INFO httpx2: POST .../v1/mcp "HTTP/1.1 401 Unauthorized"
19:42:22,336 ERROR mcp.client.auth.oauth2: OAuth flow error
```

The existing mtime disk-watch (`invalidate_if_disk_changed`) does not cover this: it runs at the start of the *next* flow, but the refresh is attempted inside the *current* one, before any 401.

## Fix (`HermesMCPOAuthProvider`)

- **Serialise the refresh across processes.** When `_initialize` finds a refresh is needed (and when `async_auth_flow` sees an initialised provider about to refresh), take an exclusive `flock` on `<tokens>.json.lock`, then re-read disk. If a sibling already rotated, adopt its pair and skip the refresh entirely. The lock is held only through the token exchange and always released in `finally`.
- **Never clear tokens a sibling just rotated.** On a non-2xx refresh, if disk now holds a refresh token different from the one we sent, adopt it and return success. A genuinely dead grant (no newer pair on disk) still clears as before.
- Windows (no `fcntl`): lock is a no-op; behaviour unchanged.

Line-level: the bug manifests at `mcp/client/auth/oauth2.py::_handle_refresh_response` (`self.context.clear_tokens()` on non-200) as invoked from `async_auth_flow`; the fix wraps that method and gates the refresh path ahead of it.

## Tests

`tests/tools/test_mcp_oauth_cross_process_refresh.py` drives two provider instances against one storage with a fake token endpoint that rotates refresh tokens and rejects reuse:

1. Second provider adopts the sibling's rotated pair; the stale token is never sent; tokens file survives. (Red on `main`: rejected=1, file wiped.)
2. A rejected refresh with a newer pair on disk adopts it and returns `True`. (Red on `main`.)
3. A rejected refresh with **no** newer pair still clears (`False`, `current_tokens is None`). Guards the fallback from masking a dead grant.

`scripts/run_tests.sh tests/tools/ -k mcp`: 730 passed, 0 failed.

## Notes

- Uses `_initialized` (private SDK attr) the same way the existing disk-watch already does.
- Live check: with the patched gateway running alongside an unpatched desktop backend on the same machine, two consecutive 15-minute CoRecruit expiries refreshed cleanly with the tokens file intact and no re-auth prompt. The race itself is timing-dependent, so the two-process tests are the authoritative reproduction.
