### PR TITLE
fix(gateway): skip duplicate-send diagnostic for interim-only stream consumers (#105341)

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3638,9 +3638,11 @@ class GatewayTurnMixin:
                     ok=("Edited streamed message %s for session %s to include plugin-transformed content.", _sc.message_id, _sk),
                     fail_result=None, fail_exc="Failed to edit streamed message for session %s: %s",
                 )
-        elif _sc is not None:
-            # DUPLICATE-RISK DIAGNOSTIC: a stream consumer existed but suppression did NOT fire; log the
-            # decision inputs ("signal never set" vs "ack-pending race").
+        elif _sc is not None and getattr(_sc, "stream_deltas_enabled", True):
+            # DUPLICATE-RISK DIAGNOSTIC: a stream consumer existed but suppression did NOT fire; log
+            # the decision inputs ("signal never set" vs "ack-pending race"). Skipped for consumers
+            # never fed the final's deltas (interim-only wiring, #105341) — they cannot have raced
+            # the normal final send, so the warning would be a guaranteed false positive.
             logger.warning(
                 "Normal final-send NOT suppressed despite active stream consumer for session %s: "
                 "streamed=%s previewed=%s content_delivered=%s transformed=%s final_len=%d — "

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -815,6 +815,10 @@ class TurnRunner:
                         initial_reply_to_id=ctx.event_message_id, run_still_current=ctx._run_still_current,
                     )
                     ctx.stream_consumer_holder[0] = stream_consumer
+                    # #105341: a consumer created only for interim commentary (text streaming off)
+                    # is never fed the final reply's deltas — mark it so the duplicate-risk
+                    # diagnostic in ``_run_agent_mark_streamed_delivery`` stays silent.
+                    stream_consumer.stream_deltas_enabled = want_stream_deltas
             except Exception as err:
                 logger.debug("Could not set up stream consumer: %s", err)
         # Deltas tee to the stream consumer (when text streaming is on) and to streaming TTS.

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -131,6 +131,12 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         self._turn_id = str(uuid.uuid4())  # keys send_stream_frame() per concurrent consumer
         # Returns False after /new or /stop; run() then abandons the stream.
         self._run_still_current = run_still_current or (lambda: True)
+        # Whether this consumer is fed the final reply's stream deltas. A consumer built only to
+        # relay interim commentary (text streaming off, ``display.interim_assistant_messages`` on)
+        # never receives the final's deltas, so the duplicate-risk diagnostic in
+        # ``_run_agent_mark_streamed_delivery`` must not fire for it (#105341). Default True: every
+        # other construction site (incl. the proxy path) creates consumers only when streaming is on.
+        self.stream_deltas_enabled = True
         # Only platforms needing an explicit finalize call (DingTalk AI Cards) force a
         # redundant final edit; ``is True`` keeps MagicMock adapters out.
         self._adapter_requires_finalize = getattr(adapter, "REQUIRES_EDIT_FINALIZE", False) is True

