### PR TITLE
feat(email): send from a configured alias instead of always the mailbox address

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1336,6 +1336,17 @@ platform_toolsets:
 #       # Omit either key to preserve Slack's default for that preview type.
 #       unfurl_links: false
 #       unfurl_media: false
+#   email:
+#     extra:
+#       # One mailbox, several verified sender identities (Gmail "send mail as",
+#       # Microsoft 365 shared mailboxes, catch-all domains). Both default to
+#       # EMAIL_ADDRESS, which stays the IMAP/SMTP login. A reply goes out from
+#       # the identity the sender wrote to; an address outside this set is
+#       # refused and the default sender is used instead.
+#       from_address: "support@example.com"
+#       from_aliases:                       # or a comma-separated string
+#         - "hr@example.com"
+#         - "billing@example.com"
 #   webhook:
 #     extra:
 #       # Route scripts default to a 30 second timeout. Scripts must live under

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -16,7 +16,7 @@ from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
-from email.utils import formatdate
+from email.utils import formatdate, getaddresses
 from email import encoders
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -246,6 +246,16 @@ def _extract_email_address(raw: str) -> str:
     return (match.group(1) if match else raw).strip().lower()
 
 
+def _parse_from_aliases(raw: Any, *defaults: str) -> Dict[str, str]:
+    """Lowercased alias -> configured spelling. Accepts a comma-separated string or a sequence
+    (config.yaml lists). ``defaults`` (the mailbox and the default sender) are always included,
+    so the pre-alias behaviour is a subset of the configured one. Entries without ``@`` are dropped."""
+    values = ([str(v) for v in raw] if isinstance(raw, (list, tuple, set))
+              else str(raw or "").split(","))
+    return {alias.lower(): alias
+            for alias in (v.strip() for v in [*values, *defaults]) if alias and "@" in alias}
+
+
 def _domain_of(address: str) -> str:
     """Lowercased domain part of an email address, or ''."""
     return address.rpartition("@")[2].strip().lower()
@@ -341,6 +351,18 @@ class EmailAdapter(BasePlatformAdapter):
         setting = lambda env, key: _get_secret(env, "") or extra.get(key, "")  # noqa: E731
         tls_verify = lambda env, key: _esecret_bool(env, is_truthy_value(extra.get(key), default=True))  # noqa: E731
         self._address = setting("EMAIL_ADDRESS", "address").strip()
+        # One physical mailbox can own several verified sender identities (Gmail "send mail as",
+        # Microsoft 365 shared mailboxes, catch-all domains). Keep the mailbox apart from the
+        # identities it may send as:
+        #   EMAIL_ADDRESS      — the mailbox this adapter watches (login, seen-UID key)
+        #   EMAIL_FROM_ADDRESS — the default visible sender
+        #   EMAIL_FROM_ALIASES — every other visible sender this account may legitimately use
+        # Both default to EMAIL_ADDRESS, so an unconfigured deployment behaves exactly as before.
+        self._from_address = (setting("EMAIL_FROM_ADDRESS", "from_address") or self._address).strip()
+        self._from_aliases = _parse_from_aliases(
+            setting("EMAIL_FROM_ALIASES", "from_aliases"), self._address, self._from_address)
+        # Self-detection must cover every identity we may send as, or the agent answers its own alias.
+        self._self_addresses = set(self._from_aliases)
         self._password = _get_secret("EMAIL_PASSWORD", "")
         self._imap_host = setting("EMAIL_IMAP_HOST", "imap_host").strip()
         self._imap_port = _esecret_int("EMAIL_IMAP_PORT", 993)
@@ -368,7 +390,8 @@ class EmailAdapter(BasePlatformAdapter):
         # Track the last IMAP fetch attempt so the poll loop can distinguish "checked, nothing new" from
         # "the check itself failed" (#80016).
         self._thread_context: Dict[str, Dict[str, str]] = {}
-        logger.info("[Email] Adapter initialized for %s", self._address)
+        logger.info("[Email] Adapter initialized for mailbox=%s from=%s aliases=%d",
+                    self._address, self._from_address, len(self._from_aliases))
 
     def _trim_seen_uids(self) -> None:
         """Keep only the highest half of UIDs once over the cap (UIDs are monotonic; UNSEEN prevents re-delivery)."""
