### PR TITLE
fix(tools): resolve systemd scope probe no-op through PATH, not /bin/true

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1115,6 +1115,57 @@ class TestSpawnRewriteCompoundBackground:
 
 
 # =========================================================================
+# systemd --user --scope probe binary portability
+# =========================================================================
+
+
+class TestSystemdScopeProbeBinary:
+    """The probe's no-op command must be resolved through PATH.
+
+    Distributions that do not populate ``/bin`` with coreutils (NixOS, and any
+    minimal image) have no ``/bin/true``. Hardcoding it makes the probe fail on
+    every call, so ``_systemd_run_user_scope_available()`` returns False
+    permanently and every restart-safe gateway child (cron jobs, kanban
+    workers) refuses to spawn.
+    """
+
+    def _probe_argv(self, monkeypatch, which_map):
+        import shutil
+
+        import tools.process_registry as _pr
+
+        _pr._SYSTEMD_SCOPE_AVAILABLE = None
+        _pr._SYSTEMD_SCOPE_PROBED_AT = 0.0
+        monkeypatch.setattr(_pr, "_IS_LINUX", True)
+        monkeypatch.setattr(shutil, "which", lambda name: which_map.get(name))
+        captured = {}
+
+        def fake_run(argv, **_kwargs):
+            captured["argv"] = argv
+            return subprocess.CompletedProcess(argv, 0, b"", b"")
+
+        monkeypatch.setattr(_pr.subprocess, "run", fake_run)
+        assert _pr._systemd_run_user_scope_available() is True
+        return captured["argv"]
+
+    def test_probe_uses_path_resolved_true(self, monkeypatch):
+        nix_true = "/nix/store/abc123-coreutils-9.5/bin/true"
+        argv = self._probe_argv(monkeypatch, {
+            "systemd-run": "/run/current-system/sw/bin/systemd-run",
+            "true": nix_true,
+        })
+        assert argv[-1] == nix_true
+        assert "/bin/true" not in argv
+
+    def test_probe_falls_back_to_bin_true_when_absent_from_path(self, monkeypatch):
+        argv = self._probe_argv(monkeypatch, {
+            "systemd-run": "/usr/bin/systemd-run",
+            "true": None,
+        })
+        assert argv[-1] == "/bin/true"
+
+
+# =========================================================================
 # Checkpoint
 # =========================================================================
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -150,7 +150,7 @@ def _systemd_run_user_scope_available() -> bool:
     """True if ``systemd-run --user --scope`` can create a cgroup.
     ``shutil.which`` alone is insufficient: system services and containers may lack
     the user D-Bus bus even with the binary on PATH (every spawn would fail with
-    ``Failed to connect to user bus``), so a cheap ``/bin/true`` probe is run and cached."""
+    ``Failed to connect to user bus``), so a cheap no-op probe is run and cached."""
     global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
     verdict = _systemd_scope_cached()
     if verdict is not None:
@@ -167,11 +167,16 @@ def _systemd_run_user_scope_available() -> bool:
                 import shutil
 
                 binary = shutil.which("systemd-run")
+                # Resolve the no-op through PATH: distributions that don't populate
+                # /bin with coreutils (NixOS, minimal images) have no /bin/true, so a
+                # hardcoded path fails the probe forever and every restart-safe
+                # gateway child refuses to spawn. Keep /bin/true as the fallback.
+                true_binary = shutil.which("true") or "/bin/true"
                 if binary:
                     # Unique unit avoids collisions; the timeout bounds D-Bus.
                     probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
                     result = subprocess.run(
-                        _systemd_scope_argv(binary, probe_unit, "/bin/true"), capture_output=True, timeout=3,
+                        _systemd_scope_argv(binary, probe_unit, true_binary), capture_output=True, timeout=3,
                     )
                     available = result.returncode == 0
                     if not available:


### PR DESCRIPTION
# fix(tools): resolve systemd scope probe no-op through PATH, not `/bin/true`

## Summary

- `_systemd_run_user_scope_available()` in `tools/process_registry.py` probed
  `systemd-run --user --scope` using a hardcoded `/bin/true` as the no-op
  command. Distributions that do not populate `/bin` with coreutils have no
  `/bin/true`, so the probe fails unconditionally.
- Resolve the no-op via `shutil.which("true")`, falling back to `/bin/true`
  when `PATH` lookup returns nothing. Behavior is unchanged on every system
  where `/bin/true` already exists.
- Adds two regression tests covering both the PATH-resolved and fallback paths.

## Why it matters

On NixOS `/bin` contains only `/bin/sh` — coreutils lives under
`/nix/store/…-coreutils-*/bin`. The probe therefore fails on every call with:

```
Failed to find executable /bin/true: No such file or directory
```

`_systemd_run_user_scope_available()` returns `False` permanently, which makes
`restart_safe_gateway_child_argv()` fail closed:

```
cannot create restart-safe systemd scope for gateway child:
systemd-run --user --scope is unavailable
```

Every restart-safe gateway child routes through that helper, so **all cron job
fires and all kanban worker dispatch stop working** on an affected host. The
same applies to any minimal container image that ships a slim `/bin`.

This is incidental fallout from #70716 (`fix(terminal): isolate local
background executors in their own systemd cgroup`), which introduced the probe
— the cgroup isolation itself is correct, the probe binary just isn't portable.

## Before / after

Measured on a NixOS host (`/bin` = `ollama`, `sh`), calling the function
directly:

```
IS_LINUX: True
systemd-run: /run/current-system/sw/bin/systemd-run
which('true'): /run/current-system/sw/bin/true
/bin/true exists: False

before:  probe rc=1  stderr="Failed to find executable /bin/true: No such file or directory"
         _systemd_run_user_scope_available() -> False
after:   _systemd_run_user_scope_available() -> True
```

systemd, the user D-Bus bus and the scope machinery were all healthy the whole
time; only the probe's argv was wrong.

## Test plan

Two new tests in `tests/tools/test_process_registry.py`
(`TestSystemdScopeProbeBinary`) stub `shutil.which` and `subprocess.run` and
assert the argv the probe actually builds:

- `test_probe_uses_path_resolved_true` — a Nix-store `true` on PATH must be the
  argv tail, and `/bin/true` must not appear. **Fails on `main`** (`assert
  '/bin/true' == '/nix/store/…/bin/true'`), passes with this change.
- `test_probe_falls_back_to_bin_true_when_absent_from_path` — when
  `shutil.which("true")` returns `None`, the argv tail is still `/bin/true`,
  pinning the no-regression case for existing hosts.

Runner: `scripts/run_tests.sh tests/tools/test_process_registry.py -q`

```
104 tests passed, 1 failed, 4 skipped
```

The single failure is
`TestStdinHelpers::test_close_stdin_allows_eof_driven_process_to_finish`
(`assert 127 == 0`). It is **pre-existing and unrelated**: verified failing
identically on unmodified `upstream/main` in this environment, because the test
spawns a literal `python3` which is not on PATH inside the hermetic runner env
on NixOS.
