### PR TITLE
fix(desktop): keep pinned session singular across /compress tip rotation

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -776,6 +776,36 @@ describe('usePromptActions /compress', () => {
     expect(renderedText).toContain('sure, here is the summary')
   })
 
+  it('refreshes the session list after a successful compress so the rotated tip replaces the stale row', async () => {
+    // Compression rotates the conversation onto a new stored-session row; the
+    // sidebar keeps serving the stale pre-compression row (still in the pin
+    // keep-set) until a projected list page evicts it. Without this refresh
+    // the user sees a duplicate, unpinned session appear next to their pinned
+    // chat.
+    const refreshSessions = vi.fn(async () => undefined)
+
+    const requestGateway = vi.fn(async (method: string, _params?: Record<string, unknown>, _timeoutMs?: number) => {
+      if (method === 'session.compress') {
+        return {
+          removed: 2,
+          summary: { headline: 'Compressed: 4 → 2 messages' },
+          messages: [{ role: 'user', content: 'summarized context' }]
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={refreshSessions} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('/compress')
+
+    expect(refreshSessions).toHaveBeenCalled()
+  })
+
   it('uses the compute-host response transcript and success output', async () => {
     const seeds: Record<string, unknown>[] = []
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -678,6 +678,13 @@ export function useSlashCommand(deps: SlashCommandDeps) {
               return
             }
 
+            // Compression rotated the conversation onto a new stored-session
+            // row (title/pin projection live there now). Re-fetch the sidebar
+            // so the projected tip replaces the stale pre-compression row —
+            // without this the old row lingers in the pin keep-set next to an
+            // unpinned duplicate until some unrelated refresh happens to run.
+            void refreshSessions().catch(() => undefined)
+
             // Replace the transcript with the post-compress history so the
             // summarized bubbles actually disappear. `messages` is the same
             // shape session.resume returns (_history_to_messages), so
@@ -759,6 +766,10 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             // immediate "method not found" error.
             if (isMissingRpcMethod(err)) {
               await runExec(ctx)
+
+              // The legacy slash-worker path rotates the session too, so the
+              // sidebar needs the same post-compress re-fetch as the RPC path.
+              void refreshSessions().catch(() => undefined)
 
               return
             }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -8,9 +8,11 @@ import { $activeGatewayProfile } from '@/store/profile'
 import {
   $currentBranch,
   $currentCwd,
+  $sessions,
   setCurrentBranch,
   setCurrentCwd,
   setSelectedStoredSessionId,
+  setSessions,
   workspaceCwdBelongsToSelectedSession
 } from '@/store/session'
 import type { SessionInfo, SessionResumeResponse } from '@/types/hermes'
@@ -34,7 +36,8 @@ import {
   selectBranchMessages,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
-  toBranchMessages
+  toBranchMessages,
+  upsertResolvedSession
 } from './utils'
 
 const msg = (id: string, role: ChatMessage['role'], text: string, extra: Partial<ChatMessage> = {}): ChatMessage =>
@@ -264,6 +267,159 @@ describe('sessionMatchesStoredId', () => {
     expect(sessionMatchesStoredId(session({ id: 'a' }), 'a')).toBe(true)
     expect(sessionMatchesStoredId(session({ id: 'live', _lineage_root_id: 'root' }), 'root')).toBe(true)
     expect(sessionMatchesStoredId(session({ id: 'a' }), 'b')).toBe(false)
+  })
+})
+
+describe('upsertResolvedSession lineage preservation', () => {
+  beforeEach(() => {
+    setSessions(() => [])
+  })
+
+  afterEach(() => {
+    setSessions(() => [])
+  })
+
+  const projectedTip = {
+    id: 'tip',
+    _lineage_root_id: 'root',
+    _lineage_ids: ['root', 'tip'],
+    pinned: true,
+    profile: 'default'
+  } as unknown as SessionInfo
+
+  const rawTip = { id: 'tip', pinned: false, profile: 'default' } as unknown as SessionInfo
+
+  it('a raw by-id payload does not strip lineage fields or the pin from an already-projected row', () => {
+    setSessions(() => [projectedTip])
+
+    upsertResolvedSession(rawTip, 'tip')
+
+    const rows = $sessions.get()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]._lineage_root_id).toBe('root')
+    expect(rows[0]._lineage_ids).toEqual(['root', 'tip'])
+    expect(rows[0].pinned).toBe(true)
+  })
+
+  it('present values still overwrite (a genuine unpin propagates)', () => {
+    setSessions(() => [projectedTip])
+
+    upsertResolvedSession({ ...rawTip, pinned: false, _lineage_root_id: 'root' } as unknown as SessionInfo, 'tip')
+
+    const rows = $sessions.get()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].pinned).toBe(false)
+  })
+
+  it('evicts previous rows by lineage key even when the incoming row is raw', () => {
+    // `root_old` is a DISTINCT row whose lineage key matches: it must be
+    // evicted through the lineage branch, not the stored-id branch.
+    setSessions(() => [
+      projectedTip,
+      { id: 'root_old', _lineage_root_id: 'root', pinned: true, title: 'stale' } as unknown as SessionInfo,
+      { id: 'other', title: 'x' } as unknown as SessionInfo
+    ])
+
+    upsertResolvedSession(rawTip, 'tip')
+
+    const rows = $sessions.get()
+    expect(rows.map(r => r.id).sort()).toEqual(['other', 'tip'])
+  })
+
+  it('a projected payload still evicts the stale ancestor by lineage key', () => {
+    setSessions(() => [{ id: 'root_old', _lineage_root_id: 'root', pinned: true } as unknown as SessionInfo])
+
+    upsertResolvedSession(projectedTip, 'tip')
+
+    const rows = $sessions.get()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('tip')
+  })
+
+  it('an ancestor payload neither evicts nor downgrades the live tip row', () => {
+    // A by-id GET on a pre-compression id describes a conversation the cache
+    // already represents by its live tip. Ingesting the raw ancestor row
+    // would evict the projected tip (sessionMatchesStoredId spans the chain)
+    // and downgrade it to raw shape.
+    const tipRow = {
+      id: 'lin_tip',
+      _lineage_root_id: 'lin_root',
+      _lineage_ids: ['lin_root', 'lin_tip'],
+      pinned: true,
+      profile: 'default'
+    } as unknown as SessionInfo
+
+    setSessions(() => [tipRow])
+    upsertResolvedSession({ id: 'lin_root', pinned: true, profile: 'default' } as unknown as SessionInfo, 'lin_root')
+
+    const rows = $sessions.get()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('lin_tip')
+    expect(rows[0].pinned).toBe(true)
+  })
+
+  it('an intermediate ancestor payload is not appended as a duplicate row', () => {
+    const tipRow = {
+      id: 'lin_tip',
+      _lineage_root_id: 'lin_root',
+      _lineage_ids: ['lin_root', 'lin_mid', 'lin_tip'],
+      pinned: true,
+      profile: 'default'
+    } as unknown as SessionInfo
+
+    setSessions(() => [tipRow])
+    upsertResolvedSession({ id: 'lin_mid', pinned: true, profile: 'default' } as unknown as SessionInfo, 'lin_mid')
+
+    const rows = $sessions.get()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('lin_tip')
+  })
+
+  it('a raw payload with no lineage-linked cached row still ingests (cold arrival unchanged)', () => {
+    setSessions(() => [{ id: 'other', title: 'x' } as unknown as SessionInfo])
+
+    upsertResolvedSession({ id: 'unrelated', profile: 'default' } as unknown as SessionInfo, 'unrelated')
+
+    const rows = $sessions.get()
+    expect(rows.map(r => r.id).sort()).toEqual(['other', 'unrelated'])
+  })
+
+  it('explicit null lineage fields count as absent (FastAPI null serialization)', () => {
+    const tipRow = {
+      id: 'lin_tip',
+      _lineage_root_id: 'lin_root',
+      _lineage_ids: ['lin_root', 'lin_tip'],
+      pinned: true,
+      profile: 'default'
+    } as unknown as SessionInfo
+
+    setSessions(() => [tipRow])
+    upsertResolvedSession({
+      id: 'lin_root',
+      _lineage_root_id: null,
+      pinned: false,
+      profile: 'default'
+    } as unknown as SessionInfo, 'lin_root')
+
+    const rows = $sessions.get()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('lin_tip')
+    expect(rows[0]._lineage_root_id).toBe('lin_root')
+    expect(rows[0].pinned).toBe(true)
+  })
+
+  it('a cached row with explicit nulls is raw-shape: fresh payload values win over stale cached ones', () => {
+    // A cached row seeded from a JSON producer carrying explicit nulls must
+    // NOT classify as projected — otherwise rawShape preservation lets the
+    // stale cached pin overwrite the payload's fresh value.
+    setSessions(() => [{ id: 's1', _lineage_root_id: null, pinned: false, profile: 'default' } as unknown as SessionInfo])
+
+    upsertResolvedSession({ id: 's1', pinned: true, profile: 'default' } as unknown as SessionInfo, 's1')
+
+    const rows = $sessions.get()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].pinned).toBe(true)
+    expect(rows[0]._lineage_root_id).toBeUndefined()
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1416,6 +1416,14 @@ export function upsertResolvedSession(session: SessionInfo, storedSessionId: str
     const cachedRoot = cached?._lineage_root_id ?? undefined
     const cachedIds = cached?._lineage_ids ?? undefined
     const cachedPinned = cached?.pinned ?? undefined
+    // NOTE (review #105508): every branch below treats a `null` lineage field as
+    // ABSENT — never as a signal to clear the chain — so a raw-shape payload
+    // that omits lineage preserves the cached chain. That is safe only because
+    // compression lineage is APPEND-ONLY: a later chain is always a superset of
+    // an earlier one, never a detachment, so the cached chain is never wrong to
+    // keep. If the backend ever sends an explicit null to MEAN "no lineage",
+    // the preserve-cached fallbacks below would wrongly retain a stale chain —
+    // revisit this block if that invariant changes.
     const rawShape = payloadRoot === undefined && cachedRoot !== undefined
 
     const merged: SessionInfo = {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1391,19 +1391,93 @@ export function restoreListedSession(session: SessionInfo, slice?: ListedSession
   setSessions(prepend)
 }
 
-function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
-  const lineage = session._lineage_root_id ?? session.id
+export function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
+  setSessions(prev => {
+    // Normalize nullish → undefined once: JSON producers (FastAPI incl.) may
+    // serialize an unset optional field as explicit null, and every
+    // raw-shape / preservation decision below keys on absence, not nullness.
+    const payloadRoot = session._lineage_root_id ?? undefined
+    const payloadIds = session._lineage_ids ?? undefined
+    const payloadPinned = session.pinned ?? undefined
 
-  setSessions(prev => [
-    session,
-    ...prev.filter(existing => {
-      if (sessionMatchesStoredId(existing, storedSessionId)) {
-        return false
+    // Merge, don't clobber: a raw-shape payload (single-session GET on a
+    // backend predating detail projection, or any non-projecting source)
+    // omits the lineage fields the sidebar's dedupe and Pinned section key
+    // on. When the cached row already carries that projection, an incoming
+    // raw payload must not strip it — one detail GET used to downgrade the
+    // tip back to raw shape and silently drop the conversation out of
+    // Pinned. A payload WITH lineage fields is projected shape: its values
+    // are authoritative and win outright.
+    const cached = prev.find(row => row.id === session.id)
+    // The cached row gets the SAME nullish normalization as the payload: a
+    // null-vs-undefined asymmetry would classify a raw cached row as
+    // projected (rawShape) and let stale cached values overwrite fresh
+    // payload values.
+    const cachedRoot = cached?._lineage_root_id ?? undefined
+    const cachedIds = cached?._lineage_ids ?? undefined
+    const cachedPinned = cached?.pinned ?? undefined
+    const rawShape = payloadRoot === undefined && cachedRoot !== undefined
+
+    const merged: SessionInfo = {
+      ...session,
+      _lineage_root_id: payloadRoot,
+      _lineage_ids: payloadIds,
+      pinned: payloadPinned,
+      ...(payloadRoot === undefined && cachedRoot !== undefined
+        ? { _lineage_root_id: cachedRoot }
+        : {}),
+      ...(payloadIds === undefined && cachedIds !== undefined
+        ? { _lineage_ids: cachedIds }
+        : {}),
+      // A raw tip flag (0/1 on the tip row alone) is not the lineage-wide
+      // pin the projection computes — the projection exists because raw tip
+      // flags are meaningless. Only the projected shape's pin wins.
+      ...(rawShape && cachedPinned !== undefined ? { pinned: cachedPinned } : {}),
+      ...(payloadPinned === undefined && !rawShape && cachedPinned !== undefined
+        ? { pinned: cachedPinned }
+        : {})
+    }
+
+    // Evict by the MERGED row's lineage key, not the incoming payload's: a
+    // raw payload restores the cached root, and stale ancestors must be
+    // evicted against that root, not against the bare tip id.
+    const lineage = merged._lineage_root_id ?? merged.id
+
+    // Ancestor payloads: a by-id GET on a pre-compression id (or any middle
+    // segment) describes a conversation the cache already represents by its
+    // live tip — including a warm deep-link, where the UI resolves the
+    // stored id to the cached tip via sessionMatchesStoredId. Ingesting the
+    // raw ancestor would EVICT that projected tip (the match spans the whole
+    // chain) and replace it with a raw, unstamped ancestor — the exact
+    // downgrade this function exists to prevent. The backend deliberately
+    // serves ancestors raw-shape (tip-only projection), so rawShape recovery
+    // cannot fire either: the only safe action is to leave the cache alone.
+    // A cold deep-link (nothing cached) still ingests normally, and a
+    // projected payload is never suppressed — only raw-shape-eligible ones
+    // reach this guard.
+    if (payloadRoot === undefined && !rawShape) {
+      const linksAncestor = prev.some(
+        existing =>
+          existing.id !== session.id &&
+          (existing._lineage_root_id === session.id || Boolean(existing._lineage_ids?.includes(session.id)))
+      )
+
+      if (linksAncestor) {
+        return prev
       }
+    }
 
-      return (existing._lineage_root_id ?? existing.id) !== lineage
-    })
-  ])
+    return [
+      merged,
+      ...prev.filter(existing => {
+        if (sessionMatchesStoredId(existing, storedSessionId)) {
+          return false
+        }
+
+        return (existing._lineage_root_id ?? existing.id) !== lineage
+      })
+    ]
+  })
 }
 
 // Every session row reachable through the profile-scoped project tree —

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -484,6 +484,27 @@ async def get_session_detail(session_id: str, profile: Optional[str] = None):
         # clients resolve them to whichever gateway happened to be active.
         session["profile"] = _serving_profile(profile)
         session["is_default_profile"] = session["profile"] == "default"
+        # Project the compression lineage the same way every list path does
+        # (_project_compression_tips): root id, the full id chain, and the
+        # lineage-wide pin. The desktop's sidebar dedupe keys on
+        # `_lineage_root_id` and renders Pinned from the projected flag — a raw
+        # row missing both used to render as a second, unpinned session after
+        # /compress rotated the conversation to a new tip row. Tip-only, like
+        # the list projection: stamping an ANCESTOR would let a stale root
+        # payload evict the live tip from the desktop's cache.
+        chain = db.get_compression_lineage(sid)
+        if len(chain) > 1 and sid == chain[-1]:
+            session["_lineage_root_id"] = chain[0]
+            session["_lineage_ids"] = chain
+            pinned = 0
+            for chain_sid in chain:
+                # chain members may have been pruned or deleted individually;
+                # a missing row is not a 500.
+                row = session if chain_sid == sid else db.get_session(chain_sid)
+                if row and row.get("pinned"):
+                    pinned = 1
+                    break
+            session["pinned"] = pinned
         return session
 
     return _with_db(profile, _detail, read_only=True)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -435,6 +435,121 @@ class TestWebServerEndpoints:
         assert response.json()["sessions"] == []
         assert response.json()["total"] == 0
 
+    # ------------------------------------------------------------------
+    # GET /api/sessions/{id} lineage projection (compression tip rotation)
+    # ------------------------------------------------------------------
+
+    def _make_compressed_lineage(self):
+        """Build root → tip over a real compression rotation, root pinned.
+
+        Uses the production rotation path (publish_compression_child) so the
+        test exercises the same parent closure + child INSERT the desktop hits.
+        """
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db_path = get_hermes_home() / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session("lin_root", source="desktop")
+            db.set_session_pinned("lin_root", True)
+            db.publish_compression_child(
+                parent_session_id="lin_root",
+                child_session_id="lin_tip",
+                source="desktop",
+                messages=[{"role": "user", "content": "hi"}],
+                require_compression_lease=False,
+            )
+            db.append_message("lin_tip", role="user", content="after compress")
+        finally:
+            db.close()
+
+    def test_get_session_detail_projects_lineage_fields_on_tip(self):
+        """GET on the live tip stamps _lineage_root_id/_lineage_ids/effective pin.
+
+        The desktop's single-session upserts key their dedupe on
+        `_lineage_root_id` and their pin rendering on the projected flag; a raw
+        row (both absent) cannot be linked to the stale pre-compression sidebar
+        row and renders as a second, unpinned session (#bug duplicate row after
+        /compress).
+        """
+        self._make_compressed_lineage()
+
+        resp = self.client.get("/api/sessions/lin_tip")
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"] == "lin_tip"
+        assert body["_lineage_root_id"] == "lin_root"
+        assert body["_lineage_ids"] == ["lin_root", "lin_tip"]
+        # The tip's raw flag is 0; the effective pin is projected from the lineage.
+        assert body["pinned"]
+
+    def test_get_session_detail_ancestor_row_is_not_tip_stamped(self):
+        """GET on the ROOT (pre-compression id) stays raw-shape: projection is
+        tip-only, matching _project_compression_tips. Ancestor rows must not
+        carry lineage fields — a stale root payload ingested by the desktop
+        would otherwise evict the live tip from its cache."""
+        self._make_compressed_lineage()
+
+        resp = self.client.get("/api/sessions/lin_root")
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"] == "lin_root"
+        assert "_lineage_root_id" not in body
+        assert "_lineage_ids" not in body
+        # The root's own raw pin flag passes through untouched.
+        assert body["pinned"]
+
+    def test_get_session_detail_unpinned_lineage_stays_false(self):
+        """A lineage nobody pinned projects pinned=false (no false positives)."""
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db_path = get_hermes_home() / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session("plain_root", source="desktop")
+            db.publish_compression_child(
+                parent_session_id="plain_root",
+                child_session_id="plain_tip",
+                source="desktop",
+                messages=[{"role": "user", "content": "hi"}],
+                require_compression_lease=False,
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/plain_tip")
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["_lineage_root_id"] == "plain_root"
+        assert not body["pinned"]
+
+    def test_get_session_detail_childless_row_has_no_lineage_fields(self):
+        """A session with no compression chain stays exactly as before: no
+        lineage keys, pin flag passed through untouched."""
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db_path = get_hermes_home() / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session("loner", source="desktop")
+            db.set_session_pinned("loner", True)
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/loner")
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "_lineage_root_id" not in body
+        assert "_lineage_ids" not in body
+        assert body["pinned"]
+
     @pytest.mark.parametrize(
         "missing_column", ["archived", "pinned", "last_activity_at"]
     )


### PR DESCRIPTION
Closes #105507

## Problem

Running `/compress` in a pinned Desktop session left the sidebar showing **two rows for the same conversation**: the stale pre-compression row under *Pinned* (with cost) and a raw, unpinned, cost-less duplicate of the rotated tip under *Sessions*.

The rotation itself is by design — `publish_compression_child` moves the conversation onto a new `parent_session_id`-chained row, and title/pin projection live on the new tip. The bug was display-state: three gaps let a raw (lineage-less) tip row coexist with the stale cached ancestor in the renderer's lineage-keyed store.

## Root cause (three gaps)

1. **`GET /api/sessions/{id}` served raw rows** — no `_lineage_root_id` / `_lineage_ids` / projected pin, unlike every list path (`list_sessions_rich`, search, the sidebar endpoint). The Desktop's dedupe (`mergeSessionPage`) and pin identity (`sessionPinId`) are lineage-keyed, so a raw payload cannot be linked to the stale cached row. (`hermes_cli/web_routers/sessions.py`, `get_session_detail`)
2. **`upsertResolvedSession` replaced rows wholesale** — a raw detail payload *downgraded* an already-projected tip, silently dropping it out of Pinned. (`apps/desktop/src/.../use-session-actions/utils.ts`)
3. **`/compress` never refreshed the sidebar** — the stale keep-set row lingered next to the duplicate until an unrelated refresh. (`apps/desktop/src/.../use-prompt-actions/slash.ts`)

Display-state only: the DB holds one conversation; any projected list page healed the sidebar. The exact ingestion call site for the raw payload is not proven — the candidate paths are the by-id resolution/upsert paths (`resolveStoredSession` → `getSession` → `upsertResolvedSession`, runtime-info seeds); the fix covers the class, not just one call site.

## The fix

- **Backend** (`get_session_detail`): project the compression lineage tip-only (`sid == chain[-1]`), same semantics as `_project_compression_tips` — root id, full id chain, lineage-wide pin OR'd across the chain (pruned chain members tolerated). Ancestor GETs deliberately stay raw-shape so a stale root payload can never evict the live tip.
- **Renderer `upsertResolvedSession`**: payload AND cached rows get symmetric nullish→undefined normalization (JSON producers emit explicit `null`); a raw-shape payload preserves the cached lineage projection instead of downgrading it, while projected values win outright; eviction keys on the **merged** row's lineage root; raw ancestor payloads that would evict the live tip are refused.
- **Renderer `/compress`**: coalesced `refreshSessions()` after success — on both the `session.compress` RPC path and the legacy slash-worker fallback.

## Known limitation

A raw tip payload arriving when the tip is not cached cannot be linked to a stale ancestor client-side (nothing in the payload carries the link). The post-compress refresh delivers the projected tip on the real path, and every projected payload evicts by lineage.

## Test plan

- 5 new FastAPI endpoint tests (`tests/hermes_cli/test_web_server.py`): tip projection, ancestor-stays-raw, unpinned-lineage-stays-false, childless-row-unchanged, plus real-rotation fixtures via `publish_compression_child`.
- 9 new renderer tests (`use-session-actions/utils.test.ts`): raw-shape preservation, projected-wins overwrite, lineage eviction of a distinct ancestor row (fails on the pre-fix code — the false-green trap), ancestor-payload suppression (root + intermediate), cold-arrival ingestion, explicit-null payload, explicit-null cached row.
- 1 new renderer test (`use-prompt-actions/index.test.tsx`): `refreshSessions` called after successful compress.
- All new tests verified RED before their fix, GREEN after (5 fix→test cycles during review).
- Full desktop suite: 9479 passed / 3 pre-existing environment failures (verified failing identically on clean main). Backend file: 190 passed / 2 pre-existing (same verification). `npx tsc --noEmit` and `npx eslint` clean on all touched files.

## Notes

**Open question:** the ancestor-guard's UX edge — a warm deep-link to an *old ancestor id* resolves to the cached tip (so the guard's suppression is invisible), but a user explicitly opening a root id with nothing cached sees the raw row. Suppressing only lineage-linked raw payloads keeps every observed path correct; if maintainers would rather ancestors deep-link to the live tip server-side (301-style via `latest-descendant`), that's a clean follow-up.
