### PR TITLE
fix(gateway): size TimeoutStopSec past the shutdown watchdog so systemd cannot SIGKILL first

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -39,6 +39,15 @@ CRON_DRAIN_CLEANUP_RESERVE_S = 10.0
 # See #94759.
 SYSTEMD_STOP_HEADROOM_S = 30.0
 SYSTEMD_TIMEOUT_STOP_SEC_FLOOR = 60.0
+# Extra leash the out-of-loop shutdown watchdog holds beyond the drain budget before it dumps
+# stacks and ``os._exit``s (``gateway.shutdown_watchdog.resolve_shutdown_watchdog_delay``). Lives
+# here, not in ``shutdown_watchdog``, because ``shutdown_watchdog`` imports this module and
+# ``TimeoutStopSec`` must be sized against the SAME number: systemd cutting in first turns a
+# diagnosable hard-exit into a blind SIGKILL.
+DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S = 60.0
+# Slack systemd leaves the watchdog after its deadline to write the faulthandler dump and
+# ``os._exit``. That work is sub-second; this only has to keep systemd from racing it.
+SHUTDOWN_WATCHDOG_EXIT_RESERVE_S = 10.0
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
@@ -139,17 +148,29 @@ def resolve_systemd_timeout_stop_sec(
     drain_timeout: float, cron_drain_timeout: float = DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT, *,
     cleanup_reserve_s: float = CRON_DRAIN_CLEANUP_RESERVE_S, headroom_s: float = SYSTEMD_STOP_HEADROOM_S,
     floor_s: float = SYSTEMD_TIMEOUT_STOP_SEC_FLOOR,
+    watchdog_grace_s: float = DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S,
+    watchdog_exit_reserve_s: float = SHUTDOWN_WATCHDOG_EXIT_RESERVE_S,
 ) -> int:
     """Seconds systemd ``TimeoutStopSec`` must cover: the stop path may first wait
     ``cron_drain_timeout`` + ``cleanup_reserve_s`` for cron work, so sizing from the chat drain
     alone lets systemd SIGKILL an in-budget drain.  A zero cron timeout is an opt-out.
 
     ``restart_drain_timeout`` is only the chat-turn interrupt budget (default 0). See #94759.
+
+    It must ALSO outlast the in-process shutdown watchdog, which hard-exits at
+    ``drain_timeout + watchdog_grace_s``. Sizing from ``headroom_s`` alone inverts the two budgets
+    whenever ``watchdog_grace_s`` exceeds the cron/headroom term (e.g. drain 180s ⇒ watchdog at
+    240s but ``TimeoutStopSec`` 210s): systemd SIGKILLs first, so the watchdog's faulthandler dump
+    never runs and every hung stop is diagnosis-free. The watchdog is the intended last resort —
+    systemd is the backstop behind it.
     """
     drain = _seconds(drain_timeout)
     cron = _seconds(cron_drain_timeout)
     cron_budget = (cron + _seconds(cleanup_reserve_s)) if cron > 0.0 else 0.0
-    return int(max(_seconds(floor_s), max(drain, cron_budget) + _seconds(headroom_s)))
+    stop_budget = max(drain, cron_budget) + _seconds(headroom_s)
+    watchdog_budget = (drain + _seconds(watchdog_grace_s, DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S)
+                       + _seconds(watchdog_exit_reserve_s, SHUTDOWN_WATCHDOG_EXIT_RESERVE_S))
+    return int(max(_seconds(floor_s), stop_budget, watchdog_budget))
 
 
 def resolve_restart_exit_wait_budget(drain_timeout: float, after_turn_timeout: float, *, headroom: float = 15.0) -> float:

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -22,15 +22,20 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
-from gateway.restart import GATEWAY_SERVICE_RESTART_EXIT_CODE
+from gateway.restart import (
+    DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S as _DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S,
+    GATEWAY_SERVICE_RESTART_EXIT_CODE,
+)
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
 # Extra leash beyond ``agent.restart_drain_timeout`` so a slow-but-progressing drain survives.
-# Matches the issue #66892 suggested hardening.
-DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S = 60.0
+# Matches the issue #66892 suggested hardening. Defined in ``gateway.restart`` so
+# ``resolve_systemd_timeout_stop_sec`` sizes ``TimeoutStopSec`` against the same value and systemd
+# cannot SIGKILL before this watchdog dumps stacks; re-exported here for existing importers.
+DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S = _DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S
 DEFAULT_HEARTBEAT_INTERVAL_S = 30.0
 DEFAULT_LOOP_FLOOR_TIMER_INTERVAL_S = 5.0
 DEFAULT_LOOP_WATCHDOG_INTERVAL_S = 30.0

