### PR TITLE
feat(kanban): expose guarded orchestrator-only dependency unlink

### DIFF
--- a/tests/tools/test_kanban_unlink.py
+++ b/tests/tools/test_kanban_unlink.py
@@ -1,0 +1,106 @@
+"""Real temporary-board integration tests for guarded dependency removal."""
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from tools import kanban_tools as kt
+
+
+@pytest.fixture
+def boards(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for key in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_DB", "HERMES_KANBAN_BOARD"):
+        monkeypatch.delenv(key, raising=False)
+    (home / "config.yaml").write_text("toolsets: [kanban]\n")
+    kb._INITIALIZED_PATHS.clear()
+    for board in ("alpha", "beta"):
+        kb.init_db(board=board)
+    return monkeypatch
+
+
+def graph(board="alpha", extra=False):
+    conn = kb.connect(board=board)
+    try:
+        root = kb.create_task(conn, title="unfinished goal", assignee="owner")
+        child = kb.create_task(conn, title="execution", assignee="worker", parents=[root])
+        other = kb.create_task(conn, title="safety prerequisite", assignee="owner")
+        if extra:
+            kb.link_tasks(conn, other, child)
+        return root, child, other
+    finally:
+        conn.close()
+
+
+def unlink(root, child, **kw):
+    return json.loads(kt._handle_unlink(dict(parent_id=root, child_id=child, **kw)))
+
+
+def test_unlink_promotes_and_audits_once(boards):
+    root, child, _ = graph()
+    out = unlink(root, child, board="alpha")
+    assert out["ok"] and out["removed"] is True
+    assert unlink(root, child, board="alpha")["removed"] is False
+    conn = kb.connect(board="alpha")
+    try:
+        assert kb.parent_ids(conn, child) == []
+        assert kb.get_task(conn, child).status == "ready"
+        assert kb.get_task(conn, root).status != "done"
+        events = conn.execute("SELECT payload FROM task_events WHERE task_id=? AND kind='unlinked'", (child,)).fetchall()
+        assert len(events) == 1
+        assert json.loads(events[0]["payload"]) == {"parent": root, "child": child}
+    finally:
+        conn.close()
+
+
+def test_preserves_other_parents_and_board(boards):
+    root, child, other = graph(extra=True)
+    beta_root, beta_child, _ = graph("beta")
+    boards.setenv("HERMES_KANBAN_BOARD", "beta")
+    assert unlink(root, child, board="alpha")["removed"] is True
+    for board, expected_child, expected_parent in (("alpha", child, other), ("beta", beta_child, beta_root)):
+        conn = kb.connect(board=board)
+        try:
+            assert kb.parent_ids(conn, expected_child) == [expected_parent]
+            assert kb.get_task(conn, expected_child).status == "todo"
+        finally:
+            conn.close()
+    assert unlink(beta_root, beta_child)["removed"] is True
+
+
+@pytest.mark.parametrize("args", [{}, {"parent_id": "x"}, {"parent_id": 1, "child_id": "y"}, {"parent_id": " ", "child_id": "y"}])
+def test_missing_or_invalid_arguments(boards, args):
+    assert json.loads(kt._handle_unlink(args)).get("error")
+
+
+def test_nonexistent_edge_is_idempotent(boards):
+    assert unlink("t_missing", "t_absent", board="alpha")["removed"] is False
+
+
+@pytest.mark.parametrize("context", ["worker", "delegated", "unconfigured"])
+def test_denied_before_connect(boards, monkeypatch, context):
+    if context == "worker":
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+    elif context == "delegated":
+        monkeypatch.setattr(kt, "_is_delegated_child_context", lambda: True)
+    else:
+        monkeypatch.setattr(kt, "_profile_has_kanban_toolset", lambda: False)
+    def forbidden(*args, **kwargs):
+        pytest.fail("unauthorized caller opened a database")
+    monkeypatch.setattr(kt, "_connect", forbidden)
+    assert unlink("root", "child", board="beta").get("error")
+
+
+def test_schema_available_only_to_orchestrator(boards):
+    from tools.registry import registry, invalidate_check_fn_cache
+    from toolsets import resolve_toolset
+    def names():
+        invalidate_check_fn_cache()
+        return {s["function"]["name"] for s in registry.get_definitions(set(resolve_toolset("kanban")), quiet=True)}
+    assert "kanban_unlink" in names()
+    boards.setenv("HERMES_KANBAN_TASK", "t_worker")
+    assert "kanban_unlink" not in names()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1666,6 +1666,32 @@ def _handle_link(args: dict, **kw) -> str:
         return tool_error(f"kanban_link: {e}")
 
 
+def _handle_unlink(args: dict, **kw) -> str:
+    """Remove one dependency using the audited kernel, orchestrators only."""
+    delegated_err = _reject_delegated_child_mutation("kanban_unlink")
+    if delegated_err:
+        return delegated_err
+    guard = _require_orchestrator_tool("kanban_unlink")
+    if guard:
+        return guard
+    # Schema checks can be cached; re-check opt-in at the mutation boundary.
+    if not _check_kanban_orchestrator_mode():
+        return tool_error("kanban_unlink requires an explicitly configured Kanban orchestrator")
+    parent_id, child_id = args.get("parent_id"), args.get("child_id")
+    if any(not isinstance(value, str) or not value.strip() for value in (parent_id, child_id)):
+        return tool_error("both parent_id and child_id must be non-empty strings")
+    try:
+        kb, conn = _connect(board=args.get("board"))
+        try:
+            removed = kb.unlink_tasks(conn, parent_id=parent_id, child_id=child_id)
+            return _ok(parent_id=parent_id, child_id=child_id, removed=removed)
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.exception("kanban_unlink failed")
+        return tool_error(f"kanban_unlink: {e}")
+
+
 # ---------------------------------------------------------------------------
 # Schemas
 # ---------------------------------------------------------------------------
@@ -2468,6 +2494,35 @@ registry.register(
     handler=_handle_unblock,
     check_fn=_check_kanban_orchestrator_mode,
     emoji="▶",
+)
+
+KANBAN_UNLINK_SCHEMA = {
+    "name": "kanban_unlink",
+    "description": (
+        "Remove exactly one parent-to-child dependency edge. Orchestrator-only; "
+        "not available to task workers or delegated agents. May immediately "
+        "release the child for dispatch; inspect its prerequisites first. "
+        "Preserves other edges and task completion state. Idempotent: removed "
+        "is false when the edge does not exist."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "parent_id": {"type": "string", "description": "Parent task id."},
+            "child_id": {"type": "string", "description": "Child task id."},
+            "board": _board_schema_prop(),
+        },
+        "required": ["parent_id", "child_id"],
+    },
+}
+
+registry.register(
+    name="kanban_unlink",
+    toolset="kanban",
+    schema=KANBAN_UNLINK_SCHEMA,
+    handler=_handle_unlink,
+    check_fn=_check_kanban_orchestrator_mode,
+    emoji="🔗",
 )
 
 registry.register(

--- a/toolsets.py
+++ b/toolsets.py
@@ -85,7 +85,7 @@ _HERMES_CORE_TOOLS = [
     "kanban_request_changes",
     "kanban_heartbeat",
     "kanban_comment", "kanban_create", "kanban_link",
-    "kanban_unblock",
+    "kanban_unblock", "kanban_unlink",
     "kanban_attach", "kanban_attach_url", "kanban_attachments",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
@@ -327,7 +327,7 @@ TOOLSETS = {
             "kanban_request_review", "kanban_request_changes",
             "kanban_heartbeat", "kanban_comment",
             "kanban_create", "kanban_link",
-            "kanban_unblock",
+            "kanban_unblock", "kanban_unlink",
             "kanban_attach", "kanban_attach_url", "kanban_attachments",
         ],
         "includes": [],


### PR DESCRIPTION
## Summary
- Add native kanban_unlink using the existing audited unlink_tasks and board resolver.
- Gate schema to opted-in orchestrators and recheck authorization before DB access; workers and delegated children remain denied.
- Preserve other prerequisites and task completion state; return removed=false for absent/repeated edges.

Closes #105408.

## Verification
- Exact development baseline: 057dcdf236f8a6a26721c10fcc6ccb72726e272a.
- scripts/run_tests.sh tests/tools/test_kanban_unlink.py tests/tools/test_kanban_tools.py -q: 43 passed, 0 failed.
- Independent agent review: PASS; focused rerun 11 passed. Its expanded delegation test run was incomplete because python-dotenv is absent from the test venv; not an all-suite-green claim.
- git diff --check clean.
- Tests mutate only temporary boards. No live board mutation or runtime deployment performed.

## Release
Draft implementation for review. Runtime image release and fresh-session availability/readback remain separate gates; this PR does not authorize dispatch or claim recovery.