### PR TITLE
fix(desktop): fold separators in the free-input model/voice combobox filter

### DIFF
--- a/apps/desktop/src/app/settings/combobox-input.test.tsx
+++ b/apps/desktop/src/app/settings/combobox-input.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, beforeAll, expect, it, vi } from 'vitest'
+
+import { ComboboxInput } from './combobox-input'
+
+// jsdom doesn't implement these; Radix's Popover (PopoverContent/Arrow) and
+// cmdk's Command list use them once the popover actually mounts.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  )
+})
+
+afterEach(cleanup)
+
+const options = ['eleven_multilingual_v2', 'eleven_flash_v2_5', 'voxtral-mini-latest', 'gpt-4o-mini-tts']
+
+function ControlledCombobox({ initialValue = '' }: { initialValue?: string }) {
+  const [value, setValue] = useState(initialValue)
+
+  return <ComboboxInput onChange={setValue} options={options} value={value} />
+}
+
+function renderCombobox(initialValue = '') {
+  render(<ControlledCombobox initialValue={initialValue} />)
+}
+
+it('matches a separator-equivalent typed query, same as every other search-fold picker', async () => {
+  renderCombobox()
+
+  fireEvent.focus(screen.getByRole('textbox'))
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'eleven multilingual' } })
+
+  await screen.findByText('eleven_multilingual_v2')
+  expect(screen.queryByText('eleven_flash_v2_5')).toBeNull()
+  expect(screen.queryByText('voxtral-mini-latest')).toBeNull()
+})
+
+it('still matches a raw substring query (regression guard)', async () => {
+  renderCombobox()
+
+  fireEvent.focus(screen.getByRole('textbox'))
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'voxtral' } })
+
+  await screen.findByText('voxtral-mini-latest')
+  expect(screen.queryByText('eleven_multilingual_v2')).toBeNull()
+})
+
+it('shows every option once the value is an exact match', async () => {
+  renderCombobox('gpt-4o-mini-tts')
+
+  fireEvent.focus(screen.getByRole('textbox'))
+
+  await screen.findByText('gpt-4o-mini-tts')
+  expect(screen.getByText('eleven_multilingual_v2')).not.toBeNull()
+  expect(screen.getByText('voxtral-mini-latest')).not.toBeNull()
+})

--- a/apps/desktop/src/app/settings/combobox-input.tsx
+++ b/apps/desktop/src/app/settings/combobox-input.tsx
@@ -4,6 +4,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import { foldIncludes } from '@/lib/text'
 import { cn } from '@/lib/utils'
 
 /**
@@ -40,7 +41,7 @@ export function ComboboxInput({
   const query = value.trim().toLowerCase()
   const isExact = options.some(option => option.toLowerCase() === query)
 
-  const visible = query && !isExact ? options.filter(option => option.toLowerCase().includes(query)) : options
+  const visible = query && !isExact ? options.filter(option => foldIncludes(option, query)) : options
 
   return (
     <Popover onOpenChange={setOpen} open={open}>


### PR DESCRIPTION
## Summary

`ComboboxInput` (`apps/desktop/src/app/settings/combobox-input.tsx`) powers the free-input model/voice name fields in Settings → Audio (`config-field.tsx`'s `FREE_INPUT_KEYS`) — things like `tts.openai.model` (`gpt-4o-mini-tts`), `tts.elevenlabs.model_id` (`eleven_multilingual_v2`), `stt.mistral.model` (`voxtral-mini-latest`). Its filter was a raw case-insensitive substring match:

```ts
const visible = query && !isExact ? options.filter(option => option.toLowerCase().includes(query)) : options
```

Typing a space-separated query never finds a hyphen/underscore-separated option — `"eleven multilingual"` doesn't surface `eleven_multilingual_v2`, `"voxtral mini"` doesn't surface `voxtral-mini-latest`.

`lib/text.ts`'s `foldIncludes()` (fold `-`/`_`/`.` to spaces on both sides, then substring) exists exactly for this — `model-catalog-menu.tsx`, `model-picker.tsx`, and `model-visibility-dialog.tsx` all already use it for the main model picker. This combobox is a separate, later consumer that never adopted it.

## Change

- Import `foldIncludes` from `@/lib/text` and use it in place of the raw `.includes()` filter. One-line fix; `isExact` (which gates whether the dropdown shows the full list vs. the filtered one) is left as a literal equality check — unrelated to this bug.

## Verification

- New test file `combobox-input.test.tsx` (no prior test coverage existed for this component): a fold-equivalent query now matches (the new behavior), a raw substring query still matches (regression guard), and an exact-match value still shows the full option list.
- Mutation-verify: reverted the fix, confirmed the fold-equivalent test fails (times out finding the expected option) while the other two pass unaffected; reapplied, confirmed all three pass.
- Full `apps/desktop/src/app/settings/` suite: 35 files, 334 tests, all passing.
- `tsc --noEmit`: clean.

## Competing PRs

Searched `ComboboxInput`, `combobox-input`, `foldIncludes free-input`, `TTS model search fold` — no PR touches this filter or this component.

## Test plan

- [x] `npx vitest run src/app/settings/combobox-input.test.tsx` — 3/3 passing
- [x] `npx vitest run src/app/settings/` — 35 files / 334 tests passing
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] Mutation-verify
