### PR TITLE
fix(checkpoints): self-heal stored checkpoint metadata

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -135,6 +135,57 @@ class TestStoreInit:
         assert (legacies[0] / fake_repo.name).exists()
         assert (legacies[0] / fake_repo.name / "HEAD").exists()
 
+    def test_checkpoint_self_heals_store_missing_git_internals(
+        self, mgr, work_dir, checkpoint_base,
+    ):
+        assert mgr.ensure_checkpoint(str(work_dir), "before corruption") is True
+        store = _store_path(checkpoint_base)
+        shutil.rmtree(store / "objects")
+        shutil.rmtree(store / "refs")
+
+        mgr.new_turn()
+        (work_dir / "main.py").write_text("print('after repair')\n")
+
+        assert mgr.ensure_checkpoint(str(work_dir), "after repair") is True
+        assert (store / "objects").is_dir()
+        assert (store / "refs").is_dir()
+        assert [c["reason"] for c in mgr.list_checkpoints(str(work_dir))] == [
+            "after repair",
+        ]
+
+    def test_reinitialization_preserves_project_and_index_metadata(
+        self, work_dir, checkpoint_base,
+    ):
+        store = _store_path(checkpoint_base)
+        assert _init_store(store, str(work_dir)) is None
+        project_meta = store / "projects" / "preserve.json"
+        index_meta = store / "indexes" / "preserve"
+        project_meta.write_text('{"marker": "project"}\n')
+        index_meta.write_bytes(b"index-marker")
+        shutil.rmtree(store / "objects")
+        shutil.rmtree(store / "refs")
+
+        assert _init_store(store, str(work_dir)) is None
+
+        assert project_meta.read_text() == '{"marker": "project"}\n'
+        assert index_meta.read_bytes() == b"index-marker"
+        assert (store / "objects").is_dir()
+        assert (store / "refs").is_dir()
+
+    def test_valid_store_is_not_reinitialized(
+        self, work_dir, checkpoint_base,
+    ):
+        store = _store_path(checkpoint_base)
+        assert _init_store(store, str(work_dir)) is None
+
+        with patch(
+            "tools.checkpoint_manager.subprocess.run", wraps=subprocess.run,
+        ) as run:
+            assert _init_store(store, str(work_dir)) is None
+
+        commands = [call.args[0] for call in run.call_args_list]
+        assert ["git", "init", "--bare", str(store)] not in commands
+
 
 # =========================================================================
 # CheckpointManager — disabled

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -389,12 +389,24 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
         except OSError as exc:
             return f"Could not create checkpoint base: {exc}"
         _migrate_legacy_store(base)
-    if _store_has_head(store):
-        return None
-    for d in (store, store / _INDEXES_DIRNAME, store / _PROJECTS_DIRNAME):
-        d.mkdir(parents=True, exist_ok=True)
 
-    # ``git init --bare`` rejects GIT_WORK_TREE, so bypass _run_git.
+    if store.exists():
+        try:
+            validity = _git_subprocess(
+                ["git", "--git-dir", str(store), "rev-parse", "--git-dir"],
+                _isolated_git_env(),
+                _GIT_TIMEOUT,
+            )
+            if validity.returncode == 0:
+                return None
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            # Let the normal init path below return the actionable error.
+            pass
+
+    store.mkdir(parents=True, exist_ok=True)
+    (store / _INDEXES_DIRNAME).mkdir(exist_ok=True)
+    (store / _PROJECTS_DIRNAME).mkdir(exist_ok=True)
+
     try:
         result = _git_subprocess(["git", "init", "--bare", str(store)], _isolated_git_env(), _GIT_TIMEOUT)
         if result.returncode != 0:


### PR DESCRIPTION
## Summary

- validate an existing checkpoint store with Git instead of treating `HEAD` alone as proof that it is usable
- reinitialize a damaged bare store while preserving Hermes project and index metadata
- cover recovery, metadata preservation, and the valid-store fast path

## Failure mode

If cleanup removes required bare-repository internals, the checkpoint store can retain `HEAD` while no longer being a valid Git repository. `_init_store` previously returned early in that state, so later checkpoint operations kept failing. This was observed after an August 21 cleanup incident.

## Test

`python -m pytest tests/tools/test_checkpoint_manager.py -o 'addopts=' -q`

Result: `56 passed`
