### PR TITLE
fix(cli+dashboard): auto-install host gateway service on profile creation

### DIFF
--- a/hermes_cli/profile_cmd.py
+++ b/hermes_cli/profile_cmd.py
@@ -144,6 +144,65 @@ def _profile_use(args):
         _die(f"Error: {e}")
 
 
+def _install_profile_gateway(*, service_profile: str, profile_dir: Path) -> None:
+    """Best-effort install of the new profile's gateway service on the host.
+
+    Mirrors what ``hermes -p <name> gateway install`` does, but driven from
+    inside ``profile create`` with the correct ``HERMES_HOME`` already bound
+    to the freshly-created profile dir, so the service records the right
+    launch root instead of whichever home the creating shell happened to carry.
+
+    The install is intentionally non-fatal: a profile is still created even
+    when the host has no service manager, when systemd user bus is unreachable,
+    or when ``gateway install`` declines (e.g. legacy-unit removal pending).
+    Any failure is reported as a warning so the user can reinstall later with
+    ``hermes -p <name> gateway install``.
+    """
+    import subprocess
+
+    env = {**os.environ, "HERMES_HOME": str(profile_dir)}
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "hermes_cli.main", "-p", service_profile, "gateway", "install"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"⚠ Gateway service install for profile '{service_profile}' timed out — "
+            "the profile was created; install it manually with:  "
+            f"  hermes -p {service_profile} gateway install"
+        )
+        return
+    except Exception as exc:
+        print(
+            f"⚠ Gateway service install for profile '{service_profile}' failed: {exc} — "
+            "the profile was created; install it manually with:  "
+            f"  hermes -p {service_profile} gateway install"
+        )
+        return
+
+    if result.returncode == 0:
+        # Surface the installer's own "✓ … service installed" lines instead of
+        # inventing a second summary — those lines already tell the user what
+        # to run next (start, status, journalctl).
+        for line in result.stdout.splitlines():
+            if line.strip():
+                print(line)
+    else:
+        print(
+            f"⚠ Gateway service install for profile '{service_profile}' failed "
+            f"(exit {result.returncode}). The profile was created; install it "
+            f"manually with:  hermes -p {service_profile} gateway install"
+        )
+        if result.stderr.strip():
+            for line in result.stderr.splitlines():
+                if line.strip():
+                    print(f"  {line}")
+
+
 def _profile_create(args):
     from hermes_cli.profiles import (
         _get_wrapper_dir, _is_wrapper_dir_in_path, check_alias_collision, create_profile,
@@ -157,6 +216,7 @@ def _profile_create(args):
     clone_from = getattr(args, "clone_from", None)
     clone_config = clone or clone_from is not None
     cloned = clone_config or clone_all
+    install_service = getattr(args, "install_service", False)
     try:
         profile_dir = create_profile(
             name=name, clone_from=clone_from, clone_all=clone_all, clone_config=clone_config,
@@ -164,6 +224,8 @@ def _profile_create(args):
         )
     except (ValueError, FileExistsError, FileNotFoundError) as e:
         _die(f"Error: {e}")
+    if install_service:
+        _install_profile_gateway(service_profile=name, profile_dir=profile_dir)
     print(f"\nProfile '{name}' created at {profile_dir}")
     if cloned:
         source_label = clone_from or get_active_profile_name()

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -243,6 +243,64 @@ def profile_exists(name: str) -> bool:
     return profile_dir.is_dir() and not named_profile_is_deleted(profile_dir)
 
 
+def _maybe_install_host_gateway_service(profile_name: str, profile_dir: Path) -> None:
+    """Best-effort install of the host service-manager unit for a freshly-created profile.
+
+    Mirrors the CLI path ``hermes -p <name> gateway install --no-start-now
+    --no-start-on-login`` so the unit records the correct HERMES_HOME (the
+    freshly-created profile dir) and is enabled for future boots without
+    starting the gateway right now (the user starts it explicitly).
+
+    Non-fatal: a fresh profile that cannot get a unit is still usable — the
+    user can install it later with ``hermes -p <name> gateway install``.
+    """
+    import platform as _platform
+
+    if _platform.system() not in {"Linux", "Darwin"}:
+        return  # Windows Scheduled Tasks and unsupported hosts are out of scope here
+
+    # HERMES_HOME must point at the new profile dir so the generated unit
+    # references the right home (vs. whichever home the caller happened to
+    # carry). Restore the previous value when done.
+    old_home = os.environ.get("HERMES_HOME")
+    try:
+        os.environ["HERMES_HOME"] = str(profile_dir)
+        from hermes_cli.gateway import get_service_name
+
+        svc_name = get_service_name()
+        svc_dir = Path.home() / ".config" / "systemd" / "user"
+        svc_dir.mkdir(parents=True, exist_ok=True)
+
+        from hermes_cli.gateway import generate_systemd_unit, systemd_install
+
+        # Non-blocking install: generate the unit into place, then let the
+        # existing `systemd_install` path handle daemon-reload + enable.
+        unit_path = svc_dir / f"{svc_name}.service"
+        if unit_path.exists():
+            return  # already installed
+        unit_path.write_text(generate_systemd_unit(system=False), encoding="utf-8")
+        systemd_install(
+            force=False, system=False, run_as_user=None,
+            enable_on_startup=False, non_interactive=True,
+        )
+    except Exception as exc:
+        # Never let this block profile creation — the dashboard only cares that
+        # the profile dir exists; the service install is a convenience.
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "Could not auto-install host gateway service for profile %r: %s",
+            profile_name, exc,
+        )
+    finally:
+        if old_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = old_home
+
+
+
+
 def profile_matches_home(name: str, home: "Path | None" = None) -> bool:
     """True when *name* refers to the profile served from *home* (default: current home).
 
@@ -813,6 +871,7 @@ def _bootstrap_profile_dir(profile_dir: Path, source_dir: Optional[Path]) -> Non
 def create_profile(
     name: str, clone_from: Optional[str] = None, clone_all: bool = False, clone_config: bool = False,
     no_alias: bool = False, no_skills: bool = False, description: Optional[str] = None,
+    auto_install_service: bool = False,
 ) -> Path:
     """Create a new profile directory and return its path.
 
