### PR TITLE
fix(gateway): return in-loop send timeout as-is, no plain-text fallback

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3207,6 +3207,11 @@ class BasePlatformAdapter(ABC):
                     or result.retry_after is not None
                     or self._is_retryable_error(error_str)
                 ):
+                    # Same guard as the first-attempt check above: a timeout may
+                    # already have delivered, so it must not fall through to the
+                    # plain-text fallback either.
+                    if self._is_timeout_error(error_str):
+                        return result
                     break  # error switched to non-transient — fall through to plain-text fallback
             else:
                 # All retries exhausted (loop completed without break) — notify user.

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -263,6 +263,31 @@ class TestSendWithRetryRateLimited:
 
 
 # ---------------------------------------------------------------------------
+# _send_with_retry — timeout surfacing INSIDE the retry loop (not just the
+# first attempt) must skip the plain-text fallback too — same rule, later hop.
+
+class TestSendWithRetryInLoopTimeout:
+    @pytest.mark.asyncio
+    async def test_in_loop_timeout_not_retried_or_fallback(self):
+        """A retryable error on the first attempt enters the retry loop. If the
+        retry itself times out, that must be treated like the first-attempt
+        timeout guard: return the failure as-is, no further retries, and no
+        plain-text fallback (the request may have already been delivered)."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="httpx.ConnectError: connection reset"),
+            SendResult(success=False, error="ReadTimeout: request timed out"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
+        assert not result.success
+        # initial + 1 retry only — no plain-text fallback send
+        assert len(adapter._send_calls) == 2
+        for _chat_id, content in adapter._send_calls:
+            assert "plain text" not in content.lower()
+
+
+# ---------------------------------------------------------------------------
 # _send_with_retry — failure-kind transitions between attempts
 # ---------------------------------------------------------------------------
 # is_rate_limited is recomputed from the refreshed error_str on every retry, so


### PR DESCRIPTION
## What does this PR do?

`BasePlatformAdapter._send_with_retry` only enforced the "never re-send after a
timeout" rule on the **first** send attempt (line ~3167: `if not is_network and
self._is_timeout_error(error_str): return result`). Once the retry loop was
running, a timeout that reclassified as non-retryable hit the generic

```python
break  # error switched to non-transient — fall through to plain-text fallback
```

and fell through to the plain-text fallback `send()`, re-delivering content
that may have already reached the recipient. This is the same class of bug as
#14061 (closed), which fixed the first-attempt guard but not this in-loop
path.

Fix: apply the identical timeout check immediately before the in-loop
`break`, mirroring the first-attempt guard, so an in-loop timeout returns the
failure as-is with no further retry and no fallback send.

## Related Issue

Fixes #105471

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: in `_send_with_retry`, return the result
  immediately (instead of `break`-ing into the plain-text fallback) when an
  in-loop retry fails with a timeout (`_is_timeout_error`).
- `tests/gateway/test_send_retry.py`: added
  `TestSendWithRetryInLoopTimeout::test_in_loop_timeout_not_retried_or_fallback`,
  which drives the adapter through one retryable failure (enters the loop)
  followed by a `ReadTimeout`, and asserts no plain-text fallback send occurs
  and the typed failure is returned.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_send_retry.py -v`
2. To see the bug reproduced pre-fix:
   `git checkout HEAD~1 -- gateway/platforms/base.py && scripts/run_tests.sh tests/gateway/test_send_retry.py -k in_loop_timeout -v && git checkout HEAD -- gateway/platforms/base.py`

### Test output (before fix — `git checkout HEAD~1 -- gateway/platforms/base.py`)

```
FAILED tests/gateway/test_send_retry.py::TestSendWithRetryInLoopTimeout::test_in_loop_timeout_not_retried_or_fallback - AssertionError: assert not True
 +  where True = SendResult(success=True, message_id='ok', ...).success
1 failed, 15 passed in 0.70s
```

### Test output (after fix)

```
tests/gateway/test_send_retry.py::TestSendWithRetryInLoopTimeout::test_in_loop_timeout_not_retried_or_fallback PASSED
16 passed in 0.30s
```

Also ran the surrounding suites to check for regressions (all green, no
skips beyond one pre-existing unrelated skip):

```
scripts/run_tests.sh tests/gateway/test_send_retry.py tests/gateway/test_platform_base.py \
  tests/gateway/test_slack_send_retry.py tests/gateway/test_discord_view_base_parity.py -v
=== Summary: 4 files, 141 tests passed, 0 failed, 1 skipped ===
```

`ruff check gateway/platforms/base.py tests/gateway/test_send_retry.py` — all checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the test suite and it passes
- [x] I've added a test for this change (proven to fail without the fix, see above)
- [x] Tested on: Linux (Ubuntu, CI runner)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed

## AI-assistance disclosure

This fix, its test, and this PR description were produced by Claude (Claude
Code) from a read of `main` at `966637323e`, working from issue #105471
(itself filed by Claude on behalf of @chiefmojo).
