### PR TITLE
fix(bot-mode): scope Bot Chat session lookup to the target profile's home

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -267,7 +267,7 @@ def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
         "researcher",
         "chat",
         "--in",
-        "~",
+        str(home / "profiles" / "researcher"),
         "-c",
         "Bot Chat",
         "--create-if-missing",

--- a/tests/tools/test_bot_relay_windows_paths.py
+++ b/tests/tools/test_bot_relay_windows_paths.py
@@ -161,3 +161,23 @@ def test_delivery_lock_recognizes_resolved_cli_paths(tmp_path, monkeypatch):
     with bot_mode_dm._delivery_lock(["python", "-m", "whatever"], stdin_file=False):
         pass
     assert acquired == ["locked", "locked", "locked"]
+
+
+def test_local_delivery_scopes_in_to_profile_home(tmp_path, monkeypatch):
+    """``--in`` must point at the target profile's OWN home, not the shared home.
+
+    ``--in ~`` scoped the ``-c "Bot Chat"`` lookup to the real home dir, which for a
+    named profile resolves to the DEFAULT profile's workspace and its live Bot Chat
+    session (held by the desktop surface) — delivery then failed with "already has a
+    live owner" → target_busy.
+    """
+    root = tmp_path / ".hermes"
+    (root / "profiles").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    argv = bot_relay.local_delivery_command("ops", "query.json")
+    assert argv[argv.index("--in") + 1] == str(root / "profiles" / "ops")
+
+    # The default profile still scopes to the root itself, never to a subdir.
+    argv_default = bot_relay.local_delivery_command("default", "query.json")
+    assert argv_default[argv_default.index("--in") + 1] == str(root)

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -182,7 +182,7 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
             BOT_CHAT_TITLE, _handle, _hermes_root, _peers, _profile_name as _self_profile_name, _roster,
             is_bot_mode_managed,
         )
