### PR TITLE
feat(kanban): add lease-scoped worker lifecycle primitives

### DIFF
--- a/agent/crew_route_contract.py
+++ b/agent/crew_route_contract.py
@@ -1,0 +1,254 @@
+"""Pure, inert crew-route and work-provenance contracts.
+
+The policy in this module is checked against local catalogs only.  Resolving a
+route never reads credentials, mutates storage, activates a worker, or contacts
+a provider.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any, Iterable, Mapping
+
+from agent.reasoning_effort import (
+    EFFORT_LADDER,
+    OPENAI_COMPAT_WIRE_EFFORTS,
+    codex_supported_efforts,
+)
+from hermes_cli.codex_models import DEFAULT_CODEX_MODELS
+
+ROUTE_POLICY_VERSION = "sunny-route-policy-v0"
+TRUSTED_WORK_PROVENANCE = frozenset({"firstmate:approved-plan"})
+
+
+class RouteContractError(ValueError):
+    """An inert route or provenance contract is incomplete or unsupported."""
+
+
+@dataclass(frozen=True)
+class Route:
+    provider: str
+    model_id: str
+    requested_effort: str
+    applied_effort: str
+    harness: str | None = None
+    display_label: str | None = None
+
+    @property
+    def effort(self) -> str:
+        return self.applied_effort
+
+    def as_tuple(self) -> tuple[str, str, str]:
+        return (self.provider, self.model_id, self.applied_effort)
+
+
+# Policy data, not an assertion about credentials, entitlement, or live reachability.
+_LOCAL_MODELS: dict[str, frozenset[str]] = {
+    "openai-codex": frozenset(DEFAULT_CODEX_MODELS),
+    "anthropic": frozenset({"claude-opus-5"}),
+    "openrouter": frozenset(
+        {
+            "openai/gpt-5.6-sol",
+            "google/gemini-3.8-flash",
+            "meta/muse-spark-1.3",
+            "deepseek/deepseek-v4-flash-0731",
+            "z-ai/glm-5.3-flash",
+            "qwen/qwen3.8-flash",
+            "x-ai/grok-4.6",
+        }
+    ),
+}
+
+_DISPLAY_LABELS = frozenset(
+    label.casefold()
+    for label in {
+        "Hermes",
+        "Zoro",
+        "Validated-plan worker",
+        "Worker/scout",
+        "Codex-unavailable fallback",
+        "No-mistakes",
+        "fm-verify",
+        "Sanji",
+        "Jinbei",
+        "Franky",
+        "Usopp",
+        "Robin",
+        "Brook",
+    }
+)
+
+
+def _required_text(value: Mapping[str, Any], name: str) -> str:
+    item = value.get(name)
+    if not isinstance(item, str) or not item.strip():
+        raise RouteContractError(f"missing route field: {name}")
+    return item.strip()
+
+
+def resolve_route(value: Mapping[str, Any]) -> Route:
+    """Resolve one exact route solely against the checked-in policy catalog.
+
+    An unsupported effort is rejected rather than clamped: a lease capability
+    is an identity assertion, so silently substituting a nearby wire level
+    would make two different declarations compare equal.
+    """
+    if not isinstance(value, Mapping):
+        raise RouteContractError("route must be a mapping")
+    aliases = ("model", "provider_ref", "model_ref", "effort_ref",
+               "requested_effort", "applied_effort")
+    ambiguous = [name for name in aliases if name in value]
+    if ambiguous:
+        raise RouteContractError(
+            f"ambiguous route identity fields: {', '.join(ambiguous)}"
+        )
+    provider = _required_text(value, "provider").lower()
+    model_id = _required_text(value, "model_id")
+    requested = _required_text(value, "effort").lower()
+    display_raw = value.get("display_label")
+    harness_raw = value.get("harness")
+    if display_raw is not None and not isinstance(display_raw, str):
+        raise RouteContractError("display_label must be text")
+    if harness_raw is not None and not isinstance(harness_raw, str):
+        raise RouteContractError("harness must be text")
+    display_label = (display_raw or "").strip() or None
+    harness = (harness_raw or "").strip() or None
+
+    if provider not in _LOCAL_MODELS:
+        raise RouteContractError(f"unknown provider: {provider}")
+    if requested not in EFFORT_LADDER:
+        raise RouteContractError(f"malformed effort: {requested}")
+    if model_id.casefold() in _DISPLAY_LABELS or (
+        display_label and model_id.casefold() == display_label.casefold()
+    ):
+        raise RouteContractError("display labels are not model identifiers")
+    if model_id not in _LOCAL_MODELS[provider]:
+        raise RouteContractError(f"model is not in local {provider} catalog: {model_id}")
+
+    supported = (
+        codex_supported_efforts(model_id)
+        if provider == "openai-codex"
+        else OPENAI_COMPAT_WIRE_EFFORTS
+    )
+    if requested not in supported:
+        raise RouteContractError(
+            f"effort is not supported by {provider}/{model_id}: {requested}"
+        )
+    return Route(provider, model_id, requested, requested, harness, display_label)
+
+
+def _route(
+    provider: str,
+    model_id: str,
+    effort: str,
+    display_label: str,
+    *,
+    harness: str | None = None,
+) -> Route:
+    return resolve_route(
+        {
+            "provider": provider,
+            "model_id": model_id,
+            "effort": effort,
+            "harness": harness,
+            "display_label": display_label,
+        }
+    )
+
+
+def sunny_routes() -> dict[str, Route]:
+    """Captain-approved, inert operational policy fixtures."""
+    return {
+        "hermes": _route("openai-codex", "gpt-5.6-luna", "xhigh", "Hermes", harness="codex"),
+        "zoro": _route("openai-codex", "gpt-5.6-luna", "xhigh", "Zoro", harness="codex"),
+        "validated-plan-worker": _route(
+            "openai-codex", "gpt-5.6-sol", "low", "Validated-plan worker", harness="codex"
+        ),
+        "worker-scout": _route(
+            "openai-codex", "gpt-5.6-luna", "xhigh", "Worker/scout", harness="codex"
+        ),
+        "codex-unavailable": _route(
+            "anthropic", "claude-opus-5", "xhigh", "Codex-unavailable fallback"
+        ),
+        "no-mistakes": _route("anthropic", "claude-opus-5", "xhigh", "No-mistakes"),
+        "fm-verify": _route("openrouter", "openai/gpt-5.6-sol", "high", "fm-verify"),
+    }
+
+
+def parliament_routes() -> dict[str, Route]:
+    """Parliament fixtures pinned to the OpenRouter/Nous route."""
+    models = {
+        "sanji": "google/gemini-3.8-flash",
+        "jinbei": "meta/muse-spark-1.3",
+        "franky": "deepseek/deepseek-v4-flash-0731",
+        "usopp": "z-ai/glm-5.3-flash",
+        "robin": "qwen/qwen3.8-flash",
+        "brook": "x-ai/grok-4.6",
+    }
+    return {
+        name: _route("openrouter", model, "xhigh", name.title())
+        for name, model in models.items()
+    }
+
+
+@dataclass(frozen=True)
+class WorkIdentity:
+    bucket_key: str
+    pool_member: str
+    business: str
+    account: str
+    board: str
+    project: str
+    worktree: str
+    idempotency_key: str
+    parent_link: str
+    route_policy_version: str
+    provenance: str
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "WorkIdentity":
+        if not isinstance(value, Mapping):
+            raise RouteContractError("work identity must be a mapping")
+        names = tuple(field.name for field in fields(cls))
+        missing = [
+            name
+            for name in names
+            if not isinstance(value.get(name), str) or not value[name].strip()
+        ]
+        if missing:
+            raise RouteContractError(f"missing work identity fields: {', '.join(missing)}")
+        normalized = {name: value[name].strip() for name in names}
+        if normalized["route_policy_version"] != ROUTE_POLICY_VERSION:
+            raise RouteContractError("unknown route-policy version")
+        if normalized["provenance"] not in TRUSTED_WORK_PROVENANCE:
+            raise RouteContractError("untrusted work provenance")
+        return cls(**normalized)
+
+
+def validate_work_batch(
+    values: Iterable[WorkIdentity], *, allowed_parent_links: set[str] | frozenset[str]
+) -> tuple[WorkIdentity, ...]:
+    """Validate a batch without consulting or mutating a database."""
+    items = tuple(values)
+    seen: set[str] = set()
+    scope: tuple[str, str, str, str, str] | None = None
+    for item in items:
+        if not isinstance(item, WorkIdentity):
+            raise RouteContractError("work batch entries must be WorkIdentity values")
+        if item.idempotency_key in seen:
+            raise RouteContractError(f"duplicate idempotency key: {item.idempotency_key}")
+        seen.add(item.idempotency_key)
+        item_scope = (
+            item.bucket_key,
+            item.business,
+            item.account,
+            item.board,
+            item.project,
+        )
+        if scope is None:
+            scope = item_scope
+        elif item_scope != scope:
+            raise RouteContractError("cross-scope work reference")
+        if item.parent_link not in allowed_parent_links:
+            raise RouteContractError("cross-scope parent reference")
+    return items

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -14,7 +14,7 @@ import shlex
 import sys
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_db_connect as kbc
@@ -32,6 +32,7 @@ from hermes_cli.kanban_ops import (
     _cmd_daemon, _kanban_config, _cmd_dispatch, _cmd_gc, _cmd_repair, _cmd_tail, _cmd_watch,
 )
 from hermes_cli.kanban_parser import build_parser  # noqa: F401  (re-exported: hermes_cli.main, run_slash)
+from hermes_cli.kanban_lease_spec import claim_lease_exec_spec
 
 
 # --- Flag parsing helpers ---
@@ -212,7 +213,7 @@ def _profile_author() -> str:
 
 _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
     "init", "create", "swarm", "assign", "reclaim", "reassign", "link", "unlink",
-    "claim", "comment", "attach", "attach-rm", "complete", "edit", "block",
+    "claim", "lease-spec", "comment", "attach", "attach-rm", "complete", "edit", "block",
     "schedule", "unblock", "promote", "archive", "dispatch", "daemon", "repair",
     "heartbeat", "notify-subscribe", "notify-unsubscribe", "specify", "decompose",
     "request-review", "request-changes", "reopen-review",
@@ -318,9 +319,13 @@ def _cmd_init(args: argparse.Namespace) -> int:
 
 
 def _cmd_heartbeat(args: argparse.Namespace) -> int:
+    try:
+        guards = _lease_guard_kwargs(args, args.task_id)
+    except ValueError as exc:
+        return _err(f"kanban: {exc}", 2)
     with kbc.connect_closing() as conn:
         ok = kbd.heartbeat_worker(conn, args.task_id, note=getattr(args, "note", None),
-                                 expected_run_id=_worker_run_id_for(args.task_id))
+                                  **guards)
     return _ok_or_err(ok, f"cannot heartbeat {args.task_id} (not running?)",
                       f"Heartbeat recorded for {args.task_id}")
 
@@ -372,6 +377,9 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             completion_contract=getattr(args, "completion_contract", None),
+            bucket_key=getattr(args, "bucket_key", None),
+            route_policy_ref=getattr(args, "route_policy_ref", None),
+            route_policy_version=getattr(args, "route_policy_version", None),
             initial_status=getattr(args, "initial_status", "running"),
             creator_task_id=(os.environ.get("HERMES_KANBAN_TASK")
                              if is_dispatcher_owned_worker_context() else None),
@@ -425,6 +433,9 @@ def _cmd_list(args: argparse.Namespace) -> int:
             conn, assignee=assignee, status=args.status, tenant=args.tenant, session_id=args.session,
             include_archived=args.archived, order_by=getattr(args, "sort", None),
             workflow_template_id=args.workflow_template_id, current_step_key=args.current_step_key,
+            bucket_key=getattr(args, "bucket_key", None),
+            route_policy_ref=getattr(args, "route_policy_ref", None),
+            route_policy_version=getattr(args, "route_policy_version", None),
         )
     if _json_out(args, [_task_to_dict(t) for t in tasks]):
         return 0
@@ -506,6 +517,10 @@ def _cmd_show(args: argparse.Namespace) -> int:
     field("assignee", task.assignee or "-")
     if task.tenant:
         field("tenant", task.tenant)
+    if task.bucket_key:
+        field("bucket", task.bucket_key)
+    if task.route_policy_ref:
+        field("route", f"{task.route_policy_ref}@{task.route_policy_version}")
     field("workspace", f"{task.workspace_kind}" + (f" @ {task.workspace_path}" if task.workspace_path else ""))
     if task.branch_name:
         field("branch", task.branch_name)
@@ -597,8 +612,14 @@ def _cmd_set_model(args: argparse.Namespace) -> int:
 
 
 def _cmd_reclaim(args: argparse.Namespace) -> int:
+    try:
+        guards = _lease_guard_kwargs(args, args.task_id)
+    except ValueError as exc:
+        return _err(f"kanban: {exc}", 2)
     with kbc.connect_closing() as conn:
-        ok = kb.reclaim_task(conn, args.task_id, reason=getattr(args, "reason", None))
+        ok = kb.reclaim_task(
+            conn, args.task_id, reason=getattr(args, "reason", None), **guards,
+        )
     return _ok_or_err(ok, f"cannot reclaim {args.task_id} (not running or unknown id)",
                       f"Reclaimed {args.task_id}")
 
@@ -724,6 +745,32 @@ def _cmd_claim(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_lease_spec(args: argparse.Namespace) -> int:
+    capabilities = []
+    for index, raw in enumerate(args.capability or ()):
+        try:
+            provider, remainder = raw.split(":", 1)
+            model, effort = remainder.rsplit(":", 1)
+        except ValueError:
+            payload = {
+                "ok": False,
+                "code": "invalid_worker_capability",
+                "error": f"worker capability {index} must use PROVIDER:MODEL:EFFORT",
+                "capability_index": index,
+            }
+            _print_json(payload)
+            return 1
+        capabilities.append({"provider": provider, "model_id": model, "effort": effort})
+    with kbc.connect_closing() as conn:
+        payload = claim_lease_exec_spec(
+            conn, worker_identity=args.worker_id, worker_capabilities=capabilities,
+            bucket_key=args.bucket_key, ttl_seconds=args.ttl,
+            board=kb.get_current_board(),
+        )
+    _print_json(payload)
+    return 0 if payload["ok"] else 1
+
+
 def _cmd_comment(args: argparse.Namespace) -> int:
     body = " ".join(args.text).strip()
     if args.max_len is not None:
@@ -802,6 +849,75 @@ def _worker_run_id_for(task_id: str) -> Optional[int]:
         return None
 
 
+def _lease_guard_kwargs(args: argparse.Namespace, task_id: str) -> dict[str, Any]:
+    """Resolve exact CLI guards, falling back to the scoped worker environment."""
+    env_task = os.environ.get("HERMES_KANBAN_TASK")
+    if env_task and env_task != task_id:
+        raise ValueError(f"worker is scoped to task {env_task}; refusing to mutate {task_id}")
+    explicit = {
+        "expected_run_id": getattr(args, "expected_run_id", None),
+        "expected_claim_lock": getattr(args, "expected_claim_lock", None),
+        "expected_tenant": getattr(args, "expected_tenant", None),
+        "expected_workspace_path": getattr(args, "expected_workspace_path", None),
+    }
+    identity_keys = (
+        "expected_claim_lock", "expected_tenant", "expected_workspace_path",
+    )
+    explicit_supplied = any(value is not None for value in explicit.values())
+
+    if env_task == task_id:
+        run_id = os.environ.get("HERMES_KANBAN_RUN_ID")
+        claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
+        workspace = os.environ.get("HERMES_KANBAN_WORKSPACE")
+        tenant = os.environ.get("HERMES_KANBAN_TENANT")
+        full_identity = claim_lock is not None or workspace is not None or tenant is not None
+        if full_identity:
+            if not run_id or not str(claim_lock or "").strip() or not str(workspace or "").strip():
+                raise ValueError("worker lease identity is incomplete")
+            try:
+                env_guards: dict[str, Any] = {
+                    "expected_run_id": int(run_id),
+                    "expected_claim_lock": claim_lock,
+                    "expected_tenant": tenant.strip() if tenant and tenant.strip() else None,
+                    "expected_workspace_path": workspace,
+                }
+            except ValueError as exc:
+                raise ValueError("worker run identity is invalid") from exc
+        elif run_id:
+            try:
+                env_guards = {"expected_run_id": int(run_id)}
+            except ValueError as exc:
+                raise ValueError("worker run identity is invalid") from exc
+        else:
+            env_guards = {}
+        if explicit_supplied:
+            identity = tuple(explicit[key] for key in identity_keys)
+            if any(value is not None for value in identity):
+                if not full_identity or (
+                    explicit["expected_run_id"] is None
+                    or any(value is None or not str(value).strip() for value in identity)
+                ):
+                    raise ValueError("worker lease identity cannot be partially overridden")
+                comparable = {**explicit, "expected_run_id": int(explicit["expected_run_id"])}
+                if comparable != env_guards:
+                    raise ValueError("explicit lease identity does not match the worker environment")
+            elif explicit["expected_run_id"] is None or (
+                int(explicit["expected_run_id"]) != env_guards.get("expected_run_id")
+            ):
+                raise ValueError("explicit run identity does not match the worker environment")
+        return env_guards
+
+    if explicit_supplied:
+        identity = tuple(explicit[key] for key in identity_keys)
+        if any(value is not None for value in identity) and (
+            explicit["expected_run_id"] is None
+            or any(value is None or not str(value).strip() for value in identity)
+        ):
+            raise ValueError("lease-scoped writes require the complete expected lease identity")
+        return {key: value for key, value in explicit.items() if value is not None}
+    return {}
+
+
 def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str):
     """Goal judge for every terminal worker handoff (including review).
 
