### PR TITLE
feat(gateway): final_gateway_send_policy plugin hook

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -98,6 +98,30 @@ def _send_result_error(result: Any) -> Optional[str]:
     return None if get("success", True) is not False else str(get("error") or "")
 
 
+def apply_final_gateway_send_policy(
+    platform: Platform, chat_id: str, content: str, metadata: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Apply registered final-send policy decisions in registration order."""
+    from hermes_cli.lifecycle import invoke_hook
+
+    final_content = content
+    for decision in invoke_hook(
+        "final_gateway_send_policy",
+        platform=platform.value,
+        chat_id=chat_id,
+        content=final_content,
+        metadata=metadata,
+    ):
+        if not isinstance(decision, dict):
+            continue
+        action = str(decision.get("action") or "").lower()
+        if action == "rewrite" and isinstance(decision.get("content"), str):
+            final_content = decision["content"]
+        elif action == "block":
+            raise PermissionError(str(decision.get("reason") or "gateway send blocked by policy"))
+    return final_content
+
+
 @dataclass
 class DeliveryTarget:
     """One target: "origin", "local", "telegram" (home channel) or "telegram:123456[:thread]"."""
@@ -302,6 +326,9 @@ class DeliveryRouter:
                 else:
                     send_metadata["telegram_dm_topic_reply_fallback"] = True
 
+        content = apply_final_gateway_send_policy(
+            target.platform, target.chat_id, content, send_metadata or None,
+        )
         for retry in (False, True):
             result = await transport.send(target.platform, target.chat_id, content, metadata=send_metadata or None)
             error = _send_result_error(result)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -106,6 +106,7 @@ _install_plugin_debug_handler()
 
 VALID_HOOKS: Set[str] = {
     "pre_tool_call", "post_tool_call", "transform_terminal_output", "transform_tool_result",
+    "final_gateway_send_policy",
     # transform_llm_output: return a replacement string (first non-None wins) or None.
     "transform_llm_output", "pre_llm_call", "post_llm_call",
     # Streaming observers (agent.plugin_stream_hooks), off the token path; payloads are immutable

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -146,6 +146,38 @@ class RecordingAdapter:
 
 
 @pytest.mark.asyncio
+async def test_final_gateway_send_policy_rewrites_immediately_before_transport(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    hook_calls = []
+
+    def invoke_hook(name, **payload):
+        hook_calls.append((name, payload))
+        return [{"action": "rewrite", "content": "policy checked"}]
+
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", invoke_hook)
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+    target = DeliveryTarget.parse("telegram:12345")
+
+    await router._deliver_to_platform(target, "original", metadata={"source": "test"})
+
+    assert hook_calls == [(
+        "final_gateway_send_policy",
+        {
+            "platform": "telegram",
+            "chat_id": "12345",
+            "content": "original",
+            "metadata": {"source": "test"},
+        },
+    )]
+    assert adapter.calls == [{
+        "chat_id": "12345",
+        "content": "policy checked",
+        "metadata": {"source": "test"},
+    }]
+
+
+@pytest.mark.asyncio
 async def test_native_adapter_wins_when_relay_also_fronts_platform(tmp_path, monkeypatch):
     monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
     native = RecordingAdapter()


### PR DESCRIPTION
## Summary

- add a `final_gateway_send_policy` plugin hook immediately before adapter transport sends
- allow policy plugins to return `allow`, `rewrite`, or `block` decisions
- include platform, chat ID, content, and optional send metadata in the additive hook payload

## Why

General plugins can observe model and tool lifecycle events, but they cannot currently apply a final policy at the actual gateway egress boundary. This small hook lets standalone policy plugins enforce recipient-specific outbound checks without adding plugin-specific logic to core.

## Test plan

- `HERMES_PYTHON=/Users/paul/.hermes/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/gateway/test_delivery.py -o 'addopts=' -q`
- `/Users/paul/.hermes/hermes-agent/.venv/bin/python -m ruff check gateway/delivery.py hermes_cli/plugins.py tests/gateway/test_delivery.py`
