### PR TITLE
fix(acp): pin reactive refresh and surface failed turns

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -891,6 +891,7 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
                 logger.debug("Could not emit ACP provenance update after rotation for %s", session_id, exc_info=True)
 
         final_response = result.get("final_response", "")
+        failed = bool(result.get("failed"))
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         # The local "waiting for model" interrupt status is metadata, not prose; stop_reason carries it.
         from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
@@ -898,7 +899,9 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         interrupted = bool(result.get("interrupted")) or cancelled
         suppress = interrupted and final_response.startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX)
         # Send the final text unless already streamed — or if a plugin hook transformed it after.
-        if final_response and conn and not suppress and (not streamed_message or result.get("response_transformed")):
+        if final_response and conn and not suppress and (
+            failed or not streamed_message or result.get("response_transformed")
+        ):
             await conn.session_update(session_id, acp.update_agent_message_text(final_response))
 
         # Go idle before draining so recursive prompt() calls can acquire the session.
@@ -922,7 +925,8 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
                 cached_read_tokens=result.get("cache_read_tokens"),
             )
         await self._send_usage_update(state)
-        return PromptResponse(stop_reason="cancelled" if cancelled else "end_turn", usage=usage)
+        stop_reason = "cancelled" if cancelled else "refusal" if failed else "end_turn"
+        return PromptResponse(stop_reason=stop_reason, usage=usage)
 
     # ---- Session settings (ACP protocol methods) -----------------------------
 

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -64,6 +64,22 @@ def _valid_credential_pair(api_key: Any, base_url: Any) -> bool:
     return bool(isinstance(api_key, str) and api_key.strip() and isinstance(base_url, str) and base_url.strip())
 
 
+def _oauth_account_identity(token: Any) -> Optional[str]:
+    """Return a stable account claim from a Codex/xAI OAuth access token."""
+    try:
+        from hermes_cli.auth_constants import _decode_jwt_claims
+
+        claims = _decode_jwt_claims(token)
+    except Exception:
+        return None
+    nested = claims.get("https://api.openai.com/auth")
+    account = nested.get("chatgpt_account_id") if isinstance(nested, dict) else None
+    for value in (account, claims.get("sub"), claims.get("email")):
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
 def _swap_fallback_clients(agent, fb_client, fb_provider: str, fb_model: str, fb_base_url: str, fb_api_mode: str) -> None:
     """Install the fallback client(s) in place, honoring request_timeout_seconds (None = SDK default)."""
     timeout = get_provider_request_timeout(fb_provider, fb_model)
@@ -563,12 +579,21 @@ class ClientLifecycleMixin:
             return False
         singleton_key = str(singleton_now.get("api_key") or "").strip()
         old_key = str(self.api_key or "").strip()
-        if singleton_key and old_key and singleton_key != old_key:
+        expected_identity = _oauth_account_identity(old_key)
+        if not expected_identity:
             logger.debug(
-                "%s singleton tokens differ from the active api_key; skipping singleton force-refresh to avoid "
-                "silent account swap. Reactive credential rotation should go through the pool.", self.provider,
+                "%s active token has no stable account claim; skipping singleton refresh to avoid a silent "
+                "account swap.", self.provider,
             )
             return False
+        if singleton_key and old_key and singleton_key != old_key:
+            singleton_identity = _oauth_account_identity(singleton_key)
+            if singleton_identity != expected_identity:
+                logger.debug(
+                    "%s singleton token belongs to an unknown or different account; skipping refresh to avoid "
+                    "a silent account swap.", self.provider,
+                )
+                return False
         try:
             creds = resolve(force_refresh=force)
         except Exception as exc:
@@ -576,6 +601,12 @@ class ClientLifecycleMixin:
             return False
         api_key, base_url = creds.get("api_key"), creds.get("base_url")
         if not _valid_credential_pair(api_key, base_url):
+            return False
+        refreshed_identity = _oauth_account_identity(api_key)
+        if expected_identity and refreshed_identity != expected_identity:
+            logger.warning(
+                "%s refreshed token belongs to a different or unknown account; refusing to adopt it.", self.provider,
+            )
             return False
         # No NEW token minted (the resolver returns the same stale token when refresh fails) → False.
         if old_key and api_key.strip() == old_key:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -410,6 +410,39 @@ class TestPrompt:
         assert resp.stop_reason == "refusal"
 
     @pytest.mark.asyncio
