### PR TITLE
fix(anthropic): merge multiple system messages instead of overwriting

### DIFF
--- a/agent/anthropic_message_convert.py
+++ b/agent/anthropic_message_convert.py
@@ -679,6 +679,23 @@ def _convert_system_content(content: Any) -> Any:
     ]
 
 
+def _merge_system_segments(segments: List[Any]) -> Any:
+    """Fold multiple converted system segments into one Anthropic ``system`` value: plain strings
+    join with a blank line; any block-list segment (cache_control present) forces the block-list
+    form, wrapping plain strings as text blocks. Breakpoints stay on their original blocks, so a
+    cached prefix is unaffected by segments appended after it (e.g. an ``llm_request`` middleware
+    note) — and vice versa, the earlier segments survive instead of being overwritten."""
+    if all(isinstance(seg, str) for seg in segments):
+        return "\n\n".join(segments)
+    blocks: List[Dict[str, Any]] = []
+    for seg in segments:
+        if isinstance(seg, list):
+            blocks.extend(b for b in seg if isinstance(b, dict))
+        else:
+            blocks.append({"type": "text", "text": seg if isinstance(seg, str) else str(seg)})
+    return blocks
+
+
 def convert_messages_to_anthropic(
     messages: List[Dict], base_url: str | None = None, model: str | None = None
 ) -> Tuple[Optional[Any], List[Dict]]:
