### PR TITLE
fix(photon): upload voice notes under an .m4a name matching the re-encoded payload

### DIFF
--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -67,6 +67,7 @@ import crypto from "node:crypto";
 import { once } from "node:events";
 import { patchSpectrumTs } from "./patch-spectrum-mixed-attachments.mjs";
 import { chooseSendFormat } from "./send-format.mjs";
+import { voiceAttachmentName } from "./voice-attachment-name.mjs";
 import {
   classifyProbeRejection,
   shouldProbe,
@@ -1091,7 +1092,16 @@ const server = http.createServer(async (req, res) => {
       // overrides only when Hermes supplied them so a known-good
       // inference isn't clobbered with an empty string.
       const opts = {};
-      if (name) opts.name = name;
+      if (kind === "voice") {
+        // spectrum-ts re-encodes non-m4a audio to m4a but uploads it under
+        // the original basename; an .mp3-named m4a voice note renders as a
+        // corrupted, unplayable bubble on iOS (#88083). Name the upload what
+        // the payload will actually be.
+        const voiceName = voiceAttachmentName(path, name);
+        if (voiceName) opts.name = voiceName;
+      } else if (name) {
+        opts.name = name;
+      }
       if (mimeType) opts.mimeType = mimeType;
       const builder =
         kind === "voice"

--- a/plugins/platforms/photon/sidecar/voice-attachment-name.mjs
+++ b/plugins/platforms/photon/sidecar/voice-attachment-name.mjs
@@ -1,0 +1,39 @@
+// Voice-attachment upload naming for the Photon sidecar.
+//
+// spectrum-ts's iMessage `voice()` path transcodes non-m4a audio to an m4a
+// container before upload, but uploads it under `content.name` — which
+// defaults to the basename of the path Hermes passes (e.g. `1234.mp3` from
+// the TTS cache). iOS then receives a voice note whose .mp3 file name
+// disagrees with its m4a payload and renders it as a short, unplayable
+// bubble (#88083). Naming the upload what the payload actually is (.m4a)
+// matches the manually-verified direct-sidecar path, where a real .m4a is
+// delivered intact.
+//
+// This lives in its own module (rather than inline in index.mjs) so tests can
+// execute the real naming logic under node instead of grepping source — see
+// tests/plugins/platforms/photon/test_voice_attachment_name.py.
+
+import { basename, extname } from "node:path";
+
+const M4A_EXTENSIONS = new Set([".m4a", ".m4b", ".m4p"]);
+
+/**
+ * Name spectrum-ts should upload a voice note under. spectrum-ts re-encodes
+ * non-m4a audio to m4a, so any non-m4a extension must be rewritten to .m4a
+ * to keep the upload name and the payload container in agreement.
+ *
+ * @param {string} path the local audio path Hermes delivers
+ * @param {string | undefined} name explicit name from the request, if any
+ * @returns {string | undefined} name to pass to the voice() builder
+ */
+export function voiceAttachmentName(path, name) {
+  const base = String(name || basename(String(path)));
+  const ext = extname(base).toLowerCase();
+  if (!ext) {
+    return base + ".m4a";
+  }
+  if (M4A_EXTENSIONS.has(ext)) {
+    return name || undefined;
+  }
+  return base.slice(0, base.length - ext.length) + ".m4a";
+}

--- a/tests/plugins/platforms/photon/test_voice_attachment_name.py
+++ b/tests/plugins/platforms/photon/test_voice_attachment_name.py
@@ -1,0 +1,102 @@
+"""Behavior tests for Photon voice-attachment upload naming (#88083).
+
+spectrum-ts's iMessage ``voice()`` path re-encodes non-m4a audio to an m4a
+container (``ensureM4a``) but uploads the result under the original basename
+of the delivered path — e.g. a TTS-cache ``1234.mp3``. iOS receives a voice
+note whose ``.mp3`` file name disagrees with its m4a payload and renders it
+as a short, unplayable bubble, while the same bytes hand-posted to the sidecar
+as a real ``.m4a`` play end-to-end. The sidecar must therefore name every
+voice upload what the payload will actually be.
+
+The naming decision lives in
+``plugins/platforms/photon/sidecar/voice-attachment-name.mjs`` (imported by
+index.mjs's ``/send-attachment`` handler). These tests *execute* that real
+module under node and assert the resulting upload name for representative
+inputs — they do not read the sidecar source.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+import pytest
+
+_MODULE = Path("plugins/platforms/photon/sidecar/voice-attachment-name.mjs").resolve()
+
+_CASES: Dict[str, Tuple[str, Optional[str], Optional[str]]] = {
+    # name: (path, explicit name, expected upload name)
+    "tts_cache_mp3_renamed_to_m4a": (
+        "/home/u/.hermes/audio_cache/1757212345.mp3",
+        None,
+        "1757212345.m4a",
+    ),
+    "ogg_voice_renamed_to_m4a": (
+        "/tmp/out.ogg",
+        None,
+        "out.m4a",
+    ),
+    "wav_voice_renamed_to_m4a": (
+        "/tmp/clip.wav",
+        "clip.wav",
+        "clip.m4a",
+    ),
+    "aac_adts_renamed_to_m4a": (
+        # Bare ADTS .aac has no ftyp header, so spectrum-ts re-encodes it too.
+        "/tmp/note.aac",
+        None,
+        "note.m4a",
+    ),
+    "m4a_keeps_its_name": (
+        "/tmp/voice.m4a",
+        None,
+        None,
+    ),
+    "explicit_m4a_name_kept_verbatim": (
+        "/tmp/anything.mp3",
+        "reply.m4a",
+        "reply.m4a",
+    ),
+    "extensionless_name_gets_m4a": (
+        "/tmp/blob",
+        "voiceclip",
+        "voiceclip.m4a",
+    ),
+}
+
+
+@pytest.fixture(scope="module")
+def verdicts() -> Dict[str, Optional[str]]:
+    """Run every case through the real voice-attachment-name module in one node call."""
+    harness = (
+        f"import {{ voiceAttachmentName }} from {json.dumps(_MODULE.as_uri())};\n"
+        "const chunks = [];\n"
+        "process.stdin.on('data', (c) => chunks.push(c));\n"
+        "process.stdin.on('end', () => {\n"
+        "  const cases = JSON.parse(Buffer.concat(chunks).toString('utf-8'));\n"
+        "  const out = {};\n"
+        "  for (const [name, [path, explicit]] of Object.entries(cases)) {\n"
+        "    out[name] = voiceAttachmentName(path, explicit ?? undefined) ?? null;\n"
+        "  }\n"
+        "  process.stdout.write(JSON.stringify(out));\n"
+        "});\n"
+    )
+    payload = {name: [path, explicit] for name, (path, explicit, _) in _CASES.items()}
+    run = subprocess.run(
+        ["node", "--input-type=module", "-e", harness],
+        input=json.dumps(payload),
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert run.returncode == 0, run.stderr
+    return json.loads(run.stdout)
+
+
+@pytest.mark.parametrize("name", sorted(_CASES))
+def test_voice_upload_name(name: str, verdicts: Dict[str, Optional[str]]) -> None:
+    _, _, expected = _CASES[name]
+    assert verdicts[name] == expected


### PR DESCRIPTION
## What does this PR do?

Fixes corrupted iMessage voice replies on the Photon channel. spectrum-ts's iMessage `voice()` path re-encodes non-m4a audio into an m4a container (`ensureM4a`) but uploads the result under `content.name`, which defaults to the basename of the path Hermes delivers. A TTS reply cached as `audio_cache/<ts>.mp3` therefore arrives on iOS as a voice note whose `.mp3` file name disagrees with its m4a payload — rendering as a ~4-second unplayable bubble (#88083). The issue's control experiment confirms the divergence is not in synthesis or the sidecar transport: hand-posting the same audio as a real `.m4a` to `/send-attachment` with `kind:"voice"` plays end-to-end, because there the upload name and the container agree.

The sidecar now names every voice upload what the payload will actually be: non-m4a (or missing) extensions are rewritten to `.m4a`, and m4a-family names pass through untouched. Plain attachments (`kind="attachment"`) are unaffected.

## Related Issue

Fixes #88083

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/photon/sidecar/voice-attachment-name.mjs` (new): `voiceAttachmentName(path, name)` — rewrites non-m4a upload names to `.m4a` so the file name always matches the container spectrum-ts uploads.
- `plugins/platforms/photon/sidecar/index.mjs`: the `/send-attachment` handler uses that helper for the `kind="voice"` branch; the attachment branch keeps the previous pass-through behavior.
- `tests/plugins/platforms/photon/test_voice_attachment_name.py` (new): executes the real naming module under node for TTS-cache `.mp3`, `.ogg`, `.wav`, bare `.aac`, `.m4a` passthrough, explicit-name, and extensionless-name cases.

## How to Test

1. `pytest tests/plugins/platforms/photon/test_voice_attachment_name.py -q` — Observed result: 7 passed.
2. `pytest tests/plugins/platforms/photon/ -q` — Observed result: 140 passed, no regressions from the `index.mjs` change.
3. End-to-end on a Photon (iMessage) channel: trigger a `text_to_speech` reply (edge or elevenlabs, cached as `.mp3`) and check the delivered voice bubble on iPhone. Should play at full duration instead of failing after ~4s.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — audio delivery behavior; covered by the node-executed behavior tests above.