@@ -485,7 +508,7 @@ class EmailAdapter(BasePlatformAdapter):
             return False
         self._running = True
         self._poll_task = asyncio.create_task(self._poll_loop())
-        print(f"[Email] Connected as {self._address}")
+        print(f"[Email] Connected mailbox={self._address} from={self._from_address}")
         self._wire_plugin_handlers(None)  # plugin-registered native handlers
         return True
 
@@ -582,6 +605,7 @@ class EmailAdapter(BasePlatformAdapter):
         # Verify From: while the trusted Authentication-Results header is in scope; the verdict is consumed at dispatch (GHSA-rxqh-5572-8m77).
         sender_authenticated, auth_reason = _verify_sender_authentication(msg, sender_addr, authserv_id=self._authserv_id)
         return {"uid": uid, "sender_addr": sender_addr, "sender_name": sender_name, "subject": subject,
+                "reply_from": self._addressed_alias(msg),
                 "message_id": msg.get("Message-ID", ""), "in_reply_to": msg.get("In-Reply-To", ""),
                 "body": _extract_text_body(msg),
                 "attachments": _extract_attachments(msg, skip_attachments=self._skip_attachments),
@@ -599,7 +623,7 @@ class EmailAdapter(BasePlatformAdapter):
 
     def _sender_accepted(self, sender_addr: str, msg_data: Dict[str, Any]) -> bool:
         """Pre-dispatch sender gate: self, automated, allowlist, From: authentication."""
-        if sender_addr == self._address.lower():
+        if sender_addr.lower() in self._self_addresses:
             return False
         if _is_automated_sender(sender_addr, {}):
             logger.debug("[Email] Dropping automated sender at dispatch: %s", sender_addr)
@@ -635,7 +659,8 @@ class EmailAdapter(BasePlatformAdapter):
         # DOCUMENT wins over PHOTO for mixed attachments: run.py keys image handling off the per-path mime type regardless
         # of message_type, but document-context injection gates strictly on MessageType.DOCUMENT — so DOCUMENT surfaces both.
         kinds = {att["type"] for att in attachments}
-        self._thread_context[sender_addr] = {"subject": subject, "message_id": msg_data["message_id"]}
+        self._thread_context[sender_addr] = {"subject": subject, "message_id": msg_data["message_id"],
+                                             "reply_from": msg_data.get("reply_from", self._from_address)}
         name = msg_data["sender_name"] or sender_addr
         event = MessageEvent(
             text=text or "(empty email)", message_id=msg_data["message_id"],
@@ -655,15 +680,41 @@ class EmailAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(e))
 
     async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
-        """Send an email reply to the given address."""
-        return await self._run_send(self._send_email, (chat_id, content, reply_to), "[Email] Send failed to %s: %s", chat_id)
+        """Send an email reply to the given address (``metadata["from_address"]`` picks an alias)."""
+        return await self._run_send(self._send_email, (chat_id, content, reply_to, (metadata or {}).get("from_address")),
+                                    "[Email] Send failed to %s: %s", chat_id)
 
-    def _message_id_domain(self) -> str:
-        """Domain for generated Message-IDs; ``localhost`` when EMAIL_ADDRESS lacks ``@``."""
-        return (self._address.rsplit("@", 1)[-1] if "@" in self._address else "") or "localhost"
+    def _addressed_alias(self, msg) -> str:
+        """The configured identity this message was addressed to, else the default sender.
+
+        Aliases share one physical mailbox, so the recipient headers are the only record of which
+        identity the sender used. Delivered-To / X-Original-To survive alias rewriting that To: does not.
+        """
+        for header in ("Delivered-To", "X-Original-To", "To", "Cc"):
+            for _name, address in getaddresses(msg.get_all(header, []) or []):
+                if alias := self._from_aliases.get(address.strip().lower()):
+                    return alias
+        return self._from_address
+
+    def _resolve_from_address(self, to_addr: str, requested_from: Optional[str] = None) -> str:
+        """Visible sender for a reply: an explicitly requested alias, else the alias this thread
+        arrived on, else the default. Fail-closed — an unconfigured request is refused, never sent,
+        so a compromised prompt cannot make the account send as an arbitrary address."""
+        if requested_from:
+            if allowed := self._from_aliases.get(str(requested_from).strip().lower()):
+                return allowed
+            logger.warning("[Email] Ignoring unconfigured From alias request; using %s", self._from_address)
+        thread_from = self._thread_context.get(to_addr, {}).get("reply_from", "")
+        return self._from_aliases.get(thread_from.strip().lower(), self._from_address)
+
+    def _message_id_domain(self, from_address: Optional[str] = None) -> str:
+        """Domain for generated Message-IDs; ``localhost`` when the sender address lacks ``@``."""
+        address = from_address or self._from_address
+        return (address.rsplit("@", 1)[-1] if "@" in address else "") or "localhost"
 
     def _new_reply(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None, *,
-                   attach_empty_body: bool = False) -> Tuple[MIMEMultipart, str, str]:
+                   attach_empty_body: bool = False,
+                   requested_from: Optional[str] = None) -> Tuple[MIMEMultipart, str, str]:
         """Build a threaded reply skeleton. Returns ``(msg, msg_id, subject)``."""
         msg, ctx = MIMEMultipart(), self._thread_context.get(to_addr, {})
         subject = ctx.get("subject", "Hermes Agent")
