### PR TITLE
feat(memory): opt-in env var to silence the Qdrant api-key-over-HTTP warning

### DIFF
--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -156,6 +156,19 @@ Circuit breaker tripped after 5 consecutive failures. Resets after 2 minutes.
 - **Platform mode**: Check API key and internet connectivity.
 - **OSS mode**: Check that your vector store (qdrant/pgvector) is running.
 
+### OSS: "Api key is used with an insecure connection" warning
+
+qdrant-client warns whenever an API key travels over plain HTTP. That is correct for
+public endpoints, but noisy for a trusted same-network deployment (Hermes and Qdrant in
+one Docker/Komodo network, no TLS termination for intra-network traffic). Opt in:
+
+```bash
+export HERMES_QDRANT_ALLOW_INSECURE=1
+```
+
+Only the qdrant-client warning is silenced, and only when explicitly set — the warning
+stays a safety net for Qdrant instances exposed to public networks.
+
 ### OSS: Qdrant connection refused
 
 ```bash

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from contextlib import closing, suppress
 from typing import Any
@@ -98,6 +99,32 @@ class SelfHostedBackend(Mem0Backend):
 _DIRECT_OPENAI_PROVIDER = "hermes_openai"
 _DIRECT_OPENAI_CLASS_PATH = "plugins.memory.mem0._openai_llm.DirectOpenAILLM"
 
+_QDRANT_INSECURE_WARNING = "Api key is used with an insecure connection."
+
+
+def _qdrant_insecure_warning_allowed() -> bool:
+    """Whether the operator opted into plain-HTTP Qdrant with an API key (trusted same-network deployments)."""
+    from utils import env_var_enabled
+
+    return env_var_enabled("HERMES_QDRANT_ALLOW_INSECURE")
+
+
+def _suppress_qdrant_insecure_warning() -> "warnings.catch_warnings | None":
+    """Context manager silencing only the Qdrant api-key-over-HTTP warning; None when not opted in.
+
+    qdrant-client raises it synchronously in QdrantRemote.__init__ whenever an api_key
+    accompanies an http:// url, so scoping to client construction covers every construction
+    site without touching unrelated warnings.
+    """
+    if not _qdrant_insecure_warning_allowed():
+        return None
+    ctx = warnings.catch_warnings()
+    ctx.__enter__()
+    warnings.filterwarnings(
+        "ignore", message=_QDRANT_INSECURE_WARNING, category=UserWarning
+    )
+    return ctx
+
 
 def _register_direct_openai_provider() -> None:
     """Register Hermes' OpenAI-only Mem0 LLM provider once per factory."""
@@ -150,9 +177,19 @@ class OSSBackend(Mem0Backend):
                 memory_config.llm.provider = _DIRECT_OPENAI_PROVIDER
             except (AttributeError, TypeError) as exc:
                 raise RuntimeError("mem0 MemoryConfig does not expose a mutable llm.provider for the Hermes OpenAI OSS backend") from exc
-            self._memory = Memory(memory_config)
+            suppress_insecure = _suppress_qdrant_insecure_warning()
+            try:
+                self._memory = Memory(memory_config)
+            finally:
+                if suppress_insecure is not None:
+                    suppress_insecure.__exit__(None, None, None)
         else:
-            self._memory = Memory.from_config(config)
+            suppress_insecure = _suppress_qdrant_insecure_warning()
+            try:
+                self._memory = Memory.from_config(config)
+            finally:
+                if suppress_insecure is not None:
+                    suppress_insecure.__exit__(None, None, None)
 
     @staticmethod
     def _recreate_collection_if_dims_changed(provider: str, vs_config: dict, expected_dims: int) -> None:
@@ -162,12 +199,17 @@ class OSSBackend(Mem0Backend):
             if provider == "qdrant":
                 from qdrant_client import QdrantClient
                 path, url = vs_config.get("path"), vs_config.get("url")
-                if path:
-                    client = QdrantClient(path=path)
-                elif url:
-                    client = QdrantClient(url=url, api_key=vs_config.get("api_key"))
-                else:
-                    return
+                suppress_insecure = _suppress_qdrant_insecure_warning()
+                try:
+                    if path:
+                        client = QdrantClient(path=path)
+                    elif url:
+                        client = QdrantClient(url=url, api_key=vs_config.get("api_key"))
+                    else:
+                        return
+                finally:
+                    if suppress_insecure is not None:
+                        suppress_insecure.__exit__(None, None, None)
                 with closing(client):
                     if not client.collection_exists(collection_name):
                         return

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 import types
+import warnings
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 
@@ -678,3 +679,133 @@ class TestSelfHostedBackend:
         s = _StubServer()
         with pytest.raises(httpx.HTTPStatusError):
             _backend(s).delete("missing")  # 404 -> raise_for_status; 'not found' won't trip breaker
+
+
+class TestQdrantInsecureWarningSuppression:
+
+    """HERMES_QDRANT_ALLOW_INSECURE=1 must silence only the Qdrant api-key-over-HTTP warning."""
+
+    @staticmethod
+    def _raw_config():
+        return {
+            "llm": {"provider": "ollama", "config": {"model": "llama3"}},
+            "embedder": {
+                "provider": "openai",
+                "config": {"model": "text-embedding-3-small"},
+            },
+            "vector_store": {
+                "provider": "qdrant",
+                "config": {"url": "http://qdrant:6333", "api_key": "secret"},
+            },
+        }
+
+    def test_opt_in_suppresses_warning_from_memory_construction(
+        self, monkeypatch, recwarn
+    ):
+        _install_fake_mem0(monkeypatch)
+        monkeypatch.setenv("HERMES_QDRANT_ALLOW_INSECURE", "1")
+        fake_mem0 = sys.modules["mem0"]
+
+        class WarningRaisingMemory(fake_mem0.Memory):
+            def __init__(self, config):
+                warnings.warn(
+                    "Api key is used with an insecure connection.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                super().__init__(config)
+
+        monkeypatch.setattr(fake_mem0, "Memory", WarningRaisingMemory)
+        OSSBackend(self._raw_config())
+        assert not [w for w in recwarn.list if "insecure connection" in str(w.message)]
+
+    def test_warning_surfaces_without_opt_in(self, monkeypatch, recwarn):
+        _install_fake_mem0(monkeypatch)
+        monkeypatch.delenv("HERMES_QDRANT_ALLOW_INSECURE", raising=False)
+        fake_mem0 = sys.modules["mem0"]
+
+        class WarningRaisingMemory(fake_mem0.Memory):
+            def __init__(self, config):
+                warnings.warn(
+                    "Api key is used with an insecure connection.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                super().__init__(config)
+
+        monkeypatch.setattr(fake_mem0, "Memory", WarningRaisingMemory)
+        OSSBackend(self._raw_config())
+        assert [w for w in recwarn.list if "insecure connection" in str(w.message)]
+
+    def test_opt_in_suppresses_warning_from_dims_check_client(
+        self, monkeypatch, recwarn
+    ):
+        qdrant_client = types.ModuleType("qdrant_client")
+
+        class WarningRaisingQdrantClient:
+            def __init__(self, url=None, api_key=None, path=None):
+                warnings.warn(
+                    "Api key is used with an insecure connection.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+        qdrant_client.QdrantClient = WarningRaisingQdrantClient
+        monkeypatch.setitem(sys.modules, "qdrant_client", qdrant_client)
+        monkeypatch.setenv("HERMES_QDRANT_ALLOW_INSECURE", "1")
+        # The dims check bails out right after construction (no collection to inspect).
+        OSSBackend._recreate_collection_if_dims_changed(
+            "qdrant", {"url": "http://qdrant:6333", "api_key": "secret"}, 1536
+        )
+        assert not [w for w in recwarn.list if "insecure connection" in str(w.message)]
+
+    def test_dims_check_warning_surfaces_without_opt_in(self, monkeypatch, recwarn):
+        qdrant_client = types.ModuleType("qdrant_client")
+
+        class WarningRaisingQdrantClient:
+            def __init__(self, url=None, api_key=None, path=None):
+                warnings.warn(
+                    "Api key is used with an insecure connection.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+        qdrant_client.QdrantClient = WarningRaisingQdrantClient
+        monkeypatch.setitem(sys.modules, "qdrant_client", qdrant_client)
+        monkeypatch.delenv("HERMES_QDRANT_ALLOW_INSECURE", raising=False)
+        OSSBackend._recreate_collection_if_dims_changed(
+            "qdrant", {"url": "http://qdrant:6333", "api_key": "secret"}, 1536
+        )
+        assert [w for w in recwarn.list if "insecure connection" in str(w.message)]
+
+    def test_unrelated_user_warning_survives_opt_in(self, monkeypatch, recwarn):
+        _install_fake_mem0(monkeypatch)
+        monkeypatch.setenv("HERMES_QDRANT_ALLOW_INSECURE", "1")
+        fake_mem0 = sys.modules["mem0"]
+
+        class NoisyMemory(fake_mem0.Memory):
+            def __init__(self, config):
+                warnings.warn(
+                    "some unrelated misconfiguration", UserWarning, stacklevel=2
+                )
+                warnings.warn(
+                    "Api key is used with an insecure connection.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                super().__init__(config)
+
+        monkeypatch.setattr(fake_mem0, "Memory", NoisyMemory)
+        OSSBackend(self._raw_config())
+        messages = [str(w.message) for w in recwarn.list]
+        assert "some unrelated misconfiguration" in messages
+        assert "Api key is used with an insecure connection." not in messages
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "0", "", "false"])
+    def test_truthy_string_set_governs_the_gate(self, monkeypatch, value):
+        from utils import TRUTHY_STRINGS
+
+        from plugins.memory.mem0._backend import _qdrant_insecure_warning_allowed
+
+        monkeypatch.setenv("HERMES_QDRANT_ALLOW_INSECURE", value)
+        assert _qdrant_insecure_warning_allowed() == (value in TRUTHY_STRINGS)

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -423,6 +423,8 @@ The plugin authenticates with `X-API-Key` and uses the server's `/search` / `/me
 | Embedder | openai, ollama |
 | Vector Store | qdrant (local/server), pgvector |
 
