### PR TITLE
fix(desktop): verify the explicit install root from the Windows update hand-off

### DIFF
--- a/hermes_cli/desktop_update_verify.py
+++ b/hermes_cli/desktop_update_verify.py
@@ -1,4 +1,6 @@
 """Read-only verification at the Windows Desktop handoff receipt boundary."""
+import argparse
+import importlib
 import json
 from pathlib import Path, PurePosixPath
 import re
@@ -81,3 +83,28 @@ def verify_windows_desktop_update(project_root: Path) -> None:
     _verify_packaged_entry(executable.parent / "resources")
     if _desktop_build_needed(desktop, project_root, source_mode=False):
         raise RuntimeError("The updated Desktop build is stale, unstamped, or incomplete")
+
+
+VERIFICATION_SENTINEL = "HERMES_DESKTOP_UPDATE_VERIFY_OK_V1"
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Verify the updated runtime and Desktop build from an explicit checkout root.
+
+    The Windows hand-off invokes this as ``python -m hermes_cli.desktop_update_verify
+    <InstallRoot>``. Importing ``hermes_cli.main`` in that fresh process is the
+    runtime half of the receipt — a torn update that breaks the CLI entry point
+    must fail here, not at the next user launch. The versioned stdout sentinel is
+    what the hand-off keys on: an older copy of this module defines no entry point,
+    exits 0, and prints nothing, so it fails closed instead of verifying nothing.
+    """
+    importlib.import_module("hermes_cli.main")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_root", type=Path)
+    args = parser.parse_args(argv)
+    verify_windows_desktop_update(args.project_root)
+    print(VERIFICATION_SENTINEL)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1606,9 +1606,11 @@ try {
 
     # A zero-exit update is not proof that the runtime survived the update.
     if ($res.Code -eq 0 -and -not $desktopBuildFailed) {
-        $verifyCode = "import hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path.cwd())"
-        $verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode) "verify"
-        if ($verify.Code -ne 0) {
+        $verify = Invoke-HermesStep $pythonExe @("-m", "hermes_cli.desktop_update_verify", $InstallRoot) "verify"
+        # The sentinel line proves the CURRENT verifier module ran to completion —
+        # a stale module (branch switch, torn update) predating the entry point
+        # exits 0 having verified nothing, and an empty/absent output must fail.
+        if ($verify.Code -ne 0 -or $verify.Output -notmatch "(?m)^HERMES_DESKTOP_UPDATE_VERIFY_OK_V1\r?$") {
             $finalCode = 8
             $finalMsg = "The updated Hermes runtime or Desktop build failed verification. Repair the installation and review antivirus quarantine before retrying."
             Write-HandoffLog $finalMsg

--- a/tests/hermes_cli/test_desktop_update_verify.py
+++ b/tests/hermes_cli/test_desktop_update_verify.py
@@ -18,6 +18,10 @@ def bundle(tmp_path, monkeypatch):
     (dist / 'assets/index.js').write_text('export {};', encoding='utf-8')
     entry = b'import "electron";'
     (dist / 'electron-main.mjs').write_bytes(entry)
+    # Keep one real source input outside the ignored release tree. Without it,
+    # the correct root and an empty cwd hash identically, so a cwd regression
+    # could pass this fixture while verifying the wrong checkout.
+    (desktop / 'package.json').write_text('{"name":"fixture"}', encoding='utf-8')
     package = json.dumps({'main': 'dist/electron-main.mjs'}).encode()
     header = json.dumps({'files': {'package.json': {'size': len(package), 'offset': '0'}, 'dist': {'files': {'electron-main.mjs': {'size': len(entry), 'unpacked': True}}}}}).encode()
     padded = header + b'\0' * (-len(header) % 4)
@@ -36,6 +40,35 @@ def bundle(tmp_path, monkeypatch):
 def test_readable_packaged_entry_passes(bundle):
     root, _, _ = bundle
     verify.verify_windows_desktop_update(root)
+
+
+def test_cli_verifies_explicit_root_from_an_unrelated_cwd(bundle, tmp_path, monkeypatch, capsys):
+    root, _, _ = bundle
+    unrelated = tmp_path / 'unrelated'
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+
+    # This is the exact regression guard: substituting Path.cwd() for the
+    # explicit hand-off root must be red under the same fixture.
+    with pytest.raises(RuntimeError, match='stale, unstamped, or incomplete'):
+        verify.verify_windows_desktop_update(unrelated)
+
+    verify.main([str(root)])
+    assert capsys.readouterr().out.strip() == verify.VERIFICATION_SENTINEL
+
+
+def test_cli_fails_closed_when_updated_runtime_cannot_import(bundle, monkeypatch):
+    root, _, _ = bundle
+    real_import_module = verify.importlib.import_module
+
+    def fail_cli_entrypoint(name, package=None):
+        if name == 'hermes_cli.main':
+            raise ImportError('simulated torn CLI runtime')
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(verify.importlib, 'import_module', fail_cli_entrypoint)
+    with pytest.raises(ImportError, match='simulated torn CLI runtime'):
+        verify.main([str(root)])
 
 
 @pytest.mark.parametrize('damage', ['archive', 'truncated', 'entry', 'empty-index', 'unreadable-index', 'no-module'])


### PR DESCRIPTION
## What does this PR do?

The Windows Desktop update hand-off invokes the post-update verifier with the child inheriting the PowerShell hand-off process's working directory (`HERMES_HOME`, not the checkout root — `apps/desktop/electron/main.ts` spawns the hand-off with `cwd: HERMES_HOME` and the script never changes location). `verify_windows_desktop_update(Path.cwd())` therefore looks for the packaged executable under the wrong directory, raises `RuntimeError("The updated Desktop executable is missing")`, and the user sees a false "Hermes update did not finish" dialog even though `hermes update` exited 0 and the build is intact. Reproduced: the inline verify one-liner fails from `HERMES_HOME` and passes from the checkout root.

This ports the inline verify into a proper `python -m hermes_cli.desktop_update_verify <InstallRoot>` entry point that:

- takes the explicit install root as an argument (the hand-off already has `$InstallRoot`), so verification no longer depends on the inherited cwd;
- re-imports `hermes_cli.main` in the fresh process (the runtime half of the receipt — a torn update that breaks the CLI entry point must fail here, preserving the guarantee from #90ac288c7d and `website/docs/getting-started/updating.md`);
- prints a versioned sentinel line `HERMES_DESKTOP_UPDATE_VERIFY_OK_V1` on success.

`windows.ps1` now requires **both** exit code 0 **and** the sentinel as an exact output line. That second condition is the fail-closed half: a stale verifier module (branch switch, downgrade, torn update) predating the entry point exits 0 having verified nothing — with exit-code-only trust that silently disables the check. The verifier test fixture also gained one non-ignored source input outside the release tree, so the correct root and an empty cwd no longer hash identically; a cwd regression in `main()` is now red under the same fixture.

## Related Issue

Follow-up to #94846-adjacent verify work shipped in 5ce8e974c2 / f4fa6bf2dc, which introduced the inline `Path.cwd()` call this fixes. (Observed twice on a stock v0.21.0 → v0.21.1 Windows 11 update; both updates actually succeeded.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/desktop_update_verify.py`: new `main()` argparse entry point (`project_root` positional), fresh `importlib.import_module("hermes_cli.main")` runtime probe, `VERIFICATION_SENTINEL` constant, `__main__` guard.
- `scripts/desktop-update/windows.ps1`: verify step now `python -m hermes_cli.desktop_update_verify $InstallRoot`; success requires exit 0 **and** output matching `(?m)^HERMES_DESKTOP_UPDATE_VERIFY_OK_V1?$`.
- `tests/hermes_cli/test_desktop_update_verify.py`: fixture no longer hashes empty-vs-correct identically; new tests for explicit-root-from-unrelated-cwd (asserts the sentinel and that `Path.cwd()` substitution is red) and fail-closed CLI import failure.

## How to Test

1. `bash scripts/run_tests.sh tests/hermes_cli/test_desktop_update_verify.py tests/test_desktop_update_windows_python_handoff.py` — all green (verified).
2. `powershell -NoProfile` AST-parse `windows.ps1` — clean (verified).
3. End-to-end on Windows 11 (verified): `venv/Scripts/python.exe -m hermes_cli.desktop_update_verify <checkout-root>` from an unrelated cwd prints the sentinel and exits 0; the same call against a damaged root raises.
4. Mutation check (verified): reverting `main()` to `Path.cwd()` makes the new explicit-root test fail under the same fixture — the test is a real regression guard.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test suites and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A (behavior-internal fix; the documented update guarantee is restored, not changed)

## Screenshots / Logs

Reproduction on stock v0.21.0 (before fix):

```
verify!| RuntimeError: The updated Desktop executable is missing
```

…from `C:/Users/<user>/AppData/Local/hermes` while `apps/desktop/release/win-unpacked/Hermes.exe` (204 MB) exists in the checkout and the desktop relaunches normally. After this PR the verify step targets `$InstallRoot` explicitly and the sentinel gates success.