@@ -871,6 +987,11 @@ def _cmd_complete(args: argparse.Namespace) -> int:
     fail_msg: dict[str, str] = {}
     with kbc.connect_closing() as conn:
         def op(tid):
+            try:
+                guards = _lease_guard_kwargs(args, tid)
+            except ValueError as exc:
+                fail_msg[tid] = f"kanban: {exc}"
+                return False
             gate_err = _goal_gate_error(
                 conn, tid, (summary or args.result or "").strip(), "completion",
                 "Re-scope with kanban edit, or record the block with kanban block instead of completing.",
@@ -880,18 +1001,41 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 return False
             fail_msg[tid] = f"cannot complete {tid} (unknown id or terminal state)"
             return kb.complete_task(conn, tid, result=args.result, summary=summary, metadata=metadata,
-                                    expected_run_id=_worker_run_id_for(tid))
+                                    **guards)
 
         return _bulk_apply(ids, op, lambda tid: f"Completed {tid}", fail_msg.__getitem__)
 
 
 def _cmd_edit(args: argparse.Namespace) -> int:
+    has_bucket = getattr(args, "bucket_key", None) is not None
+    has_ref = getattr(args, "route_policy_ref", None) is not None
+    has_version = getattr(args, "route_policy_version", None) is not None
+    if has_ref != has_version:
+        return _err(
+            "kanban: --route-policy-ref and --route-policy-version must be set together", 2,
+        )
+    if args.result is None and not has_bucket and not has_ref:
+        return _err("kanban: edit requires a result or Sunny reference", 2)
     metadata, rc = _parse_metadata_flag(getattr(args, "metadata", None))
     if rc:
         return rc
     with kbc.connect_closing() as conn:
-        ok = kb.edit_completed_task_result(conn, args.task_id, result=args.result,
-                                           summary=getattr(args, "summary", None), metadata=metadata)
+        ok = True
+        if has_bucket or has_ref:
+            route_kwargs = {}
+            if has_bucket:
+                route_kwargs["bucket_key"] = args.bucket_key
+            if has_ref:
+                route_kwargs.update(
+                    route_policy_ref=args.route_policy_ref,
+                    route_policy_version=args.route_policy_version,
+                )
+            ok = kb.update_task_route_references(conn, args.task_id, **route_kwargs)
+        if ok and args.result is not None:
+            ok = kb.edit_completed_task_result(
+                conn, args.task_id, result=args.result,
+                summary=getattr(args, "summary", None), metadata=metadata,
+            )
     return _ok_or_err(ok, f"cannot edit {args.task_id} (unknown id or task is not done)", f"Edited {args.task_id}")
 
 