@@ -671,8 +722,9 @@ class EmailAdapter(BasePlatformAdapter):
             subject = f"Re: {subject}"
         original_msg_id = reply_to_msg_id or ctx.get("message_id")
         threading = (("In-Reply-To", original_msg_id), ("References", original_msg_id)) if original_msg_id else ()
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
-        for key, value in (("From", self._address), ("To", to_addr), ("Subject", subject), *threading,
+        from_address = self._resolve_from_address(to_addr, requested_from)
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain(from_address)}>"
+        for key, value in (("From", from_address), ("To", to_addr), ("Subject", subject), *threading,
                            ("Date", formatdate(localtime=True)), ("Message-ID", msg_id)):
             msg[key] = value
         if body or attach_empty_body:
@@ -691,9 +743,11 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
-    def _send_email(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None) -> str:
+    def _send_email(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None,
+                    requested_from: Optional[str] = None) -> str:
         """Send an email via SMTP. Runs in executor thread."""
-        msg, msg_id, subject = self._new_reply(to_addr, body, reply_to_msg_id, attach_empty_body=True)
+        msg, msg_id, subject = self._new_reply(to_addr, body, reply_to_msg_id, attach_empty_body=True,
+                                               requested_from=requested_from)
         self._smtp_send(msg)
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
@@ -765,6 +819,7 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
     """Out-of-process Email delivery via SMTP (one-shot); standalone_sender_fn contract."""
     extra = getattr(pconfig, "extra", {}) or {}
     address, password = extra.get("address") or _get_secret("EMAIL_ADDRESS", ""), _get_secret("EMAIL_PASSWORD", "")
+    from_address = (extra.get("from_address") or _get_secret("EMAIL_FROM_ADDRESS", "") or address).strip()
     smtp_host, smtp_port = extra.get("smtp_host") or _get_secret("EMAIL_SMTP_HOST", ""), _esecret_int("EMAIL_SMTP_PORT", 587)
     smtp_security = _normalize_security(_get_secret("EMAIL_SMTP_SECURITY", "") or extra.get("smtp_security"), default="tls" if smtp_port == 465 else "starttls")
     smtp_tls_verify = _esecret_bool("EMAIL_SMTP_TLS_VERIFY", is_truthy_value(extra.get("smtp_tls_verify"), default=True))
@@ -772,7 +827,7 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
     try:
         msg = MIMEText(message, "plain", "utf-8")
-        for key, value in (("From", address), ("To", chat_id), ("Subject", "Hermes Agent"), ("Date", formatdate(localtime=True))):
+        for key, value in (("From", from_address), ("To", chat_id), ("Subject", "Hermes Agent"), ("Date", formatdate(localtime=True))):
             msg[key] = value
         server = _open_smtp(smtp_host, smtp_port, smtp_security, _tls_context(smtp_tls_verify, smtp_host), smtplib.SMTP, smtplib.SMTP_SSL)
         server.login(address, password)

