### PR TITLE
feat(memory): opt-in env var to silence Qdrant insecure-connection warning

### DIFF
--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -166,6 +166,17 @@ ls -la ~/.hermes/mem0_qdrant
 curl http://localhost:6333/healthz
 ```
 
+### OSS: Qdrant "Api key is used with an insecure connection" warning
+
+qdrant-client prints this warning whenever an API key is configured alongside a non-HTTPS url. For same-network deployments where Hermes and Qdrant run as containers on one private Docker network (no TLS termination needed intra-network, the key is just Qdrant's own auth token), opt in to silence exactly this warning:
+
+```bash
+# ~/.hermes/.env
+HERMES_QDRANT_ALLOW_INSECURE=1
+```
+
+Only set this when Qdrant is not reachable from the public internet — the warning stays on by default as a safety net for exposed instances.
+
 ### OSS: PGVector connection refused
 
 ```bash

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -2,9 +2,25 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from contextlib import closing, suppress
 from typing import Any
+
+_QDRANT_INSECURE_WARNING = "Api key is used with an insecure connection"
+
+
+def _apply_qdrant_insecure_warning_filter() -> None:
+    """Silence qdrant-client's api-key-over-HTTP UserWarning for trusted same-network deployments.
+
+    HERMES_QDRANT_ALLOW_INSECURE opts in; the filter targets that exact message only,
+    so genuinely internet-exposed misconfigurations still warn by default.
+    """
+    import os
+
+    if os.environ.get("HERMES_QDRANT_ALLOW_INSECURE", "").lower() not in {"1", "true", "yes"}:
+        return
+    warnings.filterwarnings("ignore", message=_QDRANT_INSECURE_WARNING, category=UserWarning)
 
 
 def _add_kwargs(user_id: str, agent_id: str, infer: bool, metadata: dict | None) -> dict[str, Any]:
@@ -118,6 +134,10 @@ class OSSBackend(Mem0Backend):
         import os
         from mem0 import Memory
         from ._oss_providers import EMBEDDER_PROVIDERS, KNOWN_DIMS, LLM_PROVIDERS
+
+        # Must run before any QdrantClient construction: both the dims-recreate
+        # probe below and Memory() (which builds its own client) emit the warning.
+        _apply_qdrant_insecure_warning_filter()
 
         def _provider_block(name: str, registry: dict) -> dict:
             """Copy of oss_config[name] with the legacy ``api_base`` key mapped to the provider's canonical base-URL key."""

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 import types
+import warnings
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 
@@ -616,6 +617,53 @@ class TestOSSBackend:
         assert "hermes_openai" not in factory.provider_to_class
         assert state.clients == []
         assert raw == before
+
+    def _qdrant_oss_config(self):
+        return {
+            "llm": {"provider": "ollama", "config": {"model": "llama3.1:8b"}},
+            "embedder": {"provider": "ollama", "config": {}},
+            "vector_store": {"provider": "qdrant", "config": {}},
+        }
+
+    def test_qdrant_insecure_warning_opt_in_silences_only_that_message(self, monkeypatch):
+        state, Memory, factory = _install_fake_mem0(monkeypatch)
+        monkeypatch.setenv("HERMES_QDRANT_ALLOW_INSECURE", "1")
+
+        with warnings.catch_warnings():
+            OSSBackend(self._qdrant_oss_config())
+            with warnings.catch_warnings(record=True) as caught:
+                # Append so the message-targeted filter registered by the backend stays
+                # first and wins over this catch-all.
+                warnings.simplefilter("always", append=True)
+                warnings.warn("Api key is used with an insecure connection", UserWarning)
+                warnings.warn("some unrelated warning", UserWarning)
+
+        assert [str(w.message) for w in caught] == ["some unrelated warning"]
+        assert len(Memory.instances) == 1
+
+    def test_qdrant_insecure_warning_still_fires_without_opt_in(self, monkeypatch):
+        state, Memory, factory = _install_fake_mem0(monkeypatch)
+        monkeypatch.delenv("HERMES_QDRANT_ALLOW_INSECURE", raising=False)
+
+        with warnings.catch_warnings():
+            OSSBackend(self._qdrant_oss_config())
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                warnings.warn("Api key is used with an insecure connection", UserWarning)
+
+        assert [str(w.message) for w in caught] == ["Api key is used with an insecure connection"]
+
+    def test_qdrant_insecure_warning_opt_in_requires_truthy_value(self, monkeypatch):
+        state, Memory, factory = _install_fake_mem0(monkeypatch)
+        monkeypatch.setenv("HERMES_QDRANT_ALLOW_INSECURE", "0")
+
+        with warnings.catch_warnings():
+            OSSBackend(self._qdrant_oss_config())
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                warnings.warn("Api key is used with an insecure connection", UserWarning)
+
+        assert [str(w.message) for w in caught] == ["Api key is used with an insecure connection"]
 
 
 httpx = pytest.importorskip("httpx")


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `HERMES_QDRANT_ALLOW_INSECURE` environment variable that narrowly silences qdrant-client's `Api key is used with an insecure connection` UserWarning for mem0 OSS deployments where Hermes and Qdrant talk over a trusted private network (e.g. containers on the same Docker network, no TLS termination needed intra-network — the api_key is just Qdrant's own auth token).

The filter is message-targeted (exact warning text, `UserWarning` category), not a blanket suppression, and is registered once at `OSSBackend.__init__` **before** any `QdrantClient` construction — that covers both places the client gets built: the embedding-dims recreate probe in `_recreate_collection_if_dims_changed` and the client mem0's `Memory()` constructs internally. Unset (or non-truthy) values change nothing, so the warning stays on by default as a safety net for Qdrant instances that really are internet-exposed.

## Related Issue

Fixes #105484

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/memory/mem0/_backend.py`: new `_apply_qdrant_insecure_warning_filter()` helper (env-var truthiness check `1`/`true`/`yes`, then `warnings.filterwarnings("ignore", message=..., category=UserWarning)`); called at the top of `OSSBackend.__init__` before any Qdrant client construction.
- `plugins/memory/mem0/README.md`: new Troubleshooting subsection documenting the variable and when it is safe to set.
- `tests/plugins/memory/test_mem0_backend.py`: three regression tests — opt-in silences exactly that message while unrelated `UserWarning`s still fire; without opt-in the warning still fires; a set-but-falsy value (`0`) keeps the warning (fail-closed).

## How to Test

1. `pytest tests/plugins/memory/test_mem0_backend.py -q` — Observed result: 17 passed (includes the 3 new tests).
2. Manual check on a same-network Qdrant deployment (`vector_store.provider: qdrant` with `url` + `api_key` over plain HTTP): with `HERMES_QDRANT_ALLOW_INSECURE=1` in `~/.hermes/.env`, the `Api key is used with an insecure connection` warning no longer appears at memory backend init; with the variable unset it still appears. (Covered programmatically by the new tests, which assert the warning's fate through the real `warnings` filter machinery.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
