### PR TITLE
feat(api-server): bind per-run workspace cwd on /v1/runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -72,7 +72,9 @@ _STATIC_FEATURE_FLAGS = {
     "admin_config_rw": False, "jobs_admin": False, "memory_write_api": False,
     "skills_api": True, "audio_api": False, "realtime_voice": False,
     "session_continuity_header": "X-Hermes-Session-Id",
-    "session_key_header": "X-Hermes-Session-Key"}
+    "session_key_header": "X-Hermes-Session-Key",
+    "workspace_header": "X-Hermes-Workspace",
+    "runs_cwd": True}
 # /v1/capabilities "endpoints" table: name -> (method, path).
 _CAPABILITY_ENDPOINTS = (
     ("health", ("GET", "/health")), ("health_detailed", ("GET", "/health/detailed")),
@@ -758,7 +760,10 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key, X-Hermes-Session-Id"}
+    "Access-Control-Allow-Headers": (
+        "Authorization, Content-Type, Idempotency-Key, "
+        "X-Hermes-Session-Id, X-Hermes-Workspace")}
+_MAX_WORKSPACE_HEADER_LEN = 4096
 _SECURITY_HEADERS = {
     "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
@@ -3531,23 +3536,113 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                 code="rate_limit_exceeded", headers={"Retry-After": "1"})
         return None
 
+    def _parse_workspace_header(self, request: "web.Request"):
+        """Extract ``X-Hermes-Workspace`` as an existing absolute directory.
+
+        Returns ``(cwd, None)`` on success/omission, or ``(None, error_response)`` on
+        invalid input. Omitted/blank headers yield ``("", None)``.
+        """
+        raw = request.headers.get("X-Hermes-Workspace", "").strip()
+        if not raw:
+            return "", None
+        return self._validate_workspace_cwd(raw, source="X-Hermes-Workspace")
+
+    def _validate_workspace_cwd(self, raw: str, *, source: str):
+        """Validate a client-supplied workspace path; *source* names the field in errors."""
+        if re.search(r"[\r\n\x00]", raw) or len(raw) > _MAX_WORKSPACE_HEADER_LEN:
+            return None, web.json_response(
+                _openai_error(
+                    f"Invalid workspace path from {source}",
+                    code="invalid_workspace"),
+                status=400)
+        try:
+            workspace = Path(raw).expanduser()
+            if not workspace.is_absolute():
+                return None, web.json_response(
+                    _openai_error(
+                        f"{source} must be an existing absolute directory",
+                        code="invalid_workspace"),
+                    status=400)
+            workspace = workspace.resolve(strict=True)
+        except (OSError, RuntimeError, ValueError):
+            return None, web.json_response(
+                _openai_error(
+                    f"{source} must be an existing absolute directory",
+                    code="invalid_workspace"),
+                status=400)
+        if not workspace.is_dir():
+            return None, web.json_response(
+                _openai_error(
+                    f"{source} must be a directory",
+                    code="invalid_workspace"),
+                status=400)
+        return str(workspace), None
+
+    def _resolve_run_workspace(self, request: "web.Request", body: dict):
+        """Resolve per-run workspace from header and/or body ``cwd``.
+
+        Both may be omitted (legacy shared ``terminal.cwd``). When both are
+        present they must resolve to the same directory; conflicts are 400.
+        """
+        header_cwd, header_err = self._parse_workspace_header(request)
+        if header_err is not None:
+            return None, header_err
+        raw_body = body.get("cwd") if isinstance(body, dict) else None
+        body_cwd = ""
+        if raw_body is not None:
+            if not isinstance(raw_body, str):
+                return None, web.json_response(
+                    _openai_error(
+                        "cwd must be a string absolute directory",
+                        code="invalid_workspace"),
+                    status=400)
+            body_cwd = raw_body.strip()
+            if body_cwd:
+                body_cwd, body_err = self._validate_workspace_cwd(body_cwd, source="cwd")
+                if body_err is not None:
+                    return None, body_err
+        if header_cwd and body_cwd and header_cwd != body_cwd:
+            return None, web.json_response(
+                _openai_error(
+                    "X-Hermes-Workspace and body cwd disagree",
+                    code="invalid_workspace"),
+                status=400)
+        return (header_cwd or body_cwd or ""), None
+
     @staticmethod
     def _bind_api_server_session(
         *, chat_id: str = "", session_key: str = "", session_id: str = "",
-        browser_control_principal: str = "", browser_control_transport_family: str = "") -> list:
+        browser_control_principal: str = "", browser_control_transport_family: str = "",
+        cwd: str = "") -> list:
         """Bind session contextvars for an API-server agent run — the SINGLE chokepoint for every
         agent-entry path. Hardwires ``platform="api_server"`` + ``async_delivery=False`` (HTTP
         can never wake the agent after the turn) so no route reintroduces the silent no-op bug.
         Returns reset tokens for ``clear_session_vars`` in a ``finally`` (request-scoped).
 
-        See #10760.
+        ``cwd`` pins the logical working directory for this turn (system prompt / context
+        discovery). When both ``cwd`` and ``session_id`` are set, the path is also recorded as
+        the session's terminal cwd via ``record_session_cwd`` — without mutating a live shared
+        ``default`` environment (cwd-only ``register_task_env_overrides`` can collapse there).
+
+        See #10760, #29531, #90439.
         """
         from gateway.session_context import set_session_vars
