### PR TITLE
fix(acp): preserve MCP failures through deferred calls

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -159,7 +159,12 @@ def make_step_cb(
 
             if not tool_name:
                 continue
-            queue = _upgrade_queue(tool_call_ids, tool_name)
+            queue_name = tool_name
+            if tool_name == "tool_call":
+                nested_name = coerce_tool_args(function_args).get("name")
+                if isinstance(nested_name, str) and nested_name in tool_call_ids:
+                    queue_name = nested_name
+            queue = _upgrade_queue(tool_call_ids, queue_name)
             if not queue:
                 continue
             tc_id = queue.popleft()
@@ -171,7 +176,7 @@ def make_step_cb(
             if tool_name == "todo" and (plan_update := _build_plan_update_from_todo_result(result)) is not None:
                 _send_update(conn, session_id, loop, plan_update)
             if not queue:
-                tool_call_ids.pop(tool_name, None)
+                tool_call_ids.pop(queue_name, None)
 
     return _step
 

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -169,7 +169,11 @@ def _fenced_text(text: str, language: str = "") -> str:
     return f"{fence}{language}\n{text}\n{fence}"
 
 
-def _tool_result_failed(result: Optional[str], tool_name: str | None = None) -> bool:
+def _tool_result_failed(
+    result: Optional[str],
+    tool_name: str | None = None,
+    function_args: Any = None,
+) -> bool:
     """Return True when a structured Hermes tool result clearly failed.
 
     Deliberately conservative: plain text may legitimately contain "error", so
@@ -185,9 +189,22 @@ def _tool_result_failed(result: Optional[str], tool_name: str | None = None) -> 
     exit_code = data.get("exit_code", data.get("returncode"))
     if any(data.get(key) is False for key in ("success", "ok")) or (isinstance(exit_code, int) and exit_code != 0):
         return True
-    # Polished tools report failures as {"error": ...} without a success flag;
-    # generic/plugin payloads stay conservative so diagnostics aren't marked failed.
-    return bool(tool_name in _POLISHED_TOOLS and data.get("error") and not data.get("content"))
+    # Polished tools and MCP handlers report failures as {"error": ...}
+    # without a success flag. Unknown/plugin payloads stay conservative so a
+    # diagnostic data field named "error" is not marked failed.
+    effective_tool_name = tool_name
+    if tool_name == "tool_call":
+        nested_name = coerce_tool_args(function_args).get("name")
+        if isinstance(nested_name, str):
+            effective_tool_name = nested_name
+    is_mcp = isinstance(effective_tool_name, str) and effective_tool_name.startswith(
+        "mcp__"
+    )
+    return bool(
+        data.get("error")
+        and not data.get("content")
+        and (tool_name in _POLISHED_TOOLS or is_mcp)
+    )
 
 
 # --- tool-call titles -------------------------------------------------------
@@ -887,7 +904,7 @@ def build_tool_complete(
     structured = isinstance(_json_loads_maybe(result), (dict, list))
     return acp.update_tool_call(
         tool_call_id, kind=get_tool_kind(tool_name),
-        status="failed" if _tool_result_failed(result, tool_name) else "completed", content=content,
+        status="failed" if _tool_result_failed(result, tool_name, function_args) else "completed", content=content,
         raw_output=None if tool_name in _POLISHED_TOOLS or structured else result,
     )
 

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -2,14 +2,16 @@
 
 import asyncio
 import gc
+import json
 import warnings
 from concurrent.futures import Future
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import acp
-from acp.schema import AgentPlanUpdate
+from acp.schema import AgentPlanUpdate, ToolCallProgress, ToolCallStart
 
 from acp_adapter.events import (
     _build_plan_update_from_todo_result,
@@ -19,6 +21,7 @@ from acp_adapter.events import (
     make_thinking_cb,
     make_tool_progress_cb,
 )
+from tools.mcp_tool_handlers import _render_call_tool_result
 
 
 @pytest.fixture()
@@ -108,6 +111,61 @@ class TestToolProgressCallback:
 
 
 class TestStepCallback:
+    @pytest.mark.parametrize("error_field", ["isError", "is_error"])
+    @pytest.mark.parametrize("deferred", [False, True])
+    @pytest.mark.parametrize(
+        ("is_error", "expected_status"),
+        [(True, "failed"), (False, "completed")],
+    )
+    def test_mcp_result_status_survives_real_callback_join(
+        self, mock_conn, event_loop_fixture, error_field, deferred, is_error, expected_status
+    ):
+        tool_name = "mcp__public_research__public_web_search"
+        tool_call_ids = {}
+        tool_call_meta = {}
+        progress_cb = make_tool_progress_cb(
+            mock_conn, "session-1", event_loop_fixture, tool_call_ids, tool_call_meta
+        )
+        step_cb = make_step_cb(
+            mock_conn, "session-1", event_loop_fixture, tool_call_ids, tool_call_meta
+        )
+        rendered = _render_call_tool_result(
+            SimpleNamespace(
+                content=[
+                    SimpleNamespace(
+                        text=(
+                            "dependency unavailable"
+                            if is_error
+                            else "research result explaining error handling"
+                        )
+                    )
+                ],
+                **{error_field: is_error},
+            ),
+            "public_research",
+        )
+        completion_name = "tool_call" if deferred else tool_name
+        completion_args = (
+            json.dumps({"name": tool_name, "arguments": {"query": "fixture"}})
+            if deferred
+            else json.dumps({"query": "fixture"})
+        )
+
+        with patch("acp_adapter.events._send_update") as send_update:
+            progress_cb("tool.started", tool_name, None, {"query": "fixture"})
+            step_cb(
+                1,
+                [{"name": completion_name, "arguments": completion_args, "result": rendered}],
+            )
+
+        start, completion = [call.args[3] for call in send_update.call_args_list]
+        assert isinstance(start, ToolCallStart)
+        assert isinstance(completion, ToolCallProgress)
+        assert completion.tool_call_id == start.tool_call_id
+        assert completion.status == expected_status
+        assert tool_call_ids == {}
+        assert tool_call_meta == {}
+
     def test_completes_tracked_tool_calls(self, mock_conn, event_loop_fixture):
         """Step callback should mark tracked tools as completed."""
         tool_call_ids = {"terminal": "tc-abc123"}

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -206,6 +206,19 @@ class TestBuildToolComplete:
         result = build_tool_complete("tc-fail", "execute_code", '{"output": "bad", "returncode": 2}')
         assert result.status == "failed"
 
+    def test_build_tool_complete_keeps_unknown_error_payload_conservative(self):
+        result = build_tool_complete(
+            "tc-diagnostic", "plugin_diagnostic", '{"error": "diagnostic"}'
+        )
+        assert result.status == "completed"
+        wrapped = build_tool_complete(
+            "tc-wrapped-diagnostic",
+            "tool_call",
+            '{"error": "diagnostic"}',
+            function_args={"name": "plugin_diagnostic", "arguments": {}},
+        )
+        assert wrapped.status == "completed"
+
 
 
 


### PR DESCRIPTION
## Problem

MCP CallToolResult errors are rendered as structured error payloads, but ACP classifies direct MCP completions as completed. Deferred tool_search calls also start under the resolved MCP name while the transcript completes under tool_call, so the ACP FIFO lookup misses the completion entirely.

This can leave clients showing a failed dependency call as green or without a terminal update.

## Fix

- classify structured MCP error results as failed while keeping unknown/plugin error fields conservative
- resolve the nested deferred tool name only for the existing ACP completion FIFO lookup
- preserve the original bridge name and arguments for completion rendering and status classification

No new tool, state, retry, service, or protocol surface is added.

## Verification

- reproduced on upstream main 03f3b092: all four MCP error variants were incorrectly completed
- `scripts/run_tests.sh tests/acp/`: 146 passed, 0 failed
- Ruff checks passed for all changed files
- `git diff --check` passed
- independent review: no remaining P0-P2 findings