### PR TITLE
fix(constants): detect Podman storage roots on cgroup v2

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1067,7 +1067,10 @@ def _detect_container() -> bool:
     # the root ("/") mount line. A host that merely *runs* containers exposes every container's
     # overlay lowerdir (``lowerdir=/var/lib/containerd/...``) at non-root mount points, which a
     # whole-file scan misread as "inside a container" and flipped subprocess HOME (#58135).
-    return _root_mount_has_marker("/proc/self/mountinfo", ("kubepods", "containerd", "crio"))
+    return _root_mount_has_marker(
+        "/proc/self/mountinfo",
+        ("kubepods", "containerd", "crio", "/containers/storage/"),
+    )
 
 
 def _root_mount_has_marker(path: str, markers: tuple[str, ...]) -> bool:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -386,6 +386,33 @@ class TestIsContainer:
         assert _root_mount_has_marker(str(container), markers) is True
         assert _root_mount_has_marker(str(tmp_path / "missing"), markers) is False
 
+    @pytest.mark.parametrize(
+        "storage_root",
+        (
+            "/var/lib/containers/storage",
+            "/home/user/.local/share/containers/storage",
+        ),
+    )
+    def test_cgroup_v2_detects_containers_storage_rootfs(self, monkeypatch, storage_root):
+        """Podman/CRI-O roots can name only the shared containers/storage tree."""
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda _path: False)
+
+        def read_proc(path):
+            if path == "/proc/1/cgroup":
+                return "0::/\n"
+            if path == "/proc/self/mountinfo":
+                return (
+                    "600 599 0:58 / / rw,relatime - overlay overlay "
+                    f"rw,lowerdir={storage_root}/overlay/l/A,"
+                    f"upperdir={storage_root}/overlay/abc/diff\n"
+                )
+            return ""
+
+        monkeypatch.setattr(hermes_constants, "_read_proc", read_proc)
+        assert is_container() is True
+
     def test_caches_result(self, monkeypatch):
         """Second call uses cached value without re-probing."""
         monkeypatch.setattr(hermes_constants, "_container_detected", True)


### PR DESCRIPTION
## Why

#105351 correctly restricts the cgroup-v2 mountinfo fallback to the process root mount, fixing the host false positive from #58135. Its production marker list is still `kubepods`, `containerd`, and `crio`, however, so a Podman/CRI-O overlay whose mount options name only the shared `containers/storage` graph root remains undetected when `/.containerenv`, `/run/.containerenv`, and cgroup markers are unavailable.

This is the unique positive-detection case retained from closed #65060. The maintainer close explicitly invited a follow-up if that branch covered a case the merged salvage missed. The containers/storage reference configuration documents `/var/lib/containers/storage` as the rootful graph root and `$HOME/.local/share/containers/storage` as the rootless default: https://github.com/containers/storage/blob/main/storage.conf

On current main, direct probes for both root shapes returned `False`.

## Change

- Add the path-delimited `/containers/storage/` marker to the existing root-mount-only fallback.
- Cover both rootful and rootless storage paths through the real `_detect_container()` path.

The root-mount boundary introduced by #105351 stays intact, so storage paths belonging to containers merely running on the host remain ignored.

## Verification

- `tests/test_hermes_constants.py`: 66 passed, 5 skipped
- Ruff: passed
- Python compilation: passed
- `git diff --check`: passed
