### PR TITLE
fix(compression): error attribution names the actual summarizer route, not the main model

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3223,7 +3223,11 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             raise AuxiliaryExplicitCancellation()
         # Reasoning-field fallback (DeepSeek/Qwen/Kimi put the summary in reasoning_content); capped.
         content = extract_content_or_reasoning(response, max_reasoning_chars=8000)
-        where = f"(provider={self.provider or 'auto'} model={self.summary_model or self.model})"
+        # Name the model that ACTUALLY generated the summary (_aux_route), not the protected main model.
+        where = (
+            f"(provider={_aux_route.get('provider') or self.provider or 'auto'} "
+            f"model={_aux_model or self.summary_model or self.model})"
+        )
         # Some OpenAI-compatible proxies (e.g. cmkey.cn, one-api channels) return a well-formed HTTP 200
         # with an empty or whitespace-only ``content`` instead of an error or empty ``choices``. That
         # payload passes ``_validate_llm_response`` (a ``message`` exists), so it reaches here and would

--- a/tests/agent/test_compressor_truncated_summary_guard.py
+++ b/tests/agent/test_compressor_truncated_summary_guard.py
@@ -163,3 +163,72 @@ class TestMicroSummarizeTruncationGuard:
         ):
             result = c._micro_summarize_one("user: hi\nassistant: hello")
         assert result == "merged summary"
+
+
+class TestFailureAttribution:
+    """Errors from the aux summary call must name the route that generated the
+    summary (_aux_route), not the main session model being protected."""
+
+    def test_truncation_error_names_actual_summarizer_route(self):
+        import time as _time
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="glm-main",
+                summary_model_override="agnes-aux",
+                quiet_mode=True,
+            )
+
+        def _fake_call(**kwargs):
+            kwargs["route_info"].update(
+                {"provider": "agnes", "model": "agnes-2.5-flash", "label": "agnes"}
+            )
+            return _mock_response("partial summary that got cut o", "length")
+
+        with patch("agent.context_compressor.call_llm", side_effect=_fake_call):
+            with pytest.raises(RuntimeError) as exc:
+                c._call_summary_llm("summarize: ...", prompt_started_at=_time.monotonic())
+
+        msg = str(exc.value)
+        assert "provider=agnes" in msg, msg
+        assert "model=agnes-2.5-flash" in msg, msg
+        assert "glm-main" not in msg, msg
+
+    def test_empty_content_error_names_actual_summarizer_route(self):
+        import time as _time
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="glm-main",
+                summary_model_override="agnes-aux",
+                quiet_mode=True,
+            )
+
+        def _fake_call(**kwargs):
+            kwargs["route_info"].update(
+                {"provider": "agnes", "model": "agnes-2.5-flash", "label": "agnes"}
+            )
+            return _mock_response("   ", "stop")
+
+        with patch("agent.context_compressor.call_llm", side_effect=_fake_call):
+            with pytest.raises(RuntimeError) as exc:
+                c._call_summary_llm("summarize: ...", prompt_started_at=_time.monotonic())
+
+        msg = str(exc.value)
+        assert "provider=agnes" in msg, msg
+        assert "model=agnes-2.5-flash" in msg, msg
+
+    def test_unknown_route_falls_back_to_main_model_name(self):
+        import time as _time
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="glm-main", quiet_mode=True)
+
+        def _fake_call(**kwargs):  # route_info left empty: transport filled nothing
+            return _mock_response("   ", "stop")
+
+        with patch("agent.context_compressor.call_llm", side_effect=_fake_call):
+            with pytest.raises(RuntimeError) as exc:
+                c._call_summary_llm("summarize: ...", prompt_started_at=_time.monotonic())
+
+        assert "model=glm-main" in str(exc.value)


### PR DESCRIPTION
## Problem

When the auxiliary compression summary call fails, the operator-facing error misattributes the model:

```
⚠ Compression aborted: Context compression summary was truncated (finish_reason=length):
generation hit the output token cap and the summary is incomplete (provider=zai model=glm-5.3)
```

Here the summary was actually generated by the configured auxiliary route (`auxiliary.compression`: agnes/agnes-2.5-flash — confirmed by attempt telemetry: `aux_provider: agnes, aux_model: agnes-2.5-flash, fallback_used: false`), but the error names the MAIN session model. Users reasonably conclude their compression config was ignored and audit the wrong layer.

## Fix

`_call_summary_llm` already computes the route `call_llm` actually selected (`_aux_route` / `_aux_model`, filled by the transport and read in the post-call `finally`). Use those for the failure annotation, falling back to the previous `self.provider` / `self.summary_model or self.model` when the transport reports no route (behavior unchanged in that case). Both shared consumers of `where` — the empty-content guard and the finish_reason=length guard — are covered.

## Tests

Three additions to `test_compressor_truncated_summary_guard.py`:
- truncation error names the aux route, not the main model
- empty-content error names the aux route
- unknown route falls back to the main model name (control)

Full file: 13/13 green.