### PR TITLE
fix(proxy): allow /v1/responses through Nous Portal subscription proxy (#104505)

### DIFF
--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Endpoints inference-api.nousresearch.com actually serves; anything else is a 404 so stray
 # clients cannot leak odd requests upstream.
-_ALLOWED_PATHS: FrozenSet[str] = frozenset({"/chat/completions", "/completions", "/embeddings", "/models"})
+_ALLOWED_PATHS: FrozenSet[str] = frozenset({"/responses", "/chat/completions", "/completions", "/embeddings", "/models"})
 
 
 class NousPortalAdapter(UpstreamAdapter):


### PR DESCRIPTION
Fixes #104505

**Problem:** The Nous Portal subscription proxy (`hermes proxy start`) rejected `POST /v1/responses` with `path_not_allowed` (`Allowed: /chat/completions, /completions, /embeddings, /models`). This breaks Responses-only clients such as modern Codex CLI even though upstream `https://inference-api.nousresearch.com/v1/responses` serves the same model correctly.

**Root cause:** `hermes_cli/proxy/adapters/nous_portal.py::_ALLOWED_PATHS` only listed chat/completions, completions, embeddings and models. The xAI adapter already included `/responses`; Nous did not.

**Fix:** Add `"/responses"` to `_ALLOWED_PATHS` in the Nous adapter. The proxy otherwise just forwards (no rewriting), so streaming and non-streaming Responses calls work unchanged.

Verified: `NousPortalAdapter().allowed_paths` now includes `/responses`; `tests/hermes_cli/test_proxy.py` (8) and `test_proxy_off_loop.py` (8) pass.