### PR TITLE
fix(web): use native ESM directory paths in Vite aliases

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -77,8 +77,8 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@hermes/shared": path.resolve(__dirname, "../apps/shared/src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
+      "@hermes/shared": path.resolve(import.meta.dirname, "../apps/shared/src"),
     },
     // When @nous-research/ui is symlinked via `file:../../design-language`,
     // Node's module resolution would pick up shared deps from


### PR DESCRIPTION
## Summary
Replace __dirname with import.meta.dirname in the two Vite resolve aliases. This removes the Vite 8.2 warning about configuration features unsupported by configLoader: native without suppressing warnings or changing dependencies.

## Verification
- Reproduced the warning before the change.
- TypeScript and production build pass after the change without the warning.
- Production build with --configLoader native passes.
- All 60 output files are SHA-256 identical across the original, corrected, and native-loader builds.
- Tested with Node 22.23.2 and Vite 8.2.0.