--- a/plugins/platforms/email/plugin.yaml
+++ b/plugins/platforms/email/plugin.yaml
@@ -37,3 +37,11 @@ optional_env:
     description: "Default address for cron / notification delivery"
     prompt: "Home address"
     password: false
+  - name: EMAIL_FROM_ADDRESS
+    description: "Default visible sender (defaults to EMAIL_ADDRESS; for mailboxes that send as an alias)"
+    prompt: "Default From address (leave empty to use EMAIL_ADDRESS)"
+    password: false
+  - name: EMAIL_FROM_ALIASES
+    description: "Comma-separated additional sender identities this account may send as"
+    prompt: "Additional From aliases (comma-separated)"
+    password: false

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -805,6 +805,10 @@ class TestSendEmailStandalone(unittest.TestCase):
         "EMAIL_PASSWORD": "secret",
         "EMAIL_SMTP_HOST": "smtp.test.com",
         "EMAIL_SMTP_PORT": "587",
+        # Scrubbed, not merged: patch.dict does not clear, so an
+        # EMAIL_FROM_ADDRESS in the developer's own shell would otherwise
+        # decide the From: header this test asserts on.
+        "EMAIL_FROM_ADDRESS": "",
     })
     def test_send_email_tool_success(self):
         """_send_email should use verified STARTTLS when sending."""

