### PR TITLE
fix(gateway): honour Telegram flood waits on streaming edits

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2905,10 +2905,19 @@ class GatewayTurnMixin:
             await asyncio.sleep(0.05)
 
     @staticmethod
-    async def _await_stream_task(stream_task) -> None:
-        """Give the stream consumer task 5s to flush, then cancel it."""
+    async def _await_stream_task(stream_task, consumer: Any = None) -> None:
+        """Give the stream consumer task 5s to flush, then cancel it.
+
+        A consumer sitting out a bounded platform flood penalty gets that wait on top of the
+        5s: cancelling it mid-penalty abandons an in-place final edit in favour of a fresh
+        send into the same ban, which is exactly what the delivery ledger then has to
+        redeliver minutes later. The budget is read once, so a penalty that only begins after
+        the join has started still cancels at 5s and falls back, as it did before."""
+        _flood_wait = 0.0
+        with suppress(Exception):
+            _flood_wait = max(0.0, float(getattr(consumer, "flood_pause_remaining", 0.0) or 0.0))
         try:
-            await asyncio.wait_for(stream_task, timeout=5.0)
+            await asyncio.wait_for(stream_task, timeout=5.0 + _flood_wait)
         except (asyncio.TimeoutError, asyncio.CancelledError):
             stream_task.cancel()
             with suppress(asyncio.CancelledError):
@@ -3344,7 +3353,7 @@ class GatewayTurnMixin:
         _sc = turn_ctx.stream_consumer_holder[0]
         if _sc and stream_task:
             try:
-                await self._await_stream_task(stream_task)
+                await self._await_stream_task(stream_task, _sc)
             except Exception as e:
                 logger.debug("Stream consumer wait before queued message failed: %s", e)
         # Delivery uses the finalized task result (empty/failure normalization), not raw ``result``.
@@ -3506,7 +3515,7 @@ class GatewayTurnMixin:
                 with suppress(asyncio.CancelledError):
                     await stream_task
             else:
-                await self._await_stream_task(stream_task)
+                await self._await_stream_task(stream_task, stream_consumer_holder[0])
 
         # Abort + bounded wait for streaming TTS: covers paths where normal finalisation was skipped.
         _stts_finally = turn_ctx.streaming_tts_consumer_holder[0]

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -74,6 +74,8 @@ class StreamConsumerConfig:
     # (progressive editMessageText).  "off" is handled by the gateway.
     transport: str = "edit"
     chat_type: str = ""  # originating chat type; gates platform-specific drafts
+    # Runtime-only bound: finalization may wait inline, but must not stall for minutes.
+    flood_pause_cap_seconds: float = 30.0
 
 
 @dataclass
@@ -150,6 +152,7 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         self._last_edit_time = 0.0
         self._last_edit_overflowed = False  # last _send_or_edit split into continuations
         self._flood_strikes = 0
+        self._flood_pause_until = 0.0
         self._current_edit_interval = self.cfg.edit_interval  # adaptive backoff
         self._delivered_commentary_texts: list[str] = []
         self._delivered_segment_texts: list[str] = []  # finalized text per past segment
@@ -261,6 +264,11 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
     final_response_sent = property(lambda self: self._final_response_sent)
     message_id = property(lambda self: self._message_id)
     final_content_delivered = property(lambda self: self._final_content_delivered)
+    # Seconds this turn must still sit out a platform flood penalty before its final edit can
+    # land; 0.0 when none. The gateway adds it to the join budget it gives run(), so waiting
+    # out a bounded ban never has to outlive a cancel.
+    flood_pause_remaining = property(
+        lambda self: max(0.0, self._flood_pause_until - time.monotonic()))
 
     async def _notify_before_finalize(self) -> None:
         """Run the pre-finalize hook exactly once, swallowing hook errors."""
@@ -697,7 +705,7 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         """Decide whether this tick flushes an edit/frame."""
         if not tick.is_interim:
             return True
-        if self.cfg.buffer_only:
+        if self.cfg.buffer_only or time.monotonic() < self._flood_pause_until:
             return False
         if self._use_native_streaming:
             # No platform edit-rate limit: push every delta immediately.