@@ -688,11 +705,14 @@ def convert_messages_to_anthropic(
     (proprietary, they 400 on them); Kimi-family endpoints/models keep unsigned
     reasoning_content-derived blocks, which Kimi requires even when empty."""
     system = None
+    system_segments: List[Any] = []
     result: List[Dict[str, Any]] = []
     for m in messages:
         role = m.get("role", "user")
         if role == "system":
-            system = _convert_system_content(m.get("content", ""))
+            converted = _convert_system_content(m.get("content", ""))
+            if converted:
+                system_segments.append(converted)
         elif role == "assistant":
             result.append(_convert_assistant_message(m))
         elif role == "tool":
@@ -705,4 +725,6 @@ def convert_messages_to_anthropic(
     _manage_thinking_signatures(result, base_url, model)
     _evict_old_screenshots(result)
     _scrub_blank_text_blocks(result)
+    if system_segments:
+        system = system_segments[0] if len(system_segments) == 1 else _merge_system_segments(system_segments)
     return system, result

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -730,6 +730,55 @@ class TestConvertMessages:
         assert system[0]["cache_control"] == {"type": "ephemeral"}
 
 
+    def test_second_system_message_merges_instead_of_overwriting(self):
+        # llm_request middleware may append a {"role": "system"} note; the real
+        # system prompt must survive the fold into the separate system param (#105370)
+        messages = [
+            {"role": "system", "content": "REAL SYSTEM PROMPT"},
+            {"role": "user", "content": "run the query"},
+            {"role": "system", "content": "PLUGIN NOTE"},
+        ]
+        system, result = convert_messages_to_anthropic(messages)
+        assert "REAL SYSTEM PROMPT" in system
+        assert "PLUGIN NOTE" in system
+        assert all(m["role"] != "system" for m in result)
+
+
+    def test_merged_system_promotes_to_block_list_when_any_segment_is_cached(self):
+        messages = [
+            {"role": "system", "content": [
+                {"type": "text", "text": "System prompt", "cache_control": {"type": "ephemeral"}},
+            ]},
+            {"role": "user", "content": "Hi"},
+            {"role": "system", "content": "PLUGIN NOTE"},
+        ]
+        system, _ = convert_messages_to_anthropic(messages)
+        assert isinstance(system, list)
+        assert system[0]["cache_control"] == {"type": "ephemeral"}
+        assert system[-1] == {"type": "text", "text": "PLUGIN NOTE"}
+
+
+    def test_merged_system_keeps_breakpoint_when_cached_segment_comes_last(self):
+        messages = [
+            {"role": "system", "content": "REAL SYSTEM PROMPT"},
+            {"role": "system", "content": [
+                {"type": "text", "text": "PLUGIN NOTE", "cache_control": {"type": "ephemeral"}},
+            ]},
+        ]
+        system, _ = convert_messages_to_anthropic(messages)
+        assert system[0] == {"type": "text", "text": "REAL SYSTEM PROMPT"}
+        assert system[1]["cache_control"] == {"type": "ephemeral"}
+
+
+    def test_trailing_empty_system_message_does_not_blank_the_prompt(self):
+        messages = [
+            {"role": "system", "content": "REAL SYSTEM PROMPT"},
+            {"role": "system", "content": ""},
+        ]
+        system, _ = convert_messages_to_anthropic(messages)
+        assert system == "REAL SYSTEM PROMPT"
+
+
     def test_assistant_cache_control_blocks_are_preserved(self):
         messages = apply_anthropic_cache_control([
             {"role": "system", "content": "System prompt"},


### PR DESCRIPTION
## What does this PR do?

`convert_messages_to_anthropic` folded every `role == "system"` message into Anthropic's separate `system` param with a plain assignment, so with more than one system message the **last one silently replaced every earlier one** — including the agent's real system prompt. A trailing empty system message blanked it entirely. Neither produced any diagnostic: the turn proceeded with no system prompt.

This is reachable from a supported extension point: `apply_llm_request_middleware` documents `{"request": {...}}` as replacing the provider kwargs, and `messages` is part of those kwargs — so a plugin appending a `{"role": "system"}` note from `llm_request` middleware destroys the prompt (see the issue's repro).

The fix collects the converted system segments and folds them instead of overwriting:

- plain-string segments join with a blank line;
- if any segment is a block list (i.e. `cache_control` markers are present), the merge promotes to the block-list form, wrapping plain strings as `{"type": "text", ...}` blocks;
- cache breakpoints stay on their original blocks, so a cached prefix is unaffected by segments appended after it — and vice versa.

A single system message (the normal path) is returned unchanged, and empty/`None` segments are dropped so they can no longer blank the merged prompt.

## Related Issue

Fixes #105370

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_message_convert.py`: added `_merge_system_segments` (fold multiple converted system segments: string join, or promote to block list when any segment carries `cache_control`); `convert_messages_to_anthropic` now accumulates system segments and merges them at the end instead of assigning per message.
- `tests/agent/test_anthropic_adapter.py`: 4 regression tests — merge-not-overwrite (the issue's repro shape), promotion to block list when the first segment is cached, breakpoint preservation when the cached segment comes last, and trailing-empty-system no longer blanks the prompt.

## How to Test

1. Run the reproduction from the issue (provider-shape level, no API call needed):

```python
from agent.anthropic_message_convert import convert_messages_to_anthropic

BASE = [
    {"role": "system", "content": "REAL SYSTEM PROMPT"},
    {"role": "user",   "content": "run the query"},
]
system2, msgs2 = convert_messages_to_anthropic(
    BASE + [{"role": "system", "content": "PLUGIN NOTE"}])
print("after append :", repr(system2))
print("REAL PROMPT SURVIVED:", "REAL SYSTEM PROMPT" in str(system2))
```

Observed result on this branch: `after append : 'REAL SYSTEM PROMPT\n\nPLUGIN NOTE'` / `REAL PROMPT SURVIVED: True` (upstream main prints `'PLUGIN NOTE'` / `False`).

2. `pytest tests/agent/test_anthropic_adapter.py -q` — 99 passed (includes the 4 new tests).
3. `pytest tests/agent/test_anthropic_kimi_signed_thinking_replay.py tests/agent/test_anthropic_request_blank_block_guard.py tests/agent/test_anthropic_thinking_block_order.py tests/agent/test_deepseek_anthropic_thinking.py tests/agent/test_kimi_coding_anthropic_thinking.py -q` — all pass. (`test_nous_portal_anthropic_wire.py` has 2 failures on a clean upstream/main checkout too — local-environment auth-header tests, unrelated to this change.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: full `tests/agent/` Anthropic conversion suites listed above; 2 pre-existing local failures in `test_nous_portal_anthropic_wire.py` reproduce on clean upstream/main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (the new helper carries a docstring covering its contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python data-shaping, no OS surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

See "How to Test" for the before/after repro output.
