### PR TITLE
fix(kanban): treat request_review/request_changes as terminal in worker stop guard

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -1,6 +1,7 @@
-"""Turn-end guard for kanban workers, which must end with ``kanban_complete`` or
-``kanban_block``. Some models narrate the next step and stop with no tool calls;
-Hermes treats that as a clean exit → ``rc=0`` → dispatcher ``protocol_violation``.
+"""Turn-end guard for kanban workers, which must end with a terminal board tool:
+``kanban_complete``, ``kanban_block``, or a review handoff (``kanban_request_review``
+/ ``kanban_request_changes``). Some models narrate the next step and stop with no tool
+calls; Hermes treats that as a clean exit → ``rc=0`` → dispatcher ``protocol_violation``.
 Policy-only: return a bounded synthetic nudge so the loop continues instead of exiting.
 """
 
@@ -10,7 +11,18 @@ import os
 from typing import Any, Iterable, Optional
 
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+_TERMINAL_KANBAN_TOOLS = frozenset(
+    {
+        "kanban_complete",
+        "kanban_block",
+        # Review handoffs are legal run-enders too: request_review closes the
+        # implementation run and moves the card to `review`; request_changes
+        # closes a review run and requeues the card. Nudging them to call
+        # complete/block again double-transitions or re-completes the card.
+        "kanban_request_review",
+        "kanban_request_changes",
+    }
+)
 
 _DEFAULT_MAX_ATTEMPTS = 2
 
@@ -64,13 +76,15 @@ def build_kanban_stop_nudge(
     return (
         "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
         "terminal state for the board.\n\n"
-        f"Task `{tid}` is still `running`. Ending now without a board tool "
-        "causes a protocol violation (clean exit with no "
-        "`kanban_complete` / `kanban_block`).\n\n"
+        f"Task `{tid}` is still `running`. Ending now without a terminal board tool "
+        "causes a protocol violation (clean exit with no board-state "
+        "transition).\n\n"
         "Do this immediately in your next response — do not narrate intent:\n"
         "1. Finish any remaining deliverable (write the required file(s) now).\n"
         "2. Call `kanban_complete(summary=..., artifacts=[...])` if the work "
-        "is done, OR `kanban_block(reason=...)` if you are blocked.\n\n"
+        "is done, `kanban_block(reason=...)` if you are blocked, or — if this run "
+        "is a review handoff — `kanban_request_review(...)` / "
+        "`kanban_request_changes(...)` as appropriate.\n\n"
         "Never end a turn with only a promise of future action. Repeated "
         "protocol violations will block this task and require manual intervention.]"
     )

--- a/agent/turn_stop_gates.py
+++ b/agent/turn_stop_gates.py
@@ -77,7 +77,8 @@ def _pre_verify_nudge(agent, final_response, attempt: int) -> Optional[str]:
 
 
 def _kanban_stop_nudge(agent, messages) -> Optional[str]:
-    """Workers must end with kanban_complete / kanban_block; a narrated stop is recorded
+    """Workers must end with a terminal board tool (kanban_complete / kanban_block /
+    kanban_request_review / kanban_request_changes); a narrated stop is recorded
     as protocol_violation, so nudge once or twice first."""
     try:
         from agent.kanban_stop import build_kanban_stop_nudge
@@ -163,8 +164,8 @@ def apply_stop_gates(
             os.environ.get("HERMES_KANBAN_TASK", ""),
         )
         agent._emit_status(
-            "⚠️ Kanban worker tried to exit without "
-            "kanban_complete/kanban_block — nudging to finish"
+            "⚠️ Kanban worker tried to exit without a terminal board tool "
+            "(kanban_complete/kanban_block/request_review/request_changes) — nudging to finish"
         )
         return verdict
     return StopGateVerdict(

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -74,6 +74,38 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+def _review_handoff_messages(tool_name: str) -> list:
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": tool_name, "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "name": tool_name, "tool_call_id": "1", "content": "done"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    ["kanban_request_review", "kanban_request_changes"],
+)
+def test_no_nudge_after_review_handoff_tool(clear_kanban_env, tool_name):
+    """Invariant: kanban_request_review / kanban_request_changes are terminal
+    board transitions (review handoff). A worker that ends after one of them
+    finished its run legally — the stop guard must NOT fire a
+    'still running, call complete/block' nudge."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_ef71e643")
+    messages = _review_handoff_messages(tool_name)
+    assert session_called_kanban_terminal(messages) is True
+    assert build_kanban_stop_nudge(messages=messages) is None
+
+
 
 
 


### PR DESCRIPTION
## Summary

The kanban worker turn-end guard (`agent/kanban_stop.py`) recognizes only `kanban_complete` / `kanban_block` as terminal board tools. `kanban_request_review` and `kanban_request_changes` — both legal, terminal run-enders (review handoff and reviewer send-back) — are not in `_TERMINAL_KANBAN_TOOLS`, so a worker that ends its turn right after a correct handoff is told:

> Task `...` is still `running`. Ending now without a board tool causes a protocol violation... call `kanban_complete` / `kanban_block`

The nudge repeats on every subsequent exit (up to the attempt budget), repeatedly prompting a worker whose run already finished legally — and inviting a double board transition (completing a card that has already moved to `review`, or re-completing one the reviewer just closed).

## Field reproduction

Hit this live on a multi-profile Bot Mode team: a reviewer run ended with `kanban_request_changes` (board shows the run ended, `outcome=changes_requested`, `current_run_id=null`, card back in `ready`), yet the stop guard kept issuing the "still running, call complete/block" nudge for the already-finished review run.

Reproduced on `main` (a9caaeb60f) with the actual session messages:

```
python3 -c 'from agent.kanban_stop import session_called_kanban_terminal; ...'
kanban_complete           session_called=True
kanban_block              session_called=True
kanban_request_review     session_called=False   <- bug
kanban_request_changes    session_called=False   <- bug
```

`build_kanban_stop_nudge` consults no board state — membership in that set is the only signal.

## Change

- `_TERMINAL_KANBAN_TOOLS` (`agent/kanban_stop.py`): add `kanban_request_review` / `kanban_request_changes`. Both are terminal board transitions from the worker's perspective: the card leaves `running` (to `review` or back to `ready`), so no nudge should fire. The guard still fires exactly as before for workers that exit without ANY terminal tool (acceptance: the existing no-terminal nudge test is untouched and green).
- Nudge copy: the parenthetical listed only `kanban_complete` / `kanban_block` as acceptable exits, which would be self-contradictory once the set widens; it now names all four. No structural change to `build_kanban_stop_nudge` — it still consults no board state (intentional: the whole bug class is "session messages say a terminal call happened; trust that").
- `agent/turn_stop_gates.py`: align the `_kanban_stop_nudge` docstring and the emitted status line with the widened set.

## Test

`tests/agent/test_kanban_stop.py::test_no_nudge_after_review_handoff_tool` — parametrized over both handoff tools, asserts `session_called_kanban_terminal` is True and `build_kanban_stop_nudge` returns `None`. RED on `main`, GREEN with the fix:

```
scripts/run_tests.sh tests/agent/test_kanban_stop.py
=== Summary: 1 files, 5 tests passed, 0 failed ===
```

Full area run (`scripts/run_tests.sh tests/agent/`): 518 files, 6501 passed, 29 skipped, 2 failed — both failures are in `test_owned_process_cleanup.py` and reproduce identically on a clean `origin/main` checkout (pre-existing, unrelated to this diff).