@@ -897,7 +905,10 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         # _accumulated holds unseen pre-boundary text — flush it before the reset.
         if (self._accumulated and not tick.update_visible and self._message_id
                 and self._message_id != "__no_edit__"):
-            await self._flush_segment_tail_on_edit_failure()
+            # A refused segment-final edit may have started a new pause. The tail
+            # send and cosmetic cursor edit share the same platform flood budget.
+            if await self._wait_for_flood_pause():
+                await self._flush_segment_tail_on_edit_failure()
         self._reset_segment_state(preserve_no_edit=True)
 
     async def _on_cancelled(self) -> None:
@@ -909,7 +920,7 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         if self._accumulated and self._message_id:
             with contextlib.suppress(Exception):
                 best_effort_ok = bool(await self._send_or_edit(
-                    self._accumulated, finalize=True, is_turn_final=False))
+                    self._accumulated, finalize=True, is_turn_final=False, wait_for_flood=False))
         elif self._message_id is None:
             # Draft path keeps _message_id=None; seal in place (else the stream stays
             # visibly live and the adapter keeps armed interception state).

--- a/gateway/stream_consumer_transport.py
+++ b/gateway/stream_consumer_transport.py
@@ -290,11 +290,31 @@ class StreamTransportMixin:
             self._message_id = "__no_edit__"
             self._message_created_ts = None
 
+    async def _wait_for_flood_pause(self) -> bool:
+        """Wait out a bounded refusal; keep its deadline to recognise continued refusal.
+
+        Cancellation propagates. The gateway grants this wait on top of its own join budget
+        (see ``flood_pause_remaining``), so a cancel arriving here is a real abort — a session
+        reset or shutdown — and swallowing it would defeat a timeout this module does not own."""
+        remaining = self._flood_pause_until - time.monotonic()
+        if remaining > 0:
+            await asyncio.sleep(remaining)
+        return self._run_still_current()
+
     async def _send_or_edit(
-        self, text: str, *, finalize: bool = False, is_turn_final: bool = True) -> bool:
+        self, text: str, *, finalize: bool = False, is_turn_final: bool = True,
+        wait_for_flood: bool = True) -> bool:
         """Send or edit the streaming message; True if delivered.  ``finalize`` marks the
         last edit.  Transport order: native frame → draft frame → edit existing → first
         send; a transport returns None to fall through to the next."""
+        if self._flood_pause_until:
+            # ``wait_for_flood`` is False on the cancellation path: teardown takes the edit it can
+            # get now, never sitting out a ban the caller has already stopped waiting for.
+            if time.monotonic() < self._flood_pause_until and (not finalize or not wait_for_flood):
+                return False
+            # A reset during the wait also invalidates later finalize passes.
+            if not await self._wait_for_flood_pause():
+                return False
         text = self._clean_for_display(text)
         # Stream-is-the-message draft frames must stay prefix-stable: a closing ```
         # on a mid-code-block frame makes frame N not a prefix of N+1 and the
@@ -457,8 +477,20 @@ class StreamTransportMixin:
         result = await self._edit_message(message_id=self._message_id, content=text,
                                           finalize=finalize)
         if not result.success:
-            return await self._on_edit_failure(result, text, finalize=finalize,
-                                               is_turn_final=is_turn_final)
+            await self._on_edit_failure(result, text, finalize=finalize,
+                                        is_turn_final=is_turn_final)
+            if not (finalize and is_turn_final and self._edit_supported
+                    and self._flood_pause_until > time.monotonic()):
+                return False
+            # A fallback send would hit the same ban. Retry this finalize edit
+            # once, bypassing fresh-final so it cannot turn into a second send.
+            if not await self._wait_for_flood_pause():
+                return False
+            result = await self._edit_message(message_id=self._message_id, content=text,
+                                              finalize=True)
+            if not result.success:
+                return await self._on_edit_failure(result, text, finalize=True,
+                                                   is_turn_final=True, final_flood_retry=True)
         self._already_sent = True
         self._track_preview_ids_from_result(result)
         # Oversized edit split across continuations: message_id is now the LAST
