### PR TITLE
fix(browser): route hosted Browser Use via Nous gateway when no direct key (#105381)

### DIFF
--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -437,8 +437,36 @@ def _resolve_backend_cdp(env: dict, task_id: Optional[str], session_name: str = 
     # DOES resolve through the provider: the gateway provisions the browser server-side and returns its CDP URL.
     provider_key = str(getattr(provider, "name", "") or "").strip().lower()
     if provider_key == _BACKEND_KEY and not _use_gateway(_read_browser_cfg()):
-        env[_PRIVATE_BROWSER_SENTINEL] = "1"  # named BU cloud browsers are exclusive to their daemon
-        return None
+        # Hosted / managed gateway: a BrowserUse provider resolved via autodetect
+        # (no explicit `use_gateway: true` in config, no BROWSER_USE_API_KEY) is
+        # still *managed* — its config comes from the Nous tool gateway, not the
+        # direct Browser Use API. The CLI has no direct credentials in that case
+        # and would fall back to local Chrome discovery → chrome-not-running.
+        # Detect the managed path and route through the provider's CDP instead.
+        try:
+            cfg = provider._get_config_or_none(refresh_token=False) if hasattr(provider, "_get_config_or_none") else None
+            if isinstance(cfg, dict) and cfg.get("managed_mode"):
+                pass  # managed — fall through to _export_session_cdp
+            elif not (os.getenv("BROWSER_USE_API_KEY") or "").strip():
+                # No direct key and not explicitly managed: probe the gateway. If a
+                # managed gateway is actually reachable, prefer it over the dead-end
+                # direct-API path (harness would otherwise need local Chrome).
+                try:
+                    from tools.managed_tool_gateway import is_managed_tool_gateway_ready
+                    if is_managed_tool_gateway_ready("browser-use"):
+                        pass  # fall through to gateway-backed session
+                    else:
+                        env[_PRIVATE_BROWSER_SENTINEL] = "1"
+                        return None
+                except Exception:
+                    env[_PRIVATE_BROWSER_SENTINEL] = "1"
+                    return None
+            else:
+                env[_PRIVATE_BROWSER_SENTINEL] = "1"  # direct API — CLI owns the cloud session
+                return None
+        except Exception:
+            env[_PRIVATE_BROWSER_SENTINEL] = "1"
+            return None
 
     provider_name = type(provider).__name__
     err = _export_session_cdp(


### PR DESCRIPTION
Fixes #105381

When `browser.cloud_provider` is unset and no `BROWSER_USE_API_KEY` is configured, autodetect still resolves a `BrowserUse` provider backed by the Nous managed tool gateway. The previous `_resolve_backend_cdp` early-return for `browser-use` without an explicit `use_gateway` flag treated every such provider as direct-API (CLI owns the cloud session) and returned without a CDP endpoint. The harness then fell back to local Chrome discovery and failed with `chrome-not-running` on hosted Hermes Cloud despite the portal reporting Browser Use as available.

This change detects the provider's `managed_mode` (or a reachable browser-use gateway) before taking the direct-API shortcut and falls through to the provider's `_export_session_cdp` so the gateway-provisioned `BU_CDP_WS` is exported.

Test: `tests/tools/test_browser_use_cli.py` (116 passed), plus targeted manual verification that managed providers now set `BU_CDP_WS` while direct providers still take the early-return path.