### PR TITLE
fix(feishu): treat 99992402 field-validation rejections as post-payload failures

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -120,6 +120,17 @@ _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+# Feishu also rejects malformed post payloads with the generic code 99992402
+# ("field validation failed") instead of the friendlier content-format message,
+# and the plain-text downgrade never fires (#81169: cron-origin post deliveries
+# failed with this code and no fallback). Matching it lets the downgrade fire
+# either way.
+_POST_FIELD_VALIDATION_RE = re.compile(r"field validation failed|\b99992402\b", re.IGNORECASE)
+
+
+def _post_rejected(text: str) -> bool:
+    """True when an error/response indicates the post payload was rejected."""
+    return bool(_POST_CONTENT_INVALID_RE.search(text) or _POST_FIELD_VALIDATION_RE.search(text))
 # --- Media type sets and upload constants ---
 _IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
 _AUDIO_EXTENSIONS = {".ogg", ".mp3", ".wav", ".m4a", ".aac", ".flac", ".opus", ".webm"}
@@ -1588,14 +1599,14 @@ class FeishuAdapter(BasePlatformAdapter):
                         chat_id=chat_id, msg_type=msg_type, payload=payload, reply_to=reply_to, metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if msg_type != "post" or not _post_rejected(str(exc)):
                         raise
                     logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
                     response = await _send_plain(chunk)
                 if (
                     msg_type == "post"
                     and not self._response_succeeded(response)
-                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+                    and _post_rejected(str(getattr(response, "msg", "") or ""))
                 ):
                     logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
                     response = await _send_plain(chunk)
@@ -1622,7 +1633,7 @@ class FeishuAdapter(BasePlatformAdapter):
         try:
             msg_type, payload = self._build_outbound_payload(content)
             result = await _update(msg_type, payload)
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
+            if not result.success and msg_type == "post" and _post_rejected(result.error or ""):
                 logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
                 result = await _update(
                     "text", json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
@@ -3779,8 +3790,45 @@ class FeishuAdapter(BasePlatformAdapter):
                 return response
             except Exception as exc:
                 last_error = exc
-                if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
-                    raise
+                if msg_type == "post" and _post_rejected(str(exc)):
+                    # Post payload rejected with field-validation: retry once as
+                    # plain text derived from the same content instead of raising.
+                    try:
+                        parsed = json.loads(payload)
+                        raw_content = parsed.get("zh_cn", {}).get("content", "") or ""
+                        # post payload content is a list of rows of elements;
+                        # join each element's text/md field into plain lines.
+                        if isinstance(raw_content, list):
+                            lines = []
+                            for row in raw_content:
+                                if not isinstance(row, list):
+                                    continue
+                                parts = []
+                                for el in row:
+                                    if isinstance(el, dict):
+                                        parts.append(str(el.get("text", "") or el.get("content", "") or ""))
+                                line = "".join(parts)
+                                if line.strip():
+                                    lines.append(line)
+                            md_text = "\n".join(lines)
+                        else:
+                            md_text = str(raw_content)
+                    except (json.JSONDecodeError, AttributeError):
+                        md_text = ""
+                    logger.warning("[Feishu] Post payload rejected by API; falling back to plain text")
+                    # Single bounded attempt (no retry loop): avoids stacking a
+                    # fresh retry budget on top of this loop's, and avoids
+                    # duplicate delivery if the API accepted but transport failed.
+                    return await self._send_raw_message(
+                        chat_id=chat_id,
+                        msg_type="text",
+                        payload=json.dumps(
+                            {"text": _strip_markdown_to_plain_text(md_text)},
+                            ensure_ascii=False,
+                        ),
+                        reply_to=reply_to,
+                        metadata=metadata,
+                    )
                 if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
                     raise
                 wait_seconds = 2 ** attempt

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -288,6 +288,48 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
             json.dumps({"text": "可以用 粗体 和 斜体。"}, ensure_ascii=False),
         )
 
+    def test_edit_message_falls_back_to_text_on_99992402_field_validation(self):
+        """Regression: post updates rejected with generic code 99992402
+        ("field validation failed") must also downgrade to plain text —
+        previously only the friendlier content-format message triggered
+        the fallback, so dispatch progress reports failed outright."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def update(self, request):
+                captured["calls"].append(request)
+                if len(captured["calls"]) == 1:
+                    return SimpleNamespace(success=lambda: False, code=99992402, msg="field validation failed")
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_progress",
+                    content="**P0-T4 完成**（commit `909814b1`）",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
+
 
 class TestAdapterModule(unittest.TestCase):
     def test_load_settings_uses_sdk_defaults_for_invalid_ws_reconnect_values(self):


### PR DESCRIPTION
## Problem

When a Feishu rich-text (`post`) payload is rejected, the API answers with either:
- the friendly `"content format of the post type is incorrect"` message, or
- the generic code **99992402 `"field validation failed"`**.

The plain-text downgrade paths in the adapter (send fallback, edit fallback) only match the friendly message. A 99992402 rejection therefore fails the delivery outright with no fallback — #81169 reports cron-origin post deliveries failing exactly this way, and the "no fallback" gap is called out in its title.

## Fix

- Add `_POST_FIELD_VALIDATION_RE` (`field validation failed|99992402`) and a `_post_rejected()` predicate covering both rejection signals.
- Use the predicate at all four downgrade sites (send-exception, send-response, edit-fallback, raw-send loop).
- In the raw-send retry loop, a rejected post payload now retries once as plain text derived from the same content (join the post rows' text elements) instead of raising.

This is deliberately complementary to the thread_id-routing fix family (#104943 / #81169 / #78975 / #35576): those stop *causing* field-validation errors; this makes any post-payload rejection degrade to plain text instead of losing the delivery.

## Testing

- New regression test `test_edit_message_falls_back_to_text_on_99992402_field_validation` (post update rejected with 99992402 → second call is plain text, result succeeds).
- Full `tests/gateway/test_feishu.py` green locally apart from two pre-existing failures on this machine (the networked rebind test and an unrelated concurrency timing test).

## Duplicate check

Searched open + merged PRs and issues for "99992402" / "feishu fallback": the existing reports target the thread_id routing root cause; no PR implements the payload-rejection downgrade.
