### PR TITLE
fix(teams): surface quoted-reply content instead of discarding it

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -127,6 +127,41 @@ def _coerce_port(value: Any, *, default: int = _DEFAULT_PORT) -> int:
         return default
 
 
+def _extract_teams_quoted_reply(html_content: str) -> str:
+    """Pull the quoted author + text out of a Bot Framework quote-reply attachment.
+
+    Teams renders a quoted reply as roughly:
+        <blockquote itemscope itemtype="http://schema.skype.com/Reply">
+          <strong itemprop="mri" itemid="...">Author Name</strong>
+          <span itemprop="time" ...>...</span>
+          <p itemprop="preview">Original message text</p>
+        </blockquote>
+
+    Exact markup varies by client, so this is deliberately tolerant: pull the
+    blockquote block, strip remaining tags, and collapse whitespace. Returns
+    "" if nothing usable is found — callers should no-op rather than surface
+    a garbled string.
+    """
+    import re
+
+    match = re.search(
+        r"<blockquote[^>]*itemtype=\"[^\"]*schema\.skype\.com/Reply\"[^>]*>(.*?)</blockquote>",
+        html_content,
+        re.IGNORECASE | re.DOTALL,
+    )
+    block = match.group(1) if match else html_content
+    author_match = re.search(r"<strong[^>]*>(.*?)</strong>", block, re.IGNORECASE | re.DOTALL)
+    author = html.unescape(re.sub(r"<[^>]+>", "", author_match.group(1))).strip() if author_match else ""
+    # Drop the <strong> (author) and <span> (timestamp) tags, then strip the rest.
+    body = re.sub(r"<strong[^>]*>.*?</strong>", "", block, flags=re.IGNORECASE | re.DOTALL)
+    body = re.sub(r"<span[^>]*itemprop=\"time\"[^>]*>.*?</span>", "", body, flags=re.IGNORECASE | re.DOTALL)
+    body_text = html.unescape(re.sub(r"<[^>]+>", " ", body))
+    body_text = re.sub(r"\s+", " ", body_text).strip()
+    if not body_text:
+        return ""
+    return f"{author}: {body_text}" if author else body_text
+
+
 class _StaticAccessTokenProvider:
     """Minimal token-provider shim so outbound Graph delivery can reuse the shared client."""
 
@@ -857,6 +892,27 @@ class TeamsAdapter(BasePlatformAdapter):
         if "<at>" in text:
             import re
             text = re.sub(r"<at>[^<]*</at>\s*", "", text).strip()
+
+        # Quoted replies: when a user quote-replies to an earlier message,
+        # Bot Framework does NOT put the quoted content in activity.text —
+        # only the new reply text lands there. The quote itself is carried
+        # in a text/html attachment as a <blockquote itemtype="...Reply">
+        # block (author + original text). Without this, Rumi silently had
+        # no visibility into what was quoted — it only ever saw the new
+        # reply in isolation. Surface it as a prefix so downstream context
+        # (and the model) sees what was quoted.
+        quoted_html = None
+        for att in getattr(activity, "attachments", None) or []:
+            content_type = (getattr(att, "content_type", None) or "").lower()
+            if content_type == "text/html":
+                content = getattr(att, "content", None)
+                if isinstance(content, str) and "schema.skype.com/Reply" in content:
+                    quoted_html = content
+                    break
+        if quoted_html:
+            quoted_text = _extract_teams_quoted_reply(quoted_html)
+            if quoted_text:
+                text = f"[Replying to: \"{quoted_text}\"]\n{text}" if text else f"[Replying to: \"{quoted_text}\"]"
 
         # Determine chat type from conversation
         conv = activity.conversation


### PR DESCRIPTION
## What
Teams quote-replies were silently losing their quoted content. Bot Framework carries the quoted message in a `text/html` attachment (a `<blockquote itemtype=".../Reply">` block with author + text) -- not in `activity.text`, which only holds the new reply text.

## Root cause
The adapter unconditionally skipped every `text/html` attachment:

```python
if content_type in ("text/html", "text/plain") and not content_url:
    continue
```

That's correct for a normal message (Teams mirrors the plain-text body as `text/html` too, so skipping it avoids a duplicate). It's wrong for a quote-reply, where that HTML attachment is the *only* place the quoted content exists.

## Fix
Added `_extract_teams_quoted_reply()` -- pulls the blockquote's author + text out of the HTML (regex-based, tolerant of markup variance across Teams clients/tenants) and prefixes it onto the incoming message text:

```
[Replying to: "Alice: original message text"]
new reply text
```

No behavior change for non-quote messages -- the existing html-attachment skip still applies whenever the `schema.skype.com/Reply` marker isn't present.

## Testing
- Verified the extraction regex against representative Bot Framework quote-reply HTML (with and without an author block) -- correctly returns `"Author: text"` / `"text"` / `""` (no false positive on the ordinary html-mirror-of-body case).
- `python3 -c "import ast; ast.parse(...)"` -- syntax-clean.
- Deployed and exercised in a live Teams tenant; confirmed quoted content now reaches the agent instead of vanishing.

No existing tests cover the Teams adapter's attachment-classification path directly (`tests/gateway/test_teams.py` is pipeline-focused); happy to add a focused unit test for `_extract_teams_quoted_reply()` if useful -- flagging instead of assuming, per repo norms around test additions.