--- a/tests/gateway/test_email_from_alias.py
+++ b/tests/gateway/test_email_from_alias.py
@@ -1,0 +1,187 @@
+"""One mailbox, several verified sender identities.
+
+Gmail "send mail as", Microsoft 365 shared mailboxes and catch-all domains all put several
+addresses on one physical mailbox. The adapter keeps the mailbox apart from the identities it
+may send as:
+
+    EMAIL_ADDRESS      the mailbox it watches and logs in with
+    EMAIL_FROM_ADDRESS the default visible sender (defaults to EMAIL_ADDRESS)
+    EMAIL_FROM_ALIASES every other identity this account may send as
+
+A reply goes out from the identity the sender wrote to; an alias that is not configured is
+refused (fail-closed), never sent. With none of the extra variables set the behaviour is
+byte-for-byte the pre-alias behaviour.
+"""
+
+from __future__ import annotations
+
+import email as email_lib
+import os
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+MAILBOX = "soporte@example.com"
+ALIAS = "hr@example.com"
+OTHER_ALIAS = "billing@example.com"
+
+BASE_ENV = {
+    "EMAIL_ADDRESS": MAILBOX,
+    "EMAIL_PASSWORD": "secret",
+    "EMAIL_IMAP_HOST": "imap.example.com",
+    "EMAIL_SMTP_HOST": "smtp.example.com",
+}
+
+
+def make_adapter(**env):
+    """Build an adapter with a clean EMAIL_* environment plus the given overrides."""
+    from plugins.platforms.email.adapter import EmailAdapter
+
+    scrubbed = {k: "" for k in ("EMAIL_FROM_ADDRESS", "EMAIL_FROM_ALIASES")}
+    with patch.dict(os.environ, {**scrubbed, **BASE_ENV, **env}, clear=False):
+        return EmailAdapter(PlatformConfig(enabled=True))
+
+
+def make_message(**headers) -> email_lib.message.Message:
+    msg = email_lib.message.EmailMessage()
+    for key, value in headers.items():
+        msg[key.replace("_", "-")] = value
+    return msg
+
+
+# ── defaults: unconfigured deployments keep the old behaviour ──────────────
+
+
+def test_defaults_collapse_to_email_address():
+    adapter = make_adapter()
+    assert adapter._from_address == MAILBOX
+    assert adapter._from_aliases == {MAILBOX: MAILBOX}
+    assert adapter._resolve_from_address("someone@else.com") == MAILBOX
+    assert adapter._message_id_domain() == "example.com"
+
+
+def test_from_address_without_at_falls_back_to_localhost():
+    adapter = make_adapter(EMAIL_ADDRESS="not-an-address")
+    assert adapter._message_id_domain() == "localhost"
+
+
+# ── configuration parsing ──────────────────────────────────────────────────
+
+
+def test_default_sender_and_aliases_are_independent_of_the_mailbox():
+    adapter = make_adapter(EMAIL_FROM_ADDRESS=ALIAS, EMAIL_FROM_ALIASES=f"{OTHER_ALIAS}, {MAILBOX}")
+    assert adapter._from_address == ALIAS
+    assert set(adapter._from_aliases) == {ALIAS, OTHER_ALIAS, MAILBOX}
+
+
+def test_alias_parsing_ignores_blanks_and_non_addresses():
+    from plugins.platforms.email.adapter import _parse_from_aliases
+
+    parsed = _parse_from_aliases(f" {ALIAS} , , not-an-address ,{OTHER_ALIAS}", MAILBOX)
+    assert set(parsed) == {ALIAS, OTHER_ALIAS, MAILBOX}
+    assert parsed[ALIAS] == ALIAS  # the configured spelling is what goes on the wire
+
+
+def test_alias_parsing_accepts_a_config_yaml_list():
+    from plugins.platforms.email.adapter import _parse_from_aliases
+
+    assert set(_parse_from_aliases([ALIAS, OTHER_ALIAS], MAILBOX)) == {ALIAS, OTHER_ALIAS, MAILBOX}
+
+
+def test_alias_lookup_is_case_insensitive_but_preserves_the_configured_spelling():
+    adapter = make_adapter(EMAIL_FROM_ALIASES="HR@Example.com")
+    assert adapter._resolve_from_address("x@y.com", "hr@EXAMPLE.COM") == "HR@Example.com"
+
+
+# ── reply follows the identity the sender addressed ────────────────────────
+
+
+@pytest.mark.parametrize("header", ["To", "Cc", "Delivered-To", "X-Original-To"])
+def test_addressed_alias_is_read_from_every_recipient_header(header):
+    adapter = make_adapter(EMAIL_FROM_ALIASES=ALIAS)
+    msg = make_message(**{header.replace("-", "_"): f"Support <{ALIAS}>"})
+    assert adapter._addressed_alias(msg) == ALIAS
+
+
+def test_unknown_recipient_falls_back_to_the_default_sender():
+    adapter = make_adapter(EMAIL_FROM_ADDRESS=ALIAS, EMAIL_FROM_ALIASES=OTHER_ALIAS)
+    assert adapter._addressed_alias(make_message(To="stranger@nowhere.com")) == ALIAS
+
+
+def test_reply_goes_out_from_the_alias_the_thread_arrived_on():
+    adapter = make_adapter(EMAIL_FROM_ALIASES=ALIAS)
+    adapter._thread_context["client@corp.com"] = {
+        "subject": "Invoice", "message_id": "<abc@corp.com>", "reply_from": ALIAS}
+    msg, msg_id, _ = adapter._new_reply("client@corp.com", "body")
+    assert msg["From"] == ALIAS
+    assert msg_id.endswith("@example.com>")
+
+
+def test_reply_without_thread_context_uses_the_default_sender():
+    adapter = make_adapter(EMAIL_FROM_ADDRESS=ALIAS, EMAIL_FROM_ALIASES=OTHER_ALIAS)
+    msg, _, _ = adapter._new_reply("client@corp.com", "body")
+    assert msg["From"] == ALIAS
+
+
+# ── fail-closed on an unconfigured alias ───────────────────────────────────
+
+
+def test_requested_alias_is_honoured_when_configured():
+    adapter = make_adapter(EMAIL_FROM_ALIASES=f"{ALIAS},{OTHER_ALIAS}")
+    assert adapter._resolve_from_address("client@corp.com", OTHER_ALIAS) == OTHER_ALIAS
+
+
+def test_requested_alias_outside_the_configured_set_is_refused():
+    adapter = make_adapter(EMAIL_FROM_ADDRESS=ALIAS, EMAIL_FROM_ALIASES=ALIAS)
+    assert adapter._resolve_from_address("client@corp.com", "ceo@victim.com") == ALIAS
+    msg, _, _ = adapter._new_reply("client@corp.com", "body", requested_from="ceo@victim.com")
+    assert msg["From"] == ALIAS
+
+
+def test_refused_alias_does_not_win_over_the_thread_alias():
+    adapter = make_adapter(EMAIL_FROM_ALIASES=f"{ALIAS},{OTHER_ALIAS}")
+    adapter._thread_context["client@corp.com"] = {"reply_from": OTHER_ALIAS}
+    assert adapter._resolve_from_address("client@corp.com", "ceo@victim.com") == OTHER_ALIAS
+
+
+# ── self-detection covers every identity ───────────────────────────────────
+
+
+@pytest.mark.parametrize("sender", [MAILBOX, ALIAS, OTHER_ALIAS])
+def test_mail_from_any_of_our_identities_is_not_answered(sender):
+    adapter = make_adapter(EMAIL_FROM_ADDRESS=ALIAS, EMAIL_FROM_ALIASES=OTHER_ALIAS)
+    assert adapter._sender_accepted(sender, {}) is False
+
+
+def test_a_real_sender_is_still_accepted():
+    adapter = make_adapter(EMAIL_FROM_ALIASES=ALIAS, EMAIL_ALLOWED_USERS="client@corp.com")
+    with patch.dict(os.environ, {"EMAIL_ALLOWED_USERS": "client@corp.com"}, clear=False):
+        assert adapter._sender_accepted("client@corp.com", {"sender_authenticated": True}) is True
+
+
+# ── the alias changes the visible sender, not the credential ───────────────
+
+
+def test_smtp_still_logs_in_with_the_mailbox_address():
+    adapter = make_adapter(EMAIL_FROM_ADDRESS=ALIAS)
+    sent = {}
+
+    class FakeSMTP:
+        def login(self, user, password):
+            sent["user"] = user
+
+        def send_message(self, msg):
+            sent["from"] = msg["From"]
+
+        def quit(self):
+            sent["quit"] = True
+
+    with patch.object(adapter, "_connect_smtp", return_value=FakeSMTP()):
+        adapter._send_email("client@corp.com", "hello")
+
+    assert sent["user"] == MAILBOX
+    assert sent["from"] == ALIAS
+    assert sent["quit"] is True

