### PR TITLE
fix(agent): report pending delegation work when turns end

### DIFF
--- a/agent/turn_final_response.py
+++ b/agent/turn_final_response.py
@@ -238,5 +238,5 @@ def finish_text_response(
 
     _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
     if not agent.quiet_mode:
-        agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
+        agent._safe_print(f"Turn ended after {api_call_count} OpenAI-compatible API call(s)")
     return _verdict("break")

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -563,6 +563,15 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    if completed and not interrupted:
+        from tools.async_delegation import pending_delegations, pending_delegation_status
+        pending = pending_delegations(agent.session_id)
+        status = pending_delegation_status(pending)
+        if status:
+            # ``completed`` is a turn/stream/recovery contract, not a workflow-completion flag. Release the turn
+            # so idle-only delivery can proceed; leave streamed text, cached history and exit reason untouched.
+            result["pending_delegations"] = pending
+            agent._emit_status("Turn ended. " + status)
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Persistence failures already set failed=True; also stamp `error` so the gateway

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -760,7 +760,9 @@ class TurnRunner:
             logger.debug("Failed to attach session title callback", exc_info=True)
 
     def _status_callback_sync(self, event_type: str, message: str) -> None:
-        from gateway.run import _prepare_gateway_status_message, _redact_gateway_user_facing_secrets, _send_or_update_status_coro
+        from gateway.run import (
+            _interim_metadata, _prepare_gateway_status_message, _redact_gateway_user_facing_secrets, _send_or_update_status_coro,
+        )
         ctx = self._ctx
         if not self._status_live():
             return
@@ -773,7 +775,10 @@ class TurnRunner:
             )
             return
         fut = self._schedule(
-            _send_or_update_status_coro(ctx._status_adapter, ctx._status_chat_id, event_type, prepared, ctx._status_thread_metadata),
+            # Lifecycle status (including pending work at turn end) is not the answer. Otherwise a
+            # stream-is-the-message adapter seals the live draft before the real final can arrive.
+            _send_or_update_status_coro(ctx._status_adapter, ctx._status_chat_id, event_type, prepared,
+                                        _interim_metadata(ctx._status_thread_metadata)),
             f"status_callback ({event_type}) scheduling error",
         )
         if fut is not None and ctx._cleanup_progress:

--- a/tests/agent/test_delegation_pending_work.py
+++ b/tests/agent/test_delegation_pending_work.py
@@ -1,0 +1,235 @@
+"""Pending delegation is a delivery state, not a reason to keep a model turn open."""
+
+import asyncio
+import queue
+import sqlite3
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_state import SessionDB
+from tools import async_delegation as ad
+from tools.delegate_tool_registry import _list_payload
+from tools.process_registry import process_registry
+from tools.process_registry_notifications import format_process_notification
+
+
+@pytest.fixture
+def ledger(monkeypatch):
+    ad._reset_for_tests()
+    monkeypatch.setattr(process_registry, "completion_queue", queue.Queue())
+    db = SessionDB()
+    db.create_session("parent", source="cli")
+    yield db
+    ad._reset_for_tests()
+    db.close()
+
+
+def _seed_unit(session_id, delegation_id, *, state="running"):
+    record = {
+        "delegation_id": delegation_id, "parent_session_id": session_id,
+        "session_key": "same-chat", "origin_ui_session_id": "reused-tab",
+        "dispatched_at": time.time(), "goal": "Review the implementation",
+    }
+    ad._persist_dispatch(record)
+    event = {
+        **record, "type": "async_delegation", "status": state,
+        "completed_at": time.time(), "summary": "Review evidence",
+    }
+    if state != "running":
+        ad._persist_completion(event, {"summary": event["summary"]})
+    return event
+
+
+def test_pending_delivery_is_conversation_owned_and_survives_child_exit(ledger, monkeypatch, tmp_path):
+    """List and completion notices must not equate an empty live roster with received evidence."""
+    _seed_unit("parent", "active")
+    event = _seed_unit("parent", "ready", state="completed")
+    _seed_unit("unrelated", "foreign")
+    parent = SimpleNamespace(session_id="parent", _session_db=ledger)
+
+    # RAM is empty, as after a parent/process rebuild. Read the durable unit lifecycle.
+    payload = _list_payload(parent)
+    expected = {"active": ["active"], "awaiting_delivery": ["ready"], "status_known": True}
+    assert payload["count"] == 0
+    assert payload["pending_delegations"] == expected
+    assert "awaiting delivery" in payload["note"]
+
+    # A claimed result is still pending until acceptance; formatting is a read, not an ack.
+    claim = ad.claim_event_delivery(event, "test")
+    assert claim
+    for shape in (event, {**event, "is_batch": True, "goals": [event["goal"]],
+                          "results": [{"task_index": 0, "status": "completed", "summary": "Review evidence"}]}):
+        text = format_process_notification(shape)
+        assert text is not None
+        assert "1 active unit(s), 0 result(s) awaiting delivery" in text
+        assert "when this notification was prepared" in text
+    assert ad.pending_delegations("parent") == expected
+    durable = ad.get_durable_delegation("ready")
+    assert durable is not None and durable["delivery_state"] == "pending"
+
+    # An interim failure shares the unit id but is not its final result.
+    interim = {**event, "delegation_id": "active", "task_failure_notice": True,
+               "n_tasks": 2, "results": [{"task_index": 0, "status": "error", "error": "test failure"}]}
+    text = format_process_notification(interim)
+    assert text is not None and "1 active unit(s), 1 result(s) awaiting delivery" in text
+
+    ledger.end_session("parent", "compression")
+    ledger.create_session("tip", source="cli", parent_session_id="parent")
+    ledger.create_session("fresh", source="cli")
+    assert ad.pending_delegations("tip") == expected
+    assert ad.pending_delegations("fresh")["active"] == []  # /new may reuse the tab/chat
+    assert ad.pending_delegations("")["status_known"] is False
+
+    ad.complete_event_delivery(event, claim)
+    # The ledger, not a stale finalizing RAM record, decides whether a result was accepted.
+    monkeypatch.setitem(ad._records, "ready", {"status": "finalizing", "parent_session_id": "parent"})
+    assert ad.pending_delegations("tip")["awaiting_delivery"] == []
+    failed = _seed_unit("parent", "failed", state="error")
+    assert ad.pending_delegations("tip")["awaiting_delivery"] == ["failed"]
+    claim = ad.claim_event_delivery(failed, "test")
+    assert claim
+    assert ad.drop_completion_delivery("failed", claim)
+    assert ad.pending_delegations("tip")["awaiting_delivery"] == []
+
+    # Read failures must not be advertised as a verified empty roster.
+    with patch.object(SessionDB, "_read_all", side_effect=sqlite3.OperationalError("database is locked")):
+        assert ad.pending_delegations("parent")["status_known"] is False
+    # A different profile is not allowed to inherit this ledger through a global RAM count.
+    with monkeypatch.context() as m:
+        m.setattr(ad, "get_hermes_home", lambda: tmp_path / "other-profile")
+        assert ad.pending_delegations("parent")["active"] == []
+        assert not (tmp_path / "other-profile" / "state.db").exists()
+
+    # The TUI poller is outside the destination turn's context. It must bind that
+    # profile for formatting AND the delivery claim/ack, then restore the caller.
+    from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
+    from tui_gateway import server
+    event = _seed_unit("parent", "profile-result", state="completed")
+    session = {"session_key": "same-chat", "profile_home": str(ledger.db_path.parent),
+               "history_lock": threading.Lock(), "running": False}
+    delivered = []
+    monkeypatch.setattr(server, "_emit", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda _rid, _sid, _s, text, **_kw: delivered.append(text))
+    other_home = tmp_path / "poller-profile"
+    other = SessionDB(other_home / "state.db")
+    token = set_hermes_home_override(other_home)
+    try:
+        server._notif_handle_ready("reused-tab", session, [event], set(), process_registry,
+                                   format_process_notification, [])
+        assert len(delivered) == 1
+        assert "1 active unit(s), 0 result(s) awaiting delivery" in delivered[0]
+        assert get_hermes_home() == other_home
+    finally:
+        reset_hermes_home_override(token)
+        other.close()
+    durable = ad.get_durable_delegation("profile-result")
+    assert durable is not None and durable["delivery_state"] == "delivered"
+
+
+def test_text_turn_releases_parent_without_hiding_pending_results(ledger):
+    """Real dispatch/SQLite/queue + model-loop test: no retry, text rewrite, or early delivery ack."""
+    from run_agent import AIAgent
+    from gateway.config import Platform
+    from gateway.run_turn_runner import TurnRunner
+    from tests.gateway.relay.test_relay_live_cards import _connected_adapter
+    from tests.run_agent.test_run_agent import _mock_response
+
+    statuses = []
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key", base_url="https://example.invalid/v1",
+            model="test-model", session_id="parent", quiet_mode=True,
+            skip_context_files=True, skip_memory=True,
+            status_callback=lambda kind, text: statuses.append((kind, text)),
+        )
+    agent._session_db = ledger
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "Stable system prefix."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.tool_delay = 0
+    answer = "Implementation done."
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content=answer, finish_reason="stop") for _ in range(3)
+    ]
+    gate = threading.Event()
+
+    def child():
+        assert gate.wait(30), "test did not release its child"
+        return {"status": "completed", "summary": "Required review finished."}
+
+    handle = ad.dispatch_async_delegation(
+        goal="Required review", context=None, toolsets=None, role="leaf", model=None,
+        session_key="", parent_session_id="parent", runner=child,
+    )
+    delegation_id = handle["delegation_id"]
+    adapter, transport = _connected_adapter(supported_ops=("send", "edit", "typing", "draft"))
+    metadata = {"thread_ts": "1700.42"}
+    loop = asyncio.new_event_loop()
+    ctx = SimpleNamespace(_status_adapter=adapter, _status_chat_id="C1", _status_thread_metadata=metadata,
+                          _run_still_current=lambda: True, _cleanup_progress=False,
+                          source=SimpleNamespace(platform=Platform.SLACK))
+    turn_runner = TurnRunner(None, ctx)
+    turn_runner._schedule = lambda coro, _log_message: loop.run_until_complete(coro)
+
+    def status_callback(kind, text):
+        statuses.append((kind, text))
+        turn_runner._status_callback_sync(kind, text)
+
+    agent.status_callback = status_callback
+    try:
+        loop.run_until_complete(adapter.send_draft("C1", 5, "Implementation", metadata=metadata))
+        result = agent.run_conversation("Implement and review this change.")
+        assert adapter._open_draft_by_chat.get(adapter._draft_key("C1", metadata)) == 5
+        assert not any(op.get("final") for op in transport.sent if op["op"] == "draft")
+        loop.run_until_complete(adapter.send("C1", result["final_response"], metadata=metadata))
+        seals = [op for op in transport.sent if op["op"] == "draft" and op.get("final")]
+        assert len(seals) == 1 and seals[0]["content"] == answer
+        assert not gate.is_set()  # The parent returned while its child was still blocked.
+        assert result["pending_delegations"]["active"] == [delegation_id]
+        assert any("1 active unit(s)" in text for _, text in statuses)
+        assert result["completed"] is True  # Preserve the existing *turn* contract.
+        assert result["final_response"] == answer
+        assert result["api_calls"] == 1
+        assert [m["role"] for m in result["messages"]] == ["user", "assistant"]
+        prefix = agent._cached_system_prompt
+
+        gate.set()
+        event = process_registry.completion_queue.get(timeout=5)
+        statuses.clear()
+        ready = agent.run_conversation("Report current progress.", conversation_history=result["messages"])
+        assert ready["pending_delegations"]["awaiting_delivery"] == [delegation_id]
+        assert any("1 result(s) awaiting delivery" in text for _, text in statuses)
+        durable = ad.get_durable_delegation(delegation_id)
+        assert durable is not None and durable["delivery_state"] == "pending"
+
+        # Match between-turn admission: accept the completion, then let the parent incorporate it.
+        claim = ad.claim_event_delivery(event, "test")
+        assert claim
+        notification = format_process_notification(event)
+        assert notification is not None
+        ad.complete_event_delivery(event, claim)
+        statuses.clear()
+        done = agent.run_conversation(notification, conversation_history=ready["messages"])
+        assert "pending_delegations" not in done
+        assert not any("awaiting delivery" in text for _, text in statuses)
+        assert done["completed"] is True and done["api_calls"] == 1
+        assert done["final_response"] == answer
+        assert agent._cached_system_prompt == prefix
+        assert agent.client.chat.completions.create.call_count == 3
+        assert [m["role"] for m in done["messages"]] == ["user", "assistant"] * 3
+        assert ledger.get_messages("parent")[-1]["content"] == answer
+    finally:
+        gate.set()
+        if ad._executor is not None:
+            ad._executor.shutdown(wait=True)
+        loop.close()

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -17,7 +17,7 @@ import threading
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
@@ -444,6 +444,54 @@ def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
 def _event_delivery(fn, evt: Dict[str, Any], claim_id: str) -> None:
     if claim_id and evt.get("type") == "async_delegation":
         fn(str(evt.get("delegation_id") or ""), claim_id)
