### PR TITLE
feat(cli): configure delegated reasoning in auxiliary model setup

### DIFF
--- a/hermes_cli/main_provider_setup.py
+++ b/hermes_cli/main_provider_setup.py
@@ -105,11 +105,14 @@ def _format_aux_current(task_cfg: dict) -> str:
 
 def _delegation_cfg_as_task(cfg: dict) -> dict:
     """Project the top-level ``delegation`` section into aux-task shape (provider/model/
-    base_url/api_key); an empty provider means "inherit parent" and renders as "auto"."""
+    base_url/api_key/reasoning); an empty provider means "inherit parent" and renders as "auto"."""
     d = cfg.get("delegation")
     if not isinstance(d, dict):
         d = {}
-    return {k: str(d.get(k) or "").strip() for k in ("provider", "model", "base_url", "api_key")}
+    return {
+        k: str(d.get(k) or "").strip()
+        for k in ("provider", "model", "base_url", "api_key", "reasoning_effort")
+    }
 
 
 def _aux_task_cfg(cfg: dict, task: str) -> dict:
@@ -128,9 +131,10 @@ def _aux_task_display_name(task: str) -> str:
 
 
 def _save_aux_choice(task: str, *, provider: str, model: str = "", base_url: str = "",
-                     api_key: str = "") -> None:
+                     api_key: str = "", reasoning_effort: str | None = None) -> None:
     """Persist an aux task's four routing fields (timeout etc. untouched; main model config never
-    modified). ``delegation`` writes the top-level section, with "auto" stored as an empty provider."""
+    modified). ``delegation`` writes the top-level section, with "auto" stored as an empty provider;
+    a non-None reasoning effort updates its independent override in the same save."""
     from hermes_cli.config import load_config, save_config
     cfg = load_config()
     if task == _DELEGATION_TASK_KEY:
@@ -142,7 +146,34 @@ def _save_aux_choice(task: str, *, provider: str, model: str = "", base_url: str
     entry["model"] = model or ""
     entry["base_url"] = base_url or ""
     entry["api_key"] = api_key or ""
+    if task == _DELEGATION_TASK_KEY and reasoning_effort is not None:
+        entry["reasoning_effort"] = reasoning_effort
     save_config(cfg)
+
+
+def _save_aux_route(task: str, task_cfg: dict, **route) -> bool:
+    """Prompt for delegation reasoning, then atomically persist the pending route."""
+    reasoning_effort = None
+    if task == _DELEGATION_TASK_KEY:
+        from hermes_constants import VALID_REASONING_EFFORTS
+
+        _say(
+            "",
+            "  Configure reasoning for delegated subagents.",
+            "  Hermes requests this level; providers may map it to a supported wire level.",
+            "",
+        )
+        reasoning_effort = _prompt_reasoning_effort_selection(
+            VALID_REASONING_EFFORTS,
+            current_effort=str(task_cfg.get("reasoning_effort") or "").strip().lower(),
+            allow_inherit=True,
+            distinguish_cancel=True,
+        )
+        if reasoning_effort is _CANCELLED:
+            print("No change.")
+            return False
+    _save_aux_choice(task, reasoning_effort=reasoning_effort, **route)
+    return True
 
 
 def _reset_aux_to_auto() -> int:
@@ -244,16 +275,16 @@ def _aux_select_for_task(task: str) -> None:
     if slug == "__back__":
         return
     if slug == "__auto__":
-        _save_aux_choice(task, provider="auto", model="", base_url="", api_key="")
-        print(f"{display_name}: reset to auto.")
+        if _save_aux_route(task, task_cfg, provider="auto", model="", base_url="", api_key=""):
+            print(f"{display_name}: reset to auto.")
     elif slug == "__custom__":
         _aux_flow_custom_endpoint(task, task_cfg)
     else:
-        _aux_flow_provider_model(task, slug, models, current_model)
+        _aux_flow_provider_model(task, slug, models, current_model, task_cfg)
 
 
 def _aux_flow_provider_model(task: str, provider_slug: str, curated_models: list,
-                             current_model: str = "") -> None:
+                             current_model: str = "", task_cfg: dict | None = None) -> None:
     """Prompt for a model under an already-authenticated provider, save to aux."""
     from hermes_cli.auth import _prompt_model_selection
     from hermes_cli.models_pricing import get_pricing_for_provider
