### PR TITLE
fix(agent): give the tool-guardrail halt response a self-contained user reason

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -483,6 +483,45 @@ def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:
     return json.dumps({"error": decision.message, "guardrail": decision.to_metadata()}, ensure_ascii=False)
 
 
+# User-facing reasons for guardrail halts surfaced as the final turn response. Messaging
+# surfaces (Telegram, gateway) never render tool results, so the halt text must explain the
+# blocker without pointing at evidence the user cannot see. Keyed by decision code, so only
+# these fixed strings can reach the user — raw arguments, payloads, and provider output
+# cannot leak through.
+_HALT_USER_REASONS: dict[str, str] = {
+    "repeated_exact_failure_block": (
+        "the same call with unchanged arguments kept failing, so the arguments "
+        "themselves must change before it can succeed"
+    ),
+    "idempotent_no_progress_block": (
+        "the same read-only call kept returning the same result, so repeating "
+        "it cannot make progress"
+    ),
+    "same_tool_failure_halt": (
+        "the operation repeatedly failed to make progress as asked"
+    ),
+    "identical_call_streak_halt": (
+        "the identical call kept returning the identical result, so repeating "
+        "it cannot make progress"
+    ),
+    "loop_web_search_cap": "the per-turn web search limit was reached",
+    "loop_subagent_cap": "the per-turn subagent limit was reached",
+}
+
+
+def toolguard_halt_user_reason(decision: ToolGuardrailDecision) -> str:
+    """Self-contained, user-safe reason a guardrail stopped the loop.
+
+    Never references tool output or raw call arguments: surfaces without a tool
+    feed would leave the user with an unexplained stop, and failure details may
+    carry secrets.
+    """
+    return (
+        _HALT_USER_REASONS.get(decision.code)
+        or "it made no progress after repeated attempts"
+    )
+
+
 def append_toolguard_guidance(result: str, decision: ToolGuardrailDecision) -> str:
     """Append runtime guidance to the current tool result content."""
     if decision.action not in {"warn", "halt"} or not decision.message:

--- a/run_agent.py
+++ b/run_agent.py
@@ -132,7 +132,12 @@ from agent.codex_responses_adapter import (
     _split_responses_tool_id as _codex_split_responses_tool_id,
     _summarize_user_message_for_log,
 )
-from agent.tool_guardrails import ToolGuardrailDecision, append_toolguard_guidance, toolguard_synthetic_result
+from agent.tool_guardrails import (
+    ToolGuardrailDecision,
+    append_toolguard_guidance,
+    toolguard_halt_user_reason,
+    toolguard_synthetic_result,
+)
 from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens
 
 