--- a/tests/gateway/test_email_robustness.py
+++ b/tests/gateway/test_email_robustness.py
@@ -21,6 +21,11 @@ def _make_adapter(address="hermes@test.com"):
         "EMAIL_PASSWORD": "secret",
         "EMAIL_IMAP_HOST": "imap.test.com",
         "EMAIL_SMTP_HOST": "smtp.test.com",
+        # Scrubbed, not merged: this patch.dict does not clear, so an
+        # EMAIL_FROM_ADDRESS in the developer's own shell would otherwise
+        # decide the visible sender these tests assert on.
+        "EMAIL_FROM_ADDRESS": "",
+        "EMAIL_FROM_ALIASES": "",
     }):
         from plugins.platforms.email.adapter import EmailAdapter
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -419,7 +419,9 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `SMS_ALLOW_ALL_USERS` | Allow all SMS senders without an allowlist |
 | `SMS_HOME_CHANNEL` | Phone number for cron job / notification delivery |
 | `SMS_HOME_CHANNEL_NAME` | Display name for the SMS home channel |
-| `EMAIL_ADDRESS` | Email address for the Email gateway adapter |
+| `EMAIL_ADDRESS` | Email address for the Email gateway adapter (mailbox polled and logged in with) |
+| `EMAIL_FROM_ADDRESS` | Default visible sender for outgoing mail (defaults to `EMAIL_ADDRESS`) |
+| `EMAIL_FROM_ALIASES` | Comma-separated additional sender identities this account may send as |
 | `EMAIL_PASSWORD` | Password or app password for the email account |
 | `EMAIL_IMAP_HOST` | IMAP hostname for the email adapter |
 | `EMAIL_IMAP_PORT` | IMAP port |

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -104,6 +104,10 @@ EMAIL_IMAP_PORT=993                    # Default: 993 (IMAP SSL)
 EMAIL_SMTP_PORT=587                    # Default: 587 (SMTP STARTTLS)
 EMAIL_POLL_INTERVAL=15                 # Seconds between inbox checks (default: 15)
 EMAIL_HOME_ADDRESS=your@email.com      # Default delivery target for cron jobs
