### PR TITLE
fix(desktop): scope thread scroll-position storage to the tile's own profile

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -695,6 +695,7 @@ const ChatViewContent = memo(function ChatViewContent({
             onCancel={haltRun}
             onDismissError={onDismissError}
             onRestoreToMessage={onRestoreToMessage}
+            profile={modelOptionsProfile || activeGatewayProfile}
             sessionId={activeSessionId}
             sessionKey={threadKey}
           />

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -43,6 +43,8 @@ interface ThreadProps {
   onCancel?: () => Promise<void> | void
   onDismissError?: (messageId: string) => void
   onRestoreToMessage?: (messageId: string, target?: RestoreMessageTarget) => Promise<void> | void
+  /** The profile that OWNS this instance (see ThreadMessageListProps). */
+  profile?: string
   sessionId?: string | null
   sessionKey?: string | null
 }
@@ -64,6 +66,7 @@ export const Thread = memo(function Thread({
   onCancel,
   onDismissError,
   onRestoreToMessage,
+  profile,
   sessionId = null,
   sessionKey
 }: ThreadProps) {
@@ -175,6 +178,7 @@ export const Thread = memo(function Thread({
           components={messageComponents}
           emptyPlaceholder={emptyPlaceholder}
           loadingIndicator={loadingIndicator}
+          profile={profile}
           sessionId={sessionId}
           sessionKey={sessionKey}
         />

--- a/apps/desktop/src/components/assistant-ui/thread/list-session-scroll.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list-session-scroll.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { rescopeConnectionScopedStores } from '@/lib/connection-scoped'
 import { setActiveProfile } from '@/store/profile'
-import { saveThreadScrollPosition } from '@/store/thread-scroll'
+import { getThreadScrollPosition, saveThreadScrollPosition, threadScrollStorageKey } from '@/store/thread-scroll'
 
 import { stubThreadEnvironment, stubThreadViewportSize } from '../test-utils'
 
@@ -79,10 +79,11 @@ function sessionMessages(key: string, turns = 1): ThreadMessage[] {
 
 interface ScrollHarnessProps {
   messages: ThreadMessage[]
+  profile?: string
   sessionKey: string | null
 }
 
-function ScrollHarness({ messages, sessionKey }: ScrollHarnessProps) {
+function ScrollHarness({ messages, profile, sessionKey }: ScrollHarnessProps) {
   const runtime = useExternalStoreRuntime<ThreadMessage>({
     isRunning: false,
     messages,
@@ -91,7 +92,7 @@ function ScrollHarness({ messages, sessionKey }: ScrollHarnessProps) {
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
-      <Thread sessionKey={sessionKey} />
+      <Thread profile={profile} sessionKey={sessionKey} />
     </AssistantRuntimeProvider>
   )
 }
@@ -168,5 +169,66 @@ describe('list session-scroll restore', () => {
     // jsdom has no native scroll anchoring; the browser probe checks the
     // resulting reader position. Here the abandoned target must not return.
     expect(vp.scrollTop).not.toBe(2000 - CLIENT_H - 800)
+  })
+
+  // A background/keep-alive tile can be owned by a DIFFERENT profile than the
+  // window's ambient active one (multi-profile Bot mode: several tabs, each
+  // bound to its own bot/profile, mounted at once). Without `profile` threaded
+  // through, every mounted instance read/wrote the ambient `$activeProfile`
+  // bucket regardless of which profile it actually belonged to, so a
+  // background tile's remembered position lived under the WRONG profile's key
+  // (or polluted it) and could never be found again.
+  describe('per-tile profile scoping (background tile owned by a non-ambient profile)', () => {
+    it('restores from the tile’s OWN profile bucket, not the ambient active one', async () => {
+      setActiveProfile('default')
+      // A position saved for a DIFFERENT profile than the window's ambient one.
+      saveThreadScrollPosition('x', { fromBottom: 800, kind: 'offset' }, threadScrollStorageKey('other'))
+
+      const { container } = render(<ScrollHarness messages={sessionMessages('x')} profile="other" sessionKey="x" />)
+
+      await settleScroll()
+
+      expect(viewportEl(container).scrollTop).toBe(SCROLL_H - 800 - CLIENT_H)
+    })
+
+    it('does not leak a background tile’s remembered position into the ambient profile’s view of the same session key', async () => {
+      setActiveProfile('default')
+      saveThreadScrollPosition('x', { fromBottom: 800, kind: 'offset' }, threadScrollStorageKey('other'))
+
+      // No `profile` prop: the primary view, which correctly follows the
+      // ambient active profile ('default') — it must NOT see 'other's position.
+      const { container } = render(<ScrollHarness messages={sessionMessages('x')} sessionKey="x" />)
+
+      await settleScroll()
+
+      expect(viewportEl(container).scrollTop).toBe(SCROLL_H - CLIENT_H)
+    })
+
+    it('persists a background tile’s position under its OWN profile, not the ambient one', async () => {
+      setActiveProfile('default')
+
+      const { container, rerender } = render(
+        <ScrollHarness messages={sessionMessages('y')} profile="other" sessionKey="y" />
+      )
+      const vp = viewportEl(container)
+
+      await settleScroll()
+
+      // Scroll away from the bottom so the cleanup below has a real offset to
+      // record (a live state at the bottom records nothing new here).
+      act(() => {
+        vp.scrollTop = SCROLL_H - CLIENT_H - 400
+        vp.dispatchEvent(new Event('scroll'))
+      })
+      await settleScroll()
+
+      // Switching sessionKey commits the outgoing instance's cleanup, which
+      // records its live state under ITS OWN (profile-scoped) storage key.
+      rerender(<ScrollHarness messages={sessionMessages('z')} profile="other" sessionKey="z" />)
+      await settleScroll()
+
+      expect(getThreadScrollPosition('y', threadScrollStorageKey('other'))).toEqual({ fromBottom: 400, kind: 'offset' })
+      expect(getThreadScrollPosition('y', threadScrollStorageKey('default'))).toBeUndefined()
+    })
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -210,6 +210,11 @@ interface ThreadMessageListProps {
   components: ThreadMessageComponents
   emptyPlaceholder?: ReactNode
   loadingIndicator?: ReactNode
+  /** The profile that OWNS this instance — a background/keep-alive tile can
+   *  belong to a different profile than the window's ambient active one.
+   *  Threaded into scroll-position storage scoping (#thread-scroll-tile-scope);
+   *  omitted for the primary view, which correctly follows the ambient profile. */
+  profile?: string
   sessionId?: string | null
   sessionKey?: string | null
 }
@@ -400,6 +405,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   components,
   emptyPlaceholder,
   loadingIndicator,
+  profile,
   sessionId = null,
   sessionKey
 }) => {
@@ -709,7 +715,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // settled gate — a close mid-settle must not persist transient clamped
   // metrics.
   useEffect(() => {
-    const storageKey = threadScrollStorageKey()
+    const storageKey = threadScrollStorageKey(profile)
 
     const flush = () => {
       if (sessionKey && loadSettledRef.current && restoredContentKeyRef.current === sessionKey) {
@@ -720,7 +726,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     window.addEventListener('beforeunload', flush)
 
     return () => window.removeEventListener('beforeunload', flush)
-  }, [sessionKey])
+  }, [profile, sessionKey])
 
   // Reset the cap and restore the remembered scroll state on mount + every
   // session switch (messages swap in place on a long-lived runtime, so
@@ -753,7 +759,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     }
 
     // Cleanup belongs to the subscription owner, not the newly active globals.
-    const storageKey = threadScrollStorageKey()
+    const storageKey = threadScrollStorageKey(profile)
     const sessionSwitched = settleKeyRef.current !== sessionKey
 
     const plan = planThreadScrollRestore(restoredContentKeyRef.current, sessionKey, hasGroups, loadSettledRef.current)
@@ -923,7 +929,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       cancelAnimationFrame(rafId)
       record()
     }
-  }, [contentRef, hasGroups, scrollRef, scrollToBottom, sessionId, sessionKey, stopScroll])
+  }, [contentRef, hasGroups, profile, scrollRef, scrollToBottom, sessionId, sessionKey, stopScroll])
 
   // A thread can mount with a run already active, without a runStart event.
   useEffect(() => {


### PR DESCRIPTION
## Summary

`threadScrollStorageKey()` (`store/thread-scroll.ts`) defaults to `$activeProfile.get()` — the window's ambient, currently-foreground profile. `list.tsx`'s scroll-position persistence (save on `beforeunload`, save+restore on session switch) called it with no argument at both of its two call sites, so every mounted `ThreadMessageList` instance read/wrote the SAME ambient bucket regardless of which profile it actually belongs to.

That's wrong for a background/keep-alive tile: `session-tile.tsx` mounts one full `Thread` tree per tile — `pane-shell/pane-visibility.ts` deliberately keeps hidden tab-stack panes mounted with a real layout box specifically so their scroll position survives a tab round-trip — and each tile has its own owning profile (`ownerRoute?.targetProfile || ownerRoute?.profile`, already resolved per-tile as `modelOptionsProfile`). A background tile owned by a different profile than the window's foreground one:

- saved its scroll offset into the **wrong** profile's storage bucket (the ambient foreground one, not its own), and
- on switching back to it, looked itself up in the **wrong** bucket too — so the position it had actually saved earlier (under whatever profile happened to be foreground back then) was never found, silently resetting to the bottom, and
- polluted / LRU-evicted entries (120-entry cap) that belong to a profile it doesn't own.

The sibling mechanism in the same file (`$threadScrolledUp`/jump-button visibility) is already correctly scoped per-pane via `usePaneVisible()`; the scroll-position storage-key path never got the same treatment.

## Change

Thread the owning profile through as an explicit prop instead of relying on the ambient default — `threadScrollStorageKey`'s own `profile = $activeProfile.get()` default parameter already covers every caller that doesn't pass one, so this is additive, not a behavior change for the primary view:

- `store/thread-scroll.ts`: unchanged (already accepts an optional `profile` override).
- `list.tsx`: add `profile?: string` to `ThreadMessageListProps`, pass it into both `threadScrollStorageKey(profile)` call sites (the `beforeunload` save effect and the session-switch restore/record `useLayoutEffect`), and add `profile` to the latter's dependency array.
- `thread/index.tsx` (`Thread`): add `profile?: string` to `ThreadProps`, forward it to `<ThreadMessageList>` — same treatment as the existing `sessionKey` passthrough, not folded into the memoized component-map (see the file's own comment on why `cwd`/`gateway`/`sessionId` stay out of those deps — `profile` doesn't change on every session switch the way those do, so no such hazard here).
- `app/chat/index.tsx` (`ChatViewContent`): pass `profile={modelOptionsProfile || activeGatewayProfile}` to `<Thread>` — the exact same expression the function already uses for its own `modelOptionsProfile` fallback a few lines up, so primary-view behavior (no owner route) is unchanged, and tile behavior picks up the real per-tile owner.

## Verification

- New tests in `list-session-scroll.test.tsx`: a background tile (`profile="other"`) restores from its own profile's bucket while the ambient active profile is `'default'`; the primary view (no `profile` prop) does not see that bucket; a background tile's scroll persists under its own profile, not the ambient one.
- Mutation-verify: reverted the three production files, confirmed the two new positive tests fail (wrong scrollTop / `undefined` where a saved position was expected), reapplied, confirmed all 5 tests in the file pass.
- Broader regression: `apps/desktop/src/components/assistant-ui/`, `apps/desktop/src/app/chat/`, `apps/desktop/src/store/thread-scroll.test.ts` — 168 files, 1446 tests, all passing.
- `tsc --noEmit`: clean.

## Competing PRs

- `#103692` (open) touches the same file but a different sub-mechanism (`$threadScrolledUp`/`$threadJumpButtonVisible` session-keying for split panes) — its `list.tsx` hunk is at the `publishThreadAtBottom`/`resetPublishedThreadScroll` call sites, not the storage-key lines this PR touches. No overlap.
- `#103365` and `#102264` (both open) also touch `list.tsx`'s scroll handling, but both predate `#105060` (merged today, `f4f691c6cc`) — verified with `git merge-base --is-ancestor` that both PRs' base commits are ancestors of `#105060`'s merge commit, i.e. they were written against the pre-`#105060` scroll mechanism and are now stale against current `main`. Neither touches profile scoping (grepped their diffs).
- `#105060` itself (merged) is explicitly framed as a "partial" fix (title: "partial #45562 / #98136") of the general reading-position tracker issues — those issues are about hydration/backfill snapping the viewport, not multi-profile tile scoping; this PR addresses a different, adjacent gap in the same feature area.

## Test plan

- [x] `npx vitest run src/components/assistant-ui/thread/list-session-scroll.test.tsx` — 5/5 passing
- [x] `npx vitest run src/components/assistant-ui/ src/app/chat/ src/store/thread-scroll.test.ts` — 168 files / 1446 tests passing
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] Mutation-verify