@@ -1235,6 +1379,7 @@ _HANDLERS = {
     "reclaim": _cmd_reclaim, "reassign": _cmd_reassign,
     "diagnostics": _cmd_diagnostics, "diag": _cmd_diagnostics,
     "link": _cmd_link, "unlink": _cmd_unlink, "claim": _cmd_claim,
+    "lease-spec": _cmd_lease_spec,
     "comment": _cmd_comment, "attach": _cmd_attach,
     "attachments": _cmd_attachments, "attach-rm": _cmd_attach_rm,
     "complete": _cmd_complete, "edit": _cmd_edit, "block": _cmd_block,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
+from hermes_cli.kanban_lease import LEASE_GUARD_UNSET, lease_guard_predicate
 from toolsets import get_toolset_names
 
 _log = logging.getLogger(__name__)
@@ -715,6 +716,9 @@ class Task:
     block_kind: Optional[str] = None
     block_recurrences: int = 0               # unblock-loop counter, see BLOCK_RECURRENCE_LIMIT
     completion_contract: Optional[str] = None
+    bucket_key: Optional[str] = None
+    route_policy_ref: Optional[str] = None
+    route_policy_version: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -745,6 +749,7 @@ _TASK_OPTIONAL_COLUMNS = (
     "branch_name", "project_id", "tenant", "result", "idempotency_key", "worker_pid",
     "max_runtime_seconds", "last_heartbeat_at", "current_run_id", "workflow_template_id",
     "current_step_key", "max_retries", "session_id", "completion_contract",
+    "bucket_key", "route_policy_ref", "route_policy_version",
 )
 # Text columns where "" is stored/read as "not set".
 _TASK_EMPTY_IS_NULL_COLUMNS = (
@@ -941,7 +946,22 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Inert, durable scheduling references. They identify policy, never
+    -- credentials, provider entitlement, or a live worker configuration.
+    bucket_key           TEXT,
+    route_policy_ref     TEXT,
+    route_policy_version INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS sunny_route_policies (
+    policy_ref      TEXT NOT NULL,
+    policy_version  INTEGER NOT NULL,
+    provider_ref    TEXT NOT NULL,
+    model_ref       TEXT NOT NULL,
+    effort_ref      TEXT,
+    created_at      INTEGER NOT NULL,
+    PRIMARY KEY (policy_ref, policy_version)
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1232,6 +1252,8 @@ def create_task(
     project_source_task_id: Optional[str] = None,
     creator_task_id: Optional[str] = None,
     completion_contract: Optional[str] = None,
+    bucket_key: Optional[str] = None, route_policy_ref: Optional[str] = None,
+    route_policy_version: Optional[int] = None,
 ) -> str:
     """Create a task (optionally under ``parents``); returns its id.
 
@@ -1248,8 +1270,12 @@ def create_task(
     """
     from hermes_cli.kanban_db_graph import initial_task_state, inherit_creator_origin
     from hermes_cli.kanban_pr_acceptance import validate_contract
+    from hermes_cli.kanban_sunny import normalize_task_route_references
 
     completion_contract = validate_contract(completion_contract)
+    bucket_key, route_policy_ref, route_policy_version = normalize_task_route_references(
+        bucket_key, route_policy_ref, route_policy_version,
+    )
     model_override, provider_override = _validate_model_override(model_override, provider_override)
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
     assignee = _canonical_assignee(assignee)
@@ -1326,8 +1352,9 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id, completion_contract
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, completion_contract,
+                        bucket_key, route_policy_ref, route_policy_version
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id, title.strip(), body, assignee, task_status, priority,
@@ -1337,6 +1364,7 @@ def create_task(
                         json.dumps(skills_list) if skills_list is not None else None,
                         _opt_int(max_retries), model_override, provider_override, reasoning_effort,
                         1 if goal_mode else 0, _opt_int(goal_max_turns), session_id, completion_contract,
+                        bucket_key, route_policy_ref, route_policy_version,
                     ),
                 )
                 for pid in parents:
@@ -1359,6 +1387,9 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "bucket_key": bucket_key,
+                        "route_policy_ref": route_policy_ref,
+                        "route_policy_version": route_policy_version,
                     },
                 )
                 # ACK-edge: the originating channel hears a child BLOCK, not just the fan-in.
@@ -1464,6 +1495,8 @@ def list_tasks(
     tenant: Optional[str] = None, session_id: Optional[str] = None, include_archived: bool = False,
     limit: Optional[int] = None, order_by: Optional[str] = None,
     workflow_template_id: Optional[str] = None, current_step_key: Optional[str] = None,
+    bucket_key: Optional[str] = None, route_policy_ref: Optional[str] = None,
+    route_policy_version: Optional[int] = None,
 ) -> list[Task]:
     if status is not None and status not in VALID_STATUSES:
         raise ValueError(f"status must be one of {sorted(VALID_STATUSES)}")
