### PR TITLE
fix(hindsight): let memory audits target banks and cite recall sources

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -61,6 +61,7 @@ Config file: `~/.hermes/hindsight/config.json`
 |-----|---------|-------------|
 | `bank_id` | `hermes` | Memory bank name (static fallback used when `bank_id_template` is unset or resolves empty) |
 | `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{session}`. Example: `hermes-{profile}` isolates memory per active Hermes profile. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
+| `recall_bank_allowlist` | — | Optional comma-separated list of banks that `hindsight_recall` and `hindsight_reflect` may target with their per-call `bank` argument. Empty permits any bank; disallowed targets return a visible error. |
 | `bank_mission` | — | Reflect mission (identity/framing for reflect reasoning). Applied via Banks API. |
 | `bank_retain_mission` | — | Retain mission (steers what gets extracted). Applied via Banks API. |
 
@@ -130,8 +131,8 @@ Available in `hybrid` and `tools` memory modes:
 | Tool | Description |
 |------|-------------|
 | `hindsight_retain` | Store information with auto entity extraction; supports optional per-call `tags` |
-| `hindsight_recall` | Multi-strategy search (semantic + entity graph) |
-| `hindsight_reflect` | Cross-memory synthesis (LLM-powered) |
+| `hindsight_recall` | Multi-strategy search (semantic + entity graph); accepts an optional `bank` and returns bank/document/source provenance per hit |
+| `hindsight_reflect` | Cross-memory synthesis (LLM-powered); accepts an optional `bank` |
 
 ## Environment Variables
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -218,8 +218,13 @@ RECALL_SCHEMA = {
         "Search long-term memory. Returns memories ranked by relevance using "
         "semantic search, keyword matching, entity graph traversal, and reranking."
     ),
-    "parameters": {"type": "object", "required": ["query"],
-                   "properties": {"query": {"type": "string", "description": "What to search for."}}},
+    "parameters": {"type": "object", "required": ["query"], "properties": {
+        "query": {"type": "string", "description": "What to search for."},
+        "bank": {"type": "string", "description": (
+            "Optional memory bank to search instead of the configured bank. "
+            "The deployment may restrict this with recall_bank_allowlist."
+        )},
+    }},
 }
 
 REFLECT_SCHEMA = {
@@ -228,8 +233,13 @@ REFLECT_SCHEMA = {
         "Synthesize a reasoned answer from long-term memories. Unlike recall, "
         "this reasons across all stored memories to produce a coherent response."
     ),
-    "parameters": {"type": "object", "required": ["query"],
-                   "properties": {"query": {"type": "string", "description": "The question to reflect on."}}},
+    "parameters": {"type": "object", "required": ["query"], "properties": {
+        "query": {"type": "string", "description": "The question to reflect on."},
+        "bank": {"type": "string", "description": (
+            "Optional memory bank to reflect on instead of the configured bank. "
+            "The deployment may restrict this with recall_bank_allowlist."
+        )},
+    }},
 }
 
 
@@ -343,6 +353,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
         self._last_recall_returned, self._last_recall_count = False, 0
+        self._recall_bank_allowlist: set[str] = set()
         self._apply_recall_settings({})
 
     @property
@@ -422,6 +433,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_tags", "description": "Tags to filter when searching memories (comma-separated)", "default": ""},
             {"key": "recall_tags_match", "description": "Tag matching mode for recall", "default": "any", "choices": ["any", "all", "any_strict", "all_strict"]},
             {"key": "recall_types", "description": "Fact types to surface on recall — applies to both auto-recall and the hindsight_recall tool (comma-separated or list). Defaults to observation-only — observations are Hindsight's consolidated, deduplicated, evidence-grounded knowledge layer; raw world/experience facts are the supporting evidence observations already summarize. Set to e.g. 'observation,world,experience' to also include raw facts.", "default": "observation"},
+            {"key": "recall_bank_allowlist", "description": "Optional comma-separated list of banks that hindsight_recall and hindsight_reflect may target per call. Empty allows any bank.", "default": ""},
             {"key": "auto_recall", "description": "Automatically recall memories before each turn", "default": True},
             {"key": "recall_sync", "description": "Recall synchronously against the current message before each turn (higher relevance, adds recall latency to the turn). Default off: recall runs in the background and is injected on the next turn.", "default": False},
             {"key": "recall_indicator", "description": "Show a '👁️ Hindsight — recalled N memories' status line when auto-recall injects memory (turn off for customer-facing agents)", "default": True},
@@ -777,6 +789,12 @@ class HindsightMemoryProvider(MemoryProvider):
             self._recall_types = list([] if configured_types is None else configured_types) or ["observation"]
         self._recall_prompt_preamble = cfg.get("recall_prompt_preamble", "")
         self._recall_indicator = bool(cfg.get("recall_indicator", True))
