### PR TITLE
fix: return MCP test exit status

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1791,7 +1791,9 @@ cmd_gateway_enroll = _forward_command("cmd_gateway_enroll", "hermes_cli.gateway_
 cmd_prompt_size = _forward_command("cmd_prompt_size", "hermes_cli.prompt_size", "cmd_prompt_size", doc='Show a byte/char breakdown of the system prompt + tool schemas.')
 cmd_pairing = _forward_command("cmd_pairing", "hermes_cli.pairing", "pairing_command")
 cmd_plugins = _forward_command("cmd_plugins", "hermes_cli.plugins_cmd", "plugins_command")
-cmd_mcp = _forward_command("cmd_mcp", "hermes_cli.mcp_config", "mcp_command")
+cmd_mcp = _forward_command(
+    "cmd_mcp", "hermes_cli.mcp_config", "mcp_command", forward_return=True,
+)
 cmd_claw = _forward_command("cmd_claw", "hermes_cli.claw", "claw_command")
 cmd_import_agent = _forward_command("cmd_import_agent", "hermes_cli.agent_import", "import_agent_command")
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -580,12 +580,12 @@ def cmd_mcp_list(args=None):
     print()
 
 
-def cmd_mcp_test(args):
-    """Test connection to an MCP server."""
+def cmd_mcp_test(args) -> int:
+    """Test connection to an MCP server and return a process exit status."""
     name = args.name
     cfg = _lookup_server(name, _get_mcp_servers(), "Available")
     if cfg is None:
-        return
+        return 1
     print()
     print(color(f"  Testing '{name}'...", Colors.CYAN))
     if "url" in cfg:
@@ -611,13 +611,14 @@ def cmd_mcp_test(args):
         tools = _probe_single_server(name, cfg)
     except Exception as exc:
         _error(f"Connection failed ({(time.monotonic() - start) * 1000:.0f}ms): {exc}")
-        return
+        return 1
     _success(f"Connected ({(time.monotonic() - start) * 1000:.0f}ms)")
     _success(f"Tools discovered: {len(tools)}")
     if tools:
         print()
         _print_tools(tools, 36, 55)
     print()
+    return 0
 
 
 def _reauth_oauth_server(name: str, server_config: dict, *, flow: str | None = None) -> bool:
@@ -902,8 +903,7 @@ def mcp_command(args):
         "config": cmd_mcp_configure, "login": cmd_mcp_login, "reauth": cmd_mcp_reauth,
     }.get(action)
     if handler:
-        handler(args)
-        return
+        return handler(args)
     # No subcommand — drop the user into the catalog picker (same UX as `hermes plugin`).
     from hermes_cli.mcp_picker import run_picker
     run_picker()

--- a/tests/hermes_cli/test_mcp_cli_exit_status.py
+++ b/tests/hermes_cli/test_mcp_cli_exit_status.py
@@ -1,0 +1,83 @@
+"""Process-level exit-status coverage for ``hermes mcp test``."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+
+
+def _run_hermes(home: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["PYTHONPATH"] = str(ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", *args],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def _write_mcp_config(home: Path, servers: dict[str, dict[str, object]]) -> None:
+    home.mkdir()
+    # JSON is valid YAML and avoids coupling this process-level CLI test to a YAML writer.
+    (home / "config.yaml").write_text(json.dumps({"mcp_servers": servers}), encoding="utf-8")
+
+
+def test_mcp_test_missing_server_returns_nonzero_exit_status(tmp_path: Path) -> None:
+    result = _run_hermes(tmp_path / "hermes", "mcp", "test", "missing")
+
+    assert result.returncode == 1
+    assert "Server 'missing' not found in config." in result.stdout
+
+
+def test_mcp_test_connection_failure_returns_nonzero_exit_status(tmp_path: Path) -> None:
+    home = tmp_path / "hermes"
+    _write_mcp_config(home, {"broken": {"command": str(tmp_path / "does-not-exist")}})
+
+    result = _run_hermes(home, "mcp", "test", "broken")
+
+    assert result.returncode == 1
+    assert "Connection failed" in result.stdout
+
+
+def test_mcp_test_success_returns_zero_exit_status(tmp_path: Path) -> None:
+    server = tmp_path / "mcp_server.py"
+    server.write_text(
+        "import json\n"
+        "import sys\n"
+        "for line in sys.stdin:\n"
+        "    request = json.loads(line)\n"
+        "    request_id = request.get('id')\n"
+        "    if request_id is None:\n"
+        "        continue\n"
+        "    if request.get('method') == 'initialize':\n"
+        "        result = {'protocolVersion': request['params']['protocolVersion'], "
+        "'capabilities': {'tools': {}}, 'serverInfo': {'name': 'fixture', 'version': '1'}}\n"
+        "    elif request.get('method') == 'tools/list':\n"
+        "        result = {'tools': [{'name': 'ping', 'description': 'Ping', "
+        "'inputSchema': {'type': 'object', 'properties': {}}}]}\n"
+        "    else:\n"
+        "        result = {}\n"
+        "    print(json.dumps({'jsonrpc': '2.0', 'id': request_id, 'result': result}), flush=True)\n",
+        encoding="utf-8",
+    )
+    home = tmp_path / "hermes"
+    _write_mcp_config(home, {
+        "fixture": {"command": sys.executable, "args": [str(server)], "connect_timeout": 10},
+    })
+
+    result = _run_hermes(home, "mcp", "test", "fixture")
+
+    assert result.returncode == 0, result.stderr
+    assert "Connected" in result.stdout
+    assert "Tools discovered: 1" in result.stdout


### PR DESCRIPTION
## Summary
- return exit status 1 when `hermes mcp test` cannot find or connect to the selected server
- preserve exit status 0 after successful tool discovery
- add process-level CLI coverage for missing, failed, and successful MCP servers

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_cli_exit_status.py` (41 passed)