### PR TITLE
fix(codex): record first Responses stream event timing

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -899,6 +899,11 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
     def _on_event(event: Any) -> None:  # TTFB/activity touch — once per SSE event.
         now = time.time()
+        # Lifecycle frames can precede text, so the first accepted parsed event is the Responses
+        # equivalent of Chat Completions' first chunk. Preserve the per-attempt reset and never let
+        # a retired worker overwrite the timestamp owned by a newer request.
+        if getattr(agent, "_last_api_first_chunk_at", None) is None and _request_is_current():
+            agent._last_api_first_chunk_at = now
         has_progress = _codex_event_has_content(event)
         if watchdog_state is not None:
             with watchdog_state.lock:

--- a/tests/agent/test_codex_first_event_timing.py
+++ b/tests/agent/test_codex_first_event_timing.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from agent.codex_runtime import run_codex_stream
+
+
+def _agent() -> SimpleNamespace:
+    return SimpleNamespace(
+        session_id="",
+        provider="openai-codex",
+        model="timing-fixture",
+        _interrupt_requested=False,
+        _last_api_first_chunk_at=None,
+        _touch_activity=lambda *_: None,
+        _fire_stream_delta=lambda *_: None,
+        _fire_reasoning_delta=lambda *_: None,
+        _client_log_context=lambda: "",
+    )
+
+
+def _completed_events():
+    yield {
+        "type": "response.created",
+        "response": {"id": "fixture", "status": "in_progress"},
+    }
+    yield {"type": "response.output_text.delta", "delta": "Yes."}
+    yield {
+        "type": "response.completed",
+        "response": {"id": "fixture", "status": "completed"},
+    }
+
+
+def test_codex_stream_records_first_lifecycle_event_before_text(monkeypatch):
+    agent = _agent()
+    ticks = iter((100.0, 200.0, 300.0))
+    monkeypatch.setattr("agent.codex_runtime.time.time", lambda: next(ticks))
+    attempts = 0
+
+    def create(**_):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise httpx.ConnectError("transient connect failure")
+        return _completed_events()
+
+    client = SimpleNamespace(responses=SimpleNamespace(create=create))
+
+    result = run_codex_stream(
+        agent, {"model": "timing-fixture", "input": "Say Yes."}, client=client
+    )
+
+    assert result.output_text == "Yes."
+    assert result.status == "completed"
+    assert attempts == 2
+    assert agent._last_api_first_chunk_at == 100.0
+
+
+@pytest.mark.parametrize("retire_before_event", [False, True])
+def test_codex_stream_without_accepted_event_keeps_timing_unset(retire_before_event):
+    agent = _agent()
+    request_token = object()
+    agent._active_codex_stream_request_token = request_token
+
+    def events():
+        if retire_before_event:
+            agent._active_codex_stream_request_token = object()
+            yield {"type": "response.created"}
+        return
+        yield
+
+    client = SimpleNamespace(responses=SimpleNamespace(create=lambda **_: events()))
+
+    with pytest.raises((RuntimeError, TimeoutError)):
+        run_codex_stream(agent, {"model": "timing-fixture"}, client=client)
+
+    assert agent._last_api_first_chunk_at is None


### PR DESCRIPTION
## Summary

The Responses/Codex streaming runtime emitted lifecycle and text events without populating the existing `post_api_request.first_chunk_at` observation field. This change records the first accepted parsed Responses event, including lifecycle events that precede answer text, while retaining the active-request retirement fence and leaving no-event requests unset.

---

## Changes

- `agent/codex_runtime.py`: records `_last_api_first_chunk_at` once, from the first accepted Responses event, without allowing retired workers or later events to overwrite it.
- `tests/agent/test_codex_first_event_timing.py`: covers lifecycle-before-text timing after a physical retry, no-event streams, and retired-request events.

## How to Test

```bash
pytest tests/agent/test_codex_first_event_timing.py tests/run_agent/test_run_agent_codex_responses.py tests/run_agent/test_stream_single_writer_65991.py tests/agent/test_codex_runtime_live_events.py -q
# 75 passed
```

## Checklist

- [x] Regression test fails without the fix
- [x] Targeted and adjacent Codex tests pass
- [x] Ruff check passes
- [x] Changes are scoped to this fix only
- [x] Agent-loop invariants are unchanged
- [x] No profile paths, configuration, or dependencies changed

## Risk & Impact

Low. The change only populates an existing per-attempt observation field on accepted stream events; response parsing, delivery, retries, and prompt state are unchanged.

Type: Bug fix

Closes #105311
