### PR TITLE
fix(gateway): clear fleet_restart_pending marker after a successful restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6011,16 +6011,35 @@ def _restart_all(system: bool) -> None:
         _service_call(kind, "start", system)
 
 
+def _clear_fleet_restart_pending_after_restart() -> None:
+    """Discharge the pull→restart breadcrumb once a ``gateway restart`` succeeded.
+
+    ``hermes update`` clears the marker only in its systemd-centric catch-up path; a
+    standalone ``hermes gateway restart`` (the macOS/launchd case) never touched it, so
+    every CLI command kept warning that pulled code had not been restarted onto. The
+    gateway has now been (re)started from current code, so the obligation is met. Never
+    raises (the lazy import keeps the updater modules out of the gateway import path).
+    """
+    try:
+        from hermes_cli.update_cmd_fleet import _clear_fleet_restart_pending_marker
+    except Exception:  # pragma: no cover — the import cannot fail in practice
+        return
+    _clear_fleet_restart_pending_marker()
+
+
 def _cmd_restart(args):
     _refuse_from_inside_gateway("restart", "restart loops")
     system = getattr(args, "system", False)
     restart_all = getattr(args, "all", False)
     if restart_all and _dispatch_all_via_service_manager_if_s6("restart"):
+        _clear_fleet_restart_pending_after_restart()
         return
     if not restart_all and _dispatch_via_service_manager_if_s6("restart"):
+        _clear_fleet_restart_pending_after_restart()
         return
     if restart_all:
         _restart_all(system)
+        _clear_fleet_restart_pending_after_restart()
         return
 
     # The Windows restart path handles both registered installs and detached restarts.
@@ -6030,6 +6049,7 @@ def _cmd_restart(args):
         swallow = (RuntimeError, OSError) if kind == "windows" else ()
         try:
             _service_call(kind, "restart", system)
+            _clear_fleet_restart_pending_after_restart()
             return
         except (subprocess.CalledProcessError, *swallow):
             pass
@@ -6059,6 +6079,7 @@ def _cmd_restart(args):
     _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
     print("Starting gateway...")
     run_gateway(verbose=0)
+    _clear_fleet_restart_pending_after_restart()
 
 
 # ``hermes gateway status`` hints for a manually-run / stopped gateway, keyed by host kind.

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -609,3 +609,35 @@ def test_startup_warn_silent_when_nothing_pending(capsys):
     captured = capsys.readouterr()
     assert captured.err == ""
     assert captured.out == ""
+
+
+def test_gateway_restart_clears_fleet_restart_pending_marker(monkeypatch):
+    """A successful ``hermes gateway restart`` discharges the pull→restart breadcrumb.
+
+    ``hermes update`` clears the marker only in its systemd-centric catch-up path; a
+    standalone restart (the macOS/launchd case) never touched it, so every CLI command
+    kept warning that pulled code had not been restarted onto. A restart brings the
+    gateway onto current code, so the marker must be gone afterward.
+    """
+    import hermes_cli.gateway as gateway
+
+    monkeypatch.setattr(gateway, "_refuse_from_inside_gateway", lambda *a, **k: None)
+    monkeypatch.setattr(
+        gateway, "_dispatch_all_via_service_manager_if_s6", lambda *a, **k: False
+    )
+    monkeypatch.setattr(
+        gateway, "_dispatch_via_service_manager_if_s6", lambda *a, **k: False
+    )
+    monkeypatch.setattr(gateway, "_installed_service_kind_for", lambda *a, **k: None)
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "stop_profile_gateway", lambda: False)
+    monkeypatch.setattr(gateway, "_wait_for_gateway_exit", lambda *a, **k: None)
+    monkeypatch.setattr(gateway, "run_gateway", lambda *a, **k: None)
+
+    update_cmd._write_fleet_restart_pending_marker(expected_sha="abc123")
+    path = update_cmd._fleet_restart_pending_marker_path()
+    assert path.is_file()
+
+    gateway._cmd_restart(SimpleNamespace(system=False, all=False))
+
+    assert not path.exists()


### PR DESCRIPTION
## Problem

`hermes update` clears the pull→restart breadcrumb (`~/.hermes/fleet_restart_pending`) **only** in its systemd-centric catch-up path:

`update_cmd_fleet._apply_pending_fleet_restart_catchup → _run_pending_fleet_restart → _clear_fleet_restart_pending_marker`

A standalone `hermes gateway restart` never touches the marker, and the systemd catch-up is a no-op on macOS/launchd. Reproduction on current `main`: pull new code (writes the marker with `expected_sha` + pre-update gateway pid), then `hermes gateway restart`. The gateway comes up on the new code (`gateway_state.json` `code_sha` matches), but the marker is never cleared, so every CLI command keeps printing:

> A previous hermes update pulled new code but did not restart running gateways

…until the marker is manually `rm`'d.

## Fix

Dispatch a marker clear from **every successful-exit path** of `_cmd_restart` in `hermes_cli/gateway.py` (`_clear_fleet_restart_pending_after_restart`), so a restart that brings the gateway onto current code discharges the obligation regardless of service manager — launchd, systemd dispatch (`_dispatch_*_via_service_manager_if_s6`), `_restart_all`, the Windows service path, and the manual `run_gateway` path are all covered. The helper lazy-imports `_clear_fleet_restart_pending_marker` from `update_cmd_fleet` (keeps the updater modules out of the gateway import path) and never raises.

## Test

`test_gateway_restart_clears_fleet_restart_pending_marker` writes a real marker, runs `_cmd_restart` (service-manager dispatch + subprocess stubs monkeypatched), and asserts the marker is gone afterward. Proven red on base, green with the fix.

```
scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_pending.py
```
