### PR TITLE
fix(cli): allow non-interactive tools summary

### DIFF
--- a/hermes_cli/main_agent_cmds.py
+++ b/hermes_cli/main_agent_cmds.py
@@ -97,7 +97,12 @@ def cmd_tools(args):
         from hermes_cli.tools_config import run_post_setup_command
         sys.exit(run_post_setup_command(args))
     else:
-        _require_tty("tools")
+        # ``--summary`` is a read-only report and is intentionally usable in
+        # pipes, cron jobs, and other non-interactive callers.  The regular
+        # configuration UI still requires a terminal so its prompts cannot
+        # block unattended invocations.
+        if not getattr(args, "summary", False):
+            _require_tty("tools")
         from hermes_cli.tools_config import tools_command
         tools_command(args)
 

--- a/hermes_cli/plugin_dev.py
+++ b/hermes_cli/plugin_dev.py
@@ -182,6 +182,50 @@ def _is_plugin_id(raw: str) -> bool:
     return bool(parts) and all(part not in {os.curdir, os.pardir} for part in parts)
 
 
+def _installed_manifest_match(raw: str) -> Path | None:
+    """Resolve a user plugin by manifest name when its directory is path-derived.
+
+    Plugin installs may use a filesystem-safe directory such as
+    ``mia_topic_router`` while exposing ``mia-coordinator`` as the public
+    manifest name.  Read manifests only; discovery/import is still handled by
+    the normal doctor runtime after resolution.
+    """
+    user_root = get_hermes_home() / "plugins"
+    if not user_root.is_dir():
+        return None
+    try:
+        import yaml
+
+        matches: list[Path] = []
+        for candidate in sorted(user_root.iterdir(), key=lambda item: item.name):
+            if not candidate.is_dir():
+                continue
+            manifest_file = next(
+                (candidate / name for name in _MANIFEST_NAMES if (candidate / name).is_file()),
+                None,
+            )
+            if manifest_file is None:
+                continue
+            try:
+                data = yaml.safe_load(manifest_file.read_text(encoding="utf-8")) or {}
+            except Exception:
+                continue
+            if isinstance(data, dict) and raw in {str(data.get("name") or ""), str(data.get("key") or "")}:
+                matches.append(candidate)
+        if len(matches) == 1:
+            return matches[0].resolve()
+        if len(matches) > 1:
+            raise FileNotFoundError(
+                f"Plugin {raw!r} matched multiple installed manifests: "
+                + ", ".join(str(path) for path in matches)
+            )
+    except FileNotFoundError:
+        raise
+    except Exception:
+        return None
+    return None
+
+
 def resolve_plugin_path(target: str | os.PathLike[str] | None = None) -> Path:
     """Resolve an explicit path or an installed/bundled plugin id."""
     raw = os.fspath(target or ".")
@@ -203,6 +247,10 @@ def resolve_plugin_path(target: str | os.PathLike[str] | None = None) -> Path:
     for candidate in candidates:
         if _holds_plugin(candidate):
             return candidate.resolve()
+    if _is_plugin_id(raw):
+        manifest_match = _installed_manifest_match(raw)
+        if manifest_match is not None:
+            return manifest_match
     if direct_is_dir:
         raise FileNotFoundError(
             f"{direct.resolve()} holds no plugin manifest "

--- a/tests/hermes_cli/test_plugin_dev.py
+++ b/tests/hermes_cli/test_plugin_dev.py
@@ -217,6 +217,24 @@ def test_resolve_prefers_installed_id_over_unrelated_local_dir(
     assert plugin_dev.resolve_plugin_path("sample") == installed.resolve()
 
 
+def test_resolve_matches_manifest_name_in_path_derived_install(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An installed plugin's public id may differ from its directory name."""
+    from hermes_cli import plugin_dev
+
+    hermes_home = tmp_path / "hermes-home"
+    installed = hermes_home / "plugins" / "mia_topic_router"
+    installed.mkdir(parents=True)
+    (installed / "plugin.yaml").write_text(
+        "name: mia-coordinator\nversion: 0.1.0\n", encoding="utf-8"
+    )
+    (installed / "__init__.py").write_text("def register(ctx):\n    pass\n", encoding="utf-8")
+    monkeypatch.setattr(plugin_dev, "get_hermes_home", lambda: hermes_home)
+
+    assert plugin_dev.resolve_plugin_path("mia-coordinator") == installed.resolve()
+
+
 def test_doctor_removes_temp_home_when_staging_copy_fails(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/hermes_cli/test_tools_summary_noninteractive.py
+++ b/tests/hermes_cli/test_tools_summary_noninteractive.py
@@ -1,0 +1,37 @@
+"""The read-only tools summary works in pipes; the configuration UI does not."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("summary", [True, False], ids=["summary", "interactive"])
+def test_tools_cli_without_terminal(tmp_path, summary):
+    config = tmp_path / "config.yaml"
+    original = "platform_toolsets:\n  cli: [terminal]\n"
+    config.write_text(original, encoding="utf-8")
+    command = [sys.executable, "-m", "hermes_cli.main", "tools"]
+    if summary:
+        command.append("--summary")
+
+    result = subprocess.run(
+        command,
+        cwd=Path(__file__).resolve().parents[2],
+        env={**os.environ, "HERMES_HOME": str(tmp_path)},
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    if summary:
+        assert result.returncode == 0, result.stderr
+        assert "Tool Summary" in result.stdout
+        assert "Terminal" in result.stdout
+    else:
+        assert result.returncode == 1
+        assert "requires an interactive terminal" in result.stderr
+    assert config.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## What changed

This PR fixes two read-only/diagnostic CLI paths that were broken on current `main`:

1. Allow the documented `hermes tools --summary` report to run without an interactive terminal. The interactive tools configuration UI remains TTY-gated.
2. Let `hermes plugins doctor <id>` resolve an installed plugin by its manifest `name`/`key` when the on-disk directory is path-derived (for example, `mia_topic_router` exposing `mia-coordinator`). Manifest matching is read-only; normal runtime discovery still performs the validation.

## Why

`tools_command()` already implements a non-interactive summary path, but `cmd_tools()` rejected every non-interactive invocation before dispatching to it. Separately, plugin installs can use filesystem-safe directory names that differ from their public manifest id, so Doctor failed before it could load an otherwise valid installed plugin.

## Verification

- Reproduced on current `main`: `hermes tools --summary </dev/null` exited 1 with the TTY error.
- Added regression coverage for both tools paths: summary succeeds and the interactive UI remains guarded.
- Added regression coverage for a manifest id resolved from a path-derived install directory.
- `scripts/run_tests.sh tests/hermes_cli/test_plugin_dev.py tests/hermes_cli/test_tools_summary_noninteractive.py -j 2` — 13 passed.
- `scripts/check-windows-footguns.py --diff HEAD` — clean.
- `ruff check` on changed files — clean.
- `git diff --check` — clean.

A previous implementation of the tools-summary fix was proposed in #76844 and closed before landing; this version targets the current refactored dispatcher and includes the negative regression case requested in that review.
