### PR TITLE
fix(codex): preserve native continuity and bounded control authority

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -381,9 +381,8 @@ def _consume_user_interrupt(agent, active: bool = True) -> tuple[bool, Any]:
 
 def _ensure_codex_session(agent) -> None:
     """Lazily spawn one CodexAppServerSession per AIAgent (reused across turns, closed by the _cleanup hook)."""
-    if getattr(agent, "_codex_session", None) is not None:
-        return
     from agent.runtime_cwd import resolve_agent_cwd
+    from agent.codex_session_binding import session_binding_options
     from agent.transports.codex_app_server_session import CodexAppServerSession, _ServerRequestRouting
     # Approval callback: Hermes' standard prompt flow when a CLI thread installed one.
     approval_callback = None
@@ -398,15 +397,25 @@ def _ensure_codex_session(agent) -> None:
         auto_approve_requests = is_approval_bypass_active()
     except Exception:
         logger.debug("codex app-server: approval-bypass lookup failed; keeping fail-closed default", exc_info=True)
+    routing = _ServerRequestRouting(auto_approve_exec=auto_approve_requests, auto_approve_apply_patch=auto_approve_requests)
+    session = getattr(agent, "_codex_session", None)
+    if session is not None:
+        # Routing and the next turn/start policy must reflect this turn's context,
+        # not the approvals state that happened to create the native thread.
+        session._routing = routing
+        session._approval_callback = approval_callback
+        return
     # Bridge codex JSON-RPC notifications (item/started, item/completed, item/agentMessage/delta, ...) into
     # Hermes' gateway UI callbacks (tool_progress_callback, _fire_stream_delta,
     # _emit_interim_assistant_message). Without this, Discord/Telegram users see no live tool-progress or
     # interim commentary while codex_app_server is running — only the final answer (#33200). Supersedes the
     # narrower item/started-only bridge from #38835.
+    cwd = getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
     agent._codex_session = CodexAppServerSession(
-        cwd=getattr(agent, "session_cwd", None) or str(resolve_agent_cwd()), approval_callback=approval_callback,
-        request_routing=_ServerRequestRouting(auto_approve_exec=auto_approve_requests, auto_approve_apply_patch=auto_approve_requests),
+        cwd=cwd, approval_callback=approval_callback,
+        request_routing=routing,
         on_event=make_codex_app_server_event_bridge(agent),
+        **session_binding_options(agent, cwd),
     )
 
 
