### PR TITLE
feat(desktop): distinguish monitoring from active agent work

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -35,10 +35,6 @@ import { SessionControlSections } from './session-control'
 import { useSessionValue } from './session-control-utils'
 import { StatusItemRow } from './status-row'
 
-// Slow safety-net poll for silent exits (processes without notify_on_complete
-// emit no event when they die). Only armed while a running row is on screen.
-const BACKGROUND_POLL_MS = 5_000
-
 // A localhost/loopback preview is only meaningful while its dev server is up, so
 // we tie it to a live background process rather than persisting dismissals or
 // letting dead URLs pile up. File previews (a real on-disk artifact) stand alone.
@@ -137,16 +133,6 @@ export function ComposerStatusStack({ onSubmit, queue, sessionId }: ComposerStat
   // Drop localhost previews once no dev server is left running — that's what made
   // dead `localhost:5174` chips stick around. On-disk file previews are kept.
   const visiblePreviews = previews.filter(item => hasRunningBackground || !isLocalhostPreview(item.target))
-
-  useEffect(() => {
-    if (!sessionId || !hasRunningBackground) {
-      return
-    }
-
-    const timer = setInterval(() => void refreshBackgroundProcesses(sessionId), BACKGROUND_POLL_MS)
-
-    return () => clearInterval(timer)
-  }, [hasRunningBackground, sessionId])
 
   const openAgents = () => navigate(AGENTS_ROUTE)
 

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -102,7 +102,7 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
     item.type === 'background'
       ? running
         ? onStop && { label: s.stop, onClick: () => onStop(item.id) }
-        : onDismiss && { label: s.dismiss, onClick: () => onDismiss(item.id) }
+        : !item.notificationPending && onDismiss && { label: s.dismiss, onClick: () => onDismiss(item.id) }
       : null
 
   const canOpen = item.type === 'subagent' && !!onOpen

--- a/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
@@ -273,6 +273,11 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>Show</DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
+              <OptionCheckbox
+                checked={rowMeta.includes('activity')}
+                onCheck={() => toggleSidebarRowMeta('activity')}
+                option={{ icon: 'pulse', id: 'activity', label: t.sidebar.row.activity }}
+              />
               {rowMetaOptions.map(option => (
                 <OptionCheckbox
                   checked={rowMeta.includes(option.id)}

--- a/apps/desktop/src/app/chat/sidebar/session-activity.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-activity.test.tsx
@@ -1,0 +1,200 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $backgroundStatusBySession } from '@/store/composer-status'
+import { $sidebarRowMeta, resetSidebarView, toggleSidebarRowMeta } from '@/store/layout'
+import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import { $sidebarActivityById } from '@/store/sidebar-activity'
+
+import { SidebarFilterMenu } from './filter-menu'
+import { SidebarSessionActivity } from './session-activity'
+
+beforeEach(() => {
+  resetSidebarView()
+  $sidebarRowMeta.set([])
+  clearAllSessionStates()
+  $backgroundStatusBySession.set({})
+})
+afterEach(() => {
+  cleanup()
+  clearAllSessionStates()
+  $backgroundStatusBySession.set({})
+  resetSidebarView()
+})
+
+const background = { id: 'process', type: 'background' as const, state: 'running' as const, title: '# Watching CI' }
+
+function seedBackground() {
+  publishSessionState('runtime', createClientSessionState('stored'))
+  $backgroundStatusBySession.set({ runtime: [background] })
+}
+
+describe('sidebar activity display', () => {
+  it('does not subscribe to transcript projection while disabled', () => {
+    const subscribe = vi.spyOn($sidebarActivityById, 'listen')
+    render(<SidebarSessionActivity sessionId="stored" />)
+    expect(subscribe).not.toHaveBeenCalled()
+    act(() => toggleSidebarRowMeta('activity'))
+    expect(subscribe).toHaveBeenCalled()
+    subscribe.mockRestore()
+  })
+
+  it('is opt-in, updates immediately, and leaves other sessions quiet', () => {
+    seedBackground()
+
+    const { container } = render(
+      <>
+        <SidebarSessionActivity sessionId="stored" />
+        <SidebarSessionActivity sessionId="other" />
+      </>
+    )
+
+    expect(container.textContent).toBe('')
+    act(() => toggleSidebarRowMeta('activity'))
+    expect(screen.getByRole('img', { name: 'Watching CI' })).toBeTruthy()
+    expect(container.textContent).toBe('')
+    expect(container.querySelectorAll('[data-session-activity]')).toHaveLength(1)
+    act(() => toggleSidebarRowMeta('activity'))
+    expect(container.textContent).toBe('')
+  })
+
+  it('clears immediately on completion, before finished status rows auto-dismiss', () => {
+    seedBackground()
+    toggleSidebarRowMeta('activity')
+    const { container } = render(<SidebarSessionActivity sessionId="stored" />)
+    expect(screen.getByRole('img', { name: 'Watching CI' })).toBeTruthy()
+    act(() => $backgroundStatusBySession.set({ runtime: [{ ...background, state: 'done' }] }))
+    expect(container.querySelector('[data-session-activity]')).toBeNull()
+  })
+
+  it.each(['Watching CI for the pull request', 'Waiting for the deployment health checks to finish'])(
+    'reveals the full reported activity on keyboard focus: %s',
+    async label => {
+      seedBackground()
+      $backgroundStatusBySession.set({ runtime: [{ ...background, title: `# ${label}` }] })
+      toggleSidebarRowMeta('activity')
+      const { container } = render(<SidebarSessionActivity sessionId="stored" />)
+      const indicator = screen.getByRole('img', { name: label })
+      expect(container.textContent).toBe('')
+      // jsdom does not model Chromium's keyboard :focus-visible state.
+      const matches = indicator.matches.bind(indicator)
+
+      const focusVisible = vi
+        .spyOn(indicator, 'matches')
+        .mockImplementation(selector => selector === ':focus-visible' || matches(selector))
+
+      fireEvent.keyDown(indicator.ownerDocument, { key: 'Tab' })
+      act(() => indicator.focus())
+      expect((await screen.findByRole('tooltip')).textContent).toBe(label)
+      focusVisible.mockRestore()
+    }
+  )
+
+  it('uses the live tool context and gives a blocking question priority', () => {
+    const state = {
+      ...createClientSessionState('stored'),
+      busy: true,
+      messages: [
+        {
+          id: 'reply',
+          role: 'assistant' as const,
+          pending: true,
+          parts: [
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'watch',
+              toolName: 'terminal',
+              args: { context: 'Watching CI on the new PR' }
+            }
+          ]
+        }
+      ]
+    }
+
+    publishSessionState('runtime', state)
+    toggleSidebarRowMeta('activity')
+    render(<SidebarSessionActivity sessionId="stored" />)
+    expect(screen.getByRole('img', { name: 'Watching CI on the new PR' })).toBeTruthy()
+    act(() => publishSessionState('runtime', { ...state, needsInput: true }))
+    expect(screen.getByRole('img', { name: 'Waiting for your answer' })).toBeTruthy()
+    expect(screen.queryByRole('img', { name: 'Watching CI on the new PR' })).toBeNull()
+  })
+
+  it('falls back to the real tool title when no human context was reported', () => {
+    publishSessionState('runtime', {
+      ...createClientSessionState('stored'),
+      busy: true,
+      messages: [
+        {
+          id: 'reply',
+          role: 'assistant',
+          pending: true,
+          parts: [
+            {
+              type: 'tool-call',
+              toolCallId: 'read',
+              toolName: 'read_file',
+              args: { path: 'README.md' }
+            }
+          ]
+        }
+      ]
+    })
+    toggleSidebarRowMeta('activity')
+    render(<SidebarSessionActivity sessionId="stored" />)
+    expect(screen.getByRole('img', { name: 'Reading README.md' })).toBeTruthy()
+  })
+
+  it('uses an explicit command comment instead of the flattened shell preview', () => {
+    publishSessionState('runtime', {
+      ...createClientSessionState('stored'),
+      busy: true,
+      messages: [
+        {
+          id: 'reply',
+          role: 'assistant',
+          pending: true,
+          parts: [
+            {
+              type: 'tool-call',
+              toolCallId: 'watch',
+              toolName: 'terminal',
+              args: {
+                command: '# Watching CI\ngh pr checks --watch',
+                context: '# Watching CI gh pr checks --watch'
+              }
+            }
+          ]
+        }
+      ]
+    })
+    toggleSidebarRowMeta('activity')
+    render(<SidebarSessionActivity sessionId="stored" />)
+    expect(screen.getByRole('img', { name: 'Watching CI' })).toBeTruthy()
+    expect(screen.queryByText(/gh pr checks/)).toBeNull()
+  })
+
+  it('can be enabled in Show without enabling inbox-style cards', async () => {
+    seedBackground()
+    render(
+      <>
+        <SidebarFilterMenu />
+        <SidebarSessionActivity sessionId="stored" />
+      </>
+    )
+    fireEvent.pointerDown(screen.getByRole('button', { name: /filter/i }), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: 'mouse'
+    })
+    const show = await screen.findByRole('menuitem', { name: 'Show' })
+    fireEvent.keyDown(show, { key: 'ArrowRight' })
+    const activity = await screen.findByRole('menuitemcheckbox', { name: 'Activity' })
+    fireEvent.click(activity)
+    expect($sidebarRowMeta.get()).toContain('activity')
+    expect(activity.getAttribute('aria-checked')).toBe('true')
+    fireEvent.keyDown(activity, { key: 'Escape' })
+    expect(await screen.findByRole('img', { name: 'Watching CI' })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-activity.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-activity.test.tsx
@@ -23,7 +23,13 @@ afterEach(() => {
   resetSidebarView()
 })
 
-const background = { id: 'process', type: 'background' as const, state: 'running' as const, title: '# Watching CI' }
+const background = {
+  id: 'process',
+  type: 'background' as const,
+  state: 'running' as const,
+  title: '# Watching CI',
+  awaitingNotification: true
+}
 
 function seedBackground() {
   publishSessionState('runtime', createClientSessionState('stored'))
@@ -91,7 +97,7 @@ describe('sidebar activity display', () => {
     }
   )
 
-  it('uses the live tool context and gives a blocking question priority', () => {
+  it('does not label an active tool or a blocking question as monitoring', () => {
     const state = {
       ...createClientSessionState('stored'),
       busy: true,
@@ -115,13 +121,13 @@ describe('sidebar activity display', () => {
     publishSessionState('runtime', state)
     toggleSidebarRowMeta('activity')
     render(<SidebarSessionActivity sessionId="stored" />)
-    expect(screen.getByRole('img', { name: 'Watching CI on the new PR' })).toBeTruthy()
+    expect(screen.queryByRole('img')).toBeNull()
     act(() => publishSessionState('runtime', { ...state, needsInput: true }))
-    expect(screen.getByRole('img', { name: 'Waiting for your answer' })).toBeTruthy()
+    expect(screen.queryByRole('img')).toBeNull()
     expect(screen.queryByRole('img', { name: 'Watching CI on the new PR' })).toBeNull()
   })
 
-  it('falls back to the real tool title when no human context was reported', () => {
+  it('leaves ordinary tool use to the existing working indication', () => {
     publishSessionState('runtime', {
       ...createClientSessionState('stored'),
       busy: true,
@@ -143,10 +149,10 @@ describe('sidebar activity display', () => {
     })
     toggleSidebarRowMeta('activity')
     render(<SidebarSessionActivity sessionId="stored" />)
-    expect(screen.getByRole('img', { name: 'Reading README.md' })).toBeTruthy()
+    expect(screen.queryByRole('img')).toBeNull()
   })
 
-  it('uses an explicit command comment instead of the flattened shell preview', () => {
+  it('does not classify a foreground tool as monitoring from its command comment', () => {
     publishSessionState('runtime', {
       ...createClientSessionState('stored'),
       busy: true,
@@ -171,7 +177,7 @@ describe('sidebar activity display', () => {
     })
     toggleSidebarRowMeta('activity')
     render(<SidebarSessionActivity sessionId="stored" />)
-    expect(screen.getByRole('img', { name: 'Watching CI' })).toBeTruthy()
+    expect(screen.queryByRole('img')).toBeNull()
     expect(screen.queryByText(/gh pr checks/)).toBeNull()
   })
 
@@ -190,7 +196,7 @@ describe('sidebar activity display', () => {
     })
     const show = await screen.findByRole('menuitem', { name: 'Show' })
     fireEvent.keyDown(show, { key: 'ArrowRight' })
-    const activity = await screen.findByRole('menuitemcheckbox', { name: 'Activity' })
+    const activity = await screen.findByRole('menuitemcheckbox', { name: 'Monitoring' })
     fireEvent.click(activity)
     expect($sidebarRowMeta.get()).toContain('activity')
     expect(activity.getAttribute('aria-checked')).toBe('true')

--- a/apps/desktop/src/app/chat/sidebar/session-activity.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-activity.tsx
@@ -1,0 +1,84 @@
+import { useStore } from '@nanostores/react'
+
+import { buildToolView } from '@/components/assistant-ui/tool/fallback-model'
+import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { summarizeShellCommand } from '@/lib/summarize-command'
+import { useStoreSelector } from '@/lib/use-session-slice'
+import { $sidebarRowMeta } from '@/store/layout'
+import { $sessionDotStateById } from '@/store/session-dot-state'
+import { $sidebarActivityById, type SidebarActivity } from '@/store/sidebar-activity'
+
+/** Display reported work, never classify a command or infer intent from prose. */
+function activityLabel(activity: SidebarActivity): string {
+  if (activity.type === 'tool-call') {
+    // Shell/code calls may carry an explicit human-readable first-line comment.
+    // Prefer that label over the gateway's flattened command preview.
+    if (['terminal', 'execute_code', 'browser_exec'].includes(activity.toolName)) {
+      const code = activity.args?.command ?? activity.args?.code
+      const comment = typeof code === 'string' ? /^[ \t]*#[ \t]+([^\r\n]+)/u.exec(code)?.[1]?.trim() : undefined
+
+      if (comment) {
+        return comment
+      }
+    }
+
+    const context = activity.args?.context
+
+    return typeof context === 'string' && context.trim() ? context.trim() : buildToolView(activity, '').title
+  }
+
+  if (activity.type === 'background') {
+    // The registry keeps the first command line. A leading shell comment is
+    // already the agent's human label, not a command to show with a '#' prefix.
+    return activity.title.startsWith('# ') ? activity.title.slice(2).trim() : summarizeShellCommand(activity.title)
+  }
+
+  return activity.title
+}
+
+export function SidebarSessionActivity({ sessionId }: { sessionId: string }) {
+  const enabled = useStore($sidebarRowMeta).includes('activity')
+
+  // Opting out must also opt out of projecting the live transcript stream.
+  return enabled ? <SessionActivityLabel sessionId={sessionId} /> : null
+}
+
+function SessionActivityLabel({ sessionId }: { sessionId: string }) {
+  const { t } = useI18n()
+  const activity = useStoreSelector($sidebarActivityById, all => all[sessionId])
+  const status = useStoreSelector($sessionDotStateById, all => all[sessionId])
+  // The selectors above only repaint for this row's activity, not text deltas
+  // in unrelated sessions. Formatting here also follows locale changes.
+  const detail = activity ? activityLabel(activity) : ''
+  const r = t.sidebar.row
+
+  const label =
+    status === 'needs-input'
+      ? r.waitingForAnswer
+      : detail ||
+        (status === 'background'
+          ? r.backgroundRunning
+          : status === 'working' || status === 'stalled'
+            ? r.sessionRunning
+            : '')
+
+  if (!label) {
+    return null
+  }
+
+  return (
+    <Tip label={label}>
+      <span
+        aria-label={label}
+        className="inline-flex size-3.5 shrink-0 items-center justify-center text-(--ui-text-tertiary) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring"
+        data-session-activity=""
+        role="img"
+        tabIndex={0}
+      >
+        <Codicon name="pulse" size="0.875rem" />
+      </span>
+    </Tip>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/session-activity.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-activity.tsx
@@ -1,6 +1,5 @@
 import { useStore } from '@nanostores/react'
 
-import { buildToolView } from '@/components/assistant-ui/tool/fallback-model'
 import { Codicon } from '@/components/ui/codicon'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
@@ -10,38 +9,15 @@ import { $sidebarRowMeta } from '@/store/layout'
 import { $sessionDotStateById } from '@/store/session-dot-state'
 import { $sidebarActivityById, type SidebarActivity } from '@/store/sidebar-activity'
 
-/** Display reported work, never classify a command or infer intent from prose. */
+/** The task label explains the monitoring state; it never determines it. */
 function activityLabel(activity: SidebarActivity): string {
-  if (activity.type === 'tool-call') {
-    // Shell/code calls may carry an explicit human-readable first-line comment.
-    // Prefer that label over the gateway's flattened command preview.
-    if (['terminal', 'execute_code', 'browser_exec'].includes(activity.toolName)) {
-      const code = activity.args?.command ?? activity.args?.code
-      const comment = typeof code === 'string' ? /^[ \t]*#[ \t]+([^\r\n]+)/u.exec(code)?.[1]?.trim() : undefined
-
-      if (comment) {
-        return comment
-      }
-    }
-
-    const context = activity.args?.context
-
-    return typeof context === 'string' && context.trim() ? context.trim() : buildToolView(activity, '').title
-  }
-
-  if (activity.type === 'background') {
-    // The registry keeps the first command line. A leading shell comment is
-    // already the agent's human label, not a command to show with a '#' prefix.
-    return activity.title.startsWith('# ') ? activity.title.slice(2).trim() : summarizeShellCommand(activity.title)
-  }
-
-  return activity.title
+  return activity.title.startsWith('# ') ? activity.title.slice(2).trim() : summarizeShellCommand(activity.title)
 }
 
 export function SidebarSessionActivity({ sessionId }: { sessionId: string }) {
   const enabled = useStore($sidebarRowMeta).includes('activity')
 
-  // Opting out must also opt out of projecting the live transcript stream.
+  // Opting out also avoids subscribing to this row's background activity.
   return enabled ? <SessionActivityLabel sessionId={sessionId} /> : null
 }
 
@@ -54,15 +30,9 @@ function SessionActivityLabel({ sessionId }: { sessionId: string }) {
   const detail = activity ? activityLabel(activity) : ''
   const r = t.sidebar.row
 
-  const label =
-    status === 'needs-input'
-      ? r.waitingForAnswer
-      : detail ||
-        (status === 'background'
-          ? r.backgroundRunning
-          : status === 'working' || status === 'stalled'
-            ? r.sessionRunning
-            : '')
+  // The existing arc already reports active work. This extra cue is only
+  // for work that remains after the agent has yielded, never another spinner.
+  const label = status === 'background' ? detail || r.activity : ''
 
   if (!label) {
     return null

--- a/apps/desktop/src/app/chat/sidebar/session-monitoring.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-monitoring.test.tsx
@@ -1,0 +1,127 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+
+import { StatusItemRow } from '@/app/chat/composer/status-stack/status-row'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import {
+  $backgroundStatusBySession,
+  dismissBackgroundProcess,
+  reconcileBackgroundProcesses,
+  resetSessionBackground
+} from '@/store/composer-status'
+import { $sidebarRowMeta, resetSidebarView } from '@/store/layout'
+import { $sessions } from '@/store/session'
+import { $sessionDotStateById, showsRunningArc } from '@/store/session-dot-state'
+import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import { $subagentsBySession, type SubagentProgress } from '@/store/subagents'
+import { makeSessionInfo } from '@/test/session-info'
+
+import { SidebarSessionActivity } from './session-activity'
+
+const child: SubagentProgress = {
+  id: 'child',
+  parentId: null,
+  goal: 'Fix the build',
+  status: 'running',
+  taskCount: 1,
+  taskIndex: 0,
+  startedAt: 1,
+  updatedAt: 1,
+  filesRead: [],
+  filesWritten: [],
+  stream: []
+}
+
+afterEach(() => {
+  cleanup()
+  clearAllSessionStates()
+  $sessions.set([])
+  $backgroundStatusBySession.set({})
+  resetSessionBackground('runtime')
+  $subagentsBySession.set({})
+  resetSidebarView()
+})
+
+it('reserves monitoring for background-only work and returns to working for delegated or parent follow-up', () => {
+  $sidebarRowMeta.set(['activity'])
+  $sessions.set([makeSessionInfo({ id: 'stored', message_count: 2 })])
+  const idle = createClientSessionState('stored')
+
+  const process = {
+    id: 'watch',
+    type: 'background' as const,
+    state: 'running' as const,
+    title: '# Watching CI',
+    awaitingNotification: true
+  }
+
+  publishSessionState('runtime', { ...idle, busy: true })
+  $backgroundStatusBySession.set({ runtime: [process] })
+  render(<SidebarSessionActivity sessionId="stored" />)
+  const status = () => $sessionDotStateById.get().stored ?? 'idle'
+
+  expect(status()).toBe('working')
+  expect(screen.queryByRole('img')).toBeNull()
+  act(() => publishSessionState('runtime', idle))
+  expect(screen.getByRole('img', { name: 'Watching CI' })).toBeTruthy()
+  expect(showsRunningArc(status())).toBe(false)
+
+  act(() => $subagentsBySession.set({ runtime: [child] }))
+  expect(status()).toBe('working')
+  expect(showsRunningArc(status())).toBe(true)
+  expect(screen.queryByRole('img')).toBeNull()
+  act(() => $subagentsBySession.set({ runtime: [{ ...child, status: 'completed' }] }))
+  expect(screen.getByRole('img', { name: 'Watching CI' })).toBeTruthy()
+
+  act(() => publishSessionState('runtime', { ...idle, busy: true }))
+  expect(screen.queryByRole('img')).toBeNull()
+  act(() => $backgroundStatusBySession.set({ runtime: [{ ...process, state: 'done' }] }))
+  expect(status()).toBe('working')
+  act(() => publishSessionState('runtime', idle))
+  expect(status()).toBe('unread')
+  expect(screen.queryByRole('img')).toBeNull()
+})
+
+it('uses notification contracts rather than process names to distinguish awaited work from a leftover server', () => {
+  $sidebarRowMeta.set(['activity'])
+  $sessions.set([makeSessionInfo({ id: 'stored', message_count: 2 })])
+  publishSessionState('runtime', createClientSessionState('stored'))
+  const process = { session_id: 'process', command: '# Watching CI', status: 'running' }
+  reconcileBackgroundProcesses('runtime', [process])
+  render(<SidebarSessionActivity sessionId="stored" />)
+  expect(screen.queryByRole('img')).toBeNull()
+  expect($sessionDotStateById.get().stored).not.toBe('background')
+
+  act(() => reconcileBackgroundProcesses('runtime', [{ ...process, notify_on_complete: true }]))
+  expect(screen.getByRole('img', { name: 'Watching CI' })).toBeTruthy()
+  act(() => reconcileBackgroundProcesses('runtime', [{ ...process, watch_patterns: ['ready'], watch_hit: false }]))
+  expect(screen.getByRole('img', { name: 'Watching CI' })).toBeTruthy()
+  act(() => reconcileBackgroundProcesses('runtime', [{ ...process, watch_patterns: ['ready'], watch_hit: true }]))
+  expect(screen.queryByRole('img')).toBeNull()
+  expect($backgroundStatusBySession.get().runtime?.[0]?.state).toBe('running')
+  act(() =>
+    reconcileBackgroundProcesses('runtime', [
+      { ...process, status: 'exited', exit_code: 0, notification_pending: true }
+    ])
+  )
+  expect(screen.getByRole('img', { name: 'Watching CI' })).toBeTruthy()
+
+  const statusRow = () => (
+    <StatusItemRow
+      item={$backgroundStatusBySession.get().runtime![0]!}
+      onDismiss={id => dismissBackgroundProcess('runtime', id)}
+    />
+  )
+
+  const row = render(statusRow())
+  expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull()
+  act(() =>
+    reconcileBackgroundProcesses('runtime', [
+      { ...process, status: 'exited', exit_code: 0, notification_pending: false }
+    ])
+  )
+  row.rerender(statusRow())
+  expect(screen.queryByRole('img')).toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+  expect($backgroundStatusBySession.get().runtime ?? []).toEqual([])
+})

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -8,6 +8,9 @@ import { createClientSessionState } from '@/lib/chat-runtime'
 import type * as ChatRuntime from '@/lib/chat-runtime'
 import type * as Time from '@/lib/time'
 import type * as ComposerStatusStore from '@/store/composer-status'
+import { $backgroundStatusBySession } from '@/store/composer-status'
+import { $sidebarRowMeta, resetSidebarView } from '@/store/layout'
+import { $pullRequestsByBranch, branchPrKey } from '@/store/pull-requests'
 import type * as SessionStore from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type * as SessionStatesStore from '@/store/session-states'
@@ -171,6 +174,76 @@ const renderRow = (session: SessionInfo, extra?: { card?: boolean }) =>
       unread={false}
     />
   )
+
+describe('session row activity integration', () => {
+  afterEach(() => {
+    clearAllSessionStates()
+    $backgroundStatusBySession.set({})
+    resetSidebarView()
+    $pullRequestsByBranch.set({})
+    vi.unstubAllGlobals()
+  })
+
+  it.each([false, true])('preserves the PR link and menu beside activity (age=%s)', showAge => {
+    const openExternal = vi.fn()
+    vi.stubGlobal('hermesDesktop', { openExternal })
+    publishSessionState('runtime', createClientSessionState('s1'))
+    $backgroundStatusBySession.set({
+      runtime: [{ id: 'watch', type: 'background', state: 'running', title: '# Watching CI' }]
+    })
+
+    const pr = {
+      branch: 'feature',
+      draft: false,
+      number: 42,
+      state: 'open',
+      title: 'Sidebar change',
+      url: 'https://example.com/pull/42'
+    }
+
+    $pullRequestsByBranch.set({ [branchPrKey('/repo', 'feature')]: pr })
+    $sidebarRowMeta.set(showAge ? ['activity', 'pr', 'updated'] : ['activity', 'pr'])
+    renderRow(makeSession({ title: 'Improve sidebar', git_repo_root: '/repo', git_branch: 'feature' }))
+    const icon = screen.getByRole('img', { name: 'Watching CI' })
+    const link = screen.getByRole('button', { name: 'Open pull request #42' })
+    expect(icon.closest('[data-row-actions]')).toBe(link.closest('[data-row-actions]'))
+    expect(screen.getByRole('button', { name: 'Session actions' })).toBeTruthy()
+    expect(Boolean(screen.queryByText('5m'))).toBe(showAge)
+    noop.mockClear()
+    fireEvent.click(link)
+    expect(openExternal).toHaveBeenCalledWith(pr.url)
+    expect(noop).not.toHaveBeenCalled()
+  })
+
+  it.each([false, true])('keeps activity in the trailing actions, not the title stack (card=%s)', card => {
+    publishSessionState('runtime', createClientSessionState('s1'))
+    $backgroundStatusBySession.set({
+      runtime: [{ id: 'watch', type: 'background', state: 'running', title: '# Watching CI' }]
+    })
+    $sidebarRowMeta.set(['activity'])
+    renderRow(makeSession({ title: 'Improve sidebar' }), { card })
+    const activity = screen.getByRole('img', { name: 'Watching CI' })
+    expect(activity.closest('[data-row-actions]')).toBeTruthy()
+
+    if (!card) {
+      expect(activity.closest('button')).toBeNull()
+    }
+
+    expect(activity.textContent).toBe('')
+    expect(screen.queryByText('Watching CI')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Session actions' })).toBeTruthy()
+  })
+
+  it('keeps archived rows quiet even if their runtime still has cached work', () => {
+    publishSessionState('runtime', createClientSessionState('s1'))
+    $backgroundStatusBySession.set({
+      runtime: [{ id: 'watch', type: 'background', state: 'running', title: '# Watching CI' }]
+    })
+    $sidebarRowMeta.set(['activity'])
+    renderRow(makeSession({ title: 'Archived', archived: true }))
+    expect(screen.queryByRole('img', { name: 'Watching CI' })).toBeNull()
+  })
+})
 
 // The row no longer takes its running state as a prop, so this drives the real
 // store the way the app does. $workingSessionIds is the actual computed here

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -7,7 +7,6 @@ import type { SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type * as ChatRuntime from '@/lib/chat-runtime'
 import type * as Time from '@/lib/time'
-import type * as ComposerStatusStore from '@/store/composer-status'
 import { $backgroundStatusBySession } from '@/store/composer-status'
 import { $sidebarRowMeta, resetSidebarView } from '@/store/layout'
 import { $pullRequestsByBranch, branchPrKey } from '@/store/pull-requests'
@@ -93,11 +92,7 @@ vi.mock('@/lib/time', async importOriginal => {
 // upstream (as happened twice already: $stalledSessionIds, then $sessions).
 // Overriding only the named atoms we actually control keeps this test
 // resilient to that drift.
-vi.mock('@/store/composer-status', async importOriginal => {
-  const actual = await importOriginal<typeof ComposerStatusStore>()
 
-  return { ...actual, $backgroundRunningSessionIds: atom<string[]>([]) }
-})
 vi.mock('@/store/session', async importOriginal => {
   const actual = await importOriginal<typeof SessionStore>()
 
@@ -189,7 +184,9 @@ describe('session row activity integration', () => {
     vi.stubGlobal('hermesDesktop', { openExternal })
     publishSessionState('runtime', createClientSessionState('s1'))
     $backgroundStatusBySession.set({
-      runtime: [{ id: 'watch', type: 'background', state: 'running', title: '# Watching CI' }]
+      runtime: [
+        { id: 'watch', type: 'background', state: 'running', title: '# Watching CI', awaitingNotification: true }
+      ]
     })
 
     const pr = {
@@ -218,7 +215,9 @@ describe('session row activity integration', () => {
   it.each([false, true])('keeps activity in the trailing actions, not the title stack (card=%s)', card => {
     publishSessionState('runtime', createClientSessionState('s1'))
     $backgroundStatusBySession.set({
-      runtime: [{ id: 'watch', type: 'background', state: 'running', title: '# Watching CI' }]
+      runtime: [
+        { id: 'watch', type: 'background', state: 'running', title: '# Watching CI', awaitingNotification: true }
+      ]
     })
     $sidebarRowMeta.set(['activity'])
     renderRow(makeSession({ title: 'Improve sidebar' }), { card })
@@ -237,7 +236,9 @@ describe('session row activity integration', () => {
   it('keeps archived rows quiet even if their runtime still has cached work', () => {
     publishSessionState('runtime', createClientSessionState('s1'))
     $backgroundStatusBySession.set({
-      runtime: [{ id: 'watch', type: 'background', state: 'running', title: '# Watching CI' }]
+      runtime: [
+        { id: 'watch', type: 'background', state: 'running', title: '# Watching CI', awaitingNotification: true }
+      ]
     })
     $sidebarRowMeta.set(['activity'])
     renderRow(makeSession({ title: 'Archived', archived: true }))

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -47,6 +47,7 @@ import {
   SidebarRowShell
 } from './chrome'
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
+import { SidebarSessionActivity } from './session-activity'
 import { sessionRowDetails } from './session-row-details'
 import { resolveSessionRowClick } from './session-row-gesture'
 import { useProfilePrewarm } from './use-profile-prewarm'
@@ -297,6 +298,9 @@ function SidebarSessionRowImpl({
   // when only the header shares its line with the age and kebab.
   const actionsNode = (
     <div className="relative z-2 flex shrink-0 items-center justify-end gap-1" data-row-actions>
+      {/* Activity owns a small inline slot before metadata. Keep it outside
+          the tail swap so the age/PR/kebab retain their existing behavior. */}
+      {!session.archived && <SidebarSessionActivity sessionId={session.id} />}
       {trailing.map(({ key, node }, index) => (
         <span
           className={

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -1,30 +1,35 @@
-import { cleanup, render } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $backgroundStatusBySession } from '@/store/composer-status'
+import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import type { VirtualSessionListProps } from './virtual-session-list'
 
 afterEach(cleanup)
 
-vi.mock('@/i18n', () => ({
-  useI18n: () => ({
-    t: {
-      sidebar: {
-        dateDivider: {
-          earlierThisMonth: 'Earlier this month',
-          lastMonth: 'Last month',
-          lastWeek: 'Last week',
-          older: 'Older',
-          today: 'Today',
-          yesterday: 'Yesterday'
-        }
+vi.mock('@/i18n', () => {
+  const t = {
+    sidebar: {
+      statusDivider: { working: 'Working', done: 'Done' },
+      projects: { toggle: (label: string) => label },
+      dateDivider: {
+        earlierThisMonth: 'Earlier this month',
+        lastMonth: 'Last month',
+        lastWeek: 'Last week',
+        older: 'Older',
+        today: 'Today',
+        yesterday: 'Yesterday'
       }
     }
-  })
-}))
+  }
+
+  return { useI18n: () => ({ t }) }
+})
 
 const mockVirtualListPropsHistory: VirtualSessionListProps[] = []
 
@@ -58,6 +63,49 @@ function generateSessions(count: number): SessionInfo[] {
 }
 
 const noop = () => {}
+
+it('keeps a monitored task outside Done until its background obligation settles', () => {
+  publishSessionState('runtime', createClientSessionState('monitor'))
+
+  const process = {
+    id: 'watch',
+    type: 'background' as const,
+    state: 'running' as const,
+    title: 'Watching checks',
+    awaitingNotification: true
+  }
+
+  $backgroundStatusBySession.set({ runtime: [process] })
+
+  try {
+    render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={null}
+        grouping="status"
+        label="Sessions"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        onToggleUnread={noop}
+        open
+        pinned={false}
+        sessions={[makeSession('monitor')]}
+      />
+    )
+    expect(screen.getByText('Working')).toBeTruthy()
+    expect(screen.queryByText('Done')).toBeNull()
+    act(() => $backgroundStatusBySession.set({ runtime: [{ ...process, state: 'done' }] }))
+    expect(screen.getByText('Done')).toBeTruthy()
+    expect(screen.queryByText('Working')).toBeNull()
+  } finally {
+    cleanup()
+    $backgroundStatusBySession.set({})
+    clearAllSessionStates()
+  }
+})
 
 describe('SidebarSessionsSection memoization & virtualizer stability', () => {
   it('memoizes flatRows and passes the exact same rows array reference across parent re-renders', () => {

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -396,7 +396,11 @@ export function SidebarSessionsSection({
         : grouping === 'status'
           ? groupEntriesByStatus(
               displayEntries,
-              entry => hasLiveTurn(dotStates[entry.session.id] ?? 'idle'),
+              entry => {
+                const status = dotStates[entry.session.id] ?? 'idle'
+
+                return hasLiveTurn(status) || status === 'background'
+              },
               statusDividerLabels
             )
           : toSessionRows(displayEntries)

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1845,6 +1845,7 @@ export const ar = defineLocale({
       needsInput: 'تحتاج إدخالا',
       waitingForAnswer: 'بانتظار إجابة',
       backgroundRunning: 'تعمل في الخلفية',
+      activity: 'النشاط',
       draftSession: 'مسودة — لم تُرسل بعد',
       finishedUnread: 'اكتملت وفيها جديد',
       hideTabBar: 'إخفاء شريط التبويبات',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1845,7 +1845,7 @@ export const ar = defineLocale({
       needsInput: 'تحتاج إدخالا',
       waitingForAnswer: 'بانتظار إجابة',
       backgroundRunning: 'تعمل في الخلفية',
-      activity: 'النشاط',
+      activity: 'المراقبة',
       draftSession: 'مسودة — لم تُرسل بعد',
       finishedUnread: 'اكتملت وفيها جديد',
       hideTabBar: 'إخفاء شريط التبويبات',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2486,6 +2486,7 @@ export const en: Translations = {
       waitingForAnswer: 'Waiting for your answer',
       finishedUnread: 'Finished — unread',
       backgroundRunning: 'Background task running',
+      activity: 'Activity',
       draftSession: 'Draft — nothing sent yet',
       handoffOrigin: platform => `Handed off from ${platform}`,
       ownedByProfile: profile => `Profile: ${profile}`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2486,7 +2486,7 @@ export const en: Translations = {
       waitingForAnswer: 'Waiting for your answer',
       finishedUnread: 'Finished — unread',
       backgroundRunning: 'Background task running',
-      activity: 'Activity',
+      activity: 'Monitoring',
       draftSession: 'Draft — nothing sent yet',
       handoffOrigin: platform => `Handed off from ${platform}`,
       ownedByProfile: profile => `Profile: ${profile}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2151,6 +2151,7 @@ export const ja = defineLocale({
       waitingForAnswer: '回答を待っています',
       finishedUnread: '完了 — 未読',
       backgroundRunning: 'バックグラウンドタスク実行中',
+      activity: 'アクティビティ',
       draftSession: '下書き — 未送信',
       handoffOrigin: platform => `${platform} から引き継ぎ`,
       ownedByProfile: profile => `プロファイル: ${profile}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2151,7 +2151,7 @@ export const ja = defineLocale({
       waitingForAnswer: '回答を待っています',
       finishedUnread: '完了 — 未読',
       backgroundRunning: 'バックグラウンドタスク実行中',
-      activity: 'アクティビティ',
+      activity: '監視中',
       draftSession: '下書き — 未送信',
       handoffOrigin: platform => `${platform} から引き継ぎ`,
       ownedByProfile: profile => `プロファイル: ${profile}`,

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2523,6 +2523,7 @@ export const ru = defineLocale({
       waitingForAnswer: 'Ждёт вашего ответа',
       finishedUnread: 'Завершён — не прочитан',
       backgroundRunning: 'Фоновая задача выполняется',
+      activity: 'Активность',
       draftSession: 'Черновик — ещё ничего не отправлено',
       handoffOrigin: platform => `Передано из ${platform}`,
       ownedByProfile: profile => `Профиль: ${profile}`,

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2523,7 +2523,7 @@ export const ru = defineLocale({
       waitingForAnswer: 'Ждёт вашего ответа',
       finishedUnread: 'Завершён — не прочитан',
       backgroundRunning: 'Фоновая задача выполняется',
-      activity: 'Активность',
+      activity: 'Мониторинг',
       draftSession: 'Черновик — ещё ничего не отправлено',
       handoffOrigin: platform => `Передано из ${platform}`,
       ownedByProfile: profile => `Профиль: ${profile}`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2128,6 +2128,7 @@ export interface Translations {
       waitingForAnswer: string
       finishedUnread: string
       backgroundRunning: string
+      activity: string
       draftSession: string
       handoffOrigin: (platform: string) => string
       ownedByProfile: (profile: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2072,6 +2072,7 @@ export const zhHant = defineLocale({
       waitingForAnswer: '等待您的回答',
       finishedUnread: '已完成 — 未讀',
       backgroundRunning: '背景任務執行中',
+      activity: '活動',
       draftSession: '草稿 — 尚未傳送',
       handoffOrigin: platform => `從 ${platform} 轉接`,
       ownedByProfile: profile => `設定檔：${profile}`,

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2072,7 +2072,7 @@ export const zhHant = defineLocale({
       waitingForAnswer: '等待您的回答',
       finishedUnread: '已完成 — 未讀',
       backgroundRunning: '背景任務執行中',
-      activity: '活動',
+      activity: '監控中',
       draftSession: '草稿 — 尚未傳送',
       handoffOrigin: platform => `從 ${platform} 轉接`,
       ownedByProfile: profile => `設定檔：${profile}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2650,6 +2650,7 @@ export const zh: Translations = {
       waitingForAnswer: '正在等待你的回答',
       finishedUnread: '已完成 — 未读',
       backgroundRunning: '后台任务运行中',
+      activity: '活动',
       draftSession: '草稿 — 尚未发送',
       handoffOrigin: platform => `从 ${platform} 转接`,
       ownedByProfile: profile => `配置档：${profile}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2650,7 +2650,7 @@ export const zh: Translations = {
       waitingForAnswer: '正在等待你的回答',
       finishedUnread: '已完成 — 未读',
       backgroundRunning: '后台任务运行中',
-      activity: '活动',
+      activity: '监控中',
       draftSession: '草稿 — 尚未发送',
       handoffOrigin: platform => `从 ${platform} 转接`,
       ownedByProfile: profile => `配置档：${profile}`,

--- a/apps/desktop/src/store/composer-status-polling.test.ts
+++ b/apps/desktop/src/store/composer-status-polling.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $backgroundRunningSessionIds,
+  $backgroundStatusBySession,
+  clearAllSessionBackground,
+  reconcileBackgroundProcesses,
+  refreshBackgroundProcesses,
+  resetSessionBackground,
+  stopBackgroundProcess
+} from './composer-status'
+import { $gateway, requestGatewayForAgent, requestGatewayForProfile } from './gateway'
+import { wipeSessionListsForGatewaySwitch } from './gateway-switch'
+import { notifyError } from './notifications'
+import { isSessionGone, resetBackgroundPollingGuard, resetRuntimeGoneHealing } from './runtime-gone'
+import { $sessions } from './session'
+import { healsByStoredId } from './session-gone-latch'
+import { $sessionStates, $sessionTiles } from './session-states'
+
+vi.mock(import('./gateway'), async importOriginal => ({
+  ...(await importOriginal()),
+  requestGatewayForAgent: vi.fn(),
+  requestGatewayForProfile: vi.fn()
+}))
+
+vi.mock('./native-notifications', () => ({ dispatchNativeNotification: vi.fn() }))
+vi.mock('./notifications', () => ({ notifyError: vi.fn() }))
+
+const running = (id: string) => ({ command: '# Watching CI', session_id: id, status: 'running' })
+const exited = (id: string) => ({ ...running(id), status: 'exited', exit_code: 0 })
+const request = vi.fn()
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  clearAllSessionBackground()
+  resetBackgroundPollingGuard()
+  resetRuntimeGoneHealing()
+  $sessions.set([])
+  $sessionStates.set({})
+  $sessionTiles.set([])
+  vi.mocked(requestGatewayForAgent).mockReset().mockResolvedValue({ processes: [] })
+  vi.mocked(requestGatewayForProfile).mockReset().mockResolvedValue({ processes: [] })
+  request.mockReset().mockResolvedValue({ processes: [] })
+  $gateway.set({ request } as never)
+})
+
+afterEach(() => {
+  clearAllSessionBackground()
+  resetBackgroundPollingGuard()
+  resetRuntimeGoneHealing()
+  $gateway.set(null)
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+describe('shared background process refresh', () => {
+  it.each(['snapshot', 'reset', 'wipe'] as const)(
+    'ignores a stale rejected read after %s without latching or healing the current session',
+    async invalidation => {
+      const sid = `stale-${invalidation}`
+      let reject!: (reason: unknown) => void
+      request.mockReturnValueOnce(
+        new Promise((_resolve, fail) => {
+          reject = fail
+        })
+      )
+      const pending = refreshBackgroundProcesses(sid)
+
+      if (invalidation === 'snapshot') {
+        reconcileBackgroundProcesses(sid, [running('current')])
+      } else if (invalidation === 'reset') {
+        resetSessionBackground(sid)
+      } else {
+        wipeSessionListsForGatewaySwitch()
+      }
+
+      $sessionStates.set({ [sid]: { storedSessionId: 'current-stored' } as never })
+      $sessionTiles.set([{ storedSessionId: 'current-stored', runtimeId: sid }])
+      healsByStoredId.set('current-stored', 2)
+      reject(new Error('session not found'))
+      await pending
+
+      expect(isSessionGone(sid)).toBe(false)
+      expect(healsByStoredId.get('current-stored')).toBe(2)
+      expect($sessionTiles.get()[0]?.runtimeId).toBe(sid)
+      await refreshBackgroundProcesses(sid)
+      expect(request).toHaveBeenCalledTimes(2)
+      expect(healsByStoredId.has('current-stored')).toBe(false)
+    }
+  )
+
+  it.each(['snapshot', 'reset', 'wipe'] as const)(
+    'does not refund the current recovery budget for a stale successful read after %s',
+    async invalidation => {
+      const sid = `stale-success-${invalidation}`
+      let resolve!: (value: unknown) => void
+      request.mockReturnValueOnce(
+        new Promise(done => {
+          resolve = done
+        })
+      )
+      const pending = refreshBackgroundProcesses(sid)
+
+      if (invalidation === 'snapshot') {
+        reconcileBackgroundProcesses(sid, [])
+      } else if (invalidation === 'reset') {
+        resetSessionBackground(sid)
+      } else {
+        wipeSessionListsForGatewaySwitch()
+      }
+
+      $sessionStates.set({ [sid]: { storedSessionId: 'current-stored' } as never })
+      healsByStoredId.set('current-stored', 2)
+      resolve({ processes: [running('obsolete')] })
+      await pending
+
+      expect($backgroundStatusBySession.get()[sid]).toBeUndefined()
+      expect(isSessionGone(sid)).toBe(false)
+      expect(healsByStoredId.get('current-stored')).toBe(2)
+    }
+  )
+
+  it('polls only known running work and stops requests after a gone-runtime rejection', async () => {
+    $sessionStates.set({ idle: { storedSessionId: 'idle-stored' } as never })
+    reconcileBackgroundProcesses('gone', [running('ci')])
+    request.mockRejectedValue(new Error('session not found'))
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(request).toHaveBeenCalledExactlyOnceWith('process.list', { session_id: 'gone' })
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(isSessionGone('gone')).toBe(true)
+  })
+
+  it('wipes cached rows, dismissals, timers and pending reads on a gateway switch', async () => {
+    reconcileBackgroundProcesses('outgoing', [running('ci'), exited('finished')])
+    let resolve!: (value: unknown) => void
+    request.mockReturnValueOnce(
+      new Promise(done => {
+        resolve = done
+      })
+    )
+    const pending = refreshBackgroundProcesses('outgoing')
+    wipeSessionListsForGatewaySwitch()
+    expect($backgroundStatusBySession.get()).toEqual({})
+    resolve({ processes: [running('ci'), running('late')] })
+    await pending
+    request.mockClear()
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect($backgroundStatusBySession.get()).toEqual({})
+    expect(request).not.toHaveBeenCalled()
+    // Old auto-dismiss timers must not dismiss a recycled id on the new backend.
+    reconcileBackgroundProcesses('outgoing', [running('finished')])
+    expect($backgroundStatusBySession.get().outgoing?.[0]?.id).toBe('finished')
+  })
+
+  it('does not let a late kill dismiss a recycled process on a new gateway', async () => {
+    reconcileBackgroundProcesses('kill-switch', [running('ci')])
+    let resolve!: (value: unknown) => void
+    request.mockReturnValueOnce(
+      new Promise(done => {
+        resolve = done
+      })
+    )
+    const pending = stopBackgroundProcess('kill-switch', 'ci')
+    wipeSessionListsForGatewaySwitch()
+    reconcileBackgroundProcesses('kill-switch', [running('ci')])
+    resolve({})
+    await pending
+    expect($backgroundStatusBySession.get()['kill-switch']?.[0]?.state).toBe('running')
+  })
+
+  it('rewind kills only running processes through their owner and drops all rows', async () => {
+    $sessions.set([{ id: 'reset-stored', profile: 'work' } as never])
+    $sessionStates.set({ reset: { storedSessionId: 'reset-stored' } as never })
+    reconcileBackgroundProcesses('reset', [running('ci'), exited('done')])
+    resetSessionBackground('reset')
+    expect(requestGatewayForProfile).toHaveBeenCalledExactlyOnceWith(
+      'work',
+      'process.kill',
+      { process_id: 'ci', session_id: 'reset' },
+      undefined,
+      undefined
+    )
+    expect(request).not.toHaveBeenCalled()
+    expect($backgroundStatusBySession.get().reset).toBeUndefined()
+    reconcileBackgroundProcesses('reset', [running('ci'), exited('done')])
+    expect($backgroundStatusBySession.get().reset).toBeUndefined()
+  })
+
+  it('retains a running row when there is no gateway to confirm a kill', async () => {
+    reconcileBackgroundProcesses('disconnected', [running('ci')])
+    $gateway.set(null)
+    await stopBackgroundProcess('disconnected', 'ci')
+    expect($backgroundStatusBySession.get().disconnected?.[0]?.state).toBe('running')
+    expect(notifyError).toHaveBeenCalled()
+  })
+
+  it('routes an unmounted runtime through its stored session owner, not the active profile', async () => {
+    $sessions.set([{ id: 'stored', profile: 'work' } as never])
+    $sessionStates.set({ owned: { storedSessionId: 'stored' } as never })
+    reconcileBackgroundProcesses('owned', [running('ci')])
+    vi.mocked(requestGatewayForProfile).mockResolvedValue({ processes: [exited('ci')] })
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(requestGatewayForProfile).toHaveBeenCalledWith(
+      'work',
+      'process.list',
+      { session_id: 'owned' },
+      undefined,
+      undefined
+    )
+    expect(request).not.toHaveBeenCalled()
+    expect($backgroundStatusBySession.get().owned?.[0]?.state).toBe('done')
+  })
+
+  it('preserves an exact tile connection route ahead of a row profile for reads and kills', async () => {
+    $sessions.set([{ id: 'tile-stored', profile: 'other' } as never])
+    $sessionTiles.set([
+      {
+        storedSessionId: 'tile-stored',
+        runtimeId: 'tile-runtime',
+        ownerRoute: { connectionId: 'remote-a', profile: 'work' }
+      }
+    ])
+    reconcileBackgroundProcesses('tile-runtime', [running('ci')])
+    await refreshBackgroundProcesses('tile-runtime')
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('remote-a', 'work', 'process.list', {
+      session_id: 'tile-runtime'
+    })
+    reconcileBackgroundProcesses('tile-runtime', [running('ci')])
+    await stopBackgroundProcess('tile-runtime', 'ci')
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('remote-a', 'work', 'process.kill', {
+      session_id: 'tile-runtime',
+      process_id: 'ci'
+    })
+    expect(request).not.toHaveBeenCalled()
+    expect($backgroundStatusBySession.get()['tile-runtime']).toBeUndefined()
+  })
+
+  it('preserves an unmounted session registry connection for background reads and kills', async () => {
+    $sessions.set([{ id: 'remote-stored', profile: 'work', connection_id: 'remote-a' } as never])
+    $sessionStates.set({ 'remote-runtime': { storedSessionId: 'remote-stored' } as never })
+    reconcileBackgroundProcesses('remote-runtime', [running('ci')])
+    await refreshBackgroundProcesses('remote-runtime')
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('remote-a', 'work', 'process.list', {
+      session_id: 'remote-runtime'
+    })
+    reconcileBackgroundProcesses('remote-runtime', [running('ci')])
+    await stopBackgroundProcess('remote-runtime', 'ci')
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('remote-a', 'work', 'process.kill', {
+      session_id: 'remote-runtime',
+      process_id: 'ci'
+    })
+    expect(requestGatewayForProfile).not.toHaveBeenCalled()
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('rechecks a tool completion that arrives during an older empty seed request', async () => {
+    let resolve!: (value: unknown) => void
+    request.mockReturnValueOnce(
+      new Promise(done => {
+        resolve = done
+      })
+    )
+    request.mockResolvedValue({ processes: [running('new-process')] })
+    const seed = refreshBackgroundProcesses('spawning')
+    const toolCompletion = refreshBackgroundProcesses('spawning')
+    expect(request).toHaveBeenCalledTimes(1)
+    resolve({ processes: [] })
+    await Promise.all([seed, toolCompletion])
+    expect(request).toHaveBeenCalledTimes(2)
+    expect($backgroundStatusBySession.get().spawning?.[0]?.state).toBe('running')
+  })
+
+  it('coalesces event, mount and polling requests while a snapshot is pending', async () => {
+    reconcileBackgroundProcesses('coalesced', [running('ci')])
+    request.mockResolvedValue({ processes: [exited('ci')] })
+    let resolve!: (value: unknown) => void
+    request.mockReturnValueOnce(
+      new Promise(done => {
+        resolve = done
+      })
+    )
+    const first = refreshBackgroundProcesses('coalesced')
+    const second = refreshBackgroundProcesses('coalesced')
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(request).toHaveBeenCalledTimes(1)
+    resolve({ processes: [exited('ci')] })
+    await Promise.all([first, second])
+    expect($backgroundStatusBySession.get().coalesced?.[0]?.state).toBe('done')
+  })
+
+  it('does not let a late snapshot roll back a newer reconciliation', async () => {
+    reconcileBackgroundProcesses('late', [running('ci')])
+    let resolve!: (value: unknown) => void
+    request.mockReturnValueOnce(
+      new Promise(done => {
+        resolve = done
+      })
+    )
+    const pending = refreshBackgroundProcesses('late')
+    reconcileBackgroundProcesses('late', [exited('ci')])
+    resolve({ processes: [running('ci')] })
+    await pending
+    expect($backgroundStatusBySession.get().late?.[0]?.state).toBe('done')
+  })
+
+  it('fences a pre-reset snapshot including processes not yet seen by the renderer', async () => {
+    let resolve!: (value: unknown) => void
+    request.mockReturnValueOnce(
+      new Promise(done => {
+        resolve = done
+      })
+    )
+    const pending = refreshBackgroundProcesses('rewound')
+    resetSessionBackground('rewound')
+    resolve({ processes: [running('unseen')] })
+    await pending
+    expect($backgroundStatusBySession.get().rewound).toBeUndefined()
+  })
+  it('clears silent exits without any composer or status subscriber mounted', async () => {
+    reconcileBackgroundProcesses('unmounted', [running('ci')])
+    request.mockResolvedValue({ processes: [exited('ci')] })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(request).toHaveBeenCalledWith('process.list', { session_id: 'unmounted' })
+    expect($backgroundStatusBySession.get().unmounted?.[0]?.state).toBe('done')
+    expect($backgroundRunningSessionIds.get()).not.toContain('unmounted')
+    request.mockClear()
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(request).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/store/composer-status-polling.test.ts
+++ b/apps/desktop/src/store/composer-status-polling.test.ts
@@ -330,4 +330,19 @@ describe('shared background process refresh', () => {
     await vi.advanceTimersByTimeAsync(30_000)
     expect(request).not.toHaveBeenCalled()
   })
+
+  it('keeps polling an exited process until its pending notification is accepted', async () => {
+    const pending = { ...exited('ci'), notification_pending: true }
+    reconcileBackgroundProcesses('unmounted', [pending])
+    request.mockResolvedValue({ processes: [pending] })
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect($backgroundRunningSessionIds.get()).toContain('unmounted')
+    expect($backgroundStatusBySession.get().unmounted?.[0]?.notificationPending).toBe(true)
+    expect(request).toHaveBeenCalledWith('process.list', { session_id: 'unmounted' })
+    request.mockResolvedValue({ processes: [{ ...pending, notification_pending: false }] })
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect($backgroundRunningSessionIds.get()).not.toContain('unmounted')
+    await vi.advanceTimersByTimeAsync(4_000)
+    expect($backgroundStatusBySession.get().unmounted).toBeUndefined()
+  })
 })

--- a/apps/desktop/src/store/composer-status.test.ts
+++ b/apps/desktop/src/store/composer-status.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   $backgroundStatusBySession,
+  clearAllSessionBackground,
   dismissBackgroundProcess,
   isSessionGoneForBackgroundPolling,
   reconcileBackgroundProcesses,
@@ -34,10 +35,11 @@ describe('reconcileBackgroundProcesses', () => {
     // Fake timers so the success self-clear (a real setTimeout) is deterministic
     // and never leaks a pending timer between tests.
     vi.useFakeTimers()
-    $backgroundStatusBySession.set({})
+    clearAllSessionBackground()
   })
 
   afterEach(() => {
+    clearAllSessionBackground()
     vi.clearAllTimers()
     vi.useRealTimers()
   })
@@ -177,11 +179,12 @@ describe('reconcileBackgroundProcesses', () => {
 // A gone session is terminal, not transient: stop polling it.
 describe('refreshBackgroundProcesses dead-session guard', () => {
   beforeEach(() => {
-    $backgroundStatusBySession.set({})
+    clearAllSessionBackground()
     resetBackgroundPollingGuard()
   })
 
   afterEach(() => {
+    clearAllSessionBackground()
     $gateway.set(null as never)
     resetBackgroundPollingGuard()
   })
@@ -319,11 +322,12 @@ describe('refreshBackgroundProcesses dead-session guard', () => {
 // ── Review-thread hardenings on the guard (#94950) ───────────────────────────
 describe('refreshBackgroundProcesses dead-session guard hardenings', () => {
   beforeEach(() => {
-    $backgroundStatusBySession.set({})
+    clearAllSessionBackground()
     resetBackgroundPollingGuard()
   })
 
   afterEach(() => {
+    clearAllSessionBackground()
     $gateway.set(null as never)
     resetBackgroundPollingGuard()
   })

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -86,6 +86,39 @@ export const $backgroundRunningSessionIds = computed(
   }
 )
 
+// Silent exits have no gateway event. The store, not a mounted composer,
+// owns one safety-net timer for all known running sessions. No idle scanning.
+const BACKGROUND_POLL_MS = 5_000
+let backgroundPollTimer: ReturnType<typeof setInterval> | undefined
+
+const stopBackgroundPolling = () => {
+  if (backgroundPollTimer !== undefined) {
+    clearInterval(backgroundPollTimer)
+    backgroundPollTimer = undefined
+  }
+}
+
+const offBackgroundPolling = $backgroundStatusBySession.listen(background => {
+  if (!Object.values(background).some(items => items.some(item => item.state === 'running'))) {
+    stopBackgroundPolling()
+  } else if (backgroundPollTimer === undefined) {
+    backgroundPollTimer = setInterval(() => {
+      for (const [sid, items] of Object.entries($backgroundStatusBySession.get())) {
+        if (!isSessionGone(sid) && items.some(item => item.state === 'running') && !backgroundRefreshes.has(sid)) {
+          void refreshBackgroundProcesses(sid)
+        }
+      }
+    }, BACKGROUND_POLL_MS)
+  }
+})
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    offBackgroundPolling()
+    clearAllSessionBackground()
+  })
+}
+
 // Rows the user X-ed away. The registry keeps finished processes around for a
 // while, so without this every refresh would resurrect a dismissed row.
 const dismissedBySession = new Map<string, Set<string>>()
@@ -96,6 +129,8 @@ const dismissedBySession = new Map<string, Set<string>>()
 const SUCCESS_LINGER_MS = 4_000
 const FAILURE_LINGER_MS = 12_000
 const autoClearTimers = new Map<string, Map<string, ReturnType<typeof setTimeout>>>()
+const backgroundRefreshes = new Map<string, { promise: Promise<void>; rerun: boolean }>()
+let backgroundEpoch = 0
 
 function scheduleAutoDismiss(sid: string, id: string, delayMs: number) {
   let timers = autoClearTimers.get(sid)
@@ -320,6 +355,12 @@ const sameItem = (a: ComposerStatusItem, b: ComposerStatusItem) =>
  * object identity so memoised rows skip re-rendering.
  */
 export function reconcileBackgroundProcesses(sid: string, procs: GatewayProcessEntry[]) {
+  // A newer authoritative snapshot supersedes any read already in flight.
+  backgroundRefreshes.delete(sid)
+  applyBackgroundProcesses(sid, procs)
+}
+
+function applyBackgroundProcesses(sid: string, procs: GatewayProcessEntry[]) {
   const dismissed = dismissedBySession.get(sid)
 
   const fresh = new Map(
@@ -394,36 +435,59 @@ export function reconcileBackgroundProcesses(sid: string, procs: GatewayProcessE
 }
 
 /** Pull the session's live process snapshot from the gateway. */
-export async function refreshBackgroundProcesses(sid: string): Promise<void> {
+export function refreshBackgroundProcesses(sid: string): Promise<void> {
   const gateway = $gateway.get()
 
   if (!sid || !gateway || isSessionGone(sid)) {
-    return
+    return Promise.resolve()
   }
 
-  try {
-    const result = await requestForOwnedSession<{ processes?: GatewayProcessEntry[] }>(
-      sid,
-      ambientRequestFor(gateway),
-      'process.list',
-      { session_id: sid }
-    )
+  const pending = backgroundRefreshes.get(sid)
 
-    reconcileBackgroundProcesses(sid, result?.processes ?? [])
-    // The binding answered, so it is healthy: refund the stored session's
-    // recovery budget (a heal that stuck must not count against the next one).
-    noteRuntimeAlive(sid)
-  } catch (error) {
-    // A gone session never comes back under this runtime id: stop polling it,
-    // or the 5s timer hammers the gateway with 4001s for the window's lifetime.
-    if (isSessionGoneForBackgroundPolling(error)) {
-      markSessionGone(sid)
+  if (pending) {
+    // A tool may have spawned work after the pending snapshot was taken. Keep
+    // one trailing read, even if that older snapshot reports no running work.
+    pending.rerun = true
 
-      return
+    return pending.promise
+  }
+
+  const refresh = { promise: Promise.resolve(), rerun: false }
+  backgroundRefreshes.set(sid, refresh)
+  refresh.promise = (async () => {
+    try {
+      const result = await requestForOwnedSession<{ processes?: GatewayProcessEntry[] }>(
+        sid,
+        ambientRequestFor(gateway),
+        'process.list',
+        { session_id: sid }
+      )
+
+      if (backgroundRefreshes.get(sid) === refresh) {
+        applyBackgroundProcesses(sid, result?.processes ?? [])
+        // A healthy binding refunds the stored session's recovery budget.
+        noteRuntimeAlive(sid)
+      }
+    } catch (error) {
+      // Obsolete reads must not latch or heal a runtime rebound after a wipe,
+      // rewind or newer snapshot, just as they must not publish stale rows.
+      if (backgroundRefreshes.get(sid) === refresh && isSessionGoneForBackgroundPolling(error)) {
+        markSessionGone(sid)
+      }
+
+      // Transient socket loss — the next trigger (event or poll) retries.
+    } finally {
+      if (backgroundRefreshes.get(sid) === refresh) {
+        backgroundRefreshes.delete(sid)
+
+        if (refresh.rerun) {
+          await refreshBackgroundProcesses(sid)
+        }
+      }
     }
+  })()
 
-    // Transient socket loss — the next trigger (event or poll) retries.
-  }
+  return refresh.promise
 }
 
 /** X on a finished row: drop it now and keep it dropped across refreshes. */
@@ -448,6 +512,7 @@ export function dismissBackgroundProcess(sid: string, id: string) {
  *  stays so the user can retry / see it didn't die. */
 export async function stopBackgroundProcess(sid: string, id: string): Promise<void> {
   const gateway = $gateway.get()
+  const epoch = backgroundEpoch
 
   if (isSessionGone(sid)) {
     // The backend has already declared this runtime gone, so there is no
@@ -466,8 +531,15 @@ export async function stopBackgroundProcess(sid: string, id: string): Promise<vo
 
   try {
     await requestForOwnedSession(sid, ambientRequestFor(gateway), 'process.kill', { process_id: id, session_id: sid })
-    dismissBackgroundProcess(sid, id)
+
+    if (epoch === backgroundEpoch) {
+      dismissBackgroundProcess(sid, id)
+    }
   } catch (err) {
+    if (epoch !== backgroundEpoch) {
+      return
+    }
+
     if (isSessionGoneForBackgroundPolling(err)) {
       dismissBackgroundProcess(sid, id)
       markSessionGone(sid)
@@ -477,6 +549,20 @@ export async function stopBackgroundProcess(sid: string, id: string): Promise<vo
 
     notifyError(err, 'Could not stop the process')
   }
+}
+
+/** Connection/mode re-home: drop only the renderer cache, never kill work. */
+export function clearAllSessionBackground() {
+  backgroundEpoch++
+  backgroundRefreshes.clear()
+  stopBackgroundPolling()
+
+  for (const sid of autoClearTimers.keys()) {
+    cancelAllAutoDismiss(sid)
+  }
+
+  dismissedBySession.clear()
+  $backgroundStatusBySession.set({})
 }
 
 /**
@@ -491,9 +577,11 @@ export function resetSessionBackground(sid: string) {
     return
   }
 
+  backgroundRefreshes.delete(sid)
   cancelAllAutoDismiss(sid)
 
   const gateway = $gateway.get()
+  const epoch = backgroundEpoch
   const list = $backgroundStatusBySession.get()[sid] ?? []
   const dismissed = dismissedBySession.get(sid) ?? new Set<string>()
 
@@ -506,7 +594,7 @@ export function resetSessionBackground(sid: string) {
           process_id: item.id,
           session_id: sid
         }).catch(error => {
-          if (isSessionGoneForBackgroundPolling(error)) {
+          if (epoch === backgroundEpoch && isSessionGoneForBackgroundPolling(error)) {
             markSessionGone(sid)
           }
         })

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -27,6 +27,10 @@ export type StatusItemState = 'done' | 'failed' | 'running'
 export type StatusItemType = 'background' | 'goal' | 'subagent' | 'todo'
 
 export interface ComposerStatusItem {
+  /** background: a completion or first watch notification is still awaited. */
+  awaitingNotification?: boolean
+  /** background: a notification obligation remains unsettled, including after exit. */
+  notificationPending?: boolean
   /** background: non-zero exit shown inline when failed. */
   exitCode?: number
   /** subagent: active tool label shown on the right. */
@@ -52,7 +56,14 @@ export interface ComposerStatusItem {
 // registry (`terminal(background=true)` spawns) via `process.list`.
 export const $backgroundStatusBySession = atom<Record<string, ComposerStatusItem[]>>({})
 
-// Stored session ids that have at least one RUNNING background process. The
+export const isAwaitedBackgroundWork = (item: ComposerStatusItem): boolean =>
+  item.type === 'background' &&
+  (item.notificationPending === true || (item.state === 'running' && item.awaitingNotification === true))
+
+const needsBackgroundRefresh = (item: ComposerStatusItem): boolean =>
+  item.state === 'running' || item.notificationPending === true
+
+// Stored session ids with awaited background work or an undelivered result. The
 // sidebar row reads this for a hollow dot — distinct from the filled dot of an
 // active LLM turn — so the user can tell at a glance "this session has
 // something chugging along in the background" even when the turn is idle.
@@ -71,7 +82,7 @@ export const $backgroundRunningSessionIds = computed(
     const ids = new Set<string>()
 
     for (const [runtimeId, items] of Object.entries(bg)) {
-      if (!items.some(i => i.state === 'running')) {
+      if (!items.some(isAwaitedBackgroundWork)) {
         continue
       }
 
@@ -99,12 +110,12 @@ const stopBackgroundPolling = () => {
 }
 
 const offBackgroundPolling = $backgroundStatusBySession.listen(background => {
-  if (!Object.values(background).some(items => items.some(item => item.state === 'running'))) {
+  if (!Object.values(background).some(items => items.some(needsBackgroundRefresh))) {
     stopBackgroundPolling()
   } else if (backgroundPollTimer === undefined) {
     backgroundPollTimer = setInterval(() => {
       for (const [sid, items] of Object.entries($backgroundStatusBySession.get())) {
-        if (!isSessionGone(sid) && items.some(item => item.state === 'running') && !backgroundRefreshes.has(sid)) {
+        if (!isSessionGone(sid) && items.some(needsBackgroundRefresh) && !backgroundRefreshes.has(sid)) {
           void refreshBackgroundProcesses(sid)
         }
       }
@@ -220,6 +231,8 @@ const goalToItem = (goal: { detail?: string; status: GoalStatus; title: string }
 // and a fully-unchanged map keeps its previous reference so `computed` skips
 // the notify entirely ("preserve reference identity on no-ops").
 const sameStatusItem = (a: ComposerStatusItem, b: ComposerStatusItem) =>
+  a.awaitingNotification === b.awaitingNotification &&
+  a.notificationPending === b.notificationPending &&
   a.id === b.id &&
   a.type === b.type &&
   a.state === b.state &&
@@ -326,9 +339,13 @@ const writeBackground = (sid: string, items: ComposerStatusItem[]) => {
 interface GatewayProcessEntry {
   command?: string
   exit_code?: number
+  notify_on_complete?: boolean
+  notification_pending?: boolean
   output_tail?: string
   session_id?: string
   status?: string
+  watch_hit?: boolean
+  watch_patterns?: string[]
 }
 
 const toBackgroundItem = (proc: GatewayProcessEntry): ComposerStatusItem => {
@@ -336,6 +353,10 @@ const toBackgroundItem = (proc: GatewayProcessEntry): ComposerStatusItem => {
   const exitCode = typeof proc.exit_code === 'number' ? proc.exit_code : undefined
 
   return {
+    // Notification metadata is the explicit completion contract. A silent
+    // server may stay in the process panel without holding the task open.
+    awaitingNotification: proc.notify_on_complete === true || (!!proc.watch_patterns?.length && !proc.watch_hit),
+    notificationPending: proc.notification_pending === true,
     exitCode,
     id: proc.session_id ?? '',
     output: proc.output_tail || undefined,
@@ -346,7 +367,12 @@ const toBackgroundItem = (proc: GatewayProcessEntry): ComposerStatusItem => {
 }
 
 const sameItem = (a: ComposerStatusItem, b: ComposerStatusItem) =>
-  a.state === b.state && a.title === b.title && a.output === b.output && a.exitCode === b.exitCode
+  a.awaitingNotification === b.awaitingNotification &&
+  a.notificationPending === b.notificationPending &&
+  a.state === b.state &&
+  a.title === b.title &&
+  a.output === b.output &&
+  a.exitCode === b.exitCode
 
 /**
  * Layout-stable sync of the registry snapshot into the store: existing rows
@@ -413,7 +439,7 @@ function applyBackgroundProcesses(sid: string, procs: GatewayProcessEntry[]) {
   // it for anything running again or gone from the snapshot.
   const finishedDelay = new Map(
     next
-      .filter(item => item.state !== 'running')
+      .filter(item => item.state !== 'running' && !item.notificationPending)
       .map(item => [item.id, item.state === 'failed' ? FAILURE_LINGER_MS : SUCCESS_LINGER_MS])
   )
 

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -4,6 +4,7 @@ import { resetLiveRuntimeTracking } from '@/app/contrib/hooks/use-background-syn
 import { resetSidebarBatchCapability } from '@/hermes'
 import { invalidateProfileScopedQueries } from '@/lib/query-client'
 import { clearArtifactRegistry } from '@/store/artifacts'
+import { clearAllSessionBackground } from '@/store/composer-status'
 import { invalidateCronJobsRequests, setCronJobs } from '@/store/cron'
 import { resetSessionsLimit } from '@/store/layout'
 import { resetLiveSync } from '@/store/live-sync'
@@ -206,6 +207,7 @@ export function wipeSessionListsForGatewaySwitch(): void {
   // session-unread.ts are keyed by durable session id and repaint the rows
   // that are still unread once the next gateway's lists load — so a profile
   // round-trip doesn't swallow green dots.
+  clearAllSessionBackground()
   clearAllSessionStates()
   // Structured goal/loop/heartbeat entries are keyed by runtime id, which the
   // next backend re-mints, so a full wipe is exact (and stale-response-safe).

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -258,7 +258,7 @@ export type SidebarOrdering = 'cost' | 'created' | 'manual' | 'status' | 'tokens
 export type SidebarSortKey = Exclude<SidebarOrdering, 'manual'>
 /** Optional per-row metadata the user can switch on. `preview` is card-only:
  *  the one-line row has nowhere to put a second line. */
-export type SidebarRowMeta = 'cost' | 'pr' | 'preview' | 'profile' | 'tokens' | 'updated'
+export type SidebarRowMeta = 'activity' | 'cost' | 'pr' | 'preview' | 'profile' | 'tokens' | 'updated'
 
 function oneOf<T extends string>(values: readonly T[], fallback: T): Codec<T> {
   return {
@@ -274,7 +274,7 @@ function listOf<T extends string>(values: readonly T[]): Codec<T[]> {
   }
 }
 
-const ROW_META: readonly SidebarRowMeta[] = ['cost', 'pr', 'preview', 'profile', 'tokens', 'updated']
+const ROW_META: readonly SidebarRowMeta[] = ['activity', 'cost', 'pr', 'preview', 'profile', 'tokens', 'updated']
 const STATUS_FILTERS: readonly SessionStatusBucket[] = ['needs-input', 'working', 'unread', 'draft', 'idle']
 const PR_FILTERS: readonly PullRequestBucket[] = ['open', 'draft', 'merged', 'closed', 'none']
 export const SIDEBAR_SORT_KEYS: readonly SidebarSortKey[] = ['updated', 'created', 'status', 'tokens', 'cost']

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -158,11 +158,9 @@ export const $sessionDotStateById = computed(
     claim(persistedUnread, 'unread')
 
     claim(background, 'background')
-    // Async delegation: the parent turn has ended but its subagents are still
-    // running, so the session's work continues in child sessions. Same visual
-    // claim as background processes — and it yields to `working` below the
-    // moment the parent turn itself is live (synchronous orchestrator children).
-    claim(delegating, 'background')
+    // Delegated agents are real work, not watch-only background presence.
+    // They keep the working treatment even after their parent's turn ends.
+    claim(delegating, 'working')
     claim(working, 'working')
 
     // Stalled REFINES working rather than rivalling it — the turn is still

--- a/apps/desktop/src/store/session-states-eviction.test.ts
+++ b/apps/desktop/src/store/session-states-eviction.test.ts
@@ -84,13 +84,14 @@ describe('publish-time eviction', () => {
 })
 
 describe('closeSessionTile eviction', () => {
-  it("drops a settled session's state on close — no later publish may come", () => {
+  it('releases a settled transcript on close but retains its background-work identity', () => {
     $sessionTiles.set([{ runtimeId: 'rt-1', storedSessionId: 'stored-1' }])
     publishSessionState('rt-1', state('stored-1', { busy: false }))
 
     closeSessionTile('stored-1')
 
-    expect($sessionStates.get()['rt-1']).toBeUndefined()
+    expect($sessionStates.get()['rt-1']?.messages).toEqual([])
+    expect($sessionStates.get()['rt-1']).toMatchObject({ storedSessionId: 'stored-1', busy: false })
   })
 
   it("keeps a busy session's state on close — the background turn is still running", () => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1735,7 +1735,9 @@ export function closeSessionTile(storedSessionId: string) {
   saveTiles($sessionTiles.get().filter(t => t.storedSessionId !== storedSessionId))
 
   // A settled session may never publish again, so the publish-time eviction
-  // in publishSessionState can't reach it — drop its cached state here. A
+  // in publishSessionState can't reach it — release its transcript here. Keep
+  // the same cheap identity projection as publish-time eviction: background
+  // processes and async children can outlive both the turn and its tile. A
   // BUSY one stays: its turn keeps streaming in the background, the sidebar
   // dot reads it, and settle evicts it. ⌘⇧T reopen re-publishes from the
   // wiring cache (resumeTile's warm path), so nothing is lost.
@@ -1743,7 +1745,7 @@ export function closeSessionTile(storedSessionId: string) {
   const state = runtimeId ? $sessionStates.get()[runtimeId] : undefined
 
   if (runtimeId && state && evictable(runtimeId, state)) {
-    dropSessionState(runtimeId)
+    releaseSessionTranscript(runtimeId, state)
   }
 }
 

--- a/apps/desktop/src/store/sidebar-activity.test.ts
+++ b/apps/desktop/src/store/sidebar-activity.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { makeSessionInfo } from '@/test/session-info'
+
+import { $backgroundStatusBySession } from './composer-status'
+import { $activeSessionId, $sessions } from './session'
+import {
+  $sessionStates,
+  $sessionTiles,
+  clearAllSessionStates,
+  closeSessionTile,
+  publishSessionState
+} from './session-states'
+import { $sidebarActivityById } from './sidebar-activity'
+import { $subagentsBySession } from './subagents'
+import { $todosBySession } from './todos'
+
+const watching = {
+  type: 'tool-call' as const,
+  toolName: 'terminal',
+  toolCallId: 'watch',
+  args: { command: 'gh pr checks --watch', context: 'Watching CI' }
+}
+
+function runningState(storedId = 'stored') {
+  return {
+    ...createClientSessionState(storedId),
+    busy: true,
+    turnLive: true,
+    messages: [{ id: 'reply', role: 'assistant' as const, pending: true, parts: [watching] }]
+  }
+}
+
+beforeEach(() => {
+  clearAllSessionStates()
+  $activeSessionId.set(null)
+  $sessionTiles.set([])
+  $sessions.set([])
+  $backgroundStatusBySession.set({})
+  $subagentsBySession.set({})
+  $todosBySession.set({})
+})
+afterEach(() => {
+  clearAllSessionStates()
+  $sessionTiles.set([])
+  $backgroundStatusBySession.set({})
+  $subagentsBySession.set({})
+  $todosBySession.set({})
+  $sessions.set([])
+})
+
+describe('sidebar activity', () => {
+  it('maps the live tool to the stored session without selecting its chat', () => {
+    publishSessionState('runtime', runningState())
+    expect($sidebarActivityById.get().stored).toBe(watching)
+  })
+
+  it('does not mistake an old unresolved tool for current work', () => {
+    publishSessionState('runtime', { ...runningState(), busy: false, turnLive: false })
+    expect($sidebarActivityById.get().stored).toBeUndefined()
+    publishSessionState('runtime', {
+      ...runningState(),
+      messages: [
+        { id: 'old', role: 'assistant', parts: [watching] },
+        { id: 'new-request', role: 'user', parts: [{ type: 'text', text: 'Next task' }] }
+      ]
+    })
+    expect($sidebarActivityById.get().stored).toBeUndefined()
+  })
+
+  it('retires a completed tool immediately, including an empty result', () => {
+    publishSessionState('runtime', {
+      ...runningState(),
+      messages: [{ id: 'reply', role: 'assistant', pending: true, parts: [{ ...watching, result: '' }] }]
+    })
+    expect($sidebarActivityById.get().stored).toBeUndefined()
+  })
+
+  it('does not keep an interrupted tool alive from its pending part', () => {
+    publishSessionState('runtime', { ...runningState(), interrupted: true })
+    expect($sidebarActivityById.get().stored).toBeUndefined()
+  })
+
+  it('keeps active delegation after the parent settles but not completed children or leftover todos', () => {
+    publishSessionState('runtime', createClientSessionState('stored'))
+
+    const child = {
+      id: 'child',
+      parentId: null,
+      goal: 'Watching CI',
+      status: 'running' as const,
+      taskCount: 1,
+      taskIndex: 0,
+      startedAt: 1,
+      updatedAt: 1,
+      filesRead: [],
+      filesWritten: [],
+      stream: []
+    }
+
+    $subagentsBySession.set({ runtime: [child] })
+    $sessionTiles.set([{ storedSessionId: 'stored', runtimeId: 'runtime' }])
+    closeSessionTile('stored')
+    expect($sidebarActivityById.get().stored).toMatchObject({ type: 'subagent', title: 'Watching CI' })
+    $subagentsBySession.set({ runtime: [{ ...child, status: 'completed' }] })
+    $todosBySession.set({ runtime: [{ id: 'todo', content: 'Watch CI', status: 'in_progress' }] })
+    expect($sidebarActivityById.get().stored).toBeUndefined()
+  })
+
+  it('keeps real background work after the turn settles and drops it on exit', () => {
+    const process = { type: 'background' as const, state: 'running' as const, title: 'Watching CI', id: 'proc' }
+    publishSessionState('runtime', createClientSessionState('stored'))
+    $backgroundStatusBySession.set({ runtime: [process] })
+    $sessionTiles.set([{ storedSessionId: 'stored', runtimeId: 'runtime' }])
+    closeSessionTile('stored')
+    expect($sessionStates.get().runtime?.messages).toEqual([])
+    expect($sidebarActivityById.get().stored).toBe(process)
+    $backgroundStatusBySession.set({ runtime: [{ ...process, state: 'done' }] })
+    expect($sidebarActivityById.get().stored).toBeUndefined()
+    $backgroundStatusBySession.set({ runtime: [{ ...process, state: 'failed' }] })
+    expect($sidebarActivityById.get().stored).toBeUndefined()
+  })
+
+  it('prefers the current tool over a background task', () => {
+    publishSessionState('runtime', runningState())
+    $backgroundStatusBySession.set({
+      runtime: [{ type: 'background', state: 'running', title: 'Dev server', id: 'proc' }]
+    })
+    expect($sidebarActivityById.get().stored).toBe(watching)
+  })
+
+  it('resolves compression aliases and draft runtime ids', () => {
+    $sessions.set([makeSessionInfo({ id: 'tip', _lineage_root_id: 'stored' })])
+    publishSessionState('runtime', runningState())
+    expect($sidebarActivityById.get().tip).toBe(watching)
+    publishSessionState('draft', { ...runningState(), storedSessionId: null })
+    expect($sidebarActivityById.get().draft).toBe(watching)
+  })
+
+  it('keeps the map reference stable across prose deltas and unrelated idle writes', () => {
+    publishSessionState('runtime', runningState())
+    const previous = $sidebarActivityById.get()
+    publishSessionState('other', createClientSessionState('other-stored'))
+    expect($sidebarActivityById.get()).toBe(previous)
+    publishSessionState('runtime', {
+      ...runningState(),
+      messages: [
+        { id: 'reply', role: 'assistant', pending: true, parts: [watching, { type: 'text', text: 'Progress' }] }
+      ]
+    })
+    expect($sidebarActivityById.get()).toBe(previous)
+  })
+})

--- a/apps/desktop/src/store/sidebar-activity.test.ts
+++ b/apps/desktop/src/store/sidebar-activity.test.ts
@@ -51,9 +51,9 @@ afterEach(() => {
 })
 
 describe('sidebar activity', () => {
-  it('maps the live tool to the stored session without selecting its chat', () => {
+  it('does not project active tools as monitoring', () => {
     publishSessionState('runtime', runningState())
-    expect($sidebarActivityById.get().stored).toBe(watching)
+    expect($sidebarActivityById.get().stored).toBeUndefined()
   })
 
   it('does not mistake an old unresolved tool for current work', () => {
@@ -82,7 +82,7 @@ describe('sidebar activity', () => {
     expect($sidebarActivityById.get().stored).toBeUndefined()
   })
 
-  it('keeps active delegation after the parent settles but not completed children or leftover todos', () => {
+  it('does not treat active delegation or leftover todos as monitoring', () => {
     publishSessionState('runtime', createClientSessionState('stored'))
 
     const child = {
@@ -102,14 +102,21 @@ describe('sidebar activity', () => {
     $subagentsBySession.set({ runtime: [child] })
     $sessionTiles.set([{ storedSessionId: 'stored', runtimeId: 'runtime' }])
     closeSessionTile('stored')
-    expect($sidebarActivityById.get().stored).toMatchObject({ type: 'subagent', title: 'Watching CI' })
+    expect($sidebarActivityById.get().stored).toBeUndefined()
     $subagentsBySession.set({ runtime: [{ ...child, status: 'completed' }] })
     $todosBySession.set({ runtime: [{ id: 'todo', content: 'Watch CI', status: 'in_progress' }] })
     expect($sidebarActivityById.get().stored).toBeUndefined()
   })
 
   it('keeps real background work after the turn settles and drops it on exit', () => {
-    const process = { type: 'background' as const, state: 'running' as const, title: 'Watching CI', id: 'proc' }
+    const process = {
+      type: 'background' as const,
+      state: 'running' as const,
+      title: 'Watching CI',
+      id: 'proc',
+      awaitingNotification: true
+    }
+
     publishSessionState('runtime', createClientSessionState('stored'))
     $backgroundStatusBySession.set({ runtime: [process] })
     $sessionTiles.set([{ storedSessionId: 'stored', runtimeId: 'runtime' }])
@@ -122,29 +129,47 @@ describe('sidebar activity', () => {
     expect($sidebarActivityById.get().stored).toBeUndefined()
   })
 
-  it('prefers the current tool over a background task', () => {
+  it('suppresses monitoring while the parent is working', () => {
     publishSessionState('runtime', runningState())
     $backgroundStatusBySession.set({
-      runtime: [{ type: 'background', state: 'running', title: 'Dev server', id: 'proc' }]
+      runtime: [
+        { type: 'background', state: 'running', title: 'Watching checks', id: 'proc', awaitingNotification: true }
+      ]
     })
-    expect($sidebarActivityById.get().stored).toBe(watching)
+    expect($sidebarActivityById.get().stored).toBeUndefined()
   })
 
   it('resolves compression aliases and draft runtime ids', () => {
     $sessions.set([makeSessionInfo({ id: 'tip', _lineage_root_id: 'stored' })])
-    publishSessionState('runtime', runningState())
-    expect($sidebarActivityById.get().tip).toBe(watching)
-    publishSessionState('draft', { ...runningState(), storedSessionId: null })
-    expect($sidebarActivityById.get().draft).toBe(watching)
+
+    const process = {
+      type: 'background' as const,
+      state: 'running' as const,
+      title: 'Watching checks',
+      id: 'proc',
+      awaitingNotification: true
+    }
+
+    publishSessionState('runtime', createClientSessionState('stored'))
+    $backgroundStatusBySession.set({ runtime: [process], draft: [process] })
+    expect($sidebarActivityById.get().tip).toBe(process)
+    publishSessionState('draft', { ...createClientSessionState(), storedSessionId: null })
+    expect($sidebarActivityById.get().draft).toBe(process)
   })
 
   it('keeps the map reference stable across prose deltas and unrelated idle writes', () => {
-    publishSessionState('runtime', runningState())
+    const idle = { ...runningState(), busy: false, turnLive: false }
+    publishSessionState('runtime', idle)
+    $backgroundStatusBySession.set({
+      runtime: [
+        { type: 'background', state: 'running', title: 'Watching checks', id: 'proc', awaitingNotification: true }
+      ]
+    })
     const previous = $sidebarActivityById.get()
     publishSessionState('other', createClientSessionState('other-stored'))
     expect($sidebarActivityById.get()).toBe(previous)
     publishSessionState('runtime', {
-      ...runningState(),
+      ...idle,
       messages: [
         { id: 'reply', role: 'assistant', pending: true, parts: [watching, { type: 'text', text: 'Progress' }] }
       ]

--- a/apps/desktop/src/store/sidebar-activity.ts
+++ b/apps/desktop/src/store/sidebar-activity.ts
@@ -1,0 +1,75 @@
+import { computed } from 'nanostores'
+
+import type { ClientSessionState } from '@/app/types'
+import type { ChatMessagePart } from '@/lib/chat-messages'
+import { stableRecord } from '@/lib/stable-array'
+import { isSilentTool } from '@/lib/tool-render-class'
+
+import { $statusItemsBySession, type ComposerStatusItem } from './composer-status'
+import { $sessions, lineageAliases } from './session'
+import { $sessionStates } from './session-states'
+
+export type SidebarActivity = Extract<ChatMessagePart, { type: 'tool-call' }> | ComposerStatusItem
+
+/** Only the current, pending reply can name a live tool. History can contain
+ * unresolved calls after interruptions; those are not evidence of ongoing work. */
+function liveTool(state: ClientSessionState | undefined): SidebarActivity | undefined {
+  if (!state?.busy || state.interrupted) {
+    return
+  }
+
+  for (let i = state.messages.length - 1; i >= 0; i--) {
+    const message = state.messages[i]!
+
+    if (message.role === 'user') {
+      break
+    }
+
+    if (!message.pending || message.hidden) {
+      continue
+    }
+
+    for (let j = message.parts.length - 1; j >= 0; j--) {
+      const part = message.parts[j]!
+
+      if (part.type === 'tool-call' && part.result === undefined && !part.completedAt && !isSilentTool(part.toolName)) {
+        return part
+      }
+    }
+  }
+}
+
+let previous: Readonly<Record<string, SidebarActivity>> = {}
+
+/** The sidebar speaks stored ids; activity feeds speak runtime ids. Reuse the
+ * dot's lineage bridge, keeping original item references so text deltas and
+ * unrelated sessions never repaint rows. Todos/goals alone aren't liveness. */
+export const $sidebarActivityById = computed(
+  [$sessionStates, $statusItemsBySession, $sessions],
+  (states, items, sessions) => {
+    const next: Record<string, SidebarActivity> = {}
+
+    for (const runtimeId of new Set([...Object.keys(states), ...Object.keys(items)])) {
+      const state = states[runtimeId]
+
+      const activity =
+        liveTool(state) ??
+        items[runtimeId]?.find(
+          item => item.state === 'running' && (item.type === 'background' || item.type === 'subagent')
+        )
+
+      if (!activity) {
+        continue
+      }
+
+      for (const alias of lineageAliases(state?.storedSessionId ?? runtimeId, sessions)) {
+        // A live tool beats background work even during runtime handoff.
+        if (next[alias]?.type !== 'tool-call') {
+          next[alias] = activity
+        }
+      }
+    }
+
+    return (previous = stableRecord(previous, next))
+  }
+)

--- a/apps/desktop/src/store/sidebar-activity.ts
+++ b/apps/desktop/src/store/sidebar-activity.ts
@@ -1,70 +1,34 @@
 import { computed } from 'nanostores'
 
-import type { ClientSessionState } from '@/app/types'
-import type { ChatMessagePart } from '@/lib/chat-messages'
 import { stableRecord } from '@/lib/stable-array'
-import { isSilentTool } from '@/lib/tool-render-class'
 
-import { $statusItemsBySession, type ComposerStatusItem } from './composer-status'
+import { $backgroundStatusBySession, type ComposerStatusItem, isAwaitedBackgroundWork } from './composer-status'
 import { $sessions, lineageAliases } from './session'
+import { $sessionDotStateById } from './session-dot-state'
 import { $sessionStates } from './session-states'
 
-export type SidebarActivity = Extract<ChatMessagePart, { type: 'tool-call' }> | ComposerStatusItem
-
-/** Only the current, pending reply can name a live tool. History can contain
- * unresolved calls after interruptions; those are not evidence of ongoing work. */
-function liveTool(state: ClientSessionState | undefined): SidebarActivity | undefined {
-  if (!state?.busy || state.interrupted) {
-    return
-  }
-
-  for (let i = state.messages.length - 1; i >= 0; i--) {
-    const message = state.messages[i]!
-
-    if (message.role === 'user') {
-      break
-    }
-
-    if (!message.pending || message.hidden) {
-      continue
-    }
-
-    for (let j = message.parts.length - 1; j >= 0; j--) {
-      const part = message.parts[j]!
-
-      if (part.type === 'tool-call' && part.result === undefined && !part.completedAt && !isSilentTool(part.toolName)) {
-        return part
-      }
-    }
-  }
-}
+export type SidebarActivity = ComposerStatusItem
 
 let previous: Readonly<Record<string, SidebarActivity>> = {}
 
-/** The sidebar speaks stored ids; activity feeds speak runtime ids. Reuse the
- * dot's lineage bridge, keeping original item references so text deltas and
- * unrelated sessions never repaint rows. Todos/goals alone aren't liveness. */
+/** Project awaited background work only, using the shared status priority.
+ * No transcript scan or prose classification: active agents keep their arc. */
 export const $sidebarActivityById = computed(
-  [$sessionStates, $statusItemsBySession, $sessions],
-  (states, items, sessions) => {
+  [$sessionStates, $backgroundStatusBySession, $sessions, $sessionDotStateById],
+  (states, items, sessions, statuses) => {
     const next: Record<string, SidebarActivity> = {}
 
-    for (const runtimeId of new Set([...Object.keys(states), ...Object.keys(items)])) {
+    for (const [runtimeId, processes] of Object.entries(items)) {
       const state = states[runtimeId]
 
-      const activity =
-        liveTool(state) ??
-        items[runtimeId]?.find(
-          item => item.state === 'running' && (item.type === 'background' || item.type === 'subagent')
-        )
+      const activity = processes.find(isAwaitedBackgroundWork)
 
       if (!activity) {
         continue
       }
 
       for (const alias of lineageAliases(state?.storedSessionId ?? runtimeId, sessions)) {
-        // A live tool beats background work even during runtime handoff.
-        if (next[alias]?.type !== 'tool-call') {
+        if (statuses[alias] === 'background' && !next[alias]) {
           next[alias] = activity
         }
       }

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -824,15 +824,17 @@ class GatewayNotificationsMixin:
         See #9290.
         """
         from gateway.run import _drain_gateway_watch_events, _format_gateway_process_notification
+        from tools.process_registry import process_registry
         watch_events = _drain_gateway_watch_events(completion_queue)
-        if self._load_background_notifications_mode() == "off":
-            return
+        enabled = self._load_background_notifications_mode() != "off"
         for evt in watch_events:
-            synth_text = _format_gateway_process_notification(evt)
-            if not synth_text:
-                continue
-            with _log_suppressed(logging.ERROR, "Watch notification injection error: %s"):
-                await self._inject_watch_notification(synth_text, evt)
+            try:
+                if enabled and (synth_text := _format_gateway_process_notification(evt)):
+                    with _log_suppressed(logging.ERROR, "Watch notification injection error: %s"):
+                        await self._inject_watch_notification(synth_text, evt)
+            finally:
+                # This existing one-shot path accepts or drops, never requeues.
+                process_registry.settle_notification(evt)
 
     def _adapter_by_platform_value(self, platform_name: str):
         """Literal ``p.value == platform_name`` scan over connected adapters (native adapters only)."""
@@ -1087,6 +1089,8 @@ class GatewayNotificationsMixin:
                     "/new); dropping notification (output remains available via process(action='log')).",
                     evt.get("session_id") or "<unknown>", parent_session_id,
                 )
+            from tools.process_registry import process_registry
+            process_registry.settle_notification(evt)
             claim.proceed = False
         elif verdict == "retry":
             # Transient uncertainty: tell the watcher to re-poll rather than drop or misroute.
@@ -1110,9 +1114,13 @@ class GatewayNotificationsMixin:
         accepted = False
         try:
             injection_result = await self._inject_watch_notification(synth_text, evt)
+            from tools.process_registry import process_registry
             if injection_result is not True:
+                if injection_result is None:  # no route: deliberate drop, not retry
+                    process_registry.settle_notification(evt)
                 return injection_result
             accepted = True
+            process_registry.settle_notification(evt)
             if identity is not None:
                 with self._completion_delivery_lock:
                     self._mark_completions_delivered_locked((identity,))
@@ -1171,6 +1179,9 @@ class GatewayNotificationsMixin:
         identities = [i for i in map(self._completion_delivery_identity, events) if i is not None]
         with self._completion_delivery_lock:
             self._mark_completions_delivered_locked(identities)
+        from tools.process_registry import process_registry
+        for event in events:
+            process_registry.settle_notification(event)
 
     async def _flush_process_completion_batch(self, key: tuple[str, ...]) -> None:
         """Deliver one short-window completion batch and resolve its waiters."""

--- a/hermes_cli/cli_process_notifications.py
+++ b/hermes_cli/cli_process_notifications.py
@@ -33,7 +33,8 @@ class CLIProcessNotificationsMixin:
             if claim is None:
                 continue
             claimed.append((event, text))
-            complete_event_delivery(event, claim)
+            if event.get("type") == "async_delegation":
+                complete_event_delivery(event, claim)
         for notifications in group_process_notifications(claimed):
             event, text = notifications[0]
             if event.get("type", "completion") == "completion":
@@ -41,6 +42,9 @@ class CLIProcessNotificationsMixin:
             else:
                 pending = SubagentNotification(text, event) if event.get("type") == "async_delegation" else text
             self._pending_input.put(pending)
+            for event, _text in notifications:
+                if event.get("type") != "async_delegation":
+                    complete_event_delivery(event, "")
 
     def _tui_unwrap_input(self, user_input):
         """Unwrap ``_VoiceInputMessage`` / ``_SeededQueryMessage`` -> ``(text_or_tuple, is_voice_input, is_seeded_query)``."""

--- a/tests/tui_gateway/test_process_notification_pending.py
+++ b/tests/tui_gateway/test_process_notification_pending.py
@@ -1,0 +1,329 @@
+"""The process RPC must not advertise Done while its follow-up is outstanding."""
+
+import asyncio
+import json
+import shlex
+from collections import OrderedDict
+from queue import Queue
+import sys
+import subprocess
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.session_context import scoped_current_session_id
+from tools import process_registry as processes
+from tools.process_registry_notifications import format_process_notification
+from tui_gateway import server
+
+
+@pytest.fixture
+def delivery(monkeypatch, tmp_path):
+    registry = processes.ProcessRegistry()
+    monkeypatch.setattr(processes, "process_registry", registry)
+    session: dict = dict(session_key="pending-owner", agent=SimpleNamespace(session_id="pending-owner"),
+                   history=[], history_lock=threading.Lock(), running=False)
+    monkeypatch.setitem(server._sessions, "pending-ui", session)
+    events = []
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: events.append(args))
+
+    def rows():
+        response = server.handle_request({"jsonrpc": "2.0", "id": 1, "method": "process.list",
+                                          "params": {"session_id": "pending-ui"}})
+        assert response is not None and "error" not in response, response
+        return {row["session_id"]: row for row in response["result"]["processes"]}
+
+    def spawn(code="input(); print('finished', flush=True)", **kwargs):
+        command = f"{shlex.quote(sys.executable)} -u -c {shlex.quote(code)}"
+        child = subprocess.Popen([sys.executable, "-u", "-c", code], text=True,
+                                 stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                 cwd=tmp_path)
+        with scoped_current_session_id(session["session_key"]):
+            return registry.adopt_local(child, command=command, cwd=str(tmp_path),
+                                        session_key=session["session_key"], notify_on_complete=False, **kwargs)
+
+    yield registry, session, events, rows, spawn
+    for proc in list(registry._running.values()) + list(registry._finished.values()):
+        if not proc.exited:
+            registry.kill_process(proc.id)
+        if proc._reader_thread:
+            proc._reader_thread.join(timeout=5)
+
+
+def _fast_terminal_launch(registry, rows, monkeypatch, *, watch=False):
+    from tools.terminal_tool_background import spawn_background_process
+    from hermes_constants import get_hermes_home
+
+    track = registry._track_started
+
+    def finish_before_spawn_returns(proc, *args):
+        track(proc, *args)
+        assert proc._completion_event.wait(5)
+        assert proc.exit_code == 0
+        assert rows()[proc.id]["notification_pending"] is True
+
+    monkeypatch.setattr(registry, "_track_started", finish_before_spawn_returns)
+    result = json.loads(spawn_background_process(
+        command=f"{shlex.quote(sys.executable)} -c \"print('READY')\"",
+        env=SimpleNamespace(env={}), env_type="local", effective_task_id="owner", task_id="owner",
+        session_key="pending-owner", workdir=None, cwd=str(get_hermes_home()), effective_pty=False,
+        notify_on_complete=not watch, watch_patterns=["READY"] if watch else None,
+        approval_note=None, pty_disabled_reason=None))
+    assert result.get("error") is None, result
+    return registry.get(result["session_id"])
+
+
+@pytest.mark.parametrize("settlement", ["poller", "post_turn", "wait", "log", "kill", "suppressed", "orphan", "dispatch_error", "gateway", "cli", "launch"])
+def test_completion_pending_survives_public_exit_dequeue_and_busy_turn(delivery, monkeypatch, settlement):
+    registry, session, events, rows, spawn = delivery
+    if settlement == "launch":
+        from tools.async_delegation import complete_event_delivery
+        proc = _fast_terminal_launch(registry, rows, monkeypatch)
+        complete_event_delivery(registry.completion_queue.get(timeout=5), "")
+        assert rows()[proc.id]["notification_pending"] is False
+        return
+    proc = spawn(owner_task_id="sa-child" if settlement == "suppressed" else "owner")
+    proc.notify_on_complete = True
+    reached_exit, release_exit = threading.Event(), threading.Event()
+    checkpoint = registry._write_checkpoint
+
+    def pause_checkpoint():
+        if proc.exited:
+            reached_exit.set()
+            assert release_exit.wait(5)
+        checkpoint()
+
+    monkeypatch.setattr(registry, "_write_checkpoint", pause_checkpoint)
+    try:
+        registry.submit_stdin(proc.id)
+        assert reached_exit.wait(5)
+        row = rows()[proc.id]
+        assert row["status"] == "exited"
+        assert row.get("notification_pending") is True
+        assert registry.completion_queue.empty()  # exit is visible BEFORE enqueue
+    finally:
+        release_exit.set()
+    assert proc._completion_event.wait(5)
+    assert proc.exit_code == 0
+    assert proc.output_buffer.strip() == "finished"
+    # The monitor's poll is observation, not consumption.
+    registry.poll(proc.id)
+    assert rows()[proc.id]["notification_pending"] is True
+    proc.started_at -= processes.FINISHED_TTL_SECONDS + 1
+    with registry._lock:
+        registry._prune_if_needed()
+    assert proc.id in rows(), "pending finished processes must survive pruning"
+
+    evt = registry.completion_queue.get(timeout=5)
+    assert rows()[proc.id]["notification_pending"] is True
+    foreign = dict(session_key="foreign-owner", agent=SimpleNamespace(session_id="foreign-owner"),
+                   history_lock=threading.Lock(), running=False)
+    deferred = []
+    server._notif_handle_ready("foreign-ui", foreign, [evt], set(), registry,
+                               format_process_notification, deferred)
+    assert deferred == [evt]
+    assert rows()[proc.id]["notification_pending"] is True  # foreign shutdown drain
+    server._notif_handle_ready("foreign-ui", foreign, deferred, set(), registry,
+                               format_process_notification, None)
+    assert rows()[proc.id]["notification_pending"] is True  # foreign poller requeue
+    assert registry.completion_queue.get(timeout=5) is evt
+    registry.completion_queue.put(evt)
+    session["running"] = True
+    server._run_post_turn_followups("test", "pending-ui", session, {}, None)
+    if settlement == "suppressed":
+        assert registry.completion_queue.empty()
+        assert rows()[proc.id]["notification_pending"] is False
+        return
+    assert rows()[proc.id]["notification_pending"] is True
+    assert registry.completion_queue.qsize() == 1  # busy requeue is NOT acceptance
+    session["running"] = False
+
+    def accepted(_rid, _sid, target, text):
+        assert "finished" in str(text)
+        assert rows()[proc.id]["notification_pending"] is True
+        target["running"] = False
+        if settlement == "dispatch_error":
+            raise RuntimeError("bounded test dispatch failure")
+
+    monkeypatch.setattr(server, "_run_prompt_submit", accepted)
+    if settlement == "cli":
+        from hermes_cli.cli_process_notifications import CLIProcessNotificationsMixin
+
+        class InputQueue(Queue):
+            def put(self, item, *args, **kwargs):
+                assert rows()[proc.id]["notification_pending"] is True
+                super().put(item, *args, **kwargs)
+
+        consumer = CLIProcessNotificationsMixin()
+        consumer.session_id = session["session_key"]
+        consumer._pending_input = InputQueue()
+        # CLI's poll-observed suppression is tested elsewhere; exercise acceptance.
+        registry._poll_observed.clear()
+        consumer._drain_process_notifications("test")
+        assert consumer._pending_input.qsize() == 1
+    elif settlement == "gateway":
+        from gateway.run import _drain_gateway_watch_events
+        from gateway.run_notifications import GatewayNotificationsMixin
+
+        # Messaging drains discard the queue copy; the watcher still owns delivery.
+        assert _drain_gateway_watch_events(registry.completion_queue) == []
+        assert rows()[proc.id]["notification_pending"] is True
+        runner = GatewayNotificationsMixin()
+        runner._completion_delivery_lock = threading.Lock()
+        runner._completion_deliveries_inflight = set()
+        runner._completion_deliveries_delivered = OrderedDict()
+        runner._completion_delivery_retention = 64
+        accepting = False
+
+        async def inject(_text, _event):
+            assert rows()[proc.id]["notification_pending"] is True
+            return accepting
+
+        monkeypatch.setattr(runner, "_inject_watch_notification", inject)
+        assert asyncio.run(runner._deliver_completion_notification("finished", evt)) is False
+        assert rows()[proc.id]["notification_pending"] is True
+        accepting = True
+        assert asyncio.run(runner._deliver_completion_notification("finished", evt)) is True
+    elif settlement in {"wait", "log", "kill"}:
+        {"wait": registry.wait, "log": registry.read_log, "kill": registry.kill_process}[settlement](proc.id)
+    elif settlement == "post_turn":
+        server._run_post_turn_followups("test", "pending-ui", session, {}, None)
+    else:
+        evt = registry.completion_queue.get(timeout=5)
+        if settlement == "orphan":
+            session["session_key"] = "another-owner"
+            session["agent"].session_id = "another-owner"
+        server._notif_handle_ready("pending-ui", session, [evt], set(), registry,
+                                   format_process_notification, [])
+        session["session_key"] = "pending-owner"
+    assert rows()[proc.id]["notification_pending"] is False
+    if settlement in {"poller", "post_turn"}:
+        assert any(event[0] == "message.start" for event in events)
+    # Settled entries become eligible again, rather than pinning the registry forever.
+    with registry._lock:
+        registry._prune_if_needed()
+    assert proc.id not in rows()
+    with scoped_current_session_id("pending-owner"):
+        retained = {row["session_id"]: row for row in registry.list_sessions(include_retained=True)}
+    assert retained[proc.id]["notification_pending"] is False  # receipts do not replay notices
+
+
+@pytest.mark.parametrize("settlement", ["poller", "post_turn", "suppressed", "poller_suppressed", "breaker", "disabled", "gateway", "gateway_off", "launch"])
+def test_watch_pending_bridges_first_hit_until_each_notice_is_settled(delivery, monkeypatch, settlement):
+    from tools.async_delegation import complete_event_delivery
+
+    registry, session, events, rows, spawn = delivery
+    if settlement == "launch":
+        proc = _fast_terminal_launch(registry, rows, monkeypatch, watch=True)
+        complete_event_delivery(registry.completion_queue.get(timeout=5), "")
+        assert rows()[proc.id]["notification_pending"] is False
+        return
+    monkeypatch.setattr(processes, "WATCH_MIN_INTERVAL_SECONDS", 0)
+    if settlement == "disabled":
+        monkeypatch.setattr(processes, "WATCH_LIFETIME_MAX_HITS", 1)
+    proc = spawn("input(); print('READY', flush=True); input(); print('READY', flush=True); input()",
+                 owner_task_id="sa-child" if "suppressed" in settlement else "owner")
+    proc.watch_patterns = ["READY"]
+    reached_hit, release_hit, ingested = threading.Event(), threading.Event(), threading.Event()
+    admit = registry._global_watch_admit
+    if settlement == "breaker":
+        registry._global_watch_tripped_until = time.time() + 60
+
+    def pause_admission(now):
+        reached_hit.set()
+        assert release_hit.wait(5)
+        return admit(now)
+
+    monkeypatch.setattr(registry, "_global_watch_admit", pause_admission)
+    registry.on_output = lambda _proc, text: ingested.set() if "READY" in text else None
+    try:
+        registry.submit_stdin(proc.id)
+        assert reached_hit.wait(5)
+        row = rows()[proc.id]
+        assert row.get("notification_pending") is True
+        assert not registry.is_session_waiting(proc.id) or settlement == "disabled"
+        assert registry.completion_queue.empty()  # first hit is public, not queued yet
+    finally:
+        release_hit.set()
+    assert ingested.wait(5)
+    if settlement == "breaker":
+        assert registry.completion_queue.empty()
+        assert rows()[proc.id]["notification_pending"] is False
+        return
+
+    first = registry.completion_queue.get(timeout=5)
+    assert rows()[proc.id]["notification_pending"] is True
+    if settlement == "disabled":
+        # The disable summary and promised exit notice remain independent obligations.
+        second = registry.completion_queue.get(timeout=5)
+        complete_event_delivery(first, "")
+        complete_event_delivery(second, "")
+        assert rows()[proc.id]["notification_pending"] is True  # exit still promised
+        registry.submit_stdin(proc.id)
+        registry.submit_stdin(proc.id)
+        assert proc._completion_event.wait(5)
+        complete_event_delivery(registry.completion_queue.get(timeout=5), "")
+        assert rows()[proc.id]["notification_pending"] is False
+        return
+
+    ingested.clear()
+    registry.submit_stdin(proc.id)
+    assert ingested.wait(5)
+    second = registry.completion_queue.get(timeout=5)
+    complete_event_delivery(first, "")
+    complete_event_delivery(first, "")  # duplicate ack must not consume a newer hit
+    assert rows()[proc.id]["notification_pending"] is True
+    registry.completion_queue.put(second)
+    registry.submit_stdin(proc.id)
+    assert proc._completion_event.wait(5)
+    assert rows()[proc.id]["status"] == "exited"
+    assert rows()[proc.id]["notification_pending"] is True
+
+    def accepted(_rid, _sid, target, text):
+        assert "READY" in str(text)
+        assert rows()[proc.id]["notification_pending"] is True
+        target["running"] = False
+
+    monkeypatch.setattr(server, "_run_prompt_submit", accepted)
+    session["running"] = True
+    if settlement.startswith("gateway"):
+        from gateway.run import GatewayRunner
+        from hermes_constants import get_hermes_home
+
+        runner = object.__new__(GatewayRunner)
+        mode = "off" if settlement == "gateway_off" else "all"
+        (get_hermes_home() / "config.yaml").write_text(
+            f"display:\n  background_process_notifications: {mode!r}\n")
+
+        async def inject(text, _event):
+            assert "READY" in text
+            assert rows()[proc.id]["notification_pending"] is True
+            return True
+
+        monkeypatch.setattr(runner, "_inject_watch_notification", inject)
+        asyncio.run(runner._drain_watch_notifications(registry.completion_queue))
+        assert rows()[proc.id]["notification_pending"] is False
+        return
+    if settlement == "poller_suppressed":
+        event = registry.completion_queue.get(timeout=5)
+        server._notif_handle_ready("pending-ui", session, [event], set(), registry,
+                                   format_process_notification, [])
+    else:
+        server._run_post_turn_followups("test", "pending-ui", session, {}, None)
+    if "suppressed" in settlement:
+        assert registry.completion_queue.empty()
+        assert rows()[proc.id]["notification_pending"] is False
+        assert not any(event[0] == "message.start" for event in events)
+        return
+    assert rows()[proc.id]["notification_pending"] is True
+    assert registry.completion_queue.qsize() == 1
+    session["running"] = False
+    if settlement == "post_turn":
+        server._run_post_turn_followups("test", "pending-ui", session, {}, None)
+    else:
+        server._notif_handle_ready("pending-ui", session, [registry.completion_queue.get(timeout=5)],
+                                   set(), registry, format_process_notification, [])
+    assert rows()[proc.id]["notification_pending"] is False
+    assert any(event[0] == "message.start" for event in events)

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -426,6 +426,9 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
 
 def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
     _event_delivery(complete_completion_delivery, evt, claim_id)
+    if evt.get("type") != "async_delegation":
+        from tools.process_registry import process_registry
+        process_registry.settle_notification(evt)
 
 
 def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -339,6 +339,11 @@ class ProcessSession:
     # session was closed at a user boundary (/new) instead of injecting into the NEW one.
     parent_session_id: str = ""
     notify_on_complete: bool = False            # Queue agent notification on exit
+    _completion_notification_settled: bool = field(default=False, repr=False)
+    _pending_watch_notifications: set = field(default_factory=set, repr=False)
+    # Never take the registry lock while holding the output lock: exit retention
+    # takes them in the opposite order. Notification state has its own short lock.
+    _notification_lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
     watch_patterns: List[str] = field(default_factory=list)
     _watch_hits: int = field(default=0, repr=False)          # total matches delivered
     _watch_suppressed: int = field(default=0, repr=False)    # matches dropped by rate limit
@@ -494,6 +499,13 @@ class ProcessRegistry(ProcessCheckpointMixin):
             session._watch_strike_candidate = False
             # Emit and start a new cooldown window.
             session._watch_cooldown_until = now + WATCH_MIN_INTERVAL_SECONDS
+            # Reserve before publishing the hit: the first hit fulfills the wait
+            # barrier, but its follow-up has not even reached the queue yet.
+            notification = {
+                **self._watch_event_base(session),
+                "type": "watch_match",
+                "pattern": matched_pattern,
+            }
             session._watch_hits += 1
             suppressed = session._watch_suppressed
             session._watch_suppressed = 0
@@ -506,15 +518,11 @@ class ProcessRegistry(ProcessCheckpointMixin):
         if len(output) > 2000:
             output = output[:2000] + "\n...(truncated)"
         if self._global_watch_admit(now):
-            notification = {
-                **self._watch_event_base(session),
-                "type": "watch_match",
-                "pattern": matched_pattern,
-                "output": output,
-                "suppressed": suppressed,
-            }
+            notification.update(output=output, suppressed=suppressed)
             _redact_process_result(notification)
             self.completion_queue.put(notification)
+        else:
+            self.settle_notification(notification)
         # Even when the breaker drops the final match, still explain the silence.
         if lifetime_exhausted:
             self._emit_watch_disabled(
@@ -533,10 +541,13 @@ class ProcessRegistry(ProcessCheckpointMixin):
                 f"exactly one notification when the process exits."),
         })
 
-    @staticmethod
-    def _watch_event_base(session: ProcessSession) -> dict:
-        """Session identity + watcher routing fields shared by every watch event."""
+    def _watch_event_base(self, session: ProcessSession) -> dict:
+        """Reserve a distinct notice before publishing its trigger or queue entry."""
+        notification_id = uuid.uuid4().hex
+        with session._notification_lock:
+            session._pending_watch_notifications.add(notification_id)
         return {
+            "notification_id": notification_id,
             "session_id": session.id,
             "session_key": session.session_key,
             "task_id": session.task_id,
@@ -746,6 +757,9 @@ class ProcessRegistry(ProcessCheckpointMixin):
             id=f"proc_{uuid.uuid4().hex[:12]}", command=command, task_id=task_id,
             owner_task_id=owner_task_id or task_id, session_key=session_key, cwd=cwd,
             parent_session_id=get_session_env("HERMES_SESSION_ID", ""),
+            **({f"watcher_{key}": get_session_env(f"HERMES_SESSION_{key.upper()}", "")
+                for key in _WATCHER_ROUTE_KEYS}
+               if extra.get("notify_on_complete") or extra.get("watch_patterns") else {}),
             started_at=time.time(), **extra)
 
     @staticmethod
@@ -827,7 +841,8 @@ class ProcessRegistry(ProcessCheckpointMixin):
 
     def spawn_local(
         self, command: str, cwd: str = None, task_id: str = "", session_key: str = "",
-        env_vars: dict = None, use_pty: bool = False, owner_task_id: str = "") -> ProcessSession:
+        env_vars: dict = None, use_pty: bool = False, owner_task_id: str = "", *,
+        notify_on_complete: bool = False, watch_patterns: Optional[List[str]] = None) -> ProcessSession:
         """Spawn a background process locally (TERMINAL_ENV=local; other backends use
         spawn_via_env()). ``use_pty`` requests a pseudo-terminal via ptyprocess/pywinpty
         for interactive CLIs, falling back to a plain pipe when unavailable or failing."""
@@ -838,7 +853,9 @@ class ProcessRegistry(ProcessCheckpointMixin):
         from tools.terminal_tool_sudo import _rewrite_compound_background as _rewrite_bg
 
         safe_command = _rewrite_bg(command)
-        session = self._new_session(command, task_id, owner_task_id, session_key, _resolve_safe_cwd(cwd or os.getcwd()))
+        session = self._new_session(
+            command, task_id, owner_task_id, session_key, _resolve_safe_cwd(cwd or os.getcwd()),
+            notify_on_complete=notify_on_complete, watch_patterns=list(watch_patterns or []))
         pty_scope_attempted = False
         if use_pty:
             try:
@@ -922,12 +939,15 @@ class ProcessRegistry(ProcessCheckpointMixin):
 
     def spawn_via_env(
         self, env: Any, command: str, cwd: str = None, task_id: str = "", session_key: str = "",
-        timeout: int = 10, owner_task_id: str = "") -> ProcessSession:
+        timeout: int = 10, owner_task_id: str = "", *,
+        notify_on_complete: bool = False, watch_patterns: Optional[List[str]] = None) -> ProcessSession:
         """Spawn a background process inside a non-local backend's sandbox.
         The command is wrapped to capture its in-sandbox PID and redirect output to a
         log file that later execute() calls poll. No live pipe or stdin, but it runs in
         the correct sandbox context."""
-        session = self._new_session(command, task_id, owner_task_id, session_key, cwd, env_ref=env, pid_scope="sandbox")
+        session = self._new_session(
+            command, task_id, owner_task_id, session_key, cwd, env_ref=env, pid_scope="sandbox",
+            notify_on_complete=notify_on_complete, watch_patterns=list(watch_patterns or []))
         temp_dir = self._env_temp_dir(env)
         log_path, pid_path, exit_path = (f"{temp_dir}/hermes_bg_{session.id}.{ext}" for ext in ("log", "pid", "exit"))
         q = shlex.quote
@@ -1219,6 +1239,36 @@ class ProcessRegistry(ProcessCheckpointMixin):
 
     # ----- Query Methods -----
 
+    def _notification_pending(self, session: ProcessSession) -> bool:
+        # Arm with notify_on_complete, before any observer can expose exit. Queue
+        # removal is not delivery: a consumer may still be waiting for an idle turn.
+        # Historical read-only receipts have no notification to replay.
+        if session.id not in self._running and session.id not in self._finished:
+            return False
+        with session._notification_lock:
+            return bool(session._pending_watch_notifications) or (
+                session.notify_on_complete and not session._completion_notification_settled
+                and session.id not in self._completion_consumed)
+
+    def settle_notification(self, event: dict) -> None:
+        """Acknowledge accepted delivery or a deliberate drop, never a dequeue/requeue.
+
+        Separate from output consumption: delivering a notice must not suppress
+        existing messaging watchers or erase a child's unread completion receipt.
+        """
+        event_type = event.get("type", "completion")
+        if event_type not in {"completion", "watch_match", "watch_disabled"}:
+            return
+        with self._lock:
+            session_id = event.get("session_id", "")
+            session = self._running.get(session_id) or self._finished.get(session_id)
+            if session is not None:
+                with session._notification_lock:
+                    if event_type == "completion":
+                        session._completion_notification_settled = True
+                    else:
+                        session._pending_watch_notifications.discard(event.get("notification_id"))
+
     def is_completion_consumed(self, session_id: str) -> bool:
         """Check if a completion notification was already consumed via wait/log."""
         return session_id in self._completion_consumed
@@ -1386,6 +1436,7 @@ class ProcessRegistry(ProcessCheckpointMixin):
             _evt_sid = evt.get("session_id", "")
             if evt.get("type") == "completion" and self._drain_should_skip(
                 _evt_sid, skip_poll_observed=skip_poll_observed):
+                self.settle_notification(evt)
                 continue
             # Subagent-owned process notifications are suppressed by default — the
             # child's delegation result is the deliverable. Judge ownership on
@@ -1403,9 +1454,12 @@ class ProcessRegistry(ProcessCheckpointMixin):
                         "(delegation.surface_child_process_notifications=false): "
                         "type=%s session_id=%s task_id=%s",
                         evt.get("type", "completion"), _evt_sid, _evt_task_id)
+                    self.settle_notification(evt)
                     continue
             if text := format_process_notification(evt):
                 results.append((evt, text))
+            else:
+                self.settle_notification(evt)
         for evt in requeue:
             self.completion_queue.put(evt)
         return results
@@ -1840,6 +1894,7 @@ class ProcessRegistry(ProcessCheckpointMixin):
                 entry["exit_code"] = s.exit_code
             if s.detached:
                 entry["detached"] = True
+            entry["notification_pending"] = self._notification_pending(s)
             result.append(entry)
         return result
 
@@ -1936,9 +1991,10 @@ class ProcessRegistry(ProcessCheckpointMixin):
         """Drop expired finished sessions, then the oldest survivor while over
         MAX_PROCESSES. Must hold _lock."""
         now = time.time()
-        expired = [sid for sid, s in self._finished.items() if (now - s.started_at) > FINISHED_TTL_SECONDS]
+        eligible = {sid: s for sid, s in self._finished.items() if not self._notification_pending(s)}
+        expired = [sid for sid, s in eligible.items() if (now - s.started_at) > FINISHED_TTL_SECONDS]
         over_cap = len(self._running) + len(self._finished) - len(expired) >= MAX_PROCESSES
-        if over_cap and (survivors := [sid for sid in self._finished if sid not in expired]):
+        if over_cap and (survivors := [sid for sid in eligible if sid not in expired]):
             expired.append(min(survivors, key=lambda sid: self._finished[sid].started_at))
         for sid in expired:
             del self._finished[sid]

--- a/tools/terminal_tool_background.py
+++ b/tools/terminal_tool_background.py
@@ -86,9 +86,16 @@ def _stamp_gateway_routing(proc_session, get_session_env) -> None:
 
 
 def _spawn(process_registry, *, env, env_type, command, cwd, effective_task_id, task_id,
-           session_key, effective_pty):
+           session_key, effective_pty, notify_on_complete=False, watch_patterns=None):
+    from gateway.session_context import async_delivery_supported
+
     common = dict(command=command, cwd=cwd, task_id=effective_task_id,
                   owner_task_id=task_id or effective_task_id, session_key=session_key)
+    # Arm the contract and routing before a reader can publish its first hit/exit.
+    # Keep the post-spawn helper for result notes and gateway watcher registration.
+    if async_delivery_supported() and (notify_on_complete or watch_patterns):
+        common.update(notify_on_complete=bool(notify_on_complete),
+                      watch_patterns=None if notify_on_complete else watch_patterns)
     if env_type == "local":
         return process_registry.spawn_local(
             env_vars=env.env if hasattr(env, 'env') else None, use_pty=effective_pty, **common)
@@ -149,7 +156,8 @@ def spawn_background_process(
         proc_session = _spawn(
             process_registry, env=env, env_type=env_type, command=command, cwd=effective_cwd,
             effective_task_id=effective_task_id, task_id=task_id, session_key=session_key,
-            effective_pty=effective_pty,
+            effective_pty=effective_pty, notify_on_complete=notify_on_complete,
+            watch_patterns=watch_patterns,
         )
         result_data = {"output": "Background process started", "session_id": proc_session.id,
                        "pid": proc_session.pid, "exit_code": 0, "error": None}

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -390,6 +390,9 @@ def _notif_dispatch_event(sid: str, session: dict, evt: dict, text: str) -> None
         _notif_submit(f"__notif__{int(time.time() * 1000)}", sid, session, text, "notification poller dispatch failed", **kwargs)
     except Exception:
         release_event_delivery(evt, claim)
+        # Process notices are non-durable and this failure path drops them.
+        from tools.process_registry import process_registry
+        process_registry.settle_notification(evt)
         return
     complete_event_delivery(evt, claim)
 
@@ -417,13 +420,21 @@ def _notif_handle_event(sid, session, evt, emitted, registry, fmt, deferred, com
                 evt_type, origin, key, sid)
         elif is_delegation:
             deferred.append(evt)
+            return True  # retained for resume, not accepted or dropped
         else:
             logger.debug("Dropping unowned %s notification during shutdown drain (origin=%r key=%r)", evt_type, origin, key)
+        registry.settle_notification(evt)
+        return True
+    owner = str(evt.get("owner_task_id") or evt.get("task_id") or "")
+    if not is_delegation and owner.startswith("sa-") and not registry._surface_child_process_notifications():
+        registry.settle_notification(evt)
         return True
     if evt_type == "completion" and registry.is_completion_consumed(evt.get("session_id", "")):
+        registry.settle_notification(evt)
         return True
     text = fmt(evt)
     if not text:
+        registry.settle_notification(evt)
         return True
     # Emit once per dedup key: a re-queued completion would otherwise re-emit every 0.5s while the session is busy,
     # while distinct watch_match events from one process must stay visible.
@@ -470,6 +481,7 @@ def _notif_dispatch_completions(sid, session, notifications, registry, deferred)
     except Exception:
         for event, _text, claim in claimed:
             release_event_delivery(event, claim)
+            registry.settle_notification(event)
         return
     for event, _text, claim in claimed:
         complete_event_delivery(event, claim)


### PR DESCRIPTION
## What does this PR do?

Distinguish **actively working** from **waiting for background work** in the Desktop sidebar. A CI watch can outlive the agent's reply: the session is not finished, but the agent is not actively working either. The extra indicator should explain that state, not repeat the existing working animation.

Enable **Filters → Show → Monitoring** for a compact, steady waveform with the reported task label in its hover/keyboard tooltip:

- Active parent or delegated agent: existing working arc; no monitoring waveform.
- Idle parent with awaited background work: monitoring waveform; session stays out of Done.
- Completion accepted for follow-up: active-work styling returns.
- Follow-up finished: normal finished/unread state.
- Silent long-lived servers: no monitoring obligation merely because a process exists.

The indicator does not add a subtitle, increase row height/sidebar width, or displace PR, age, or action controls. This is an opt-in display preference, not a session filter.

## Related Issue

No issue claimed as fixed. This updates the original feature in the same PR rather than creating a duplicate. Related scope: #103370 (different status-dot treatment), #67674 (separate background-work panel), #105335 (Working/Done grouping), and #105337 (PR discovery).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Sidebar activity now projects only explicit background notification obligations, not live tool calls, subagent labels, command-name guesses, or historical transcript entries. Active parent/subagent and attention states retain precedence through the shared status resolver and runtime/stored/lineage mapping.
- Preserve the original opt-in preference, accessible tooltip, compact row geometry, and store-owned background polling. All locale labels now say Monitoring.
- `process.list` adds `notification_pending`. Reserve notification obligations before fast process exit or first watch-hit publication; retain them across dequeue, foreign-owner deferral, busy requeue, and finished-process pruning until accepted delivery or deliberate suppression/consumption.
- Reuse existing delivery acknowledgments across Desktop, CLI, and messaging gateway. No new model tools, RPC methods, dependencies, or prompt changes. Tracking is process-local, not durable notification replay across backend restarts.
- Keep polling and monitoring alive for exited-but-undelivered results. Neither automatic dismissal nor the finished-row Dismiss button can hide those pending results. Stop/rewind remain explicit cancellation actions.
- Working/Done grouping treats monitoring as unfinished without giving it an active-work animation.

## How to Test

1. Enable **Filters → Show → Monitoring**. Start an awaited background task, such as a completion-notifying check watcher.
2. While the parent or a delegated agent is working, verify the normal working arc remains and no extra waveform appears.
3. Let the parent yield. Verify the steady monitoring waveform and task tooltip appear, including while viewing another chat or after closing the idle originating tile.
4. Start a silent preview server separately; it must not become Monitoring merely because it remains running.
5. Finish the awaited task. Verify pending delivery cannot prematurely move the session to Done or be dismissed; follow-up work restores active styling, and final settlement clears monitoring.
6. Check the opt-in preference, row actions, PR controls, and Working/Done grouping.

### Verification performed

- Full Desktop UI + Electron suite: **9,518 passed, 6 skipped**. After the final pending-dismissal fix, the monitoring/composer/polling suite was rerun: **45 passed**.
- Renderer/Electron/E2E TypeScript checks, production Desktop build, changed-file ESLint, and whitespace checks passed.
- Python regression run via `scripts/run_tests.sh`: **1,960 passed, 4 skipped across 133 files**, excluding one known baseline failure described below.
- Two new parameterized backend invariants cover **20 cases** using real processes, real `process.list`, and delivery/post-turn seams. All 20 were observed failing on the archived base and passing with the fix; the final targeted rerun also passed.
- Real isolated Linux dev Desktop: active work → background-only monitoring → switch to another session with a silent server → completion-triggered active follow-up → finished/unread. Registry and renderer state were checked, and no page errors were observed. The final dismissal interaction also has a real-component regression test and independent re-review.
- The integration uses a credential-free scripted local provider and real local processes, **not live GitHub CI or external model inference**.
- Known baseline failure: `test_model_options_preserves_canonical_custom_row_after_agent_init` exposes an unexpected `anthropic` provider and also fails on the unchanged base. It is excluded from the regression count above; the full Python suite is not claimed green.
- macOS/Windows runtime validation and the full Python suite were not run.

## Checklist

### Code

- [x] Read the contributing and scoped engineering/design guides.
- [x] Conventional commit messages; focused feature changes only.
- [x] Existing PRs checked; original PR updated instead of duplicated.
- [x] Behavioral tests added and independently reviewed.
- [x] Tested in a real isolated Linux Desktop app.
- [ ] Full Python suite — not run; targeted regression results and baseline exception disclosed above.

### Documentation & Housekeeping

- [x] Component/store lifecycle comments and all locale labels updated.
- [x] CLI config examples: N/A; Desktop display preference remains renderer-owned.
- [x] Cross-platform impact considered; native runtime testing is Linux-only.
- [x] No new model-tool schema or prompt changes.

## Screenshots / Logs

Cropped real dev-app rows showing the same session during active work, background-only monitoring, and final unread completion. The fixture contains no private user content. Screenshot metadata, code diff, commit message, and PR text were scrubbed for credentials, private paths, rig ports, and task/session identifiers. The uploaded screenshot was downloaded and its bytes verified. Evidence lives on a separate fork-only branch, not in the code diff.

![Real Desktop: active work, monitoring only, and finished unread](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/eda95481f4326bfed4e6463d05d3578f98eb2f77/monitoring-comparison.png)

---
Implemented by gpt-6-astra via Hermes Agent.
