### PR TITLE
fix(gateway): cron and Kanban children start under a system-level systemd unit (#104893, salvage #105037)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2064,6 +2064,26 @@ def _ensure_user_systemd_env() -> None:
             os.environ["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path={bus_path}"
 
 
+def _adopt_user_bus_when_started_by_systemd() -> None:
+    """Point a systemd-launched gateway at its own user bus before it boots (#104893).
+
+    A *system*-level unit (``/etc/systemd/system``, ``User=<someone>``) is exec'd with
+    neither ``XDG_RUNTIME_DIR`` nor ``DBUS_SESSION_BUS_ADDRESS``, and a process environment
+    is fixed at exec time — so ``systemd-run --user`` fails for the whole lifetime of that
+    gateway even once ``/run/user/<uid>/bus`` is up.  Every restart-safe worker crosses that
+    seam (``tools.process_registry.restart_safe_gateway_child_argv``) and it fails closed by
+    design, so cron and Kanban dispatch died at every fire on headless service installs.
+    ``_ensure_user_systemd_env`` derives both values from our own uid and adopts them only
+    when the runtime dir is really ours and the socket really exists, so a host with no user
+    manager keeps its honest "unavailable" verdict instead of a fabricated bus address.
+    Doing it here rather than at the dispatch seam matters: worker environments are snapshots
+    of ``os.environ`` taken at different points, so the adoption has to precede all of them.
+    """
+    if os.name != "posix" or not os.environ.get("INVOCATION_ID"):
+        return
+    _ensure_user_systemd_env()
+
+
 def _wait_for_user_dbus_socket(timeout: float = 3.0) -> bool:
     """Poll up to ``timeout`` s for a user systemd control socket (user@.service takes a moment after enable-linger)."""
     deadline = time.monotonic() + timeout
@@ -4529,6 +4549,8 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
     _absorb = _windows_gateway_should_absorb_console_controls()
     if _absorb:
         _absorb_windows_console_controls()
+
+    _adopt_user_bus_when_started_by_systemd()
 
     # Refresh the systemd unit on every boot so restart settings stay current even after an
     # exit-code-75 respawn (stale-code or /restart), which bypasses `hermes gateway restart`.

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2064,26 +2064,6 @@ def _ensure_user_systemd_env() -> None:
             os.environ["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path={bus_path}"
 
 
-def _adopt_user_bus_when_started_by_systemd() -> None:
-    """Point a systemd-launched gateway at its own user bus before it boots (#104893).
-
-    A *system*-level unit (``/etc/systemd/system``, ``User=<someone>``) is exec'd with
-    neither ``XDG_RUNTIME_DIR`` nor ``DBUS_SESSION_BUS_ADDRESS``, and a process environment
-    is fixed at exec time — so ``systemd-run --user`` fails for the whole lifetime of that
-    gateway even once ``/run/user/<uid>/bus`` is up.  Every restart-safe worker crosses that
-    seam (``tools.process_registry.restart_safe_gateway_child_argv``) and it fails closed by
-    design, so cron and Kanban dispatch died at every fire on headless service installs.
-    ``_ensure_user_systemd_env`` derives both values from our own uid and adopts them only
-    when the runtime dir is really ours and the socket really exists, so a host with no user
-    manager keeps its honest "unavailable" verdict instead of a fabricated bus address.
-    Doing it here rather than at the dispatch seam matters: worker environments are snapshots
-    of ``os.environ`` taken at different points, so the adoption has to precede all of them.
-    """
-    if os.name != "posix" or not os.environ.get("INVOCATION_ID"):
-        return
-    _ensure_user_systemd_env()
-
-
 def _wait_for_user_dbus_socket(timeout: float = 3.0) -> bool:
     """Poll up to ``timeout`` s for a user systemd control socket (user@.service takes a moment after enable-linger)."""
     deadline = time.monotonic() + timeout
@@ -4550,7 +4530,10 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
     if _absorb:
         _absorb_windows_console_controls()
 
-    _adopt_user_bus_when_started_by_systemd()
+    # A system-level unit execs us without XDG_RUNTIME_DIR/DBUS_SESSION_BUS_ADDRESS; adopt our own
+    # user bus before any worker env snapshot so `systemd-run --user --scope` works (#104893).
+    if is_linux() and os.environ.get("INVOCATION_ID"):
+        _ensure_user_systemd_env()
 
     # Refresh the systemd unit on every boot so restart settings stay current even after an
     # exit-code-75 respawn (stale-code or /restart), which bypasses `hermes gateway restart`.

--- a/tests/hermes_cli/test_gateway_user_bus_adoption.py
+++ b/tests/hermes_cli/test_gateway_user_bus_adoption.py
@@ -1,11 +1,4 @@
-"""#104893: a systemd-launched gateway must adopt its own user bus at boot.
-
-A *system*-level unit (``/etc/systemd/system``, ``User=<someone>``) is exec'd with
-neither ``XDG_RUNTIME_DIR`` nor ``DBUS_SESSION_BUS_ADDRESS``, and a process environment
-is fixed at exec time.  ``systemd-run --user`` is the seam every restart-safe cron and
-Kanban worker crosses, and it fails closed by design — so on a headless service install
-every agent-driven scheduled job died at dispatch, even once the user manager was up.
-"""
+"""#104893: a gateway started by a system-level systemd unit adopts its own user bus at boot."""
 
 import os
 
@@ -77,7 +70,7 @@ def test_absent_user_bus_is_never_fabricated(monkeypatch):
     _fake_user_bus(monkeypatch, present=False)
     _service_manager_env(monkeypatch)
 
-    gw._adopt_user_bus_when_started_by_systemd()
+    gw._ensure_user_systemd_env()
 
     assert "XDG_RUNTIME_DIR" not in os.environ
     assert "DBUS_SESSION_BUS_ADDRESS" not in os.environ

--- a/tests/hermes_cli/test_gateway_user_bus_adoption.py
+++ b/tests/hermes_cli/test_gateway_user_bus_adoption.py
@@ -1,0 +1,83 @@
+"""#104893: a systemd-launched gateway must adopt its own user bus at boot.
+
+A *system*-level unit (``/etc/systemd/system``, ``User=<someone>``) is exec'd with
+neither ``XDG_RUNTIME_DIR`` nor ``DBUS_SESSION_BUS_ADDRESS``, and a process environment
+is fixed at exec time.  ``systemd-run --user`` is the seam every restart-safe cron and
+Kanban worker crosses, and it fails closed by design — so on a headless service install
+every agent-driven scheduled job died at dispatch, even once the user manager was up.
+"""
+
+import os
+
+import pytest
+
+import hermes_cli.gateway as gw
+
+
+class _BootReached(Exception):
+    """Stands in for the first boot step past the adoption call."""
+
+
+def _fake_user_bus(monkeypatch, *, present: bool) -> str:
+    """Fake the on-disk state ``loginctl enable-linger`` leaves behind (or its absence)."""
+    runtime_dir = f"/run/user/{os.getuid()}"
+    monkeypatch.setattr(
+        gw, "_runtime_dir_is_ours", lambda d: present and str(d) == runtime_dir)
+    monkeypatch.setattr(
+        gw, "_path_exists_safe", lambda p: present and str(p) == f"{runtime_dir}/bus")
+    return runtime_dir
+
+
+def _service_manager_env(monkeypatch) -> None:
+    """The environment systemd hands a system-level unit: no bus, but INVOCATION_ID."""
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+    monkeypatch.setenv("INVOCATION_ID", "system-unit-104893")
+
+
+@pytest.mark.linux_only
+def test_service_gateway_boot_adopts_its_user_bus(monkeypatch):
+    runtime_dir = _fake_user_bus(monkeypatch, present=True)
+    _service_manager_env(monkeypatch)
+    for guard in (
+        "_guard_official_docker_root_gateway",
+        "_guard_named_profile_under_multiplexer",
+        "_guard_supervised_gateway_conflict",
+        "_guard_existing_gateway_process_conflict",
+        "_apply_startup_watchdog_config",
+    ):
+        monkeypatch.setattr(gw, guard, lambda *_a, **_kw: None)
+
+    def _stop_here() -> bool:
+        raise _BootReached
+
+    # First boot step after the adoption — stop there instead of starting a gateway.
+    monkeypatch.setattr(gw, "supports_systemd_services", _stop_here)
+
+    with pytest.raises(_BootReached):
+        gw.run_gateway()
+
+    assert os.environ["XDG_RUNTIME_DIR"] == runtime_dir
+    assert os.environ["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={runtime_dir}/bus"
+
+    # Worker environments are snapshots of os.environ taken at various points in the
+    # dispatch paths, so the bus address must also survive the secret scrubber they all
+    # go through — otherwise systemd-run still cannot connect and the fix is a no-op.
+    from tools.environments.local import build_subprocess_env
+
+    worker_env = build_subprocess_env(scrub_secrets=True)
+    assert worker_env["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={runtime_dir}/bus"
+
+
+@pytest.mark.linux_only
+def test_absent_user_bus_is_never_fabricated(monkeypatch):
+    """Fail closed, never invent. With no user manager the env must stay bare so the
+    scope probe keeps reaching its honest "unavailable" verdict — a bus address pointing
+    at nothing would turn a clear dispatch refusal into a confusing connect failure."""
+    _fake_user_bus(monkeypatch, present=False)
+    _service_manager_env(monkeypatch)
+
+    gw._adopt_user_bus_when_started_by_systemd()
+
+    assert "XDG_RUNTIME_DIR" not in os.environ
+    assert "DBUS_SESSION_BUS_ADDRESS" not in os.environ

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -235,9 +235,15 @@ def restart_safe_gateway_child_argv(
     if not _is_supervised_gateway_process() or not os.environ.get("INVOCATION_ID"):
         return command
     if not _systemd_run_user_scope_available():
+        # This text is what the operator actually sees: it is stored as the cron
+        # execution's error and printed on the job row, so it names the remedy
+        # rather than only the symptom.
         raise RuntimeError(
             "cannot create restart-safe systemd scope for gateway child: "
-            "systemd-run --user --scope is unavailable"
+            "systemd-run --user --scope is unavailable — this gateway has no reachable "
+            f"user D-Bus session (expected /run/user/{os.getuid()}/bus). On a system-level "  # windows-footgun: ok — behind the _IS_LINUX return above
+            "service install, run `sudo loginctl enable-linger <gateway-user>` and restart "
+            "the gateway."
         )
     scoped = _build_systemd_scope_argv(command, unit_suffix=unit_suffix)
     if scoped == command:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -235,15 +235,12 @@ def restart_safe_gateway_child_argv(
     if not _is_supervised_gateway_process() or not os.environ.get("INVOCATION_ID"):
         return command
     if not _systemd_run_user_scope_available():
-        # This text is what the operator actually sees: it is stored as the cron
-        # execution's error and printed on the job row, so it names the remedy
-        # rather than only the symptom.
+        # Stored as the cron execution's error and shown on the job row: name the remedy.
         raise RuntimeError(
             "cannot create restart-safe systemd scope for gateway child: "
-            "systemd-run --user --scope is unavailable — this gateway has no reachable "
-            f"user D-Bus session (expected /run/user/{os.getuid()}/bus). On a system-level "  # windows-footgun: ok — behind the _IS_LINUX return above
-            "service install, run `sudo loginctl enable-linger <gateway-user>` and restart "
-            "the gateway."
+            "systemd-run --user --scope is unavailable (usually no reachable user D-Bus session at "
+            f"/run/user/{os.getuid()}/bus). On a system-level service install, run "  # windows-footgun: ok — behind the _IS_LINUX return above
+            "`sudo loginctl enable-linger <gateway-user>` and restart the gateway."
         )
     scoped = _build_systemd_scope_argv(command, unit_suffix=unit_suffix)
     if scoped == command:


### PR DESCRIPTION
A gateway run from a system-level systemd unit (`/etc/systemd/system`, `User=<someone>`) can now dispatch cron jobs and Kanban tasks: every restart-safe child crosses `systemd-run --user --scope`, which needs `XDG_RUNTIME_DIR`/`DBUS_SESSION_BUS_ADDRESS`, and a system unit execs the gateway with neither, so every fire died with `error` on the job row even after `loginctl enable-linger`.

Based on #105037 by @HexLab98 — cherry-picked so authorship is preserved. Refs #104893 — this lands the env-inheritance half only (hosts where linger is on but the system unit's env never carried the bus address, the reporter's manual drop-in); hosts where no user manager exists at all still need linger provisioned (#105222) or the degraded dispatch in #102431, so the issue stays open.

- `run_gateway()` now calls the existing `_ensure_user_systemd_env()` when `is_linux()` and `INVOCATION_ID` is set, before any worker env snapshot. The helper adopts the bus only when `/run/user/<uid>` is ours and the socket exists, so a host with no user manager keeps the honest fail-closed refusal.
- `restart_safe_gateway_child_argv` error text names the usual cause and the remedy (`loginctl enable-linger`), hedged because the probe also fails when `systemd-run` is missing.
- Follow-up commit (ours): inlined the 3-line facade wrapper at the call site, gate on `is_linux()` to match the process_registry seam, trimmed docstrings.

Validation: `tests/hermes_cli/test_gateway_user_bus_adoption.py` (2, linux_only; also run on macOS with the marker stripped and `is_linux` patched) red with `hermes_cli/gateway.py` reverted to main, green on the stack; `tests/cron/test_restart_safe_worker.py` 17 passed; footgun/compat checks clean. Live systemd not exercised here (macOS); the reporter's drop-in with the same two `Environment=` lines fixed their fleet.

Related: #105222 (provision linger for system-service users) is the complementary half of #104893; #102431 covers the no-user-bus degrade path and will need a trivial rebase over the message text.