### PR TITLE
fix(model-metadata): cap opted-in codex -900k alias at live catalog max_context_window (#105443)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1518,7 +1518,7 @@ def _verified_codex_ctx_for_slug(model_bare: str) -> Optional[int]:
     return next((ctx for key, ctx in _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES.items() if base == key or base.startswith((key + "-", key + "."))), None)
 
 
-_codex_oauth_context_cache: Dict[str, Tuple[Dict[str, int], float]] = {}
+_codex_oauth_context_cache: Dict[str, Tuple[Dict[str, int], Dict[str, int], float]] = {}
 _CODEX_OAUTH_CONTEXT_CACHE_TTL = 3600  # 1 hour
 
 
@@ -1540,15 +1540,16 @@ def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:
         return None
 
 
-def _fetch_codex_oauth_context_lengths_with_source(access_token: str) -> Tuple[Dict[str, int], bool]:
-    """Codex catalogue ``{slug: context_window}`` plus whether it came from HTTP. Cached per token
-    fingerprint (windows vary by entitlement). An in-process hit reports False: not a fresh
-    provider confirmation, must not drive persistent writes."""
+def _fetch_codex_oauth_context_lengths_with_source(access_token: str) -> Tuple[Dict[str, int], Dict[str, int], bool]:
+    """Codex catalogue ``{slug: context_window}`` and ``{slug: max_context_window}`` plus whether it
+    came from HTTP. Cached per token fingerprint (windows vary by entitlement; the ``v2:`` key prefix
+    versions the cache shape so pre-max entries are never misread). An in-process hit reports False:
+    not a fresh provider confirmation, must not drive persistent writes."""
     now = time.time()
-    cache_key = _codex_oauth_token_fingerprint(access_token)
+    cache_key = "v2:" + _codex_oauth_token_fingerprint(access_token)
     cached = _codex_oauth_context_cache.get(cache_key)
-    if cached is not None and now - cached[1] < _CODEX_OAUTH_CONTEXT_CACHE_TTL:
-        return cached[0], False
+    if cached is not None and now - cached[2] < _CODEX_OAUTH_CONTEXT_CACHE_TTL:
+        return cached[0], cached[1], False
     headers = {"Authorization": f"Bearer {access_token}"}
     acct_id = _extract_chatgpt_account_id(access_token)
     if acct_id:
@@ -1558,19 +1559,28 @@ def _fetch_codex_oauth_context_lengths_with_source(access_token: str) -> Tuple[D
         resp = requests.get("https://chatgpt.com/backend-api/codex/models?client_version=1.0.0", headers=headers, timeout=(5, 10), verify=_resolve_requests_verify())
         if resp.status_code != 200:
             logger.debug("Codex /models probe returned HTTP %s; falling back to hardcoded defaults", resp.status_code)
-            return {}, False
+            return {}, {}, False
         data = resp.json()
     except Exception as exc:
         logger.debug("Codex /models probe failed: %s", exc)
-        return {}, False
+        return {}, {}, False
     result: Dict[str, int] = {}
+    max_result: Dict[str, int] = {}
     for item in data.get("models", []) if isinstance(data, dict) else []:
-        slug, ctx = (item.get("slug"), item.get("context_window")) if isinstance(item, dict) else (None, None)
-        if isinstance(slug, str) and isinstance(ctx, int) and ctx > 0:
+        if not isinstance(item, dict):
+            continue
+        slug = item.get("slug")
+        if not isinstance(slug, str):
+            continue
+        ctx = item.get("context_window")
+        if isinstance(ctx, int) and ctx > 0:
             result[slug.strip()] = ctx
+        max_ctx = item.get("max_context_window")
+        if isinstance(max_ctx, int) and max_ctx > 0:
+            max_result[slug.strip()] = max_ctx
     if result:
-        _codex_oauth_context_cache[cache_key] = (result, now)
-    return result, True
+        _codex_oauth_context_cache[cache_key] = (result, max_result, now)
+    return result, max_result, True
 
 
 def _resolve_codex_oauth_context_length_with_source(model: str, access_token: str = "") -> Tuple[Optional[int], str]:
@@ -1594,13 +1604,21 @@ def _resolve_codex_oauth_context_length_with_source(model: str, access_token: st
     # (#92797 review).
     lookup_bare = _bare_codex_slug(strip_codex_context_variant_suffix(model_bare))
     if access_token:
-        live, fresh_probe = _fetch_codex_oauth_context_lengths_with_source(access_token)
+        live, live_max, fresh_probe = _fetch_codex_oauth_context_lengths_with_source(access_token)
         # Exact slug, then case-insensitive in case casing drifts.
         hit = live.get(lookup_bare)
         if hit is None:
             hit = next((ctx for slug, ctx in live.items() if slug.lower() == lookup_bare.lower()), None)
         if hit is not None:
-            return _apply_verified_bump(hit, "live" if fresh_probe else "memory")
+            ctx, source = _apply_verified_bump(hit, "live" if fresh_probe else "memory")
+            if ctx != hit:
+                # Opted-in ``-900k`` variant: never claim more than the authenticated catalogue
+                # maximum. ``max_context_window`` can sit below the hardcoded live-verified cap
+                # (e.g. 872K vs 900K, #105443); the hardcoded cap remains the offline fallback.
+                catalog_max = live_max.get(lookup_bare)
+                if catalog_max is not None and catalog_max < ctx:
+                    ctx = catalog_max
+            return ctx, source
     hit = _longest_key_match(_CODEX_OAUTH_CONTEXT_FALLBACK, lookup_bare.lower())
     return _apply_verified_bump(hit[1], "fallback") if hit else (None, "")
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -617,6 +617,84 @@ class TestCodexOAuthContextLength:
                 )
             assert ctx == advertised, f"advertised {advertised} must be trusted"
 
+    def test_opted_in_variant_capped_at_live_catalog_max(self):
+        """An explicit ``-900k`` opt-in may not claim more than the authenticated
+        catalogue ``max_context_window`` (gpt-5.6-sol advertises 272K context with a
+        872K max, below the 900K live-verified cap) — #105443."""
+        from agent.model_metadata import get_model_context_length
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "models": [{
+                "slug": "gpt-5.6-sol",
+                "context_window": 272_000,
+                "max_context_window": 872_000,
+            }]
+        }
+        import agent.model_metadata as mm
+        mm._codex_oauth_context_cache = {}
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model="gpt-5.6-sol-900k",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+        assert ctx == 872_000
+
+    def test_opted_in_variant_keeps_verified_cap_when_catalog_omits_max(self):
+        """Without ``max_context_window`` in the catalogue the hardcoded
+        live-verified 900K cap still applies to opted-in variants."""
+        from agent.model_metadata import get_model_context_length
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "models": [{"slug": "gpt-5.6-sol", "context_window": 272_000}]
+        }
+        import agent.model_metadata as mm
+        mm._codex_oauth_context_cache = {}
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model="gpt-5.6-sol-900k",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+        assert ctx == 900_000
+
+    def test_base_slug_keeps_advertised_ctx_even_with_catalog_max(self):
+        """The catalogue max never leaks into the base slug: extended context is
+        opt-in via the ``-900k`` alias only."""
+        from agent.model_metadata import get_model_context_length
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "models": [{
+                "slug": "gpt-5.6-sol",
+                "context_window": 272_000,
+                "max_context_window": 872_000,
+            }]
+        }
+        import agent.model_metadata as mm
+        mm._codex_oauth_context_cache = {}
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model="gpt-5.6-sol",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+        assert ctx == 272_000
+
     @pytest.mark.parametrize("slug", ["gpt-5.5", "gpt-5.4-mini"])
     def test_slugs_that_enforce_272k_keep_advertised_value(self, slug):
         """gpt-5.5 and gpt-5.4-mini both rejected large inputs in the live probe (360K and 500K respectively) —


### PR DESCRIPTION
Closes #105443

## Problem

The opted-in Codex OAuth `-900k` alias resolves to a hardcoded 900,000-token window (`agent/model_metadata.py`), but the authenticated `/backend-api/codex/models` catalog now reports `max_context_window=872000` for every eligible base (gpt-6-astra, gpt-5.6-sol/terra/luna). Hermes only consumed the catalog's `context_window` (272K) and replaced it with 900K on the stale-advertisement bump — budgeting the client-side context window **above** the backend's authenticated maximum.

## Change

- `_fetch_codex_oauth_context_lengths_with_source()` now also captures each model's `max_context_window` from the live catalog and returns it alongside `context_window` (cache shape versioned via a `v2:` key prefix so pre-max entries are never misread).
- When an opted-in `-900k` variant is bumped, the result is capped at the catalog's `max_context_window` for that base slug when present and lower than the verified cap (872K vs 900K today). The hardcoded 900K live-verified cap still applies when the catalog omits `max_context_window` or the probe fails (offline fallback unchanged).
- Base slugs (no `-900k` suffix) are untouched: the catalog max never leaks into the cheaper default window — extended context stays opt-in.

## Tests

- `test_opted_in_variant_capped_at_live_catalog_max` — 272K advertised + 872K max → `-900k` resolves to 872,000.
- `test_opted_in_variant_keeps_verified_cap_when_catalog_omits_max` — no `max_context_window` in the catalog → 900,000 preserved.
- `test_base_slug_keeps_advertised_ctx_even_with_catalog_max` — max never leaks into the base slug.
- Ran: `python -m pytest tests/agent/test_model_metadata.py tests/agent/test_astra_baseline_runtime.py tests/hermes_cli/test_codex_models.py -q` → 142 passed in 5.78s.