+    async def test_failed_turn_surfaces_error_after_partial_stream_and_refuses(self, agent, mock_manager):
+        resp = await agent.new_session(cwd=".")
+        state = mock_manager.get_session(resp.session_id)
+        state.agent.model = "test-model"
+        state.agent.provider = "openai-codex"
+        state.agent.run_conversation.return_value = {
+            "final_response": "Authentication expired; renew this account and retry.",
+            "messages": [],
+            "failed": True,
+            "failure_reason": "auth",
+        }
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        result = await agent._finish_turn(
+            state, resp.session_id, mock_conn, state.agent.run_conversation.return_value,
+            state.agent.session_id, streamed_message=True,
+        )
+
+        assert result.stop_reason == "refusal"
+        updates = [
+            call.kwargs.get("update", call.args[1] if len(call.args) > 1 else None)
+            for call in mock_conn.session_update.await_args_list
+        ]
+        assert any(
+            isinstance(update, AgentMessageChunk)
+            and update.content.text == "Authentication expired; renew this account and retry."
+            for update in updates
+        )
+
+    @pytest.mark.asyncio
     async def test_prompt_binds_session_id_into_subprocess_env(self, agent, mock_manager):
         """The ACP prompt path must bridge the session id into child subprocesses.
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import sys
 import types
 from types import SimpleNamespace
@@ -114,6 +116,21 @@ def _codex_message_response(text: str):
         status="completed",
         model="gpt-5-codex",
     )
+
+
+def _oauth_jwt(*, subject: str, account_id: str, token_id: str = "initial") -> str:
+    def _segment(value):
+        return base64.urlsafe_b64encode(json.dumps(value).encode()).decode().rstrip("=")
+
+    return ".".join((
+        _segment({"alg": "none"}),
+        _segment({
+            "sub": subject,
+            "jti": token_id,
+            "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+        }),
+        "signature",
+    ))
 
 
 def _codex_tool_call_response():
@@ -1324,6 +1341,7 @@ def test_try_refresh_codex_client_credentials_handles_xai_oauth(monkeypatch):
     xai-oauth (both speak codex_responses) — covering both cases prevents
     silent regressions where the function gets gated to a single provider."""
     agent = _build_xai_oauth_agent(monkeypatch)
+    agent.api_key = _oauth_jwt(subject="xai-user", account_id="xai-account")
     closed = {"value": False}
     rebuilt = {"kwargs": None}
 
@@ -1334,6 +1352,8 @@ def test_try_refresh_codex_client_credentials_handles_xai_oauth(monkeypatch):
     class _RebuiltClient:
         pass
 
+    renewed = _oauth_jwt(subject="xai-user", account_id="xai-account", token_id="renewed")
+
     def _fake_openai(**kwargs):
         rebuilt["kwargs"] = kwargs
         return _RebuiltClient()
@@ -1343,7 +1363,7 @@ def test_try_refresh_codex_client_credentials_handles_xai_oauth(monkeypatch):
         # to verify that the agent's active key still matches; the actual
         # refresh later passes force_refresh=True.  Both calls must succeed.
         return {
-            "api_key": "fresh-xai-token" if force_refresh else agent.api_key,
+            "api_key": renewed if force_refresh else agent.api_key,
             "base_url": "https://api.x.ai/v1",
         }
 
@@ -1369,10 +1389,10 @@ def test_try_refresh_codex_client_credentials_handles_xai_oauth(monkeypatch):
     # vector) — it is retired (sockets shutdown, FD release via GC).
     assert closed["value"] is False
     assert retired["client"] is existing
-    assert rebuilt["kwargs"]["api_key"] == "fresh-xai-token"
+    assert rebuilt["kwargs"]["api_key"] == renewed
     assert rebuilt["kwargs"]["base_url"] == "https://api.x.ai/v1"
     assert isinstance(agent.client, _RebuiltClient)
-    assert agent.api_key == "fresh-xai-token"
+    assert agent.api_key == renewed
 
 
 def test_try_refresh_codex_client_credentials_skips_xai_oauth_when_singleton_differs(monkeypatch):
@@ -1423,6 +1443,108 @@ def test_try_refresh_codex_client_credentials_skips_xai_oauth_when_singleton_dif
         "agent that wasn't even using the singleton."
     )
     assert agent.api_key == pre_refresh_key