-        return set_session_vars(
+        session_cwd = (cwd or "").strip()
+        tokens = set_session_vars(
             platform="api_server", chat_id=chat_id, session_key=session_key, session_id=session_id,
             browser_control_principal=browser_control_principal,
             browser_control_transport_family=browser_control_transport_family,
+            cwd=session_cwd,
             async_delivery=False, cron_session="")
+        if session_cwd and session_id:
+            try:
+                from tools.terminal_tool import record_session_cwd
+                record_session_cwd(session_id, session_cwd)
+            except Exception:
+                logger.debug(
+                    "[api_server] failed to record session cwd for %s",
+                    session_id, exc_info=True)
+        return tokens
 
     def _turn_runtime_metadata(
         self, agent: Any, *, route: Optional[Dict[str, Any]], requested_runtime: Optional[Dict[str, Any]],

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -13,9 +13,13 @@ from typing import Any, Callable, Dict, List, Optional
 
 try:
     from aiohttp import web
+except ImportError:  # pragma: no cover - exercised only without aiohttp
+    web = None  # type: ignore[assignment]
+
+try:
+    # aiohttp>=3.12 exposes RequestKey; older 3.11 builds do not.
     from aiohttp.web_request import RequestKey
 except ImportError:
-    web = None  # type: ignore[assignment]
     RequestKey = None  # type: ignore[assignment,misc]
 
 from gateway.platforms.api_server_room_grants import _json_error, _room_grant_error_response
@@ -322,6 +326,7 @@ class _RunLaunch:
     request_profile: Any
     browser_control_principal: Any
     browser_control_transport_family: Any
+    workspace_cwd: str = ""  # client-supplied absolute dir (body cwd / X-Hermes-Workspace)
 
     @property
     def approval_session_key(self) -> str:
@@ -365,6 +370,9 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
     body, room_error = await self._normalize_room_dispatch(request, body)
     if room_error is not None:
         return room_error
+    workspace_cwd, workspace_err = self._resolve_run_workspace(request, body if isinstance(body, dict) else {})
+    if workspace_err is not None:
+        return workspace_err
     room_dispatch, room_execution_policy = (
         v if isinstance(v, dict) else None for v in (
             (body.get("hosted_room_dispatch"), body.get("_room_execution_policy"))
@@ -377,8 +385,14 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
     idempotency_scope = idempotency_fingerprint = ""
     if idempotency_key:
         idempotency_scope = self._run_idempotency_scope(request)
+        # Include resolved workspace so the same Idempotency-Key cannot replay
+        # across different working directories.
         idempotency_fingerprint = hashlib.sha256(json.dumps(
-            {"body": body, "gateway_session_key": gateway_session_key or ""},
+            {
+                "body": body,
+                "gateway_session_key": gateway_session_key or "",
+                "workspace_cwd": workspace_cwd or "",
+            },
             sort_keys=True, separators=(",", ":"), ensure_ascii=False,
         ).encode()).hexdigest()
     raw_input = body.get("input")
@@ -450,7 +464,8 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
             **{k: agent_overrides.get(k) for k in ("requested_model", "requested_provider", "model_options")}),
         request_profile=_api_server._api_request_profile.get(),
         browser_control_principal=_api_server._api_request_browser_control_principal.get(),
-        browser_control_transport_family=_api_server._api_request_browser_control_transport_family.get())
+        browser_control_transport_family=_api_server._api_request_browser_control_transport_family.get(),
+        workspace_cwd=workspace_cwd or "")
     self._activate_admitted_request()
     task = self._active_run_tasks[run_id] = asyncio.create_task(_execute_run(self, launch, _api_server=_api_server))
     with suppress(TypeError):
@@ -486,9 +501,23 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
             session_tokens = self._bind_api_server_session(
                 chat_id=session_id or "", session_key=run.approval_session_key, session_id=session_id or "",
                 browser_control_principal=run.browser_control_principal,
-                browser_control_transport_family=run.browser_control_transport_family)
+                browser_control_transport_family=run.browser_control_transport_family,
+                cwd=run.workspace_cwd or "")
             if session_tokens:
                 resets.append((session_tokens, clear_session_vars))
