### PR TITLE
fix(weixin): gate outbound context_token echo behind a send_context_token opt-out

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -714,6 +714,11 @@ class WeixinAdapter(BasePlatformAdapter):
         # Tunables: ``extra.<key>`` else env ``WEIXIN_<KEY>`` (e.g. WEIXIN_SEND_CHUNK_RETRIES).
         self._send_chunk_delay_seconds = float(_extra_or_env(extra, "send_chunk_delay_seconds", "1.5"))
         self._send_chunk_retries = int(_extra_or_env(extra, "send_chunk_retries", "4"))
+        # iLink renders an outbound reply twice when sendmessage echoes the peer's context_token (#105506);
+        # keep echoing by default, but let operators turn it off per account.
+        self._send_context_token = _coerce_bool(
+            _extra_or_env(extra, "send_context_token", "true"), default=True
+        )
         self._send_chunk_retry_delay_seconds = float(_extra_or_env(extra, "send_chunk_retry_delay_seconds", "1.0"))
         self._send_text_gate = asyncio.Lock()
         self._rate_limit_circuit_threshold = max(1, int(_extra_or_env(extra, "rate_limit_circuit_threshold", "1")))
@@ -1072,7 +1077,11 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
-        context_token = self._token_store.get(self._account_id, chat_id)
+        context_token = (
+            self._token_store.get(self._account_id, chat_id)
+            if self._send_context_token
+            else None
+        )
         last_message_id: Optional[str] = None
         # Extract MEDIA: tags and bare local file paths before text delivery.
         media_files, cleaned_content = self.extract_media(content)
@@ -1189,7 +1198,11 @@ class WeixinAdapter(BasePlatformAdapter):
         if not upload_url:
             raise RuntimeError(f"getUploadUrl returned neither upload_param nor upload_full_url: {upload_response}")
         encrypted_query_param = await _upload_ciphertext(self._send_session, ciphertext=ciphertext, upload_url=upload_url)
-        context_token = self._token_store.get(self._account_id, chat_id)
+        context_token = (
+            self._token_store.get(self._account_id, chat_id)
+            if self._send_context_token
+            else None
+        )
         # iLink expects aes_key as base64(hex_string), not base64(raw_bytes) — otherwise images render as grey boxes.
         item_kwargs = {
             "encrypt_query_param": encrypted_query_param, "aes_key_for_api": base64.b64encode(aes_key.hex().encode("ascii")).decode("ascii"),
@@ -1255,7 +1268,10 @@ async def send_weixin_direct(
         return {"error": "Weixin account ID missing. Configure WEIXIN_ACCOUNT_ID or platforms.weixin.extra.account_id."}
     token_store = ContextTokenStore(str(get_hermes_home()))
     token_store.restore(account_id)
-    context_token = token_store.get(account_id, chat_id)
+    send_context_token = _coerce_bool(
+        _extra_or_env(extra, "send_context_token", "true"), default=True
+    )
+    context_token = token_store.get(account_id, chat_id) if send_context_token else None
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
     if send_session is not None and not send_session.closed and send_session._loop is asyncio.get_running_loop():

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -880,3 +880,68 @@ class TestWeixinVoiceGatewayHandoff:
             "the wrong transcript instead of re-transcribing (#27300)."
         )
 
+class TestWeixinContextTokenToggle:
+    """Outbound context_token echo must stay opt-out-able (#105506): echoing it on sendmessage
+    makes the WeChat client render the bot's reply twice on iLink v2.1+."""
+
+    def _connected_adapter(self, extra=None) -> WeixinAdapter:
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True, token="test-token", extra={"account_id": "test-account", **(extra or {})}
+            )
+        )
+        adapter._session = object()
+        adapter._send_session = adapter._session
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
+        return adapter
+
+    def test_context_token_echoed_by_default(self):
+        assert self._connected_adapter()._send_context_token is True
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_extra_false_omits_context_token_from_text_sends(
+        self, send_message_mock, _sleep_mock
+    ):
+        adapter = self._connected_adapter(extra={"send_context_token": "false"})
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+        assert result.success is True
+        assert send_message_mock.await_count == 1
+        assert send_message_mock.await_args.kwargs["context_token"] is None
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_default_still_echoes_cached_token_on_text_sends(
+        self, send_message_mock, _sleep_mock
+    ):
+        adapter = self._connected_adapter()
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+        assert result.success is True
+        assert send_message_mock.await_args.kwargs["context_token"] == "ctx-token"
+
+    @patch("gateway.platforms.weixin._get_upload_url", new=AsyncMock(return_value={"upload_full_url": "https://upload.example.com/media"}))
+    @patch("gateway.platforms.weixin._upload_ciphertext", new=AsyncMock(return_value="enc-param"))
+    @patch("gateway.platforms.weixin._send_items", new_callable=AsyncMock)
+    def test_extra_false_omits_context_token_from_media_sends(
+        self, send_items_mock, tmp_path
+    ):
+        adapter = self._connected_adapter(extra={"send_context_token": "false"})
+        image_path = tmp_path / "demo.png"
+        image_path.write_bytes(b"fake-png-bytes")
+        with (
+            patch("gateway.platforms.weixin.secrets.token_hex", return_value="filekey-123"),
+            patch("gateway.platforms.weixin.secrets.token_bytes", return_value=bytes(range(16))),
+        ):
+            asyncio.run(adapter._send_file("wxid_test123", str(image_path), ""))
+        assert send_items_mock.await_args.kwargs["context_token"] is None
+
+    def test_env_form_disables_echo(self, monkeypatch):
+        monkeypatch.setenv("WEIXIN_SEND_CONTEXT_TOKEN", "false")
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True, token="test-token", extra={"account_id": "test-account"}
+            )
+        )
+        assert adapter._send_context_token is False


### PR DESCRIPTION
## Summary

On iLink v2.1+, echoing the peer's `context_token` on `sendmessage` makes the WeChat client render the bot's reply **twice** (issue #105506 — one send logged, two bubbles displayed). The adapter had no way to opt out: all three outbound paths unconditionally read the cached token.

This adds an opt-out tunable following the existing `extra.<key>` / `WEIXIN_<KEY>` pattern, **default on** so current deployments are unchanged:

- `platforms.weixin.extra.send_context_token: false` (or `WEIXIN_SEND_CONTEXT_TOKEN=false`)

## Changes

- `gateway/platforms/weixin.py`
  - `__init__`: new `_send_context_token` tunable, documented at the read site
  - `send()` text path: cached-token read is gated
  - `_send_file()` media path (captions + `item_list` sends): gated
  - `send_weixin_direct()` cron/one-shot path: gated, `context_token_used` in the result stays truthful
  - inbound polling and the `getConfig` typing-ticket flow are untouched — they consume the token, not echo it
- `tests/gateway/test_weixin.py`: `TestWeixinContextTokenToggle` — default echo unchanged, `extra.send_context_token: "false"` omits the token from text and media sends, env form works

## Verification

- pristine baseline 44 passed / with-diff 49 passed (`tests/gateway/test_weixin*.py`, `test_weixin_typing.py`)
- mutation gate: reverting the `send()` gate locally turns `test_extra_false_omits_context_token_from_text_sends` red
- `ruff check` clean; `ruff format --diff` stable on every added line

Closes #105506