### PR TITLE
fix(desktop): thread foreground spawn priority through requestGatewayForAgent/retainGatewayForAgent

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -876,7 +876,10 @@ describe('createBackendSessionForSend profile routing', () => {
       'source-a',
       'default',
       'session.create',
-      expect.objectContaining({ profile: 'backend-default', source: 'desktop' })
+      expect.objectContaining({ profile: 'backend-default', source: 'desktop' }),
+      undefined,
+      undefined,
+      'foreground'
     )
     expect(ambientRequest).not.toHaveBeenCalledWith('session.create', expect.anything())
   })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -569,8 +569,12 @@ export function useSessionActions({
         // foreground hold below takes over from that point until the created
         // chat is selected. Between the two, nothing may close the socket
         // that just minted the runtime.
+        //
+        // 'foreground' spawn priority (#102281 primitive): this is the user
+        // hitting send on a fresh chat, so the dial must not queue behind
+        // background roster hydration on a saturated pool.
         const releaseCreateLease = capturedRoute
-          ? await retainGatewayForAgent(capturedRoute.connectionId, capturedRoute.profile)
+          ? await retainGatewayForAgent(capturedRoute.connectionId, capturedRoute.profile, 'foreground')
           : () => undefined
 
         let created: SessionCreateResponse
@@ -582,7 +586,10 @@ export function useSessionActions({
                 capturedRoute.connectionId,
                 capturedRoute.profile,
                 'session.create',
-                params
+                params,
+                undefined,
+                undefined,
+                'foreground'
               )
             : await requestGateway<SessionCreateResponse>('session.create', params)
 
@@ -765,9 +772,11 @@ export function useSessionActions({
 
         // Same lease chain as createBackendSessionForSend: owner socket held
         // across the create, then the foreground hold carries it until the
-        // tile is mounted ($sessionTiles names the owner from then on).
+        // tile is mounted ($sessionTiles names the owner from then on). Same
+        // 'foreground' spawn priority too — this is also a direct user click
+        // ("New session" / tab-strip "+"), not background hydration.
         const releaseCreateLease = capturedRoute
-          ? await retainGatewayForAgent(capturedRoute.connectionId, capturedRoute.profile)
+          ? await retainGatewayForAgent(capturedRoute.connectionId, capturedRoute.profile, 'foreground')
           : () => undefined
 
         let created: SessionCreateResponse
@@ -779,7 +788,10 @@ export function useSessionActions({
                 capturedRoute.connectionId,
                 capturedRoute.profile,
                 'session.create',
-                params
+                params,
+                undefined,
+                undefined,
+                'foreground'
               )
             : await requestGateway<SessionCreateResponse>('session.create', params)
 

--- a/apps/desktop/src/store/gateway-spawn-priority.test.ts
+++ b/apps/desktop/src/store/gateway-spawn-priority.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/hermes', () => ({
     }
     onEvent = vi.fn(() => () => {})
     onState = vi.fn(() => () => {})
+    request = vi.fn(async () => ({}))
   }
 }))
 vi.mock('@/store/session', () => ({ setConnection: vi.fn(), setGatewayState: vi.fn() }))
@@ -31,6 +32,8 @@ const {
   ensureGatewayForProfile,
   openGatewayForAgent,
   openGatewayForProfile,
+  requestGatewayForAgent,
+  retainGatewayForAgent,
   setPrimaryGateway
 } = await import('./gateway')
 
@@ -108,5 +111,59 @@ describe('user opens dial main as foreground from the first IPC (#102281)', () =
     const seen = priorities(desktop.getConnectionFor, args => (args[0] as { priority?: string }).priority)
     expect(seen.length).toBeGreaterThanOrEqual(1)
     expect(seen.every(priority => priority === 'foreground')).toBe(true)
+  })
+
+  // requestGatewayForAgent/retainGatewayForAgent are the session-scoped RPC
+  // lease pair createBackendSessionForSend/openNewSessionTile dial through for
+  // a user's first message / "New session" click on a not-yet-open registry
+  // route — the same user-initiated-open contract as the activation doors
+  // above, just reached through a different pair of functions. Unlike those
+  // doors, neither of these hardcodes 'foreground' or forwarded a caller's
+  // priority before, so a saturated pool queued the click behind background
+  // roster hydration exactly like the pre-#102281 bug.
+  it('requestGatewayForAgent forwards spawnPriority to the registry dial', async () => {
+    const desktop = installDesktop()
+    setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+
+    await requestGatewayForAgent('homelab', 'research', 'session.create', {}, undefined, undefined, 'foreground')
+
+    const seen = priorities(desktop.getConnectionFor, args => (args[0] as { priority?: string }).priority)
+    expect(seen.length).toBeGreaterThanOrEqual(1)
+    expect(seen.every(priority => priority === 'foreground')).toBe(true)
+  })
+
+  it('requestGatewayForAgent without a priority never tags the registry dial as foreground', async () => {
+    const desktop = installDesktop()
+    setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+
+    await requestGatewayForAgent('homelab', 'research', 'session.create', {})
+
+    const seen = priorities(desktop.getConnectionFor, args => (args[0] as { priority?: string }).priority)
+    expect(seen.length).toBeGreaterThanOrEqual(1)
+    expect(seen.every(priority => priority === undefined)).toBe(true)
+  })
+
+  it('retainGatewayForAgent forwards spawnPriority to the registry dial', async () => {
+    const desktop = installDesktop()
+    setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+
+    const release = await retainGatewayForAgent('homelab', 'research', 'foreground')
+    release()
+
+    const seen = priorities(desktop.getConnectionFor, args => (args[0] as { priority?: string }).priority)
+    expect(seen.length).toBeGreaterThanOrEqual(1)
+    expect(seen.every(priority => priority === 'foreground')).toBe(true)
+  })
+
+  it('retainGatewayForAgent without a priority never tags the registry dial as foreground', async () => {
+    const desktop = installDesktop()
+    setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+
+    const release = await retainGatewayForAgent('homelab', 'research')
+    release()
+
+    const seen = priorities(desktop.getConnectionFor, args => (args[0] as { priority?: string }).priority)
+    expect(seen.length).toBeGreaterThanOrEqual(1)
+    expect(seen.every(priority => priority === undefined)).toBe(true)
   })
 })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -949,7 +949,8 @@ export async function requestGatewayForAgent<T>(
   method: string,
   params: Record<string, unknown> = {},
   timeoutMs?: number,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  spawnPriority: SpawnPriority = 'background'
 ): Promise<T> {
   const key = normKey(profile)
   const scope = registryBackendScopeKey(connectionId, key)
@@ -970,7 +971,7 @@ export async function requestGatewayForAgent<T>(
     return requestGatewayForProfile<T>(key, method, params, timeoutMs, signal)
   }
 
-  if (await isAttachedSharedRemote(connectionId, key)) {
+  if (await isAttachedSharedRemote(connectionId, key, spawnPriority)) {
     return requestOnPrimaryGateway<T>(method, { ...params, profile: key }, timeoutMs, signal)
   }
 
@@ -994,7 +995,7 @@ export async function requestGatewayForAgent<T>(
 
   try {
     if (!isOpen(entry.gateway)) {
-      await openSecondary(entry)
+      await openSecondary(entry, spawnPriority)
     }
 
     return await (timeoutMs === undefined && signal === undefined
@@ -1146,7 +1147,11 @@ export function retainGatewayForRelay(connectionId: null | string, profile: stri
  * `finally`; the refcount keeps the socket (and the session it minted) alive
  * for the whole sequence. Primary/shared-primary routes return a no-op release.
  */
-export async function retainGatewayForAgent(connectionId: null | string, profile: string): Promise<() => void> {
+export async function retainGatewayForAgent(
+  connectionId: null | string,
+  profile: string,
+  spawnPriority: SpawnPriority = 'background'
+): Promise<() => void> {
   const key = normKey(profile)
   const scope = registryBackendScopeKey(connectionId, key)
 
@@ -1158,7 +1163,7 @@ export async function retainGatewayForAgent(connectionId: null | string, profile
     return route.release
   }
 
-  if (isPrimaryRegistryRoute(connectionId, key) || (await isAttachedSharedRemote(connectionId, key))) {
+  if (isPrimaryRegistryRoute(connectionId, key) || (await isAttachedSharedRemote(connectionId, key, spawnPriority))) {
     // Primary socket stays open for the window lifetime — no secondary to hold.
     return () => undefined
   }
@@ -1214,7 +1219,7 @@ export async function retainGatewayForAgent(connectionId: null | string, profile
 
   try {
     if (!isOpen(entry.gateway)) {
-      await openSecondary(entry)
+      await openSecondary(entry, spawnPriority)
     }
   } catch (error) {
     release()


### PR DESCRIPTION
## Summary

`requestGatewayForAgent`/`retainGatewayForAgent` are the session-scoped RPC lease pair `createBackendSessionForSend` (send on a fresh chat) and `openNewSessionTile` ("New session" row / tab-strip "+") dial through when the target registry route isn't already open. Neither function ever forwards a `spawnPriority`, so every dial through them defaults to `'background'` — even though both call sites are a direct user click.

The `#102281`/`#104139` chain (merged) tagged every *activation-door* dial (`openGatewayForAgent`, `openGatewayForProfile`, `ensureGatewayForAgent`, `sharedPrimaryRoute`) as `'foreground'` specifically so a user-initiated open takes a reserved pool slot instead of queuing behind background roster-hydration spawns. `requestGatewayForAgent`/`retainGatewayForAgent` were not part of that chain's diff (verified against PR #104139's actual patch — neither function name appears in it), so they still hit the same class of bug the chain fixed: on a saturated pool (`maxBackends = 3`), a user's first message to a not-yet-dialed bot, or a "New session" click, can queue behind background hydration for up to the pool slot wait timeout.

## Change

- `gateway.ts`: add an optional `spawnPriority` parameter to `requestGatewayForAgent` (7th positional arg) and `retainGatewayForAgent` (3rd positional arg), both defaulting to `'background'` (matching every other dial function in this file, e.g. `openGatewayForAgent`/`openGatewayForProfile`). Thread it into their internal `isAttachedSharedRemote`/`openSecondary` calls — the same two chokepoints the activation-door functions already use.
- `use-session-actions/index.ts`: pass `'foreground'` from the two confirmed user-initiated call sites — `createBackendSessionForSend`'s `retainGatewayForAgent`/`requestGatewayForAgent('session.create', ...)` pair, and `openNewSessionTile`'s identical pair.

Deliberately left unchanged:
- The `session.close` cleanup calls in both functions (failure-path cleanup, not a user-facing dial).
- `createSessionBranch`'s `requestGatewayForAgent` call (line ~2082) — it runs *after* `ensureGatewayAgent`, which already dials at foreground priority internally (`ensureGatewayForAgent` hardcodes `'foreground'`, it doesn't take a priority param), so by the time this call runs the socket is already open and the priority argument would be a no-op.
- Every other `requestGatewayForAgent`/`retainGatewayForAgent` caller (`session-import/api.ts`, `sdk/index.ts`, `api/mcp.ts`, `session-request-router.ts`) — these are import/plugin/OAuth/generic-routed paths, not direct user-open clicks.

## Verification

- New regression tests in `gateway-spawn-priority.test.ts` (mirroring the existing `#102281` test file's pattern): both functions now tag the registry dial `'foreground'` when asked, and leave it untagged by default.
- Mutation-verify: reverted the `gateway.ts` change only, confirmed the two new positive tests fail (`expected false to be true`), reapplied, confirmed all pass again.
- Full `apps/desktop/src/store/gateway*.test.ts` suite: 14 files, 107 tests, all passing.
- `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx`: 105 tests passing (one pre-existing exact-arg assertion on the `createBackendSessionForSend` → `requestGatewayForAgent` call updated to include the new trailing args).
- `tsc --noEmit`: clean.

## Competing PRs

Checked `#101554`, `#100467`, `#101482`, `#103275`, `#104871` (all open, adjacent territory — bot-mode routing, floating pets, session-tile pinning, cross-profile bridge timeouts, LRU pool eviction) and the closed/merged `#102281` chain PRs (`#104139` merged, `#102496` closed-salvaged-into-104139). None touch `requestGatewayForAgent`/`retainGatewayForAgent` — confirmed by grepping the actual diffs, not just titles. `#104871`'s `gateway.ts` hunks (`retainGatewayForSessionTurn`, `openSecondaryCount`) don't overlap the lines this PR touches.

## Test plan

- [x] `npx vitest run src/store/gateway-spawn-priority.test.ts` — 8/8 passing
- [x] `npx vitest run src/store/gateway*.test.ts` — 14 files / 107 tests passing
- [x] `npx vitest run src/app/session/hooks/use-session-actions.test.tsx` — 105/105 passing
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] Mutation-verify on the two new positive tests
