### PR TITLE
fix(mcp): return schema-valid consent responses

### DIFF
--- a/tests/tools/test_mcp_elicitation.py
+++ b/tests/tools/test_mcp_elicitation.py
@@ -70,7 +70,10 @@ class TestElicitationHandlerFormMode:
         handler = ElicitationHandler("pay", {"timeout": 5})
         params = _form_params(
             "authorize a payment of $0.50",
-            {"properties": {"approved": {"type": "boolean"}}},
+            {
+                "properties": {"approved": {"type": "boolean"}},
+                "required": ["approved"],
+            },
         )
 
         with patch("tools.approval_prompt.request_elicitation_consent", return_value="accept"):
@@ -78,9 +81,52 @@ class TestElicitationHandlerFormMode:
 
         assert isinstance(result, ElicitResult)
         assert result.action == "accept"
-        assert result.content == {}
+        assert result.content == {"approved": True}
         assert handler.metrics["accepted"] == 1
         assert handler.metrics["declined"] == 0
+
+    def test_user_accepts_composio_style_form_returns_allow_once(self):
+        handler = ElicitationHandler("apps", {"timeout": 5})
+        params = _form_params(
+            "Allow an operation?",
+            {
+                "type": "object",
+                "properties": {
+                    "decision": {
+                        "type": "string",
+                        "oneOf": [
+                            {"const": "allow_once", "title": "Allow once"},
+                            {"const": "allow_session", "title": "Allow for this session"},
+                            {"const": "deny", "title": "Deny"},
+                        ],
+                    }
+                },
+                "required": ["decision"],
+            },
+        )
+
+        with patch("tools.approval_prompt.request_elicitation_consent", return_value="accept"):
+            result = asyncio.run(handler(context=None, params=params))
+
+        assert result.action == "accept"
+        assert result.content == {"decision": "allow_once"}
+
+    def test_user_accepts_arbitrary_form_declines_instead_of_sending_empty_content(self):
+        handler = ElicitationHandler("pay", {"timeout": 5})
+        params = _form_params(
+            "Enter a card number",
+            {
+                "properties": {"card_number": {"type": "string"}},
+                "required": ["card_number"],
+            },
+        )
+
+        with patch("tools.approval_prompt.request_elicitation_consent", return_value="accept"):
+            result = asyncio.run(handler(context=None, params=params))
+
+        assert result.action == "decline"
+        assert handler.metrics["accepted"] == 0
+        assert handler.metrics["declined"] == 1
 
 
     def test_schema_read_from_real_sdk_params_reaches_the_summary(self):

--- a/tools/mcp_tool_sampling.py
+++ b/tools/mcp_tool_sampling.py
@@ -241,6 +241,38 @@ def _format_elicitation_schema_summary(schema: dict, server_name: str) -> str:
     return "\n".join(lines)
 
 
+def _accepted_consent_content(schema: dict) -> Optional[dict]:
+    """Translate a binary approval into a safe, schema-valid consent form.
+
+    Hermes' approval surfaces can answer yes/no, not collect arbitrary form
+    fields.  A required single boolean is unambiguous.  A required single
+    enum is only unambiguous when it offers the conventional one-shot
+    ``allow_once`` choice; choosing a session-wide grant would silently
+    broaden the user's approval.  Every other form must be declined rather
+    than submitted with the historical (and invalid) empty object.
+    """
+    if not isinstance(schema, dict):
+        return None
+    props = schema.get("properties")
+    required = schema.get("required")
+    # No required fields: the empty object already satisfies the form.
+    if required in (None, []):
+        return {}
+    if not isinstance(props, dict) or not isinstance(required, list) or len(required) != 1:
+        return None
+    field = required[0]
+    spec = props.get(field)
+    if not isinstance(field, str) or not isinstance(spec, dict):
+        return None
+    if spec.get("type") == "boolean":
+        return {field: True}
+    choices = spec.get("enum")
+    if not isinstance(choices, list):
+        choices = [choice.get("const") for choice in spec.get("oneOf", [])
+                   if isinstance(choice, dict) and "const" in choice]
+    return {field: "allow_once"} if "allow_once" in choices else None
+
+
 class ElicitationHandler:
     """``elicitation_callback`` for one MCP server. Form-mode routes through Hermes' approval system
     (CLI, TUI, Telegram, ...); URL-mode is declined. Fail-closed: any timeout, exception or unexpected
@@ -267,10 +299,10 @@ class ElicitationHandler:
         """Kwargs to pass to ClientSession for elicitation support."""
         return {"elicitation_callback": self}
 
-    def _result(self, action: str, metric: str):
-        """Count *metric* and return ``ElicitResult(action)`` (accept carries empty content)."""
+    def _result(self, action: str, metric: str, content: Optional[dict] = None):
+        """Count *metric* and return an ``ElicitResult``."""
         self.metrics[metric] += 1
-        return _core.ElicitResult(action=action, **({"content": {}} if action == "accept" else {}))
+        return _core.ElicitResult(action=action, **({"content": content or {}} if action == "accept" else {}))
 
     def _consent_thunk(self, message: str, description: str) -> Callable[[], str]:
         """Sync consent call replaying the agent's contextvars snapshot when the owning task captured one
@@ -310,4 +342,12 @@ class ElicitationHandler:
         except Exception as exc:
             logger.error("MCP server '%s' elicitation failed: %s", self.server_name, exc, exc_info=True)
             return self._result("decline", "errors")
-        return self._result(*self._ANSWER_RESULTS.get(answer, ("decline", "declined")))
+        action, metric = self._ANSWER_RESULTS.get(answer, ("decline", "declined"))
+        if action != "accept":
+            return self._result(action, metric)
+        content = _accepted_consent_content(schema)
+        if content is None:
+            logger.warning("MCP server '%s' elicitation requires form input that Hermes' binary "
+                           "approval surface cannot collect; declining", self.server_name)
+            return self._result("decline", "declined")
+        return self._result("accept", metric, content)


### PR DESCRIPTION
## Problem

Hermes routes MCP form-mode elicitation through a binary approval surface, but every accepted request currently returns `content={}`. Servers whose schema requires a consent field reject that as malformed. A live MCP reproduced this with a required `decision` enum (`allow_once`, `allow_session`, `deny`); the same call succeeded when the callback returned `{"decision":"allow_once"}`.

## Fix

- Required single booleans map approval to `true`.
- Required single-choice consent enums map approval only to the least-broad `allow_once` value.
- Forms with no required fields preserve the valid empty object.
- Arbitrary forms the binary surface cannot fill decline instead of submitting invalid content.

This does not special-case a vendor or silently grant session-wide access.

## Verification

- `tests/tools/test_mcp_elicitation.py`: 16 passed in the official Docker image with the MCP 2.0 runtime.
- Added regressions for the structured consent schema and unsupported arbitrary required input.
- Broader MCP-suite attempt in the runtime image: 631 passed / 49 failed; failures are pre-existing harness/dependency/process-isolation failures (including missing pytest-asyncio before dev extras), none in the changed elicitation file.
- `git diff --check`: clean.