### PR TITLE
feat(skills): add buzz-hermes-profile-setup optional skill

### DIFF
--- a/optional-skills/devops/buzz-hermes-profile-setup/SKILL.md
+++ b/optional-skills/devops/buzz-hermes-profile-setup/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: buzz-hermes-profile-setup
+description: Connect a Hermes profile to a Buzz (Nostr) community.
+version: 2.0.0
+author: Marco Rodrigues (dadhalfdev), Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [buzz, nostr, gateway, profiles, onboarding, installer, block]
+    category: devops
+    requires_toolsets: [terminal]
+---
+
+# Buzz Hermes Profile Setup Skill
+
+Joins a self-hosted Hermes profile (one whose gateway runs as a background service on a
+Linux or macOS box) to a Buzz community as its own first-class agent identity. One script
+locates or builds the `buzz` CLI, mints a dedicated Nostr keypair, claims relay membership,
+sets the agent's profile, writes the Hermes config, restarts the gateway, and verifies the
+connection. It does not cover Buzz Desktop managed runtimes or the `buzz-acp` relay bridge;
+for those see the Hermes docs on Buzz integration.
+
+## When to Use
+
+- The user runs a Hermes profile on a server and wants it live in a
+  `*.communities.buzz.xyz` community as a member they can DM or `@`-mention.
+- The user has tried `hermes gateway setup` for Buzz and is stuck on membership, keys,
+  or a gateway that never reaches `connected`.
+- The user wants to re-run onboarding for an existing profile (the script is idempotent:
+  it reuses the key already in the profile's `.env` and skips the invite step).
+
+Do not use for Buzz Desktop-only setups, or hosts without a shell you can reach through
+`terminal`.
+
+## Prerequisites
+
+- A Hermes profile that already exists (`hermes profile create <name>`) with its gateway
+  installed as a service.
+- `git` and `cargo` on the host if the `buzz` CLI still needs to be built (first run only,
+  1-2 minutes). Alternatively set `BUZZ_INSTALL_CLI_PATH` to a prebuilt binary.
+- `curl` on the host (the relay is behind Cloudflare and rejects Python's `urllib`).
+- The community relay URL, e.g. `https://my-team.communities.buzz.xyz`.
+- For a first join: an **owner or admin key** of the community (nsec or hex). It signs the
+  invite once and is never written to disk. Not needed when re-running for a key that is
+  already a member.
+
+No Python packages are required; the script is standard library only.
+
+## How to Run
+
+Run the installer through `terminal`. It prompts for anything it cannot infer:
+
+```bash
+python3 ~/.hermes/skills/devops/buzz-hermes-profile-setup/scripts/buzz_install.py
+```
+
+Preview the plan without changing anything:
+
+```bash
+python3 ~/.hermes/skills/devops/buzz-hermes-profile-setup/scripts/buzz_install.py --dry-run
+```
+
+Headless (no prompts; every required value must come from the environment):
+
+```bash
+export BUZZ_INSTALL_PROFILE=my-agent
+export BUZZ_INSTALL_RELAY=https://my-team.communities.buzz.xyz
+export BUZZ_INSTALL_OWNER_NSEC=nsec1...           # first join only
+export BUZZ_INSTALL_AGENT_NAME="My Agent"
+export BUZZ_INSTALL_AGENT_AVATAR=https://example.com/agent.png
+python3 ~/.hermes/skills/devops/buzz-hermes-profile-setup/scripts/buzz_install.py --non-interactive
+```
+
+Ask the user for the profile name, relay URL, owner key, and how open the agent should be
+before running. Never paste the owner key into chat logs; have the user export it in their
+shell or type it at the prompt (input is hidden).
+
+## Quick Reference
+
+Every input has an env var. Prompts only fire when the env var is unset and stdin is a TTY.
+
+| Env var | Required | Default | Controls |
+|---|---|---|---|
+| `BUZZ_INSTALL_PROFILE` | yes | - | Which `~/.hermes/profiles/<name>` gets wired |
+| `BUZZ_INSTALL_RELAY` | yes | - | `https://<community>.communities.buzz.xyz` |
+| `BUZZ_INSTALL_OWNER_NSEC` | first join | - | Owner/admin key (nsec or hex) that mints the invite |
+| `BUZZ_INSTALL_AGENT_NAME` | no | profile name | Display name in the community |
+| `BUZZ_INSTALL_AGENT_AVATAR` | no | - | Avatar image URL (hosted, not uploaded) |
+| `BUZZ_INSTALL_AGENT_ABOUT` | no | - | Short bio |
+| `BUZZ_INSTALL_AGENT_NIP05` | no | - | NIP-05 identifier, e.g. `agent@example.com` |
+| `BUZZ_INSTALL_PRESENCE` | no | `online` | `online` / `away` / `offline` |
+| `BUZZ_INSTALL_STATUS_TEXT` / `_EMOJI` | no | - | NIP-38 status line and emoji |
+| `BUZZ_INSTALL_ALLOW_ALL` | no | `true` | `true` = any member may chat; `false` = whitelist |
+| `BUZZ_INSTALL_ALLOWED_USERS` | no | - | Comma-separated npub/hex for whitelist mode |
+| `BUZZ_INSTALL_CHANNELS` | no | all joined | Comma-separated channel UUIDs to watch |
+| `BUZZ_INSTALL_HOME_CHANNEL` | no | first watched | Where cron/notify deliveries land |
+| `BUZZ_INSTALL_REQUIRE_MENTION` | no | `true` | In channels, reply only when addressed (DMs always) |
+| `BUZZ_INSTALL_POLL_INTERVAL` | no | `4` | Seconds between relay polls |
+| `BUZZ_INSTALL_CLI_PATH` | no | `~/bin/buzz` | Where the `buzz` binary lives or gets built |
+| `BUZZ_INSTALL_SOUL` | no | - | Text file copied to the profile's `SOUL.md` |
+| `BUZZ_INSTALL_ROTATE_KEY` | no | `false` | Ignore the existing key and mint a new identity |
+
+Flags: `--dry-run` (print plan, change nothing), `--non-interactive` (never prompt).
+
+Access matrix: community mode (`ALLOW_ALL=true`) lets any relay member chat and only the
+owner is admin; whitelist mode (`ALLOW_ALL=false` + `ALLOWED_USERS`) restricts to listed
+keys; `REQUIRE_MENTION` applies to channels only, direct messages always dispatch.
+
+## Procedure
+
+1. Collect inputs from the user: profile name, relay URL, whether this is a first join
+   (owner key needed) or a re-run, agent name/avatar/bio, and the access mode.
+2. Run `--dry-run` through `terminal` and show the user the plan (identity reuse vs. new
+   key, access mode, CLI path). Adjust env vars if anything is off.
+3. Run the installer. Each step logs a `[tag]` line: `[cli]`, `[identity]`,
+   `[membership]`, `[profile]`, `[env]`, `[config]`, `[gateway]`, `[verify]`.
+4. When it exits `0` with `[verify] gateway_state.json: buzz connected`, read the SUMMARY
+   block and report the agent's `npub` and display name back to the user.
+5. If it exits `1`, jump to Pitfalls; the failing `[tag]` line names the stage.
+6. Ask the user to DM the agent from an account other than the owner key and confirm the
+   reply round-trips. That is the final proof.
+
+What the script writes:
+
+- `~/.hermes/profiles/<name>/.env` gains `BUZZ_PRIVATE_KEY=nsec1...` (mode 0600).
+- `hermes -p <name> config set` writes `gateway.platforms.buzz.enabled` plus `extra.relay_url`,
+  `channels`, `home_channel`, `poll_interval`, `cli_path`, `allowed_users`,
+  `require_mention`, `allow_all_users`, and the recommended display defaults
+  (`interim_assistant_messages: false`, `tool_progress: off`).
+- Optionally `SOUL.md` when `BUZZ_INSTALL_SOUL` points at a file.
+
+## Pitfalls
+
+1. **No prebuilt CLI.** The Buzz repo publishes desktop binaries only; the script runs
+   `cargo build --release -p buzz-cli` on first use. Without `cargo`, point
+   `BUZZ_INSTALL_CLI_PATH` at a binary you built elsewhere.
+2. **Relay membership is not channel membership.** `buzz channels add-member` answers
+   `accepted:true` yet the key still gets `403 relay_membership_required`. Only the invite
+   mint+claim grants real membership, which is what the script does.
+3. **Never reuse the owner's key for the agent.** The adapter suppresses self-echo by
+   pubkey, so an agent running as the owner ignores the owner. The script always uses a
+   dedicated keypair.
+4. **Buzz Desktop's "Create agent" wizard is the wrong flow.** It provisions Buzz-native
+   harness agents (goose/Codex). A Hermes gateway is a plain relay member.
+5. **`join_policy_required` on claim.** The community has a join policy; the script
+   accepts it automatically (`age_confirmed=true`, matching `policy_version`). A policy
+   change mid-run can race; re-run.
+6. **Gateway stays `disconnected`.** Usually the gateway restarted before `.env` was
+   written. Run `hermes -p <name> gateway restart` again and re-check.
+7. **journalctl shows nothing.** The Buzz adapter logs to a different sink than
+   Telegram/Slack; the truth is `gateway_state.json`, not `journalctl`.
+8. **Owner key format.** Both `nsec1...` and 64-char hex are accepted. Mixed-case bech32
+   is rejected by design.
+
+Deep protocol notes (NIP-98 signing, invite HTTP contract, Cloudflare, bech32 padding) live
+in `references/buzz-internals.md`.
+
+## Verification
+
+Read the profile's state file with `read_file`:
+
+```text
+~/.hermes/profiles/<name>/gateway_state.json
+```
+
+Success is `"platforms": {"buzz": {"state": "connected"}}`. For a membership check
+through `terminal`:
+
+```bash
+set -a; . ~/.hermes/profiles/<name>/.env; set +a
+BUZZ_RELAY_URL=https://my-team.communities.buzz.xyz ~/bin/buzz users get
+```
+
+Exit `0` with your agent's `display_name` and `role: member` means the identity is live.

--- a/optional-skills/devops/buzz-hermes-profile-setup/references/buzz-internals.md
+++ b/optional-skills/devops/buzz-hermes-profile-setup/references/buzz-internals.md
@@ -1,0 +1,91 @@
+# Buzz relay and membership: how it works under the hood
+
+Notes for debugging the installer or for anyone who wants the standalone building
+blocks. Source of truth: the `block/buzz` repository (relay, desktop, mobile, CLI) and the
+Hermes Buzz adapter at `plugins/platforms/buzz/` (`adapter.py`, `nostr_auth.py`,
+`plugin.yaml`).
+
+## Relay info (NIP-11)
+
+`GET https://<community>.communities.buzz.xyz/` returns NIP-11 JSON: `name`,
+`description`, `version`, `supported_nips` and `auth_required: true`,
+`restricted_writes: true`. The `wss://` endpoint is the Nostr WebSocket relay. The
+`https://` base URL is what `relay_url` / `BUZZ_RELAY_URL` expects.
+
+## Membership: relay vs channel
+
+- Channel membership (`buzz channels add-member --channel <uuid> --pubkey <hex> --role bot`)
+  writes a channel-member event and returns `accepted:true` immediately.
+- It does **not** grant relay membership. Acting as that key afterwards returns
+  `{"error":"auth_error","message":"relay error 403: relay_membership_required"}`.
+- Relay membership for an agent is granted one of two ways:
+  - **Invite mint+claim (the Hermes path, fully programmatic).** An owner/admin mints an
+    invite (`POST /api/invites`, NIP-98 signed by the owner); the joining key claims it
+    (`POST /api/invites/claim`, NIP-98 signed by the joining key), after accepting the join
+    policy if the community has one. Result: a `member`-role relay member, which is exactly
+    what the Hermes adapter needs.
+  - **Native agent / NIP-OA attestation (the Buzz Desktop path).** Buzz Desktop's
+    "Create a new agent" wizard generates a key plus a NIP-OA auth tag for a Buzz-native
+    harness (goose/Codex). A Hermes gateway does not use this flow.
+- **Self-echo suppression by pubkey.** The adapter ignores inbound events whose pubkey
+  equals its own. A profile that runs on the owner's own key *is* the owner and ignores the
+  owner's messages. Always use a dedicated keypair. `buzz users get` reveals the identity
+  (`display_name`, `role: owner`).
+
+## Invite mint+claim: the HTTP contract
+
+Relative to the relay's HTTPS base URL:
+
+| Step | Method + path | Auth | Body | Returns |
+|---|---|---|---|---|
+| 1. mint | `POST /api/invites` | NIP-98 (owner/admin) | `{}` or `{"ttl_secs":N,"max_uses":N}` | `{code, expires_at, max_uses, url}` |
+| 2. accept-policy | `POST /api/invites/accept-policy` | none | `{code, policy_version, age_confirmed:true}` | `{receipt}` |
+| 3. claim | `POST /api/invites/claim` | NIP-98 (joining key) | `{code, policy_receipt}` | `{status:"joined", role:"member", community_id, host}` |
+
+Step 2 is only required when `GET /api/join-policy` returns `{"policy":{...}}`. If it
+returns `{}` there is no policy and the claim body is just `{code}`. When
+`age_attestation_required` is true, `age_confirmed` must be `true` and `policy_version`
+must match `policy.version` exactly, otherwise accept-policy returns
+`join_policy_not_accepted` and claim returns `join_policy_required`.
+
+### NIP-98 signing (kind 27235)
+
+`Authorization: Nostr <base64(json)>` where the JSON event is:
+
+```json
+{"id":"<hex>","pubkey":"<hex>","created_at":<unix>,"kind":27235,
+ "tags":[["u","<url>"],["method","POST"],["payload","<sha256hex(body)>"]],
+ "content":"","sig":"<64-byte BIP-340 schnorr hex>"}
+```
+
+- `id` = sha256 of the canonical serialization `[0, pubkey_hex, created_at, 27235, tags, ""]`
+  as compact JSON (`separators=(",", ":")`, lowercase hex pubkey).
+- `sig` = BIP-340 Schnorr over the 32-byte `id`. The installer implements this with the
+  standard library (same construction as Hermes' `nostr_auth.py`). ECDSA-only libraries
+  cannot produce it.
+- `u` is the exact request URL (HTTPS base, not `wss://`), `method` is `POST`, `payload` is
+  the sha256 hex of the exact body bytes.
+- `created_at` must be within about 60 seconds of server time.
+- No nonce tag; replay protection is by event `id`, which is unique per body.
+
+## Cloudflare (why the script uses curl)
+
+The relay sits behind Cloudflare. Python `urllib` requests are rejected with error `1010`
+(browser-signature ban) while `curl` with a browser User-Agent passes. The installer shells
+out to `curl` for every relay HTTP call.
+
+## Keypair / bech32 padding
+
+When encoding 32 bytes to bech32 (8-bit to 5-bit groups), the final partial group **must be
+padded**. A non-padding conversion drops the last bit and produces an nsec that decodes to a
+*different* private key, silently. The installer encodes with padding and verifies that
+`decode(encode(key)) == key` before using any key.
+
+## Verification: state files, not logs
+
+- `~/.hermes/profiles/<name>/gateway_state.json` contains
+  `"platforms": {"buzz": {"state": "connected"}}` when healthy.
+- `~/.hermes/profiles/<name>/channel_directory.json` gains a `"buzz"` entry once channels
+  surface (empty is normal right after connect).
+- The Buzz adapter logs to a different sink than Telegram/Slack, so its lines do not appear
+  in `journalctl -u hermes-gateway-<name>`. Absence there is not a failure.

--- a/optional-skills/devops/buzz-hermes-profile-setup/scripts/buzz_install.py
+++ b/optional-skills/devops/buzz-hermes-profile-setup/scripts/buzz_install.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+"""buzz_install.py — connect a Hermes profile to a Buzz (Nostr) community.
+
+Standard library only. bech32 (NIP-19) and BIP-340 Schnorr signing are implemented
+inline, mirroring the dependency-free signer in Hermes' bundled Buzz adapter
+(``plugins/platforms/buzz/nostr_auth.py``), so no ``pip install`` is needed.
+
+Pipeline (each step is logged):
+  1. Resolve inputs: BUZZ_INSTALL_* env vars -> interactive prompts -> defaults.
+  2. Locate the ``buzz`` CLI (configured path, PATH, ~/bin) or build it from source.
+  3. Reuse the profile's existing BUZZ_PRIVATE_KEY, or mint a fresh keypair
+     (bech32 round-trip self-verified so a padding bug cannot slip through).
+  4. If the key is not yet a relay member: owner mints an invite (NIP-98),
+     accept the join policy when the community has one, agent claims (NIP-98).
+  5. Set the agent's Buzz profile: name / avatar / about / NIP-05, presence, status.
+  6. Write BUZZ_PRIVATE_KEY to the profile's .env (0600); never into config.yaml.
+  7. ``hermes -p <profile> config set`` every Buzz key.
+  8. Restart the profile's gateway and confirm ``gateway_state.json`` says connected.
+
+``--dry-run`` resolves inputs and prints the plan without touching the network,
+the filesystem, or the gateway.
+
+Relay HTTP goes through ``curl``: the relay sits behind Cloudflare, which rejects
+Python's ``urllib`` User-Agent (error 1010).
+"""
+from __future__ import annotations
+
+import argparse
+import getpass
+import hashlib
+import json
+import os
+import pathlib
+import secrets
+import shutil
+import subprocess
+import sys
+import time
+from typing import Optional
+
+UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126 Safari/537.36"
+BUZZ_REPO = "https://github.com/block/buzz.git"
+HOME = pathlib.Path.home()
+PROFILES = HOME / ".hermes" / "profiles"
+DEFAULT_CLI = HOME / "bin" / "buzz"
+BUILD_DIR = HOME / ".buzz-build"
+PRESENCE_VALUES = ("online", "away", "offline")
+TRUE_WORDS = {"1", "true", "yes", "y", "on"}
+FALSE_WORDS = {"0", "false", "no", "n", "off", ""}
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def warn(msg: str) -> None:
+    print(f"WARN: {msg}", file=sys.stderr, flush=True)
+
+
+def die(msg: str) -> None:
+    print(f"\nFATAL: {msg}", file=sys.stderr, flush=True)
+    sys.exit(1)
+
+
+def to_bool(value: str, *, name: str) -> bool:
+    v = (value or "").strip().lower()
+    if v in TRUE_WORDS:
+        return True
+    if v in FALSE_WORDS:
+        return False
+    die(f"{name} must be true/false, got {value!r}")
+    return False  # unreachable; keeps type-checkers happy
+
+
+# ---------------------------------------------------------------- bech32 (NIP-19)
+CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+_GENERATORS = (0x3B6A57B2, 0x26508E6D, 0x1EA119FA, 0x3D4233DD, 0x2A1462B3)
+
+
+def _polymod(values: list[int]) -> int:
+    chk = 1
+    for v in values:
+        top = chk >> 25
+        chk = ((chk & 0x1FFFFFF) << 5) ^ v
+        for i, g in enumerate(_GENERATORS):
+            if (top >> i) & 1:
+                chk ^= g
+    return chk
+
+
+def _hrp_expand(hrp: str) -> list[int]:
+    return [ord(c) >> 5 for c in hrp] + [0] + [ord(c) & 31 for c in hrp]
+
+
+def _convertbits(data, from_bits: int, to_bits: int, pad: bool) -> list[int]:
+    acc = bits = 0
+    out: list[int] = []
+    maxv = (1 << to_bits) - 1
+    for v in data:
+        acc = (acc << from_bits) | v
+        bits += from_bits
+        while bits >= to_bits:
+            bits -= to_bits
+            out.append((acc >> bits) & maxv)
+    if pad and bits:
+        # Without this final padded group the last bit of the key is silently dropped
+        # and the nsec decodes to a *different* private key.
+        out.append((acc << (to_bits - bits)) & maxv)
+    return out
+
+
+def bech32_encode(hrp: str, data: bytes) -> str:
+    vals = _convertbits(list(data), 8, 5, pad=True)
+    pm = _polymod(_hrp_expand(hrp) + vals + [0] * 6) ^ 1
+    vals += [(pm >> 5 * (5 - i)) & 31 for i in range(6)]
+    return hrp + "1" + "".join(CHARSET[d] for d in vals)
+
+
+def bech32_decode(expected_hrp: str, text: str) -> bytes:
+    if text.lower() != text and text.upper() != text:
+        raise ValueError("bech32 string mixes upper- and lowercase")
+    text = text.lower()
+    pos = text.rfind("1")
+    if pos < 1 or pos + 7 > len(text):
+        raise ValueError("invalid bech32 string")
+    hrp, payload = text[:pos], text[pos + 1 :]
+    if hrp != expected_hrp:
+        raise ValueError(f"expected {expected_hrp}1..., got {hrp}1...")
+    try:
+        vals = [CHARSET.index(c) for c in payload]
+    except ValueError as exc:
+        raise ValueError("invalid character in bech32 string") from exc
+    if _polymod(_hrp_expand(hrp) + vals) != 1:
+        raise ValueError("bech32 checksum mismatch")
+    out = bytes(_convertbits(vals[:-6], 5, 8, pad=False))
+    if len(out) != 32:
+        raise ValueError(f"{expected_hrp} must encode exactly 32 bytes")
+    return out
+
+
+# ---------------------------------------------------------------- secp256k1 / BIP-340
+_P = 2**256 - 2**32 - 977
+_N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+_G = (
+    0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798,
+    0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8,
+)
+Point = Optional[tuple[int, int]]
+
+
+def _point_add(a: Point, b: Point) -> Point:
+    if a is None or b is None:
+        return b if a is None else a
+    x1, y1 = a
+    x2, y2 = b
+    if x1 == x2:
+        if (y1 + y2) % _P == 0:
+            return None
+        lam = (3 * x1 * x1) * pow(2 * y1, _P - 2, _P)
+    else:
+        lam = (y2 - y1) * pow(x2 - x1, _P - 2, _P)
+    lam %= _P
+    x3 = (lam * lam - x1 - x2) % _P
+    return x3, (lam * (x1 - x3) - y1) % _P
+
+
+def _point_mul(k: int, point: Point = _G) -> Point:
+    result: Point = None
+    addend = point
+    while k:
+        if k & 1:
+            result = _point_add(result, addend)
+        addend = _point_add(addend, addend)
+        k >>= 1
+    return result
+
+
+def _tagged_hash(tag: str, payload: bytes) -> bytes:
+    th = hashlib.sha256(tag.encode()).digest()
+    return hashlib.sha256(th + th + payload).digest()
+
+
+def decode_private_key(value: str) -> bytes:
+    """Accept an ``nsec1...`` or 64-hex private key and return 32 raw bytes."""
+    raw = value.strip()
+    if raw.lower().startswith("nsec1"):
+        key = bech32_decode("nsec", raw)
+    else:
+        try:
+            key = bytes.fromhex(raw)
+        except ValueError as exc:
+            raise ValueError("private key must be nsec or 64 hex chars") from exc
+        if len(key) != 32:
+            raise ValueError("private key must be 32 bytes")
+    k = int.from_bytes(key, "big")
+    if not 1 <= k < _N:
+        raise ValueError("private key outside the secp256k1 range")
+    return key
+
+
+def pubkey_x(secret: bytes) -> bytes:
+    pt = _point_mul(int.from_bytes(secret, "big"))
+    assert pt is not None
+    return pt[0].to_bytes(32, "big")
+
+
+def schnorr_sign(msg32: bytes, secret: bytes, aux: Optional[bytes] = None) -> bytes:
+    if len(msg32) != 32:
+        raise ValueError("BIP-340 signs a 32-byte message")
+    d = int.from_bytes(secret, "big")
+    pt = _point_mul(d)
+    assert pt is not None
+    px = pt[0].to_bytes(32, "big")
+    d = d if pt[1] % 2 == 0 else _N - d
+    aux = aux if aux is not None else secrets.token_bytes(32)
+    t = (d ^ int.from_bytes(_tagged_hash("BIP0340/aux", aux), "big")).to_bytes(32, "big")
+    k = int.from_bytes(_tagged_hash("BIP0340/nonce", t + px + msg32), "big") % _N
+    if k == 0:
+        raise RuntimeError("BIP-340 produced a zero nonce")
+    rpt = _point_mul(k)
+    assert rpt is not None
+    rx = rpt[0].to_bytes(32, "big")
+    k = k if rpt[1] % 2 == 0 else _N - k
+    e = int.from_bytes(_tagged_hash("BIP0340/challenge", rx + px + msg32), "big") % _N
+    return rx + ((k + e * d) % _N).to_bytes(32, "big")
+
+
+def generate_keypair() -> tuple[str, str, str]:
+    """Return (nsec, npub, pubkey_hex) for a brand-new random identity."""
+    sec = secrets.token_bytes(32)
+    while not 1 <= int.from_bytes(sec, "big") < _N:  # pragma: no cover - astronomically rare
+        sec = secrets.token_bytes(32)
+    x = pubkey_x(sec)
+    nsec, npub = bech32_encode("nsec", sec), bech32_encode("npub", x)
+    if bech32_decode("nsec", nsec) != sec or bech32_decode("npub", npub) != x:
+        die("keypair self-check failed (bech32 round-trip)")
+    return nsec, npub, x.hex()
+
+
+# ---------------------------------------------------------------- NIP-98 (kind 27235)
+def sign_nip98(secret: bytes, url: str, body: bytes, method: str = "POST") -> str:
+    """Return an ``Authorization: Nostr <b64>`` header value for one HTTP request."""
+    pub_hex = pubkey_x(secret).hex()
+    created_at = int(time.time())
+    tags = [["u", url], ["method", method], ["payload", hashlib.sha256(body).hexdigest()]]
+    serialized = json.dumps([0, pub_hex, created_at, 27235, tags, ""], separators=(",", ":"))
+    event_id = hashlib.sha256(serialized.encode()).digest()
+    event = {
+        "id": event_id.hex(),
+        "pubkey": pub_hex,
+        "created_at": created_at,
+        "kind": 27235,
+        "tags": tags,
+        "content": "",
+        "sig": schnorr_sign(event_id, secret).hex(),
+    }
+    import base64
+
+    return "Nostr " + base64.b64encode(json.dumps(event, separators=(",", ":")).encode()).decode()
+
+
+# ---------------------------------------------------------------- process helpers
+def curl(url: str, body: Optional[dict] = None, auth: Optional[str] = None) -> tuple[int, str, str]:
+    if not shutil.which("curl"):
+        die("curl not found on PATH (needed because the relay rejects urllib behind Cloudflare)")
+    cmd = ["curl", "-sS", "-m", "30", "-H", f"User-Agent: {UA}"]
+    if body is not None:
+        cmd += ["-X", "POST", "-H", "Content-Type: application/json", "-d", json.dumps(body, separators=(",", ":"))]
+    if auth:
+        cmd += ["-H", f"Authorization: {auth}"]
+    cmd.append(url)
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    return p.returncode, p.stdout, p.stderr
+
+
+def sh(cmd: list[str], env=None, cwd=None, check: bool = True) -> tuple[int, str]:
+    p = subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=cwd)
+    out = (p.stdout or "").strip()
+    if check and p.returncode != 0:
+        die(f"command failed ({p.returncode}): {' '.join(cmd)}\n{(p.stderr or out).strip()}")
+    return p.returncode, out
+
+
+def parse_json(text: str, what: str) -> dict:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        die(f"{what}: relay returned non-JSON: {text[:200]!r}")
+    if isinstance(data, dict) and data.get("error"):
+        die(f"{what} failed: {data.get('error')}: {data.get('message', '')}".rstrip(": "))
+    return data if isinstance(data, dict) else {}
+
+
+# ---------------------------------------------------------------- input resolution
+def _env(key: str) -> str:
+    return os.environ.get(key, "").strip()
+
+
+def resolve_inputs(interactive: Optional[bool] = None) -> dict:
+    tty = sys.stdin.isatty() if interactive is None else interactive
+
+    def ask(key: str, prompt: str, *, required: bool = False, default: str = "", secret: bool = False) -> str:
+        v = _env(key)
+        if v:
+            return v
+        if not tty:
+            if required:
+                die(f"missing required env var {key} (set it, or run from a terminal)")
+            return default
+        p = f"{prompt} [{default}]: " if default else f"{prompt}: "
+        raw = (getpass.getpass(p) if secret else input(p)).strip()
+        return raw or default
+
+    cfg = {
+        "profile": ask("BUZZ_INSTALL_PROFILE", "Hermes profile name", required=True),
+        "relay": ask("BUZZ_INSTALL_RELAY", "Community relay URL (https://<c>.communities.buzz.xyz)", required=True),
+        "owner_key": ask(
+            "BUZZ_INSTALL_OWNER_NSEC",
+            "Owner nsec/hex (mints the invite; used once, never saved; blank if already a member)",
+            secret=True,
+        ),
+        "agent_name": ask("BUZZ_INSTALL_AGENT_NAME", "Agent display name"),
+        "avatar": ask("BUZZ_INSTALL_AGENT_AVATAR", "Agent avatar URL (hosted image)"),
+        "about": ask("BUZZ_INSTALL_AGENT_ABOUT", "Agent bio / about"),
+        "nip05": ask("BUZZ_INSTALL_AGENT_NIP05", "NIP-05 id (optional)"),
+        "presence": ask("BUZZ_INSTALL_PRESENCE", "Presence (online/away/offline)", default="online"),
+        "status_text": ask("BUZZ_INSTALL_STATUS_TEXT", "Status line (optional)"),
+        "status_emoji": ask("BUZZ_INSTALL_STATUS_EMOJI", "Status emoji (optional)"),
+        "allow_all": ask("BUZZ_INSTALL_ALLOW_ALL", "Allow all community members to chat? (true/false)", default="true"),
+        "allowed_users": ask("BUZZ_INSTALL_ALLOWED_USERS", "Allowed users (comma-sep npub/hex, whitelist mode)"),
+        "channels": ask("BUZZ_INSTALL_CHANNELS", "Channels to watch (comma-sep UUIDs; empty = all)"),
+        "home_channel": ask("BUZZ_INSTALL_HOME_CHANNEL", "Home channel UUID (cron/notify delivery)"),
+        "require_mention": ask(
+            "BUZZ_INSTALL_REQUIRE_MENTION", "Only reply when @-mentioned in channels? (true/false)", default="true"
+        ),
+        "poll_interval": ask("BUZZ_INSTALL_POLL_INTERVAL", "Poll interval (seconds)", default="4"),
+        "cli_path": ask("BUZZ_INSTALL_CLI_PATH", "buzz CLI path", default=str(DEFAULT_CLI)),
+        "soul": ask("BUZZ_INSTALL_SOUL", "Personality: path to a text file -> SOUL.md (optional)"),
+        "rotate_key": ask("BUZZ_INSTALL_ROTATE_KEY", "Ignore existing key and mint a new identity? (true/false)", default="false"),
+    }
+    cfg["relay"] = cfg["relay"].rstrip("/")
+    if not cfg["relay"].startswith("https://"):
+        die("relay URL must start with https://")
+    if cfg["presence"] not in PRESENCE_VALUES:
+        die(f"presence must be one of {', '.join(PRESENCE_VALUES)}")
+    try:
+        float(cfg["poll_interval"])
+    except ValueError:
+        die("poll interval must be a number of seconds")
+    cfg["agent_name"] = cfg["agent_name"] or cfg["profile"]
+    cfg["allow_all"] = to_bool(cfg["allow_all"], name="BUZZ_INSTALL_ALLOW_ALL")
+    cfg["require_mention"] = to_bool(cfg["require_mention"], name="BUZZ_INSTALL_REQUIRE_MENTION")
+    cfg["rotate_key"] = to_bool(cfg["rotate_key"], name="BUZZ_INSTALL_ROTATE_KEY")
+    if not cfg["allow_all"] and not cfg["allowed_users"]:
+        warn("allow_all=false with an empty allowed_users list: nobody will be able to talk to the agent")
+    return cfg
+
+
+# ---------------------------------------------------------------- buzz CLI
+def ensure_cli(cli_path: str) -> str:
+    """Return a path to an executable ``buzz`` binary, building it if necessary."""
+    candidate = pathlib.Path(cli_path).expanduser()
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        log(f"[cli] using {candidate}")
+        return str(candidate)
+    on_path = shutil.which("buzz")
+    if on_path:
+        log(f"[cli] using {on_path} (found on PATH)")
+        return on_path
+    for tool in ("git", "cargo"):
+        if not shutil.which(tool):
+            die(f"{tool} not found; install it or point BUZZ_INSTALL_CLI_PATH at a prebuilt buzz binary")
+    log("[cli] building buzz-cli from source (first run only, ~1-2 min)...")
+    if not (BUILD_DIR / "Cargo.toml").exists():
+        sh(["git", "clone", "--depth", "1", BUZZ_REPO, str(BUILD_DIR)])
+    sh(["cargo", "build", "--release", "-p", "buzz-cli"], cwd=str(BUILD_DIR))
+    built = BUILD_DIR / "target" / "release" / "buzz"
+    if not built.exists():
+        die("cargo build finished but target/release/buzz is missing")
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(built, candidate)
+    candidate.chmod(0o755)
+    log(f"[cli] built -> {candidate}")
+    return str(candidate)
+
+
+def buzz_env(cfg: dict, nsec: str) -> dict:
+    env = os.environ.copy()
+    env["BUZZ_RELAY_URL"] = cfg["relay"]
+    env["BUZZ_PRIVATE_KEY"] = nsec
+    return env
+
+
+def is_member(cli: str, cfg: dict, nsec: str) -> bool:
+    rc, _ = sh([cli, "channels", "list"], env=buzz_env(cfg, nsec), check=False)
+    return rc == 0
+
+
+# ---------------------------------------------------------------- membership
+def mint_and_claim(cfg: dict, agent_secret: bytes) -> None:
+    if not cfg["owner_key"]:
+        die("this key is not a relay member yet; set BUZZ_INSTALL_OWNER_NSEC so the owner can mint an invite")
+    try:
+        owner_secret = decode_private_key(cfg["owner_key"])
+    except ValueError as exc:
+        die(f"owner key: {exc}")
+    relay = cfg["relay"]
+
+    url = f"{relay}/api/invites"
+    body: dict = {}
+    raw = json.dumps(body, separators=(",", ":")).encode()
+    rc, out, err = curl(url, body, sign_nip98(owner_secret, url, raw))
+    if rc:
+        die(f"mint request failed: {err or out}")
+    code = parse_json(out, "mint").get("code")
+    if not code:
+        die(f"mint returned no invite code: {out[:200]}")
+    log("[membership] invite minted")
+
+    rc, out, _ = curl(f"{relay}/api/join-policy")
+    version = ""
+    if rc == 0:
+        try:
+            version = (json.loads(out).get("policy") or {}).get("version", "")
+        except (json.JSONDecodeError, AttributeError):
+            version = ""
+
+    claim_body: dict = {"code": code}
+    if version:
+        rc, out, err = curl(
+            f"{relay}/api/invites/accept-policy",
+            {"code": code, "policy_version": version, "age_confirmed": True},
+        )
+        if rc:
+            die(f"accept-policy request failed: {err or out}")
+        receipt = parse_json(out, "accept-policy").get("receipt")
+        if not receipt:
+            die(f"accept-policy returned no receipt: {out[:200]}")
+        claim_body["policy_receipt"] = receipt
+        log(f"[membership] join policy v{version} accepted")
+
+    url = f"{relay}/api/invites/claim"
+    raw = json.dumps(claim_body, separators=(",", ":")).encode()
+    rc, out, err = curl(url, claim_body, sign_nip98(agent_secret, url, raw))
+    if rc:
+        die(f"claim request failed: {err or out}")
+    result = parse_json(out, "claim")
+    log(f"[membership] claimed -> status={result.get('status')} role={result.get('role')}")
+
+
+# ---------------------------------------------------------------- buzz profile
+def set_profile(cli: str, cfg: dict, nsec: str) -> None:
+    env = buzz_env(cfg, nsec)
+    args = [cli, "users", "set-profile", "--name", cfg["agent_name"]]
+    if cfg["avatar"]:
+        args += ["--avatar", cfg["avatar"]]
+    if cfg["about"]:
+        args += ["--about", cfg["about"]]
+    if cfg["nip05"]:
+        args += ["--nip05", cfg["nip05"]]
+    sh(args, env=env)
+    sh([cli, "users", "set-presence", "--status", cfg["presence"]], env=env)
+    if cfg["status_text"]:
+        args = [cli, "users", "set-status", "--text", cfg["status_text"]]
+        if cfg["status_emoji"]:
+            args += ["--emoji", cfg["status_emoji"]]
+        sh(args, env=env)
+    log(f"[profile] name={cfg['agent_name']!r} avatar={'yes' if cfg['avatar'] else 'no'} presence={cfg['presence']}")
+
+
+# ---------------------------------------------------------------- hermes wiring
+def profile_dir(profile: str) -> pathlib.Path:
+    d = PROFILES / profile
+    if not d.is_dir():
+        die(f"Hermes profile {profile!r} not found at {d} (create it with `hermes profile create {profile}`)")
+    return d
+
+
+def read_existing_key(profile: str) -> str:
+    env_path = PROFILES / profile / ".env"
+    if not env_path.exists():
+        return ""
+    for line in env_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if line.startswith("BUZZ_PRIVATE_KEY="):
+            return line.split("=", 1)[1].strip().strip('"').strip("'")
+    return ""
+
+
+def write_env(profile: str, nsec: str) -> pathlib.Path:
+    env_path = profile_dir(profile) / ".env"
+    lines = env_path.read_text(encoding="utf-8", errors="replace").splitlines() if env_path.exists() else []
+    lines = [ln for ln in lines if not ln.startswith("BUZZ_PRIVATE_KEY=")]
+    lines.append(f"BUZZ_PRIVATE_KEY={nsec}")
+    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    try:
+        env_path.chmod(0o600)
+    except OSError:  # pragma: no cover - non-POSIX filesystems
+        pass
+    log(f"[env] BUZZ_PRIVATE_KEY -> {env_path}")
+    return env_path
+
+
+def csv_json(csv: str) -> str:
+    return json.dumps([x.strip() for x in (csv or "").split(",") if x.strip()])
+
+
+def config_set(profile: str, key: str, value: str) -> None:
+    rc, out = sh(["hermes", "-p", profile, "config", "set", key, value], check=False)
+    if rc:
+        warn(f"hermes config set {key} failed: {out or rc}")
+
+
+def write_config(cfg: dict, cli: str) -> None:
+    if not shutil.which("hermes"):
+        die("hermes not found on PATH")
+    p, pre = cfg["profile"], "gateway.platforms.buzz"
+    settings = {
+        f"{pre}.enabled": "true",
+        f"{pre}.extra.relay_url": cfg["relay"],
+        f"{pre}.extra.channels": csv_json(cfg["channels"]),
+        f"{pre}.extra.home_channel": cfg["home_channel"],
+        f"{pre}.extra.poll_interval": cfg["poll_interval"],
+        f"{pre}.extra.cli_path": cli,
+        f"{pre}.extra.allowed_users": csv_json(cfg["allowed_users"]),
+        f"{pre}.extra.require_mention": str(cfg["require_mention"]).lower(),
+        f"{pre}.extra.allow_all_users": str(cfg["allow_all"]).lower(),
+        # Recommended defaults from the Buzz messaging docs: keep channels clean.
+        "display.platforms.buzz.interim_assistant_messages": "false",
+        "display.platforms.buzz.tool_progress": "off",
+    }
+    for key, value in settings.items():
+        config_set(p, key, value)
+    log(f"[config] {len(settings)} Buzz keys written for profile {p!r}")
+
+
+def write_soul(cfg: dict) -> None:
+    if not cfg["soul"]:
+        return
+    src = pathlib.Path(cfg["soul"]).expanduser()
+    if not src.is_file():
+        die(f"soul file not found: {src}")
+    dst = profile_dir(cfg["profile"]) / "SOUL.md"
+    dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    log(f"[soul] {src} -> {dst}")
+
+
+def restart_gateway(profile: str) -> None:
+    rc, out = sh(["hermes", "-p", profile, "gateway", "restart"], check=False)
+    if rc:
+        warn(f"gateway restart returned {rc}: {out}")
+    else:
+        log("[gateway] restarted")
+
+
+def verify(profile: str, attempts: int = 30, delay: float = 2.0) -> bool:
+    state = PROFILES / profile / "gateway_state.json"
+    for _ in range(attempts):
+        if state.exists():
+            try:
+                data = json.loads(state.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                data = {}
+            buzz = data.get("platforms", data).get("buzz") if isinstance(data, dict) else None
+            if isinstance(buzz, dict) and buzz.get("state") == "connected":
+                log("[verify] gateway_state.json: buzz connected")
+                return True
+        time.sleep(delay)
+    warn("buzz is not 'connected' in gateway_state.json yet; it may still be starting - re-check shortly")
+    return False
+
+
+# ---------------------------------------------------------------- main
+def print_plan(cfg: dict, existing_key: str) -> None:
+    mode = "community (any member)" if cfg["allow_all"] else f"whitelist ({cfg['allowed_users'] or 'EMPTY'})"
+    identity = "reuse key from profile .env" if existing_key and not cfg["rotate_key"] else "mint a NEW keypair"
+    log("---- PLAN (dry run, nothing changed) ----")
+    log(f"profile:     {cfg['profile']}")
+    log(f"relay:       {cfg['relay']}")
+    log(f"identity:    {identity}")
+    log(f"owner key:   {'provided' if cfg['owner_key'] else 'not provided (ok only if already a member)'}")
+    log(f"agent name:  {cfg['agent_name']}")
+    log(f"avatar:      {cfg['avatar'] or '-'}")
+    log(f"access:      {mode}; require_mention={cfg['require_mention']}")
+    log(f"channels:    {cfg['channels'] or 'all joined'}; home={cfg['home_channel'] or 'first watched'}")
+    log(f"cli path:    {cfg['cli_path']}")
+    log(f"soul:        {cfg['soul'] or '-'}")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Connect a Hermes profile to a Buzz community.")
+    parser.add_argument("--dry-run", action="store_true", help="resolve inputs and print the plan; change nothing")
+    parser.add_argument("--non-interactive", action="store_true", help="never prompt; fail on missing required env vars")
+    args = parser.parse_args(argv)
+
+    log("== buzz-hermes-profile-setup ==")
+    cfg = resolve_inputs(interactive=False if args.non_interactive else None)
+    profile_dir(cfg["profile"])
+    existing = read_existing_key(cfg["profile"])
+
+    if args.dry_run:
+        print_plan(cfg, existing)
+        return 0
+
+    cli = ensure_cli(cfg["cli_path"])
+
+    if existing and not cfg["rotate_key"]:
+        try:
+            secret = decode_private_key(existing)
+        except ValueError as exc:
+            die(f"existing BUZZ_PRIVATE_KEY in profile .env is invalid ({exc}); set BUZZ_INSTALL_ROTATE_KEY=true")
+        nsec, npub = bech32_encode("nsec", secret), bech32_encode("npub", pubkey_x(secret))
+        log(f"[identity] reusing existing key {npub}")
+    else:
+        nsec, npub, _ = generate_keypair()
+        secret = decode_private_key(nsec)
+        log(f"[identity] new keypair {npub}")
+
+    if is_member(cli, cfg, nsec):
+        log("[membership] key is already a relay member; skipping invite")
+    else:
+        mint_and_claim(cfg, secret)
+
+    set_profile(cli, cfg, nsec)
+    write_env(cfg["profile"], nsec)
+    write_config(cfg, cli)
+    write_soul(cfg)
+    restart_gateway(cfg["profile"])
+    ok = verify(cfg["profile"])
+
+    log("\n---- SUMMARY ----")
+    log(f"profile:  {cfg['profile']}")
+    log(f"npub:     {npub}")
+    log(f"pubkey:   {pubkey_x(secret).hex()}")
+    log(f"name:     {cfg['agent_name']}")
+    log(f"relay:    {cfg['relay']}")
+    log(f"member:   {'yes' if is_member(cli, cfg, nsec) else 'NO - see references/buzz-internals.md'}")
+    log("\nNext: DM the agent from a different account than the owner key and confirm it replies.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/test_buzz_hermes_profile_setup_skill.py
+++ b/tests/skills/test_buzz_hermes_profile_setup_skill.py
@@ -1,0 +1,412 @@
+"""Tests for the buzz-hermes-profile-setup optional skill.
+
+Covers:
+  - SKILL.md frontmatter meets the authoring standards (<=60-char description, fields,
+    human-first author credit).
+  - scripts/buzz_install.py imports with the standard library only.
+  - bech32 (NIP-19) and BIP-340 Schnorr against published test vectors.
+  - NIP-98 header construction and signature validity.
+  - Input resolution, .env key handling, config writes, invite flow, gateway verification,
+    and --dry-run, all with subprocess/network mocked out.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+import json
+import re
+import stat
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO / "optional-skills" / "devops" / "buzz-hermes-profile-setup"
+SCRIPT = SKILL_DIR / "scripts" / "buzz_install.py"
+
+# NIP-19 reference vectors.
+NSEC_VECTOR = "nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5"
+NSEC_HEX = "67dea2ed018072d675f5415ecfaed7d2597555e202d85b3d65ea4e58d2d92ffa"
+NPUB_VECTOR = "npub10elfcs4fr0l0r8af98jlmgdh9c8tcxjvz9qkw038js35mp4dma8qzvjptg"
+NPUB_HEX = "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"
+
+# BIP-340 test vector index 1 (deterministic auxiliary randomness).
+BIP340_SK = bytes.fromhex("B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF")
+BIP340_PK = "dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659"
+BIP340_AUX = bytes.fromhex("0000000000000000000000000000000000000000000000000000000000000001")
+BIP340_MSG = bytes.fromhex("243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89")
+BIP340_SIG = (
+    "6896bd60eeae296db48a229ff71dfe071bde413e6d43f917dc8dcf8c78de3341"
+    "8906d11ac976abccb20b091292bff4ea897efcb639ea871cfa95f6de339e4b0a"
+)
+
+
+@pytest.fixture(scope="module")
+def skill_source() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_source) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", skill_source, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("buzz_install", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def profiles(tmp_path, monkeypatch, mod):
+    root = tmp_path / "profiles"
+    (root / "agent").mkdir(parents=True)
+    monkeypatch.setattr(mod, "PROFILES", root)
+    return root
+
+
+BASE_ENV = {
+    "BUZZ_INSTALL_PROFILE": "agent",
+    "BUZZ_INSTALL_RELAY": "https://team.communities.buzz.xyz/",
+}
+
+
+def _set_env(monkeypatch, **extra):
+    for key in list(BASE_ENV) + [k for k in extra]:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in {**BASE_ENV, **extra}.items():
+        monkeypatch.setenv(key, value)
+
+
+def _verify_schnorr(mod, msg: bytes, pub_x: bytes, sig: bytes) -> bool:
+    """Minimal BIP-340 verifier built on the script's curve helpers."""
+    p, n = mod._P, mod._N
+    px = int.from_bytes(pub_x, "big")
+    y_sq = (pow(px, 3, p) + 7) % p
+    y = pow(y_sq, (p + 1) // 4, p)
+    if pow(y, 2, p) != y_sq:
+        return False
+    if y % 2:
+        y = p - y
+    r = int.from_bytes(sig[:32], "big")
+    s = int.from_bytes(sig[32:], "big")
+    if r >= p or s >= n:
+        return False
+    e = int.from_bytes(mod._tagged_hash("BIP0340/challenge", sig[:32] + pub_x + msg), "big") % n
+    sg = mod._point_mul(s)
+    ep = mod._point_mul((n - e) % n, (px, y))
+    rp = mod._point_add(sg, ep)
+    return rp is not None and rp[1] % 2 == 0 and rp[0] == r
+
+
+# ---------------------------------------------------------------- SKILL.md
+def test_skill_layout_exists() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+    assert SCRIPT.is_file()
+    assert (SKILL_DIR / "references" / "buzz-internals.md").is_file()
+
+
+def test_description_hardline(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars: {desc!r}"
+    assert desc.endswith(".")
+
+
+def test_required_frontmatter_fields(frontmatter) -> None:
+    for field in ("name", "description", "version", "author", "license", "platforms"):
+        assert field in frontmatter, f"missing frontmatter field: {field}"
+    assert frontmatter["name"] == SKILL_DIR.name
+    assert frontmatter["metadata"]["hermes"]["tags"]
+
+
+def test_author_credits_human_first(frontmatter) -> None:
+    assert str(frontmatter["author"]).startswith("Marco Rodrigues (dadhalfdev)")
+
+
+def test_skill_points_at_helper_script(skill_source) -> None:
+    assert "scripts/buzz_install.py" in skill_source
+    assert "--dry-run" in skill_source
+
+
+# ---------------------------------------------------------------- crypto primitives
+def test_script_is_stdlib_only(mod) -> None:
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert "coincurve" not in src
+    assert "import requests" not in src
+
+
+def test_bech32_nip19_vectors(mod) -> None:
+    assert mod.bech32_decode("nsec", NSEC_VECTOR).hex() == NSEC_HEX
+    assert mod.bech32_encode("nsec", bytes.fromhex(NSEC_HEX)) == NSEC_VECTOR
+    assert mod.bech32_decode("npub", NPUB_VECTOR).hex() == NPUB_HEX
+    assert mod.bech32_encode("npub", bytes.fromhex(NPUB_HEX)) == NPUB_VECTOR
+
+
+def test_bech32_rejects_bad_input(mod) -> None:
+    with pytest.raises(ValueError):
+        mod.bech32_decode("nsec", NSEC_VECTOR[:-1] + "q")  # checksum
+    with pytest.raises(ValueError):
+        mod.bech32_decode("nsec", NPUB_VECTOR)  # wrong hrp
+    with pytest.raises(ValueError):
+        mod.bech32_decode("nsec", NSEC_VECTOR[:10].upper() + NSEC_VECTOR[10:])  # mixed case
+
+
+def test_decode_private_key_accepts_nsec_and_hex(mod) -> None:
+    assert mod.decode_private_key(NSEC_VECTOR).hex() == NSEC_HEX
+    assert mod.decode_private_key(NSEC_HEX).hex() == NSEC_HEX
+    with pytest.raises(ValueError):
+        mod.decode_private_key("00" * 32)  # zero is out of range
+    with pytest.raises(ValueError):
+        mod.decode_private_key("not-a-key")
+
+
+def test_bip340_public_key_and_signature_vector(mod) -> None:
+    assert mod.pubkey_x(BIP340_SK).hex() == BIP340_PK
+    sig = mod.schnorr_sign(BIP340_MSG, BIP340_SK, aux=BIP340_AUX)
+    assert sig.hex() == BIP340_SIG
+
+
+def test_generate_keypair_round_trips_and_signs(mod) -> None:
+    nsec, npub, pub_hex = mod.generate_keypair()
+    secret = mod.bech32_decode("nsec", nsec)
+    assert mod.bech32_decode("npub", npub).hex() == pub_hex
+    assert mod.pubkey_x(secret).hex() == pub_hex
+    msg = hashlib.sha256(b"hello buzz").digest()
+    assert _verify_schnorr(mod, msg, bytes.fromhex(pub_hex), mod.schnorr_sign(msg, secret))
+
+
+def test_nip98_header_structure_and_signature(mod) -> None:
+    secret = bytes.fromhex(NSEC_HEX)
+    url = "https://team.communities.buzz.xyz/api/invites"
+    body = b"{}"
+    header = mod.sign_nip98(secret, url, body)
+    assert header.startswith("Nostr ")
+    event = json.loads(base64.b64decode(header[len("Nostr ") :]))
+    assert event["kind"] == 27235
+    assert event["pubkey"] == mod.pubkey_x(secret).hex()
+    assert ["u", url] in event["tags"]
+    assert ["method", "POST"] in event["tags"]
+    assert ["payload", hashlib.sha256(body).hexdigest()] in event["tags"]
+    serialized = json.dumps(
+        [0, event["pubkey"], event["created_at"], 27235, event["tags"], ""], separators=(",", ":")
+    ).encode()
+    assert event["id"] == hashlib.sha256(serialized).hexdigest()
+    assert _verify_schnorr(mod, bytes.fromhex(event["id"]), bytes.fromhex(event["pubkey"]), bytes.fromhex(event["sig"]))
+
+
+# ---------------------------------------------------------------- input resolution
+def test_resolve_inputs_from_env_normalizes(mod, monkeypatch) -> None:
+    _set_env(monkeypatch, BUZZ_INSTALL_ALLOW_ALL="no", BUZZ_INSTALL_ALLOWED_USERS="npub1a,npub1b")
+    cfg = mod.resolve_inputs(interactive=False)
+    assert cfg["relay"] == "https://team.communities.buzz.xyz"  # trailing slash stripped
+    assert cfg["agent_name"] == "agent"  # defaults to profile
+    assert cfg["allow_all"] is False
+    assert cfg["require_mention"] is True
+    assert cfg["rotate_key"] is False
+    assert cfg["presence"] == "online"
+    assert cfg["cli_path"].endswith("buzz")
+
+
+def test_resolve_inputs_missing_required_is_fatal(mod, monkeypatch) -> None:
+    for key in BASE_ENV:
+        monkeypatch.delenv(key, raising=False)
+    with pytest.raises(SystemExit):
+        mod.resolve_inputs(interactive=False)
+
+
+def test_resolve_inputs_rejects_bad_values(mod, monkeypatch) -> None:
+    _set_env(monkeypatch, BUZZ_INSTALL_RELAY="http://insecure.example")
+    with pytest.raises(SystemExit):
+        mod.resolve_inputs(interactive=False)
+    _set_env(monkeypatch, BUZZ_INSTALL_PRESENCE="busy")
+    with pytest.raises(SystemExit):
+        mod.resolve_inputs(interactive=False)
+    _set_env(monkeypatch, BUZZ_INSTALL_ALLOW_ALL="maybe")
+    with pytest.raises(SystemExit):
+        mod.resolve_inputs(interactive=False)
+
+
+def test_csv_json(mod) -> None:
+    assert mod.csv_json("") == "[]"
+    assert json.loads(mod.csv_json(" a, b ,,c ")) == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------- profile .env
+def test_write_env_replaces_existing_key_and_restricts_mode(mod, profiles) -> None:
+    env_path = profiles / "agent" / ".env"
+    env_path.write_text("OPENROUTER_API_KEY=x\nBUZZ_PRIVATE_KEY=old\n", encoding="utf-8")
+    mod.write_env("agent", "nsec1new")
+    lines = env_path.read_text(encoding="utf-8").splitlines()
+    assert lines == ["OPENROUTER_API_KEY=x", "BUZZ_PRIVATE_KEY=nsec1new"]
+    assert mod.read_existing_key("agent") == "nsec1new"
+    if sys.platform != "win32":
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+
+
+def test_write_env_creates_file_when_missing(mod, profiles) -> None:
+    assert mod.read_existing_key("agent") == ""
+    mod.write_env("agent", "nsec1fresh")
+    assert mod.read_existing_key("agent") == "nsec1fresh"
+
+
+def test_profile_dir_missing_is_fatal(mod, profiles) -> None:
+    with pytest.raises(SystemExit):
+        mod.profile_dir("ghost")
+
+
+# ---------------------------------------------------------------- invite flow (mocked curl)
+def _cfg(**overrides) -> dict:
+    cfg = {
+        "profile": "agent",
+        "relay": "https://team.communities.buzz.xyz",
+        "owner_key": NSEC_VECTOR,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def test_mint_and_claim_with_join_policy(mod, monkeypatch) -> None:
+    calls: list[tuple] = []
+    responses = iter(
+        [
+            (0, json.dumps({"code": "v2.abc"}), ""),
+            (0, json.dumps({"policy": {"version": "3"}}), ""),
+            (0, json.dumps({"receipt": "r-1"}), ""),
+            (0, json.dumps({"status": "joined", "role": "member"}), ""),
+        ]
+    )
+
+    def fake_curl(url, body=None, auth=None):
+        calls.append((url, body, auth))
+        return next(responses)
+
+    monkeypatch.setattr(mod, "curl", fake_curl)
+    agent_secret = bytes.fromhex(NPUB_HEX)  # any in-range scalar works as a secret here
+    mod.mint_and_claim(_cfg(), agent_secret)
+
+    assert [c[0].rsplit("/", 1)[-1] for c in calls] == ["invites", "join-policy", "accept-policy", "claim"]
+    # Mint is signed by the owner; claim is signed by the agent.
+    owner_pub = mod.pubkey_x(bytes.fromhex(NSEC_HEX)).hex()
+    agent_pub = mod.pubkey_x(agent_secret).hex()
+    mint_event = json.loads(base64.b64decode(calls[0][2][len("Nostr ") :]))
+    claim_event = json.loads(base64.b64decode(calls[3][2][len("Nostr ") :]))
+    assert mint_event["pubkey"] == owner_pub
+    assert claim_event["pubkey"] == agent_pub
+    assert calls[2][1] == {"code": "v2.abc", "policy_version": "3", "age_confirmed": True}
+    assert calls[3][1] == {"code": "v2.abc", "policy_receipt": "r-1"}
+
+
+def test_mint_and_claim_without_policy(mod, monkeypatch) -> None:
+    responses = iter(
+        [
+            (0, json.dumps({"code": "v2.xyz"}), ""),
+            (0, "{}", ""),
+            (0, json.dumps({"status": "joined", "role": "member"}), ""),
+        ]
+    )
+    calls: list[tuple] = []
+
+    def fake_curl(url, body=None, auth=None):
+        calls.append((url, body, auth))
+        return next(responses)
+
+    monkeypatch.setattr(mod, "curl", fake_curl)
+    mod.mint_and_claim(_cfg(), bytes.fromhex(NPUB_HEX))
+    assert len(calls) == 3
+    assert calls[2][1] == {"code": "v2.xyz"}
+
+
+def test_mint_and_claim_requires_owner_key(mod, monkeypatch) -> None:
+    monkeypatch.setattr(mod, "curl", mock.Mock(side_effect=AssertionError("network must not be touched")))
+    with pytest.raises(SystemExit):
+        mod.mint_and_claim(_cfg(owner_key=""), bytes.fromhex(NPUB_HEX))
+
+
+def test_mint_error_payload_is_fatal(mod, monkeypatch) -> None:
+    monkeypatch.setattr(mod, "curl", lambda *a, **k: (0, json.dumps({"error": "forbidden", "message": "nope"}), ""))
+    with pytest.raises(SystemExit):
+        mod.mint_and_claim(_cfg(), bytes.fromhex(NPUB_HEX))
+
+
+# ---------------------------------------------------------------- hermes wiring
+def test_write_config_sets_every_buzz_key(mod, monkeypatch) -> None:
+    seen: dict[str, str] = {}
+
+    def fake_sh(cmd, env=None, cwd=None, check=True):
+        assert cmd[:5] == ["hermes", "-p", "agent", "config", "set"]
+        seen[cmd[5]] = cmd[6]
+        return 0, ""
+
+    monkeypatch.setattr(mod, "sh", fake_sh)
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/bin/hermes" if name == "hermes" else None)
+    cfg = {
+        "profile": "agent",
+        "relay": "https://team.communities.buzz.xyz",
+        "channels": "c1,c2",
+        "home_channel": "c1",
+        "poll_interval": "4",
+        "allowed_users": "",
+        "require_mention": True,
+        "allow_all": False,
+    }
+    mod.write_config(cfg, "/opt/bin/buzz")
+    pre = "gateway.platforms.buzz"
+    assert seen[f"{pre}.enabled"] == "true"
+    assert seen[f"{pre}.extra.relay_url"] == cfg["relay"]
+    assert json.loads(seen[f"{pre}.extra.channels"]) == ["c1", "c2"]
+    assert seen[f"{pre}.extra.cli_path"] == "/opt/bin/buzz"
+    assert seen[f"{pre}.extra.allow_all_users"] == "false"
+    assert seen[f"{pre}.extra.require_mention"] == "true"
+    assert seen["display.platforms.buzz.tool_progress"] == "off"
+    assert f"{pre}.extra.credentials_file" not in seen
+
+
+def test_ensure_cli_uses_existing_executable(mod, tmp_path, monkeypatch) -> None:
+    binary = tmp_path / "buzz"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary.chmod(0o755)
+    monkeypatch.setattr(mod, "sh", mock.Mock(side_effect=AssertionError("must not build")))
+    assert mod.ensure_cli(str(binary)) == str(binary)
+
+
+def test_ensure_cli_falls_back_to_path(mod, tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(mod.shutil, "which", lambda name: "/usr/local/bin/buzz" if name == "buzz" else None)
+    monkeypatch.setattr(mod, "sh", mock.Mock(side_effect=AssertionError("must not build")))
+    assert mod.ensure_cli(str(tmp_path / "missing")) == "/usr/local/bin/buzz"
+
+
+def test_verify_reads_platform_state(mod, profiles) -> None:
+    state = profiles / "agent" / "gateway_state.json"
+    state.write_text(json.dumps({"platforms": {"buzz": {"state": "connected"}}}), encoding="utf-8")
+    assert mod.verify("agent", attempts=1, delay=0) is True
+    state.write_text(json.dumps({"platforms": {"buzz": {"state": "disconnected"}}}), encoding="utf-8")
+    assert mod.verify("agent", attempts=1, delay=0) is False
+    state.write_text("not json", encoding="utf-8")
+    assert mod.verify("agent", attempts=1, delay=0) is False
+
+
+# ---------------------------------------------------------------- dry run
+def test_dry_run_touches_nothing(mod, profiles, monkeypatch, capsys) -> None:
+    _set_env(monkeypatch)
+    monkeypatch.setattr(mod, "curl", mock.Mock(side_effect=AssertionError("no network in dry run")))
+    monkeypatch.setattr(mod, "sh", mock.Mock(side_effect=AssertionError("no subprocess in dry run")))
+    assert mod.main(["--dry-run", "--non-interactive"]) == 0
+    out = capsys.readouterr().out
+    assert "PLAN" in out
+    assert "mint a NEW keypair" in out
+    assert not (profiles / "agent" / ".env").exists()
+
+
+def test_dry_run_reports_key_reuse(mod, profiles, monkeypatch, capsys) -> None:
+    _set_env(monkeypatch)
+    (profiles / "agent" / ".env").write_text(f"BUZZ_PRIVATE_KEY={NSEC_VECTOR}\n", encoding="utf-8")
+    assert mod.main(["--dry-run", "--non-interactive"]) == 0
+    assert "reuse key from profile .env" in capsys.readouterr().out

--- a/tests/skills/test_buzz_hermes_profile_setup_skill.py
+++ b/tests/skills/test_buzz_hermes_profile_setup_skill.py
@@ -4,7 +4,9 @@ Covers:
   - SKILL.md frontmatter meets the authoring standards (<=60-char description, fields,
     human-first author credit).
   - scripts/buzz_install.py imports with the standard library only.
-  - bech32 (NIP-19) and BIP-340 Schnorr against published test vectors.
+  - bech32 (NIP-19) and BIP-340 Schnorr against *published* test vectors
+    (not sign-then-verify with the same code), plus a byte-exact cross-check
+    against Hermes' in-tree ``plugins/platforms/buzz/nostr_auth.py``.
   - NIP-98 header construction and signature validity.
   - Input resolution, .env key handling, config writes, invite flow, gateway verification,
     and --dry-run, all with subprocess/network mocked out.
@@ -28,21 +30,73 @@ REPO = Path(__file__).resolve().parents[2]
 SKILL_DIR = REPO / "optional-skills" / "devops" / "buzz-hermes-profile-setup"
 SCRIPT = SKILL_DIR / "scripts" / "buzz_install.py"
 
-# NIP-19 reference vectors.
+# Published NIP-19 bech32 examples (nsec / npub) from
+# https://github.com/nostr-protocol/nips/blob/master/19.md
 NSEC_VECTOR = "nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5"
 NSEC_HEX = "67dea2ed018072d675f5415ecfaed7d2597555e202d85b3d65ea4e58d2d92ffa"
 NPUB_VECTOR = "npub10elfcs4fr0l0r8af98jlmgdh9c8tcxjvz9qkw038js35mp4dma8qzvjptg"
 NPUB_HEX = "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"
 
-# BIP-340 test vector index 1 (deterministic auxiliary randomness).
-BIP340_SK = bytes.fromhex("B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF")
-BIP340_PK = "dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659"
-BIP340_AUX = bytes.fromhex("0000000000000000000000000000000000000000000000000000000000000001")
-BIP340_MSG = bytes.fromhex("243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89")
-BIP340_SIG = (
-    "6896bd60eeae296db48a229ff71dfe071bde413e6d43f917dc8dcf8c78de3341"
-    "8906d11ac976abccb20b091292bff4ea897efcb639ea871cfa95f6de339e4b0a"
-)
+# Official BIP-340 Schnorr vectors 0, 1, 2 from
+# https://github.com/bitcoin/bips/blob/master/bip-0340/test-vectors.csv
+# (32-byte messages, valid keys, deterministic aux). Compared byte-for-byte
+# against the BIP — a sign-then-verify loop on this same module would not
+# catch a systematic deviation that relays would reject.
+BIP340_VECTORS = [
+    {
+        "index": 0,
+        "sk": bytes.fromhex("00" * 31 + "03"),
+        "pk": "F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9",
+        "aux": bytes(32),
+        "msg": bytes(32),
+        "sig": (
+            "E907831F80848D1069A5371B402410364BDF1C5F8307B0084C55F1CE2DCA8215"
+            "25F66A4A85EA8B71E482A74F382D2CE5EBEEE8FDB2172F477DF4900D310536C0"
+        ),
+    },
+    {
+        "index": 1,
+        "sk": bytes.fromhex("B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF"),
+        "pk": "DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659",
+        "aux": bytes.fromhex("00" * 31 + "01"),
+        "msg": bytes.fromhex("243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89"),
+        "sig": (
+            "6896BD60EEAE296DB48A229FF71DFE071BDE413E6D43F917DC8DCF8C78DE3341"
+            "8906D11AC976ABCCB20B091292BFF4EA897EFCB639EA871CFA95F6DE339E4B0A"
+        ),
+    },
+    {
+        "index": 2,
+        "sk": bytes.fromhex("C90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B14E5C9"),
+        "pk": "DD308AFEC5777E13121FA72B9CC1B7CC0139715309B086C960E18FD969774EB8",
+        "aux": bytes.fromhex("C87AA53824B4D7AE2EB035A2B5BBBCCC080E76CDC6D1692C4B0B62D798E6D906"),
+        "msg": bytes.fromhex("7E2D58D8B3BCDF1ABADEC7829054F90DDA9805AAB56C77333024B9D0A508B75C"),
+        "sig": (
+            "5831AAEED7B44BB74E5EAB94BA9D4294C49BCF2A60728D8B4C200F50DD313C1B"
+            "AB745879A5AD954A72C45A91C3A51D3C7ADEA98D82F8481E0E1E03674A6F3FB7"
+        ),
+    },
+    {
+        "index": 3,
+        "sk": bytes.fromhex("0B432B2677937381AEF05BB02A66ECD012773062CF3FA2549E44F58ED2401710"),
+        "pk": "25D1DFF95105F5253C4022F628A996AD3A0D95FBF21D468A1B33F8C160D8F517",
+        "aux": bytes.fromhex("FF" * 32),
+        "msg": bytes.fromhex("FF" * 32),
+        "sig": (
+            "7EB0509757E246F19449885651611CB965ECC1A187DD51B64FDA1EDC9637D5EC"
+            "97582B9CB13DB3933705B32BA982AF5AF25FD78881EBB32771FC5922EFC66EA3"
+        ),
+    },
+]
+
+
+def _load_nostr_auth():
+    """Hermes' production BIP-340 signer — an independent implementation."""
+    path = REPO / "plugins" / "platforms" / "buzz" / "nostr_auth.py"
+    spec = importlib.util.spec_from_file_location("hermes_nostr_auth", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 @pytest.fixture(scope="module")
@@ -168,19 +222,38 @@ def test_decode_private_key_accepts_nsec_and_hex(mod) -> None:
         mod.decode_private_key("not-a-key")
 
 
-def test_bip340_public_key_and_signature_vector(mod) -> None:
-    assert mod.pubkey_x(BIP340_SK).hex() == BIP340_PK
-    sig = mod.schnorr_sign(BIP340_MSG, BIP340_SK, aux=BIP340_AUX)
-    assert sig.hex() == BIP340_SIG
+@pytest.mark.parametrize("vec", BIP340_VECTORS, ids=lambda v: f"bip340-{v['index']}")
+def test_schnorr_matches_official_bip340_vector(mod, vec) -> None:
+    """Byte-exact against the BIP CSV — not against a verifier we wrote."""
+    assert mod.pubkey_x(vec["sk"]).hex().upper() == vec["pk"]
+    sig = mod.schnorr_sign(vec["msg"], vec["sk"], aux=vec["aux"])
+    assert sig.hex().upper() == vec["sig"]
 
 
-def test_generate_keypair_round_trips_and_signs(mod) -> None:
+def test_signer_matches_in_tree_nostr_auth(mod) -> None:
+    """Same bytes as Hermes' production signer (independent implementation)."""
+    nostr_auth = _load_nostr_auth()
+    for vec in BIP340_VECTORS:
+        theirs = nostr_auth.schnorr_sign(
+            vec["msg"], vec["sk"].hex(), auxiliary_randomness=vec["aux"]
+        )
+        ours = mod.schnorr_sign(vec["msg"], vec["sk"], aux=vec["aux"])
+        assert ours == theirs
+        assert nostr_auth.public_key_hex(vec["sk"].hex()).upper() == vec["pk"]
+        assert theirs.hex().upper() == vec["sig"]
+
+
+def test_generate_keypair_round_trips_and_matches_nostr_auth(mod) -> None:
+    nostr_auth = _load_nostr_auth()
     nsec, npub, pub_hex = mod.generate_keypair()
     secret = mod.bech32_decode("nsec", nsec)
     assert mod.bech32_decode("npub", npub).hex() == pub_hex
-    assert mod.pubkey_x(secret).hex() == pub_hex
+    assert nostr_auth.public_key_hex(nsec) == pub_hex
     msg = hashlib.sha256(b"hello buzz").digest()
-    assert _verify_schnorr(mod, msg, bytes.fromhex(pub_hex), mod.schnorr_sign(msg, secret))
+    aux = bytes(range(32))
+    assert mod.schnorr_sign(msg, secret, aux=aux) == nostr_auth.schnorr_sign(
+        msg, nsec, auxiliary_randomness=aux
+    )
 
 
 def test_nip98_header_structure_and_signature(mod) -> None:
@@ -199,6 +272,8 @@ def test_nip98_header_structure_and_signature(mod) -> None:
         [0, event["pubkey"], event["created_at"], 27235, event["tags"], ""], separators=(",", ":")
     ).encode()
     assert event["id"] == hashlib.sha256(serialized).hexdigest()
+    # Signature is a valid BIP-340 Schnorr over the event id (own-code verifier
+    # is fine here — the signer itself is pinned to official vectors above).
     assert _verify_schnorr(mod, bytes.fromhex(event["id"]), bytes.fromhex(event["pubkey"]), bytes.fromhex(event["sig"]))
 
 


### PR DESCRIPTION
## What does this PR do?

Adds **`buzz-hermes-profile-setup`** as an official optional skill under `optional-skills/devops/`.

The bundled Buzz platform plugin (`plugins/platforms/buzz/`) is excellent once a profile has a Nostr key that is already a **relay member** of a community. Getting to that point on a self-hosted box is where people get stuck today, and the failure modes are silent:

- there is no prebuilt `buzz` CLI (must `cargo build -p buzz-cli`);
- `buzz channels add-member` returns `accepted:true` but does **not** grant relay membership — writes still 403 with `relay_membership_required`; only an invite mint+claim does;
- reusing the owner's own nsec makes the agent *be* the owner, so self-echo suppression silently drops the owner's messages;
- a bech32 encoder without final-group padding produces an nsec that round-trips to a *different* key;
- the relay sits behind Cloudflare, which rejects Python `urllib` (error 1010).

This skill ships one script that does the whole pipeline — locate/build the CLI, mint a dedicated keypair, owner mints an invite (NIP-98), accept the join policy if the community has one, agent claims (NIP-98), set the Buzz profile (name/avatar/about/NIP-05/presence), write `BUZZ_PRIVATE_KEY` to the profile `.env` (0600), `hermes -p <profile> config set` every Buzz key (matching the recommended defaults in `website/docs/user-guide/messaging/buzz.md`), restart the gateway, and confirm `gateway_state.json` reports `platforms.buzz.state == connected`.

**Standard library only.** bech32 (NIP-19) and BIP-340 Schnorr are implemented inline using the same construction as `plugins/platforms/buzz/nostr_auth.py`, so there is no `pip install`/`uv run --with` step. The script is idempotent (reuses the profile's existing key, skips the invite when already a member) and has `--dry-run` / `--non-interactive` so the agent can preview the plan and run headless.

Placed in `optional-skills/` rather than `skills/` because it is niche (Buzz users with a self-hosted gateway) and has a heavyweight first-run step (cargo build), per `skills/AGENTS.md`.

Originally published at https://github.com/dadhalfdev/buzz-hermes-profile-setup and reworked here to the authoring standards.

## Related Issue

None — new skill. Searched open/closed PRs and issues for `buzz skill` / `buzz setup`; the many `fix(buzz)`/`feat(buzz)` PRs are adapter work, none cover onboarding.

## Type of Change

- [x] 🎯 New skill (bundled or hub)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `optional-skills/devops/buzz-hermes-profile-setup/SKILL.md` — hardline format (53-char description, `When to Use → Prerequisites → How to Run → Quick Reference → Procedure → Pitfalls → Verification`, native tool names, `platforms: [linux, macos]`, `requires_toolsets: [terminal]`).
- `optional-skills/devops/buzz-hermes-profile-setup/scripts/buzz_install.py` — the installer (stdlib only; `curl` via `subprocess` for relay HTTP).
- `optional-skills/devops/buzz-hermes-profile-setup/references/buzz-internals.md` — relay vs channel membership, invite HTTP contract, NIP-98 signing, bech32 padding pitfall, verification via state files.
- `tests/skills/test_buzz_hermes_profile_setup_skill.py` — 29 tests, stdlib + pytest + `unittest.mock`, no network:
  - NIP-19 bech32 against published vectors, plus checksum / hrp / mixed-case rejection
  - BIP-340 against the official test vector (deterministic aux → byte-exact signature), and a verifier for random keys
  - NIP-98 header structure and signature validity
  - input resolution (env → normalization; fatal on missing required / bad values in non-TTY)
  - `.env` key replace-not-duplicate and 0600 (skipped on win32)
  - invite flow with mocked `curl`: mint signed by owner, claim signed by agent, join-policy branch and no-policy branch, error payloads fatal
  - `hermes config set` keys written, CLI resolution (existing path / PATH fallback, never builds), `gateway_state.json` parsing, `--dry-run` touches nothing

No changes outside these four new files.

## How to Test

1. `scripts/run_tests.sh tests/skills/test_buzz_hermes_profile_setup_skill.py -q` → 29 passed.
2. `scripts/run_tests.sh tests/skills/test_authoring_standards.py -q` → all pass (new skill included, no grandfather entry).
3. `python3 scripts/check-windows-footguns.py optional-skills/devops/buzz-hermes-profile-setup/scripts/buzz_install.py` → clean.
4. Dry run without touching anything:
   ```bash
   BUZZ_INSTALL_PROFILE=<existing-profile> BUZZ_INSTALL_RELAY=https://<c>.communities.buzz.xyz \
     python3 optional-skills/devops/buzz-hermes-profile-setup/scripts/buzz_install.py --dry-run --non-interactive
   ```
5. Real run on a host with a Hermes profile + gateway service and an owner key for a Buzz community: run without `--dry-run`, then confirm `~/.hermes/profiles/<name>/gateway_state.json` shows `"platforms": {"buzz": {"state": "connected"}}` and DM the agent from a non-owner account.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(skills): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the skill tests + authoring standards (`tests/skills/`) and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 6.8), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — SKILL.md + references are the docs; no changes to `website/` needed
- [x] `cli-config.yaml.example` — N/A (no new config keys; the script writes existing `gateway.platforms.buzz.*` keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform: `platforms: [linux, macos]` declared; script uses `pathlib`, `shutil.which`, no POSIX-only primitives; `check-windows-footguns.py` clean
