### PR TITLE
fix(terminal): bind sandbox env_type by keyword

### DIFF
--- a/tests/tools/test_terminal_sandbox_builders.py
+++ b/tests/tools/test_terminal_sandbox_builders.py
@@ -1,0 +1,66 @@
+"""Regression coverage for the shared sandbox environment builders."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tools import terminal_tool_backends as backends
+
+
+class _FakeEnvironment:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+@pytest.mark.parametrize(
+    ("env_type", "module_name", "class_name", "image", "container_config"),
+    [
+        ("singularity", None, None, "test.sif", {}),
+        ("daytona", "tools.environments.daytona", "DaytonaEnvironment", "test:latest", {"container_cpu": 2}),
+        (
+            "vercel_sandbox",
+            "tools.environments.vercel_sandbox",
+            "VercelSandboxEnvironment",
+            "ignored",
+            {"vercel_runtime": "node24"},
+        ),
+    ],
+)
+def test_create_environment_dispatches_sandbox_backends_without_duplicate_env_type(
+    monkeypatch, env_type, module_name, class_name, image, container_config
+):
+    """The dispatch path must pass ``env_type`` exactly once to sandbox builders."""
+    if env_type == "singularity":
+        monkeypatch.setattr(backends, "_SingularityEnvironment", _FakeEnvironment)
+    else:
+        real_import_module = backends.importlib.import_module
+
+        def fake_import_module(name):
+            if name == module_name:
+                return SimpleNamespace(**{class_name: _FakeEnvironment})
+            return real_import_module(name)
+
+        monkeypatch.setattr(backends.importlib, "import_module", fake_import_module)
+
+    env = backends._create_environment(
+        env_type=env_type,
+        image=image,
+        cwd="/workspace",
+        timeout=60,
+        container_config=container_config,
+        task_id="test-task",
+    )
+
+    assert isinstance(env, _FakeEnvironment)
+    assert env.kwargs["cwd"] == "/workspace"
+    assert env.kwargs["timeout"] == 60
+    assert env.kwargs["task_id"] == "test-task"
+
+    if env_type == "vercel_sandbox":
+        assert "image" not in env.kwargs
+        assert env.kwargs["runtime"] == "node24"
+    else:
+        assert env.kwargs["image"] == image
+
+    if env_type == "daytona":
+        assert env.kwargs["cpu"] == 2

--- a/tools/terminal_tool_backends.py
+++ b/tools/terminal_tool_backends.py
@@ -168,9 +168,9 @@ def _build_sandbox_env(env_type, *, image, cwd, timeout, cc, task_id, **_):
     return cls()(**kwargs)
 
 
-_build_singularity_env = functools.partial(_build_sandbox_env, "singularity")
-_build_daytona_env = functools.partial(_build_sandbox_env, "daytona")
-_build_vercel_env = functools.partial(_build_sandbox_env, "vercel_sandbox")
+_build_singularity_env = functools.partial(_build_sandbox_env, env_type="singularity")
+_build_daytona_env = functools.partial(_build_sandbox_env, env_type="daytona")
+_build_vercel_env = functools.partial(_build_sandbox_env, env_type="vercel_sandbox")
 
 
 def _build_ssh_env(*, cwd, timeout, ssh_config, probe_only=False, **_):


### PR DESCRIPTION
## What does this PR do?

Fixes the sandbox-builder dispatch crash reported in #105414. The shared Singularity, Daytona, and Vercel sandbox builders were created with a positional `functools.partial` binding for `env_type`, while `_create_environment()` also passes `env_type` by keyword. That supplies the same argument twice and raises `TypeError` before the backend environment can be constructed.

This change binds `env_type` by keyword in the three partials, which is compatible with the keyword-only dispatch shape used by `_create_environment()`.

## Related Issue

Fixes #105414

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/terminal_tool_backends.py`: bind `env_type` by keyword for the Singularity, Daytona, and Vercel sandbox partial builders.
- `tests/tools/test_terminal_sandbox_builders.py`: add regression coverage that exercises `_create_environment()` for all three sandbox backends and verifies construction reaches the backend class without duplicate-argument failure.

## How to Test

1. Run `pytest tests/tools/test_terminal_sandbox_builders.py -q`.
2. Configure `terminal.backend: singularity` and start a Hermes CLI or gateway session.
3. Execute a terminal command such as `pwd`; backend construction should succeed instead of raising `_build_sandbox_env() got multiple values for argument 'env_type'`.

Manual reproduction on Ubuntu 22.04 with SingularityCE 3.8.1: the failure occurred before this change and terminal execution succeeded after applying the same three-line partial-binding fix locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04, Python 3.11.16, SingularityCE 3.8.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: no user-facing behavior/config change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — argument binding is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before:

```text
_build_sandbox_env() got multiple values for argument 'env_type'
```

After the same fix was applied locally, Singularity terminal commands including `pwd` and `ls -la` completed successfully.