### PR TITLE
fix(desktop): stop marking Bot Mode side sessions as hidden

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -759,8 +759,7 @@ export function useSessionActions({
           options?.cwd === null ? '' : typeof options?.cwd === 'string' ? options.cwd.trim() : resolveNewSessionCwd()
 
         const params = {
-          ...(await desktopSessionCreateParams(cwd, capturedRoute)),
-          ...(workspaceScope.workspaceMode === 'bots' ? { hidden: true } : {})
+          ...(await desktopSessionCreateParams(cwd, capturedRoute))
         }
 
         // Same lease chain as createBackendSessionForSend: owner socket held

--- a/apps/desktop/src/app/session/hooks/use-session-actions/open-new-session-tile.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/open-new-session-tile.test.tsx
@@ -13,18 +13,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getSession } from '@/hermes'
 import { ensureGatewayProfile } from '@/store/profile'
 import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
-import {
-  requestGateway,
-  requestGatewayForAgent,
-} from '@/store/gateway'
-import {
-  $activeSessionStoredIdRotation,
-  $messages,
-  $sessions,
-  sessionPinId,
-} from '@/store/session'
-import type { SessionInfo } from '@/types/hermes'
-import type { ClientSessionState } from '@/store/session'
+import { requestGatewayForAgent } from '@/store/gateway'
+import type { ClientSessionState } from '@/app/types'
 
 import { useSessionActions } from './index'
 
@@ -48,7 +38,6 @@ vi.mock('@/store/gateway', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
   openGatewayForAgent: vi.fn(),
   openGatewayForProfile: vi.fn(),
-  requestGateway: vi.fn().mockResolvedValue({ ok: true, stored_session_id: 'stored-1' }),
   requestGatewayForAgent: vi.fn().mockResolvedValue({ ok: true, stored_session_id: 'stored-1' }),
   retainGatewayForAgent: vi.fn().mockResolvedValue(() => undefined),
 }))
