### PR TITLE
fix(timeouts): resolve named custom provider config keys

### DIFF
--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -9,38 +9,83 @@ def _coerce_timeout(raw: object) -> float | None:
     return timeout if timeout > 0 else None
 
 
-def _configured_timeout(provider_id: str, model: str | None, model_key: str, provider_key: str) -> float | None:
+def _provider_config_keys(provider_id: str, providers: dict) -> list[str]:
+    """Provider keys to try: named custom aliases first, then bare provider_id.
+
+    For bare "custom", tries every named custom provider's config key (the durable slug
+    under providers.<key>) before falling back to providers.custom, so a user setting
+    stale_timeout_seconds under providers.sglgateway has it honoured when the runtime
+    provider is "custom".
+    """
+    if not provider_id or provider_id.strip().lower() != "custom":
+        return [provider_id]
+    if not isinstance(providers, dict):
+        return ["custom"]
+    candidates: list[str] = []
+    for key, entry in providers.items():
+        if not isinstance(entry, dict):
+            continue
+        base_url = entry.get("base_url") or entry.get("url") or entry.get("api")
+        if not (isinstance(base_url, str) and base_url.strip()):
+            continue
+        enabled = entry.get("enabled")
+        if enabled is False:
+            continue
+        candidates.append(str(key))
+    return candidates + ["custom"]
+
+
+def _configured_timeout(
+    provider_id: str, model: str | None, model_key: str, provider_key: str
+) -> float | None:
     """Per-model ``providers.<id>.models.<model>.<model_key>`` wins over ``providers.<id>.<provider_key>``."""
     if not provider_id:
         return None
     try:
         from hermes_cli.config import load_config_readonly
+
         config = load_config_readonly()
     except Exception:
         return None
     providers = config.get("providers", {}) if isinstance(config, dict) else {}
-    provider_config = providers.get(provider_id, {}) if isinstance(providers, dict) else {}
-    if not isinstance(provider_config, dict):
+    if not isinstance(providers, dict):
         return None
-    model_config = _get_model_config(provider_config, model)
-    if model_config is not None:
-        timeout = _coerce_timeout(model_config.get(model_key))
+    for key in _provider_config_keys(provider_id, providers):
+        provider_config = providers.get(key, {})
+        if not isinstance(provider_config, dict):
+            continue
+        model_config = _get_model_config(provider_config, model)
+        if model_config is not None:
+            timeout = _coerce_timeout(model_config.get(model_key))
+            if timeout is not None:
+                return timeout
+        timeout = _coerce_timeout(provider_config.get(provider_key))
         if timeout is not None:
             return timeout
-    return _coerce_timeout(provider_config.get(provider_key))
+    return None
 
 
-def get_provider_request_timeout(provider_id: str, model: str | None = None) -> float | None:
+def get_provider_request_timeout(
+    provider_id: str, model: str | None = None
+) -> float | None:
     """Return a configured provider request timeout in seconds, if any."""
-    return _configured_timeout(provider_id, model, "timeout_seconds", "request_timeout_seconds")
+    return _configured_timeout(
+        provider_id, model, "timeout_seconds", "request_timeout_seconds"
+    )
 
 
-def get_provider_stale_timeout(provider_id: str, model: str | None = None) -> float | None:
+def get_provider_stale_timeout(
+    provider_id: str, model: str | None = None
+) -> float | None:
     """Return a configured non-stream stale timeout in seconds, if any."""
-    return _configured_timeout(provider_id, model, "stale_timeout_seconds", "stale_timeout_seconds")
+    return _configured_timeout(
+        provider_id, model, "stale_timeout_seconds", "stale_timeout_seconds"
+    )
 
 
-def _get_model_config(provider_config: dict[str, object], model: str | None) -> dict[str, object] | None:
+def _get_model_config(
+    provider_config: dict[str, object], model: str | None
+) -> dict[str, object] | None:
     if not model:
         return None
     models = provider_config.get("models", {})

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -12,14 +12,6 @@ def _write_config(tmp_path, body: str) -> None:
     (tmp_path / "config.yaml").write_text(textwrap.dedent(body), encoding="utf-8")
 
 
-
-
-
-
-
-
-
-
 def test_anthropic_adapter_honors_timeout_kwarg():
     """build_anthropic_client(timeout=X) overrides the 900s default read timeout."""
     pytest = __import__("pytest")
@@ -46,17 +38,21 @@ def test_resolved_api_call_timeout_priority(monkeypatch, tmp_path):
     (tmp_path / ".env").write_text("", encoding="utf-8")
 
     # Case A: config wins over env var