+
+
+@pytest.mark.parametrize("renewed_account, expected", [("account-a", True), ("account-b", False)])
+def test_codex_refresh_adopts_only_the_active_account(monkeypatch, renewed_account, expected):
+    agent = _build_agent(monkeypatch)
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_responses"
+    agent.api_key = _oauth_jwt(subject="user-a", account_id="account-a")
+    renewed = _oauth_jwt(
+        subject="user-a" if expected else "user-b",
+        account_id=renewed_account,
+        token_id="renewed",
+    )
+    refresh_calls = {"count": 0}
+
+    def _resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        if force_refresh:
+            refresh_calls["count"] += 1
+        return {"api_key": renewed, "base_url": "https://chatgpt.com/backend-api/codex"}
+
+    monkeypatch.setattr("hermes_cli.auth.resolve_codex_runtime_credentials", _resolve)
+    monkeypatch.setattr(agent, "_adopt_openai_credentials", lambda *_args, **_kwargs: True)
+
+    assert agent._try_refresh_codex_client_credentials(force=True) is expected
+    assert refresh_calls["count"] == (1 if expected else 0)
+
+
+def test_codex_refresh_rejects_account_change_during_forced_refresh(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_responses"
+    active = _oauth_jwt(subject="user-a", account_id="account-a")
+    agent.api_key = active
+    replacement = _oauth_jwt(subject="user-b", account_id="account-b", token_id="renewed")
+
+    def _resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        return {
+            "api_key": replacement if force_refresh else active,
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.resolve_codex_runtime_credentials", _resolve)
+    monkeypatch.setattr(agent, "_adopt_openai_credentials", lambda *_args, **_kwargs: pytest.fail("must reject"))
+
+    assert agent._try_refresh_codex_client_credentials(force=True) is False
+
+
+@pytest.mark.parametrize("singleton_key", ["opaque-active-token", ""])
+def test_codex_refresh_rejects_unknown_active_identity_even_when_singleton_matches(monkeypatch, singleton_key):
+    agent = _build_agent(monkeypatch)
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_responses"
+    agent.api_key = "opaque-active-token"
+    refresh_calls = {"count": 0}
+
+    def _resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        if force_refresh:
+            refresh_calls["count"] += 1
+        return {"api_key": singleton_key, "base_url": "https://chatgpt.com/backend-api/codex"}
+
+    monkeypatch.setattr("hermes_cli.auth.resolve_codex_runtime_credentials", _resolve)
+
+    assert agent._try_refresh_codex_client_credentials(force=True) is False
+    assert refresh_calls["count"] == 0
+
+
+def test_codex_401_recovery_rebuilds_once_with_same_account_token(monkeypatch):
+    from agent.turn_recovery import _refresh_credentials_after_401
+    from agent.turn_retry_state import TurnRetryState
+
+    agent = _build_agent(monkeypatch)
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_responses"
+    active = _oauth_jwt(subject="user-a", account_id="account-a")
+    renewed = _oauth_jwt(subject="user-a", account_id="account-a", token_id="renewed")
+    agent.api_key = active
+    rebuilt = {"keys": []}
+
+    class _RebuiltClient:
+        pass
+
+    def _resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        return {
+            "api_key": renewed if force_refresh else active,
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+
+    def _fake_openai(**kwargs):
+        rebuilt["keys"].append(kwargs["api_key"])
+        return _RebuiltClient()
+
+    monkeypatch.setattr("hermes_cli.auth.resolve_codex_runtime_credentials", _resolve)
+    monkeypatch.setattr("agent.process_bootstrap.OpenAI", _fake_openai)
+    monkeypatch.setattr(agent, "_retire_shared_openai_client", lambda *_args, **_kwargs: None)
+    retry = TurnRetryState()
+
+    assert _refresh_credentials_after_401(agent, RuntimeError("401 token_expired"), retry, 401) is True
+    assert rebuilt["keys"] == [renewed]
+    assert agent.api_key == renewed
+    assert retry.codex_auth_retry_attempted is True
+    assert _refresh_credentials_after_401(agent, RuntimeError("401 token_expired"), retry, 401) is False
+    assert rebuilt["keys"] == [renewed]
 
 
 


### PR DESCRIPTION
## What does this PR do?

Lets a long-lived ACP agent adopt a renewed OAuth credential only when the access-token claims identify the same account, and makes terminal ACP failures observable to clients.

A production long-lived `hermes acp` process admitted prompts normally but failed five turns across two already-running sessions with OpenAI Codex `401 token_expired`. The same process remained alive throughout. Current `main`'s singleton fallback refuses any changed token, so a legitimate same-account renewal performed by another process leaves the ACP agent stale.

This change requires a stable account claim on the active token, then compares it across the current singleton and force-refreshed access tokens. It permits same-account renewal, fails closed when active identity is unavailable (including equal or empty singleton state), rejects a different account before mutating refresh state, and rechecks the forced-refresh result before adoption. It deliberately does not change the credential pool's existing generic profile-relogin semantics.

The ACP server also returned `end_turn` for `result["failed"]`. If any content had streamed first, it suppressed the terminal error text as though the turn had completed normally. This change always emits a failed turn's final diagnostic and returns ACP `refusal`, while preserving `cancelled` precedence.

Related prior work: #70292, #70465, #77029.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/client_lifecycle.py`: permit reactive singleton refresh only for the active OAuth account and revalidate the refreshed token before adoption.
- `acp_adapter/server.py`: emit terminal failed-turn text even after a partial stream and return `refusal`, not `end_turn`.
- Add invariant tests for same-account renewal, unknown/different-account rejection before refresh, account change during refresh, the actual one-shot 401 recovery/client-rebuild path, and failed-turn delivery semantics.

## How to Test

1. Keep one ACP process/session running, renew the same account's OAuth credential through another process, and send the next prompt through the original session.
2. Verify the original agent refreshes and retries successfully; substitute a token whose stable account claim differs and verify no forced refresh or adoption occurs.
3. Force a terminal provider error after a partial stream and verify the client receives the diagnostic with stop reason `refusal`.

Automated: `scripts/run_tests.sh tests/acp/ tests/acp_adapter/ tests/run_agent/` → **2,266 passed, 0 failed, 4 skipped** on Linux/Python 3.13 using the official Hermes image runtime dependencies.

## Checklist

### Code

- [x] I've read the Contributing Guide / repository instructions
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs and described the overlap above
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire `tests/` tree
- [x] I've added tests for my changes
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Documentation update N/A — no user-facing config or command changes
- [x] `cli-config.yaml.example` N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A
- [x] Cross-platform impact considered: Python/ACP protocol logic only
- [x] Tool descriptions/schemas N/A
