### PR TITLE
fix(gateway): whitelist SCM service names so update pause path cannot target Windows system services

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -73,6 +73,18 @@ logger = logging.getLogger(__name__)
 # Shared ``subprocess.run`` kwargs for text-mode probes (stdout/stderr captured, decode-tolerant).
 _CAPTURE_TEXT = dict(capture_output=True, text=True, encoding="utf-8", errors="replace")
 
+# SCM service-name prefixes that ``find_windows_gateway_services`` may treat as an owned gateway.
+# Only Hermes-supervised SCM services fall in this set; Windows-shipped system services (``Schedule``,
+# ``RpcSs``, ``W32Time``, ``BFE``, ...) must NEVER match — the SCM host-PID check alone is not enough,
+# because a gateway's ancestor chain can include a ``services.exe``-owned svchost that *also* hosts an
+# unrelated system service on the same PID (which our shared-host guard already rejects) — but a
+# host-pid that maps to exactly one system service (no shared host) was previously misidentified, and
+# ``sc.exe stop`` would then target the system service in the updater pause path, requiring SYSTEM.
+# Match by case-insensitive prefix; covers the legacy ``HermesGateway`` name and the per-profile
+# ``HermesGateway-<profile>`` form. Task Scheduler uses ``Hermes_Gateway`` (underscore) and is handled
+# separately by ``gateway_windows``; we never touch Task Scheduler through this path.
+_HERMES_SCM_SERVICE_NAME_PREFIXES: tuple[str, ...] = ("HermesGateway", "HermesAgent")
+
 # =============================================================================
 # Process Management (for manual gateway runs)
 # =============================================================================
