### PR TITLE
fix(kanban): avoid duplicate completion run records

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2583,8 +2583,13 @@ def complete_task(
             conn, task_id, outcome="completed", status="done", summary=handoff_summary,
             metadata=metadata,
         )
-        # Never-claimed task: synthesize a run so the handoff fields survive.
-        if run_id is None and (summary or metadata or result or prior_status == "review"):
+        # Only a never-claimed task needs a synthetic completion run. A prior
+        # execution already has its own task_runs row; administrative completion
+        # must not manufacture a second execution attempt.
+        had_prior_run = run_id is None and conn.execute(
+            "SELECT 1 FROM task_runs WHERE task_id = ? LIMIT 1", (task_id,),
+        ).fetchone()
+        if run_id is None and not had_prior_run and (summary or metadata or result or prior_status == "review"):
             synth_summary, synth_metadata = handoff_summary, metadata
             if prior_status == "review" and not synth_summary and not synth_metadata:
                 synth_summary = _REVIEW_APPROVED_NOTE

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1198,6 +1198,28 @@ def test_complete_can_retry_after_phantom_rejection(kanban_home):
         conn.close()
 
 
+def test_completion_after_blocked_claim_does_not_synthesize_second_run(kanban_home):
+    """Administrative completion after a blocked execution is not a second run."""
+    conn = kbc.connect()
+    try:
+        task_id = kb.create_task(conn, title="blocked completion", assignee="worker")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert run_id is not None
+        assert kb.block_task(
+            conn, task_id, reason="handoff needs correction", expected_run_id=run_id,
+        )
+
+        assert kb.complete_task(conn, task_id, result="done", summary="validated")
+        runs = kb.list_runs(conn, task_id)
+        assert [run.id for run in runs] == [run_id]
+        assert runs[0].outcome == "blocked"
+        completed = [event for event in kb.list_events(conn, task_id) if event.kind == "completed"]
+        assert len(completed) == 1
+        assert completed[0].run_id is None
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> AI-assisted contribution: I used an AI coding agent during investigation and implementation. I reviewed the final diff and ran the verification listed below. I am responsible for the submitted change and follow-up.

## What does this PR do?

A claimed Kanban task can finish an execution as `blocked`, leaving a closed `task_runs` row. If that task is later completed administratively with a result or summary, `complete_task()` sees no *active* run and currently synthesizes a zero-duration `completed` run. That makes one execution look like two attempts in run history.

This only synthesizes a completion run when the task has no prior `task_runs` row. The administrative completion is still recorded by the existing `completed` event.

## Related Issue

N/A — no matching issue or PR found during the duplicate search.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/kanban_db.py`: check execution history before synthesizing a completion run.
- `tests/hermes_cli/test_kanban_core_functionality.py`: cover blocked execution followed by administrative completion.

## How to Test

Baseline reproduction on current `main`:
- one blocked execution has 1 run before administrative completion;
- after `complete_task(..., result="done", summary="validated")`, current main records 2 runs (`blocked`, `completed`).

Verification with this change:
- `pytest -q tests/hermes_cli/test_kanban_core_functionality.py::test_completion_after_blocked_claim_does_not_synthesize_second_run` → **1 passed**
- `pytest -q tests/hermes_cli/test_kanban_review_lifecycle.py` → **19 passed**
- `pytest -q tests/hermes_cli/test_kanban_core_functionality.py` → **25 passed**
- Ruff on the touched files → **passed**
- `py_compile`, `git diff --check`, and Windows-footgun scan → **passed**

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] Commit message follows Conventional Commits.
- [x] I searched open and closed PRs/issues for duplicate work.
- [x] The PR contains only this fix and its regression test.
- [ ] Full `pytest tests/ -q` was not run; focused and adjacent Kanban suites are listed above.
- [x] Regression coverage was added.
- [x] Tested on Linux.

### Documentation & Housekeeping

- [x] Documentation changes — N/A.
- [x] `cli-config.yaml.example` changes — N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes — N/A.
- [x] Cross-platform impact considered; this is SQLite/query logic with no platform-specific API.
- [x] Tool schema changes — N/A.

## Screenshots / Logs

N/A — this is an audit-history correctness fix covered by automated tests.