### PR TITLE
fix(web): stop web_search sending an empty query to a paid backend

### DIFF
--- a/tests/tools/test_web_search_arg_shapes.py
+++ b/tests/tools/test_web_search_arg_shapes.py
@@ -1,0 +1,91 @@
+"""web_search argument-shape contracts.
+
+Guards two behaviours that a bare ``args.get("query", "")`` handler broke:
+an empty query was forwarded to a paid backend (burning a request plus a
+paid keyless-rescue retry) and returned a provider error that never said the
+parameter was missing, and the ``queries`` shape models reach for silently
+became an empty search instead of the search the model asked for.
+"""
+import json
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _registry():
+    import model_tools
+    model_tools.discover_builtin_tools()
+
+
+def _dispatch(args):
+    from tools.registry import registry
+    result = registry.dispatch("web_search", args)
+    return result if isinstance(result, dict) else json.loads(result)
+
+
+def test_missing_query_fails_without_calling_a_backend(monkeypatch):
+    """An unusable query is rejected locally, so no paid request is sent."""
+    import tools.web_tools as web_tools
+
+    called = []
+    monkeypatch.setattr(
+        web_tools, "_memoized_search",
+        lambda *a, **kw: called.append(a) or {"success": True, "data": {"web": []}},
+    )
+
+    for args in ({}, {"query": ""}, {"query": "   "}, {"query": None}):
+        result = _dispatch(args)
+        assert result["success"] is False, args
+        # The message must name the parameter; a provider's own error does not.
+        assert "query" in result["error"]
+
+    assert called == [], "an unusable query must not reach a search backend"
+
+
+def test_plural_queries_resolves_to_a_query(monkeypatch):
+    """`queries` (list or JSON-encoded list) searches instead of sending empty."""
+    import tools.web_tools as web_tools
+
+    seen = []
+
+    def _fake(provider, query, limit):
+        seen.append(query)
+        return {"success": True, "data": {"web": []}}
+
+    monkeypatch.setattr(web_tools, "_memoized_search", _fake)
+
+    for args in (
+        {"queries": ["standards based grading"]},
+        {"queries": '["standards based grading", "second"]'},
+        {"queries": "standards based grading"},
+        {"query": ["standards based grading"]},
+    ):
+        seen.clear()
+        result = _dispatch(args)
+        assert result["success"] is True, args
+        assert seen and seen[0].strip(), f"{args} produced an empty query"
+
+
+def test_singular_query_is_passed_through_unchanged(monkeypatch):
+    """The documented shape keeps working, operators and all."""
+    import tools.web_tools as web_tools
+
+    seen = []
+    monkeypatch.setattr(
+        web_tools, "_memoized_search",
+        lambda provider, query, limit: seen.append((query, limit)) or {"success": True, "data": {"web": []}},
+    )
+
+    assert _dispatch({"query": 'site:example.com "exact phrase"', "limit": 3})["success"] is True
+    assert seen[0][0] == 'site:example.com "exact phrase"'
+    assert seen[0][1] == 3
+
+
+def test_schema_documents_the_singular_parameter():
+    """The schema must steer models away from the plural form."""
+    from tools.web_tools import WEB_SEARCH_SCHEMA
+
+    assert "query" in WEB_SEARCH_SCHEMA["parameters"]["properties"]
+    assert WEB_SEARCH_SCHEMA["parameters"]["required"] == ["query"]
+    assert "queries" not in WEB_SEARCH_SCHEMA["parameters"]["properties"]
+    assert "queries" in WEB_SEARCH_SCHEMA["description"]

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -269,6 +269,17 @@ def web_search_tool(query: str, limit: int = 5) -> str:
     Returns a JSON string ``{"success": bool, "data": {"web": [{"title", "url", "description", "position"},
     ...]}}`` (metadata only — use web_extract_tool for page content) or ``{"success": false, "error": ...}``.
     """
+    # Guard before any network call: an empty query cannot succeed on any backend,
+    # and calling out anyway burns a paid request plus a paid keyless-rescue retry
+    # while returning a provider error that does not say the parameter was missing.
+    if not isinstance(query, str) or not query.strip():
+        return json.dumps({
+            "success": False,
+            "error": "web_search requires a non-empty 'query' string (one query per call). "
+                     "No request was sent. If you passed 'queries' or a list, retry as "
+                     "web_search(query=\"<single query>\") and call it once per query.",
+        }, indent=2, ensure_ascii=False)
+
     try:
         limit = min(max(int(limit), 1), 100)
     except (TypeError, ValueError):
@@ -451,7 +462,7 @@ from tools.registry import registry, tool_error
 
 WEB_SEARCH_SCHEMA = {
     "name": "web_search",
-    "description": "Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
+    "description": "Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. Takes ONE query string per call (the parameter is 'query', not 'queries') — call it again for each additional query. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -493,9 +504,45 @@ WEB_EXTRACT_SCHEMA = {
     }
 }
 
+def _web_search_query_arg(args: dict) -> str:
+    """Read the query from `query`, tolerating the `queries` shape models reach for.
+
+    The schema asks for a single string `query`. Models trained on multi-query search
+    tools send `queries` (sometimes a list, sometimes a JSON-encoded list). Coercing
+    the first element is strictly better than sending an empty query to a paid
+    backend, which is what a bare `args.get("query", "")` did.
+    """
+    raw = args.get("query")
+    if isinstance(raw, str) and raw.strip():
+        return raw
+    if isinstance(raw, list) and raw:
+        first = raw[0]
+        if isinstance(first, str) and first.strip():
+            return first
+    alt = args.get("queries")
+    if isinstance(alt, str) and alt.strip():
+        text = alt.strip()
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+            except (ValueError, TypeError):
+                parsed = None
+            if isinstance(parsed, list):
+                for item in parsed:
+                    if isinstance(item, str) and item.strip():
+                        return item
+            return ""
+        return text
+    if isinstance(alt, list):
+        for item in alt:
+            if isinstance(item, str) and item.strip():
+                return item
+    return ""
+
+
 registry.register(
     name="web_search", toolset="web", schema=WEB_SEARCH_SCHEMA,
-    handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
+    handler=lambda args, **kw: web_search_tool(_web_search_query_arg(args), limit=args.get("limit", 5)),
     check_fn=check_web_api_key, requires_env=_web_requires_env(), emoji="🔍",
     max_result_size_chars=100_000,
 )


### PR DESCRIPTION
## Problem

`web_search`'s handler read `args.get("query", "")`, so a call that omitted `query` — or sent the plural `queries` shape that multi-query search tools train models to emit — reached the provider with an empty string.

Three consequences, all bad:

1. The empty query **hit the network**, burning a paid request.
2. The one-shot keyless rescue then fired, burning a **second** paid request.
3. The error surfaced to the model came from the provider (`{"detail":{"error":"Query is missing."}}`) and never named the parameter the caller got wrong.

Reproduced on `main` via the registry:

```python
registry.dispatch("web_search", {"queries": '["a","b"]'})
# -> {"success": false, "error": "{\"detail\":{\"error\":\"Query is missing.\"}} (keyless rescue also failed: ...)"}
```

A subagent hit this eight consecutive times and abandoned `web_search` for the rest of its run.

## Fix

- **Guard before any network call** in `web_search_tool`. An empty or non-string query returns immediately with an error naming `query`; no request is sent and no rescue fires.
- **`_web_search_query_arg`** resolves `queries` (list, JSON-encoded list, or bare string) and a list-valued `query`. Coercing the first element is strictly better than searching for `""`.
- **Schema description** now states the parameter is `query`, not `queries`, and that it takes one query per call.

The schema was already correct (`query`, required); only the handler and the description changed. No behavior change for the documented singular form.

## Tests

`tests/tools/test_web_search_arg_shapes.py` — 4 tests, contracts not snapshots:

- an unusable query must not reach a backend (patches `_memoized_search`, asserts it is never called)
- the plural forms must produce a non-empty query
- the documented singular form passes through unchanged, operators included
- the schema keeps `query` required and mentions `queries`

Proven red on base, green after.

## Verification

```
scripts/run_tests.sh tests/tools/test_web_search_arg_shapes.py
=== Summary: 1 files, 4 tests passed, 0 failed
```

Regression check on the surrounding suite, baselined by stashing the change and re-running the same selection: `tests/tools/ -k "web or browser_secret"` had the **same 12 pre-existing failures** before and after (optional provider SDKs gated behind `security.allow_lazy_installs=false`). **Zero regressions.**

Live check that the previously failing call now works:

```python
registry.dispatch("web_search", {"queries": '["Alpine School District administration", "second"]'})
# -> success: True, 5 results
```
