### PR TITLE
docs(bot-mode): document the real availability requirements of message_agent on headless installs

### DIFF
--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -116,6 +116,28 @@ agent:
   bot_mode_protocol: true   # inject the bot-to-bot messaging protocol into canonical Bot Chats
 ```
 
+### What actually makes a chat a Bot Chat
+
+`agent.bot_mode_protocol` is only the master switch. Before the protocol section — or the `message_agent` tool — is injected, two further conditions must hold, and on a desktop install the Bots pane satisfies both for you the moment it creates a Bot:
+
+1. **The session is titled exactly `Bot Chat`.** That exact title is the canonical chat's identity (it is what the desktop plugin's createCanonicalChat uses and what `hermes -p <bot> chat -c "Bot Chat"` resumes); any other title, or an untitled scratch session, gets neither the section nor the tool.
+2. **At least one profile on the install carries a `ui_meta: { hermes-bots: … }` block in its `profile.yaml`.** This is the "Bot-Mode-managed" marker the desktop plugin writes for every Bot it owns; the gate scans every profile, so one marked profile marks the whole install. There is no CLI command that writes it.
+
+The practical consequence: on a **headless install with no desktop app** (gateway plus Telegram, say) nothing ever writes either marker, so `message_agent` is unreachable even though the docs-level switch is on — bots message each other fine over the messaging platform, but the agent-side `message_agent` tool never appears. To enable it headless, satisfy both conditions by hand:
+
+```bash
+# the canonical forever-chat, created once per Bot (later runs resume it)
+hermes -p <bot> chat -c "Bot Chat" --create-if-missing
+```
+
+```yaml
+# ~/.hermes/profiles/<any-bot>/profile.yaml — an empty block is enough to mark the install
+ui_meta:
+  hermes-bots: {}
+```
+
+From the next turn in that Bot Chat the teammate roster, the protocol section, and `message_agent` are all picked up — including over `hermes -p <bot> chat` on a purely terminal box.
+
 :::note
 Bot-to-bot delivery is per-invocation: the receiving Bot picks the message up when it next runs. Live interrupt of a Bot mid-conversation is future work.
 :::


### PR DESCRIPTION
## Summary

Closes #105359.

`message_agent` was documented as generally available in every canonical Bot Chat with `agent.bot_mode_protocol` on (the default), but the injection gate in `tools/bot_mode_dm.py` requires two further conditions the docs never mentioned — so on a headless install (no desktop app) the tool is unreachable and there was no documented way to understand why, let alone fix it.

## What the docs now say

New subsection **"What actually makes a chat a Bot Chat"** right under the `bot_mode_protocol` switch:

1. The session must be titled exactly `Bot Chat` — that exact title is the canonical chat's identity (createCanonicalChat title, `-c "Bot Chat"` resume target); any other title gets neither the protocol section nor the tool.
2. At least one profile on the install carries `ui_meta: { hermes-bots: … }` in `profile.yaml` — the "Bot-Mode-managed" marker the desktop plugin writes; the gate scans every profile, and no CLI command writes it.

Plus the headless consequence spelled out, and the working by-hand recipe: `hermes -p <bot> chat -c "Bot Chat" --create-if-missing` plus an empty `ui_meta: { hermes-bots: {} }` block in any profile's `profile.yaml` (an empty block satisfies `is_bot_mode_managed` — it checks for a dict, not contents).

## Verification

- Gate logic confirmed against `tools/bot_mode_dm.py` (`message_agent_authorized`), `tools/bot_mode_probe.py` (`BOT_CHAT_TITLE`, `is_bot_mode_managed`, `_bots_meta`), `agent/system_prompt.py` (`_bot_mode_parts`), and the desktop plugin's writer (`apps/desktop/src/plugins/hermes-bots/data.ts` → `profiles.configure` / `tui_gateway/methods_profiles.py::_configure_ui_meta`) — plus `tests/agent/test_soul_legacy_bot_protocol.py`, which marks an install managed with exactly `ui_meta:\n  hermes-bots: {}`.
- CLI surface for the canonical chat verified: `chat -c <title> --create-if-missing` (`hermes_cli/main.py::_create_titled_session`, #86794) creates/resumes the titled session.
- `npm run build:fast` (Docusaurus, en locale) — SUCCESS; the two `llms.txt` broken-link warnings are pre-existing (those files are generated only in deploy-site.yml).
- No `website/i18n` translation of `bot-mode.md` exists, so only the English page changes.

Docs-only change — no code paths touched.