+
+# Sender aliases (optional) — see "Sending as an alias" below
+EMAIL_FROM_ADDRESS=support@example.com
+EMAIL_FROM_ALIASES=hr@example.com,billing@example.com
 ```
 
 ---
@@ -146,6 +150,42 @@ Replies are sent via SMTP with proper email threading:
 - **Subject line** preserved with `Re:` prefix (no double `Re: Re:`)
 - **Message-ID** generated with the agent's domain
 - Responses are sent as plain text (UTF-8)
+
+### Sending as an alias
+
+One mailbox often owns several verified sender identities: Gmail's *Send mail as*, a Microsoft 365
+shared mailbox, a catch-all domain. By default the agent replies from `EMAIL_ADDRESS`, the mailbox
+it polls. Two optional variables separate the mailbox from the identities it may send as:
+
+- `EMAIL_FROM_ADDRESS` — the default visible sender, when it differs from the mailbox
+- `EMAIL_FROM_ALIASES` — every other identity this account may send as (comma-separated)
+
+Both default to `EMAIL_ADDRESS`, so leaving them unset keeps the previous behaviour exactly.
+
+With aliases configured, a reply goes out from the identity the sender wrote to. The adapter reads
+that identity off the recipient headers of the inbound message (`Delivered-To`, `X-Original-To`,
+`To`, `Cc`) — mail addressed to `hr@example.com` is answered from `hr@example.com`, not from the
+shared mailbox address. The generated `Message-ID` uses the domain of the visible sender.
+
+Alias resolution is fail-closed: an address outside the configured set is refused and the default
+sender is used instead, so a prompt-injected request cannot make the account send as an arbitrary
+third party. Self-detection covers every configured identity, so the agent never answers its own
+alias.
+
+`EMAIL_ADDRESS` remains the IMAP/SMTP login. Your provider must already authorise the account to
+send as each alias — Hermes sets the `From:` header, it does not grant the right to use it.
+
+The same settings are available in `config.yaml`, where `from_aliases` also accepts a YAML list:
+
+```yaml
+platforms:
+  email:
+    extra:
+      from_address: support@example.com
+      from_aliases:
+        - hr@example.com
+        - billing@example.com
+```
 
 ### File Attachments
 
@@ -211,7 +251,7 @@ Email access is stricter by default than chat-style platforms:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `EMAIL_ADDRESS` | Yes | — | Agent's email address |
+| `EMAIL_ADDRESS` | Yes | — | Mailbox the agent polls and logs in with |
 | `EMAIL_PASSWORD` | Yes | — | Email password or app password |
 | `EMAIL_IMAP_HOST` | Yes | — | IMAP server host (e.g., `imap.gmail.com`) |
 | `EMAIL_SMTP_HOST` | Yes | — | SMTP server host (e.g., `smtp.gmail.com`) |
@@ -220,4 +260,6 @@ Email access is stricter by default than chat-style platforms:
 | `EMAIL_POLL_INTERVAL` | No | `15` | Seconds between inbox checks |
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
+| `EMAIL_FROM_ADDRESS` | No | `EMAIL_ADDRESS` | Default visible sender (`From:`) |
+| `EMAIL_FROM_ALIASES` | No | — | Comma-separated additional identities this account may send as |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |


### PR DESCRIPTION
## What does this PR do?

One physical mailbox often owns several verified sender identities: Gmail's *Send mail as*, a Microsoft 365 shared mailbox, a catch-all domain. The email adapter folded all of that into `EMAIL_ADDRESS` and stamped every `From:` with it, so a message sent to `hr@example.com` was answered from `support@example.com` — the shared mailbox address, not the identity the sender wrote to.

This keeps the mailbox apart from the identities it may send as:

| Variable | Meaning |
|---|---|
| `EMAIL_ADDRESS` | the mailbox this adapter watches and logs in with (unchanged) |
| `EMAIL_FROM_ADDRESS` | the default visible sender |
| `EMAIL_FROM_ALIASES` | every other identity this account may send as |

Both new variables default to `EMAIL_ADDRESS`, so an unconfigured deployment is byte-for-byte unchanged.

A reply goes out from the identity the sender addressed. The alias is read off the inbound message's recipient headers at parse time — `Delivered-To`, `X-Original-To`, `To`, `Cc`, in that order, because `Delivered-To` / `X-Original-To` survive the alias rewriting that `To:` does not — and carried in the thread context. `metadata["from_address"]` lets a caller pick an identity explicitly.

Three details that make this safe rather than just convenient:

- **Fail-closed resolution.** An address outside the configured set is refused and the default sender is used instead. A prompt-injected `from_address` cannot make the account send as an arbitrary third party.
- **Self-detection covers every identity.** Previously only `EMAIL_ADDRESS` was recognised as "us"; mail arriving at an alias would have been answered, looping the agent against itself.
- **The `Message-ID` domain follows the visible sender**, not the mailbox, so the generated ID doesn't disclose a different domain than the `From:`.

Config keys `from_address` / `from_aliases` under `platforms.email.extra` mirror the env vars, and `from_aliases` accepts a YAML list as well as a comma-separated string.

Deliberately **not** in scope: separating the IMAP/SMTP login from the mailbox. #77384 already does that with `EMAIL_LOGIN_USER`, and the two changes compose cleanly — that PR decides what the adapter authenticates as, this one decides what it sends as. `EMAIL_ADDRESS` remains the login here.

## Related Issue

No dedicated issue for the alias case — the closest ones are all about the login split, which #77384 covers, not this PR.

- Complementary, not competing: #77384 (separate IMAP/SMTP login user)
- Related background: #41331, #46676, #25849


## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/email/adapter.py` — `_parse_from_aliases()`, `_addressed_alias()`, `_resolve_from_address()`; `_new_reply()` and `_send_email()` take an optional `requested_from`; `_message_id_domain()` takes the visible sender; `_sender_accepted()` checks every configured identity; `_standalone_send()` honours `EMAIL_FROM_ADDRESS`
- `tests/gateway/test_email_from_alias.py` — new, 21 tests
- `tests/gateway/test_email.py`, `tests/gateway/test_email_robustness.py` — the two adapter-building helpers patch `os.environ` without clearing it, so they now scrub the new keys; otherwise an `EMAIL_FROM_ADDRESS` in a contributor's own shell decides the `From:` header those tests assert on
- `plugins/platforms/email/plugin.yaml` — both variables added to `optional_env`
- `cli-config.yaml.example` — `platforms.email.extra` block
- `website/docs/user-guide/messaging/email.md` — new "Sending as an alias" section, `.env` sample, variables table
- `website/docs/reference/environment-variables.md` — both variables

