### PR TITLE
feat(kanban): let workers close the gates they opened (kanban_close_gate)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2521,6 +2521,113 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+def _unlink_blocking_parents(conn: sqlite3.Connection, task_id: str) -> list[str]:
+    """Delete parent links whose parent is not yet terminal (a parking sentinel is
+    ``blocked``), so a gate can be completed. Deliberately does NOT call
+    ``recompute_ready``: the caller completes in the same txn, so the gate never
+    transiently lands ``ready`` (dispatcher bait for an ``assignee``-carrying gate)."""
+    rows = conn.execute(
+        "SELECT l.parent_id FROM task_links l JOIN tasks p ON p.id = l.parent_id "
+        "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived')",
+        (task_id,),
+    ).fetchall()
+    unlinked = [r["parent_id"] for r in rows]
+    for pid in unlinked:
+        conn.execute(
+            "DELETE FROM task_links WHERE parent_id = ? AND child_id = ?", (pid, task_id),
+        )
+        _append_event(conn, task_id, "unlinked", {"parent": pid, "child": task_id})
+    return unlinked
+
+
+def _complete_task_write(
+    conn: sqlite3.Connection, task_id: str, *, result: Optional[str],
+    summary: Optional[str], metadata: Optional[dict], verified_cards: list[str],
+    expected_run_id: Optional[int], now: int,
+) -> tuple[bool, Optional[int]]:
+    """The completion write, inside an ALREADY-OPEN write txn; returns ``(ok, run_id)``.
+
+    ``complete_task`` re-checks ``_parents_satisfied`` before calling; ``close_gate``
+    unlinks still-open parents first. Extracted so both paths share one source of truth
+    for the status/run/event writes (no divergence between the two entry points)."""
+    prior_status = _task_status(conn, task_id)
+    sql = """
+            UPDATE tasks
+               SET status       = 'done',
+                   result       = ?,
+                   completed_at = ?,
+                   claim_lock   = NULL,
+                   claim_expires= NULL,
+                   worker_pid   = NULL,
+                   block_kind   = NULL,
+                   block_recurrences = 0
+             WHERE id = ?
+               AND status IN ('running', 'ready', 'blocked', 'review')
+            """
+    params: tuple = (result, now, task_id)
+    if expected_run_id is not None:
+        sql += " AND current_run_id = ?"
+        params = (*params, int(expected_run_id))
+    if conn.execute(sql, params).rowcount != 1:
+        return False, None
+    if isinstance(metadata, dict):
+        _stage_completion_artifacts(conn, task_id, metadata, now)
+    run_id = _end_run(
+        conn, task_id, outcome="completed", status="done", summary=summary,
+        metadata=metadata,
+    )
+    # Never-claimed task: synthesize a run so the handoff fields survive.
+    if run_id is None and (summary or metadata or result or prior_status == "review"):
+        synth_summary, synth_metadata = summary, metadata
+        if prior_status == "review" and not synth_summary and not synth_metadata:
+            synth_summary = _REVIEW_APPROVED_NOTE
+            synth_metadata = {"source_status": "review", "approval": "manual"}
+        run_id = _synthesize_ended_run(
+            conn, task_id, outcome="completed", summary=synth_summary, metadata=synth_metadata,
+        )
+    event_summary = summary
+    if prior_status == "review" and not event_summary:
+        event_summary = _REVIEW_APPROVED_NOTE
+    _append_event(
+        conn, task_id, "completed",
+        _completed_event_payload(result, event_summary, verified_cards, metadata),
+        run_id=run_id,
+    )
+    return True, run_id
+
+
+def close_gate(
+    conn: sqlite3.Connection, gate_id: str, *, result: Optional[str] = None,
+    summary: Optional[str] = None, metadata: Optional[dict] = None,
+    expected_run_id: Optional[int] = None, fire_lifecycle_hook: bool = True,
+) -> bool:
+    """Atomically close a worker-opened gate: unlink its still-open (parking-sentinel)
+    parents and complete it in ONE txn, so an ``assignee``-carrying gate never sits
+    ``ready``. The caller (``kanban_close_gate``) has already verified the gate is
+    ``blocked`` and belongs to this worker; ``created_cards`` is intentionally
+    unsupported — a gate close claims no child cards."""
+    now = int(time.time())
+    metadata = _merge_completion_prose_artifacts(
+        conn, gate_id, metadata, summary=summary, result=result,
+    )
+    handoff_summary = summary if summary is not None else result
+    with write_txn(conn):
+        _unlink_blocking_parents(conn, gate_id)
+        ok, run_id = _complete_task_write(
+            conn, gate_id, result=result, summary=handoff_summary, metadata=metadata,
+            verified_cards=[], expected_run_id=expected_run_id, now=now,
+        )
+        if not ok:
+            return False
+    _clear_failure_counter(conn, gate_id)
+    recompute_ready(conn)
+    _cleanup_workspace(conn, gate_id)
+    done_task = get_task(conn, gate_id)
+    if fire_lifecycle_hook:
+        _fire_task_hook("kanban_task_completed", done_task, gate_id, run_id, summary=handoff_summary)
+    return True
+
+
 def complete_task(
     conn: sqlite3.Connection, task_id: str, *, result: Optional[str] = None,
     summary: Optional[str] = None, metadata: Optional[dict] = None,
@@ -2557,49 +2664,12 @@ def complete_task(
             return False
         if acceptance is not None and not record_acceptance(conn, task_id, acceptance):
             return False
-        prior_status = _task_status(conn, task_id)
-        sql = """
-                UPDATE tasks
-                   SET status       = 'done',
-                       result       = ?,
-                       completed_at = ?,
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL,
-                       block_kind   = NULL,
-                       block_recurrences = 0
-                 WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked', 'review')
-                """
-        params: tuple = (result, now, task_id)
-        if expected_run_id is not None:
-            sql += " AND current_run_id = ?"
-            params = (*params, int(expected_run_id))
-        if conn.execute(sql, params).rowcount != 1:
+        ok, run_id = _complete_task_write(
+            conn, task_id, result=result, summary=handoff_summary, metadata=metadata,
+            verified_cards=verified_cards, expected_run_id=expected_run_id, now=now,
+        )
+        if not ok:
             return False
-        if isinstance(metadata, dict):
-            _stage_completion_artifacts(conn, task_id, metadata, now)
-        run_id = _end_run(
-            conn, task_id, outcome="completed", status="done", summary=handoff_summary,
-            metadata=metadata,
-        )
-        # Never-claimed task: synthesize a run so the handoff fields survive.
-        if run_id is None and (summary or metadata or result or prior_status == "review"):
-            synth_summary, synth_metadata = handoff_summary, metadata
-            if prior_status == "review" and not synth_summary and not synth_metadata:
-                synth_summary = _REVIEW_APPROVED_NOTE
-                synth_metadata = {"source_status": "review", "approval": "manual"}
-            run_id = _synthesize_ended_run(
-                conn, task_id, outcome="completed", summary=synth_summary, metadata=synth_metadata,
-            )
-        event_summary = handoff_summary
-        if prior_status == "review" and not event_summary:
-            event_summary = _REVIEW_APPROVED_NOTE
-        _append_event(
-            conn, task_id, "completed",
-            _completed_event_payload(result, event_summary, verified_cards, metadata),
-            run_id=run_id,
-        )
     _flag_phantom_prose_refs(conn, task_id, run_id, summary, result, verified_cards)
     # Success wipes the breaker counter (history stays on the event log).
     _clear_failure_counter(conn, task_id)

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1161,3 +1161,142 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# kanban_close_gate — the sanctioned narrow cross-task close for workers
+# ---------------------------------------------------------------------------
+
+def _make_gate(worker_env, *, created_by="test-worker", link_to_worker=True, blocked=True):
+    """Create a gate (or card) the worker may or may not be allowed to close."""
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
+    try:
+        parents = []
+        if blocked:
+            sentinel = kb.create_task(
+                conn, title="parking sentinel", assignee="human", initial_status="blocked",
+            )
+            parents = [sentinel]
+        gate = kb.create_task(
+            conn, title="Gate: Lucas release", assignee="test-worker",
+            created_by=created_by, parents=parents,
+            initial_status="blocked" if blocked else "running",
+        )
+        if link_to_worker:
+            kb.link_tasks(conn, parent_id=gate, child_id=worker_env)
+    finally:
+        conn.close()
+    return gate
+
+
+def test_close_gate_happy_path(worker_env):
+    """A worker may close a blocked gate it opened (created_by == profile) that
+    lists its own task among its children — the sanctioned narrow close."""
+    from tools import kanban_tools as kt
+    gate = _make_gate(worker_env)
+
+    out = kt._handle_close_gate({"gate_id": gate, "result": "Lucas said ship it"})
+    d = json.loads(out)
+    assert d.get("ok") is True, d
+    assert d.get("status") == "done"
+    assert d.get("unblocked_child") == worker_env
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
+    try:
+        done = kb.get_task(conn, gate)
+        assert done.status == "done"
+        assert done.result == "Lucas said ship it"
+        # The parking sentinel parent was unlinked; no residual parent edge.
+        assert kb.parent_ids(conn, gate) == []
+    finally:
+        conn.close()
+
+
+def test_close_gate_refuses_when_not_opened_by_this_worker(worker_env):
+    """created_by must be the worker's own profile — a gate another profile
+    opened is off limits even if it lists this task as a child."""
+    from tools import kanban_tools as kt
+    gate = _make_gate(worker_env, created_by="vx-spec")
+
+    out = kt._handle_close_gate({"gate_id": gate, "result": "x"})
+    d = json.loads(out)
+    assert d.get("error")
+    assert "created by" in d["error"]
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
+    try:
+        assert kb.get_task(conn, gate).status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_close_gate_refuses_when_child_not_listed(worker_env):
+    """The gate must list the worker's current task among its children; a gate
+    the worker opened that does not block this task is not closable here."""
+    from tools import kanban_tools as kt
+    gate = _make_gate(worker_env, link_to_worker=False)
+
+    out = kt._handle_close_gate({"gate_id": gate, "result": "x"})
+    d = json.loads(out)
+    assert d.get("error")
+    assert "children" in d["error"]
+
+
+def test_close_gate_refuses_when_not_blocked(worker_env):
+    """close_gate only closes blocked gates; a ready card the worker opened is
+    not a gate and must not be reachable through this narrow close."""
+    from tools import kanban_tools as kt
+    gate = _make_gate(worker_env, blocked=False)
+
+    out = kt._handle_close_gate({"gate_id": gate, "result": "x"})
+    d = json.loads(out)
+    assert d.get("error")
+    assert "not blocked" in d["error"]
+
+
+def test_close_gate_requires_worker_context(monkeypatch, worker_env):
+    """Without HERMES_KANBAN_TASK (an orchestrator) close_gate points at
+    kanban_complete instead of silently no-opping."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from tools import kanban_tools as kt
+    out = kt._handle_close_gate({"gate_id": "t_whatever", "result": "x"})
+    d = json.loads(out)
+    assert d.get("error")
+    assert "HERMES_KANBAN_TASK" in d["error"]
+
+
+def test_refused_complete_leaves_diagnostic_comment(worker_env):
+    """A refused cross-task lifecycle mutation is loud: it leaves a diagnostic
+    comment on the TARGET card, not just a warning in a log nobody reads."""
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
+    try:
+        other = kb.create_task(conn, title="sibling")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (other,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({"task_id": other, "summary": "HIJACK"})
+    d = json.loads(out)
+    assert d.get("ok") is not True
+    assert "refusing to mutate" in d.get("error", "")
+    # The guard now also names the sanctioned alternative.
+    assert "kanban_close_gate" in d.get("error", "")
+
+    conn = kbc.connect()
+    try:
+        # Target still untouched, but the refusal is recorded on it.
+        assert kb.get_task(conn, other).status == "ready"
+        comments = kb.list_comments(conn, other)
+        assert any("refused lifecycle mutation" in c.body for c in comments)
+    finally:
+        conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -21,7 +21,8 @@ from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get, load_config
 from tools.kanban_tools_schemas import (
     KANBAN_ATTACH_SCHEMA,
-    KANBAN_ATTACH_URL_SCHEMA, KANBAN_ATTACHMENTS_SCHEMA, KANBAN_BLOCK_SCHEMA, KANBAN_COMMENT_SCHEMA,
+    KANBAN_ATTACH_URL_SCHEMA, KANBAN_ATTACHMENTS_SCHEMA, KANBAN_BLOCK_SCHEMA,
+    KANBAN_CLOSE_GATE_SCHEMA, KANBAN_COMMENT_SCHEMA,
     KANBAN_COMPLETE_SCHEMA, KANBAN_CREATE_SCHEMA, KANBAN_HEARTBEAT_SCHEMA, KANBAN_LINK_SCHEMA,
     KANBAN_LIST_SCHEMA, KANBAN_REQUEST_CHANGES_SCHEMA, KANBAN_REQUEST_REVIEW_SCHEMA,
     KANBAN_SHOW_SCHEMA, KANBAN_UNBLOCK_SCHEMA)
@@ -161,7 +162,25 @@ def _stamp_worker_session_metadata(task_id: str, metadata: Optional[dict]) -> Op
     return {**(metadata or {}), "worker_session_id": session_id} if session_id else metadata
 
 
-def _enforce_worker_task_ownership(tid: str) -> None:
+def _record_refusal_diagnostic(tool_name: str, env_tid: str, tid: str, board: Optional[str]) -> None:
+    """Best-effort loud artifact for a refused cross-task lifecycle mutation: a
+    diagnostic comment on the TARGET card, so a silently-survived refusal is still
+    visible where a human looks instead of only in a log nobody reads."""
+    try:
+        author = os.environ.get("HERMES_PROFILE") or "worker"
+        body = (
+            f"[refused lifecycle mutation] {tool_name or 'a kanban tool'} by {author} "
+            f"(scoped to {env_tid}) on this card was refused by the ownership guard; "
+            f"no state changed. If this card is a gate you opened to unblock {env_tid}, "
+            f"use kanban_close_gate instead of {tool_name or 'kanban_complete'}."
+        )
+        with _board(board, quiet_close=True) as (kb, conn):
+            kb.add_comment(conn, tid, author=author, body=body)
+    except Exception:
+        logger.debug("refusal diagnostic on %s failed", tid, exc_info=True)
+
+
+def _enforce_worker_task_ownership(tid: str, *, tool_name: str = "", board: Optional[str] = None) -> None:
     """A dispatcher-spawned worker may only mutate its own HERMES_KANBAN_TASK; a
     prompt-injected ``task_id`` must not corrupt sibling/cross-tenant runs.
     Orchestrators (toolset enabled, no env task) legitimately route child tasks.
@@ -172,9 +191,11 @@ def _enforce_worker_task_ownership(tid: str) -> None:
     """
     env_tid = os.environ.get("HERMES_KANBAN_TASK")
     if env_tid and tid != env_tid:
+        _record_refusal_diagnostic(tool_name, env_tid, tid, board)
         raise _Reject(
             f"worker is scoped to task {env_tid}; refusing to mutate {tid}. Use kanban_comment "
-            f"to hand off information to other tasks, or kanban_create to spawn follow-up work.")
+            f"to hand off information to other tasks, kanban_create to spawn follow-up work, or "
+            f"kanban_close_gate to close a gate you opened that lists this task among its children.")
 
 
 def _worker_guard(tool_name: str, args: dict) -> str:
@@ -182,7 +203,7 @@ def _worker_guard(tool_name: str, args: dict) -> str:
     resolution, task-scope ownership. Returns the task id."""
     _reject_delegated_child_mutation(tool_name)
     tid = _require_task_id(args)
-    _enforce_worker_task_ownership(tid)
+    _enforce_worker_task_ownership(tid, tool_name=tool_name, board=args.get("board"))
     return tid
 
 
@@ -625,6 +646,45 @@ def _handle_block(args: dict, **kw) -> str:
         return _ok_landed(kb, conn, tid, "blocked", block_kind=kind)
 
 
+@_kanban_handler("kanban_close_gate")
+def _handle_close_gate(args: dict, **kw) -> str:
+    """Close a gate this worker itself opened, to unblock its own current task.
+
+    The one sanctioned cross-task completion for a dispatcher worker: the gate
+    must be ``blocked``, ``created_by`` this worker's profile, and list the
+    worker's current task among its children. Unlink + complete are atomic so
+    the gate never sits ``ready`` (dispatcher bait)."""
+    _reject_delegated_child_mutation("kanban_close_gate")
+    gate_id = args.get("gate_id")
+    _check(gate_id, "gate_id is required")
+    gate_id = str(gate_id)
+    env_tid = os.environ.get("HERMES_KANBAN_TASK")
+    _check(env_tid, "kanban_close_gate is a worker tool (HERMES_KANBAN_TASK required); "
+                    "an orchestrator closes gates with kanban_complete")
+    summary = _redact_opt(args.get("summary"))
+    result = _redact_opt(args.get("result"))
+    metadata = args.get("metadata")
+    _require_dict_metadata(metadata)
+    _check(summary or result, "provide at least one of: summary, result (the evidence that resumed work)")
+    with _board(args.get("board")) as (kb, conn):
+        gate = kb.get_task(conn, gate_id)
+        _check(gate is not None, f"gate {gate_id} not found")
+        _check((gate.status or "") == "blocked",
+               f"gate {gate_id} is {gate.status or 'unknown'}, not blocked — nothing to close")
+        profile = os.environ.get("HERMES_PROFILE") or ""
+        _check(bool(profile) and gate.created_by == profile,
+               f"refusing to close {gate_id}: it was created by {gate.created_by or 'unknown'}, "
+               f"not this worker ({profile or 'unknown'})")
+        _check(env_tid in kb.child_ids(conn, gate_id),
+               f"refusing to close {gate_id}: it does not list this worker's task "
+               f"{env_tid} among its children")
+        ok = kb.close_gate(conn, gate_id, result=result, summary=summary, metadata=metadata)
+        _check(ok, f"could not close {gate_id}")
+        landed = kb.get_task(conn, gate_id)
+        return _ok(task_id=gate_id, status=landed.status if landed else "done",
+                   unblocked_child=env_tid)
+
+
 @_kanban_handler("kanban_request_review")
 def _handle_request_review(args: dict, **kw) -> str:
     """Move implementation into the first-class review phase."""
@@ -965,6 +1025,7 @@ _TOOLS = (
     ("kanban_list", KANBAN_LIST_SCHEMA, _handle_list, "📋"),
     ("kanban_complete", KANBAN_COMPLETE_SCHEMA, _handle_complete, "✔"),
     ("kanban_block", KANBAN_BLOCK_SCHEMA, _handle_block, "⏸"),
+    ("kanban_close_gate", KANBAN_CLOSE_GATE_SCHEMA, _handle_close_gate, "🚪"),
     ("kanban_request_review", KANBAN_REQUEST_REVIEW_SCHEMA, _handle_request_review, "👀"),
     ("kanban_request_changes", KANBAN_REQUEST_CHANGES_SCHEMA, _handle_request_changes, "↩"),
     ("kanban_heartbeat", KANBAN_HEARTBEAT_SCHEMA, _handle_heartbeat, "💓"),

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -198,6 +198,33 @@ KANBAN_BLOCK_SCHEMA = _schema(
     ["reason"],
 )
 
+KANBAN_CLOSE_GATE_SCHEMA = _schema(
+    "kanban_close_gate",
+    (
+        "Close a gate this worker itself opened, to unblock its own current "
+        "task. The one sanctioned cross-task completion for a dispatcher "
+        "worker: the gate must be 'blocked', ``created_by`` this worker's "
+        "profile, and list the worker's current task among its children. "
+        "Unlink + complete are atomic, so the gate never sits 'ready'. A "
+        "worker closing a card it did not open, or completing other cards, "
+        "must instead use kanban_complete on its OWN task (the ownership "
+        "guard refuses every other cross-task mutation)."
+    ),
+    {
+        "gate_id": _prop("string", "The blocked gate task id to close."),
+        "summary": _prop("string", (
+                "Optional 1-2 sentence handoff describing why the gate's "
+                "resume condition is now met."
+        )),
+        "result": _prop("string", (
+                "Short result line — the evidence that resumed work "
+                "(e.g. a PR URL or a human answer)."
+        )),
+        "metadata": _prop("object", "Optional structured handoff metadata."),
+    },
+    ["gate_id"],
+)
+
 KANBAN_REQUEST_REVIEW_SCHEMA = _schema(
     "kanban_request_review",
     (


### PR DESCRIPTION
## Problem

A tier-1/tier-2 gate is created `blocked` (`assignee=<self>`, `initial_status="blocked"`), so it is never dispatched and no run is ever scoped to it — yet the gate protocol assigns the worker the duty of closing it. `kanban_complete(task_id=<gate>)` is refused by `_enforce_worker_task_ownership`, so a worker that detected "resume condition met" could only narrate the close and leave the gate `blocked` forever. Live instance: gate `t_43b09dd5` accumulated three refusals from three runs and sat `blocked` ~6h while its child sat `todo`.

The guard is correct and is **not weakened** — a worker must not complete arbitrary sibling/cross-tenant cards.

## Change

**1. Sanctioned narrow close — `kanban_close_gate(gate_id)`**

Closes a `blocked` card whose `created_by` is this worker's profile **and** that lists the worker's current task among its `children` — a tight, injection-resistant predicate ("close the gate you yourself opened to unblock yourself") that opens no sibling or cross-tenant cards.

- `kanban_db.close_gate()` unlinks still-open (parking-sentinel) parents and completes in **one** write txn, so an `assignee`-carrying gate never transiently sits `ready` (dispatcher bait; the relay only polls `blocked`).
- The completion write is extracted into `_complete_task_write` so `complete_task` and `close_gate` share a single source of truth. `complete_task` behavior (including the PR-acceptance hook) is unchanged.

**2. Loud refusals**

A refused cross-task lifecycle mutation now also leaves a best-effort diagnostic comment on the **target** card, so a silently-survived refusal is visible where a human looks instead of only in a log nobody reads. The `_Reject` message now names `kanban_close_gate` as the sanctioned alternative.

## Tests

- `kanban_close_gate` happy path (gate → done, sentinel unlinked, child unblocked)
- refuses: `created_by` mismatch, child not listed, not `blocked`, missing `HERMES_KANBAN_TASK`
- refused `kanban_complete` leaves a diagnostic comment on the target

Verified: `test_kanban_tools.py` (38), kanban core/review/block-kinds/goal-mode/lifecycle-hooks/delegate-isolation (58), pr-acceptance/review-lifecycle/review-surfaces (34) — all passing.

Fleet backfill (separate): 12 of 13 targets from the 3-week sweep are terminal (10 done, 2 archived); one (`t_96cd4c14`) remains `todo` behind a `capability`-blocked release parent — superseded externally, out of this predicate's scope.