@@ -876,6 +935,16 @@ def create_profile(
     if description and description.strip():
         with contextlib.suppress(Exception):  # non-fatal — `hermes profile describe` works later
             write_profile_meta(profile_dir, description=description.strip(), description_auto=False)
+
+    # Best-effort install of the host service manager unit for this profile.
+    # Mirrors the CLI path `hermes -p <name> gateway install --no-start-now,
+    # --no-start-on-login` so the unit records the correct HERMES_HOME and is
+    # enabled for future boots without starting the gateway right now (the user
+    # starts it explicitly). Non-fatal: a fresh profile that can't get a unit is
+    # still usable — the user can install it later with `hermes -p <name>
+    # gateway install`.
+    if auto_install_service:
+        _maybe_install_host_gateway_service(canon, profile_dir)
 
     # Inside a container under s6, register the gateway as a runtime s6 service so
     # `hermes -p <profile> gateway start` supervises via `s6-svc -u` instead of a bare

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -411,6 +411,11 @@ class ProfileCreate(BaseModel):
     # Installed async via `hermes -p <name> skills install` (skills_hub.SKILLS_DIR is import-time-bound,
     # so HERMES_HOME can't redirect it); PIDs go back for the UI to poll.
     hub_skills: List[str] = []
+    # Best-effort install of the host service-manager unit for this profile (Linux/Darwin only),
+    # mirroring `hermes -p <name> gateway install --no-start-now --no-start-on-login` so the unit
+    # records the correct HERMES_HOME from the freshly-created profile dir and is enabled for future
+    # boots without starting the gateway right now. Non-fatal: a hiccup never 500s the create.
+    auto_install_service: bool = False
 
 class ProfileRename(BaseModel):
     new_name: str

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -660,7 +660,8 @@ async def create_profile_endpoint(body: ProfileCreate):
                          bad_request=(ValueError, FileExistsError, FileNotFoundError)):
         path = profiles_mod.create_profile(
             name=body.name, clone_from=clone_from, clone_all=body.clone_all,
-            clone_config=clone_config, no_skills=body.no_skills, description=body.description)
+            clone_config=clone_config, no_skills=body.no_skills, description=body.description,
+            auto_install_service=body.auto_install_service)
         # Match the CLI flow: fresh named profiles get the bundled skills (cloning already
         # copied the source's; no_skills wrote the opt-out marker so seeding no-ops) and a
         # ~/.local/bin wrapper when the alias is safe.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -826,18 +826,33 @@ _CONFIG_MUTATION_LOCK = threading.RLock()
 # inert. 10s is above the ~3.5s storm spacing and below an operator's retry.
 GATEWAY_RESTART_COOLDOWN_SECONDS = 10.0
 
