### PR TITLE
fix(telegram): preserve literal hash references in rich messages

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1317,7 +1317,9 @@ class TelegramAdapter(BasePlatformAdapter):
     def _rich_message_payload(self, content: str, *, skip_entity_detection: bool = False) -> Dict[str, Any]:
         """``InputRichMessage`` from RAW markdown — never ``format_message(content)``, whose MarkdownV2
         escaping destroys table pipes."""
-        payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(content)}
+        from .rich_markdown import escape_literal_hash_prefixes
+
+        payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(escape_literal_hash_prefixes(content))}
         if skip_entity_detection:
             payload["skip_entity_detection"] = True
         return payload

--- a/plugins/platforms/telegram/rich_markdown.py
+++ b/plugins/platforms/telegram/rich_markdown.py
@@ -1,0 +1,31 @@
+"""Normalization for Telegram's permissive Rich Markdown block parser."""
+
+import re
+
+
+# Consume code/math before looking for block prefixes so their literal contents
+# survive unchanged, including an unfinished code fence in a streaming draft.
+_LITERAL_HASH_RE = re.compile(
+    r"(?P<fence>`{3,}|~{3,})[^\n]*\n.*?(?:(?P=fence)(?![`~])|\Z)"
+    r"|(?P<ticks>`+)(?!`).*?(?<!`)(?P=ticks)(?!`)"
+    r"|\$\$.*?(?:\$\$|\Z)"
+    r"|(?P<prefix>^[ \t]*(?:(?:>[ \t]*|[-+*][ \t]+|\d+[.)][ \t]+))*)"
+    r"(?P<hashes>#+)(?=[^\s#])",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def escape_literal_hash_prefixes(text: str) -> str:
+    """Keep ``#89``/``#tag`` as prose, including in lists and blockquotes.
+
+    Telegram accepts these as headings even without the whitespace required by
+    standard Markdown. Escape only such block-start hashes, not real headings,
+    inline references, links, code, or already escaped prefixes.
+    """
+    def replace(match: re.Match[str]) -> str:
+        hashes = match.group("hashes")
+        if hashes is None:
+            return match.group(0)
+        return match.group("prefix") + r"\#" * len(hashes)
+
+    return _LITERAL_HASH_RE.sub(replace, text)

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -86,6 +86,55 @@ def _rich_api_kwargs(adapter):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["send", "edit", "draft"])
+async def test_rich_delivery_keeps_literal_hash_references(operation):
+    adapter = _make_adapter({"rich_drafts": True})
+    content = (
+        "#89 remains open.\n\n- #181 reported a problem.\n\n> #tag is literal.\n\n"
+        "## Real heading\n\n- [x] rich delivery\n\n`#89` stays code."
+    )
+    if operation == "send":
+        result = await adapter.send("12345", content)
+        assert result.success
+    elif operation == "edit":
+        result = await adapter.edit_message("12345", "123", content, finalize=True)
+        assert result.success
+    else:
+        assert await adapter.send_draft("12345", 123, content)
+    assert adapter._bot is not None
+    payload = adapter._bot.do_api_request.call_args.kwargs["api_kwargs"]["rich_message"]
+    assert r"\#89 remains open." in payload["markdown"]
+    assert r"- \#181 reported a problem." in payload["markdown"]
+    assert r"> \#tag is literal." in payload["markdown"]
+    assert "## Real heading" in payload["markdown"]
+    assert "`#89` stays code." in payload["markdown"]
+    adapter._bot.send_message.assert_not_called()
+    adapter._bot.edit_message_text.assert_not_called()
+    adapter._bot.send_message_draft.assert_not_called()
+
+
+@pytest.mark.parametrize("content", [
+    "# Heading\n\n## Heading 2\n\n###### Heading 6",
+    "Use #89 and https://example.com/#anchor inline.",
+    r"\#89 is already escaped.",
+    "`code\n#89\ncode`",
+    "``code ` #89``",
+    "```python\n#89 is a comment\n```",
+    "~~~python\n#89 is a comment\n~~~",
+    "````markdown\n```\n#89\n```\n````",
+    "```python\n#89 unfinished fence",
+    "$$\n#89\n$$",
+])
+def test_literal_hash_normalization_preserves_markdown_regions(content):
+    from plugins.platforms.telegram.rich_markdown import escape_literal_hash_prefixes
+
+    assert escape_literal_hash_prefixes(content) == content
+    escaped = escape_literal_hash_prefixes("1. #89\n\n> - ##tag\n\n#release")
+    assert escaped == "1. \\#89\n\n> - \\#\\#tag\n\n\\#release"
+    assert escape_literal_hash_prefixes(escaped) == escaped
+
+
+@pytest.mark.asyncio
 async def test_details_without_math_still_uses_rich_send():
     adapter = _make_adapter()
 


### PR DESCRIPTION
## What Does This PR Do?

Keep literal references such as `#89` and `- #181` from becoming headings in Telegram Rich Messages. Telegram's rich parser accepts these without the whitespace required by standard Markdown. Escape only literal block-start hash prefixes at the shared rich payload boundary, rather than disabling rich delivery.

## Related Issue

Fixes #105483

## Type of Change

- [x] Bug fix

## Changes Made

- Add a focused Rich Markdown normalizer for literal hash prefixes in paragraphs, lists, and blockquotes.
- Apply it through `_rich_message_payload`, shared by fresh rich sends, finalized edits, and rich drafts.
- Preserve genuine spaced headings, inline references, existing escapes, code spans/fences, and block math.
- Add regressions through all three adapter delivery paths plus preservation and idempotence cases.

No configuration changes or new dependencies.

## Verification

- RED: the new send/edit/draft regressions failed against unpatched upstream because literal prefixes reached the rich parser unchanged.
- GREEN: `scripts/run_tests.sh tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_format.py` passed 92 tests.
- Broader Telegram suite: 670 passed, 2 failed, 2 skipped. Both failures are existing DNS-dependent image timeout tests in `test_telegram_media_read_timeout.py`. Both also fail on the clean upstream base `966637323e6f90864e069dbc12755934c2c86387`, where this environment resolves `example.com` into the SSRF-blocked `198.18.0.0/15` range. This PR does not change media or DNS handling.
- `ruff check .` and `git diff --check` passed.
- Live Bot API test: unescaped `#89` returned a size-1 heading, while `\#89` returned a paragraph retaining the hash. The same comparison reproduced inside a list.
- Sent the candidate adapter's actual rich payload and forwarded the exact stored message for readback. Literal paragraph/list references remained paragraphs with their hashes. The real heading remained a size-2 heading, inline code remained code, and the table remained native.

## Checklist

- [x] Read the contributing guide and searched existing issues and PRs.
- [x] Conventional commit and narrowly scoped changes.
- [x] Added and exercised regression tests on macOS.
- [ ] Full repository test suite passes. Not claimed, see the targeted and broader-suite evidence above.
- [x] Documentation, configuration, architecture, and tool schema changes are not needed for this boundary fix.
- [x] Cross-platform behavior considered: standard-library string normalization, no OS-specific operations.

## AI Assistance

Implemented with AI assistance. The live reproduction and test results above were executed, not inferred from mocks alone. Independent review was requested through a separate provider before publication.
