### PR TITLE
fix(display): label requested process wait timeout

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -394,7 +394,7 @@ def _preview_delegate_task(args: dict, max_len: int) -> str | None:
 def _preview_process_manage(args: dict, _max_len: int) -> str | None:
     action, sid, data, timeout_val = (args.get(k) for k in ("action", "session_id", "data", "timeout"))
     parts = [str(action) if action else "", str(sid)[:16] if sid else "",
-             f'"{_oneline(str(data)[:20])}"' if data else "", f"{timeout_val}s" if timeout_val and action == "wait" else ""]
+             f'"{_oneline(str(data)[:20])}"' if data else "", f"timeout={timeout_val}s" if timeout_val and action == "wait" else ""]
     return " ".join(p for p in parts if p) or None
 
 

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -48,6 +48,49 @@ class TestBuildToolPreview:
         """Empty dict has no keys to preview."""
         assert build_tool_preview("terminal", {}) is None
 
+    @pytest.mark.parametrize(
+        ("args", "expected"),
+        [
+            pytest.param(
+                {"action": "wait", "session_id": "proc_scout", "timeout": 40},
+                "wait proc_scout timeout=40s",
+                id="40-seconds",
+            ),
+            pytest.param(
+                {"action": "wait", "session_id": "proc_scout", "timeout": 40000},
+                "wait proc_scout timeout=40000s",
+                id="40000-seconds",
+            ),
+        ],
+    )
+    def test_process_wait_preview_labels_raw_timeout(self, args, expected):
+        original_args = args.copy()
+
+        assert build_tool_preview("process_manage", args) == expected
+        assert args == original_args
+
+    @pytest.mark.parametrize(
+        ("args", "expected"),
+        [
+            pytest.param({"action": "wait", "session_id": "proc_scout"}, "wait proc_scout", id="omitted-timeout"),
+            pytest.param(
+                {"action": "wait", "session_id": "proc_scout", "timeout": 0},
+                "wait proc_scout",
+                id="zero-timeout",
+            ),
+            pytest.param(
+                {"action": "poll", "session_id": "proc_scout", "timeout": 40},
+                "poll proc_scout",
+                id="non-wait-action",
+            ),
+        ],
+    )
+    def test_process_preview_only_labels_wait_timeout(self, args, expected):
+        original_args = args.copy()
+
+        assert build_tool_preview("process_manage", args) == expected
+        assert args == original_args
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Label the requested timeout in process-wait previews so it cannot be mistaken for elapsed runtime. For example, `wait proc_scout 40000s` becomes `wait proc_scout timeout=40000s`.

The timeout remains in seconds. This is a display-only change: it does not convert units, change the requested value, alter wait execution or clamping, or modify the tool schema.

## Related Issue

Fixes #83807

## Type of Change

- [x] Bug fix (non-breaking)

## Changes Made

- `agent/display.py`: add `timeout=` under the existing truthy-timeout and `action == "wait"` guard.
- `tests/agent/test_display.py`: add two parameterized regression tests covering 40 and 40000 seconds, omitted and zero timeouts, non-wait actions, and argument immutability through `build_tool_preview`.

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_display*.py tests/agent/test_summarize_tool_result_type_safety.py tests/tools/test_process_wait_clarity.py --file-retries 0 -q
.venv/bin/ruff check agent/display.py tests/agent/test_display.py
git diff --check
```

Verified locally on macOS after fast-forwarding to upstream commit `2237be355906fbe6065ce1815711eee52b2d646e`:

- **74 tests passed across 6 files; 0 failed**, with file retries disabled.
- Ruff and whitespace checks passed.
- Before the production fix, the two labeled-timeout cases failed on the old bare suffix; the omitted-timeout and non-wait controls passed.
- Independent AI-assisted review of the final patch found no blockers.

The full repository test suite was not run. GitHub CI results are reported separately by the PR checks.

## Checklist

- [x] Conventional commit; only changes related to this fix.
- [x] Existing PRs checked for overlapping behavior.
- [x] Regression tests added and relevant tests passed.
- [x] Cross-platform impact considered: only shared Python string formatting changes.
- Documentation, configuration, architecture, and tool-schema changes: N/A.

AI-assisted implementation and review; verification above was executed against the actual contribution worktree.
