### PR TITLE
fix(desktop): retry the i18n startup config fetch after update relaunches

### DIFF
--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -77,6 +77,8 @@ describe('I18nProvider', () => {
   })
 
   it('keeps English usable when config loading fails', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
     const configClient: I18nConfigClient = {
       getConfig: vi.fn().mockRejectedValue(new Error('config unavailable')),
       saveConfig: vi.fn()
@@ -88,11 +90,76 @@ describe('I18nProvider', () => {
       </I18nProvider>
     )
 
+    // The startup fetch retries three times (500ms, 1000ms, 1500ms) before
+    // giving up — a backend that is merely slow must not read as "English".
+    await vi.advanceTimersByTimeAsync(500)
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(1500)
     await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
 
     expect(screen.getByTestId('locale').textContent).toBe('en')
     expect(screen.getByTestId('label').textContent).toBe('Language')
+    expect(configClient.getConfig).toHaveBeenCalledTimes(4)
     expect(configClient.saveConfig).not.toHaveBeenCalled()
+
+    vi.useRealTimers()
+  })
+
+  it('recovers the persisted locale when the config fetch fails transiently (#105465)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    // Update-relaunch race: the renderer's first config GETs hit a backend
+    // connection that is still settling; a later attempt succeeds and must
+    // apply the persisted display.language instead of pinning English.
+    const configClient: I18nConfigClient = {
+      getConfig: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('backend starting'))
+        .mockRejectedValueOnce(new Error('backend starting'))
+        .mockResolvedValueOnce({ display: { language: 'zh' } }),
+      saveConfig: vi.fn()
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+    await vi.advanceTimersByTimeAsync(1000)
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+
+    expect(screen.getByTestId('locale').textContent).toBe('zh')
+    expect(screen.getByTestId('label').textContent).toBe('语言')
+    expect(configClient.getConfig).toHaveBeenCalledTimes(3)
+    expect(configClient.saveConfig).not.toHaveBeenCalled()
+
+    vi.useRealTimers()
+  })
+
+  it('stops retrying once the provider unmounts', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockRejectedValue(new Error('backend starting')),
+      saveConfig: vi.fn()
+    }
+
+    const { unmount } = render(
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    unmount()
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(configClient.getConfig).toHaveBeenCalledTimes(2)
+
+    vi.useRealTimers()
   })
 
   it('loads zh-hant from display.language config', async () => {

--- a/apps/desktop/src/i18n/context.tsx
+++ b/apps/desktop/src/i18n/context.tsx
@@ -66,6 +66,23 @@ function applyDocumentLocale(locale: Locale) {
   document.documentElement.dir = RTL_LOCALES.has(locale) ? 'rtl' : 'ltr'
 }
 
+// The renderer mounts right after the backend announces readiness, but on an
+// update relaunch the connection is still settling and the one-shot config GET
+// can fail — pinning the locale to English for the whole session even though
+// display.language is intact on disk (#105465). Retry the fetch a bounded
+// number of times with linear backoff (same shape as refreshProfiles, #70679)
+// so a backend that comes up a moment late still gets its language applied.
+const CONFIG_FETCH_MAX_RETRIES = 3
+const CONFIG_FETCH_RETRY_DELAY_MS = 500
+
+function configFetchRetryDelayMs(attempt: number): number {
+  return CONFIG_FETCH_RETRY_DELAY_MS * (attempt + 1)
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
 export interface I18nContextValue {
   configLoadError: Error | null
   isLoadingConfig: boolean
@@ -114,27 +131,45 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
 
     let cancelled = false
 
-    setIsLoadingConfig(true)
-    setConfigLoadError(null)
+    const loadLocale = async () => {
+      setIsLoadingConfig(true)
+      setConfigLoadError(null)
 
-    configClient
-      .getConfig()
-      .then(config => {
-        if (!cancelled) {
-          setLocaleState(normalizeLocale(getConfigDisplayLanguage(config)))
+      let lastError: unknown
+
+      for (let attempt = 0; ; attempt++) {
+        try {
+          const config = await configClient.getConfig()
+
+          if (!cancelled) {
+            setLocaleState(normalizeLocale(getConfigDisplayLanguage(config)))
+            setIsLoadingConfig(false)
+          }
+
+          return
+        } catch (error) {
+          lastError = error
+
+          if (cancelled || attempt >= CONFIG_FETCH_MAX_RETRIES) {
+            break
+          }
+
+          await sleep(configFetchRetryDelayMs(attempt))
+
+          if (cancelled) {
+            return
+          }
         }
-      })
-      .catch(error => {
-        if (!cancelled) {
-          setConfigLoadError(toError(error))
-          setLocaleState(DEFAULT_LOCALE)
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsLoadingConfig(false)
-        }
-      })
+      }
+
+      if (!cancelled) {
+        setConfigLoadError(toError(lastError))
+        setLocaleState(DEFAULT_LOCALE)
+        setIsLoadingConfig(false)
+      }
+    }
+
+    void loadLocale()
 
     return () => {
       cancelled = true


### PR DESCRIPTION
## Summary

After a `hermes update` relaunch, the Desktop renderer mounts right after `HERMES_BACKEND_READY` while the backend connection is still settling. `I18nProvider` fetched the config **exactly once** on mount, and its `catch` branch pinned the locale to `DEFAULT_LOCALE` (English) for the whole session — the persisted `display.language` was never re-read, even though the value is intact on disk (re-selecting the language writes back the same value and it sticks, exactly as reported in #105465).

The startup config fetch now retries a bounded number of times with linear backoff (500ms → 1000ms → 1500ms, 4 attempts total) — the same shape as `refreshProfiles` in `src/store/profile.ts` (#70679):

- an intermediate failure keeps the loading state instead of pinning English;
- a late-but-successful attempt applies the persisted `display.language`;
- after the retry budget is exhausted, behavior is unchanged (English fallback + `configLoadError` surfaced);
- the retry chain is cancelled on unmount (no fetches or state writes from a dead provider, including the post-`sleep` window);
- the success path restores `isLoadingConfig: false` (previously owned by `.finally`).

## Testing

- `npx vitest run src/i18n/ --project ui` — **30 passed (4 files)**, including 13 in `context.test.tsx`:
  - new: *recovers the persisted locale when the config fetch fails transiently (#105465)* — two transient failures then a success applies `zh`;
  - new: *stops retrying once the provider unmounts* — no fetch escapes after unmount;
  - updated: *keeps English usable when config loading fails* — now asserts the full 4-attempt chain before the fallback;
  - mutation check: with the retry budget removed the recovery test fails (`expected 'en' to be 'zh'`), restored afterwards.
- `tsc -p . --noEmit` — clean.
- `eslint` on both files — 0 errors, 0 new warnings (5 pre-existing `no-restricted-globals` warnings on the untouched RTL test, counted identical to the stashed baseline).
- `prettier --check` — clean.

Fixes #105465