### PR TITLE
feat(kanban): gate native claims with opt-in board policy

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -182,7 +182,11 @@ def kanban_command(args: argparse.Namespace) -> int:
         # init_db is idempotent (one sqlite_master SELECT when tables exist) and prevents
         # "no such table: tasks" on first use from a fresh HERMES_HOME.
         try:
-            kb.init_db()
+            observational = (
+                action in ("list", "ls") and bool(getattr(args, "no_promote", False))
+            ) or (action == "show" and bool(getattr(args, "read_only", False)))
+            if not observational:
+                kb.init_db()
         except Exception as exc:
             return _err(f"kanban: could not initialize database: {exc}")
 
@@ -221,7 +225,7 @@ _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
 
 _DELEGATED_CHILD_DENIED_BOARD_ACTIONS: frozenset[str] = frozenset({
     "create", "new", "rm", "remove", "delete", "switch", "use", "rename",
-    "set-default-workdir", "import",
+    "set-default-workdir", "set-pre-claim", "import",
 })
 
 
@@ -414,9 +418,11 @@ def _cmd_list(args: argparse.Namespace) -> int:
     assignee = args.assignee
     if args.mine and not assignee:
         assignee = _profile_author()
-    with kbc.connect_closing() as conn:
+    no_promote = bool(getattr(args, "no_promote", False))
+    with kbc.connect_closing(read_only=no_promote) as conn:
         # Cheap mini-dispatch so list reflects dependencies cleared since the last tick.
