### PR TITLE
fix(codex): allow delayed turn-start responses

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -275,10 +275,12 @@ class CodexAppServerSession:
         result.thread_id = self._thread_id
         return True
 
-    def _request_for(self, result: TurnResult, method: str, params: dict, label: str) -> Optional[dict]:
+    def _request_for(
+        self, result: TurnResult, method: str, params: dict, label: str, *, timeout: float = 10.0,
+    ) -> Optional[dict]:
         """Issue ``method``; on failure fill ``result.error`` and return None. A timeout always retires."""
         try:
-            return self._client.request(method, params, timeout=10)
+            return self._client.request(method, params, timeout=timeout)
         except CodexAppServerError as exc:
             self._set_classified_error(result, f"{label} failed", exc.message, exc)
         except TimeoutError as exc:
@@ -344,10 +346,11 @@ class CodexAppServerSession:
                 result.interrupted = True
             else:
                 result.submitted_user_text = _coerce_turn_input_text(user_input)
+                # Accepting a turn can outlast a control RPC while Codex waits on local state.
                 ts = self._request_for(
                     result, "turn/start",
                     {"threadId": self._thread_id, "input": [{"type": "text", "text": result.submitted_user_text}]},
-                    "turn/start",
+                    "turn/start", timeout=min(turn_timeout, 60.0),
                 )
                 if ts is not None:
                     self._run_started_turn(result, ts, turn_timeout, notification_poll_timeout, post_tool_quiet_timeout)

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -186,6 +186,36 @@ class TestLifecycle:
 # ---- turn loop ----
 
 class TestRunTurn:
+    @pytest.mark.parametrize(("reply_delay", "turn_timeout", "completes"), [
+        (12.0, 600.0, True),
+        (6.0, 5.0, False),
+        (65.0, 600.0, False),
+    ])
+    def test_turn_start_waits_within_a_bounded_budget(
+        self, monkeypatch, reply_delay, turn_timeout, completes,
+    ):
+        client = FakeClient()
+        request = client.request
+
+        def delayed_request(method, params=None, timeout=30.0):
+            response = request(method, params, timeout=timeout)
+            if method == "turn/start" and reply_delay > timeout:
+                raise TimeoutError(f"turn/start reply missed its {timeout}s deadline")
+            return response
+
+        monkeypatch.setattr(client, "request", delayed_request)
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "turn-fake-001", "status": "completed"},
+        )
+        result = make_session(client).run_turn("hi", turn_timeout=turn_timeout)
+
+        assert [method for method, _ in client.requests].count("turn/start") == 1
+        assert (result.error is None) is completes
+        assert result.should_retire is not completes
+        if not completes:
+            assert "turn/start timed out" in result.error
+
     def test_simple_text_turn_returns_final_message(self):
         client = FakeClient()
         client.queue_notification("turn/started", threadId="t", turn={"id": "tu1"})


### PR DESCRIPTION
Slow Codex `turn/start` acknowledgements currently hit a 10-second RPC deadline and retire the conversation. Allow up to 60 seconds for this request, capped by the caller's shorter turn timeout. Expired requests still retire the session without resubmitting the turn.

- Regression coverage includes a delayed reply, a shorter caller deadline, and an acknowledgement beyond the maximum wait. The new regression failed on the base before the fix.
- All eight Codex app-server test files passed: 127 tests, zero failures, with automatic test-file retries disabled. Coverage includes session startup, cancellation, compaction, persistence, and gateway event delivery.
- Ruff and syntax checks passed. Type checking reports the same six existing optional-client diagnostics on base and head; this change adds none.
- Matched live fault injection with Codex CLI 0.153.4: delayed the real `turn/start` reply by 12 seconds. Before: timeout at 10.13 seconds and session retirement. After: reply accepted at 13.37 seconds, final response `TURN_START_OK`, and one turn submission.
- The installed runtime also passed the same delayed-reply probe. Stalled starts can now take up to 60 seconds to report failure.
- No rendered UI changes; screenshots are not applicable.
