### PR TITLE
fix(mcp): keep cached tokens when a refresh fails on transport

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -488,3 +488,78 @@ async def test_manager_refresh_read_error_clears_tokens(tmp_path, monkeypatch):
 
     assert result is False
     assert provider.context.current_tokens is None
+
+# ---------------------------------------------------------------------------
+# A transport failure is not a credential rejection.
+#
+# Measured against a live MCP server over ~2 weeks: 148 refresh failures were
+# 5xx (102x502, 44x530 Cloudflare "origin unreachable", 2x500), not 400s. On
+# one day, seven 530s at 04:02 were followed by nothing but invalid_grant from
+# 08:07 onward -- the transient blip is what killed the session for good.
+#
+# Discarding cached tokens on a 5xx makes every later probe fall through to the
+# full browser authorization flow, which in a background gateway means either a
+# hard failure or (with an inherited TTY) an unattended browser window every
+# retry interval.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [500, 502, 503, 530])
+async def test_refresh_5xx_keeps_tokens(tmp_path, monkeypatch, status):
+    """A 5xx means the refresh token was never evaluated -- keep it."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_with_token_endpoint(
+        tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
+    )
+    sentinel = object()
+    provider.context.current_tokens = sentinel
+
+    response = _fake_response(status, "https://idp.example.com/oauth/token", b"upstream down")
+    result = await provider._handle_refresh_response(response)
+
+    assert result is False, "the refresh still did not succeed"
+    assert provider.context.current_tokens is sentinel, (
+        f"HTTP {status} is a transport failure, not a rejected credential: "
+        "the cached tokens must survive so the next attempt can retry"
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_429_keeps_tokens(tmp_path, monkeypatch):
+    """429 is a quota verdict about the caller, not about the credential."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_with_token_endpoint(
+        tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
+    )
+    sentinel = object()
+    provider.context.current_tokens = sentinel
+
+    response = _fake_response(429, "https://idp.example.com/oauth/token", b"slow down")
+    result = await provider._handle_refresh_response(response)
+
+    assert result is False
+    assert provider.context.current_tokens is sentinel
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [400, 401, 403])
+async def test_refresh_4xx_still_clears_tokens(tmp_path, monkeypatch, status):
+    """Positive control: an explicit rejection must still drop the tokens.
+
+    Without this, "keep the tokens on failure" would silently become "never
+    clear them", and a genuinely dead refresh token would be replayed forever.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_with_token_endpoint(
+        tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
+    )
+    provider.context.current_tokens = object()
+
+    response = _fake_response(
+        status, "https://idp.example.com/oauth/token", b'{"error": "invalid_grant"}'
+    )
+    result = await provider._handle_refresh_response(response)
+
+    assert result is False
+    assert provider.context.current_tokens is None

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -45,6 +45,23 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 
+def _is_credential_rejection(status: int) -> bool:
+    """Return True if ``status`` is the server rejecting the credential itself.
+
+    Only a 4xx that speaks about authorization tells us the refresh token is no
+    good. Anything else — 5xx (the origin never answered; Cloudflare's 530 is
+    literally "origin unreachable"), 429 (quota, a verdict about the caller's
+    rate, not its identity), or a redirect — leaves the credential's validity
+    unknown, so the cached tokens must survive for the next attempt.
+
+    408 and 425 are excluded on purpose: they are retryable timing failures
+    dressed as 4xx, not authorization verdicts.
+    """
+    if status in (408, 425, 429):
+        return False
+    return 400 <= status < 500
+
+
 def _same_endpoint(a: str, b: str) -> bool:
     """Return True if two URLs target the same endpoint (ignoring query/fragment).
 
@@ -219,10 +236,20 @@ def _make_hermes_provider_class() -> Optional[type]:
             raise OAuthTokenError(f"Token exchange failed ({response.status_code})")
 
         async def _handle_refresh_response(self, response) -> bool:
-            """Accept any 2xx refresh response and avoid logging token bodies."""
+            """Accept any 2xx refresh response and avoid logging token bodies.
+
+            On failure, only discard the cached tokens when the server actually
+            *rejected the credential*. A 5xx (including Cloudflare's 530
+            "origin unreachable") or a 429 means the refresh token was never
+            evaluated: dropping it there turns a seconds-long upstream blip
+            into a dead session, because the next attempt has nothing left to
+            refresh and falls through to the full browser authorization flow —
+            which no background gateway can complete.
+            """
             if not (200 <= response.status_code < 300):
                 logger.warning("Token refresh failed: %s", response.status_code)
-                self.context.clear_tokens()
+                if _is_credential_rejection(response.status_code):
+                    self.context.clear_tokens()
                 return False
 
             from mcp.shared.auth import OAuthToken


### PR DESCRIPTION
## The bug

`_handle_refresh_response` (`tools/mcp_oauth_manager.py`) discarded the cached tokens on **any** non-2xx:

```python
if not (200 <= response.status_code < 300):
    logger.warning("Token refresh failed: %s", response.status_code)
    self.context.clear_tokens()      # ← also on 502, 530, 500
    return False
```

A 5xx means the origin never answered — Cloudflare's **530 is literally "origin unreachable"** — so the refresh token was never evaluated. It is not a verdict about the credential.

## Why it is permanent, not transient

The failure path writes nothing to disk, and the on-disk token file is only re-read when its **mtime changes** (`invalidate_if_disk_changed`). So after a 5xx:

- in-memory tokens: gone
- on-disk tokens: still valid, but never reloaded — mtime never moved

Every later probe finds no credential and falls through to the full browser authorization flow, which a background gateway cannot complete. A seconds-long blip costs the whole session, and the only way out is a manual `hermes mcp login`.

## Measurement

Against a live MCP server over ~2 weeks, refresh failures by status:

```
626 × 400   invalid_grant  (genuine rejection)
102 × 502
 44 × 530
  2 × 500
```

**148 of them were 5xx.** The ordering on 1-Sep shows the causal chain — seven `530` in a row at 04:02, then nothing but `400` from 08:07 onward. The transient failure is what killed the session; the invalid_grants afterwards are the symptom of a client with no usable credential left.

Downstream, the user-visible effect was an unattended browser window every 300s probe interval (43 in one day), because the gateway process had inherited a TTY and so passed the interactive check before reaching the authorization flow.

## The fix

Only clear when the server actually rejected the credential:

```python
if _is_credential_rejection(response.status_code):
    self.context.clear_tokens()
```

`_is_credential_rejection` returns True for 4xx **except** 429, 408 and 425 — a 429 is a verdict about the caller's *rate*, not its identity, and 408/425 are retryable timing failures dressed as 4xx.

## Verification

7 new tests (parametrized over 500/502/503/530 and 400/401/403). Mutation results:

| Mutation | Tests killed |
|---|---|
| revert to the unconditional `clear_tokens()` | 5 |
| never clear (`return False` always) | 3 — the positive controls |
| count 429 as a rejection | 1 |

The second one matters: it is the over-correction this fix could have shipped, and the positive controls exist to catch it. A genuinely dead refresh token must still be dropped, or it would be replayed forever.

```
tests/tools/test_mcp_oauth_manager.py    22 passed
```

## Timeline of the observed failure

The full sequence from the same day, from the client's HTTP log:

```
00:42 → 09:49   POST /oauth/token → 200, hourly. Healthy.
10:44:54        POST /mcp → 502          ← origin starts failing
10:45:54 …      POST /mcp → 530 × 10     ← "origin unreachable", ~50s
10:58:38        POST /oauth/token → 400  ← credential already gone
(never a 200 again)
```

The refresh landed inside that 530 window, `clear_tokens()` discarded the credential, and every later attempt had nothing left to present.

Worth noting what did **not** break it: on two earlier occasions (05:46:02 and 08:47:57) a `200` and a `400` on the token endpoint land in the same second — two refreshes racing under mandatory rotation. The session survived both, because the winner wrote to disk, the mtime moved, and the reload path picked the new token up. That race is real but self-healing; the 5xx is not.
