### PR TITLE
feat(models): add scriptable provider model discovery

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -317,6 +317,7 @@ from hermes_cli.subcommands.sync import build_sync_parser
 from hermes_cli.subcommands.gateway import build_gateway_parser
 from hermes_cli.subcommands.profile import build_profile_parser
 from hermes_cli.subcommands.model import build_model_parser
+from hermes_cli.subcommands.models import build_models_parser
 from hermes_cli.subcommands.setup import build_setup_parser
 
 from hermes_cli.subcommands.whatsapp import build_whatsapp_parser, build_whatsapp_cloud_parser
@@ -3150,6 +3151,13 @@ def _cmd_sessions_lazy(args, **kwargs):
     return cmd_sessions(args, **kwargs)
 
 
+def _cmd_models_lazy(args):
+    """``hermes models`` handler; discovery imports only when invoked."""
+    from hermes_cli.model_discovery import models_command
+
+    return models_command(args)
+
+
 def _build_cli_parser():
     """Build the full ``hermes`` argparse tree -> ``(parser, subparsers)``.
 
@@ -3163,6 +3171,7 @@ def _build_cli_parser():
     chat_parser.set_defaults(func=cmd_chat)
 
     build_model_parser(subparsers, cmd_model=cmd_model)
+    build_models_parser(subparsers, cmd_models=_cmd_models_lazy)
     build_moa_parser(subparsers)
     build_fallback_parser(subparsers)
     build_worktree_parser(subparsers)

--- a/hermes_cli/model_discovery.py
+++ b/hermes_cli/model_discovery.py
@@ -1,0 +1,246 @@
+"""Stable, noninteractive provider/model discovery for external integrations."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+SCHEMA_VERSION = "1"
+_CACHE_TTL_SECONDS = 3600
+
+
+@dataclass(frozen=True)
+class ModelDiscoveryRequest:
+    provider: str | None = None
+    refresh: bool = False
+    offline: bool = False
+
+
+def _registered_provider_ids() -> list[str]:
+    from hermes_cli.models_catalog_static import CANONICAL_PROVIDERS
+
+    return list(dict.fromkeys(entry.slug for entry in CANONICAL_PROVIDERS))
+
+
+def _catalog_model_ids(provider: str) -> list[str]:
+    """Bundled, network-free catalog for one registered provider."""
+    from hermes_cli.models_catalog_static import _PROVIDER_MODELS
+    from providers import get_provider_profile
+
+    models = list(_PROVIDER_MODELS.get(provider, ()))
+    profile = get_provider_profile(provider)
+    if not models and profile is not None:
+        models = list(profile.fallback_models or ())
+    return list(dict.fromkeys(str(model).strip() for model in models if str(model).strip()))
+
+
+def _provider_cache_entry(provider: str) -> dict[str, Any] | None:
+    """Read one credential-bound picker cache entry without refreshing it."""
+    try:
+        from hermes_cli.models import _credential_fingerprint, _load_provider_models_cache
+
+        entry = _load_provider_models_cache().get(provider)
+        if not isinstance(entry, dict) or entry.get("fp") != _credential_fingerprint(provider):
+            return None
+        if not isinstance(entry.get("models"), list) or not entry["models"]:
+            return None
+        at = entry.get("at")
+        if not isinstance(at, (int, float)) or isinstance(at, bool):
+            return None
+        return {"at": float(at), "fp": entry["fp"], "models": list(entry["models"])}
+    except Exception:
+        return None
+
+
+def _refresh_provider_models(provider: str) -> list[str] | None:
+    """Run only the registered provider's live catalog hook and cache normalized IDs."""
+    from hermes_cli.models import _api_key_credentials, update_provider_cache_entry
+    from providers import get_provider_profile
+
+    profile = get_provider_profile(provider)
+    if profile is None or profile.auth_type != "api_key" or not profile.base_url:
+        return None
+    api_key, base_url = _api_key_credentials(provider)
+    models = profile.fetch_models(api_key=api_key, base_url=base_url or profile.base_url or None)
+    normalized = list(dict.fromkeys(str(model).strip() for model in (models or ()) if str(model).strip()))
+    if not normalized:
+        return None
+    update_provider_cache_entry(provider, normalized)
+    return normalized
+
+
+def _iso(timestamp: float) -> str:
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _model_payload(provider: str, model_id: str) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "id": model_id,
+        "capabilities": ["chat"],
+        "input_modalities": ["text"],
+        "output_modalities": ["text"],
+        "deprecated": False,
+    }
+    try:
+        from agent.models_dev import get_model_info
+
+        info = get_model_info(provider, model_id, allow_network=False)
+    except Exception:
+        info = None
+    if info is None:
+        return row
+
+    capabilities = ["chat"]
+    if info.tool_call:
+        capabilities.append("tools")
+    if info.reasoning:
+        capabilities.append("reasoning")
+    if info.supports_vision():
+        capabilities.append("vision")
+    row.update({
+        "capabilities": capabilities,
+        "input_modalities": list(info.input_modalities) or ["text"],
+        "output_modalities": list(info.output_modalities) or ["text"],
+        "deprecated": info.status == "deprecated",
+    })
+    if info.name:
+        row["display_name"] = info.name
+    if info.context_window > 0:
+        row["context_window"] = info.context_window
+    if info.max_output > 0:
+        row["max_output_tokens"] = info.max_output
+    return row
+
+
+def _provider_payload(
+    provider: str,
+    source: str,
+    models: list[str],
+    *,
+    cache_at: float | None = None,
+    stale: bool = False,
+    warnings: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "id": provider,
+        "source": source,
+        "models": [_model_payload(provider, model_id) for model_id in models],
+        "warnings": warnings or [],
+    }
+    if source == "cache" and cache_at is not None:
+        row["retrieved_at"] = _iso(cache_at)
+        row["expires_at"] = _iso(cache_at + _CACHE_TTL_SECONDS)
+        row["stale"] = stale
+    elif source == "live":
+        now = time.time()
+        row.update({"retrieved_at": _iso(now), "expires_at": _iso(now + _CACHE_TTL_SECONDS), "stale": False})
+    return row
+
+
+def _base_response(request: ModelDiscoveryRequest) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "request": {
+            "provider": request.provider,
+            "refresh": request.refresh,
+            "offline": request.offline,
+        },
+        "providers": [],
+        "errors": [],
+    }
+
+
+def discover_models(request: ModelDiscoveryRequest) -> tuple[dict[str, Any], int]:
+    """Return a stable response and process exit code; network is opt-in and provider-scoped."""
+    response = _base_response(request)
+    provider_ids = _registered_provider_ids()
+    selected = [request.provider] if request.provider else provider_ids
+
+    for provider in selected:
+        cache = _provider_cache_entry(provider)
+        cache_age = time.time() - cache["at"] if cache else None
+        cache_fresh = cache_age is not None and cache_age < _CACHE_TTL_SECONDS
+        warnings: list[dict[str, str]] = []
+
+        if request.refresh:
+            try:
+                live = _refresh_provider_models(provider)
+            except Exception:
+                live = None
+                response["errors"].append({
+                    "code": "refresh_failed",
+                    "provider": provider,
+                    "message": "Live model discovery failed; a fallback source was used.",
+                })
+            if live:
+                response["providers"].append(_provider_payload(provider, "live", live))
+                continue
+            if not response["errors"] or response["errors"][-1].get("provider") != provider:
+                response["errors"].append({
+                    "code": "refresh_unavailable",
+                    "provider": provider,
+                    "message": "Live model discovery produced no usable result; a fallback source was used.",
+                })
+
+        if cache and (cache_fresh or request.offline or request.refresh):
+            stale = not cache_fresh
+            if stale:
+                warnings.append({"code": "stale_cache", "message": "Using an expired cached catalog."})
+            response["providers"].append(
+                _provider_payload(provider, "cache", cache["models"], cache_at=cache["at"], stale=stale, warnings=warnings)
+            )
+            continue
+
+        catalog = _catalog_model_ids(provider)
+        if catalog:
+            response["providers"].append(_provider_payload(provider, "catalog", catalog))
+
+    if request.provider and not response["providers"]:
+        response["errors"].append({
+            "code": "no_usable_result",
+            "provider": request.provider,
+            "message": "The requested provider has no usable model catalog under this policy.",
+        })
+        return response, 3
+    return response, 0
+
+
+def _argument_error(args: Any, code: str, message: str) -> int:
+    request = ModelDiscoveryRequest(
+        provider=getattr(args, "provider", None),
+        refresh=bool(getattr(args, "refresh", False)),
+        offline=bool(getattr(args, "offline", False)),
+    )
+    response = _base_response(request)
+    response["errors"].append({"code": code, "message": message})
+    print(json.dumps(response, sort_keys=True, separators=(",", ":")))
+    return 2
+
+
+def models_command(args: Any) -> int:
+    """CLI boundary: always write exactly one JSON document to stdout."""
+    provider = str(getattr(args, "provider", "") or "").strip().lower() or None
+    refresh = bool(getattr(args, "refresh", False))
+    offline = bool(getattr(args, "offline", False))
+    if refresh and offline:
+        return _argument_error(args, "conflicting_options", "--refresh and --offline are mutually exclusive.")
+    if refresh and provider is None:
+        return _argument_error(args, "provider_required", "--refresh requires --provider ID.")
+    if provider is not None and provider not in _registered_provider_ids():
+        return _argument_error(args, "unsupported_provider", "The provider identifier is not registered.")
+
+    request = ModelDiscoveryRequest(provider=provider, refresh=refresh, offline=offline)
+    try:
+        response, exit_code = discover_models(request)
+    except Exception:
+        response = _base_response(request)
+        response["errors"].append({
+            "code": "internal_error",
+            "message": "Model discovery failed unexpectedly.",
+        })
+        exit_code = 4
+    print(json.dumps(response, sort_keys=True, separators=(",", ":")))
+    return exit_code