+
+
+def pending_delegations(parent_session_id: Optional[str], *, exclude_delegation_id: Optional[str] = None) -> Dict[str, Any]:
+    """Read this conversation's outstanding completion units, including results whose children exited.
+
+    This is a delivery snapshot, NOT proof of task completion or result incorporation. A claim is still pending
+    until its consumer accepts it. Use the durable parent/compression lineage, never a reused chat/tab id or the
+    process-global live count. The ledger is committed before dispatch returns and owns delivery state even while
+    RAM still says ``finalizing``. Reads must not claim results, initialize storage, or wait for children.
+    """
+    snapshot: Dict[str, Any] = {"active": [], "awaiting_delivery": [], "status_known": bool(parent_session_id)}
+    if not parent_session_id:
+        return snapshot
+    try:
+        path = _db_path()
+        if not path.exists():
+            return snapshot
+        from hermes_state import SessionDB
+        with closing(SessionDB(path, read_only=True)) as db:
+            tables = {row[0] for row in db._read_all(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('sessions', 'async_delegations')")}
+            if "async_delegations" not in tables:
+                return snapshot
+            lineage = db.get_compression_lineage(parent_session_id) if "sessions" in tables else []
+            owners = lineage or [parent_session_id]
+            rows = db._read_all(
+                "SELECT delegation_id, state FROM async_delegations WHERE delivery_state='pending' "
+                f"AND parent_session_id IN ({','.join('?' for _ in owners)}) ORDER BY delegation_id", tuple(owners))
+            for delegation_id, state in rows:
+                if delegation_id != exclude_delegation_id:
+                    key = "active" if state in _LIVE_STATES else "awaiting_delivery"
+                    snapshot[key].append(delegation_id)
+    except Exception:
+        # Status reporting is additive; a busy/unavailable store must not abort a produced answer or pretend
+        # there is no outstanding work. Keep the failure distinct from a verified empty snapshot.
+        snapshot["status_known"] = False
+        logger.debug("Could not read pending delegations for %s", parent_session_id, exc_info=True)
+    return snapshot
+
+
+def pending_delegation_status(snapshot: Dict[str, Any]) -> Optional[str]:
+    """Shared status text for turn-end, control responses and completion notifications."""
+    if not snapshot["status_known"]:
+        return "Background delegation status is unavailable."
+    active, ready = len(snapshot["active"]), len(snapshot["awaiting_delivery"])
+    if active or ready:
+        return f"Background delegations: {active} active unit(s), {ready} result(s) awaiting delivery."
+    return None
 
 
 def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -630,7 +630,7 @@ DELEGATE_TASK_SCHEMA = {
             "action": _p(
                 "string",
                 "Default 'spawn'. Live control of running children: "
-                "'list' = ids/goals/status/transcripts; 'steer' = queue "
+                "'list' = ids/goals/status/transcripts plus pending completion units; 'steer' = queue "
                 "course-correction text into one child (subagent_id + "
                 "message) without stopping it; 'stop' = end one child "
                 "early (subagent_id; partial result still returns). "

--- a/tools/delegate_tool_registry.py
+++ b/tools/delegate_tool_registry.py
@@ -236,7 +236,16 @@ def _list_payload(parent_agent: Any) -> Dict[str, Any]:
             "live_transcript": getattr(r.get("agent"), "_live_transcript_path", None),
         })
     payload: Dict[str, Any] = {"action": "list", "count": len(entries), "subagents": entries}
-    if not entries:
+    from tools.async_delegation import pending_delegations, pending_delegation_status
+    pending = pending_delegations(getattr(parent_agent, "session_id", None))
+    status = pending_delegation_status(pending)
+    payload["pending_delegations"] = pending
+    if status:
+        payload["note"] = (
+            status + " Results arrive between turns. If the current request depends on them, report it as pending "
+            "and end your turn; do not poll or re-dispatch to wait."
+        )
+    elif not entries:
         payload["note"] = (
             "No live subagents right now. Children that already finished "
             "have delivered (or will deliver) their results as normal "

--- a/tools/process_registry_notifications.py
+++ b/tools/process_registry_notifications.py
@@ -132,9 +132,24 @@ def _notice_lines(results) -> "list[str]":
     return ["", *notice] if notice else []
 
 
+def _pending_delegation_lines(evt: dict) -> "list[str]":
+    """Sample siblings at formatting time, not at dispatch or inside the provider loop."""
+    from tools.async_delegation import is_interim_delegation_event, pending_delegations, pending_delegation_status
+    pending = pending_delegations(
+        evt.get("parent_session_id"),
+        exclude_delegation_id=None if is_interim_delegation_event(evt) else evt.get("delegation_id"))
+    status = pending_delegation_status(pending) or "No other delegation results are outstanding."
+    lines = ["Delegation status when this notification was prepared: " + status]
+    if pending["active"] or pending["awaiting_delivery"] or not pending["status_known"]:
+        lines.append(
+            "If the current request depends on outstanding results, report it as pending and end your turn to "
+            "receive them; do not poll or re-dispatch to wait. This snapshot is not confirmation of result incorporation.")
+    return lines
+
+
 def _preamble(evt: dict, title: str, intro: str, completed_at: float, *, with_goal: bool) -> "list[str]":
     """Shared preamble: title, intro, blank, dispatch time, [goal], context/toolsets, role+model."""
-    lines = [title, intro, ""]
+    lines = [title, intro, *_pending_delegation_lines(evt), ""]
     dispatched_at = evt.get("dispatched_at")
     if isinstance(dispatched_at, (int, float)):
         ts = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(dispatched_at))
@@ -160,6 +175,7 @@ def _format_task_failure_notice(evt: dict, deleg_id: str) -> str:
         "One subagent in a background fan-out you dispatched has failed while its siblings are still running. "
         "The batch's consolidated results will still arrive when the last sibling finishes; this is an early "
         "warning so you can re-dispatch or investigate now instead of then.",
+        *_pending_delegation_lines(evt),
         f"Task: {goal}" if goal else "",
         f"Status: {r.get('status', '?')}   Duration: {r.get('duration_seconds', '?')}s" + (f"\nError: {err}" if err else ""),
     ]

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -477,16 +477,23 @@ def _notif_dispatch_completions(sid, session, notifications, registry, deferred)
 
 def _notif_handle_ready(sid, session, events, emitted, registry, fmt, deferred, *, owned=False):
     """One ready snapshot: ownership and UI emission per event, one turn per completion run."""
-    completions = []
-    for index, event in enumerate(events):
-        if event.get("type", "completion") != "completion":
-            _notif_dispatch_completions(sid, session, completions, registry, deferred)
-            completions = []
-        if not _notif_handle_event(sid, session, event, emitted, registry, fmt, deferred, completions, owned=owned):
-            for remaining in events[index + 1:]:
-                (deferred.append if deferred is not None else registry.completion_queue.put)(remaining)
-            break
-    _notif_dispatch_completions(sid, session, completions, registry, deferred)
+    from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
+    # Poller threads have no turn scope. Formatting, sibling snapshots and delivery claims must
+    # all read the destination profile's ledger, not whichever profile launched the desktop.
+    token = set_hermes_home_override(session.get("profile_home") or get_hermes_home())
+    try:
+        completions = []
+        for index, event in enumerate(events):
+            if event.get("type", "completion") != "completion":
+                _notif_dispatch_completions(sid, session, completions, registry, deferred)
+                completions = []
+            if not _notif_handle_event(sid, session, event, emitted, registry, fmt, deferred, completions, owned=owned):
+                for remaining in events[index + 1:]:
+                    (deferred.append if deferred is not None else registry.completion_queue.put)(remaining)
+                break
+        _notif_dispatch_completions(sid, session, completions, registry, deferred)
+    finally:
+        reset_hermes_home_override(token)
 
 
 def _notification_poller_loop(stop_event: threading.Event, sid: str, session: dict) -> None:

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -12,6 +12,22 @@ Top-level model calls run in the background automatically. Hermes returns a hand
 
 ## Completion delivery
 
+Ending a parent turn is not the same as finishing work that depends on its subagents.
+At turn end, Hermes reports outstanding delegation units through its status channel and
+the additive `pending_delegations` field in `run_conversation()` results. The snapshot
+distinguishes `active` units from terminal results `awaiting_delivery`; both are lists of
+delegation IDs. `status_known: false` means the snapshot could not be established, not
+that no work remains. `delegate_task(action="list")` includes the same snapshot alongside
+its live-child roster. Completion messages include remaining-work counts sampled when
+the notification was prepared, excluding that result (but not an interim failure notice).
+
+These snapshots are conversation/profile-scoped and follow compression lineage, not a
+reused chat or tab ID. They do not prove that delivered results were incorporated. If a
+required review is pending, the parent should report that status and end its turn so the
+result can arrive, rather than poll, re-dispatch just to wait, or claim the task is done.
+Hermes preserves the model's answer and the existing turn-level `completed` flag; this
+reporting does not impose a task-completion gate or a budget across successive turns.
+
 Messaging gateways acknowledge background completions only after their adapter actually
 schedules the event or inserts it into the session's queue. Missing handlers, mismatched
 session routes, and full queues leave the completion pending for retry; these admission


### PR DESCRIPTION
## What does this PR do?

Distinguishes a finished model turn from outstanding delegated work without blocking between-turn completion delivery.

A parent can return a final answer while children are running, or after they have finished but before their results have been delivered. The live-child roster can already be empty at the latter boundary. Previously neither the turn result nor `delegate_task(action="list")` exposed this distinction, and the text-stop path printed “Conversation completed.” Later notifications can then reopen work the parent presented as finished.

This is **pending-state reporting and model-context enrichment**, not a hard task-completion gate. It preserves the model's answer and the existing turn-level `completed` contract used by streaming and crash recovery. It does not guarantee that a model incorporates every result or prevent all notification-driven delegation cascades. No provider-specific branch, extra inference call, synthetic mid-loop user message, task graph, configuration knob, or budget change is introduced.

## Related Issue

Related but distinct proposals found during cross-state issue/PR searches:
- #77978: prompt-only blocking/advisory completion guidance.
- #105065: conversation-scoped TUI live-delegation badge.
- #104434: mid-turn delivery/injection policy.
- #104594: pending completion delivery to stateless API clients.

This PR is independent of those proposals; it does not adopt their implementations or change when a completion starts a model turn.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update only
- [ ] ✅ Tests only
- [ ] ♻️ Refactor only

## Changes Made

- `tools/async_delegation.py`: read-only, profile-local ledger snapshot of `active` completion-unit IDs and terminal results `awaiting_delivery`, with explicit `status_known`. Uses the durable parent and compression lineage, not process-global counts or reused chat/tab IDs. Does not claim/acknowledge results or initialize storage.
- `tools/delegate_tool_registry.py`, `tools/delegate_tool.py`: expose the snapshot through the existing list action and describe the additive result.
- `tools/process_registry_notifications.py`: include remaining-work counts at notification formatting time. Exclude the current final result, but keep an interim child-failure notice's still-running unit pending. Advise yielding rather than polling/re-dispatching merely to wait.
- `agent/turn_final_response.py`, `agent/turn_finalizer.py`: say “Turn ended,” add `pending_delegations` metadata when work remains or its status is unavailable, and emit a lifecycle status. Preserve streamed answer text, history, system prompt, exit reason, and `completed`.
- `gateway/run_turn_runner.py`: mark status sends with the existing interim metadata contract so the notice cannot seal a Relay Slack draft before the real final answer.
- `tui_gateway/session_notifications.py`: bind the destination session's profile while formatting notifications and claiming/acknowledging delivery; restore the caller's scope afterward.
- Two invariant tests in `tests/agent/test_delegation_pending_work.py`, plus documentation in `website/docs/user-guide/features/delegation.md`.

## How to Test

The new tests use real async dispatch, event-gated child execution, SQLite, completion queues, the parent conversation loop, TUI notification admission, and RelayAdapter. The model/provider and external transport boundaries are controlled; no live LLM or Slack calls were made.

They verify:
1. A parent releases its turn while a required child is blocked, without retrying, rewriting the answer, or mutating cached history. Finished-but-unaccepted evidence stays pending; accepted evidence clears from the next turn's snapshot.
2. Pending state survives an empty RAM roster and compression rotation, excludes unrelated/fresh conversations, distinguishes unavailable storage, and respects claims, terminal failures, drops, and interim notices. A two-profile notification reads and acknowledges the owning ledger; a lifecycle status does not seal a live Slack draft.

Both tests were observed red on base `6178e9f4eed8d99f4fc550add939d58c7bed6206` due to missing pending state. A read-only review then identified stream sealing and ambient-profile errors; the expanded tests reproduced both defects before their corrections and pass afterward.

### Verification actually run

| Check | Result |
| --- | --- |
| Final focused delegation, lifecycle, persistence, Relay streaming, Slack/Telegram status suite (15 files) | **218 passed, 0 failed, 1 macOS-only skip** |
| Final affected-surface sweep including `tests/tui_gateway/` and `tests/test_tui_gateway_server.py` (135 files) | **2,018 passed, 1 failed, 5 skipped**. The model-picker failure reproduces on the untouched base with matching assertion diagnostics. |
| Broader core-loop sweep before the final adapter/poller corrections (727 files) | **8,695 passed, 20 failed, 37 skipped**. All 20 failing test IDs and assertion diagnostics reproduce on the untouched base: absent Anthropic SDK and incompatible installed Relay APIs. |
| Ruff on changed Python files, `scripts/check_compat_pointers.py`, `git diff --check` | **Passed** |

The broad sweeps are **not claimed green**. Baseline checks used the same interpreter/environment in a separate, unmodified worktree. Unrelated source or shared dependencies were not modified to hide those failures. No full repository suite, live Astra/Grok/Fable A/B run, or live desktop/Slack deployment is claimed. Remote CI is separate from these local results.

<details>
<summary>Canonical test commands</summary>

```bash
scripts/run_tests.sh tests/agent/test_delegation_pending_work.py tests/tools/test_async_delegation.py tests/tools/test_async_delegation_fd_leak.py tests/tools/test_delegate.py tests/tools/test_delegate_control_actions.py tests/tools/test_restored_delegation_ownership.py tests/tui_gateway/test_delegation_session_lifecycle.py tests/cli/test_cli_async_delegation_delivery.py tests/gateway/test_async_delegation_session_binding.py tests/run_agent/test_81641_text_turn_incremental_persistence.py tests/agent/test_turn_finalizer_final_response_persistence.py tests/gateway/test_stream_final_contract.py tests/gateway/relay/test_relay_live_cards.py tests/gateway/test_slack_status_update.py tests/gateway/test_telegram_status_update.py -j 6 --file-retries 0 -q

scripts/run_tests.sh tests/tui_gateway/ tests/test_tui_gateway_server.py tests/agent/test_delegation_pending_work.py tests/tools/test_async_delegation.py tests/tools/test_async_delegation_fd_leak.py tests/tools/test_delegate.py tests/tools/test_delegate_control_actions.py tests/tools/test_restored_delegation_ownership.py tests/tools/test_async_batch_task_failure_notice.py tests/tools/test_process_registry.py tests/tools/test_subagent_process_handoff.py tests/cli/test_subagent_notification_display.py tests/cli/test_cli_async_delegation_delivery.py tests/gateway/test_async_delegation_session_binding.py tests/gateway/test_stream_final_contract.py tests/gateway/relay/test_relay_live_cards.py tests/run_agent/test_81641_text_turn_incremental_persistence.py tests/agent/test_turn_finalizer_final_response_persistence.py -j 6 --file-retries 0 -q

scripts/run_tests.sh tests/agent/ tests/run_agent/ tests/tools/test_async_batch_task_failure_notice.py tests/tools/test_process_registry.py tests/tools/test_subagent_process_handoff.py tests/cli/test_subagent_notification_display.py -j 8 --file-retries 0 -q
```

</details>

## Checklist

### Code

- [x] I've read the Contributing Guide and applicable AGENTS.md files.
- [x] Commit message follows Conventional Commits.
- [x] Searched existing issues and PRs across states.
- [x] Only changes related to pending-delegation reporting and its delivery safety are included.
- [ ] Full repository suite passes — not run; actual focused/broader results and baseline failures are above.
- [x] Added invariant regression tests and exercised the real storage/delivery paths.
- [x] Tested on Linux; platform-specific skips remain for CI.

### Documentation & Housekeeping

- [x] Updated relevant user documentation and helper docstrings.
- [x] `cli-config.yaml.example`: N/A, no config changes.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no new architecture or workflow.
- [x] Considered cross-platform impact; no OS-specific runtime behavior added.
- [x] Updated the list-action description for the additive pending-completion snapshot.
