### PR TITLE
fix(desktop): preserve spaces in standalone media paths

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -29,6 +29,7 @@ export interface ArtifactLoadResult {
 
 const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g
 const MARKDOWN_LINK_RE = /\[([^\]]+)\]\(([^)\s]+)\)/g
+const MEDIA_LINE_RE = /(^|\n)[\t ]*(?<wrapper>[`"']?)MEDIA:\s*(?<line>[^\n]+)[\t ]*(\n|$)/g
 const MEDIA_RE = /[`"']?MEDIA:\s*(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
 const URL_RE = /https?:\/\/[^\s<>"')]+/g
 const PATH_RE = /(^|[\s("'`])((?:\/|~[\\/]|\.\.?[\\/]|\\\\)[^\s"'`<>]+(?:\.[a-z0-9]{1,8})?)/gi
@@ -73,7 +74,19 @@ function unquoteMediaValue(value: string): string {
 }
 
 function collectMediaValues(text: string, pushValue: (value: string) => void): void {
-  for (const match of text.matchAll(MEDIA_RE)) {
+  const inlineText = text.replace(
+    MEDIA_LINE_RE,
+    (match, _lead: string, wrapper: string, value: string) => {
+      const trimmed = value.trim()
+      const path = wrapper && trimmed.endsWith(wrapper) ? trimmed.slice(0, -1) : trimmed
+
+      pushValue(unquoteMediaValue(path))
+
+      return match.replace(/[^\n]/g, ' ')
+    }
+  )
+
+  for (const match of inlineText.matchAll(MEDIA_RE)) {
     pushValue(unquoteMediaValue(match[1] || ''))
   }
 }

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -241,13 +241,19 @@ ${payload}
         content: 'Third render. "MEDIA:/tmp/generated/quoted.mp4"',
         role: 'assistant',
         timestamp: 1_781_774_003
+      },
+      {
+        content: 'MEDIA:/srv/projects/My Project/sample video.mp4',
+        role: 'assistant',
+        timestamp: 1_781_774_004
       }
     ])
 
     expect(artifacts.map(artifact => artifact.value)).toEqual([
       '/tmp/generated/demo.mp4',
       '/tmp/generated/demo clip.mp4',
-      '/tmp/generated/quoted.mp4'
+      '/tmp/generated/quoted.mp4',
+      '/srv/projects/My Project/sample video.mp4'
     ])
   })
 

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -471,11 +471,42 @@ describe('renderMediaTags', () => {
     expect(renderMediaTags('MEDIA:/tmp/demo.mp4')).toBe('[Video: demo.mp4](#media:%2Ftmp%2Fdemo.mp4)')
   })
 
+  it('preserves spaces in an unquoted standalone MEDIA path', () => {
+    const path = '/srv/projects/My Project/sample video.mp4'
+
+    expect(renderMediaTags(`Готово:\n\nMEDIA:${path}`)).toBe(
+      `Готово:\n\n[Video: sample video.mp4](#media:${encodeURIComponent(path)})`
+    )
+  })
+
+  it('preserves a quoted standalone MEDIA path after the tag prefix', () => {
+    const path = '/srv/projects/My Project/sample video.mp4'
+
+    expect(renderMediaTags(`MEDIA:"${path}"`)).toBe(
+      `[Video: sample video.mp4](#media:${encodeURIComponent(path)})`
+    )
+    expect(renderMediaTags(`"MEDIA:${path}"`)).toBe(
+      `[Video: sample video.mp4](#media:${encodeURIComponent(path)})`
+    )
+  })
+
   it('renders streamed assistant media once the tag is complete', () => {
     const parts = appendAssistantTextPart(appendAssistantTextPart([], 'ok\nMEDIA:'), '/tmp/voice.mp3')
     const text = chatMessageText({ id: 'a', role: 'assistant', parts })
 
     expect(text).toBe('ok\n[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
+  })
+
+  it('waits for a complete extension before rendering a streamed path with spaces', () => {
+    let parts = appendAssistantTextPart([], 'ok\nMEDIA:/srv/My')
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe('ok\nMEDIA:/srv/My')
+
+    parts = appendAssistantTextPart(parts, ' Project/video.mp4')
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(
+      'ok\n[Video: video.mp4](#media:%2Fsrv%2FMy%20Project%2Fvideo.mp4)'
+    )
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -1,4 +1,4 @@
-import { mediaDisplayLabel, mediaMarkdownHref } from '@/lib/media'
+import { mediaDisplayLabel, mediaKind, mediaMarkdownHref } from '@/lib/media'
 
 import type { ChatMessage, ChatMessagePart } from './types'
 
@@ -10,7 +10,11 @@ export function reasoningPart(text: string, timestamp?: number): ChatMessagePart
   return { type: 'reasoning', text, ...(timestamp !== undefined ? { timestamp } : {}) }
 }
 
-const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
+// A standalone MEDIA tag owns the rest of its line. Remote filesystem paths
+// commonly contain spaces and agents do not always quote them. Inline tags
+// remain token-bounded via MEDIA_TAG_RE below so surrounding prose is kept.
+const MEDIA_LINE_RE = /(^|\n)[\t ]*(?<wrapper>[`"']?)MEDIA:\s*(?<line>[^\n]+)[\t ]*(\n|$)/g
+const TRAILING_MEDIA_LINE_RE = /(?:^|\n)[\t ]*(?<wrapper>[`"']?)MEDIA:\s*(?<line>[^\n]+)$/
 
 const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
 
@@ -27,11 +31,19 @@ function mediaLink(value: string): string {
   return `[${mediaDisplayLabel(path)}](${mediaMarkdownHref(path)})`
 }
 
+function standaloneMediaPath(wrapper: string, value: string): string {
+  const trimmed = value.trim()
+
+  return wrapper && trimmed.endsWith(wrapper) ? trimmed.slice(0, -1) : trimmed
+}
+
 export function renderMediaTags(text: string): string {
   return text
     .replace(
       MEDIA_LINE_RE,
-      (_match, lead: string, value: string, trailer: string) => `${lead}${mediaLink(value)}${trailer}`
+      (_match, lead: string, wrapper: string, value: string, trailer: string) => {
+        return `${lead}${mediaLink(standaloneMediaPath(wrapper, value))}${trailer}`
+      }
     )
     .replace(MEDIA_TAG_RE, (_match, value: string) => mediaLink(value))
 }
@@ -293,6 +305,19 @@ export function appendAssistantTextPart(
     delta.includes('MEDIA:') || delta.includes('DIA:') || delta.includes('EDIA:') || delta.includes('IA:')
 
   if (mayContainMedia || part.text.includes('MEDIA:')) {
+    const trailing = part.text.match(TRAILING_MEDIA_LINE_RE)
+
+    const trailingPath = trailing?.groups
+      ? standaloneMediaPath(trailing.groups.wrapper || '', trailing.groups.line || '')
+      : ''
+
+    // A streaming chunk ending mid-path is indistinguishable from a complete
+    // unquoted line. Wait for a recognizable media extension (or a later
+    // newline/final response) before replacing it with immutable Markdown.
+    if (trailingPath && mediaKind(unquoteMediaPath(trailingPath)) === 'file') {
+      return next
+    }
+
     const rendered = renderMediaTags(part.text)
 
     if (rendered !== part.text) {


### PR DESCRIPTION
## What does this PR do?

Preserves spaces when Hermes Desktop parses standalone `MEDIA:` output lines. Generated audio and video paths such as `/srv/projects/My Project/sample video.mp4` no longer get truncated to the first whitespace-delimited segment.

Quoted forms remain supported, and streaming waits for a recognizable media extension before replacing a partial trailing path. The artifacts indexer now follows the same standalone-line contract while retaining token-bounded parsing for inline `MEDIA:` tags.

Related: #103430

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Parse one complete path from standalone `MEDIA:` lines, including quoted variants.
- Defer immutable media rendering when a streaming chunk ends in an incomplete file path.
- Keep artifact extraction consistent with transcript rendering.
- Add regression coverage for paths with spaces, wrappers, and split streaming chunks.

## How to Test

1. Run `cd apps/desktop && npx vitest run --project ui src/lib/chat-messages.test.ts src/app/artifacts/index.test.ts`.
2. Send a standalone `MEDIA:/srv/projects/My Project/sample video.mp4` line, including a split streaming delivery, and verify the full path becomes one media attachment.
3. Run `npm run typecheck`, `npm run lint`, and `npm run build` from `apps/desktop`.

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing issues and PRs for duplicates.
- [x] My PR contains only related changes.
- [ ] I ran the full Python `pytest tests/ -q` suite (not applicable: Desktop-only TypeScript change).
- [x] I added regression tests.
- [x] Tested on macOS arm64.

### Documentation & Housekeeping

- [x] Documentation update: N/A.
- [x] `cli-config.yaml.example`: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A.
- [x] Cross-platform impact considered; paths are treated as opaque text and Windows checks pass.
- [x] Tool descriptions/schemas: N/A.

## Verification

- 92 targeted UI tests passed.
- TypeScript typecheck passed.
- ESLint completed with no errors (repository baseline warnings only).
- Desktop production build passed.