### PR TITLE
fix(mcp): upgrade SDK for cross-revision responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,7 @@ modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
+dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.1.1", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.2", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.30.0", "slack-sdk==3.43.0", "aiohttp==3.14.3"]
@@ -261,14 +261,14 @@ pty = []
 # extra that exposes a Starlette-backed server surface so pip/uv can't resolve
 # a vulnerable pre-1.0.1 transitive. Bump in lockstep with uv.lock.
 #
-# mcp 2.0.0 implements MCP revision 2026-07-28 and moved its own HTTP stack
+# mcp 2.1.1 implements MCP revision 2026-07-28 and moved its own HTTP stack
 # from `httpx` to `httpx2`. httpx2 arrives transitively, but tools/mcp_tool.py
 # and tools/mcp_oauth_manager.py import it by name to build the client objects
 # they hand to the SDK, so it is pinned here explicitly rather than left to
 # resolution. Hermes' own `httpx[socks]==0.28.1` in [dependencies] is
 # unaffected — the two distributions install side by side under different
 # module names.
-mcp = ["mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1"]  # starlette: CVE-2026-48710
+mcp = ["mcp==2.1.1", "httpx2==2.7.0", "starlette==1.3.1"]  # starlette: CVE-2026-48710
 # Backwards-compatible no-op alias. Relay is a core dependency on supported
 # wheel targets and intentionally unavailable on other platforms.
 nemo-relay = []
@@ -279,7 +279,7 @@ teams = ["microsoft-teams-apps==2.0.13.4", "aiohttp==3.14.3"]  # aiohttp 3.14.3:
 # The cua-driver binary itself is installed via `hermes tools` post-setup
 # (curl install script); this extra just pins the MCP client used to talk
 # to it, which is already provided by the `mcp` extra.
-computer-use = ["mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1"]  # starlette: CVE-2026-48710
+computer-use = ["mcp==2.1.1", "httpx2==2.7.0", "starlette==1.3.1"]  # starlette: CVE-2026-48710
 acp = ["agent-client-protocol==0.9.0"]
 # mistral: Voxtral STT + TTS. Pinned to an exact verified-clean version.
 # The `mistralai` PyPI project was quarantined 2026-05-12 after the malicious
@@ -423,7 +423,8 @@ exclude-newer = "14 days"
 # risk — their newest releases are years old — and unbricks resolvers that
 # cannot see upload dates.
 #
-# setuptools, wheel, pillow, mcp: build/core pin bricks (#78227, #75992, #76020, #96488). uv
+# setuptools, wheel, pillow, mcp, mcp-types: build/core pin bricks
+# (#78227, #75992, #76020, #96488). uv
 # applies exclude-newer to build-system.requires and core deps too; when a
 # resolver cannot see an upload date (old uv, mirror index, stale HTTP cache)
 # it filters the pinned version and the package cannot even BUILD
@@ -503,6 +504,7 @@ markdown = false
 maturin = false
 mautrix = false
 mcp = false
+mcp-types = false
 mem0ai = false
 microsoft-teams-apps = false
 mistralai = false

--- a/tests/tools/test_mcp_sdk_cross_revision.py
+++ b/tests/tools/test_mcp_sdk_cross_revision.py
@@ -1,0 +1,52 @@
+"""MCP SDK cross-revision response compatibility."""
+
+from collections.abc import Mapping
+from typing import Any
+
+import anyio
+import pytest
+from anyio.abc import TaskStatus
+from mcp import ClientSession
+from mcp.shared.dispatcher import CallOptions, OnNotify, OnNotifyIntercept, OnRequest
+
+
+class _ListToolsDispatcher:
+    async def send_raw_request(
+        self,
+        method: str,
+        params: Mapping[str, Any] | None,
+        opts: CallOptions | None = None,
+    ) -> dict[str, Any]:
+        assert method == "tools/list"
+        return {"tools": [], "cacheScope": ""}
+
+    async def notify(
+        self,
+        method: str,
+        params: Mapping[str, Any] | None,
+        opts: CallOptions | None = None,
+    ) -> None:
+        raise AssertionError(f"unexpected notification: {method}")
+
+    async def run(
+        self,
+        on_request: OnRequest,
+        on_notify: OnNotify,
+        on_notify_intercept: OnNotifyIntercept | None = None,
+        *,
+        task_status: TaskStatus[None] = anyio.TASK_STATUS_IGNORED,
+    ) -> None:
+        task_status.started()
+        await anyio.sleep_forever()
+
+
+@pytest.mark.asyncio
+async def test_future_cache_scope_is_ignored_for_older_negotiated_revision():
+    """A future cache hint must not invalidate an older tools/list response."""
+    session = ClientSession(dispatcher=_ListToolsDispatcher())
+    session._negotiated_version = "2025-11-25"
+
+    result = await session.list_tools()
+
+    assert result.tools == []
+    assert result.cache_scope == "private"

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -186,7 +186,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "tool.doc_extract": ("firecrawl-anydoc==0.2.4",),  # imports as `anydoc`; lockstep with pyproject
     # MCP client SDK for the cua-driver, so computer_use never dead-ends on `No module named 'mcp'`.
     "tool.computer_use": (
-        "mcp==2.0.0",
+        "mcp==2.1.1",
         "httpx2==2.7.0",  # mcp 2.x HTTP stack — sync with pyproject [computer-use]
         "starlette==1.3.1",
     ),