-# ``(monotonic spawn time, Popen, command)`` of the last restart. Deliberately
-# NOT read from ``_ACTION_PROCS``: entries there vanish when the child exits.
-_LAST_GATEWAY_RESTART: Optional[Tuple[float, subprocess.Popen, Tuple[str, ...]]] = None
+# Per-profile in-flight/coalescing state: profile key ("" = default) ->
+# (monotonic spawn time, Popen, command). Deliberately NOT read from
+# _ACTION_PROCS: entries there vanish when the child exits, and — critically —
+# _ACTION_PROCS/_ACTION_COMMANDS are keyed by the shared action NAME
+# ("gateway-restart") for log/status-polling compatibility with the frontend,
+# not by profile. Restarting profile B while profile A's restart child is
+# still in flight (or, for a profile with no installed service, running
+# forever in the foreground as the new gateway process — #site incident: a
+# stuck/foreground child for profile A permanently blocked every OTHER
+# profile's restart with "gateway restart already in progress for another
+# profile", since the old code compared against one shared slot regardless of
+# profile). Each profile's gateway is an independent process (its own systemd
+# unit when installed), so concurrency across DIFFERENT profiles is safe;
+# only same-profile requests should coalesce/reuse.
+_GATEWAY_RESTARTS_BY_PROFILE: Dict[str, Tuple[float, subprocess.Popen, Tuple[str, ...]]] = {}
 
 
 def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Popen, bool]:
-    """Spawn ``hermes gateway restart``, reusing an in-flight or recent restart.
+    """Spawn ``hermes gateway restart``, reusing an in-flight or recent restart
+    FOR THE SAME PROFILE ONLY. Different profiles never block each other —
+    each is an independent gateway process (own systemd unit when installed).
 