@@ -781,6 +793,27 @@ def find_profile_gateway_processes(exclude_pids: set | None = None, *, strict: b
     return processes
 
 
+def _is_hermes_owned_service_name(name: str) -> bool:
+    """True iff *name* looks like a Hermes-supervised SCM service.
+
+    Windows ships dozens of system services whose SCM host-PID may transiently coincide with a
+    gateway's ancestor chain — most visibly ``Schedule`` (Task Scheduler), ``RpcSs``, ``W32Time``,
+    ``BFE`` — and ``sc.exe stop`` against them requires SYSTEM and aborts the update with a
+    misleading error. ``find_windows_gateway_services`` previously trusted the SCM host-PID alone
+    plus a "single service on this host PID" guard, but that guard does not protect against a
+    system service that is the *only* SCM entry on a host PID the gateway traverses (the bug class
+    behind the "sc.exe stop Schedule fails during hermes update" reports). The prefix match here
+    is the belt; the host-PID guard below is the suspenders.
+    """
+    if not name:
+        return False
+    lowered = name.casefold()
+    return any(
+        lowered == prefix.casefold() or lowered.startswith(prefix.casefold() + "-")
+        for prefix in _HERMES_SCM_SERVICE_NAME_PREFIXES
+    )
+
+
 def find_windows_gateway_services(
     *, psutil_module=None, profile_processes: list[ProfileGatewayProcess] | None = None
 ) -> list[WindowsGatewayService]:
@@ -815,6 +848,15 @@ def find_windows_gateway_services(
                 raise RuntimeError("SCM service inspection failed") from exc
             if not service_name:
                 raise RuntimeError("SCM service has an empty name")
+            # Name whitelist: SCM host-PID ancestry is necessary but not sufficient — a svchost
+            # that happens to host a Windows system service (``Schedule``, ``RpcSs``, ...) can
+            # transiently appear in a gateway's ancestor chain without owning the gateway. The
+            # host-PID + descendants check below is the structural proof; this guard rejects
+            # names that no Hermes install would ever create before they enter ANY of the
+            # cross-checks below — including the indeterminate-status path, so a system service
+            # mid-transition cannot abort the update on a gateway it does not own.
+            if not _is_hermes_owned_service_name(service_name):
+                continue
             if service_status == "stopped":
                 continue
             if service_status != "running":

--- a/hermes_cli/update_cmd_windows.py
+++ b/hermes_cli/update_cmd_windows.py
@@ -757,13 +757,30 @@ def _pause_windows_gateway_services(service_gateways, token: dict, profiles: dic
     """Stop each SCM gateway service, recording them on *token*; roll everything back on failure.
 
     Runs after every fallible ordinary-gateway step so a failure here restores the attempted
-    services AND the already-paused ordinary gateways before re-raising."""
+    services AND the already-paused ordinary gateways before re-raising.
+
+    Defense in depth: every *service_gateways* entry must pass the same name whitelist
+    ``find_windows_gateway_services`` applies during enumeration. If a future caller passes
+    a hand-rolled WindowsGatewayService (tests, profile-create hooks, third-party plugins),
+    we refuse to invoke ``sc.exe`` on a Windows system service — better to raise here than
+    to halt the update mid-stop with a SYSTEM-only ``sc.exe stop`` error. The whitelist is
+    the single source of truth; update it in one place (``hermes_cli.gateway``).
+    """
+    from hermes_cli.gateway import _HERMES_SCM_SERVICE_NAME_PREFIXES, _is_hermes_owned_service_name
     from hermes_cli.update_cmd import _restore_windows_gateway_service, _stop_windows_gateway_service
     paused_services = []
     current_service_name = None
     try:
         for service in service_gateways:
             current_service_name = str(service.name)
+            if not _is_hermes_owned_service_name(current_service_name):
+                raise RuntimeError(
+                    f"Refusing to stop Windows service {current_service_name!r}: "
+                    "name does not match the Hermes SCM service whitelist "
+                    f"({_HERMES_SCM_SERVICE_NAME_PREFIXES!r}). This usually means a Windows "
+                    "system service (Schedule, RpcSs, ...) leaked into the gateway "
+                    "service list — abort the update and file a bug."
+                )
             _stop_windows_gateway_service(
                 current_service_name, expected_processes=tuple(getattr(service, "descendant_identities", ())),
                 expected_service_identity=(int(service.service_pid), float(service.service_create_time)),

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1190,8 +1190,182 @@ def test_find_windows_gateway_services_rejects_transitional_ancestor(monkeypatch
         )
 
 
+def test_find_windows_gateway_services_ignores_indeterminate_system_service(monkeypatch):
+    """A system service mid-transition (stop_pending/start_pending) must NOT abort the update
+    via the indeterminate-status guard — it is not a Hermes service at all. Complements
+    ``test_find_windows_gateway_services_rejects_transitional_ancestor`` which pins the
+    fail-closed path for a *whitelisted* (Hermes) service.
+    """
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class FakeService:
+        def __init__(self, status):
+            self.status = status
+
+        def as_dict(self):
+            return {"name": "Schedule", "pid": 100, "status": self.status}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            return [FakeProcess(100)]
+
+        def children(self, recursive=False):
+            return []
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [FakeService("stop_pending"), FakeService("start_pending")],
+        Process=FakeProcess,
+    )
+
+    # Both indeterminate states are ignored entirely — no raise, no match.
+    assert gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil, profile_processes=[profile],
+    ) == []
+
+
 def test_find_windows_gateway_services_rejects_shared_service_host_pid(monkeypatch):
-    """A shared host PID cannot prove which service owns the gateway subtree."""
+    """Two Hermes-named SCM services sharing one host PID cannot prove which owns the gateway subtree.
+    The host-PID guard fires before the name whitelist enters the picture; both names pass the whitelist
+    but the structural proof (single-service-on-host) fails closed."""
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class FakeService:
+        def __init__(self, name):
+            self.name = name
+
+        def as_dict(self):
+            return {"name": self.name, "pid": 100, "status": "running"}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            # Two host PIDs, one of which is shared between the two Hermes-named services.
+            # The shared one (100) must trigger the fail-closed guard.
+            return [FakeProcess(100), FakeProcess(99)]
+
+        def children(self, recursive=False):
+            # Use the unambiguous host PID 99 as the source of the gateway descendant set.
+            assert self.pid == 99
+            return [FakeProcess(200), FakeProcess(300)]
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [FakeService("HermesGateway"), FakeService("HermesGateway-default")],
+        Process=FakeProcess,
+    )
+
+    with pytest.raises(RuntimeError, match="shared SCM host"):
+        gateway.find_windows_gateway_services(
+            psutil_module=fake_psutil,
+            profile_processes=[profile],
+        )
+
+
+def test_find_windows_gateway_services_rejects_windows_system_services(monkeypatch):
+    """System services that share a single SCM host PID with a gateway ancestor must NOT be
+    treated as a Hermes gateway service. Covers the ``sc.exe stop Schedule`` bug: a svchost
+    hosting ``Schedule`` (Task Scheduler) sits in a Windows service's parent chain, and the
+    SCM host-PID ancestry alone is not enough to prove Hermes ownership. Without the name
+    whitelist the updater's pause path would invoke ``sc.exe stop Schedule``, which requires
+    SYSTEM and aborts the update.
+    """
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class FakeService:
+        def __init__(self, name):
+            self.name = name
+
+        def as_dict(self):
+            return {"name": self.name, "pid": 100, "status": "running"}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            return [FakeProcess(100)]
+
+        def children(self, recursive=False):
+            # The whitelist rejects Schedule before descendants are checked, but mirror the
+            # real layout (a real svchost hosting Schedule never spawns the gateway, so this
+            # branch would never return the gateway PID either way).
+            return []
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [
+            FakeService("Schedule"),
+            FakeService("RpcSs"),
+            FakeService("W32Time"),
+            FakeService("BFE"),
+        ],
+        Process=FakeProcess,
+    )
+
+    # No service should match — return [] rather than raise, so the updater's pause path sees
+    # an empty SCM list and proceeds to the cold-start / restart branch.
+    assert gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil, profile_processes=[profile],
+    ) == []
+
+
+def test_find_windows_gateway_services_matches_per_profile_service_name(monkeypatch):
+    """Per-profile SCM service names (``HermesGateway-<profile>``) match the whitelist."""
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="work", pid=300, create_time=300.0)
+
+    class FakeService:
+        def __init__(self, name):
+            self.name = name
+
+        def as_dict(self):
+            return {"name": self.name, "pid": 100, "status": "running"}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            return [FakeProcess(100)]
+
+        def children(self, recursive=False):
+            return [FakeProcess(200), FakeProcess(300)]
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [FakeService("HermesGateway-work")],
+        Process=FakeProcess,
+    )
+
+    result = gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil, profile_processes=[profile],
+    )
+    assert [r.name for r in result] == ["HermesGateway-work"]
+    assert [r.profile for r in result] == ["work"]
+
+
+def test_find_windows_gateway_services_rejects_partial_prefix_overlap(monkeypatch):
+    """``HermesGatewaysAreCool`` (no ``-`` separator after the prefix) does NOT match.
+    Guards against prefix over-matching if Hermes ever adds a service whose name happens
+    to share the leading characters without the dash boundary.
+    """
     monkeypatch.setattr(gateway.sys, "platform", "win32")
     profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
 
@@ -1216,15 +1390,13 @@ def test_find_windows_gateway_services_rejects_shared_service_host_pid(monkeypat
             return float(self.pid)
 
     fake_psutil = SimpleNamespace(
-        win_service_iter=lambda: [FakeService("ServiceA"), FakeService("ServiceB")],
+        win_service_iter=lambda: [FakeService("HermesGatewaysAreCool")],
         Process=FakeProcess,
     )
 
-    with pytest.raises(RuntimeError, match="shared SCM host"):
-        gateway.find_windows_gateway_services(
-            psutil_module=fake_psutil,
-            profile_processes=[profile],
-        )
+    assert gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil, profile_processes=[profile],
+    ) == []
 
 
 def test_find_windows_gateway_services_fails_closed_on_service_access_error(


### PR DESCRIPTION
## Summary

`hermes update` on Windows could abort mid-stop with a misleading `sc.exe stop <name>: Access denied` error when a Windows system service (most visibly `Schedule`, the Task Scheduler) appeared in the SCM enumeration alongside any Hermes gateway ancestor. The only ownership proof in `find_windows_gateway_services` was SCM host-PID ancestry plus a "single service on this host PID" guard — the latter caught the multi-service case but left the single-service case exposed, so a svchost hosting `Schedule` (running, no other SCM sibling on that PID) was accepted as a Hermes gateway and the pause path called `sc.exe stop Schedule` against it. Stopping Task Scheduler requires SYSTEM, so the update failed and the workaround became `hermes gateway stop` first.

## Fix

Add a name whitelist (`_HERMES_SCM_SERVICE_NAME_PREFIXES`, currently `HermesGateway` and `HermesAgent` with optional `-<profile>` suffix) plus `_is_hermes_owned_service_name`. Three enforcement points:

1. **`find_windows_gateway_services`** skips any SCM entry whose name is not on the whitelist *before any status cross-check* — running, stopped, and indeterminate (start/stop_pending) system services all return `[]`, and the updater falls through to the existing cold-start / restart branch.
2. **`_pause_windows_gateway_services`** re-checks the name before calling `_sc_exe` (belt-and-suspenders: hand-rolled `WindowsGatewayService` entries from tests, profile-create hooks, or third-party plugins cannot slip past).
3. The structural "shared SCM host PID" guard is preserved as-is — it still fires for two whitelist-passing services that share one host PID.

Task Scheduler continues to use the `_TASK_NAME_DEFAULT = "Hermes_Gateway"` Scheduled Task path (handled in `gateway_windows.py`), which is separate from this code path.

## Tests

`tests/hermes_cli/test_gateway.py` (9 tests, `scripts/run_tests.sh -k find_windows_gateway_services` → 9 passed, 0 failed):

- `test_find_windows_gateway_services_rejects_windows_system_services` — `Schedule` / `RpcSs` / `W32Time` / `BFE` → `[]`
- `test_find_windows_gateway_services_ignores_indeterminate_system_service` — `Schedule` in `stop_pending`/`start_pending` is ignored entirely (no `indeterminate status` abort)
- `test_find_windows_gateway_services_rejects_transitional_ancestor` — unchanged: a *whitelisted* Hermes service mid-transition still fails closed
- `test_find_windows_gateway_services_matches_per_profile_service_name` — `HermesGateway-work` accepted
- `test_find_windows_gateway_services_rejects_partial_prefix_overlap` — `HermesGatewaysAreCool` (no `-` separator) rejected
- `test_find_windows_gateway_services_rejects_shared_service_host_pid` — fixture updated to use two whitelist-passing names (`HermesGateway` + `HermesGateway-default`) on the same host PID so the structural guard still fires

The four pre-existing failures in `TestReapUnsupervisedGatewayOrphans*` are unrelated to this change (verified against a `main`-baseline shared clone) — they fail on `main` with or without this PR.

## Reproduction (Windows)

Before:

```
PS> sc.exe query Schedule
SERVICE_NAME: Schedule
  STATE: 4 RUNNING

PS> hermes update
  ⚠ Could not stop Windows gateway service Schedule: ...sc.exe stop failed with 5...
[update aborted; user must run `hermes gateway stop` first, then re-run `hermes update`]
```

After:

```
PS> hermes update
  → no SCM gateway services detected
  → proceeds to Scheduled-Task / cold-start restart path automatically
```

## Notes for reviewers

- AGENTS.md rubrics followed: extend existing code (no new core surface, no new CLI), behavior contract test (`_is_hermes_owned_service_name` is a pure function), single commit / single bug class.
- `_HERMES_SCM_SERVICE_NAME_PREFIXES` is the single source of truth — extend the tuple when a new SCM service name is introduced; the docstring on the constant enumerates which prefixes are currently in scope.
- No compat shim, no re-exports, no env var addition. The whitelist is module-local state, not config.
