### PR TITLE
fix: harden gateway startup and streaming

### DIFF
--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -13,10 +13,10 @@ from typing import Any, Callable, Dict, List, Optional
 
 try:
     from aiohttp import web
-    from aiohttp.web_request import RequestKey
 except ImportError:
     web = None  # type: ignore[assignment]
-    RequestKey = None  # type: ignore[assignment,misc]
+
+RequestKey = getattr(web, "AppKey", None) if web is not None else None
 
 from gateway.platforms.api_server_room_grants import _json_error, _room_grant_error_response
 from gateway.platforms.api_server_run_idempotency import TERMINAL_STATUSES

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -7,9 +7,10 @@ subprocess. Anything that waits belongs in the async helper, never in the probe.
 """
 
 from __future__ import annotations
-
 import json
+import logging
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -146,11 +147,12 @@ def spawn_async_diagnostic(log_path: Path, signal_name: str, *,
         fd = os.open(str(log_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
     except OSError:
         return None
+    timeout_cmd = shutil.which("timeout")
+    command = [timeout_cmd, f"{timeout_seconds:.0f}", "bash", "-c", script] if timeout_cmd else ["bash", "-c", script]
     try:  # start_new_session: outlive systemd killing our cgroup (KillMode=control-group) to flush
         return subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script], stdout=fd,
-            stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, start_new_session=True,
-            close_fds=True).pid
+            command, stdout=fd, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL,
+            start_new_session=True, close_fds=True).pid
     except OSError:
         return None
     finally:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2805,6 +2805,27 @@ class MatrixAdapter(BasePlatformAdapter):
         i = 0
         while i < len(lines):
             line = lines[i]
+            if i + 1 < len(lines):
+                header_cells = MatrixAdapter._markdown_table_cells(line)
+                separator_cells = MatrixAdapter._markdown_table_cells(lines[i + 1])
+                if header_cells and separator_cells and len(header_cells) == len(separator_cells) and all(
+                    re.fullmatch(r":?-{3,}:?", cell.strip()) for cell in separator_cells
+                ):
+                    rows: list[list[str]] = []
+                    i += 2
+                    while i < len(lines):
+                        row_cells = MatrixAdapter._markdown_table_cells(lines[i])
+                        if not row_cells:
+                            break
+                        rows.append(row_cells)
+                        i += 1
+                    header_html = "".join(f"<th>{cell.strip()}</th>" for cell in header_cells)
+                    body_html = "".join(
+                        "<tr>" + "".join(f"<td>{cell.strip()}</td>" for cell in row) + "</tr>"
+                        for row in rows
+                    )
+                    out_lines.append(f"<table><thead><tr>{header_html}</tr></thead><tbody>{body_html}</tbody></table>")
+                    continue
             if re.match(r"^[\s]*([-*_])\s*\1\s*\1[\s\-*_]*$", line):
                 out_lines.append("<hr>")
                 i += 1
@@ -2846,6 +2867,14 @@ class MatrixAdapter(BasePlatformAdapter):
         for idx, original in enumerate(placeholders):
             result = result.replace(f"\x00PROTECTED{idx}\x00", original)
         return result
+
+    @staticmethod
+    def _markdown_table_cells(line: str) -> list[str] | None:
+        stripped = line.strip()
+        if not stripped.startswith("|") or not stripped.endswith("|"):
+            return None
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        return cells if cells and all(cell for cell in cells) else None
 
 
 async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_files=None, force_document=False):

--- a/plugins/teams_pipeline/runtime.py
+++ b/plugins/teams_pipeline/runtime.py
@@ -53,6 +53,9 @@ def build_pipeline_runtime(gateway: Any) -> TeamsMeetingPipeline:
     pipeline_config = build_pipeline_runtime_config(gateway.config)
     if teams_config and teams_config.enabled and (pipeline_config.get("teams_delivery") or {}).get("enabled"):
         try:
+            from plugins.platforms.teams import adapter as teams_adapter
+            if not hasattr(teams_adapter, "TeamsAdapter"):
+                raise ImportError("Teams adapter layer is unavailable")
             from plugins.platforms.teams.summary_writer import TeamsSummaryWriter
         except ImportError:
             logger.debug("TeamsSummaryWriter unavailable; Teams outbound delivery remains disabled until the adapter layer is present.")

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -380,8 +380,6 @@ def _run_one_file_once(
     file_timeout: float,
 ) -> Tuple[Path, int, str, dict[str, int], float]:
     """Single attempt of a per-file pytest subprocess (see _run_one_file)."""
-    cmd = [sys.executable, "-m", "pytest", str(file), *pytest_args]
-
     # Give this subprocess its own pytest temp root.
     #
     # pytest builds its tmp_path root as <temproot>/pytest-of-<user>/. At the
@@ -401,6 +399,7 @@ def _run_one_file_once(
     env = os.environ.copy()
     temproot = tempfile.mkdtemp(prefix="hermes-pytest-tmproot-")
     env["PYTEST_DEBUG_TEMPROOT"] = temproot
+    cmd = [sys.executable, "-m", "pytest", str(file), "--basetemp", temproot, *pytest_args]
 
     subproc_start = time.monotonic()
     # launch the pytest process

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -3065,7 +3065,9 @@ class TestInboundMediaAuthorizationGate:
         parent = tmp_path
         private_parts = []
         for index in range(6):
-            part = f"private-{index}-" + ("x" * 150)
+            # Keep each component/path under macOS limits while still proving
+            # that long private path material is redacted before message bounding.
+            part = f"private-{index}-" + ("x" * 80)
             private_parts.append(part)
             parent = parent / part
             parent.mkdir()

--- a/tests/gateway/test_scale_to_zero.py
+++ b/tests/gateway/test_scale_to_zero.py
@@ -124,7 +124,13 @@ _FLY_ENV = {FLY_APP_NAME_ENV: "hermes-agent-stg-test", FLY_MACHINE_ID_ENV: "d891
 
 def _fake_flaps(tmp_path, status_line, capture):
     """One-shot unix-socket HTTP server standing in for flaps."""
-    sock_path = str(tmp_path / "fly-api.sock")
+    # Keep AF_UNIX paths under macOS' shorter sockaddr_un limit even when
+    # pytest's tmp_path root is deeply nested.
+    sock_path = f"/tmp/hermes-flaps-{os.getpid()}-{id(capture)}.sock"
+    try:
+        os.unlink(sock_path)
+    except FileNotFoundError:
+        pass
     server = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
     server.bind(sock_path)
     server.listen(1)

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import socket
+import sys
 
 import pytest
 
 
 @pytest.mark.skipif(
     not hasattr(socket, "AF_UNIX"), reason="Unix datagram sockets are unavailable"
+)
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="systemd abstract notify sockets are Linux-only"
 )
 def test_notify_supports_systemd_abstract_socket(monkeypatch):
     name = "\0hermes-test-notify"


### PR DESCRIPTION
## Summary
- add gateway /start handling so Telegram onboarding routes to help instead of the agent
- recover Codex Responses streaming output when the SDK crashes after collecting output items
- make chat-completions SSE keepalives honor the configured keepalive interval during quiet tool gaps
- make shutdown diagnostics spawn on POSIX hosts without GNU timeout and reduce a flaky memory monitor timing test

## Test Plan
- python -m ruff check agent/codex_runtime.py gateway/run.py gateway/platforms/api_server.py gateway/shutdown_forensics.py hermes_cli/commands.py tests/run_agent/test_run_agent_codex_responses.py tests/test_gateway_start_command.py tests/gateway/test_memory_monitor.py
- python -m compileall -q agent/codex_runtime.py gateway/run.py gateway/platforms/api_server.py gateway/shutdown_forensics.py hermes_cli/commands.py
- python -m pytest tests/run_agent/test_run_agent_codex_responses.py tests/test_gateway_start_command.py tests/gateway/test_api_server.py::TestChatCompletionsEndpoint::test_stream_sends_keepalive_during_quiet_tool_gap tests/gateway/test_shutdown_forensics.py::TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output tests/gateway/test_memory_monitor.py::test_periodic_timer_fires -o 'addopts=' -q --tb=short
- ulimit -n 4096; python -m pytest tests/gateway tests/test_gateway_start_command.py -o 'addopts=' -q --tb=short
- uv build