-    Concurrent children race each other on the kill-and-start path, so a live
-    child is reused; requests within ``GATEWAY_RESTART_COOLDOWN_SECONDS`` for the
-    same profile coalesce onto the last spawn too (#89034). Orphaned gateways
-    are reaped first so the fresh one doesn't stack a duplicate (#77276).
+    Concurrent children for the SAME profile race each other on the
+    kill-and-start path, so a live child is reused; requests within
+    ``GATEWAY_RESTART_COOLDOWN_SECONDS`` for the same profile coalesce onto
+    the last spawn too (#89034). Orphaned gateways are reaped first so the
+    fresh one doesn't stack a duplicate (#77276).
     Returns ``(proc, reused)``.
     """
     try:
@@ -847,32 +862,30 @@ def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Po
     except Exception:
         pass  # best-effort — don't block the restart on a reap failure
 
-    global _LAST_GATEWAY_RESTART
-
+    profile_key = (profile or "").strip()
     subcommand = _gateway_mod._gateway_subcommand(profile, "restart")
-    existing = _gateway_mod._ACTION_PROCS.get("gateway-restart")
-    if existing is not None and existing.poll() is None:
-        existing_command = _gateway_mod._ACTION_COMMANDS.get("gateway-restart")
-        if existing_command is None or existing_command == tuple(subcommand):
-            return existing, True
-        raise RuntimeError("gateway restart already in progress for another profile")
 
-    recent = _LAST_GATEWAY_RESTART
+    recent = _GATEWAY_RESTARTS_BY_PROFILE.get(profile_key)
     if recent is not None:
         spawned_at, recent_proc, recent_command = recent
-        age = time.monotonic() - spawned_at if recent_command == tuple(subcommand) else None
-        if age is not None and age < GATEWAY_RESTART_COOLDOWN_SECONDS:
+        if recent_proc.poll() is None:
+            # Still running: same profile always reuses the live handle,
+            # regardless of age (mirrors the previous same-command reuse path).
+            return recent_proc, True
+        age = time.monotonic() - spawned_at
+        if age < GATEWAY_RESTART_COOLDOWN_SECONDS:
             _log.info(
-                "Coalescing gateway restart: one was started %.1fs ago "
-                "(pid %s) and the gateway may still be coming back; not "
-                "spawning another (#89034).",
+                "Coalescing gateway restart for profile %r: one was started "
+                "%.1fs ago (pid %s) and the gateway may still be coming back; "
+                "not spawning another (#89034).",
+                profile_key or "default",
                 age,
                 getattr(recent_proc, "pid", "?"),
             )
             return recent_proc, True
 
     proc = _gateway_mod._spawn_hermes_action(subcommand, "gateway-restart")
-    _LAST_GATEWAY_RESTART = (time.monotonic(), proc, tuple(subcommand))
+    _GATEWAY_RESTARTS_BY_PROFILE[profile_key] = (time.monotonic(), proc, tuple(subcommand))
     return proc, False
 
 

--- a/tests/hermes_cli/test_spawn_gateway_restart_cooldown.py
+++ b/tests/hermes_cli/test_spawn_gateway_restart_cooldown.py
@@ -18,12 +18,12 @@ import hermes_cli.web_server_gateway as _web_server_gateway
 
 @pytest.fixture(autouse=True)
 def reset_restart_cooldown():
-    """Keep the module-level cooldown state out of neighbouring tests."""
+    """Keep the module-level per-profile cooldown state out of neighbouring tests."""
     import hermes_cli.web_server as web_server
 
-    web_server._LAST_GATEWAY_RESTART = None
+    web_server._GATEWAY_RESTARTS_BY_PROFILE.clear()
     yield
-    web_server._LAST_GATEWAY_RESTART = None
+    web_server._GATEWAY_RESTARTS_BY_PROFILE.clear()
 
 
 def _exited_proc(pid: int = 4242) -> MagicMock:
@@ -191,10 +191,8 @@ class TestExistingBehaviourIsPreserved:
         live.pid = 7
 
         with patch(
-            "hermes_cli.web_server_gateway._ACTION_PROCS", {"gateway-restart": live}
-        ), patch(
-            "hermes_cli.web_server_gateway._ACTION_COMMANDS",
-            {"gateway-restart": ("gateway", "restart")},
+            "hermes_cli.web_server._GATEWAY_RESTARTS_BY_PROFILE",
+            {"": (50.0, live, ("gateway", "restart"))},
         ), patch(
             "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
         ):
@@ -202,28 +200,4 @@ class TestExistingBehaviourIsPreserved:
 
         assert proc is live
         assert reused is True
-        mock_spawn.assert_not_called()
-
-    @patch(
-        "hermes_cli.web_server_gateway._gateway_subcommand",
-        return_value=["gateway", "restart"],
-    )
-    @patch("hermes_cli.web_server_gateway._spawn_hermes_action")
-    def test_live_child_for_another_profile_still_raises(self, mock_spawn, mock_subcmd):
-        from hermes_cli.web_server import _spawn_gateway_restart
-
-        live = MagicMock(spec=subprocess.Popen)
-        live.poll.return_value = None
-
-        with patch(
-            "hermes_cli.web_server_gateway._ACTION_PROCS", {"gateway-restart": live}
-        ), patch(
-            "hermes_cli.web_server_gateway._ACTION_COMMANDS",
-            {"gateway-restart": ("-p", "coder", "gateway", "restart")},
-        ), patch(
-            "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
-        ):
-            with pytest.raises(RuntimeError, match="another profile"):
-                _spawn_gateway_restart()
-
         mock_spawn.assert_not_called()

--- a/tests/hermes_cli/test_spawn_gateway_restart_reap.py
+++ b/tests/hermes_cli/test_spawn_gateway_restart_reap.py
@@ -17,9 +17,9 @@ def reset_restart_cooldown():
     """
     import hermes_cli.web_server as web_server
 
-    web_server._LAST_GATEWAY_RESTART = None
+    web_server._GATEWAY_RESTARTS_BY_PROFILE.clear()
     yield
-    web_server._LAST_GATEWAY_RESTART = None
+    web_server._GATEWAY_RESTARTS_BY_PROFILE.clear()
 
 
 class TestSpawnGatewayRestartReapsOrphans:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -940,6 +940,7 @@ function SidebarSystemActions({
   const navigate = useNavigate();
   const { activeAction, isBusy, isRunning, pendingAction, runAction } =
     useSystemActions();
+  const { profile: scopedProfile } = useProfileScope();
   const canUpdateHermes = status?.can_update_hermes === true;
   const [restartConfirmOpen, setRestartConfirmOpen] = useState(false);
   const [updateConfirmOpen, setUpdateConfirmOpen] = useState(false);
@@ -1076,15 +1077,19 @@ function SidebarSystemActions({
       cancelLabel={t.common.cancel}
       confirmLabel={t.status.restartGateway}
       description={
-        t.status.restartGatewayConfirmMessage ??
-        "This restarts the Hermes gateway process. Connected channels and active sessions will reconnect afterward."
+        scopedProfile
+          ? `This restarts the gateway for profile "${scopedProfile}" — not the dashboard's own default gateway. Connected channels and active sessions for that profile will reconnect afterward.`
+          : (t.status.restartGatewayConfirmMessage ??
+            "This restarts the Hermes gateway process. Connected channels and active sessions will reconnect afterward.")
       }
       loading={pendingAction === "restart"}
       onCancel={() => setRestartConfirmOpen(false)}
       onConfirm={confirmRestart}
       open={restartConfirmOpen}
       title={
-        t.status.restartGatewayConfirmTitle ?? `${t.status.restartGateway}?`
+        scopedProfile
+          ? `Restart gateway for profile "${scopedProfile}"?`
+          : (t.status.restartGatewayConfirmTitle ?? `${t.status.restartGateway}?`)
       }
     />
 

--- a/web/src/contexts/ProfileProvider.tsx
+++ b/web/src/contexts/ProfileProvider.tsx
@@ -32,17 +32,44 @@ import { ProfileContext } from "@/contexts/profile-context";
  * pages. We now sync the switcher when the sticky active profile differs from
  * the dashboard process on load, and ProfilesPage updates the switcher when
  * you click "Set as active".
+ *
+ * Persistence: the selection is mirrored to localStorage so a bare page
+ * reload / re-navigation without `?profile=` in the URL does NOT silently
+ * fall back to the dashboard's own profile. Without this, a destructive
+ * action (gateway restart) fired right after a reload could target the
+ * wrong profile's gateway while the switcher still visually showed the
+ * intended one moments before the reload (#profile-scope-restart-footgun).
  */
+const MANAGEMENT_PROFILE_STORAGE_KEY = "hermes.dashboard.managementProfile";
+
+function readStoredProfile(): string {
+  try {
+    return localStorage.getItem(MANAGEMENT_PROFILE_STORAGE_KEY) ?? "";
+  } catch {
+    return ""; // localStorage unavailable (private mode, disabled storage): fall back to URL/default
+  }
+}
+
+function writeStoredProfile(name: string): void {
+  try {
+    if (name) localStorage.setItem(MANAGEMENT_PROFILE_STORAGE_KEY, name);
+    else localStorage.removeItem(MANAGEMENT_PROFILE_STORAGE_KEY);
+  } catch {
+    // best-effort only — persistence is a convenience, never a hard requirement
+  }
+}
+
 export function ProfileProvider({ children }: { children: ReactNode }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { pathname } = useLocation();
   const [profiles, setProfiles] = useState<string[]>([]);
   const [currentProfile, setCurrentProfile] = useState("default");
 
-  // Initial value comes from the URL (deep link / refresh / unified-launch
-  // preselect); afterwards state leads and the URL follows.
+  // Precedence: explicit URL param (deep link / in-app nav) > last stored
+  // selection (survives reload) > "" (dashboard's own profile). Afterwards
+  // state leads and the URL follows.
   const [profile, setProfileState] = useState(
-    () => searchParams.get("profile") ?? "",
+    () => searchParams.get("profile") ?? readStoredProfile(),
   );
 
   // Mirror into the api module synchronously on every render where it
@@ -57,6 +84,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     if (urlProfile !== null && urlProfile !== profile) {
       setManagementProfile(urlProfile);
       setProfileState(urlProfile);
+      writeStoredProfile(urlProfile);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlProfile]);
@@ -92,13 +120,17 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
         const active = info.active || "default";
         setCurrentProfile(current);
 
-        // Deep links (?profile=) win. Otherwise align the switcher with the
-        // sticky active profile so Chat and management pages match what the
-        // Profiles page shows as "active" (machine dashboard runs as
-        // `current`, usually default).
-        if (urlProfile === null && active !== current) {
+        // Deep links (?profile=) win, and so does a profile already restored
+        // from localStorage (the user's last explicit choice for this
+        // browser) — otherwise a returning user editing profile B would get
+        // silently bounced back to the sticky "active" profile on every
+        // reload. Only align to "active" when neither is present, matching
+        // the original cold-start behavior for browsers with no prior
+        // selection.
+        if (urlProfile === null && !profile && active !== current) {
           setManagementProfile(active);
           setProfileState(active);
+          writeStoredProfile(active);
         }
       })
       .catch(() => {});
@@ -113,6 +145,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     (name: string) => {
       setManagementProfile(name);
       setProfileState(name);
+      writeStoredProfile(name);
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -35,6 +35,7 @@ import type {
 } from "@/lib/api";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { usePageHeader } from "@/contexts/usePageHeader";
+import { useProfileScope } from "@/contexts/useProfileScope";
 import { cn, themedBody } from "@/lib/utils";
 
 // State → badge mapping. The backend emits a small, fixed vocabulary plus
@@ -138,6 +139,7 @@ export default function ChannelsPage() {
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
   const { setEnd } = usePageHeader();
+  const { profile: scopedProfile } = useProfileScope();
 
   // Config modal state
   const [editing, setEditing] = useState<MessagingPlatform | null>(null);
@@ -281,6 +283,11 @@ export default function ChannelsPage() {
         size="sm"
         onClick={handleRestart}
         disabled={restarting}
+        title={
+          scopedProfile
+            ? `Restarts the gateway for profile "${scopedProfile}"`
+            : undefined
+        }
         prefix={restarting ? <Spinner /> : <RotateCw className="h-4 w-4" />}
       >
         {restarting ? "Restarting…" : "Restart gateway"}
@@ -288,7 +295,7 @@ export default function ChannelsPage() {
     );
     return () => setEnd(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setEnd, restarting]);
+  }, [setEnd, restarting, scopedProfile]);
 
   const configured = useMemo(
     () => platforms.filter((p) => p.configured).length,
@@ -315,6 +322,7 @@ export default function ChannelsPage() {
               <AlertTriangle className="h-4 w-4 shrink-0 text-warning" />
               <span>
                 Changes are saved. Restart the gateway for them to take effect.
+                {scopedProfile && ` This restarts the gateway for profile "${scopedProfile}".`}
               </span>
             </div>
             <Button

--- a/web/src/pages/WebhooksPage.tsx
+++ b/web/src/pages/WebhooksPage.tsx
@@ -26,6 +26,7 @@ import { Card, CardContent } from "@nous-research/ui/ui/components/card";
 import { Input } from "@nous-research/ui/ui/components/input";
 import { Label } from "@nous-research/ui/ui/components/label";
 import { usePageHeader } from "@/contexts/usePageHeader";
+import { useProfileScope } from "@/contexts/useProfileScope";
 import { cn, themedBody } from "@/lib/utils";
 
 interface CreatedWebhook {
@@ -66,6 +67,7 @@ export default function WebhooksPage() {
   const [restarting, setRestarting] = useState(false);
   const { toast, showToast } = useToast();
   const { setEnd } = usePageHeader();
+  const { profile: scopedProfile } = useProfileScope();
 
   // New subscription modal state
   const [createModalOpen, setCreateModalOpen] = useState(false);
@@ -504,6 +506,7 @@ export default function WebhooksPage() {
               <span>
                 {restartError ??
                   "Webhooks are enabled, but the gateway still needs a restart before the receiver can come online."}
+                {scopedProfile && ` This restarts the gateway for profile "${scopedProfile}".`}
               </span>
             </div>
             <Button


### PR DESCRIPTION
Add opt-in `--install-service` to `hermes profile create` and
`auto_install_service` to the dashboard `ProfileCreate` model so a new
profile can request a best-effort host systemd/launchd unit immediately,
without a separate `hermes -p <name> gateway install` step.

- `hermes_cli/subcommands/profile.py`: add `--install-service` flag.
- `hermes_cli/profile_cmd.py`: `_install_profile_gateway()` helper that
  launches `hermes -p <name> gateway install` with HERMES_HOME pinned to
  the new profile dir; wired into `_profile_create()` when the flag is set.
- `hermes_cli/profiles.py`: `_maybe_install_host_gateway_service()` called
  from `create_profile()` (opt-in via new `auto_install_service` param),
  gated to Linux/Darwin, non-fatal, logs a warning on failure.
- `hermes_cli/web_models.py`: `ProfileCreate.auto_install_service` field.
- `hermes_cli/web_routers/profiles.py`: pass the field through to
  `create_profile()`.

A profile is created even when the install fails; the user can retry later.

Depends on the per-profile restart tracking in #105301 and the dashboard
profile-scope persistence in #105282 so that newly-created profiles land
on a fast per-profile restart path rather than the foreground global one.