-        from tools.bot_relay import BOT_CHAT_TURN_ARGS
+        from tools.bot_relay import _bot_chat_turn_args
 
         if _session_title(agent) != BOT_CHAT_TITLE:
             return _err("message_agent is only available in a Bot Mode 'Bot Chat' session. "
@@ -251,7 +251,7 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
         return _roster_err(f"No teammate named '{raw_target}' on this install, on a connected "
                            "machine, or on a registered peer. Pick a name from the roster "
                            "(roles are listed in your system prompt).")
-    return _start_delivery(["hermes", "-p", resolved, *BOT_CHAT_TURN_ARGS], content, f"@{_handle(resolved)}",
+    return _start_delivery(["hermes", "-p", resolved, *_bot_chat_turn_args(resolved, root)], content, f"@{_handle(resolved)}",
                            stdin_file=False, profile_home=roster_homes[resolved], author=author, **delivery)
 
 

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -63,6 +63,17 @@ def _profile_name(home: Path) -> str:
     return home.name if home.parent.name == "profiles" else "default"
 
 
+def profile_home_dir(root: Path, name: str) -> Path:
+    """Home dir for a profile name: 'default' → root, else root/profiles/<name>.
+
+    Inverts ``_hermes_root``/``_profile_name``. Used to scope a Bot Chat turn's
+    ``--in`` to the profile's OWN sessions rather than the shared home (which maps to
+    the default profile and its desktop-held live session — delivery then failed with
+    "already has a live owner" → target_busy).
+    """
+    return root if name == "default" else root / "profiles" / name
+
+
 def _handle(name: str) -> str:
     # The mention middleware aliases the default profile as @hermes.
     return "hermes" if name == "default" else name

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -27,7 +27,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Iterator, Optional
 
-from tools.bot_mode_probe import _default_home, _hermes_root
+from tools.bot_mode_probe import _default_home, _hermes_root, profile_home_dir
 
 logger = logging.getLogger(__name__)
 
@@ -74,9 +74,18 @@ class EnvelopeRefusedError(RuntimeError):
 # ``message_agent`` target grammar in ``tools/bot_mode_dm.py``).
 _HANDLE_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 
-# One turn in a profile's canonical Bot Chat: ``hermes -p <profile> *BOT_CHAT_TURN_ARGS``.
+# One turn in a profile's canonical Bot Chat: ``hermes -p <profile> *_bot_chat_turn_args(...)``.
 # ``-c "Bot Chat"`` must match ``bot_mode_probe.BOT_CHAT_TITLE``.
-BOT_CHAT_TURN_ARGS = ("chat", "--in", "~", "-c", "Bot Chat", "--create-if-missing", "-Q")
+def _bot_chat_turn_args(profile: str, root: Path) -> tuple[str, ...]:
+    """Turn args scoping the ``-c "Bot Chat"`` lookup to the profile's OWN home.
+
+    ``--in ~`` scoped the session lookup to the real home directory, which for a named
+    profile resolves to the DEFAULT profile's workspace and its live Bot Chat session
+    (held by the desktop surface) — delivery then failed with "already has a live
+    owner" → target_busy. Scope to the profile's home instead.
+    """
+    home = str(profile_home_dir(root, profile))
+    return ("chat", "--in", home, "-c", "Bot Chat", "--create-if-missing", "-Q")
 
 
 def relay_root(root: Path | str) -> Path:
@@ -381,7 +390,8 @@ def _hermes_cli() -> str:
 
 def local_delivery_command(profile: str, query_file: str) -> list[str]:
     """argv that delivers a DM into ``profile``'s Bot Chat on THIS gateway."""
-    return [_hermes_cli(), "-p", profile, *BOT_CHAT_TURN_ARGS, "--query-file", query_file]
+    root = _hermes_root(Path(_default_home()))
+    return [_hermes_cli(), "-p", profile, *_bot_chat_turn_args(profile, root), "--query-file", query_file]
 
 
 class DeliveryAuthor:


### PR DESCRIPTION
## Problem

`message_agent` delivery runs `hermes -p <profile> chat --in '~' -c 'Bot Chat'`. `tools/bot_relay.py` hard-coded the turn args as:

```python
BOT_CHAT_TURN_ARGS = ("chat", "--in", "~", "-c", "Bot Chat", "--create-if-missing", "-Q")
```

`--in ~` scopes the session lookup to the shared home directory, which for a **named** profile resolves to the *default* profile's workspace. When the default profile's Bot Chat session is held "live" by the desktop surface, delivery fails with `already has a live owner`, surfaced to the sender as `target_busy` — breaking DMs to any bot on the install (coder, majordomo, …).

## Fix

Scope the `-c "Bot Chat"` lookup to the target profile's **own** home:

- `tools/bot_mode_probe.py`: add `profile_home_dir(root, name)` — `root` for `"default"`, else `root/profiles/<name>` (inverse of the existing `_hermes_root`/`_profile_name` pair).
- `tools/bot_relay.py`: replace the constant `BOT_CHAT_TURN_ARGS` with `_bot_chat_turn_args(profile, root)`, which builds the profile-scoped argv, and route `local_delivery_command` through it.
- `tools/bot_mode_dm.py`: `message_agent_tool` now passes `_bot_chat_turn_args(resolved, root)` into the delivery argv.

## Test

- `test_local_delivery_scopes_in_to_profile_home`: asserts `--in` resolves to `root/profiles/<profile>` (and to `root` for the default profile).
- `test_local_delivery_command_and_ack` updated to the profile-scoped `--in`.

Both proven red on base, green with the fix.

```
scripts/run_tests.sh tests/tools/test_bot_relay_windows_paths.py tests/tools/test_bot_mode_dm.py tests/tools/test_bot_turn_lock.py
```

## Related Issue

Fixes #105460

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `scripts/run_tests.sh tests/tools/test_bot_relay_windows_paths.py tests/tools/test_bot_mode_dm.py tests/tools/test_bot_turn_lock.py` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (internal bug fix; no user-facing behavior change, in-code docstrings updated)
- [x] I've updated `cli-config.yaml.example` — or N/A (no config keys added or changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A (no contribution/agent-instruction change)
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (Path-based; Windows path test covers it)
- [x] I've updated tool descriptions/schemas — or N/A (`message_agent` tool interface unchanged)