+**Same-network Qdrant over HTTP:** qdrant-client logs `Api key is used with an insecure connection` whenever an API key travels over plain HTTP. For trusted same-network deployments (Hermes + Qdrant in one Docker network) opt in with `HERMES_QDRANT_ALLOW_INSECURE=1` — only that warning is silenced; it stays on for publicly exposed Qdrant instances.
+
 **Switching modes:** Re-run `hermes memory setup mem0 --mode <platform|selfhosted|oss>` or edit `mem0.json` directly.
 
 ---


### PR DESCRIPTION
## Summary

qdrant-client emits `UserWarning: Api key is used with an insecure connection` from `QdrantRemote.__init__` (qdrant_remote.py:157) whenever an `api_key` is configured alongside an `http://` url. That is the right default for public endpoints, but noisy for a common legitimate deployment shape — Hermes and Qdrant on the same private Docker/Komodo network with no TLS termination for intra-network traffic.

This adds an explicit operator opt-in, `HERMES_QDRANT_ALLOW_INSECURE` (truthy: `1`/`true`/`yes`/`on`, via the shared `utils.env_var_enabled`), that silences exactly that one warning and nothing else:

- `plugins/memory/mem0/_backend.py` — new `_suppress_qdrant_insecure_warning()` helper wraps every Qdrant client construction site in the mem0 OSS backend:
  - the direct `QdrantClient(url=..., api_key=...)` in `_recreate_collection_if_dims_changed` (_backend.py:168),
  - `Memory(memory_config)` / `Memory.from_config(config)`, where mem0's vector-store factory builds the client internally.
  The suppression is scoped to construction via `warnings.catch_warnings()` + a message-anchored `filterwarnings` — the warning fires synchronously inside `QdrantRemote.__init__`, so the scope covers it; unrelated warnings (including other qdrant-client warnings) are untouched, and without the env var the behavior is byte-identical to before.

- Docs: plugin README troubleshooting section + `website/docs/user-guide/features/memory-providers.md`, both stating the trusted-same-network intent so the warning remains a safety net for publicly exposed Qdrant instances.

## Testing

- `env -u HERMES_YOLO_MODE .venv/bin/python -m pytest tests/plugins/memory/test_mem0_backend.py tests/plugins/memory/test_mem0_v3.py -q` → **49 passed** (12 new tests in `TestQdrantInsecureWarningSuppression`: opt-in suppression at both construction sites, default pass-through at both, unrelated-warning survival under opt-in, and the truthy-string gate).
- Mutation checks: forcing the helper to always-return-`None` (never suppress) fails 3 tests; forcing always-suppress fails 2 — the suite catches both directions.
- `ruff check` clean on both touched Python files; `ruff format --diff` complaints limited to pre-existing drift, none on new lines.

Fixes #105484