+        configured_banks = cfg.get("recall_bank_allowlist") or []
+        if isinstance(configured_banks, str):
+            configured_banks = configured_banks.split(",")
+        self._recall_bank_allowlist = {
+            str(bank).strip() for bank in configured_banks if str(bank).strip()
+        }
 
     def _start_embedded_daemon(self) -> None:
         """Start the embedded daemon on a background thread (Rich output -> log file)."""
@@ -841,8 +859,8 @@ class HindsightMemoryProvider(MemoryProvider):
             logger.debug("Prefetch: skipped (%s)", why)
         return why is not None
 
-    def _recall(self, query: str) -> list:
-        kwargs: dict = {"bank_id": self._bank_id, "query": query, "budget": self._budget, "max_tokens": self._recall_max_tokens}
+    def _recall(self, query: str, *, bank_id: str | None = None) -> list:
+        kwargs: dict = {"bank_id": bank_id or self._bank_id, "query": query, "budget": self._budget, "max_tokens": self._recall_max_tokens}
         if self._recall_tags:
             kwargs.update(tags=self._recall_tags, tags_match=self._recall_tags_match)
         if self._recall_types:
@@ -850,11 +868,18 @@ class HindsightMemoryProvider(MemoryProvider):
         resp = self._run_hindsight_operation(lambda client: client.arecall(**kwargs))
         return resp.results or []
 
-    def _reflect(self, query: str) -> str | None:
+    def _reflect(self, query: str, *, bank_id: str | None = None) -> str | None:
         resp = self._run_hindsight_operation(
-            lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget)
+            lambda client: client.areflect(bank_id=bank_id or self._bank_id, query=query, budget=self._budget)
         )
         return resp.text
