### PR TITLE
fix(desktop): respect flat sidebar view in followActiveSessionCwd (#105207)

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -18,6 +18,7 @@ import {
   enterProject,
   exitProjectScope,
   fetchProjectSessions,
+  followActiveSessionCwd,
   openProjectCreate,
   pickProjectFolder,
   projectIdForCwd,
@@ -923,5 +924,73 @@ describe('tombstone pruning', () => {
     await refreshProjectTree()
 
     expect($removedSessionIds.get().has('sess-1')).toBe(false)
+  })
+})
+
+describe('followActiveSessionCwd (#105207)', () => {
+  const REPO_CWD = '/repo/ys/src'
+
+  function gatewayServingRepoProject() {
+    const project = {
+      id: 'p_ys',
+      label: 'Yoon-Suin',
+      path: '/repo/ys',
+      isAuto: false,
+      isNoProject: false,
+      repos: [],
+      sessionCount: 1
+    }
+
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.list') {
+        return { active_id: 'p_ys', projects: [project], scoped_session_ids: [] }
+      }
+
+      return { active_id: 'p_ys', projects: [project], scoped_session_ids: [] }
+    })
+
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    return request
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    $projectScope.set(ALL_PROJECTS)
+    $activeProjectId.set(null)
+    $projectsRpcAvailable.set(null)
+  })
+
+  it('keeps a flat Recents view — no silent flip into project grouping (#105207)', async () => {
+    setSidebarAgentsGrouped(false)
+    const request = gatewayServingRepoProject()
+
+    await followActiveSessionCwd(REPO_CWD)
+
+    // The user's flat view is preserved: data refreshes, but the sidebar is
+    // not re-grouped and no project drill-in happens.
+    expect($sidebarAgentsGrouped.get()).toBe(false)
+    expect($projectScope.get()).toBe(ALL_PROJECTS)
+    expect(request).toHaveBeenCalledWith('projects.list', expect.anything())
+  })
+
+  it('still drills into the session project when the project tree is already visible', async () => {
+    setSidebarAgentsGrouped(true)
+    gatewayServingRepoProject()
+
+    await followActiveSessionCwd(REPO_CWD)
+
+    expect($sidebarAgentsGrouped.get()).toBe(true)
+    expect($projectScope.get()).toBe('p_ys')
+  })
+
+  it('does not flip a flat view when the cwd is outside every project', async () => {
+    setSidebarAgentsGrouped(false)
+    gatewayServingRepoProject()
+
+    await followActiveSessionCwd('/home/user/elsewhere')
+
+    expect($sidebarAgentsGrouped.get()).toBe(false)
+    expect($projectScope.get()).toBe(ALL_PROJECTS)
   })
 })

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -15,7 +15,7 @@ import { isMissingRestEndpoint, isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { isUnderPath } from '@/lib/path-compare'
 import { persistentAtom } from '@/lib/persisted'
 import { $gateway, activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
-import { setSidebarAgentsGrouped } from '@/store/layout'
+import { $sidebarAgentsGrouped, setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
 import {
   $activeGatewayProfile,
@@ -250,15 +250,18 @@ export async function followActiveSessionCwd(cwd: string): Promise<void> {
   // Resolve only after the refresh, so a just-created/auto project is in the tree.
   const projectId = projectIdForCwd(target)
 
-  if (projectId) {
-    // The Projects tree only renders in grouped mode, so flip the sidebar into
-    // it — otherwise following from the flat Sessions list would change scope
-    // invisibly. Then drill into the thread's project.
-    setSidebarAgentsGrouped(true)
+  // The Projects tree only renders in grouped mode, and flipping the sidebar
+  // from a flat view is the user's choice, not the agent's: a session
+  // activation whose cwd sits in a repo must not silently replace the flat
+  // "Recents" list with project buckets (#105207). Follow the relocated
+  // session's project only when the project tree is already the visible
+  // surface — in a flat view the refresh above still keeps rows/data live.
+  if (!projectId || !$sidebarAgentsGrouped.get()) {
+    return
+  }
 
-    if (projectId !== $projectScope.get()) {
-      enterProject(projectId)
-    }
+  if (projectId !== $projectScope.get()) {
+    enterProject(projectId)
   }
 }
 


### PR DESCRIPTION
Closes #105207

## Problem

Activating (or switching to) a session whose working directory lives in a git repo silently yanks the entire left sidebar out of the user's flat view into the project-grouped tree. `followActiveSessionCwd()` — fed by the `session.info` gateway event — unconditionally called `setSidebarAgentsGrouped(true)` whenever the resolved cwd belonged to a known project, so the grouping preference was never the user's to keep.

## Fix

`followActiveSessionCwd()` now respects the current sidebar view:

- The `projects.list`/`projects.tree` refreshes still run, so rows and project data stay live.
- The project-tree flip + `enterProject()` drill-in only happens when the sidebar is **already** in grouped/project mode (i.e. the project tree is the visible surface).
- From a flat "Recents" view the follow is a no-op beyond the refresh — re-grouping the sidebar is a user choice, not something a session event should do invisibly.

## Tests

- `apps/desktop/src/store/projects.test.ts` — 3 new cases:
  - flat view preserved: follow of a repo cwd keeps `sidebarAgentsGrouped=false` and the `ALL_PROJECTS` scope, while still hitting the refresh RPCs;
  - grouped view unchanged: follow still drills into the session's project (`p_ys`) when the project tree is visible;
  - cwd outside every project: flat view stays flat.
- Full file: **44 passed (44)**; `tsc -p apps/desktop --noEmit` clean.