@@ -1472,7 +1505,8 @@ def list_tasks(
     for col, val in (
         ("assignee", _canonical_assignee(assignee)), ("status", status), ("tenant", tenant),
         ("session_id", session_id), ("workflow_template_id", workflow_template_id),
-        ("current_step_key", current_step_key),
+        ("current_step_key", current_step_key), ("bucket_key", bucket_key),
+        ("route_policy_ref", route_policy_ref), ("route_policy_version", route_policy_version),
     ):
         if val is not None:
             query += f" AND {col} = ?"
@@ -2245,15 +2279,28 @@ def goal_run_status(
 def heartbeat_claim(
     conn: sqlite3.Connection, task_id: str, *, ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
+    expected_claim_lock: Any = LEASE_GUARD_UNSET,
+    expected_tenant: Any = LEASE_GUARD_UNSET,
+    expected_workspace_path: Any = LEASE_GUARD_UNSET,
 ) -> bool:
     """Extend a running claim; True if we still own it."""
     expires = int(time.time()) + _resolve_claim_ttl_seconds(ttl_seconds)
     lock = claimer or _claimer_id()
+    guard_sql, guard_params, full_lease_guard = lease_guard_predicate(
+        expected_run_id=expected_run_id,
+        expected_claim_lock=expected_claim_lock,
+        expected_tenant=expected_tenant,
+        expected_workspace_path=expected_workspace_path,
+    )
     with write_txn(conn):
-        cur = conn.execute(
-            "UPDATE tasks SET claim_expires = ? "
-            "WHERE id = ? AND status = 'running' AND claim_lock = ?", (expires, task_id, lock),
-        )
+        sql = "UPDATE tasks SET claim_expires = ? WHERE id = ? AND status = 'running'"
+        params: tuple[Any, ...] = (expires, task_id, *guard_params)
+        sql += guard_sql
+        if not full_lease_guard:
+            sql += " AND claim_lock = ?"
+            params = (*params, lock)
+        cur = conn.execute(sql, params)
         if cur.rowcount != 1:
             return False
         _extend_run_claim(conn, task_id, expires)
@@ -2400,34 +2447,76 @@ def _extend_live_stale_claim(conn: sqlite3.Connection, row: sqlite3.Row, now: in
 
 def reclaim_task(
     conn: sqlite3.Connection, task_id: str, *, reason: Optional[str] = None, signal_fn=None,
+    expected_run_id: Optional[int] = None,
+    expected_claim_lock: Any = LEASE_GUARD_UNSET,
+    expected_tenant: Any = LEASE_GUARD_UNSET,
+    expected_workspace_path: Any = LEASE_GUARD_UNSET,
 ) -> bool:
     """Operator reclaim regardless of TTL: release the claim, restore the source
     phase, reset the failure counter. False when not running."""
-    row = conn.execute(
-        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?", (task_id,),
-    ).fetchone()
-    if not row:
-        return False
-    if row["status"] != "running" and row["claim_lock"] is None:
-        # Nothing to reclaim — already ready / blocked / done.
-        return False
-    prev_lock = row["claim_lock"]
-    termination = _terminate_reclaimed_worker(row["worker_pid"], prev_lock, signal_fn=signal_fn)
-    with write_txn(conn):
-        retry_status = _retry_status_for_run(conn, task_id)
-        cur = conn.execute(
-            "UPDATE tasks SET status = ?, claim_lock = NULL, "
-            "claim_expires = NULL, worker_pid = NULL "
-            "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
-            "AND claim_lock IS ?", (retry_status, task_id, prev_lock),
-        )
-        if cur.rowcount != 1:
+    guard_sql, guard_params, _ = lease_guard_predicate(
+        expected_run_id=expected_run_id,
+        expected_claim_lock=expected_claim_lock,
+        expected_tenant=expected_tenant,
+        expected_workspace_path=expected_workspace_path,
+    )
+    if guard_sql:
+        with write_txn(conn):
+            row = conn.execute(
+                "UPDATE tasks SET claim_expires = claim_expires "
+                "WHERE id = ? AND status = 'running'" + guard_sql
+                + " RETURNING worker_pid, claim_lock",
+                (task_id, *guard_params),
+            ).fetchone()
+            if row is None:
+                return False
+            prev_lock = row["claim_lock"]
+            termination = _terminate_reclaimed_worker(
+                row["worker_pid"], prev_lock, signal_fn=signal_fn,
+            )
+            retry_status = _retry_status_for_run(conn, task_id)
+            if conn.execute(
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL WHERE id = ?",
+                (retry_status, task_id),
+            ).rowcount != 1:
+                return False
+            _record_reclaim(
+                conn, task_id, termination,
+                error=(f"manual_reclaim: {reason}" if reason
+                       else f"manual_reclaim lock={prev_lock}"),
+                payload={"manual": True, "reason": reason, "prev_lock": prev_lock,
+                         "retry_status": retry_status},
+            )
+    else:
+        row = conn.execute(
+            "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if not row:
             return False
-        _record_reclaim(
-            conn, task_id, termination,
-            error=f"manual_reclaim: {reason}" if reason else f"manual_reclaim lock={prev_lock}",
-            payload={"manual": True, "reason": reason, "prev_lock": prev_lock, "retry_status": retry_status},
+        if row["status"] != "running" and row["claim_lock"] is None:
+            return False
+        prev_lock = row["claim_lock"]
+        termination = _terminate_reclaimed_worker(
+            row["worker_pid"], prev_lock, signal_fn=signal_fn,
         )
+        with write_txn(conn):
+            retry_status = _retry_status_for_run(conn, task_id)
+            cur = conn.execute(
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL "
+                "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
+                "AND claim_lock IS ?", (retry_status, task_id, prev_lock),
+            )
+            if cur.rowcount != 1:
+                return False
+            _record_reclaim(
+                conn, task_id, termination,
+                error=(f"manual_reclaim: {reason}" if reason
+                       else f"manual_reclaim lock={prev_lock}"),
+                payload={"manual": True, "reason": reason, "prev_lock": prev_lock,
+                         "retry_status": retry_status},
+            )
     # Operator intervention = fresh retry budget (own txn, runs after commit).
     _clear_failure_counter(conn, task_id)
     return True
@@ -2521,10 +2610,17 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+class TerminalReadbackError(RuntimeError):
+    """A terminal transition could not be read back under its lease identity."""
+
+
 def complete_task(
     conn: sqlite3.Connection, task_id: str, *, result: Optional[str] = None,
     summary: Optional[str] = None, metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None, expected_run_id: Optional[int] = None,
+    expected_claim_lock: Any = LEASE_GUARD_UNSET,
+    expected_tenant: Any = LEASE_GUARD_UNSET,
+    expected_workspace_path: Any = LEASE_GUARD_UNSET,
     fire_lifecycle_hook: bool = True,
 ) -> bool:
     """``running|ready|blocked|review -> done``; records ``result``.
@@ -2538,11 +2634,25 @@ def complete_task(
     prose is scanned for unresolvable ``t_<hex>`` refs (advisory event only).
     """
     now = int(time.time())
+    guard_sql, guard_params, full_lease_guard = lease_guard_predicate(
+        expected_run_id=expected_run_id,
+        expected_claim_lock=expected_claim_lock,
+        expected_tenant=expected_tenant,
+        expected_workspace_path=expected_workspace_path,
+    )
+    if full_lease_guard and conn.execute(
+        "SELECT 1 FROM tasks WHERE id = ? AND status = 'running'" + guard_sql,
+        (task_id, *guard_params),
+    ).fetchone() is None:
+        return False
     # Cheap pre-check; re-checked inside the txn to close the parent-reopen race.
     if not _parents_satisfied(conn, task_id):
         return False
     from hermes_cli.kanban_pr_acceptance_store import prepare_acceptance, record_acceptance
-    verified_cards = _gate_created_cards(conn, task_id, created_cards, summary or result)
+    verified_cards = _gate_created_cards(
+        conn, task_id, created_cards, summary or result,
+        audit_rejection=not full_lease_guard,
+    )
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
@@ -2551,6 +2661,11 @@ def complete_task(
     if acceptance is False:
         return False
     with write_txn(conn):
+        if full_lease_guard and conn.execute(
+            "SELECT 1 FROM tasks WHERE id = ? AND status = 'running'" + guard_sql,
+            (task_id, *guard_params),
+        ).fetchone() is None:
+            return False
         # Hard invariant even for human review approval: a parent may have
         # reopened while this task waited.
         if not _parents_satisfied(conn, task_id):
@@ -2571,10 +2686,8 @@ def complete_task(
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked', 'review')
                 """
-        params: tuple = (result, now, task_id)
-        if expected_run_id is not None:
-            sql += " AND current_run_id = ?"
-            params = (*params, int(expected_run_id))
+        params: tuple = (result, now, task_id, *guard_params)
+        sql += guard_sql
         if conn.execute(sql, params).rowcount != 1:
             return False
         if isinstance(metadata, dict):
@@ -2600,6 +2713,24 @@ def complete_task(
             _completed_event_payload(result, event_summary, verified_cards, metadata),
             run_id=run_id,
         )
+        terminal = conn.execute(
+            "SELECT status, claim_lock, current_run_id, tenant, workspace_path "
+            "FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if (
+            terminal is None
+            or terminal["status"] != "done"
+            or terminal["claim_lock"] is not None
+            or terminal["current_run_id"] is not None
+            or (full_lease_guard and (
+                run_id != guard_params[0]
+                or terminal["tenant"] != expected_tenant
+                or terminal["workspace_path"] != expected_workspace_path
+            ))
+        ):
+            raise TerminalReadbackError(
+                f"completion of {task_id} could not be read back exactly"
+            )
     _flag_phantom_prose_refs(conn, task_id, run_id, summary, result, verified_cards)
     # Success wipes the breaker counter (history stays on the event log).
     _clear_failure_counter(conn, task_id)
@@ -2616,6 +2747,7 @@ _REVIEW_APPROVED_NOTE = "Review approved without additional evidence."
 
 def _gate_created_cards(
     conn: sqlite3.Connection, task_id: str, created_cards: Optional[Iterable[str]], preview_text: Optional[str],
+    *, audit_rejection: bool = True,
 ) -> list[str]:
     """Verify ``created_cards`` BEFORE the main write txn; returns the verified
     ids. A phantom id is recorded in its own tiny txn (auditable) then raised
@@ -2624,15 +2756,16 @@ def _gate_created_cards(
         return []
     verified_cards, phantom_cards = _verify_created_cards(conn, task_id, created_cards)
     if phantom_cards:
-        with write_txn(conn):
-            _append_event(
-                conn, task_id, "completion_blocked_hallucination",
-                {
-                    "phantom_cards": phantom_cards,
-                    "verified_cards": verified_cards,
-                    "summary_preview": _first_line(preview_text, 200) or None,
-                },
-            )
+        if audit_rejection:
+            with write_txn(conn):
+                _append_event(
+                    conn, task_id, "completion_blocked_hallucination",
+                    {
+                        "phantom_cards": phantom_cards,
+                        "verified_cards": verified_cards,
+                        "summary_preview": _first_line(preview_text, 200) or None,
+                    },
+                )
         raise HallucinatedCardsError(phantom_cards, task_id)
     return verified_cards
 
@@ -4041,6 +4174,12 @@ from hermes_cli.kanban_db_dispatch import (  # noqa: E402
     _terminate_reclaimed_worker,
     _worker_survived_termination,
     _worker_terminal_timeout_env,
+)
+from hermes_cli.kanban_sunny import (  # noqa: E402
+    RoutePolicy,
+    get_route_policy,
+    put_route_policy,
+    update_task_route_references,
 )
 
 

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -813,6 +813,9 @@ _LATER_TASK_COLUMNS = (
     # Typed block reason (VALID_BLOCK_KINDS); NULL = generic human blocker.
     ("block_kind", "block_kind TEXT"),
     ("block_recurrences", "block_recurrences INTEGER NOT NULL DEFAULT 0"),
+    ("bucket_key", "bucket_key TEXT"),
+    ("route_policy_ref", "route_policy_ref TEXT"),
+    ("route_policy_version", "route_policy_version INTEGER"),
 )
 
 _NOTIFY_SUB_COLUMNS = (
@@ -874,6 +877,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_tenant ON tasks(tenant)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_bucket_key ON tasks(bucket_key)")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_route_policy "
+        "ON tasks(route_policy_ref, route_policy_version)"
+    )
 
     # task_events.run_id back-fills as NULL for historical events (they predate
     # runs and can't be attributed).

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -24,6 +24,8 @@ from typing import Mapping
 from typing import Optional
 from typing import TYPE_CHECKING
 
+from hermes_cli.kanban_lease import LEASE_GUARD_UNSET, lease_guard_predicate
+
 if TYPE_CHECKING:
     from hermes_cli.kanban_db import Task
 
@@ -382,6 +384,9 @@ def heartbeat_worker(
     *,
     note: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    expected_claim_lock: Any = LEASE_GUARD_UNSET,
+    expected_tenant: Any = LEASE_GUARD_UNSET,
+    expected_workspace_path: Any = LEASE_GUARD_UNSET,
 ) -> bool:
     """Record a ``heartbeat`` event + touch ``last_heartbeat_at``.
 
@@ -390,12 +395,16 @@ def heartbeat_worker(
     Returns False if the task is not running or its claim expired.
     """
     now = int(time.time())
+    guard_sql, guard_params, _ = lease_guard_predicate(
+        expected_run_id=expected_run_id,
+        expected_claim_lock=expected_claim_lock,
+        expected_tenant=expected_tenant,
+        expected_workspace_path=expected_workspace_path,
+    )
     with _kb.write_txn(conn):
         sql = "UPDATE tasks SET last_heartbeat_at = ? WHERE id = ? AND status = 'running'"
-        params: tuple = (now, task_id)
-        if expected_run_id is not None:
-            sql += " AND current_run_id = ?"
-            params += (int(expected_run_id),)
+        params: tuple = (now, task_id, *guard_params)
+        sql += guard_sql
         cur = conn.execute(sql, params)
         if cur.rowcount != 1:
             return False
@@ -2188,6 +2197,12 @@ def _default_spawn(task: Task, workspace: str, *, board: Optional[str] = None) -
     from gateway.session_context import _VAR_MAP
     for key in _VAR_MAP:
         env.pop(key, None)
+    for key in (
+        "HERMES_KANBAN_BOARD", "HERMES_KANBAN_TASK", "HERMES_KANBAN_RUN_ID",
+        "HERMES_KANBAN_CLAIM_LOCK", "HERMES_KANBAN_TENANT", "HERMES_KANBAN_WORKSPACE",
+        "HERMES_TENANT",
+    ):
+        env.pop(key, None)
 
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml:
     # without it the child's get_hermes_home() falls back to the DEFAULT
@@ -2201,6 +2216,7 @@ def _default_spawn(task: Task, workspace: str, *, board: Optional[str] = None) -
         pass
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
+        env["HERMES_KANBAN_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
     # Tag the session `kanban` so session-browsing surfaces filter it out by

--- a/hermes_cli/kanban_lease.py
+++ b/hermes_cli/kanban_lease.py
@@ -1,0 +1,53 @@
+"""Shared predicates for writes scoped to one active Kanban lease."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+LEASE_GUARD_UNSET = object()
+
+
+def lease_guard_predicate(
+    *,
+    expected_run_id: Optional[int],
+    expected_claim_lock: Any,
+    expected_tenant: Any,
+    expected_workspace_path: Any,
+) -> tuple[str, tuple[Any, ...], bool]:
+    """Return the SQL predicate, parameters, and whether the full guard is active.
+
+    ``expected_run_id`` alone retains the existing run-scoped API. Supplying
+    any newer identity field requires the whole lease identity, preventing a
+    partial claim/workspace check from being mistaken for a complete binding.
+    """
+    identity = (expected_claim_lock, expected_tenant, expected_workspace_path)
+    supplied = tuple(value is not LEASE_GUARD_UNSET for value in identity)
+    if not any(supplied):
+        if expected_run_id is None:
+            return "", (), False
+        try:
+            run_id = int(expected_run_id)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("expected_run_id must be an integer") from exc
+        return " AND current_run_id = ?", (run_id,), False
+
+    if expected_run_id is None or not all(supplied):
+        raise ValueError(
+            "lease-scoped writes require expected_run_id, expected_claim_lock, "
+            "expected_tenant, and expected_workspace_path"
+        )
+    try:
+        run_id = int(expected_run_id)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("expected_run_id must be an integer") from exc
+    claim_lock = str(expected_claim_lock).strip()
+    tenant = None if expected_tenant is None else str(expected_tenant).strip()
+    workspace_path = str(expected_workspace_path).strip()
+    if not claim_lock or tenant == "" or not workspace_path:
+        raise ValueError("lease-scoped identity guards cannot be empty")
+    return (
+        " AND current_run_id = ? AND claim_lock = ? "
+        "AND tenant IS ? AND workspace_path = ?",
+        (run_id, claim_lock, tenant, workspace_path),
+        True,
+    )

--- a/hermes_cli/kanban_lease_spec.py
+++ b/hermes_cli/kanban_lease_spec.py
@@ -1,0 +1,224 @@
+"""Atomic Kanban claims that return credential-free worker specifications."""
+
+from __future__ import annotations
+
+import secrets
+import time
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from agent.crew_route_contract import Route, RouteContractError, resolve_route
+
+
+class _LeaseReadbackError(RuntimeError):
+    pass
+
+
+def _error(code: str, message: str, **context: Any) -> dict[str, Any]:
+    return {"ok": False, "code": code, "error": message, **context}
+
+
+def _capability_routes(
+    values: Iterable[Mapping[str, Any] | Route],
+) -> tuple[set[tuple[str, str, str]] | None, dict[str, Any] | None]:
+    try:
+        items = tuple(values)
+    except TypeError:
+        return None, _error(
+            "invalid_worker_capabilities", "worker capabilities must be an iterable",
+        )
+    if not items:
+        return None, _error(
+            "missing_worker_capabilities",
+            "at least one complete provider/model/effort capability is required",
+        )
+    routes: set[tuple[str, str, str]] = set()
+    for index, value in enumerate(items):
+        try:
+            route = value if isinstance(value, Route) else resolve_route(value)
+        except (RouteContractError, TypeError, AttributeError) as exc:
+            return None, _error(
+                "invalid_worker_capability",
+                f"worker capability {index} is invalid: {exc}",
+                capability_index=index,
+            )
+        routes.add(route.as_tuple())
+    return routes, None
+
+
+def _candidate_route(conn, row) -> tuple[Route | None, dict[str, Any] | None]:
+    from hermes_cli.kanban_sunny import get_route_policy
+
+    task_id = row["id"]
+    required = (
+        ("bucket_key", "missing_bucket_key", "ready task has no bucket key"),
+        ("tenant", "missing_tenant", "ready task has no tenant/business binding"),
+        ("workspace_path", "missing_workspace", "ready task has no workspace binding"),
+    )
+    for field, code, message in required:
+        if not str(row[field] or "").strip():
+            return None, _error(code, f"{message}; set it before leasing", task_id=task_id)
+    if not row["route_policy_ref"] or row["route_policy_version"] is None:
+        return None, _error(
+            "missing_route_policy",
+            "ready task has no complete route-policy reference; set ref and version before leasing",
+            task_id=task_id,
+        )
+    policy = get_route_policy(
+        conn, row["route_policy_ref"], row["route_policy_version"],
+    )
+    if policy is None:
+        return None, _error(
+            "unknown_route_policy", "task route-policy reference does not exist",
+            task_id=task_id, route_policy_ref=row["route_policy_ref"],
+            route_policy_version=row["route_policy_version"],
+        )
+    try:
+        route = resolve_route(
+            {"provider": policy.provider_ref, "model_id": policy.model_ref,
+             "effort": policy.effort_ref}
+        )
+    except RouteContractError as exc:
+        return None, _error(
+            "invalid_route_policy", f"route policy is invalid: {exc}",
+            task_id=task_id, route_policy_ref=policy.policy_ref,
+            route_policy_version=policy.policy_version,
+        )
+    return route, None
+
+
+def _verify_claim_readback(task, *, run_id: int, claim_token: str, candidate) -> None:
+    fields = (
+        "tenant", "workspace_path", "bucket_key", "route_policy_ref",
+        "route_policy_version",
+    )
+    if (
+        task is None
+        or task.status != "running"
+        or task.current_run_id != int(run_id)
+        or task.claim_lock != claim_token
+        or any(getattr(task, field) != candidate[field] for field in fields)
+    ):
+        raise _LeaseReadbackError("claimed lease identity could not be read back exactly")
+
+
+def claim_lease_exec_spec(
+    conn,
+    *,
+    worker_identity: str,
+    worker_capabilities: Iterable[Mapping[str, Any] | Route],
+    bucket_key: str | None = None,
+    ttl_seconds: int | None = None,
+    board: str | None = None,
+) -> dict[str, Any]:
+    """Claim at most one compatible ready task and return its exact lease identity."""
+    from hermes_cli import kanban_db as kb
+
+    worker = str(worker_identity or "").strip()
+    if not worker:
+        return _error("missing_worker_identity", "worker identity is required")
+    capabilities, capability_error = _capability_routes(worker_capabilities)
+    if capability_error is not None:
+        return capability_error
+    assert capabilities is not None
+    bucket = str(bucket_key).strip() if bucket_key is not None else None
+    if bucket_key is not None and not bucket:
+        return _error("invalid_bucket_key", "bucket key cannot be empty")
+
+    resolved_board = str(board or kb.get_current_board()).strip()
+    if not resolved_board:
+        return _error("missing_board", "board identity is required")
+    now = int(time.time())
+    ttl = kb._resolve_claim_ttl_seconds(ttl_seconds)
+    expires = now + ttl
+    claim_token = f"{worker}:{secrets.token_urlsafe(18)}"
+    selected = selected_route = selected_run_id = None
+    parents: list[str] = []
+    attempt_number = 0
+    try:
+        with kb.write_txn(conn):
+            query = "SELECT * FROM tasks WHERE status = 'ready' AND claim_lock IS NULL"
+            params: list[Any] = []
+            if bucket is not None:
+                query += " AND bucket_key = ?"
+                params.append(bucket)
+            query += " ORDER BY priority DESC, created_at ASC, id ASC"
+            for row in conn.execute(query, params).fetchall():
+                route, route_error = _candidate_route(conn, row)
+                if route_error is not None:
+                    return route_error
+                assert route is not None
+                if route.as_tuple() not in capabilities:
+                    continue
+                if not kb._parents_satisfied(conn, row["id"]):
+                    continue
+                run_id = kb._claim_and_open_run(
+                    conn, row["id"], "ready", claim_token, expires, now,
+                    event_extra={"worker_identity": worker},
+                )
+                if run_id is None:
+                    continue
+                selected = kb.get_task(conn, row["id"])
+                _verify_claim_readback(
+                    selected, run_id=run_id, claim_token=claim_token, candidate=row,
+                )
+                selected_route = route
+                selected_run_id = run_id
+                attempt_number = int(conn.execute(
+                    "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (row["id"],),
+                ).fetchone()[0])
+                parents = kb.parent_ids(conn, row["id"])
+                break
+            if selected is None:
+                return _error("no_candidate", "no eligible ready task")
+    except _LeaseReadbackError as exc:
+        return _error("lease_readback_failed", str(exc))
+
+    assert selected_route is not None and selected_run_id is not None
+    kb._fire_kanban_lifecycle_hook(
+        "kanban_task_claimed", selected.id, board=resolved_board,
+        assignee=selected.assignee, run_id=selected_run_id,
+    )
+    route = {
+        "provider": selected_route.provider,
+        "model": selected_route.model_id,
+        "requested_effort": selected_route.requested_effort,
+        "applied_effort": selected_route.applied_effort,
+    }
+    return {
+        "ok": True,
+        "task_id": selected.id,
+        "worker_identity": worker,
+        "claim_token": claim_token,
+        "claim_lock": claim_token,
+        "run_id": int(selected_run_id),
+        "claim_expires": expires,
+        "heartbeat_at": now,
+        "last_heartbeat_at": selected.last_heartbeat_at,
+        "heartbeat_ttl_seconds": ttl,
+        "heartbeat_interval_seconds": max(1, ttl // 3),
+        "attempt_number": attempt_number,
+        "run_number": attempt_number,
+        "board": resolved_board,
+        "tenant": selected.tenant,
+        "business_scope": selected.tenant,
+        "scope": {"tenant": selected.tenant, "business": selected.tenant},
+        "project_id": selected.project_id,
+        "workspace_kind": selected.workspace_kind,
+        "workspace_path": selected.workspace_path,
+        "branch_name": selected.branch_name,
+        "project": selected.project_id,
+        "workspace": selected.workspace_path,
+        "branch": selected.branch_name,
+        "parent_links": parents,
+        "bucket_key": selected.bucket_key,
+        "route_policy_ref": selected.route_policy_ref,
+        "route_policy_version": selected.route_policy_version,
+        "route_policy": {"ref": selected.route_policy_ref,
+                         "version": selected.route_policy_version},
+        "provider": selected_route.provider,
+        "model": selected_route.model_id,
+        "requested_effort": selected_route.requested_effort,
+        "applied_effort": selected_route.applied_effort,
+        "route": route,
+    }

--- a/hermes_cli/kanban_output.py
+++ b/hermes_cli/kanban_output.py
@@ -20,7 +20,9 @@ _TASK_DICT_FIELDS = (
     "workspace_kind", "workspace_path", "branch_name", "project_id",
     "created_by", "created_at", "started_at", "completed_at", "result",
     "skills", "max_retries", "model_override", "provider_override",
-    "session_id", "workflow_template_id", "current_step_key", "completion_contract", "last_failure_error",
+    "reasoning_effort", "session_id", "workflow_template_id", "current_step_key",
+    "completion_contract", "bucket_key", "route_policy_ref", "route_policy_version",
+    "current_run_id", "last_failure_error",
 )
 _SHOW_RUN_FIELDS = (
     "id", "profile", "step_key", "status", "outcome", "summary", "error",

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -81,6 +81,12 @@ _STEP_HANDOFF = (
     _arg("--summary", help="Structured handoff summary. Falls back to --result if omitted."),
     _arg("--metadata", help="JSON dict of structured facts to store on the latest completed run."),
 )
+_LEASE_GUARD_ARGS = (
+    _arg("--expected-run-id", type=int),
+    _arg("--expected-claim-lock", "--expected-claim-token", dest="expected_claim_lock"),
+    _arg("--expected-tenant", "--expected-business", dest="expected_tenant"),
+    _arg("--expected-workspace-path"),
+)
 
 _BOARD_SPECS = [
     _cmd("list", [
@@ -188,6 +194,10 @@ _SPECS = [
                   "the worker). Requires --model."),
         _arg("--completion-contract", metavar="CONTRACT",
              help="local-only (default), OWNER/REPO for publication, or exact GitHub PR URL; required CI gates done."),
+        _arg("--bucket-key", help="Persist an inert Sunny bucket reference"),
+        _arg("--route-policy-ref", help="Persist a Sunny route-policy reference"),
+        _arg("--route-policy-version", type=int,
+             help="Version paired with --route-policy-ref"),
         _arg("--goal", action="store_true", dest="goal_mode",
              help="Run the worker in a goal loop: after each turn a judge checks the "
                   "response against the card title/body and, if not done, the worker "
@@ -219,6 +229,9 @@ _SPECS = [
         _arg("--assignee"),
         _arg("--status", choices=sorted(kb.VALID_STATUSES)),
         _arg("--tenant"),
+        _arg("--bucket-key"),
+        _arg("--route-policy-ref"),
+        _arg("--route-policy-version", type=int),
         _arg("--session",
              help="Filter by originating chat/agent session id (set on tasks created from inside an ACP loop)"),
         _arg("--archived", action="store_true", help="Include archived tasks"),
@@ -240,7 +253,8 @@ _SPECS = [
              help="Provider the model belongs to (worker is spawned with "
                   "--provider <name>). Cleared together with the model."),
     ], help="Set or clear a task's model/provider override (takes effect on the next dispatch)"),
-    _cmd("reclaim", [_TASK_ID, _RECLAIM_REASON], help="Release an active worker claim on a running task"),
+    _cmd("reclaim", [_TASK_ID, _RECLAIM_REASON, *_LEASE_GUARD_ARGS],
+         help="Release an active worker claim on a running task"),
     _cmd("reassign", [
         _TASK_ID,
         _arg("profile", help="New profile name (or 'none' to unassign)"),
@@ -260,6 +274,14 @@ _SPECS = [
         _TASK_ID,
         _arg("--ttl", type=int, default=kb.DEFAULT_CLAIM_TTL_SECONDS, help="Claim TTL in seconds (default: 900)"),
     ], help="Atomically claim a ready task (prints resolved workspace path)"),
+    _cmd("lease-spec", [
+        _arg("--worker-id", default=""),
+        _arg("--capability", action="append", metavar="PROVIDER:MODEL:EFFORT",
+             help="Complete worker route capability; repeat for multiple routes"),
+        _arg("--bucket-key"),
+        _arg("--ttl", type=int, default=kb.DEFAULT_CLAIM_TTL_SECONDS),
+        _json_flag(help="Emit JSON (the only output format)"),
+    ], help="Atomically lease one compatible ready task and emit a worker JSON spec"),
     _cmd("comment", [
         _TASK_ID,
         _arg("text", nargs="+", help="Comment body"),
@@ -283,11 +305,15 @@ _SPECS = [
         _arg("--metadata",
              help='JSON dict of structured facts (e.g. \'{"changed_files": [...], '
                   '"tests_run": 12}\'). Stored on the closing run.'),
+        *_LEASE_GUARD_ARGS,
     ], help="Mark one or more tasks done"),
     _cmd("edit", [
         _TASK_ID,
-        _arg("--result", required=True, help="Backfilled task result text for a done task"),
+        _arg("--result", help="Backfilled task result text for a done task"),
         *_STEP_HANDOFF,
+        _arg("--bucket-key"),
+        _arg("--route-policy-ref"),
+        _arg("--route-policy-version", type=int),
     ], help="Edit recovery fields on an already-completed task"),
     _cmd("block", [
         _TASK_ID,
@@ -394,6 +420,7 @@ _SPECS = [
     _cmd("heartbeat", [
         _TASK_ID,
         _arg("--note", help="Optional short note attached to the heartbeat event"),
+        *_LEASE_GUARD_ARGS,
     ], help="Emit a heartbeat event for a running task (worker liveness signal)"),
     _cmd("assignees", [_json_flag()],
          help="List known profiles + per-profile task counts (union of ~/.hermes/profiles/ and current assignees on the board)"),

--- a/hermes_cli/kanban_pr_acceptance_store.py
+++ b/hermes_cli/kanban_pr_acceptance_store.py
@@ -6,7 +6,10 @@ from hermes_cli.kanban_pr_acceptance import _PR, collect_acceptance
 
 
 def _snapshot(conn, task_id):
-    row = conn.execute("SELECT current_run_id, status, completion_contract FROM tasks WHERE id=?", (task_id,)).fetchone()
+    row = conn.execute(
+        "SELECT current_run_id, status, completion_contract, claim_lock, tenant, workspace_path "
+        "FROM tasks WHERE id=?", (task_id,),
+    ).fetchone()
     return tuple(row) if row else None
 
 
@@ -14,22 +17,23 @@ def prepare_acceptance(conn, task_id, expected_run_id, metadata):
     snapshot = _snapshot(conn, task_id)
     if snapshot is None:
         return False
-    run_id, status, contract = snapshot
+    run_id, status, contract = snapshot[:3]
     if not contract or contract == "local-only":
         return None
+    contract_text: str = f"{contract}"
     if status not in {"running", "ready", "blocked", "review"} or (expected_run_id is not None and run_id != expected_run_id):
         return False
     published_pr = metadata.get("published_pr") if isinstance(metadata, dict) else None
     match = _PR.fullmatch(published_pr) if isinstance(published_pr, str) else None
     # Publication binds once. Retrying cannot replace the task's PR with a green sibling.
-    if match and contract == match[1]:
+    if match and contract_text == match[1]:
         with write_txn(conn):
             if _snapshot(conn, task_id) != snapshot:
                 return False
             conn.execute("UPDATE tasks SET completion_contract=? WHERE id=?", (published_pr, task_id))
-        snapshot = (run_id, status, published_pr)
-        contract = published_pr
-    return snapshot, collect_acceptance(contract, published_pr)
+        snapshot = (run_id, status, published_pr, *snapshot[3:])
+        contract_text = f"{published_pr}"
+    return snapshot, collect_acceptance(contract_text, published_pr)
 
 
 def record_acceptance(conn, task_id, acceptance):

--- a/hermes_cli/kanban_sunny.py
+++ b/hermes_cli/kanban_sunny.py
@@ -1,0 +1,170 @@
+"""Durable, inert Thousand Sunny route and bucket references."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class RoutePolicy:
+    """One immutable, versioned, credential-free route reference."""
+
+    policy_ref: str
+    policy_version: int
+    provider_ref: str
+    model_ref: str
+    effort_ref: Optional[str]
+    created_at: int
+
+
+def normalize_task_route_references(
+    bucket_key: Optional[str],
+    route_policy_ref: Optional[str],
+    route_policy_version: Optional[int],
+) -> tuple[Optional[str], Optional[str], Optional[int]]:
+    bucket = str(bucket_key).strip() or None if bucket_key is not None else None
+    policy_ref = (
+        str(route_policy_ref).strip() or None
+        if route_policy_ref is not None
+        else None
+    )
+    version = None
+    if route_policy_version is not None:
+        version = int(route_policy_version)
+        if version < 1:
+            raise ValueError("route_policy_version must be >= 1")
+    if (policy_ref is None) != (version is None):
+        raise ValueError("route_policy_ref and route_policy_version must be set together")
+    return bucket, policy_ref, version
+
+
+def put_route_policy(
+    conn,
+    *,
+    policy_ref: str,
+    policy_version: int,
+    provider_ref: str,
+    model_ref: str,
+    effort_ref: Optional[str] = None,
+) -> RoutePolicy:
+    """Persist an immutable contract version without credentials or entitlement state."""
+    values = {
+        "policy_ref": str(policy_ref).strip(),
+        "provider_ref": str(provider_ref).strip(),
+        "model_ref": str(model_ref).strip(),
+    }
+    if not all(values.values()):
+        raise ValueError("policy_ref, provider_ref, and model_ref are required")
+    version = int(policy_version)
+    if version < 1:
+        raise ValueError("policy_version must be >= 1")
+    effort = str(effort_ref).strip() if effort_ref is not None else None
+    effort = effort or None
+    with _kb.write_txn(conn):
+        conn.execute(
+            "INSERT OR IGNORE INTO sunny_route_policies "
+            "(policy_ref, policy_version, provider_ref, model_ref, effort_ref, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                values["policy_ref"],
+                version,
+                values["provider_ref"],
+                values["model_ref"],
+                effort,
+                int(time.time()),
+            ),
+        )
+        row = conn.execute(
+            "SELECT * FROM sunny_route_policies "
+            "WHERE policy_ref = ? AND policy_version = ?",
+            (values["policy_ref"], version),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("route policy write could not be read back")
+        stored = RoutePolicy(**dict(row))
+        if (
+            stored.provider_ref != values["provider_ref"]
+            or stored.model_ref != values["model_ref"]
+            or stored.effort_ref != effort
+        ):
+            raise ValueError(
+                "route policy reference/version already identifies a different contract"
+            )
+    return stored
+
+
+def get_route_policy(
+    conn, policy_ref: str, policy_version: int
+) -> Optional[RoutePolicy]:
+    row = conn.execute(
+        "SELECT * FROM sunny_route_policies "
+        "WHERE policy_ref = ? AND policy_version = ?",
+        (policy_ref, int(policy_version)),
+    ).fetchone()
+    return RoutePolicy(**dict(row)) if row else None
+
+
+REFERENCE_UNSET = object()
+
+
+def update_task_route_references(
+    conn,
+    task_id: str,
+    *,
+    bucket_key: Any = REFERENCE_UNSET,
+    route_policy_ref: Any = REFERENCE_UNSET,
+    route_policy_version: Any = REFERENCE_UNSET,
+) -> bool:
+    """Update inert references without changing task lifecycle state."""
+    changed_fields: tuple[str, ...] = ()
+    with _kb.write_txn(conn):
+        existing = conn.execute(
+            "SELECT bucket_key, route_policy_ref, route_policy_version "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if existing is None:
+            return False
+        updates: list[str] = []
+        params: list[Any] = []
+        normalized: dict[str, Any] = {}
+        for column, value in (
+            ("bucket_key", bucket_key),
+            ("route_policy_ref", route_policy_ref),
+            ("route_policy_version", route_policy_version),
+        ):
+            if value is REFERENCE_UNSET:
+                continue
+            if column == "route_policy_version" and value is not None:
+                value = int(value)
+                if value < 1:
+                    raise ValueError("route_policy_version must be >= 1")
+            elif value is not None:
+                value = str(value).strip() or None
+            updates.append(f"{column} = ?")
+            params.append(value)
+            normalized[column] = value
+        if not updates:
+            return True
+        final_ref = normalized.get("route_policy_ref", existing["route_policy_ref"])
+        final_version = normalized.get(
+            "route_policy_version", existing["route_policy_version"]
+        )
+        if (final_ref is None) != (final_version is None):
+            raise ValueError(
+                "route_policy_ref and route_policy_version must be set or cleared together"
+            )
+        cur = conn.execute(
+            f"UPDATE tasks SET {', '.join(updates)} WHERE id = ?",
+            (*params, task_id),
+        )
+        changed_fields = tuple(normalized)
+    if cur.rowcount:
+        _kb.notify_task_updated(conn, task_id, changed_fields)
+    return bool(cur.rowcount)
+
+
+# Imported last so the facade can import these public entry points at its tail.
+from hermes_cli import kanban_db as _kb  # noqa: E402

--- a/tests/agent/test_crew_route_contract.py
+++ b/tests/agent/test_crew_route_contract.py
@@ -1,0 +1,55 @@
+import pytest
+
+from agent.crew_route_contract import (
+    ROUTE_POLICY_VERSION,
+    RouteContractError,
+    WorkIdentity,
+    resolve_route,
+    sunny_routes,
+    validate_work_batch,
+)
+
+
+def _work(**overrides):
+    values = {
+        "bucket_key": "coding",
+        "pool_member": "zoro",
+        "business": "sunny",
+        "account": "crew-primary",
+        "board": "board-a",
+        "project": "project-a",
+        "worktree": "/worktrees/a",
+        "idempotency_key": "idem-a",
+        "parent_link": "parent-a",
+        "route_policy_version": ROUTE_POLICY_VERSION,
+        "provenance": "firstmate:approved-plan",
+    }
+    values.update(overrides)
+    return values
+
+
+def test_routes_are_exact_inert_identities_and_never_clamp_effort():
+    assert sunny_routes()["validated-plan-worker"].as_tuple() == (
+        "openai-codex", "gpt-5.6-sol", "low",
+    )
+    invalid = (
+        {"provider": "unknown", "model_id": "gpt-5.6-sol", "effort": "low"},
+        {"provider": "openai-codex", "model_id": "Hermes", "effort": "xhigh"},
+        {"provider": "openai-codex", "model_id": "gpt-5.5", "effort": "max"},
+        {"provider": "openai-codex", "model_id": "gpt-5.6-sol"},
+        {"provider": "openai-codex", "model_id": "gpt-5.6-sol",
+         "model": "gpt-5.6-luna", "effort": "low"},
+    )
+    for route in invalid:
+        with pytest.raises(RouteContractError):
+            resolve_route(route)
+
+
+def test_work_provenance_and_scope_fail_closed():
+    item = WorkIdentity.from_mapping(_work())
+    assert validate_work_batch([item], allowed_parent_links={"parent-a"}) == (item,)
+    with pytest.raises(RouteContractError, match="untrusted work provenance"):
+        WorkIdentity.from_mapping(_work(provenance="caller:claimed"))
+    other = WorkIdentity.from_mapping(_work(idempotency_key="idem-b", business="other"))
+    with pytest.raises(RouteContractError, match="cross-scope"):
+        validate_work_batch([item, other], allowed_parent_links={"parent-a"})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,6 +315,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "HERMES_KANBAN_WORKSPACE",
     "HERMES_KANBAN_RUN_ID",
     "HERMES_KANBAN_CLAIM_LOCK",
+    "HERMES_KANBAN_TENANT",
     "HERMES_KANBAN_DISPATCH_IN_GATEWAY",
     # Pytest is routinely launched from a delegated worker.  The worker
     # lineage marker must not make parent-state tests run as delegated

--- a/tests/hermes_cli/test_kanban_lease_guards.py
+++ b/tests/hermes_cli/test_kanban_lease_guards.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+from tools import kanban_tools
+
+
+def _running_task(tmp_path, suffix):
+    path = tmp_path / f"{suffix}.db"
+    conn = kbc.connect(db_path=path)
+    task_id = kb.create_task(
+        conn, title=suffix, assignee="worker", tenant="business-a",
+        workspace_kind="dir", workspace_path=str(tmp_path / f"workspace-{suffix}"),
+    )
+    assert kb.claim_task(conn, task_id, claimer=f"worker:{suffix}")
+    task = kb.get_task(conn, task_id)
+    guards = {
+        "expected_run_id": task.current_run_id,
+        "expected_claim_lock": task.claim_lock,
+        "expected_tenant": task.tenant,
+        "expected_workspace_path": task.workspace_path,
+    }
+    return conn, task_id, guards
+
+
+def _snapshot(conn, task_id):
+    return (
+        asdict(kb.get_task(conn, task_id)),
+        [asdict(run) for run in kb.list_runs(conn, task_id)],
+        [asdict(event) for event in kb.list_events(conn, task_id)],
+    )
+
+
+@pytest.mark.parametrize("action", ("heartbeat", "reclaim", "complete"))
+def test_old_lease_cannot_mutate_a_successor_attempt(tmp_path, action):
+    conn, task_id, old = _running_task(tmp_path, action)
+    try:
+        assert kb.reclaim_task(conn, task_id, **old)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET tenant = ?, workspace_path = ? WHERE id = ?",
+                ("business-b", str(tmp_path / "successor"), task_id),
+            )
+        assert kb.claim_task(conn, task_id, claimer=f"successor:{action}")
+        before = _snapshot(conn, task_id)
+        if action == "heartbeat":
+            changed = kbd.heartbeat_worker(conn, task_id, note="stale", **old)
+        elif action == "reclaim":
+            changed = kb.reclaim_task(conn, task_id, reason="stale", **old)
+        else:
+            changed = kb.complete_task(
+                conn, task_id, summary="stale", created_cards=["t_deadbeefcafe"], **old,
+            )
+        assert changed is False
+        assert _snapshot(conn, task_id) == before
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("action", ("heartbeat", "reclaim", "complete"))
+def test_partial_new_lease_identity_is_rejected_without_mutation(tmp_path, action):
+    conn, task_id, guards = _running_task(tmp_path, f"partial-{action}")
+    try:
+        before = _snapshot(conn, task_id)
+        partial = {
+            "expected_run_id": guards["expected_run_id"],
+            "expected_claim_lock": guards["expected_claim_lock"],
+        }
+        with pytest.raises(ValueError, match="require expected_run_id"):
+            if action == "heartbeat":
+                kbd.heartbeat_worker(conn, task_id, **partial)
+            elif action == "reclaim":
+                kb.reclaim_task(conn, task_id, **partial)
+            else:
+                kb.complete_task(conn, task_id, summary="partial", **partial)
+        assert _snapshot(conn, task_id) == before
+    finally:
+        conn.close()
+
+
+def test_worker_tool_uses_all_environment_lease_fields(tmp_path, monkeypatch):
+    conn, task_id, guards = _running_task(tmp_path, "worker-tool")
+    path = tmp_path / "worker-tool.db"
+    try:
+        before = _snapshot(conn, task_id)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(path))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(guards["expected_run_id"]))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", guards["expected_claim_lock"])
+    monkeypatch.setenv("HERMES_KANBAN_TENANT", "stale-business")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", guards["expected_workspace_path"])
+    monkeypatch.setattr(kanban_tools, "_is_dispatcher_owned_worker", lambda: True)
+
+    assert "error" in json.loads(kanban_tools._handle_complete({"summary": "stale"}))
+    explicit_run_only = SimpleNamespace(
+        expected_run_id=guards["expected_run_id"], expected_claim_lock=None,
+        expected_tenant=None, expected_workspace_path=None,
+    )
+    resolved = kc._lease_guard_kwargs(explicit_run_only, task_id)
+    assert set(resolved) == {
+        "expected_run_id", "expected_claim_lock", "expected_tenant",
+        "expected_workspace_path",
+    }
+    with pytest.raises(ValueError, match="worker is scoped"):
+        kc._lease_guard_kwargs(explicit_run_only, "foreign-task")
+    with kbc.connect_closing(db_path=path) as check:
+        assert _snapshot(check, task_id) == before
+
+
+def test_failed_terminal_readback_rolls_back_to_the_guarded_running_lease(tmp_path):
+    conn, task_id, guards = _running_task(tmp_path, "terminal-readback")
+    try:
+        conn.execute(
+            "CREATE TRIGGER corrupt_terminal AFTER UPDATE OF status ON tasks "
+            f"WHEN NEW.id = '{task_id}' AND NEW.status = 'done' BEGIN "
+            "UPDATE tasks SET status = 'running', claim_lock = NULL WHERE id = NEW.id; END"
+        )
+        conn.commit()
+        before = _snapshot(conn, task_id)
+        with pytest.raises(kb.TerminalReadbackError):
+            kb.complete_task(conn, task_id, summary="done", **guards)
+        assert _snapshot(conn, task_id) == before
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_lease_spec.py
+++ b/tests/hermes_cli/test_kanban_lease_spec.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import json
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban as kc
+from hermes_cli.kanban_lease_spec import claim_lease_exec_spec
+
+
+CAPABILITY = {
+    "provider": "openai-codex",
+    "model_id": "gpt-5.6-sol",
+    "effort": "low",
+}
+
+
+def _routed_task(conn, title: str, *, priority: int = 0) -> str:
+    kb.put_route_policy(
+        conn, policy_ref="sunny.worker", policy_version=1,
+        provider_ref=CAPABILITY["provider"], model_ref=CAPABILITY["model_id"],
+        effort_ref=CAPABILITY["effort"],
+    )
+    return kb.create_task(
+        conn, title=title, priority=priority, tenant="business-a",
+        workspace_kind="dir", workspace_path=f"/workspaces/{title}",
+        bucket_key="coding", route_policy_ref="sunny.worker", route_policy_version=1,
+    )
+
+
+def test_lease_spec_selects_one_task_and_returns_the_complete_identity(tmp_path):
+    path = tmp_path / "kanban.db"
+    with kbc.connect_closing(db_path=path) as conn:
+        wanted = _routed_task(conn, "high", priority=9)
+        _routed_task(conn, "low", priority=1)
+        result = claim_lease_exec_spec(
+            conn, worker_identity="worker-7", worker_capabilities=[CAPABILITY],
+            bucket_key="coding", ttl_seconds=120, board="default",
+        )
+        assert result["ok"] is True
+        assert result["task_id"] == wanted
+        assert result["claim_lock"] == result["claim_token"]
+        assert result["claim_lock"].startswith("worker-7:")
+        assert result["scope"] == {"tenant": "business-a", "business": "business-a"}
+        assert result["workspace"] == "/workspaces/high"
+        assert result["route"] == {
+            "provider": "openai-codex", "model": "gpt-5.6-sol",
+            "requested_effort": "low", "applied_effort": "low",
+        }
+        assert result["claim_expires"] - result["heartbeat_at"] == 120
+        assert len(kb.list_runs(conn, wanted)) == 1
+
+
+def test_lease_claim_is_atomic_and_failed_readback_rolls_back(tmp_path, monkeypatch):
+    path = tmp_path / "kanban.db"
+    with kbc.connect_closing(db_path=path) as conn:
+        task_id = _routed_task(conn, "only")
+
+    def claim(worker):
+        with kbc.connect_closing(db_path=path) as conn:
+            return claim_lease_exec_spec(
+                conn, worker_identity=worker, worker_capabilities=[CAPABILITY],
+            )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(claim, ("worker-a", "worker-b")))
+    assert sum(result["ok"] for result in results) == 1
+    with kbc.connect_closing(db_path=path) as conn:
+        winner = next(result for result in results if result["ok"])
+        guards = {
+            "expected_run_id": winner["run_id"],
+            "expected_claim_lock": winner["claim_lock"],
+            "expected_tenant": winner["tenant"],
+            "expected_workspace_path": winner["workspace"],
+        }
+        assert kb.reclaim_task(conn, task_id, **guards)
+
+        original = kb.get_task
+        monkeypatch.setattr(kb, "get_task", lambda *_args, **_kwargs: None)
+        failed = claim_lease_exec_spec(
+            conn, worker_identity="worker-c", worker_capabilities=[CAPABILITY],
+        )
+        monkeypatch.setattr(kb, "get_task", original)
+        assert failed["code"] == "lease_readback_failed"
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.claim_lock is None
+        assert len(kb.list_runs(conn, task_id)) == 1
+
+
+def test_lease_spec_cli_emits_the_same_exact_contract(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    with kbc.connect_closing() as conn:
+        task_id = _routed_task(conn, "cli")
+    result = json.loads(kc.run_slash(
+        "lease-spec --worker-id fm-1 "
+        "--capability openai-codex:gpt-5.6-sol:low --json"
+    ))
+    assert result["ok"] is True
+    assert result["task_id"] == task_id
+    assert result["board"] == "default"
+    assert result["worker_identity"] == "fm-1"

--- a/tests/hermes_cli/test_kanban_sunny_persistence.py
+++ b/tests/hermes_cli/test_kanban_sunny_persistence.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import sqlite3
+import json
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban as kc
+
+
+def _legacy_db(path):
+    conn = sqlite3.connect(path)
+    conn.executescript(kb.SCHEMA_SQL)
+    conn.execute("DROP TABLE sunny_route_policies")
+    for column in ("route_policy_version", "route_policy_ref", "bucket_key"):
+        conn.execute(f"ALTER TABLE tasks DROP COLUMN {column}")
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) VALUES (?, ?, ?, ?)",
+        ("legacy-1", "Legacy", "done", 100),
+    )
+    conn.execute(
+        "INSERT INTO task_events (task_id, kind, created_at) VALUES (?, ?, ?)",
+        ("legacy-1", "completed", 101),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_sunny_migration_preserves_legacy_rows_with_null_references(tmp_path):
+    path = tmp_path / "kanban.db"
+    _legacy_db(path)
+    with kbc.connect_closing(db_path=path) as conn:
+        task = kb.get_task(conn, "legacy-1")
+        assert task is not None
+        assert (task.bucket_key, task.route_policy_ref, task.route_policy_version) == (
+            None, None, None,
+        )
+        assert [event.kind for event in kb.list_events(conn, task.id)] == ["completed"]
+        assert conn.execute("SELECT COUNT(*) FROM sunny_route_policies").fetchone()[0] == 0
+
+
+def test_route_policies_are_immutable_and_task_references_are_queryable(tmp_path):
+    with kbc.connect_closing(db_path=tmp_path / "kanban.db") as conn:
+        policy = kb.put_route_policy(
+            conn, policy_ref="sunny.worker", policy_version=1,
+            provider_ref="openai-codex", model_ref="gpt-5.6-sol", effort_ref="low",
+        )
+        assert kb.put_route_policy(
+            conn, policy_ref="sunny.worker", policy_version=1,
+            provider_ref="openai-codex", model_ref="gpt-5.6-sol", effort_ref="low",
+        ) == policy
+        with pytest.raises(ValueError, match="different contract"):
+            kb.put_route_policy(
+                conn, policy_ref="sunny.worker", policy_version=1,
+                provider_ref="openrouter", model_ref="openai/gpt-5.6-sol",
+            )
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(sunny_route_policies)")}
+        assert not columns & {"api_key", "credential", "credentials", "entitlement"}
+
+        task_id = kb.create_task(
+            conn, title="Routed", bucket_key="coding",
+            route_policy_ref=policy.policy_ref, route_policy_version=policy.policy_version,
+        )
+        assert [task.id for task in kb.list_tasks(
+            conn, bucket_key="coding", route_policy_ref="sunny.worker",
+            route_policy_version=1,
+        )] == [task_id]
+        before = kb.get_task(conn, task_id)
+        assert kb.update_task_route_references(conn, task_id, bucket_key="review")
+        after = kb.get_task(conn, task_id)
+        assert after.bucket_key == "review"
+        assert (after.status, after.claim_lock, after.current_run_id) == (
+            before.status, before.claim_lock, before.current_run_id,
+        )
+
+
+def test_cli_round_trips_sunny_references(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    created = json.loads(kc.run_slash(
+        "create Routed --bucket-key coding --route-policy-ref sunny.worker "
+        "--route-policy-version 1 --json"
+    ))
+    assert (created["bucket_key"], created["route_policy_ref"],
+            created["route_policy_version"]) == ("coding", "sunny.worker", 1)
+    listed = json.loads(kc.run_slash(
+        "list --bucket-key coding --route-policy-ref sunny.worker "
+        "--route-policy-version 1 --json"
+    ))
+    assert [task["id"] for task in listed] == [created["id"]]
+    assert "Edited" in kc.run_slash(f"edit {created['id']} --bucket-key review")
+    shown = json.loads(kc.run_slash(f"show {created['id']} --json"))
+    assert shown["task"]["bucket_key"] == "review"

--- a/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
@@ -32,7 +32,7 @@ def _make_task(kb, *, assignee: str = "w"):
         workspace_path=None,
         claim_lock="lock",
         claim_expires=None,
-        tenant=None,
+        tenant="business-a",
         current_run_id=1,
     )
 
@@ -77,5 +77,7 @@ def test_terminal_cwd_pinned_to_workspace(monkeypatch, tmp_path):
     # The subprocess cwd and TERMINAL_CWD must agree — both anchor the workspace.
     assert captured["cwd"] == str(workspace)
     assert captured["env"]["HERMES_KANBAN_WORKSPACE"] == str(workspace)
-
+    assert captured["env"]["HERMES_KANBAN_RUN_ID"] == "1"
+    assert captured["env"]["HERMES_KANBAN_CLAIM_LOCK"] == "lock"
+    assert captured["env"]["HERMES_KANBAN_TENANT"] == "business-a"
 

--- a/tests/tools/test_kanban_descendant_scope.py
+++ b/tests/tools/test_kanban_descendant_scope.py
@@ -18,14 +18,23 @@ ROOT = Path(__file__).resolve().parents[2]
 def _worker_board(tmp_path, monkeypatch):
     db = tmp_path / "assigned.db"
     conn = connect(db)
-    own, foreign = [kb.create_task(conn, title=title) for title in ("own", "foreign")]
+    own, foreign = [
+        kb.create_task(
+            conn, title=title, tenant="business-a", workspace_kind="dir",
+            workspace_path=str(tmp_path / f"workspace-{title}"),
+        )
+        for title in ("own", "foreign")
+    ]
     for tid in (own, foreign):
         kb.claim_task(conn, tid)
     task = kb.get_task(conn, own)
     for key, value in {
         "HERMES_KANBAN_DB": str(db), "HERMES_KANBAN_BOARD": "default",
         "HERMES_KANBAN_TASK": own, "HERMES_KANBAN_RUN_ID": str(task.current_run_id),
-        "HERMES_KANBAN_CLAIM_LOCK": task.claim_lock, "HOME": str(tmp_path),
+        "HERMES_KANBAN_CLAIM_LOCK": task.claim_lock,
+        "HERMES_KANBAN_TENANT": task.tenant,
+        "HERMES_KANBAN_WORKSPACE": task.workspace_path,
+        "HOME": str(tmp_path),
     }.items():
         monkeypatch.setenv(key, value)
     monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -155,6 +155,36 @@ def _worker_run_id(task_id: str) -> Optional[int]:
         return None
 
 
+def _worker_lease_guards(task_id: str) -> dict[str, Any]:
+    """Exact active lease identity for a dispatcher-owned worker."""
+    run_id = _own_task_env(task_id, "HERMES_KANBAN_RUN_ID")
+    claim_lock = _own_task_env(task_id, "HERMES_KANBAN_CLAIM_LOCK")
+    workspace = _own_task_env(task_id, "HERMES_KANBAN_WORKSPACE")
+    tenant = _own_task_env(task_id, "HERMES_KANBAN_TENANT")
+    if claim_lock is not None or workspace is not None or tenant is not None:
+        _check(run_id, "worker lease identity is incomplete: missing run id")
+        _check(str(claim_lock or "").strip(),
+               "worker lease identity is incomplete: missing claim lock")
+        _check(str(workspace or "").strip(),
+               "worker lease identity is incomplete: missing workspace")
+        try:
+            parsed_run_id = int(str(run_id))
+        except ValueError as exc:
+            raise _Reject("worker lease identity has an invalid run id") from exc
+        return {
+            "expected_run_id": parsed_run_id,
+            "expected_claim_lock": claim_lock,
+            "expected_tenant": tenant.strip() if tenant and tenant.strip() else None,
+            "expected_workspace_path": workspace,
+        }
+    if not run_id:
+        return {}
+    try:
+        return {"expected_run_id": int(run_id)}
+    except ValueError as exc:
+        raise _Reject("worker lease identity has an invalid run id") from exc
+
+
 def _stamp_worker_session_metadata(task_id: str, metadata: Optional[dict]) -> Optional[dict]:
     """Add trusted worker session id metadata for this worker's own task."""
     session_id = _own_task_env(task_id, "HERMES_SESSION_ID")
@@ -428,14 +458,18 @@ def heartbeat_current_worker_from_env() -> bool:
     try:
         from hermes_cli import kanban_db_dispatch as kbd
         with _board(None, quiet_close=True) as (kb, conn):
-            ops = ((kb.heartbeat_claim, {"claimer": os.environ.get("HERMES_KANBAN_CLAIM_LOCK")}),
-                   (kbd.heartbeat_worker, {"note": None, "expected_run_id": _worker_run_id(tid)}))
-            for fn, kwargs in ops:
-                op = fn.__name__
-                try:
-                    fn(conn, tid, **kwargs)
-                except Exception:
-                    logger.debug("auto-heartbeat: %s failed", op, exc_info=True)
+            guards = _worker_lease_guards(tid)
+            try:
+                kbd.heartbeat_worker(conn, tid, note=None, **guards)
+            except Exception:
+                logger.debug("auto-heartbeat: heartbeat_worker failed", exc_info=True)
+            try:
+                kb.heartbeat_claim(
+                    conn, tid, claimer=os.environ.get("HERMES_KANBAN_CLAIM_LOCK"),
+                    **guards,
+                )
+            except Exception:
+                logger.debug("auto-heartbeat: heartbeat_claim failed", exc_info=True)
         return True
     except Exception:
         logger.debug("auto-heartbeat: bridge failed", exc_info=True)
@@ -556,6 +590,7 @@ def _handle_complete(args: dict, **kw) -> str:
     _check(summary or result, "provide at least one of: summary (preferred), result")
     _require_dict_metadata(metadata)
     metadata = _stamp_worker_session_metadata(tid, metadata)
+    guards = _worker_lease_guards(tid)
     with _board(args.get("board")) as (kb, conn):
         # Goal-mode pre-completion judge gate (Issue #38367). Prevent workers from bypassing the auxiliary
         # judge by calling kanban_complete before acceptance criteria are met. Only enforce when a judge is
@@ -565,7 +600,7 @@ def _handle_complete(args: dict, **kw) -> str:
         try:
             ok = kb.complete_task(
                 conn, tid, result=result, summary=summary, metadata=metadata,
-                created_cards=created_cards, expected_run_id=_worker_run_id(tid))
+                created_cards=created_cards, **guards)
         except kb.ArtifactPreservationError as artifact_err:
             # Structured rejection — surface the phantom ids so the worker can retry with a corrected list
             # or drop the field. Audit event already landed in the DB. The task itself was NOT mutated (the
@@ -669,14 +704,20 @@ def _handle_heartbeat(args: dict, **kw) -> str:
     Without the claim half, a worker blocked in one long tool call would still
     be reclaimed by ``release_stale_claims``."""
     tid = _worker_guard("kanban_heartbeat", args)
+    guards = _worker_lease_guards(tid)
     from hermes_cli import kanban_db_dispatch as kbd
     with _board(args.get("board")) as (kb, conn):
         # The dispatcher pins HERMES_KANBAN_CLAIM_LOCK at spawn; the default
         # claimer covers locally-driven workers that bypassed the dispatcher.
-        kb.heartbeat_claim(conn, tid, claimer=os.environ.get("HERMES_KANBAN_CLAIM_LOCK"))
         ok = kbd.heartbeat_worker(
-            conn, tid, note=args.get("note"), expected_run_id=_worker_run_id(tid))
+            conn, tid, note=args.get("note"), **guards)
         _check(ok, f"could not heartbeat {tid} (unknown id or not running)")
+        _check(
+            kb.heartbeat_claim(
+                conn, tid, claimer=os.environ.get("HERMES_KANBAN_CLAIM_LOCK"), **guards,
+            ),
+            f"could not extend claim for {tid} (stale lease identity)",
+        )
         return _ok(task_id=tid)
 
 


### PR DESCRIPTION
## Summary
- add provider-neutral route/provenance validation with fail-closed ambiguous identity handling
- persist Sunny bucket and route references with migration/legacy compatibility
- add atomic one-task lease execution specs and lease-scoped lifecycle guards
- preserve terminal readback, worker-environment, and descendant-scope protections

## Validation
- 135 focused tests passed through `scripts/run_tests.sh`
- 2 Windows-only tests skipped by host marker
- `compileall`, Ruff, targeted `ty`, compatibility-pointer checks, and Windows-footgun checks passed

## Publication notes
- This branch is based directly on upstream `main` and contains one focused commit.
- Paired FirstMate publication is tracked separately in Kadokk/thousand-sunny PR #2.
- No merge, gateway restart, scheduler activation, provider activation, or live worker pool was performed.