### PR TITLE
fix(process-registry): use portable /bin/sh probe for systemd-run scope availability (#105365)

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2375,6 +2375,34 @@ class TestSystemdCgroupIsolation:
             value.startswith("OOMPolicy=") for value in probe_argv if isinstance(value, str)
         ), probe_argv
 
+    def test_probe_uses_portable_payload_not_hardcoded_bin_true(
+        self, registry, monkeypatch
+    ):
+        """The probe payload must not hardcode ``/bin/true``: NixOS has no FHS
+        ``/bin`` (only ``sh``), so an absolute ``/bin/true`` probe fails there for
+        a reason unrelated to scope availability and disables restart-safe cron
+        dispatch on every scheduled fire (#105365). The payload is
+        ``/bin/sh -c 'exit 0'``, which exists on every Linux."""
+        import tools.process_registry as pr
+
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_PROBED_AT", 0.0, raising=False)
+        probe_calls = []
+
+        def fake_run(*args, **kwargs):
+            probe_calls.append(args)
+            return subprocess.CompletedProcess(args=args[0], returncode=0)
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        assert pr._systemd_run_user_scope_available() is True
+        probe_argv = probe_calls[0][0]
+        sep_idx = probe_argv.index("--")
+        payload = probe_argv[sep_idx + 1 :]
+        assert "/bin/true" not in payload, probe_argv
+        assert payload[:3] == ["/bin/sh", "-c", "exit 0"], probe_argv
+
     def test_systemd_scope_first_probe_is_serialized(self, monkeypatch):
         """Concurrent first-use callers must wait for one definitive probe.
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -150,7 +150,12 @@ def _systemd_run_user_scope_available() -> bool:
     """True if ``systemd-run --user --scope`` can create a cgroup.
     ``shutil.which`` alone is insufficient: system services and containers may lack
     the user D-Bus bus even with the binary on PATH (every spawn would fail with
-    ``Failed to connect to user bus``), so a cheap ``/bin/true`` probe is run and cached."""
+    ``Failed to connect to user bus``), so a cheap probe is run and cached.
+
+    The probe payload is ``/bin/sh -c 'exit 0'`` rather than ``/bin/true``: NixOS has
+    no FHS ``/bin`` (only ``sh``), so an absolute ``/bin/true`` probe fails there for a
+    reason unrelated to scope availability and disables restart-safe cron dispatch on
+    every scheduled fire (#105365).``"""
     global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
     verdict = _systemd_scope_cached()
     if verdict is not None:
@@ -171,7 +176,8 @@ def _systemd_run_user_scope_available() -> bool:
                     # Unique unit avoids collisions; the timeout bounds D-Bus.
                     probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
                     result = subprocess.run(
-                        _systemd_scope_argv(binary, probe_unit, "/bin/true"), capture_output=True, timeout=3,
+                        _systemd_scope_argv(binary, probe_unit, "/bin/sh", "-c", "exit 0"),
+                        capture_output=True, timeout=3,
                     )
                     available = result.returncode == 0
                     if not available:


### PR DESCRIPTION
Closes #105365

## Problem

On NixOS, every scheduled cron job fire fails at dispatch: the restart-safe worker path probes `systemd-run --user --scope` availability by running a hardcoded `/bin/true`, but NixOS has no FHS `/bin` (only `sh`) — the probe itself fails with `Failed to find executable /bin/true: No such file or directory` (rc=1) for a reason unrelated to scope availability, and `restart_safe_gateway_child_argv` raises on every fire.

## Fix

`tools/process_registry.py::_systemd_run_user_scope_available` now probes with a portable payload — `/bin/sh -c 'exit 0'` — instead of `/bin/true`. `/bin/sh` exists on every Linux (including NixOS, where it is the only entry in `/bin`), so the probe verdict again reflects only whether a transient user scope can actually be created. The real-spawn argv builder (`_systemd_scope_argv`) is untouched.

## Tests

New regression in `TestSystemdCgroupIsolation` (`tests/tools/test_process_registry.py`): `test_probe_uses_portable_payload_not_hardcoded_bin_true` — captures the probe argv and asserts the payload after `--` is `["/bin/sh", "-c", "exit 0"]` and contains no `/bin/true`, while the probe still returns available on rc=0.

Full run: `tests/tools/test_process_registry.py` — 104 passed, 4 skipped (includes the existing probe-caching and serialization tests).