@@ -474,6 +506,7 @@ class StreamTransportMixin:
         else:
             self._last_sent_text = text
         self._flood_strikes = 0
+        self._flood_pause_until = 0.0
         return True
 
     def _enter_fallback_mode(self, prefix: str) -> None:
@@ -484,6 +517,7 @@ class StreamTransportMixin:
         self._already_sent = True
 
     async def _on_edit_failure(self, result, text: str, *, finalize: bool, is_turn_final: bool,
+                               final_flood_retry: bool = False,
                                ) -> bool:
         """Classify a failed edit: partial overflow, flood backoff, or fallback mode.  Always
         False; the caller's finalize path may still deliver the tail."""
@@ -517,19 +551,37 @@ class StreamTransportMixin:
                 self._notify_new_message()
             return False
 
-        # Flood control: adaptive backoff (double the interval); disable edits only
-        # after _MAX_FLOOD_STRIKES in a row.
         immediate_final_fallback = False
         if self._is_flood_error(result):
-            self._flood_strikes += 1
-            self._current_edit_interval = min(self._current_edit_interval * 2, 10.0)
-            logger.debug("Flood control on edit (strike %d/%d), backoff interval → %.1fs",
-                         self._flood_strikes, self._MAX_FLOOD_STRIKES, self._current_edit_interval)
             immediate_final_fallback = (
-                turn_final and getattr(self.adapter, "FALLBACK_ON_FINAL_EDIT_FLOOD", False) is True)
-            if self._flood_strikes < self._MAX_FLOOD_STRIKES and not immediate_final_fallback:
-                self._last_edit_time = time.monotonic()  # honor the new interval
-                return False
+                turn_final and (final_flood_retry
+                               or getattr(self.adapter, "FALLBACK_ON_FINAL_EDIT_FLOOD", False) is True))
+            try:
+                wait = float(getattr(result, "retry_after", None) or 0.0)
+            except (TypeError, ValueError):
+                wait = 0.0
+            now = time.monotonic()
+            if 0 < wait <= self.cfg.flood_pause_cap_seconds and not immediate_final_fallback:
+                # The first refusal costs no strike. Only continued refusal after
+                # complying with the last deadline counts toward abandoning edits.
+                if self._flood_pause_until and now >= self._flood_pause_until:
+                    self._flood_strikes += 1
+                # A turn-final still gets its single edit retry: a fallback send
+                # would hit the same ban even when preview strikes are exhausted.
+                if self._flood_strikes < self._MAX_FLOOD_STRIKES or turn_final:
+                    self._flood_pause_until = now + wait
+                    logger.debug("Flood control on edit; pausing %.1fs (strikes=%d/%d)",
+                                 wait, self._flood_strikes, self._MAX_FLOOD_STRIKES)
+                    return False
+            else:
+                # No usable bounded wait: preserve the legacy strike + doubling path.
+                self._flood_strikes += 1
+                self._current_edit_interval = min(self._current_edit_interval * 2, 10.0)
+                logger.debug("Flood control on edit (strike %d/%d), backoff interval → %.1fs",
+                             self._flood_strikes, self._MAX_FLOOD_STRIKES, self._current_edit_interval)
+                if self._flood_strikes < self._MAX_FLOOD_STRIKES and not immediate_final_fallback:
+                    self._last_edit_time = now  # honor the new interval
+                    return False
             if immediate_final_fallback:
                 logger.debug("Turn-final edit hit flood control; entering fallback immediately")
 

