### PR TITLE
fix(kanban): require using-superpowers before board mutations

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -2203,6 +2203,11 @@ def _default_spawn(task: Task, workspace: str, *, board: Optional[str] = None) -
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
+    # Expose the card's force-loaded skills to the worker tooling: the kanban
+    # mutation gate accepts these as proof the worker-contract skill is in context.
+    preloaded_skills = [sk for sk in (task.skills or ()) if sk]
+    if preloaded_skills:
+        env["HERMES_KANBAN_PRELOADED_SKILLS"] = ",".join(preloaded_skills)
     # Tag the session `kanban` so session-browsing surfaces filter it out by
     # source instead of rendering one sidebar row per attempt.
     env["HERMES_SESSION_SOURCE"] = "kanban"

--- a/tests/cron/test_cron_kanban_env_isolation.py
+++ b/tests/cron/test_cron_kanban_env_isolation.py
@@ -392,7 +392,8 @@ def test_dispatcher_grants_only_the_assigned_worker_scope(tmp_path, monkeypatch)
     db = tmp_path / "board.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db))
     conn = connect(db)
-    tid = kb.create_task(conn, title="assigned child", assignee="default")
+    tid = kb.create_task(conn, title="assigned child", assignee="default",
+                         skills=["using-superpowers"])
     kb.claim_task(conn, tid)
     task = kb.get_task(conn, tid)
     output = tmp_path / "worker-result.json"

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -841,13 +841,15 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
 
     conn = kbc.connect()
     try:
-        tid = kb.create_task(conn, title="t", assignee="worker1")
+        tid = kb.create_task(conn, title="t", assignee="worker1",
+                             skills=["using-superpowers"])
         kbn.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
     finally:
         conn.close()
 
     import os
     os.environ["HERMES_KANBAN_TASK"] = tid
+    os.environ["HERMES_KANBAN_PRELOADED_SKILLS"] = "using-superpowers"
     try:
         kt._handle_complete({
             "summary": "one real, one ghost",

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -23,10 +23,12 @@ def review_worker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> str:
     kb._INITIALIZED_PATHS.clear()
     kb.init_db()
     with kbc.connect() as conn:
-        task_id = kb.create_task(conn, title="Review tool contract", assignee="builder")
+        task_id = kb.create_task(conn, title="Review tool contract", assignee="builder",
+                                 skills=["using-superpowers"])
         task = kb.claim_task(conn, task_id, claimer="builder:1")
         assert task is not None
     monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_PRELOADED_SKILLS", "using-superpowers")
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(task.current_run_id))
     return task_id
 
@@ -305,10 +307,12 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
             title="Goal-mode tool task",
             assignee="builder",
             goal_mode=True,
+            skills=["using-superpowers"],
         )
         claimed = kb.claim_task(conn, tool_task, claimer="builder:1")
         assert claimed is not None
     monkeypatch.setenv("HERMES_KANBAN_TASK", tool_task)
+    monkeypatch.setenv("HERMES_KANBAN_PRELOADED_SKILLS", "using-superpowers")
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
 
     from tools import kanban_tools as tools
@@ -340,10 +344,12 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
             title="Goal-mode CLI task",
             assignee="builder",
             goal_mode=True,
+            skills=["using-superpowers"],
         )
         cli_claimed = kb.claim_task(conn, cli_task, claimer="builder:2")
         assert cli_claimed is not None
     monkeypatch.setenv("HERMES_KANBAN_TASK", cli_task)
+    monkeypatch.setenv("HERMES_KANBAN_PRELOADED_SKILLS", "using-superpowers")
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(cli_claimed.current_run_id))
 
     import agent.auxiliary_client as auxiliary_client

--- a/tests/tools/test_kanban_descendant_scope.py
+++ b/tests/tools/test_kanban_descendant_scope.py
@@ -26,6 +26,7 @@ def _worker_board(tmp_path, monkeypatch):
         "HERMES_KANBAN_DB": str(db), "HERMES_KANBAN_BOARD": "default",
         "HERMES_KANBAN_TASK": own, "HERMES_KANBAN_RUN_ID": str(task.current_run_id),
         "HERMES_KANBAN_CLAIM_LOCK": task.claim_lock, "HOME": str(tmp_path),