@@ -278,7 +309,15 @@ def _aux_flow_provider_model(task: str, provider_slug: str, curated_models: list
             print("No change.")
             return
 
-    _save_aux_choice(task, provider=provider_slug, model=selected or "", base_url="", api_key="")
+    if not _save_aux_route(
+        task,
+        task_cfg or {},
+        provider=provider_slug,
+        model=selected or "",
+        base_url="",
+        api_key="",
+    ):
+        return
     if selected:
         print(f"{display_name}: {provider_slug} · {selected}")
     else:
@@ -309,7 +348,10 @@ def _aux_flow_custom_endpoint(task: str, task_cfg: dict) -> None:
     if api_key is None:
         return
 
-    _save_aux_choice(task, provider="custom", model=model, base_url=url, api_key=api_key)
+    if not _save_aux_route(
+        task, task_cfg, provider="custom", model=model, base_url=url, api_key=api_key
+    ):
+        return
     print(f"{display_name}: custom ({_short_url(url)})" + (f" · {model}" if model else ""))
 
 
@@ -523,8 +565,10 @@ def _remove_custom_provider(config):
     print(f'✅ Removed "{removed_name}" from custom providers.')
 
 
-def _prompt_reasoning_effort_selection(efforts, current_effort=""):
-    """Prompt for a reasoning effort. Returns effort, 'none', or None to keep current."""
+def _prompt_reasoning_effort_selection(
+    efforts, current_effort="", *, allow_inherit=False, distinguish_cancel=False
+):
+    """Prompt for reasoning; delegation can distinguish inherit, skip, and cancellation."""
     deduped = list(dict.fromkeys(str(effort).strip().lower() for effort in efforts if str(effort).strip()))
     canonical_order = ("minimal", "low", "medium", "high", "xhigh", "max", "ultra")
     ordered = [effort for effort in canonical_order if effort in deduped]
@@ -536,34 +580,57 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
         return f"{effort}  ← currently in use" if effort == current_effort else effort
 
     disable_label = "Disable reasoning"
+    inherit_label = "Inherit parent"
+    if allow_inherit and not current_effort:
+        inherit_label += "  ← currently in use"
     skip_label = "Skip (keep current)"
     if current_effort == "none":
         default_idx = len(ordered)
     elif current_effort in ordered:
         default_idx = ordered.index(current_effort)
+    elif allow_inherit:
+        default_idx = len(ordered) + 1
     elif "medium" in ordered:
         default_idx = ordered.index("medium")
     else:
         default_idx = 0
 
     n = len(ordered)
-    idx = _radiolist("Select reasoning effort:", [_label(effort) for effort in ordered] + [disable_label, skip_label],
-                     default_idx)
+    extra_choices = [disable_label]
+    if allow_inherit:
+        extra_choices.append(inherit_label)
+    extra_choices.append(skip_label)
+    idx = _radiolist(
+        "Select reasoning effort:",
+        [_label(effort) for effort in ordered] + extra_choices,
+        default_idx,
+    )
     if idx is not None:
         if idx < 0:
-            return None
+            return _CANCELLED if distinguish_cancel else None
         print()
     else:
         print("Select reasoning effort:")
         for i, effort in enumerate(ordered, 1):
             print(f"  {i}. {_label(effort)}")
-        _say(f"  {n + 1}. {disable_label}", f"  {n + 2}. {skip_label}", "")
-        idx = _ask_index(f"Choice [1-{n + 2}] (default: keep current): ", n + 2, echo_cancel=False)
-        if idx is None or idx is _CANCELLED:
+        for offset, label in enumerate(extra_choices, 1):
+            print(f"  {n + offset}. {label}")
+        print()
+        count = n + len(extra_choices)
+        idx = _ask_index(
+            f"Choice [1-{count}] (default: keep current): ", count, echo_cancel=False
+        )
+        if idx is _CANCELLED:
+            return _CANCELLED if distinguish_cancel else None
+        if idx is None:
             return None
     if idx < n:
         return ordered[idx]
-    return "none" if idx == n else None
+    if idx == n:
+        return "none"
+    if allow_inherit and idx == n + 1:
+        return ""
+    return None
 
 
 def _prompt_api_key(pconfig, existing_key: str, provider_id: str = "", existing_source: str = "") -> tuple:

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -12,9 +12,13 @@ here (they're stdin-driven curses prompts).
 
 from __future__ import annotations
 
+from copy import deepcopy
+
 import pytest
 
-from hermes_cli.config import DEFAULT_CONFIG, load_config
+from hermes_constants import VALID_REASONING_EFFORTS
+from hermes_cli.config import DEFAULT_CONFIG, load_config, save_config
+import hermes_cli.main_provider_setup as provider_setup
 from hermes_cli.main_provider_setup import _AUX_TASKS, _DELEGATION_TASK_KEY, _delegation_cfg_as_task, _format_aux_current, _reset_aux_to_auto, _save_aux_choice
 
 
@@ -194,3 +198,111 @@ def test_leave_unchanged_replaces_cancel_label(tmp_path, monkeypatch):
     assert "Leave unchanged" in labels
     assert "Cancel" not in labels, "Cancel label should be replaced"
     assert any("Configure auxiliary models" in label for label in labels)
+
+
+@pytest.mark.parametrize("route", ["auto", "provider", "custom"])
+@pytest.mark.parametrize(
+    ("effort_choice", "expected_effort", "cancelled"),
+    [
+        ("high", "high", False),
+        ("", "", False),
+        (None, "low", False),
+        (provider_setup._CANCELLED, "low", True),
+    ],
+)
+def test_delegation_route_and_reasoning_are_saved_atomically(
+    tmp_path, monkeypatch, route, effort_choice, expected_effort, cancelled
+):
+    """Every delegation route shares select/inherit/skip/cancel semantics."""
+    _isolate_home(tmp_path, monkeypatch)
+    cfg = load_config()
+    cfg["model"] = {"default": "parent-model", "provider": "parent-provider"}
+    cfg["auth"] = {"active_provider": "parent-provider"}
+    cfg["delegation"].update(
+        {
+            "provider": "old-provider",
+            "model": "old-model",
+            "base_url": "https://old.example/v1",
+            "api_key": "old-key",
+            "reasoning_effort": "low",
+            "max_concurrent_children": 7,
+        }
+    )
+    save_config(cfg)
+    original = deepcopy(load_config())
+
+    route_index = {"auto": 0, "provider": 1, "custom": 2}[route]
+    monkeypatch.setattr(provider_setup, "_prompt_provider_choice", lambda *_args, **_kwargs: route_index)
+    monkeypatch.setattr("hermes_cli.inventory.build_aux_picker_rows", lambda **_kwargs: [object()])
+    monkeypatch.setattr(
+        "hermes_cli.inventory.format_aux_picker_entries",
+        lambda *_args, **_kwargs: [("openrouter", "OpenRouter", ["child-model"])],
+    )
+    monkeypatch.setattr("hermes_cli.auth._prompt_model_selection", lambda *_args, **_kwargs: "child-model")
+    monkeypatch.setattr("hermes_cli.models_pricing.get_pricing_for_provider", lambda *_args: {})
+    custom_answers = iter(["https://new.example/v1", "custom-model", "new-key"])
+    monkeypatch.setattr(provider_setup, "_ask", lambda *_args, **_kwargs: next(custom_answers))
+
+    effort_prompts = []
+
+    def choose_effort(efforts, current_effort="", **kwargs):
+        effort_prompts.append((tuple(efforts), current_effort, kwargs))
+        return effort_choice
+
+    monkeypatch.setattr(provider_setup, "_prompt_reasoning_effort_selection", choose_effort)
+
+    provider_setup._aux_select_for_task(_DELEGATION_TASK_KEY)
+
+    persisted = load_config()
+    assert effort_prompts == [
+        (
+            tuple(VALID_REASONING_EFFORTS),
+            "low",
+            {"allow_inherit": True, "distinguish_cancel": True},
+        )
+    ]
+    assert persisted["model"] == original["model"]
+    assert persisted["auth"] == original["auth"]
+    if cancelled:
+        assert persisted["delegation"] == original["delegation"]
+        return
+
+    expected_routes = {
+        "auto": {"provider": "", "model": "", "base_url": "", "api_key": ""},
+        "provider": {
+            "provider": "openrouter",
+            "model": "child-model",
+            "base_url": "",
+            "api_key": "",
+        },
+        "custom": {
+            "provider": "custom",
+            "model": "custom-model",
+            "base_url": "https://new.example/v1",
+            "api_key": "new-key",
+        },
+    }
+    delegation = persisted["delegation"]
+    assert {key: delegation[key] for key in expected_routes[route]} == expected_routes[route]
+    assert delegation["reasoning_effort"] == expected_effort
+    assert delegation["max_concurrent_children"] == 7
+
+
+@pytest.mark.parametrize(
+    ("selected_index", "expected"),
+    [(-1, provider_setup._CANCELLED), (8, ""), (9, None)],
+)
+def test_delegation_reasoning_prompt_distinguishes_cancel_inherit_and_skip(
+    monkeypatch, selected_index, expected
+):
+    """The shared reasoning picker can expose delegation-only atomic choices."""
+    monkeypatch.setattr(provider_setup, "_radiolist", lambda *_args: selected_index)
+
+    result = provider_setup._prompt_reasoning_effort_selection(
+        VALID_REASONING_EFFORTS,
+        current_effort="low",
+        allow_inherit=True,
+        distinguish_cancel=True,
+    )
+
+    assert result is expected or result == expected

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -205,6 +205,7 @@ def test_leave_unchanged_replaces_cancel_label(tmp_path, monkeypatch):
     ("effort_choice", "expected_effort", "cancelled"),
     [
         ("high", "high", False),
+        ("none", "none", False),
         ("", "", False),
         (None, "low", False),
         (provider_setup._CANCELLED, "low", True),
@@ -231,8 +232,16 @@ def test_delegation_route_and_reasoning_are_saved_atomically(
     save_config(cfg)
     original = deepcopy(load_config())
 
-    route_index = {"auto": 0, "provider": 1, "custom": 2}[route]
-    monkeypatch.setattr(provider_setup, "_prompt_provider_choice", lambda *_args, **_kwargs: route_index)
+    route_label = {
+        "auto": "auto (inherit main agent)",
+        "provider": "OpenRouter",
+        "custom": "Custom endpoint (direct URL)",
+    }[route]
+
+    def choose_route(choices, **_kwargs):
+        return next(i for i, label in enumerate(choices) if route_label in label)
+
+    monkeypatch.setattr(provider_setup, "_prompt_provider_choice", choose_route)
     monkeypatch.setattr("hermes_cli.inventory.build_aux_picker_rows", lambda **_kwargs: [object()])
     monkeypatch.setattr(
         "hermes_cli.inventory.format_aux_picker_entries",
@@ -289,14 +298,24 @@ def test_delegation_route_and_reasoning_are_saved_atomically(
 
 
 @pytest.mark.parametrize(
-    ("selected_index", "expected"),
-    [(-1, provider_setup._CANCELLED), (8, ""), (9, None)],
+    ("selected_label", "expected"),
+    [
+        (None, provider_setup._CANCELLED),
+        ("Disable reasoning", "none"),
+        ("Inherit parent", ""),
+        ("Skip (keep current)", None),
+    ],
 )
 def test_delegation_reasoning_prompt_distinguishes_cancel_inherit_and_skip(
-    monkeypatch, selected_index, expected
+    monkeypatch, selected_label, expected
 ):
     """The shared reasoning picker can expose delegation-only atomic choices."""
-    monkeypatch.setattr(provider_setup, "_radiolist", lambda *_args: selected_index)
+    def choose_reasoning(_title, choices, _default):
+        if selected_label is None:
+            return -1
+        return next(i for i, label in enumerate(choices) if selected_label in label)
+
+    monkeypatch.setattr(provider_setup, "_radiolist", choose_reasoning)
 
     result = provider_setup._prompt_reasoning_effort_selection(
         VALID_REASONING_EFFORTS,


### PR DESCRIPTION
## What does this PR do?

Adds delegation reasoning-effort selection to the existing `hermes model` auxiliary-model setup flow. Users can now configure the child-agent route and reasoning override together without hand-editing `delegation.reasoning_effort`, while preserving the parent model and authentication route.

### Motivation

The existing Delegation entry configures provider and model routing but leaves its already-supported reasoning override inaccessible from the same UI. This gap was surfaced by @Xipong while exploring delegated model controls.

### Behavior

After choosing an inherited, built-in-provider, or custom-endpoint delegation route, the flow offers the canonical reasoning levels, explicit disable, inherit-parent, and skip choices. Skipping preserves the existing override; cancelling leaves both the pending route and effort unchanged. Hermes also explains that providers may map the configured request to a supported wire level.

A separate `/subagent` picker and agent-selected per-task routing are intentionally out of scope.

### Implementation

The shared reasoning picker now optionally distinguishes cancellation from skip and exposes an inherit-parent choice. Delegation routes defer their single config save until that prompt completes, and a parameterized behavior contract covers route and effort combinations without provider credentials.

## Related Issue

Closes #105411

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/main_provider_setup.py` - prompt for delegation reasoning and persist route/effort atomically across all route types.
- `tests/hermes_cli/test_aux_config.py` - cover select, inherit, skip, and cancel semantics for inherited, built-in, and custom routes.

## How to Test

1. Run `hermes model` and choose `Configure auxiliary models` -> `Delegation`.
2. Select any route, then choose a reasoning level, inherit parent, skip, or cancel.
3. Run the focused regression suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_aux_config.py tests/hermes_cli/test_reasoning_effort_menu.py tests/hermes_cli/test_aux_picker_inventory.py tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
```

Result: 34 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is unchanged because this exposes an existing documented config key in an existing setup flow
- [x] `cli-config.yaml.example` is unchanged because no config key was added or changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are unchanged because architecture and workflows are unchanged
- [x] Cross-platform impact was considered; the implementation reuses the existing curses/fallback picker abstraction
- [x] Tool descriptions and schemas are unchanged because tool behavior is unchanged

## Screenshots / Logs

Focused regression suite: 34 passed, 0 failed.
