### PR TITLE
fix(local-models): stop CPU-only hosts from claiming GPU-fit models

### DIFF
--- a/apps/desktop/src/app/settings/local-models-settings.test.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.test.tsx
@@ -248,6 +248,40 @@ describe('LocalModelsSettings', () => {
     expect(screen.getByText(/256\.0 GB RAM/)).toBeTruthy()
   })
 
+  it('shows CPU-only recommendations without claiming GPU memory', async () => {
+    mocked.getLocalHardware.mockResolvedValue({
+      ...BASE_HARDWARE,
+      uma: false,
+      vram_total_bytes: 0,
+      vram_usable_bytes: 0,
+      vram_label: '0.0 GB',
+      gpu_name: null,
+      gpu_util_percent: null,
+      vram_used_bytes: null
+    })
+    mocked.getLocalCatalog.mockResolvedValue({
+      models: [
+        {
+          ...SPILLED_MODEL,
+          recommended: true,
+          recommended_reason: 'best-cpu-only',
+          quant_reason: 'Best CPU build for this machine — runs from system RAM'
+        }
+      ]
+    })
+
+    await renderFullPane()
+    await screen.findByText('Spilled Model')
+
+    expect(screen.queryByText(/GPU memory/)).toBeNull()
+    expect(screen.queryByText('Fits your GPU')).toBeNull()
+    expect(screen.getByText('Uses system RAM')).toBeTruthy()
+
+    fireEvent.pointerMove(screen.getByText('Recommended'))
+    fireEvent.pointerEnter(screen.getByText('Recommended'))
+    await waitFor(() => expect(screen.getAllByText(/best model for CPU-only inference/).length).toBeGreaterThan(0))
+  })
+
   it('tracks a download job to completion and refreshes', async () => {
     mocked.getLocalModelsStatus.mockResolvedValue({
       ...BASE_STATUS,

--- a/apps/desktop/src/app/settings/local-models-settings.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.tsx
@@ -530,10 +530,12 @@ export function LocalModelsSettings() {
               </span>
             )}
 
-            <span className="inline-flex items-center gap-1.5">
-              <Cpu className="size-3.5" />
-              {copy.vram(gbLabel(hardware.vram_total_bytes))}
-            </span>
+            {hardware.vram_total_bytes > 0 && (
+              <span className="inline-flex items-center gap-1.5">
+                <Cpu className="size-3.5" />
+                {copy.vram(gbLabel(hardware.vram_total_bytes))}
+              </span>
+            )}
 
             <span className="inline-flex items-center gap-1.5">
               <Package className="size-3.5" />

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1192,7 +1192,8 @@ export const en: Translations = {
           'A higher-quality model fits this machine but would respond too slowly on its memory bandwidth — this is the best model that stays fast.',
         'fastest-resident':
           'No model reaches full speed on this hardware; this one comes closest while running entirely in GPU memory.',
-        'least-painful-spilled': 'No model fits entirely in GPU memory here — this one runs best from system RAM.'
+        'least-painful-spilled': 'No model fits entirely in GPU memory here — this one runs best from system RAM.',
+        'best-cpu-only': 'This machine has no detected GPU — this is the best model for CPU-only inference.'
       } as Record<string, string>,
       downloaded: 'Downloaded',
       downloadAction: size => `Download · ${size}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1386,7 +1386,8 @@ export const zh: Translations = {
         'best-quality-resident': '在完全驻留 GPU 且保持全速的模型中质量最高。推荐会在质量与该硬件的预计速度之间权衡。',
         'speed-gated-quality': '有更高质量的模型可以装入这台机器，但受内存带宽限制响应会太慢——这是保持流畅的最佳模型。',
         'fastest-resident': '没有模型能在该硬件上达到全速；这是完全驻留 GPU 内存中最快的一个。',
-        'least-painful-spilled': '没有模型能完全装入 GPU 内存——这是从系统内存运行表现最好的一个。'
+        'least-painful-spilled': '没有模型能完全装入 GPU 内存——这是从系统内存运行表现最好的一个。',
+        'best-cpu-only': '未检测到 GPU——这是仅使用 CPU 推理时表现最好的模型。'
       } as Record<string, string>,
       downloaded: '已下载',
       downloadAction: size => `下载 · ${size}`,

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1324,7 +1324,7 @@ export interface LocalCatalogModel {
   recommended: boolean
   /** Why the resolver picked this entry (recommended rows only):
    *  best-quality-resident | speed-gated-quality | fastest-resident |
-   *  least-painful-spilled. Renders as the Recommended badge's tooltip. */
+   *  least-painful-spilled | best-cpu-only. Renders as the Recommended badge's tooltip. */
   recommended_reason?: string | null
   downloaded: boolean
   downloaded_model_id?: string | null

--- a/hermes_cli/local_runtime/catalog.py
+++ b/hermes_cli/local_runtime/catalog.py
@@ -197,7 +197,8 @@ def recommended_entry(budget: HardwareBudget,
     (engine too old). Reasons: best-quality-resident (quality won among resident entries clearing
     the pleasant floor); speed-gated-quality (same, but the floor eliminated a HIGHER quality
     candidate); fastest-resident (nothing resident clears the floor); least-painful-spilled
-    (nothing runs resident; fastest from host memory — MoE by construction).
+    (nothing runs resident; fastest from host memory — MoE by construction), or best-cpu-only
+    (the same host-memory comparison on a machine with no GPU device).
     """
     pool = CATALOG if entries is None else entries
     fitting = [(e, c) for e in pool if (c := select_variant(e, budget)) is not None]
@@ -215,7 +216,8 @@ def recommended_entry(budget: HardwareBudget,
         return (pick, "speed-gated-quality" if floor_gated else "best-quality-resident")
     if resident:
         return (max(resident, key=speed)[0], "fastest-resident")
-    return (max(fitting, key=lambda t: speed(t, spilled=True))[0], "least-painful-spilled")
+    reason = "best-cpu-only" if budget.total_device_bytes <= 0 else "least-painful-spilled"
+    return (max(fitting, key=lambda t: speed(t, spilled=True))[0], reason)
 
 
 # ── catalog data: packaged JSON, refreshed from GitHub in memory ─

--- a/hermes_cli/local_runtime/estimator.py
+++ b/hermes_cli/local_runtime/estimator.py
@@ -65,7 +65,8 @@ class ModelProfile:
 class HardwareBudget:
     """Memory the physics check may budget against. Discrete cards may trust the device query;
     unified-memory devices must budget from OS free memory minus headroom (device queries observed
-    off by 3x). Callers construct this accordingly; the estimator just consumes it."""
+    off by 3x). CPU-only runtimes have zero device memory and carry their headroom-adjusted host
+    memory in ``ram_available_bytes``. Callers construct this accordingly; the estimator consumes it."""
 
     usable_vram_bytes: int      # live free (discrete) / derived (UMA)
     total_device_bytes: int

--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -239,6 +239,12 @@ def _unified_pool_bytes(smi_total: int, ram_total: int) -> int | None:
     attribute-less engine fallback needs the two numeric gates, both of which must hold.
     """
     view = _device_pool_view()
+    return _unified_pool_from_view(view, smi_total, ram_total)
+
+
+def _unified_pool_from_view(
+        view: "tuple[int, bool | None] | None", smi_total: int, ram_total: int) -> int | None:
+    """Classify a captured allocator view without discarding a discrete-device verdict."""
     if view is None:
         return None
     pool, integrated = view
@@ -263,6 +269,17 @@ def _cpu_budget(base: int) -> HardwareBudget:
                           ram_available_bytes=usable, uma=False)
 
 
+def _discrete_budget(
+        total: int, free: int | None, ram_bytes: int, *, planning: bool) -> HardwareBudget:
+    """Budget a known discrete device; unknown live-free capacity fails conservatively closed."""
+    margin = max(_MARGIN_FLOOR, int(total * _MARGIN_FRACTION))
+    base = total if planning else (free or 0)
+    return HardwareBudget(usable_vram_bytes=max(0, base - margin),
+                          total_device_bytes=total,
+                          ram_available_bytes=ram_bytes,
+                          uma=False)
+
+
 def probe_budget(*, planning: bool = False, platform_name: str | None = None) -> HardwareBudget:
     """Construct the budget per the source rules above.
 
@@ -274,13 +291,14 @@ def probe_budget(*, planning: bool = False, platform_name: str | None = None) ->
     platform_name = sys.platform if platform_name is None else platform_name
     ram_total, ram_avail = _ram_bytes()
     vram = _nvidia_vram()
+    pool_view = _device_pool_view()
 
     # Unified-memory NVIDIA: the CUDA allocator pool is the real capacity. Classification comes
     # from the driver API/engine and must not require nvidia-smi (stripped-PATH sessions lose smi
     # but nvcuda loads via the system loader). Crossing the carve-out costs nothing — it is an OS
     # accounting knob, not a GPU limit. Deliberately NOT clamped to OS RAM: carved-out memory is
     # invisible to GlobalMemoryStatusEx, so a RAM clamp would throw away exactly that capacity.
-    unified = _unified_pool_bytes(vram[0] if vram else 0, ram_total)
+    unified = _unified_pool_from_view(pool_view, vram[0] if vram else 0, ram_total)
     if unified is not None:
         logger.info(
             "unified-memory NVIDIA device: allocator pool %.1f GiB "
@@ -298,6 +316,12 @@ def probe_budget(*, planning: bool = False, platform_name: str | None = None) ->
         return _uma_budget(base, unified)
 
     if vram is None:
+        if pool_view is not None and pool_view[1] is False:
+            # nvidia-smi can fail transiently even though the CUDA driver positively identifies a
+            # discrete device. Preserve that device and its measured capacity. The driver view has
+            # no free-memory fact, so live grants remain zero rather than risking overcommit.
+            return _discrete_budget(
+                pool_view[0], None, ram_total if planning else ram_avail, planning=planning)
         # Metal is unified memory. Everywhere else, no detected device means the CPU backend:
         # RAM is still usable, but calling it GPU memory makes both fit labels and speed pricing
         # wrong. Non-NVIDIA discrete devices remain conservative until a vendor probe lands.
@@ -307,8 +331,5 @@ def probe_budget(*, planning: bool = False, platform_name: str | None = None) ->
         return _cpu_budget(base)
 
     total, free = vram
-    margin = max(_MARGIN_FLOOR, int(total * _MARGIN_FRACTION))
-    return HardwareBudget(usable_vram_bytes=max(0, (total if planning else free) - margin),
-                          total_device_bytes=total,
-                          ram_available_bytes=ram_total if planning else ram_avail,
-                          uma=False)
+    return _discrete_budget(
+        total, free, ram_total if planning else ram_avail, planning=planning)

--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -1,9 +1,9 @@
 """Live hardware budget probe.
 
 Budget-source rule: discrete cards may trust the device query (measured honest within rounding);
-unified-memory devices must budget from OS free physical memory minus headroom — their device
-queries have been observed off by 3x in both directions. Every probe here must work under a
-stripped PATH — gateway and service sessions don't inherit the interactive environment.
+unified-memory devices and CPU-only runtimes budget from OS free physical memory minus headroom.
+Device queries are absent or have been observed off by 3x in both directions. Every probe here
+must work under a stripped PATH because service sessions do not inherit the interactive environment.
 """
 
 from __future__ import annotations
@@ -256,7 +256,14 @@ def _uma_budget(base: int, total: int) -> HardwareBudget:
                           ram_available_bytes=0, uma=True)
 
 
-def probe_budget(*, planning: bool = False) -> HardwareBudget:
+def _cpu_budget(base: int) -> HardwareBudget:
+    """Host RAM available to CPU inference, after leaving the OS/app headroom."""
+    usable = max(0, int(base * (1 - _UMA_HEADROOM_FRACTION)))
+    return HardwareBudget(usable_vram_bytes=0, total_device_bytes=0,
+                          ram_available_bytes=usable, uma=False)
+
+
+def probe_budget(*, planning: bool = False, platform_name: str | None = None) -> HardwareBudget:
     """Construct the budget per the source rules above.
 
     ``planning=False``: LIVE budget (free VRAM now) for launch-time fit and growth re-grants.
@@ -264,6 +271,7 @@ def probe_budget(*, planning: bool = False) -> HardwareBudget:
     selection — pricing against live-free while a model was loaded made every row read as too
     large. The managed server unloads/relaunches itself, so capacity is real.
     """
+    platform_name = sys.platform if platform_name is None else platform_name
     ram_total, ram_avail = _ram_bytes()
     vram = _nvidia_vram()
 
@@ -290,9 +298,13 @@ def probe_budget(*, planning: bool = False) -> HardwareBudget:
         return _uma_budget(base, unified)
 
     if vram is None:
-        # No NVIDIA device visible: Metal/Vulkan/CPU paths budget from RAM as UMA (Apple
-        # Silicon) — conservative for discrete AMD until a vendor probe lands.
-        return _uma_budget(ram_total if planning else ram_avail, ram_total)
+        # Metal is unified memory. Everywhere else, no detected device means the CPU backend:
+        # RAM is still usable, but calling it GPU memory makes both fit labels and speed pricing
+        # wrong. Non-NVIDIA discrete devices remain conservative until a vendor probe lands.
+        base = ram_total if planning else ram_avail
+        if platform_name == "darwin":
+            return _uma_budget(base, ram_total)
+        return _cpu_budget(base)
 
     total, free = vram
     margin = max(_MARGIN_FLOOR, int(total * _MARGIN_FRACTION))

--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -522,10 +522,12 @@ _QUANT_REASONS = {
                   "runs fully on your GPU"),
 }
 _QUANT_REASON_COMPACT = "Compact build sized for this machine ({quant}) — larger than GPU memory, runs slower"
+_QUANT_REASON_CPU = "Best CPU build for this machine ({quant}) — runs from system RAM"
 
 
 def _catalog_row(entry, budget, recommended, recommended_reason, staged_ids) -> Dict[str, Any]:
     choice = catalog.select_variant(entry, budget)
+    cpu_only = budget.total_device_bytes <= 0
     # Any variant of this family on disk counts as downloaded.
     dl = next((v for v in entry.variants if v.model_id in staged_ids), None)
     row: Dict[str, Any] = {
@@ -547,7 +549,7 @@ def _catalog_row(entry, budget, recommended, recommended_reason, staged_ids) -> 
             "fits": False, "size_bytes": smallest_total, "size_label": _human_gb(smallest_total),
             "fit_summary": "Needs more memory than this machine has",
             "fit_detail": (f"even the most compact build ({smallest.quant}, {_human_gb(smallest_total)}) "
-                           "exceeds GPU + system memory"),
+                           + ("exceeds available system memory" if cpu_only else "exceeds GPU + system memory")),
         })
         return row
 
@@ -563,7 +565,8 @@ def _catalog_row(entry, budget, recommended, recommended_reason, staged_ids) -> 
         "fits": True, "model_id": variant.model_id, "quant": variant.quant,
         "quant_validated": variant.validated, "size_bytes": download_total,
         "size_label": _human_gb(download_total), "variant_count": len(entry.variants),
-        "quant_reason": _QUANT_REASONS.get(choice.reason_key, _QUANT_REASON_COMPACT).format(quant=variant.quant),
+        "quant_reason": (_QUANT_REASON_CPU if cpu_only else
+                         _QUANT_REASONS.get(choice.reason_key, _QUANT_REASON_COMPACT)).format(quant=variant.quant),
     })
     if isinstance(decision, estimator.PhysicsRefusal):
         row["fit_summary"] = row["quant_reason"]
@@ -573,7 +576,10 @@ def _catalog_row(entry, budget, recommended, recommended_reason, staged_ids) -> 
         shape = f"runs at its full {row['native_context_label']} context"
     else:
         shape = f"starts at {row['start_window_label']} and grows toward {row['native_context_label']} as you use it"
-    row["fit_summary"] = shape + (" (larger than your GPU memory — runs slower)" if decision.spilled else "")
+    if decision.spilled:
+        shape += (" (runs from system RAM — CPU inference is slower)" if cpu_only
+                  else " (larger than your GPU memory — runs slower)")
+    row["fit_summary"] = shape
     return row
 
 

--- a/tests/hermes_cli/test_local_recommendation.py
+++ b/tests/hermes_cli/test_local_recommendation.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import pytest
 
+from hermes_cli.local_runtime import hardware
 from hermes_cli.local_runtime.catalog import (
     CATALOG,
     PLEASANT_FLOOR_TOK_S,
@@ -167,3 +168,36 @@ def test_quality_decides_where_speed_permits():
         if (c := select_variant(e, budget)) is not None and c.zero_spill
     ]
     assert pick == max(resident, key=lambda e: e.quality).id
+
+
+def test_cpu_only_host_budgets_ram_without_inventing_gpu_memory(monkeypatch):
+    """A CPU backend may use host RAM, but it has no resident-GPU tier.
+
+    Windows Server machines without a display adapter used to turn all RAM
+    into an UMA device. That made the catalog price CPU inference at GPU
+    bandwidth and recommend the dense 27B model as fully GPU-resident.
+    """
+    total = 32 * _GIB
+    monkeypatch.setattr(hardware, "_ram_bytes", lambda: (total, 24 * _GIB))
+    monkeypatch.setattr(hardware, "_nvidia_vram", lambda: None)
+    monkeypatch.setattr(hardware, "_unified_pool_bytes", lambda *_: None)
+
+    budget = hardware.probe_budget(planning=True, platform_name="win32")
+
+    assert budget == HardwareBudget(
+        usable_vram_bytes=0,
+        total_device_bytes=0,
+        ram_available_bytes=int(total * 0.80),
+        uma=False,
+    )
+    picked = recommended_entry(budget)
+    assert picked is not None
+    assert (picked[0].id, picked[1]) == ("qwen3.6-35b-a3b", "best-cpu-only")
+
+    mac_budget = hardware.probe_budget(planning=True, platform_name="darwin")
+    assert mac_budget == HardwareBudget(
+        usable_vram_bytes=int(total * 0.80),
+        total_device_bytes=total,
+        ram_available_bytes=0,
+        uma=True,
+    )

--- a/tests/hermes_cli/test_local_recommendation.py
+++ b/tests/hermes_cli/test_local_recommendation.py
@@ -180,7 +180,7 @@ def test_cpu_only_host_budgets_ram_without_inventing_gpu_memory(monkeypatch):
     total = 32 * _GIB
     monkeypatch.setattr(hardware, "_ram_bytes", lambda: (total, 24 * _GIB))
     monkeypatch.setattr(hardware, "_nvidia_vram", lambda: None)
-    monkeypatch.setattr(hardware, "_unified_pool_bytes", lambda *_: None)
+    monkeypatch.setattr(hardware, "_device_pool_view", lambda: None)
 
     budget = hardware.probe_budget(planning=True, platform_name="win32")
 

--- a/tests/hermes_cli/test_unified_pool_quirk.py
+++ b/tests/hermes_cli/test_unified_pool_quirk.py
@@ -163,18 +163,41 @@ def test_budget_discrete_unchanged_when_probe_unavailable(monkeypatch):
     assert b.ram_available_bytes == UMA_RAM
 
 
+def test_budget_discrete_driver_survives_smi_failure(monkeypatch):
+    """A positive CUDA discrete verdict must not become a CPU-only budget when smi fails."""
+    _no_cache(monkeypatch)
+    total = 32 * GIB
+    monkeypatch.setattr(hw, "_nvidia_vram", lambda: None)
+    monkeypatch.setattr(hw, "_ram_bytes", lambda: (64 * GIB, 48 * GIB))
+    monkeypatch.setattr(hw, "_device_pool_view", lambda: (total, False))
+
+    planning = hw.probe_budget(planning=True, platform_name="win32")
+    margin = max(hw._MARGIN_FLOOR, int(total * hw._MARGIN_FRACTION))
+    assert planning.total_device_bytes == total
+    assert planning.usable_vram_bytes == total - margin
+    assert planning.ram_available_bytes == 64 * GIB
+    assert planning.uma is False
+
+    live = hw.probe_budget(planning=False, platform_name="win32")
+    assert live.total_device_bytes == total
+    assert live.usable_vram_bytes == 0
+    assert live.ram_available_bytes == 48 * GIB
+    assert live.uma is False
+
+
 def test_engine_fallback_without_smi_stays_conservative(monkeypatch):
     """Engine-fallback view (no INTEGRATED verdict) + no smi numbers: the
     disagreement gate has nothing to compare against, so the quirk stays
-    off and budgeting falls to the conservative RAM-as-UMA path — an
-    attribute-less pool claim alone must never flip the verdict."""
+    off and budgeting falls to the CPU path — an attribute-less pool claim
+    alone must never invent GPU or unified-memory capacity."""
     _no_cache(monkeypatch)
     monkeypatch.setattr(hw, "_nvidia_vram", lambda: None)
     monkeypatch.setattr(hw, "_ram_bytes", lambda: (UMA_RAM, 32 * GIB))
     monkeypatch.setattr(hw, "_device_pool_view", lambda: (UMA_POOL, None))
-    b = hw.probe_budget(planning=True)
-    assert b.uma is True
-    assert b.total_device_bytes == UMA_RAM  # RAM path, not the pool
+    b = hw.probe_budget(planning=True, platform_name="win32")
+    assert b.uma is False
+    assert b.total_device_bytes == 0
+    assert b.ram_available_bytes == int(UMA_RAM * (1 - hw._UMA_HEADROOM_FRACTION))
 
 
 def test_smi_resolver_caches_and_survives_empty_path(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

CPU-only machines no longer report system RAM as GPU memory or recommend a model as GPU-resident. Hermes now budgets host RAM as host RAM, prices CPU recommendations at host-memory bandwidth, and presents the CPU-only recommendation without GPU claims.

### Symptom

On a Windows Server 2022 host with no GPU, Local Models showed 31.1 GB of GPU memory, marked Qwen3.8 27B as "Fits your GPU," and recommended it. The CPU backend then spent more than 15 minutes processing the prompt.

### Impact

Users on CPU-only hosts can be directed to a dense model under false GPU-fit and speed assumptions, consuming most available RAM while remaining impractically slow.

### Bug Cause

**Trigger:** `hermes_cli/local_runtime/hardware.py:266` / `probe_budget()` when NVIDIA and unified-device probes return no device.

**Causal chain:**
1. A CPU-only host returned no device VRAM.
2. The fallback converted all physical RAM into a unified GPU budget, so catalog selection treated the CPU host as a resident accelerator with UMA bandwidth.
3. The API and Desktop rendered that invented device budget as GPU memory and recommended the dense 27B model as GPU-resident.

**Why it is wrong:** Absence of a device probe is not evidence of unified GPU memory. CPU inference can consume host RAM, but it has no resident-GPU tier and must use host-memory speed assumptions.

**Working sibling / contrast:** macOS Metal hosts retain the existing unified-memory budget. Detected NVIDIA discrete and unified devices continue to use their device-backed probes.

**Ruled out:** Backend selection was not the source of the false claim. The captured runtime already selected the `cpu` backend, while the hardware budget independently labeled RAM as GPU memory.

### Fix

Represent CPU-only capacity as zero device memory plus headroom-adjusted host RAM. The recommendation resolver now selects the fastest host-memory model with an explicit CPU-only reason, catalog copy describes system-RAM execution, and Desktop hides the GPU-memory fact when no device exists. Regression coverage also verifies the macOS unified-memory contrast.

## Related Issue

Fixes #105389

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/local_runtime/hardware.py` - distinguish CPU-only host RAM from unified GPU memory.
- `hermes_cli/local_runtime/catalog.py` and `hermes_cli/web_routers/local_models.py` - use host-memory speed and honest CPU-only recommendation copy.
- `apps/desktop/src/app/settings/local-models-settings.tsx` and i18n/types - hide nonexistent GPU memory and explain CPU-only recommendations.
- Python and Desktop tests - cover CPU-only recommendation behavior, UI claims, and the macOS UMA contrast.

## How to Test

1. Run the local recommendation and route tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_local_recommendation.py tests/hermes_cli/test_local_models_routes.py
```

2. Run the Desktop settings test:

```bash
npm exec --workspace apps/desktop vitest run src/app/settings/local-models-settings.test.tsx
```

3. Run Desktop type and lint checks:

```bash
npm run --workspace apps/desktop typecheck
npm exec --workspace apps/desktop eslint src/app/settings/local-models-settings.tsx src/app/settings/local-models-settings.test.tsx src/i18n/en.ts src/i18n/zh.ts src/types/hermes.ts
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant docstrings
- [x] Config example changes are N/A because no config keys changed
- [x] Architecture or workflow documentation changes are N/A
- [x] I've considered cross-platform impact and preserved macOS unified-memory behavior
- [x] Tool description or schema changes are N/A

## Screenshots / Logs

The linked issue includes the Windows Server 2022 Local Models screenshot and Task Manager evidence used for the reproduction contract.
