### PR TITLE
fix(telegram): measure inbound splits in UTF-16

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2295,7 +2295,7 @@ class BasePlatformAdapter(ABC):
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
-        existing._last_chunk_len = len(event.text or "")  # type: ignore[attr-defined]
+        existing._last_chunk_len = self.message_len_fn(event.text or "")  # type: ignore[attr-defined]
         prior_task = self._pending_text_batch_tasks.get(key)
         if prior_task and not prior_task.done():
             prior_task.cancel()

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5710,9 +5710,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         await self._ensure_forum_commands(msg)
         event = await self._build_triggered_event(msg, update, MessageType.COMMAND)
-        # A >4096-char command paste arrives as a near-limit COMMAND chunk plus TEXT continuations; dispatching
+        # A >4096 UTF-16 command paste arrives as a near-limit COMMAND chunk plus TEXT continuations; dispatching
         # immediately would orphan them. Near-limit commands go through text batching.
-        if len(event.text or "") >= self._SPLIT_THRESHOLD:
+        if self.message_len_fn(event.text or "") >= self._SPLIT_THRESHOLD:
             self._enqueue_text_event(event)
             return
         await self.handle_message(event)

--- a/tests/gateway/test_telegram_long_command_batching.py
+++ b/tests/gateway/test_telegram_long_command_batching.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import utf16_len
 
 
 def _make_adapter():
@@ -110,3 +111,35 @@ async def test_split_queue_command_merges_with_continuation():
     assert "y" * 500 in dispatched.text
     # One merged event — the continuation never dispatched on its own.
     assert not adapter._pending_text_batches
+
+
+def _emoji_near_utf16_split(prefix: str = "/queue ") -> str:
+    """Chunk with Python len() < 4000 but UTF-16 >= 4000 (Telegram's split unit)."""
+    emoji = "\U0001F600"  # 1 Python char, 2 UTF-16 units
+    text = prefix + emoji * 2000
+    assert len(text) < 4000
+    assert utf16_len(text) >= 4000
+    return text
+
+
+@pytest.mark.asyncio
+async def test_emoji_near_utf16_limit_command_is_batched_not_dispatched():
+    adapter = _make_adapter()
+
+    await adapter._handle_command(_make_update(_emoji_near_utf16_split()), SimpleNamespace())
+
+    adapter.handle_message.assert_not_awaited()
+    assert len(adapter._pending_text_batches) == 1
+
+
+@pytest.mark.asyncio
+async def test_emoji_chunk_records_utf16_last_chunk_len():
+    adapter = _make_adapter()
+    text = "\U0001F600" * 2000
+    assert len(text) == 2000
+    assert utf16_len(text) == 4000
+
+    await adapter._handle_text_message(_make_update(text), SimpleNamespace())
+
+    pending = next(iter(adapter._pending_text_batches.values()))
+    assert pending._last_chunk_len == utf16_len(text)


### PR DESCRIPTION
## Bug Description

A long Telegram paste can appear in the chat while Hermes never starts a turn. Telegram clients split inbound text above **4096 UTF-16 code units**. Hermes batches those chunks, but inbound split detection used Python `len()`. Astral characters (emoji) cost two UTF-16 units and one Python char, so a maxed first chunk can be well under the 4000 Python-char near-split gate, flush on the short delay, and leave the continuation unmerged.

Outbound already measures Telegram length with `utf16_len` / `message_len_fn`. Inbound did not.

## Root Cause

- `TelegramAdapter._handle_command` compared `len(event.text)` to `_SPLIT_THRESHOLD` (4000).
- `BasePlatformAdapter._enqueue_text_event` stored `_last_chunk_len = len(event.text)`, so the 1s split delay never fired for those chunks.

ASCII pastes happen to match UTF-16 and were fine. Emoji / mixed-script pastes were not.

## Fix

- Command near-split gate uses `self.message_len_fn` (Telegram overrides this to `utf16_len`).
- Shared text enqueue records `_last_chunk_len` with `message_len_fn`. Other platforms keep `len` unless they override the property.

## How to Verify

1. `scripts/run_tests.sh tests/gateway/test_telegram_long_command_batching.py`
2. New tests: emoji command with Python `len() < 4000` and UTF-16 `>= 4000` is batched, not dispatched; `_last_chunk_len` is UTF-16.

## Test Plan

- [x] Added regression tests for this bug
- [x] Existing long-command batching tests still pass (5 passed)
- [ ] CI on this PR

## Risk Assessment

Low — inbound batching only. Weixin and others that do not override `message_len_fn` keep Python `len()`.