### PR TITLE
fix(agent): populate first_chunk_at for Codex Responses streams

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -908,6 +908,11 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 watchdog_state.last_event_ts = now
                 if has_progress:
                     watchdog_state.last_progress_ts = now
+        # Export first-chunk timing for the post_api_request hook (mirroring the Chat
+        # Completions path at chat_completion_helpers.py:3316). The fence ensures a
+        # retired request never overwrites the current attempt's stamp.
+        if getattr(agent, "_last_api_first_chunk_at", None) is None and _request_is_current():
+            agent._last_api_first_chunk_at = now
         agent._touch_activity("receiving stream response")
 
     def _interrupt_or_superseded() -> bool:

--- a/tests/agent/test_codex_stream_first_chunk_timing.py
+++ b/tests/agent/test_codex_stream_first_chunk_timing.py
@@ -1,0 +1,123 @@
+"""Regression tests for Codex Responses stream first_chunk_at export.
+
+The ``post_api_request`` hook receives ``first_chunk_at`` (epoch seconds when
+the initial parsed event arrived). The streaming Chat Completions path populates
+it from a diag object when the stream completes. The Responses path runs a
+different event-driven consumer that never built a diag object; this corrects
+the omission so plugins receive timing for both code paths.
+
+Issue #105311.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import types
+from types import SimpleNamespace
+
+# Stub heavy imports to run in isolation.
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *_: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from agent.codex_runtime import run_codex_stream
+
+
+def _make_agent():
+    return SimpleNamespace(
+        session_id="",
+        provider="openai-codex",
+        model="timing-fixture",
+        _interrupt_requested=False,
+        _last_api_first_chunk_at=None,
+        _touch_activity=lambda *_: None,
+        _fire_stream_delta=lambda _text: None,
+        _fire_reasoning_delta=lambda *_: None,
+    )
+
+
+def test_first_chunk_at_populated_when_events_arrive():
+    """The first parsed stream event stamps agent._last_api_first_chunk_at."""
+    agent = _make_agent()
+    received_events = []
+
+    def events():
+        received_events.append(time.time())
+        yield {"type": "response.created", "response": {"id": "r1", "status": "in_progress"}}
+        yield {"type": "response.output_text.delta", "delta": "Hello"}
+        yield {"type": "response.completed", "response": {"id": "r1", "status": "completed"}}
+
+    client = SimpleNamespace(responses=SimpleNamespace(create=lambda **_kw: events()))
+    before = time.time()
+    result = run_codex_stream(agent, {"model": "timing-fixture", "input": "Go."}, client=client)
+    after = time.time()
+
+    assert result.output_text == "Hello"
+    assert result.status == "completed"
+    assert agent._last_api_first_chunk_at is not None
+    assert before <= agent._last_api_first_chunk_at <= after
+    assert len(received_events) == 1  # generator fired once (first event)
+
+
+def test_first_chunk_at_remains_none_when_no_events():
+    """Streams with zero parsed events leave first_chunk_at None."""
+    agent = _make_agent()
+
+    def events():
+        # Immediately raise before yielding any event.
+        raise RuntimeError("Stream connect failed before any event")
+
+    client = SimpleNamespace(responses=SimpleNamespace(create=lambda **_kw: events()))
+
+    try:
+        run_codex_stream(agent, {"model": "timing-fixture", "input": "Go."}, client=client)
+    except RuntimeError:
+        pass
+
+    assert agent._last_api_first_chunk_at is None
+
+
+def test_first_chunk_at_not_overwritten_by_later_events():
+    """Subsequent events do not replace the initial stamp."""
+    agent = _make_agent()
+    event_times = []
+
+    def events():
+        event_times.append(time.time())
+        yield {"type": "response.created", "response": {"id": "r1", "status": "in_progress"}}
+        time.sleep(0.05)  # let the clock tick
+        event_times.append(time.time())
+        yield {"type": "response.output_text.delta", "delta": "later"}
+        yield {"type": "response.completed", "response": {"id": "r1", "status": "completed"}}
+
+    client = SimpleNamespace(responses=SimpleNamespace(create=lambda **_kw: events()))
+    run_codex_stream(agent, {"model": "timing-fixture", "input": "Go."}, client=client)
+
+    first_stamp = agent._last_api_first_chunk_at
+    # The stamp should match the time of the first event, not the second.
+    assert abs(first_stamp - event_times[0]) < 0.01
+    # and it must NOT match the second (50ms later)
+    assert abs(first_stamp - event_times[1]) >= 0.04
+
+
+def test_first_chunk_timing_lifecycle_events_before_text():
+    """Lifecycle events arriving before text deltas count as the first chunk."""
+    agent = _make_agent()
+    lifecycle_time = None
+
+    def events():
+        nonlocal lifecycle_time
+        lifecycle_time = time.time()
+        # Lifecycle frame with no delta content arrives first.
+        yield {"type": "response.created", "response": {"id": "r1", "status": "in_progress"}}
+        time.sleep(0.03)
+        # Output text arrives later.
+        yield {"type": "response.output_text.delta", "delta": "text"}
+        yield {"type": "response.completed", "response": {"id": "r1", "status": "completed"}}
+
+    client = SimpleNamespace(responses=SimpleNamespace(create=lambda **_kw: events()))
+    run_codex_stream(agent, {"model": "timing-fixture", "input": "Go."}, client=client)
+
+    # The stamp matches the lifecycle event, not the text delta.
+    assert abs(agent._last_api_first_chunk_at - lifecycle_time) < 0.001


### PR DESCRIPTION
Closes #105311.

## Root Cause

`agent/codex_runtime.py:run_codex_stream._on_event` touches the watchdog and activity state when each SSE event arrives, but the existing `_last_api_first_chunk_at` export is never populated. The Chat Completions streaming path updates `agent._last_api_first_chunk_at` from a diag object once the worker completes (chat_completion_helpers.py:3316). The Codex Responses streaming path runs a different event-driven consumer (`_consume_codex_event_stream`) that never builds a diag object, so the field stays `None` for the entire request lifecycle and `post_api_request` hooks receive no first-chunk timing.

## Fix

Populate `agent._last_api_first_chunk_at` at the same gate that sets `watchdog_state.last_event_ts` (line 908) — when the first event passes `_request_is_current()` and is not a retirement or stale-request guard, stamp the agent field with the current clock reading. Preserve the per-attempt reset (turn_api_request.py:108) and retirement fence the Chat Completions path keeps, so retries don't overwrite the current attempt and retired workers don't taint a new request.

## Tests

Four new regression cases in `tests/agent/test_codex_stream_first_chunk_timing.py`:
- first event stamps the field
- no events leave it `None`
- later events don't overwrite the initial stamp
- lifecycle events arriving before text deltas count as the first chunk

The repro from the issue body now returns epoch seconds instead of `null`. Existing Codex transport and live-event tests remain green.

## Verification

Ran locally with the venv pytest + the issue's repro script:
```bash
pytest tests/agent/test_codex_stream_first_chunk_timing.py -v  # 4 passed
PYTHONPATH=/tmp/ha105311 python3 /tmp/repro_105311.py
# {"...", "first_chunk_at": 1788811040.881377, "expected": "epoch seconds of first parsed event"}
```

CI gating deferred to fork-PR checks.