### PR TITLE
fix(desktop): route remote transcript media through its owner

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -360,7 +360,8 @@ import {
   createSessionWindowRegistry,
   instanceWindowBounds,
   SESSION_WINDOW_MIN_HEIGHT,
-  SESSION_WINDOW_MIN_WIDTH
+  SESSION_WINDOW_MIN_WIDTH,
+  sessionWindowRegistryKey
 } from './session-windows'
 import { ensureLoginShellPath } from './shell-path'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
@@ -8163,6 +8164,7 @@ interface GatewayFileSavePayload {
   path?: unknown
   profile?: unknown
   suggestedName?: unknown
+  targetProfile?: unknown
 }
 
 async function gatedFileAuth(connection: GatewayFileConnection) {
@@ -8199,9 +8201,11 @@ async function saveGatewayFile(payload: GatewayFileSavePayload = {}) {
   const fallbackName = path.basename(filePath) || suggested || 'download'
   const ctx = { suggested, fallbackName }
 
+  const targetProfile = String(payload.targetProfile ?? '').trim() || profile
+
   const requestPaths = gatewayFileRequestPaths(
     filePath,
-    requestPath => gatewayFileRequestPath(connection, connectionId, profile, requestPath),
+    requestPath => gatewayFileRequestPath(connection, connectionId, targetProfile, requestPath),
     payload.sessionId
   )
 
@@ -13426,10 +13430,18 @@ function focusWindow(win) {
 }
 
 function spawnSecondaryWindow({
+  connectionId,
   sessionId,
   profile,
+  targetProfile,
   watch
-}: { sessionId?: string; profile?: null | string; watch?: boolean } = {}) {
+}: {
+  connectionId?: null | string
+  sessionId?: string
+  profile?: null | string
+  targetProfile?: null | string
+  watch?: boolean
+} = {}) {
   const icon = getAppIconPath()
 
   const win = new BrowserWindow({
@@ -13491,8 +13503,10 @@ function spawnSecondaryWindow({
     win,
     buildSessionWindowUrl(sessionId, {
       devServer: DEV_SERVER,
+      connectionId,
       profile,
       rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex(),
+      targetProfile,
       watch
     }),
     'Session window'
@@ -13502,8 +13516,15 @@ function spawnSecondaryWindow({
 }
 
 // Open (or focus) a standalone window for a single chat session.
-function createSessionWindow(sessionId, { profile = null, watch = false } = {}) {
-  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ sessionId, profile, watch }))
+function createSessionWindow(
+  sessionId,
+  { connectionId = null, profile = null, targetProfile = null, watch = false } = {}
+) {
+  const registryKey = sessionWindowRegistryKey(sessionId, { connectionId, profile, targetProfile })
+
+  return sessionWindows.openOrFocus(registryKey, () =>
+    spawnSecondaryWindow({ connectionId, sessionId, profile, targetProfile, watch })
+  )
 }
 
 // Popped-out in-app Browser: same webview + address bar as a docked Browser
@@ -15028,7 +15049,9 @@ ipcMain.handle('hermes:window:openSession', async (_event, sessionId, opts) => {
   }
 
   createSessionWindow(sessionId.trim(), {
+    connectionId: typeof opts?.connectionId === 'string' ? opts.connectionId : null,
     profile: typeof opts?.profile === 'string' ? opts.profile : null,
+    targetProfile: typeof opts?.targetProfile === 'string' ? opts.targetProfile : null,
     watch: opts?.watch === true
   })
 

--- a/apps/desktop/electron/media-protocol.test.ts
+++ b/apps/desktop/electron/media-protocol.test.ts
@@ -53,7 +53,7 @@ describe('media protocol helpers', () => {
   it('preserves a configured gateway path prefix', () => {
     const endpoint = new URL(remoteMediaEndpoint('https://gateway.test/hermes/', '/tmp/a b.mp4'))
 
-    expect(endpoint.pathname).toBe('/hermes/api/files/stream')
+    expect(endpoint.pathname).toBe('/hermes/api/fs/stream')
     expect(endpoint.searchParams.get('path')).toBe('/tmp/a b.mp4')
   })
 })
@@ -105,7 +105,7 @@ describe('createMediaProtocolHandler', () => {
     })
 
     const response = await createMediaProtocolHandler(deps)(
-      request('hermes-media://remote/%2Froot%2Foutputs%2Frender.mp4?connectionId=work-ssh&profile=reviewer', {
+      request('hermes-media://remote/%2Froot%2Foutputs%2Frender.mp4?connectionId=work-ssh&profile=reviewer&sessionId=session-7', {
         Range: 'bytes=0-1023'
       })
     )
@@ -115,8 +115,9 @@ describe('createMediaProtocolHandler', () => {
     expect(deps.fetchRemote).toHaveBeenCalledOnce()
     const [rawUrl, headers] = vi.mocked(deps.fetchRemote).mock.calls[0]
     const url = new URL(rawUrl)
-    expect(url.pathname).toBe('/hermes/api/files/stream')
+    expect(url.pathname).toBe('/hermes/api/fs/stream')
     expect(url.searchParams.get('path')).toBe('/root/outputs/render.mp4')
+    expect(url.searchParams.get('session_id')).toBe('session-7')
     expect(url.searchParams.has('token')).toBe(false)
     expect(headers.get('x-hermes-session-token')).toBe('s e/cret')
     expect(headers.get('range')).toBe('bytes=0-1023')
@@ -134,7 +135,9 @@ describe('createMediaProtocolHandler', () => {
     })
 
     await createMediaProtocolHandler(deps)(
-      request('hermes-media://remote/%2Froot%2Foutputs%2Frender.mp4?connectionId=cloud&profile=research')
+      request(
+        'hermes-media://remote/%2Froot%2Foutputs%2Frender.mp4?connectionId=cloud&profile=desktop-alias&targetProfile=research'
+      )
     )
 
     const [rawUrl] = vi.mocked(deps.fetchRemote).mock.calls[0]
@@ -142,6 +145,99 @@ describe('createMediaProtocolHandler', () => {
 
     expect(url.searchParams.get('path')).toBe('/root/outputs/render.mp4')
     expect(url.searchParams.get('profile')).toBe('research')
+    expect(deps.resolveRemoteConnection).toHaveBeenCalledWith({
+      connectionId: 'cloud',
+      profile: 'desktop-alias'
+    })
+  })
+
+  it('falls back to the legacy managed stream only when the new route is missing', async () => {
+    const fetchRemote = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ detail: 'Not Found' }, { status: 404 }))
+      .mockResolvedValueOnce(new Response('legacy', { status: 206 }))
+
+    const deps = dependencies({ fetchRemote })
+
+    const response = await createMediaProtocolHandler(deps)(
+      request('hermes-media://remote/%2Froot%2Foutputs%2Frender.mp4?connectionId=work-ssh')
+    )
+
+    expect(response.status).toBe(206)
+    expect(fetchRemote).toHaveBeenCalledTimes(2)
+    expect(new URL(fetchRemote.mock.calls[0][0]).pathname).toBe('/api/fs/stream')
+    expect(new URL(fetchRemote.mock.calls[1][0]).pathname).toBe('/api/files/stream')
+  })
+
+  it('uses the same OAuth cookie transport for the legacy 404 fallback', async () => {
+    const fetchRemoteWithCookies = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ detail: 'Not Found' }, { status: 404 }))
+      .mockResolvedValueOnce(new Response('legacy', { status: 206 }))
+
+    const deps = dependencies({
+      fetchRemoteWithCookies,
+      resolveRemoteConnection: vi.fn(async () => ({
+        authMode: 'oauth' as const,
+        baseUrl: 'https://gateway.test',
+        mode: 'remote' as const,
+        token: null
+      }))
+    })
+
+    const response = await createMediaProtocolHandler(deps)(
+      request('hermes-media://remote/%2Froot%2Foutputs%2Frender.mp4')
+    )
+
+    expect(response.status).toBe(206)
+    expect(fetchRemoteWithCookies).toHaveBeenCalledTimes(2)
+    expect(new URL(fetchRemoteWithCookies.mock.calls[1][0]).pathname).toBe('/api/files/stream')
+  })
+
+  it('safely probes a missing HEAD route before using the legacy endpoint', async () => {
+    const fetchRemote = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(Response.json({ detail: 'Not Found' }, { status: 404 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+
+    const deps = dependencies({ fetchRemote })
+
+    const response = await createMediaProtocolHandler(deps)(
+      request('hermes-media://remote/%2Froot%2Foutputs%2Frender.mp4', {}, 'HEAD')
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchRemote).toHaveBeenCalledTimes(3)
+    expect(fetchRemote.mock.calls.map(call => call[2])).toEqual(['HEAD', 'GET', 'HEAD'])
+    expect((fetchRemote.mock.calls[1][1] as Headers).get('range')).toBe('bytes=0-0')
+    expect(new URL(fetchRemote.mock.calls[2][0]).pathname).toBe('/api/files/stream')
+  })
+
+  it('does not retry auth or server failures against the legacy endpoint', async () => {
+    for (const status of [401, 500]) {
+      const fetchRemote = vi.fn(async () => new Response('failed', { status }))
+      const deps = dependencies({ fetchRemote })
+
+      const response = await createMediaProtocolHandler(deps)(
+        request('hermes-media://remote/%2Froot%2Foutputs%2Frender.mp4')
+      )
+
+      expect(response.status).toBe(status)
+      expect(fetchRemote).toHaveBeenCalledOnce()
+    }
+  })
+
+  it('does not turn a file or session 404 into an unscoped legacy request', async () => {
+    const fetchRemote = vi.fn(async () => Response.json({ detail: 'Session not found' }, { status: 404 }))
+    const deps = dependencies({ fetchRemote })
+
+    const response = await createMediaProtocolHandler(deps)(
+      request('hermes-media://remote/%2Froot%2Foutputs%2Frender.mp4?sessionId=unknown')
+    )
+
+    expect(response.status).toBe(404)
+    expect(fetchRemote).toHaveBeenCalledOnce()
   })
 
   it('preserves explicit HEAD requests through the token-auth remote proxy', async () => {

--- a/apps/desktop/electron/media-protocol.ts
+++ b/apps/desktop/electron/media-protocol.ts
@@ -23,6 +23,8 @@ interface MediaProtocolTarget {
   filePath: string
   mode: MediaProtocolMode
   profile?: string
+  sessionId?: string
+  targetProfile?: string
 }
 
 export interface MediaRemoteScope {
@@ -65,8 +67,10 @@ function parseMediaProtocolTarget(rawUrl: string): MediaProtocolTarget {
 
   const connectionId = url.searchParams.get('connectionId')?.trim() || undefined
   const profile = url.searchParams.get('profile')?.trim() || undefined
+  const sessionId = url.searchParams.get('sessionId')?.trim() || undefined
+  const targetProfile = url.searchParams.get('targetProfile')?.trim() || undefined
 
-  return { connectionId, filePath, mode, profile }
+  return { connectionId, filePath, mode, profile, sessionId, targetProfile }
 }
 
 export function isStreamableMediaPath(filePath: string): boolean {
@@ -89,7 +93,28 @@ export function mediaRequestHeaders(source: Headers): Headers {
   return forwarded
 }
 
-export function remoteMediaEndpoint(baseUrl: string, filePath: string, profile?: string): string {
+export function remoteMediaEndpoint(baseUrl: string, filePath: string, profile?: string, sessionId?: string): string {
+  const normalizedBase = baseUrl.replace(/\/+$/, '')
+  const url = new URL(`${normalizedBase}/api/fs/stream`)
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Unsupported Hermes backend URL protocol: ${url.protocol}`)
+  }
+
+  url.searchParams.set('path', filePath)
+
+  if (profile) {
+    url.searchParams.set('profile', profile)
+  }
+
+  if (sessionId) {
+    url.searchParams.set('session_id', sessionId)
+  }
+
+  return url.toString()
+}
+
+export function legacyRemoteMediaEndpoint(baseUrl: string, filePath: string, profile?: string): string {
   const normalizedBase = baseUrl.replace(/\/+$/, '')
   const url = new URL(`${normalizedBase}/api/files/stream`)
 
@@ -104,6 +129,20 @@ export function remoteMediaEndpoint(baseUrl: string, filePath: string, profile?:
   }
 
   return url.toString()
+}
+
+async function isMissingStreamRoute(response: Response, method: MediaRequestMethod): Promise<boolean> {
+  if (method !== 'GET' || response.status !== 404) {
+    return false
+  }
+
+  try {
+    const body = (await response.clone().json()) as { detail?: unknown }
+
+    return body.detail === 'Not Found'
+  } catch {
+    return false
+  }
 }
 
 export function createMediaProtocolHandler(dependencies: MediaProtocolDependencies) {
@@ -157,28 +196,63 @@ export function createMediaProtocolHandler(dependencies: MediaProtocolDependenci
       const endpoint = remoteMediaEndpoint(
         connection.baseUrl,
         target.filePath,
-        connection.sharedRemote ? target.profile : undefined
+        connection.sharedRemote ? target.targetProfile || target.profile : undefined,
+        target.sessionId
       )
+
+      let fetchAuthenticated: (url: string, requestMethod?: MediaRequestMethod, requestHeaders?: Headers) => Promise<Response>
 
       if (connection.authMode === 'oauth') {
         const bearer = await dependencies.ensureRemoteBearer(connection.baseUrl)
 
         if (bearer) {
           headers.set('authorization', `Bearer ${bearer}`)
-
-          return await dependencies.fetchRemote(endpoint, headers, method)
+          fetchAuthenticated = (url, requestMethod = method, requestHeaders = headers) =>
+            dependencies.fetchRemote(url, requestHeaders, requestMethod)
+        } else {
+          fetchAuthenticated = (url, requestMethod = method, requestHeaders = headers) =>
+            dependencies.fetchRemoteWithCookies(url, requestHeaders, requestMethod)
+        }
+      } else {
+        if (!connection.token) {
+          return new Response('Remote media authentication unavailable', { status: 401 })
         }
 
-        return await dependencies.fetchRemoteWithCookies(endpoint, headers, method)
+        headers.set('x-hermes-session-token', connection.token)
+        fetchAuthenticated = (url, requestMethod = method, requestHeaders = headers) =>
+          dependencies.fetchRemote(url, requestHeaders, requestMethod)
       }
 
-      if (!connection.token) {
-        return new Response('Remote media authentication unavailable', { status: 401 })
+      const response = await fetchAuthenticated(endpoint)
+      let missingRoute = await isMissingStreamRoute(response, method)
+
+      if (!missingRoute && method === 'HEAD' && response.status === 404) {
+        // HEAD bodies cannot distinguish a missing route from a missing file.
+        // Probe the same authenticated endpoint with a one-byte GET; only the
+        // canonical FastAPI route-missing body unlocks the legacy fallback.
+        const probeHeaders = new Headers(headers)
+
+        probeHeaders.set('range', 'bytes=0-0')
+        missingRoute = await isMissingStreamRoute(
+          await fetchAuthenticated(endpoint, 'GET', probeHeaders),
+          'GET'
+        )
       }
 
-      headers.set('x-hermes-session-token', connection.token)
+      if (!missingRoute) {
+        return response
+      }
 
-      return await dependencies.fetchRemote(endpoint, headers, method)
+      // Desktop and remote gateways update independently. Retry only a
+      // confirmed FastAPI missing-route response against the older
+      // managed-root endpoint. File/session 404s must keep failing closed.
+      return await fetchAuthenticated(
+        legacyRemoteMediaEndpoint(
+          connection.baseUrl,
+          target.filePath,
+          connection.sharedRemote ? target.targetProfile || target.profile : undefined
+        )
+      )
     } catch {
       return new Response('Remote media unavailable', { status: 502 })
     }

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -7,7 +7,8 @@ import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
   createSessionWindowRegistry,
-  instanceWindowBounds
+  instanceWindowBounds,
+  sessionWindowRegistryKey
 } from './session-windows'
 
 // A minimal fake BrowserWindow: tracks listeners + destroyed state and lets a
@@ -74,6 +75,20 @@ test('buildSessionWindowUrl carries the owning profile in the query before the h
   assert.equal(url, 'http://localhost:5173/?win=secondary&watch=1&profile=work#/abc123')
 })
 
+test('buildSessionWindowUrl carries an exact connection route', () => {
+  const url = buildSessionWindowUrl('abc123', {
+    connectionId: 'remote box',
+    devServer: 'http://localhost:5173',
+    profile: 'desktop-alias',
+    targetProfile: 'backend-worker'
+  })
+
+  assert.equal(
+    url,
+    'http://localhost:5173/?win=secondary&connectionId=remote%20box&profile=desktop-alias&targetProfile=backend-worker#/abc123'
+  )
+})
+
 test('buildSessionWindowUrl encodes the session id in the hash route', () => {
   const url = buildSessionWindowUrl('a b/c', { devServer: 'http://localhost:5173' })
 
@@ -138,6 +153,25 @@ test('registry opens one window per session and focuses on re-open', () => {
   assert.equal(first, second)
   assert.equal(registry.size, 1)
   assert.equal(win.calls.focus, 1, 'second open focuses the existing window')
+})
+
+test('registry distinguishes the same session id on different owner routes', () => {
+  const registry = createSessionWindowRegistry()
+  const routeA = { connectionId: 'source-a', profile: 'default', targetProfile: 'default' }
+  const routeB = { connectionId: 'source-b', profile: 'default', targetProfile: 'default' }
+  const keyA = sessionWindowRegistryKey('shared-session', routeA)
+  const keyB = sessionWindowRegistryKey('shared-session', routeB)
+  const first = makeFakeWindow()
+  const second = makeFakeWindow()
+
+  registry.openOrFocus(keyA, () => first)
+  registry.openOrFocus(keyB, () => second)
+  registry.openOrFocus(keyA, () => makeFakeWindow())
+
+  assert.equal(registry.size, 2)
+  assert.equal(first.calls.focus, 1)
+  assert.equal(second.calls.focus, 0)
+  assert.equal(sessionWindowRegistryKey('legacy-session'), 'legacy-session')
 })
 
 test('registry restores + shows a minimized/hidden window on re-open', () => {

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -68,9 +68,14 @@ function chatWindowWebPreferences(preloadPath: string) {
 // HUD's buildHudWindowUrl): without it a pop-out/watch window adopts the
 // PRIMARY profile and resolves the session id against the wrong backend
 // (#82768, #61286). Absent → unchanged primary adoption.
-function buildSessionWindowUrl(sessionId: string, { devServer, profile, rendererIndexPath, watch }: any = {}) {
+function buildSessionWindowUrl(
+  sessionId: string,
+  { connectionId, devServer, profile, rendererIndexPath, targetProfile, watch }: any = {}
+) {
   const profileKey = typeof profile === 'string' ? profile.trim() : ''
-  const query = `?win=secondary${watch ? '&watch=1' : ''}${profileKey ? `&profile=${encodeURIComponent(profileKey)}` : ''}`
+  const connectionKey = typeof connectionId === 'string' ? connectionId.trim() : ''
+  const targetProfileKey = typeof targetProfile === 'string' ? targetProfile.trim() : ''
+  const query = `?win=secondary${watch ? '&watch=1' : ''}${connectionKey ? `&connectionId=${encodeURIComponent(connectionKey)}` : ''}${profileKey ? `&profile=${encodeURIComponent(profileKey)}` : ''}${targetProfileKey ? `&targetProfile=${encodeURIComponent(targetProfileKey)}` : ''}`
   const route = `#/${encodeURIComponent(sessionId)}`
 
   if (devServer) {
@@ -121,7 +126,27 @@ function instanceWindowBounds(base: { x: number; y: number; width: number; heigh
   }
 }
 
-// A small registry keyed by sessionId that guarantees one window per chat:
+function sessionWindowRegistryKey(
+  sessionId: string,
+  { connectionId, profile, targetProfile }: any = {}
+): string {
+  const id = typeof sessionId === 'string' ? sessionId.trim() : ''
+  const connection = typeof connectionId === 'string' ? connectionId.trim() : ''
+
+  if (!id || !connection) {
+    return id
+  }
+
+  return JSON.stringify([
+    connection,
+    typeof profile === 'string' ? profile.trim() : '',
+    typeof targetProfile === 'string' ? targetProfile.trim() : '',
+    id
+  ])
+}
+
+// A small registry keyed by exact owner + session that guarantees one window
+// per chat. Legacy callers without an owner retain the bare session-id key:
 // opening a session that already has a live window focuses it instead of
 // spawning a duplicate, and a window removes itself from the registry when it
 // closes. The actual BrowserWindow construction is injected (the `factory`) so
@@ -188,5 +213,6 @@ export {
   createSessionWindowRegistry,
   instanceWindowBounds,
   SESSION_WINDOW_MIN_HEIGHT,
-  SESSION_WINDOW_MIN_WIDTH
+  SESSION_WINDOW_MIN_WIDTH,
+  sessionWindowRegistryKey
 }

--- a/apps/desktop/src/app/chat/composer/inline-refs.ts
+++ b/apps/desktop/src/app/chat/composer/inline-refs.ts
@@ -1,6 +1,7 @@
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { translateNow } from '@/i18n'
 import { contextPath } from '@/lib/chat-runtime'
+import type { SessionOwnerRoute } from '@/store/session-request-router'
 
 import type { DroppedFile } from '../hooks/use-composer-actions'
 
@@ -19,6 +20,7 @@ export type InlineRefInput = string | { kind: string; label?: string; value: str
  *  (session-drag.ts); sessions never ride native DnD. */
 export interface SessionDragPayload {
   id: string
+  ownerRoute?: SessionOwnerRoute
   profile: string
   title: string
 }

--- a/apps/desktop/src/app/chat/composer/model-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.test.tsx
@@ -95,6 +95,7 @@ describe('ModelPill per-surface model label', () => {
       $messages: atom([]),
       $messagesEmpty: atom(true),
       $model: atom('tile/claude-sonnet'),
+      $ownerRoute: atom(undefined),
       $provider: atom('anthropic'),
       $reasoningEffort: atom('high'),
       $runtimeId: atom('tile-runtime'),

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -265,9 +265,9 @@ function dataUrlToBlob(dataUrl: string) {
   return new Blob([bytes], { type: 'application/pdf' })
 }
 
-async function readTextPreview(filePath: string) {
+async function readTextPreview(filePath: string, ownerRoute?: PreviewTarget['ownerRoute']) {
   try {
-    return await readDesktopFileText(filePath)
+    return ownerRoute ? await readDesktopFileText(filePath, ownerRoute) : await readDesktopFileText(filePath)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
 
@@ -735,7 +735,11 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
         if (isImage || isPdf) {
           // Prefer bytes the caller already handed us (a pasted/dropped
           // screenshot) over re-reading a path that may be transient/unreadable.
-          const dataUrl = target.dataUrl || (await readDesktopFileDataUrl(filePath))
+          const dataUrl =
+            target.dataUrl ||
+            (target.ownerRoute
+              ? await readDesktopFileDataUrl(filePath, target.ownerRoute)
+              : await readDesktopFileDataUrl(filePath))
 
           if (active) {
             setState({ dataUrl, loading: false })
@@ -744,7 +748,7 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
           return
         }
 
-        const result = await readTextPreview(filePath)
+        const result = await readTextPreview(filePath, target.ownerRoute)
 
         if (active) {
           const shouldBlock = !forcePreview && (result.binary || (result.byteSize ?? 0) > TEXT_PREVIEW_MAX_BYTES)
@@ -763,8 +767,15 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
           // Empty (clean file / not a repo / remote) just hides the option.
           if (!shouldBlock) {
             try {
-              const root = await desktopGitRoot(filePath)
-              const diff = root ? await desktopFileDiff(root, filePath) : ''
+              const root = target.ownerRoute
+                ? await desktopGitRoot(filePath, target.ownerRoute)
+                : await desktopGitRoot(filePath)
+
+              const diff = root
+                ? target.ownerRoute
+                  ? await desktopFileDiff(root, filePath, target.ownerRoute)
+                  : await desktopFileDiff(root, filePath)
+                : ''
 
               if (active && diff.trim()) {
                 setState(prev => (prev.text === result.text ? { ...prev, diff } : prev))
@@ -800,7 +811,8 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
     reloadKey,
     selfReload,
     target.dataUrl,
-    target.language
+    target.language,
+    target.ownerRoute
   ])
 
   useEffect(() => {
@@ -933,7 +945,7 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
       // choice. `force` is the user picking "overwrite" from that banner.
       if (!force) {
         try {
-          const current = await readTextPreview(filePath)
+          const current = await readTextPreview(filePath, target.ownerRoute)
 
           if (!current.binary && (current.text ?? '') !== baselineRef.current) {
             setConflict(true)
@@ -946,7 +958,12 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
         }
       }
 
-      await writeDesktopFileText(filePath, draftRef.current)
+      if (target.ownerRoute) {
+        await writeDesktopFileText(filePath, draftRef.current, target.ownerRoute)
+      } else {
+        await writeDesktopFileText(filePath, draftRef.current)
+      }
+
       baselineRef.current = draftRef.current
       setDirty(false)
       setConflict(false)

--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -61,8 +61,13 @@ function mountStackedTabs() {
 
 /** Press on `source`, drag to (x, y), release. The drag session flushes its
  *  pending move synchronously on release, so no frame wait is needed. */
-function dragTo(source: HTMLElement, x: number, y: number) {
-  startSessionDrag({ id: 'dragged', profile: 'default', title: 'Dragged chat' }, {
+function dragTo(
+  source: HTMLElement,
+  x: number,
+  y: number,
+  ownerRoute?: { connectionId: string; profile: string; targetProfile?: string }
+) {
+  startSessionDrag({ id: 'dragged', ownerRoute, profile: 'default', title: 'Dragged chat' }, {
     button: 0,
     clientX: 0,
     clientY: 0,
@@ -99,6 +104,18 @@ describe('session drop targeting across stacked tabs', () => {
 
     expect(openSessionTile).toHaveBeenCalledWith('dragged', 'right', 'session-tile:visible', undefined)
     expect(requestComposerInsertRefs).not.toHaveBeenCalled()
+  })
+
+  it('carries an exact sidebar owner route into a new tile', () => {
+    const row = mountStackedTabs()
+    const ownerRoute = { connectionId: 'source-b', profile: 'desktop-alias', targetProfile: 'worker' }
+
+    dragTo(row, 980, 400, ownerRoute)
+
+    expect(openSessionTile).toHaveBeenCalledWith('dragged', 'right', 'session-tile:visible', undefined, {
+      ownerRoute,
+      workspaceMode: 'sessions'
+    })
   })
 
   it('commits nothing over a zone that hosts no chat surface', () => {

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -176,7 +176,15 @@ export function startSessionDrag(
 
     onCommit() {
       if (split) {
-        openSessionTile(payload.id, split.pos, split.anchor, split.before)
+        if (payload.ownerRoute) {
+          openSessionTile(payload.id, split.pos, split.anchor, split.before, {
+            ownerRoute: payload.ownerRoute,
+            workspaceMode: 'sessions'
+          })
+        } else {
+          openSessionTile(payload.id, split.pos, split.anchor, split.before)
+        }
+
         // A tile for this session may already exist (openSessionTile is
         // idempotent — e.g. persisted from an earlier run): a drop must never
         // feel dead, so front/unhide/un-dismiss it either way.

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -136,6 +136,12 @@ function buildTileView(storedSessionId: string): SessionView {
 
   const $messages = computed($state, state => state?.messages ?? NO_MESSAGES)
 
+  const $ownerRoute = computed(
+    [$sessionTiles, $sessions, $cronSessions, $messagingSessions],
+    (tiles, sessionRows, cronRows, messagingRows) =>
+      tileOwnerRoute(tiles, [...sessionRows, ...cronRows, ...messagingRows], storedSessionId)
+  )
+
   return {
     kind: 'tile',
     $awaitingResponse: computed($state, state => Boolean(state?.awaitingResponse)),
@@ -146,6 +152,7 @@ function buildTileView(storedSessionId: string): SessionView {
     $messages,
     $messagesEmpty: computed($messages, messages => messages.length === 0),
     $model: computed($state, state => state?.model ?? ''),
+    $ownerRoute,
     $provider: computed($state, state => state?.provider ?? ''),
     $reasoningEffort: computed($state, state => state?.reasoningEffort ?? ''),
     $runtimeId,

--- a/apps/desktop/src/app/chat/session-view.tsx
+++ b/apps/desktop/src/app/chat/session-view.tsx
@@ -7,6 +7,7 @@ import {
   $activeSessionId,
   $awaitingResponse,
   $busy,
+  $connection,
   $currentCwd,
   $currentFastMode,
   $currentModel,
@@ -14,8 +15,10 @@ import {
   $currentReasoningEffort,
   $messages,
   $selectedStoredSessionId,
-  $turnStartedAt
+  $turnStartedAt,
+  getSessionOwnerHint
 } from '@/store/session'
+import type { SessionOwnerRoute } from '@/store/session-request-router'
 import { $sessionStates } from '@/store/session-states'
 
 import { lastVisibleMessageIsUser } from './thread-loading'
@@ -55,6 +58,7 @@ export interface SessionView {
   $turnStartedAt: ReadableAtom<number | null>
   $cwd: ReadableAtom<string>
   $model: ReadableAtom<string>
+  $ownerRoute: ReadableAtom<SessionOwnerRoute | undefined>
   $provider: ReadableAtom<string>
   $fast: ReadableAtom<boolean>
   $reasoningEffort: ReadableAtom<string>
@@ -92,6 +96,24 @@ const $primaryBusy = computed([$primaryState, $busy, $selectedStoredSessionId], 
   state ? state.busy : selected ? false : draftBusy
 )
 
+const $primaryOwnerRoute = computed([$selectedStoredSessionId, $connection], (storedId, connection) => {
+  if (!storedId || !connection?.connectionId) {
+    return undefined
+  }
+
+  const scope = {
+    connectionId: connection.connectionId,
+    profile: connection.profile || 'default'
+  }
+
+  return (
+    getSessionOwnerHint(storedId, scope) ?? {
+      ...scope,
+      mode: connection.mode
+    }
+  )
+})
+
 export const PRIMARY_SESSION_VIEW: SessionView = {
   kind: 'primary',
   $awaitingResponse: primaryField<boolean>(state => state.awaitingResponse, $awaitingResponse),
@@ -102,6 +124,7 @@ export const PRIMARY_SESSION_VIEW: SessionView = {
   $messages: $primaryMessages,
   $messagesEmpty: computed($primaryMessages, messages => messages.length === 0),
   $model: primaryField<string>(state => state.model, $currentModel),
+  $ownerRoute: $primaryOwnerRoute,
   $provider: primaryField<string>(state => state.provider, $currentProvider),
   $reasoningEffort: primaryField<string>(state => state.reasoningEffort, $currentReasoningEffort),
   $runtimeId: $activeSessionId,

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -44,6 +44,7 @@ import {
   setSessions
 } from '@/store/session'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
+import type { SessionOwnerRoute } from '@/store/session-request-router'
 import { $sessionTiles, closeAllOpenSessionTiles } from '@/store/session-states'
 import { ackStoredSessionId } from '@/store/session-unread'
 import { canOpenSessionInTerminal, canOpenSessionWindow, openSessionInTerminal } from '@/store/windows'
@@ -98,6 +99,7 @@ export async function renameSessionPreferringRpc(
 interface SessionActions {
   sessionId: string
   title: string
+  ownerRoute?: SessionOwnerRoute
   pinned?: boolean
   /** Backend-derived read state — drives the Mark as unread/read label. */
   unread?: boolean
@@ -184,6 +186,7 @@ function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; session
 function useSessionActions({
   sessionId,
   title,
+  ownerRoute,
   pinned = false,
   unread = false,
   profile,
@@ -236,7 +239,7 @@ function useSessionActions({
               // Stack into the MAIN zone as a tab (center dock; the strip
               // sticky-shows on gain) — the door to the tab bar. Focuses first
               // if the session is already on screen.
-              openSession(sessionId, () => undefined, 'tab')
+              openSession(sessionId, () => undefined, 'tab', { ownerRoute, workspaceMode: 'sessions' })
             }
           })
         ]
@@ -249,7 +252,7 @@ function useSessionActions({
             label: r.newWindow,
             onSelect: () => {
               triggerHaptic('selection')
-              openSession(sessionId, () => undefined, 'window')
+              openSession(sessionId, () => undefined, 'window', { ownerRoute, workspaceMode: 'sessions' })
             }
           })
         ]

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -3,6 +3,8 @@ import { atom } from 'nanostores'
 import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { startSessionDrag } from '@/app/chat/session-drag'
+import { openSession } from '@/app/open-session'
 import type { SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type * as ChatRuntime from '@/lib/chat-runtime'
@@ -52,6 +54,7 @@ vi.mock('@/i18n', () => ({
 
 vi.mock('@/app/chat/profile-tag', () => ({ ProfileTag: () => null }))
 vi.mock('@/app/chat/session-drag', () => ({ startSessionDrag: vi.fn() }))
+vi.mock('@/app/open-session', () => ({ openSession: vi.fn() }))
 // PlatformAvatar is intentionally NOT mocked (do not reintroduce this — see
 // #67500, Gille's third pass): it's a forwardRef component that spreads its
 // props onto the rendered span, and mocking it with a stand-in that spreads
@@ -171,6 +174,35 @@ const renderRow = (session: SessionInfo, extra?: { card?: boolean }) =>
       unread={false}
     />
   )
+
+it('stamps the exact connection owner into a sidebar drag', () => {
+  const session = makeSession({ connection_id: 'source-b', profile: 'worker', title: 'Remote row' })
+
+  renderRow(session)
+  fireEvent.pointerDown(screen.getByText('Remote row'), { button: 0 })
+
+  expect(startSessionDrag).toHaveBeenCalledWith(
+    {
+      id: 's1',
+      ownerRoute: { connectionId: 'source-b', profile: 'worker', targetProfile: 'worker' },
+      profile: 'worker',
+      title: 'Remote row'
+    },
+    expect.anything()
+  )
+})
+
+it('carries the exact owner into a modifier-click tab open', () => {
+  const session = makeSession({ connection_id: 'source-b', profile: 'worker', title: 'Remote row' })
+
+  renderRow(session)
+  fireEvent.click(screen.getByText('Remote row'), { metaKey: true })
+
+  expect(openSession).toHaveBeenCalledWith('s1', expect.any(Function), 'tab', {
+    ownerRoute: { connectionId: 'source-b', profile: 'worker', targetProfile: 'worker' },
+    workspaceMode: 'sessions'
+  })
+})
 
 // The row no longer takes its running state as a prop, so this drives the real
 // store the way the app does. $workingSessionIds is the actual computed here

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -28,6 +28,7 @@ import { $sidebarRowMeta } from '@/store/layout'
 import { normalizeProfileKey } from '@/store/profile'
 import { $projects } from '@/store/projects'
 import { $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
+import { sessionOwnerRouteFromRow } from '@/store/session'
 import { $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
 import { $sessionListDensity } from '@/store/session-list-density'
 import { $openStoredSessionIds } from '@/store/session-states'
@@ -313,6 +314,7 @@ function SidebarSessionRowImpl({
         onDelete={onDelete}
         onPin={onPin}
         onToggleUnread={onToggleUnread}
+        ownerRoute={sessionOwnerRouteFromRow(session)}
         pinned={isPinned}
         profile={session.profile}
         sessionId={session.id}
@@ -342,6 +344,7 @@ function SidebarSessionRowImpl({
       onDelete={onDelete}
       onPin={onPin}
       onToggleUnread={onToggleUnread}
+      ownerRoute={sessionOwnerRouteFromRow(session)}
       pinned={isPinned}
       profile={session.profile}
       sessionId={session.id}
@@ -389,7 +392,15 @@ function SidebarSessionRowImpl({
           // no macOS snap-back, Esc aborts instantly). Sub-threshold releases
           // stay ordinary clicks, so resume / pin / open-in-window are
           // untouched.
-          startSessionDrag({ id: session.id, profile: session.profile || 'default', title }, event)
+          startSessionDrag(
+            {
+              id: session.id,
+              ownerRoute: sessionOwnerRouteFromRow(session),
+              profile: session.profile || 'default',
+              title
+            },
+            event
+          )
           dragHandleProps?.onPointerDown?.(event)
         }}
         // Hovering a row from another profile (the all-profiles view) telegraphs
@@ -422,7 +433,10 @@ function SidebarSessionRowImpl({
           // Middle-click = open in a new tab (browser muscle memory).
           {...middleClickHandlers(() => {
             triggerHaptic('selection')
-            openSession(session.id, () => undefined, 'tab')
+            openSession(session.id, () => undefined, 'tab', {
+              ownerRoute: sessionOwnerRouteFromRow(session),
+              workspaceMode: 'sessions'
+            })
           })}
           onClick={event => {
             // Modifier-click gestures on a row (see `resolveSessionRowClick`):
@@ -452,9 +466,15 @@ function SidebarSessionRowImpl({
             } else if (action === 'pin') {
               onPin()
             } else if (action === 'newTab') {
-              openSession(session.id, () => undefined, 'tab')
+              openSession(session.id, () => undefined, 'tab', {
+                ownerRoute: sessionOwnerRouteFromRow(session),
+                workspaceMode: 'sessions'
+              })
             } else {
-              openSession(session.id, () => undefined, 'window')
+              openSession(session.id, () => undefined, 'window', {
+                ownerRoute: sessionOwnerRouteFromRow(session),
+                workspaceMode: 'sessions'
+              })
             }
           }}
         >

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -81,10 +81,19 @@ import {
   recordSessionEventScope,
   resetTileRuntimeBindings
 } from '@/store/session-states'
-import { windowProfileOverride } from '@/store/windows'
+import { windowConnectionOverride, windowProfileOverride } from '@/store/windows'
 import type { RpcEvent } from '@/types/hermes'
 
 import { stashGatewaySurvivor, survivorIsStale, takeGatewaySurvivor } from './gateway-hmr-survivor'
+
+function getWindowConnection(desktop: NonNullable<typeof window.hermesDesktop>) {
+  const connectionId = windowConnectionOverride()
+  const profile = windowProfileOverride()
+
+  return connectionId && desktop.getConnectionFor
+    ? desktop.getConnectionFor({ connectionId, profile, priority: 'foreground' })
+    : desktop.getConnection(profile)
+}
 
 // After the reconnect loop has been failing for this long, raise a NON-blocking
 // warning toast. Full-screen BootFailureOverlay used to lock the user out of
@@ -616,7 +625,7 @@ export function useGatewayBoot({
         // shared backend-boot budget rather than the reconnect budget because
         // ensureBackend may cold-spawn a pooled helper backend here.
         const conn = await withTimeout(
-          desktop.getConnection(windowProfileOverride() ?? undefined),
+          getWindowConnection(desktop),
           BACKEND_BOOT_WAIT_TIMEOUT_MS,
           'Timed out reconnecting to Hermes backend'
         )
@@ -1026,7 +1035,7 @@ export function useGatewayBoot({
         // rides out a full backend cold spawn, so it gets the shared 45s
         // backend-boot budget, not the 20s reconnect budget.
         const conn = await withTimeout(
-          desktop.getConnection(windowProfileOverride() ?? undefined),
+          getWindowConnection(desktop),
           BACKEND_BOOT_WAIT_TIMEOUT_MS,
           'Timed out connecting to Hermes backend'
         )

--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -212,6 +212,14 @@ describe('openSession', () => {
     expect(openSessionTile).not.toHaveBeenCalled()
   })
 
+  it('passes an exact owner route to a standalone window', () => {
+    const ownerRoute = { connectionId: 'source-b', profile: 'desktop-alias', targetProfile: 'worker' }
+
+    openSession('s1', navigate, 'window', { ownerRoute, workspaceMode: 'sessions' })
+
+    expect(openSessionInNewWindow).toHaveBeenCalledWith('s1', { ownerRoute })
+  })
+
   it('window falls back to a tab when pop-out is unavailable', () => {
     canOpenSessionWindow.mockReturnValue(false)
     focusOpenSession.mockReturnValue(null)

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -101,7 +101,11 @@ export function openSession(
 
   if (resolved === 'window') {
     if (canOpenSessionWindow()) {
-      void openSessionInNewWindow(storedSessionId)
+      if (workspaceScope.ownerRoute) {
+        void openSessionInNewWindow(storedSessionId, { ownerRoute: workspaceScope.ownerRoute })
+      } else {
+        void openSessionInNewWindow(storedSessionId)
+      }
 
       return
     }

--- a/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
@@ -1,12 +1,36 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
 import { $connection } from '@/store/session'
+import { _resetSessionOwnerHintsForTests, setSessionOwnerHint } from '@/store/session'
+import { clearAllSessionStates } from '@/store/session-states'
 
 import { MarkdownImage, MarkdownTextContent } from './markdown-text'
 
 const REMOTE_IMAGE_PATH = '/home/user/project/images/remote-preview.png'
 const REMOTE_IMAGE_DATA_URL = 'data:image/png;base64,cmVtb3RlLWltYWdl'
+
+function sessionView(storedId: string): SessionView {
+  return {
+    kind: 'primary',
+    $awaitingResponse: atom(false),
+    $busy: atom(false),
+    $cwd: atom('/srv/work'),
+    $fast: atom(false),
+    $lastVisibleIsUser: atom(false),
+    $messages: atom([]),
+    $messagesEmpty: atom(true),
+    $model: atom(''),
+    $ownerRoute: atom({ connectionId: 'remote-gateway', mode: 'remote', profile: 'assistant' }),
+    $provider: atom(''),
+    $reasoningEffort: atom(''),
+    $runtimeId: atom(null),
+    $storedId: atom(storedId),
+    $turnStartedAt: atom(null)
+  }
+}
 
 describe('MarkdownTextContent remote images', () => {
   const api = vi.fn(async ({ path }: { path: string }) => {
@@ -49,6 +73,23 @@ describe('MarkdownTextContent remote images', () => {
       profile: 'remote-work'
     })
   })
+
+  it('routes raw Markdown images through the transcript owner instead of the foreground', async () => {
+    $connection.set({ connectionId: 'local-device', mode: 'local', profile: 'default' } as never)
+
+    render(
+      <SessionViewProvider value={sessionView('remote-session')}>
+        <MarkdownTextContent isRunning={false} text="![Remote preview](/srv/media/frame.png)" />
+      </SessionViewProvider>
+    )
+
+    await screen.findByRole('img', { name: 'Remote preview' })
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'remote-gateway',
+      path: '/api/fs/read-data-url?path=%2Fsrv%2Fmedia%2Fframe.png&session_id=remote-session',
+      profile: 'assistant'
+    })
+  })
 })
 
 // Regression for #40896: generated media often arrives as image markdown
@@ -77,5 +118,81 @@ describe('MarkdownImage media routing', () => {
 
     expect(container.querySelector('video')).toBeNull()
     expect(container.querySelector('audio')).toBeNull()
+  })
+})
+
+describe('MarkdownTextContent remote video actions', () => {
+  const saveGatewayFile = vi.fn(async () => ({ saved: true }))
+
+  beforeEach(() => {
+    saveGatewayFile.mockClear()
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { saveGatewayFile }
+    })
+    $connection.set({ connectionId: 'local-device', mode: 'local', profile: 'default' } as never)
+    setSessionOwnerHint('remote-session', {
+      connectionId: 'remote-gateway',
+      mode: 'remote',
+      profile: 'assistant'
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearAllSessionStates()
+    _resetSessionOwnerHintsForTests()
+    $connection.set(null)
+  })
+
+  it('offers an explicit download routed through the transcript owner', async () => {
+    render(
+      <SessionViewProvider value={sessionView('remote-session')}>
+        <MarkdownTextContent
+          isRunning={false}
+          text="[Video: movie.mp4](#media:%2Fsrv%2Fmedia%2Fmovie.mp4)"
+        />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Download' }))
+
+    await waitFor(() =>
+      expect(saveGatewayFile).toHaveBeenCalledWith({
+        connectionId: 'remote-gateway',
+        path: '/srv/media/movie.mp4',
+        profile: 'assistant',
+        sessionId: 'remote-session',
+        suggestedName: 'movie.mp4'
+      })
+    )
+  })
+
+  it('routes colliding stored ids by the runtime bound to this transcript', async () => {
+    setSessionOwnerHint('remote-session', {
+      connectionId: 'other-gateway',
+      mode: 'remote',
+      profile: 'assistant'
+    })
+    render(
+      <SessionViewProvider value={sessionView('remote-session')}>
+        <MarkdownTextContent
+          isRunning={false}
+          text="[Video: movie.mp4](#media:%2Fsrv%2Fmedia%2Fmovie.mp4)"
+        />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Download' }))
+
+    await waitFor(() =>
+      expect(saveGatewayFile).toHaveBeenCalledWith({
+        connectionId: 'remote-gateway',
+        path: '/srv/media/movie.mp4',
+        profile: 'assistant',
+        sessionId: 'remote-session',
+        suggestedName: 'movie.mp4'
+      })
+    )
   })
 })

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -7,14 +7,17 @@ import {
   type SyntaxHighlighterProps,
   tailBoundedRemend
 } from '@assistant-ui/react-streamdown'
+import { useStore } from '@nanostores/react'
 import type { code as streamdownCode } from '@streamdown/code'
 import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
 
+import { useSessionView } from '@/app/chat/session-view'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { ErrorBoundary } from '@/components/error-boundary'
+import { useI18n } from '@/i18n'
 import { detectArtifact } from '@/lib/artifact-detect'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
@@ -22,10 +25,11 @@ import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
   downloadGatewayMediaFile,
+  type GatewayMediaOrigin,
+  gatewayMediaOriginIsRemote,
   isFileMediaPath,
   isInlineMediaSrc,
   isMarkdownDocumentPath,
-  isRemoteGateway,
   mediaExternalUrl,
   mediaKind,
   mediaName,
@@ -103,19 +107,40 @@ function preprocessWithTailRepair(text: string): string {
   }
 }
 
-function useOpenMediaFile(path: string) {
+function useOpenMediaFile(path: string, origin?: GatewayMediaOrigin) {
   const [openFailed, setOpenFailed] = useState(false)
 
   const open = () => {
-    if (window.hermesDesktop && isRemoteGateway()) {
+    if (window.hermesDesktop && gatewayMediaOriginIsRemote(origin)) {
       setOpenFailed(false)
-      void downloadGatewayMediaFile(path).catch(() => setOpenFailed(true))
+      void downloadGatewayMediaFile(path, origin).catch(() => setOpenFailed(true))
     } else {
       openExternalLink(mediaExternalUrl(path))
     }
   }
 
   return { open, openFailed }
+}
+
+function useTranscriptMediaOrigin(): GatewayMediaOrigin {
+  const view = useSessionView()
+  const owner = useStore(view.$ownerRoute)
+  const storedId = useStore(view.$storedId)
+  const connectionId = owner?.connectionId
+  const mode = owner?.mode
+  const profile = owner?.profile
+  const targetProfile = owner?.targetProfile
+
+  return useMemo(
+    () => ({
+      connectionId,
+      mode,
+      profile,
+      sessionId: storedId || undefined,
+      targetProfile
+    }),
+    [connectionId, mode, profile, storedId, targetProfile]
+  )
 }
 
 function OpenMediaFailedNote({ name }: { name: string }) {
@@ -126,8 +151,8 @@ function OpenMediaFailedNote({ name }: { name: string }) {
   )
 }
 
-function OpenMediaButton({ kind, path }: { kind: 'audio' | 'video'; path: string }) {
-  const { open, openFailed } = useOpenMediaFile(path)
+function OpenMediaButton({ kind, origin, path }: { kind: 'audio' | 'video'; origin?: GatewayMediaOrigin; path: string }) {
+  const { open, openFailed } = useOpenMediaFile(path, origin)
 
   return (
     <span className="block">
@@ -144,11 +169,15 @@ function OpenMediaButton({ kind, path }: { kind: 'audio' | 'video'; path: string
 }
 
 function MediaAttachment({ path }: { path: string }) {
+  const { t } = useI18n()
   const [src, setSrc] = useState('')
   const [failed, setFailed] = useState(false)
-  const { open, openFailed } = useOpenMediaFile(path)
   const kind = mediaKind(path)
   const name = mediaName(path)
+  const origin = useTranscriptMediaOrigin()
+
+  const { open, openFailed } = useOpenMediaFile(path, origin)
+  const showDownload = Boolean(window.hermesDesktop && gatewayMediaOriginIsRemote(origin))
 
   useEffect(() => {
     let cancelled = false
@@ -165,7 +194,7 @@ function MediaAttachment({ path }: { path: string }) {
       }
     }
 
-    void resolveMediaPlaybackSrc(path)
+    void resolveMediaPlaybackSrc(path, origin)
       .then(value => {
         if (value.startsWith('blob:')) {
           objectUrl = value
@@ -190,7 +219,7 @@ function MediaAttachment({ path }: { path: string }) {
         URL.revokeObjectURL(objectUrl)
       }
     }
-  }, [kind, path])
+  }, [kind, origin, path])
 
   if (kind === 'image' && src) {
     return (
@@ -205,7 +234,13 @@ function MediaAttachment({ path }: { path: string }) {
       <span className="my-3 block max-w-md rounded-xl border border-(--ui-stroke-tertiary) bg-muted/35 p-3">
         <span className="mb-2 block truncate text-xs font-medium text-muted-foreground">{name}</span>
         <audio className="block w-full" controls onError={() => setFailed(true)} preload="metadata" src={src} />
-        {failed && <OpenMediaButton kind="audio" path={path} />}
+        {showDownload && (
+          <button className="mt-2 ref text-xs font-medium" onClick={open} type="button">
+            {t.fileMenu.download}
+          </button>
+        )}
+        {failed && <OpenMediaButton kind="audio" origin={origin} path={path} />}
+        {openFailed && <OpenMediaFailedNote name={name} />}
       </span>
     )
   }
@@ -220,7 +255,13 @@ function MediaAttachment({ path }: { path: string }) {
           onError={() => setFailed(true)}
           src={src}
         />
-        {failed && <OpenMediaButton kind="video" path={path} />}
+        {showDownload && (
+          <button className="mt-2 ref text-xs font-medium" onClick={open} type="button">
+            {t.fileMenu.download}
+          </button>
+        )}
+        {failed && <OpenMediaButton kind="video" origin={origin} path={path} />}
+        {openFailed && <OpenMediaFailedNote name={name} />}
       </span>
     )
   }
@@ -371,7 +412,8 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
   const rawSrc = typeof src === 'string' ? src : ''
   const [resolvedSrc, setResolvedSrc] = useState(() => (rawSrc && isInlineMediaSrc(rawSrc) ? rawSrc : ''))
   const [failed, setFailed] = useState(false)
-  const { open, openFailed } = useOpenMediaFile(rawSrc)
+  const origin = useTranscriptMediaOrigin()
+  const { open, openFailed } = useOpenMediaFile(rawSrc, origin)
   const name = mediaName(rawSrc || String(alt || 'image'))
 
   useEffect(() => {
@@ -386,7 +428,7 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
       }
     }
 
-    void resolveMediaDisplaySrc(rawSrc)
+    void resolveMediaDisplaySrc(rawSrc, origin)
       .then(value => {
         if (!cancelled) {
           setResolvedSrc(value)
@@ -401,7 +443,7 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
     return () => {
       cancelled = true
     }
-  }, [rawSrc])
+  }, [origin, rawSrc])
 
   if (!rawSrc) {
     return null

--- a/apps/desktop/src/components/chat/preview-attachment.remote.test.tsx
+++ b/apps/desktop/src/components/chat/preview-attachment.remote.test.tsx
@@ -1,0 +1,256 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
+import { $previewTabs, $previewTarget } from '@/store/preview'
+import { $connection, _resetSessionOwnerHintsForTests, setSessionOwnerHint } from '@/store/session'
+import type { SessionOwnerRoute } from '@/store/session-request-router'
+import { clearAllSessionStates } from '@/store/session-states'
+
+import { PreviewAttachment } from './preview-attachment'
+
+const saveGatewayFile = vi.fn(async () => ({ saved: true }))
+
+function view(
+  storedId: string,
+  ownerRoute: SessionOwnerRoute = { connectionId: 'remote-gateway', mode: 'remote', profile: 'assistant' }
+): SessionView {
+  return {
+    kind: 'primary',
+    $awaitingResponse: atom(false),
+    $busy: atom(false),
+    $cwd: atom('/srv/work'),
+    $fast: atom(false),
+    $lastVisibleIsUser: atom(false),
+    $messages: atom([]),
+    $messagesEmpty: atom(true),
+    $model: atom(''),
+    $ownerRoute: atom(ownerRoute),
+    $provider: atom(''),
+    $reasoningEffort: atom(''),
+    $runtimeId: atom(null),
+    $storedId: atom(storedId),
+    $turnStartedAt: atom(null)
+  }
+}
+
+describe('PreviewAttachment remote session routing', () => {
+  beforeEach(() => {
+    saveGatewayFile.mockClear()
+    vi.stubGlobal('hermesDesktop', { saveGatewayFile })
+    $previewTabs.set([])
+    $connection.set({ connectionId: 'local-device', mode: 'local', profile: 'default' } as never)
+    setSessionOwnerHint('remote-session', {
+      connectionId: 'remote-gateway',
+      mode: 'remote',
+      profile: 'assistant'
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearAllSessionStates()
+    _resetSessionOwnerHintsForTests()
+    $connection.set(null)
+    vi.unstubAllGlobals()
+  })
+
+  it('downloads through the backend and profile that own the transcript', async () => {
+    render(
+      <SessionViewProvider value={view('remote-session')}>
+        <PreviewAttachment target="/srv/media/movie.mp4" />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download' }))
+
+    await waitFor(() =>
+      expect(saveGatewayFile).toHaveBeenCalledWith({
+        connectionId: 'remote-gateway',
+        path: '/srv/media/movie.mp4',
+        profile: 'assistant',
+        sessionId: 'remote-session',
+        suggestedName: 'movie.mp4'
+      })
+    )
+  })
+
+  it('toggles a local-owner preview using its persisted raw source', async () => {
+    render(
+      <SessionViewProvider
+        value={view('local-session', {
+          connectionId: 'local-device',
+          mode: 'local',
+          profile: 'default'
+        })}
+      >
+        <PreviewAttachment target="/tmp/report.md" />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open preview' }))
+    await waitFor(() => expect($previewTarget.get()?.source).toBe('/tmp/report.md'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide' }))
+    await waitFor(() => expect($previewTabs.get()).toHaveLength(0))
+  })
+
+  it('previews remote video through the transcript owner stream', async () => {
+    render(
+      <SessionViewProvider value={view('remote-session')}>
+        <PreviewAttachment target="/srv/media/movie.mp4" />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open preview' }))
+
+    await waitFor(() =>
+      expect($previewTarget.get()).toMatchObject({
+        kind: 'url',
+        label: 'movie.mp4',
+        source: 'gateway:remote-gateway:assistant::remote-session:%2Fsrv%2Fmedia%2Fmovie.mp4',
+        url: 'hermes-media://remote/%2Fsrv%2Fmedia%2Fmovie.mp4?connectionId=remote-gateway&profile=assistant&sessionId=remote-session'
+      })
+    )
+  })
+
+  it('loads a remote image through the transcript owner instead of the foreground', async () => {
+    render(
+      <SessionViewProvider value={view('remote-session')}>
+        <PreviewAttachment target="/srv/media/frame.png" />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open preview' }))
+
+    await waitFor(() => expect($previewTarget.get()?.previewKind).toBe('image'))
+    expect($previewTarget.get()).toMatchObject({
+      ownerRoute: {
+        connectionId: 'remote-gateway',
+        mode: 'remote',
+        profile: 'assistant'
+      },
+      previewKind: 'image',
+      source: 'gateway:remote-gateway:assistant::remote-session:%2Fsrv%2Fmedia%2Fframe.png',
+      transient: true
+    })
+  })
+
+  it('keeps the Desktop route profile separate from the backend target profile', async () => {
+    render(
+      <SessionViewProvider
+        value={view('remote-session', {
+          connectionId: 'remote-gateway',
+          mode: 'remote',
+          profile: 'desktop-alias',
+          targetProfile: 'backend-profile'
+        })}
+      >
+        <PreviewAttachment target="/srv/media/movie.mp4" />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download' }))
+
+    await waitFor(() =>
+      expect(saveGatewayFile).toHaveBeenCalledWith({
+        connectionId: 'remote-gateway',
+        path: '/srv/media/movie.mp4',
+        profile: 'desktop-alias',
+        sessionId: 'remote-session',
+        suggestedName: 'movie.mp4',
+        targetProfile: 'backend-profile'
+      })
+    )
+  })
+
+  it('does not treat the same path on two gateways as the same preview', async () => {
+    const first = render(
+      <SessionViewProvider value={view('remote-session')}>
+        <PreviewAttachment target="/srv/media/movie.mp4" />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open preview' }))
+    await waitFor(() =>
+      expect($previewTarget.get()?.source).toBe(
+        'gateway:remote-gateway:assistant::remote-session:%2Fsrv%2Fmedia%2Fmovie.mp4'
+      )
+    )
+    first.unmount()
+
+    render(
+      <SessionViewProvider
+        value={view('remote-session', {
+          connectionId: 'second-gateway',
+          mode: 'remote',
+          profile: 'assistant'
+        })}
+      >
+        <PreviewAttachment target="/srv/media/movie.mp4" />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open preview' }))
+    await waitFor(() =>
+      expect($previewTarget.get()?.source).toBe(
+        'gateway:second-gateway:assistant::remote-session:%2Fsrv%2Fmedia%2Fmovie.mp4'
+      )
+    )
+  })
+
+  it('does not treat the same path in two sessions as the same preview', async () => {
+    const first = render(
+      <SessionViewProvider value={view('remote-session')}>
+        <PreviewAttachment target="/srv/media/movie.mp4" />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open preview' }))
+    await waitFor(() =>
+      expect($previewTarget.get()?.source).toBe(
+        'gateway:remote-gateway:assistant::remote-session:%2Fsrv%2Fmedia%2Fmovie.mp4'
+      )
+    )
+    first.unmount()
+
+    render(
+      <SessionViewProvider value={view('second-session')}>
+        <PreviewAttachment target="/srv/media/movie.mp4" />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open preview' }))
+    await waitFor(() =>
+      expect($previewTarget.get()?.source).toBe(
+        'gateway:remote-gateway:assistant::second-session:%2Fsrv%2Fmedia%2Fmovie.mp4'
+      )
+    )
+  })
+
+  it('uses the view runtime owner when stored session ids collide across gateways', async () => {
+    setSessionOwnerHint('remote-session', {
+      connectionId: 'other-gateway',
+      mode: 'remote',
+      profile: 'assistant'
+    })
+    render(
+      <SessionViewProvider value={view('remote-session')}>
+        <PreviewAttachment target="/srv/media/movie.mp4" />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download' }))
+
+    await waitFor(() =>
+      expect(saveGatewayFile).toHaveBeenCalledWith({
+        connectionId: 'remote-gateway',
+        path: '/srv/media/movie.mp4',
+        profile: 'assistant',
+        sessionId: 'remote-session',
+        suggestedName: 'movie.mp4'
+      })
+    )
+  })
+})

--- a/apps/desktop/src/components/chat/preview-attachment.tsx
+++ b/apps/desktop/src/components/chat/preview-attachment.tsx
@@ -5,28 +5,68 @@ import { useSessionView } from '@/app/chat/session-view'
 import { useI18n } from '@/i18n'
 import { Download, MonitorPlay } from '@/lib/icons'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
-import { downloadGatewayMediaFile } from '@/lib/media'
+import {
+  downloadGatewayMediaFile,
+  gatewayMediaOriginIsRemote,
+  mediaGatewayStreamUrl,
+  mediaKind
+} from '@/lib/media'
 import { previewName } from '@/lib/preview-targets'
 import { notifyError } from '@/store/notifications'
-import { $previewTabSources, closePreviewForSource, openPreview, type PreviewRecordSource } from '@/store/preview'
+import {
+  $previewTabSources,
+  closePreviewForSource,
+  openPreview,
+  type PreviewRecordSource,
+  type PreviewTarget
+} from '@/store/preview'
 
 export function PreviewAttachment({ source = 'manual', target }: { source?: PreviewRecordSource; target: string }) {
   const { t } = useI18n()
   // This link lives in one session's transcript; resolve it against THAT
   // session's cwd, not the primary chat's.
-  const cwd = useStore(useSessionView().$cwd)
+  const view = useSessionView()
+  const cwd = useStore(view.$cwd)
+  const owner = useStore(view.$ownerRoute)
+  const storedId = useStore(view.$storedId)
   const openSources = useStore($previewTabSources)
   const [opening, setOpening] = useState(false)
   const [downloading, setDownloading] = useState(false)
   const [downloaded, setDownloaded] = useState(false)
   const cwdRef = useRef(cwd)
   const mountedRef = useRef(false)
+  const previewSourceRef = useRef('')
   const requestTokenRef = useRef(0)
   const targetRef = useRef(target)
   const name = previewName(target)
-  const isActive = openSources.includes(target)
+
+  const ownerOrigin = {
+    connectionId: owner?.connectionId,
+    mode: owner?.mode,
+    profile: owner?.profile,
+    sessionId: storedId || undefined,
+    targetProfile: owner?.targetProfile
+  }
+
+  const remote = gatewayMediaOriginIsRemote(ownerOrigin)
+
+  const previewSource = remote && owner?.connectionId
+    ? [
+        'gateway',
+        owner.connectionId,
+        owner.profile || 'default',
+        owner.targetProfile || '',
+        storedId || '',
+        target
+      ]
+        .map(part => encodeURIComponent(part))
+        .join(':')
+    : target
+
+  const isActive = openSources.includes(previewSource)
 
   cwdRef.current = cwd
+  previewSourceRef.current = previewSource
   targetRef.current = target
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
@@ -43,7 +83,7 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
   useEffect(() => {
     requestTokenRef.current += 1
     setOpening(false)
-  }, [cwd, target])
+  }, [cwd, previewSource, target])
 
   async function togglePreview() {
     if (opening) {
@@ -51,7 +91,7 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
     }
 
     if (isActive) {
-      closePreviewForSource(target)
+      closePreviewForSource(previewSource)
 
       return
     }
@@ -59,15 +99,34 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
     const requestToken = ++requestTokenRef.current
     const requestTarget = target
     const requestCwd = cwd
+    const requestSource = previewSource
 
     setOpening(true)
 
     try {
-      const preview = await normalizeOrLocalPreviewTarget(requestTarget, requestCwd || undefined)
+      const kind = mediaKind(requestTarget)
+
+      let preview: PreviewTarget | null
+
+      if (remote && (kind === 'audio' || kind === 'video')) {
+        preview = {
+          kind: 'url',
+          label: name,
+          source: previewSource,
+          url: mediaGatewayStreamUrl(requestTarget, ownerOrigin)
+        }
+      } else {
+        preview = await normalizeOrLocalPreviewTarget(requestTarget, requestCwd || undefined, owner)
+
+        if (remote && preview?.kind === 'file') {
+          preview = { ...preview, source: previewSource, url: previewSource }
+        }
+      }
 
       if (
         !mountedRef.current ||
         requestTokenRef.current !== requestToken ||
+        previewSourceRef.current !== requestSource ||
         targetRef.current !== requestTarget ||
         cwdRef.current !== requestCwd
       ) {
@@ -83,6 +142,7 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
       if (
         !mountedRef.current ||
         requestTokenRef.current !== requestToken ||
+        previewSourceRef.current !== requestSource ||
         targetRef.current !== requestTarget ||
         cwdRef.current !== requestCwd
       ) {
@@ -108,7 +168,7 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
       // Works in both modes: the Electron main process fetches the bytes
       // through the session's backend connection (local gateway or remote)
       // and prompts for a save location.
-      const result = await downloadGatewayMediaFile(target)
+      const result = await downloadGatewayMediaFile(target, ownerOrigin)
 
       if (mountedRef.current && result.saved) {
         setDownloaded(true)

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -68,7 +68,7 @@ declare global {
       // a running subagent's session.
       openSessionWindow: (
         sessionId: string,
-        opts?: { profile?: null | string; watch?: boolean }
+        opts?: { connectionId?: string; profile?: null | string; targetProfile?: string; watch?: boolean }
       ) => Promise<{ ok: boolean; error?: string }>
       // Resume this session in the user's own terminal emulator (`hermes --tui
       // --resume <id>`) — the external terminal, not the in-app pane.
@@ -274,6 +274,7 @@ declare global {
         profile?: null | string
         sessionId?: string
         suggestedName?: string
+        targetProfile?: null | string
       }) => Promise<{
         canceled?: boolean
         path?: string

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -13,7 +13,8 @@ import {
   readDesktopFileDataUrlLocalFirst,
   readDesktopFileText,
   selectDesktopPaths,
-  setDesktopFsRemotePicker
+  setDesktopFsRemotePicker,
+  writeDesktopFileText
 } from './desktop-fs'
 
 const readDir = vi.fn(async () => ({ entries: [{ name: 'local', path: '/local', isDirectory: true }] }))
@@ -37,6 +38,10 @@ const api = vi.fn(async ({ path }: { path: string }) => {
 
   if (path.startsWith('/api/fs/git-root?')) {
     return { root: '/remote' }
+  }
+
+  if (path === '/api/fs/write-text') {
+    return { ok: true, path: '/srv/project/notes.md' }
   }
 
   if (path === '/api/fs/default-cwd') {
@@ -163,6 +168,41 @@ describe('desktop filesystem facade', () => {
       path: '/api/fs/read-data-url?path=%2Fsrv%2Fproject%2Fimage.png',
       profile: 'default'
     })
+  })
+
+  it('uses an explicit remote owner even while the foreground is local', async () => {
+    $connection.set({ connectionId: 'local', mode: 'local', profile: 'default' } as never)
+
+    const owner = {
+      connectionId: 'work-ssh',
+      mode: 'remote' as const,
+      profile: 'desktop-alias',
+      targetProfile: 'backend-profile'
+    }
+
+    await readDesktopFileText('/srv/project/notes.md', owner)
+    await readDesktopFileDataUrl('/srv/project/image.png', owner)
+    await writeDesktopFileText('/srv/project/notes.md', 'updated', owner)
+
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'work-ssh',
+      path: '/api/fs/read-text?path=%2Fsrv%2Fproject%2Fnotes.md&profile=backend-profile',
+      profile: 'desktop-alias'
+    })
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'work-ssh',
+      path: '/api/fs/read-data-url?path=%2Fsrv%2Fproject%2Fimage.png&profile=backend-profile',
+      profile: 'desktop-alias'
+    })
+    expect(api).toHaveBeenCalledWith({
+      body: { content: 'updated', path: '/srv/project/notes.md' },
+      connectionId: 'work-ssh',
+      method: 'POST',
+      path: '/api/fs/write-text',
+      profile: 'desktop-alias'
+    })
+    expect(readFileText).not.toHaveBeenCalled()
+    expect(readFileDataUrl).not.toHaveBeenCalled()
   })
 
   it('pins remote filesystem requests to the active registry connection', async () => {

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -6,6 +6,7 @@ import type {
   HermesSelectPathsOptions
 } from '@/global'
 import { $connection } from '@/store/session'
+import type { SessionOwnerRoute } from '@/store/session-request-router'
 
 export interface DesktopFsRemotePicker {
   selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
@@ -41,7 +42,15 @@ export function desktopFsCacheKey(connection: HermesConnection | null = $connect
   return connectionCacheKey(connection)
 }
 
-export function isDesktopFsRemoteMode() {
+export function isDesktopFsRemoteMode(owner?: SessionOwnerRoute) {
+  if (owner?.mode) {
+    return owner.mode === 'remote'
+  }
+
+  if (owner?.connectionId) {
+    return owner.connectionId !== 'local'
+  }
+
   return $connection.get()?.mode === 'remote'
 }
 
@@ -51,8 +60,10 @@ export function desktopFsProfile(): string | undefined {
   return $connection.get()?.profile || undefined
 }
 
-function fsPath(endpoint: string, filePath: string) {
-  return `/api/fs/${endpoint}?path=${encodeURIComponent(filePath)}`
+function fsPath(endpoint: string, filePath: string, owner?: SessionOwnerRoute) {
+  const profile = owner?.targetProfile ? `&profile=${encodeURIComponent(owner.targetProfile)}` : ''
+
+  return `/api/fs/${endpoint}?path=${encodeURIComponent(filePath)}${profile}`
 }
 
 function bridge() {
@@ -65,9 +76,23 @@ function bridge() {
   return desktop
 }
 
-function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
+function remoteFsApi<T>(path: string, body?: Record<string, unknown>, owner?: SessionOwnerRoute): Promise<T> {
+  if (!owner) {
+    return hermesApi<T>(
+      body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
+    )
+  }
+
   return hermesApi<T>(
-    body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
+    body
+      ? {
+          body,
+          connectionId: owner.connectionId,
+          method: 'POST',
+          path,
+          profile: owner.profile
+        }
+      : { connectionId: owner.connectionId, path, profile: owner.profile }
   )
 }
 
@@ -79,22 +104,26 @@ export async function readDesktopDir(path: string): Promise<HermesReadDirResult>
   return remoteFsApi<HermesReadDirResult>(fsPath('list', path))
 }
 
-export async function readDesktopFileText(path: string): Promise<HermesReadFileTextResult> {
-  if (!isDesktopFsRemoteMode()) {
+export async function readDesktopFileText(path: string, owner?: SessionOwnerRoute): Promise<HermesReadFileTextResult> {
+  if (!isDesktopFsRemoteMode(owner)) {
     return bridge().readFileText(path)
   }
 
-  return remoteFsApi<HermesReadFileTextResult>(fsPath('read-text', path))
+  return remoteFsApi<HermesReadFileTextResult>(fsPath('read-text', path, owner), undefined, owner)
 }
 
 // Save UTF-8 text back to a file. Local writes go through the hardened Electron
 // IPC; remote writes hit the dashboard's POST /api/fs/write-text (same path
 // hardening, parent-must-exist, size cap) so the editor behaves identically in
 // both modes. Stale-on-disk detection is the caller's job (re-read before save).
-export async function writeDesktopFileText(path: string, content: string): Promise<{ path: string }> {
+export async function writeDesktopFileText(
+  path: string,
+  content: string,
+  owner?: SessionOwnerRoute
+): Promise<{ path: string }> {
   const desktop = bridge()
 
-  if (!isDesktopFsRemoteMode()) {
+  if (!isDesktopFsRemoteMode(owner)) {
     if (!desktop.writeTextFile) {
       throw new Error('Saving is not available')
     }
@@ -102,17 +131,17 @@ export async function writeDesktopFileText(path: string, content: string): Promi
     return desktop.writeTextFile(path, content)
   }
 
-  const result = await remoteFsApi<{ ok?: boolean; path?: string }>('/api/fs/write-text', { content, path })
+  const result = await remoteFsApi<{ ok?: boolean; path?: string }>('/api/fs/write-text', { content, path }, owner)
 
   return { path: result.path || path }
 }
 
-export async function readDesktopFileDataUrl(path: string): Promise<string> {
-  if (!isDesktopFsRemoteMode()) {
+export async function readDesktopFileDataUrl(path: string, owner?: SessionOwnerRoute): Promise<string> {
+  if (!isDesktopFsRemoteMode(owner)) {
     return bridge().readFileDataUrl(path)
   }
 
-  const result = await remoteFsApi<string | { dataUrl?: string }>(fsPath('read-data-url', path))
+  const result = await remoteFsApi<string | { dataUrl?: string }>(fsPath('read-data-url', path, owner), undefined, owner)
 
   return typeof result === 'string' ? result : result.dataUrl || ''
 }
@@ -140,14 +169,14 @@ export async function readDesktopFileDataUrlLocalFirst(path: string): Promise<st
   return readDesktopFileDataUrl(path)
 }
 
-export async function desktopGitRoot(path: string): Promise<string | null> {
+export async function desktopGitRoot(path: string, owner?: SessionOwnerRoute): Promise<string | null> {
   const desktop = bridge()
 
-  if (!isDesktopFsRemoteMode()) {
+  if (!isDesktopFsRemoteMode(owner)) {
     return desktop.gitRoot ? desktop.gitRoot(path) : null
   }
 
-  return (await remoteFsApi<{ root: string | null }>(fsPath('git-root', path))).root
+  return (await remoteFsApi<{ root: string | null }>(fsPath('git-root', path), undefined, owner)).root
 }
 
 export async function desktopDefaultCwd(): Promise<{ branch: string; cwd: string } | null> {
@@ -193,10 +222,16 @@ export async function copyTextToClipboard(text: string): Promise<void> {
 
 // Working-tree-vs-HEAD diff for one file. Empty when unchanged / not a repo.
 // Remote gateway → backend git (/api/git/file-diff); local → Electron git.
-export async function desktopFileDiff(repoRoot: string, filePath: string): Promise<string> {
-  if (isDesktopFsRemoteMode()) {
+export async function desktopFileDiff(
+  repoRoot: string,
+  filePath: string,
+  owner?: SessionOwnerRoute
+): Promise<string> {
+  if (isDesktopFsRemoteMode(owner)) {
     const result = await remoteFsApi<{ diff: string }>(
-      `/api/git/file-diff?path=${encodeURIComponent(repoRoot)}&file=${encodeURIComponent(filePath)}`
+      `/api/git/file-diff?path=${encodeURIComponent(repoRoot)}&file=${encodeURIComponent(filePath)}`,
+      undefined,
+      owner
     )
 
     return result.diff || ''

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { readDesktopFileDataUrl } = vi.hoisted(() => ({ readDesktopFileDataUrl: vi.fn() }))
+const { isDesktopFsRemoteMode, readDesktopFileDataUrl } = vi.hoisted(() => ({
+  isDesktopFsRemoteMode: vi.fn(() => true),
+  readDesktopFileDataUrl: vi.fn()
+}))
 
 vi.mock('@/lib/desktop-fs', () => ({
-  isDesktopFsRemoteMode: () => true,
+  isDesktopFsRemoteMode,
   readDesktopFileDataUrl,
   readDesktopFileText: vi.fn()
 }))
@@ -28,6 +31,7 @@ const remoteTarget = {
 describe('remote HTML previews', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    isDesktopFsRemoteMode.mockReturnValue(true)
     window.hermesDesktop = {
       normalizePreviewTarget: vi.fn(async () => remoteTarget)
     } as never
@@ -131,6 +135,40 @@ describe('remote HTML previews', () => {
 
   it('preserves POSIX double-slash file paths', () => {
     expect(localPreviewTarget('//srv/share/report #1?.html')?.url).toBe('file:////srv/share/report%20%231%3F.html')
+  })
+
+  it('keeps local-owner previews persistable', () => {
+    isDesktopFsRemoteMode.mockReturnValue(false)
+
+    expect(
+      localPreviewTarget('/tmp/report.md', undefined, {
+        connectionId: 'local-device',
+        mode: 'local',
+        profile: 'default'
+      })
+    ).toMatchObject({
+      source: '/tmp/report.md',
+      transient: undefined
+    })
+  })
+
+  it('preserves a local owner after Electron normalization', async () => {
+    const ownerRoute = { connectionId: 'local-device', mode: 'local' as const, profile: 'default' }
+    isDesktopFsRemoteMode.mockReturnValue(false)
+    window.hermesDesktop = {
+      normalizePreviewTarget: vi.fn(async () => ({
+        ...remoteTarget,
+        path: '/tmp/report.md',
+        previewKind: 'text',
+        source: '/tmp/report.md',
+        url: 'file:///tmp/report.md'
+      }))
+    } as never
+
+    await expect(normalizeOrLocalPreviewTarget('/tmp/report.md', undefined, ownerRoute)).resolves.toMatchObject({
+      ownerRoute,
+      source: '/tmp/report.md'
+    })
   })
 
   it('opens ordinary targets without staging them', async () => {

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -2,6 +2,7 @@ import DOMPurify from 'dompurify'
 
 import { isDesktopFsRemoteMode, readDesktopFileDataUrl, readDesktopFileText } from '@/lib/desktop-fs'
 import type { PreviewTarget } from '@/store/preview'
+import type { SessionOwnerRoute } from '@/store/session-request-router'
 
 const HTML_EXTENSIONS = new Set(['.htm', '.html'])
 const IMAGE_EXTENSIONS = new Set(['.bmp', '.gif', '.jpeg', '.jpg', '.png', '.svg', '.webp'])
@@ -178,7 +179,11 @@ export async function openPreviewTargetInBrowser(target: PreviewTarget): Promise
   await bridge.openPreviewInBrowser(pathToFileUrl(filePath))
 }
 
-export function localPreviewTarget(rawTarget: string, cwd?: string | null): PreviewTarget | null {
+export function localPreviewTarget(
+  rawTarget: string,
+  cwd?: string | null,
+  ownerRoute?: SessionOwnerRoute
+): PreviewTarget | null {
   const raw = rawTarget.trim().replace(/^`|`$/g, '')
 
   if (!raw) {
@@ -205,24 +210,28 @@ export function localPreviewTarget(rawTarget: string, cwd?: string | null): Prev
   const isHtml = HTML_EXTENSIONS.has(ext)
   const isImage = IMAGE_EXTENSIONS.has(ext)
   const isPdf = PDF_EXTENSIONS.has(ext)
+  const remoteOwner = ownerRoute ? isDesktopFsRemoteMode(ownerRoute) : false
 
   return {
     kind: 'file',
     label: basename(path),
     language: LANGUAGE_BY_EXT[ext] || 'text',
+    ownerRoute,
     path,
     // Renderer fallback can't stat/sniff without reading; assume text unless
     // image/html/pdf extension says otherwise. LocalFilePreview still guards
     // binary/large files when readFileText/readFileDataUrl returns metadata.
     previewKind: isHtml ? 'html' : isImage ? 'image' : isPdf ? 'pdf' : 'text',
-    source: raw,
+    source:
+      remoteOwner && ownerRoute ? `gateway:${ownerRoute.connectionId}:${ownerRoute.profile}:${raw}` : raw,
+    transient: remoteOwner ? true : undefined,
     url: pathToFileUrl(path)
   }
 }
 
 async function enrichPreviewTarget(target: PreviewTarget | null): Promise<PreviewTarget | null> {
   if (
-    !isDesktopFsRemoteMode() ||
+    !isDesktopFsRemoteMode(target?.ownerRoute) ||
     !target ||
     target.kind !== 'file' ||
     target.previewKind === 'image' ||
@@ -233,7 +242,11 @@ async function enrichPreviewTarget(target: PreviewTarget | null): Promise<Previe
 
   if (target.previewKind === 'html') {
     try {
-      const dataUrl = validatedRemoteHtmlDataUrl(await readDesktopFileDataUrl(target.path || target.source))
+      const dataUrl = validatedRemoteHtmlDataUrl(
+        target.ownerRoute
+          ? await readDesktopFileDataUrl(target.path || target.source, target.ownerRoute)
+          : await readDesktopFileDataUrl(target.path || target.source)
+      )
 
       return dataUrl ? { ...target, dataUrl } : { ...target, renderMode: 'source', transient: true }
     } catch {
@@ -242,7 +255,9 @@ async function enrichPreviewTarget(target: PreviewTarget | null): Promise<Previe
   }
 
   try {
-    const result = await readDesktopFileText(target.path || target.source)
+    const result = target.ownerRoute
+      ? await readDesktopFileText(target.path || target.source, target.ownerRoute)
+      : await readDesktopFileText(target.path || target.source)
 
     return {
       ...target,
@@ -259,18 +274,23 @@ async function enrichPreviewTarget(target: PreviewTarget | null): Promise<Previe
 
 export async function normalizeOrLocalPreviewTarget(
   rawTarget: string,
-  cwd?: string | null
+  cwd?: string | null,
+  ownerRoute?: SessionOwnerRoute
 ): Promise<PreviewTarget | null> {
+  if (ownerRoute && isDesktopFsRemoteMode(ownerRoute)) {
+    return enrichPreviewTarget(localPreviewTarget(rawTarget, cwd, ownerRoute))
+  }
+
   try {
     const normalized = await window.hermesDesktop?.normalizePreviewTarget?.(rawTarget, cwd || undefined)
 
     if (normalized) {
-      return enrichPreviewTarget(normalized)
+      return enrichPreviewTarget(ownerRoute ? { ...normalized, ownerRoute } : normalized)
     }
   } catch {
     // Running Electron may still have the old HTML-only preview IPC. Fall
     // through to renderer-side local classification so text/images still open.
   }
 
-  return enrichPreviewTarget(localPreviewTarget(rawTarget, cwd))
+  return enrichPreviewTarget(localPreviewTarget(rawTarget, cwd, ownerRoute))
 }

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { $connectionsRegistry } from '@/store/connection-registry-state'
 import { $connection } from '@/store/session'
 
 import {
@@ -104,6 +105,21 @@ describe('mediaGatewayStreamUrl', () => {
       'hermes-media://remote/%2Ftmp%2Fa.mp4?connectionId=studio-ssh&profile=voice%20reviewer'
     )
   })
+
+  it('keeps registry and backend profile names separate in stream URLs', () => {
+    $connection.set({ connectionId: 'local-device', mode: 'local', profile: 'default' } as never)
+
+    expect(
+      mediaGatewayStreamUrl('/tmp/a.mp4', {
+        connectionId: 'studio-ssh',
+        mode: 'remote',
+        profile: 'desktop-alias',
+        targetProfile: 'backend-profile'
+      })
+    ).toBe(
+      'hermes-media://remote/%2Ftmp%2Fa.mp4?connectionId=studio-ssh&profile=desktop-alias&targetProfile=backend-profile'
+    )
+  })
 })
 
 describe('resolveMediaDisplaySrc', () => {
@@ -121,6 +137,7 @@ describe('resolveMediaDisplaySrc', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    $connectionsRegistry.set(null)
     $connection.set(null)
   })
 
@@ -152,6 +169,20 @@ describe('resolveMediaDisplaySrc', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/fs/read-data-url?path=%2FUsers%2Fme%2Fproject%2Fa%20b.png',
       profile: 'remote-work'
+    })
+  })
+
+  it('keeps the active legacy remote profile when the view has no exact connection id', async () => {
+    vi.stubGlobal('window', { hermesDesktop: { api } })
+    $connection.set({ mode: 'remote', profile: 'voice' } as never)
+
+    await expect(
+      resolveMediaDisplaySrc('/srv/media/frame.png', { mode: 'remote', sessionId: 'stored-session' })
+    ).resolves.toBe('data:image/png;base64,ZHVtbXk=')
+    expect(api).toHaveBeenCalledWith({
+      connectionId: undefined,
+      path: '/api/fs/read-data-url?path=%2Fsrv%2Fmedia%2Fframe.png&session_id=stored-session',
+      profile: 'voice'
     })
   })
 
@@ -266,5 +297,55 @@ describe('downloadGatewayMediaFile', () => {
     await expect(downloadGatewayMediaFile('/Users/me/project/report.md')).rejects.toThrow(
       'Desktop file download bridge'
     )
+  })
+})
+
+describe('remote media playback routing', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    $connectionsRegistry.set(null)
+    $connection.set(null)
+  })
+
+  it('keeps the transcript owner route when the foreground connection is local', async () => {
+    vi.stubGlobal('hermesDesktop', {})
+    $connection.set({ connectionId: 'local-device', mode: 'local', profile: 'default' } as never)
+    $connectionsRegistry.set({
+      connections: [{ id: 'remote-gateway', kind: 'ssh', label: 'Remote Gateway' }]
+    } as never)
+
+    await expect(
+      resolveMediaPlaybackSrc('/srv/media/movie.mp4', {
+        connectionId: 'remote-gateway',
+        profile: 'assistant'
+      })
+    ).resolves.toBe(
+      'hermes-media://remote/%2Fsrv%2Fmedia%2Fmovie.mp4?connectionId=remote-gateway&profile=assistant'
+    )
+  })
+
+  it('uses an explicit non-foreground owner while the registry is still hydrating', async () => {
+    vi.stubGlobal('hermesDesktop', {})
+    $connection.set({ connectionId: 'local', mode: 'local', profile: 'default' } as never)
+
+    await expect(
+      resolveMediaPlaybackSrc('/srv/media/movie.mp4', {
+        connectionId: 'remote-gateway',
+        profile: 'assistant'
+      })
+    ).resolves.toContain('hermes-media://remote/')
+  })
+
+  it('keeps an explicitly local transcript on the local stream while the foreground connection is remote', async () => {
+    vi.stubGlobal('hermesDesktop', {})
+    $connection.set({ connectionId: 'remote-gateway', mode: 'remote', profile: 'assistant' } as never)
+
+    await expect(
+      resolveMediaPlaybackSrc('/srv/media/movie.mp4', {
+        connectionId: 'local-device',
+        mode: 'local',
+        profile: 'default'
+      })
+    ).resolves.toBe('hermes-media://stream/%2Fsrv%2Fmedia%2Fmovie.mp4')
   })
 })

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -1,8 +1,39 @@
 import { readDesktopFileDataUrl } from '@/lib/desktop-fs'
 import { capitalize } from '@/lib/text'
+import { $connectionsRegistry } from '@/store/connection-registry-state'
 import { $connection } from '@/store/session'
 
 export type MediaKind = 'audio' | 'image' | 'video' | 'file'
+
+export interface GatewayMediaOrigin {
+  connectionId?: string
+  mode?: 'local' | 'remote'
+  profile?: string
+  sessionId?: string
+  targetProfile?: string
+}
+
+export function gatewayMediaOriginIsRemote(origin?: GatewayMediaOrigin): boolean {
+  if (origin?.mode) {
+    return origin.mode === 'remote'
+  }
+
+  const connection = origin?.connectionId
+    ? $connectionsRegistry.get()?.connections.find(candidate => candidate.id === origin.connectionId)
+    : undefined
+
+  if (connection) {
+    return connection.kind !== 'local'
+  }
+
+  const foreground = $connection.get()
+
+  if (origin?.connectionId && origin.connectionId !== foreground?.connectionId) {
+    return true
+  }
+
+  return foreground?.mode === 'remote'
+}
 
 interface MediaInfo {
   kind: MediaKind
@@ -81,13 +112,13 @@ export function isFileMediaPath(path: string): boolean {
   return /^(?:file:|\/|~\/|[a-z]:[\\/]|\\\\)/i.test(path)
 }
 
-export async function resolveMediaDisplaySrc(path: string): Promise<string> {
+export async function resolveMediaDisplaySrc(path: string, origin?: GatewayMediaOrigin): Promise<string> {
   if (isInlineMediaSrc(path) || !isFileMediaPath(path)) {
     return path
   }
 
-  if (window.hermesDesktop && isRemoteGateway()) {
-    return gatewayMediaDataUrl(path)
+  if (window.hermesDesktop && gatewayMediaOriginIsRemote(origin)) {
+    return gatewayMediaDataUrl(path, origin)
   }
 
   if (!window.hermesDesktop?.readFileDataUrl) {
@@ -101,16 +132,18 @@ export async function resolveMediaDisplaySrc(path: string): Promise<string> {
 // remote URLs untouched and route filesystem paths through the Electron media
 // protocol. Its main-process handler reads local files directly or proxies a
 // remote gateway with the connection's bearer/cookie/token authentication.
-export async function resolveMediaPlaybackSrc(path: string): Promise<string> {
+export async function resolveMediaPlaybackSrc(path: string, origin?: GatewayMediaOrigin): Promise<string> {
   if (isInlineMediaSrc(path)) {
     return path
   }
 
   if (window.hermesDesktop && ['audio', 'video'].includes(mediaKind(path))) {
-    return isRemoteGateway() ? mediaGatewayStreamUrl(path) : mediaStreamUrl(path)
+    const remote = gatewayMediaOriginIsRemote(origin)
+
+    return remote ? mediaGatewayStreamUrl(path, origin) : mediaStreamUrl(path)
   }
 
-  return resolveMediaDisplaySrc(path)
+  return resolveMediaDisplaySrc(path, origin)
 }
 
 // Resolve a media path to a URL the shell can open. Remote mode rewrites
@@ -137,16 +170,20 @@ export function mediaExternalUrl(path: string): string {
 // Remote gateway audio/video is proxied by the Electron main process. OAuth
 // connections intentionally expose no static token to the renderer, so a bare
 // HTTPS source cannot authenticate reliably. The custom protocol keeps secrets
-// out of renderer URLs while forwarding Range requests to /api/files/stream.
-export function mediaGatewayStreamUrl(path: string): string {
+// out of renderer URLs while forwarding Range requests to /api/fs/stream.
+export function mediaGatewayStreamUrl(path: string, origin?: GatewayMediaOrigin): string {
   const conn = $connection.get()
 
-  if (isRemoteGateway()) {
+  if (gatewayMediaOriginIsRemote(origin)) {
     const file = encodeURIComponent(filePathFromMediaPath(path))
 
     const scope = [
-      conn?.connectionId ? `connectionId=${encodeURIComponent(conn.connectionId)}` : '',
-      conn?.profile ? `profile=${encodeURIComponent(conn.profile)}` : ''
+      origin?.connectionId || conn?.connectionId
+        ? `connectionId=${encodeURIComponent(origin?.connectionId || conn!.connectionId!)}`
+        : '',
+      origin?.profile || conn?.profile ? `profile=${encodeURIComponent(origin?.profile || conn!.profile!)}` : '',
+      origin?.targetProfile ? `targetProfile=${encodeURIComponent(origin.targetProfile)}` : '',
+      origin?.sessionId ? `sessionId=${encodeURIComponent(origin.sessionId)}` : ''
     ]
       .filter(Boolean)
       .join('&')
@@ -198,7 +235,28 @@ export function isRemoteGateway(): boolean {
 // bridge. Remote Desktop artifacts can live anywhere the gateway can read
 // (workspace, skills, ~/.hermes/cache, etc.); /api/media is intentionally
 // narrower and rejects non-images plus images outside its media roots.
-export async function gatewayMediaDataUrl(path: string): Promise<string> {
+export async function gatewayMediaDataUrl(path: string, origin?: GatewayMediaOrigin): Promise<string> {
+  if (origin && window.hermesDesktop?.api) {
+    const connection = $connection.get()
+    const params = new URLSearchParams({ path: filePathFromMediaPath(path) })
+
+    if (origin.targetProfile) {
+      params.set('profile', origin.targetProfile)
+    }
+
+    if (origin.sessionId) {
+      params.set('session_id', origin.sessionId)
+    }
+
+    const result = await window.hermesDesktop.api<string | { dataUrl?: string }>({
+      connectionId: origin.connectionId ?? connection?.connectionId,
+      path: `/api/fs/read-data-url?${params.toString()}`,
+      profile: origin.profile ?? connection?.profile
+    })
+
+    return typeof result === 'string' ? result : result.dataUrl || ''
+  }
+
   return readDesktopFileDataUrl(filePathFromMediaPath(path))
 }
 
@@ -209,7 +267,7 @@ export async function gatewayMediaDataUrl(path: string): Promise<string> {
 // used by preview endpoints.
 export async function downloadGatewayMediaFile(
   path: string,
-  origin?: { sessionId: string; profile?: string }
+  origin?: GatewayMediaOrigin
 ): Promise<{ canceled?: boolean; path?: string; saved: boolean }> {
   // URI conversion belongs to the gateway OS, not the renderer's URL parser.
   const file = path
@@ -220,10 +278,11 @@ export async function downloadGatewayMediaFile(
   }
 
   return window.hermesDesktop.saveGatewayFile({
-    connectionId: conn?.connectionId,
+    connectionId: origin?.connectionId ?? conn?.connectionId,
     path: file,
     profile: origin?.profile ?? conn?.profile,
-    ...(origin ? { sessionId: origin.sessionId } : {}),
+    ...(origin?.targetProfile ? { targetProfile: origin.targetProfile } : {}),
+    ...(origin?.sessionId ? { sessionId: origin.sessionId } : {}),
     suggestedName: mediaName(file).replace(/(?:%[0-9a-f]{2})+/gi, encoded => {
       try {
         return decodeURIComponent(encoded)

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -3,6 +3,7 @@ import { atom, computed } from 'nanostores'
 import { persistentAtom } from '@/lib/persisted'
 import { readKey } from '@/lib/storage'
 import { normalize } from '@/lib/text'
+import type { SessionOwnerRoute } from '@/store/session-request-router'
 
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from './layout'
 import { canOpenBrowserWindow, openBrowserInNewWindow } from './windows'
@@ -36,6 +37,8 @@ export interface PreviewTarget {
   large?: boolean
   language?: string
   mimeType?: string
+  /** Exact backend that owns this file. */
+  ownerRoute?: SessionOwnerRoute
   path?: string
   previewKind?: 'binary' | 'html' | 'image' | 'pdf' | 'text'
   renderMode?: 'preview' | 'source'

--- a/apps/desktop/src/store/windows.test.ts
+++ b/apps/desktop/src/store/windows.test.ts
@@ -9,7 +9,9 @@ import {
   isPeerInstanceWindow,
   openBrowserInNewWindow,
   openNewWindow,
-  openSessionInNewWindow
+  openSessionInNewWindow,
+  windowConnectionOverride,
+  windowTargetProfileOverride
 } from './windows'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
@@ -71,6 +73,15 @@ describe('isPeerInstanceWindow', () => {
   })
 })
 
+describe('standalone window owner overrides', () => {
+  it('reads the exact connection and backend target profile', () => {
+    const search = '?win=secondary&connectionId=source-b&profile=desktop-alias&targetProfile=worker'
+
+    expect(windowConnectionOverride(search)).toBe('source-b')
+    expect(windowTargetProfileOverride(search)).toBe('worker')
+  })
+})
+
 describe('openSessionInNewWindow', () => {
   it('no-ops without a session id', async () => {
     const open = vi.fn().mockResolvedValue({ ok: true })
@@ -102,6 +113,26 @@ describe('openSessionInNewWindow', () => {
     expect(open).toHaveBeenCalledWith('s1', { profile: 'research' })
     expect(open).toHaveBeenCalledWith('child-not-listed-yet', { profile: 'work', watch: true })
     expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('carries an exact owner route across the preload boundary', async () => {
+    const open = vi.fn().mockResolvedValue({ ok: true })
+    installBridge(open)
+
+    await openSessionInNewWindow('s1', {
+      ownerRoute: {
+        connectionId: 'source-b',
+        profile: 'desktop-alias',
+        targetProfile: 'worker'
+      }
+    })
+
+    expect(open).toHaveBeenCalledWith('s1', {
+      connectionId: 'source-b',
+      profile: 'desktop-alias',
+      targetProfile: 'worker',
+      watch: undefined
+    })
   })
 
   it('notifies on an ok:false result', async () => {

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -1,4 +1,5 @@
 import { notifyError } from './notifications'
+import type { SessionOwnerRoute } from './session-request-router'
 
 // Window flag set by the Electron main process when it opens a standalone
 // session window (see electron/main.ts buildSessionWindowUrl). It rides in the
@@ -141,6 +142,24 @@ export function windowProfileOverride(): null | string {
   }
 }
 
+export function windowConnectionOverride(search = typeof window === 'undefined' ? '' : window.location.search): null | string {
+  try {
+    return new URLSearchParams(search).get('connectionId')?.trim() || null
+  } catch {
+    return null
+  }
+}
+
+export function windowTargetProfileOverride(
+  search = typeof window === 'undefined' ? '' : window.location.search
+): null | string {
+  try {
+    return new URLSearchParams(search).get('targetProfile')?.trim() || null
+  } catch {
+    return null
+  }
+}
+
 // True when running inside the Electron desktop shell (the preload bridge is
 // present). The "open in new window" affordance is desktop-only.
 export function canOpenSessionWindow(): boolean {
@@ -194,7 +213,10 @@ async function runWindowOpen(call: () => Promise<WindowOpenResult>, failMessage:
 // #82285): the session's stamped owner wins, and an unstamped/uncached id —
 // a brand-new subagent child — inherits the profile the user is looking at
 // (#82768, #61286).
-export async function openSessionInNewWindow(sessionId: string, opts?: { watch?: boolean }): Promise<void> {
+export async function openSessionInNewWindow(
+  sessionId: string,
+  opts?: { ownerRoute?: SessionOwnerRoute; watch?: boolean }
+): Promise<void> {
   if (!sessionId || !canOpenSessionWindow()) {
     return
   }
@@ -206,10 +228,18 @@ export async function openSessionInNewWindow(sessionId: string, opts?: { watch?:
     import('./session')
   ])
 
-  const profile = normalizeProfileKey(rememberedSessionProfile($sessions.get(), sessionId, $activeGatewayProfile.get()))
+  const profile = normalizeProfileKey(
+    opts?.ownerRoute?.profile ?? rememberedSessionProfile($sessions.get(), sessionId, $activeGatewayProfile.get())
+  )
 
   await runWindowOpen(
-    () => window.hermesDesktop.openSessionWindow(sessionId, { ...opts, profile }),
+    () =>
+      window.hermesDesktop.openSessionWindow(sessionId, {
+        connectionId: opts?.ownerRoute?.connectionId,
+        profile,
+        targetProfile: opts?.ownerRoute?.targetProfile,
+        watch: opts?.watch
+      }),
     'Could not open chat in a new window'
   )
 }

--- a/hermes_cli/web_routers/files.py
+++ b/hermes_cli/web_routers/files.py
@@ -733,6 +733,26 @@ async def fs_download(
     )
 
 
+@router.get("/api/fs/stream")
+@router.head("/api/fs/stream")
+async def fs_stream(
+    path: str, profile: Optional[str] = None, session_id: Optional[str] = None,
+):
+    """Stream session-scoped audio/video inline with HTTP Range support."""
+    target, _st = _fs_regular_file(await _fs_download_path(path, profile, session_id))
+    if _is_sensitive_path(target):
+        raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
+    if target.suffix.lower() not in _STREAMABLE_MEDIA_EXTENSIONS:
+        raise HTTPException(status_code=415, detail="Unsupported media type")
+    return FileResponse(
+        path=str(target),
+        media_type=_fs_mime_type(target),
+        filename=target.name,
+        content_disposition_type="inline",
+        headers={"X-Content-Type-Options": "nosniff"},
+    )
+
+
 @router.get("/api/fs/git-root")
 async def fs_git_root(path: str):
     target = _fs_path(path)

--- a/tests/hermes_cli/test_web_server_fs_stream.py
+++ b/tests/hermes_cli/test_web_server_fs_stream.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import web_server
+
+pytest.importorskip("starlette.testclient")
+from starlette.testclient import TestClient
+
+
+@pytest.fixture
+def client(monkeypatch):
+    previous_auth_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.auth_required = False
+    test_client = TestClient(web_server.app)
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    try:
+        yield test_client
+    finally:
+        if previous_auth_required is None:
+            try:
+                delattr(web_server.app.state, "auth_required")
+            except AttributeError:
+                pass
+        else:
+            web_server.app.state.auth_required = previous_auth_required
+
+
+def test_fs_stream_serves_video_inline_with_range_support(client, tmp_path: Path):
+    target = tmp_path / "movie.mp4"
+    target.write_bytes(b"0123456789")
+
+    response = client.get(
+        "/api/fs/stream",
+        params={"path": str(target)},
+        headers={"Range": "bytes=2-5"},
+    )
+
+    assert response.status_code == 206
+    assert response.content == b"2345"
+    assert response.headers["content-type"].startswith("video/mp4")
+    assert response.headers["content-disposition"].startswith("inline")
+    assert response.headers["x-content-type-options"] == "nosniff"
+
+    head = client.head("/api/fs/stream", params={"path": str(target)})
+    assert head.status_code == 200
+    assert head.content == b""
+    assert head.headers["content-length"] == "10"
+
+
+def test_fs_stream_resolves_relative_path_in_originating_session(client, tmp_path: Path, monkeypatch):
+    from hermes_state import SessionDB
+
+    hermes_home = tmp_path / "hermes-home"
+    session_cwd = tmp_path / "session-workspace"
+    gateway_cwd = tmp_path / "gateway-workspace"
+    session_cwd.mkdir()
+    gateway_cwd.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(gateway_cwd)
+
+    expected = session_cwd / "movie.mp4"
+    expected.write_bytes(b"session media")
+    (gateway_cwd / expected.name).write_bytes(b"wrong gateway media")
+
+    hermes_home.mkdir(parents=True)
+    db = SessionDB(db_path=hermes_home / "state.db")
+    try:
+        db.create_session("origin-session", source="gui", cwd=str(session_cwd))
+    finally:
+        db.close()
+
+    response = client.get(
+        "/api/fs/stream",
+        params={"path": "./movie.mp4", "profile": "default", "session_id": "origin-session"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.content == b"session media"
+    assert response.headers["content-disposition"].startswith("inline")
+
+    missing = client.get(
+        "/api/fs/stream",
+        params={"path": str(expected), "profile": "default", "session_id": "missing-session"},
+    )
+    assert missing.status_code == 404
+
+
+def test_fs_stream_rejects_sensitive_and_non_media_files(client, tmp_path: Path):
+    sensitive = tmp_path / ".env"
+    sensitive.write_text("SECRET=1", encoding="utf-8")
+    unsupported = tmp_path / "page.html"
+    unsupported.write_text("<h1>active content</h1>", encoding="utf-8")
+
+    sensitive_response = client.get("/api/fs/stream", params={"path": str(sensitive)})
+    unsupported_response = client.get("/api/fs/stream", params={"path": str(unsupported)})
+
+    assert sensitive_response.status_code == 403
+    assert unsupported_response.status_code == 415
+
+
+def test_fs_stream_requires_auth(tmp_path: Path):
+    client = TestClient(web_server.app)
+    target = tmp_path / "movie.mp4"
+    target.write_bytes(b"video")
+
+    response = client.get("/api/fs/stream", params={"path": str(target)})
+    query_token_response = client.get(
+        "/api/fs/stream",
+        params={"path": str(target), "token": web_server._SESSION_TOKEN},
+    )
+
+    assert response.status_code == 401
+    assert query_token_response.status_code == 401


### PR DESCRIPTION
## Summary

- bind transcript media previews and downloads to the exact connection, Desktop profile, backend target profile, and stored session that own the transcript
- proxy remote audio and video through an authenticated custom protocol backed by a session-scoped streaming endpoint with Range and HEAD support
- keep image, text, PDF, edit conflict checks, sidebar opens, drag actions, and standalone windows on the same owner route
- use collision-safe preview and standalone-window identities when different gateways expose the same session or file path
- retain safe fallback behavior for older gateways that do not expose the new stream route

## Validation

- 203 targeted UI tests passed
- 41 targeted Electron tests passed
- 4 backend filesystem-stream tests passed
- TypeScript typecheck passed
- Ruff and Windows footgun checks passed
- full Desktop lint passed with repository baseline warnings only
- production Desktop build passed

Manual packaged macOS validation also covered playback, seeking, and the native Save dialog through an SSH-backed remote gateway.