### PR TITLE
fix(picker): an exhausted credential pool hides the whole provider from /model

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -190,6 +190,13 @@ def build_model_options_payload(
         ctx, explicit_only=bool(explicit_only), include_unconfigured=bool(include_unconfigured),
         picker_hints=True, canonical_order=True, pricing=True, pricing_cache_only=not refresh,
         capabilities=True, featured=True,
+        # #66624 fixed this for the auxiliary pickers; the main picker had the same gap.
+        # Without ``for_picker`` a provider whose credential pool is entirely in cooldown is
+        # dropped from the payload, so the *whole* provider group disappears from /model and
+        # the Desktop picker. Rate limits are per-model, so an exhausted pool does not mean
+        # every model is unusable — and hiding the row removes the only UI path to switch to
+        # one that still works, including switching away from the model that hit the limit.
+        for_picker=True,
         refresh=refresh, probe_custom_providers=refresh, probe_current_custom_provider=not refresh,
     )
     if not refresh:

--- a/tests/hermes_cli/test_aux_picker_inventory.py
+++ b/tests/hermes_cli/test_aux_picker_inventory.py
@@ -105,6 +105,28 @@ def test_aux_picker_requests_exhausted_pool_visibility(configured_home):
     assert seen.get("for_picker") is True
 
 
+def test_model_options_payload_requests_exhausted_pool_visibility():
+    """The MAIN picker needs the same visibility the aux pickers got in #66624.
+
+    ``build_model_options_payload`` backs ``/model``, ``GET /api/model/options``
+    and the Desktop ``ModelPickerDialog``. Without ``for_picker`` a provider whose
+    credential pool is entirely in cooldown is dropped, so the whole group vanishes
+    from the picker — leaving no way to switch to one of its other models, or away
+    from the model that hit the limit."""
+    from hermes_cli import inventory
+
+    seen = {}
+
+    def _capture(_ctx, **kwargs):
+        seen.update(kwargs)
+        return {"providers": []}
+
+    with patch.object(inventory, "build_models_payload", _capture):
+        inventory.build_model_options_payload(inventory.load_picker_context())
+
+    assert seen.get("for_picker") is True
+
+
 # ─── Shared rendering ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

`build_model_options_payload` backs `/model`, `GET /api/model/options` and the Desktop `ModelPickerDialog`, but it does not forward `for_picker` to `build_models_payload`. Any provider whose credential pool is entirely in cooldown is therefore dropped from the payload, so the **entire provider group disappears from the picker**.

I hit this with an `openai-codex` ChatGPT subscription that had reached its weekly limit. The whole *"ChatGPT or Codex Subscription"* group — 12 models — vanished from every profile's picker, while the running session was still successfully serving requests on one of those models. The only visible entry under that heading was the currently-selected model, which made it look like the account had been reduced to a single model.

Because rate limits are **per-model**, the effect is worse than cosmetic: there is no longer any UI path to switch to a model that still works, or to switch *away* from the model that hit the limit.

## Why `for_picker` is the right fix

`build_aux_picker_rows` already forwards this flag for exactly this reason (#66624, @Drexuxux), and the flag's own comment in `model_switch_providers` states the rationale:

> Show providers whose pool is entirely in cooldown: limits are per-model for many providers, so another model may work.

The auxiliary pickers got that fix; the main picker was simply missing it.

## Change

- `hermes_cli/inventory.py` — forward `for_picker=True` from `build_model_options_payload`.
- `tests/hermes_cli/test_aux_picker_inventory.py` — regression test placed next to the existing #66624 aux-picker test, pinning the same seam for the main payload builder.

## Verification

- The new test **fails without** the one-line change and passes with it (confirmed by stashing the fix and re-running).
- `tests/hermes_cli/test_inventory.py`, `test_aux_picker_inventory.py`, `test_codex_cli_model_picker.py`, `test_anthropic_picker_curated.py` — 29 passed.
- Confirmed on a live install: the provider payload went from 9 providers with 0 `openai-codex` rows to 11 providers including `ChatGPT or Codex Subscription` with all 12 models. On this install it also restored a hidden OpenRouter row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
