### PR TITLE
fix(desktop): retry startup locale config read after update relaunch

### DIFF
--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesConfigRecord } from '@/hermes'
@@ -28,6 +28,7 @@ describe('I18nProvider', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    vi.useRealTimers()
   })
 
   it('defaults to English without a config client', () => {
@@ -76,7 +77,9 @@ describe('I18nProvider', () => {
     expect(configClient.saveConfig).not.toHaveBeenCalled()
   })
 
-  it('keeps English usable when config loading fails', async () => {
+  it('keeps English usable when config loading permanently fails', async () => {
+    vi.useFakeTimers()
+
     const configClient: I18nConfigClient = {
       getConfig: vi.fn().mockRejectedValue(new Error('config unavailable')),
       saveConfig: vi.fn()
@@ -88,11 +91,95 @@ describe('I18nProvider', () => {
       </I18nProvider>
     )
 
-    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+    // Exhaust the bounded retry backoff (~6.2s of retries).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(7000)
+    })
 
     expect(screen.getByTestId('locale').textContent).toBe('en')
     expect(screen.getByTestId('label').textContent).toBe('Language')
     expect(configClient.saveConfig).not.toHaveBeenCalled()
+  })
+
+  it('retries the startup config read after a transient failure', async () => {
+    vi.useFakeTimers()
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi
+        .fn()
+        // The backend stack from a `hermes update` relaunch is still settling:
+        // the first reads reject, then the persisted language becomes reachable.
+        .mockRejectedValueOnce(new Error('backend still settling'))
+        .mockRejectedValueOnce(new Error('backend still settling'))
+        .mockResolvedValueOnce({ display: { language: 'zh-Hans' } }),
+      saveConfig: vi.fn()
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    // Attempt 0 rejects immediately; attempt 1 after 200ms; attempt 2 after
+    // another 400ms and succeeds.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(700)
+    })
+
+    expect(screen.getByTestId('locale').textContent).toBe('zh')
+    expect(screen.getByTestId('label').textContent).toBe('语言')
+    expect(screen.getByTestId('loading').textContent).toBe('false')
+    expect(configClient.saveConfig).not.toHaveBeenCalled()
+  })
+
+  it('does not let a late config read clobber a language picked mid-retry', async () => {
+    vi.useFakeTimers()
+
+    let calls = 0
+    const getConfig = vi.fn(async () => {
+      calls += 1
+      // Startup effect attempts 1 and 2 fail while the backend settles; the
+      // read triggered by the user's explicit save succeeds, and the effect's
+      // later retries resolve with the (older) persisted English record.
+      if (calls <= 2) {
+        throw new Error('backend still settling')
+      }
+      return { display: { language: 'en', skin: 'mono' } }
+    })
+
+    const configClient: I18nConfigClient = {
+      getConfig,
+      saveConfig: vi.fn().mockResolvedValue({ ok: true })
+    }
+
+    render(
+      <I18nProvider configClient={configClient} initialLocale="zh">
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    // Let the first two startup attempts reject (200ms apart), then pick a
+    // language while the next retry is still waiting out its backoff.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'switch' }))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(screen.getByTestId('locale').textContent).toBe('zh')
+
+    // The effect's late retry resolves with `en` from the old record — it must
+    // not override the explicit choice.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    expect(screen.getByTestId('locale').textContent).toBe('zh')
+    expect(screen.getByTestId('label').textContent).toBe('语言')
+    expect(screen.getByTestId('loading').textContent).toBe('false')
+    expect(configClient.saveConfig).toHaveBeenCalledTimes(1)
   })
 
   it('loads zh-hant from display.language config', async () => {

--- a/apps/desktop/src/i18n/context.tsx
+++ b/apps/desktop/src/i18n/context.tsx
@@ -57,6 +57,12 @@ function toError(error: unknown): Error {
 
 const RTL_LOCALES = new Set<Locale>(['ar'])
 
+// Startup config read: the renderer mounts while the backend stack from a
+// `hermes update` relaunch is still settling, so the one-shot GET can reject
+// in the first moments even though the persisted `display.language` is intact.
+// Retry with bounded backoff instead of pinning the session to English.
+const CONFIG_READ_RETRY_DELAYS_MS = [200, 400, 800, 1600, 3200]
+
 function applyDocumentLocale(locale: Locale) {
   if (typeof document === 'undefined') {
     return
@@ -100,6 +106,10 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
   const [saveError, setSaveError] = useState<Error | null>(null)
   const localeRef = useRef(locale)
 
+  // Set when the user picks a language through setLocale. A late config read
+  // (retry resolution) must never overwrite an explicit in-session choice.
+  const userLocaleRef = useRef(false)
+
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
     localeRef.current = locale
@@ -113,37 +123,63 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
     }
 
     let cancelled = false
+    let retryTimer: ReturnType<typeof setTimeout> | undefined
 
     setIsLoadingConfig(true)
     setConfigLoadError(null)
 
-    configClient
-      .getConfig()
-      .then(config => {
-        if (!cancelled) {
+    const readConfig = async (attempt: number) => {
+      try {
+        const config = await configClient.getConfig()
+        if (!cancelled && !userLocaleRef.current) {
           setLocaleState(normalizeLocale(getConfigDisplayLanguage(config)))
         }
-      })
-      .catch(error => {
-        if (!cancelled) {
-          setConfigLoadError(toError(error))
-          setLocaleState(DEFAULT_LOCALE)
+      } catch (error) {
+        if (cancelled) {
+          return
         }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsLoadingConfig(false)
+
+        const delay = CONFIG_READ_RETRY_DELAYS_MS[attempt]
+        if (delay === undefined) {
+          // Exhausted every retry: the config is genuinely unreachable. Keep
+          // English usable as the deterministic fallback — unless the user has
+          // already picked a language this session, which outranks a stale read.
+          if (!userLocaleRef.current) {
+            setConfigLoadError(toError(error))
+            setLocaleState(DEFAULT_LOCALE)
+          }
+          return
         }
-      })
+
+        await new Promise<void>(resolve => {
+          retryTimer = setTimeout(resolve, delay)
+        })
+        if (!cancelled) {
+          await readConfig(attempt + 1)
+        }
+      }
+    }
+
+    void readConfig(0).finally(() => {
+      if (!cancelled) {
+        setIsLoadingConfig(false)
+      }
+    })
 
     return () => {
       cancelled = true
+      if (retryTimer !== undefined) {
+        clearTimeout(retryTimer)
+      }
     }
   }, [configClient, initialLocale])
 
   const setLocale = useCallback(
     async (next: Locale) => {
       const previousLocale = localeRef.current
+
+      // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
+      userLocaleRef.current = true
 
       setSaveError(null)
       setLocaleState(next)


### PR DESCRIPTION
## Summary

The desktop renderer issues a **one-shot** config GET when `I18nProvider` mounts. Right after a `hermes update` relaunch, the backend stack is still settling, so that single read can reject even though the persisted `display.language` is intact — and the provider then pinned the session to English (`DEFAULT_LOCALE`) with no recovery path.

## Changes

- **`apps/desktop/src/i18n/context.tsx`**
  - Retry the startup config read with a bounded backoff (`[200, 400, 800, 1600, 3200]` ms) instead of falling back on the first transient rejection. The deterministic English fallback still applies after every retry is exhausted (genuinely unreachable config).
  - A late retry resolution can never clobber a language the user explicitly picked mid-retry (`userLocaleRef`).
  - The retry timer is cleared on unmount; no setState after cancellation.

- **`apps/desktop/src/i18n/context.test.tsx`**
  - Converted the permanent-failure test to fake timers (it now exercises the full retry window).
  - New: transient failure on the first two reads, success on the third → the persisted language (zh-Hans) is applied.
  - New: user picks a language while a retry is in backoff → the late stale read (en) does not override it.

## Tests

- `vitest run src/i18n/context.test.tsx` → 13/13 pass
- `tsc -p apps/desktop --noEmit` → clean

Closes #105465
