### PR TITLE
fix(qqbot): approval buttons in QQ private chats resolve instead of timing out (salvage #31593)

### DIFF
--- a/contributors/emails/penginman@users.noreply.github.com
+++ b/contributors/emails/penginman@users.noreply.github.com
@@ -1,0 +1,2 @@
+penginman
+# PR #31593 salvage

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -668,7 +668,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
         if chat_type in {"group", "guild"}:
             event_chat = str(event.group_openid or event.guild_id or "").strip()

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -668,6 +668,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
+        # Approval keys come from build_source (chat_type="dm"); update-prompt keys from event.scene ("c2c").
         if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -920,13 +920,13 @@ class TestDefaultInteractionDispatch:
                 "id": "i",
                 "chat_type": 2,
                 "user_openid": "u-42",
-                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:c2c:u-42:allow-once"}},
+                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:dm:u-42:allow-once"}},
             })
             await adapter._default_interaction_dispatch(event)
         finally:
             tools.approval.resolve_gateway_approval = orig
 
-        assert resolve_calls == [("agent:main:qqbot:c2c:u-42", "once", False)]
+        assert resolve_calls == [("agent:main:qqbot:dm:u-42", "once", False)]
 
 
     @pytest.mark.asyncio
@@ -954,33 +954,6 @@ class TestDefaultInteractionDispatch:
             tools.approval.resolve_gateway_approval = orig
 
         assert resolve_calls == []
-
-    @pytest.mark.asyncio
-    async def test_approval_click_dm_session_authorizes_owner(self):
-        """dm-typed session key with matching operator should be authorized."""
-        adapter = self._make_adapter()
-        resolve_calls = []
-
-        def fake_resolve(session_key, choice, resolve_all=False):
-            resolve_calls.append((session_key, choice, resolve_all))
-            return 1
-
-        import tools.approval
-        orig = tools.approval.resolve_gateway_approval
-        tools.approval.resolve_gateway_approval = fake_resolve
-        try:
-            from gateway.platforms.qqbot.keyboards import parse_interaction_event
-            event = parse_interaction_event({
-                "id": "i",
-                "chat_type": 2,
-                "user_openid": "u-42",
-                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:dm:u-42:allow-once"}},
-            })
-            await adapter._default_interaction_dispatch(event)
-        finally:
-            tools.approval.resolve_gateway_approval = orig
-
-        assert resolve_calls == [("agent:main:qqbot:dm:u-42", "once", False)]
 
     @pytest.mark.asyncio
     async def test_update_prompt_click_writes_response_file(self, tmp_path, monkeypatch):

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -956,6 +956,33 @@ class TestDefaultInteractionDispatch:
         assert resolve_calls == []
 
     @pytest.mark.asyncio
+    async def test_approval_click_dm_session_authorizes_owner(self):
+        """dm-typed session key with matching operator should be authorized."""
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,
+                "user_openid": "u-42",
+                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:dm:u-42:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:main:qqbot:dm:u-42", "once", False)]
+
+    @pytest.mark.asyncio
     async def test_update_prompt_click_writes_response_file(self, tmp_path, monkeypatch):
         """update_prompt:y click writes 'y' to ~/.hermes/.update_response."""
         adapter = self._make_adapter()


### PR DESCRIPTION
Every approval-button click in a QQ C2C (private) chat was rejected as unauthorized and the agent waited out the 300s approval timeout: the authorization check compared the session key's chat_type against `"c2c"`, but `build_source` keys C2C sessions as `chat_type="dm"` (`agent:main:qqbot:dm:<openid>`).

Based on #31593 by @penginman — cherry-picked, authorship preserved. Four independent field confirmations on the original PR (Ubuntu 24.04, macOS 15, two more), each reporting the same `Rejected unauthorized approval click for session agent:main:qqbot:dm:...` line and immediate resolution after the change.

- `_is_authorized_interaction_for_session` accepts `dm` for the owner check. `c2c` stays because update-prompt keys are built from `event.scene`.
- Contributor email mapping (commit 1).
- Follow-up commit (ours): the added test duplicated `test_approval_click_once_maps_to_once`; that test now asserts the real `dm` key instead.

Validation: `tests/gateway/test_qqbot.py` 63 passed; the retargeted test fails with the adapter reverted to main.