--- a/tests/gateway/test_stream_edit_flood_pause.py
+++ b/tests/gateway/test_stream_edit_flood_pause.py
@@ -1,0 +1,395 @@
+"""Streaming edits must respect a bounded server wait without losing buffered text."""
+
+import asyncio
+from collections import deque
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.platforms.base import SendResult
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+class Clock:
+    def __init__(self):
+        self.now = 100.0
+        self.waits = []
+        self.ticks = deque()
+
+    def monotonic(self):
+        return self.now
+
+    async def sleep(self, seconds):
+        if seconds == 0.05:
+            if not self.ticks:
+                pytest.fail("Consumer ran past the scripted ticks")
+            self.ticks.popleft()()
+        else:
+            self.waits.append(seconds)
+            self.now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    clock = Clock()
+    for module in ("gateway.stream_consumer", "gateway.stream_consumer_transport"):
+        monkeypatch.setattr(f"{module}.time", clock)
+    monkeypatch.setattr("gateway.stream_consumer.asyncio.sleep", clock.sleep)
+    return clock
+
+
+def flood(wait=9.0):
+    return SendResult(success=False, error=f"flood_control:{wait}", retry_after=wait)
+
+
+def make_consumer(clock, **config):
+    results = deque()
+    edit_times = []
+
+    async def edit(**kwargs):
+        edit_times.append(clock.now)
+        return results.popleft() if results else SendResult(
+            success=True, message_id=kwargs["message_id"])
+
+    adapter = SimpleNamespace(
+        MAX_MESSAGE_LENGTH=4096,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="preview")),
+        edit_message=AsyncMock(side_effect=edit),
+        delete_message=AsyncMock(return_value=True),
+        edit_results=results,
+        edit_times=edit_times,
+    )
+    cfg = StreamConsumerConfig(edit_interval=0.25, buffer_threshold=1, cursor=" ▉")
+    for key, value in config.items():
+        setattr(cfg, key, value)
+    return GatewayStreamConsumer(adapter, "chat", cfg), adapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("buffer_threshold", [1, 10_000])
+async def test_pause_gates_ticks_and_resumes_with_all_buffered_text(clock, buffer_threshold):
+    consumer, adapter = make_consumer(clock, buffer_threshold=buffer_threshold)
+    await consumer._send_or_edit("First ▉")
+    adapter.edit_results.append(flood())
+    consumer.on_delta("First plus")
+    snapshots = []
+
+    def during_pause():
+        snapshots.append((consumer._flood_strikes, consumer._edit_supported,
+                          consumer._fallback_final_send))
+        consumer.on_delta(" buffered text")
+        clock.now = 108.99
+
+    def just_before_deadline():
+        snapshots.append(adapter.edit_message.await_count)
+        clock.now = 109.0
+
+    def finish():
+        snapshots.append(adapter.edit_message.call_args.kwargs["content"])
+        consumer.finish()
+
+    clock.ticks.extend([during_pause, just_before_deadline, finish])
+    await consumer.run()
+
+    assert snapshots == [(0, True, False), 1, "First plus buffered text ▉"]
+    assert adapter.edit_times == [100.0, 109.0, 109.0]
+    assert adapter.edit_message.call_args.kwargs["content"] == "First plus buffered text"
+    assert adapter.edit_message.call_args.kwargs["finalize"] is True
+    assert consumer.final_content_delivered is True
+    assert consumer.delivered_final_matches("First plus buffered text")
+    assert adapter.send.await_count == 1
+    assert clock.waits == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("retry_after", [None, 0.0, -1.0, 271.0])
+async def test_unhonoured_wait_keeps_legacy_strikes_and_doubling(clock, retry_after):
+    consumer, adapter = make_consumer(clock)
+    await consumer._send_or_edit("First ▉")
+    adapter.edit_results.extend([SendResult(
+        success=False, error="flood_control:9.0", retry_after=retry_after)] * 4)
+
+    for attempt, interval in enumerate([0.5, 1.0, 2.0], start=1):
+        assert not await consumer._send_or_edit(f"First plus {attempt} ▉")
+        assert consumer._flood_strikes == attempt
+        assert consumer._current_edit_interval == interval
+        assert consumer._fallback_final_send is (attempt == 3)
+        assert consumer._edit_supported is (attempt < 3)
+        assert getattr(consumer, "_flood_pause_until", 0.0) == 0.0
+
+    # The third strike still makes the existing best-effort cursor-strip attempt.
+    assert adapter.edit_message.await_count == 4
+    assert clock.waits == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cap, expected_strikes", [(8.0, 1), (9.0, 0)])
+async def test_configured_cap_controls_whether_wait_is_honoured(clock, cap, expected_strikes):
+    consumer, adapter = make_consumer(clock, flood_pause_cap_seconds=cap)
+    await consumer._send_or_edit("First ▉")
+    adapter.edit_results.append(flood())
+    await consumer._send_or_edit("First plus ▉")
+
+    assert consumer._flood_strikes == expected_strikes
+    assert consumer._current_edit_interval == (0.5 if expected_strikes else 0.25)
+    assert getattr(consumer, "_flood_pause_until", 0.0) == (0.0 if expected_strikes else 109.0)
+
+
+@pytest.mark.asyncio
+async def test_three_refusals_after_honoured_waits_enter_fallback(clock):
+    consumer, adapter = make_consumer(clock)
+    await consumer._send_or_edit("First ▉")
+    adapter.edit_results.extend([flood()] * 5)
+
+    for strike in range(4):
+        clock.now = 100.0 + strike * 9.0
+        await consumer._send_or_edit(f"First plus {strike} ▉")
+        assert consumer._flood_strikes == strike
+        assert consumer._fallback_final_send is (strike == 3)
+        assert consumer._edit_supported is (strike < 3)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("retry_succeeds", [True, False])
+async def test_turn_final_waits_and_retries_only_once(clock, retry_succeeds):
+    consumer, adapter = make_consumer(clock)
+    await consumer._send_or_edit("First ▉")
+    adapter.edit_results.append(flood())
+    if not retry_succeeds:
+        adapter.edit_results.append(flood())
+    consumer.finish("First plus the final answer")
+    await consumer.run()
+
+    assert clock.waits == [9.0]
+    assert adapter.edit_times == [100.0, 109.0]
+    assert all(call.kwargs["finalize"] for call in adapter.edit_message.call_args_list)
+    assert consumer.final_content_delivered is True
+    assert adapter.send.await_count == (1 if retry_succeeds else 2)
+    if not retry_succeeds:
+        assert adapter.send.call_args.kwargs["content"] == "plus the final answer"
+        assert consumer._edit_supported is False
+
+
+@pytest.mark.asyncio
+async def test_turn_final_gets_one_retry_when_refusal_reaches_strike_limit(clock):
+    consumer, adapter = make_consumer(clock)
+    await consumer._send_or_edit("First ▉")
+    adapter.edit_results.extend([flood()] * 4)
+    for attempt in range(3):
+        clock.now = 100.0 + attempt * 9.0
+        await consumer._send_or_edit(f"First plus {attempt} ▉")
+    assert consumer._flood_strikes == 2
+    clock.now = 127.0
+    consumer.finish("First plus the final answer")
+    await consumer.run()
+
+    assert clock.waits == [9.0]
+    assert adapter.edit_times == [100.0, 109.0, 118.0, 127.0, 136.0]
+    assert adapter.edit_message.call_args.kwargs["finalize"] is True
+    assert adapter.send.await_count == 1
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("segment_break", [False, True])
+async def test_boundary_waits_for_active_pause_before_finalizing(clock, segment_break):
+    consumer, adapter = make_consumer(clock)
+    await consumer._send_or_edit("First ▉")
+    adapter.edit_results.append(flood())
+    await consumer._send_or_edit("First plus ▉")
+    clock.now = 102.0
+    consumer.on_delta("First plus buffered tail")
+    if segment_break:
+        consumer.on_segment_break()
+
+        def next_segment():
+            consumer.on_delta("Next segment answer")
+            consumer.finish()
+
+        clock.ticks.append(next_segment)
+    else:
+        consumer.finish()
+    await consumer.run()
+
+    assert clock.waits == [7.0]
+    assert adapter.edit_times == [100.0, 109.0]
+    assert adapter.edit_message.call_args.kwargs["content"] == "First plus buffered tail"
+    assert adapter.edit_message.call_args.kwargs["finalize"] is True
+    assert adapter.send.await_count == (2 if segment_break else 1)
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_segment_refusal_flushes_unseen_tail_after_wait(clock):
+    consumer, adapter = make_consumer(clock)
+    await consumer._send_or_edit("First ▉")
+    adapter.edit_results.append(flood())
+    consumer.on_delta("First plus segment tail")
+    consumer.on_segment_break()
+
+    def next_segment():
+        consumer.on_delta("Next segment answer")
+        consumer.finish()
+
+    clock.ticks.append(next_segment)
+    await consumer.run()
+
+    assert clock.waits == [9.0]
+    assert adapter.edit_times == [100.0, 109.0]
+    tail = adapter.send.call_args_list[1].kwargs
+    assert tail["content"] == "plus segment tail"
+    assert tail["metadata"]["_interim_send"] is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_success_resets_pause_and_strikes(clock):
+    consumer, adapter = make_consumer(clock)
+    await consumer._send_or_edit("First ▉")
+    adapter.edit_results.extend([flood(), flood()])
+    await consumer._send_or_edit("First plus ▉")
+    clock.now = 109.0
+    await consumer._send_or_edit("First plus more ▉")
+    assert consumer._flood_strikes == 1
+    clock.now = 118.0
+    assert await consumer._send_or_edit("First plus more text ▉")
+    assert consumer._flood_strikes == 0
+    assert consumer._flood_pause_until == 0.0
+
+    adapter.edit_results.append(flood())
+    await consumer._send_or_edit("First plus more text again ▉")
+    assert consumer._flood_strikes == 0
+    assert consumer._edit_supported is True
+
+
+@pytest.mark.asyncio
+async def test_final_flood_opt_in_still_falls_back_immediately(clock):
+    consumer, adapter = make_consumer(clock)
+    adapter.FALLBACK_ON_FINAL_EDIT_FLOOD = True
+    await consumer._send_or_edit("First ▉")
+    adapter.edit_results.append(flood())
+    consumer.finish("First plus the final answer")
+    await consumer.run()
+
+    assert clock.waits == []
+    assert adapter.edit_times == [100.0]
+    assert adapter.send.await_count == 2
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_cursor_only_failure_keeps_final_content_delivered(clock):
+    consumer, adapter = make_consumer(clock)
+    await consumer._send_or_edit("Complete answer ▉")
+    adapter.edit_results.append(flood())
+    seen_during_wait = []
+    sleep = clock.sleep
+
+    async def observe_wait(seconds):
+        seen_during_wait.append(consumer.final_content_delivered)
+        await sleep(seconds)
+
+    with patch("gateway.stream_consumer.asyncio.sleep", observe_wait):
+        consumer.finish("Complete answer")
+        await consumer.run()
+
+    assert seen_during_wait == [True]
+    assert consumer.final_content_delivered is True
+    assert consumer.delivered_final_matches("Complete answer")
+    assert adapter.send.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pause_already_active", [False, True])
+async def test_turn_reset_during_wait_does_not_deliver_stale_final(clock, pause_already_active):
+    consumer, adapter = make_consumer(clock)
+    await consumer._send_or_edit("First ▉")
+    adapter.edit_results.append(flood())
+    if pause_already_active:
+        await consumer._send_or_edit("First plus ▉")
+    sleep = clock.sleep
+
+    async def reset_during_wait(seconds):
+        await sleep(seconds)
+        consumer._run_still_current = lambda: False
+
+    with patch("gateway.stream_consumer.asyncio.sleep", reset_during_wait):
+        consumer.finish("First plus the final answer")
+        await consumer.run()
+
+    assert clock.waits == [9.0]
+    assert adapter.edit_times == [100.0]
+    assert adapter.send.await_count == 1
+    assert consumer.final_content_delivered is False
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_during_the_wait_aborts_instead_of_being_swallowed(clock):
+    """The join budget belongs to the gateway, which grants the flood wait up front (see the
+    next two tests). A cancel arriving here is therefore a real abort — a session reset or a
+    shutdown — and catching it would silently defeat a timeout this module does not own."""
+    consumer, adapter = make_consumer(clock)
+    await consumer._send_or_edit("First \u2589")
+    adapter.edit_results.append(flood())
+
+    sleep = clock.sleep
+    cancelled = False
+
+    async def cancel_once(seconds):
+        # Exactly one cancel, the shape of the gateway's join timeout firing mid-wait.
+        nonlocal cancelled
+        if not cancelled:
+            cancelled = True
+            clock.now += 5.0
+            raise asyncio.CancelledError
+        await sleep(seconds)
+
+    with patch("gateway.stream_consumer.asyncio.sleep", cancel_once):
+        consumer.finish("First plus the final answer")
+        await consumer.run()   # run() owns cancellation: it finalizes best-effort, never re-raises
+
+    # The refused edit only. No retry at 109.0, and teardown did not sit out the rest of the ban.
+    assert adapter.edit_times == [100.0]
+    assert clock.waits == []
+    assert consumer.final_content_delivered is False
+
+
+@pytest.mark.asyncio
+async def test_the_outstanding_wait_is_published_for_the_join_budget(clock):
+    consumer, adapter = make_consumer(clock)
+    assert consumer.flood_pause_remaining == 0.0
+
+    await consumer._send_or_edit("First \u2589")
+    adapter.edit_results.append(flood())
+    await consumer._send_or_edit("First plus \u2589")
+    assert consumer.flood_pause_remaining == 9.0
+
+    clock.now += 4.0
+    assert consumer.flood_pause_remaining == 5.0
+    clock.now += 9.0
+    assert consumer.flood_pause_remaining == 0.0   # never negative once the ban has passed
+
+
+@pytest.mark.asyncio
+async def test_the_gateway_join_grants_the_outstanding_flood_wait():
+    """Without this the consumer would have to outlive the cancel to finish its final edit."""
+    from gateway.run import GatewayRunner
+
+    budgets = []
+
+    async def fake_wait_for(task, timeout):
+        budgets.append(timeout)
+        task.cancel()
+        raise asyncio.TimeoutError
+
+    async def _never():
+        await asyncio.sleep(60)
+
+    with patch("gateway.run_turn.asyncio.wait_for", fake_wait_for):
+        for consumer in (None,
+                         SimpleNamespace(flood_pause_remaining=9.0),
+                         SimpleNamespace(flood_pause_remaining=0.0)):
+            await GatewayRunner._await_stream_task(asyncio.create_task(_never()), consumer)
+
+    assert budgets == [5.0, 14.0, 5.0]

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -70,8 +70,14 @@ async def test_turn_final_flood_immediately_delivers_missing_tail():
 
 
 @pytest.mark.asyncio
