### PR TITLE
fix(update): discharge fleet_restart_pending when the fleet provably serves expected_sha

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -183,6 +183,64 @@ def _live_fleet_covers_receipt(expected_sha: str | None) -> bool:
         return False
 
 
+def _read_fleet_marker_expected_sha() -> str:
+    """``expected_sha`` recorded in the pending marker ("" when absent/unreadable)."""
+    with suppress(OSError):
+        for line in _fleet_restart_pending_marker_path().read_text(encoding="utf-8").splitlines():
+            if line.startswith("expected_sha="):
+                return line.split("=", 1)[1].strip()
+    return ""
+
+
+def _marker_only_restart_obsolete() -> bool:
+    """True when the pending marker is a leftover: the fleet already runs the expected code.
+
+    A supervisor-level restart (``systemctl --user restart``, launchctl, ops scripts) never
+    goes through this module's clear path, so the marker survives a restart that DID bring
+    every live gateway to the pulled code — and every later CLI call then prints the
+    interrupted-update warning forever (false positive).
+
+    The marker is not an *unknown* obligation: it records its own ``expected_sha``, so it can
+    be checked against the live fleet directly — no receipt required. Hold it to the same
+    evidence bar ``_live_fleet_covers_receipt`` applies to one: at least one row, and every
+    row a ``current`` gateway under a known profile whose ``code_sha`` equals that
+    ``expected_sha``, with the checkout HEAD not moved past the marker.
+
+    Keep the marker on stale/down rows, on an all-``unknown`` fleet (pre-code-identity
+    gateways cannot prove currency — same conservatism as the silent-failure class
+    #88848/#74973), on a marker with no ``expected_sha``, when a newer pull moved the
+    checkout, and when the probe fails or answers empty.
+    """
+    expected_sha = _read_fleet_marker_expected_sha()
+    if not expected_sha:
+        return False  # pre-expected_sha marker: nothing to verify against
+    checkout_sha = _current_checkout_sha()
+    if checkout_sha and checkout_sha != expected_sha:
+        return False  # a newer pull moved HEAD; it owns a fresh obligation
+    try:
+        from hermes_cli.update_receipt import collect_fleet_versions
+        fleet = collect_fleet_versions()
+    except Exception as exc:
+        logger.debug("Fleet probe failed; keeping fleet-restart-pending marker: %s", exc)
+        return False
+    if not fleet:
+        return False  # probe answered empty: no proof either way
+    for row in fleet:
+        if not isinstance(row, dict):
+            return False
+        profile = row.get("profile")
+        if not profile or profile == "unknown":
+            return False  # unidentified runtime: the matrix cannot vouch for it
+        if row.get("state") != "current" or str(row.get("code_sha")) != expected_sha:
+            return False  # stale / down / unknown-identity row still owes the restart
+    _clear_fleet_restart_pending_marker()
+    logger.debug(
+        "Fleet-restart-pending marker discharged: %d gateway(s) already serve %s",
+        len(fleet), expected_sha[:10],
+    )
+    return True
+
+
 def _pending_fleet_restart_needed() -> bool:
     """Reconcile old restart obligations against current, identity-matched gateways."""
     from hermes_cli.update_cmd import _current_checkout_sha
@@ -191,6 +249,8 @@ def _pending_fleet_restart_needed() -> bool:
     # than latest.json. An older receipt cannot discharge that unknown obligation.
     with suppress(OSError):
         if _fleet_restart_pending_marker_path().is_file():
+            if _marker_only_restart_obsolete():
+                return False
             return True
     if not _receipt_reports_stale_runtime():
         return False

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -609,3 +609,110 @@ def test_startup_warn_silent_when_nothing_pending(capsys):
     captured = capsys.readouterr()
     assert captured.err == ""
     assert captured.out == ""