--- a/hermes_cli/subcommands/models.py
+++ b/hermes_cli/subcommands/models.py
@@ -1,0 +1,22 @@
+"""``hermes models`` machine-readable model discovery parser."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_models_parser(subparsers, *, cmd_models: Callable) -> None:
+    parser = subparsers.add_parser(
+        "models",
+        help="Discover provider model catalogs as JSON",
+        description="Noninteractively discover registered provider model metadata",
+    )
+    parser.add_argument("--json", action="store_true", required=True, help="Emit one JSON document")
+    parser.add_argument("--provider", metavar="ID", help="Limit discovery to one registered provider")
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Refresh the selected provider's live catalog (requires --provider)",
+    )
+    parser.add_argument("--offline", action="store_true", help="Prohibit network access and allow stale cache data")
+    parser.set_defaults(func=cmd_models)

--- a/tests/hermes_cli/test_model_discovery.py
+++ b/tests/hermes_cli/test_model_discovery.py
@@ -1,0 +1,159 @@
+"""Behavior contracts for noninteractive provider-scoped model discovery."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hermes_cli.model_discovery import (
+    ModelDiscoveryRequest,
+    _refresh_provider_models,
+    discover_models,
+    models_command,
+)
+from hermes_cli.subcommands.models import build_models_parser
+
+
+def _cache_entry(models, *, age=0):
+    return {"fp": "fp", "at": time.time() - age, "models": list(models)}
+
+
+def test_default_discovery_is_network_free_and_prefers_fresh_cache():
+    request = ModelDiscoveryRequest(provider="openai-api")
+    with (
+        patch("hermes_cli.model_discovery._registered_provider_ids", return_value=["openai-api"]),
+        patch("hermes_cli.model_discovery._provider_cache_entry", return_value=_cache_entry(["cached-model"])),
+        patch("hermes_cli.model_discovery._catalog_model_ids", return_value=["catalog-model"]),
+        patch("hermes_cli.model_discovery._refresh_provider_models") as refresh,
+    ):
+        response, exit_code = discover_models(request)
+
+    assert exit_code == 0
+    assert response["providers"][0]["source"] == "cache"
+    assert [model["id"] for model in response["providers"][0]["models"]] == ["cached-model"]
+    refresh.assert_not_called()
+
+
+def test_offline_discovery_serves_stale_cache_without_refresh():
+    request = ModelDiscoveryRequest(provider="openai-api", offline=True)
+    with (
+        patch("hermes_cli.model_discovery._registered_provider_ids", return_value=["openai-api"]),
+        patch(
+            "hermes_cli.model_discovery._provider_cache_entry",
+            return_value=_cache_entry(["stale-model"], age=7200),
+        ),
+        patch("hermes_cli.model_discovery._refresh_provider_models") as refresh,
+    ):
+        response, exit_code = discover_models(request)
+
+    provider = response["providers"][0]
+    assert exit_code == 0
+    assert provider["source"] == "cache"
+    assert provider["stale"] is True
+    assert provider["warnings"][0]["code"] == "stale_cache"
+    refresh.assert_not_called()
+
+
+def test_catalog_fallback_has_required_public_model_fields():
+    request = ModelDiscoveryRequest(provider="openai-api", offline=True)
+    with (
+        patch("hermes_cli.model_discovery._registered_provider_ids", return_value=["openai-api"]),
+        patch("hermes_cli.model_discovery._provider_cache_entry", return_value=None),
+        patch("hermes_cli.model_discovery._catalog_model_ids", return_value=["catalog-model"]),
+        patch("agent.models_dev.get_model_info", return_value=None),
+    ):
+        response, exit_code = discover_models(request)
+
+    provider = response["providers"][0]
+    assert exit_code == 0
+    assert provider["source"] == "catalog"
+    assert provider["warnings"] == []
+    assert provider["models"] == [{
+        "id": "catalog-model",
+        "capabilities": ["chat"],
+        "input_modalities": ["text"],
+        "output_modalities": ["text"],
+        "deprecated": False,
+    }]
+
+
+def test_live_refresh_uses_one_registered_profile_and_updates_one_cache_entry():
+    profile = SimpleNamespace(
+        auth_type="api_key",
+        base_url="https://public.provider.example/v1",
+        fetch_models=lambda **kwargs: ["live-a", "live-a", "live-b"],
+    )
+    with (
+        patch("providers.get_provider_profile", return_value=profile) as get_profile,
+        patch("hermes_cli.models._api_key_credentials", return_value=("secret", profile.base_url)),
+        patch("hermes_cli.models.update_provider_cache_entry") as update_cache,
+    ):
+        assert _refresh_provider_models("openai-api") == ["live-a", "live-b"]
+
+    get_profile.assert_called_once_with("openai-api")
+    update_cache.assert_called_once_with("openai-api", ["live-a", "live-b"])
+
+
+def test_refresh_is_scoped_and_falls_back_without_leaking_exception_details():
+    request = ModelDiscoveryRequest(provider="openai-api", refresh=True)
+    with (
+        patch("hermes_cli.model_discovery._registered_provider_ids", return_value=["openai-api", "anthropic"]),
+        patch(
+            "hermes_cli.model_discovery._refresh_provider_models",
+            side_effect=RuntimeError("Bearer secret-value at https://private.example/v1/models"),
+        ) as refresh,
+        patch(
+            "hermes_cli.model_discovery._provider_cache_entry",
+            return_value=_cache_entry(["cached-model"], age=7200),
+        ),
+    ):
+        response, exit_code = discover_models(request)
+
+    assert exit_code == 0
+    refresh.assert_called_once_with("openai-api")
+    assert response["providers"][0]["source"] == "cache"
+    rendered = json.dumps(response)
+    assert "secret-value" not in rendered
+    assert "private.example" not in rendered
+    assert response["errors"] == [{
+        "code": "refresh_failed",
+        "provider": "openai-api",
+        "message": "Live model discovery failed; a fallback source was used.",
+    }]
+
+
+def test_argument_errors_are_structured_json(capsys):
+    args = SimpleNamespace(json=True, provider=None, refresh=True, offline=False)
+    assert models_command(args) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["errors"][0]["code"] == "provider_required"
+
+    args = SimpleNamespace(json=True, provider="openai-api", refresh=True, offline=True)
+    assert models_command(args) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["errors"][0]["code"] == "conflicting_options"
+
+
+def test_unknown_provider_is_rejected_before_discovery(capsys):
+    args = SimpleNamespace(json=True, provider="not-registered", refresh=False, offline=True)
+    with patch("hermes_cli.model_discovery._registered_provider_ids", return_value=["openai-api"]):
+        assert models_command(args) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["providers"] == []
+    assert payload["errors"][0]["code"] == "unsupported_provider"
+
+
+def test_models_parser_wires_machine_readable_flags():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_models_parser(subparsers, cmd_models=lambda args: 0)
+
+    args = parser.parse_args(["models", "--json", "--provider", "openai-api", "--offline"])
+    assert args.command == "models"
+    assert args.provider == "openai-api"
+    assert args.json is True
+    assert args.offline is True
+    assert args.refresh is False