@@ -477,8 +486,8 @@ def run_codex_app_server_turn(agent, *, user_message: str, original_user_message
         from agent.conversation_compression import _checkpoint_blocked
         raise _checkpoint_blocked("codex_app_server owns the authoritative thread and compacts it "
                                   "without a truthful pre-compaction transcript boundary")
-    _ensure_codex_session(agent)
     try:
+        _ensure_codex_session(agent)
         turn = agent._codex_session.run_turn(user_input=user_message)
     except Exception as exc:
         logger.exception("codex app-server turn failed")
@@ -500,6 +509,7 @@ def run_codex_app_server_turn(agent, *, user_message: str, original_user_message
         interrupt, messages, api_calls=1, completed=not turn.interrupted and turn.error is None, error=turn.error,
         # We flushed the projected rows ourselves (agent_persisted); the gateway must skip its own DB write.
         final_response=turn.final_text, agent_persisted=True, codex_thread_id=turn.thread_id, codex_turn_id=turn.turn_id,
+        native_terminal_acknowledged=getattr(turn, "terminal_acknowledged", False),
         **usage_result,
     )
 

--- a/agent/codex_session_binding.py
+++ b/agent/codex_session_binding.py
@@ -1,0 +1,38 @@
+"""Codex continuation in the existing Hermes session metadata, before native work."""
+
+import os
+from pathlib import Path
+
+
+def session_binding_options(agent, cwd: str) -> dict:
+    codex_home = str(Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex").resolve())
+    scope = {"session_id": agent.session_id, "cwd": str(Path(cwd).resolve()), "codex_home": codex_home}
+    db = getattr(agent, "_session_db", None)
+    binding = (db.get_session_model_config_value(agent.session_id, "codex_native_session")
+               if db is not None else getattr(agent, "_codex_thread_binding", None))
+    if binding is None and db is not None and db.get_session_model_config_value(agent.session_id, "_branched_from"):
+        # Hermes' copied projection is not a fork of Codex's authoritative history.
+        raise RuntimeError("Codex native history branching is unsupported; use /new or resume the original session")
+    if binding is None and db is not None and any(
+        message.get("role") == "assistant"
+        for message in db.get_messages(agent.session_id, include_inactive=True)
+    ):
+        # Legacy sessions have no native marker. Their projection cannot prove
+        # a fresh thread is safe, including tool-only or archived assistant rows.
+        raise RuntimeError("Codex native history has no binding; use /new or resume a bound session")
+    if binding is not None:
+        if not isinstance(binding, dict) or any(binding.get(k) != v for k, v in scope.items()):
+            raise RuntimeError("Codex native session scope changed; explicit new session required")
+        if not isinstance(binding.get("thread_id"), str) or not binding["thread_id"]:
+            raise RuntimeError("Codex native session has no resumable thread ID")
+
+    def persist(thread_id: str) -> None:
+        value = {**scope, "thread_id": thread_id}
+        if db is not None:
+            db.patch_session_model_config(agent.session_id, {"codex_native_session": value})
+            if db.get_session_model_config_value(agent.session_id, "codex_native_session") != value:
+                raise RuntimeError("Codex native binding was not persisted; turn not submitted")
+        agent._codex_thread_binding = value
+
+    return {"thread_id": binding["thread_id"] if binding else None,
+            "codex_home": codex_home, "on_thread_ready": persist}

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -133,9 +133,13 @@ class CodexAppServerClient:
 
     def close(self, timeout: float = 3.0) -> None:
         """Close stdin and wait for the subprocess to exit, escalating to kill."""
-        if self._closed:
-            return
-        self._closed = True
+        with self._pending_lock:
+            if self._closed:
+                return
+            self._closed = True
+            for pending in self._pending.values():
+                pending.put_nowait({"error": {"code": -32600, "message": "codex app-server client is closed"}})
+            self._pending.clear()
         with contextlib.suppress(Exception):
             if self._proc.stdin and not self._proc.stdin.closed:
                 self._proc.stdin.close()
@@ -155,17 +159,20 @@ class CodexAppServerClient:
 
     def request(self, method: str, params: Optional[dict] = None, timeout: float = 30.0) -> dict:
         """Send a request and block for ``result``; raise CodexAppServerError on ``error``."""
-        rid, self._next_id = self._next_id, self._next_id + 1
         q: queue.Queue = queue.Queue(maxsize=1)
         with self._pending_lock:
+            if self._closed:
+                raise CodexAppServerError(-32600, "codex app-server client is closed")
+            rid, self._next_id = self._next_id, self._next_id + 1
             self._pending[rid] = q
-        self._send({"id": rid, "method": method, "params": params or {}})
         try:
+            self._send({"id": rid, "method": method, "params": params or {}})
             msg = q.get(timeout=timeout)
         except queue.Empty:
+            raise TimeoutError(f"codex app-server method {method!r} timed out after {timeout}s")
+        finally:
             with self._pending_lock:
                 self._pending.pop(rid, None)
-            raise TimeoutError(f"codex app-server method {method!r} timed out after {timeout}s")
         if "error" in msg:
             err = msg["error"]
             raise CodexAppServerError(code=err.get("code", -1), message=err.get("message", ""), data=err.get("data"))

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -10,6 +10,8 @@ reader threads feed queues that this adapter polls, like the chat_completions lo
 from __future__ import annotations
 
 import contextlib
+import contextvars
+import inspect
 import logging
 import os
 import threading
@@ -53,6 +55,7 @@ class TurnResult:
     compacted: bool = False
     # Codex likely wedged (turn timeout, watchdog, token refresh failure): caller respawns next turn.
     should_retire: bool = False
+    terminal_acknowledged: bool = False
 
 
 # Some codex versions stream ``<turn_aborted>`` as raw agentMessage text when an
@@ -82,24 +85,79 @@ def _notification_scope_ids(note: dict) -> tuple[Optional[str], Optional[str]]:
     )
 
 
+def _has_exact_turn_scope(note: dict, *, thread_id: Optional[str], turn_id: Optional[str]) -> bool:
+    """Authority cannot inherit absent coordinates or hide a conflicting alias."""
+    if not all(isinstance(value, str) and value for value in (thread_id, turn_id)):
+        return False
+    if _notification_scope_ids(note) != (thread_id, turn_id):
+        return False
+    params = note["params"]
+    for source, thread_keys, turn_keys in (
+        (params, ("threadId", "thread_id"), ("turnId", "turn_id")),
+        (params.get("turn", {}), ("threadId", "thread_id"), ("id", "turnId", "turn_id")),
+        (params.get("item", {}), ("threadId", "thread_id"), ("turnId", "turn_id")),
+    ):
+        if not isinstance(source, dict):
+            return False
+        if any(key in source and source[key] != thread_id for key in thread_keys):
+            return False
+        if any(key in source and source[key] != turn_id for key in turn_keys):
+            return False
+    return True
+
+
 def _notification_belongs_to_turn(note: dict, *, thread_id: Optional[str], turn_id: Optional[str]) -> bool:
     """Whether a multiplexed notification belongs to this turn.
 
     One connection can carry parent and hosted subagent threads; an explicitly
     foreign thread/turn event must not mutate this transcript. Unscoped
-    notifications remain accepted for protocol compatibility.
+    nonterminal notifications remain accepted for protocol compatibility;
+    terminal authority requires both exact coordinates and a terminal status.
     """
     if not isinstance(note, dict):
         return False
     observed = _notification_scope_ids(note)
+    if note.get("method") == "turn/completed":
+        params = note.get("params")
+        turn = params.get("turn") if isinstance(params, dict) else None
+        if not isinstance(turn, dict) or turn.get("status") not in ("completed", "interrupted", "failed"):
+            return False
+        return _has_exact_turn_scope(note, thread_id=thread_id, turn_id=turn_id)
     return not any(
         expected is not None and seen is not None and str(seen) != str(expected)
         for expected, seen in zip((thread_id, turn_id), observed)
     )
 
 
+def _coerce_turn_input(user_input: Any) -> list[dict]:
+    """Preserve supported media on the native wire; never imply omitted bytes arrived."""
+    if not isinstance(user_input, list):
+        return [{"type": "text", "text": "" if user_input is None else str(user_input)}]
+    parts = []
+    for item in user_input:
+        if isinstance(item, str):
+            item = {"type": "text", "text": item}
+        if not isinstance(item, dict):
+            raise ValueError("Unsupported Codex input part")
+        kind = item.get("type")
+        if kind in {"text", "input_text"}:
+            parts.append({"type": "text", "text": str(item.get("text") or item.get("content") or "")})
+        elif kind in {"image", "image_url", "input_image"}:
+            url = item.get("image_url") or item.get("url")
+            if isinstance(url, dict):
+                url = url.get("url")
+            if not isinstance(url, str) or not url.startswith(("data:image/", "https://", "http://")):
+                raise ValueError("Unsupported Codex image input: expected an image URL or data URL")
+            parts.append({"type": "image", "url": url})
+        elif kind == "localImage" and isinstance(item.get("path"), str) and os.path.isabs(item["path"]):
+            parts.append({"type": "localImage", "path": item["path"]})
+        else:
+            raise ValueError(f"Unsupported Codex input type: {kind}")
+    return parts
+
+
 def _coerce_turn_input_text(user_input: Any) -> str:
-    """Collapse rich content parts into app-server text (``turn/start`` is text-only; images become a marker)."""
+    """Return the submitted text used to distinguish a Codex input echo."""
     if isinstance(user_input, str):
         return user_input
     if not isinstance(user_input, list):
@@ -111,9 +169,7 @@ def _coerce_turn_input_text(user_input: Any) -> str:
                 parts.append(str(item))
         elif item.get("type") in {"text", "input_text"}:
             parts.append(str(item.get("text") or item.get("content") or ""))
-        elif item.get("type") in {"image", "image_url", "input_image"}:
-            parts.append("[image attached]")
-    return "\n\n".join(p for p in parts if p).strip() or "What do you see in this image?"
+    return "\n\n".join(p for p in parts if p).strip()
 
 
 # Substrings in codex stderr / JSON-RPC errors signalling expired OAuth creds.
@@ -145,6 +201,10 @@ class _ServerRequestRouting:
     auto_approve_apply_patch: bool = False
 
 
+class _SubmissionCancelled(Exception):
+    """Stop retired a child before its startup/submission RPC resolved."""
+
+
 class CodexAppServerSession:
     """One Codex thread per Hermes session, lifetime owned by AIAgent. Not thread-safe: one caller at a time."""
 
@@ -155,6 +215,8 @@ class CodexAppServerSession:
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
+        thread_id: Optional[str] = None,
+        on_thread_ready: Optional[Callable[[str], None]] = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
@@ -169,7 +231,11 @@ class CodexAppServerSession:
 
         self._client: Optional[CodexAppServerClient] = None
         self._thread_id: Optional[str] = None
+        self._resume_thread_id = thread_id
+        self._on_thread_ready = on_thread_ready
         self._interrupt_event = threading.Event()
+        self._interrupt_deadline: Optional[float] = None
+        self._turn_deadline: Optional[float] = None
         self._active_turn_id: Optional[str] = None
         self._active_turn_lock = threading.Lock()
         # In-progress fileChange items by id (item/started -> item/completed):
@@ -178,22 +244,51 @@ class CodexAppServerSession:
         self._closed = False
 
     def ensure_started(self) -> str:
-        """Spawn, handshake, and ``thread/start``; idempotent, returns the codex thread id."""
+        """Start or explicitly resume; persist the binding before accepting a turn."""
+        if self._closed:
+            raise CodexAppServerError(-32600, "Codex session is closed")
         if self._thread_id is not None:
             return self._thread_id
         if self._client is None:
             self._client = self._client_factory(codex_bin=self._codex_bin, codex_home=self._codex_home)
-        self._client.initialize(client_name="hermes", client_title="Hermes Agent", client_version=_get_hermes_version())
+        try:
+            self._call_before_turn(
+                self._client.initialize, client_name="hermes", client_title="Hermes Agent",
+                client_version=_get_hermes_version(),
+            )
+        except Exception:
+            self.close()
+            raise
         # Permissions are NOT sent on thread/start: codex gates ``thread/start.permissions``
         # behind experimentalApi + a matching ``[permissions]`` table in ~/.codex/config.toml.
-        result = self._client.request("thread/start", {"cwd": self._cwd}, timeout=15)
+        method = "thread/resume" if self._resume_thread_id else "thread/start"
+        params = {"cwd": self._cwd}
+        if self._resume_thread_id:
+            params["threadId"] = self._resume_thread_id
+        if self._routing.auto_approve_exec and self._routing.auto_approve_apply_patch:
+            params["approvalPolicy"] = "never"
+        try:
+            result = self._call_before_turn(self._client.request, method, params, timeout=15)
+        except Exception:
+            self.close()
+            raise
         # Different codex versions serialize the id under thread.id / sessionId / threadId.
         thread_obj = result.get("thread") or {}
         thread_id = thread_obj.get("id") or thread_obj.get("sessionId") or result.get("sessionId") or result.get("threadId")
         if not thread_id:
+            self.close()
             raise CodexAppServerError(
-                code=-32603, message=f"codex thread/start returned no thread id (payload keys: {sorted(result.keys())})",
+                code=-32603, message=f"codex {method} returned no thread id (payload keys: {sorted(result.keys())})",
             )
+        if self._resume_thread_id and thread_id != self._resume_thread_id:
+            self.close()
+            raise CodexAppServerError(-32603, "Codex resume returned a different thread; refusing fresh history")
+        try:
+            if self._on_thread_ready is not None:
+                self._on_thread_ready(thread_id)
+        except Exception:
+            self.close()
+            raise
         self._thread_id = thread_id
         logger.info("codex app-server thread started: id=%s profile=%s cwd=%s", thread_id[:8], self._permission_profile, self._cwd)
         return thread_id
@@ -212,7 +307,10 @@ class CodexAppServerSession:
 
     def request_interrupt(self) -> None:
         """Idempotent: signal the active turn loop to issue turn/interrupt and unwind."""
-        self._interrupt_event.set()
+        with self._active_turn_lock:
+            if not self._interrupt_event.is_set():
+                self._interrupt_deadline = time.monotonic() + 5.0
+                self._interrupt_event.set()
 
     def request_steer(self, text: str) -> bool:
         """Append user guidance to the active Codex turn via ``turn/steer``."""
@@ -264,10 +362,49 @@ class CodexAppServerSession:
         else:
             result.error = self._format_error_with_stderr(prefix, detail)
 
+    def _call_before_turn(self, call: Callable, *args, **kwargs) -> dict:
+        """Bound startup/submission waits even before a turn ID exists to interrupt.
+
+        The worker owns only one RPC, never thread binding or the next request.
+        Closing the captured client fences late replies from admitting more work.
+        """
+        if self._interrupt_event.is_set():
+            self.close()
+            raise _SubmissionCancelled()
+        done = threading.Event()
+        replies, errors = [], []
+
+        def invoke() -> None:
+            try:
+                replies.append(call(*args, **kwargs))
+            except Exception as exc:
+                errors.append(exc)
+            finally:
+                done.set()
+
+        context = contextvars.copy_context()
+        threading.Thread(target=context.run, args=(invoke,), daemon=True, name="codex-submission").start()
+        while not done.wait(0.05):
+            if self._interrupt_event.is_set():
+                # No exact turn identity is available yet. Retire immediately,
+                # leaving the five-second Stop budget for process teardown.
+                self.close()
+                raise _SubmissionCancelled()
+        if errors:
+            raise errors[0]
+        return replies[0]
+
+    def _cancel_submission(self, result: TurnResult) -> None:
+        result.interrupted = True
+        self._retire(result, "Codex submission cancelled without terminal acknowledgement; native outcome is uncertain")
+
     def _start_for(self, result: TurnResult) -> bool:
         """ensure_started(); startup failures become a retiring TurnResult.error instead of raw exceptions."""
         try:
             self.ensure_started()
+        except _SubmissionCancelled:
+            self._cancel_submission(result)
+            return False
         except (CodexAppServerError, TimeoutError) as exc:
             self._retire(result, self._format_error_with_stderr("codex app-server startup failed", exc))
             return False
@@ -275,10 +412,12 @@ class CodexAppServerSession:
         result.thread_id = self._thread_id
         return True
 
-    def _request_for(self, result: TurnResult, method: str, params: dict, label: str) -> Optional[dict]:
+    def _request_for(self, result: TurnResult, method: str, params: dict, label: str, *, timeout: float = 10.0) -> Optional[dict]:
         """Issue ``method``; on failure fill ``result.error`` and return None. A timeout always retires."""
         try:
-            return self._client.request(method, params, timeout=10)
+            return self._call_before_turn(self._client.request, method, params, timeout=timeout)
+        except _SubmissionCancelled:
+            self._cancel_submission(result)
         except CodexAppServerError as exc:
             self._set_classified_error(result, f"{label} failed", exc.message, exc)
         except TimeoutError as exc:
@@ -337,21 +476,33 @@ class CodexAppServerSession:
         full turn deadline.
         """
         result = TurnResult()
+        try:
+            turn_input = _coerce_turn_input(user_input)
+        except ValueError as exc:
+            result.error = str(exc)
+            return result
         if self._start_for(result):
             # Do not clear first: a hard stop arriving during ensure_started() must
             # be honored before launching a Codex turn.
             if self._interrupt_event.is_set():
                 result.interrupted = True
             else:
-                result.submitted_user_text = _coerce_turn_input_text(user_input)
+                result.submitted_user_text = CodexEventProjector().project({
+                    "method": "item/completed",
+                    "params": {"item": {"type": "userMessage", "content": turn_input}},
+                }).messages[0]["content"]
                 ts = self._request_for(
                     result, "turn/start",
-                    {"threadId": self._thread_id, "input": [{"type": "text", "text": result.submitted_user_text}]},
-                    "turn/start",
+                    {"threadId": self._thread_id, "input": turn_input,
+                     # Codex persists this override. Omitting it on revocation
+                     # would retain a previous turn's native bypass authority.
+                     "approvalPolicy": "never" if self._routing.auto_approve_exec and self._routing.auto_approve_apply_patch else "on-request"},
+                    "turn/start", timeout=min(turn_timeout, 60.0),
                 )
                 if ts is not None:
                     self._run_started_turn(result, ts, turn_timeout, notification_poll_timeout, post_tool_quiet_timeout)
         self._interrupt_event.clear()
+        self._interrupt_deadline = None
         return result
 
     def _run_started_turn(
@@ -376,21 +527,7 @@ class CodexAppServerSession:
 
         def on_server_request(sreq: dict) -> bool:
             nonlocal last_tool_completion_at
-            # Drain pending notifications first (bounded) so _pending_file_changes is
-            # current for the approval decision and display events still reach on_event.
-            turn_complete = False
-            for _ in range(8):
-                pending = self._client.take_notification(timeout=0)
-                if pending is None:
-                    break
-                if not _notification_belongs_to_turn(pending, thread_id=self._thread_id, turn_id=result.turn_id):
-                    logger.debug("ignoring foreign codex notification while draining server request: method=%s", pending.get("method"))
-                    continue
-                proj, aborted = self._absorb_notification(result, projector, pending)
-                if proj.is_tool_iteration:
-                    last_tool_completion_at = time.monotonic()
-                turn_complete = turn_complete or aborted
-            self._handle_server_request(sreq)
+            turn_complete = self._drain_before_request(result, sreq, on_note)
             # An approval round-trip is live signal — don't let it trip the watchdog.
             last_tool_completion_at = None
             return turn_complete
@@ -404,27 +541,57 @@ class CodexAppServerSession:
                 last_tool_completion_at = None
             if method != "turn/completed":
                 return aborted
+            result.terminal_acknowledged = True
             turn_obj = (note.get("params") or {}).get("turn") or {}
             turn_status = turn_obj.get("status")
-            if turn_status and turn_status not in {"completed", "interrupted"} and turn_obj.get("error"):
-                err_msg = _format_responses_error(turn_obj["error"], str(turn_status))
+            result.interrupted = result.interrupted or turn_status == "interrupted"
+            if turn_status == "failed":
+                err_msg = _format_responses_error(turn_obj.get("error"), str(turn_status))
                 self._set_classified_error(result, f"turn ended status={turn_status}", err_msg, err_msg)
             return True
 
-        self._drive_turn(
-            result, turn_timeout=turn_timeout, notification_poll_timeout=notification_poll_timeout,
-            timeout_label="turn", before_poll=watchdog_tripped, on_server_request=on_server_request,
-            on_note=on_note, accept_final_text_at_deadline=True,
-        )
-        with self._active_turn_lock:
-            self._active_turn_id = None
+        try:
+            self._drive_turn(
+                result, turn_timeout=turn_timeout, notification_poll_timeout=notification_poll_timeout,
+                timeout_label="turn", before_poll=watchdog_tripped, on_server_request=on_server_request,
+                on_note=on_note,
+            )
+        finally:
+            with self._active_turn_lock:
+                self._active_turn_id = None
+            self._turn_deadline = None
+
+    def _drain_before_request(self, result, req, on_note, pre_scope_filter=None) -> bool:
+        """Refresh approval context, stopping at the terminal boundary in either caller."""
+        complete = False
+        expired = False
+        while True:
+            deadlines = [d for d in (self._turn_deadline, self._interrupt_deadline) if d is not None]
+            if deadlines and time.monotonic() >= min(deadlines):
+                expired = True
+                break
+            note = self._client.take_notification(timeout=0)
+            if note is None:
+                break
+            method = note.get("method", "")
+            if pre_scope_filter is not None and not pre_scope_filter(note, method):
+                continue
+            if not _notification_belongs_to_turn(note, thread_id=self._thread_id, turn_id=result.turn_id):
+                continue
+            complete = on_note(note, method)
+            if complete:
+                result.terminal_acknowledged = method == "turn/completed"
+                with self._active_turn_lock:
+                    self._active_turn_id = None
+                break
+        self._handle_server_request(req, active=not complete and not expired and result.turn_id is not None)
+        return complete
 
     def _drive_turn(
         self, result: TurnResult, *, turn_timeout: float, notification_poll_timeout: float,
         timeout_label: str, on_server_request: Callable[[dict], bool],
         on_note: Callable[[dict, str], bool], before_poll: Optional[Callable[[], bool]] = None,
         pre_scope_filter: Optional[Callable[[dict, str], bool]] = None,
-        accept_final_text_at_deadline: bool = False,
     ) -> None:
         """Shared poll loop for run_turn / compact_thread until turn/completed or deadline.
 
@@ -435,21 +602,26 @@ class CodexAppServerSession:
         retires the session.
         """
         deadline = time.monotonic() + turn_timeout
+        self._turn_deadline = deadline
         turn_complete = False
+        interrupt_sent = False
         while time.monotonic() < deadline and not turn_complete:
-            if self._interrupt_event.is_set():
-                self._issue_interrupt(result.turn_id)
+            if self._interrupt_event.is_set() and not interrupt_sent:
                 result.interrupted = True
-                break
+                interrupt_sent = True
+                deadline = min(deadline, self._interrupt_deadline or deadline)
+                self._issue_interrupt(result.turn_id, timeout=max(0.0, deadline - time.monotonic()))
+                if time.monotonic() >= deadline:
+                    break
             if self._subprocess_died(result):
                 break
-            if before_poll is not None and before_poll():
+            if not interrupt_sent and before_poll is not None and before_poll():
                 break
             sreq = self._client.take_server_request(timeout=0)
             if sreq is not None:
                 turn_complete = on_server_request(sreq)
                 continue
-            note = self._client.take_notification(timeout=notification_poll_timeout)
+            note = self._client.take_notification(timeout=min(notification_poll_timeout, max(0.0, deadline - time.monotonic())))
             if note is None:
                 continue
             method = note.get("method", "")
@@ -459,20 +631,20 @@ class CodexAppServerSession:
                 logger.debug("ignoring foreign codex notification: method=%s", method)
                 continue
             turn_complete = on_note(note, method)
+            if turn_complete and method == "turn/completed":
+                result.terminal_acknowledged = True
 
-        if accept_final_text_at_deadline and not turn_complete and not result.interrupted and result.final_text and result.error is None:
-            logger.warning(
-                "codex app-server turn reached deadline after a completed assistant message but before "
-                "turn/completed; accepting the assistant text as the terminal response"
-            )
-            turn_complete = True
+        if interrupt_sent and not result.terminal_acknowledged:
+            result.interrupted = True
+            self._retire(result, "Codex cancellation unacknowledged; native outcome is uncertain")
 
         if not turn_complete and not result.interrupted:
-            self._issue_interrupt(result.turn_id)
+            self._issue_interrupt(result.turn_id, timeout=0)
             result.interrupted = True
             if not result.error:
                 result.error = self._format_error_with_stderr(f"{timeout_label} timed out after {turn_timeout}s")
             result.should_retire = True
+        self._turn_deadline = None
 
     def compact_thread(
         self, *, turn_timeout: float = 600.0, notification_poll_timeout: float = 0.25
@@ -485,7 +657,6 @@ class CodexAppServerSession:
         result = TurnResult()
         if not self._start_for(result):
             return result
-        self._interrupt_event.clear()
         projector = CodexEventProjector()
 
         if self._request_for(result, "thread/compact/start", {"threadId": self._thread_id}, "thread/compact/start") is None:
@@ -503,6 +674,8 @@ class CodexAppServerSession:
                     logger.debug("ignoring compact turn/started without a turn id")
                     return False
                 result.turn_id = str(observed_turn_id)
+                with self._active_turn_lock:
+                    self._active_turn_id = result.turn_id
             elif observed_turn_id is not None or method in {"item/completed", "turn/completed"}:
                 # Before the new turn/started, terminal/projectable events are stale or unattributable.
                 logger.debug("ignoring codex notification before compact turn start: method=%s", method)
@@ -527,28 +700,34 @@ class CodexAppServerSession:
             return True
 
         def on_server_request(sreq: dict) -> bool:
-            self._handle_server_request(sreq)
-            return False
+            return self._drain_before_request(result, sreq, on_note, pre_scope_filter)
 
-        self._drive_turn(
-            result, turn_timeout=turn_timeout, notification_poll_timeout=notification_poll_timeout,
-            timeout_label="compact turn", on_server_request=on_server_request, on_note=on_note,
-            pre_scope_filter=pre_scope_filter,
-        )
+        try:
+            self._drive_turn(
+                result, turn_timeout=turn_timeout, notification_poll_timeout=notification_poll_timeout,
+                timeout_label="compact turn", on_server_request=on_server_request, on_note=on_note,
+                pre_scope_filter=pre_scope_filter,
+            )
+        finally:
+            with self._active_turn_lock:
+                self._active_turn_id = None
+            self._turn_deadline = None
+            self._interrupt_event.clear()
+            self._interrupt_deadline = None
         return result
 
-    def _issue_interrupt(self, turn_id: Optional[str]) -> None:
+    def _issue_interrupt(self, turn_id: Optional[str], *, timeout: float = 5.0) -> None:
         if self._client is None or self._thread_id is None or turn_id is None:
             return
         try:
-            self._client.request("turn/interrupt", {"threadId": self._thread_id, "turnId": turn_id}, timeout=5)
+            self._client.request("turn/interrupt", {"threadId": self._thread_id, "turnId": turn_id}, timeout=timeout)
         except CodexAppServerError as exc:
             # "no active turn to interrupt" is fine — already done.
             logger.debug("turn/interrupt non-fatal: %s", exc)
         except TimeoutError:
             logger.warning("turn/interrupt timed out")
 
-    def _handle_server_request(self, req: dict) -> None:
+    def _handle_server_request(self, req: dict, *, active: bool = True) -> None:
         """Answer a codex server request (approval / elicitation) via Hermes' approval flow.
 
         Permission escalations are always declined (the user chose their profile in
@@ -563,6 +742,12 @@ class CodexAppServerSession:
         if handler is None:
             logger.warning("Unknown codex server request: %s", method)
             self._client.respond_error(rid, code=-32601, message=f"Unsupported method: {method}")
+            return
+        if not _has_exact_turn_scope(req, thread_id=self._thread_id, turn_id=self._active_turn_id):
+            self._client.respond_error(rid, code=-32600, message="Native request does not belong to the active thread/turn")
+            return
+        if not active:
+            self._client.respond_error(rid, code=-32600, message="Native request has no active turn")
             return
         self._client.respond(rid, handler(self, params))
 
@@ -585,17 +770,48 @@ class CodexAppServerSession:
         Approval mode/timeout resolution lives upstream (codex_runtime.py derives the
         auto flags; the callback runs the shared gate). Do not re-read config here.
         """
+        if self._interrupt_event.is_set():
+            return "decline"
         if auto_approve:
             return "accept"
         if self._approval_callback is None:
             return "decline"
         command, description = prompt()
+        callback = self._approval_callback
+        done = threading.Event()
+        cancelled = threading.Event()
+        decision = ["decline"]
+        kwargs = {"allow_permanent": False}
         try:
-            choice = self._approval_callback(command, description, allow_permanent=False)
-            return _approval_choice_to_codex_decision(choice)
-        except Exception:
-            logger.exception("approval_callback raised on %s", log_label)
-            return "decline"
+            inspect.signature(callback).bind(command, description, **kwargs, cancel_check=cancelled.is_set)
+        except (TypeError, ValueError):
+            pass  # Legacy callbacks still get bounded waits, but cannot tear down their UI cooperatively.
+        else:
+            kwargs["cancel_check"] = cancelled.is_set
+
+        def ask() -> None:
+            try:
+                choice = callback(command, description, **kwargs)
+                decision[0] = _approval_choice_to_codex_decision(choice)
+            except Exception:
+                logger.exception("approval_callback raised on %s", log_label)
+            finally:
+                done.set()
+
+        # A legacy callback may block indefinitely. It never owns the wire: only
+        # this turn's polling thread may publish its decision, and late answers
+        # are discarded after cancellation or the turn deadline.
+        context = contextvars.copy_context()
+        threading.Thread(target=context.run, args=(ask,), daemon=True, name="codex-approval").start()
+        while True:
+            if self._interrupt_event.is_set() or (
+                self._turn_deadline is not None and time.monotonic() >= self._turn_deadline
+            ):
+                cancelled.set()
+                return "decline"
+            if done.is_set():
+                return decision[0]
+            done.wait(0.05)
 
     def _decide_exec_approval(self, params: dict) -> str:
         def prompt() -> tuple[str, str]:

--- a/hermes_cli/cli_modal_mixin.py
+++ b/hermes_cli/cli_modal_mixin.py
@@ -265,7 +265,7 @@ class CLIModalMixin:
             _ask()
         return result[0]
 
-    def _poll_modal_queue(self, response_queue, deadline_attr, *, refresh=1.0, paint=None):
+    def _poll_modal_queue(self, response_queue, deadline_attr, *, refresh=1.0, paint=None, cancel_check=None):
         """Block until a value lands on ``response_queue`` or ``self.<deadline_attr>`` passes
         (``None`` deadline = unlimited). Returns the value or ``_TIMED_OUT``.
 
@@ -276,8 +276,11 @@ class CLIModalMixin:
         paint = paint or self._paint_now
         last = _time.monotonic()
         while True:
+            if cancel_check is not None and cancel_check():
+                return "deny"
             try:
-                return response_queue.get(timeout=1)
+                result = response_queue.get(timeout=0.1 if cancel_check is not None else 1)
+                return "deny" if cancel_check is not None and cancel_check() else result
             except queue.Empty:
                 deadline = getattr(self, deadline_attr)
                 if deadline is not None and deadline - _time.monotonic() <= 0:
@@ -762,7 +765,8 @@ class CLIModalMixin:
     def _approval_callback(self, command: str, description: str,
                            *, allow_permanent: bool = True,
                            allow_session: bool = True,
-                           smart_denied: bool = False) -> str:
+                           smart_denied: bool = False,
+                           cancel_check=None) -> str:
         """Dangerous-command approval through the prompt_toolkit UI (agent thread).
 
         Choices: once / session / always / deny (see ``_approval_choices``), plus 'view' for long
@@ -771,7 +775,12 @@ class CLIModalMixin:
         """
         from cli import CLI_CONFIG, _DIM, _RST, _cprint
 
-        with self._approval_lock:
+        while not self._approval_lock.acquire(timeout=0.1):
+            if cancel_check is not None and cancel_check():
+                return "deny"
+        try:
+            if cancel_check is not None and cancel_check():
+                return "deny"
             timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 300))
             response_queue = queue.Queue()
             self._approval_state = {
@@ -788,7 +797,7 @@ class CLIModalMixin:
             self._ring_bell(prompt=True, context="approval", detail=command)
             self._paint_now()
 
-            result = self._poll_modal_queue(response_queue, "_approval_deadline")
+            result = self._poll_modal_queue(response_queue, "_approval_deadline", cancel_check=cancel_check)
             self._approval_state = None
             self._approval_deadline = 0
             self._paint_now()
@@ -799,6 +808,9 @@ class CLIModalMixin:
             self._persist_prompt_summary(
                 "⚠", "Approval", command, _APPROVAL_OUTCOME_LABELS.get(result, str(result)))
             return result
+
+        finally:
+            self._approval_lock.release()
 
     def _approval_choices(self, command: str, *, allow_permanent: bool = True,
                           allow_session: bool = True,

--- a/run_agent.py
+++ b/run_agent.py
@@ -385,6 +385,13 @@ class AIAgent(
         With ``previous_messages`` / ``old_session_id`` / ``carry_over_context`` the context engine gets the
         full transition lifecycle instead of a bare reset.
         """
+        # Warm /new, /resume and /branch retain this AIAgent, not its native
+        # process. Resolve the destination's durable binding on the next turn.
+        from agent.codex_runtime import _close_codex_session
+        _close_codex_session(self)
+        binding = getattr(self, "_codex_thread_binding", None)
+        if binding is not None and binding.get("session_id") != getattr(self, "session_id", None):
+            self._codex_thread_binding = None
         for counter in (
             "session_total_tokens", "session_input_tokens", "session_output_tokens", "session_prompt_tokens",
             "session_completion_tokens", "session_cache_read_tokens", "session_cache_write_tokens",
@@ -902,6 +909,7 @@ class AIAgent(
         # and a cross-thread close can release TLS FDs under a still-unwinding worker.
         _quietly(self._drop_shared_client, lambda c: self._retire_shared_openai_client(c, reason="cache_evict"))
         self._close_request_clients("cache_evict")
+        _quietly(self._close_codex_session)
 
     def close(self) -> None:
         """Release every resource this agent holds (idempotent); each phase is guarded so one failure never

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -350,6 +350,7 @@ class TestBridgeWiredInRuntime:
         # Minimal stub agent — the runtime only touches a handful of
         # attributes and we mock the heavy ones to keep the test fast.
         agent = SimpleNamespace(
+            session_id="event-bridge-fixture",
             session_cwd=None,
             _codex_session=None,
             tool_progress_callback=MagicMock(),

--- a/tests/agent/test_codex_echo_ownership.py
+++ b/tests/agent/test_codex_echo_ownership.py
@@ -48,3 +48,58 @@ def test_only_submitted_leading_echo_is_excluded(tmp_path, platform_id, projecti
         assert users == (["accepted"] + extra) * 2
     finally:
         db.close()
+
+
+@pytest.mark.parametrize("user_input", [
+    [{"type": "text", "text": "alpha"}, {"type": "text", "text": "beta"}],
+    [{"type": "text", "text": "note"}, {"type": "image", "url": "data:image/png;base64,abc"},
+     {"type": "text", "text": "caption"}],
+    ["alpha", "beta"],
+    [{"type": "image", "url": "data:image/png;base64,abc"}],
+    [{"type": "text", "text": "  alpha  "}, {"type": "text", "text": ""},
+     {"type": "text", "text": "beta\n"}],
+])
+def test_rich_wire_echo_does_not_create_another_sqlite_user_row(tmp_path, user_input):
+    from tests.agent.transports.test_codex_app_server_session import FakeClient, make_session
+
+    client = FakeClient()
+
+    def respond(method, params):
+        if method == "thread/start":
+            return {"thread": {"id": "thread-fake-001"}}
+        if method == "turn/start":
+            client._notifications.extend([
+                {"method": "item/completed", "params": {"item": {
+                    "type": "userMessage", "content": params["input"]}}},
+                {"method": "item/completed", "params": {"item": {
+                    "type": "agentMessage", "text": "reply"}}},
+                {"method": "turn/completed", "params": {"threadId": "thread-fake-001",
+                    "turn": {"id": "turn-fake-001", "status": "completed"}}},
+            ])
+            return {"turn": {"id": "turn-fake-001"}}
+        return {}
+
+    client._request_handler = respond
+    session = make_session(client)
+    db = SessionDB(tmp_path / "rich-echo.db")
+    try:
+        db.create_session(session_id="rich", source="cli", model="codex")
+        agent = SessionPersistenceMixin()
+        agent.session_id = "rich"
+        agent._session_db = db
+        agent._session_db_created = True
+        agent._last_flushed_db_idx = 0
+        agent._session_persist_lock = threading.RLock()
+        messages = []
+        append_message(messages, {"role": "user", "content": "accepted original"})
+        assert agent._flush_messages_to_session_db(messages)
+        turn = session.run_turn(user_input, turn_timeout=1)
+        assert turn.error is None and turn.terminal_acknowledged
+        _persist_projected_messages(agent, turn, messages)
+        assert agent._flush_messages_to_session_db(messages)
+        rows = db.get_messages_as_conversation("rich")
+        assert [row["role"] for row in rows] == ["user", "assistant"]
+        assert rows[0]["content"] == "accepted original"
+    finally:
+        session.close()
+        db.close()

--- a/tests/agent/test_codex_native_continuity.py
+++ b/tests/agent/test_codex_native_continuity.py
@@ -1,0 +1,288 @@
+"""Real SQLite + stdio child lifecycle tests; the child is NOT vendor acceptance."""
+
+import json
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+from agent.codex_runtime import _ensure_codex_session
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+@pytest.fixture
+def wire_runtime(tmp_path, monkeypatch):
+    script = tmp_path / "wire.py"
+    log = tmp_path / "wire.jsonl"
+    script.write_text('''import json, sys, uuid
+from pathlib import Path
+for line in sys.stdin:
+    req = json.loads(line)
+    with open(sys.argv[1], "a") as f:
+        f.write(json.dumps(req) + "\\n")
+    method, params = req.get("method"), req.get("params", {})
+    if "id" not in req:
+        continue
+    blocked = Path(__file__).with_name("block-method")
+    if blocked.exists() and blocked.read_text() == method:
+        print(json.dumps({"method": "test/blocked"}), flush=True)
+        continue
+    result = {}
+    if method == "thread/start":
+        result = {"thread": {"id": str(uuid.uuid4())}}
+    if method == "thread/resume":
+        result = {"thread": {"id": params["threadId"]}}
+        flag = Path(__file__).with_name("resume-mode")
+        if flag.exists():
+            if flag.read_text() == "unsupported":
+                print(json.dumps({"id": req["id"], "error": {"code": -32601,
+                    "message": "thread/resume unsupported"}}), flush=True)
+                continue
+            result = {"thread": {"id": "unexpected-replacement"}}
+    if method == "turn/start":
+        result = {"turn": {"id": str(uuid.uuid4())}}
+    print(json.dumps({"id": req["id"], "result": result}), flush=True)
+    if method == "turn/start":
+        print(json.dumps({"method": "turn/completed", "params": {
+            "threadId": params["threadId"],
+            "turn": {"id": result["turn"]["id"], "status": "completed"}}}), flush=True)
+''', encoding="utf-8")
+    original = subprocess.Popen
+    children = []
+
+    def spawn(cmd, **kwargs):
+        child = original([sys.executable, str(script), str(log)], **kwargs)
+        children.append(child)
+        return child
+
+    monkeypatch.setattr("agent.transports.codex_app_server.subprocess.Popen", spawn)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-home"))
+    yield children, lambda: [json.loads(line) for line in log.read_text().splitlines()] if log.exists() else []
+    for child in children:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=5)
+
+
+@pytest.mark.parametrize("method", ["initialize", "thread/start", "thread/resume", "turn/start", "thread/compact/start"])
+def test_stop_retires_real_stdio_child_and_releases_pending_rpc(tmp_path, wire_runtime, method):
+    from agent.transports.codex_app_server import CodexAppServerClient
+    from agent.transports.codex_app_server_session import CodexAppServerSession
+
+    children, requests = wire_runtime
+    entered, rpc_returned = threading.Event(), threading.Event()
+    (tmp_path / "block-method").write_text(method)
+
+    class Client(CodexAppServerClient):
+        def _dispatch(self, message):
+            if message.get("method") == "test/blocked":
+                entered.set()
+            super()._dispatch(message)
+
+        def request(self, name, *args, **kwargs):
+            try:
+                return super().request(name, *args, **kwargs)
+            finally:
+                if name == method:
+                    rpc_returned.set()
+
+    session = CodexAppServerSession(cwd=str(tmp_path), client_factory=Client,
+                                   thread_id="saved-thread" if method == "thread/resume" else None)
+    results = []
+    target = session.compact_thread if method == "thread/compact/start" else lambda: session.run_turn("blocked")
+    worker = threading.Thread(target=lambda: results.append(target()), daemon=True)
+    worker.start()
+    try:
+        assert entered.wait(5), "fixture child did not receive RPC"
+        started = time.monotonic()
+        session.request_interrupt()
+        worker.join(timeout=5)
+        assert not worker.is_alive()
+        assert time.monotonic() - started < 5
+        assert results[0].interrupted and results[0].should_retire
+        assert not results[0].terminal_acknowledged
+        assert children[-1].poll() is not None
+        assert rpc_returned.wait(2), "closing the child left its RPC worker blocked"
+        recorded = requests()
+        assert recorded[-1]["method"] == method
+        assert session.run_turn("must not restart").should_retire
+        assert requests() == recorded
+    finally:
+        session.close()
+        worker.join(timeout=12)
+
+
+def test_retirement_and_database_reopen_resume_exact_native_threads(tmp_path, wire_runtime):
+    children, requests = wire_runtime
+    db_path = tmp_path / "state.db"
+    bindings = {}
+    for iteration in range(2):
+        with SessionDB(db_path) as db:
+            for sid in ("member-thread-a", "member-thread-b"):
+                if iteration == 0:
+                    db.create_session(session_id=sid, source="gui")
+                agent = AIAgent.__new__(AIAgent)
+                agent.session_id, agent._session_db = sid, db
+                agent.session_cwd = str(tmp_path)
+                agent.client = None
+                _ensure_codex_session(agent)
+                session = agent._codex_session
+                tid = session.ensure_started()
+                # Binding must be durable BEFORE any native model/tool work is admitted.
+                binding = db.get_session_model_config_value(sid, "codex_native_session")
+                assert binding and binding["thread_id"] == tid
+                if iteration:
+                    assert tid == bindings[sid]
+                bindings[sid] = tid
+                result = session.run_turn("fixture")
+                assert result.error is None
+                agent.release_clients()
+                assert children[-1].poll() is not None
+                assert agent._codex_session is None
+    assert len(set(bindings.values())) == 2
+    methods = [r["method"] for r in requests()]
+    assert methods.count("thread/start") == methods.count("thread/resume") == 2
+
+
+@pytest.mark.parametrize("assistant_content", ["Previous native answer", ""])
+def test_persisted_history_without_binding_never_admits_native_work(tmp_path, wire_runtime, assistant_content):
+    _, requests = wire_runtime
+    db_path = tmp_path / "state.db"
+    with SessionDB(db_path) as db:
+        db.create_session(session_id="legacy", source="cli", model_config={"api_mode": "codex_app_server"})
+        db.append_message("legacy", "user", "Previous question")
+        db.append_message("legacy", "assistant", assistant_content)
+    with SessionDB(db_path) as db:
+        agent = AIAgent.__new__(AIAgent)
+        agent.session_id, agent._session_db = "legacy", db
+        agent.session_cwd, agent.client = str(tmp_path), None
+        try:
+            with pytest.raises(RuntimeError, match="history.*binding"):
+                _ensure_codex_session(agent)
+                agent._codex_session.run_turn("must not execute")
+        finally:
+            agent.release_clients()
+        assert not any(r["method"] in {"thread/start", "turn/start"} for r in requests())
+        assert db.get_session_model_config_value("legacy", "codex_native_session") is None
+
+
+@pytest.mark.parametrize("states", [(False, True), (True, False), (True, None)])
+def test_reused_session_refreshes_both_approval_policies_before_work(tmp_path, wire_runtime, monkeypatch, states):
+    from unittest.mock import Mock
+
+    _, requests = wire_runtime
+    lookup = Mock(side_effect=[RuntimeError("lookup failed") if state is None else state for state in states])
+    monkeypatch.setattr("tools.approval.is_approval_bypass_active", lookup)
+    monkeypatch.setattr("tools.terminal_tool._get_approval_callback", lambda: None)
+    with SessionDB(tmp_path / "state.db") as db:
+        db.create_session(session_id="policy", source="cli")
+        agent = AIAgent.__new__(AIAgent)
+        agent.session_id, agent._session_db = "policy", db
+        agent.session_cwd, agent.client = str(tmp_path), None
+        sessions, threads = [], []
+        try:
+            for state in states:
+                _ensure_codex_session(agent)
+                session = agent._codex_session
+                sessions.append(session)
+                result = session.run_turn("fixture")
+                assert result.error is None
+                threads.append(result.thread_id)
+                assert session._decide_exec_approval({"command": "fixture"}) == ("accept" if state else "decline")
+                assert session._decide_apply_patch_approval({}) == ("accept" if state else "decline")
+            assert lookup.call_count == len(states)
+            assert sessions[0] is sessions[1]
+            assert threads[0] == threads[1]
+            sent = [r["params"] for r in requests() if r["method"] == "turn/start"]
+            assert [p.get("approvalPolicy") for p in sent] == ["never" if state else "on-request" for state in states]
+            assert all(p["threadId"] == threads[0] for p in sent)
+            assert sum(r["method"] == "thread/start" for r in requests()) == 1
+        finally:
+            agent.release_clients()
+
+
+@pytest.mark.parametrize("transition", ["resume", "new", "branch"])
+def test_warm_session_reset_detaches_native_source(tmp_path, wire_runtime, transition):
+    from types import SimpleNamespace
+    from hermes_cli.cli_commands_mixin import _sync_agent_to_session
+
+    children, requests = wire_runtime
+    with SessionDB(tmp_path / "state.db") as db:
+        db.create_session(session_id="source", source="cli")
+        db.create_session(session_id="destination", source="cli", model_config=(
+            {"_branched_from": "source"} if transition == "branch" else {}))
+        agent = AIAgent.__new__(AIAgent)
+        agent.session_id, agent._session_db = "source", db
+        agent.session_cwd, agent.client = str(tmp_path), None
+        _ensure_codex_session(agent)
+        source = agent._codex_session.ensure_started()
+        source_child = children[-1]
+        source_binding = db.get_session_model_config_value("source", "codex_native_session")
+        saved_destination = {**source_binding, "session_id": "destination", "thread_id": "saved-destination-thread"}
+        if transition == "resume":
+            db.patch_session_model_config("destination", {"codex_native_session": saved_destination})
+        agent._invalidate_system_prompt = lambda: None
+        if transition == "new":
+            # Same-model /new keeps this AIAgent and calls this exact boundary.
+            agent.session_id = "destination"
+            agent.reset_session_state()
+        else:
+            cli = SimpleNamespace(agent=agent, conversation_history=[])
+            _sync_agent_to_session(cli, "destination", parent_session_id="source", reason=transition)
+        assert source_child.poll() is not None, "warm reset retained the source native process"
+        assert db.get_session_model_config_value("source", "codex_native_session") == source_binding
+        if transition == "branch":
+            with pytest.raises(RuntimeError, match="native.*branch.*unsupported"):
+                _ensure_codex_session(agent)
+            assert not any(r["method"] == "turn/start" for r in requests())
+            return
+        _ensure_codex_session(agent)
+        try:
+            result = agent._codex_session.run_turn("destination fixture")
+            assert result.error is None
+            destination = result.thread_id
+            assert destination != source
+            if transition == "resume":
+                assert destination == saved_destination["thread_id"]
+            assert db.get_session_model_config_value("destination", "codex_native_session")["thread_id"] == destination
+            assert [r["params"]["threadId"] for r in requests() if r["method"] == "turn/start"] == [destination]
+        finally:
+            agent.release_clients()
+
+
+def test_native_image_input_crosses_stdio_and_unsupported_media_is_explicit(tmp_path, wire_runtime):
+    from agent.transports.codex_app_server_session import CodexAppServerSession
+
+    _, requests = wire_runtime
+    data_url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+    session = CodexAppServerSession(cwd=str(tmp_path))
+    try:
+        result = session.run_turn([
+            {"type": "text", "text": "Describe the fixture"},
+            {"type": "image_url", "image_url": {"url": data_url}},
+        ])
+        assert result.error is None
+        sent = next(r["params"]["input"] for r in requests() if r["method"] == "turn/start")
+        assert sent == [{"type": "text", "text": "Describe the fixture"},
+                        {"type": "image", "url": data_url}]
+        result = session.run_turn([{"type": "input_audio", "data": "fixture"}])
+        assert "unsupported" in result.error.lower()
+        assert sum(r["method"] == "turn/start" for r in requests()) == 1
+    finally:
+        session.close()
+
+
+@pytest.mark.parametrize("mode", ["unsupported", "wrong-thread"])
+def test_resume_failure_never_submits_or_starts_a_replacement(tmp_path, wire_runtime, mode):
+    from agent.transports.codex_app_server_session import CodexAppServerSession
+
+    children, requests = wire_runtime
+    (tmp_path / "resume-mode").write_text(mode)
+    session = CodexAppServerSession(cwd=str(tmp_path), thread_id="saved-thread")
+    result = session.run_turn("must not execute")
+    assert result.error and result.should_retire
+    assert not any(r["method"] in {"thread/start", "turn/start"} for r in requests())
+    assert children[-1].poll() is not None

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -7,6 +7,7 @@ deadline timeouts. These tests pin all of that without spawning real codex.
 
 from __future__ import annotations
 
+import threading
 import time
 from unittest.mock import patch
 from typing import Any, Optional
@@ -18,7 +19,7 @@ from agent.transports.codex_app_server_session import (
     CodexAppServerSession,
     _ServerRequestRouting,
     _approval_choice_to_codex_decision,
-    _coerce_turn_input_text,
+    _coerce_turn_input,
 )
 
 
@@ -111,11 +112,25 @@ class FakeClient:
         self._notifications.append({"method": method, "params": params})
 
     def queue_server_request(self, method: str, request_id: Any = "srv-1", **params):
+        if params.get("threadId") in {"t", "th"}:
+            params["threadId"] = "thread-fake-001"
+        if params.get("turnId") == "tu1":
+            params["turnId"] = "turn-fake-001"
         self._server_requests.append({"id": request_id, "method": method, "params": params})
 
     def set_stderr_tail(self, lines):
         """Test helper: seed stderr_tail() output for OAuth-refresh classifier tests."""
         self._stderr_tail = list(lines)
+
+    def complete_after_response(self):
+        """An approval-dependent turn cannot finish before its approval response."""
+        original = self.respond
+
+        def respond(request_id, result):
+            original(request_id, result)
+            self.queue_notification("turn/completed", threadId="t", turn={"id": "tu1", "status": "completed"})
+
+        self.respond = respond
 
 
 def make_session(client: FakeClient, **kwargs) -> CodexAppServerSession:
@@ -124,6 +139,96 @@ def make_session(client: FakeClient, **kwargs) -> CodexAppServerSession:
         client_factory=lambda **kw: client,
         **kwargs,
     )
+
+
+@pytest.mark.parametrize("method", list(CodexAppServerSession._SERVER_REQUEST_HANDLERS))
+@pytest.mark.parametrize("scope", [
+    {}, {"threadId": "thread-fake-001"}, {"turnId": "turn-fake-001"},
+    {"threadId": "", "turnId": "turn-fake-001"},
+    {"threadId": "thread-fake-001", "turnId": None},
+    {"threadId": "foreign", "turnId": "turn-fake-001"},
+    {"threadId": "thread-fake-001", "turnId": "stale"},
+    {"threadId": "thread-fake-001", "turnId": "turn-fake-001", "thread_id": "foreign"},
+    {"threadId": "thread-fake-001", "turnId": "turn-fake-001", "turn": {"id": "stale"}},
+    {"threadId": "thread-fake-001", "turnId": "turn-fake-001", "item": {"turn_id": "stale"}},
+    {"threadId": "thread-fake-001", "turnId": "turn-fake-001", "item": {"threadId": None}},
+])
+def test_server_request_authority_requires_unambiguous_exact_scope(method, scope):
+    client = FakeClient()
+    calls = []
+    session = make_session(client, approval_callback=lambda *a, **kw: calls.append(a) or "once",
+                           request_routing=_ServerRequestRouting(True, True))
+    session.ensure_started()
+    session._active_turn_id = "turn-fake-001"
+    session._handle_server_request({"id": "ambiguous", "method": method,
+                                    "params": {"command": "fixture", "serverName": "hermes-tools", **scope}})
+    assert not calls
+    assert not client.responses
+    assert client.error_responses and client.error_responses[0][:2] == ("ambiguous", -32600)
+
+
+@pytest.mark.parametrize("active_turn_id", [None, "", 7])
+def test_server_request_cannot_inherit_invalid_active_identity(active_turn_id):
+    client = FakeClient()
+    session = make_session(client, request_routing=_ServerRequestRouting(True, True))
+    session.ensure_started()
+    session._active_turn_id = active_turn_id
+    session._handle_server_request({"id": "invalid", "method": "item/commandExecution/requestApproval",
+                                    "params": {"threadId": "thread-fake-001", "turnId": active_turn_id}})
+    assert not client.responses
+    assert client.error_responses[0][:2] == ("invalid", -32600)
+
+
+@pytest.mark.parametrize("bypass", [False, True])
+@pytest.mark.parametrize("method", list(CodexAppServerSession._SERVER_REQUEST_HANDLERS))
+def test_scoped_server_requests_reach_only_the_current_approval_route(bypass, method):
+    client = FakeClient()
+    calls = []
+    session = make_session(client, approval_callback=lambda *a, **kw: calls.append(a) or "deny",
+                           request_routing=_ServerRequestRouting(bypass, bypass))
+    session.ensure_started()
+    session._active_turn_id = "turn-fake-001"
+    for scope in (
+        {"threadId": "thread-fake-001", "turnId": "turn-fake-001"},
+        {"thread_id": "thread-fake-001", "turn_id": "turn-fake-001"},
+        {"turn": {"threadId": "thread-fake-001", "id": "turn-fake-001"}},
+        {"item": {"thread_id": "thread-fake-001", "turn_id": "turn-fake-001"}},
+    ):
+        session._handle_server_request({"id": "scoped", "method": method,
+                                        "params": {"command": "fixture", "serverName": "hermes-tools", **scope}})
+    assert not client.error_responses
+    assert len(client.responses) == 4
+    if method == "mcpServer/elicitation/request":
+        expected = {"action": "accept", "content": None, "_meta": None}
+    else:
+        expected = {"decision": "accept" if bypass and method != "item/permissions/requestApproval" else "decline"}
+    assert all(response == ("scoped", expected) for response in client.responses)
+    assert len(calls) == (4 if not bypass and method in {
+        "item/commandExecution/requestApproval", "item/fileChange/requestApproval"} else 0)
+
+
+@pytest.mark.parametrize("turn_timeout,ack_delay", [(600.0, 12.0), (20.0, 12.0), (5.0, 12.0), (600.0, 61.0)])
+def test_turn_start_acknowledgement_uses_caller_capped_window(turn_timeout, ack_delay):
+    client = FakeClient()
+    original = client.request
+    budgets = []
+
+    def request(method, params=None, timeout=30):
+        if method == "turn/start":
+            budgets.append(timeout)
+            if ack_delay > timeout:
+                raise TimeoutError("delayed acknowledgement exceeded request budget")
+            client.queue_notification("turn/completed", threadId="t", turn={"id": "tu1", "status": "completed"})
+        return original(method, params, timeout)
+
+    client.request = request
+    result = make_session(client).run_turn("fixture", turn_timeout=turn_timeout)
+    assert budgets == [min(turn_timeout, 60.0)]
+    if ack_delay > min(turn_timeout, 60.0):
+        assert result.should_retire and not result.terminal_acknowledged
+        assert "timed out" in result.error
+    else:
+        assert result.error is None and result.terminal_acknowledged
 
 
 # ---- choice mapping ----
@@ -141,12 +246,429 @@ class TestApprovalChoiceMapping:
 
 
 class TestTurnInputCoercion:
-    def test_list_content_keeps_text_and_marks_images(self):
-        text = _coerce_turn_input_text([
+    def test_list_content_keeps_text_and_images(self):
+        parts = _coerce_turn_input([
             {"type": "text", "text": "caption"},
             {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
         ])
-        assert text == "caption\n\n[image attached]"
+        assert parts == [{"type": "text", "text": "caption"},
+                         {"type": "image", "url": "data:image/png;base64,abc"}]
+
+
+@pytest.mark.parametrize("blocked_method", ["initialize", "thread/start", "thread/resume", "turn/start", "thread/compact/start"])
+def test_stop_during_submission_retires_without_admitting_later_work(blocked_method):
+    entered, release, returned = threading.Event(), threading.Event(), threading.Event()
+    client = FakeClient()
+    original_request, original_initialize = client.request, client.initialize
+
+    def block():
+        entered.set()
+        assert release.wait(12), "test did not release blocked RPC"
+
+    def initialize(**kwargs):
+        if blocked_method == "initialize":
+            block()
+            returned.set()
+        return original_initialize(**kwargs)
+
+    def request(method, params=None, timeout=30):
+        if method == blocked_method:
+            block()
+            returned.set()
+        if method == "thread/resume":
+            client.requests.append((method, params))
+            return {"thread": {"id": "saved-thread"}}
+        return original_request(method, params, timeout)
+
+    client.initialize, client.request = initialize, request
+    session = make_session(client, thread_id="saved-thread" if blocked_method == "thread/resume" else None)
+    results = []
+    def target():
+        if blocked_method == "thread/compact/start":
+            return session.compact_thread(turn_timeout=0.1)
+        return session.run_turn("no later work", turn_timeout=0.1)
+
+    worker = threading.Thread(target=lambda: results.append(target()), daemon=True)
+    worker.start()
+    try:
+        assert entered.wait(5)
+        started = time.monotonic()
+        session.request_interrupt()
+        first_deadline = session._interrupt_deadline
+        session.request_interrupt()
+        assert session._interrupt_deadline == first_deadline
+        worker.join(timeout=5)
+        assert not worker.is_alive(), "Stop did not bound the blocked startup/submission RPC"
+        assert time.monotonic() - started < 5
+        assert results[0].interrupted and results[0].should_retire
+        assert not results[0].terminal_acknowledged
+        assert client._closed
+    finally:
+        release.set()
+        assert returned.wait(2)
+        worker.join(timeout=12)
+        session.close()
+    if blocked_method != "turn/start":
+        assert not any(method == "turn/start" for method, _ in client.requests)
+    request_count = len(client.requests)
+    assert session.run_turn("must remain retired").should_retire
+    assert len(client.requests) == request_count
+
+
+def test_interrupt_waits_for_matching_terminal_notification():
+    client = FakeClient()
+    session = make_session(client)
+
+    def request(method, params):
+        if method == "thread/start":
+            return {"thread": {"id": "thread-fake-001"}}
+        if method == "turn/start":
+            session.request_interrupt()
+            return {"turn": {"id": "turn-fake-001"}}
+        return {}
+
+    client._request_handler = request
+    client.queue_notification("turn/completed", threadId="foreign", turn={"id": "foreign", "status": "interrupted"})
+    client.queue_notification("turn/completed", threadId="t", turn={"id": "tu1", "status": "interrupted"})
+    result = session.run_turn("stop fixture", turn_timeout=0.1)
+    assert client._notifications == []
+    assert result.interrupted and result.terminal_acknowledged
+    assert sum(method == "turn/interrupt" for method, _ in client.requests) == 1
+
+
+@pytest.mark.parametrize("turn_timeout", [2.0, 30.0])
+def test_interrupt_rpc_and_ack_share_one_deadline(monkeypatch, turn_timeout):
+    clock = [100.0]
+    monkeypatch.setattr(session_mod.time, "monotonic", lambda: clock[0])
+    client = FakeClient()
+    session = make_session(client)
+    original_request = client.request
+    budgets = []
+
+    def request(method, params=None, timeout=30):
+        if method == "turn/start":
+            session.request_interrupt()
+        if method == "turn/interrupt":
+            budgets.append(timeout)
+            clock[0] += timeout
+            raise TimeoutError("missing interrupt RPC response")
+        return original_request(method, params, timeout)
+
+    def poll(timeout=0):
+        clock[0] += max(timeout, 0.1)
+        return None
+
+    client.request = request
+    client.take_notification = poll
+    result = session.run_turn("stop", turn_timeout=turn_timeout)
+    assert clock[0] <= 100.0 + min(turn_timeout, 5.0)
+    assert budgets == [min(turn_timeout, 5.0)]
+    assert result.interrupted and result.should_retire
+    assert not result.terminal_acknowledged
+    assert "unacknowledged" in result.error
+
+
+@pytest.mark.parametrize("stop_during_approval", [False, True])
+def test_stop_cannot_be_extended_by_approval(stop_during_approval):
+    client = FakeClient()
+    entered, release, finished = threading.Event(), threading.Event(), threading.Event()
+    results = []
+
+    def approve(*args, **kwargs):
+        entered.set()
+        release.wait(10)
+        return "once"
+
+    session = make_session(client, approval_callback=approve)
+    original_request = client.request
+
+    def request(method, params=None, timeout=30):
+        if method == "turn/start" and not stop_during_approval:
+            session.request_interrupt()
+        if method == "turn/interrupt":
+            client.queue_notification("turn/completed", threadId="t", turn={"id": "tu1", "status": "interrupted"})
+        return original_request(method, params, timeout)
+
+    client.request = request
+    client.queue_server_request("item/commandExecution/requestApproval", command="fixture", threadId="t", turnId="tu1")
+
+    def run():
+        try:
+            results.append(session.run_turn("stop", turn_timeout=30))
+        finally:
+            finished.set()
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    try:
+        if stop_during_approval:
+            assert entered.wait(2)
+            session.request_interrupt()
+        assert finished.wait(2), "approval blocked native cancellation"
+        assert results[0].terminal_acknowledged and results[0].interrupted
+        assert not any(response.get("decision") != "decline" for _, response in client.responses)
+        assert len(client.responses) + len(client.error_responses) == 1
+        assert entered.is_set() == stop_during_approval
+    finally:
+        release.set()
+        worker.join(2)
+    assert not any(response.get("decision") != "decline" for _, response in client.responses)
+
+
+@pytest.mark.parametrize("waiting_for_lock", [False, True])
+def test_stop_releases_real_cli_approval_wait(waiting_for_lock):
+    from hermes_cli.cli_modal_mixin import CLIModalMixin
+
+    entered, painted, callback_done = threading.Event(), threading.Event(), threading.Event()
+
+    class UI(CLIModalMixin):
+        _approval_state = None
+        _approval_lock = threading.Lock()
+
+        def _paint_now(self):
+            if self._approval_state is not None:
+                painted.set()
+
+        def _ring_bell(self, **kwargs):
+            pass
+
+        def _persist_prompt_summary(self, *args):
+            pass
+
+    ui = UI()
+
+    def approve(*args, **kwargs):
+        entered.set()
+        try:
+            return ui._approval_callback(*args, **kwargs)
+        finally:
+            callback_done.set()
+
+    client = FakeClient()
+    session = make_session(client, approval_callback=approve)
+    original_request = client.request
+
+    def request(method, params=None, timeout=30):
+        if method == "turn/interrupt":
+            client.queue_notification("turn/completed", threadId="t", turn={"id": "tu1", "status": "interrupted"})
+        return original_request(method, params, timeout)
+
+    client.request = request
+    client.queue_server_request("item/commandExecution/requestApproval", command="fixture", threadId="t", turnId="tu1")
+    worker = threading.Thread(target=lambda: session.run_turn("stop", turn_timeout=30), daemon=True)
+    if waiting_for_lock:
+        ui._approval_lock.acquire()
+    worker.start()
+    try:
+        assert (entered if waiting_for_lock else painted).wait(2)
+        session.request_interrupt()
+        worker.join(2)
+        assert not worker.is_alive()
+        assert callback_done.wait(2), "cancelled native approval still owns/waits for the CLI modal"
+        assert ui._approval_state is None
+        assert client.responses == [("srv-1", {"decision": "decline"})]
+    finally:
+        if waiting_for_lock:
+            ui._approval_lock.release()
+            painted.wait(2)
+        if ui._approval_state is not None:
+            ui._approval_state["response_queue"].put("deny")
+        worker.join(2)
+        callback_done.wait(2)
+
+
+def test_approval_worker_preserves_turn_context():
+    from contextvars import ContextVar
+
+    scope = ContextVar("native-approval-scope", default=None)
+    observed = []
+    client = FakeClient()
+    client.queue_server_request("item/commandExecution/requestApproval", command="fixture", threadId="t", turnId="tu1")
+    client.complete_after_response()
+
+    def approve(*args, **kwargs):
+        observed.append(scope.get())
+        return "once"
+
+    session = make_session(client, approval_callback=approve)
+    token = scope.set("source-turn")
+    try:
+        result = session.run_turn("fixture")
+    finally:
+        scope.reset(token)
+    assert result.terminal_acknowledged
+    assert observed == ["source-turn"]
+    assert client.responses == [("srv-1", {"decision": "accept"})]
+
+
+def test_foreign_native_approval_never_reaches_callback():
+    client = FakeClient()
+    decisions = []
+    session = make_session(client, approval_callback=lambda *a, **kw: decisions.append(a) or "once")
+    session.ensure_started()
+    session._active_turn_id = "turn-fake-001"
+    session._handle_server_request({"id": "foreign-approval", "method": "item/commandExecution/requestApproval",
+                                    "params": {"threadId": "wrong-thread", "turnId": "turn-fake-001", "command": "echo fixture"}})
+    assert decisions == []
+    assert client.error_responses and not client.responses
+
+
+@pytest.mark.parametrize("phase", ["before-start", "active", "after-terminal"])
+def test_compaction_approval_requires_live_matching_turn(phase):
+    client = FakeClient()
+    decisions = []
+    session = make_session(client, approval_callback=lambda *a, **kw: decisions.append(a) or "once")
+    request = {"id": "stale", "method": "item/commandExecution/requestApproval",
+               "params": {"threadId": "thread-fake-001", "turnId": "wrong-turn", "command": "fixture"}}
+    if phase == "before-start":
+        client._server_requests.append(request)
+
+    def on_event(note):
+        if note["method"] == "turn/started" and phase != "before-start":
+            client._server_requests.append(request)
+        if note["method"] == "turn/started" and phase == "after-terminal":
+            request["params"]["turnId"] = "compact-turn"
+
+    session._on_event = on_event
+    if phase != "before-start":
+        client.queue_notification("turn/started", threadId="t", turn={"id": "compact-turn"})
+    if phase in {"before-start", "active"}:
+        # Put completion behind the rejection, so this specifically tests the
+        # wrong-turn fence rather than only the terminal-drain boundary.
+        original_error = client.respond_error
+
+        def reject(*args, **kwargs):
+            original_error(*args, **kwargs)
+            if phase == "before-start":
+                client.queue_notification("turn/started", threadId="t", turn={"id": "compact-turn"})
+            client.queue_notification("turn/completed", threadId="t", turn={"id": "compact-turn", "status": "completed"})
+
+        client.respond_error = reject
+    else:
+        client.queue_notification("turn/completed", threadId="t", turn={"id": "compact-turn", "status": "completed"})
+    result = session.compact_thread(turn_timeout=0.2)
+    assert decisions == []
+    assert client.error_responses and not client.responses
+    assert result.terminal_acknowledged and not result.error
+    assert not session.request_steer("stale guidance")
+
+
+@pytest.mark.parametrize("mode", ["normal", "stop", "compact"])
+@pytest.mark.parametrize("approval", [False, True])
+@pytest.mark.parametrize("params", [
+    {},
+    {"threadId": "thread-fake-001", "turn": {"status": "completed"}},
+    {"turn": {"id": "turn-fake-001", "status": "completed"}},
+    {"threadId": "thread-fake-001", "turnId": "turn-fake-001", "turn": {}},
+    {"threadId": "thread-fake-001", "turn": {"id": "stale", "status": "completed"}},
+    {"threadId": "thread-fake-001", "turn": {"id": "turn-fake-001"}},
+    {"threadId": "thread-fake-001", "turn": {"id": "turn-fake-001", "status": "inProgress"}},
+    {"threadId": "thread-fake-001", "turn": {"id": "turn-fake-001", "status": []}},
+    {"threadId": "thread-fake-001", "turnId": "turn-fake-001", "turn": {"id": "stale", "status": "completed"}},
+    {"threadId": "thread-fake-001", "turn_id": "stale", "turn": {"id": "turn-fake-001", "status": "completed"}},
+    {"threadId": "thread-fake-001", "turn": {"id": "turn-fake-001", "status": "completed"}, "item": {"turnId": "stale"}},
+])
+def test_terminal_authority_requires_exact_identity_and_valid_status(mode, approval, params):
+    client = FakeClient()
+    observed = []
+    session = make_session(client)
+
+    def on_event(note):
+        observed.append(note)
+        if note["method"] == "test/ready" and mode == "stop":
+            session.request_interrupt()
+
+    session._on_event = on_event
+    if mode == "compact":
+        client.queue_notification("turn/started", threadId="t", turn={"id": "tu1"})
+    client.queue_notification("test/ready")
+    invalid = {"method": "turn/completed", "params": params}
+    client._notifications.append(invalid)
+    client.queue_notification("test/after-invalid")
+    client.queue_notification("turn/completed", threadId="t", turn={"id": "tu1", "status": "interrupted" if mode == "stop" else "completed"})
+    if approval:
+        client.queue_server_request("item/commandExecution/requestApproval", command="obsolete", threadId="t", turnId="tu1")
+    result = session.compact_thread(turn_timeout=0.2) if mode == "compact" else session.run_turn("test", turn_timeout=0.2)
+    assert invalid not in observed, "malformed terminal was given projection/acknowledgement authority"
+    assert any(note["method"] == "test/after-invalid" for note in observed)
+    assert result.terminal_acknowledged and not result.should_retire
+    assert result.interrupted == (mode == "stop")
+
+
+def test_acknowledged_compaction_stop_does_not_cancel_the_next_user_turn():
+    client = FakeClient()
+    session = make_session(client)
+
+    def on_event(note):
+        if note["method"] == "turn/started":
+            session.request_interrupt()
+
+    session._on_event = on_event
+    client.queue_notification("turn/started", threadId="t", turn={"id": "tu1"})
+    client.queue_notification("turn/completed", threadId="t", turn={"id": "tu1", "status": "interrupted"})
+    first = session.compact_thread(turn_timeout=0.2)
+    assert first.interrupted and first.terminal_acknowledged
+    client.queue_notification("turn/completed", threadId="t", turn={"id": "tu1", "status": "completed"})
+    second = session.run_turn("explicit next user turn", turn_timeout=0.2)
+    assert second.terminal_acknowledged and not second.interrupted and not second.error
+
+
+@pytest.mark.parametrize("compact", [False, True])
+def test_failed_terminal_is_acknowledged_but_never_successful(compact):
+    client = FakeClient()
+    session = make_session(client)
+    if compact:
+        client.queue_notification("turn/started", threadId="t", turn={"id": "tu1"})
+    client.queue_notification("turn/completed", threadId="t", turn={"id": "tu1", "status": "failed"})
+    result = session.compact_thread() if compact else session.run_turn("failed")
+    assert result.terminal_acknowledged
+    assert result.error and "failed" in result.error
+
+
+@pytest.mark.parametrize("compact", [False, True])
+@pytest.mark.parametrize("backlog", [0, 9, 100])
+def test_terminal_drain_never_prompts_obsolete_approval(compact, backlog):
+    client = FakeClient()
+    decisions = []
+    session = make_session(client, approval_callback=lambda *a, **kw: decisions.append(a) or "once")
+    client.queue_server_request("item/commandExecution/requestApproval", command="fixture", threadId="t", turnId="tu1")
+    if compact:
+        client.queue_notification("turn/started", threadId="t", turn={"id": "tu1"})
+    for _ in range(backlog):
+        client.queue_notification("thread/status/changed", threadId="t", turnId="tu1")
+    client.queue_notification("turn/completed", threadId="t", turn={"id": "tu1", "status": "completed"})
+    result = session.compact_thread() if compact else session.run_turn("finished")
+    assert result.terminal_acknowledged
+    assert decisions == []
+    assert client.error_responses and not client.responses
+
+
+@pytest.mark.parametrize("compact", [False, True])
+@pytest.mark.parametrize("stop", [False, True])
+def test_continuous_notification_drain_is_deadline_bounded(monkeypatch, compact, stop):
+    client = FakeClient()
+    decisions = []
+    session = make_session(client, approval_callback=lambda *a, **kw: decisions.append(a) or "once")
+    session.ensure_started()
+    clock = [0.0]
+    monkeypatch.setattr(session_mod.time, "monotonic", lambda: clock[0])
+
+    def on_event(note):
+        if stop:
+            session.request_interrupt()
+        clock[0] += 1
+        client.queue_notification("thread/status/changed", threadId="t", turnId="tu1")
+
+    session._on_event = on_event
+    if compact:
+        client.queue_notification("turn/started", threadId="t", turn={"id": "tu1"})
+    else:
+        client.queue_notification("thread/status/changed", threadId="t", turnId="tu1")
+    client.queue_server_request("item/commandExecution/requestApproval", command="never prompt", threadId="t", turnId="tu1")
+    result = session.compact_thread(turn_timeout=100 if stop else 3) if compact else session.run_turn("flood", turn_timeout=100 if stop else 3)
+    assert result.interrupted and result.should_retire and not result.terminal_acknowledged
+    assert clock[0] <= (5 if stop else 3)
+    assert not decisions and client.error_responses and not client.responses
 
 
 # ---- lifecycle ----
@@ -230,7 +752,7 @@ class TestRunTurn:
         """Approval draining must not project a child result into the parent."""
         client = FakeClient()
         client.queue_server_request(
-            "item/commandExecution/requestApproval",
+            "item/commandExecution/requestApproval", threadId="t", turnId="tu1",
             request_id="approval-1",
             command="pwd",
             cwd="/tmp",
@@ -525,7 +1047,7 @@ class TestServerRequestRouting:
 
     def test_unknown_server_request_replied_with_error(self):
         client = FakeClient()
-        client.queue_server_request("totally/unknown", request_id="req-3")
+        client.queue_server_request("totally/unknown", threadId="t", turnId="tu1", request_id="req-3")
         client.queue_notification(
             "turn/completed", threadId="t",
             turn={"id": "tu1", "status": "completed", "error": None},
@@ -561,7 +1083,7 @@ class TestServerRequestRouting:
             },
         )
         client.queue_server_request(
-            "item/commandExecution/requestApproval", request_id="req-d",
+            "item/commandExecution/requestApproval", threadId="t", turnId="tu1", request_id="req-d",
             command="echo drained",
             cwd="/tmp",
         )
@@ -599,12 +1121,9 @@ class TestServerRequestRouting:
 
     def test_routing_auto_approve_bypass(self):
         client = FakeClient()
-        client.queue_server_request("item/commandExecution/requestApproval", request_id="r1",
+        client.queue_server_request("item/commandExecution/requestApproval", threadId="t", turnId="tu1", request_id="r1",
                                     command="ls", cwd="/")
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
+        client.complete_after_response()
         # No callback, but routing says auto-approve. Should approve.
         s = make_session(client, request_routing=_ServerRequestRouting(
             auto_approve_exec=True))
@@ -624,13 +1143,10 @@ class TestApprovalPromptEnrichment:
         the session cwd, not an empty string."""
         client = FakeClient()
         client.queue_server_request(
-            "item/commandExecution/requestApproval", request_id="r1",
+            "item/commandExecution/requestApproval", threadId="t", turnId="tu1", request_id="r1",
             command="ls",  # no cwd
         )
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
+        client.complete_after_response()
         captured = {}
         def cb(command, description, *, allow_permanent=True):
             captured["description"] = description
@@ -661,10 +1177,7 @@ class TestApprovalPromptEnrichment:
             startedAtMs=1234567890,
             reason="add and update files",
         )
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
+        client.complete_after_response()
         captured = {}
         def cb(command, description, *, allow_permanent=True):
             captured["command"] = command
@@ -689,10 +1202,7 @@ class TestApprovalPromptEnrichment:
             startedAtMs=1234567890,
             reason="apply some changes",
         )
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
+        client.complete_after_response()
         captured = {}
         def cb(command, description, *, allow_permanent=True):
             captured["command"] = command
@@ -719,10 +1229,8 @@ class TestSessionRetirement:
 
 
 
-    def test_final_agent_message_without_turn_completed_is_recovered(self):
-        """A completed assistant item is still a usable terminal response when
-        codex omits turn/completed and then goes quiet.
-        """
+    def test_final_agent_message_without_turn_completed_remains_uncertain(self):
+        """Displayable text does not prove the native tool loop has stopped."""
         client = FakeClient()
         client.queue_notification(
             "item/completed",
@@ -737,14 +1245,15 @@ class TestSessionRetirement:
             notification_poll_timeout=0.01,
         )
         assert r.final_text == "done"
-        assert r.interrupted is False
-        assert r.error is None
-        assert r.should_retire is False
+        assert r.interrupted is True
+        assert r.error is not None
+        assert r.should_retire is True
+        assert r.terminal_acknowledged is False
         assert any(
             msg["role"] == "assistant" and msg.get("content") == "done"
             for msg in r.projected_messages
         )
-        assert not any(method == "turn/interrupt" for method, _ in client.requests)
+        assert any(method == "turn/interrupt" for method, _ in client.requests)
 
 
     def test_post_tool_watchdog_uses_monotonic_clock(self):
@@ -760,12 +1269,16 @@ class TestSessionRetirement:
             threadId="t", turnId="tu1",
         )
         s = make_session(client)
-        monotonic_values = iter([1000.0, 999.0, 999.0, 999.0, 1000.2])
-        with patch.object(
-            session_mod.time,
-            "monotonic",
-            side_effect=lambda: next(monotonic_values),
-        ):
+        clock = [1000.0]
+        original_poll = client.take_notification
+
+        def poll(timeout=0):
+            clock[0] += 0.2
+            return original_poll(timeout=0)
+
+        client.take_notification = poll
+        with patch.object(session_mod.time, "monotonic", side_effect=lambda: clock[0]), \
+                patch.object(session_mod.time, "time", return_value=999.0):
             r = s.run_turn(
                 "tool then silence",
                 turn_timeout=5.0,
@@ -910,4 +1423,3 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure() is None
         assert _classify_oauth_failure("") is None
         assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
-

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -197,6 +197,35 @@ model:
   openai_runtime: codex_app_server   # default is "auto" (= Hermes runtime)
 ```
 
+## Session continuity and scope
+
+For sessions stored in Hermes' session database, Hermes saves a durable binding to the native Codex thread before submitting `turn/start`. The `codex_native_session` entry in the session's `model_config` records:
+
+- Hermes session ID
+- Codex thread ID
+- Resolved working directory
+- Resolved Codex home directory (`CODEX_HOME`, or Codex's default)
+
+Rebuilding the agent or reopening the database resumes that exact thread through `thread/resume`. Hermes does not reconstruct native history from its displayed transcript. A persisted conversation with prior assistant history but no binding—including sessions created before binding support—cannot start native work; use `/new` or resume a bound session. Without a session database, the binding is process-local and does not survive a restart.
+
+Hermes rejects a saved binding if its session ID, working directory, or Codex home differs from the current scope. Missing resume support, an invalid saved thread ID, or a resume response containing a different thread ID also fails explicitly. Hermes does not silently substitute a new thread. Restore the original scope to resume, or use `/new` for a separate conversation.
+
+Branching a Hermes transcript does not fork Codex's native history. Native continuation from that copied transcript is unsupported; resume the original session or start a new one. Integrations that need independent conversations must assign distinct durable Hermes sessions rather than reuse a session based on its title.
+
+The binding identifies the conversation, not the outcome of each submission. A crash after `turn/start` can leave the outcome unknown. Do not automatically replay an uncertain submission: it may already have executed commands or changed files. Inspect native history and affected resources before deciding what to submit next.
+
+Hermes closes the app-server child when it retires the agent. Closing the child does not delete native history. The binding uses existing session metadata and requires no schema migration; older Hermes versions that ignore it cannot preserve this resume contract. Stop native work before downgrading.
+
+## Image input and unsupported media
+
+Hermes passes supported image inputs to Codex as native `turn/start` input items rather than replacing them with text descriptions. Supported inputs are:
+
+- Text, including text combined with images
+- HTTP or HTTPS image URLs and `data:image/` URLs, sent as `image` items
+- Native `localImage` items with absolute paths accessible to the app-server process
+
+Relative local-image paths, malformed image inputs, and other media types return an unsupported-input error. Audio and video are not native inputs on this path. Native image support does not guarantee attachment upload, validation, or delivery on every client; the client must supply a supported input that Codex can access.
+
 ## Self-improvement loop (memory + skill nudges)
 
 Hermes' background self-improvement fires on counter thresholds:
@@ -243,6 +272,29 @@ Codex requests approval before executing commands or applying patches. These get
 - **Deny** → command is rejected; Codex continues in read-only mode.
 
 For `apply_patch` (file edit) approvals, Hermes shows a summary of what changed (`1 add, 1 update: /tmp/new.py, /tmp/old.py`) when codex provides the data via the corresponding `fileChange` item.
+
+Before every user turn, Hermes resolves current approval bypass and sends an explicit `turn/start` policy: `never` when bypass is active, otherwise `on-request`. Disabling bypass or a failed policy lookup restores gated policy on the same native thread; no restart or new thread is needed. Codex still owns native tool execution and sandbox enforcement. Approval and elicitation requests must carry nonempty, exact thread and turn IDs; absent or conflicting coordinates are rejected before a callback or automatic approval.
+
+## Stopping a native turn
+
+Stop distinguishes a confirmed terminal outcome from an uncertain submission. It does not treat an interrupt request or a displayed final message as proof that native execution ended.
+
+For an active turn with a known ID, Hermes sends one `turn/interrupt` request. The interrupt remote procedure call (RPC) and the wait for a terminal event share one five-second deadline from the Stop request, bounded by the remaining turn deadline. They do not receive separate five-second budgets.
+
+Hermes sets `native_terminal_acknowledged: true` only after receiving a `turn/completed` notification that satisfies both conditions:
+
+- Both the thread ID and turn ID exactly match the active turn.
+- The turn status is `completed`, `interrupted`, or `failed`.
+
+This flag confirms a terminal outcome, not necessarily successful cancellation or task success. A turn can finish before the interrupt takes effect. A matching terminal event drained while Hermes services an approval request also counts.
+
+Notifications with foreign thread or turn IDs cannot update the active transcript or acknowledge termination. Nonterminal notifications without scope IDs remain compatible, but a terminal notification missing either ID does not count as acknowledgment. Final assistant text without an exact terminal notification remains available for display but cannot establish successful completion.
+
+If the deadline expires without acknowledgment, Hermes reports an uncertain outcome and retires the app-server child. The result keeps `native_terminal_acknowledged: false`; closing a process is not a native terminal acknowledgment.
+
+If Stop arrives during startup or while `turn/start` is awaiting a response, Hermes promptly closes the child and retires the session with an unknown outcome. The retired session admits no later RPC, even if the pending operation returns afterward. This path does not claim terminal acknowledgment, and Hermes does not replay the uncertain submission automatically.
+
+After an uncertain Stop, inspect native history and any affected files or external systems before retrying. Stop cannot undo side effects that already occurred.
 
 ## Permission profiles
 
@@ -408,9 +460,27 @@ Known limitations:
 - **Hermes auth and codex auth are separate sessions.** You need both `codex login` AND `hermes auth add openai-codex` for the cleanest UX (the runtime uses codex's session for the LLM call). This is a deliberate design choice in Hermes' `_import_codex_cli_tokens` — Hermes won't share OAuth state with codex CLI to avoid clobbering each other on token refresh.
 - **`delegate_task`, `memory`, `session_search`, `todo` are unavailable on this runtime.** They need the running AIAgent context which a stateless MCP callback can't provide. Use `/codex-runtime auto` when you need these.
 - **No inline patch preview in approval prompts when codex doesn't track the changeset.** Codex's `fileChange` approval params don't always carry the changeset. Hermes caches the data from the corresponding `item/started` notification when possible, but if approval arrives before the item has streamed, the prompt falls back to whatever `reason` codex provides.
-- **Sub-second cancellation isn't guaranteed.** Mid-stream interrupts (Ctrl+C while codex is responding) are sent via `turn/interrupt`, but if codex has already flushed the final message, you get the response anyway.
+- **Stop can leave an uncertain outcome.** Only an exact terminal notification acknowledges termination; interrupt replies and final text do not. See [Stopping a native turn](#stopping-a-native-turn) for deadlines and recovery guidance.
 
 If you find a bug, [open an issue](https://github.com/NousResearch/hermes-agent/issues) with the output of `hermes logs --since 5m`. Mention `codex-runtime` in the title so it's easy to triage.
+
+## Testing native continuity and cancellation
+
+From the repository root, use the canonical test runner with a repository-local development environment (`.venv` or `venv`):
+
+```bash
+scripts/run_tests.sh -j 4 \
+  tests/agent/test_codex_native_continuity.py \
+  tests/agent/transports/test_codex_app_server_session.py \
+  tests/agent/transports/test_codex_app_server_runtime.py \
+  tests/agent/test_codex_runtime_live_events.py \
+  tests/agent/test_codex_app_server_persist.py \
+  tests/run_agent/test_codex_app_server_lifecycle.py \
+  tests/run_agent/test_codex_app_server_integration.py \
+  tests/run_agent/test_codex_app_server_compaction.py
+```
+
+The continuity tests exercise database reopen and real standard-input/output child processes with a deterministic protocol test double. They test Hermes' binding, input, scope, and cancellation contracts without vendor calls; they do not establish compatibility with every installed Codex version or end-to-end attachment delivery on every client.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Preserve native Codex conversation continuity and make cancellation, approval, and terminal authority follow the exact active session/turn. This is a standalone native-runtime correction against `main`, not the hosted-room backend or a client release.

The contribution is now **one author-signed-off commit**, `4955ff1ed0627c50b2a5146c77d5e519c789bf42`. It consolidates only this PR's same-author iterations, preserves the tested final tree and existing upstream history, and removes the need to qualify the earlier intermediate contribution train as separate landing objects.

## Changes

- Persist the exact Codex thread binding in existing Hermes session metadata before admitting input; resume it across process rebuilds and reject mismatched scope/resume results.
- Refuse persisted assistant history without a binding, including archived/tool-only assistant rows, before any native startup. No silent empty-thread replacement or automatic history reconstruction.
- Recompute Hermes approval routing/callbacks on every turn and explicitly send the corresponding native `approvalPolicy` in every `turn/start`. Revocation and lookup failure replace stale bypass authority while retaining the same bound thread.
- Require nonempty exact thread/turn coordinates for authority-bearing server requests and terminal completion, including agreement of all recognized aliases. Display-only notification compatibility does not confer approval authority.
- Preserve cancellable startup/submission. Allow `turn/start` acknowledgement up to `min(turn_timeout, 60s)` instead of the former fixed ten seconds; timeout retires rather than resubmits.
- Share the Stop budget across interruption, approval cancellation, and terminal drain. Final text alone is not terminal acknowledgement; late approval workers cannot write after cancellation/terminal completion.
- Retain rich image inputs, canonical multi-fragment/image echo deduplication, context propagation, and warm session-reset adapter cleanup.

## Review findings addressed

The three P1 findings on `4dd7556` have direct regressions:

1. **Unbound old history:** reopened real SQLite sessions with prior assistant history now fail before `thread/start` or `turn/start`.
2. **Approval revocation:** one reused adapter/thread covers bypass enabled→disabled, disabled→enabled, and lookup failure; both Hermes routing and native wire policy are checked.
3. **Missing approval coordinates:** absent, mismatched, malformed, and conflicting-alias authority requests are rejected before callbacks/automatic decisions. Positive fixtures now carry exact scope.

The delayed-start overlap is also reconciled with a caller-capped acknowledgement window while retaining the cancellable submission worker. Terminal scope validation additionally rejects conflicting item aliases and invalid active identity types.

## Verification

Final exact commit `4955ff1ed0627c50b2a5146c77d5e519c789bf42`: **694 tests passed across 30 files, zero failures**, using the canonical runner with retries disabled. Ruff and `git diff --check` passed. The earlier 341-test focused and 681-test broad selections overlap this final result and are not additional totals.

```bash
scripts/run_tests.sh -j 4 --file-retries 0 \
  tests/agent/test_codex_app_server_event_bridge.py \
  tests/agent/test_codex_app_server_persist.py \
  tests/agent/test_codex_native_continuity.py \
  tests/agent/test_codex_runtime_live_events.py \
  tests/agent/transports/test_bedrock_transport.py \
  tests/agent/transports/test_chat_completions.py \
  tests/agent/transports/test_chat_completions_empty_tool_calls.py \
  tests/agent/transports/test_chat_completions_xai_tool_search_alias.py \
  tests/agent/transports/test_codex_app_server_runtime.py \
  tests/agent/transports/test_codex_app_server_session.py \
  tests/agent/transports/test_codex_event_projector.py \
  tests/agent/transports/test_codex_transport.py \
  tests/agent/transports/test_hermes_tools_mcp_server.py \
  tests/agent/transports/test_meta_codex_cache.py \
  tests/agent/transports/test_reasoning_effort_sibling_sites.py \
  tests/agent/transports/test_router_codex_efforts.py \
  tests/agent/transports/test_transport.py \
  tests/agent/transports/test_types.py \
  tests/cli/test_cli_approval_ui.py \
  tests/cli/test_cli_new_session.py \
  tests/cli/test_session_boundary_hooks.py \
  tests/gateway/test_codex_hygiene_compaction.py \
  tests/hermes_cli/test_codex_runtime_plugin_migration.py \
  tests/hermes_cli/test_codex_runtime_switch.py \
  tests/run_agent/test_codex_app_server_compaction.py \
  tests/run_agent/test_codex_app_server_integration.py \
  tests/run_agent/test_codex_app_server_lifecycle.py \
  tests/run_agent/test_session_reset_fix.py \
  tests/tui_gateway/test_codex_app_server_live_events.py \
  tests/agent/test_codex_echo_ownership.py
```

Tests use real SQLite and an offline stdio child alongside deterministic transport seams. Native per-turn policy support was checked against the official `TurnStartParams` schema. This is not fresh vendor/model, physical-device, or production acceptance. The full repository suite was not run locally. A prior local website-index selection exposed unchanged Windows path-separator failures with the original documentation; those were not folded into this runtime change.

Final exact commit `4955ff1ed0627c50b2a5146c77d5e519c789bf42` also passed [all required hosted CI checks](https://github.com/NousResearch/hermes-agent/actions/runs/34184571217/job/101931060313), Docker builds, and [Nix](https://github.com/NousResearch/hermes-agent/actions/runs/34184570718/job/101930241185). The surviving contribution train contains one commit, so this is exact-object hosted proof for the complete current train, not reuse of an older head's receipts. Maintainer review/merge remains separate.

## Related work, credit, and landing boundaries

| Prior/complementary contribution | Reconciliation |
| --- | --- |
| Haseeb Qureshi's #99012 and Ben Awad's #103352 | Prior native-thread persistence and fail-closed continuity work. This carrier preserves the missing-binding/history invariant using one existing SessionDB metadata authority. It does not replace their record of discovery or justify merging two binding stores. |
| @jimsen153's #102926 | Approval-currentness work is complementary. This carrier refreshes routing and also explicitly overrides the provider policy on every turn. Avoid applying a second routing owner over the same lifecycle. |
| @s905060's #105403 | Delayed acknowledgement behavior is retained: caller-capped 60-second `turn/start` window, combined with cancellable submission and no retry-on-timeout. |
| Merged #104899 by @teknium1 | The accepted-input ownership foundation remains intact. Rich-input canonicalization here extends that foundation, whose credited lineage includes Xinmin Zeng / @fancyboi999 (#93546), VECTOR / @vectorcmd (#43127), @vashkartik, and diagnosis by @gitszabolcs. |
| @s905060's #105297 | Broader settings/instruction/history-import/runtime-transition work is not silently claimed here. Whichever carrier lands first, restack the other and remove duplicate lifecycle/binding hunks; preserve its distinct handoff functionality. |
| Rodrigo Coelho's #98995 | Overlaps continuity, terminal scope, cancellation and echoes. Its configurable whole-lifecycle deadlines, poisoned-write behavior, workspace policies, and other distinct features are not claimed as implemented by this PR. Reconcile those separately rather than merging parallel lifecycle implementations. |

This is an integration map and attribution, not a claim that the other authors have approved a supersession or that every feature of those PRs is included. Native history branching remains unsupported; existing unbound history requires explicit recovery or `/new`, not silent reconstruction.

The [room-backend companion](https://github.com/dokterdok/hermes-agent/pull/4) consumes this PR's native terminal evidence. [Desktop](https://github.com/dokterdok/hermes-agent/pull/3) and [draft Android Relay](https://github.com/Codename-11/hermes-relay/pull/559) depend on the hosted-room service separately. They are not prerequisites for landing this standalone runtime correction. No dependency/configuration migration, deployment, or history deletion is included.
