### PR TITLE
fix(disk-cleanup): protect checkpoints/ from empty-dir sweep

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -85,6 +85,9 @@ _EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
     "logs", "memories", "sessions", "cron", "cronjobs",
     "cache", "skills", "plugins", "disk-cleanup", "optional-skills",
     "hermes-agent", "backups", "profiles", ".worktrees",
+    # Bare git shadow stores: refs/ and objects/ are legitimately empty on a
+    # fresh store, and deleting them makes git report "not a git repository".
+    "checkpoints",
     "patches", "projects", "skins", "themes", "contributors"})
 
 _EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -225,6 +225,24 @@ class TestStaleCronEntryMigration:
         assert not run_md.exists()
 
 
+class TestEmptyDirectorySweep:
+    def test_preserves_empty_checkpoint_git_internals(self, _isolate_env):
+        dg = _load_lib()
+        objects = _isolate_env / "checkpoints" / "store" / "objects"
+        refs = _isolate_env / "checkpoints" / "store" / "refs"
+        objects.mkdir(parents=True)
+        refs.mkdir()
+        disposable = _isolate_env / "scratch" / "empty"
+        disposable.mkdir(parents=True)
+
+        removed = dg._sweep_empty_dirs(_isolate_env)
+
+        assert objects.is_dir()
+        assert refs.is_dir()
+        assert not disposable.exists()
+        assert removed > 0
+
+
 class TestTrackForgetQuick:
     def test_track_then_quick_deletes_test(self, _isolate_env):
         dg = _load_lib()


### PR DESCRIPTION
## Summary

- exclude `checkpoints/` from the empty-directory sweep
- cover preservation of empty bare-repository internals while confirming disposable empty directories are still removed

## Failure mode

The empty-directory sweep can remove empty `objects/` and `refs/` directories from a fresh bare checkpoint store. Git then reports that the store is not a repository and checkpoint operations stop working. This was observed during an August 21 cleanup incident.

## Test

`python -m pytest tests/plugins/test_disk_cleanup_plugin.py -o 'addopts=' -q`

Result: `28 passed`