+
+
+# ── Self-heal: marker left behind by a supervisor-level restart (TRA-1180 class) ──
+#
+# `systemctl --user restart hermes-gateway` (weekly-update fallback, manual ops) never
+# runs this module's clear path, so the marker survives a restart that DID bring the
+# fleet to the pulled code — and every later CLI call warns forever. The marker must be
+# discharged when (and only when) the fleet provably serves expected_sha.
+
+
+def _patch_marker_sha(monkeypatch, disk_sha):
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: disk_sha)
+
+
+def test_startup_warn_discharged_when_fleet_current(monkeypatch, capsys):
+    disk_sha = "e" * 40
+    update_cmd._write_fleet_restart_pending_marker(expected_sha=disk_sha)
+    _patch_marker_sha(monkeypatch, disk_sha)
+    monkeypatch.setattr(
+        update_cmd_fleet,
+        "_marker_only_restart_obsolete",
+        update_cmd_fleet._marker_only_restart_obsolete,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda **kwargs: [
+            {"profile": "default", "pid": 42, "code_sha": disk_sha, "code_version": "0.21.0", "state": "current"}
+        ],
+    )
+
+    update_cmd._warn_pending_fleet_restart_on_startup()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert not update_cmd._fleet_restart_pending_marker_path().exists()
+
+
+def test_startup_warn_kept_when_fleet_stale(monkeypatch, capsys):
+    disk_sha = "e" * 40
+    update_cmd._write_fleet_restart_pending_marker(expected_sha=disk_sha)
+    _patch_marker_sha(monkeypatch, disk_sha)
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda **kwargs: [
+            {"profile": "default", "pid": 42, "code_sha": "7" * 40, "code_version": "0.20.0", "state": "stale"}
+        ],
+    )
+
+    update_cmd._warn_pending_fleet_restart_on_startup()
+
+    err = capsys.readouterr().err
+    assert "did not restart running gateways" in err
+    assert update_cmd._fleet_restart_pending_marker_path().exists()
+
+
+def test_startup_warn_kept_when_fleet_probe_empty(monkeypatch, capsys):
+    disk_sha = "e" * 40
+    update_cmd._write_fleet_restart_pending_marker(expected_sha=disk_sha)
+    _patch_marker_sha(monkeypatch, disk_sha)
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda **kwargs: [],
+    )
+
+    update_cmd._warn_pending_fleet_restart_on_startup()
+
+    err = capsys.readouterr().err
+    assert "did not restart running gateways" in err
+    assert update_cmd._fleet_restart_pending_marker_path().exists()
+
+
+def test_startup_warn_kept_when_fleet_identity_unknown(monkeypatch, capsys):
+    disk_sha = "e" * 40
+    update_cmd._write_fleet_restart_pending_marker(expected_sha=disk_sha)
+    _patch_marker_sha(monkeypatch, disk_sha)
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda **kwargs: [
+            {"profile": "default", "pid": 42, "code_sha": None, "code_version": None, "state": "unknown"}
+        ],
+    )
+
+    update_cmd._warn_pending_fleet_restart_on_startup()
+
+    err = capsys.readouterr().err
+    assert "did not restart running gateways" in err
+    assert update_cmd._fleet_restart_pending_marker_path().exists()
+
+
+def test_marker_kept_when_newer_pull_moved_checkout_past_marker(monkeypatch, capsys):
+    update_cmd._write_fleet_restart_pending_marker(expected_sha="d" * 40)
+    _patch_marker_sha(monkeypatch, "e" * 40)  # checkout advanced after the marker
+    seen = {"called": False}
+
+    def _collect(**kwargs):
+        seen["called"] = True
+        return [{"profile": "default", "pid": 42, "code_sha": "d" * 40, "code_version": None, "state": "current"}]
+
+    monkeypatch.setattr("hermes_cli.update_receipt.collect_fleet_versions", _collect)
+
+    update_cmd._warn_pending_fleet_restart_on_startup()
+
+    err = capsys.readouterr().err
+    assert "did not restart running gateways" in err
+    assert update_cmd._fleet_restart_pending_marker_path().exists()
+    assert seen["called"] is False  # short-circuits before probing the fleet


### PR DESCRIPTION
## What does this PR do?

Closes the **marker** half of the interrupted-update false positive that #98588 reports — the half that 89c85b846 deliberately left open.

`_pending_fleet_restart_needed()` has two independent triggers: a `fleet_restart_pending` **marker**, and a stale-runtime **receipt**. 89c85b846 (*"settle stale receipt warnings from matching live gateways"*) fixed the receipt trigger by adding `_live_fleet_covers_receipt()`, and its own commit message says it preserved *"independently authoritative pending markers"*. The marker trigger is still `return True` on file existence alone:

```python
# The marker has no runtime inventory and may belong to a newer, killed update
# than latest.json. An older receipt cannot discharge that unknown obligation.
with suppress(OSError):
    if _fleet_restart_pending_marker_path().is_file():
        return True
```