+            # Mechanical terminal/file cwd: register under both keys the tool chain
+            # consults (session task id for later commands; run_id for the first).
+            if run.workspace_cwd:
+                try:
+                    from tools.terminal_tool import register_task_env_overrides
+                    override = {"cwd": run.workspace_cwd}
+                    register_task_env_overrides(effective_task_id, override)
+                    if run.run_id and run.run_id != effective_task_id:
+                        register_task_env_overrides(run.run_id, override)
+                except Exception:
+                    logger.debug(
+                        "[api_server] failed to register run task cwd for %s",
+                        run.run_id, exc_info=True)
             if run.agent_kwargs["room_dispatch"] is not None:
                 policy = RoomExecutionPolicy.from_mapping(run.agent_kwargs["room_execution_policy"] or {})
                 resets.append((bind_room_execution_policy(policy), reset_room_execution_policy))
@@ -563,9 +592,24 @@ async def _execute_run(self, run: _RunLaunch, *, _api_server) -> None:
             _finish("cancelled")
             return
         with self._profile_scope(run.request_profile):
-            agent = self._create_agent(
-                stream_delta_callback=_text_cb, tool_progress_callback=self._make_run_event_callback(run_id, loop),
-                **run.agent_kwargs)
+            # /v1/runs builds the agent before _run_agent_sync binds session
+            # context. Pin the logical cwd around construction so the system
+            # prompt / context discovery advertise this workspace.
+            pinned_cwd_token = None
+            if run.workspace_cwd:
+                try:
+                    from agent.runtime_cwd import set_session_cwd
+                    pinned_cwd_token = set_session_cwd(run.workspace_cwd)
+                except Exception:
+                    logger.debug("[api_server] failed to pin run cwd", exc_info=True)
+            try:
+                agent = self._create_agent(
+                    stream_delta_callback=_text_cb, tool_progress_callback=self._make_run_event_callback(run_id, loop),
+                    **run.agent_kwargs)
+            finally:
+                if pinned_cwd_token is not None:
+                    with suppress(Exception):
+                        pinned_cwd_token.var.reset(pinned_cwd_token)
         self._active_run_agents[run_id] = agent
         approval_notify = _make_approval_notify(self, run, _api_server=_api_server)
         result, usage = await loop.run_in_executor(

--- a/tests/gateway/test_api_server_runs_workspace.py
+++ b/tests/gateway/test_api_server_runs_workspace.py
@@ -1,0 +1,296 @@
+"""Tests: POST /v1/runs accepts body cwd and X-Hermes-Workspace.
+
+Covers client-supplied per-run working directories (#29531 / #90439): validation,
+binding into session/task cwd machinery, and isolation from a shared default
+terminal environment.
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware, security_headers_middleware
+from tools import terminal_tool
+
+
+def _make_adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True))
+
+
+def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    return app
+
+
+class TestValidateWorkspaceCwd:
+    def test_accepts_existing_absolute_dir(self, tmp_path: Path):
+        adapter = _make_adapter()
+        cwd, err = adapter._validate_workspace_cwd(str(tmp_path), source="cwd")
+        assert err is None
+        assert Path(cwd) == tmp_path.resolve()
+
+    def test_rejects_relative_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.chdir(tmp_path)
+        adapter = _make_adapter()
+        cwd, err = adapter._validate_workspace_cwd("relative-dir", source="cwd")
+        assert cwd is None
+        assert err is not None
+        assert err.status == 400
+
+    def test_rejects_missing_dir(self, tmp_path: Path):
+        adapter = _make_adapter()
+        missing = tmp_path / "nope"
+        cwd, err = adapter._validate_workspace_cwd(str(missing), source="cwd")
+        assert cwd is None
+        assert err is not None
+        assert err.status == 400
+
+    def test_rejects_file_path(self, tmp_path: Path):
+        adapter = _make_adapter()
+        file_path = tmp_path / "file.txt"
+        file_path.write_text("x", encoding="utf-8")
+        cwd, err = adapter._validate_workspace_cwd(str(file_path), source="cwd")
+        assert cwd is None
+        assert err is not None
+        assert err.status == 400
+
+
+class TestResolveRunWorkspace:
+    def test_prefers_either_source(self, tmp_path: Path):
+        adapter = _make_adapter()
+        request = MagicMock()
+        request.headers = {"X-Hermes-Workspace": str(tmp_path)}
+        cwd, err = adapter._resolve_run_workspace(request, {})
+        assert err is None
+        assert Path(cwd) == tmp_path.resolve()
+
+        request.headers = {}
+        cwd, err = adapter._resolve_run_workspace(request, {"cwd": str(tmp_path)})
+        assert err is None
+        assert Path(cwd) == tmp_path.resolve()
+
+    def test_conflict_when_header_and_body_disagree(self, tmp_path: Path):
+        adapter = _make_adapter()
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        request = MagicMock()
+        request.headers = {"X-Hermes-Workspace": str(a)}
+        cwd, err = adapter._resolve_run_workspace(request, {"cwd": str(b)})
+        assert cwd is None
+        assert err is not None
+        assert err.status == 400
+
+    def test_agreeing_header_and_body(self, tmp_path: Path):
+        adapter = _make_adapter()
+        request = MagicMock()
+        request.headers = {"X-Hermes-Workspace": str(tmp_path)}
+        cwd, err = adapter._resolve_run_workspace(request, {"cwd": str(tmp_path)})
+        assert err is None
+        assert Path(cwd) == tmp_path.resolve()
+
+    def test_omitted_returns_empty(self):
+        adapter = _make_adapter()
+        request = MagicMock()
+        request.headers = {}
+        cwd, err = adapter._resolve_run_workspace(request, {"input": "hi"})
+        assert err is None
+        assert cwd == ""
+
+
+class TestBindWorkspaceCwd:
+    def test_logical_cwd_and_session_record(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from agent.runtime_cwd import resolve_agent_cwd
+
+        monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+        adapter = _make_adapter()
+        session_id = "workspace-session"
+        tokens = adapter._bind_api_server_session(
+            chat_id=session_id,
+            session_key=session_id,
+            session_id=session_id,
+            cwd=str(tmp_path),
+        )
+        try:
+            assert resolve_agent_cwd() == tmp_path.resolve()
+            assert terminal_tool.get_session_cwd(session_id) == str(tmp_path)
+        finally:
+            from gateway.session_context import clear_session_vars
+
+            clear_session_vars(tokens)
+
+    def test_bind_does_not_mutate_shared_default_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """API workspace binding must not move another session's shared env."""
+        monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+        shared_env = types.SimpleNamespace(cwd=str(tmp_path / "other-session"))
+        monkeypatch.setattr(
+            terminal_tool,
+            "_active_environments",
+            {"default": shared_env},
+        )
+        adapter = _make_adapter()
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        tokens = adapter._bind_api_server_session(
+            chat_id="workspace-session",
+            session_key="workspace-session",
+            session_id="workspace-session",
+            cwd=str(workspace),
+        )
+        try:
+            assert shared_env.cwd == str(tmp_path / "other-session")
+            assert terminal_tool.get_session_cwd("workspace-session") == str(workspace)
+        finally:
+            from gateway.session_context import clear_session_vars
+
+            clear_session_vars(tokens)
+
+
+@pytest.mark.asyncio
+class TestRunsWorkspaceHTTP:
+    async def test_rejects_missing_cwd_directory(self, tmp_path: Path):
+        adapter = _make_adapter()
+        app = _create_runs_app(adapter)
+        missing = tmp_path / "missing"
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/v1/runs",
+                json={"input": "hello", "cwd": str(missing)},
+            )
+            assert resp.status == 400
+            payload = await resp.json()
+            assert payload["error"]["code"] == "invalid_workspace"
+
+    async def test_body_cwd_reaches_bind_and_task_override(self, tmp_path: Path):
+        adapter = _make_adapter()
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+        captured: dict = {}
+
+        def _capture_create_agent(**kwargs):
+            from agent.runtime_cwd import resolve_agent_cwd
+
+            captured["create_cwd"] = resolve_agent_cwd()
+            agent = MagicMock()
+            agent.run_conversation.return_value = {
+                "final_response": "ok",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+            }
+            agent.session_prompt_tokens = 0
+            agent.session_completion_tokens = 0
+            agent.session_total_tokens = 0
+            return agent
+
+        original_bind = adapter._bind_api_server_session
+
+        def _capture_bind(**kwargs):
+            captured["bind_cwd"] = kwargs.get("cwd", "")
+            return original_bind(**kwargs)
+
+        with (
+            patch.object(adapter, "_create_agent", side_effect=_capture_create_agent),
+            patch.object(adapter, "_bind_api_server_session", side_effect=_capture_bind),
+            patch.object(terminal_tool, "clear_task_env_overrides"),
+        ):
+            # Ensure overrides map is clean for assertions after the run.
+            terminal_tool.clear_task_env_overrides("ws-sess-1")
+            app = _create_runs_app(adapter)
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "session_id": "ws-sess-1",
+                        "cwd": str(workspace),
+                    },
+                )
+                assert resp.status == 202, await resp.text()
+                body = await resp.json()
+                run_id = body["run_id"]
+
+                # Wait until the background run finishes.
+                for _ in range(100):
+                    status_resp = await client.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status.get("status") in {"completed", "failed", "cancelled"}:
+                        break
+                    import asyncio
+
+                    await asyncio.sleep(0.05)
+                else:
+                    pytest.fail("run did not complete")
+
+                assert status.get("status") == "completed"
+                assert Path(captured["bind_cwd"]) == workspace.resolve()
+                assert captured["create_cwd"] == workspace.resolve()
+                assert terminal_tool.get_session_cwd("ws-sess-1") == str(workspace.resolve()) or (
+                    terminal_tool.get_session_cwd("ws-sess-1") == str(workspace)
+                )
+
+    async def test_header_cwd_accepted(self, tmp_path: Path):
+        adapter = _make_adapter()
+        workspace = tmp_path / "hdr"
+        workspace.mkdir()
+        captured: dict = {}
+
+        def _capture_bind(**kwargs):
+            captured["bind_cwd"] = kwargs.get("cwd", "")
+            return []
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=MagicMock(
+                run_conversation=MagicMock(return_value={
+                    "final_response": "ok", "messages": [], "api_calls": 0, "tools": [],
+                }),
+                session_prompt_tokens=0,
+                session_completion_tokens=0,
+                session_total_tokens=0,
+            )),
+            patch.object(adapter, "_bind_api_server_session", side_effect=_capture_bind),
+        ):
+            app = _create_runs_app(adapter)
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "hdr-sess"},
+                    headers={"X-Hermes-Workspace": str(workspace)},
+                )
+                assert resp.status == 202, await resp.text()
+                body = await resp.json()
+                run_id = body["run_id"]
+                import asyncio
+
+                for _ in range(100):
+                    status_resp = await client.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status.get("status") in {"completed", "failed", "cancelled"}:
+                        break
+                    await asyncio.sleep(0.05)
+                assert Path(captured["bind_cwd"]) == workspace.resolve()
+
+    async def test_capabilities_advertise_workspace(self):
+        adapter = _make_adapter()
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/v1/capabilities")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["features"]["workspace_header"] == "X-Hermes-Workspace"
+            assert data["features"]["runs_cwd"] is True


