### PR TITLE
feat(gateway): configure successful provider fallback notices

### DIFF
--- a/agent/status_output.py
+++ b/agent/status_output.py
@@ -159,14 +159,15 @@ class StatusOutputMixin:
             buf.clear()
 
     def _emit_pending_fallback_notice(self) -> None:
-        """Surface the one-shot fallback-switch notice on successful recovery: a provider switch is durable
-        state operators must see, unlike the retry chatter ``_clear_status_buffer`` drops. Emitted once, then
+        """Surface the optional one-shot fallback-switch notice on successful recovery. Emitted once, then
         cleared; on terminal failure the buffered switch line is flushed instead (``_flush_status_buffer``)."""
         notice = getattr(self, "_pending_fallback_notice", None)
         if not notice:
             return
         # Clear before emitting so a (swallowed) callback error can't leave a stale re-emit.
         self._pending_fallback_notice = None
+        if not getattr(self, "show_provider_fallback_notices", True):
+            return
         for item in notice if isinstance(notice, list) else [notice]:
             try:
                 self._emit_status(str(item))

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -21,6 +21,7 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "streaming": None,  # None = follow top-level streaming config
     # Gateway-only assistant/status chatter; mobile platforms opt down to final-answer-first.
     "interim_assistant_messages": True,
+    "provider_fallback_notices": True,
     "long_running_notifications": True,
     "busy_ack_detail": True,
     "busy_steer_ack_enabled": True,  # busy_input_mode=steer echo; the text still lands in the run
@@ -152,6 +153,7 @@ _NORMALISERS: dict[str, Any] = {
     "show_reasoning": _norm_bool,
     "streaming": _norm_bool,
     "interim_assistant_messages": _norm_bool,
+    "provider_fallback_notices": _norm_bool,
     "long_running_notifications": _norm_long_running,
     "busy_ack_detail": _norm_bool,
     "busy_steer_ack_enabled": _norm_bool,

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1644,6 +1644,9 @@ class TurnRunner:
             turn_route, platform_key, combined_ephemeral, max_iterations, reasoning_config, pr,
         )
         self._wire_turn_agent_callbacks(agent, turn_route, reasoning_config, stream_delta_cb, interim_cb, want_interim)
+        agent.show_provider_fallback_notices = ctx.resolve_display_setting(
+            ctx.user_config, platform_key, "provider_fallback_notices", True,
+        )
         agent_history, observed_group_context, history_media_paths = self._load_turn_history(agent, reused_cached_agent)
         persist_msg, persist_ts = self._prepare_turn_message(agent_history)
         result = self._run_conversation_with_approval(agent, agent_history, observed_group_context, persist_msg, persist_ts)

--- a/tests/run_agent/test_retry_status_buffer.py
+++ b/tests/run_agent/test_retry_status_buffer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 
 from run_agent import AIAgent
+from gateway.display_config import resolve_display_setting
 
 
 def _make_bare_agent():
@@ -24,6 +25,27 @@ def _make_bare_agent():
     agent._executing_tools = False
     agent._print_fn = None
     return agent
+
+
+def test_quiet_recovery_keeps_terminal_failure_diagnostics():
+    agent = _make_bare_agent()
+    emitted = []
+    agent._emit_status = emitted.append
+    agent.show_provider_fallback_notices = False
+    agent._pending_fallback_notice = ["Recovered using provider B"]
+    agent._emit_pending_fallback_notice()
+    assert emitted == []
+    assert agent._pending_fallback_notice is None
+    agent._buffer_status("Provider B failed too")
+    agent._flush_status_buffer()
+    assert emitted == ["Provider B failed too"]
+
+
+def test_fallback_visibility_is_platform_scoped_and_defaults_on():
+    config = {"display": {"platforms": {"slack": {"provider_fallback_notices": "false"}}}}
+    assert resolve_display_setting(config, "slack", "provider_fallback_notices") is False
+    assert resolve_display_setting(config, "cli", "provider_fallback_notices") is True
+    assert resolve_display_setting({}, "slack", "provider_fallback_notices") is True
 
 
 def test_buffer_status_accumulates_then_flushes(capsys):

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2168,6 +2168,8 @@ Signal is listed as a valid platform key because the setting can be saved per pl
 
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
 
+`provider_fallback_notices` (default `true`) controls successful provider-recovery notices on the gateway. Set `display.platforms.slack.provider_fallback_notices: false` for a quiet Slack surface. Provider selection, backend logs, terminal-failure diagnostics, warnings, and approval requests are unchanged. Other platforms retain their own display settings.
+
 `show_commentary` (default `true`) controls Codex Responses models' commentary channel — the polished progress narration these models produce alongside their private reasoning. When enabled, each completed commentary message is delivered as a visible mid-turn update (on the gateway this also requires `interim_assistant_messages`). Set it to `false` if the extra narration annoys you: commentary then falls back to the reasoning channel and is only shown when `show_reasoning` is enabled.
 
 ## Privacy


### PR DESCRIPTION
## Summary
Add the native per-platform display.provider_fallback_notices boolean, defaulting to true. Quiet messaging surfaces can opt out of successful recovery notices without hiding terminal-failure diagnostics, warnings, or approval requests. The setting is refreshed on each gateway turn, including cached agents. CLI defaults and provider selection are unchanged.

## Verification
Two added invariant tests fail before the fix and pass after it. Native scripts/run_tests.sh passes all 42 tests in retry-status-buffer, display-config, and turn-context suites. Self-reviewed; no independent review requested.