A supervisor-level gateway restart — `systemctl --user restart`, a launchd `KeepAlive` respawn after the ~6h rotation exit described in #98588, or a plain ops script — never passes through `_clear_fleet_restart_pending_marker()`. So when the supervisor brings the gateway back from the **already-pulled** checkout, the restart genuinely happened, the fleet genuinely serves the new code, and the marker still survives.

That one stale file then drives both consumers of the predicate:

- `_warn_pending_fleet_restart_on_startup()` — prints `⚠ A previous hermes update pulled new code but did not restart running gateways.` on **every** CLI invocation, forever.
- `_apply_pending_fleet_restart_catchup()` — guarded by `if not _pending_fleet_restart_needed(): return`, so every already-up-to-date `hermes update` re-runs a redundant fleet restart, including the drain timeout #98588 measures at up to 1995s.

`_live_fleet_covers_receipt()` cannot cover this case: it is receipt-anchored and returns `False` when `owed` is empty, which is exactly the marker-only situation.

### Why the in-code objection does not block this

> The marker has no runtime inventory … An older receipt cannot discharge that unknown obligation.

Both clauses are true, and neither applies. The obligation is not *unknown*: `_write_fleet_restart_pending_marker()` records `expected_sha=<sha>` **in the marker itself**, so it can be verified against the live fleet directly with no receipt involved. This PR reads the marker's own `expected_sha` and holds the fleet to the same evidence bar `_live_fleet_covers_receipt()` applies to a receipt:

- at least one probed row;
- every row `state == "current"` **and** `row["code_sha"] == marker.expected_sha`;
- every row a gateway under a known, non-`"unknown"` profile;
- the checkout HEAD has **not** moved past the marker.

Only when all four hold is the marker deleted and the warning suppressed. The historical receipt is left untouched — a supervisor restart is still not a successful update, same as 89c85b846.

## Related Issue

Fixes #98588

Refs #95294 (marker introduced), #98022 / #103590 (receipt-side siblings, both since fixed), #88848 / #74973 (the silent-failure class whose conservatism this reuses).

### Relationship to the other open PRs in this cluster (duplicate check)

| PR | Touches | Overlap |
|----|---------|---------|
| #98612 | `_apply_pending_fleet_restart_catchup` in the pre-split `update_cmd.py` (+ an unrelated `plugins/platforms/telegram/adapter.py`) | Same probe idea, but only skips the *restart*; does not change `_pending_fleet_restart_needed()`, so the startup warning still fires on every CLI call. Also predates the `update_cmd_fleet.py` split. |
| #104295 | `_apply_pending_fleet_restart_catchup` + receipt stamping (`fleet_restart_resolved_sha`) | Probe-first discharge of the **receipt** obligation. Complementary — it stamps receipts, this PR reads markers. |
| #105322 / #98024 / #105102 | marker clear/rewrite ordering around the restart itself | Prevent *future* orphans. This PR heals markers that are *already* orphaned, which those cannot reach. |