@@ -105,9 +94,7 @@ async function mountHarness(): Promise<Handle> {
 
 describe('openNewSessionTile × Bot Mode hidden flag', () => {
   beforeEach(() => {
-    vi.mocked(requestGateway).mockReset()
     vi.mocked(requestGatewayForAgent).mockReset()
-    vi.mocked(requestGateway).mockResolvedValue({ ok: true, stored_session_id: 'stored-1' })
     vi.mocked(requestGatewayForAgent).mockResolvedValue({ ok: true, stored_session_id: 'stored-1' })
     $activeGatewayProfile.set('default')
     $newChatProfile.set('')

--- a/apps/desktop/src/app/session/hooks/use-session-actions/open-new-session-tile.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/open-new-session-tile.test.tsx
@@ -1,0 +1,129 @@
+// Regression: openNewSessionTile in Bot Mode was setting the persistent
+// hidden: true flag, making user-initiated side sessions permanently
+// invisible in the Sessions list.
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { useEffect } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { useSessionActions } from './index'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteSession: vi.fn(),
+  getSession: vi.fn(),
+  getAllSessionMessages: vi.fn(),
+  getLatestSessionMessages: vi.fn(),
+  listAllProfileSessions: vi.fn(),
+  setApiRequestProfile: vi.fn(),
+  setSessionArchived: vi.fn()
+}))
+
+vi.mock('@/store/profile', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ensureGatewayProfile: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('@/store/gateway', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  openGatewayForAgent: vi.fn(),
+  openGatewayForProfile: vi.fn(),
+  requestGateway: vi.fn().mockResolvedValue({ ok: true, stored_session_id: 'stored-1' }),
+  requestGatewayForAgent: vi.fn().mockResolvedValue({ ok: true, stored_session_id: 'stored-1' }),
+  retainGatewayForAgent: vi.fn().mockResolvedValue(() => undefined)
+}))
+
+import { requestGateway, requestGatewayForAgent } from '@/store/gateway'
+
+type Handle = Pick<ReturnType<typeof useSessionActions>, 'openNewSessionTile'>
+
+function Harness({ onReady }: { onReady: (handle: Handle) => void }) {
+  const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+  const actions = useSessionActions({
+    activeSessionId: null,
+    activeSessionIdRef: ref<string | null>(null),
+    busyRef: ref(false),
+    creatingSessionRef: ref(false),
+    ensureSessionState: () => ({}) as never,
+    getRouteToken: () => 'token',
+    getRoutedStoredSessionId: () => null,
+    navigate: vi.fn() as never,
+    requestGateway: vi.fn().mockResolvedValue(undefined),
+    resetViewSync: vi.fn(),
+    runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
+    selectedStoredSessionId: null,
+    selectedStoredSessionIdRef: ref<string | null>(null),
+    sessionStateByRuntimeIdRef: ref(new Map<string, never>()),
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: () => ({}) as never
+  })
+
+  useEffect(() => {
+    onReady({ openNewSessionTile: actions.openNewSessionTile })
+  }, [actions, onReady])
+
+  return null
+}
+
+async function mountHarness(): Promise<Handle> {
+  let handle: Handle | undefined
+  render(<Harness onReady={h => (handle = h)} />)
+  await waitFor(() => expect(handle).toBeDefined())
+
+  return handle as Handle
+}
+
+describe('openNewSessionTile × Bot Mode hidden flag', () => {
+  beforeEach(() => {
+    vi.mocked(requestGateway).mockReset()
+    vi.mocked(requestGatewayForAgent).mockReset()
+    vi.mocked(requestGateway).mockResolvedValue({ ok: true, stored_session_id: 'stored-1' })
+    vi.mocked(requestGatewayForAgent).mockResolvedValue({ ok: true, stored_session_id: 'stored-1' })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('does NOT pass hidden: true when workspaceMode is "bots"', async () => {
+    const handle = await mountHarness()
+
+    await act(() =>
+      handle.openNewSessionTile('right', {
+        workspaceScope: { workspaceMode: 'bots' }
+      })
+    )
+
+    // Find the session.create call
+    const createCall = vi.mocked(requestGatewayForAgent).mock.calls.find(
+      call => call[2] === 'session.create'
+    )
+
+    expect(createCall).toBeDefined()
+    const params = createCall?.[3] as Record<string, unknown> | undefined
+    expect(params).toBeDefined()
+    expect(params?.hidden).toBeUndefined()
+  })
+
+  it('does NOT pass hidden: true in normal sessions mode', async () => {
+    const handle = await mountHarness()
+
+    await act(() =>
+      handle.openNewSessionTile('right', {
+        workspaceScope: { workspaceMode: 'sessions' }
+      })
+    )
+
+    const createCall = vi.mocked(requestGatewayForAgent).mock.calls.find(
+      call => call[2] === 'session.create'
+    )
+
+    expect(createCall).toBeDefined()
+    const params = createCall?.[3] as Record<string, unknown> | undefined
+    expect(params).toBeDefined()
+    expect(params?.hidden).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/open-new-session-tile.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/open-new-session-tile.test.tsx
@@ -15,15 +15,16 @@ import { ensureGatewayProfile } from '@/store/profile'
 import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
 import {
   requestGateway,
-  requestGatewayForAgent
+  requestGatewayForAgent,
 } from '@/store/gateway'
 import {
   $activeSessionStoredIdRotation,
   $messages,
   $sessions,
-  sessionPinId
+  sessionPinId,
 } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
+import type { ClientSessionState } from '@/store/session'
 
 import { useSessionActions } from './index'
 
@@ -35,12 +36,12 @@ vi.mock('@/hermes', async importOriginal => ({
   getLatestSessionMessages: vi.fn(),
   listAllProfileSessions: vi.fn(),
   setApiRequestProfile: vi.fn(),
-  setSessionArchived: vi.fn()
+  setSessionArchived: vi.fn(),
 }))
 
 vi.mock('@/store/profile', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
-  ensureGatewayProfile: vi.fn().mockResolvedValue(undefined)
+  ensureGatewayProfile: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('@/store/gateway', async importOriginal => ({
@@ -49,7 +50,7 @@ vi.mock('@/store/gateway', async importOriginal => ({
   openGatewayForProfile: vi.fn(),
   requestGateway: vi.fn().mockResolvedValue({ ok: true, stored_session_id: 'stored-1' }),
   requestGatewayForAgent: vi.fn().mockResolvedValue({ ok: true, stored_session_id: 'stored-1' }),
-  retainGatewayForAgent: vi.fn().mockResolvedValue(() => undefined)
+  retainGatewayForAgent: vi.fn().mockResolvedValue(() => undefined),
 }))
 
 type SessionCreateParams = Record<string, unknown>
@@ -74,7 +75,7 @@ function Harness({ onReady }: HarnessProps) {
     activeSessionIdRef: ref<string | null>(null),
     busyRef: ref(false),
     creatingSessionRef: ref(false),
-    ensureSessionState: () => ({}) as SessionInfo,
+    ensureSessionState: () => ({}) as ClientSessionState,
     getRouteToken: () => 'token',
     getRoutedStoredSessionId: () => null,
     navigate: vi.fn() as never,
@@ -83,9 +84,9 @@ function Harness({ onReady }: HarnessProps) {
     runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
     selectedStoredSessionId: null,
     selectedStoredSessionIdRef: ref<string | null>(null),
-    sessionStateByRuntimeIdRef: ref(new Map<string, SessionInfo>()),
+    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
     syncSessionStateToView: vi.fn(),
-    updateSessionState: () => ({}) as SessionInfo
+    updateSessionState: () => ({}) as ClientSessionState,
   })
 
   useEffect(() => {
@@ -123,8 +124,8 @@ describe('openNewSessionTile × Bot Mode hidden flag', () => {
 
     await act(() =>
       handle.openNewSessionTile('right', {
-        workspaceScope: { workspaceMode: 'bots' }
-      })
+        workspaceScope: { workspaceMode: 'bots' },
+      }),
     )
 
     const params = extractSessionCreateParams()
@@ -138,8 +139,8 @@ describe('openNewSessionTile × Bot Mode hidden flag', () => {
 
     await act(() =>
       handle.openNewSessionTile('right', {
-        workspaceScope: { workspaceMode: 'sessions' }
-      })
+        workspaceScope: { workspaceMode: 'sessions' },
+      }),
     )
 
     const params = extractSessionCreateParams()
@@ -152,8 +153,8 @@ describe('openNewSessionTile × Bot Mode hidden flag', () => {
 
     await act(() =>
       handle.openNewSessionTile('right', {
-        workspaceScope: { workspaceMode: 'bots' }
-      })
+        workspaceScope: { workspaceMode: 'bots' },
+      }),
     )
 
     const params = extractSessionCreateParams()

--- a/apps/desktop/src/app/session/hooks/use-session-actions/open-new-session-tile.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/open-new-session-tile.test.tsx
@@ -1,11 +1,28 @@
 // Regression: openNewSessionTile in Bot Mode was setting the persistent
 // hidden: true flag, making user-initiated side sessions permanently
 // invisible in the Sessions list.
+//
+// This test verifies the fix: openNewSessionTile must NOT pass hidden: true
+// in the session.create params, regardless of workspaceMode.
+
 import { act, cleanup, render, waitFor } from '@testing-library/react'
 import type { MutableRefObject } from 'react'
 import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { getSession } from '@/hermes'
+import { ensureGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
+import {
+  requestGateway,
+  requestGatewayForAgent
+} from '@/store/gateway'
+import {
+  $activeSessionStoredIdRotation,
+  $messages,
+  $sessions,
+  sessionPinId
+} from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import { useSessionActions } from './index'
@@ -35,11 +52,21 @@ vi.mock('@/store/gateway', async importOriginal => ({
   retainGatewayForAgent: vi.fn().mockResolvedValue(() => undefined)
 }))
 
-import { requestGateway, requestGatewayForAgent } from '@/store/gateway'
+type SessionCreateParams = Record<string, unknown>
+
+function extractSessionCreateParams(): SessionCreateParams | undefined {
+  const calls = vi.mocked(requestGatewayForAgent).mock.calls
+  const createCall = calls.find(call => call[2] === 'session.create')
+  return createCall?.[3] as SessionCreateParams | undefined
+}
 
 type Handle = Pick<ReturnType<typeof useSessionActions>, 'openNewSessionTile'>
 
-function Harness({ onReady }: { onReady: (handle: Handle) => void }) {
+interface HarnessProps {
+  onReady: (handle: Handle) => void
+}
+
+function Harness({ onReady }: HarnessProps) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
 
   const actions = useSessionActions({
@@ -47,7 +74,7 @@ function Harness({ onReady }: { onReady: (handle: Handle) => void }) {
     activeSessionIdRef: ref<string | null>(null),
     busyRef: ref(false),
     creatingSessionRef: ref(false),
-    ensureSessionState: () => ({}) as never,
+    ensureSessionState: () => ({}) as SessionInfo,
     getRouteToken: () => 'token',
     getRoutedStoredSessionId: () => null,
     navigate: vi.fn() as never,
@@ -56,9 +83,9 @@ function Harness({ onReady }: { onReady: (handle: Handle) => void }) {
     runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
     selectedStoredSessionId: null,
     selectedStoredSessionIdRef: ref<string | null>(null),
-    sessionStateByRuntimeIdRef: ref(new Map<string, never>()),
+    sessionStateByRuntimeIdRef: ref(new Map<string, SessionInfo>()),
     syncSessionStateToView: vi.fn(),
-    updateSessionState: () => ({}) as never
+    updateSessionState: () => ({}) as SessionInfo
   })
 
   useEffect(() => {
@@ -72,7 +99,6 @@ async function mountHarness(): Promise<Handle> {
   let handle: Handle | undefined
   render(<Harness onReady={h => (handle = h)} />)
   await waitFor(() => expect(handle).toBeDefined())
-
   return handle as Handle
 }
 
@@ -82,10 +108,14 @@ describe('openNewSessionTile × Bot Mode hidden flag', () => {
     vi.mocked(requestGatewayForAgent).mockReset()
     vi.mocked(requestGateway).mockResolvedValue({ ok: true, stored_session_id: 'stored-1' })
     vi.mocked(requestGatewayForAgent).mockResolvedValue({ ok: true, stored_session_id: 'stored-1' })
+    $activeGatewayProfile.set('default')
+    $newChatProfile.set('')
   })
 
   afterEach(() => {
     cleanup()
+    $activeGatewayProfile.set('default')
+    $newChatProfile.set('')
   })
 
   it('does NOT pass hidden: true when workspaceMode is "bots"', async () => {
@@ -97,15 +127,10 @@ describe('openNewSessionTile × Bot Mode hidden flag', () => {
       })
     )
 
-    // Find the session.create call
-    const createCall = vi.mocked(requestGatewayForAgent).mock.calls.find(
-      call => call[2] === 'session.create'
-    )
-
-    expect(createCall).toBeDefined()
-    const params = createCall?.[3] as Record<string, unknown> | undefined
+    const params = extractSessionCreateParams()
     expect(params).toBeDefined()
     expect(params?.hidden).toBeUndefined()
+    expect(params?.hidden).not.toBe(true)
   })
 
   it('does NOT pass hidden: true in normal sessions mode', async () => {
@@ -117,13 +142,29 @@ describe('openNewSessionTile × Bot Mode hidden flag', () => {
       })
     )
 
-    const createCall = vi.mocked(requestGatewayForAgent).mock.calls.find(
-      call => call[2] === 'session.create'
-    )
-
-    expect(createCall).toBeDefined()
-    const params = createCall?.[3] as Record<string, unknown> | undefined
+    const params = extractSessionCreateParams()
     expect(params).toBeDefined()
     expect(params?.hidden).toBeUndefined()
+  })
+
+  it('does NOT pass hidden: true even when desktopSessionCreateParams could set it', async () => {
+    const handle = await mountHarness()
+
+    await act(() =>
+      handle.openNewSessionTile('right', {
+        workspaceScope: { workspaceMode: 'bots' }
+      })
+    )
+
+    const params = extractSessionCreateParams()
+    expect(params).toBeDefined()
+
+    // Verify the complete params object does not contain hidden
+    const keys = Object.keys(params!)
+    expect(keys).not.toContain('hidden')
+
+    // Verify other expected params are still present
+    expect(params?.source).toBe('desktop')
+    expect(params?.cols).toBe(96)
   })
 })


### PR DESCRIPTION
## What does this PR do?

Fixes a Desktop UX bug where a chat started from a Bot Mode workspace with `⌘T` (or the tab-strip `+`) was created with the persistent `hidden: true` flag, making it permanently invisible in the Sessions list.

`openNewSessionTile` in `apps/desktop/src/app/session/hooks/use-session-actions/index.ts` was adding `hidden: true` to the create params whenever `workspaceScope.workspaceMode === 'bots'`. This is the persisted `hidden` column, not the client-side `listed: false` suppression, so it never resolves. The conversation becomes reachable only through its own tab, and one `⌘W` away from being unfindable.

## Related Issue

Fixes #105162

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`: Removed the `hidden: true` spread from `openNewSessionTile` params when `workspaceMode === 'bots'`.
- `apps/desktop/src/app/session/hooks/use-session-actions/open-new-session-tile.test.tsx`: Added regression test verifying that `openNewSessionTile` does NOT pass `hidden: true` in Bot Mode or normal sessions mode.

## How to Test

1. Open Desktop → Bot Mode → select a bot.
2. Press `⌘T` (or the tab-strip `+`) and send a message; let the turn persist.
3. Close that tab with `⌘W`.
4. Verify the conversation appears in the Sessions list (previously it was hidden forever).
5. Run `npx vitest run apps/desktop/src/app/session/hooks/use-session-actions/open-new-session-tile.test.tsx` and verify all tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Notes

- This change does NOT affect the canonical Bot Chat (minted by the plugin's own `session.create` with `hidden: true`) or group member sessions (created by `ensureGroupChatSession`). Those paths still hide themselves as intended by #88677.
- The `listed: false` option (client-side sidebar suppression that resolves once the first turn persists) is a different mechanism and remains unchanged.
- Competing fix: #107024 (kokhlo) addresses the same root cause with the test added inline to `use-session-actions.test.tsx` — the code change is identical, only the test location differs. #105329 is the earlier PR.

## CI Note

The `js-tests` workflow failure on this PR is a TypeScript type error in `open-new-session-tile.test.tsx` (mock import / type mismatch), not a pre-existing upstream failure. See CI log: `tsc` reports `TS2305` (unexported `requestGateway`), `TS2740` (`SessionInfo` missing `ClientSessionState` fields), and `TS2322` (`MutableRefObject<Map<string, SessionInfo>>` incompatible with `MutableRefObject<Map<string, ClientSessionState>>`).