### PR TITLE
fix(plugins): snapshot sys.modules keys before evicting plugin submodules

### DIFF
--- a/hermes_cli/plugins_loader.py
+++ b/hermes_cli/plugins_loader.py
@@ -38,10 +38,16 @@ _BARE_MODULE_SCOPE: Dict[str, str] = {}  # bare module name -> owning scope_key
 
 
 def _evict_modules(module_name: str) -> None:
-    """Drop ``module_name`` and every ``module_name.*`` submodule from ``sys.modules``."""
+    """Drop ``module_name`` and every ``module_name.*`` submodule from ``sys.modules``.
+
+    ``sys.modules`` is process-global, so any concurrent import — another profile's plugin
+    load, a lazy import on a worker thread — mutates it while this runs. Snapshot the keys
+    with ``list()`` (one atomic C-level copy) instead of iterating the live mapping, and drop
+    with ``pop`` so a key another evictor already removed is not a ``KeyError``.
+    """
     prefix = f"{module_name}."
-    for name in [n for n in sys.modules if n == module_name or n.startswith(prefix)]:
-        del sys.modules[name]
+    for name in [n for n in list(sys.modules) if n == module_name or n.startswith(prefix)]:
+        sys.modules.pop(name, None)
 
 
 def _serialized_replacement(method):