-async def test_non_opt_in_adapter_keeps_adaptive_final_edit_retry():
-    """Immediate final fallback remains scoped to opted-in adapters."""
+async def test_non_opt_in_adapter_keeps_adaptive_final_edit_retry(monkeypatch):
+    """Immediate final fallback remains scoped to opted-in adapters.
+
+    A non-opt-in adapter now sits out the server's bounded penalty and retries the final edit
+    once, rather than charging the first refusal a strike. Only a refusal that survives that
+    compliance falls back, so the fresh send is never fired straight into the same ban."""
+    sleep = AsyncMock()
+    monkeypatch.setattr("gateway.stream_consumer.asyncio.sleep", sleep)
     adapter = _adapter()
     adapter.FALLBACK_ON_FINAL_EDIT_FLOOD = False
     adapter.edit_message.return_value = SendResult(
@@ -92,8 +98,10 @@ async def test_non_opt_in_adapter_keeps_adaptive_final_edit_retry():
     )
 
     assert ok is False
-    assert consumer._flood_strikes == 1
-    assert consumer._fallback_final_send is False
+    assert adapter.edit_message.await_count == 2   # the refusal, then one retry after the wait
+    assert sleep.await_count == 1                  # the penalty was waited out, not burned
+    assert consumer._flood_strikes == 1            # only the post-compliance refusal counts
+    assert consumer._fallback_final_send is True   # and only then does the fallback arm
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A streaming preview is abandoned mid-render whenever Telegram asks the gateway to wait, because the consumer never reads the wait it was given. The reader is left with a truncated raw-markdown message, and the complete answer arrives separately minutes later.

