### PR TITLE
fix(kanban): bind direct gateway creator session

### DIFF
--- a/tests/tools/test_kanban_provenance.py
+++ b/tests/tools/test_kanban_provenance.py
@@ -40,6 +40,136 @@ def test_worker_create_keeps_durable_origin(tmp_path, monkeypatch, linked, expli
         assert bool(conn.execute("SELECT 1 FROM task_links WHERE child_id = ?", (child.id,)).fetchone()) == linked
 
 
+@pytest.mark.parametrize("trusted", ["host-worker-runtime", None])
+def test_cross_board_worker_create_keeps_legacy_session_fallback(
+    tmp_path, monkeypatch, trusted
+):
+    from agent.delegation_context import is_dispatcher_owned_worker_context
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from hermes_cli import kanban_db as kb, kanban_db_connect as kbc
+    from tools import async_delegation
+    import model_tools
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "source")
+    monkeypatch.setenv("HERMES_SESSION_ID", "legacy-worker-runtime")
+    monkeypatch.setattr(async_delegation, "_current_origin_session_id", lambda: "")
+    with kbc.connect_closing(board="source") as conn:
+        owner = kb.create_task(conn, title="owner", session_id="durable-owner-session")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", owner)
+
+    tokens = set_session_vars(platform="discord", chat_id="thread")
+    try:
+        assert is_dispatcher_owned_worker_context()
+        result = json.loads(
+            model_tools.handle_function_call(
+                "kanban_create",
+                {"title": "cross-board", "assignee": "default", "board": "destination"},
+                session_id=trusted,
+            )
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert result["ok"], result
+    with kbc.connect_closing(board="destination") as conn:
+        assert kb.get_task(conn, owner) is None
+        child = kb.get_task(conn, result["task_id"])
+        assert child is not None
+        assert child.session_id == "legacy-worker-runtime"
+        assert not conn.execute(
+            "SELECT 1 FROM task_links WHERE child_id = ?", (child.id,)
+        ).fetchone()
+
+
+def test_direct_create_prefers_trusted_handler_session_over_polluted_state(
+    tmp_path, monkeypatch
+):
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from hermes_cli import kanban_db as kb, kanban_db_connect as kbc
+    from tools import async_delegation
+    import model_tools
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_SESSION_ID", "polluted-child-session")
+    monkeypatch.setattr(async_delegation, "_current_origin_session_id", lambda: "")
+    kb.init_db()
+    tokens = set_session_vars(
+        platform="discord",
+        chat_id="thread",
+        session_id="internal-child-context",
+    )
+    try:
+        result = json.loads(
+            model_tools.handle_function_call(
+                "kanban_create",
+                {"title": "direct", "assignee": "default"},
+                session_id="coordinator-session",
+            )
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert result["ok"], result
+    with kbc.connect_closing() as conn:
+        child = kb.get_task(conn, result["task_id"])
+        assert child is not None
+        assert child.session_id == "coordinator-session"
+
+
+@pytest.mark.parametrize(
+    "explicit,trusted,api_origin,platform,legacy,expected",
+    [
+        ("explicit", "trusted", "api", "discord", "legacy", "explicit"),
+        (None, "trusted", "api", "discord", "legacy", "trusted"),
+        (None, None, "api", "discord", "legacy", "api"),
+        (None, None, "", "telegram", "legacy", "legacy"),
+        (None, None, "", "discord", "legacy", ""),
+    ],
+)
+def test_non_worker_create_session_precedence(
+    tmp_path,
+    monkeypatch,
+    explicit,
+    trusted,
+    api_origin,
+    platform,
+    legacy,
+    expected,
+):
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from hermes_cli import kanban_db as kb, kanban_db_connect as kbc
+    from tools import async_delegation
+    import model_tools
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_SESSION_ID", legacy)
+    monkeypatch.setattr(
+        async_delegation, "_current_origin_session_id", lambda: api_origin
+    )
+    kb.init_db()
+    tokens = set_session_vars(platform=platform, chat_id="chat")
+    args = {"title": "direct", "assignee": "default"}
+    if explicit:
+        args["session_id"] = explicit
+    try:
+        result = json.loads(
+            model_tools.handle_function_call(
+                "kanban_create", args, session_id=trusted
+            )
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert result["ok"], result
+    with kbc.connect_closing() as conn:
+        child = kb.get_task(conn, result["task_id"])
+        assert child is not None
+        assert child.session_id == expected
+
+
 def test_tool_subscription_captures_conversation_anchors(tmp_path, monkeypatch):
     from hermes_cli import kanban_db as kb, kanban_db_connect as kbc, kanban_db_notify as kn
     from tools import kanban_tools as kt

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -830,8 +830,22 @@ def _handle_create(args: dict, **kw) -> str:
                     if _is_dispatcher_owned_worker() else None)
         self_task = kb.get_task(conn, self_tid) if self_tid else None
         # The worker/API runtime may be transient; the owning task's origin is durable.
-        session_id = (args.get("session_id") or (self_task.session_id if self_task else None)
-                      or _current_origin_session_id() or os.environ.get("HERMES_SESSION_ID"))
+        session_id = args.get("session_id") or (self_task.session_id if self_task else None)
+        if not session_id and not self_tid:
+            # Registry kwargs are host-supplied, unlike model-visible args. The agent/tool
+            # boundary forwards the running coordinator's session id explicitly, so prefer
+            # it over process state that in-process child construction can overwrite.
+            session_id = kw.get("session_id")
+        session_id = session_id or _current_origin_session_id()
+        if not session_id:
+            from gateway.session_context import get_session_env
+            # Keep the legacy env fallback for workers and non-Discord callers. A Discord
+            # delivery route alone is not a session identity, so an unbound direct call
+            # must not stamp a child/sibling id left in process-global state.
+            if self_tid or get_session_env(
+                "HERMES_SESSION_PLATFORM", ""
+            ).lower() != "discord":
+                session_id = os.environ.get("HERMES_SESSION_ID")
         if project_id is None and workspace_kind is None and workspace_path is None:
             if self_task is not None and self_task.project_id:
                 project_id, project_source_task_id = self_task.project_id, self_task.id


### PR DESCRIPTION
<!-- Proposed title: fix(kanban): bind direct gateway creator session -->

## What does this PR do?

`kanban_create` already receives the running agent's `session_id` as a registry-handler kwarg, but the handler ignored it. For direct gateway-created cards, an in-process child can overwrite process-level `HERMES_SESSION_ID` before creation, causing the card's persisted `tasks.session_id` to identify the child rather than the active coordinator.

This patch gives non-worker creation the following precedence:

`explicit argument -> trusted handler kwarg -> API origin -> non-Discord legacy environment`

Discord creation without a trusted session binding now leaves the persisted session identity empty instead of consuming a potentially polluted process-global fallback. Dispatcher-owned worker creation remains unchanged, including when a worker creates on a different board where its owning row is absent: worker classification follows the already-resolved trusted task identity, the owning card's durable session is preferred when available, and existing fallback behavior is preserved otherwise. `creator_task_id` still performs same-board transactional session and subscription inheritance without adding a dependency edge.

This is a persisted-identity correction. It does not claim that current upstream notification delivery always fails: upstream can reconstruct a push route from subscription coordinates even when `tasks.session_id` is wrong.

## Related Issue

No direct issue is filed for this narrow path.

Related work is distinct:

- #105356 merged dispatcher-worker session and subscription inheritance through `self_task` / `creator_task_id`; this patch preserves that path.
- #85687 addressed dispatcher-worker inheritance and was closed after #105356 merged; it did not consume the direct registry-handler session kwarg.
- #65409 is a broader open ContextVar-precedence change. Its `kanban_create` hunk reads `HERMES_SESSION_ID` through session context but does not define the trusted handler-kwarg precedence used here, so it can still observe a child-mutated tool context.
- #101460, #58914, and #58978 bind `SessionContext.session_id` at the gateway turn boundary for subprocess propagation. They do not change `kanban_create`'s direct handler-kwarg resolution.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/kanban_tools.py`: consume the host-supplied `session_id` kwarg only for non-worker direct creation, preserve explicit/API/legacy precedence, fail closed for unbound Discord process-env fallback, and classify workers by trusted dispatcher identity rather than destination-board row presence.
- `tests/tools/test_kanban_provenance.py`: add real registry/SQLite regressions for polluted direct creation, unbound Discord, the full non-worker precedence matrix, cross-board workers with and without a host kwarg, and existing same-board worker provenance coverage.

## How to Test

1. Reproduce the direct non-worker failures on base `2237be355906fbe6065ce1815711eee52b2d646e` using base production source plus an explicit test-only overlay from the candidate checkout:

   ```sh
   BASE=2237be355906fbe6065ce1815711eee52b2d646e
   OVERLAY="$(mktemp -d)"
   git clone --no-hardlinks . "$OVERLAY/repo"
   git -C "$OVERLAY/repo" checkout --detach "$BASE"
   git show HEAD:tests/tools/test_kanban_provenance.py > "$OVERLAY/repo/tests/tools/test_kanban_provenance.py"
   git -C "$OVERLAY/repo" diff --name-only
   (cd "$OVERLAY/repo" && scripts/run_tests.sh -j 1 tests/tools/test_kanban_provenance.py -k 'direct_create_prefers_trusted_handler_session_over_polluted_state or non_worker_create_session_precedence' -q --tb=short)
   ```

   The diff-name check must print only `tests/tools/test_kanban_provenance.py`, proving production source remains at the exact base. Expected result: exit 1 with 3 failed and 3 passed. The failures persist `polluted-child-session` instead of `coordinator-session`, choose API origin over the trusted kwarg, and reuse the polluted env value for unbound Discord. These candidate regression tests do not exist in the clean base without the documented overlay.

2. Run the focused candidate suites:

   ```sh
   scripts/run_tests.sh -j 1 tests/tools/test_kanban_provenance.py tests/hermes_cli/test_kanban_creator_origin.py tests/tools/test_kanban_tools.py tests/gateway/test_session_env.py tests/run_agent/test_tool_executor_contextvar_propagation.py tests/tools/test_local_env_session_leak.py -q --tb=short
   ```

   Expected result: 67 passed, 0 failed. This includes cross-board worker cases with `session_id="host-worker-runtime"` and with no host kwarg; both persist the legacy worker fallback, and neither adds a dependency edge.

3. Run API ingress session-header controls:

   ```sh
   scripts/run_tests.sh -j 1 tests/gateway/test_api_server.py -k TestSessionIdHeader -q --tb=short
   ```

   Expected result: 2 passed, 0 failed.

4. Run `ruff check tools/kanban_tools.py tests/tools/test_kanban_provenance.py` and `git diff --check "$BASE"...HEAD`.

   Expected result: both pass.

A controlled real-registry/SQLite probe imported every application module from the exact candidate checkout with a disposable `HERMES_HOME` and no live-checkout application modules. Base persisted `polluted-child-session` for both polluted and unbound Discord creation. Candidate persisted `coordinator-session` for the trusted direct call and an empty session for unbound Discord. Explicit, API-origin, and non-Discord legacy cases remained compatible. Same-board dispatcher-worker creation retained `durable-parent-session`, one inherited subscription, and no dependency edge. A two-board probe confirmed that a trusted dispatcher worker whose owning row is absent from the destination ignores the host kwarg and preserves `legacy-worker-runtime` with and without that kwarg.

The probe is controlled and local. It does not send a real Discord message, exercise a provider turn, or prove every notification/wake stage.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, focused single-process suites only

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public configuration or command surface changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-independent Python resolution logic; only Linux was executed locally
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model-visible schema changed

## Screenshots / Logs

Not applicable. Exact local command logs, base/candidate probe JSON, per-process import-origin receipts, and rehydration artifacts are retained with the local preparation task. No live gateway, deployment, service restart, GitHub mutation, or notification delivery was performed.
