### PR TITLE
fix(slack): preserve rich blocks in standalone delivery

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6319,8 +6319,18 @@ async def _standalone_send(
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = _standalone_post_kwargs(chat_id, formatted, unfurl_kwargs, thread_id)
+            # Reuse the live adapter's renderer without opening a gateway/socket.
+            renderer = SlackAdapter.__new__(SlackAdapter)
+            renderer.config = pconfig
+            blocks = renderer._maybe_blocks(message)
+            if blocks:
+                payload["blocks"] = blocks
             for tok in tokens:
                 data = await _slack_json_post(session, tok, "chat.postMessage", payload, _req_kw)
+                if (not data.get("ok") and "blocks" in payload
+                        and SlackAdapter._is_block_payload_rejection(RuntimeError(data.get("error", "")))):
+                    payload.pop("blocks")
+                    data = await _slack_json_post(session, tok, "chat.postMessage", payload, _req_kw)
                 if data.get("ok"):
                     return {
                         "success": True, "platform": "slack", "chat_id": chat_id,

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -59,6 +59,34 @@ def _slack_connection_key():
 
 class TestSendMessageBlocks:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("rich", [False, True])
+    async def test_standalone_preserves_live_rendering_and_text(self, monkeypatch, rich):
+        config = PlatformConfig(enabled=True, token="xoxb-fake", extra={"rich_blocks": rich})
+        monkeypatch.setattr(slack_module, "_load_slack_bot_tokens", lambda *a, **k: ["xoxb-fake"])
+        post = AsyncMock(return_value={"ok": True, "ts": "111.222"})
+        monkeypatch.setattr(slack_module, "_slack_json_post", post)
+        result = await slack_module._standalone_send(config, "C1", RICH_TABLE_MD, thread_id="100.1")
+        payload = post.await_args.args[3]
+        assert result["success"]
+        assert payload["text"] == slack_module._standalone_format_mrkdwn(RICH_TABLE_MD)
+        assert payload["thread_ts"] == "100.1"
+        assert payload.get("blocks") == SlackAdapter(config)._maybe_blocks(RICH_TABLE_MD)
+
+    @pytest.mark.asyncio
+    async def test_standalone_rejected_blocks_retry_text_only(self, monkeypatch):
+        config = PlatformConfig(enabled=True, token="xoxb-fake", extra={"rich_blocks": True})
+        monkeypatch.setattr(slack_module, "_load_slack_bot_tokens", lambda *a, **k: ["xoxb-fake"])
+        payloads = []
+        async def post(session, token, method, payload, request):
+            payloads.append(dict(payload))
+            return {"ok": False, "error": "invalid_blocks"} if len(payloads) == 1 else {"ok": True, "ts": "111.222"}
+        monkeypatch.setattr(slack_module, "_slack_json_post", post)
+        result = await slack_module._standalone_send(config, "C1", RICH_TABLE_MD)
+        assert result["success"]
+        assert "blocks" in payloads[0] and "blocks" not in payloads[1]
+        assert payloads[0]["text"] == payloads[1]["text"]
+
+    @pytest.mark.asyncio
     async def test_disabled_by_default_no_blocks(self):
         adapter, client = _make_adapter()
         await adapter.send("C1", RICH_MD)
@@ -197,5 +225,4 @@ class TestMarkdownBlockMode:
         kwargs = client.chat_update.await_args.kwargs
         assert kwargs["blocks"][0]["type"] == "markdown"
         assert kwargs["blocks"][0]["text"] == RICH_TABLE_MD
-
 


### PR DESCRIPTION
## Problem

With `platforms.slack.extra.rich_blocks: true`, gateway replies render native tables, but the standalone sender used by `hermes send` and out-of-process delivery sends only mrkdwn. The same content therefore loses its native table structure depending on its delivery path. Reproduced against main 966637323e6f90864e069dbc12755934c2c86387.

## Change

Reuse the existing SlackAdapter renderer with the receiving platform configuration, retaining the text fallback and thread target. Retry without blocks only when Slack explicitly rejects the block payload, matching the live adapter behavior. Defaults, token scope, media handling, and ambiguous transport-error behavior are unchanged.

## Verification

Two behavior tests cover opt-in/live-renderer parity and explicit block-rejection fallback. On unmodified main, the rich case and rejection recovery fail; the default plain case passes. Focused adapter, renderer, and media tests run through scripts/run_tests.sh. Self-reviewed.