--- a/tests/gateway/test_interim_only_consumer_warning.py
+++ b/tests/gateway/test_interim_only_consumer_warning.py
@@ -1,0 +1,74 @@
+"""Regression coverage for #105341 — interim-only stream consumers must not
+fire the duplicate-send diagnostic.
+
+With ``streaming.enabled: false`` and ``display.interim_assistant_messages:
+true`` the gateway still builds a ``GatewayStreamConsumer`` (interim
+commentary is relayed through it), but the consumer is never fed the final
+reply's stream deltas. ``_run_agent_mark_streamed_delivery`` could not tell
+\"consumer built only for interim messages\" from \"consumer that streamed but
+lost its delivery confirmation\", so it logged a guaranteed-false-positive
+``possible duplicate send`` warning once per turn.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.run_turn import GatewayTurnMixin
+
+
+class _InterimOnlyHarness(GatewayTurnMixin):
+    """Mixin with the delivery-confirmation helper stubbed to False so the
+    turn always reaches the duplicate-risk diagnostic branch."""
+
+    def _run_agent_stream_confirmed_final_delivery(self, _sc, _final, *, previewed=False):
+        return False
+
+
+def _run_mark_streamed_delivery(consumer, caplog):
+    harness = _InterimOnlyHarness()
+    turn_ctx = SimpleNamespace(
+        stream_consumer_holder=[consumer],
+        source=SimpleNamespace(platform="telegram"),
+        session_key="sess-105341",
+    )
+    with caplog.at_level("WARNING", logger="gateway.run_turn"):
+        asyncio.run(
+            harness._run_agent_mark_streamed_delivery(
+                {"final_response": "olá"}, turn_ctx
+            )
+        )
+    return caplog
+
+
+def _consumer(stream_deltas_enabled):
+    return SimpleNamespace(
+        final_content_delivered=False,
+        delivered_final_matches=None,
+        message_id=None,
+        stream_deltas_enabled=stream_deltas_enabled,
+    )
+
+
+def test_stream_capable_consumer_still_warns(caplog):
+    """Control: a consumer that CAN receive final deltas keeps the diagnostic
+    (the wecom ack-timeout case it was written for)."""
+    caplog = _run_mark_streamed_delivery(_consumer(True), caplog)
+    assert any("possible duplicate send" in r.message for r in caplog.records)
+
+
+def test_interim_only_consumer_skips_duplicate_warning(caplog):
+    """#105341: consumer created only for interim commentary (streaming off,
+    interim messages on) is never fed the final's deltas — no false positive."""
+    caplog = _run_mark_streamed_delivery(_consumer(False), caplog)
+    assert not any("possible duplicate send" in r.message for r in caplog.records)
+
+
+def test_consumer_flag_defaults_true_on_real_consumer():
+    """Every construction site that can race the final send keeps the warning:
+    the flag defaults to True on the real consumer."""
+    from gateway.stream_consumer import GatewayStreamConsumer
+
+    consumer = GatewayStreamConsumer(adapter=SimpleNamespace(), chat_id="c")
+    assert consumer.stream_deltas_enabled is True


### PR DESCRIPTION
Closes #105341

## Problem

With `streaming.enabled: false` and `display.interim_assistant_messages: true`, every gateway turn logs a `possible duplicate send` warning — a guaranteed false positive (321/day on the reporter's install). The `GatewayStreamConsumer` is still built (interim commentary is relayed through it, `gateway/run_turn_runner.py:800`), but with text streaming off it is never fed the final reply's deltas. `_run_agent_mark_streamed_delivery` (gateway/run_turn.py:3595+) could not distinguish "consumer built only for interim messages" from "consumer that streamed but lost its delivery confirmation", so it logged the duplicate-risk diagnostic on every turn.

## Change

- `GatewayStreamConsumer` gains `stream_deltas_enabled = True` (default; every construction site that can race the final send — incl. the proxy path, which only builds consumers when streaming is on — keeps the diagnostic).
- `_setup_stream_consumer` (run_turn_runner.py) sets `stream_consumer.stream_deltas_enabled = want_stream_deltas`, marking interim-only consumers (streaming off, interim messages on).
- The duplicate-risk diagnostic branch in `_run_agent_mark_streamed_delivery` now requires `stream_deltas_enabled` — a consumer never fed the final's deltas cannot have raced the normal final send, so the warning is skipped. The wecom ack-timeout case the diagnostic was written for is untouched (that consumer streams).

## Tests

- `test_interim_only_consumer_skips_duplicate_warning` — interim-only consumer: no warning.
- `test_stream_capable_consumer_still_warns` — control: stream-capable consumer keeps the diagnostic.
- `test_consumer_flag_defaults_true_on_real_consumer` — real consumer defaults to stream-capable.
- Ran: `python -m pytest tests/gateway/test_interim_only_consumer_warning.py tests/gateway/test_stale_finalize_suppression.py tests/gateway/test_duplicate_reply_suppression.py tests/gateway/test_wecom_double_send.py tests/gateway/test_telegram_final_delivery.py tests/gateway/test_silent_partial_delivery_95382.py tests/gateway/test_stream_consumer.py -q` → 123 passed, 1 xfailed.