--- a/tests/gateway/test_cron_drain_floor.py
+++ b/tests/gateway/test_cron_drain_floor.py
@@ -27,6 +27,7 @@ from gateway.restart import (
     resolve_cron_drain_budget,
     resolve_systemd_timeout_stop_sec,
 )
+from gateway.shutdown_watchdog import resolve_shutdown_watchdog_delay
 from tests.gateway.restart_test_helpers import make_restart_runner
 
 
@@ -177,15 +178,17 @@ class TestResolveSystemdTimeoutStopSec:
         assert timeout > 60
 
     def test_configured_drain_still_extends_the_deadline_directly(self):
-        assert resolve_systemd_timeout_stop_sec(60.0, 30.0) == 90
-        assert resolve_systemd_timeout_stop_sec(180.0, 30.0) == 210
+        # Each is watchdog-bound: drain + 60s watchdog grace + 10s exit reserve.
+        assert resolve_systemd_timeout_stop_sec(60.0, 30.0) == 130
+        assert resolve_systemd_timeout_stop_sec(180.0, 30.0) == 250
 
     def test_larger_cron_floor_raises_timeout_stop_sec(self):
-        # 60s cron + 10s reserve + 30s headroom = 100s
+        # 60s cron + 10s reserve + 30s headroom = 100s, above the 0+60+10 watchdog budget.
         assert resolve_systemd_timeout_stop_sec(0.0, 60.0) == 100
 
     def test_zero_cron_floor_is_an_opt_out_not_a_hidden_default(self):
-        assert resolve_systemd_timeout_stop_sec(0.0, 0.0) == 60
+        # Cron opted out, but the watchdog still hard-exits at 0+60s, so systemd waits past it.
+        assert resolve_systemd_timeout_stop_sec(0.0, 0.0) == 70
 
     def test_cron_floor_never_shortens_a_long_drain(self):
         assert resolve_systemd_timeout_stop_sec(180.0, 30.0) == resolve_systemd_timeout_stop_sec(
@@ -193,4 +196,12 @@ class TestResolveSystemdTimeoutStopSec:
         )
 
     def test_garbage_inputs_degrade_to_the_floor(self):
-        assert resolve_systemd_timeout_stop_sec("soon", None) == 60
+        # Unparseable drain reads as 0s, leaving the watchdog budget (0+60+10) as the binding term.
+        assert resolve_systemd_timeout_stop_sec("soon", None) == 70
+
+    @pytest.mark.parametrize("drain", [0.0, 30.0, 60.0, 180.0, 600.0])
+    @pytest.mark.parametrize("cron", [0.0, 30.0, 300.0])
+    def test_systemd_never_sigkills_before_the_shutdown_watchdog_hard_exits(self, drain, cron):
+        """The watchdog dumps stacks then ``os._exit``s at drain+grace; systemd SIGKILLing first
+        destroys the only forensic artifact a wedged stop leaves behind (#66892 vs #94759)."""
+        assert resolve_systemd_timeout_stop_sec(drain, cron) > resolve_shutdown_watchdog_delay(drain)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -256,7 +256,9 @@ class TestGeneratedSystemdUnits:
         monkeypatch.setattr(gateway_cli, "_get_cron_drain_timeout", lambda: 0.0)
 
         unit = gateway_cli.generate_systemd_unit(system=False)
