### PR TITLE
chore: release v0.21.1 (2026.9.7)

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -3,8 +3,8 @@
 import os
 import sys
 
-__version__ = "0.21.0"
-__release_date__ = "2026.8.31"
+__version__ = "0.21.1"
+__release_date__ = "2026.9.7"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "hermes-agent"
-version = "0.21.0"
+version = "0.21.1"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/uv.lock
+++ b/uv.lock
@@ -1670,7 +1670,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.21.0"
+version = "0.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
This prepares Hermes Agent v0.21.1 (v2026.9.7) so downstream consumers can deploy the current main as a tagged patch release.

- Bumps the CLI version/release date, project version, and lockfile self-version only.
- Full curated notes and contributor credits for this window are deferred to v0.22.0, whose curation baseline remains v2026.8.31.
- Window at base `6178e9f4eed8d99f4fc550add939d58c7bed6206`: 5,139 non-merge commits, 632 merged PRs, 4,364 files changed (+601,014 / −768,419), excluding this release commit.

## Validation

- Runtime import, pyproject, and lockfile agree on 0.21.1; release date is 2026.9.7.
- CI-pinned uv 0.9.28: `uv lock --check` passes (255 packages); no dependency changes.
- Ruff, Windows-footgun scan, compatibility-pointer scan, and `git diff --check` pass.
- Bootstrap history reviewed: no full-file rewrite-shaped installer commits in this window.
- Revert scan reviewed; brief notes make no claims about removed features.
- No behavioral fix is introduced by this release PR; runtime version import was exercised. Broad tests run in CI, not as a local publication prerequisite.
- Merge, tag, and publication await maintainer approval.

## Infographic

![Hermes Agent v0.21.1 patch release](https://v3b.fal.media/files/b/0aa98502/hRsd3uBG2KwD26nvqLTht_rgpBkq2r.png)
