### PR TITLE
fix: route desktop-bridge RPC replies to the owning session

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge-respond.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge-respond.ts
@@ -1,0 +1,32 @@
+import { requestGatewayForAgent } from '@/store/gateway'
+import { requestForOwnedSession } from '@/store/session-states'
+import type { RpcEvent } from '@/types/hermes'
+
+type GatewayRequest = (method: string, params?: Record<string, unknown>) => Promise<unknown>
+
+export async function respondOnOwnedGateway(
+  event: RpcEvent,
+  method: string,
+  params: Record<string, unknown>,
+  ambientRequest: GatewayRequest | null,
+): Promise<void> {
+  if (ambientRequest) {
+    try {
+      await requestForOwnedSession(event.session_id, ambientRequest, method, params)
+      return
+    } catch {
+      // Unknown owner (fresh Bot Chat runtime): fall through to the event's profile tag.
+    }
+  }
+
+  const profile = typeof event.profile === 'string' ? event.profile.trim() : ''
+
+  if (profile) {
+    await requestGatewayForAgent(event.connectionId ?? null, profile, method, params)
+    return
+  }
+
+  if (ambientRequest) {
+    await ambientRequest(method, params)
+  }
+}

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const requestForOwnedSession = vi.fn()
+const requestGatewayForAgent = vi.fn()
+const ambientRequest = vi.fn()
+
+vi.mock('@/store/session-states', () => ({
+  requestForOwnedSession: (...args: unknown[]) => requestForOwnedSession(...args)
+}))
+
+vi.mock('@/store/gateway', () => ({
+  requestGatewayForAgent: (...args: unknown[]) => requestGatewayForAgent(...args)
+}))
+
+describe('respondOnOwnedGateway', () => {
+  beforeEach(() => {
+    requestForOwnedSession.mockReset()
+    requestGatewayForAgent.mockReset()
+    ambientRequest.mockReset()
+  })
+
+  it('answers on the owning session gateway before the ambient profile', async () => {
+    const { respondOnOwnedGateway } = await import('./desktop-bridge-respond')
+    requestForOwnedSession.mockResolvedValue(undefined)
+
+    await respondOnOwnedGateway(
+      { session_id: 'rosie-bot-chat', profile: 'rosie' } as never,
+      'preview.read.respond',
+      { request_id: 'req-1', text: '{}' },
+      ambientRequest
+    )
+
+    expect(requestForOwnedSession).toHaveBeenCalledWith(
+      'rosie-bot-chat',
+      ambientRequest,
+      'preview.read.respond',
+      { request_id: 'req-1', text: '{}' }
+    )
+    expect(requestGatewayForAgent).not.toHaveBeenCalled()
+  })
+
+  it('falls through to the event profile when the owner is unknown', async () => {
+    const { respondOnOwnedGateway } = await import('./desktop-bridge-respond')
+    requestForOwnedSession.mockRejectedValue(new Error('unknown owner'))
+    requestGatewayForAgent.mockResolvedValue(undefined)
+
+    await respondOnOwnedGateway(
+      { session_id: 'fresh-runtime', profile: 'rosie', connectionId: 'local' } as never,
+      'preview.act.respond',
+      { request_id: 'req-2', text: '{}' },
+      ambientRequest
+    )
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'local',
+      'rosie',
+      'preview.act.respond',
+      { request_id: 'req-2', text: '{}' }
+    )
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -10,8 +10,27 @@ import { recordAgentReaction } from '@/store/reactions-local'
 import { setMessages } from '@/store/session'
 import { $tipsEnabled, type ActiveTip, showTip } from '@/store/tips'
 import { $toursEnabled } from '@/store/tours'
+import type { RpcEvent } from '@/types/hermes'
 
+import { respondOnOwnedGateway } from './desktop-bridge-respond'
 import type { GatewayEventContext } from './types'
+
+/**
+ * Answer a blocking desktop-bridge RPC on the socket that raised it.
+ *
+ * Same client half as clarify/approval (#91684): `$gateway` follows the
+ * foreground profile, so a Rosie Bot Chat's `preview.*.respond` sent there
+ * lands on the default serve and the bot serve waits out the 45s tool timeout.
+ * The in-app browser looks live; this chat cannot read or click it.
+ */
+export function respondOnEventGateway(event: RpcEvent, method: string, params: Record<string, unknown>): void {
+  const gateway = $gateway.get()
+  const ambientRequest = gateway
+    ? (gateway.request.bind(gateway) as typeof gateway.request)
+    : null
+
+  void respondOnOwnedGateway(event, method, params, ambientRequest).catch(() => undefined)
+}
 
 /** The preview engine, loaded on demand so ~25KB of page-injectable source stays
  *  off the boot path.
@@ -57,7 +76,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const count = typeof payload?.count === 'number' ? payload.count : undefined
       const result = readActiveTerminal({ start, count })
 
-      void $gateway.get()?.request('terminal.read.respond', {
+      respondOnEventGateway(event, 'terminal.read.respond', {
         request_id: requestId,
         text: result ? JSON.stringify(result) : ''
       })
@@ -76,7 +95,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const count = typeof payload?.count === 'number' ? payload.count : undefined
 
       void readActivePreview({ count, start }).then(result => {
-        void $gateway.get()?.request('preview.read.respond', {
+        respondOnEventGateway(event, 'preview.read.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
@@ -96,7 +115,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
 
     if (requestId) {
       const answer = (result: unknown) =>
-        $gateway.get()?.request('preview.act.respond', {
+        respondOnEventGateway(event, 'preview.act.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
@@ -140,7 +159,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const read = window.hermesDesktop?.readWindowBelow
 
       const answer = (result: unknown) =>
-        $gateway.get()?.request('window.read.respond', {
+        respondOnEventGateway(event, 'window.read.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
@@ -180,7 +199,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
 
     if (requestId) {
       const answer = (result: unknown) =>
-        $gateway.get()?.request('tour.respond', {
+        respondOnEventGateway(event, 'tour.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })


### PR DESCRIPTION
## Summary
Bot Chat preview reads/actions timed out because `preview.*.respond` went over the ambient foreground `$gateway`. Route the reply to the owning session first, then the event profile.

## Test plan
- `npm test -- src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts` in `apps/desktop`