### PR TITLE
fix(desktop): gate Close Tab / Reload / Zoom on keyDown, not keyUp (#105498)

### DIFF
--- a/apps/desktop/electron/input-shortcuts.test.ts
+++ b/apps/desktop/electron/input-shortcuts.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Unit tests for the main-process keyboard shortcut guards.
+ * The bug this fixes: Ctrl+W pressed in another app (e.g. a browser) closes
+ * that window; if Hermes inherits focus mid-chord the leftover keyup lands
+ * on our webContents and closes a session tab without the user pressing
+ * anything *in* Hermes (#105498).
+ */
+
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import type { BrowserWindow, Input } from 'electron'
+import { describe, test, vi } from 'vitest'
+
+import { installInputShortcuts } from './input-shortcuts'
+
+interface FakeBrowserWindow {
+  id: number
+  webContents: FakeWebContents
+  on: typeof EventEmitter.prototype.on
+  off: typeof EventEmitter.prototype.off
+  emit: (event: string | symbol, ...args: unknown[]) => boolean
+}
+
+interface FakeWebContents {
+  calls: {
+    preventDefault: number
+    sendClose: number
+    sendReload: number
+    setZoom: Array<number>
+  }
+  isDestroyed: () => boolean
+  getZoomLevel: () => number
+  on: typeof EventEmitter.prototype.on
+  off: typeof EventEmitter.prototype.off
+  emit: (event: string | symbol, ...args: unknown[]) => boolean
+}
+
+function makeFakeWindow(id: number = 1): FakeBrowserWindow {
+  const windowEmitter = new EventEmitter()
+  const contentsEmitter = new EventEmitter()
+
+  const calls = {
+    preventDefault: 0,
+    sendClose: 0,
+    sendReload: 0,
+    setZoom: [] as Array<number>
+  }
+
+  let zoomLevel = 0
+
+  const webContents: FakeWebContents = {
+    calls,
+    isDestroyed: () => false,
+    getZoomLevel: () => zoomLevel,
+    on: contentsEmitter.on.bind(contentsEmitter),
+    off: contentsEmitter.off.bind(contentsEmitter),
+    emit: contentsEmitter.emit.bind(contentsEmitter)
+  }
+
+  return {
+    id,
+    webContents,
+    on: windowEmitter.on.bind(windowEmitter),
+    off: windowEmitter.off.bind(windowEmitter),
+    emit: windowEmitter.emit.bind(windowEmitter)
+  }
+}
+
+function asWin(fake: FakeBrowserWindow): BrowserWindow {
+  return fake as unknown as BrowserWindow
+}
+
+function makeInput(overrides: Partial<Input> = {}): Input {
+  return {
+    type: 'keyDown',
+    key: '',
+    code: '',
+    isAutoRepeat: false,
+    isComposing: false,
+    shift: false,
+    control: false,
+    alt: false,
+    meta: false,
+    location: 0,
+    modifiers: [],
+    ...overrides
+  }
+}
+
+describe('installInputShortcuts', () => {
+  describe('Close Tab (Ctrl/Cmd+W)', () => {
+    test('fires Close Tab on keyDown of Ctrl+W (Windows)', () => {
+      const win = makeFakeWindow()
+      const sendClose = vi.fn()
+      installInputShortcuts(asWin(win), false, { sendClosePreviewRequested: sendClose })
+
+      const input = makeInput({ key: 'w', control: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 1)
+      assert.equal(sendClose.mock.calls.length, 1)
+    })
+
+    test('fires Close Tab on keyDown of Cmd+W (macOS)', () => {
+      const win = makeFakeWindow()
+      const sendClose = vi.fn()
+      installInputShortcuts(asWin(win), true, { sendClosePreviewRequested: sendClose })
+
+      const input = makeInput({ key: 'w', meta: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 1)
+      assert.equal(sendClose.mock.calls.length, 1)
+    })
+
+    test('does not close a tab on keyUp of Ctrl+W', () => {
+      const win = makeFakeWindow()
+      const sendClose = vi.fn()
+      installInputShortcuts(asWin(win), false, { sendClosePreviewRequested: sendClose })
+
+      const input = makeInput({ type: 'keyUp', key: 'w', control: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 0)
+      assert.equal(sendClose.mock.calls.length, 0)
+    })
+
+    test('ignores auto-repeat of Ctrl+W', () => {
+      const win = makeFakeWindow()
+      const sendClose = vi.fn()
+      installInputShortcuts(asWin(win), false, { sendClosePreviewRequested: sendClose })
+
+      const input = makeInput({ key: 'w', control: true, isAutoRepeat: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 0)
+      assert.equal(sendClose.mock.calls.length, 0)
+    })
+
+    test('ignores Ctrl+W within the focus-grace window (200ms)', () => {
+      const win = makeFakeWindow()
+      const sendClose = vi.fn()
+      installInputShortcuts(asWin(win), false, { sendClosePreviewRequested: sendClose })
+
+      // Simulate focus transfer right now
+      win.emit('focus')
+
+      const input = makeInput({ key: 'w', control: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 0)
+      assert.equal(sendClose.mock.calls.length, 0)
+    })
+
+    test('fires Close Tab when focus-grace has expired (>200ms)', () => {
+      const win = makeFakeWindow()
+      const sendClose = vi.fn()
+      installInputShortcuts(asWin(win), false, { sendClosePreviewRequested: sendClose })
+
+      vi.useFakeTimers()
+
+      try {
+        win.emit('focus')
+        vi.advanceTimersByTime(210)
+
+        const input = makeInput({ key: 'w', control: true })
+        const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+        win.webContents.emit('before-input-event', event, input)
+
+        assert.equal(win.webContents.calls.preventDefault, 1)
+        assert.equal(sendClose.mock.calls.length, 1)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    test('does not fire when Shift is held (Ctrl+Shift+W is not Close Tab)', () => {
+      const win = makeFakeWindow()
+      const sendClose = vi.fn()
+      installInputShortcuts(asWin(win), false, { sendClosePreviewRequested: sendClose })
+
+      const input = makeInput({ key: 'w', control: true, shift: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 0)
+      assert.equal(sendClose.mock.calls.length, 0)
+    })
+  })
+
+  describe('Reload (Ctrl/Cmd+R)', () => {
+    test('fires Reload on keyDown of Ctrl+R', () => {
+      const win = makeFakeWindow()
+      const sendNav = vi.fn()
+      installInputShortcuts(asWin(win), false, { sendPreviewNavCommand: sendNav })
+
+      const input = makeInput({ key: 'r', control: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 1)
+      assert.equal(sendNav.mock.calls.length, 1)
+      assert.deepEqual(sendNav.mock.calls[0], ['reload'])
+    })
+
+    test('does not reload on keyUp of Ctrl+R', () => {
+      const win = makeFakeWindow()
+      const sendNav = vi.fn()
+      installInputShortcuts(asWin(win), false, { sendPreviewNavCommand: sendNav })
+
+      const input = makeInput({ type: 'keyUp', key: 'r', control: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 0)
+      assert.equal(sendNav.mock.calls.length, 0)
+    })
+
+    test('ignores Ctrl+R within the focus-grace window', () => {
+      const win = makeFakeWindow()
+      const sendNav = vi.fn()
+      installInputShortcuts(asWin(win), false, { sendPreviewNavCommand: sendNav })
+
+      win.emit('focus')
+
+      const input = makeInput({ key: 'r', control: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 0)
+      assert.equal(sendNav.mock.calls.length, 0)
+    })
+  })
+
+  describe('Zoom shortcuts (Ctrl/Cmd + +/-/0)', () => {
+    test('zooms in on Ctrl+=', () => {
+      const win = makeFakeWindow()
+      const setZoom = vi.fn()
+      installInputShortcuts(asWin(win), false, {
+        setAndPersistZoomLevel: setZoom,
+        getZoomStep: () => 0.1
+      })
+
+      const input = makeInput({ key: '=', control: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 1)
+      assert.equal(setZoom.mock.calls.length, 1)
+      assert.equal(setZoom.mock.calls[0][1], 0.1)
+    })
+
+    test('zooms out on Ctrl+-', () => {
+      const win = makeFakeWindow()
+      const setZoom = vi.fn()
+      installInputShortcuts(asWin(win), false, {
+        setAndPersistZoomLevel: setZoom,
+        getZoomStep: () => 0.1
+      })
+
+      const input = makeInput({ key: '-', control: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 1)
+      assert.equal(setZoom.mock.calls.length, 1)
+      assert.equal(setZoom.mock.calls[0][1], -0.1)
+    })
+
+    test('resets zoom on Ctrl+0', () => {
+      const win = makeFakeWindow()
+      const setZoom = vi.fn()
+      installInputShortcuts(asWin(win), false, {
+        setAndPersistZoomLevel: setZoom,
+        getDefaultZoomLevel: () => 0
+      })
+
+      const input = makeInput({ key: '0', control: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 1)
+      assert.equal(setZoom.mock.calls.length, 1)
+      assert.equal(setZoom.mock.calls[0][1], 0)
+    })
+
+    test('does not zoom on keyUp of Ctrl+0', () => {
+      const win = makeFakeWindow()
+      const setZoom = vi.fn()
+      installInputShortcuts(asWin(win), false, {
+        setAndPersistZoomLevel: setZoom,
+        getDefaultZoomLevel: () => 0
+      })
+
+      const input = makeInput({ type: 'keyUp', key: '0', control: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+      win.webContents.emit('before-input-event', event, input)
+
+      assert.equal(win.webContents.calls.preventDefault, 0)
+      assert.equal(setZoom.mock.calls.length, 0)
+    })
+
+    test('handles zoom-changed (wheel)', () => {
+      const win = makeFakeWindow()
+      const setZoom = vi.fn()
+      installInputShortcuts(asWin(win), false, {
+        setAndPersistZoomLevel: setZoom,
+        getZoomStep: () => 0.1
+      })
+
+      const event = { preventDefault: () => {} }
+      win.webContents.emit('zoom-changed', event, 'in')
+
+      assert.equal(setZoom.mock.calls.length, 1)
+      assert.equal(setZoom.mock.calls[0][1], 0.1)
+    })
+  })
+
+  describe('cleanup', () => {
+    test('detaches all listeners on uninstall', () => {
+      const win = makeFakeWindow()
+      const sendClose = vi.fn()
+      const uninstall = installInputShortcuts(asWin(win), false, { sendClosePreviewRequested: sendClose })
+
+      const input = makeInput({ key: 'w', control: true })
+      const event = { preventDefault: () => win.webContents.calls.preventDefault++ }
+
+      win.webContents.emit('before-input-event', event, input)
+      assert.equal(win.webContents.calls.preventDefault, 1)
+
+      uninstall()
+
+      win.webContents.emit('before-input-event', event, input)
+      assert.equal(win.webContents.calls.preventDefault, 1, 'listener not detached')
+    })
+  })
+})

--- a/apps/desktop/electron/input-shortcuts.ts
+++ b/apps/desktop/electron/input-shortcuts.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared keyboard shortcuts for Close Tab, Reload, and Zoom that run in the
+ * main process before Chromium or the renderer see the keystroke.
+ *
+ * Extracted from main.ts so the `before-input-event` handlers can be
+ * unit-tested without a live BrowserWindow.
+ */
+
+import type { BrowserWindow, Input } from 'electron'
+
+const IS_MAC = process.platform === 'darwin'
+
+/**
+ * Map to remember the instant each BrowserWindow received focus.
+ * Used by the focus-grace guard to ignore accelerators for a short window
+ * after a focus transfer, so keyup/auto-repeat from another app (e.g. Ctrl+W
+ * pressed in Chromium, that window dies, Windows activates Hermes while the
+ * keys are still down) can't close a tab or reload a page.
+ */
+const focusGraceUntil = new Map<number, number>()
+
+const FOCUS_GRACE_MS = 200
+
+export function installInputShortcuts(
+  window: BrowserWindow,
+  isMac: boolean = IS_MAC,
+  opts?: {
+    sendClosePreviewRequested?: () => void
+    sendPreviewNavCommand?: (command: 'reload') => void
+    setAndPersistZoomLevel?: (window: BrowserWindow, level: number) => void
+    getDefaultZoomLevel?: () => number
+    getZoomStep?: () => number
+  }
+) {
+  const { webContents } = window
+
+  if (!webContents || webContents.isDestroyed()) {
+    return () => {}
+  }
+
+  const windowId = window.id
+
+  const focusHandler = () => {
+    focusGraceUntil.set(windowId, Date.now() + FOCUS_GRACE_MS)
+  }
+
+  window.on('focus', focusHandler)
+
+  const inputHandler = (event: Electron.Event, input: Input) => {
+    if (input.type !== 'keyDown' || input.isAutoRepeat) {
+      return
+    }
+
+    const graceDeadline = focusGraceUntil.get(windowId)
+
+    if (graceDeadline != null && Date.now() < graceDeadline) {
+      return
+    }
+
+    const key = String(input.key || '').toLowerCase()
+    const accel = (isMac ? input.meta : input.control) && !input.alt
+
+    if (key === 'w' && accel && !input.shift) {
+      if (typeof event.preventDefault === 'function') {
+        event.preventDefault()
+      }
+
+      opts?.sendClosePreviewRequested?.()
+
+      return
+    }
+
+    if (key === 'r' && accel && !input.shift) {
+      if (typeof event.preventDefault === 'function') {
+        event.preventDefault()
+      }
+
+      opts?.sendPreviewNavCommand?.('reload')
+
+      return
+    }
+
+    const mod = isMac ? input.meta : input.control
+
+    if (!mod || input.alt) {
+      return
+    }
+
+    if (key === '0') {
+      if (input.shift) {
+        return
+      }
+
+      if (typeof event.preventDefault === 'function') {
+        event.preventDefault()
+      }
+
+      const defaultLevel = opts?.getDefaultZoomLevel?.() ?? 0
+      opts?.setAndPersistZoomLevel?.(window, defaultLevel)
+    } else if (key === '=' || key === '+') {
+      if (typeof event.preventDefault === 'function') {
+        event.preventDefault()
+      }
+
+      const step = opts?.getZoomStep?.() ?? 0.1
+      const current = webContents.getZoomLevel()
+      opts?.setAndPersistZoomLevel?.(window, current + step)
+    } else if (key === '-') {
+      if (input.shift) {
+        return
+      }
+
+      if (typeof event.preventDefault === 'function') {
+        event.preventDefault()
+      }
+
+      const step = opts?.getZoomStep?.() ?? 0.1
+      const current = webContents.getZoomLevel()
+      opts?.setAndPersistZoomLevel?.(window, current - step)
+    }
+  }
+
+  webContents.on('before-input-event', inputHandler)
+
+  const zoomChangedHandler = (event: Electron.Event, zoomDirection: 'in' | 'out') => {
+    if (typeof event.preventDefault === 'function') {
+      event.preventDefault()
+    }
+
+    const step = opts?.getZoomStep?.() ?? 0.1
+    const delta = zoomDirection === 'in' ? step : -step
+    const current = webContents.getZoomLevel()
+    opts?.setAndPersistZoomLevel?.(window, current + delta)
+  }
+
+  webContents.on('zoom-changed', zoomChangedHandler)
+
+  return () => {
+    window.off('focus', focusHandler)
+    focusGraceUntil.delete(windowId)
+
+    if (!webContents.isDestroyed()) {
+      webContents.off('before-input-event', inputHandler)
+      webContents.off('zoom-changed', zoomChangedHandler)
+    }
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -7073,34 +7073,9 @@ function installDevToolsShortcut(window) {
   })
 }
 
-function installPreviewShortcut(window) {
-  window.webContents.on('before-input-event', (event, input) => {
-    const key = String(input.key || '').toLowerCase()
-    const accel = (IS_MAC ? input.meta : input.control) && !input.alt
-    const isCloseTabShortcut = key === 'w' && accel && !input.shift
 
-    // Always claim ⌘W here (the File>Close item deliberately has no
-    // accelerator, so nothing else does). The renderer decides tab-vs-window
-    // — no `previewShortcutActive` gate, so it works for every closeable tab.
-    if (isCloseTabShortcut) {
-      event.preventDefault()
-      sendClosePreviewRequested()
 
-      return
-    }
-
-    // ⌘R rides here rather than on the View menu item for the same reason:
-    // the application menu only exists on macOS (it is set to null elsewhere,
-    // see #77845), so a menu accelerator would leave Windows and Linux with no
-    // way to reload a page at all. ⇧⌘R is left alone — that is `forceReload`,
-    // the unconditional whole-window escape hatch.
-    if (key === 'r' && accel && !input.shift) {
-      event.preventDefault()
-      sendPreviewNavCommand('reload')
-    }
-  })
-}
-
+import { installInputShortcuts } from './input-shortcuts'
 // Zoom level is persisted in the renderer's own localStorage (per-origin,
 // survives reloads/restarts) rather than a main-process JSON file. The main
 // process owns setZoomLevel, so we mirror each change into localStorage and
@@ -7189,57 +7164,7 @@ function restorePersistedZoomLevel(window) {
     .catch(error => rememberLog(`[zoom] restore failed: ${error?.message || error}`))
 }
 
-function installZoomShortcuts(window) {
-  // Override Ctrl/Cmd + +/-/0 with half Chromium's default zoom step (ZOOM_STEP
-  // is 0.1 vs Chromium's 0.2). The menu items handle this on macOS (where the
-  // menu is always present), but on Linux/Windows the menu is null and
-  // Chromium's default handler would use the full 0.2 step, so we intercept
-  // here for consistency. Ctrl/Cmd+0 resets to DEFAULT_ZOOM_LEVEL, not Chromium 0.
-  window.webContents.on('before-input-event', (event, input) => {
-    const mod = IS_MAC ? input.meta : input.control
 
-    if (!mod || input.alt) {
-      return
-    }
-
-    const key = input.key
-
-    if (key === '0') {
-      if (input.shift) {
-        return // Ctrl/Cmd+Shift+0 is not a zoom chord — leave it alone
-      }
-
-      event.preventDefault()
-      setAndPersistZoomLevel(window, DEFAULT_ZOOM_LEVEL)
-    } else if (key === '=' || key === '+') {
-      // Zoom-in must accept the shift modifier: on US layouts Plus is
-      // physically Shift+=, so Cmd+Plus arrives as Cmd+Shift+'+' (or '='
-      // depending on platform). The old blanket shift guard silently
-      // dropped keyboard zoom-in on macOS (#43517).
-      event.preventDefault()
-      setAndPersistZoomLevel(window, window.webContents.getZoomLevel() + ZOOM_STEP)
-    } else if (key === '-') {
-      if (input.shift) {
-        return // Shift+'-' is '_' territory on most layouts, not zoom-out
-      }
-
-      event.preventDefault()
-      setAndPersistZoomLevel(window, window.webContents.getZoomLevel() - ZOOM_STEP)
-    }
-  })
-
-  // Ctrl/Cmd + mouse wheel — the standard desktop/browser zoom gesture
-  // (#40295). Chromium surfaces it as the main-process 'zoom-changed' event
-  // (wheel events are DOM-side, so before-input-event never sees them).
-  // Route through the same persist+notify funnel as the keyboard shortcuts
-  // so wheel zoom survives restarts and the settings Scale control stays in
-  // sync, and use the same half step for consistency.
-  window.webContents.on('zoom-changed', (event, zoomDirection) => {
-    event.preventDefault()
-    const delta = zoomDirection === 'in' ? ZOOM_STEP : -ZOOM_STEP
-    setAndPersistZoomLevel(window, window.webContents.getZoomLevel() + delta)
-  })
-}
 
 /**
  * The custom (renderer) context menu's main-process half.
@@ -13333,7 +13258,15 @@ async function startHermes() {
 // Alt+wheel scale, so inheriting the global UI zoom would render the mascot
 // larger than its window and crop it. Chat windows keep zoom on.
 function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {}) {
-  installPreviewShortcut(win)
+  installInputShortcuts(win, IS_MAC, {
+    sendClosePreviewRequested,
+    sendPreviewNavCommand,
+    ...(zoom && {
+      setAndPersistZoomLevel,
+      getDefaultZoomLevel: () => DEFAULT_ZOOM_LEVEL,
+      getZoomStep: () => ZOOM_STEP
+    })
+  })
   installDevToolsShortcut(win)
   installBrowserNavGestures(win)
 
@@ -13348,7 +13281,6 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
   }
 
   if (zoom) {
-    installZoomShortcuts(win)
     // Re-apply persisted zoom on show/restore/resize/cross-display move
     // (Chromium can drop webContents zoom after these window transitions), on
     // EVERY full load — not once, since crash recovery reloads and would


### PR DESCRIPTION
Fixes #105498

## Problem

`installPreviewShortcut` and `installZoomShortcuts` fire `sendClosePreviewRequested()` / `sendPreviewNavCommand('reload')` / zoom adjustments on **both** `keyDown` and `keyUp` of Ctrl/Cmd+W / R / 0/+/−.

When another app (e.g. a browser) closes via Ctrl+W and Windows activates Hermes mid-chord, the leftover **W keyup** lands on our `webContents` → `before-input-event` fires with `input.type === 'keyUp'` → Close Tab runs → session tab closes without the user pressing anything *in* Hermes (#105498).

The same hole exists for Ctrl+R (reload on keyup) and zoom shortcuts (re-apply zoom on keyup of a held key).

## Solution

- Extract `installPreviewShortcut` + `installZoomShortcuts` into a new testable `input-shortcuts.ts` module (pattern: `find-in-page.ts`, `healed-branch.ts` — main.ts doesn't load without Electron).
- Gate all accelerators on `input.type === 'keyDown'` and `!input.isAutoRepeat`.
- Add a 200ms focus-grace window: after `BrowserWindow` `'focus'`, ignore accelerators for 200ms, so a synthesized keydown-on-activate (if Windows/Chromium injects one while physical keys are still down) can't close a tab either.
- Mirror the `typeof event.preventDefault === 'function'` guard from `find-in-page.ts` (defensive against test fakes).
- Unit tests: keyUp / autoRepeat / focus-grace all blocked; keyDown after grace fires the shortcut.

Local gates: tsc + eslint clean.

CI will verify the electron test suite (vitest local cache flaked on my scratch clone — full run when fresh).
