### PR TITLE
fix(gateway): let Discord own connect timeout cleanup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -46,6 +46,8 @@ from hermes_cli.fallback_config import get_fallback_chain
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
+# Discord has the same inner ready deadline; leave a bounded cleanup window before the outer detach.
+_DISCORD_CONNECT_CLEANUP_GRACE_SECS = 5.0
 # Telegram connect proves a real getUpdates round trip; must cover polling-start deadlines + readiness.
 _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT = 180.0
 # The initial Telegram connect gates `running` for EVERY platform, so it must not spend the full 180s.

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -159,6 +159,11 @@ class GatewayAdapterLifecycleMixin:
         to spend before the gateway reaches ``running`` (#85993 — Telegram's 180s).
         """
         timeout = self._platform_connect_timeout_secs(platform, initial=initial)
+        if platform == Platform.DISCORD and timeout > 0:
+            # Discord owns an inner ready deadline using the same configured budget.
+            # Let its timeout handler cancel/await Bot.start() before detaching it here.
+            from gateway.run import _DISCORD_CONNECT_CLEANUP_GRACE_SECS
+            timeout += _DISCORD_CONNECT_CLEANUP_GRACE_SECS
         if timeout <= 0:
             return await adapter.connect(is_reconnect=is_reconnect)
         task = asyncio.ensure_future(adapter.connect(is_reconnect=is_reconnect))

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -836,6 +836,28 @@ class TestConnectAdapterDetachOnTimeout:
         # cancelled and detached, so the event loop can move on.
         await asyncio.sleep(0)
 
+    @pytest.mark.asyncio
+    async def test_discord_inner_timeout_gets_cleanup_grace(self):
+        """Discord's inner timeout must finish cleanup before the outer detach."""
+        runner = _make_runner()
+        adapter = StubAdapter(succeed=True)
+        cleanup_completed = False
+
+        async def _discord_owned_timeout(**kwargs):
+            nonlocal cleanup_completed
+            # Deliberately outlive the base outer budget. Without Discord's
+            # cleanup grace this coroutine is cancelled before returning.
+            await asyncio.sleep(0.02)
+            cleanup_completed = True
+            return False
+
+        with patch.object(adapter, "connect", side_effect=_discord_owned_timeout):
+            with patch.object(runner, "_platform_connect_timeout_secs", return_value=0.01):
+                result = await runner._connect_adapter_with_timeout(adapter, Platform.DISCORD)
+
+        assert result is False
+        assert cleanup_completed is True
+
 
 class TestReconnectWatcherHandleTracking:
     """Regression: the supervisor's own backoff respawn must keep


### PR DESCRIPTION
**AI-assisted contribution:** I used AI during investigation, implementation, and review. I reviewed the final diff and ran the verification listed below. I am responsible for this submission and follow-up.

## What does this PR do?

Discord already owns a 30-second ready timeout and cancels/awaits `Bot.start()` in its timeout handler. The generic gateway connect watchdog uses the same 30-second budget, so both deadlines can fire together and the outer watchdog can cancel Discord while its cleanup is still running.

This gives Discord's outer watchdog a bounded 5-second cleanup grace. Other platforms keep their existing timeout behavior.

## Related Issue

N/A — found while reviewing the Discord connection lifecycle.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/run.py` — define the 5-second Discord cleanup grace.
- `gateway/run_adapters.py` — apply the grace only to Discord's outer connect watchdog.
- `tests/gateway/test_platform_reconnect.py` — regression proving Discord cleanup may outlive the base outer budget without being cancelled.

## How to Test

- `pytest -q tests/gateway/test_platform_reconnect.py::TestConnectAdapterDetachOnTimeout` → **2 passed**
- `pytest -q tests/gateway/test_discord_connect.py` → **13 passed**
- Ruff on the three touched files → **passed**
- `py_compile`, `git diff --check`, and Windows-footgun scan → **passed**
- Mutation/control check with the grace forced to zero reproduced the old behavior: the cleanup coroutine was cancelled before completing.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] Commit message follows Conventional Commits.
- [x] I searched open and closed PRs/issues for duplicate work.
- [x] The PR contains only this fix and its regression test.
- [ ] Full `pytest tests/ -q` was not run; the focused and adjacent suites above were run.
- [x] Regression coverage was added.
- [x] Tested on Linux.

### Documentation & Housekeeping

- [x] Documentation changes — N/A.
- [x] `cli-config.yaml.example` changes — N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes — N/A.
- [x] Cross-platform impact considered; change is limited to asyncio timeout ordering.
- [x] Tool schema changes — N/A.