### PR TITLE
fix(openviking): report recall timeouts without extra requests

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -454,6 +454,17 @@ _TOOL_STATUS_ERROR_ALIASES = {"error", "failed", "failure"}
 _TOOL_STATUS_COMPLETED_ALIASES = {"completed", "complete", "success", "succeeded"}
 
 
+def _is_timeout_error(error: BaseException) -> bool:
+    """True for httpx/socket timeouts raised anywhere in the recall path."""
+    if isinstance(error, TimeoutError):
+        return True
+    try:
+        import httpx
+        return isinstance(error, httpx.TimeoutException)
+    except Exception:
+        return False
+
+
 def _resolve_user_space(client, *, timeout: Optional[float] = None) -> Optional[str]:
     """Server-asserted current user for explicit-uid URIs; ``None`` when the probe fails or
     reports no user. Callers may fall back to a configured value for that one operation but
@@ -1613,7 +1624,14 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 deadline=deadline, request_timeout=cfg["request_timeout_seconds"], full_read_limit=cfg["full_read_limit"],
             ))
         except Exception as e:
-            logger.debug("OpenViking context search failed: %s", e)
+            # A recall timeout is a silent capability loss (no memories injected, no user-visible
+            # error), so it is logged at WARNING while other failures stay at debug.
+            if _is_timeout_error(e):
+                logger.warning("OpenViking recall timed out user=%s budget_s=%s request_s=%s: %s",
+                               self._user_space(client), cfg["timeout_seconds"],
+                               cfg["request_timeout_seconds"], e)
+            else:
+                logger.debug("OpenViking context search failed: %s", e)
             return ""
 
     # -- typed settings ------------------------------------------------------

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -458,11 +458,8 @@ def _is_timeout_error(error: BaseException) -> bool:
     """True for httpx/socket timeouts raised anywhere in the recall path."""
     if isinstance(error, TimeoutError):
         return True
-    try:
-        import httpx
-        return isinstance(error, httpx.TimeoutException)
-    except Exception:
-        return False
+    httpx = _get_httpx()
+    return httpx is not None and isinstance(error, httpx.TimeoutException)
 
 
 def _resolve_user_space(client, *, timeout: Optional[float] = None) -> Optional[str]:
@@ -1624,12 +1621,11 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 deadline=deadline, request_timeout=cfg["request_timeout_seconds"], full_read_limit=cfg["full_read_limit"],
             ))
         except Exception as e:
-            # A recall timeout is a silent capability loss (no memories injected, no user-visible
-            # error), so it is logged at WARNING while other failures stay at debug.
+            # Recall contributes no query context after a timeout. Report the configured
+            # budgets without private exception text or another request to resolve identity.
             if _is_timeout_error(e):
-                logger.warning("OpenViking recall timed out user=%s budget_s=%s request_s=%s: %s",
-                               self._user_space(client), cfg["timeout_seconds"],
-                               cfg["request_timeout_seconds"], e)
+                logger.warning("OpenViking recall timed out (%s; budget_s=%s request_s=%s); no query context injected",
+                               type(e).__name__, cfg["timeout_seconds"], cfg["request_timeout_seconds"])
             else:
                 logger.debug("OpenViking context search failed: %s", e)
             return ""

--- a/tests/plugins/memory/test_openviking_recall_timeout_log.py
+++ b/tests/plugins/memory/test_openviking_recall_timeout_log.py
@@ -1,0 +1,39 @@
+"""Recall timeouts must be visible: a silent timeout injects no memories and shows no error."""
+
+import logging
+
+import httpx
+import pytest
+
+from plugins.memory.openviking import _is_timeout_error
+
+
+@pytest.mark.parametrize("error, expected", [
+    (httpx.ReadTimeout("read"), True),
+    (httpx.ConnectTimeout("connect"), True),
+    (TimeoutError("socket"), True),
+    (httpx.HTTPError("boom"), False),
+    (ValueError("boom"), False),
+])
+def test_timeout_classification(error, expected):
+    assert _is_timeout_error(error) is expected
+
+
+def test_recall_timeout_logs_warning(monkeypatch, caplog):
+    from plugins.memory import openviking as mod
+
+    provider = mod.OpenVikingMemoryProvider.__new__(mod.OpenVikingMemoryProvider)
+    monkeypatch.setattr(provider, "_user_space", lambda *a, **k: "u1", raising=False)
+    monkeypatch.setattr(provider, "_recall_config", lambda: {
+        "timeout_seconds": 4.0, "request_timeout_seconds": 3.0, "limit": 6,
+        "score_threshold": 0.15, "max_injected_chars": 4000, "full_read_limit": 2,
+        "prefer_abstract": False, "resources": False}, raising=False)
+
+    def boom(*a, **k):
+        raise httpx.ReadTimeout("upstream slow")
+
+    monkeypatch.setattr(provider, "_post_prefetch_search", boom, raising=False)
+    with caplog.at_level(logging.WARNING):
+        assert provider._search_prefetch_context("what did we decide about billing",
+                                                     session_id="sess", client=object()) == ""
+    assert any("recall timed out" in r.message for r in caplog.records)

--- a/tests/plugins/memory/test_openviking_recall_timeout_runtime.py
+++ b/tests/plugins/memory/test_openviking_recall_timeout_runtime.py
@@ -1,0 +1,133 @@
+"""Recall diagnostics through real provider discovery, config, and HTTP client."""
+
+import logging
+import os
+from pathlib import Path
+import time
+
+import httpx
+import pytest
+import yaml
+
+from hermes_cli import config
+from plugins.memory import load_memory_provider
+
+
+@pytest.fixture
+def recall_provider(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    for name in list(os.environ):
+        if name.startswith("OPENVIKING_"):
+            monkeypatch.delenv(name, raising=False)
+    (home / "config.yaml").write_text(yaml.safe_dump({
+        "memory": {"provider": "openviking", "openviking": {
+            "endpoint": "http://127.0.0.1:19473",
+            "user": "private-user-fixture",
+            "recall_timeout_seconds": 1.5,
+            "recall_request_timeout_seconds": 0.75,
+            "recall_prefer_abstract": True,
+        }},
+    }), encoding="utf-8")
+    config._LOAD_CONFIG_CACHE.clear()
+    requests = []
+    behavior = {"error": None, "fallback": False}
+
+    def handle(request):
+        requests.append(request)
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "ok", "healthy": True, "version": "test"})
+        if request.url.path == "/api/v1/system/status":
+            return httpx.Response(200, json={"result": {"user": "private-user-fixture"}})
+        if request.url.path == "/api/v1/content/read":
+            return httpx.Response(200, json={"result": {"content": ""}})
+        if request.url.path == "/api/v1/fs/ls":
+            return httpx.Response(200, json={"result": []})
+        assert request.url.path in {"/api/v1/search/search", "/api/v1/search/find"}
+        if behavior["error"] is not None and not (
+                behavior["fallback"] and request.url.path.endswith("/find")):
+            raise behavior["error"]("private-query-fixture in transport error")
+        return httpx.Response(200, json={"result": {"memories": [{
+            "uri": "viking://user/test/memories/events/decision.md",
+            "abstract": "A remembered decision.", "score": 0.9,
+        }]}})
+
+    with httpx.Client(transport=httpx.MockTransport(handle)) as client:
+        monkeypatch.setattr(httpx, "get", client.get)
+        monkeypatch.setattr(httpx, "post", client.post)
+        provider = load_memory_provider("openviking", register_skills=False)
+        assert provider is not None
+        provider.initialize("recall-test", hermes_home=str(home))
+        assert provider._client is not None
+        requests.clear()
+        try:
+            yield provider, behavior, requests
+        finally:
+            provider.shutdown()
+    config._LOAD_CONFIG_CACHE.clear()
+
+
+@pytest.mark.parametrize("error", [
+    httpx.ReadTimeout, httpx.ConnectTimeout, httpx.WriteTimeout, httpx.PoolTimeout, TimeoutError,
+])
+def test_recall_timeout_warns_without_identity_probe_or_private_text(recall_provider, caplog, error):
+    provider, behavior, requests = recall_provider
+    behavior["error"] = error
+    with caplog.at_level(logging.WARNING, logger="plugins.memory.openviking"):
+        assert provider._search_prefetch_context("private-query-fixture") == ""
+    warnings = [r for r in caplog.records if r.name == "plugins.memory.openviking" and r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "recall timed out" in message
+    assert error.__name__ in message
+    assert "budget_s=1.5" in message
+    assert "request_s=0.75" in message
+    assert "private-query-fixture" not in message
+    assert "private-user-fixture" not in message
+    assert [request.url.path for request in requests] == ["/api/v1/search/find"]
+    assert requests[0].extensions["timeout"]["read"] <= 0.75
+
+
+def test_recovered_session_search_timeout_keeps_recall_and_stays_quiet(recall_provider, caplog):
+    provider, behavior, requests = recall_provider
+    behavior.update(error=httpx.ReadTimeout, fallback=True)
+    with caplog.at_level(logging.WARNING, logger="plugins.memory.openviking"):
+        result = provider._search_prefetch_context("private-query-fixture", session_id="session")
+    assert "A remembered decision." in result
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert [request.url.path for request in requests] == ["/api/v1/search/search", "/api/v1/search/find"]
+
+
+def test_public_prefetch_warns_when_session_search_exhausts_total_budget(recall_provider, monkeypatch, caplog):
+    provider, behavior, requests = recall_provider
+    provider.prefetch("")  # Complete the once-per-session profile stage through HTTP.
+    requests.clear()
+    now = [100.0]
+    monkeypatch.setattr(time, "monotonic", lambda: now[0])
+
+    def exhaust_budget(message):
+        now[0] += 2.0
+        return httpx.ReadTimeout(message)
+
+    behavior["error"] = exhaust_budget
+    with caplog.at_level(logging.WARNING, logger="plugins.memory.openviking"):
+        assert provider.prefetch("private-query-fixture") == ""
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "TimeoutError" in warnings[0].getMessage()
+    assert "budget_s=1.5" in warnings[0].getMessage()
+    assert [request.url.path for request in requests] == ["/api/v1/search/search"]
+
+
+@pytest.mark.parametrize("error", [ValueError, httpx.ConnectError])
+def test_non_timeout_search_failure_keeps_debug_level(recall_provider, caplog, error):
+    provider, behavior, requests = recall_provider
+    behavior["error"] = error
+    with caplog.at_level(logging.DEBUG, logger="plugins.memory.openviking"):
+        assert provider._search_prefetch_context("private-query-fixture") == ""
+    assert any("context search failed" in r.getMessage() and r.levelno == logging.DEBUG for r in caplog.records)
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert [request.url.path for request in requests] == ["/api/v1/search/find"]


### PR DESCRIPTION
## What does this PR do?

When OpenViking query recall times out, Hermes continues without recalled query context and currently logs the failure only at DEBUG. Emit a WARNING for HTTP timeout exceptions and total-budget exhaustion, including the exception class and configured total/per-request budgets.

The warning uses local diagnostic values: no identity lookup after timeout, and no query, identity, or raw exception text in the message. Recovered session-aware searches remain quiet, and other search errors keep their existing DEBUG behavior.

## Related work

Checked open, closed, and merged PRs. #88873 covers connection failures in session commit and `system_prompt_block`; this change covers the separate query-recall search path. #51222 is a pending behavior-preserving OpenViking refactor.

## Type of Change

- [x] Bug fix

## How to Test

```sh
scripts/run_tests.sh -j2 tests/plugins/memory/test_openviking*.py tests/openviking_plugin/test_openviking.py
```

The new integration tests discover and initialize the real provider using temporary home/config files, with requests handled by `httpx.MockTransport`. They exercise each HTTP timeout class, exhausted total budget through public `prefetch()`, successful fallback after a session-aware timeout, and non-timeout controls. They also verify that a timeout warning does not trigger another identity request or expose synthetic private text.

On baseline `966637323e`, the new runtime file has six failures for missing warnings and three passing controls. With this change, all 176 related tests pass on Linux/Python 3.11.16 (five existing ephemeral-loopback tests were rerun with socket permission after sandbox restrictions blocked listener creation). Ruff and `git diff --check` pass. No live OpenViking/model service was used; the full repository suite was not run.

Example warning:

```text
OpenViking recall timed out (ReadTimeout; budget_s=4.0 request_s=3.0); no query context injected
```