## How to Test

1. Set `EMAIL_ADDRESS` to a mailbox that owns a verified alias, then add `EMAIL_FROM_ALIASES=<the alias>` (the provider must already authorise the account to send as it — Hermes sets the header, it doesn't grant the right).
2. Send mail to the alias. The reply arrives `From:` the alias, and the `Message-ID` uses the alias's domain. Send to the mailbox address instead and the reply comes from the mailbox address.
3. Leave both new variables unset and repeat: identical behaviour to before this PR.
4. `pytest tests/gateway/ -q -k email` — 113 passed, 1 skipped.

On the full suite: this repo has a large pre-existing Windows failure baseline, so rather than claim a clean `pytest tests/ -q` I compared failure *sets* across `tests/gateway/` + `tests/agent/` (the blast radius of this change), untouched `main` vs this branch, same interpreter and a clean `HERMES_HOME`:

| | failed | passed |
|---|---|---|
| `main` @ 2237be3559 | 186 | 14131 |
| this branch | 185 | 14153 |

No new failures. The one that flipped to passing is `test_external_drain_control.py::TestDrainWatcher::test_watcher_enters_then_exits_with_marker`, a timing-sensitive watcher test unrelated to email. Two modules under `tests/` cannot be collected on Windows at all and were excluded from both runs: `tests/hermes_cli/test_doctor_journal_modes.py` (`os.geteuid`) and `tests/tools/test_bot_turn_lock.py` (`import fcntl`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
