### PR TITLE
fix(kanban): deduplicate repeated completion attachments

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5439,6 +5439,7 @@ def complete_task(
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
+    metadata = _deduplicate_completion_artifacts(metadata)
     with write_txn(conn):
         # Parent completion is a hard invariant even for direct human review
         # approval. A parent may have been reopened after this task entered
@@ -5762,6 +5763,44 @@ def _persist_scratch_completion_artifacts(
         metadata["_staged_artifacts"] = [
             path for path in persisted if path.startswith(str(attachment_dir.resolve()))
         ]
+
+
+def _deduplicate_completion_artifacts(metadata: Optional[dict]) -> Optional[dict]:
+    """Keep one declaration for each completion artifact, in input order.
+
+    A repeated artifact must not be mistaken for a second version during
+    scratch staging, where the collision-safe destination helper would append
+    ``_1`` and create a duplicate attachment. Resolve existing path aliases so
+    an absolute path and a symlink to it are treated as the same artifact.
+    """
+    if not isinstance(metadata, dict):
+        return metadata
+    artifacts = metadata.get("artifacts")
+    if not isinstance(artifacts, (list, tuple)):
+        return metadata
+
+    deduplicated: list[object] = []
+    seen: set[str] = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, str):
+            deduplicated.append(artifact)
+            continue
+        path = artifact.strip()
+        if not path:
+            continue
+        try:
+            key = str(Path(path).expanduser().resolve(strict=False))
+        except OSError:
+            key = path
+        if key not in seen:
+            seen.add(key)
+            deduplicated.append(path)
+
+    if len(deduplicated) == len(artifacts):
+        return metadata
+    updated = dict(metadata)
+    updated["artifacts"] = deduplicated
+    return updated
 
 
 def _insert_completion_attachment(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -612,6 +612,51 @@ def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
     ]
 
 
+def test_complete_task_stores_repeated_artifact_path_once(kanban_home):
+    """A repeated artifact path yields one attachment, not a ``_1`` twin.
+
+    Regression: a single worker run that named the same deliverable twice in
+    ``metadata['artifacts']`` had it copied once per entry, so the attachment
+    dir held ``report.md`` and a byte-identical ``report_1.md`` and the card
+    showed two rows for one file. Distinct artifacts must still be preserved.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="research writeup")
+        task = kb.get_task(conn, t)
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, t, ws)
+        report = ws / "report.md"
+        report.write_bytes(b"report-bytes")
+        notes = ws / "notes.md"
+        notes.write_bytes(b"notes-bytes")
+
+        assert kb.complete_task(
+            conn,
+            t,
+            result="ok",
+            metadata={
+                "artifacts": [str(report), str(notes), str(report)],
+            },
+        )
+
+        completed = [e for e in kb.list_events(conn, t) if e.kind == "completed"][-1]
+        event_artifacts = completed.payload["artifacts"]
+        run = kb.latest_run(conn, t)
+
+    attachment_dir = kb.task_attachments_dir(t)
+    assert sorted(p.name for p in attachment_dir.iterdir()) == ["notes.md", "report.md"]
+    assert (attachment_dir / "report.md").read_bytes() == b"report-bytes"
+    assert (attachment_dir / "notes.md").read_bytes() == b"notes-bytes"
+
+    assert len(event_artifacts) == 2
+    assert run is not None
+    assert run.metadata["artifacts"] == event_artifacts
+
+    with kb.connect() as conn:
+        attachments = kb.list_attachments(conn, t)
+    assert sorted(a.filename for a in attachments) == ["notes.md", "report.md"]
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 問題
同一 completion artifact 重複宣告時，scratch staging 將它存成 `report.md` 與 `report_1.md`，造成使用者收到偽版本。

## 修正
在 completion metadata 進入 scratch artifact staging 前，依解析後路徑保留首個 artifact。

## 驗證
- 新增真實 scratch workspace／SQLite attachment regression test
- `67 passed, 1 skipped`：Kanban DB、Kanban tools、stop guard 範圍

## 範圍外
- 不回溯清理既有重複附件
- 不合併、不部署；CI 結果後續回報。