### PR TITLE
fix(skills): render each operation of a staged batch in /skills diff

### DIFF
--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -293,3 +293,49 @@ class TestSkillGist:
         assert wa.skill_gist("remove_file", "demo", file_path="a.py") == "remove a.py from 'demo'"
         assert wa.skill_gist("delete", "demo") == "delete skill 'demo'"
         assert wa.skill_gist("unknown", "demo") == "unknown 'demo'"
+
+
+class TestSkillPendingDiffBatch:
+    """A gated operations[] batch stages as ONE pending record whose payload is
+    {action: batch, operations: [...]} with no top-level name — the exact shape
+    _skill_manage_batch stages. /skills diff <id> must render the ops, not the
+    pre-fix '(batch on '')' dead end."""
+
+    def _batch_payload(self, **overrides):
+        ops = [
+            {"action": "create", "name": "probe", "content": "---\nname: probe\ndescription: Batch probe.\n---\n# Probe\n"},
+            {"action": "write_file", "name": "probe", "file_path": "scripts/a.py", "file_content": "pass"},
+        ]
+        ops.extend(overrides.pop("extra_ops", []))
+        payload = {"action": "batch", "operations": ops}
+        payload.update(overrides)
+        return payload
+
+    def test_batch_renders_each_operation_in_order(self):
+        from tools import write_approval as wa
+        out = wa.skill_pending_diff({"payload": self._batch_payload()})
+        assert "(batch on '')" not in out
+        assert out.count("## op ") == 2
+        assert "## op 1/2: create 'probe'" in out
+        assert "---\nname: probe" in out  # create content shown verbatim
+        assert "## op 2/2: write scripts/a.py in 'probe'" in out
+
+    def test_batch_edit_op_shows_unified_diff(self, hermes_home, monkeypatch):
+        from tools import write_approval as wa
+        skill_dir = os.path.join(hermes_home, "skills", "probe")
+        os.makedirs(skill_dir)
+        with open(os.path.join(skill_dir, "SKILL.md"), "w") as f:
+            f.write("old body\n")
+        monkeypatch.setattr(wa, "_find_skill_path", lambda name: __import__("pathlib").Path(skill_dir))
+        payload = self._batch_payload(extra_ops=[
+            {"action": "edit", "name": "probe", "content": "new body\n"},
+        ])
+        out = wa.skill_pending_diff({"payload": payload})
+        assert "## op 3/3: rewrite 'probe'" in out
+        assert "-old body" in out and "+new body" in out
+
+    def test_batch_without_operations_is_explicit(self):
+        from tools import write_approval as wa
+        out = wa.skill_pending_diff({"payload": {"action": "batch", "operations": []}})
+        assert out == "(empty batch)"
+

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -249,12 +249,33 @@ def _find_skill_path(name: str) -> Optional[Path]:
     return found["path"] if found else None
 
 
+def _batch_pending_diff(payload: Dict[str, Any], fallback_name: str) -> str:
+    """A gated ``operations[]`` batch stages as one pending write; render each op in
+    order (per-op gist header + the same create-content/diff body as a solo op)."""
+    ops = payload.get("operations")
+    if not isinstance(ops, list) or not ops:
+        return f"(batch on '{fallback_name}')" if fallback_name else "(empty batch)"
+    blocks = []
+    for i, op in enumerate(ops, 1):
+        op = op if isinstance(op, dict) else {}
+        header = skill_gist(op.get("action", ""), op.get("name", "") or fallback_name,
+                            content=op.get("content") or "",
+                            file_path=op.get("file_path") or "",
+                            old_string=op.get("old_string") or "",
+                            new_string=op.get("new_string") or "")
+        body = skill_pending_diff({"payload": op}) or "(empty)"
+        blocks.append(f"## op {i}/{len(ops)}: {header}\n\n{body}")
+    return "\n\n".join(blocks)
+
+
 def skill_pending_diff(record: Dict[str, Any]) -> str:
     """Full content (create) or unified diff vs. the on-disk skill (edit/patch/write_file),
     rendered by /skills diff <id> on surfaces that can show it."""
     payload = record.get("payload", {})
     action = payload.get("action", "")
     name = payload.get("name", "")
+    if action == "batch":
+        return _batch_pending_diff(payload, name)
     if action == "create":
         return payload.get("content") or ""
     if action not in {"edit", "patch", "write_file"}:


### PR DESCRIPTION
## Summary

`/skills diff <id>` on a pending **batch** skill write rendered `(batch on '')` with no content.

Root cause: `skill_manage(operations=[...])` under the approval gate stages the whole batch as ONE pending record with payload `{"action": "batch", "operations": [...]}` and no top-level `name` (`tools/skill_manager_batch.py` `_skill_manage_batch` staging branch). `skill_pending_diff` (`tools/write_approval.py`) only knew `create`/`edit`/`patch`/`write_file`/`remove_file`/`delete`, so `batch` fell into the catch-all `f"({action} on '{name}')"`, producing the reported dead end.

## Fix

- `skill_pending_diff` detects `action == "batch"` and renders each operation in order via a new `_batch_pending_diff` helper: per-op gist header (`## op i/N: <skill_gist>`) + the same body a solo op gets (create content verbatim, unified diff vs the on-disk skill for edit/patch/write_file, reused recursively through `skill_pending_diff`).
- Empty/degenerate `operations` renders an explicit `(empty batch)` instead of a misleading name.

## Testing

- New `TestSkillPendingDiffBatch` in `tests/tools/test_write_approval.py`:
  - renders each op in order, create content verbatim, correct headers;
  - an `edit` op inside the batch shows a real unified diff (`-old`/`+new`) against the on-disk SKILL.md;
  - empty batch is explicit.
- Mutation check: disabling the `action == "batch"` branch turns all three new tests red; restored → 18/18 green.
- `tests/tools/test_skill_manage_batch.py` (staging round-trip) still 9/9 green; `ruff check` clean; no new `ruff format` drift on touched lines (pre-existing file drift untouched).

Fixes #105399