### PR TITLE
fix(cron): reject unbounded recurring deliver=local jobs that can never terminate

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -95,6 +95,17 @@ _JOBS_LOCK_TIMEOUT_SECONDS = 30.0
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
+# A recurring job delivered locally has no external consumer and no external
+# stop signal, so an unbounded local recurrence can never terminate. It must
+# carry a reachable finite repeat bound. 2016 = 7 days at a 5-minute cadence.
+LOCAL_RECURRING_MAX_REPEAT = 2016
+
+
+def _is_reachable_local_bound(times: Any) -> bool:
+    """True iff ``times`` is a reachable finite bound for a recurring
+    deliver=local job: a real int in ``[1, LOCAL_RECURRING_MAX_REPEAT]``."""
+    return type(times) is int and 0 < times <= LOCAL_RECURRING_MAX_REPEAT
+
 
 @dataclass(frozen=True)
 class _CronStorePaths:
@@ -1724,11 +1735,36 @@ def create_job(
     # Normalize repeat: treat 0 or negative values as None (infinite). String forms
     # ('forever'/'once'/numeric) coerce via normalize_repeat_value — the shared chokepoint with update paths
     # (#66824/#64520/#7142/#71987/#95706).
+    _repeat_raw = repeat  # caller intent before coercion (bounded-stop guard)
     repeat = normalize_repeat_value(repeat)
     if parsed_schedule["kind"] == "once" and repeat is None:
         repeat = 1
     if deliver is None:
         deliver = "origin" if origin else "local"
+
+    # Bounded-stop invariant: a recurring locally-delivered job has no
+    # external stop condition, so it must carry a reachable finite bound.
+    # An omitted repeat defaults to the ceiling (create contract preserved);
+    # an explicit unbounded request, or a bound above the ceiling, is refused.
+    if parsed_schedule["kind"] != "once" and str(deliver or "").strip().lower() in ("", "local"):
+        if _repeat_raw is None:
+            if repeat is None:
+                repeat = LOCAL_RECURRING_MAX_REPEAT
+        elif repeat is None:
+            raise ValueError(
+                "recurring deliver=local cron jobs must carry a reachable finite "
+                f"repeat bound (1..{LOCAL_RECURRING_MAX_REPEAT}); an explicit "
+                "'forever' repeat is refused because a locally-delivered job has "
+                "no external stop condition. Pass an explicit repeat in that "
+                "range, or deliver to an external channel (origin/discord/"
+                "telegram) that can terminate the job."
+            )
+        elif not _is_reachable_local_bound(repeat):
+            raise ValueError(
+                "recurring deliver=local cron jobs may repeat at most "
+                f"{LOCAL_RECURRING_MAX_REPEAT} times; got repeat={repeat}. Lower "
+                "the bound, or deliver to an external channel."
+            )
     job_id = uuid.uuid4().hex[:12]
     now = _hermes_now().isoformat()
 
@@ -1964,6 +2000,21 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
         _fill_missing_next_run(updated)
         _reject_terminal_activation(job, updated, job_id)
         jobs[i] = updated
+        # Bounded-stop invariant (update door): keep the create-time rule
+        # closed. Evaluate only when this update (re)defines delivery,
+        # repeat, or schedule, so unrelated edits are never retro-refused.
+        if {"deliver", "repeat", "schedule"}.intersection(updates):
+            _kind = (updated.get("schedule") or {}).get("kind")
+            _dl = str(updated.get("deliver") or "").strip().lower()
+            _times = (updated.get("repeat") or {}).get("times")
+            if _kind != "once" and _dl in ("", "local") and not _is_reachable_local_bound(_times):
+                raise ValueError(
+                    "recurring deliver=local cron jobs must carry a reachable "
+                    f"finite repeat bound (1..{LOCAL_RECURRING_MAX_REPEAT}); this "
+                    "update would leave the job unbounded or above the local "
+                    "ceiling. Set an explicit repeat, or deliver to an external "
+                    "channel."
+                )
         save_jobs(jobs)
         return _normalize_job_record(updated)
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -403,7 +403,7 @@ class TestJobCRUD:
         schema documents repeat as an integer but user-facing forms are
         strings; coerce at create_job so every entry point inherits it.
         """
-        forever = create_job(prompt="Str forever", schedule="every 1h", repeat="forever")
+        forever = create_job(prompt="Str forever", schedule="every 1h", repeat="forever", deliver="discord")
         assert forever["repeat"]["times"] is None  # None = infinite
         once = create_job(prompt="Str once", schedule="every 1h", repeat="once")
         assert once["repeat"]["times"] == 1
@@ -423,7 +423,7 @@ class TestJobCRUD:
         """
         from cron.jobs import mark_job_run, update_job
 
-        job = create_job(prompt="t", schedule="every 1h", repeat=2)
+        job = create_job(prompt="t", schedule="every 1h", repeat=2, deliver="discord")
         mark_job_run(job["id"], success=True)  # completed=1
 
         updated = update_job(job["id"], {"repeat": "forever"})

--- a/tests/cron/test_local_recurring_bound.py
+++ b/tests/cron/test_local_recurring_bound.py
@@ -1,0 +1,57 @@
+"""Bounded-stop invariant: a recurring deliver=local cron job must carry a
+reachable finite repeat bound, otherwise its stop condition is unsatisfiable
+(the terminal gate only releases on a delivered platform receipt, which local
+delivery never produces) and it fires forever."""
+import pytest
+
+from cron.jobs import (
+    create_job,
+    update_job,
+    mark_job_run,
+    LOCAL_RECURRING_MAX_REPEAT,
+)
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Redirect cron storage to a temp directory."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+def test_omitted_repeat_on_recurring_local_defaults_to_ceiling(tmp_cron_dir):
+    job = create_job(prompt="p", schedule="every 5m")  # local, repeat omitted
+    assert job["repeat"]["times"] == LOCAL_RECURRING_MAX_REPEAT
+
+
+def test_explicit_forever_on_recurring_local_is_refused(tmp_cron_dir):
+    with pytest.raises(ValueError, match="reachable"):
+        create_job(prompt="p", schedule="every 5m", repeat="forever")
+
+
+def test_above_ceiling_on_recurring_local_is_refused(tmp_cron_dir):
+    with pytest.raises(ValueError, match="at most"):
+        create_job(prompt="p", schedule="every 5m", repeat=LOCAL_RECURRING_MAX_REPEAT + 1)
+
+
+def test_bounded_local_is_allowed(tmp_cron_dir):
+    job = create_job(prompt="p", schedule="every 5m", repeat=10)
+    assert job["repeat"]["times"] == 10
+
+
+def test_external_channel_forever_is_allowed(tmp_cron_dir):
+    job = create_job(prompt="p", schedule="every 5m", repeat="forever", deliver="discord")
+    assert job["repeat"]["times"] is None  # forever is fine on an external channel
+
+
+def test_once_is_unaffected(tmp_cron_dir):
+    job = create_job(prompt="p", schedule="every monday 9am", repeat="once")
+    assert job["repeat"]["times"] == 1
+
+
+def test_update_door_flip_to_local_unbounded_is_refused(tmp_cron_dir):
+    job = create_job(prompt="p", schedule="every 5m", repeat="forever", deliver="discord")
+    with pytest.raises(ValueError, match="reachable"):
+        update_job(job["id"], {"deliver": "local"})


### PR DESCRIPTION
## Problem
A recurring cron job with `deliver="local"` (or no deliver, which defaults to local when there is no origin) and no repeat bound (`repeat=None` / "forever") has no external consumer and no external stop signal. The terminal/follower gate only releases such a job on a delivered platform receipt (`platform:chat_id:message_id`), which local delivery can never produce, so the stop condition is unsatisfiable and the job fires forever, accumulating over time.

## Fix (minimal, `cron/jobs.py`)
When a recurring job is delivered locally, require a reachable finite repeat bound:
- omitted repeat -> defaults to a visible ceiling (`LOCAL_RECURRING_MAX_REPEAT` = 2016, 7 days at a 5-min cadence); the create contract is preserved;
- explicit `forever`, or a bound above the ceiling -> refused with a clear `ValueError` pointing at the ceiling or at an external delivery channel that can terminate the job.

The same guard closes the `update_job` door. Non-local deliveries (origin/discord/telegram) and one-shot jobs are unaffected.

## Why not silently clamp
A silent clamp mutates caller intent and is easy to regress. A loud refusal is explicit; the omitted-repeat default keeps ergonomics.

## Tests
- New `tests/cron/test_local_recurring_bound.py` (7 cases).
- Reconciled two existing coercion tests to an external channel (`deliver="discord"`), since coercion is orthogonal to delivery and forever-local is now refused by design.
- Full `tests/cron/` green locally (120 passed).

## Alternatives welcome
Happy to adjust to maintainer preference (hard reject as here, a warning + config flag, or a documented default).