--- a/website/docs/reference/model-catalog.md
+++ b/website/docs/reference/model-catalog.md
@@ -67,6 +67,30 @@ Field notes:
 
 Cache location: `~/.hermes/cache/model_catalog.json`.
 
+## Machine-readable discovery
+
+External integrations can inspect the normalized provider catalogs without opening the
+interactive picker or reading Hermes configuration files:
+
+```bash
+hermes models --json
+hermes models --json --provider openai-api
+hermes models --json --provider openai-api --offline
+hermes models --json --provider openai-api --refresh
+```
+
+The default and `--offline` forms never make network requests. The default uses fresh provider
+cache entries and otherwise falls back to bundled catalogs; `--offline` may also return an expired
+cache entry marked `"stale": true`. A live refresh is opt-in, requires one registered
+`--provider`, and updates only that provider's cache entry. `--refresh` and `--offline` cannot be
+combined.
+
+Stdout is exactly one JSON document with `schema_version`, `request`, `providers`, and `errors`.
+Each provider reports `source` as `live`, `cache`, or `catalog`; errors use stable codes and omit
+credentials, endpoint details, account data, and raw provider responses. Exit codes are `0` for a
+usable response (including fallback warnings), `2` for invalid arguments or provider ids, `3` when
+the selected provider has no usable result, and `4` for an unexpected internal failure.
+
 ## Config
 
 ```yaml


### PR DESCRIPTION
## What does this PR do?

Adds a stable, noninteractive `hermes models --json` interface for integrations that need provider and model metadata without parsing the interactive picker or reading private configuration state.

### Motivation

External adapters currently have no supported machine-readable model discovery surface. This command reuses the registered provider catalog and existing provider cache while making network access explicitly opt-in and provider-scoped.

### Behavior

- `hermes models --json` reads fresh provider cache entries and bundled catalogs without network access.
- `--provider ID` scopes output to one registered provider.
- `--offline` permits stale cache fallback while prohibiting refresh behavior.
- `--refresh` requires one provider, calls only that provider's registered catalog hook, and updates only its cache entry.
- Responses use schema version `1`, stable source and error codes, normalized public metadata, and documented exit codes.
- Interactive selection, model configuration, credential management, arbitrary endpoint probing, pricing, quota, and health checks remain unchanged.

### Implementation

A dedicated discovery module owns request handling, cache/catalog precedence, public metadata normalization, and sanitized errors. A small lazy-loaded subcommand module connects it to the existing CLI parser without adding discovery work to unrelated commands. Behavior tests cover validation, network-free defaults, stale offline fallback, refresh scoping, cache updates, required model fields, and redaction.

## Related Issue

Closes #105413

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/model_discovery.py` - implements the versioned discovery response and source policy.
- `hermes_cli/subcommands/models.py` - defines the machine-readable CLI flags.
- `hermes_cli/main.py` - lazily registers the new command.
- `tests/hermes_cli/test_model_discovery.py` - verifies the command contract and safety boundaries.
- `website/docs/reference/model-catalog.md` - documents usage, precedence, schema, and exit codes.

## How to Test

1. Run `hermes models --json --provider openai-api --offline` and parse stdout as JSON.
2. Verify the response reports schema version `1`, provider `openai-api`, and source `cache` or `catalog`.
3. Run the automated tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_model_discovery.py tests/hermes_cli/test_inventory.py tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_subcommands_batch.py
```

Result: 50 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the repository test entry point on all related test files and all 50 tests pass
- [x] I've added behavior tests for the new feature
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because architecture and workflows did not change
- [x] I've considered cross-platform impact; the implementation uses Python and standard CLI abstractions
- [x] Tool descriptions and schemas are N/A because no model-facing tool changed

## Screenshots / Logs

N/A - this is a JSON CLI interface verified by automated tests and a parsed end-to-end command invocation.