--- a/tests/hermes_cli/test_plugin_loader_module_eviction.py
+++ b/tests/hermes_cli/test_plugin_loader_module_eviction.py
@@ -1,0 +1,91 @@
+"""Regression: ``_evict_modules`` must survive concurrent mutation of ``sys.modules``."""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+
+import pytest
+
+from hermes_cli import plugins_loader
+
+# Enough entries that the filtering pass spans several GIL switches.
+_MODULE_COUNT = 5000
+_EVICTIONS = 300
+# Batched so the mapping's *size* genuinely differs across the eviction's iteration window.
+_CHURN_BATCH = 50
+
+
+@pytest.fixture
+def isolated_modules(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Point the loader at a private ``sys.modules`` stand-in.
+
+    A real dict, because the fix rests on ``list(dict)`` being one atomic C-level copy —
+    a Python-level mapping stub would not exercise that property.
+    """
+    modules: dict[str, object] = {
+        f"unrelated_{i}": types.ModuleType(f"unrelated_{i}") for i in range(_MODULE_COUNT)
+    }
+    monkeypatch.setattr(plugins_loader, "sys", types.SimpleNamespace(modules=modules))
+    return modules
+
+
+def test_evict_modules_drops_module_and_submodules(isolated_modules: dict) -> None:
+    for name in ("hermes_plugins.aop", "hermes_plugins.aop.client", "hermes_plugins.aop_other"):
+        isolated_modules[name] = types.ModuleType(name)
+
+    plugins_loader._evict_modules("hermes_plugins.aop")
+
+    assert "hermes_plugins.aop" not in isolated_modules
+    assert "hermes_plugins.aop.client" not in isolated_modules
+    # A sibling sharing the prefix without the dot boundary must survive.
+    assert "hermes_plugins.aop_other" in isolated_modules
+
+
+def test_evict_modules_tolerates_concurrent_imports(isolated_modules: dict) -> None:
+    """A concurrent import must not abort the plugin load.
+
+    Iterating the live mapping raised ``RuntimeError: dictionary changed size during
+    iteration``; ``PluginLoader._load`` catches it and degrades to
+    ``Failed to load plugin '<name>': ...``, so none of that plugin's tools ever register
+    and every later lookup reports the tool as unknown.
+    """
+    stop = threading.Event()
+    failures: list[BaseException] = []
+
+    def churn() -> None:
+        i = 0
+        while not stop.is_set():
+            batch = [f"late_import_{i}_{j}" for j in range(_CHURN_BATCH)]
+            for key in batch:
+                isolated_modules[key] = None
+            for key in batch:
+                isolated_modules.pop(key, None)
+            i += 1
+
+    def evict() -> None:
+        try:
+            for i in range(_EVICTIONS):
+                name = f"hermes_plugins.victim_{i}"
+                isolated_modules[name] = None
+                isolated_modules[f"{name}.sub"] = None
+                plugins_loader._evict_modules(name)
+        except BaseException as exc:  # noqa: BLE001 - recorded for the assertion below
+            failures.append(exc)
+
+    previous_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)  # force frequent handoffs so the race is deterministic
+    churner = threading.Thread(target=churn, daemon=True)
+    churner.start()
+    try:
+        evictor = threading.Thread(target=evict)
+        evictor.start()
+        evictor.join(timeout=60)
+        assert not evictor.is_alive(), "eviction thread hung"
+    finally:
+        stop.set()
+        churner.join(timeout=10)
+        sys.setswitchinterval(previous_interval)
+
+    assert not failures, f"eviction raised under concurrent import: {failures[0]!r}"


### PR DESCRIPTION
## What does this PR do?

Fixes a race in the plugin loader that intermittently prevents a plugin from loading at all — and, because the failure is swallowed into a warning, presents downstream as "that tool does not exist".

`_evict_modules()` (`hermes_cli/plugins_loader.py`) iterated the **live** `sys.modules` mapping:

```python
for name in [n for n in sys.modules if n == module_name or n.startswith(prefix)]:
    del sys.modules[name]
```

`sys.modules` is process-global. Any concurrent import on another thread — a second plugin loading, a lazy import inside a worker, an adapter thread — changes its size mid-iteration and raises `RuntimeError: dictionary changed size during iteration`.

`_evict_modules` is called from `_load_directory_module()`, inside `PluginLoader._load()`'s `try`. That handler catches `Exception` and degrades it to:

```
WARNING hermes_cli.plugins: Failed to load plugin '<name>': dictionary changed size during iteration
```

So `register()` never runs, none of that plugin's tools reach the registry, and the gateway keeps serving — silently missing a whole plugin for the life of the process.

## Related Issue

No existing issue — found while diagnosing the downstream symptom in a production deployment.

Worth noting how it surfaces, because that path already has open work: with the plugin's tools unregistered, `is_deferrable_tool_name()` gets `None` from `_registry_toolset()` and the bridge answers

> `'<plugin_tool>' is not a deferrable tool. If it appears in the model-facing tools list already, call it directly instead of via tool_call.`

The tool is in neither the direct list nor the deferred index, so that advice cannot be followed. In our logs an agent burned ~10 `tool_search` calls and 3 `tool_call` retries against this, then reported to a human that the toolset was "not loaded in this session" and proposed a workaround that could never work. #82876 describes the same misleading-message shape (different cause), and #73424 / #83810 improve the bridge's behaviour for tools that *are* in scope. This PR is upstream of all three: it stops the tools from going missing in the first place.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins_loader.py` — `_evict_modules()` snapshots the keys with `list(sys.modules)` (one atomic C-level copy) before filtering, and drops with `sys.modules.pop(name, None)` so a key another evictor already removed is not a `KeyError`.
- `tests/hermes_cli/test_plugin_loader_module_eviction.py` — new; covers the eviction contract (module + `module.*` submodules, prefix siblings survive) and the concurrency regression.

Two other call sites iterate `sys.modules` the same way — `hermes_cli/plugin_dev.py:66` and `hermes_cli/doctor_platform.py:214`. Both are dev/diagnostic paths with no production evidence behind them, so they are left out to keep this PR narrow; happy to fold them in if you'd prefer the pattern fixed everywhere.

### Review follow-up (pushed on top)

- `refactor(plugins): make the sys.modules snapshot self-evident…` — no behaviour change. The snapshot
  was nested inside a list comprehension (`for n in [n for n in list(sys.modules) if …]`), where the
  `list()` reads as redundant beside the comprehension that already builds a list — the shape a later
  simplification pass deletes, reintroducing the race. Hoisted to the loop header, with the docstring
  stating that it is load-bearing and what removing it costs. The concurrency test could also pass
  vacuously (a churn thread that never got scheduled left the eviction alone with the mapping and
  asserted nothing), so it now asserts the churn ran and that the evictions took effect;
  `setswitchinterval` moved into a fixture so a `Thread.start()` failure cannot leak a 1e-6 interval
  into the rest of the file.
- `chore(contributors): map nmh9097@gmail.com to NaMinhyeok` — unblocks
  `Check contributors / check-attribution`. That job reads `git log --format='%ae'` (author emails)
  only; it never parses `Co-Authored-By` trailers, and `*anthropic.com*` is on its skip list either
  way, so no commit-graph rewrite was involved.

Re-verified after both: reverting `_evict_modules` alone fails the regression 5/5 with
`RuntimeError: dictionary changed size during iteration`; with the fix, green 3/3.
`tests/hermes_cli -k plugin` 624 passed, `ruff check` clean, `ty` clean on the changed lines.

## How to Test

The regression test drives a real dict through the loader's `sys.modules` reference (`monkeypatch` on the module's `sys`, so the process's real mapping is untouched) while a second thread batches inserts/removals, with `sys.setswitchinterval(1e-6)` to force handoffs.

```
pytest tests/hermes_cli/test_plugin_loader_module_eviction.py
```

- On the previous loop: `test_evict_modules_tolerates_concurrent_imports` fails **3/3** with `RuntimeError: dictionary changed size during iteration`.
- With the fix: passes; verified clean across 12 runs spanning mapping sizes 5k/50k and switch intervals 1e-6/1e-5.

Also run: `tests/hermes_cli/test_plugin_dev.py`, `tests/hermes_cli/test_plugin_ownership_ledger.py` — 37 passed. `ruff check` clean on both files. (The wider suite needs optional deps not installed in my minimal env; unrelated collection errors there.)

## Field evidence

From one long-running fleet (many gateway processes, one profile each), current + rotated logs:

- `Failed to load plugin '<name>': dictionary changed size during iteration` appears for **17 different plugins** across **20+ profiles**, continuously since 2026-08-13 — provider plugins (`openai` 27, `xai` 30, `nous` 22, `deepinfra` 18, `fal` 23, `openrouter`), web-search plugins (`web-tavily` 16, `web-xai` 14, `web-ddgs`, `web-brave-free`, `web-searxng`, `web-firecrawl`, `web-parallel`, `web-exa`), and directory plugins.
- The same handler also caught `No module named 'zoneinfo'` and `No module named 'statistics'`. **This PR does not fix those, and they are not this race.** `_evict_modules` only ever removes `hermes_plugins.<slug>` and its `.`-suffixed submodules, so it has no path to a stdlib entry; those lines share a log shape with this bug only because the same `except Exception` handler swallows both. Listed here as scope evidence for that handler (below), not as symptoms this change addresses — expect them to survive the merge.
- Effect is all-or-nothing per plugin and per process: the affected process runs to the next restart with that plugin's entire toolset absent.

