### PR TITLE
fix(tui): match the redo chord case-insensitively so Cmd+Shift+Z works on extended-key terminals

### DIFF
--- a/ui-tui/src/__tests__/textInputRedoShift.test.tsx
+++ b/ui-tui/src/__tests__/textInputRedoShift.test.tsx
@@ -1,0 +1,117 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@hermes/ink'
+import React, { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TextInput } from '../components/textInput.js'
+import type * as PlatformModule from '../lib/platform.js'
+
+// Treat the kitty `super` bit as the action modifier regardless of host OS so
+// the Cmd+Shift+Z chord below is exercised on every CI lane.
+vi.mock('../lib/platform.js', async importOriginal => {
+  const mod = await importOriginal<typeof PlatformModule>()
+
+  return {
+    ...mod,
+    isActionMod: (key: { ctrl: boolean; meta: boolean; super?: boolean }) => key.ctrl || key.super === true
+  }
+})
+
+class FakeInput extends EventEmitter {
+  chunks: string[] = []
+  isRaw = false
+  isTTY = true
+  readableLength = 0
+
+  read() {
+    const next = this.chunks.shift() ?? null
+    this.readableLength = this.chunks.length
+
+    return next
+  }
+
+  ref = vi.fn()
+
+  send(...chunks: string[]) {
+    this.chunks.push(...chunks)
+    this.readableLength = this.chunks.length
+    this.emit('readable')
+  }
+
+  setEncoding = vi.fn()
+
+  setRawMode = vi.fn((enabled: boolean) => {
+    this.isRaw = enabled
+  })
+
+  unref = vi.fn()
+}
+
+const settle = (ms = 25) => new Promise(resolve => setTimeout(resolve, ms))
+
+function makeStreams() {
+  const stdin = new FakeInput()
+  const stdout = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+  Object.assign(stderr, { columns: 80, isTTY: false, rows: 24 })
+
+  return { stderr, stdin, stdout }
+}
+
+describe('TextInput redo chord under extended-key terminals', () => {
+  it('Cmd+Shift+Z delivered as uppercase "Z" (kitty CSI-u) redoes instead of typing Z', async () => {
+    const streams = makeStreams()
+    const changes: string[] = []
+
+    function Harness() {
+      const [value, setValue] = useState('')
+
+      return (
+        <TextInput
+          columns={80}
+          onChange={next => {
+            changes.push(next)
+            setValue(next)
+          }}
+          onSubmit={() => {}}
+          value={value}
+        />
+      )
+    }
+
+    const instance = renderSync(React.createElement(Harness), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as unknown as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    await settle()
+
+    streams.stdin.send('a')
+    await settle()
+    streams.stdin.send('b')
+    await settle()
+    expect(changes.at(-1)).toBe('ab')
+
+    // Undo: super+z (CSI-u, modifier 9 = 1 + super bit 8).
+    streams.stdin.send('\u001b[122;9u')
+    await settle()
+    expect(changes.at(-1)).toBe('a')
+
+    // Redo: super+shift+z (modifier 10). hermes-ink restores the shifted
+    // letter's case, so the composer sees inp 'Z' with key.shift set.
+    streams.stdin.send('\u001b[122;10u')
+    await settle()
+
+    instance.unmount()
+    instance.cleanup()
+
+    expect(changes.at(-1)).toBe('ab')
+    expect(changes).not.toContain('aZ')
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1447,7 +1447,10 @@ export function TextInput({
         return swap(undo, redo)
       }
 
-      if ((mod && inp === 'y') || (mod && k.shift && inp === 'z')) {
+      // Extended-key terminals (kitty CSI-u / modifyOtherKeys) deliver a shifted
+      // letter as its uppercase char, so Cmd+Shift+Z arrives as inp 'Z' — match
+      // case-insensitively like the copy/paste chords above.
+      if ((mod && inp === 'y') || (mod && k.shift && inp.toLowerCase() === 'z')) {
         return swap(redo, undo)
       }
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to #90674. That fix makes hermes-ink restore the shifted letter's case for CSI-u / modifyOtherKeys input, so on macOS extended-key terminals (iTerm2, kitty, WezTerm, Ghostty) **Cmd+Shift+Z now reaches the composer as `inp === 'Z'`** with `key.shift` set. The redo binding in `textInput.tsx` compared `inp === 'z'`, missed, and fell through to the printable path — typing a literal `Z` instead of redoing.

The legacy raw-byte path (`ESC Z`) already delivered `'Z'`, so the binding was latently case-sensitive on both paths; #90674 just made the extended-key path agree. This PR matches case-insensitively, the same way the copy/paste chords (`inp.toLowerCase() === 'c'` / `'v'`) a few lines above already do.

Linux Ctrl+Shift+Z is unaffected: ctrl chords keep the lowercase key name (`input = keypress.name`), verified against both the pre- and post-#90674 parser.

## Related Issue

Follow-up to #90674 / #90663.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `ui-tui/src/components/textInput.tsx` — redo chord: `inp === 'z'` → `inp.toLowerCase() === 'z'` (one line + comment).
- `ui-tui/src/__tests__/textInputRedoShift.test.tsx` — drives the real `TextInput` via `renderSync` with kitty CSI-u bytes: type `ab`, `super+z` (`ESC[122;9u`) → `a`, `super+shift+z` (`ESC[122;10u`) → `ab` again, and asserts `aZ` never appears. `isActionMod` is mocked to accept the `super` bit on every host so the chord is exercised on the Linux CI lane too.

## How to Test

1. On macOS in Ghostty/iTerm2/kitty, `hermes --tui`, type text, Cmd+Z, then Cmd+Shift+Z → redo lands, no stray `Z`.
2. `cd ui-tui && npx vitest run src/__tests__/textInputRedoShift.test.tsx`
   - Green on this branch; **red on main** with `Expected: "ab" / Received: "aZ"`.
3. `npx vitest run src/__tests__/textInput` → 15 files / 130 tests pass. `npm run typecheck` → 0 errors. eslint clean on both touched files (the `useEffect` deps warning at line ~999 is pre-existing and untouched).

Swept `ui-tui/src` for other `k.shift && inp === '<lowercase>'` bindings — this was the only one.

## Checklist

- [x] Conventional commit (`fix(tui): ...`)
- [x] Only changes related to this fix
- [x] Tests added and proven red on the unfixed tree
- [x] N/A — no docs/config changes