-    _write_config(tmp_path, """\
+    _write_config(
+        tmp_path,
+        """\
         providers:
           openrouter:
             request_timeout_seconds: 77
             models:
               openai/gpt-4o-mini:
                 timeout_seconds: 42
-        """)
+        """,
+    )
     monkeypatch.setenv("HERMES_API_TIMEOUT", "999")
 
     from run_agent import AIAgent
+
     agent = AIAgent(
         model="openai/gpt-4o-mini",
         provider="openrouter",
@@ -79,10 +75,13 @@ def test_resolved_api_call_timeout_priority(monkeypatch, tmp_path):
     # Clear the cached config load
     import importlib
     from hermes_cli import config as cfg_mod
+
     importlib.reload(cfg_mod)
     from hermes_cli import timeouts as to_mod
+
     importlib.reload(to_mod)
     import run_agent as ra_mod
+
     importlib.reload(ra_mod)
 
     agent2 = ra_mod.AIAgent(
@@ -102,5 +101,82 @@ def test_resolved_api_call_timeout_priority(monkeypatch, tmp_path):
     assert agent2._resolved_api_call_timeout() == 1800.0
 
 
+def test_named_custom_provider_stale_timeout(monkeypatch, tmp_path):
+    """Named custom provider stale_timeout_seconds under providers.sglgateway is honoured."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          sglgateway:
+            base_url: http://localhost:8000/v1
+            stale_timeout_seconds: 36000
+        """,
+    )
+    import importlib
+    from hermes_cli import config as cfg_mod
+
+    importlib.reload(cfg_mod)
+    from hermes_cli import timeouts as to_mod
+
+    importlib.reload(to_mod)
+    timeout = to_mod.get_provider_stale_timeout("custom", "deepseek-v4-flash")
+    assert timeout == 36000.0
 
 
+def test_named_custom_provider_model_override_timeout(monkeypatch, tmp_path):
+    """Named custom provider model-specific timeout wins over provider-level."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          sglgateway:
+            base_url: http://localhost:8000/v1
+            stale_timeout_seconds: 36000
+            models:
+              deepseek-v4-flash:
+                stale_timeout_seconds: 72000
+        """,
+    )
+    import importlib
+    from hermes_cli import config as cfg_mod
+
+    importlib.reload(cfg_mod)
+    from hermes_cli import timeouts as to_mod
+
+    importlib.reload(to_mod)
+    timeout_override = to_mod.get_provider_stale_timeout("custom", "deepseek-v4-flash")
+    timeout_fallback = to_mod.get_provider_stale_timeout("custom", "other-model")
+    assert timeout_override == 72000.0
+    assert timeout_fallback == 36000.0
+
+
+def test_named_custom_provider_disabled_skipped(monkeypatch, tmp_path):
+    """Disabled named custom provider is skipped in timeout lookup."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    _write_config(
+        tmp_path,
+        """\
+        providers:
+          sglgateway:
+            base_url: http://localhost:8000/v1
+            enabled: false
+            stale_timeout_seconds: 36000
+          backup:
+            base_url: http://localhost:9000/v1
+            stale_timeout_seconds: 18000
+        """,
+    )
+    import importlib
+    from hermes_cli import config as cfg_mod
+
+    importlib.reload(cfg_mod)
+    from hermes_cli import timeouts as to_mod
+
+    importlib.reload(to_mod)
+    timeout = to_mod.get_provider_stale_timeout("custom", "some-model")
+    assert timeout == 18000.0


### PR DESCRIPTION
Fixes #105371

## Problem

Named custom providers (e.g., `providers.sglgateway` with `model.provider: custom:sglgateway`) always resolve at runtime to `provider="custom"` (the runtime dict from `_custom_runtime` always sets `{"provider": "custom", ...}`).

However, `hermes_cli/timeouts.py::_configured_timeout` looked up timeouts with the runtime id directly:

```python
provider_config = providers.get(provider_id, {})  # provider_id == "custom"
```

This meant documented per-provider timeout knobs (`stale_timeout_seconds`, `request_timeout_seconds`) were read from `providers.custom`, **ignoring** settings under the named key (`providers.sglgateway`).

Net effect: a user setting `stale_timeout_seconds: 360000` (100h) under `providers.sglgateway` saw it **silently ignored** — the non-stream watchdog still killed at the reasoning-model floor (e.g. 600s).

## Solution

Introduce `_provider_config_keys(provider_id: str, providers: dict) -> list[str]` to return every named custom provider's config key before the bare `"custom"` fallback.

For bare `"custom"`, `_configured_timeout` now tries each named custom provider's key until one returns a timeout.

## Testing

- `test_named_custom_provider_stale_timeout`: timeout under `providers.sglgateway` is honoured for `provider_id="custom"`.
- `test_named_custom_provider_model_override_timeout`: model-specific timeout wins over provider-level.
- `test_named_custom_provider_disabled_skipped`: `enabled: false` entries are skipped.

All existing tests pass.
