### PR TITLE
fix(cli): preserve line boundaries in large log tails

### DIFF
--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -4,6 +4,7 @@
 ``hermes logs list`` shows the available files.
 """
 
+import io
 import re
 import sys
 import time
@@ -203,8 +204,10 @@ def _read_last_n_lines(path: Path, n: int) -> list:
                 else:
                     lines = chunk_lines
                 chunk_size = min(chunk_size * 2, 65536)
-            decoded = [raw.decode("utf-8", errors="replace") + "\n" for raw in lines if raw.strip()]
-            return decoded[-n:]
+            # Match text-mode readlines(): preserve blank lines and an unterminated
+            # final line, and normalize CRLF just like the small-file path.
+            text = b"\n".join(lines).decode("utf-8", errors="replace")
+            return io.StringIO(text, newline=None).readlines()[-n:]
     except Exception:
         return _read_all_lines(path)[-n:]
 

--- a/tests/hermes_cli/test_logs.py
+++ b/tests/hermes_cli/test_logs.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 
+import pytest
 
 from hermes_cli.logs import (
     LOG_FILES,
@@ -13,6 +14,7 @@ from hermes_cli.logs import (
     _parse_since,
     _read_last_n_lines,
     _read_tail,
+    tail_log,
 )
 
 
@@ -137,6 +139,35 @@ class TestReadTail:
         result = _read_last_n_lines(log_file, 5)
         assert len(result) == 5
         assert "line 9" in result[-1]
+
+    @pytest.mark.parametrize("newline", [b"\n", b"\r\n"])
+    @pytest.mark.parametrize("terminated", [False, True])
+    def test_tail_preserves_lines_across_file_sizes(self, tmp_path, newline, terminated):
+        suffix = newline.join([b"first", b"", b" \t", "last café".encode("utf-8")])
+        if terminated:
+            suffix += newline
+        log_file = tmp_path / "test.log"
+        for prefix in (b"", b"older entry\n" * 100_000):
+            log_file.write_bytes(prefix + suffix)
+            with log_file.open(encoding="utf-8", errors="replace") as stream:
+                expected = stream.readlines()
+            for count in (1, 3, 4, 10):
+                assert _read_last_n_lines(log_file, count) == expected[-count:]
+
+    def test_large_log_tail_keeps_blank_lines_in_cli_output(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        suffix = "\n \t\n2026-01-01 00:00:00 ERROR demo: latest café\n"
+        (log_dir / "agent.log").write_text(
+            "2026-01-01 00:00:00 INFO demo: older entry\n" * 30_000 + suffix,
+            encoding="utf-8",
+        )
+
+        tail_log(num_lines=3)
+
+        output = capsys.readouterr().out
+        assert output.split("\n", 1)[1] == suffix
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes size-dependent output in `hermes logs`: above 1 MiB, requesting the last three lines can replace blank or whitespace-only lines with older entries. The binary reader filters out `raw.strip()`-empty lines, adds a newline to an unterminated final line, and preserves CRLF where the small-file text reader normalizes it.

Decode the reassembled tail through `StringIO(newline=None)` so both paths follow text-mode `readlines()` semantics. The existing backward chunk reader still limits how much of a large file is read. The dashboard's `/api/logs` also uses this reader.

## Related Issue

Self-contained reproduction on current `main` (`2237be3559`); no existing issue found for this behavior. Checked related PRs: #27273 concerns the filtered scan window; #62855 and #88026 concern follow-mode rotation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/logs.py`: preserve line contents and endings when decoding a large-file tail.
- `tests/hermes_cli/test_logs.py`: two behavioral tests (five cases), using real files below/above the threshold and the public `tail_log()` path. Covers whitespace, UTF-8, LF/CRLF, and terminated/unterminated final lines.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_logs.py -q --file-retries 0
```

On unmodified main: **5 new cases fail, 14 existing tests pass**. With the fix: **19 pass**.

Minimal reproduction from the checkout:

```python
import os
import subprocess
import sys
import tempfile
from pathlib import Path

with tempfile.TemporaryDirectory() as home:
    logs = Path(home) / "logs"
    logs.mkdir()
    (logs / "gateway.log").write_text(
        "older entry\n" * 100_000 + "first\n\n \t\nlast\n", encoding="utf-8"
    )
    subprocess.run(
        [sys.executable, "-m", "hermes_cli.main", "logs", "gateway", "-n", "3"],
        env=dict(os.environ, HERMES_HOME=home), check=True,
    )
```

The output after the header should be `"\n \t\nlast\n"`; main prints `"older entry\nfirst\nlast\n"`.

Also verified the real CLI with and without `--level ERROR` against a temporary `HERMES_HOME`. Repository-wide `ruff check .`, `ty check hermes_cli/logs.py`, `scripts/check_compat_pointers.py`, and `git diff --check` pass. Tested on macOS with Python 3.11.11. Dashboard HTTP execution and native Windows execution were not run locally.

Revalidated on September 12 against GitHub's merge preview with `main` at `e440bf3547`: **19 tests passed**, along with lint, type, and whitespace checks on the changed files. No merge conflicts.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing PRs to check for duplicates.
- [x] This PR contains only changes related to this fix.
- [ ] Full test suite passes — not run locally; focused results are above.
- [x] I've added regression tests, proven failing on the base commit.
- [x] I've tested on my platform: macOS, Python 3.11.11.

### Documentation & Housekeeping

- [x] Relevant documentation/docstrings: the decoding comment explains the invariant.
- [x] Config examples: N/A; no configuration changes.
- [x] Architecture/workflow documentation: N/A.
- [x] Cross-platform impact considered; LF and CRLF are fixture data, with no simulated host OS.
- [x] Tool descriptions/schemas: N/A.
