### PR TITLE
fix(proxy): return retryable responses for cooling xAI credentials

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -960,17 +960,21 @@ class CredentialPool(CredentialPoolAdminMixin):
             available, _pending = self._available_entries()
             return bool(available)
 
-    def next_available_at(self) -> Optional[float]:
+    def next_available_at(
+        self, *, eligible: Optional[Callable[[PooledCredential], bool]] = None,
+    ) -> Optional[float]:
         """Earliest epoch time (seconds) any entry re-enters rotation.
 
         ``None`` when an entry is available now, or when no exhausted entry
         carries a usable recovery time (empty pool, or only ``STATUS_DEAD``
         entries). Callers must treat ``None`` as "no wait information".
         Runs under ``self._lock`` for the same reason as ``has_available``.
+        ``eligible`` limits the answer to a subset, e.g. proxy credentials
+        recovering from transient failures rather than authentication failures.
         """
         with self._lock:
             available, _pending = self._available_entries()
-            if available:
+            if available and (eligible is None or any(eligible(entry) for entry in available)):
                 return None
             # Mirror _available_entries: a sole credential's transient throttle
             # cools down in seconds, and the fallback restore gate must not
@@ -982,6 +986,7 @@ class CredentialPool(CredentialPoolAdminMixin):
                     _exhausted_until(entry, sole_credential=sole_credential)
                     for entry in self._entries
                     if entry.last_status == STATUS_EXHAUSTED
+                    and (eligible is None or eligible(entry))
                 )
                 if until is not None
             ]

--- a/hermes_cli/proxy/adapters/base.py
+++ b/hermes_cli/proxy/adapters/base.py
@@ -7,6 +7,14 @@ from dataclasses import dataclass
 from typing import FrozenSet, Optional
 
 
+class UpstreamCredentialsCoolingDown(RuntimeError):
+    """All configured upstream credentials are temporarily unavailable."""
+
+    def __init__(self, message: str, retry_after_seconds: int) -> None:
+        super().__init__(message)
+        self.retry_after_seconds = max(1, int(retry_after_seconds))
+
+
 @dataclass(frozen=True)
 class UpstreamCredential:
     """A resolved bearer + base URL ready to forward to."""
@@ -38,13 +46,17 @@ class UpstreamAdapter(ABC):
 
     @abstractmethod
     def is_authenticated(self) -> bool:
-        """Cheap (no network) usable-credentials check; ``proxy start`` uses it for a clear
-        up-front error before binding a port."""
+        """Cheap (no network) usable-credentials check for health reporting."""
+
+    def is_configured(self) -> bool:
+        """Return True if credentials exist, even when temporarily unavailable."""
+        return self.is_authenticated()
 
     @abstractmethod
     def get_credential(self) -> UpstreamCredential:
         """Fresh credential (refreshing/rotating + persisting as needed). Raises RuntimeError when
-        unauthenticated or refresh fails; the proxy then returns 401 to the client."""
+        unauthenticated or refresh fails; the proxy then returns 401 to the client.
+        Temporary pool exhaustion raises UpstreamCredentialsCoolingDown (429)."""
 
     def get_retry_credential(
         self, *, failed_credential: UpstreamCredential, status_code: int
@@ -64,4 +76,8 @@ class UpstreamAdapter(ABC):
         return f"{self.display_name}: {cred.base_url}{ttl}"
 
 
-__all__ = ["UpstreamAdapter", "UpstreamCredential"]
+__all__ = [
+    "UpstreamAdapter",
+    "UpstreamCredential",
+    "UpstreamCredentialsCoolingDown",
+]

--- a/hermes_cli/proxy/adapters/xai.py
+++ b/hermes_cli/proxy/adapters/xai.py
@@ -70,25 +70,26 @@ class XAIGrokAdapter(UpstreamAdapter):
                 )
             entry = pool.select()
             if entry is None:
-                available_at = pool.next_available_at()
-                entries = pool.entries()
-                exhausted = [
-                    item for item in entries
+                retryable_ids = {
+                    item.id for item in pool.entries()
                     if item.last_status == STATUS_EXHAUSTED
-                ]
-                if not exhausted or not all(
-                    item.last_error_code in {429, 500, 502, 503, 504}
-                    or (
-                        item.last_error_code == 403
-                        and item.extra.get("failure_reason") == "rate_limit"
+                    and (
+                        item.last_error_code in {429, 500, 502, 503, 504}
+                        or (item.last_error_code == 403
+                            and item.extra.get("failure_reason") == "rate_limit")
                     )
-                    for item in exhausted
-                ):
+                }
+                if not retryable_ids:
                     raise RuntimeError(
                         "No available xAI OAuth credentials found. Run "
                         "`hermes auth reset xai-oauth` or re-authenticate with "
                         "`hermes auth add xai-oauth --type oauth`."
                     )
+                # A permanent failure in another entry does not prevent recovery.
+                # Its earlier deadline must not shorten this Retry-After either.
+                available_at = pool.next_available_at(
+                    eligible=lambda item: item.id in retryable_ids,
+                )
                 retry_after = (
                     math.ceil(available_at - time.time())
                     if available_at is not None

--- a/hermes_cli/proxy/adapters/xai.py
+++ b/hermes_cli/proxy/adapters/xai.py
@@ -3,12 +3,24 @@
 from __future__ import annotations
 
 import logging
+import math
 import threading
+import time
 from typing import FrozenSet, Optional
 
-from agent.credential_pool import CredentialPool, PooledCredential, load_pool
+from agent.credential_pool import (
+    EXHAUSTED_TTL_SOLE_CREDENTIAL_SECONDS,
+    STATUS_EXHAUSTED,
+    CredentialPool,
+    PooledCredential,
+    load_pool,
+)
 from hermes_cli.auth import DEFAULT_XAI_OAUTH_BASE_URL
-from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+from hermes_cli.proxy.adapters.base import (
+    UpstreamAdapter,
+    UpstreamCredential,
+    UpstreamCredentialsCoolingDown,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +57,10 @@ class XAIGrokAdapter(UpstreamAdapter):
         pool = self._load_pool()
         return bool(pool and pool.has_available())
 
+    def is_configured(self) -> bool:
+        pool = self._load_pool()
+        return bool(pool and pool.has_credentials())
+
     def get_credential(self) -> UpstreamCredential:
         with self._lock:
             pool = self._load_pool()
@@ -54,9 +70,35 @@ class XAIGrokAdapter(UpstreamAdapter):
                 )
             entry = pool.select()
             if entry is None:
-                raise RuntimeError(
-                    "No available xAI OAuth credentials found. Run "
-                    "`hermes auth reset xai-oauth` or re-authenticate with `hermes auth add xai-oauth --type oauth`."
+                available_at = pool.next_available_at()
+                entries = pool.entries()
+                exhausted = [
+                    item for item in entries
+                    if item.last_status == STATUS_EXHAUSTED
+                ]
+                if not exhausted or not all(
+                    item.last_error_code in {429, 500, 502, 503, 504}
+                    or (
+                        item.last_error_code == 403
+                        and item.extra.get("failure_reason") == "rate_limit"
+                    )
+                    for item in exhausted
+                ):
+                    raise RuntimeError(
+                        "No available xAI OAuth credentials found. Run "
+                        "`hermes auth reset xai-oauth` or re-authenticate with "
+                        "`hermes auth add xai-oauth --type oauth`."
+                    )
+                retry_after = (
+                    math.ceil(available_at - time.time())
+                    if available_at is not None
+                    else EXHAUSTED_TTL_SOLE_CREDENTIAL_SECONDS
+                )
+                retry_after = max(1, retry_after)
+                raise UpstreamCredentialsCoolingDown(
+                    "all xAI OAuth credentials are cooling down after transient "
+                    f"upstream failures; retry after {retry_after} s",
+                    retry_after,
                 )
             self._pool = pool
             return self._credential_from_entry(entry)

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -30,7 +30,7 @@ def cmd_proxy_start(args: Any) -> int:
     except ValueError as exc:
         _err(f"Error: {exc}")
         return 2
-    if not adapter.is_authenticated():
+    if not adapter.is_configured():
         auth_hint = getattr(adapter, "auth_hint", f"hermes auth add {adapter.name}")
         _err(f"Not logged into {adapter.display_name}. Run `{auth_hint}` first.")
         return 2
@@ -59,7 +59,7 @@ def cmd_proxy_status(args: Any) -> int:
     print("Hermes proxy upstream adapters\n")
     for name in sorted(ADAPTERS):
         adapter = get_adapter(name)
-        if not adapter.is_authenticated():
+        if not adapter.is_configured():
             print(f"  [{name:8s}] {adapter.display_name} — not logged in")
             continue
         try:

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -21,7 +21,11 @@ except ImportError:
     web = None  # type: ignore[assignment]
     AIOHTTP_AVAILABLE = False
 
-from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+from hermes_cli.proxy.adapters.base import (
+    UpstreamAdapter,
+    UpstreamCredential,
+    UpstreamCredentialsCoolingDown,
+)
 from hermes_cli.proxy.sse_done import DONE_SSE_FRAME, SseDoneTracker, content_type_is_sse
 
 logger = logging.getLogger(__name__)
@@ -149,6 +153,17 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
             )
         try:
             cred = await asyncio.to_thread(adapter.get_credential)
+        except UpstreamCredentialsCoolingDown as exc:
+            retry_after = exc.retry_after_seconds
+            logger.warning(
+                "proxy: credential resolution failed: %s retry_after=%s",
+                exc, retry_after,
+            )
+            response = _json_error(
+                429, str(exc), code="upstream_rate_limited",
+            )
+            response.headers["Retry-After"] = str(retry_after)
+            return response
         except Exception as exc:
             logger.warning("proxy: credential resolution failed: %s", exc)
             return _json_error(401, str(exc), code="upstream_auth_failed")

--- a/tests/hermes_cli/test_proxy_xai_cooldown.py
+++ b/tests/hermes_cli/test_proxy_xai_cooldown.py
@@ -1,0 +1,98 @@
+"""Exercise the real xAI pool and proxy route using temporary auth state."""
+import asyncio
+import json
+import time
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("aiohttp")
+from aiohttp.test_utils import make_mocked_request
+
+from hermes_cli.proxy import cli, server
+from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
+
+
+@pytest.fixture
+def auth_store(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    def write(*, code=429, reason=None, status="exhausted", delay=900, empty=False):
+        now = time.time()
+        entry = {
+            "id": "test-key", "label": "test-key", "auth_type": "oauth",
+            "priority": 0, "source": "manual:xai_pkce",
+            "access_token": "synthetic-test-bearer", "expires_at": now + 3600,
+            "last_status": status, "last_status_at": now,
+            "last_error_code": code, "last_error_reset_at": now + delay,
+        }
+        if reason:
+            entry["failure_reason"] = reason
+        (home / "auth.json").write_text(json.dumps({
+            "version": 1, "credential_pool": {"xai-oauth": [] if empty else [entry]},
+        }))
+    return write
+
+
+def request(adapter):
+    async def run():
+        app = server.create_app(adapter)
+        req = make_mocked_request("POST", "/v1/chat/completions", app=app)
+        match = await app.router.resolve(req)
+        req._match_info = match
+        response = await match.handler(req)
+        return response.status, dict(response.headers), json.loads(response.body)
+    return asyncio.run(run())
+
+
+@pytest.mark.parametrize("code,reason", [(429, None), (503, None), (403, "rate_limit")])
+def test_cooling_credentials_return_retry_after(auth_store, code, reason):
+    auth_store(code=code, reason=reason)
+    status, headers, body = request(XAIGrokAdapter())
+    assert status == 429
+    # Respect the actual pool deadline, including waits longer than five minutes.
+    assert 895 <= int(headers["Retry-After"]) <= 900
+    assert body["error"]["code"] == "upstream_rate_limited"
+
+
+@pytest.mark.parametrize("entry", [
+    {"empty": True}, {"code": 401}, {"code": 401, "status": "dead"},
+    {"code": 403, "reason": "billing"}, {"code": 403},
+])
+def test_auth_failures_are_not_reported_as_retryable(auth_store, entry):
+    auth_store(**entry)
+    status, headers, body = request(XAIGrokAdapter())
+    assert status == 401
+    assert "Retry-After" not in headers
+    assert body["error"]["code"] == "upstream_auth_failed"
+
+
+def test_proxy_start_accepts_cooling_credentials(auth_store, monkeypatch):
+    auth_store()
+    started = []
+
+    async def run_server(adapter, *, host, port):
+        started.append(adapter.name)
+
+    monkeypatch.setattr(cli, "run_server", run_server)
+    assert cli.cmd_proxy_start(Namespace(provider="xai", host="127.0.0.1", port=8645)) == 0
+    assert started == ["xai"]
+
+
+def test_cooldown_expiry_restores_normal_credentials(auth_store):
+    auth_store(delay=-1)
+    adapter = XAIGrokAdapter()
+    assert adapter.get_credential().bearer == "synthetic-test-bearer"
+
+
+def test_proxy_status_describes_cooldown(auth_store, capsys, monkeypatch):
+    auth_store()
+    monkeypatch.setattr(cli, "ADAPTERS", {"xai": XAIGrokAdapter})
+    assert cli.cmd_proxy_status(Namespace()) == 0
+    output = capsys.readouterr().out
+    assert "cooling down" in output
+    assert "not logged in" not in output

--- a/tests/hermes_cli/test_proxy_xai_cooldown.py
+++ b/tests/hermes_cli/test_proxy_xai_cooldown.py
@@ -34,7 +34,8 @@ def auth_store(tmp_path, monkeypatch):
             entry["failure_reason"] = reason
         (home / "auth.json").write_text(json.dumps({
             "version": 1, "credential_pool": {"xai-oauth": [] if empty else [entry]},
-        }))
+        }), encoding="utf-8")
+        return home
     return write
 
 
@@ -96,3 +97,30 @@ def test_proxy_status_describes_cooldown(auth_store, capsys, monkeypatch):
     output = capsys.readouterr().out
     assert "cooling down" in output
     assert "not logged in" not in output
+
+
+@pytest.mark.parametrize("peer_code,peer_status,reason,expected_delay", [
+    (401, "exhausted", None, 900),
+    (403, "exhausted", "billing", 900),
+    (401, "dead", None, 900),
+    (503, "exhausted", None, 60),
+])
+def test_mixed_pool_retries_at_the_first_transient_recovery(
+    auth_store, peer_code, peer_status, reason, expected_delay,
+):
+    home = auth_store(delay=900)
+    path = home / "auth.json"
+    state = json.loads(path.read_text(encoding="utf-8"))
+    entries = state["credential_pool"]["xai-oauth"]
+    peer = dict(entries[0], id="peer-key", label="peer-key", last_error_code=peer_code,
+                last_status=peer_status, last_error_reset_at=time.time() + 60)
+    if reason:
+        peer["failure_reason"] = reason
+    entries.append(peer)
+    path.write_text(json.dumps(state), encoding="utf-8")
+
+    status, headers, body = request(XAIGrokAdapter())
+    assert status == 429
+    # An earlier auth/billing deadline cannot promise the retryable credential is ready.
+    assert expected_delay - 5 <= int(headers["Retry-After"]) <= expected_delay
+    assert body["error"]["code"] == "upstream_rate_limited"


### PR DESCRIPTION
## What does this PR do?

After xAI rate-limits the last available credential, the next request to `hermes proxy` currently receives HTTP 401 and advice to reauthenticate. Starting the proxy during that cooldown also reports “not logged in.” The credential exists and is only temporarily benched.

Return HTTP 429 with `Retry-After` derived from the pool's recovery deadline for transient cooldowns, and allow the proxy to start while waiting. Pools with no recoverable transient credential retain the existing authentication failure response. In mixed pools, an auth- or billing-failed credential does not hide another credential's recovery or shorten its advertised wait. Health reporting still describes current availability.

## Related Issue

Follow-up to merged #33743: that change benches a credential after an upstream 429; this fixes resolution of the already-benched pool on subsequent requests. Searched open and closed PRs/issues for proxy cooldown, 429 and Retry-After; no equivalent patch found.

## Type of Change

- [x] Bug fix

## Changes Made

- Add a typed temporary-unavailability result to the upstream adapter contract, with a default configuration check for existing adapters.
- Distinguish configured xAI credentials from credentials available immediately.
- Map known transient exhaustion to 429 and preserve the full advertised pool wait, including waits longer than five minutes.
- Reuse the pool's deadline policy with an optional eligible-entry filter; existing callers retain their behavior.
- Exercise real temporary auth-store loading, pool selection, request routing, startup, status, expiry, and nonretryable failures.

## How to Test

`scripts/run_tests.sh -j2 tests/hermes_cli/test_proxy_xai_cooldown.py tests/hermes_cli/test_proxy_off_loop.py tests/agent/test_credential_pool_sole_cooldown.py tests/test_iron_proxy_cli.py`

On current main, the new tests produce **5 failures and 6 passes**: cooldown requests return 401, startup is rejected and status says not logged in. With the fix, **41 tests pass** across these four files. Tests use temporary auth stores, synthetic credentials and local test sockets; no real xAI requests are made. Linux, Python 3.11, aiohttp 3.14.3. Ruff, whitespace checks and the Windows-footgun scan pass for changed files. The full project suite and other operating systems were not run.

The mixed-pool regression also reproduced **2 failures and 13 passes** against the initial single-credential fix. With the follow-up, **95 tests pass** across the proxy regression, credential-pool, sole-cooldown and pool-operations suites. The final proxy file has **15 passing cases**, including mixed authentication, billing, dead and transient entries with distinct deadlines.

## Checklist

- [x] Read the contributing guide and searched existing PRs.
- [x] Focused conventional commit and behavioral regression tests.
- [x] Tested on Linux; considered cross-platform behavior.
- [ ] Ran the entire project test suite.
- [x] Documentation/config/tool-schema updates are not applicable; no user configuration or dependency changes.