-        kb.recompute_ready(conn)
+        if not no_promote:
+            kb.recompute_ready(conn)
         tasks = kb.list_tasks(
             conn, assignee=assignee, status=args.status, tenant=args.tenant, session_id=args.session,
             include_archived=args.archived, order_by=getattr(args, "sort", None),
@@ -471,7 +477,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
         return rc
     graph = None
     want_json = getattr(args, "json", False)
-    with kbc.connect_closing() as conn:
+    with kbc.connect_closing(read_only=bool(getattr(args, "read_only", False))) as conn:
         task = kb.get_task(conn, args.task_id)
         if not task:
             return _err(f"no such task: {args.task_id}")
@@ -489,7 +495,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
         _print_json({
             "task": _task_to_dict(task), "latest_summary": latest_summary, "parents": parents, "children": children,
             "comments": [_obj_dict(c, ("author", "body", "created_at")) for c in comments],
-            "events": [_obj_dict(e, ("kind", "payload", "created_at", "run_id")) for e in events],
+            "events": [_obj_dict(e, ("id", "kind", "payload", "created_at", "run_id")) for e in events],
             "runs": [_obj_dict(r, _SHOW_RUN_FIELDS) for r in runs],
         })
         return 0

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -11,6 +11,7 @@ import contextlib
 import json
 import os
 import shlex
+import sqlite3
 import sys
 import time
 from pathlib import Path
@@ -195,7 +196,9 @@ def kanban_command(args: argparse.Namespace) -> int:
             return _err(f"kanban: unknown action {action!r}", 2)
         try:
             return int(handler(args) or 0)
-        except (ValueError, RuntimeError, PermissionError) as exc:
+        except (ValueError, RuntimeError, PermissionError, sqlite3.OperationalError) as exc:
+            if isinstance(exc, sqlite3.OperationalError) and not observational:
+                raise
             return _err(f"kanban: {exc}")
 
 

--- a/hermes_cli/kanban_boards.py
+++ b/hermes_cli/kanban_boards.py
@@ -155,6 +155,28 @@ def _cmd_boards_set_default_workdir(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_boards_set_pre_claim(args: argparse.Namespace) -> int:
+    slug, rc = _board_slug_arg(args, "set-pre-claim", must_exist=True)
+    if rc:
+        return rc
+    native = kb.kanban_home() / "kanban.db" if slug == kb.DEFAULT_BOARD else kb.board_dir(slug) / "kanban.db"
+    if kb.kanban_db_path(slug).resolve() != native.resolve():
+        return _err("pre-claim policy requires this board's canonical native database", 2)
+    command = args.policy_command[1:] if args.policy_command[:1] == ["--"] else args.policy_command
+    if args.clear and command:
+        return _err("cannot set and clear pre-claim together", 2)
+    try:
+        meta = kb.write_board_metadata(
+            slug, clear_pre_claim=args.clear,
+            pre_claim=None if args.clear else {"command": command, "timeout_seconds": args.timeout},
+        )
+    except ValueError as exc:
+        return _err(str(exc), 2)
+    if not _json_out(args, meta):
+        print(f"Board {slug!r} pre-claim policy {'cleared' if args.clear else 'configured'}.")
+    return 0
+
+
 def _cmd_boards_export(args: argparse.Namespace) -> int:
     from hermes_cli import kanban_transfer
     from hermes_cli.sizefmt import format_bytes
@@ -209,6 +231,7 @@ _BOARD_HANDLERS = {
     "show": _cmd_boards_show, "current": _cmd_boards_show,
     "rename": _cmd_boards_rename,
     "set-default-workdir": _cmd_boards_set_default_workdir,
+    "set-pre-claim": _cmd_boards_set_pre_claim,
     "export": _cmd_boards_export,
     "import": _cmd_boards_import,
 }

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -517,7 +517,7 @@ def worker_logs_dir(board: Optional[str] = None) -> Path:
 
 
 def board_metadata_path(board: Optional[str] = None) -> Path:
-    """``board.json`` path — display metadata only; the directory slug is the identity."""
+    """``board.json`` settings path; the directory slug is the identity."""
     return board_dir(_slug_or_default(board)) / "board.json"
 
 
@@ -526,9 +526,13 @@ def _default_board_display_name(slug: str) -> str:
     return " ".join(part.capitalize() for part in slug.replace("_", "-").split("-") if part) or slug
 
 
-def read_board_metadata(board: Optional[str] = None) -> dict:
-    """``board.json`` merged over defaults, plus ``slug`` and ``db_path``. Never
-    raises — a missing/malformed file yields the synthesized entry."""
+def read_board_metadata(
+    board: Optional[str] = None, *, strict: bool = False, metadata_path: Optional[Path] = None,
+) -> dict:
+    """Native settings plus defaults. Strict policy reads reject malformed files;
+    the ordinary display read still synthesizes defaults. Missing is unconfigured.
+    ``metadata_path`` lets enforcement bind to an already-open DB, not a selector.
+    """
     slug = _slug_or_default(board)
     meta: dict[str, Any] = {
         "slug": slug,
@@ -543,16 +547,20 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
         "archived": False,
     }
     try:
-        p = board_metadata_path(slug)
-        if p.exists():
-            raw = json.loads(p.read_text(encoding="utf-8"))
-            if isinstance(raw, dict):
-                # Never let the metadata file claim a different slug than
-                # its directory — trust the filesystem.
-                raw["slug"] = slug
-                meta.update(raw)
-    except (OSError, json.JSONDecodeError):
+        p = metadata_path if metadata_path is not None else board_metadata_path(slug)
+        raw = json.loads(p.read_text(encoding="utf-8"))
+        if isinstance(raw, dict):
+            # Never let the metadata file claim a different slug than
+            # its directory — trust the filesystem.
+            raw["slug"] = slug
+            meta.update(raw)
+        elif strict:
+            raise ValueError("board metadata must be an object")
+    except FileNotFoundError:
         pass
+    except (OSError, ValueError, UnicodeError):
+        if strict:
+            raise
     meta["db_path"] = str(kanban_db_path(slug))
     return meta
 
@@ -561,6 +569,7 @@ def write_board_metadata(
     board: Optional[str], *, name: Optional[str] = None, description: Optional[str] = None,
     icon: Optional[str] = None, color: Optional[str] = None, archived: Optional[bool] = None,
     default_workdir: Optional[str] = None, project_id: Optional[str] = None,
+    pre_claim: Optional[dict] = None, clear_pre_claim: bool = False,
 ) -> dict:
     """Create/update ``board.json``; unmentioned fields are preserved, ``created_at``
     set on first write. ``project_id``/``default_workdir``: ``None`` = unchanged,
@@ -570,6 +579,13 @@ def write_board_metadata(
     meta = read_board_metadata(slug)
     # db_path is derived on every read; never persist it into board.json.
     meta.pop("db_path", None)
+    if pre_claim is not None:
+        from hermes_cli.kanban_db_policy import validate_policy
+        if clear_pre_claim:
+            raise ValueError("cannot set and clear pre_claim together")
+        meta["pre_claim"] = validate_policy(pre_claim)
+    elif clear_pre_claim:
+        meta.pop("pre_claim", None)
     if name is not None:
         meta["name"] = str(name).strip() or _default_board_display_name(slug)
     for key, value in (("description", description), ("icon", icon), ("color", color)):
@@ -2007,6 +2023,10 @@ def recompute_ready(conn: sqlite3.Connection, failure_limit: int = None) -> int:
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
+    from hermes_cli import kanban_db_policy
+    policy = kanban_db_policy.board_policy(conn)
+    if policy is not None:
+        return kanban_db_policy.recompute_ready(conn, policy, failure_limit)
     promoted = 0
     with write_txn(conn):
         todo_rows = conn.execute(
@@ -2125,10 +2145,13 @@ def claim_task(
     Returns the claimed ``Task`` on success, ``None`` if the task was
     already claimed (or is not in ``ready`` status).
     """
-    now = int(time.time())
     lock = claimer or _claimer_id()
-    expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
-    with write_txn(conn):
+    from hermes_cli.kanban_db_policy import policy_transaction
+    with policy_transaction(conn, task_id, "ready") as allowed:
+        if not allowed:
+            return None
+        now = int(time.time())
+        expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
         # Single enforcement point: never ready -> running with an undone
         # parent, whichever writer set 'ready'. Demote to 'todo';
         # recompute_ready re-promotes when the parents finish.
@@ -2158,10 +2181,13 @@ def claim_review_task(
     """Atomic ``review -> running`` (None when lost). Parents are re-checked
     (one may have reopened meanwhile) and a NEW run tracks the reviewer
     separately from the implementer."""
-    now = int(time.time())
     lock = claimer or _claimer_id()
-    expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
-    with write_txn(conn):
+    from hermes_cli.kanban_db_policy import policy_transaction
+    with policy_transaction(conn, task_id, "review") as allowed:
+        if not allowed:
+            return None
+        now = int(time.time())
+        expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
         if not _parents_satisfied(conn, task_id):
             demoted = conn.execute(
                 "UPDATE tasks SET status = 'todo' "

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import os
 import random
 import re
 import secrets
@@ -157,11 +158,18 @@ def _cross_process_init_lock(path: Path):
             handle.close()
 
 
+_DISPATCH_HELD = threading.local()
+
+
 @contextlib.contextmanager
-def _dispatch_tick_lock(db_path: Path):
+def _dispatch_tick_lock(db_path: Path, *, reentrant: bool = False, required: bool = False):
     """Non-blocking single-writer guard around one dispatcher tick; yields
     ``True`` if this process holds the board's ``.dispatch.lock``, else
     ``False`` (caller skips the tick).
+
+    Internal policy callers may join the same PID/thread's actual held FD with
+    ``reentrant=True``. Ordinary nested ticks remain non-reentrant. ``required``
+    refuses the legacy open-failure fallback; fallback is never recorded as ownership.
 
     Two dispatchers (e.g. an orphan gateway escaping its service cgroup) both
     pass ``busy_timeout`` and race on WAL frames — the root cause of
@@ -177,6 +185,14 @@ def _dispatch_tick_lock(db_path: Path):
     lock is the defense-in-depth that prevents two dispatchers from ever writing concurrently *regardless of
     how the second one got there*.
     """
+    db_path = db_path.resolve()
+    owned = getattr(_DISPATCH_HELD, "handles", None)
+    if owned is None:
+        owned = _DISPATCH_HELD.handles = {}
+    owner = owned.get(db_path)
+    if reentrant and owner and owner[0] == os.getpid() and not owner[1].closed:
+        yield True
+        return
     lock_path = db_path.with_name(db_path.name + ".dispatch.lock")
     handle = None
     acquired = False
@@ -190,14 +206,17 @@ def _dispatch_tick_lock(db_path: Path):
     except OSError:
         # Can't even open the lock file (permissions, read-only FS): degrade to
         # a no-op so a probe failure never blocks dispatch.
-        acquired = True
+        acquired = not required
         handle = None
+    if acquired and handle is not None:
+        owned[db_path] = (os.getpid(), handle)
     try:
         yield acquired
     finally:
         if handle is not None:
             try:
                 if acquired:
+                    owned.pop(db_path, None)
                     _unlock(handle)
             except (OSError, AttributeError):
                 pass
@@ -664,7 +683,9 @@ def _open_configured(path: Path, under_lock) -> tuple[sqlite3.Connection, Any]:
     return conn, out
 
 
-def connect(db_path: Optional[Path] = None, *, board: Optional[str] = None) -> sqlite3.Connection:
+def connect(
+    db_path: Optional[Path] = None, *, board: Optional[str] = None, read_only: bool = False,
+) -> sqlite3.Connection:
     """Open (and initialize if needed) the kanban DB. WAL is (re)enabled on
     every connection so a re-created file stays robust; the first connection
     per path auto-runs :func:`init_db`, later ones skip via
@@ -673,14 +694,14 @@ def connect(db_path: Optional[Path] = None, *, board: Optional[str] = None) -> s
     ``<root>/kanban/current`` -> ``default``)."""
     path = db_path if db_path is not None else _kb.kanban_db_path(board=board)
     from agent.delegation_context import is_delegated_child_process_context
-    if is_delegated_child_process_context():
-        # Reads must not enter schema/backfill write transactions. Never create a
-        # missing board or migrate on a descendant's behalf; the owner initializes it.
-        conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True)
+    if read_only or is_delegated_child_process_context():
+        # Observational policy reads, like descendants, must not initialize or
+        # migrate. The owner establishes the schema before these reads are possible.
+        conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True, isolation_level=None)
         conn.row_factory = sqlite3.Row
         if not _schema_is_present(conn):
             conn.close()
-            raise PermissionError("Kanban descendants require an initialized board; ask its owner to initialize it")
+            raise PermissionError("Read-only Kanban access requires an initialized board; ask its owner to initialize it")
         return conn
     path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -734,7 +755,9 @@ def connect(db_path: Optional[Path] = None, *, board: Optional[str] = None) -> s
 
 
 @contextlib.contextmanager
-def connect_closing(db_path: Optional[Path] = None, *, board: Optional[str] = None):
+def connect_closing(
+    db_path: Optional[Path] = None, *, board: Optional[str] = None, read_only: bool = False,
+):
     """Open a kanban DB connection and guarantee it is closed on exit. Use
     instead of ``with kb.connect() as conn:`` — sqlite3's context manager only
     commits/rolls back, it does NOT close the fd, so long-lived processes
@@ -742,7 +765,7 @@ def connect_closing(db_path: Optional[Path] = None, *, board: Optional[str] = No
 
     See #33159 for the production incident.
     """
-    conn = connect(db_path=db_path, board=board)
+    conn = connect(db_path=db_path, board=board, read_only=read_only)
     try:
         yield conn
     finally:

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -697,7 +697,12 @@ def connect(
     if read_only or is_delegated_child_process_context():
         # Observational policy reads, like descendants, must not initialize or
         # migrate. The owner establishes the schema before these reads are possible.
-        conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True, isolation_level=None)
+        from hermes_cli.sqlite_safe_read import connect_tracked
+
+        conn = connect_tracked(
+            path.resolve().as_uri() + "?mode=ro", connect_fn=sqlite3.connect,
+            uri=True, isolation_level=None, timeout=_resolve_busy_timeout_ms() / 1000.0,
+        )
         conn.row_factory = sqlite3.Row
         if not _schema_is_present(conn):
             conn.close()

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1454,20 +1454,23 @@ def dispatch_once(
             reconcile_orphans=reconcile_orphans,
         )
 
+    from hermes_cli.kanban_db_policy import board_policy
+    policy = board_policy(conn)
     try:
-        db_path = _kb.kanban_db_path(board=board)
+        db_path = policy.db_path if policy is not None else _kb.kanban_db_path(board=board)
     except Exception:
         # Must not lose the tick — fall through to an unguarded dispatch.
         result = _locked_tick()
         _kb._fire_dispatch_tick_hook(result, board=board, dry_run=dry_run)
         return result
-    with _kbc._dispatch_tick_lock(db_path) as held:
+    with _kbc._dispatch_tick_lock(db_path, required=policy is not None) as held:
         if not held:
             result = DispatchResult(skipped_locked=True)
         else:
             result = _locked_tick()
             # Still under the dispatch lock: periodic PASSIVE WAL checkpoint.
-            _kbc._maybe_checkpoint_wal(conn, db_path)
+            if not (dry_run and policy is not None):
+                _kbc._maybe_checkpoint_wal(conn, db_path)
     # Lock released. Fire the tick observer strictly OUTSIDE the critical
     # section: a slow subscriber must never stall a sibling dispatcher's tick.
     _kb._fire_dispatch_tick_hook(result, board=board, dry_run=dry_run)
@@ -1768,10 +1771,12 @@ def _dispatch_once_locked(
     the PID so later ticks catch crashes before the TTL. Cap semantics:
     :func:`_tick_spawn_budget`."""
     result = DispatchResult()
-    _run_reclaim_phase(
-        conn, result, stale_timeout_seconds=stale_timeout_seconds,
-        failure_limit=failure_limit, reconcile_orphans=reconcile_orphans,
-    )
+    from hermes_cli.kanban_db_policy import board_policy
+    if not (dry_run and board_policy(conn) is not None):
+        _run_reclaim_phase(
+            conn, result, stale_timeout_seconds=stale_timeout_seconds,
+            failure_limit=failure_limit, reconcile_orphans=reconcile_orphans,
+        )
     may_spawn, spawn_budget = _tick_spawn_budget(
         conn, result, max_spawn=max_spawn, max_in_progress=max_in_progress, board=board,
     )

--- a/hermes_cli/kanban_db_policy.py
+++ b/hermes_cli/kanban_db_policy.py
@@ -1,0 +1,190 @@
+"""Optional board-owned policy, checked before promotion and every native claim.
+
+The operator's command runs under the dispatch lock, never a SQLite transaction.
+Its answer is check-time evidence, not a cross-system transaction or reusable permit.
+"""
+from __future__ import annotations
+
+import contextlib
+import json
+import math
+import sqlite3
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+
+
+@dataclass(frozen=True)
+class BoardPolicy:
+    db_path: Path
+    board: str
+    metadata_path: Path
+    config: dict | None
+
+
+def validate_policy(value: object) -> dict:
+    if not isinstance(value, dict) or set(value) != {"command", "timeout_seconds"}:
+        raise ValueError("pre_claim requires command and timeout_seconds")
+    command, timeout = value["command"], value["timeout_seconds"]
+    if (not isinstance(command, list) or not command
+            or any(not isinstance(arg, str) or not arg or "\x00" in arg for arg in command)
+            or not Path(command[0]).is_absolute()):
+        raise ValueError("pre_claim command must be fixed argv with an absolute executable")
+    if type(timeout) not in (int, float) or not math.isfinite(timeout) or not 1 <= timeout <= 60:
+        raise ValueError("pre_claim timeout_seconds must be between 1 and 60")
+    return value
+
+
+def board_policy(conn: sqlite3.Connection) -> BoardPolicy | None:
+    row = conn.execute("PRAGMA database_list").fetchone()
+    if not row or not row[2]:  # In-memory databases have no native board metadata.
+        return None
+    path = Path(row[2]).resolve()
+    if path.name != "kanban.db":
+        return None
+    parent = path.parent
+    if parent.parent.name == "boards" and parent.parent.parent.name == "kanban":
+        board = parent.name
+        metadata = parent / "board.json"
+    else:
+        board = kb.DEFAULT_BOARD
+        metadata = parent / "kanban" / "boards" / board / "board.json"
+    try:
+        value = kb.read_board_metadata(board, strict=True, metadata_path=metadata)
+        if "pre_claim" not in value:
+            return None
+        config = validate_policy(value["pre_claim"])
+    except (OSError, ValueError, UnicodeError):
+        config = None  # A malformed/unreadable existing file must not disable policy.
+    return BoardPolicy(path, board, metadata, config)
+
+
+def _snapshot(conn: sqlite3.Connection, task_id: str):
+    row = conn.execute("SELECT * FROM tasks WHERE id=?", (task_id,)).fetchone()
+    if row is None:
+        return None
+    event = conn.execute(
+        "SELECT id, kind, payload FROM task_events WHERE task_id=? ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    parents = conn.execute(
+        "SELECT p.id, p.status FROM tasks p JOIN task_links l ON l.parent_id=p.id "
+        "WHERE l.child_id=? ORDER BY p.id", (task_id,),
+    ).fetchall()
+    return dict(row), dict(event) if event else None, [tuple(p) for p in parents]
+
+
+def _decision(policy: BoardPolicy, row: dict, phase: str) -> tuple[bool, str]:
+    if policy.config is None:
+        return False, "pre_claim_invalid_configuration"
+    packet = {
+        "board": policy.board, "phase": phase, "source_status": row["status"],
+        "task": {key: row[key] for key in ("id", "status", "assignee", "project_id", "idempotency_key")},
+    }
+    try:
+        result = subprocess.run(
+            policy.config["command"], input=json.dumps(packet).encode("utf-8"),
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            timeout=policy.config["timeout_seconds"], check=False, shell=False,
+        )
+        if result.returncode != 0:
+            return False, "pre_claim_command_failed"
+        if len(result.stdout) > 4096:
+            return False, "pre_claim_invalid_response"
+        value = json.loads(result.stdout)
+        if (not isinstance(value, dict) or set(value) != {"allow", "reason"}
+                or type(value["allow"]) is not bool or not isinstance(value["reason"], str)
+                or len(value["reason"].encode("utf-8")) > 512):
+            return False, "pre_claim_invalid_response"
+        return value["allow"], value["reason"]
+    except subprocess.TimeoutExpired:
+        return False, "pre_claim_timeout"
+    except (OSError, ValueError, UnicodeError):
+        return False, "pre_claim_command_error"
+
+
+def _eligible(conn, snapshot, status, phase, failure_limit):
+    if snapshot is None:
+        return False
+    row = snapshot[0]
+    if row["status"] != status or row["claim_lock"] is not None:
+        return False
+    if phase == "promote" and status == "blocked":
+        limit = row["max_retries"] if row["max_retries"] is not None else failure_limit
+        return not kb._has_sticky_block(conn, row["id"]) and int(row["consecutive_failures"] or 0) < limit
+    return True
+
+
+def _wait(conn, snapshot, reason):
+    row, event, _ = snapshot
+    lane = row["status"] if row["status"] in ("ready", "review") else kb._resume_status_from_events(conn, row["id"])
+    payload = {"source": "pre_claim", "reason": reason, "source_status": lane}
+    if row["status"] == "todo" and event and event["kind"] == "dependency_wait":
+        if kb._json_dict(event["payload"]) == payload:
+            return
+    conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (row["id"],))
+    kb._append_event(conn, row["id"], "dependency_wait", payload)
+
+
+@contextlib.contextmanager
+def policy_transaction(conn, task_id, status, *, phase="claim", failure_limit=kb.DEFAULT_FAILURE_LIMIT):
+    """Yield permission inside the caller's native write boundary, holding one FD.
+
+    An unavailable lock or caller-owned transaction leaves the task untouched. A
+    verified denial records Todo only after snapshot revalidation in our own txn.
+    """
+    kb._assert_not_delegated_child_mutation()
+    policy = board_policy(conn)
+    if policy is None:
+        with kbc.write_txn(conn):
+            yield True
+        return
+    if conn.in_transaction:
+        yield False
+        return
+    with kbc._dispatch_tick_lock(policy.db_path, reentrant=True, required=True) as held:
+        if not held:
+            yield False
+            return
+        before = _snapshot(conn, task_id)
+        if not _eligible(conn, before, status, phase, failure_limit):
+            yield False
+            return
+        allow, reason = _decision(policy, before[0], phase)
+        with kbc.write_txn(conn):
+            if before != _snapshot(conn, task_id) or policy != board_policy(conn):
+                yield False
+            elif not allow:
+                _wait(conn, before, reason)
+                yield False
+            else:
+                yield True
+
+
+def recompute_ready(conn, policy: BoardPolicy, failure_limit: int) -> int:
+    if conn.in_transaction:
+        return 0
+    promoted = 0
+    with kbc._dispatch_tick_lock(policy.db_path, reentrant=True, required=True) as held:
+        if not held:
+            return 0
+        rows = conn.execute(
+            "SELECT id, status FROM tasks WHERE status IN ('todo','blocked') "
+            "ORDER BY priority DESC, created_at ASC, id ASC",
+        ).fetchall()
+        for row in rows:
+            if board_policy(conn) != policy:
+                break
+            with policy_transaction(
+                conn, row["id"], row["status"], phase="promote", failure_limit=failure_limit,
+            ) as allowed:
+                if not allowed or not kb._parents_satisfied(conn, row["id"]):
+                    continue
+                lane = kb._resume_status_from_events(conn, row["id"])
+                conn.execute("UPDATE tasks SET status=? WHERE id=?", (lane, row["id"]))
+                kb._append_event(conn, row["id"], "promoted", {"status": lane} if lane != "ready" else None)
+                promoted += 1
+    return promoted

--- a/hermes_cli/kanban_output.py
+++ b/hermes_cli/kanban_output.py
@@ -17,7 +17,7 @@ _STATUS_ICONS = {
 
 _TASK_DICT_FIELDS = (
     "id", "title", "body", "assignee", "status", "priority", "tenant",
-    "workspace_kind", "workspace_path", "branch_name", "project_id",
+    "workspace_kind", "workspace_path", "branch_name", "project_id", "idempotency_key",
     "created_by", "created_at", "started_at", "completed_at", "result",
     "skills", "max_retries", "model_override", "provider_override",
     "session_id", "workflow_template_id", "current_step_key", "completion_contract", "last_failure_error",

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -110,6 +110,12 @@ _BOARD_SPECS = [
         _SLUG,
         _arg("path", nargs="?", help="Absolute path to use as default workdir. Omit to clear."),
     ], help="Set the default workspace path for tasks on a board"),
+    _cmd("set-pre-claim", [
+        _arg("--timeout", type=float, default=10, help="Command timeout, 1–60 seconds (before slug)"),
+        _arg("--clear", action="store_true", help="Remove the board's pre-claim policy"),
+        _json_flag(), _SLUG,
+        _arg("policy_command", nargs=argparse.REMAINDER, help="Fixed argv after --; executable must be absolute"),
+    ], help="Configure the optional board pre-claim policy (options before slug)"),
     _cmd("export", [
         _arg("slug", nargs="?", help="Board to export (default: the current board)"),
         _arg("-o", "--output", help="Archive path (default: ./<slug>.tar.gz)"),
@@ -216,6 +222,7 @@ _SPECS = [
     ], help="Create a Kanban Swarm v1 graph (parallel workers → verifier → synthesizer)"),
     _cmd("list", [
         _arg("--mine", action="store_true", help="Filter by $HERMES_PROFILE as assignee"),
+        _arg("--no-promote", action="store_true", help="Read-only inventory: no initialization or promotion"),
         _arg("--assignee"),
         _arg("--status", choices=sorted(kb.VALID_STATUSES)),
         _arg("--tenant"),
@@ -229,7 +236,9 @@ _SPECS = [
         _arg("--step-key", dest="current_step_key", metavar="KEY",
              help="Restrict to tasks with this current_step_key"),
     ], aliases=["ls"], help="List tasks"),
-    _cmd("show", [_TASK_ID, _json_flag(), *_run_state_args("filter listed runs by task_runs column")],
+    _cmd("show", [_TASK_ID, _json_flag(),
+                  _arg("--read-only", action="store_true", help="Read an initialized board without migrations"),
+                  *_run_state_args("filter listed runs by task_runs column")],
          help="Show a task with comments + events"),
     _cmd("assign", [_TASK_ID, _arg("profile", help="Profile name (or 'none' to unassign)")],
          help="Assign or reassign a task"),

--- a/tests/hermes_cli/test_kanban_pre_claim.py
+++ b/tests/hermes_cli/test_kanban_pre_claim.py
@@ -1,0 +1,415 @@
+"""An external dependency wait must gate native claims, not just first admission."""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    kb.create_board("policy")
+    with kbc.connect_closing(board="policy") as conn:
+        yield home, conn
+
+
+def configure(home, code, *, timeout=2):
+    script = home / "policy.py"
+    script.write_text("import json, sys, time\n" + code + "\n", encoding="utf-8")
+    path = kb.board_metadata_path("policy")
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+    metadata["pre_claim"] = {
+        "command": [sys.executable, str(script)], "timeout_seconds": timeout,
+    }
+    path.write_text(json.dumps(metadata), encoding="utf-8")
+
+
+def response(allow, reason="github_dependencies_incomplete"):
+    return "print(" + repr(json.dumps({"allow": allow, "reason": reason})) + ")"
+
+
+def task(conn, status="ready", **kwargs):
+    task_id = kb.create_task(conn, title="original", assignee="default", **kwargs)
+    if status != kb.get_task(conn, task_id).status:
+        conn.execute("UPDATE tasks SET status=? WHERE id=?", (status, task_id))
+    return task_id
+
+
+@pytest.mark.parametrize("status", ["ready", "review"])
+@pytest.mark.parametrize("code", [
+    response(False), "sys.exit(3)", "print('not JSON')", "print('x' * 4097)",
+    "print('{\"allow\":1,\"reason\":\"bad\"}')", "time.sleep(5)",
+])
+def test_denied_claim_never_opens_run_and_wait_is_stable(board, status, code):
+    home, conn = board
+    original = task(conn, status)
+    configure(home, code)
+    claim = kb.claim_review_task if status == "review" else kb.claim_task
+    assert claim(conn, original) is None
+    waiting = kb.get_task(conn, original)
+    assert waiting.status == "todo"
+    assert waiting.current_run_id is None and waiting.consecutive_failures == 0
+    assert kb.list_runs(conn, original) == []
+    events = kb.list_events(conn, original)
+    assert events[-1].kind == "dependency_wait"
+    assert events[-1].payload["source"] == "pre_claim"
+    assert events[-1].payload["source_status"] == status
+    assert kb.recompute_ready(conn) == 0
+    assert kb.list_events(conn, original) == events
+
+
+def test_parent_wait_and_review_resume_require_fresh_policy(board):
+    home, conn = board
+    parent = task(conn)
+    original = task(conn, "todo", parents=[parent], body="DO NOT SEND BODY")
+    configure(home, response(False))
+    assert kb.recompute_ready(conn) == 0
+    assert kb.list_events(conn, original)[-1].payload["reason"] == "github_dependencies_incomplete"
+    configure(home, response(True))
+    assert kb.recompute_ready(conn) == 0  # External allow cannot override native parents.
+    conn.execute("UPDATE tasks SET status='done' WHERE id=?", (parent,))
+    assert kb.recompute_ready(conn) == 1
+    conn.execute("UPDATE tasks SET status='review' WHERE id=?", (original,))
+    configure(home, response(False))
+    assert kb.claim_review_task(conn, original) is None
+    configure(home, response(True))
+    assert kb.recompute_ready(conn) == 1
+    assert kb.get_task(conn, original).status == "review"
+    configure(home, response(False, "fresh_claim_denied"))
+    assert kb.claim_review_task(conn, original) is None
+    assert kb.list_events(conn, original)[-1].payload["reason"] == "fresh_claim_denied"
+    assert kb.list_runs(conn, original) == []
+
+
+def test_dispatch_joins_lock_and_outer_transaction_cannot_invoke_policy(board):
+    home, conn = board
+    original = task(conn)
+    configure(home, response(False))
+    assert conn.isolation_level is None
+    conn.execute("SELECT 1").fetchone()
+    assert not conn.in_transaction
+    with kbc.write_txn(conn):
+        assert kb.claim_task(conn, original) is None
+        assert conn.in_transaction
+        assert kb.get_task(conn, original).status == "ready"
+    with kbc._dispatch_tick_lock(kb.kanban_db_path("policy")) as held:
+        assert held
+        assert kbd.dispatch_once(conn, board="policy").skipped_locked
+        # The same actual FD may be joined by a direct claim, not a second tick.
+        assert kb.claim_task(conn, original) is None
+        assert kb.get_task(conn, original).status == "todo"
+    conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (original,))
+    spawned = []
+    result = kbd.dispatch_once(
+        conn, board="policy", spawn_fn=lambda *a, **kw: spawned.append(a),
+        reconcile_orphans=False,
+    )
+    assert not result.skipped_locked
+    assert spawned == [] and kb.get_task(conn, original).status == "todo"
+    assert kb.list_runs(conn, original) == []
+
+
+def cli(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "kanban", *args],
+        capture_output=True, text=True, encoding="utf-8", timeout=20, check=False,
+    )
+
+
+def test_native_read_only_inventory_and_setup_round_trip(board):
+    home, conn = board
+    identity = "external:example/original#17"
+    original = task(conn, "todo", idempotency_key=identity)
+    kb.add_comment(conn, original, "tester", "event ordering")
+    event_ids = sorted(event.id for event in kb.list_events(conn, original))
+    conn.execute("UPDATE task_events SET created_at=-id WHERE task_id=?", (original,))
+    # A normal fresh connection would backfill this legacy running row.
+    legacy = task(conn, "running")
+    before = conn.execute("PRAGMA data_version").fetchone()[0]
+    with kbc._dispatch_tick_lock(kb.kanban_db_path("policy")) as held:
+        assert held
+        listed = cli("--board", "policy", "list", "--no-promote", "--json")
+        assert listed.returncode == 0, listed.stderr
+        shown = cli("--board", "policy", "show", original, "--read-only", "--json")
+        assert shown.returncode == 0, shown.stderr
+    detail = json.loads(shown.stdout)
+    assert detail["task"]["idempotency_key"] == identity
+    assert next(row for row in json.loads(listed.stdout) if row["id"] == original)["idempotency_key"] == identity
+    assert all(type(event["id"]) is int for event in detail["events"])
+    assert [event["id"] for event in detail["events"]] == list(reversed(event_ids))
+    assert kb.get_task(conn, original).status == "todo"
+    assert kb.get_task(conn, legacy).current_run_id is None
+    assert conn.execute("PRAGMA data_version").fetchone()[0] == before
+    with kbc.connect_closing(board="policy", read_only=True) as observer:
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            observer.execute("UPDATE tasks SET status='ready' WHERE id=?", (original,))
+    configured = cli(
+        "boards", "set-pre-claim", "--timeout", "2", "--json", "policy", "--",
+        sys.executable, "-c", response(False),
+    )
+    assert configured.returncode == 0, configured.stderr
+    assert json.loads(configured.stdout)["pre_claim"]["timeout_seconds"] == 2
+    assert kb.claim_task(conn, original) is None
+    cleared = cli("boards", "set-pre-claim", "--clear", "--json", "policy")
+    assert cleared.returncode == 0, cleared.stderr
+    assert "pre_claim" not in json.loads(cleared.stdout)
+    assert kb.recompute_ready(conn) == 1
+    assert kb.claim_task(conn, original) is not None
+
+
+def test_policy_child_can_read_board_without_recursion_and_dry_run_is_observational(board):
+    home, conn = board
+    original = task(conn, body="PRIVATE TASK PROSE")
+    capture = home / "request.json"
+    configure(home, "\n".join([
+        "import subprocess",
+        "from pathlib import Path",
+        "request = json.load(sys.stdin)",
+        f"Path({str(capture)!r}).write_text(json.dumps(request), encoding='utf-8')",
+        "base = [sys.executable, '-m', 'hermes_cli.main', 'kanban', '--board', request['board']]",
+        "for args in [['list', '--no-promote', '--json'], ['show', request['task']['id'], '--read-only', '--json']]:",
+        "    subprocess.run(base + args, stdout=subprocess.DEVNULL, check=True, timeout=10)",
+        response(False),
+    ]), timeout=20)
+    before = kb.list_events(conn, original)
+    kbd.dispatch_once(conn, board="policy", dry_run=True, reconcile_orphans=False)
+    assert not capture.exists()
+    assert kb.list_events(conn, original) == before
+    assert kb.claim_task(conn, original) is None
+    packet = json.loads(capture.read_text(encoding="utf-8"))
+    assert set(packet["task"]) == {"id", "status", "assignee", "project_id", "idempotency_key"}
+    assert packet["board"] == "policy" and packet["phase"] == "claim"
+    assert kb.get_task(conn, original).status == "todo"
+    assert kb.list_runs(conn, original) == []
+
+
+@pytest.mark.parametrize("child_kind", ["fresh", "fork"])
+def test_only_actual_process_owner_can_reenter_canonical_lock(board, child_kind):
+    if child_kind == "fork" and not hasattr(os, "fork"):
+        pytest.skip("fork inheritance is unavailable on this platform")
+    home, _ = board
+    path = kb.kanban_db_path("policy")
+    alias = home / "lock-alias.db"
+    alias.symlink_to(path)
+    script = "\n".join([
+        "import os, subprocess, sys",
+        "from pathlib import Path",
+        "from hermes_cli import kanban_db_connect as kbc",
+        "path, alias = map(Path, sys.argv[1:3])",
+        "with kbc._dispatch_tick_lock(path, required=True) as held:",
+        "    assert held",
+        "    with kbc._dispatch_tick_lock(alias, reentrant=True, required=True) as joined:",
+        "        assert joined",
+        "    if sys.argv[3] == 'fork':",
+        "        pid = os.fork()",
+        "        if pid == 0:",
+        "            with kbc._dispatch_tick_lock(alias, reentrant=True, required=True) as inherited:",
+        "                os._exit(1 if inherited else 0)",
+        "        assert os.waitpid(pid, 0)[1] == 0",
+        "    else:",
+        "        child = 'from pathlib import Path; from hermes_cli import kanban_db_connect as kbc; import sys\\nwith kbc._dispatch_tick_lock(Path(sys.argv[1]), reentrant=True, required=True) as held: assert not held'",
+        "        subprocess.run([sys.executable, '-c', child, str(alias)], check=True, timeout=10)",
+        "    with kbc._dispatch_tick_lock(path, required=True) as contender:",
+        "        assert not contender  # Neither child nor alias join released the owner.",
+        "with kbc._dispatch_tick_lock(alias, required=True) as released:",
+        "    assert released",
+    ])
+    subprocess.run(
+        [sys.executable, "-c", script, str(path), str(alias), child_kind],
+        check=True, capture_output=True, text=True, timeout=20,
+    )
+
+
+@pytest.mark.parametrize("raw", ["{", "[]", '{"pre_claim":null}', '{"pre_claim":{}}',
+                                     '{"pre_claim":{"command":["relative"],"timeout_seconds":2}}'])
+def test_bad_existing_metadata_cannot_disable_policy(board, raw):
+    _, conn = board
+    original = task(conn)
+    kb.board_metadata_path("policy").write_text(raw, encoding="utf-8")
+    assert kb.claim_task(conn, original) is None
+    assert kb.get_task(conn, original).status == "todo"
+    assert kb.list_events(conn, original)[-1].payload["reason"] == "pre_claim_invalid_configuration"
+    assert kb.list_runs(conn, original) == []
+
+
+@pytest.mark.parametrize("identity", ["wrong-current", "alias", "default"])
+def test_actual_connection_identity_selects_the_policy(board, monkeypatch, identity):
+    home, existing = board
+    configure(home, response(False))
+    path = kb.kanban_db_path("policy")
+    if identity == "default":
+        policy = json.loads(kb.board_metadata_path("policy").read_text(encoding="utf-8"))["pre_claim"]
+        kb.create_board("default")
+        kb.write_board_metadata("default", pre_claim=policy)
+        path = kb.kanban_db_path("default")
+    if identity == "alias":
+        alias = home / "alias.db"
+        alias.symlink_to(path)
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(alias))
+        path = alias
+    kb.set_current_board("default" if identity != "default" else "policy")
+    with kbc.connect_closing(path) as conn:
+        original = task(conn)
+        assert kb.claim_task(conn, original) is None
+        assert kb.get_task(conn, original).status == "todo"
+        assert kb.list_runs(conn, original) == []
+    if identity == "alias":
+        assert existing.execute("SELECT COUNT(*) FROM task_runs").fetchone()[0] == 0
+
+
+def test_required_lock_failure_cannot_fall_through_to_legacy_promotion(board, monkeypatch):
+    home, conn = board
+    original = task(conn, "todo")
+    configure(home, response(True))
+    real_open = Path.open
+
+    def deny_lock(path, *args, **kwargs):
+        if path.name.endswith(".dispatch.lock"):
+            raise PermissionError("fixture lock unavailable")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", deny_lock)
+    assert kb.recompute_ready(conn) == 0
+    assert kb.get_task(conn, original).status == "todo"
+    conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (original,))
+    assert kb.claim_task(conn, original) is None
+    assert kb.list_runs(conn, original) == []
+    assert kbd.dispatch_once(conn, board="policy").skipped_locked
+
+
+@pytest.mark.parametrize("change", ["body", "event", "parent", "policy", "competing-claim"])
+def test_external_check_holds_no_database_transaction_and_stale_allow_cannot_claim(board, change):
+    home, conn = board
+    parent = task(conn)
+    conn.execute("UPDATE tasks SET status='done' WHERE id=?", (parent,))
+    original = task(conn, parents=[parent])
+    started, release = home / "started", home / "release"
+    configure(home, "\n".join([
+        "from pathlib import Path",
+        f"Path({str(started)!r}).touch()",
+        f"while not Path({str(release)!r}).exists(): time.sleep(0.01)",
+        response(True),
+    ]), timeout=15)
+
+    def first_claim():
+        with kbc.connect_closing(board="policy") as other:
+            return kb.claim_task(other, original)
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(first_claim)
+        try:
+            deadline = time.monotonic() + 10
+            while not started.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert started.exists(), "policy did not start"
+            # This real write succeeds while the external command is still waiting.
+            mutations = {
+                "body": lambda: conn.execute("UPDATE tasks SET body='changed' WHERE id=?", (original,)),
+                "event": lambda: kb.add_comment(conn, original, author="tester", body="changed"),
+                "parent": lambda: conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,)),
+                "policy": lambda: kb.write_board_metadata("policy", clear_pre_claim=True),
+                "competing-claim": lambda: kb.claim_task(conn, original),
+            }
+            result = mutations[change]()
+            if change == "competing-claim":
+                assert result is None
+        finally:
+            release.touch()
+        claimed = future.result(timeout=10)
+    if change == "competing-claim":
+        assert claimed is not None and len(kb.list_runs(conn, original)) == 1
+    else:
+        assert claimed is None and kb.list_runs(conn, original) == []
+        assert kb.get_task(conn, original).status == "ready"
+
+
+def test_promotion_commits_each_slot_and_keeps_sticky_and_breaker_holds(board):
+    home, conn = board
+    originals = [task(conn, "todo", priority=p) for p in (1, 3, 2)]
+    recoverable = task(conn, "blocked", priority=4, max_retries=2)
+    conn.execute("UPDATE tasks SET consecutive_failures=1 WHERE id=?", (recoverable,))
+    sticky = task(conn)
+    assert kb.block_task(conn, sticky, reason="human decision")
+    breaker = task(conn, "blocked", max_retries=1)
+    conn.execute("UPDATE tasks SET consecutive_failures=1 WHERE id=?", (breaker,))
+    trace = home / "promotion-trace.jsonl"
+    configure(home, "\n".join([
+        "import subprocess",
+        "from pathlib import Path",
+        "request = json.load(sys.stdin)",
+        "out = subprocess.check_output([sys.executable, '-m', 'hermes_cli.main', 'kanban', '--board', request['board'], 'list', '--no-promote', '--json'])",
+        "ready = [row['id'] for row in json.loads(out) if row['status'] == 'ready']",
+        f"with Path({str(trace)!r}).open('a', encoding='utf-8') as stream: stream.write(json.dumps([request['task']['id'], ready]) + '\\n')",
+        "print(json.dumps({'allow':len(ready) < 1,'reason':'capacity'}))",
+    ]), timeout=20)
+    assert kb.recompute_ready(conn) == 1
+    rows = [json.loads(line) for line in trace.read_text(encoding="utf-8").splitlines()]
+    assert [row[0] for row in rows] == [recoverable, originals[1], originals[2], originals[0]]
+    assert rows[0][1] == [] and rows[1][1] == [recoverable]
+    assert kb.get_task(conn, recoverable).status == "ready"
+    assert kb.get_task(conn, sticky).status == "blocked"
+    assert kb.get_task(conn, breaker).status == "blocked"
+
+
+@pytest.mark.parametrize("status", ["ready", "review"])
+def test_policy_latency_does_not_consume_the_new_claim_lease(board, status):
+    home, conn = board
+    original = task(conn, status)
+    checked_at = home / "checked-at"
+    configure(home, "\n".join([
+        "from pathlib import Path", "time.sleep(2)",
+        f"Path({str(checked_at)!r}).write_text(str(int(time.time())), encoding='utf-8')",
+        response(True),
+    ]), timeout=10)
+    claim = kb.claim_review_task if status == "review" else kb.claim_task
+    claimed = claim(conn, original, ttl_seconds=30)
+    assert claimed is not None
+    assert claimed.claim_expires >= int(checked_at.read_text(encoding="utf-8")) + 30
+
+
+def test_delegated_claim_is_refused_before_external_policy_runs(board):
+    from agent.delegation_context import delegated_child_context
+
+    home, conn = board
+    original = task(conn)
+    invoked = home / "must-not-invoke"
+    configure(home, f"from pathlib import Path\nPath({str(invoked)!r}).touch()\n" + response(True))
+    with delegated_child_context():
+        with pytest.raises(PermissionError):
+            kb.claim_task(conn, original)
+        with pytest.raises(PermissionError):
+            kb.write_board_metadata("policy", clear_pre_claim=True)
+    assert not invoked.exists()
+    assert kb.get_task(conn, original).status == "ready"
+    assert kb.list_runs(conn, original) == []
+
+
+def test_setup_rejects_custom_database_and_read_only_requires_existing_schema(board, monkeypatch):
+    home, conn = board
+    path = kb.board_metadata_path("policy")
+    before = path.read_text(encoding="utf-8")
+    custom = home / "custom.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(custom))
+    result = cli("boards", "set-pre-claim", "--json", "policy", "--", sys.executable, "-c", response(True))
+    assert result.returncode != 0 and "canonical" in result.stderr
+    assert path.read_text(encoding="utf-8") == before
+    with pytest.raises(sqlite3.OperationalError):
+        with kbc.connect_closing(custom, read_only=True):
+            pytest.fail("missing board was opened")
+    assert not custom.exists()

--- a/tests/hermes_cli/test_kanban_pre_claim.py
+++ b/tests/hermes_cli/test_kanban_pre_claim.py
@@ -413,3 +413,84 @@ def test_setup_rejects_custom_database_and_read_only_requires_existing_schema(bo
         with kbc.connect_closing(custom, read_only=True):
             pytest.fail("missing board was opened")
     assert not custom.exists()
+
+
+@pytest.mark.parametrize("action", ["list", "show"])
+@pytest.mark.parametrize("database", ["missing", "uninitialized"])
+def test_observational_cli_reports_unavailable_schema_without_traceback(tmp_path, monkeypatch, action, database):
+    home = tmp_path / "fresh-home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    path = home / "kanban.db"
+    if database == "uninitialized":
+        home.mkdir()
+        with sqlite3.connect(path) as conn:
+            conn.execute("CREATE TABLE unrelated (id INTEGER)")
+        conn.close()
+    before = path.read_bytes() if path.exists() else None
+    args = ["list", "--no-promote"] if action == "list" else ["show", "t_missing", "--read-only"]
+    result = cli("--board", "default", *args, "--json")
+    assert result.returncode == 1
+    assert not result.stdout
+    assert result.stderr.startswith("kanban:")
+    assert "Traceback" not in result.stderr
+    assert (path.read_bytes() if path.exists() else None) == before
+
+
+@pytest.mark.parametrize("delegated", [False, True])
+def test_read_only_connection_uses_native_tracking_and_timeout(tmp_path, monkeypatch, delegated):
+    from agent.delegation_context import DELEGATED_CHILD_ENV_MARKER
+    from hermes_cli.sqlite_safe_read import has_live_connection, read_header_bytes_preopen
+
+    path = tmp_path / "observed.db"
+    with kbc.connect_closing(path):
+        pass
+    assert not has_live_connection(path)
+    monkeypatch.setenv("HERMES_KANBAN_BUSY_TIMEOUT_MS", "1234")
+    if delegated:
+        monkeypatch.setenv(DELEGATED_CHILD_ENV_MARKER, "1")
+    with kbc.connect_closing(path, read_only=not delegated) as observer:
+        assert has_live_connection(path)
+        assert read_header_bytes_preopen(path) is None
+        assert observer.execute("PRAGMA busy_timeout").fetchone()[0] == 1234
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            observer.execute("UPDATE tasks SET status='ready'")
+    assert not has_live_connection(path)
+    assert read_header_bytes_preopen(path).startswith(b"SQLite format 3")
+
+
+def test_read_only_missing_schema_releases_native_tracking(tmp_path):
+    from hermes_cli.sqlite_safe_read import has_live_connection
+
+    path = tmp_path / "uninitialized.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE unrelated (id INTEGER)")
+    conn.close()
+    with pytest.raises(PermissionError, match="initialized board"):
+        with kbc.connect_closing(path, read_only=True):
+            pytest.fail("uninitialized board was opened")
+    assert not has_live_connection(path)
+
+
+@pytest.mark.parametrize("error", [PermissionError, sqlite3.OperationalError])
+def test_observational_error_mapping_does_not_change_ordinary_handlers(board, monkeypatch, capsys, error):
+    import argparse
+
+    from hermes_cli import kanban
+
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "policy")
+
+    def unavailable(*args, **kwargs):
+        raise error("fixture ordinary handler failure")
+
+    monkeypatch.setattr(kb, "list_tasks", unavailable)
+    parser = kanban.build_parser(argparse.ArgumentParser().add_subparsers())
+    args = parser.parse_args(["list", "--json"])
+    if error is PermissionError:
+        assert kanban.kanban_command(args) == 1
+        assert "kanban: fixture ordinary handler failure" in capsys.readouterr().err
+    else:
+        with pytest.raises(error, match="fixture ordinary handler failure"):
+            kanban.kanban_command(args)

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -45,6 +45,55 @@ This is the shape that covers the workloads `delegate_task` can't:
 
 For the full design rationale, comparative analysis against Cline Kanban / Paperclip / NanoClaw / Google Gemini Enterprise, and the eight canonical collaboration patterns, see `docs/hermes-kanban-v1-spec.pdf` in the repository.
 
+## Optional pre-claim policy
+
+An initial intake check is not sufficient when external prerequisites can change
+after a task is admitted. A board can require an operator-owned command before
+automatic promotion and **every** Ready/Review claim, including direct CLI/API
+claims and resumptions. This is disabled by default and contains no provider or
+issue-tracker policy of its own.
+
+Configure fixed argv in the existing board metadata through the native CLI.
+Put options before the board slug; `--` separates the executable and its arguments:
+
+```bash
+hermes kanban boards set-pre-claim --timeout 10 --json example -- /usr/local/bin/board-policy --check
+hermes kanban boards set-pre-claim --clear --json example
+```
+
+The command receives UTF-8 JSON on stdin: `board`, `phase` (`promote` or `claim`),
+`source_status`, and `task` containing only `id`, `status`, `assignee`, `project_id`,
+and `idempotency_key`. Task titles/bodies are not sent. It must exit zero and return
+an object shaped like `{"allow":true,"reason":"policy_allowed"}` or an equivalent denial object.
+`allow` must be a boolean; `reason` is a nonsecret string of at most 512 UTF-8 bytes;
+the whole response is limited to 4096 bytes. Timeout is 1–60 seconds. Invalid
+configuration, errors, timeout, or malformed output deny; stderr is not published.
+
+The command runs without a SQLite transaction but under the existing board dispatch
+lock. **Do not acquire that lock in the command.** For native inventory, use
+`kanban list --no-promote --json` and `kanban show ID --read-only --json`. These
+require an initialized board and neither initialize, migrate nor promote it.
+Task JSON includes the existing `idempotency_key` for independent source binding.
+Show events include their native integer `id`; use that revision rather than wall
+clock timestamps when ordering lifecycle evidence.
+
+A validated denial leaves the original task in Todo with a `dependency_wait` event
+whose `source` is `pre_claim`. Unchanged repeated denial is deduplicated; Review
+resumptions retain their review lane. No run, worker, failure count or replacement
+workspace is allocated. Incomplete native parents still veto an external allow;
+sticky and breaker-limited Blocked tasks are not automatically released. Lock
+contention, a caller-owned transaction or a changed task/configuration leaves the
+task untouched instead of applying stale evidence. Each real claim checks again;
+promotion is not a reusable permit. Opted-in dry-runs do not invoke policy or mutate
+tasks, and their previews are **not** policy approvals.
+
+This is a trusted operator extension, not an OS sandbox. Metadata can be changed
+or removed by its owner, and arbitrary custom DB files cannot be configured through
+this native board setter. External facts can change after the response: the lock
+and native snapshot recheck do not make external APIs and SQLite atomic. Standard
+subprocess timeout bounds the direct command only; descendant cleanup or finally
+blocks (such as token revocation) are not guaranteed after forced termination.
+
 ## PR completion contracts
 
 Declare PR work at creation with `--completion-contract OWNER/REPO` (or an exact


### PR DESCRIPTION
## What does this PR do?

Adds an optional board-owned pre-claim command for integrations that must verify external eligibility before any native worker claim. A card admitted earlier can acquire an external dependency later, or return through retry/review/unblock paths that never revisit the original intake filter. An admission-only filter therefore cannot enforce that dependency at execution time.

The operator supplies fixed argv in native board metadata. Core checks it before promotion and both public Ready/Review claims under the existing dispatch lock. A verified denial leaves the original card in Todo, preserving its worktree and review lane without allocating a run, recording a failure, or starting a worker. Non-opt-in boards keep existing behavior.

External policy runs outside SQLite transactions. Core revalidates the task, latest event, parents and policy configuration before committing the decision. Native parent, sticky-block and retry limits remain independent gates. This is check-time evidence, not an atomic transaction across an external system and SQLite.

## Related Issue

Related prior art: #68173, reviewed at `5e8dba9778bae6cbb635202ba1e2dadfd599d45d`. That proposal offers broader plugin dispositions in dispatcher loops. Its defer retains Ready/Review and command errors synthesize failure/run state; it does not cover direct claim functions or promotion. This patch instead targets a fixed operator command, stable Todo and every native claim. No code from that PR was copied. Maintainer guidance on consolidating these related approaches is welcome.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Small `kanban_db_policy.py` helper; existing promotion/direct-claim integration and lock ownership reuse. No GitHub client, service, scheduler, schema or policy-specific rules in Core.
- Native `boards set-pre-claim` setter/readback; existing metadata remains the configuration source.
- Observational `list --no-promote` and `show --read-only` use a real read-only connection and skip startup initialization. Existing integer event IDs are included in show JSON so consumers need not infer event order from wall-clock timestamps. Task JSON exposes the existing idempotency key for independent readback. These reads are necessary for a policy child to inspect the board without recursively invoking itself or migrating state under the parent lock.
- 37 native regression cases and user-guide documentation.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_kanban_pre_claim.py --file-retries 0` using the repository test environment. This covers real policy subprocesses, native CLI reads under the held lock, Ready/Review denials/resumptions, caller-owned transactions, races, strict response/config handling, dry-run and unchanged parent/sticky/retry gates.
2. Configure a disposable board with the documented `boards set-pre-claim --timeout 60 --json BOARD -- /absolute/command args` command. Deny at both promotion and direct claim; verify Todo, one deduplicated wait event, no run and no worker. Return allow and confirm normal native flow. Do not use a live board for this test.
3. Run `scripts/run_tests.sh -j 8 --file-retries 0`, configured Ruff for changed Python, and `scripts/check_compat_pointers.py`.

Executed evidence: four focused native files pass 62 tests, including all 37 new cases. Ruff, compatibility-pointer check and diff check pass. A real shared subprocess canary exposed the missing JSON idempotency key; a native CLI regression reproduced the omission before the additive field fix. The canary now demonstrates denial to the same Todo card without a run, promotion/claim after a synthetic repair merge, and denial of a second worker. External GitHub/token boundaries are test fixtures, not live authorization or deployment proof.

Full-suite limitation: untouched base `869228cab4a8276d3b4c78da9d9939670c47bd0f` had 45,676 passed / 38 failed / 491 skipped, plus one file that crashed with a Python Bus error. Final post-fix run: **45,723 passed / the same exact 38 failing test IDs / 491 skipped**, 3822 files, 740.2 seconds; the previously crashed file completed 10/10. Exit status remains 1. No new observed failures, but this is **not** an all-green suite or a waiver of those failures. Unrelated tests were not repaired or excluded. This PR remains Draft for human/maintainer review of that baseline and runtime integration.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing PRs; the related #68173 distinction is above.
- [x] This PR contains only changes related to this feature.
- [ ] I've run `pytest tests/ -q` and all tests pass. (Repository-mandated `scripts/run_tests.sh` used instead; full baseline and implementation both fail as detailed above.)
- [x] I've added tests for my changes.
- [x] I've tested on my platform: macOS ARM64; cross-platform/live deployment not claimed.

### Documentation & Housekeeping

- [x] Updated relevant user-guide documentation.
- [x] `cli-config.yaml.example`: N/A; board metadata configuration, not profile/global config.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no new development workflow.
- [x] Considered cross-platform impact: existing native lock primitives and standard subprocess argv, no shell-specific policy launcher in Core.
- [x] Tool descriptions/schemas: N/A; native CLI options documented and tested.

## Review and deployment limits

Independent native security review plus two distinct external models (Grok4.6 and Meta Muse1.3) reviewed the complete source and bounded remediation. Actual runtime identities and packet-only read operations were verified. The missing process-lock regression and canary-discovered JSON omission were fixed and confirmed by originating reviewers. Final Core findings: **0 Blockers, 0 Should-fixes, 0 Nice-to-haves; 1 harmless Nit retained** (`validate_policy` returns its trusted input dictionary). Reviewed commit `57fe05bb12a3f5bacd95c5de335ed94a167d596b` has full diff SHA256 `ebd41daa522740c08202df9a5d5087b75ea6b01ab584f57ef0d14076cc0939e5` against the base above, exactly matching tested and peer-reviewed source. Independent native exact-head attestation confirmed the match and clean worktree. Reviews do not waive baseline failures.

Upstream main advanced during testing; its changes to the touched files concern notification lineage/schema/docs, separate from these hunks. This PR preserves the reviewed merge base rather than silently incorporating those changes as tested feature source. Maintainer integration testing remains required.

No live external-policy activation, deployment or older-Core backport is established. An operator command is trusted configuration, not an OS sandbox. Timeout bounds the direct subprocess wait, not arbitrary descendant cleanup or guaranteed consumer token revocation. Installing this feature on an older deployment requires a separately reviewed/tested narrow backport or release decision, not an automatic full upstream upgrade. The downstream collection's separate disable-intake pause-versus-retirement decision is not made by this generic Core PR.

## Follow-up: native read-only safety (96a64dc2b9)

The earlier execution/review census above describes commit `57fe05bb`. This follow-up adds only the two matching read-only fixes: reuse native SQLite connection tracking/busy timeout for explicit and delegated read-only connections, and map observational SQLite open errors to concise CLI diagnostics. Ordinary PermissionError handling is preserved; ordinary OperationalError still propagates. No installer/runtime changes or broader upgrade are included.

Nine new regression cases bring the pre-claim module to 46 cases. RED reproduced four failures; the final six-file focused run passed **81/81**. Ruff, compatibility-pointer and diff checks pass.

The final full run at `96a64dc2b9d52b476f4e5e902c6110c64341ed43` completed 3,822 files: **45,728 passed / 42 failed / 491 skipped**, exit 1. All previous 38 failing IDs remain, plus four additional observed failures. A bounded comparison of those four unchanged files on both the previous PR head and this head, using the same current interpreter/environment, returned **27 passed / the same one failure** on each. The other three full-run failures passed on both rechecks; they are not erased from the full-run census. The remaining readiness assertion fails on both heads: its actual diagnostics report disk utilization 90.1%, which triggers the existing degraded threshold. No threshold, test, unrelated source or gate was changed to obtain green. **The full suite remains non-green and this PR remains Draft.**

Independent native review and actual Grok 4.6 / Meta Muse 1.3 originating reviews found **0 remaining Blockers, Should-fixes or Nice-to-haves** in these fixes. One proposed cleanup was withdrawn by its originator after inspecting the existing SQLite DatabaseError handler; no speculative cleanup was added. The prior harmless alias Nit is unchanged. Full-guideline/source-read completion and actual model identities were verified; reviews do not waive test failures.

Exact reviewed follow-up delta SHA256: `9d25f555fe8d112fe99714b71fb15040b87a856868bfdf7f21b9852fb9cd7f7a`. Full feature diff against `869228cab4a8276d3b4c78da9d9939670c47bd0f`: `c2b947a612ca433fa2b90d0d296e8417163711402c1499bebec46ce737845149`. Native exact-head attestation confirmed these fingerprints and a clean worktree. This is source/test evidence, not merge, deployment or live policy activation approval.