-        assert "TimeoutStopSec=60" in unit
+        # Cron opted out, but the shutdown watchdog still hard-exits at 0+60s;
+        # systemd's leash must sit past it (+10s exit reserve), not at the 60s floor.
+        assert "TimeoutStopSec=70" in unit
 
     def test_restart_exit_code_is_also_declared_a_success_status(self):
         """#104251: a planned restart (gateway/restart.py's exit 75) is force-restarted
@@ -1356,7 +1358,8 @@ class TestSystemUnitRefreshSyncsHermesHome:
         # Correct installed unit (operator's HERMES_HOME + drain timeout).
         monkeypatch.setenv("HERMES_HOME", str(alice_hermes))
         good_unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
-        assert "TimeoutStopSec=210" in good_unit
+        # alice's 180s drain: watchdog hard-exits at 240s, so the leash is 250s.
+        assert "TimeoutStopSec=250" in good_unit
         unit_path.write_text(good_unit, encoding="utf-8")
 
         # Simulate sudo without inherited HERMES_HOME (falls back to root).
@@ -2587,12 +2590,10 @@ class TestTimeoutStopSecCoversCronFloor:
             monkeypatch,
             "agent:\n  restart_drain_timeout: 60\n",
         )
-        # An explicit restart drain above the default cron floor (30+10=40)
-        # keeps the old formula's result — no regression for
-        # restart-drain-dominated installs. (Default installs differ from
-        # main: restart_drain_timeout defaults to 0, so the cron floor 40+30
-        # raises the leash from 60 to 70 — see the PR description.)
-        assert "TimeoutStopSec=90" in unit
+        # An explicit restart drain above the default cron floor (30+10=40) makes the
+        # restart drain the dominant stop-path term; the leash is then sized off the
+        # shutdown watchdog it must outlast: 60 drain + 60 grace + 10 exit reserve.
+        assert "TimeoutStopSec=130" in unit
 
     def test_env_override_extends_the_leash(self, tmp_path, monkeypatch):
         unit = self._unit_with_config(


### PR DESCRIPTION
Fixes #105517.

## Problem

`resolve_systemd_timeout_stop_sec()` sizes the systemd leash from the stop-path drain budget alone; `arm_shutdown_watchdog()` hard-exits at `drain + DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S` (60s). The two live in different modules and nothing compares them, so whenever the 60s watchdog grace exceeds the 30s `SYSTEMD_STOP_HEADROOM_S` term the budgets invert:

```
agent.restart_drain_timeout: 180
  TimeoutStopSec  = max(60, max(180, 40) + 30) = 210s   <-- systemd SIGKILLs here
  watchdog fires  = 180 + 60                   = 240s   <-- never reached
```

Field evidence (210s to the second, no dump file written, `lifecycle_ledger` reporting an unclean exit) is in the issue. The startup alignment check added by #94759 cannot flag it, because it validates the unit against this same function.

## Fix

Size `TimeoutStopSec` from **both** budgets:

```python
stop_budget     = max(drain, cron_budget) + headroom_s
watchdog_budget = drain + watchdog_grace_s + watchdog_exit_reserve_s
return int(max(floor_s, stop_budget, watchdog_budget))
```

`DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S` moves to `gateway/restart.py` — which `gateway/shutdown_watchdog.py` already imports for `GATEWAY_SERVICE_RESTART_EXIT_CODE`, so there is no new dependency edge and no cycle — and is re-exported under its original name, leaving every existing importer (including `tests/gateway/test_shutdown_watchdog.py`) untouched. One constant now feeds both the watchdog arming and unit generation.

`SHUTDOWN_WATCHDOG_EXIT_RESERVE_S = 10.0` keeps systemd from racing the watchdog's own faulthandler dump + `os._exit`, which is sub-second work.

## Effect on generated units

| `restart_drain_timeout` | `cron_drain_timeout` | before | after |
|---|---|---|---|
| 0 (default) | 30 (default) | 70 | 70 (unchanged) |
| 0 | 0 (opt-out) | 60 | 70 |
| 0 | 60 | 100 | 100 (unchanged) |
| 60 | 30 | 90 | 130 |
| 180 | 30 | 210 | 250 |

Default installs are unchanged. Only configs where the watchdog was previously unreachable get a longer leash — which is the bug being fixed. The leash only ever grows, so no install starts SIGKILLing earlier than it did.

## Tests

- **New invariant** (`test_systemd_never_sigkills_before_the_shutdown_watchdog_hard_exits`): parametrized over drain × cron, asserts `resolve_systemd_timeout_stop_sec(drain, cron) > resolve_shutdown_watchdog_delay(drain)`. Proven red on `main` — 10 of 15 combinations fail, including the `(180, 30)` field case.
- Existing arithmetic expectations in `test_cron_drain_floor.py` and `test_gateway_service.py` updated to the new values, with comments naming the binding term (stop budget vs watchdog budget) rather than restating the number.

```
scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py tests/gateway/test_shutdown_forensics.py \
  tests/gateway/test_cron_drain_floor.py tests/gateway/test_shutdown_watchdog.py \
  tests/gateway/test_restart_drain.py tests/gateway/test_gateway_shutdown.py
=== Summary: 6 files, 183 tests passed, 0 failed, 3 skipped in 11.3s ===
```

Operators on an affected install pick the fix up with `hermes gateway install --force`.