### PR TITLE
test: Desktop deadline checks no longer race CI scheduling

### DIFF
--- a/apps/desktop/electron/backend-ownership.test.ts
+++ b/apps/desktop/electron/backend-ownership.test.ts
@@ -178,16 +178,19 @@ test('startup reap preserves failed stops for the next launch', async () => {
   assert.deepEqual(parseBackendOwnership(store.value()), [entry])
 })
 
-test('startup reap stops at the deadline and preserves the unprocessed records', async () => {
+test('startup reap stops at the deadline and preserves the unprocessed records', async ({ onTestFinished }) => {
+  // Advance only when the first probe completes, never with runner scheduling.
+  const now = vi.spyOn(Date, 'now').mockReturnValue(0)
+  onTestFinished(() => now.mockRestore())
   const first = ownershipEntry({ pid: 60 })
   const second = ownershipEntry({ pid: 61 })
   const store = memoryStore(stored([first, second]))
   const stop = vi.fn()
 
   const ownership = createOwnership(store, {
-    // Each probe is slow enough to blow a 1ms budget after the first entry.
+    // Exhaust the budget exactly at the boundary after processing one entry.
     matchesIdentity: async () => {
-      await new Promise(resolve => setTimeout(resolve, 10))
+      now.mockReturnValue(1)
 
       return false
     },
@@ -201,7 +204,9 @@ test('startup reap stops at the deadline and preserves the unprocessed records',
   assert.deepEqual(parseBackendOwnership(store.value()), [second])
 })
 
-test('startup reap preserves would-be-reaped records when the budget runs out', async () => {
+test('startup reap preserves would-be-reaped records when the budget runs out', async ({ onTestFinished }) => {
+  const now = vi.spyOn(Date, 'now').mockReturnValue(0)
+  onTestFinished(() => now.mockRestore())
   const first = ownershipEntry({ pid: 62 })
   const second = ownershipEntry({ pid: 63 })
   const store = memoryStore(stored([first, second]))
@@ -209,7 +214,7 @@ test('startup reap preserves would-be-reaped records when the budget runs out', 
 
   const ownership = createOwnership(store, {
     matchesIdentity: async () => {
-      await new Promise(resolve => setTimeout(resolve, 10))
+      now.mockReturnValue(1)
 
       return true
     },

--- a/evals/desktop-reap-clock-pressure.cjs
+++ b/evals/desktop-reap-clock-pressure.cjs
@@ -1,0 +1,12 @@
+// Replay scheduling pressure without changing Date.now() results:
+// NODE_OPTIONS="--require=$PWD/evals/desktop-reap-clock-pressure.cjs" \
+//   npm run test:desktop:platforms -w apps/desktop -- electron/backend-ownership.test.ts
+// The old 1ms fixtures can expire before their first record is processed.
+const now = Date.now.bind(Date)
+const gate = new Int32Array(new SharedArrayBuffer(4))
+Date.now = function () {
+  if (new Error().stack.includes('/electron/backend-ownership.ts:')) {
+    Atomics.wait(gate, 0, 0, 5)
+  }
+  return now()
+}


### PR DESCRIPTION
Desktop orphan-reap deadline tests no longer race CI scheduling before their first record.

- Freeze each existing budget fixture's clock until its first identity probe completes, then advance to the exact deadline; always restore the clock on test completion.
- Retain both invariants: confirmed PID mismatches are discarded, confirmed orphans are stopped, and unprocessed records survive budget exhaustion.
- Add an opt-in scheduling-pressure replay under `evals/`; production code and deadline behavior are unchanged.

**Root cause:** the fixtures allowed only 1 ms of real time before the first iteration, so a scheduling pause correctly preserved both records instead of processing the first.

**Live repro:** scheduling-controlled execution of the real ownership module on base `2237be355906fbe6065ce1815711eee52b2d646e` and post-merge main `5280fe99872a58f1b9d25b00a79d240ecd035f7d` reproduces the run [34171261707](https://github.com/NousResearch/hermes-agent/actions/runs/34171261707) assertion (`[]` instead of `[62]`). Both source and test files are byte-identical across those commits; this is preexisting, not caused by #105442. The deadline fixtures originated in #101929; existing-fix sweep found no superseding clock fix.

## Validation

| Check | Before | After |
| --- | --- | --- |
| Same 5 ms real scheduling delay at ownership clock reads | 2 failed, 17 passed | 19 passed |
| Disable production deadline guard (mutation control) | — | Both deadline tests reject over-processing |
| Change `>=` deadline boundary to `>` (mutation control) | — | Both deadline tests reject over-processing |
| Full Electron platform suite, normal and pressure replay | — | Each: 151 files / 2,139 tests passed; 2 files / 6 tests skipped |
| Desktop typecheck, touched-file ESLint and Prettier | — | Passed |
| Windows footguns, compat-pointer gate, diff whitespace | — | Passed |

The replay injects actual pauses, not fabricated timestamps; the corrected fixtures explicitly control time. Local dependency setup initially lacked desktop packages/Electron; a clean lockfile install and Electron install resolved that before the full green runs.

```sh
NODE_OPTIONS="--require=$PWD/evals/desktop-reap-clock-pressure.cjs" \
  npm run test:desktop:platforms -w apps/desktop -- electron/backend-ownership.test.ts
```

## Infographic
![Deterministic desktop deadline tests](https://v3b.fal.media/files/b/0aa987eb/yqKlWgxaZvY4PHtfQs-B6_hGlv8Seu.png)
