### PR TITLE
fix(desktop): keep background work out of Done

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -1,18 +1,32 @@
-import { cleanup, render } from '@testing-library/react'
+import { act, cleanup, render } from '@testing-library/react'
 import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $sessions, $unreadFinishedSessionIds } from '@/store/session'
+import { $sessionDotStateById, sessionStatusBucket } from '@/store/session-dot-state'
+import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
 
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import type { VirtualSessionListProps } from './virtual-session-list'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  clearAllSessionStates()
+  $sessions.set([])
+  $unreadFinishedSessionIds.set([])
+  $subagentsBySession.set({})
+})
+
+const statusDivider = vi.hoisted(() => ({ done: 'Done', working: 'Working' }))
 
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
     t: {
       sidebar: {
+        statusDivider,
         dateDivider: {
           earlierThisMonth: 'Earlier this month',
           lastMonth: 'Last month',
@@ -60,6 +74,83 @@ function generateSessions(count: number): SessionInfo[] {
 const noop = () => {}
 
 describe('SidebarSessionsSection memoization & virtualizer stability', () => {
+  it('keeps delegated work in Working until it settles, independently of unread state', () => {
+    mockVirtualListPropsHistory.length = 0
+    const sessions = generateSessions(VIRTUALIZE_THRESHOLD + 1)
+    const storedId = sessions[0].id
+    $sessions.set(sessions)
+    const state = createClientSessionState(storedId)
+    publishSessionState('runtime', { ...state, busy: true })
+
+    render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>Empty</div>}
+        grouping="status"
+        label="Sessions"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        onToggleUnread={noop}
+        open={true}
+        pinned={false}
+        sessions={sessions}
+      />
+    )
+
+    const groupOfSession = () => {
+      let group = ''
+
+      for (const row of mockVirtualListPropsHistory.at(-1)!.rows) {
+        if (row.kind === 'divider') {
+          group = row.key
+        } else if (row.entry.session.id === storedId) {
+          return group
+        }
+      }
+    }
+
+    expect(groupOfSession()).toBe('status:working')
+    act(() => {
+      upsertSubagent('runtime', { subagent_id: 'child', status: 'queued' }, true, 'subagent.start')
+      publishSessionState('runtime', { ...state, busy: false })
+    })
+    expect($sessionDotStateById.get()[storedId]).toBe('background')
+    expect(sessionStatusBucket($sessionDotStateById.get()[storedId])).toBe('working')
+    expect(groupOfSession()).toBe('status:working')
+
+    act(() => {
+      upsertSubagent('runtime', { subagent_id: 'child', status: 'running' }, true, 'subagent.progress')
+      $unreadFinishedSessionIds.set([storedId])
+    })
+    expect(groupOfSession()).toBe('status:working')
+    act(() => $unreadFinishedSessionIds.set([]))
+    expect(groupOfSession()).toBe('status:working')
+
+    act(() => publishSessionState('runtime', { ...state, busy: true, needsInput: true }))
+    expect($sessionDotStateById.get()[storedId]).toBe('needs-input')
+    expect(groupOfSession()).toBe('status:working')
+    act(() => publishSessionState('runtime', { ...state, busy: false }))
+    expect($sessionDotStateById.get()[storedId]).toBe('background')
+    expect(groupOfSession()).toBe('status:working')
+
+    act(() => {
+      upsertSubagent('runtime', { subagent_id: 'child', status: 'completed' }, true, 'subagent.complete')
+      publishSessionState('runtime', { ...state, busy: true })
+    })
+    expect(groupOfSession()).toBe('status:working')
+    act(() => {
+      publishSessionState('runtime', { ...state, busy: false })
+      $unreadFinishedSessionIds.set([storedId])
+    })
+    expect($sessionDotStateById.get()[storedId]).toBe('unread')
+    expect(groupOfSession()).toBe('status:done')
+    act(() => $unreadFinishedSessionIds.set([]))
+    expect(groupOfSession()).toBe('status:done')
+  })
+
   it('memoizes flatRows and passes the exact same rows array reference across parent re-renders', () => {
     mockVirtualListPropsHistory.length = 0
 

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -27,7 +27,7 @@ import {
   toggleWorkspaceNodeCollapsed
 } from '@/store/layout'
 import { sessionPinId } from '@/store/session'
-import { $sessionDotStateById, hasLiveTurn } from '@/store/session-dot-state'
+import { $sessionDotStateById, sessionStatusBucket } from '@/store/session-dot-state'
 
 import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
 import { mergeVisibleReorder, orderRowsWithinGroups, reorderableRowIds } from './order'
@@ -396,7 +396,11 @@ export function SidebarSessionsSection({
         : grouping === 'status'
           ? groupEntriesByStatus(
               displayEntries,
-              entry => hasLiveTurn(dotStates[entry.session.id] ?? 'idle'),
+              entry => {
+                const bucket = sessionStatusBucket(dotStates[entry.session.id])
+
+                return bucket === 'working' || bucket === 'needs-input'
+              },
               statusDividerLabels
             )
           : toSessionRows(displayEntries)

--- a/apps/desktop/src/components/assistant-ui/thread/background-resume-notice.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/background-resume-notice.test.tsx
@@ -1,0 +1,41 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+
+import { en } from '@/i18n/en'
+import { $activeSessionId, $busy } from '@/store/session'
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
+
+import { BackgroundResumeNotice } from './status'
+
+afterEach(() => {
+  cleanup()
+  $activeSessionId.set(null)
+  $busy.set(false)
+  $subagentsBySession.set({})
+})
+
+it('identifies parked background work instead of presenting child thinking as parent activity', () => {
+  $activeSessionId.set('parent')
+  $busy.set(false)
+  upsertSubagent('parent', { subagent_id: 'first', status: 'running', text: 'Ruminating…' }, true, 'subagent.thinking')
+  upsertSubagent('parent', { subagent_id: 'second', status: 'queued' }, true, 'subagent.start')
+
+  render(<BackgroundResumeNotice />)
+  expect(screen.getByRole('status').textContent).toBe(en.assistant.thread.resumeWhenBackgroundDone(2))
+  expect(screen.getByTitle('Ruminating…')).toBeTruthy()
+
+  act(() => $activeSessionId.set('elsewhere'))
+  expect(screen.queryByRole('status')).toBeNull()
+  act(() => $activeSessionId.set('parent'))
+  expect(screen.getByRole('status').textContent).toBe(en.assistant.thread.resumeWhenBackgroundDone(2))
+
+  act(() => upsertSubagent('parent', { subagent_id: 'first', status: 'completed' }, true, 'subagent.complete'))
+  expect(screen.getByRole('status').textContent).toBe(en.assistant.thread.resumeWhenBackgroundDone(1))
+  act(() => $busy.set(true))
+  expect(screen.queryByRole('status')).toBeNull()
+  act(() => {
+    upsertSubagent('parent', { subagent_id: 'second', status: 'failed' }, true, 'subagent.complete')
+    $busy.set(false)
+  })
+  expect(screen.queryByRole('status')).toBeNull()
+})

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -282,7 +282,7 @@ export const BackgroundResumeNotice: FC = () => {
     return null
   }
 
-  const label = resume.activity ?? t.assistant.thread.resumeWhenBackgroundDone(resume.count)
+  const label = t.assistant.thread.resumeWhenBackgroundDone(resume.count)
 
   return (
     <div
@@ -292,7 +292,9 @@ export const BackgroundResumeNotice: FC = () => {
       role="status"
     >
       <Codicon className="text-muted-foreground/55" name="sync" size="0.75rem" />
-      <span className="shimmer min-w-0 truncate">{label}</span>
+      <span className="min-w-0 truncate" title={resume.activity ?? undefined}>
+        {label}
+      </span>
     </div>
   )
 }

--- a/apps/desktop/src/store/background-delegation.ts
+++ b/apps/desktop/src/store/background-delegation.ts
@@ -4,9 +4,8 @@ import { $activeSessionId, $busy } from './session'
 import { $subagentsBySession, type SubagentProgress } from './subagents'
 
 export interface BackgroundResume {
-  /** Latest live activity from the primary child (its newest stream line), or
-   *  null when nothing readable has arrived yet — the UI then falls back to the
-   *  generic "will resume" copy. */
+  /** Latest live activity from the primary child, for on-demand detail without
+   *  replacing the notice's explicit background-resume label. */
   activity: string | null
   /** Running/queued background children for the active session. */
   count: number
@@ -20,9 +19,9 @@ const RUNNING = (s: SubagentProgress) => s.status === 'running' || s.status === 
  * A top-level `delegate_task` always runs in the background: the parent turn
  * ends (`$busy` -> false) while the subagent keeps running, and its result
  * re-enters the conversation as a fresh turn when it finishes. During that
- * window the app is genuinely idle but work is still happening elsewhere, so we
- * surface a calm, shimmering status line (its latest activity, or a generic
- * "will resume" fallback) instead of a spinner that reads as "stuck."
+ * window the parent is idle but its work is not finished. Surface an explicit
+ * "will resume" status, with child activity available on demand, rather than
+ * presenting the child's thinking as if the parent were still running.
  *
  * Null while `$busy`: an active turn already owns the main loader, and subagents
  * spawned inside a running turn (synchronous orchestrator children) are part of


### PR DESCRIPTION
## What does this PR do?

A Desktop conversation can appear under **Done** while its background subagents are still working. The same session is included by the **Working** status filter and shows a hollow background dot. Its transcript footer may also show a child's raw thinking text, making it look as if the parent model is still running.

Use the existing aggregate `sessionStatusBucket` for Working/Done grouping, instead of the parent-only `hasLiveTurn` predicate. Keep the footer's explicit background-resume label visible and retain child activity as hover detail, without the thinking shimmer.

This preserves the distinction between parent activity, delegated/background work, and unread results. Opening a conversation may acknowledge a new result, but does not mark live background work finished. Parent-only arcs and timers are unchanged.

## Related Issue

No issue claimed as fixed. Reproduced on upstream `main`.

Related prior work: #87915 changes delegated lifecycle/rehydration and parent working claims; #103370 proposes distinct purple child/background dots but retains parent-only status grouping. This is the narrower grouping/filter consistency fix and explicit parked-work notice, with no new status type, hydration API, or dot redesign. #98673 addresses separate cross-pane notice ownership; #105093 addresses completed handoff transcript clutter. Those concerns are not changed here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/sessions-section.tsx`: group aggregate working and needs-input buckets under Working, matching the existing filter's classification of background work.
- `apps/desktop/src/components/assistant-ui/thread/status.tsx`: always display existing localized background-resume copy; keep detailed child activity in the title tooltip.
- `apps/desktop/src/store/background-delegation.ts`: update comments to reflect the notice's presentation contract.
- Two behavioral regression tests cover runtime/stored identity, queued/running children, unread acknowledgement, needs-input priority, parent resumption, final settlement, child failure, and switching the active session.

## How to Test

1. Select status grouping in the Sessions sidebar. Start a turn that delegates work and ends its own response while children remain active.
2. Verify the parent stays under Working, including when opened/read. Its footer should explicitly say it will resume when background tasks finish, not display the child's thinking as the parent's activity.
3. Let the children finish and the parent resume. Verify Working persists during the resumed turn, then becomes Done after settlement. Opening an unread result should clear unread without changing that settled grouping.
4. Verify needs-input retains its attention dot and remains outside Done.

### Verification performed

- Both new regressions observed failing on unfixed code for the exact symptoms, then passing with the fix.
- Focused regression and sibling-path matrix: 85 tests passed across eight files.
- Extended needs-input phase and notice/store tests: 10 tests passed across three files.
- Renderer TypeScript, changed-file ESLint/Prettier, and staged whitespace checks passed.
- Independent read-only review: no correctness, security, or privacy blockers.
- First full UI + Electron run: 9,473 passed, 6 skipped, one failure in the untouched `shiki-block.test.tsx` multi-block highlighting wait. The test and directly imported component/cache/config are byte-identical to upstream; the file passed its direct rerun and ten additional isolated runs. No unrelated highlighting changes are included.
- Final full UI + Electron run after updating onto upstream: **9,474 passed, 6 skipped**, across 897 passing files and two skipped files.
- Real isolated Linux Electron integration, independently rerun against the updated base: eight DOM/RPC checkpoints passed. The pending parent stayed Working across opening/read acknowledgement; real child completion re-entered the parent; its resumed turn stayed Working across away/back; final settlement became Done/unread, then read on opening, with no lingering background notice. SQLite confirmed the child-parent relationship and stored handoff/final reply; no page errors were observed.
- Integration used a credential-free local deterministic OpenAI-compatible provider, not external model inference or fabricated renderer atoms. Chromium-loaded source-map contents matched the checked-out implementation.
- Production renderer build passed. Both unfixed and fixed real-app captures used the same viewport, zoom, and theme; the latest fixed capture comes from the independent rerun.

## Checklist

### Code

- [x] I've read the Contributing Guide and scoped Desktop engineering guides.
- [x] Commit messages follow Conventional Commits.
- [x] I searched existing PRs; overlap is disclosed above.
- [x] This PR contains only changes related to this fix.
- [ ] I've run the entire Python suite and all tests pass — not run for this renderer-only change.
- [x] I've added behavioral regression tests.
- [x] I've tested the live Desktop behavior on Linux.

### Documentation & Housekeeping

- [x] Relevant comments updated; existing translated copy reused.
- [x] Config examples: N/A.
- [x] Architecture/workflow changes: N/A.
- [x] Cross-platform impact considered; no OS-specific code added. macOS/Windows not exercised locally.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

Sanitized synthetic-checklist integration in the real Desktop app. No real conversation content, session/task identifiers, private home paths, credentials, or raw logs are published. PNG metadata was stripped; uploaded bytes were read back and SHA-256 verified. Commit identity uses a GitHub noreply address.

[Full-size before](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/64f8d2d908e43c66e0ae900a6d66f995914b13ed/before.png) · [Full-size after](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/64f8d2d908e43c66e0ae900a6d66f995914b13ed/after.png)

![Before: background work appears under Done. After: it stays under Working.](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/64f8d2d908e43c66e0ae900a6d66f995914b13ed/sidebar-before-after-2x.png)

![Before: raw child thinking. After: explicit background-resume notice.](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/64f8d2d908e43c66e0ae900a6d66f995914b13ed/notice-before-after-2x.png)

![Full desktop comparison](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/64f8d2d908e43c66e0ae900a6d66f995914b13ed/before-after.png)

---
Implemented by gpt-6-astra via Hermes Agent.