+        "HERMES_KANBAN_PRELOADED_SKILLS": "using-superpowers",
     }.items():
         monkeypatch.setenv(key, value)
     monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -47,7 +47,8 @@ def test_kanban_tools_hidden_without_env_var(monkeypatch, tmp_path):
 @pytest.fixture
 def worker_env(monkeypatch, tmp_path):
     """Simulate being a worker: HERMES_HOME isolated, HERMES_KANBAN_TASK set
-    after we've created the task."""
+    after we've created the task. The card force-loads the worker-contract
+    skill, matching a dispatcher spawn with --skill using-superpowers."""
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
@@ -67,6 +68,7 @@ def worker_env(monkeypatch, tmp_path):
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_PRELOADED_SKILLS", "using-superpowers")
     return tid
 
 
@@ -192,6 +194,7 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_PRELOADED_SKILLS", "using-superpowers")
 
     # Mock the judge to reject the completion. The gate only runs when a
     # judge is reachable, so force the availability probe True as well.
@@ -260,6 +263,7 @@ def _make_goal_mode_worker_env(monkeypatch, tmp_path):
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_PRELOADED_SKILLS", "using-superpowers")
     return goal_task_id
 
 

--- a/tests/tools/test_kanban_worker_skill_gate.py
+++ b/tests/tools/test_kanban_worker_skill_gate.py
@@ -1,0 +1,94 @@
+"""Gate: board mutations from a dispatcher-spawned worker require the
+worker-contract skill (using-superpowers) to be loaded first.
+
+Acceptance (issue #105286):
+  - worker without the skill loaded -> mutation rejected with a helpful reason
+  - worker with the skill viewed via skill_view -> normal lifecycle
+  - dispatcher force-load (card --skill) counts as loaded
+  - kanban_show (read-only) never gated
+  - non-worker contexts (orchestrator) unaffected
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.tools.test_kanban_tools import worker_env  # noqa: F401  (fixture reuse)
+
+
+@pytest.fixture
+def clean_skill_state(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_PRELOADED_SKILLS", raising=False)
+    from tools.skills_tool_dedup import _skill_view_tracker
+    _skill_view_tracker.clear()
+
+
+def _load_skill_via_view(task_id: str, tmp_path) -> None:
+    """Simulate skill_view having served using-superpowers to this task
+    (the dedup registry fingerprints the file on disk, so a real file is needed)."""
+    import os
+    from tools.skills_tool_dedup import _record_skill_view
+    src = tmp_path / "using-superpowers.md"
+    src.write_text("skill content")
+    _record_skill_view(task_id, "using-superpowers", None,
+                       {"name": "using-superpowers", "_source_path": str(src)})
+
+
+def test_mutation_denied_without_skill(worker_env, clean_skill_state):
+    from tools import kanban_tools as kt
+    out = kt._handle_heartbeat({})
+    d = json.loads(out)
+    assert "using-superpowers" in d.get("error", "")
+    assert "skill_view" in d.get("error", "")
+
+
+def test_mutation_allowed_after_skill_view(worker_env, clean_skill_state, tmp_path):
+    _load_skill_via_view(worker_env, tmp_path)
+    from tools import kanban_tools as kt
+    out = kt._handle_heartbeat({})
+    d = json.loads(out)
+    assert "using-superpowers" not in (d.get("error") or "")
+    assert "heartbeat" in json.dumps(d).lower() or d.get("ok") or d.get("task_id") or "error" not in d
+
+
+def test_preloaded_counts_as_loaded(worker_env, clean_skill_state, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_PRELOADED_SKILLS", "using-superpowers")
+    from tools import kanban_tools as kt
+    out = kt._handle_heartbeat({})
+    d = json.loads(out)
+    assert "using-superpowers" not in (d.get("error") or "")
+
+
+def test_show_not_gated(worker_env, clean_skill_state):
+    from tools import kanban_tools as kt
+    out = kt._handle_show({})
+    d = json.loads(out)
+    assert "task" in d  # read-only works without the skill
+
+
+def test_orchestrator_unaffected(monkeypatch, tmp_path, clean_skill_state):
+    monkeypatch.delenv("HEMMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-orchestrator")
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="orchestrator-test", assignee="orch")
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_heartbeat({"task_id": tid})
+    d = json.loads(out)
+    assert "using-superpowers" not in (d.get("error") or "")

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -177,12 +177,48 @@ def _enforce_worker_task_ownership(tid: str) -> None:
             f"to hand off information to other tasks, or kanban_create to spawn follow-up work.")
 
 
+REQUIRED_WORKER_SKILL = "using-superpowers"
+
+
+def _skill_loaded_for_task(task_id: str, skill_name: str) -> bool:
+    """True when this task context has actually loaded the named skill — either
+    viewed via skill_view (per-task tracker) or force-loaded by the dispatcher
+    when the card's skill list includes it."""
+    from tools.skills_tool_dedup import _skill_view_tracker, _skill_view_tracker_lock
+
+    with _skill_view_tracker_lock:
+        cache = _skill_view_tracker.get(str(task_id), {})
+        for rec_name, _file_path in cache:
+            if rec_name == skill_name or rec_name.endswith(":" + skill_name) or rec_name.endswith("/" + skill_name):
+                return True
+    return skill_name in (os.environ.get("HERMES_KANBAN_PRELOADED_SKILLS") or "").split(",")
+
+
+def _enforce_required_worker_skill(tool_name: str, task_id: str) -> None:
+    """Board mutations from a dispatcher-spawned worker require the worker-contract
+    skill to be loaded first: the governance rule says a card's updater must have
+    using-superpowers in context before touching the board, so an agent that skipped
+    the reading step cannot complete/block/comment/create on its own task."""
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return
+    if _skill_loaded_for_task(task_id, REQUIRED_WORKER_SKILL):
+        return
+    logger.info(
+        "kanban %s denied: %s not loaded for task %s",
+        tool_name, REQUIRED_WORKER_SKILL, task_id)
+    raise _Reject(
+        f"{tool_name} requires the {REQUIRED_WORKER_SKILL} skill to be loaded first "
+        f"(skill_view('{REQUIRED_WORKER_SKILL}')). Load it, then retry the board "
+        "mutation. Read-only kanban_show stays available to inspect the board.")
+
+
 def _worker_guard(tool_name: str, args: dict) -> str:
     """Worker mutation preamble, in order: delegate-child rejection, task id
-    resolution, task-scope ownership. Returns the task id."""
+    resolution, task-scope ownership, worker-contract skill gate. Returns the task id."""
     _reject_delegated_child_mutation(tool_name)
     tid = _require_task_id(args)
     _enforce_worker_task_ownership(tid)
+    _enforce_required_worker_skill(tool_name, tid)
     return tid
 
 


### PR DESCRIPTION
## Summary
Implements the gate requested in #105286: a dispatcher-spawned worker cannot call `kanban_complete`, `kanban_block`, `kanban_comment`, `kanban_create`, `kanban_link`, `kanban_unblock`, `kanban_heartbeat` (any `_worker_guard` tool) unless the `using-superpowers` worker-contract skill is loaded in the current task context.

## Design
- **Single choke point**: the check lives in `_worker_guard` (tools/kanban_tools.py) — the mutation preamble every board-mutating handler already calls. One gate, no per-tool duplication.
- **Two proof paths** for "skill loaded": (a) `skill_view('using-superpowers')` served in this task — detected via the existing per-task dedup registry (`_skill_view_tracker`, tools/skills_tool_dedup.py); (b) dispatcher force-load — the card's `--skills` list, now exposed to the worker via `HERMES_KANBAN_PRELOADED_SKILLS` (kanban_db_dispatch.py).
- **Denial is greppable**: `logger.info("kanban %s denied: using-superpowers not loaded for task %s")` lands in the standard task run/event log; the tool error tells the worker exactly how to proceed (`skill_view('using-superpowers')` then retry).
- **Read access preserved by construction**: `kanban_show` doesn't route through `_worker_guard` — the worker can always inspect the board to explain the block.
- **Non-worker contexts unaffected**: the gate only fires when `HERMES_KANBAN_TASK` is set (dispatcher-spawned worker); orchestrators and normal sessions keep the previous behaviour.

## Acceptance criteria (#105286)
- [x] documented, testable gate
- [x] worker without the skill cannot mutate Kanban
- [x] worker with the skill follows the normal lifecycle
- [x] denial recorded in the task run/event log (INFO log + tool error)
- [x] read-only kanban_show access preserved

## Tests
New `tests/tools/test_kanban_worker_skill_gate.py` (5 tests): denial without skill, allow after skill_view, allow via preloaded env, show not gated, orchestrator unaffected. Existing worker-lifecycle fixtures updated to model a card that force-loads the contract skill (matches a real dispatcher spawn).

```
tests/tools/test_kanban_tools.py ............... 32 passed
tests/tools/test_kanban_worker_skill_gate.py ... 5 passed
kanban-related suites (6 files) ................ 84 passed, 1 skipped
```

Closes #105286