+
+    @staticmethod
+    def _recall_provenance(result: Any, bank_id: str) -> str:
+        metadata = getattr(result, "metadata", None) or {}
+        document_id = getattr(result, "document_id", None) or "unknown"
+        source = getattr(result, "source", None) or metadata.get("source") or "unknown"
+        return f"[bank={bank_id}; document_id={document_id}; source={source}]"
 
     def _do_recall(self, query: str) -> tuple[str, int]:
         """One recall/reflect for *query* (background prefetch and ``recall_sync`` paths)
@@ -869,7 +894,10 @@ class HindsightMemoryProvider(MemoryProvider):
                          self._bank_id, len(query), self._budget)
             results = self._recall(query)
             logger.debug("Recall: returned %d results", len(results))
-            return "\n".join(f"- {r.text}" for r in results if r.text), len(results)
+            return "\n".join(
+                f"- {result.text} {self._recall_provenance(result, self._bank_id)}"
+                for result in results if result.text
+            ), len(results)
         except Exception as e:
             logger.debug("Hindsight recall failed: %s", e, exc_info=True)
             return "", 0
@@ -1066,19 +1094,36 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def _tool_recall(self, args: dict) -> str:
         query = args["query"]
+        bank_id = self._tool_bank_id(args)
         logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
-                     self._bank_id, len(query), self._budget)
-        results = self._recall(query)
+                     bank_id, len(query), self._budget)
+        results = self._recall(query, bank_id=bank_id)
         logger.debug("Tool hindsight_recall: %d results", len(results))
-        return "\n".join(f"{i}. {r.text}" for i, r in enumerate(results, 1)) or "No relevant memories found."
+        lines = [
+            f"{i}. {result.text} {self._recall_provenance(result, bank_id)}"
+            for i, result in enumerate(results, 1)
+        ]
+        return "\n".join(lines) or "No relevant memories found."
 
     def _tool_reflect(self, args: dict) -> str:
         query = args["query"]
+        bank_id = self._tool_bank_id(args)
         logger.debug("Tool hindsight_reflect: bank=%s, query_len=%d, budget=%s",
-                     self._bank_id, len(query), self._budget)
-        text = self._reflect(query) or ""
+                     bank_id, len(query), self._budget)
+        text = self._reflect(query, bank_id=bank_id) or ""
         logger.debug("Tool hindsight_reflect: response_len=%d", len(text))
         return text or "No relevant memories found."
+
+    def _tool_bank_id(self, args: dict) -> str:
+        if "bank" not in args:
+            return self._bank_id
+        bank_id = str(args["bank"] or "").strip()
+        if not bank_id:
+            raise ValueError("bank must not be blank")
+        if self._recall_bank_allowlist and bank_id not in self._recall_bank_allowlist:
+            allowed = ", ".join(sorted(self._recall_bank_allowlist))
+            raise ValueError(f"bank {bank_id!r} is not allowed; allowed banks: {allowed}")
+        return bank_id
 
     # tool name -> (required arg, handler, user-facing failure prefix)
     _TOOL_HANDLERS = {

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -510,6 +510,61 @@ class TestToolHandlers:
         assert "Memory 1" in result["result"]
         assert "Memory 2" in result["result"]
 
+    def test_recall_and_reflect_support_allowlisted_per_call_bank(self, provider_with_config):
+        provider = provider_with_config(recall_bank_allowlist="audit-bank, other-bank")
+
+        recall_props = RECALL_SCHEMA["parameters"]["properties"]
+        reflect_props = REFLECT_SCHEMA["parameters"]["properties"]
+        assert "bank" in recall_props
+        assert "bank" in reflect_props
+        assert "bank" not in RECALL_SCHEMA["parameters"]["required"]
+        assert "bank" not in REFLECT_SCHEMA["parameters"]["required"]
+
+        default_recall = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "default"}
+        ))
+        assert "bank=test-bank" in default_recall["result"]
+        assert provider._client.arecall.call_args.kwargs["bank_id"] == "test-bank"
+
+        recall = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "audit", "bank": "audit-bank"}
+        ))
+        reflect = json.loads(provider.handle_tool_call(
+            "hindsight_reflect", {"query": "audit", "bank": "other-bank"}
+        ))
+
+        assert "error" not in recall
+        assert "error" not in reflect
+        assert provider._client.arecall.call_args.kwargs["bank_id"] == "audit-bank"
+        assert provider._client.areflect.call_args.kwargs["bank_id"] == "other-bank"
+
+        blocked = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "audit", "bank": "private-bank"}
+        ))
+        assert "not allowed" in blocked["error"]
+        assert provider._client.arecall.await_count == 2
+
+    def test_recall_result_preserves_per_hit_provenance(self, provider):
+        provider._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="Auditable memory",
+                document_id="doc-17",
+                metadata={"source": "session-import"},
+            ),
+            SimpleNamespace(text="Legacy memory", document_id=None, metadata=None),
+        ])
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "audit"}
+        ))["result"]
+
+        assert "Auditable memory [bank=test-bank; document_id=doc-17; source=session-import]" in result
+        assert "Legacy memory [bank=test-bank; document_id=unknown; source=unknown]" in result
+
+        prefetch_result, count = provider._do_recall("audit")
+        assert count == 2
+        assert "Auditable memory [bank=test-bank; document_id=doc-17; source=session-import]" in prefetch_result
+
 
     def test_reflect_success(self, provider):
         result = json.loads(provider.handle_tool_call(
@@ -542,7 +597,10 @@ class TestToolHandlers:
             "hindsight_recall", {"query": "test"}
         ))
 
-        assert result["result"] == "1. Recovered memory"
+        assert result["result"] == (
+            "1. Recovered memory "
+            "[bank=test-bank; document_id=unknown; source=unknown]"
+        )
         assert provider._client is second_client
         first_client.arecall.assert_called_once()
         second_client.arecall.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Hindsight memory audits can now target a specific bank per recall or reflect call instead of silently querying only the profile-pinned bank. Recall results also expose the effective bank, document ID, and source for every hit, so agents can audit and cite the memory that produced a fact. An optional `recall_bank_allowlist` rejects unauthorized overrides before any server call.

### Symptom

`hindsight_recall` and `hindsight_reflect` accepted only a query, so requests intended for another bank still queried the configured bank. Recall formatting returned only text and discarded document/source metadata.

### Impact

Operators could not distinguish a clean target bank from a query that never reached that bank, and downstream agents could not cite which stored document produced a recalled fact.

### Bug Cause

**Trigger:** `plugins/memory/hindsight/__init__.py` tool schemas, `_tool_recall`, `_tool_reflect`, and `_do_recall`

**Causal chain:**
1. A caller needed to audit a bank other than the profile default.
2. The tool contract had no bank field and both client calls always used `self._bank_id`.
3. The recall formatters emitted only `result.text`, discarding `document_id` and `metadata.source`.

**Why it is wrong:** The provider removed targeting and provenance that the Hindsight client API already supports, making cross-bank negative results and recalled facts unauditable.

**Working sibling / contrast:** Direct Hindsight client calls accept `bank_id` and return structured recall results containing document and metadata fields.

**Ruled out:** This is not a server-side bank routing defect; varying `bank_id` through the direct client produces bank-specific results, while the provider previously hard-coded one bank before dispatch.

### Fix

Add an optional `bank` field to both tool schemas, pass the selected bank through recall and reflect, and validate overrides against an optional configured allowlist without changing profile-pinned auto-prefetch behavior. Format tool and prefetched recall hits with the effective bank, document ID, and source, using explicit `unknown` markers when legacy results omit a field.

## Related Issue

Fixes #105353

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py` - route optional per-call banks, enforce the allowlist, and retain recall provenance.
- `plugins/memory/hindsight/README.md` - document bank targeting, provenance, and allowlist configuration.
- `tests/plugins/memory/test_hindsight_provider.py` - cover pinned/overridden/blocked bank routing and per-hit provenance.

## How to Test

1. Run the focused Hindsight provider suite.
2. Confirm all bank-routing and provenance invariants pass.

```bash
scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py
```

Result: 87 passed, 1 skipped.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant suite and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because this provider owns its config schema and README
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because architecture and workflows are unchanged
- [x] I've considered cross-platform impact; the change is platform-independent Python
- [x] I've updated tool descriptions and schemas