--- a/uv.lock
+++ b/uv.lock
@@ -89,6 +89,7 @@ nemo-relay = false
 requests = false
 httplib2 = false
 httpx = false
+mcp-types = false
 pyasn1 = false
 snowballstemmer = false
 concurrent-log-handler = false
@@ -1983,9 +1984,9 @@ requires-dist = [
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
     { name = "markdown", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.1" },
-    { name = "mcp", marker = "extra == 'computer-use'", specifier = "==2.0.0" },
-    { name = "mcp", marker = "extra == 'dev'", specifier = "==2.0.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = "==2.0.0" },
+    { name = "mcp", marker = "extra == 'computer-use'", specifier = "==2.1.1" },
+    { name = "mcp", marker = "extra == 'dev'", specifier = "==2.1.1" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = "==2.1.1" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = "==2.0.10" },
     { name = "microsoft-teams-apps", marker = "extra == 'teams'", specifier = "==2.0.13.4" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = "==2.4.8" },
@@ -2530,7 +2531,7 @@ encryption = [
 
 [[package]]
 name = "mcp"
-version = "2.0.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2548,22 +2549,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
 ]
 
 [[package]]
 name = "mcp-types"
-version = "2.0.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- upgrade the MCP client and companion `mcp-types` package from 2.0.0 to 2.1.1 across the `dev`, `mcp`, and `computer-use` extras
- keep the computer-use lazy dependency pin in sync so enabling that feature cannot downgrade MCP again
- exempt the new exact `mcp-types` pin from `exclude-newer`, matching the existing MCP exemption
- add a real-SDK regression test for a pre-2026 `tools/list` response carrying the future `cacheScope: ""` field

## Why

A server can negotiate an older MCP revision but return a field introduced by a later revision. Upwork currently does this with an empty `cacheScope`. MCP 2.0.0 validates the version-free result model and rejects the response, aborting discovery for an otherwise authenticated and reachable server.

MCP 2.1.1 contains the SDK-level cross-revision compatibility fix: fields introduced after the negotiated protocol are dropped before the version-free model is validated. This preserves strict validation for fields that belong to the negotiated revision and avoids a vendor-specific Hermes transport shim.

This is an SDK-upgrade alternative to the currently conflict-blocked #94995.

Fixes #94992.

## Verification

- `scripts/run_tests.sh tests/test_packaging_metadata.py tests/test_project_metadata.py tests/tools/test_mcp*.py tests/tools/test_refresh_agent_mcp_tools.py tests/tools/test_setup_mcp_tool.py`
  - 66 files, **724 tests passed**, 0 failed
- regression test sabotage:
  - passes with `mcp==2.1.1`
  - fails with `mcp==2.0.0` on the exact `cacheScope` Pydantic validation error
  - passes again after restoring the locked environment
- `uv lock --check`
- Ruff lint and format check for the new test; Ruff lint for the changed lazy dependency entry
- `ty check tests/tools/test_mcp_sdk_cross_revision.py`
- live `hermes mcp test upwork`: authenticated, connected, **29 tools discovered**

## Platform tested

- macOS 26.6.2
- Python 3.11.15
