### PR TITLE
fix(codex): preserve tool strictness across auxiliary requests

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1328,7 +1328,7 @@ class _CodexCompletionsAdapter:
         # includes assistant tool_calls + role="tool" results). The shared converter encodes assistant tool
         # calls as `function_call` items and tool results as `function_call_output` items with a valid
         # call_id, so every Responses path normalizes tool history identically and cannot drift.
-        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input, _responses_tools
         model = kwargs.get("model", self._model)
         host = str(getattr(self._client, "base_url", "") or "")
         is_xai = base_url_host_matches(host, "x.ai") or base_url_host_matches(host, "api.x.ai")
@@ -1406,15 +1406,7 @@ class _CodexCompletionsAdapter:
                     "Auxiliary client: failed to sanitize tool schemas for "
                     "Codex/xAI Responses path: %s", exc,
                 )
-            converted = []
-            for t in tools:
-                fn = t.get("function", {}) if isinstance(t, dict) else {}
-                name = fn.get("name")
-                if name:
-                    converted.append({
-                        "type": "function", "name": name, "description": fn.get("description", ""),
-                        "parameters": fn.get("parameters", {}),
-                    })
+            converted = _responses_tools(tools)
             if converted:
                 resp_kwargs["tools"] = converted
         # Stable prompt-cache routing: key is content-addressed from the static prefix

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -291,7 +291,8 @@ def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[L
     fns = [item.get("function", {}) if isinstance(item, dict) else {} for item in tools or []]
     converted = [
         {
-            "type": "function", "name": fn["name"], "description": fn.get("description", ""), "strict": False,
+            "type": "function", "name": fn["name"], "description": fn.get("description", ""),
+            "strict": fn.get("strict") if isinstance(fn.get("strict"), bool) else False,
             "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
         }
         for fn in fns if _nonblank(fn.get("name"))

--- a/tests/agent/test_codex_tool_schema_parity.py
+++ b/tests/agent/test_codex_tool_schema_parity.py
@@ -1,0 +1,84 @@
+"""Codex Responses tool-schema conversion contracts shared by direct and auxiliary paths."""
+
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent.auxiliary_client import _CodexCompletionsAdapter
+from agent.transports.codex import ResponsesApiTransport
+
+
+def _chat_tool(*, strict: bool | None = None, parameters: dict[str, Any] | None = None) -> dict[str, Any]:
+    function: dict[str, Any] = {
+        "name": "search_records",
+        "description": "Search records.",
+        "parameters": parameters or {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1},
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+    }
+    if strict is not None:
+        function["strict"] = strict
+    return {"type": "function", "function": function}
+
+
+def _auxiliary_tools(tools: list[dict[str, Any]], *, base_url: str = "https://chatgpt.com/backend-api/codex") -> list[dict[str, Any]]:
+    adapter = _CodexCompletionsAdapter(SimpleNamespace(base_url=base_url), "gpt-5.6-terra")
+    response_kwargs, _, _ = adapter._build_responses_kwargs({
+        "messages": [{"role": "user", "content": "find it"}],
+        "tools": tools,
+    })
+    return response_kwargs["tools"]
+
+
+@pytest.mark.parametrize("strict", [True, False, None])
+def test_direct_and_auxiliary_codex_schema_conversion_match_strict_and_optional_contract(strict):
+    """Both Responses callers retain intentional strictness and optional fields unchanged."""
+    tools = [_chat_tool(strict=strict)]
+
+    direct = ResponsesApiTransport().convert_tools(tools)
+    auxiliary = _auxiliary_tools(tools)
+
+    assert direct is not None
+    assert direct == auxiliary
+    assert direct == [{
+        "type": "function", "name": "search_records", "description": "Search records.",
+        "strict": strict if strict is not None else False,
+        "parameters": tools[0]["function"]["parameters"],
+    }]
+    assert direct[0]["strict"] is (strict if strict is not None else False)
+    assert direct[0]["parameters"]["required"] == ["query"]
+    assert "limit" not in direct[0]["parameters"]["required"]
+
+
+@pytest.mark.parametrize("strict", [True, False, None])
+@pytest.mark.parametrize("base_url", ["https://api.x.ai/v1", "https://chatgpt.com/backend-api/codex"])
+def test_auxiliary_codex_schema_sanitizes_provider_rejections_without_mutating_caller_schema(strict, base_url):
+    """The xAI sanitizer remains active before the shared conversion and owns a private copy."""
+    tools = [_chat_tool(
+        strict=strict,
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "pattern": "^[a-z]+$", "format": "email"},
+            },
+            "required": [],
+        },
+    )]
+    original = copy.deepcopy(tools)
+
+    converted = _auxiliary_tools(tools, base_url=base_url)
+
+    assert converted[0]["strict"] is (strict if strict is not None else False)
+    assert "pattern" not in converted[0]["parameters"]["properties"]["query"]
+    assert "format" not in converted[0]["parameters"]["properties"]["query"]
+    assert tools == original


### PR DESCRIPTION
## Summary

Direct and auxiliary Codex requests now preserve the same function-tool strictness. Ordinary tools explicitly use non-strict mode, while intentional boolean `strict` declarations survive conversion.

## Motivation

The auxiliary adapter built its own Responses tool payload and omitted `strict`, unlike the direct route. The direct converter also overwrote explicit `strict: true`. Identical tool definitions therefore changed semantics depending on routing. Sharing the existing converter removes that drift without adding a new mechanism.

## Related Issue

Fixes #105401.

## Type of Change

- [x] Bug fix
- [x] Regression tests

## Changes Made

- Route auxiliary tool conversion through the existing Responses converter after provider sanitization.
- Preserve explicit boolean strict values and default omitted/non-boolean values to false.
- Test parity at `ResponsesApiTransport.convert_tools`, complete parameter/description preservation, and strict/default sanitizer behavior for Codex and xAI.

## How to Test

```sh
scripts/run_tests.sh -j 4 tests/agent/test_codex_tool_schema_parity.py tests/agent/test_auxiliary_client.py tests/agent/test_codex_responses_adapter.py tests/agent/transports/test_codex_transport.py
```

The final candidate passed all 360 tests across these four files with `-j 2`, including all 9 expanded parity cases. Independent review identified coverage gaps, now addressed by the production-boundary assertion and provider/default matrix. An earlier broader rerun exceeded its local time budget and was not counted as a pass. The bounded final rerun completed successfully.

`git diff --check` passes. Tested on macOS 26.6.2 with Python 3.11.15. Full repository suite was not run.

## Risk and Exclusions

No configuration, dependencies, migrations, tool registry changes or runtime lifecycle changes. The existing deep-copy provider sanitization remains in place. This PR fixes the outgoing schema contract, not a guarantee that a model will never produce invalid arguments. Retry policy and goal tooling are outside this PR.

## Checklist

- [x] Read contributing guidance and searched existing PRs
- [x] Conventional commit and focused diff
- [x] Added regression tests and tested on macOS
- [ ] Full repository test suite
- [x] Considered cross-platform impact: no platform-specific code
- [x] Documentation/config changes not required