None of them change the marker branch of `_pending_fleet_restart_needed()`, which is where the permanent warning originates.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_cmd_fleet.py`
  - `_read_fleet_marker_expected_sha()` — parse `expected_sha` out of the marker (`""` when absent or unreadable).
  - `_marker_only_restart_obsolete()` — probe `collect_fleet_versions()` and discharge the marker only when the fleet provably serves the marker's `expected_sha` under the four conditions above.
  - `_pending_fleet_restart_needed()` — two-line hook in the marker branch: `if _marker_only_restart_obsolete(): return False` before the unconditional `return True`.
- `tests/hermes_cli/test_update_fleet_restart_pending.py` — 5 regression tests (see below).

Still **warns** (marker kept) on: `stale` / `down` rows; an all-`unknown` fleet (pre-code-identity gateways cannot prove currency — same conservatism as #88848/#74973); a marker with no `expected_sha` (nothing to verify against); a checkout that moved past the marker; a probe that raises; a probe that answers empty; and any row that is not a dict or has no usable profile.

## How to Test

Reproduction on a supervisor-managed gateway:

1. Start from a clean tree, then make a code-advancing pull whose restart is performed by the supervisor rather than by the update — e.g. kill `hermes update` after the pull, or just `systemctl --user restart hermes-gateway@…` / let launchd respawn it.
2. Confirm the fleet is actually current: `collect_fleet_versions()` reports the gateway `state="current"` with `code_sha` equal to both the checkout HEAD and the marker's `expected_sha` (`cat ~/.hermes/fleet_restart_pending`).
3. **On base:** every `hermes` CLI call prints the `did not restart running gateways` warning, and `~/.hermes/fleet_restart_pending` survives indefinitely; every already-up-to-date `hermes update` re-runs the fleet restart.
4. **With this PR:** the first CLI call discharges the marker (debug log `Fleet-restart-pending marker discharged: N gateway(s) already serve <sha>`) and the warning and the redundant catch-up restart both stop.

Controls (each must still warn): flip a row to `stale`; empty the probe; blank `code_sha` for `unknown`; advance the checkout past the marker.

Unit tests:

```
$ pytest tests/hermes_cli/test_update_fleet_restart_pending.py -q
26 passed in 42.02s          # 21 pre-existing + 5 new
```

The 5 new tests: `test_startup_warn_discharged_when_fleet_current`, `test_startup_warn_kept_when_fleet_stale`, `test_startup_warn_kept_when_fleet_probe_empty`, `test_startup_warn_kept_when_fleet_identity_unknown`, `test_marker_kept_when_newer_pull_moved_checkout_past_marker` (this one also asserts the fleet is never probed once HEAD has moved).

Wider scoped run — every test file that references the marker, the obligation predicate, the receipt-staleness helper, or the fleet probe (13 files):

```
$ pytest tests/gateway/test_control_socket.py tests/gateway/test_control_socket_windows_live.py \
      tests/hermes_cli/conftest.py tests/hermes_cli/test_cmd_update.py \
      tests/hermes_cli/test_fleet_matrix_down_state.py tests/hermes_cli/test_pending_supervisor_recovery.py \
      tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_update_fleet_check_fail_closed.py \
      tests/hermes_cli/test_update_fleet_probe_resume_token.py tests/hermes_cli/test_update_fleet_restart_pending.py \
      tests/hermes_cli/test_update_obligation_identity.py tests/hermes_cli/test_update_receipt.py \
      tests/hermes_cli/test_update_serve_generation_recovery.py -q
248 passed, 2 skipped, 5 warnings in 122.01s (0:02:02)
```

Real-world evidence (systemd `--user` install, v0.21.0): the marker recorded `expected_sha=9dd6634c56…` and the sole live gateway's `gateway_state.json` reported `code_sha=9dd6634c56…` — byte-identical — yet every `hermes` invocation printed the warning until the marker was removed by hand.

Platform tested: Ubuntu (systemd `--user`, gateway under `hermes-gateway.service`), Python 3.11.15. Not exercised on macOS/launchd or WSL2, though the code path is supervisor-agnostic — it reads only the marker file and the fleet matrix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(update):` — the dominant scope for this module, 119 prior commits)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (table above)
- [x] My PR contains **only** changes related to this fix/feature (1 commit, 2 files, +167/-0)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the 13-file scoped suite above (248 passed, 2 skipped) instead of the full 9297-test `tests/hermes_cli` tree; happy to run wider on request
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (systemd `--user`), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on both new helpers; the existing in-code objection comment is answered in `_marker_only_restart_obsolete`'s docstring rather than deleted
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — supervisor-agnostic: reads the marker file (explicit `encoding="utf-8"`, satisfying `PLW1514`) and the fleet matrix; no new subprocess, path, or terminal handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Open question for maintainers

This PR discharges only when the checkout HEAD still equals the marker's `expected_sha`. @prasta1's repro in #98588 describes the adjacent variant — a marker whose `expected_sha` was *superseded* by a later pull, plus a `partial` receipt. There, HEAD has moved past the marker, so this PR conservatively keeps warning: a newer pull owns a fresh obligation, and `_write_fleet_restart_pending_marker()` should have rewritten `expected_sha` on that pull.

If maintainers would rather also discharge when the fleet provably serves the **current** HEAD (strictly newer than the marker's `expected_sha`, so the older obligation is superseded), that is a one-line relaxation of the `checkout_sha != expected_sha` guard plus one more test. I left it out to keep this PR to the case the in-code comment actually objects to, and because it edges toward the "newer, killed update" hazard that comment warns about.
