### PR TITLE
fix(docker): add compatible Teams SDK overlay for v2026.8.31

### DIFF
--- a/docker/teams-pilot/Dockerfile
+++ b/docker/teams-pilot/Dockerfile
@@ -1,0 +1,15 @@
+FROM nousresearch/hermes-agent:v2026.8.31@sha256:64923faeae267792bf9bf87fe3b4c4869e35004e360c7df01730ad801b74d524
+
+# The bundled Teams 2.0.13.4 pins MSAL and cryptography incompatibly.
+# Keep the base image and all other Hermes code; update only the Teams SDK pin.
+RUN sed -i 's/microsoft-teams-apps==2\.0\.13\.4/microsoft-teams-apps==2.0.16/g' \
+        /opt/hermes/tools/lazy_deps.py /opt/hermes/pyproject.toml \
+    && uv pip install --python /opt/hermes/.venv/bin/python \
+        'microsoft-teams-apps==2.0.16' 'microsoft-teams-api==2.0.16' \
+        'microsoft-teams-common==2.0.16' 'microsoft-teams-cards==2.0.16' \
+        'dependency-injector==4.49.1' 'pydantic-settings==2.15.0' \
+        'aiohttp==3.14.3'
+
+# Verify the real adapter imports and lazy installer accepts the installed SDK.
+RUN HERMES_HOME=/tmp/hermes-teams-build-check /opt/hermes/.venv/bin/python -c \
+    "from tools.lazy_deps import feature_missing; from plugins.platforms.teams.adapter import check_teams_requirements; assert not feature_missing('platform.teams'); assert check_teams_requirements()"

--- a/docker/teams-pilot/README.md
+++ b/docker/teams-pilot/README.md
@@ -1,0 +1,24 @@
+# Teams pilot image
+
+The `v2026.8.31` image bundles a Teams SDK pin (`2.0.13.4`) whose exact
+MSAL and cryptography requirements conflict. This image keeps that exact
+Hermes base and changes only the Teams SDK pin to Microsoft's stable
+`2.0.16`, installing its missing dependencies. Existing base packages are
+not downgraded, and Teams JWT verification is not disabled.
+
+Build from this worktree:
+
+```sh
+docker build -t hermes-agent-teams-pilot:v2026.8.31-sdk2.0.16 docker/teams-pilot
+```
+
+The final build step checks real SDK imports and the Hermes lazy-dependency
+contract. Runtime verification must additionally check `/health`, an unsigned
+`POST /api/messages` returning 401, and an authorized message from Teams.
+
+The local Compose deployment supplies the credentials, persistent state and
+workspaces. None is copied into this image. Its only public ingress is the
+separate Teams webhook via a Microsoft Dev Tunnel; the dashboard stays private.
+
+This is a local pilot image, not an upstream Hermes release. Remove this
+overlay when a verified official image provides compatible Teams dependencies.


### PR DESCRIPTION
## Summary

- Add an opt-in Docker overlay for the pinned official Hermes v2026.8.31 image.
- Update only its Teams SDK pin to 2.0.16 and install the missing, explicitly pinned SDK dependencies.
- Document the temporary pilot scope and retirement path; no Desktop changes, deployment credentials or user configuration are included.

## Motivation

The SDK bundled with this image cannot be installed: microsoft-teams-apps 2.0.13.4 pins cryptography 50.0.0 and MSAL 1.36.0, but that MSAL release requires cryptography below 49. The 2.0.16 SDK resolves without downgrading existing base-image packages.

This is a compatibility overlay for that released image, not a change to the default image or current main's runtime dependencies. Bot Framework JWT verification remains enabled.

## Validation

- Docker image build passed, including real Teams adapter imports and the Hermes lazy-dependency contract.
- Live gateway reported Teams connected; local and tunneled health checks returned HTTP 200.
- Unsigned and invalid-bearer webhook requests returned HTTP 401.
- Dashboard authentication remained enforced; its API was not reachable through the webhook tunnel.
- Bot Framework client-credentials authentication succeeded.
- An actual Teams chat round trip remains pending; it is not claimed as tested.
