### PR TITLE
fix(desktop): tear Electron rigs down root-first, not children-first

### DIFF
--- a/apps/desktop/scripts/run-short-session-hang-repro.mjs
+++ b/apps/desktop/scripts/run-short-session-hang-repro.mjs
@@ -662,6 +662,27 @@ function pidIsLive(pid) {
   }
 }
 
+/**
+ * Split a captured Electron process tree into the browser process and its
+ * children.
+ *
+ * Chromium's browser process supervises its zygote and GPU process and treats
+ * their unexpected death as fatal: three failed GPU launches in a row trip the
+ * `CHECK` in `gpu_data_manager_impl_private.cc` ("GPU process isn't usable.
+ * Goodbye."), which aborts the browser with SIGTRAP and dumps core. Signalling
+ * the tree children-first therefore manufactures a crash out of an ordinary
+ * shutdown.
+ *
+ * Teardown must give the root the first and only word: signal it alone, let it
+ * reap its own children, and sweep survivors afterwards.
+ */
+function teardownOrder(captured, rootPid) {
+  const root = captured.filter(row => row.pid === rootPid)
+  const children = captured.filter(row => row.pid !== rootPid)
+
+  return { root, children }
+}
+
 async function stopProcessTree(rootPid) {
   const captured = processTree(rootPid)
   const processDiscoveryErrors = new Set()
@@ -680,7 +701,30 @@ async function stopProcessTree(rootPid) {
     return live
   }
 
-  for (const { pid } of [...captured].reverse()) {
+  const { root, children } = teardownOrder(captured, rootPid)
+
+  // Root first, alone. Chromium tears its own children down in the right
+  // order; signalling them ourselves is what turns a clean exit into a
+  // SIGTRAP core dump.
+  for (const { pid } of root) {
+    try {
+      process.kill(pid, 'SIGTERM')
+    } catch {
+      // It already exited.
+    }
+  }
+
+  const rootDeadline = Date.now() + 3_000
+
+  while (Date.now() < rootDeadline && currentLive().some(row => row.pid === rootPid)) {
+    await sleep(100)
+  }
+
+  // Only now sweep whatever the browser failed to reap. A child outliving its
+  // browser is already orphaned, so SIGTERM here cannot fake a GPU crash.
+  const strays = currentLive().filter(row => children.some(child => child.pid === row.pid))
+
+  for (const { pid } of strays.reverse()) {
     try {
       process.kill(pid, 'SIGTERM')
     } catch {
@@ -1706,6 +1750,7 @@ export {
   classify,
   pairedSoftSignal,
   resultForError,
+  teardownOrder,
   validateArtifactBundle,
   validateSummary,
   waitFor,

--- a/apps/desktop/scripts/run-short-session-hang-repro.test.mjs
+++ b/apps/desktop/scripts/run-short-session-hang-repro.test.mjs
@@ -8,6 +8,7 @@ import {
   classify,
   pairedSoftSignal,
   resultForError,
+  teardownOrder,
   validateSummary,
   waitFor,
   waitForPredicate,
@@ -168,4 +169,39 @@ test('removes the exact temporary sandbox when the run body throws', async () =>
 
   assert.ok(sandbox)
   assert.equal(existsSync(sandbox), false)
+})
+
+test('teardown signals the browser process alone, never its children first', () => {
+  // A realistic Electron tree: the browser plus the children whose death it
+  // treats as fatal (zygote, GPU process).
+  const captured = [
+    { command: 'electron .', pid: 100, ppid: 1 },
+    { command: 'electron --type=zygote', pid: 101, ppid: 100 },
+    { command: 'electron --type=gpu-process', pid: 102, ppid: 101 },
+    { command: 'electron --type=renderer', pid: 103, ppid: 101 }
+  ]
+
+  const { root, children } = teardownOrder(captured, 100)
+
+  // The first signal must reach the browser and nothing else. Killing the
+  // zygote or GPU process while the browser lives trips
+  // "GPU process isn't usable. Goodbye." — a SIGTRAP core dump manufactured
+  // out of an ordinary shutdown.
+  assert.deepEqual(root.map(row => row.pid), [100])
+  assert.deepEqual(children.map(row => row.pid), [101, 102, 103])
+})
+
+test('teardown still names a root that process discovery never observed', () => {
+  // processTree() synthesises the root row when `ps` cannot see it. The
+  // synthetic root must still be signalled first rather than dropped, or the
+  // sweep becomes children-first again.
+  const captured = [
+    { command: '<synthetic-root>', pid: 200, ppid: 0, synthetic: true },
+    { command: 'electron --type=zygote', pid: 201, ppid: 200 }
+  ]
+
+  const { root, children } = teardownOrder(captured, 200)
+
+  assert.deepEqual(root.map(row => row.pid), [200])
+  assert.deepEqual(children.map(row => row.pid), [201])
 })


### PR DESCRIPTION
## Problem

`stopProcessTree()` in the desktop hang-repro harness signalled the captured
process tree in reverse order, so Electron's zygote and GPU process were
SIGTERMed while the browser process was still running.

Chromium's browser process supervises those children and treats their
unexpected death as fatal. The result is a fixed log signature:

```
zygote_communication_linux.cc:293  Failed to send GetTerminationStatus message to zygote
gpu_process_host.cc:998            GPU process launch failed: error_code=1002   (x3)
gpu_data_manager_impl_private.cc:415  FATAL: GPU process isn't usable. Goodbye.
```

That `CHECK` aborts the browser with SIGTRAP and dumps core, so an ordinary
teardown is recorded as a crash. On desktop environments that surface core
dumps, every harness run raises a "Process crashed: electron" notification for
a shutdown that was about to succeed — and the run also pays a 20s SIGKILL
escalation because the browser never exits on its own.

## Solution

Signal the root alone, wait for it to reap its own tree, then sweep only the
processes that outlived it before escalating to SIGKILL. Anything still alive
at that point is already orphaned, so signalling it cannot be mistaken by a
live browser for a GPU crash.

`teardownOrder()` is extracted as a pure function so the ordering invariant is
asserted directly, rather than by faking a live process group or grepping the
source for a call shape.

Scope is deliberately narrow. The shipped teardown paths were checked and are
**not** affected:

- Playwright's `app.close()`, used by every `e2e/fixtures.ts` fixture — clean,
  5/5 rounds, ~40ms, zero core dumps.
- The `process.kill(-pid, ...)` group sends in `backend-child.ts` / `main.ts`
  target the **backend** child (`hermes serve`, spawned with
  `start_new_session=True`). Electron's browser is not in that group, so its
  zygote is never touched. Group-killing is correct there; this harness had
  copied the pattern onto an Electron tree, where it is fatal.

## Verification

Real Electron 40.10.2, trivial app, core dumps attributed per round by browser
PID (a time-window counter mis-credits dumps across rounds):

| teardown | rounds | SIGKILL escalations | core dumps | orphans | median |
|---|---|---|---|---|---|
| children-first (before) | 10 | 10 | 7 | 0 | 20.0s |
| children-first, `--disable-gpu` | 6 | 2 | 2 | 0 | 0.06s |
| root-first (after) | 12 | 0 | 0 | 0 | 0.06s |

Every dump reproduced the `error_code=1002` → "GPU process isn't usable"
signature above.

Unit tests: `node --test apps/desktop/scripts/run-short-session-hang-repro.test.mjs`
→ 9/9 pass. Both new tests were confirmed red on the base commit (the
implementation reverted alone fails the import), then green with it restored.

## Note: unrelated upstream Electron issue found while investigating

Not addressed here, but worth recording. On Electron 40.10.2,
`new BrowserWindow()` never returns under `--ozone-platform=headless`:
`whenReady` resolves at +12ms, the constructor never returns, and ~60s later
the process segfaults, so no window is ever rendered. The same app is fine
with `--headless=new` (`did-finish-load` at +133ms, exit 0),
`--ozone-platform=x11`, and `--ozone-platform=wayland`. No code in this repo
launches with that flag, so nothing here changes; reporting upstream
separately.