@@ -1212,9 +1217,9 @@ class AIAgent(
     def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
         return (
             f"I stopped retrying {decision.tool_name or 'a tool'} because it hit the tool-call guardrail "
-            f"({decision.code}) after {decision.count} repeated non-progressing "
-            "attempts. The last tool result explains the blocker; the next step is "
-            "to change strategy instead of repeating the same call."
+            f"({decision.code}) after {decision.count} repeated non-progressing attempts: "
+            f"{toolguard_halt_user_reason(decision)}. The next step is to change strategy "
+            "instead of repeating the same call."
         )
 
     def _append_guardrail_observation(self, tool_name: str, function_args: dict, function_result: str, *,

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -5,9 +5,11 @@ import json
 from agent.tool_guardrails import (
     ToolCallGuardrailConfig,
     ToolCallGuardrailController,
+    ToolGuardrailDecision,
     ToolCallSignature,
     canonical_tool_args,
     classify_tool_failure,
+    toolguard_halt_user_reason,
 )
 
 
@@ -376,3 +378,50 @@ def test_supervised_task_platforms_keep_warning_only_default():
     for platform in ("telegram", "discord", "cron", "kanban"):
         cfg = ToolCallGuardrailConfig.from_mapping({}, platform=platform)
         assert cfg.hard_stop_enabled is True, platform
+
+
+def test_halt_user_reason_is_self_contained_per_failure_class():
+    """The final halt response reaches messaging users with no tool feed, so each
+    failure class must carry its own actionable reason, not a reference to a
+    tool result the user cannot see (#105404)."""
+    arg_replay = toolguard_halt_user_reason(
+        ToolGuardrailDecision(
+            action="block", code="repeated_exact_failure_block", tool_name="web_search"
+        )
+    )
+    assert "arguments" in arg_replay
+    streak = toolguard_halt_user_reason(
+        ToolGuardrailDecision(
+            action="halt", code="identical_call_streak_halt", tool_name="read_file"
+        )
+    )
+    assert "identical result" in streak
+    cap = toolguard_halt_user_reason(
+        ToolGuardrailDecision(
+            action="block", code="loop_web_search_cap", tool_name="web_search"
+        )
+    )
+    assert "limit" in cap
+    # Distinct failure classes must not collapse into one shared reason.
+    assert len({arg_replay, streak, cap}) == 3
+
+
+def test_halt_user_reason_fails_closed_on_unknown_code_and_never_leaks_details():
+    secret = "sk-live-supersecret-value"
+    unknown = toolguard_halt_user_reason(
+        ToolGuardrailDecision(
+            action="halt", code="totally_new_guardrail", message=f"boom {secret}"
+        )
+    )
+    assert unknown == "it made no progress after repeated attempts"
+    assert secret not in unknown
+    for code in (
+        "repeated_exact_failure_block",
+        "same_tool_failure_halt",
+        "identical_call_streak_halt",
+        "loop_subagent_cap",
+    ):
+        reason = toolguard_halt_user_reason(
+            ToolGuardrailDecision(action="halt", code=code, message=f"raw {secret}")
+        )
+        assert secret not in reason

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -454,3 +454,38 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+def test_guardrail_halt_final_response_is_self_contained_for_messaging_users():
+    """Regression for #105404: the halt text is the user's answer on Telegram
+    and similar surfaces where tool results are never rendered, so it must
+    explain the blocker itself instead of referring to the last tool result."""
+    agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
+    same_args = {"query": "same"}
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("web_search", json.dumps(same_args), f"c{i}")],
+        )
+        for i in range(1, 10)
+    ]
+    agent.client.chat.completions.create.side_effect = responses
+    agent._disable_streaming = True
+
+    with (
+        patch("model_tools.handle_function_call", return_value=json.dumps({"error": "boom"})),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("search repeatedly")
+
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    halt_text = result["final_response"]
+    # No reference to evidence the messaging user cannot open.
+    assert "last tool result" not in halt_text
+    # The safe per-code reason is rendered, not just the guardrail code and count.
+    assert "arguments" in halt_text
+    # Raw tool payload never reaches the user-visible answer.
+    assert "boom" not in halt_text


### PR DESCRIPTION
## Summary

The controlled tool-loop halt response told users "The last tool result explains the blocker". On messaging surfaces (Telegram, gateway, cron) tool results are never rendered, so the final answer pointed at evidence the user cannot see and carried no actionable reason beyond a guardrail code and a retry count.

- `agent/tool_guardrails.py`: new `toolguard_halt_user_reason(decision)` maps every halt/block code to a fixed, self-contained user-facing reason (argument replays → "the arguments themselves must change"; identical-result streaks → "repeating it cannot make progress"; loop caps → per-turn limit reached; unknown code → fail-closed generic reason). Keyed by decision code, so only these fixed strings can reach the user — raw arguments, tool payloads, and provider output cannot leak through.
- `run_agent.py::_toolguard_controlled_halt_response` renders that reason instead of the reference to the invisible tool result. Hard-stop semantics, code, and count are unchanged.

Fixes #105404

## Testing

- `tests/agent/test_tool_guardrails.py`: per-failure-class reasons are distinct and self-contained; unknown code fails closed; `decision.message` (which may carry raw failure detail) never leaks into the user reason.
- `tests/run_agent/test_tool_call_guardrail_runtime.py`: full turn-loop halt — final response contains no "last tool result" reference, renders the safe reason, and never echoes the raw tool error payload.

Both new tests are RED against unpatched main and GREEN with the fix; the existing 33 tests in the two files still pass.

```text
$ pytest tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py -q
35 passed
```