### PR TITLE
fix(model-metadata): forward custom-provider key to endpoint probes

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1906,6 +1906,15 @@ def get_model_context_length(
     # 2. Live /models for truly custom endpoints. Known providers skip this: their /models may
     # report a provider-imposed limit (Copilot: 128k) rather than the window.
     if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url):
+        # Forward the route's configured key: callers that never resolved the custom provider's
+        # credential would reach the probes with the default empty key and spray a 401 per
+        # waterfall leg against keyed local servers (#105379 — the #89863 key-forwarding class).
+        if not api_key and custom_providers:
+            try:
+                from hermes_cli.config_providers import get_custom_provider_api_key
+                api_key = get_custom_provider_api_key(base_url, custom_providers) or api_key
+            except Exception:
+                pass
         return _resolve_custom_endpoint_context_length(model, base_url, api_key, provider)
     # 4. Anthropic /v1/models API (only for regular API keys, not OAuth)
     if provider == "anthropic" or (base_url and base_url_hostname(base_url) == "api.anthropic.com"):

--- a/hermes_cli/config_providers.py
+++ b/hermes_cli/config_providers.py
@@ -462,6 +462,28 @@ def get_custom_provider_extra_headers(
     return {}
 
 
+def get_custom_provider_api_key(
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None) -> str:
+    """``api_key`` of the first route-matching entry declaring one, else ``""``.
+
+    Resolution chains that probe an endpoint (server-type fingerprint, live context
+    length) forward this instead of reaching the probe with the default empty key and
+    spraying a 401 per waterfall leg against keyed local servers. See #105379.
+    SECURITY: the value is a credential — callers must never log it.
+    """
+    import os
+    for entry in _entries_for_route(base_url, custom_providers, config):
+        key = str(entry.get("api_key") or "").strip()
+        if key:
+            return key
+        env_name = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
+        if env_name and os.environ.get(env_name):
+            return os.environ[env_name]
+    return ""
+
+
 def apply_custom_provider_extra_headers_to_client_kwargs(
     client_kwargs: Dict[str, Any],
     base_url: str,

--- a/tests/agent/test_capability_probe_credentials.py
+++ b/tests/agent/test_capability_probe_credentials.py
@@ -8,6 +8,73 @@ from agent import auxiliary_client, image_routing, model_metadata
 from hermes_cli import models_local
 
 
+def test_custom_provider_api_key_route_match():
+    from hermes_cli.config_providers import get_custom_provider_api_key
+    route_key = "probe" + "-route-" + "credential"
+    entry = {"name": "llamacpp-keyed", "base_url": "http://127.0.0.1:8107/v1", "api_key": route_key}
+    assert get_custom_provider_api_key("http://127.0.0.1:8107/v1", [entry]) == route_key
+    assert get_custom_provider_api_key("http://127.0.0.1:9999/v1", [entry]) == ""
+    assert get_custom_provider_api_key("http://127.0.0.1:8107/v1", []) == ""
+
+
+def test_custom_provider_api_key_key_env_hint(monkeypatch):
+    from hermes_cli.config_providers import get_custom_provider_api_key
+    env_key = "probe" + "-env-" + "credential"
+    monkeypatch.setenv("HERMES_TEST_PROBE_KEY", env_key)
+    entry = {"name": "llamacpp-env", "base_url": "http://127.0.0.1:8108/v1", "key_env": "HERMES_TEST_PROBE_KEY"}
+    assert get_custom_provider_api_key("http://127.0.0.1:8108/v1", [entry]) == env_key
+
+
+def test_context_length_probe_forwards_custom_provider_key():
+    """An empty api_key reaching the custom-endpoint probe is backfilled from the
+    route-matching entry — a keyed local server must not be sprayed with 401s (#105379)."""
+    route_key = "probe" + "-route-" + "credential"
+    entry = {"name": "llamacpp-keyed", "base_url": "http://127.0.0.1:8107/v1", "api_key": route_key}
+    seen = {}
+
+    def fake_resolve(model, base_url, api_key=""):
+        seen["api_key"] = api_key
+        return 8192
+
+    with patch.object(model_metadata, "_resolve_endpoint_context_length", side_effect=fake_resolve):
+        ctx = model_metadata.get_model_context_length(
+            "fixture-keyed-model", base_url="http://127.0.0.1:8107/v1",
+            provider="custom", custom_providers=[entry])
+    assert ctx == 8192
+    assert seen["api_key"] == route_key
+
+
+def test_context_length_probe_keeps_empty_key_without_route_match():
+    seen = {}
+
+    def fake_resolve(model, base_url, api_key=""):
+        seen["api_key"] = api_key
+        return 4096
+
+    entry = {"name": "other-route", "base_url": "http://127.0.0.1:9999/v1", "api_key": "probe" + "-other-" + "credential"}
+    with patch.object(model_metadata, "_resolve_endpoint_context_length", side_effect=fake_resolve):
+        model_metadata.get_model_context_length(
+            "fixture-unkeyed-model", base_url="http://127.0.0.1:8107/v1",
+            provider="custom", custom_providers=[entry])
+    assert seen["api_key"] == ""
+
+
+def test_explicit_api_key_wins_over_custom_provider_entry():
+    explicit_key = "probe" + "-explicit-" + "credential"
+    seen = {}
+
+    def fake_resolve(model, base_url, api_key=""):
+        seen["api_key"] = api_key
+        return 2048
+
+    entry = {"name": "llamacpp-keyed", "base_url": "http://127.0.0.1:8107/v1", "api_key": "probe" + "-route-" + "credential"}
+    with patch.object(model_metadata, "_resolve_endpoint_context_length", side_effect=fake_resolve):
+        model_metadata.get_model_context_length(
+            "fixture-explicit-model", base_url="http://127.0.0.1:8107/v1",
+            api_key=explicit_key, provider="custom", custom_providers=[entry])
+    assert seen["api_key"] == explicit_key
+
+
 @pytest.mark.parametrize("credential,expected", [(lambda: "minted", "minted"), ("static", "static")])
 def test_capability_paths_share_concrete_bearer(credential, expected):
     auxiliary_client.set_runtime_main("custom", "fixture", api_key=credential)


### PR DESCRIPTION
## What does this PR do?

Server-type and context-length probes against a keyed local endpoint fired without the configured API key: `get_model_context_length(...)` defaults `api_key=""`, and several resolution chains (gateway start, model switch, agent init paths that never resolved the custom provider's credential) reach the probe with that default. The result is a 401 per waterfall leg (4–5 lines per probe, 16–28-line bursts on multi-model refresh) against llama.cpp/vLLM servers started with `--api-key`, and the endpoint can never be positively identified because every unauthenticated probe is rejected.

This backfills the probe key from the route-matching `custom_providers` entry (same resolution the `extra_headers`/`context_length` helpers already use), mirroring the key-forwarding fix #89863 applied to `image_routing._should_probe_ollama_vision`. The choke point covers every caller: any chain that reaches the custom-endpoint step with an empty key now authenticates. An explicitly passed `api_key` always wins.

## Related Issue

Fixes #105379

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config_providers.py`: new `get_custom_provider_api_key(base_url, custom_providers, config)` — returns the `api_key` (or `key_env`/`api_key_env` env hint) of the first route-matching entry, else `""`. Same `_entries_for_route` matching and SECURITY-no-logging contract as the existing `get_custom_provider_extra_headers` family.
- `agent/model_metadata.py`: in `get_model_context_length`, before the custom-endpoint probe step (step 2), backfill an empty `api_key` from the route-matching entry so `_resolve_custom_endpoint_context_length` (and the local waterfall it triggers) authenticates.
- `tests/agent/test_capability_probe_credentials.py`: 5 regression tests — helper route match / no-match / `key_env` hint, probe key forwarded end-to-end, empty key preserved without a route match, explicit key wins.

## How to Test

1. `venv/bin/python -m pytest tests/agent/test_capability_probe_credentials.py -q` → 8 passed (3 existing instances + 5 new tests).
2. `venv/bin/python -m pytest tests/agent/test_model_metadata.py tests/agent/test_model_metadata_local_ctx.py tests/hermes_cli/test_custom_provider_context_length.py tests/hermes_cli/test_custom_provider_extra_headers.py tests/hermes_cli/test_custom_provider_tls.py tests/hermes_cli/test_custom_provider_normalize_no_mutate.py -q` → 186 passed.
3. `venv/bin/python -m pytest tests/agent/test_image_routing.py tests/agent/test_model_metadata_ssl.py -q` → 55 passed.
4. Observed result: with a `custom_providers` entry whose `base_url` points at a keyed llama.cpp server, the context-length resolution path now sends `Authorization: Bearer <configured key>` on the probe legs instead of an empty key (asserted via the forwarded-key regression test), so the 401 spray described in the issue no longer occurs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable (no UI change; behavior verified via the regression tests above).