## What happens

`_on_edit_failure` in `gateway/stream_consumer_transport.py` treats a flood-refused preview edit as a generic failure: it doubles `_current_edit_interval` and counts a strike, giving up after `_MAX_FLOOD_STRIKES`. It ignores `retry_after`, which the adapter has already put on the result (`_flood_cap_result` returns `error="flood_control:<secs>"` with `retry_after` set whenever the wait exceeds the adapter's 5 second inline cap).

Because the edit interval starts well under a second, doubling it three times still lands far below any real penalty, so all three strikes are spent almost immediately. Each refused edit is itself another request against the same limit, so complying is replaced by hammering.

## Observed

On a 1 GB deployment running the Telegram adapter, 7 September 2026:

```
19:35:25  [Telegram] Telegram flood control, waiting 9.0s      (x4, within 0.4s)
19:35:31  Normal final-send NOT suppressed despite active stream consumer
          for session ...: streamed=False previewed=False content_delivered=False
19:35:31  [Telegram] Sending response (3886 chars) to ...
19:35:34  [Telegram] Telegram flood control on send (retry_after=271.0s > 5s); failing closed
19:35:34  Flood control refused a final reply on telegram (default); ledger redelivery in 273s
19:40:08  Redelivered recovered final response to telegram:... (attempt 1)
```

Four preview edits were refused inside 0.4 seconds, each asking for 9 seconds. The preview froze mid-sentence showing raw MarkdownV2, because a partial preview is rendered without it. The 9 second penalty had escalated to 271 seconds by the time the gateway sent the complete reply itself, so that send was refused too and the delivery ledger redelivered it 4.5 minutes after the question. The same pattern appears twice that day and six times since 25 May.

## The change

**Honour the wait.** A flood refusal carrying a positive `retry_after` within a cap sets a monotonic pause deadline instead of a strike. Interim ticks are gated while the pause is active and keep accumulating, so the first edit after it carries everything buffered. A successful edit clears the pause and the strikes.

**Keep the runaway bounded.** The first compliant refusal costs no strike. A refusal arriving after an honoured deadline has elapsed does count, so three refusals despite compliance still fall back. A missing, invalid, non-positive or over-cap wait keeps the existing strike and interval doubling byte for byte.

**Retry the final edit once.** A turn-final edit refused with a bounded wait is retried after it, because the fallback send would go into the same ban. A second refusal takes the existing fallback path. The cursor-stuck delivery rule and the `FALLBACK_ON_FINAL_EDIT_FLOOD` adapter opt-in are unchanged.

**Let the gateway grant the wait.** `_await_stream_task` joins the consumer task for 5 seconds. A consumer sitting out a penalty needs longer, so the consumer publishes `flood_pause_remaining` and the gateway adds it to that budget. Cancellation therefore still propagates: rather than the consumer swallowing a cancel to outlive a timeout it does not own, the owner of the timeout extends it. A cancel that does arrive is a real abort, and teardown takes the edit it can get immediately rather than sitting out a ban nobody is waiting for. A penalty that only begins after the join has started still cancels at 5 seconds and falls back, as before.

The cap is a consumer config field, `flood_pause_cap_seconds`, defaulting to 30 seconds. It is not wired to user config, matching the other timing fields on that dataclass.

## Tests

`tests/gateway/test_stream_edit_flood_pause.py`, 23 cases driving the real consumer with refused `SendResult`s and a controllable monotonic clock. Nothing sleeps in real time. 17 fail without the change.

They pin the pause and the coalesced resume, the cap boundary, the legacy path for an unusable wait, bounded repeated refusal, the single final retry and its fallback, segment finalization and tail flushing, the success reset, cursor accounting, a stale turn during the wait, that a cancel aborts instead of being swallowed, the published remaining wait, and the gateway's extended join budget.

One existing case changes: `test_non_opt_in_adapter_keeps_adaptive_final_edit_retry` asserted a strike on the first refusal and no fallback. A non-opt-in adapter now waits out the penalty and retries once, so the strike lands on the second refusal and the fallback arms after it. Its intent, that immediate fallback stays scoped to opted-in adapters, is unchanged. The test also no longer sleeps for the 30 seconds it was asking for.

Full gateway suite: no failures introduced.

## Scope

The consumer and its transport, plus the join budget in `gateway/run_turn.py`. No adapter changes, no change to the adapter's 5 second inline cap, and nothing in the delivery ledger. Fresh-final, draft and native streaming keep their existing selection and delivery behaviour, with the pause enforced before delivery. No dependency or user-config schema changes.
