### PR TITLE
fix(cli): bound serve graceful shutdown so a single SIGTERM can't orphan the backend

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1171,6 +1171,11 @@ def _build_uvicorn_server(host: str, port: int, *, ssh_isolated: bool = False):
         ws_ping_interval=ping_interval,
         ws_ping_timeout=ping_timeout,
         ws_max_size=_DESKTOP_ATTACHMENT_WS_MAX_BYTES,
+        # Desktop sends a single SIGTERM and escalates to SIGKILL ~5s later;
+        # uvicorn's default (None) waits on lingering ASGI tasks forever, so a
+        # mid-turn request orphans the backend past that budget (#76244). 3s
+        # leaves room for lifespan shutdown + cron_stop before the kill.
+        timeout_graceful_shutdown=3,
     )
     return config, uvicorn.Server(config)
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -338,3 +338,66 @@ def test_start_server_treats_windows_fallback_keyboardinterrupt_as_clean_shutdow
             "start_server must treat serve-time KeyboardInterrupt as a clean "
             "shutdown on the Windows pre-0.36 fallback, not propagate it"
         )
+
+
+def test_start_server_bounds_graceful_shutdown_within_desktop_kill_budget(monkeypatch):
+    """uvicorn's default timeout_graceful_shutdown=None waits on lingering
+    ASGI tasks forever, so the single SIGTERM Desktop sends (no second signal
+    to force-exit) hangs the backend until it is orphaned past the desktop's
+    ~5s SIGKILL budget (#76244). The configured bound must be positive and
+    stay under that kill budget.
+    """
+    captured = _stub_uvicorn(monkeypatch)
+
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+
+    assert 0 < captured["timeout_graceful_shutdown"] < 5
+
+
+def test_shutdown_returns_when_lingering_task_never_completes(monkeypatch):
+    """Behavior-level #76244 regression: with the production Config kwargs, a
+    live ASGI task that never finishes (a mid-turn request) must not make
+    Server.shutdown() hang — the orphan forensics (sockets closed, worker
+    threads parked, event loop never returning) is exactly that unbounded
+    task wait. shutdown() must honour the grace window, then cancel the
+    lingerer and return instead of waiting forever.
+    """
+    # Real classes grabbed before the stub replaces them (monkeypatch patches
+    # uvicorn.Config/Server for the whole test, which is exactly how the
+    # production kwargs get captured without binding a port).
+    real_config, real_server = uvicorn.Config, uvicorn.Server
+    captured = _stub_uvicorn(monkeypatch)
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+    bound = captured.get("timeout_graceful_shutdown")
+    assert bound is not None, "graceful shutdown must be bounded (#76244)"
+
+    async def _linger():
+        await asyncio.Event().wait()
+
+    async def scenario():
+        # Real uvicorn objects built from the production kwargs. The ASGI app
+        # is unused on the task-wait path and lifespan="off" isolates the
+        # lifespan handshake (which needs a started server), keeping the test
+        # focused on the task-wait bound.
+        config = real_config(None, lifespan="off", **captured)
+        server = real_server(config)
+        # startup() owns the servers list; empty mirrors the #76244 forensic
+        # state (sockets already closed, only the lingering task remains).
+        # LifespanOff makes the lifespan shutdown a no-op: its handshake needs
+        # a started server and is not what this test is about.
+        from uvicorn.lifespan.off import LifespanOff
+
+        server.servers = []
+        server.lifespan = LifespanOff(config)
+        lingerer = asyncio.ensure_future(_linger())
+        server.server_state.tasks.add(lingerer)
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        # Pre-fix this never returns (timeout=None) until wait_for aborts.
+        await asyncio.wait_for(server.shutdown(), timeout=bound + 5)
+        elapsed = loop.time() - start
+        assert elapsed >= bound, "the grace window must be honoured, not skipped"
+        assert elapsed < bound + 5, "shutdown must be bounded by the grace timeout"
+        assert lingerer.cancelled(), "the lingering task must be cancelled, not leaked"
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## What does this PR do?

Bounds uvicorn's graceful-shutdown wait in the `hermes serve` backend so a single SIGTERM can actually tear the process down.

`_build_uvicorn_server` never set `timeout_graceful_shutdown`, so uvicorn's default (`None`) makes `Server.shutdown()` wait forever on a lingering ASGI task (`_wait_tasks_to_complete()` spins on `server_state.tasks` with no deadline). A single SIGTERM — all Electron Desktop sends before its ~5s SIGKILL escalation — therefore hangs a backend that is mid-turn, and the process is orphaned past the kill budget. The #76244 forensics match exactly: 0 listening sockets, worker threads parked in `queue.get()`, main thread in `kevent`, event loop never returning.

`timeout_graceful_shutdown=3` sits under the desktop's kill budget, so shutdown waits up to 3s for in-flight tasks, then cancels them and still runs lifespan shutdown (`cron_stop` etc.) before the kill arrives. This is the root-cause fix; #83406 (parent-death watchdog / reap) and the Electron-side teardown in #82461 recover orphans after the fact but cannot unblock the hang itself. The 2026-09-07 reproduction on the issue (7 `serve --isolated` backends all surviving quit) is still this root cause on current builds.

## Related Issue

Fixes #76244

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — pass `timeout_graceful_shutdown=3` to `uvicorn.Config(...)` in `_build_uvicorn_server` (1 line + comment): a lingering ASGI task can no longer make shutdown unbounded.
- `tests/test_web_server.py` — two regression tests: (1) the configured bound is positive and under the ~5s desktop kill budget; (2) behavior-level coverage of the gap called out in triage of the earlier attempt (#76265): with the production Config kwargs and a real `uvicorn.Server`, a task that never completes must not hang `Server.shutdown()` — the grace window is honoured, then the lingerer is cancelled and shutdown returns.

## How to Test

1. `pytest tests/test_web_server.py -q` — Observed result: `8 passed, 3 skipped` (skips are the pre-existing Windows-only tests).
2. Revert the one-line production change and rerun the two new tests — Observed result: both fail (`graceful shutdown must be bounded (#76244)`), i.e. they genuinely pin the fix.
3. The behavior test drives a real `Server.shutdown()` with a never-completing task in `server_state.tasks` (the forensic state: sockets closed, one lingering task) and asserts it returns within `bound + 5s` while the lingerer is cancelled — pre-fix this hangs until SIGKILL.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
