### PR TITLE
fix(desktop): keep new chats with focused owner

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -13,6 +13,7 @@ import { requestGatewayForAgent } from '@/store/gateway'
 import { $goalsBySession, setSessionGoal } from '@/store/goals'
 import { $hudMode } from '@/store/hud'
 import { $notifications, clearNotifications } from '@/store/notifications'
+import { $newChatConnectionId, $newChatProfile, $newChatRoute } from '@/store/profile'
 import {
   $busy,
   $connection,
@@ -120,6 +121,7 @@ function Harness({
   refreshSessions,
   requestGateway,
   resumeStoredSession,
+  startFreshSessionDraft,
   runtimeIdByStoredSessionIdRef: runtimeIdByStoredSessionIdRefProp,
   seedMessages,
   seedStreamId,
@@ -145,6 +147,7 @@ function Harness({
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
+  startFreshSessionDraft?: () => void
   runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
   seedMessages?: unknown[]
   seedStreamId?: null | string
@@ -202,7 +205,7 @@ function Harness({
     resumeStoredSession: resumeStoredSession ?? (() => undefined),
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionIdRef,
-    startFreshSessionDraft: () => undefined,
+    startFreshSessionDraft: startFreshSessionDraft ?? (() => undefined),
     sttEnabled: false,
     updateSessionState: (sessionId, updater, storedSessionId) => {
       // Seed with interrupted:true so we can prove a fresh submit clears it.
@@ -248,6 +251,57 @@ function Harness({
 
   return null
 }
+
+describe('usePromptActions /new owner routing', () => {
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    $newChatProfile.set(null)
+    $newChatRoute.set(null)
+    $newChatConnectionId.set(null)
+    vi.restoreAllMocks()
+  })
+
+  it('pins the fresh draft to the focused session owner instead of stale profile intent', async () => {
+    const focusedStoredSessionId = 'specter-chat'
+
+    const focusedRoute = {
+      connectionId: 'local:specter',
+      profile: 'default'
+    }
+
+    setSessions(() => [
+      sessionInfo({
+        connection_id: focusedRoute.connectionId,
+        id: focusedStoredSessionId,
+        profile: focusedRoute.profile
+      })
+    ])
+
+    $newChatProfile.set('siren')
+    $newChatRoute.set({ connectionId: 'local:siren', profile: 'siren' })
+    $newChatConnectionId.set('local:siren')
+
+    const startFreshSessionDraft = vi.fn()
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={value => (handle = value)}
+        refreshSessions={async () => undefined}
+        requestGateway={vi.fn(async () => ({} as never))}
+        selectedStoredSessionIdRef={{ current: focusedStoredSessionId }}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    await handle!.submitText('/new')
+
+    expect(startFreshSessionDraft).toHaveBeenCalledTimes(1)
+    expect($newChatProfile.get()).toBe('default')
+    expect($newChatRoute.get()).toEqual(focusedRoute)
+    expect($newChatConnectionId.get()).toBe(focusedRoute.connectionId)
+  })
+})
 
 describe('usePromptActions /title', () => {
   beforeEach(() => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -27,12 +27,14 @@ import {
   $newChatProfile,
   captureNewChatSource,
   ensureGatewayProfile,
-  normalizeProfileKey
+  normalizeProfileKey,
+  pinNewChatOwner
 } from '@/store/profile'
 import {
   $connection,
   $sessions,
   $yoloActive,
+  knownSessionOwner,
   setActiveSessionId,
   setCurrentUsage,
   setModelPickerOpen,
@@ -494,6 +496,12 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       // new branch in a dispatch ladder.
       const actionHandlers: Record<DesktopActionId, (ctx: SlashActionCtx) => Promise<void>> = {
         new: async () => {
+          const focusedStoredSessionId = selectedStoredSessionIdRef.current
+
+          if (focusedStoredSessionId) {
+            pinNewChatOwner(knownSessionOwner($sessions.get(), focusedStoredSessionId))
+          }
+
           startFreshSessionDraft()
         },
         branch: async () => {

--- a/apps/desktop/src/plugins/hermes-bots/canonical-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-chat.ts
@@ -78,6 +78,35 @@ export function isCanonicalChatOnScreen(
   return [canonical.id, canonical.resolved_id].filter(Boolean).map(String).includes(String(storedSessionId))
 }
 
+/** Return the bot whose canonical forever-chat is focused, independent of
+ * roster selection. The focused stored session is authoritative: selection
+ * can lag after restoring a window or switching profiles. */
+export function canonicalChatOnScreen(
+  roster: null | RosterRow[] | undefined,
+  storedSessionId: null | string | undefined,
+  owner?: null | { connectionId: string; profile: string }
+): RosterRow | null {
+  const ownerMatches = (bot: RosterRow) => {
+    if (!owner) {
+      return true
+    }
+
+    const sameProfile = (bot.name || 'default').trim() === (owner.profile || 'default').trim()
+
+    if (!sameProfile) {
+      return false
+    }
+
+    return bot.sourceScoped || bot.remoteSource
+      ? String(bot.connectionId || '').trim() === String(owner.connectionId || '').trim()
+      : true
+  }
+
+  return (
+    roster?.find(bot => ownerMatches(bot) && isCanonicalChatOnScreen(bot, storedSessionId)) ?? null
+  )
+}
+
 async function openStoredBotChat(
   owner: RosterRow | string,
   storedId: string,

--- a/apps/desktop/src/plugins/hermes-bots/new-compact-guard.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/new-compact-guard.test.ts
@@ -42,7 +42,7 @@ vi.mock('./data', () => ({
 }))
 vi.mock('./shared', () => ({ getPluginCtx: () => null }))
 
-const { isCanonicalChatOnScreen } = await import('./canonical-chat')
+const { canonicalChatOnScreen, isCanonicalChatOnScreen } = await import('./canonical-chat')
 
 function bot(canonical: null | { id?: string; resolved_id?: string }): RosterRow {
   return { canonical_session: canonical, name: 'ops' } as RosterRow
@@ -78,5 +78,18 @@ describe('isCanonicalChatOnScreen', () => {
     expect(isCanonicalChatOnScreen(bot({ id: 'forever-chat' }), null)).toBe(false)
     expect(isCanonicalChatOnScreen(bot({ id: 'forever-chat' }), '')).toBe(false)
     expect(isCanonicalChatOnScreen(undefined, 'forever-chat')).toBe(false)
+  })
+})
+
+describe('canonicalChatOnScreen', () => {
+  it('finds the focused canonical chat without trusting a stale selected bot', () => {
+    const specter = { canonical_session: { id: 'specter-chat' }, name: 'default' } as RosterRow
+    const siren = { canonical_session: { id: 'siren-chat' }, name: 'siren' } as RosterRow
+
+    // The roster selection may still say Siren while Specter's canonical chat
+    // is visibly focused. The focused chat is authoritative for /new.
+    expect(
+      canonicalChatOnScreen([specter, siren], 'specter-chat', { connectionId: 'local', profile: 'default' })
+    ).toBe(specter)
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
@@ -60,7 +60,7 @@ const ROSTER = {
 }
 
 const { cache, hostMock, live } = vi.hoisted(() => {
-  const live = { focused: 'default', profile: 'default', stored: null as string | null }
+  const live = { connection: 'local', focused: 'default', profile: 'default', stored: null as string | null }
 
   return {
     cache: new Map<string, { key: unknown[]; value: unknown }>(),
@@ -70,6 +70,10 @@ const { cache, hostMock, live } = vi.hoisted(() => {
       requestProfile: vi.fn(async () => ({})),
       state: {
         connectionId: { get: () => 'local', listen: () => () => undefined },
+        focusedSessionOwner: {
+          get: () => ({ connectionId: live.connection, profile: live.focused }),
+          listen: () => () => undefined
+        },
         focusedSessionProfile: { get: () => live.focused, listen: () => () => undefined },
         focusedStoredSessionId: { get: () => live.stored, listen: () => () => undefined },
         gateway: { get: () => null, listen: () => () => undefined },
@@ -183,7 +187,7 @@ describe('Bot Chat reset guard', () => {
     { connectionId: 'local', sourceScoped: true },
     { connectionId: 'remote', remoteSource: true, sourceScoped: true },
     {}
-  ])('compacts only the selected bot canonical chat: %j', async source => {
+  ])('compacts only the focused bot canonical chat: %j', async source => {
     const { handler } = await contributions()
     const { $lastRoster } = await import('./data')
     const { saveSelectedRosterBot } = await import('./bot-state')
@@ -200,6 +204,8 @@ describe('Bot Chat reset guard', () => {
       selected
     ])
     saveSelectedRosterBot(selected)
+    live.focused = 'writer'
+    live.connection = source.connectionId || 'local'
 
     for (const stored of ['bot-root', 'bot-tip']) {
       live.stored = stored
@@ -222,6 +228,35 @@ describe('Bot Chat reset guard', () => {
         expect(hostMock.notify).not.toHaveBeenCalled()
       }
     }
+  })
+
+  it('keeps Specter focused when the selected roster bot is stale Siren', async () => {
+    const { handler } = await contributions()
+    const { $lastRoster } = await import('./data')
+    const { saveSelectedRosterBot } = await import('./bot-state')
+
+    const specter = {
+      connectionId: 'local',
+      name: 'default',
+      sourceScoped: true,
+      canonical_session: { id: 'specter-chat' }
+    } as RosterRow
+
+    const siren = {
+      connectionId: 'local',
+      name: 'siren',
+      sourceScoped: true,
+      canonical_session: { id: 'siren-chat' }
+    } as RosterRow
+
+    $lastRoster.set([specter, siren])
+    saveSelectedRosterBot(siren)
+    live.connection = 'local'
+    live.focused = 'default'
+    live.stored = 'specter-chat'
+
+    expect(await handler({ text: '/new' })).toEqual({ text: '/compact' })
+    expect(hostMock.notify).toHaveBeenCalledWith(expect.objectContaining({ title: 'This chat never resets' }))
   })
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -24,12 +24,11 @@ import {
   $botsPaneVisible,
   $focusedBotOwner,
   $openBotChat,
-  $selectedBot,
   $selectedRosterHydrated,
   $selectedRosterKey,
   focusedMentionProfile
 } from './bot-state'
-import { isCanonicalChatOnScreen, openBotCanonicalChat } from './canonical-chat'
+import { canonicalChatOnScreen, openBotCanonicalChat } from './canonical-chat'
 import { BotChatEmpty } from './chat-empty'
 import { bindProfileSync, RoutinesPane } from './cron'
 import {
@@ -37,7 +36,6 @@ import {
   $lastRoster,
   botHandle,
   botMentionTag,
-  botSelectionKey,
   cachedUnionRoster,
   isActiveRosterBot,
   migrateBotMeta,
@@ -660,20 +658,25 @@ export default {
           const slashNew = /^\/(new|reset)\s*$/.exec(text.trim())
 
           if (slashNew) {
-            const activeBot = $selectedBot.get()
             // Canonical identity is the profile's "Bot Chat" registry row —
-            // read it from the roster cache (canonical_session, resolved
-            // server-side by name), matching either the durable row id or
-            // the compression-lineage tip currently on screen.
+            // read it from the full roster cache (canonical_session, resolved
+            // server-side by name), matching either the durable row id or the
+            // compression-lineage tip currently on screen. The focused chat,
+            // not a potentially stale roster selection, is authoritative.
             const roster = $lastRoster.get()
-            const row = Array.isArray(roster) ? roster.find(bot => botSelectionKey(bot) === activeBot) : null
+
+            const row = canonicalChatOnScreen(
+              Array.isArray(roster) ? roster : null,
+              host.state.focusedStoredSessionId.get(),
+              host.state.focusedSessionOwner.get()
+            )
 
             // The STORED id, which is the id space canonical_session is keyed
             // in. `host.state.activeSessionId` is the runtime id and could
             // never match, so the guard read `host.activeSessionId` — no such
             // property — and silently resolved to null on every turn: /new
             // reset the forever-chat instead of compacting it.
-            if (activeBot && isCanonicalChatOnScreen(row, host.state.focusedStoredSessionId.get())) {
+            if (row) {
               host.notify({
                 kind: 'info',
                 title: 'This chat never resets',

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -28,7 +28,7 @@ import { notifyError } from '@/store/notifications'
 import { $poolLimits } from '@/store/pool-limits'
 import { notifyRemoteOverrideAuthFailure } from '@/store/profile-remote-override'
 import { clearComposerSelectionOwner, setComposerSelectionOwner, setConnection } from '@/store/session'
-import type { SessionOwnerRoute } from '@/store/session-request-router'
+import { isSessionOwnerRoute, type SessionOwnerRoute, type SessionOwnerScope } from '@/store/session-request-router'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
 
@@ -885,6 +885,35 @@ export function pinNewChatProfile(name: string): string {
   return target
 }
 
+function pinNewChatAgentRoute(route: AgentProfileRoute): AgentProfileRoute {
+  const captured = {
+    ...route,
+    connectionId: route.connectionId.trim(),
+    profile: normalizeProfileKey(route.profile),
+    ...(route.targetProfile ? { targetProfile: normalizeProfileKey(route.targetProfile) } : {})
+  }
+
+  if (!captured.connectionId) {
+    throw new Error('Agent profile route is missing connectionId')
+  }
+
+  $newChatProfile.set(captured.profile)
+  $newChatRoute.set(captured)
+  $newChatConnectionId.set(captured.connectionId)
+
+  return captured
+}
+
+/** Carry a focused session's owner into a fresh draft before the focused
+ * session is cleared. A stale profile-picker intent must not own `/new`. */
+export function pinNewChatOwner(owner: SessionOwnerScope): void {
+  if (isSessionOwnerRoute(owner)) {
+    pinNewChatAgentRoute(owner)
+  } else if (typeof owner === 'string' && owner.trim()) {
+    pinNewChatProfile(owner)
+  }
+}
+
 // Start a fresh session in `name` WITHOUT collapsing the "All profiles" browse
 // view. Unlike selectProfile, it leaves $showAllProfiles untouched, so the
 // unified sidebar stays put — used by the per-profile "+" in the all-profiles
@@ -906,20 +935,7 @@ export function newSessionInProfile(name: string): void {
  * only a presentation step; the route stays attached to the draft for the
  * eventual session.create request. */
 export function newSessionInAgent(route: AgentProfileRoute): void {
-  const captured = {
-    ...route,
-    connectionId: route.connectionId.trim(),
-    profile: normalizeProfileKey(route.profile),
-    ...(route.targetProfile ? { targetProfile: normalizeProfileKey(route.targetProfile) } : {})
-  }
-
-  if (!captured.connectionId) {
-    throw new Error('Agent profile route is missing connectionId')
-  }
-
-  $newChatProfile.set(captured.profile)
-  $newChatRoute.set(captured)
-  $newChatConnectionId.set(captured.connectionId)
+  const captured = pinNewChatAgentRoute(route)
   requestFreshSession()
   // #81094: surface the failed dial instead of failing silently.
   void ensureGatewayAgent(captured.connectionId, captured.profile).catch((error: unknown) => {


### PR DESCRIPTION
## Summary
- Resolve canonical Bot Chat identity from the focused stored conversation and its profile/backend owner, rather than stale selected-roster state.
- Preserve canonical compression lineage when handling `/new`.
- Pin generic `/new` drafts to the focused stored session owner rather than stale new-chat profile intent.
- Add regression coverage for a focused conversation whose owner differs from the selected bot/pending profile.

## Problem
When the focused conversation and persisted selected-bot state disagree, canonical `/new` interception can miss the focused Bot Chat. Generic fresh-chat routing can then use a different pending owner. This fixes the ownership authority rather than hardcoding a profile or resetting user state.

## Validation
- Local focused prompt-actions and Bot Mode test run passed before commit.
- Desktop TypeScript checks passed; focused ESLint had no errors (one warning).
- Renderer production build passed during implementation.
- Windows installer packaging and installed-app end-to-end verification were not completed on the Linux build host.

## Scope
Seven desktop routing/test files only. No profile deletion, gateway configuration changes, or forced default-profile routing.
