### PR TITLE
fix(desktop): recover sidebar badges for agent-created pull requests

### DIFF
--- a/apps/desktop/electron/git-ipc.ts
+++ b/apps/desktop/electron/git-ipc.ts
@@ -98,8 +98,8 @@ export function registerGitIpc({ resolveGitBinary, resolveGhBinary }: GitIpcDeps
   )
   ipcMain.handle('hermes:git:review:push', async (_event, repoPath) => reviewPush(repoPath, resolveGitBinary()))
   ipcMain.handle('hermes:git:review:shipInfo', async (_event, repoPath) => reviewShipInfo(repoPath, resolveGhBinary()))
-  ipcMain.handle('hermes:git:review:prList', async (_event, repoPath, branches, numbers) =>
-    reviewPrList(repoPath, resolveGhBinary(), branches, numbers)
+  ipcMain.handle('hermes:git:review:prList', async (_event, repoPath, branches, numbers, urls) =>
+    reviewPrList(repoPath, resolveGhBinary(), branches, numbers, urls)
   )
   ipcMain.handle('hermes:git:review:fetchPrComment', async (_event, repoPath, url) =>
     reviewFetchPrComment(repoPath, resolveGhBinary(), url)

--- a/apps/desktop/electron/git-pr-list-ipc.test.ts
+++ b/apps/desktop/electron/git-pr-list-ipc.test.ts
@@ -1,0 +1,44 @@
+import { expect, it, vi } from 'vitest'
+
+import { registerGitIpc } from './git-ipc'
+
+interface PrListBridge {
+  git: { review: { prList: (...args: unknown[]) => Promise<{ prs: { url: string }[] }> } }
+}
+
+const bridge = vi.hoisted(() => ({
+  exposed: null as PrListBridge | null,
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  execFile: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({ execFile: bridge.execFile }))
+vi.mock('electron', () => ({
+  contextBridge: {
+    exposeInMainWorld: (_name: string, api: PrListBridge) => {
+      bridge.exposed = api
+    }
+  },
+  ipcMain: { handle: (name: string, handler: (...args: unknown[]) => unknown) => bridge.handlers.set(name, handler) },
+  ipcRenderer: {
+    sendSync: () => ({}),
+    invoke: (name: string, ...args: unknown[]) => bridge.handlers.get(name)!({}, ...args)
+  },
+  webFrame: {},
+  webUtils: {}
+}))
+
+it('carries URL-only PR hydration through the actual preload and IPC handler', async () => {
+  const url = 'https://github.com/other/repository/pull/42'
+
+  bridge.execFile.mockImplementation((_bin, args, _options, callback) => {
+    callback(null, JSON.stringify({ headRefName: 'feature', number: 42, url: args[2], state: 'OPEN' }))
+  })
+  registerGitIpc({ resolveGitBinary: () => 'git', resolveGhBinary: () => 'gh' })
+  await import('./preload')
+
+  const result = await bridge.exposed!.git!.review.prList('', [], [], [url])
+
+  expect(result.prs.map(pr => pr.url)).toEqual([url])
+  expect(bridge.execFile.mock.calls[0][1].slice(0, 3)).toEqual(['pr', 'view', url])
+})

--- a/apps/desktop/electron/git-pr-list.test.ts
+++ b/apps/desktop/electron/git-pr-list.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { reviewPrList } from './git-review-ops'
+
+const { execFile } = vi.hoisted(() => ({ execFile: vi.fn() }))
+
+vi.mock('node:child_process', () => ({ execFile }))
+
+afterEach(() => vi.resetAllMocks())
+
+it('keeps legacy branch/number results while marking failed URL hydration non-authoritative', async () => {
+  const known = { headRefName: 'feature', number: 42, state: 'OPEN', url: 'https://github.com/owner/repo/pull/42' }
+
+  const queries: string[] = []
+
+  execFile.mockImplementation((_bin, args, _options, callback) => {
+    if (args[0] === 'repo') {
+      callback(null, 'owner/repo')
+    } else if (args[0] === 'api') {
+      queries.push(args[3])
+      callback(null, JSON.stringify({ data: { repository: { b0: { nodes: [known] }, n0: known } } }))
+    } else {
+      callback(null, 'not JSON')
+    }
+  })
+
+  const legacy = await reviewPrList(process.cwd(), 'gh', ['feature'], [42])
+
+  expect(queries.join('\n')).toContain('headRefName: "feature"')
+  expect(queries.join('\n')).toContain('pullRequest(number: 42)')
+  expect(legacy.ghReady).toBe(true)
+  expect(legacy.prs.map(pr => pr.url)).toContain(known.url)
+
+  const failed = await reviewPrList(process.cwd(), 'gh', ['feature'], [42], ['https://github.com/other/repo/pull/42'])
+
+  expect(failed.prs.map(pr => pr.url)).toContain(known.url)
+  expect(failed.ghReady).toBe(false)
+  execFile.mockImplementation((_bin, _args, _options, callback) => callback(new Error('network unavailable'), ''))
+  expect(await reviewPrList('', 'gh', [], [], [known.url])).toEqual({ ghReady: false, prs: [] })
+})
+
+it('hydrates explicit GitHub PR identities without a checkout using bounded, validated reads', async () => {
+  const urls = [
+    ...Array.from({ length: 9 }, (_, i) => `https://github.com/owner/repo-${i}/pull/42`),
+    'https://github.com/actions/.github/pull/221',
+    'https://github.com/owner/.config/pull/42/'
+  ]
+
+  const calls: string[][] = []
+  let active = 0
+  let peak = 0
+
+  execFile.mockImplementation((_bin, args, options, callback) => {
+    calls.push(args)
+    expect(options.cwd).toBeUndefined()
+    active++
+    peak = Math.max(peak, active)
+    setImmediate(() => {
+      active--
+      callback(
+        null,
+        JSON.stringify({
+          headRefName: 'feature',
+          isDraft: true,
+          number: 42,
+          state: 'MERGED',
+          title: args[2],
+          url: args[2]
+        })
+      )
+    })
+  })
+
+  const result = await reviewPrList(
+    '',
+    'gh',
+    [],
+    [],
+    [
+      ...urls,
+      urls[0],
+      'https://evil.example/owner/repo/pull/42',
+      'https://github.com.evil.example/owner/repo/pull/42',
+      'https://github.com@evil.example/owner/repo/pull/42',
+      'http://github.com/owner/repo/pull/42',
+      'https://github.com/owner/repo/pull/0',
+      'https://github.com/owner/./pull/42',
+      'https://github.com/owner/../pull/42',
+      'https://github.com/./repo/pull/42',
+      'https://github.com/../repo/pull/42',
+      'https://github.com/owner/%2e/pull/42',
+      'https://github.com/owner/%2e%2e/pull/42',
+      'https://github.com/owner/.github/../repo/pull/42',
+      'https://github.com/owner/repo/pull/42\n'
+    ]
+  )
+
+  expect(result.ghReady).toBe(true)
+  expect(result.prs.map(pr => pr.url)).toEqual(urls)
+  expect(result.prs[0]).toMatchObject({ branch: 'feature', draft: true, number: 42, state: 'merged' })
+  expect(calls.map(args => args.slice(0, 3))).toEqual(urls.map(url => ['pr', 'view', url]))
+  expect(calls.every(args => args[3] === '--json' && args[4].includes('headRefName'))).toBe(true)
+  expect(peak).toBeGreaterThan(1)
+  expect(peak).toBeLessThanOrEqual(4)
+})

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -693,7 +693,59 @@ async function reviewFetchPrComment(repoPath, ghBin, url) {
 // branches we actually have sessions on rather than listing the repo's newest
 // PRs and hoping ours are in the page — on a busy repo they are not. One
 // GraphQL request per 50 branches; reads only.
-async function reviewPrList(repoPath, ghBin, branches, numbers) {
+async function reviewPrList(repoPath, ghBin, branches, numbers, urls?: string[]) {
+  // Explicit URLs carry their own repository identity; never resolve them against
+  // a session checkout (which may be unrelated, deleted, or absent).
+  const wantedUrls = [
+    ...new Set(
+      (urls || []).filter(
+        url =>
+          typeof url === 'string' &&
+          /^https:\/\/github\.com\/[A-Za-z0-9][A-Za-z0-9-]*\/(?!\.{1,2}\/)[A-Za-z0-9_.][A-Za-z0-9_.-]*\/pull\/[1-9][0-9]*\/?$/.test(
+            url
+          ) &&
+          !/\s/.test(url)
+      )
+    )
+  ].slice(0, PR_QUERY_BRANCH_CAP)
+
+  const result =
+    branches?.length || numbers?.length
+      ? await reviewRepoPrList(repoPath, ghBin, branches, numbers)
+      : { ghReady: false, prs: [] }
+
+  let urlsReady = true
+
+  for (let start = 0; start < wantedUrls.length; start += 4) {
+    const batch = await Promise.all(
+      wantedUrls.slice(start, start + 4).map(async url => {
+        const res = await runGh(['pr', 'view', url, '--json', PR_NODE_FIELDS.split(' ').join(',')], undefined, ghBin)
+
+        if (!res.ok) {
+          return null
+        }
+
+        result.ghReady = true
+
+        try {
+          const pr = JSON.parse(res.stdout)
+
+          return pr?.headRefName ? prPayload(pr) : null
+        } catch {
+          return null
+        }
+      })
+    )
+
+    urlsReady &&= batch.every(pr => pr !== null)
+    result.prs.push(...batch.filter(pr => pr !== null))
+  }
+
+  // A partial/network failure must not evict previously confirmed badges.
+  return { ghReady: result.ghReady && urlsReady, prs: [...new Map(result.prs.map(pr => [pr.url, pr])).values()] }
+}
+
+async function reviewRepoPrList(repoPath, ghBin, branches, numbers) {
   let cwd
 
   try {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -350,8 +350,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
       commitContext: repoPath => ipcRenderer.invoke('hermes:git:review:commitContext', repoPath),
       push: repoPath => ipcRenderer.invoke('hermes:git:review:push', repoPath),
       shipInfo: repoPath => ipcRenderer.invoke('hermes:git:review:shipInfo', repoPath),
-      prList: (repoPath, branches, numbers) =>
-        ipcRenderer.invoke('hermes:git:review:prList', repoPath, branches, numbers),
+      prList: (repoPath, branches, numbers, urls) =>
+        ipcRenderer.invoke('hermes:git:review:prList', repoPath, branches, numbers, urls),
       fetchPrComment: (repoPath, url) => ipcRenderer.invoke('hermes:git:review:fetchPrComment', repoPath, url),
       createPr: repoPath => ipcRenderer.invoke('hermes:git:review:createPr', repoPath)
     }

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -242,10 +242,8 @@ async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<S
   }
 }
 
-/** The PR each of these sessions opened, recovered from its own transcript —
- *  for sessions whose recorded branch can't answer (they started on trunk and
- *  did the work in a worktree). Also returns every id it looked at, so the
- *  caller can remember a miss and never ask again. */
+/** Recover the PR opened in each session's transcript. `scanned` acknowledges
+ *  the rows read; callers cache that result only for that transcript revision. */
 export function scanSessionPullRequests(
   ids: string[]
 ): Promise<{ pull_requests: Record<string, { number: number; url: string }>; scanned: string[] }> {

--- a/apps/desktop/src/app/chat/pr-tag.test.tsx
+++ b/apps/desktop/src/app/chat/pr-tag.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import type { HermesBranchPullRequest } from '@/global'
+
+import { PrTag } from './pr-tag'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+const pr: HermesBranchPullRequest = {
+  branch: 'fix',
+  draft: false,
+  number: 42,
+  state: 'open',
+  title: 'Restore session metadata',
+  url: 'https://github.com/example/project/pull/42'
+}
+
+it('keeps PR identity and state while only the sidebar opts out of the number', () => {
+  const { rerender } = render(<PrTag pr={pr} showIcon={false} />)
+  const button = () => screen.getByRole('button', { name: 'Open pull request #42' })
+  expect(button().textContent).toBe('#42')
+  expect(button().querySelector('.codicon')).toBeNull()
+
+  for (const [state, draft, icon, color] of [
+    ['open', false, 'git-pull-request', 'green'],
+    ['merged', false, 'git-merge', 'purple'],
+    ['closed', false, 'git-pull-request-closed', 'red'],
+    ['open', true, 'git-pull-request-draft', 'text-quaternary']
+  ] as const) {
+    rerender(<PrTag iconOnly pr={{ ...pr, draft, state }} />)
+    expect(button().textContent).toBe('')
+    expect(button().querySelector(`.codicon-${icon}`)).not.toBeNull()
+    expect(button().classList.contains(`text-(--ui-${color})`)).toBe(true)
+    expect(button().getAttribute('data-slot')).toBe('tooltip-trigger')
+    expect(button().getAttribute('title')).toBeNull()
+  }
+
+  rerender(<PrTag pr={pr} />)
+  expect(button().textContent).toBe('42')
+})
+
+it('opens an icon-only PR without selecting or pinning the containing session', () => {
+  const openExternal = vi.fn()
+  const rowClick = vi.fn()
+  const rowPointerDown = vi.fn()
+  vi.stubGlobal('hermesDesktop', { openExternal })
+  render(
+    <div onClick={rowClick} onPointerDown={rowPointerDown}>
+      <PrTag iconOnly pr={pr} />
+    </div>
+  )
+  const button = screen.getByRole('button', { name: 'Open pull request #42' })
+  fireEvent.pointerDown(button)
+  fireEvent.click(button, { shiftKey: true })
+  expect(openExternal).toHaveBeenCalledWith(pr.url)
+  expect(rowPointerDown).not.toHaveBeenCalled()
+  expect(rowClick).not.toHaveBeenCalled()
+})

--- a/apps/desktop/src/app/chat/pr-tag.tsx
+++ b/apps/desktop/src/app/chat/pr-tag.tsx
@@ -27,23 +27,28 @@ export function openPullRequest(pr: HermesBranchPullRequest): void {
  *  so the chip doesn't stack a second one beside it. */
 export function PrTag({
   className,
+  iconOnly = false,
   pr,
   showIcon = true
 }: {
   className?: string
+  /** Compact sidebar indicator; other surfaces retain their number label. */
+  iconOnly?: boolean
   pr: HermesBranchPullRequest
   showIcon?: boolean
 }) {
   const style = PR_STYLE[pullRequestBucket(pr)] ?? PR_STYLE.open
 
   return (
-    <Tip label={`#${pr.number} ${pr.title}`}>
+    <Tip align={iconOnly ? 'end' : undefined} label={`#${pr.number} ${pr.title}`} side="top">
       <button
         aria-label={`Open pull request #${pr.number}`}
         // A flex box doesn't pass text-decoration down to its items, so the
         // underline goes on the number itself rather than the chip.
         className={cn(
-          'group/pr flex shrink-0 items-center gap-0.5 text-[0.625rem] leading-none tabular-nums',
+          iconOnly
+            ? 'flex size-4 shrink-0 items-center justify-center rounded-[2.5px] hover:bg-(--chrome-action-hover) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring'
+            : 'group/pr flex shrink-0 items-center gap-0.5 text-[0.625rem] leading-none tabular-nums',
           style.className,
           className
         )}
@@ -61,9 +66,11 @@ export function PrTag({
         onPointerDown={event => event.stopPropagation()}
         type="button"
       >
-        {showIcon && <Codicon name={style.icon} size="0.75rem" />}
+        {(showIcon || iconOnly) && <Codicon name={style.icon} size="0.75rem" />}
         {/* Without the glyph the number needs the `#` to still read as a PR. */}
-        <span className="underline-offset-1 group-hover/pr:underline">{showIcon ? pr.number : `#${pr.number}`}</span>
+        {!iconOnly && (
+          <span className="underline-offset-1 group-hover/pr:underline">{showIcon ? pr.number : `#${pr.number}`}</span>
+        )}
       </button>
     </Tip>
   )

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -798,21 +798,22 @@ export function ChatSidebar({
     return () => window.clearTimeout(warm)
   }, [activeConnectionId, worktreeGroupingActive, showAllProfiles, profileScope, gatewayReady])
 
-  // Sessions the branch join can't answer for get one look at their own
-  // transcript — a `gh pr create` in there names the PR outright. Backfills
-  // whatever is loaded, whether or not the badge is on: gating it on the badge
-  // meant switching PR on showed a half-empty list until a second pass caught
-  // up. One request per batch of never-scanned rows, and the scanned set makes
-  // that batch empty from the second pass on, so this settles to nothing.
+  // Revisit changed transcripts: agents may open a PR later in the conversation
+  // or work in a different checkout from the branch recorded at session start.
   useEffect(() => {
-    if (!gatewayReady) {
+    if (!gatewayReady || !prDataWanted) {
       return
     }
 
-    const warm = window.setTimeout(() => void recoverSessionPullRequests(scopedSessions), PROJECT_TREE_WARM_MS)
+    const recover = () => void recoverSessionPullRequests(scopedSessions)
+    const warm = window.setTimeout(recover, PROJECT_TREE_WARM_MS)
+    window.addEventListener('focus', recover)
 
-    return () => window.clearTimeout(warm)
-  }, [gatewayReady, scopedSessions])
+    return () => {
+      window.clearTimeout(warm)
+      window.removeEventListener('focus', recover)
+    }
+  }, [gatewayReady, prDataWanted, scopedSessions])
 
   // PR state is only fetched for someone who asked to see it — the badge or the
   // filter — and it asks about the branches on screen, so the answer can't be

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -164,7 +164,7 @@ it.each([false, true])('updates a recovered PR association on an already mounted
   renderRow(makeSession({ id: 'pr-row', title: 'PR row', git_repo_root: '/repo', git_branch: 'main' }), { card })
   expect(screen.queryByRole('button', { name: 'Open pull request #42' })).toBeNull()
   act(() => $prBranchBySession.set({ 'pr-row': key }))
-  expect(screen.getByRole('button', { name: 'Open pull request #42' })).toBeTruthy()
+  expect(screen.getByRole('button', { name: 'Open pull request #42' }).textContent).toBe('')
   act(() => $sidebarRowMeta.set([]))
   expect(screen.queryByRole('button', { name: 'Open pull request #42' })).toBeNull()
   $prBranchBySession.set({})

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -8,6 +8,8 @@ import { createClientSessionState } from '@/lib/chat-runtime'
 import type * as ChatRuntime from '@/lib/chat-runtime'
 import type * as Time from '@/lib/time'
 import type * as ComposerStatusStore from '@/store/composer-status'
+import { $sidebarRowMeta } from '@/store/layout'
+import { $prBranchBySession, $pullRequestsByBranch, numberPrKey } from '@/store/pull-requests'
 import type * as SessionStore from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type * as SessionStatesStore from '@/store/session-states'
@@ -143,6 +145,32 @@ function makeSession(overrides: Partial<SessionInfo> & { title: string }): Sessi
     ...overrides
   } as unknown as SessionInfo
 }
+
+it.each([false, true])('updates a recovered PR association on an already mounted row (card=%s)', card => {
+  const key = numberPrKey('/repo', 42)
+  const previousMeta = $sidebarRowMeta.get()
+  $sidebarRowMeta.set(['pr'])
+  $prBranchBySession.set({})
+  $pullRequestsByBranch.set({
+    [key]: {
+      number: 42,
+      url: 'https://github.com/example/project/pull/42',
+      title: 'Fix',
+      branch: 'fix',
+      state: 'open',
+      draft: false
+    }
+  })
+  renderRow(makeSession({ id: 'pr-row', title: 'PR row', git_repo_root: '/repo', git_branch: 'main' }), { card })
+  expect(screen.queryByRole('button', { name: 'Open pull request #42' })).toBeNull()
+  act(() => $prBranchBySession.set({ 'pr-row': key }))
+  expect(screen.getByRole('button', { name: 'Open pull request #42' })).toBeTruthy()
+  act(() => $sidebarRowMeta.set([]))
+  expect(screen.queryByRole('button', { name: 'Open pull request #42' })).toBeNull()
+  $prBranchBySession.set({})
+  $pullRequestsByBranch.set({})
+  act(() => $sidebarRowMeta.set(previousMeta))
+})
 
 const tipTrigger = (el: HTMLElement) => el.closest('[data-slot="tooltip-trigger"]')
 

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -205,7 +205,7 @@ function SidebarSessionRowImpl({
   }
 
   if (pr) {
-    trailing.push({ key: 'pr', node: <PrTag pr={pr} /> })
+    trailing.push({ key: 'pr', node: <PrTag iconOnly pr={pr} /> })
   }
 
   const showAge = pinnedAge || card

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -27,7 +27,7 @@ import { cn } from '@/lib/utils'
 import { $sidebarRowMeta } from '@/store/layout'
 import { normalizeProfileKey } from '@/store/profile'
 import { $projects } from '@/store/projects'
-import { $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
+import { $prBranchBySession, $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
 import { $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
 import { $sessionListDensity } from '@/store/session-list-density'
 import { $openStoredSessionIds } from '@/store/session-states'
@@ -173,7 +173,7 @@ function SidebarSessionRowImpl({
   // The branch's PR, if the row was asked to show one. A selector, not a plain
   // useStore: a repo's PRs land as a single map write, and only the rows on
   // those branches should repaint.
-  const prKey = sessionPrKey(session)
+  const prKey = useStoreSelector($prBranchBySession, () => sessionPrKey(session))
   const pr = useStoreSelector($pullRequestsByBranch, prs => (rowMeta.includes('pr') && prKey ? prs[prKey] : undefined))
   // Open in a pane, but not the focused one. A selector rather than a prop:
   // it reaches all four row render paths at once, the set only changes when a

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -439,7 +439,12 @@ declare global {
           // The PR on each of the given branches — plus any known only by
           // number — for badging a list of sessions in one request instead of
           // one `pr view` per checkout.
-          prList: (repoPath: string, branches: string[], numbers?: number[]) => Promise<HermesRepoPullRequests>
+          prList: (
+            repoPath: string,
+            branches: string[],
+            numbers?: number[],
+            urls?: string[]
+          ) => Promise<HermesRepoPullRequests>
           // A pasted PR review/issue comment URL resolved to its structured
           // context (author, body, file + line anchor, diff hunk). Null when
           // gh can't answer — the paste stays a plain URL.

--- a/apps/desktop/src/lib/desktop-git.test.ts
+++ b/apps/desktop/src/lib/desktop-git.test.ts
@@ -113,6 +113,23 @@ describe('desktop git facade', () => {
     })
   })
 
+  it('preserves URL-only PR identities and owning connection/profile over the remote facade', async () => {
+    const urls = ['https://github.com/other/repository/pull/42']
+
+    setApiRequestConnection('remote-owner')
+    $connection.set({ mode: 'remote', profile: 'pr-owner' } as never)
+    await desktopGit()?.review.prList('', [], [], urls)
+
+    expect(api).toHaveBeenCalledWith({
+      body: { branches: [], numbers: [], path: '', urls },
+      connectionId: 'remote-owner',
+      method: 'POST',
+      path: '/api/git/review/pr-list',
+      profile: 'pr-owner'
+    })
+    expect(repoStatus).not.toHaveBeenCalled()
+  })
+
   it('sends mutations as POST bodies on a remote gateway', async () => {
     $connection.set({ mode: 'remote' } as never)
 

--- a/apps/desktop/src/lib/desktop-git.ts
+++ b/apps/desktop/src/lib/desktop-git.ts
@@ -94,8 +94,13 @@ const remoteGit: GitBridge = {
 
     shipInfo: repoPath => gitGet<HermesReviewShipInfo>('review/ship-info', { path: repoPath }),
 
-    prList: (repoPath, branches, numbers) =>
-      gitPost<HermesRepoPullRequests>('review/pr-list', { branches, numbers: numbers ?? [], path: repoPath }),
+    prList: (repoPath, branches, numbers, urls) =>
+      gitPost<HermesRepoPullRequests>('review/pr-list', {
+        branches,
+        numbers: numbers ?? [],
+        path: repoPath,
+        urls: urls ?? []
+      }),
 
     // Remote gateways have no PR-comment route yet; resolve to null so the
     // paste degrades to a plain URL instead of throwing mid-paste.

--- a/apps/desktop/src/store/pull-requests.test.ts
+++ b/apps/desktop/src/store/pull-requests.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+const { scan, prList } = vi.hoisted(() => ({ scan: vi.fn(), prList: vi.fn() }))
+vi.mock('@/hermes', () => ({ scanSessionPullRequests: scan }))
+vi.mock('@/lib/desktop-git', () => ({ desktopGit: () => ({ review: { prList } }) }))
+
+beforeEach(() => {
+  vi.resetModules()
+  localStorage.clear()
+  scan.mockReset()
+  prList.mockReset()
+})
+
+it('recovers the PR actually opened even when a session already records another branch, and retries changed transcripts', async () => {
+  const store = await import('./pull-requests')
+
+  const session = {
+    id: 'worktree',
+    git_repo_root: '/repo',
+    git_branch: 'integration',
+    message_count: 1,
+    last_active: 1
+  } as SessionInfo
+
+  scan.mockResolvedValueOnce({ pull_requests: {}, scanned: [session.id] })
+  await store.recoverSessionPullRequests([session])
+  expect(scan).toHaveBeenCalledOnce()
+  await store.recoverSessionPullRequests([session])
+  expect(scan).toHaveBeenCalledOnce()
+  const url = 'https://github.com/example/project/pull/42'
+  scan.mockResolvedValueOnce({ pull_requests: { [session.id]: { number: 42, url } }, scanned: [session.id] })
+  await store.recoverSessionPullRequests([{ ...session, message_count: 3, last_active: 2 }])
+  expect(scan).toHaveBeenCalledTimes(2)
+  expect(store.sessionPrKey(session)).toBe(store.numberPrKey('https://github.com/example/project', 42))
+  const unbound = { ...session, id: 'outside-git', git_repo_root: null, git_branch: null }
+  scan.mockResolvedValueOnce({ pull_requests: { [unbound.id]: { number: 42, url } }, scanned: [unbound.id] })
+  await store.recoverSessionPullRequests([unbound])
+  expect(store.sessionPrKey(unbound)).toBe(store.sessionPrKey(session))
+  prList.mockResolvedValue({ prs: [{ number: 42, url, branch: 'fix', title: 'Fix', state: 'open', draft: false }] })
+  await store.refreshPullRequests({ 'https://github.com/example/project': ['#42'] })
+  expect(prList).toHaveBeenCalledWith('', [], [], [url])
+  expect(store.$pullRequestsByBranch.get()[store.sessionPrKey(unbound)!]?.url).toBe(url)
+})
+
+it.each(['before', 'during'])(
+  'preserves a desktop-created association stamped %s an older transcript scan',
+  async timing => {
+    const store = await import('./pull-requests')
+    const session = { id: 'replacement', message_count: 3, last_active: 2 } as SessionInfo
+    let finishScan!: (value: unknown) => void
+    scan.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          finishScan = resolve
+        })
+    )
+
+    if (timing === 'before') {
+      store.stampSessionPrBranch(session.id, '/repo', 'replacement')
+    }
+
+    const recovery = store.recoverSessionPullRequests([session])
+
+    if (timing === 'during') {
+      store.stampSessionPrBranch(session.id, '/repo', 'replacement')
+    }
+
+    finishScan({
+      pull_requests: { [session.id]: { number: 42, url: 'https://github.com/example/project/pull/42' } },
+      scanned: [session.id]
+    })
+    await recovery
+    expect(store.sessionPrKey(session)).toBe(store.branchPrKey('/repo', 'replacement'))
+  }
+)
+
+it('fetches only current lookups while preserving unrelated cache entries and their own freshness', async () => {
+  const store = await import('./pull-requests')
+  const now = vi.spyOn(Date, 'now').mockReturnValue(100_000)
+  const branches = Array.from({ length: 300 }, (_, i) => `old-${i}`)
+
+  const found = {
+    number: 42,
+    url: 'https://github.com/example/project/pull/42',
+    branch: 'new-visible',
+    title: 'Fix',
+    state: 'open',
+    draft: false
+  }
+
+  const old = { ...found, number: 41, url: 'https://github.com/example/project/pull/41', branch: 'old-0' }
+  prList.mockImplementation(async (_root, requested: string[]) => ({
+    ghReady: true,
+    prs: [old, found].filter(pr => requested.slice(0, 300).includes(pr.branch))
+  }))
+
+  try {
+    await store.refreshPullRequests({ '/repo': branches })
+    now.mockReturnValue(130_001)
+    await store.refreshPullRequests({ '/repo': ['new-visible'] })
+    const oldKey = store.branchPrKey('/repo', old.branch)
+    const newKey = store.branchPrKey('/repo', found.branch)
+    expect(store.$pullRequestsByBranch.get()[newKey]).toEqual(found)
+    expect(prList.mock.calls[1]).toEqual(['/repo', ['new-visible'], []])
+    expect(store.$pullRequestsByBranch.get()[oldKey]).toEqual(old)
+
+    now.mockReturnValue(160_001)
+    await store.refreshPullRequests({ '/repo': ['old-0'] })
+    expect(prList).toHaveBeenCalledTimes(3)
+    expect(prList.mock.calls[2]).toEqual(['/repo', ['old-0'], []])
+    await store.refreshPullRequests({ '/repo': ['new-visible'] })
+    expect(prList).toHaveBeenCalledTimes(3)
+
+    prList.mockResolvedValue({ ghReady: true, prs: [] })
+    await store.refreshPullRequests({ '/repo': ['old-0'] }, true)
+    expect(store.$pullRequestsByBranch.get()[oldKey]).toBeUndefined()
+    expect(store.$pullRequestsByBranch.get()[newKey]).toEqual(found)
+  } finally {
+    now.mockRestore()
+  }
+})
+
+it.each(['/repo', 'https://github.com/example/project'])(
+  'hydrates every requested lookup beyond the API cap for %s',
+  async root => {
+    const store = await import('./pull-requests')
+
+    const prs = Array.from({ length: 301 }, (_, i) => ({
+      number: i + 1,
+      url: `https://github.com/example/project/pull/${i + 1}`,
+      branch: `branch-${i}`,
+      title: 'Fix',
+      state: 'open',
+      draft: false
+    }))
+
+    const lookups = prs.map((pr, i) => (root === '/repo' && i % 2 === 0 ? pr.branch : `#${pr.number}`))
+    prList.mockImplementation(async (_root, branches: string[], numbers: number[] = [], urls: string[] = []) => ({
+      ghReady: true,
+      prs: prs
+        .filter(pr => branches.includes(pr.branch) || numbers.includes(pr.number) || urls.includes(pr.url))
+        .slice(0, 300)
+    }))
+    await store.refreshPullRequests({ [root]: [...lookups, lookups[0]] })
+    expect(prList).toHaveBeenCalledTimes(2)
+
+    for (const [, branches, numbers = [], urls = []] of prList.mock.calls) {
+      expect(branches.length + numbers.length + urls.length).toBeLessThanOrEqual(300)
+    }
+
+    for (const [i, lookup] of lookups.entries()) {
+      expect(store.$pullRequestsByBranch.get()[store.branchPrKey(root, lookup)]).toEqual(prs[i])
+    }
+
+    await store.refreshPullRequests({ [root]: lookups })
+    expect(prList).toHaveBeenCalledTimes(2)
+  }
+)
+
+it('fetches newly requested lookups without waiting for the previous repo query to become stale', async () => {
+  const store = await import('./pull-requests')
+  let finishList!: (value: unknown) => void
+  prList.mockImplementationOnce(
+    () =>
+      new Promise(resolve => {
+        finishList = resolve
+      })
+  )
+  prList.mockResolvedValue({ prs: [] })
+  const initial = store.refreshPullRequests({ '/repo': ['integration'] })
+  const expanded = store.refreshPullRequests({ '/repo': ['integration', '#42'] })
+  const duplicate = store.refreshPullRequests({ '/repo': ['integration', '#42'] })
+  expect(prList).toHaveBeenCalledOnce()
+  finishList({ prs: [] })
+  await Promise.all([initial, expanded, duplicate])
+  expect(prList).toHaveBeenCalledTimes(2)
+  expect(prList.mock.calls[1]).toEqual(['/repo', ['integration'], [42]])
+  const key = store.numberPrKey('/repo', 42)
+
+  const known = {
+    number: 42,
+    url: 'https://github.com/example/project/pull/42',
+    branch: 'fix',
+    title: 'Fix',
+    state: 'open' as const,
+    draft: false
+  }
+
+  store.$pullRequestsByBranch.set({ [key]: known })
+  prList.mockResolvedValue({ ghReady: false, prs: [] })
+  await store.refreshPullRequests({ '/repo': ['#42'] }, true)
+  expect(store.$pullRequestsByBranch.get()[key]).toEqual(known)
+  prList.mockRejectedValueOnce(new Error('network unavailable'))
+  await store.refreshPullRequests({ '/repo': ['#42'] }, true)
+  expect(store.$pullRequestsByBranch.get()[key]).toEqual(known)
+  prList.mockResolvedValue({ ghReady: true, prs: [] })
+  await store.refreshPullRequests({ '/repo': ['#42'] }, true)
+  expect(store.$pullRequestsByBranch.get()[key]).toBeUndefined()
+})

--- a/apps/desktop/src/store/pull-requests.ts
+++ b/apps/desktop/src/store/pull-requests.ts
@@ -13,6 +13,7 @@ export type PullRequestBucket = 'closed' | 'draft' | 'merged' | 'none' | 'open'
 // window focus, and whenever the set of repos on screen changes — this keeps
 // those from stacking into a burst of identical requests.
 const PR_STALE_MS = 60_000
+const PR_LOOKUP_CAP = 300
 
 /** Every known PR keyed by `${repoRoot}\n${branch}` — the join a session row
  *  makes with its own `git_repo_root` + `git_branch`. */
@@ -29,15 +30,12 @@ export const $prBranchBySession = persistentAtom<Record<string, string>>(
   Codecs.stringRecord
 )
 
-/** Sessions already scanned for a PR url. A transcript doesn't grow a new PR,
- *  so a miss is permanent and a hit is already in {@link $prBranchBySession} —
- *  either way the session is never scanned again. */
-const $prScannedSessions = persistentAtom<string[]>('hermes.desktop.prScannedSessions', [], Codecs.stringArray)
-
+// A miss belongs to this transcript revision, not the lifetime of a session.
+// Do not reuse the old persisted miss list: it can predate the PR being opened.
+const scannedRevisions = new Map<string, string>()
 const fetchedAt = new Map<string, number>()
-const inFlight = new Set<string>()
-let scanUnavailable = false
-let scanInFlight = false
+const inFlight = new Map<string, Promise<void>>()
+let scanInFlight: Promise<void> | undefined
 
 // A session sitting on the trunk has no PR of its own, and asking GitHub about
 // "main" is how a stranger's fork branch — forks share our branch namespace —
@@ -71,47 +69,78 @@ export function stampSessionPrBranch(sessionId: string, repoRoot: string, branch
   $prBranchBySession.set({ ...$prBranchBySession.get(), [sessionId]: branchPrKey(repoRoot, branch) })
 }
 
-/** Recover PRs the branch join can't see, from the sessions' own transcripts.
- *  A session that ran in the main checkout and worked in a worktree recorded
- *  `main` (or nothing) as its branch, but it ran `gh pr create` — whose output
- *  is a bare PR url, the one shape that's a claim rather than a mention. Scans
- *  each session at most once, ever. */
+/** Recover the PR actually opened, even when work left the starting checkout. */
 export async function recoverSessionPullRequests(sessions: SessionInfo[]): Promise<void> {
-  const scanned = new Set($prScannedSessions.get())
-  const roots = new Map<string, string>()
+  if (scanInFlight) {
+    await scanInFlight
 
-  for (const session of sessions) {
-    if (session.git_repo_root && !scanned.has(session.id) && !sessionPrKey(session)) {
-      roots.set(session.id, session.git_repo_root)
-    }
+    return recoverSessionPullRequests(sessions)
   }
 
-  if (roots.size === 0 || scanUnavailable || scanInFlight) {
+  const revisions = new Map(
+    sessions.map(session => [
+      session.id,
+      JSON.stringify([session.message_count, session.tool_call_count, session.last_active])
+    ])
+  )
+
+  const ids = [...revisions.keys()].filter(id => scannedRevisions.get(id) !== revisions.get(id))
+
+  if (!ids.length) {
     return
   }
 
-  scanInFlight = true
+  scanInFlight = (async () => {
+    try {
+      for (let offset = 0; offset < ids.length; offset += 2000) {
+        const { pull_requests: found, scanned: asked } = await scanSessionPullRequests(ids.slice(offset, offset + 2000))
+        const stamps = { ...$prBranchBySession.get() }
+        let changed = false
+
+        for (const [id, pr] of Object.entries(found)) {
+          // Branch stamps are explicit desktop intent; number stamps are recovered.
+          // Read after the scan so a PR created while it was pending also wins.
+          if (stamps[id] && !/\n#\d+$/.test(stamps[id])) {
+            continue
+          }
+
+          // The URL owns repository identity. The session may have started outside
+          // Git, changed repositories, or opened an upstream PR from a fork.
+          const match = /^https:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/pull\/(\d+)\/?$/.exec(pr.url)
+
+          if (!revisions.has(id) || !match || Number(match[2]) !== pr.number) {
+            continue
+          }
+
+          const key = numberPrKey(`https://github.com/${match[1]}`, pr.number)
+
+          if (stamps[id] !== key) {
+            stamps[id] = key
+            changed = true
+          }
+        }
+
+        if (changed) {
+          $prBranchBySession.set(stamps)
+        }
+
+        for (const id of asked) {
+          const revision = revisions.get(id)
+
+          if (revision) {
+            scannedRevisions.set(id, revision)
+          }
+        }
+      }
+    } catch {
+      // A failed read is not an authoritative miss. Retry on the next refresh.
+    }
+  })()
 
   try {
-    const { pull_requests: found, scanned: asked } = await scanSessionPullRequests([...roots.keys()])
-    const stamps = { ...$prBranchBySession.get() }
-
-    for (const [id, pr] of Object.entries(found)) {
-      const root = roots.get(id)
-
-      if (root) {
-        stamps[id] = numberPrKey(root, pr.number)
-      }
-    }
-
-    $prBranchBySession.set(stamps)
-    $prScannedSessions.set([...new Set([...scanned, ...asked])])
-  } catch {
-    // An older backend has no such route. Stop asking rather than retrying on
-    // every list refresh; the branch join still covers the common case.
-    scanUnavailable = true
+    await scanInFlight
   } finally {
-    scanInFlight = false
+    scanInFlight = undefined
   }
 }
 
@@ -133,7 +162,8 @@ export function pullRequestBucket(pr: HermesBranchPullRequest | undefined): Pull
 
 /** Pull PRs for the given lookups, grouped by the repo they live in. Each entry
  *  is a branch name, or `#<number>` for a PR recovered from a transcript. Skips
- *  repos fetched recently or still in flight. Goes through the remote-aware git
+ *  lookups fetched recently, coalescing in-flight repo reads before rechecking.
+ *  Goes through the remote-aware git
  *  facade, so a desktop pointed at a remote gateway asks the BACKEND's `gh`
  *  about the backend's checkout. */
 export async function refreshPullRequests(lookupsByRepo: Record<string, string[]>, force = false): Promise<void> {
@@ -143,48 +173,82 @@ export async function refreshPullRequests(lookupsByRepo: Record<string, string[]
     return
   }
 
-  const now = Date.now()
-
-  const stale = Object.keys(lookupsByRepo).filter(
-    root => !inFlight.has(root) && (force || now - (fetchedAt.get(root) ?? 0) > PR_STALE_MS)
-  )
-
   await Promise.all(
-    stale.map(async root => {
-      inFlight.add(root)
+    Object.entries(lookupsByRepo).map(async ([root, requested]) => {
+      const pending = inFlight.get(root)
 
-      const lookups = lookupsByRepo[root]
-      const numbers = lookups.filter(l => l.startsWith('#')).map(l => Number(l.slice(1)))
+      if (pending) {
+        await pending
 
-      try {
-        const { prs } = await review.prList(
-          root,
-          lookups.filter(l => !l.startsWith('#')),
-          numbers
-        )
+        return refreshPullRequests({ [root]: requested }, force)
+      }
 
-        fetchedAt.set(root, Date.now())
+      if (
+        !force &&
+        requested.every(lookup => Date.now() - (fetchedAt.get(branchPrKey(root, lookup)) ?? -Infinity) < PR_STALE_MS)
+      ) {
+        return
+      }
 
-        // Replace this repo's slice wholesale: a PR that closed since the last
-        // pull has to disappear, not linger as a stale merge of old and new.
-        const next = Object.fromEntries(
-          Object.entries($pullRequestsByBranch.get()).filter(([key]) => !key.startsWith(`${root}\n`))
-        )
+      const requestedLookups = [...new Set(requested)]
 
-        for (const pr of prs) {
-          next[branchPrKey(root, pr.branch)] = pr
+      const task = (async () => {
+        for (let offset = 0; offset < requestedLookups.length; offset += PR_LOOKUP_CAP) {
+          const lookups = requestedLookups.slice(offset, offset + PR_LOOKUP_CAP)
+          const numbers = lookups.filter(l => l.startsWith('#')).map(l => Number(l.slice(1)))
 
-          // The session that recovered it looks it up by number, and its branch
-          // may well be someone else's by now (or deleted).
-          if (numbers.includes(pr.number)) {
-            next[numberPrKey(root, pr.number)] = pr
+          try {
+            const { ghReady, prs } = /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+$/.test(root)
+              ? await review.prList(
+                  '',
+                  [],
+                  [],
+                  numbers.map(number => `${root}/pull/${number}`)
+                )
+              : await review.prList(
+                  root,
+                  lookups.filter(l => !l.startsWith('#')),
+                  numbers
+                )
+
+            if (ghReady === false) {
+              continue
+            }
+
+            // A composer subset is authoritative only for the lookups it asked for.
+            const next = { ...$pullRequestsByBranch.get() }
+
+            for (const lookup of lookups) {
+              delete next[branchPrKey(root, lookup)]
+            }
+
+            for (const pr of prs) {
+              if (lookups.includes(pr.branch)) {
+                next[branchPrKey(root, pr.branch)] = pr
+              }
+
+              if (numbers.includes(pr.number)) {
+                next[numberPrKey(root, pr.number)] = pr
+              }
+            }
+
+            $pullRequestsByBranch.set(next)
+          } catch {
+            // gh missing, unauthenticated, or off-repo — leave confirmed data intact.
+          } finally {
+            const now = Date.now()
+
+            for (const lookup of lookups) {
+              fetchedAt.set(branchPrKey(root, lookup), now)
+            }
           }
         }
+      })()
 
-        $pullRequestsByBranch.set(next)
-      } catch {
-        // gh missing, unauthenticated, or off-repo — leave what we had.
-        fetchedAt.set(root, Date.now())
+      inFlight.set(root, task)
+
+      try {
+        await task
       } finally {
         inFlight.delete(root)
       }

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -14,6 +14,7 @@ import os
 import re
 import shutil
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from hermes_cli._subprocess_compat import harden_git_argv, noninteractive_git_env
@@ -27,7 +28,7 @@ _COMMIT_CONTEXT_UNTRACKED_MAX = 80
 _TRUNK_BRANCHES = ("main", "master")
 
 
-def _run(argv: list[str], cwd: str, timeout: int, env: dict) -> subprocess.CompletedProcess | None:
+def _run(argv: list[str], cwd: str | None, timeout: int, env: dict) -> subprocess.CompletedProcess | None:
     """Non-interactive subprocess (stdin nulled, prompts disabled): a credential prompt from
     ``fetch``/``push`` could never be answered from a REST request, so fail fast and surface
     the real auth error in the toast. None when the process could not run at all."""
@@ -383,7 +384,7 @@ def review_commit_context(cwd: str) -> dict:
 # ── ship flow (gh) ───────────────────────────────────────────────────────────
 
 
-def _gh(cwd: str, args: list[str]) -> tuple[bool, str]:
+def _gh(cwd: str | None, args: list[str]) -> tuple[bool, str]:
     if not shutil.which("gh"):
         return False, ""
     # GH_PROMPT_DISABLED: gh's documented kill-switch for interactive prompts.
@@ -453,7 +454,45 @@ def _own_pr(key: str, field: dict) -> dict | None:
     return next((n for n in (field.get("nodes") or []) if n and not n.get("isCrossRepository")), None)
 
 
-def review_pr_list(cwd: str, branches: list[str], numbers: list[int] = None) -> dict:
+def review_pr_list(
+    cwd: str, branches: list[str], numbers: list[int] | None = None, urls: list[str] | None = None,
+) -> dict:
+    """Explicit GitHub URLs retain repository identity even without a checkout."""
+    wanted_urls = list(dict.fromkeys(
+        url for url in (urls or []) if isinstance(url, str) and re.fullmatch(
+            r"https://github\.com/[A-Za-z0-9][A-Za-z0-9-]*/(?!\.{1,2}/)[A-Za-z0-9_.][A-Za-z0-9_.-]*/pull/[1-9][0-9]*/?", url,
+        )
+    ))[:_PR_QUERY_BRANCH_CAP]
+    result = (_review_repo_pr_list(cwd, branches, numbers) if branches or numbers
+              else {"ghReady": False, "prs": []})
+    urls_ready = True
+    if wanted_urls:
+        # No cwd or repo probe: gh pr view URL resolves the repository itself.
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            results = pool.map(lambda url: _gh(
+                None, ["pr", "view", url, "--json", _PR_NODE_FIELDS.replace(" ", ",")],
+            ), wanted_urls)
+            for ok, out in results:
+                if not ok:
+                    urls_ready = False
+                    continue
+                result["ghReady"] = True
+                try:
+                    pr = json.loads(out)
+                except json.JSONDecodeError:
+                    urls_ready = False
+                    continue
+                if isinstance(pr, dict) and pr.get("headRefName"):
+                    result["prs"].append(_pr_payload(pr))
+                else:
+                    urls_ready = False
+    # A partial/network failure must not evict previously confirmed badges.
+    result["ghReady"] = result["ghReady"] and urls_ready
+    result["prs"] = list({pr["url"]: pr for pr in result["prs"]}.values())
+    return result
+
+
+def _review_repo_pr_list(cwd: str, branches: list[str], numbers: list[int] | None = None) -> dict:
     """PRs on the given branches (plus any asked for by number) — queried per branch
     rather than paging the repo's newest PRs and hoping ours are in the page."""
     not_ready = {"ghReady": False, "prs": []}

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -172,6 +172,8 @@ class GitPrListBody(BaseModel):
     branches: List[str] = []
     # PRs a session recovered from its transcript — known by number, not branch.
     numbers: List[int] = []
+    # Explicit identities do not depend on a session checkout.
+    urls: List[str] = []
 
 class SessionPrScanBody(BaseModel):
     ids: List[str] = []

--- a/hermes_cli/web_routers/git.py
+++ b/hermes_cli/web_routers/git.py
@@ -136,7 +136,8 @@ async def git_ship_info_route(path: str):
 
 @router.post("/api/git/review/pr-list")
 async def git_pr_list_route(body: GitPrListBody):
-    return await _git_op(_web_git.review_pr_list, _git_path(body.path), body.branches, body.numbers)
+    cwd = _git_path(body.path) if body.branches or body.numbers else ""
+    return await _git_op(_web_git.review_pr_list, cwd, body.branches, body.numbers, body.urls)
 
 
 @router.post("/api/git/review/stage")

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -9,6 +9,7 @@ Shared helpers are reached via the late-binding seam in :mod:`hermes_cli.web_dep
 so a test's ``monkeypatch.setattr(<owning module>, "_helper", ...)`` keeps working.
 """
 
+import ast
 import contextlib
 import copy
 import functools
@@ -16,6 +17,7 @@ import inspect
 import json
 import logging
 import re
+import shlex
 import subprocess
 import sys
 import threading
@@ -169,16 +171,20 @@ def _best_effort(log_msg: str, *args, fn, default=None):
         return default
 
 
-def _profile_targets(log_label: str, *, lightweight: bool) -> List[Tuple[str, Path]]:
+def _profile_targets(log_label: str, *, lightweight: bool,
+                     errors: Optional[List[Dict[str, str]]] = None) -> List[Tuple[str, Path]]:
     """(name, home) for every profile, falling back to ``default`` alone. ``lightweight``
     uses ``profiles_to_serve`` (name/path only) instead of ``list_profiles``, which parses
-    config/meta and probes gateways/skills per profile — too heavy per sidebar refresh."""
+    config/meta and probes gateways/skills per profile — too heavy per sidebar refresh.
+    PR recovery collects inventory errors so incomplete scans remain retryable."""
     from hermes_cli import profiles as profiles_mod
     try:
         targets = (list(profiles_mod.profiles_to_serve(multiplex=True)) if lightweight
                    else [(info.name, info.path) for info in profiles_mod.list_profiles()])
     except Exception:
         _log.exception("%s: list_profiles failed", log_label)
+        if errors is not None:
+            errors.append({"error": "profile-inventory-unavailable"})
         targets = []
     if not targets:
         targets.append(("default", profiles_mod.get_profile_dir("default")))
@@ -588,21 +594,143 @@ def get_profiles_projects_tree(preview_limit: int = 3, session_limit: int = 2000
             "errors": errors}
 
 
-# `gh pr create` prints the PR url and nothing else, so a tool result whose whole output IS a
-# PR url means this session opened that PR; a url inside prose is a session TALKING about one.
-_PR_URL_RE = re.compile(r"^https://github\.com/[\w.-]+/[\w.-]+/pull/(\d+)/?$")
+_PR_URL_RE = re.compile(
+    r"https://github\.com/[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/"
+    r"(?!\.{1,2}/)[A-Za-z0-9_.-]+/pull/([1-9][0-9]*)/?")
 
 
-def _pr_url_from_tool_output(content: str) -> Optional[Tuple[int, str]]:
-    """The (number, url) a tool result announces, or None."""
+def _ends_with_pr_create(command: Any) -> bool:
+    """Recognize a creation command, optionally piped to a display-only tail.
+
+    The badge associates a PR returned by a creation attempt; it does not certify
+    that GitHub created it during this call (gh may return an existing PR).
+    Quoted heredoc bodies are data, never shell-command provenance.
+    """
+    from tools.terminal_tool_sudo import _scan_shell
+
+    if not isinstance(command, str) or len(command) > 100_000:
+        return False
+    command = command.rstrip(" \t\r\n;")
+    words, preceding = [], ""
+    last_words, last_preceding = [], ""
     try:
-        output = (json.loads(content) or {}).get("output")
-    except (json.JSONDecodeError, TypeError, AttributeError):
+        for kind, start, end, at_start in _scan_shell(command):
+            text = command[start:end]
+            if kind == "op" or (kind == "ws" and text == "\n"):
+                if text == "&" and command[:start].rstrip().endswith((">", "<")):
+                    continue  # Descriptor duplication (2>&1), not background work.
+                if text in {"(", ")", ";;"}:
+                    return False
+                # A trailing semicolon/newline does not change the exit status.
+                if text == "\n" and not words:
+                    continue  # Newlines/comments after an operator do not replace it.
+                if words:
+                    last_words, last_preceding = words, preceding
+                words, preceding = [], text
+            elif kind == "word":
+                heredoc = re.fullmatch(r"<<(['\"])([A-Za-z_][A-Za-z_0-9]*)\1", text)
+                if heredoc:
+                    rest = command[end:]
+                    header, newline, body = rest.partition("\n")
+                    lines = body.splitlines()
+                    # Only a single quoted, final body: no expansion, extra
+                    # redirections, or commands after its closing delimiter.
+                    if (header.strip() or not newline or not lines
+                            or lines[-1] != heredoc[2] or heredoc[2] in lines[:-1]):
+                        return False
+                    return _ends_with_pr_create(command[:start])
+                if any(s in text for s in ("<<", "$(", "`")):
+                    return False
+                tokens = shlex.split(text)
+                if at_start and tokens and tokens[0] in {
+                    "if", "then", "else", "elif", "fi", "while", "until", "for", "case",
+                    "do", "done", "esac", "function", "{", "}", "!", "exit", "return", "exec",
+                }:
+                    return False
+                words.extend(tokens)
+        if not words:
+            if preceding not in {";", "\n"}:
+                return False
+            words, preceding = last_words, last_preceding
+    except ValueError:
+        return False
+    allowed = {"", ";", "\n", "&&"}
+    if words[:3] == ["gh", "pr", "create"] and preceding in allowed:
+        return True
+    return (preceding == "|" and last_preceding in allowed
+            and last_words[:3] == ["gh", "pr", "create"]
+            and re.fullmatch(r"tail (?:-[0-9]+|-n [0-9]+)", " ".join(words)) is not None)
+
+
+def _printed_terminal_call(code: Any) -> Optional[dict]:
+    """Recognize only ``from hermes_tools import terminal; print(terminal(...))``.
+
+    AST literals, never execution: arbitrary code, variables, loops and additional
+    calls cannot reliably associate printed results with one particular command.
+    """
+    if not isinstance(code, str) or len(code) > 100_000:
         return None
-    if not isinstance(output, str):
+    try:
+        tree = ast.parse(code)
+        if len(tree.body) != 2:
+            return None
+        imported, printed = tree.body
+        if not (isinstance(imported, ast.ImportFrom) and imported.module == "hermes_tools"
+                and imported.level == 0 and len(imported.names) == 1
+                and imported.names[0].name == "terminal" and imported.names[0].asname is None
+                and isinstance(printed, ast.Expr)):
+            return None
+        call = printed.value
+        if not (isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+                and call.func.id == "print" and len(call.args) == 1 and not call.keywords):
+            return None
+        terminal = call.args[0]
+        if not (isinstance(terminal, ast.Call) and isinstance(terminal.func, ast.Name)
+                and terminal.func.id == "terminal" and not terminal.args
+                and all(kw.arg is not None for kw in terminal.keywords)):
+            return None
+        return {kw.arg: ast.literal_eval(kw.value) for kw in terminal.keywords}
+    except (SyntaxError, ValueError, TypeError, RecursionError):
         return None
-    match = _PR_URL_RE.match(output.strip())
-    return (int(match.group(1)), match.group(0)) if match else None
+
+
+def _pr_url_from_tool_output(content: str, tool_call: dict) -> Optional[Tuple[int, str]]:
+    """One unambiguous URL line from a successful, associated creation command."""
+    try:
+        result = json.loads(content)
+        args = tool_call.get("arguments")
+        args = json.loads(args) if isinstance(args, str) else args
+        if not isinstance(result, dict) or not isinstance(args, dict):
+            return None
+        if tool_call.get("name") == "execute_code":
+            args = _printed_terminal_call(args.get("code"))
+            if (args is None or result.get("status") != "success"
+                    or result.get("exit_code") != 0 or result.get("tool_calls_made") != 1
+                    or result.get("stdout_truncated") or result.get("error")):
+                return None
+            # print(dict) produces Python literals, not JSON. Parse the entire
+            # stdout as one record; do not search prose for embedded dictionaries.
+            output = result.get("output")
+            if not isinstance(output, str) or len(output) > 100_000:
+                return None
+            result = ast.literal_eval(output.strip())
+        elif tool_call.get("name") != "terminal":
+            return None
+        if (not isinstance(result, dict) or type(result.get("exit_code")) is not int
+                or result["exit_code"] != 0 or result.get("error")
+                or args.get("background") or not _ends_with_pr_create(args.get("command"))):
+            return None
+        output = result.get("output")
+        if not isinstance(output, str):
+            return None
+        urls = {match.group(0).rstrip("/"): int(match.group(1))
+                for line in output.splitlines() if (match := _PR_URL_RE.fullmatch(line.strip()))}
+        if len(urls) == 1:
+            url, number = next(iter(urls.items()))
+            return number, url
+    except (json.JSONDecodeError, SyntaxError, ValueError, TypeError, RecursionError):
+        return None
+    return None
 
 
 @sessions_router.post("/api/profiles/sessions/pull-requests")
@@ -619,16 +747,23 @@ def post_profiles_sessions_pull_requests(body: SessionPrScanBody):
 
     def _read(db):
         for pr in db.find_pr_url_messages(wanted):
-            parsed = _pr_url_from_tool_output(pr["content"])
+            parsed = _pr_url_from_tool_output(pr["content"], pr["tool_call"])
             if parsed:
                 # Oldest-first, so a later `gh pr create` (the replacement PR) wins.
                 found[pr["session_id"]] = {"number": parsed[0], "url": parsed[1]}
+        return True
 
-    for name, home in _profile_targets("POST /api/profiles/sessions/pull-requests", lightweight=False):
-        _read_profile_db(name, home, None, _read)
+    errors: List[Dict[str, str]] = []
+    complete = True
+    for name, home in _profile_targets(
+            "POST /api/profiles/sessions/pull-requests", lightweight=False, errors=errors):
+        if _read_profile_db(name, home, errors, _read) is None:
+            complete = False
 
-    # ``scanned``: every id looked at, so the caller can remember "nothing there".
-    return {"pull_requests": found, "scanned": wanted}
+    # Raw IDs carry no owning profile. An unread target might contain any miss,
+    # so only acknowledge negative coverage when the entire fanout completed.
+    return {"pull_requests": found, "scanned": wanted if complete and not errors else [],
+            "errors": errors}
 
 
 @router.get("/api/profiles")

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -659,15 +659,34 @@ class SessionMessagesMixin:
         return [self._row_to_message_dict(row, warn_context="get_messages", summary_flag=True) for row in rows]
 
     def find_pr_url_messages(self, session_ids: List[str]) -> List[Dict[str, Any]]:
-        """Tool results containing ``/pull/``: a deliberately loose scan, oldest-first so the caller takes the last."""
-        ids = [s for s in session_ids if s]
-        chunks = (ids[start : start + 900] for start in range(0, len(ids), 900))  # SQLite's bound-variable ceiling.
-        return [{"session_id": row[0], "content": row[1]} for chunk in chunks for row in self._read_all(
-                f"""SELECT session_id, content FROM messages
-                    WHERE session_id IN ({_placeholders(chunk)})
-                      AND role = 'tool' AND content LIKE '%/pull/%'
-                    ORDER BY id ASC""",
-                chunk)]
+        """Candidate results with their preceding, same-session call; oldest first.
+
+        Keep archived history: compression/rewind does not undo an external PR creation.
+        The loose prefilter also admits JSON slash escapes; the route validates provenance.
+        """
+        ids = list(dict.fromkeys(s for s in session_ids if s))
+        found = []
+        for start in range(0, len(ids), 900):  # SQLite's bound-variable ceiling.
+            chunk = ids[start : start + 900]
+            calls = {}
+            for row in self._read_all(
+                f"""SELECT session_id, role, content, tool_call_id, tool_calls, tool_name
+                    FROM messages WHERE session_id IN ({_placeholders(chunk)})
+                      AND ((role = 'assistant' AND tool_calls IS NOT NULL)
+                        OR (role = 'tool' AND tool_name IN ('terminal', 'execute_code')
+                            AND content LIKE '%pull%'))
+                    ORDER BY id ASC""", chunk):
+                if row["role"] == "assistant":
+                    parsed = _parse_tool_calls(row["tool_calls"])
+                    for call in parsed if isinstance(parsed, list) else []:
+                        if isinstance(call, dict) and isinstance(call.get("id"), str):
+                            calls[(row["session_id"], call["id"])] = call.get("function")
+                else:
+                    call = calls.get((row["session_id"], row["tool_call_id"]))
+                    if isinstance(call, dict) and call.get("name") == row["tool_name"]:
+                        found.append({"session_id": row["session_id"], "content": row["content"],
+                                      "tool_call": call})
+        return found
 
     def get_messages_around(self, session_id: str, around_message_id: int, window: int = 5) -> Dict[str, Any]:
         """Up to *window* messages either side of an anchor id (ascending). ``messages_before``/``_after`` count

--- a/tests/hermes_cli/test_git_pr_list.py
+++ b/tests/hermes_cli/test_git_pr_list.py
@@ -1,0 +1,86 @@
+"""Explicit PR URLs retain repository identity across the remote git route."""
+
+import json
+import threading
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_git
+from hermes_cli.web_routers.git import router
+
+
+def test_url_only_route_hydrates_valid_github_identities_without_checkout(monkeypatch):
+    urls = [f"https://github.com/owner/repo-{i}/pull/42" for i in range(9)]
+    urls += ["https://github.com/actions/.github/pull/221", "https://github.com/owner/.config/pull/42/"]
+    calls = []
+    lock = threading.Lock()
+    overlapped = threading.Event()
+    active = peak = 0
+
+    def gh(cwd, args):
+        nonlocal active, peak
+        assert cwd is None
+        assert args[:2] == ["pr", "view"]
+        with lock:
+            calls.append(args)
+            active += 1
+            peak = max(peak, active)
+            if active > 1:
+                overlapped.set()
+        assert overlapped.wait(5), "URL reads never overlapped"
+        with lock:
+            active -= 1
+        return True, json.dumps({"headRefName": "feature", "isDraft": True,
+                                 "number": 42, "state": "MERGED", "title": args[2], "url": args[2]})
+
+    monkeypatch.setattr(web_git, "_gh", gh)
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as client:
+        response = client.post("/api/git/review/pr-list", json={
+            "path": "", "branches": [], "numbers": [], "urls": [
+                *urls, urls[0], "https://evil.example/owner/repo/pull/42",
+                "https://github.com.evil.example/owner/repo/pull/42",
+                "https://github.com@evil.example/owner/repo/pull/42",
+                "http://github.com/owner/repo/pull/42", "https://github.com/owner/repo/pull/0",
+                "https://github.com/owner/./pull/42", "https://github.com/owner/../pull/42",
+                "https://github.com/./repo/pull/42", "https://github.com/../repo/pull/42",
+                "https://github.com/owner/%2e/pull/42", "https://github.com/owner/%2e%2e/pull/42",
+                "https://github.com/owner/.github/../repo/pull/42", "https://github.com/owner/repo/pull/42\n",
+            ],
+        })
+    assert response.status_code == 200, response.text
+    result = response.json()
+    assert result["ghReady"] is True
+    assert [pr["url"] for pr in result["prs"]] == urls
+    assert all(pr["state"] == "merged" and pr["draft"] for pr in result["prs"])
+    assert sorted(args[2] for args in calls) == sorted(urls)
+    assert all(args[3] == "--json" and "headRefName" in args[4] for args in calls)
+    assert 1 < peak <= 4
+
+
+def test_failed_url_reads_are_not_authoritative_but_legacy_results_survive(tmp_path, monkeypatch):
+    known = {"headRefName": "feature", "number": 42, "state": "OPEN",
+             "url": "https://github.com/owner/repo/pull/42"}
+    queries = []
+
+    def gh(cwd, args):
+        if args[0] == "repo":
+            return True, "owner/repo"
+        if args[0] == "api":
+            queries.append(args[3])
+            return True, json.dumps({"data": {"repository": {"b0": {"nodes": [known]}, "n0": known}}})
+        return True, "not JSON"
+
+    monkeypatch.setattr(web_git, "_gh", gh)
+    legacy = web_git.review_pr_list(str(tmp_path), ["feature"], [42])
+    assert legacy["ghReady"] is True
+    assert known["url"] in [pr["url"] for pr in legacy["prs"]]
+    assert 'headRefName: "feature"' in "\n".join(queries)
+    assert 'pullRequest(number: 42)' in "\n".join(queries)
+    failed = web_git.review_pr_list(str(tmp_path), ["feature"], [42], ["https://github.com/other/repo/pull/42"])
+    assert known["url"] in [pr["url"] for pr in failed["prs"]]
+    assert failed["ghReady"] is False
+    monkeypatch.setattr(web_git, "_gh", lambda *_: (False, "network unavailable"))
+    assert web_git.review_pr_list("", [], [], [known["url"]]) == {"ghReady": False, "prs": []}

--- a/tests/hermes_cli/test_session_pr_recovery.py
+++ b/tests/hermes_cli/test_session_pr_recovery.py
@@ -1,0 +1,161 @@
+"""Persisted transcript -> REST: creation evidence, not PR mentions."""
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli.web_routers import profiles
+from hermes_state import SessionDB
+
+URL = "https://github.com/example/base/pull/7"
+REPLACEMENT = "https://github.com/example/base/pull/8"
+
+
+def _terminal(output=URL, exit_code=0, **extra):
+    return {"output": output, "exit_code": exit_code, **extra}
+
+
+def _persist(db, session, name, args, result, *, linked=True):
+    call_id = f"call-{db.get_active_message_watermark(session)}"
+    db.append_message(session, "assistant", tool_calls=[{
+        "id": call_id, "type": "function",
+        "function": {"name": name, "arguments": json.dumps(args)},
+    }])
+    content = json.dumps(result)
+    if session == "mixed":
+        content = content.replace("/", "\\/")
+    db.append_message(session, "tool", tool_name=name,
+                      tool_call_id=call_id if linked else "missing-call", content=content)
+
+
+def _client(monkeypatch, tmp_path, targets):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "isolated-home"))
+    monkeypatch.setattr(profiles, "_profile_targets", lambda *a, **k: targets)
+    app = FastAPI()
+    app.include_router(profiles.sessions_router)
+    return TestClient(app)
+
+
+@pytest.mark.parametrize("compacted", [False, True], ids=["live", "compacted"])
+def test_only_successful_linked_creations_survive_later_research(tmp_path, monkeypatch, compacted):
+    nested_code = 'from hermes_tools import terminal\nprint(terminal(command="gh pr create --fill"))'
+    nested_result = {"status": "success", "exit_code": 0, "tool_calls_made": 1,
+                     "output": repr(_terminal("body scrub done\n" + URL)) + "\n"}
+    cases = {
+        "bare": ("terminal", {"command": "gh pr create --fill"}, _terminal(), True),
+        "mixed": ("terminal", {"command": "git push 2>&1 | tail -1; echo 'body scrub done'; gh pr create --fill"}, _terminal("body scrub done\n" + URL + "\n"), True),
+        "create-heredoc": ("terminal", {"command": "git push && gh pr create --body-file - <<'EOF'\n# Body\nReference gh pr view\nEOF"}, _terminal("pushed\n" + URL), True),
+        "create-tail": ("terminal", {"command": "git push; gh pr create --fill 2>&1 | tail -2"}, _terminal("body scrub done\n" + URL), True),
+        "create-redirect": ("terminal", {"command": "gh pr create --fill 2>&1"}, _terminal(), True),
+        "tail-file": ("terminal", {"command": "gh pr create --fill | tail -2 saved.txt"}, _terminal(), False),
+        "tail-skipped": ("terminal", {"command": "true || gh pr create --fill | tail -2"}, _terminal(), False),
+        "heredoc-followed": ("terminal", {"command": "cat <<'EOF'\nbody\nEOF\ngh pr view"}, _terminal(), False),
+        "nested": ("execute_code", {"code": nested_code}, nested_result, True),
+        "view": ("terminal", {"command": "gh pr view --json url --jq .url"}, _terminal(), False),
+        "review": ("terminal", {"command": "gh pr review --approve"}, _terminal(), False),
+        "comment": ("terminal", {"command": "gh pr view # gh pr create"}, _terminal(), False),
+        "body": ("terminal", {"command": "gh pr comment 7 --body 'notes; gh pr create'"}, _terminal(), False),
+        "heredoc": ("terminal", {"command": "cat <<'EOF'\ngh pr create\nEOF"}, _terminal(), False),
+        "prose": ("terminal", {"command": "gh pr create --fill"}, _terminal("Review " + URL), False),
+        "failed": ("terminal", {"command": "gh pr create --fill"}, _terminal(exit_code=1), False),
+        "error": ("terminal", {"command": "gh pr create --fill"}, _terminal(error="failed"), False),
+        "unknown-status": ("terminal", {"command": "gh pr create --fill"}, {"output": URL}, False),
+        "masked-failure": ("terminal", {"command": "gh pr create || true"}, _terminal(), False),
+        "skipped": ("terminal", {"command": "true || gh pr create"}, _terminal(), False),
+        "skipped-newline": ("terminal", {"command": "true ||\n# still conditional\ngh pr create"}, _terminal(), False),
+        "background-newline": ("terminal", {"command": "gh pr create &\n"}, _terminal(), False),
+        "unlinked": ("terminal", {"command": "gh pr create --fill"}, _terminal(), False),
+        "bad-host": ("terminal", {"command": "gh pr create --fill"}, _terminal(URL.replace("github.com", "github.com.evil")), False),
+        "bad-number": ("terminal", {"command": "gh pr create --fill"}, _terminal(URL[:-1] + "0"), False),
+        "bad-owner": ("terminal", {"command": "gh pr create --fill"}, _terminal(URL.replace("/example/", "/../")), False),
+        "ambiguous": ("terminal", {"command": "gh pr create --fill"}, _terminal(URL + "\n" + REPLACEMENT), False),
+        "nested-failed": ("execute_code", {"code": nested_code}, {**nested_result, "output": json.dumps(_terminal(exit_code=1))}, False),
+        "nested-mention": ("execute_code", {"code": '# gh pr create\nprint("reference")'}, nested_result, False),
+        "nested-body": ("execute_code", {"code": 'from hermes_tools import terminal\nprint(terminal(command="gh pr comment 7 --body \'gh pr create\'"))'}, nested_result, False),
+        "nested-fake": ("execute_code", {"code": 'from hermes_tools import terminal\nif False:\n terminal(command="gh pr create")\nprint({"output": "reference", "exit_code": 0})'}, nested_result, False),
+    }
+    with SessionDB(tmp_path / "state.db") as db:
+        for session, (name, args, result, created) in cases.items():
+            db.create_session(session_id=session, source="desktop")
+            _persist(db, session, name, args, result, linked=session != "unlinked")
+            if compacted:
+                db.archive_and_compact(session, [{"role": "user", "content": "summary"}])
+    with _client(monkeypatch, tmp_path, [("worker", tmp_path)]) as client:
+        response = client.post("/api/profiles/sessions/pull-requests", json={"ids": list(cases)})
+        assert response.status_code == 200
+        assert response.json()["pull_requests"] == {
+            session: {"number": 7, "url": URL}
+            for session, (_, _, _, created) in cases.items() if created
+        }
+        with SessionDB(tmp_path / "state.db") as db:
+            for session, (_, _, _, created) in cases.items():
+                if created:
+                    _persist(db, session, "terminal", {"command": "gh pr create --fill"}, _terminal(REPLACEMENT))
+                    _persist(db, session, "terminal", {"command": "gh pr view"}, _terminal(URL))
+        response = client.post("/api/profiles/sessions/pull-requests", json={"ids": list(cases)})
+    assert response.status_code == 200
+    assert response.json()["pull_requests"] == {
+        session: {"number": 8, "url": REPLACEMENT}
+        for session, (_, _, _, created) in cases.items() if created
+    }
+    assert set(response.json()["scanned"]) == set(cases)
+
+
+@pytest.mark.parametrize("inventory_failure", [False, True])
+def test_scan_uses_real_profile_discovery(tmp_path, monkeypatch, inventory_failure):
+    from hermes_cli import profiles as profiles_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    with SessionDB(home / "state.db") as db:
+        db.create_session("discovered", "desktop")
+        _persist(db, "discovered", "terminal", {"command": "gh pr create --fill"}, _terminal())
+    if inventory_failure:
+        def unavailable():
+            raise OSError("inventory unavailable")
+        monkeypatch.setattr(profiles_mod, "list_profiles", unavailable)
+    app = FastAPI()
+    app.include_router(profiles.sessions_router)
+    with TestClient(app) as client:
+        response = client.post("/api/profiles/sessions/pull-requests", json={"ids": ["discovered"]})
+    assert response.status_code == 200
+    assert response.json()["pull_requests"] == {"discovered": {"number": 7, "url": URL}}
+    assert response.json()["scanned"] == ([] if inventory_failure else ["discovered"])
+
+
+@pytest.mark.parametrize("unavailable", ["corrupt", "missing", "inventory"])
+def test_unread_profiles_remain_retryable_until_real_read_succeeds(tmp_path, monkeypatch, unavailable):
+    healthy, unread = tmp_path / "healthy", tmp_path / "unread"
+    healthy.mkdir()
+    unread.mkdir()
+    with SessionDB(healthy / "state.db") as db:
+        db.create_session(session_id="known-empty", source="desktop")
+    if unavailable == "corrupt":
+        (unread / "state.db").write_bytes(b"not a SQLite database")
+    targets = [("healthy", healthy), ("unread", unread)]
+    with _client(monkeypatch, tmp_path, targets) as client:
+        if unavailable == "inventory":
+            def failed_inventory(*args, errors=None, **kwargs):
+                errors.append({"error": "profile-inventory-unavailable"}) if errors is not None else None
+                return [("healthy", healthy)]
+            monkeypatch.setattr(profiles, "_profile_targets", failed_inventory)
+        payload = {"ids": ["known-empty", "unread-session"]}
+        first = client.post("/api/profiles/sessions/pull-requests", json=payload)
+        assert first.status_code == 200
+        assert "unread-session" not in first.json()["scanned"]
+        assert "unread-session" not in first.json()["pull_requests"]
+        if unavailable == "corrupt":
+            (unread / "state.db").unlink()
+        with SessionDB(unread / "state.db") as db:
+            db.create_session(session_id="unread-session", source="desktop")
+            _persist(db, "unread-session", "terminal", {"command": "gh pr create --fill"}, _terminal())
+        monkeypatch.setattr(profiles, "_profile_targets", lambda *a, **k: targets)
+        retried = client.post("/api/profiles/sessions/pull-requests", json=payload)
+        assert retried.status_code == 200
+        assert retried.json()["pull_requests"] == {"unread-session": {"number": 7, "url": URL}}
+        assert set(retried.json()["scanned"]) == set(payload["ids"])


### PR DESCRIPTION
## What does this PR do?

Repairs **Show → PR** for sessions in which an agent opened a pull request. The toggle could be checked while the sidebar remained empty: recovery skipped non-trunk/no-checkout sessions, remembered transcript misses indefinitely, rejected successful creation output containing other text, and tried to hydrate recovered PR numbers against the session's starting checkout. Mounted rows also did not subscribe to newly recovered associations.

This is a PR-data-path fix, not a Show → Activity feature change. It extends the existing recovery endpoint, PR store, and native/remote metadata APIs rather than adding a new service or model tool.

### Icon-only sidebar refinement

The sidebar now shows only the state-colored PR glyph at rest. The existing Hermes tooltip reveals the PR number and title above it on hover or keyboard focus. Open/merged/closed/draft colors and shapes, click-to-open, row height, and the age/action slots are preserved. The composer keeps its number-only presentation. No Activity changes.

Design consultation used Claude Code with Opus 5 at high effort. This follow-up passed independent review, 16 focused UI tests, all TypeScript projects, lint/format checks, and the full desktop suite (9,487 passed, 6 skipped). Actual dev checks covered 16px targets, 12px glyphs, hover/keyboard tooltips, and toggle off/on. Screenshots below use explicitly seeded PR-state fixtures in the actual dev app.

## Related Issue

No separate issue. Related to #89709's branch-enrichment and project-lane badge work, but addresses transcript discovery, session association, URL-based metadata hydration, and mounted session-row updates instead.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_messages.py` and the profiles router associate successful output with the same-session creating tool call. Standalone GitHub PR URL lines can appear alongside other output; views, mentions, failed commands, and shell-body text are not treated as creation provenance. Archived/compacted history remains searchable. Nested Python support is deliberately limited to statically verifiable literal terminal calls; no code is evaluated.
- A scan is acknowledged only after successful profile/inventory reads, so unavailable profiles remain retryable.
- The PR store retries when a transcript revision changes, supports non-trunk/no-root sessions, and preserves explicit desktop-created associations, including a stamp arriving during recovery.
- Native and remote `review.prList` accept validated full GitHub URLs, independently of cwd. Repository identity comes from that URL, avoiding collisions between equal PR numbers in different repositories.
- Current lookups are chunked at the API limit, with per-lookup freshness/reconciliation and confirmed-cache retention on failed hydration. Historical requests cannot starve newly visible sessions.
- Compact and card rows subscribe to PR-association changes. The existing toggle controls visibility; Activity is unchanged.

## How to Test

1. In an isolated dev profile, create fixture histories representing an agent-created PR from a feature branch, a session started outside a repository, a PR added after an earlier scan miss, and a negative session with no PR. Use a real public PR URL for read-only metadata hydration.
2. Enable **Show → PR**. Before the fix, the reproduction showed no badges. With the fix, the three relevant sessions show badges and the negative session remains blank. Toggle off/on and reload; verify visibility and preference/association persistence.
3. Run the focused store/row/native/remote regression tests and the backend session-recovery tests. Regressions were demonstrated red before their fixes, including explicit-association races, request-cap starvation, unavailable profile reads, and actual profile-discovery integration.
4. Validate native and remote URL hydration from outside a checkout using real `gh`, without creating a new remote PR.

Final verification on the upstream port:
- Full desktop UI + Electron suite: **9,487 passed, 6 skipped** (900 passing files, 2 skipped).
- Renderer/Electron/e2e TypeScript projects: passed.
- Six focused backend files: **62 passed, 0 failed** using the canonical hermetic runner with retries disabled.
- Targeted ESLint, Prettier, Ruff, and diff whitespace checks: passed.
- Parent-rerun native and remote REST reads of `actions/.github#221` returned the actual PR metadata with `ghReady: true` from outside a checkout; literal and encoded traversal inputs remain rejected.
- Isolated dev proof: three expected badges, negative control blank, toggle off/on, stored association/preference read-back, and reload persistence.

The dev screenshots use persisted test fixtures and real read-only GitHub metadata, not real-model inference. Live-history inspection was read-only. Full Python-suite coverage is not claimed.

## Checklist

### Code

- [ ] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux, isolated Electron dev instance

### Documentation & Housekeeping

- [x] Relevant docstrings and API contract comments updated
- [x] Config example changes: N/A; no new config keys
- [x] Architecture/workflow documentation changes: N/A
- [x] Cross-platform impact considered; existing native/remote subprocess APIs retained (macOS/Windows not exercised locally)
- [x] Model tool descriptions/schemas: N/A; no model tool changes

## Screenshots / Logs

### Current icon-only presentation

![Icon-only before and after](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/ef6c7760f35a86ecbea279a423f3c12bdbd00ccd/icon-comparison.png)

![Native Hermes hover tooltip](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/ef6c7760f35a86ecbea279a423f3c12bdbd00ccd/icon-hover-detail.png)

### Original data-recovery reproduction (before the visual refinement)


Same viewport, theme, and fixture identities; before/after captured in the actual dev app. The baseline was captured before editing in a checkout matching the installed source; the final proof was repeated after porting the PR-only changes onto current upstream main. No production profile writes or Activity changes.

![Sidebar detail](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/6aa4d3c59b71de7d269885dbddedde2f439274f8/sidebar-detail.png)

![Full before and after](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/6aa4d3c59b71de7d269885dbddedde2f439274f8/comparison.png)

Public-surface scrub: source diff and screenshots checked for credentials, private paths, local ports, and real session/task identifiers. PNG metadata is empty; uploaded assets were read back and verified against local SHA-256 hashes.

---
Implemented by GPT-6 Astra via Hermes Agent.
