### PR TITLE
fix(desktop): use live busy state for voice submits

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.tsx
@@ -1,0 +1,154 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useComposerVoice } from './use-composer-voice'
+
+const mocks = vi.hoisted(() => ({
+  clearDraft: vi.fn(),
+  conversationSubmits: [] as Array<(text: string) => Promise<void>>,
+  onSubmit: vi.fn(async () => true),
+  resetBrowseState: vi.fn(),
+  triggerHaptic: vi.fn()
+}))
+
+vi.mock('@nanostores/react', () => ({
+  useStore: (store: { get: () => unknown }) => store.get()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      assistant: { thread: { readAloudFailed: '' } },
+      notifications: { voice: { sayStopToEnd: () => '' } },
+      settings: { config: { autosaveFailed: '' } }
+    }
+  })
+}))
+
+vi.mock('@/lib/haptics', () => ({
+  triggerHaptic: mocks.triggerHaptic
+}))
+
+vi.mock('@/lib/spoken-reply', () => ({
+  adoptSpokenReplySession: vi.fn(),
+  markAssistantIdSpoken: vi.fn(),
+  resolveSpokenReply: vi.fn(() => null)
+}))
+
+vi.mock('@/lib/tts-lease', () => ({
+  CONVERSATION_LEASE: 'conversation',
+  READ_ALOUD_LEASE: 'read-aloud',
+  syncTtsLease: vi.fn(async () => undefined)
+}))
+
+vi.mock('@/lib/wake-indicator', () => ({
+  clearWakeIndicator: vi.fn(),
+  syncWakeIndicatorWithVoice: vi.fn(() => false)
+}))
+
+vi.mock('@/store/composer', () => ({
+  $voiceConversationStartRequest: { get: () => null },
+  takeVoiceConversationStart: vi.fn(() => false)
+}))
+
+vi.mock('@/store/composer-input-history', () => ({
+  resetBrowseState: mocks.resetBrowseState
+}))
+
+vi.mock('@/store/gateway', () => ({
+  $gateway: { get: () => null }
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/store/voice-prefs', () => ({
+  $autoSpeakReplies: { get: () => false },
+  $voiceStopPhrase: { get: () => null },
+  setAutoSpeakReplies: vi.fn(async () => undefined)
+}))
+
+vi.mock('@/store/wake-word', () => ({
+  resumeWakeAfterVoice: vi.fn(async () => undefined)
+}))
+
+vi.mock('../focus', () => ({
+  onComposerVoiceToggleRequest: vi.fn(() => () => undefined)
+}))
+
+vi.mock('../scope', () => ({
+  useComposerScope: () => ({ $messages: { get: () => [] } })
+}))
+
+vi.mock('./use-auto-speak-replies', () => ({
+  useAutoSpeakReplies: vi.fn()
+}))
+
+vi.mock('./use-voice-conversation', () => ({
+  useVoiceConversation: ({ onSubmit }: { onSubmit: (text: string) => Promise<void> }) => {
+    mocks.conversationSubmits.push(onSubmit)
+
+    return {
+      end: vi.fn(async () => undefined),
+      level: 0,
+      muted: false,
+      start: vi.fn(async () => undefined),
+      status: 'idle',
+      stopTurn: vi.fn(),
+      toggleMute: vi.fn()
+    }
+  }
+}))
+
+vi.mock('./use-voice-recorder', () => ({
+  useVoiceRecorder: () => ({
+    dictate: vi.fn(),
+    voiceActivityState: { elapsedSeconds: 0, level: 0, status: 'idle' },
+    voiceStatus: 'idle'
+  })
+}))
+
+describe('useComposerVoice voice submission', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    mocks.conversationSubmits.length = 0
+  })
+
+  it('uses live busy state when a retained voice callback submits after barge-in', async () => {
+    const hook = renderHook(
+      ({ busy }) =>
+        useComposerVoice({
+          busy,
+          clearDraft: mocks.clearDraft,
+          disabled: false,
+          focusInput: vi.fn(),
+          insertText: vi.fn(),
+          maxRecordingSeconds: 60,
+          onSubmit: mocks.onSubmit,
+          onTranscribeAudio: vi.fn(async () => ''),
+          sessionId: 'session-1',
+          target: 'tile:test'
+        }),
+      { initialProps: { busy: true } }
+    )
+
+    const retainedSubmit = mocks.conversationSubmits[0]
+
+    hook.rerender({ busy: false })
+    await act(async () => retainedSubmit('change direction'))
+
+    expect(mocks.onSubmit).toHaveBeenCalledWith('change direction')
+    expect(mocks.clearDraft).toHaveBeenCalledTimes(1)
+    expect(mocks.resetBrowseState).toHaveBeenCalledWith('session-1')
+    expect(mocks.triggerHaptic).toHaveBeenCalledWith('submit')
+
+    hook.rerender({ busy: true })
+    await act(async () => retainedSubmit('do not double-submit'))
+
+    expect(mocks.onSubmit).toHaveBeenCalledTimes(1)
+    expect(mocks.clearDraft).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -64,6 +64,11 @@ export function useComposerVoice({
   // A tile's composer speaks ITS transcript, not the primary chat's.
   const { $messages } = useComposerScope()
   const [voiceConversationActive, setVoiceConversationActive] = useState(false)
+  // Barge-in can retain a submit callback from a render where the interrupted
+  // turn was still busy. Read the current gate when its transcript arrives so
+  // that stale closure does not silently drop the next voice turn.
+  const busyRef = useRef(busy)
+  busyRef.current = busy
   const ownsWakeIndicatorRef = useRef(false)
   const previousSessionIdRef = useRef(sessionId)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
@@ -125,7 +130,7 @@ export function useComposerVoice({
   }
 
   const submitVoiceTurn = async (text: string) => {
-    if (busy) {
+    if (busyRef.current) {
       return
     }
 


### PR DESCRIPTION
## What does this PR do?

Prevents a Desktop Voice Conversation barge-in transcript from being silently dropped when its retained submit callback was created while the interrupted agent turn was still busy.

`useVoiceConversation()` already waits on live busy state before submitting a captured interruption. The parent `submitVoiceTurn()` callback, however, could still read `busy=true` from the older render retained by the barge monitor and return without reaching the composer. This keeps the existing safety gate but makes it read the current busy value through a synchronously updated ref.

The reporter's [independent RED → GREEN follow-up](https://github.com/NousResearch/hermes-agent/issues/105497#issuecomment-5578216067) confirms the causal sequence at unit level: the retained callback produced zero semantic submissions before the fix, exactly one after it, and remained blocked while live busy was true. A patched live Windows Voice canary remains a separate follow-up.

Draft #95180 is adjacent but not a duplicate: it changes turn and capture lifetimes inside `useVoiceConversation()` and does not update this parent submit guard.

## Related Issue

Fixes #105497

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts`: read the live busy gate from a ref when a Voice callback submits.
- `apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.tsx`: retain the callback from a `busy=true` render, prove it submits after live busy clears, and preserve the live-busy block.

## How to Test

1. From `apps/desktop`, run the focused and adjacent Voice suites:

   ```bash
   npx vitest run --project ui \
     src/app/chat/composer/hooks/use-composer-voice.test.tsx \
     src/app/chat/composer/hooks/use-voice-conversation.test.tsx \
     src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
   ```

2. Verify all 12 tests pass.
3. Run `npm run typecheck`.
4. Run ESLint and Prettier against the two changed files.

The new regression was also run against the unfixed base first and failed with zero calls to the semantic `onSubmit`; the identical test passes after this patch.

The full UI suite was attempted: 7,334 tests passed and two existing `src/store/voice-prefs.test.ts` localStorage assertions failed. Those two failures reproduce when that unchanged file is run alone; its source, test, and `vitest.setup.ts` have no diff from `main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this Desktop TypeScript-only change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (x86_64), Node.js 24.11.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only state fix; no platform API changes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — this async coordination bug is covered by the retained-callback regression and the reporter's independent RED → GREEN verification.
