### PR TITLE
feat: expose resolved vision route

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2409,12 +2409,15 @@ def _set_relay_auxiliary_route(provider: str | None, model: str | None, api_mode
 
 
 def _record_route_info(
-    route_info: Optional[Dict[str, str]], provider: Optional[str], model: Optional[str]
+    route_info: Optional[Dict[str, str]], provider: Optional[str], model: Optional[str], *,
+    fallback_reason: Optional[str] = None,
 ) -> None:
-    """Expose the concrete route selected for one auxiliary call."""
+    """Expose the concrete route selected for one auxiliary call without request secrets."""
     if route_info is not None:
         route_info["provider"] = provider or "auto"
         route_info["model"] = model or "default"
+        if fallback_reason:
+            route_info["fallback_reason"] = fallback_reason
 
 
 def _relay_auxiliary_metadata(
@@ -6888,7 +6891,10 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
         # Second pass: the candidate credential was stale and quarantined — walk the discovery
         # chain once more (unhealthy entries are skipped).
         for _pass in range(2):
-            _record_route_info(route.route_info, _fallback_provider_from_label(fb_label), fb_model)
+            _record_route_info(
+                route.route_info, _fallback_provider_from_label(fb_label), fb_model,
+                fallback_reason=reason,
+            )
             fb_resp = yield _LadderStep("fallback", (fb_client, fb_model, fb_label))
             if fb_resp is not None:
                 return fb_resp

--- a/tests/agent/test_auxiliary_route_info.py
+++ b/tests/agent/test_auxiliary_route_info.py
@@ -1,0 +1,34 @@
+"""Route-info contracts for successful auxiliary provider fallback."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.auxiliary_client import _LadderRoute, _ladder_provider_fallback
+
+
+def test_provider_fallback_records_final_destination_and_reason(monkeypatch) -> None:
+    route_info: dict[str, str] = {}
+    route = _LadderRoute(
+        object(), "vision", "", True, "", "primary-provider", "primary/model", None,
+        None, None, "primary/model", None, route_info,
+    )
+    fallback_client = object()
+    monkeypatch.setattr(
+        "agent.auxiliary_client._try_configured_fallback_chain",
+        lambda *args, **kwargs: (fallback_client, "fallback/model", "fallback_chain[0](fallback-provider)"),
+    )
+
+    ladder = _ladder_provider_fallback(RuntimeError("payment required"), route)
+    step = next(ladder)
+
+    assert step.kind == "fallback"
+    assert step.args == (fallback_client, "fallback/model", "fallback_chain[0](fallback-provider)")
+    assert route_info == {
+        "provider": "fallback-provider",
+        "model": "fallback/model",
+        "fallback_reason": "payment error",
+    }
+    with pytest.raises(StopIteration) as completed:
+        ladder.send(object())
+    assert completed.value.value is not None

--- a/tests/tools/test_vision_result_observability.py
+++ b/tests/tools/test_vision_result_observability.py
@@ -1,0 +1,53 @@
+"""Behavioral coverage for auxiliary vision route observability."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tools.vision_tools import vision_analyze_tool
+
+
+VALID_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc```\x00\x00"
+    b"\x00\x04\x00\x01\xf6\x178U\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def _response(content: str) -> SimpleNamespace:
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
+
+
+@pytest.mark.asyncio
+async def test_vision_result_reports_final_route_without_credentials(tmp_path: Path) -> None:
+    image = tmp_path / "fixture.png"
+    image.write_bytes(VALID_PNG)
+
+    async def resolved_call(**kwargs):
+        kwargs["route_info"].update(
+            provider="fallback-provider",
+            model="fallback/model",
+            fallback_reason="payment error",
+            api_key="must-not-leak",
+            base_url="https://must-not-leak.example",
+        )
+        return _response("A blue pixel.")
+
+    with (
+        patch("tools.vision_tools._image_to_base64_data_url", return_value="data:image/png;base64,AA=="),
+        patch("tools.vision_tools.async_call_llm", new=resolved_call),
+    ):
+        result = json.loads(await vision_analyze_tool(str(image), "describe", "requested/model"))
+
+    assert result == {
+        "success": True,
+        "analysis": "A blue pixel.",
+        "provider": "fallback-provider",
+        "model": "fallback/model",
+        "fallbackReason": "payment error",
+    }

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -688,16 +688,33 @@ def _debug_call_data(kind: str, source: str, user_prompt: str, model) -> dict:
         "error": None, "success": False, "analysis_length": 0, "model_used": model, f"{kind}_size_bytes": 0}
 
 
-async def _call_vision_llm(call_kwargs: dict, empty_log: str, response=None):
-    """Aux vision LLM analysis text, retrying once on empty content (reasoning-only response).
-    ``response``: an already-made first call (the image path handles size-error retries itself)."""
+def _safe_route_info(route_info: Optional[dict]) -> dict:
+    """Keep only display-safe route identifiers from the auxiliary resolver."""
+    if not isinstance(route_info, dict):
+        return {}
+    return {
+        key: value.strip()
+        for key in ("provider", "model", "fallback_reason")
+        if isinstance((value := route_info.get(key)), str) and value.strip()
+    }
+
+
+async def _call_vision_llm(
+    call_kwargs: dict, empty_log: str, response=None, *, route_info: Optional[dict] = None,
+):
+    """Aux vision analysis text, retrying once on empty content.
+
+    ``route_info`` is populated by the auxiliary resolver with the selected provider/model and,
+    when provider fallback succeeds, a normalized fallback reason. It never carries credentials.
+    """
     _load_auxiliary_client()
     if response is None:
-        response = await async_call_llm(**call_kwargs)
+        response = await async_call_llm(**call_kwargs, route_info=route_info)
     analysis = extract_content_or_reasoning(response)
     if not analysis:
         logger.warning(empty_log)
-        analysis = extract_content_or_reasoning(await async_call_llm(**call_kwargs))
+        analysis = extract_content_or_reasoning(
+            await async_call_llm(**call_kwargs, route_info=route_info))
     return analysis
 
 
@@ -734,6 +751,12 @@ async def _run_analysis(
         result = {"success": True, "analysis": f"[{scale_note}] {analysis}" if scale_note else analysis}
         if scale_note:
             result["scale_note"] = scale_note
+        route_info = _safe_route_info(debug_call_data.get("route_info"))
+        for key in ("provider", "model"):
+            if value := route_info.get(key):
+                result[key] = value
+        if fallback_reason := route_info.get("fallback_reason"):
+            result["fallbackReason"] = fallback_reason
         debug_call_data.update(success=True, analysis_length=analysis_length)
         return finish(result)
     except Exception as e:
@@ -779,9 +802,10 @@ async def vision_analyze_tool(
         messages = _media_messages(prompt, "image_url", image_data_url)
         logger.info("Processing image with vision model...")
         call_kwargs = _aux_call_kwargs(messages, model, 120.0)
+        route_info: dict = {}
         _load_auxiliary_client()
         try:
-            response = await async_call_llm(**call_kwargs)
+            response = await async_call_llm(**call_kwargs, route_info=route_info)
         except Exception as _api_err:
             if not (_is_image_size_error(_api_err) and len(image_data_url) > _RESIZE_TARGET_BYTES):
                 raise
@@ -790,9 +814,12 @@ async def vision_analyze_tool(
                 len(image_data_url) / (1024 * 1024), _RESIZE_TARGET_BYTES / (1024 * 1024))
             image_data_url = await _resize_prepared(prepared, _scale_info)
             messages[0]["content"][1]["image_url"]["url"] = image_data_url
-            response = await async_call_llm(**call_kwargs)
+            response = await async_call_llm(**call_kwargs, route_info=route_info)
         analysis = await _call_vision_llm(
-            call_kwargs, "Vision LLM returned empty content, retrying once", response)
+            call_kwargs, "Vision LLM returned empty content, retrying once", response,
+            route_info=route_info,
+        )
+        debug_call_data["route_info"] = route_info
         return analysis, _build_scale_note(_scale_info or None, prepared.crop_offset or None)
     return await _run_analysis("image", image_url, user_prompt, model, stage)
 
@@ -999,7 +1026,11 @@ async def video_analyze_tool(
         debug_call_data["video_size_bytes"] = video_size_bytes
         messages = _media_messages(prompt, "video_url", video_data_url)
         call_kwargs = _aux_call_kwargs(messages, model, 180.0, min_timeout=180.0)
-        analysis = await _call_vision_llm(call_kwargs, "Empty video response, retrying once")
+        route_info: dict = {}
+        analysis = await _call_vision_llm(
+            call_kwargs, "Empty video response, retrying once", route_info=route_info,
+        )
+        debug_call_data["route_info"] = route_info
         return analysis, None
     return await _run_analysis("video", video_url, user_prompt, model, stage)
 


### PR DESCRIPTION
## Summary
- return the resolved auxiliary provider and model in successful vision/video tool results
- include a normalized fallback reason when provider fallback succeeds
- allowlist only display-safe route metadata so credentials and endpoint values cannot enter the result

## Test plan
- `scripts/run_tests.sh tests/agent/test_auxiliary_route_info.py tests/tools/test_vision_result_observability.py tests/tools/test_vision_tools.py` (39 passed)