### PR DESCRIPTION
## What does this PR do?

Allows API clients to pin a **per-run working directory** on `POST /v1/runs` via:
- body field `cwd` (absolute existing directory), and/or
- request header `X-Hermes-Workspace` (same validation rules)
When set, the path is bound through the existing session/task cwd machinery (`set_session_vars(cwd=…)`, `record_session_cwd`, `register_task_env_overrides`, and a short `set_session_cwd` pin around agent creation) so concurrent sessions no longer share a single process-level `terminal.cwd`.
Omitted values keep legacy behavior (shared `terminal.cwd`). If both header and body are present they must resolve to the same directory; conflicts and invalid paths return `400` with `invalid_workspace`. Resolved cwd is included in idempotency fingerprints. Capabilities advertise `workspace_header` / `runs_cwd`, and CORS allows `X-Hermes-Workspace` (alongside the existing `X-Hermes-Session-Id` allowlist).
Also splits the `aiohttp` `web` / `RequestKey` imports in `api_server_runs.py` so aiohttp 3.11 (no `RequestKey`) does not null out `web` and break 202 responses.
**Why this approach:** TUI/Desktop already pass an explicit cwd; `/v1/chat/completions` & `/v1/responses` have related open work (#78923). Orchestrators that use the durable **Runs** API (e.g. SCLAW) need the same client-supplied pin on `/v1/runs`, including a body field for non-browser clients. This reuses the existing cwd binding chokepoints instead of mutating process-global `TERMINAL_CWD`.
**Not a duplicate of:**
- #78923 — header on chat/completions & responses (does not cover `/v1/runs`)
- #96304 — profile-home workspace anchor (not client-supplied per-session path)

## Related Issue

Fixes #29531
Related: #90439, #78923, #96304

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made


- `gateway/platforms/api_server.py` — `_validate_workspace_cwd` / `_parse_workspace_header` / `_resolve_run_workspace`; `_bind_api_server_session(..., cwd=)` + `record_session_cwd`; capabilities + CORS for `X-Hermes-Workspace`
- `gateway/platforms/api_server_runs.py` — resolve workspace on admit; carry `workspace_cwd` on `_RunLaunch`; bind + task env overrides in `_run_agent_sync`; pin session cwd around `_create_agent`; include cwd in idempotency fingerprint; split aiohttp imports
- `tests/gateway/test_api_server_runs_workspace.py` — validation, header/body agreement, HTTP bind/override wiring, capabilities


## How to Test

1. `uv run pytest tests/gateway/test_api_server_runs_workspace.py -q`
2. Manual (optional): start api-server, `POST /v1/runs` with `"cwd": "/abs/existing/dir"` (or `X-Hermes-Workspace`) and a `session_id`; confirm terminal/file tools resolve under that directory for that run only.
3. Omit both header and body — behavior unchanged (shared `terminal.cwd`).
4. Send disagreeing header vs body — expect `400` / `invalid_workspace`.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## Screenshots / Logs


N/A — covered by `tests/gateway/test_api_server_runs_workspace.py` (14 passed after rebase onto current `main`).
