### PR TITLE
feat(providers): add LongCat support

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -457,7 +457,10 @@ def reasoning_echo_family(provider: Any, model: Any, base_url: Any) -> "str | No
 
 def needs_reasoning_echo(provider: Any, model: Any, base_url: Any) -> bool:
     """True when the endpoint requires reasoning_content echo-back."""
-    return reasoning_echo_family(provider, model, base_url) is not None
+    from providers import get_provider_profile
+
+    profile = get_provider_profile(provider)
+    return bool(profile and profile.requires_reasoning_echo) or reasoning_echo_family(provider, model, base_url) is not None
 
 
 def stale_thinking_reaches_wire(api_mode: Any, provider: Any, model: Any, base_url: Any) -> bool:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -343,6 +343,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
     "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-chat": 1_000_000,
     "deepseek-reasoner": 1_000_000, "deepseek": 128000,
+    # Offline fallback; provider-aware catalog metadata takes precedence.
+    # https://longcat.chat/platform/docs/zh/api/model
+    "longcat-2.0": 1_048_576,
     # Meta; Muse Spark family (1.1/1.2/1.3, -contributor(-free), meta/ prefixed) is 1M per OpenRouter,
     # models.dev and api.commandcode.ai /models — keep the "muse-spark" prefix (bare "muse" would match
     # muse-image/muse-voice). Thinking Machines inkling (covers inkling-small and :free/:batch variants)

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -122,7 +122,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "huggingface": "huggingface", "gemini": "google", "google": "google",
     "xai": "xai",
     "xai-oauth": "xai",  # OAuth is a transport path for the same xAI catalog
-    "xiaomi": "xiaomi", "nvidia": "nvidia",
+    "xiaomi": "xiaomi", "nvidia": "nvidia", "longcat": "longcat",
     # Meta Model API (Muse Spark, api.meta.ai): models.dev keys it "meta", the
     # Hermes provider is "meta-ai"; both aliases are needed or muse-spark-*
     # falls back to the generic 256K default instead of its true 1M window.

--- a/agent/reasoning_params.py
+++ b/agent/reasoning_params.py
@@ -8,7 +8,7 @@ import time
 from typing import Optional
 
 from agent.lazy_forward import forward as _forward, forward_static as _forward_static
-from agent.message_sanitization import matches_reasoning_echo_family
+from agent.message_sanitization import matches_reasoning_echo_family, needs_reasoning_echo
 from utils import base_url_host_matches
 
 # Static OpenRouter fallback when the live /v1/models capability cache is cold.
@@ -140,8 +140,8 @@ class ReasoningParamsMixin:
         cached = getattr(self, "_thinking_pad_cache", None)
         if cached is not None and cached[0] == key:
             return cached[1]
-        result = (self._needs_deepseek_tool_reasoning() or self._needs_kimi_tool_reasoning()
-                  or self._needs_mimo_tool_reasoning() or self._reasoning_echo_opt_in())
+        result = (needs_reasoning_echo(self.provider, self.model, self.base_url)
+                  or self._reasoning_echo_opt_in())
         self._thinking_pad_cache = (key, result)
         return result
 

--- a/plugins/model-providers/longcat/__init__.py
+++ b/plugins/model-providers/longcat/__init__.py
@@ -1,0 +1,29 @@
+"""LongCat's OpenAI-compatible API with binary thinking and reasoning replay."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class LongCatProfile(ProviderProfile):
+    def build_api_kwargs_extras(self, *, reasoning_config=None, **context):
+        config = reasoning_config if isinstance(reasoning_config, dict) else {}
+        disabled = config.get("enabled") is False or config.get("effort") == "none"
+        return {"thinking": {"type": "disabled" if disabled else "enabled"}}, {}
+
+    def prepare_messages(self, messages):
+        # Tool-call-only assistant turns may have null content in durable history;
+        # LongCat requires a string on the wire. Leave the cached history untouched.
+        return [
+            {**message, "content": ""}
+            if message.get("role") == "assistant" and message.get("content") is None
+            else message
+            for message in messages
+        ]
+
+
+register_provider(LongCatProfile(
+    name="longcat", display_name="LongCat", description="LongCat (direct API)",
+    signup_url="https://longcat.chat/platform/api_keys", env_vars=("LONGCAT_API_KEY",),
+    base_url="https://api.longcat.chat/openai/v1", fallback_models=("LongCat-2.0",),
+    requires_reasoning_echo=True,
+))

--- a/plugins/model-providers/longcat/plugin.yaml
+++ b/plugins/model-providers/longcat/plugin.yaml
@@ -1,0 +1,5 @@
+name: longcat-provider
+kind: model-provider
+version: 1.0.0
+description: LongCat direct API with thinking and tool calling
+author: yuzehui02 (ffyuuu)

--- a/providers/base.py
+++ b/providers/base.py
@@ -110,6 +110,10 @@ class ProviderProfile:
     )
     # empty = use main model
 
+    # The endpoint requires reasoning_content on replayed assistant tool calls.
+    # Shared replay and context-budget policies both consult this declaration.
+    requires_reasoning_echo: bool = False
+
     # ── Hooks (override in subclass for complex providers) ───
 
     def resolve_aux_model(self, *, vision: bool = False) -> str:

--- a/tests/providers/test_longcat_profile.py
+++ b/tests/providers/test_longcat_profile.py
@@ -1,0 +1,202 @@
+"""LongCat's declared route must work through discovery and tool-call replay."""
+
+import copy
+import json
+
+import httpx
+from openai import OpenAI
+
+
+def _seed_catalog(tmp_path, model):
+    entry = {
+        "id": model,
+        "name": model,
+        "tool_call": True,
+        "reasoning": True,
+        "modalities": {"input": ["text"], "output": ["text"]},
+        "limit": {"context": 777_777, "output": 12_345},
+        "cost": {"input": 0.42, "output": 1.23, "cache_read": 0.01},
+    }
+    (tmp_path / "models_dev_cache.json").write_text(
+        json.dumps({"longcat": {"id": "longcat", "models": {model: entry}}}),
+        encoding="utf-8",
+    )
+    return entry
+
+
+def _agent(profile, model, key):
+    from run_agent import AIAgent
+
+    return AIAgent(
+        model=model, provider=profile.name, base_url=profile.base_url, api_key=key,
+        quiet_mode=True, skip_context_files=True, skip_memory=True,
+        enabled_toolsets=[], save_trajectories=False,
+    )
+
+
+def test_discovered_longcat_route_reaches_chat_and_catalog_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("longcat")
+    assert profile is not None, "The bundled LongCat plugin must be discoverable"
+    model = profile.fallback_models[0]
+    entry = _seed_catalog(tmp_path, model)
+
+    from hermes_cli.models import parse_model_input, provider_model_ids
+    from hermes_cli.provider_catalog import provider_catalog_by_slug
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    # A fresh offline install can select a model before entering a key.
+    assert provider_model_ids(profile.name) == list(profile.fallback_models)
+    assert parse_model_input(f"{profile.name}:{model}", "custom") == (profile.name, model)
+    descriptor = provider_catalog_by_slug()[profile.name]
+    assert descriptor.api_key_env_vars == profile.env_vars
+    assert descriptor.signup_url == profile.signup_url
+
+    (tmp_path / ".env").write_text(f"{profile.env_vars[0]}=test-longcat-key\n", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(
+        f"model:\n  provider: {profile.name}\n  default: {model}\n", encoding="utf-8",
+    )
+    resolved = resolve_runtime_provider(requested=profile.name)
+    assert resolved["base_url"] == profile.base_url
+    assert resolved["api_mode"] == profile.api_mode
+
+    from agent import models_dev
+    from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT, get_model_context_length
+    from agent.auxiliary_client import _build_call_kwargs
+
+    # Use the actual disk-cache path and preserve changing catalog values.
+    monkeypatch.setattr(models_dev, "_models_dev_cache", {})
+    monkeypatch.setattr(models_dev, "_models_dev_cache_time", 0)
+    info = models_dev.get_model_info(profile.name, model)
+    assert info is not None
+    assert info.context_window == entry["limit"]["context"]
+    assert info.cost_input == entry["cost"]["input"]
+    assert info.cost_cache_read == entry["cost"]["cache_read"]
+    assert info.supports_vision() is False
+    assert get_model_context_length(model, profile.base_url, provider=profile.name) == info.context_window
+
+    agent = _agent(profile, model, resolved["api_key"])
+    received = []
+
+    def handle(request):
+        received.append(json.loads(request.content))
+        assert str(request.url) == profile.base_url + "/chat/completions"
+        assert request.headers["Authorization"] == "Bearer " + resolved["api_key"]
+        return httpx.Response(200, json={
+            "id": "chat-test", "object": "chat.completion", "created": 0, "model": model,
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "Ready"}, "finish_reason": "stop"}],
+        })
+
+    with OpenAI(api_key=resolved["api_key"], base_url=resolved["base_url"],
+                http_client=httpx.Client(transport=httpx.MockTransport(handle))) as client:
+        for config, expected in ((None, "enabled"), ({"enabled": False}, "disabled"),
+                                 ({"effort": "none"}, "disabled"), ({"effort": "high"}, "enabled")):
+            agent.reasoning_config = config
+            kwargs = agent._build_api_kwargs([{"role": "user", "content": "Hello"}], tools_for_api=[])
+            response = client.chat.completions.create(**kwargs)
+            assert response.choices[0].message.content == "Ready"
+            assert received[-1]["thinking"] == {"type": expected}
+            assert "reasoning_effort" not in received[-1]
+            assert "reasoning" not in received[-1]
+            aux = _build_call_kwargs(profile.name, model, [{"role": "user", "content": "Summarize"}],
+                                     reasoning_config=config, base_url=profile.base_url)
+            assert aux["extra_body"]["thinking"] == received[-1]["thinking"]
+            assert "reasoning_effort" not in aux
+            assert "reasoning" not in aux["extra_body"]
+
+    # A fresh offline catalog must still avoid the generic unknown-model window.
+    (tmp_path / "models_dev_cache.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(models_dev, "_models_dev_cache", {})
+    monkeypatch.setattr(models_dev, "_models_dev_cache_time", 0)
+    assert get_model_context_length(model, profile.base_url, provider=profile.name) != DEFAULT_FALLBACK_CONTEXT
+
+
+def test_longcat_tool_round_preserves_reasoning_and_strict_fallback_strips_it(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("longcat")
+    assert profile is not None, "The bundled LongCat plugin must be discoverable"
+    model = profile.fallback_models[0]
+    _seed_catalog(tmp_path, model)
+    agent = _agent(profile, model, "test-longcat-key")
+    reasoning = "I need the tool result before answering."
+    messages = [{"role": "user", "content": "What is 2 + 2?"}]
+    tools = [{"type": "function", "function": {
+        "name": "calculate", "description": "Calculate a sum", "parameters": {
+            "type": "object", "properties": {"expression": {"type": "string"}}, "required": ["expression"],
+        },
+    }}]
+    received = []
+
+    def handle(request):
+        body = json.loads(request.content)
+        received.append(body)
+        assert body["stream"] is True
+        assert body["stream_options"]["include_usage"] is True
+        if len(received) == 1:
+            deltas = [
+                {"role": "assistant", "content": "", "reasoning_content": ""},
+                {"reasoning_content": reasoning},
+                {"tool_calls": [{"index": 0, "id": "call_sum", "type": "function", "function": {
+                    "name": "calculate", "arguments": '{"expression":',
+                }}]},
+                {"tool_calls": [{"index": 0, "id": None, "function": {"name": None, "arguments": '"2+2"}'}}]},
+            ]
+            finish = "tool_calls"
+        else:
+            replay = body["messages"][1]
+            assert replay["reasoning_content"] == reasoning
+            assert replay["content"] == ""
+            assert replay["tool_calls"][0]["id"] == body["messages"][2]["tool_call_id"]
+            assert replay["tool_calls"][0]["function"] == {"name": "calculate", "arguments": '{"expression":"2+2"}'}
+            deltas, finish = [{"role": "assistant", "content": "4"}], "stop"
+        chunks = [{
+            "id": "chat-tool-test", "object": "chat.completion.chunk", "created": 0, "model": model,
+            "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+        } for delta in deltas]
+        chunks.append({**chunks[0], "choices": [{"index": 0, "delta": {}, "finish_reason": finish}]})
+        chunks.append({**chunks[0], "choices": [], "usage": {
+            "prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120,
+            "prompt_tokens_details": {"cached_tokens": 50},
+        }})
+        sse = "".join("data: " + json.dumps(chunk) + "\n\n" for chunk in chunks) + "data: [DONE]\n\n"
+        return httpx.Response(200, headers={"Content-Type": "text/event-stream"}, content=sse)
+
+    with OpenAI(api_key=agent.api_key, base_url=agent.base_url,
+                http_client=httpx.Client(transport=httpx.MockTransport(handle))) as client:
+        monkeypatch.setattr(agent, "_create_request_openai_client", lambda **kwargs: client)
+        monkeypatch.setattr(agent, "_close_request_openai_client", lambda *args, **kwargs: None)
+        first = agent._interruptible_streaming_api_call(agent._build_api_kwargs(messages, tools_for_api=tools))
+        assistant = agent._build_assistant_message(first.choices[0].message, first.choices[0].finish_reason)
+        assert first.usage.prompt_tokens_details.cached_tokens == 50
+        # Resumed sessions can contain null from non-streaming tool responses.
+        assistant["content"] = None
+        original = copy.deepcopy(assistant)
+        replay = {k: v for k, v in assistant.items() if k != "reasoning_content"}
+        agent._copy_reasoning_content_for_api(assistant, replay)
+        messages += [replay, {"role": "tool", "tool_call_id": "call_sum", "content": "4"}]
+        second = agent._interruptible_streaming_api_call(agent._build_api_kwargs(messages, tools_for_api=tools))
+        assert second.choices[0].message.content == "4"
+        assert assistant == original, "Wire normalization must preserve cached conversation history"
+
+    from agent.message_sanitization import stale_thinking_reaches_wire
+
+    assert stale_thinking_reaches_wire(agent.api_mode, agent.provider, agent.model, agent.base_url)
+    agent.provider, agent.base_url = "custom", "https://strict.example/v1"
+    assert agent._reapply_reasoning_echo_for_provider(messages) == 1
+    assert "reasoning_content" not in messages[1]
+    assert not stale_thinking_reaches_wire(agent.api_mode, agent.provider, agent.model, agent.base_url)
+
+    # The same replay capability works for another plugin, without name checks.
+    import providers
+    from providers.base import ProviderProfile
+
+    other = ProviderProfile(name="test-echo", requires_reasoning_echo=True)
+    monkeypatch.setitem(providers._REGISTRY, other.name, other)
+    agent.provider = other.name
+    agent._copy_reasoning_content_for_api(assistant, messages[1])
+    assert messages[1]["reasoning_content"] == reasoning
+    assert stale_thinking_reaches_wire(agent.api_mode, agent.provider, agent.model, agent.base_url)

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -105,6 +105,7 @@ Full definition in `providers/base.py`. The most useful ones:
 | `fixed_temperature` | Any | `None` = use caller's value; `OMIT_TEMPERATURE` sentinel = don't send temperature at all (Kimi) |
 | `default_max_tokens` | `int \| None` | Provider-level max_tokens cap (Nvidia: 16384) |
 | `default_aux_model` | str | Cheap model for auxiliary tasks (compression, vision, summarization) |
+| `requires_reasoning_echo` | bool | Preserve `reasoning_content` when replaying assistant tool calls; also accounts for that reasoning in context budgets. Defaults to `False` for endpoints that reject this field. |
 
 ## Overridable hooks
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -54,6 +54,7 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `KILOCODE_API_KEY` | Kilo Code API key ([kilo.ai](https://kilo.ai)) |
 | `KILOCODE_BASE_URL` | Override Kilo Code base URL (default: `https://api.kilo.ai/api/gateway`) |
 | `XIAOMI_API_KEY` | Xiaomi MiMo API key ([platform.xiaomimimo.com](https://platform.xiaomimimo.com)) |
+| `LONGCAT_API_KEY` | LongCat API key ([longcat.chat](https://longcat.chat/platform/api_keys)); select `longcat` with `hermes model` |
 | `XIAOMI_BASE_URL` | Override Xiaomi MiMo base URL (default: `https://api.xiaomimimo.com/v1`) |
 | `UPSTAGE_API_KEY` | Upstage API key for Solar models ([console.upstage.ai](https://console.upstage.ai/api-keys)) |
 | `UPSTAGE_BASE_URL` | Override Upstage base URL (default: `https://api.upstage.ai/v1`) |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -50,6 +50,27 @@ hermes config set OPENROUTER_API_KEY sk-or-...  # Saves to .env
 The `hermes config set` command automatically routes values to the right file — API keys are saved to `.env`, everything else to `config.yaml`.
 :::
 
+## LongCat
+
+Run `hermes model`, select **LongCat**, and enter a key from the
+[LongCat API keys page](https://longcat.chat/platform/api_keys). Hermes saves
+the key as `LONGCAT_API_KEY` in your profile's `.env` and offers `LongCat-2.0`.
+You can also select it for a single request:
+
+```bash
+hermes chat --provider longcat --model LongCat-2.0 -q "Hello"
+```
+
+LongCat uses `https://api.longcat.chat/openai/v1`. To use a proxy, set
+`model.base_url` in `config.yaml`. LongCat-2.0 supports text input and tool
+calling. Thinking is enabled by default; `/reasoning none` disables it.
+Other reasoning levels enable thinking, since LongCat's API has a binary
+switch. Hermes preserves reasoning content when replaying tool calls.
+
+Context and pricing follow the models.dev catalog. If catalog metadata is
+unavailable, Hermes uses the model's documented 1,048,576-token context
+window. See the [LongCat model details](https://longcat.chat/platform/docs/zh/api/model).
+
 ## Configuration Precedence
 
 Settings are resolved in this order (highest priority first):


### PR DESCRIPTION
## What does this PR do?

Add a native LongCat model-provider profile so `LONGCAT_API_KEY` and `LongCat-2.0` work through Hermes' existing setup, model picker, runtime routing, and auxiliary calls. The profile uses LongCat's OpenAI-compatible endpoint and sends its binary `thinking.type` toggle instead of `reasoning_effort`.

Tool-call replay preserves `reasoning_content` and normalizes null assistant content to an empty string on the wire without modifying durable history. A default-off `ProviderProfile.requires_reasoning_echo` capability lets the shared sanitizer and context-budget logic honor this requirement without a LongCat-specific core branch. models.dev remains authoritative for online metadata, with the documented context limit as an offline fallback.

## Related Issue

Related: #54680. That earlier mixed PR includes a picker-only LongCat entry for older models; this change implements the current provider-profile path and `LongCat-2.0` transport behavior.

Protocol references: [chat completions](https://longcat.chat/platform/docs/zh/api/chat), [model metadata](https://longcat.chat/platform/docs/zh/api/model).

## Type of Change

- [x] New feature

## Changes Made

- Register the LongCat profile through the existing model-provider plugin discovery system.
- Reuse profile hooks for thinking and message normalization, and add an opt-in reasoning-echo capability.
- Connect catalog metadata and document credentials/configuration.
- Add two behavioral integration tests through real discovery, runtime resolution, AIAgent, and the OpenAI SDK.

## How to Test

On macOS, the following passed:

```text
scripts/run_tests.sh tests/providers/ tests/hermes_cli/test_provider_parity.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_setup_model_provider.py tests/cli/test_cli_provider_resolution.py tests/agent/test_models_dev.py tests/agent/test_model_metadata.py tests/agent/test_message_sanitization_policy.py tests/agent/test_estimator_parity_84371.py tests/run_agent/test_reasoning_echo_resolver_e2e.py tests/run_agent/test_provider_parity.py tests/run_agent/test_partial_stream_finish_reason.py -q
# 509 passed across 23 files

scripts/run_tests.sh tests/run_agent/test_run_agent.py -k 'reasoning or replay or fallback' -q
# 22 passed
```

The two new tests also passed independently and failed before implementation. They cover thinking on/off, real SDK request serialization, fragmented SSE tool calls, reasoning replay, catalog data, and fallback to a strict provider. Ruff, the Windows footgun check, compatibility-pointer check, and whitespace checks passed.

The automated regression suite uses simulated HTTP/SSE responses. Four additional live API checks on 2026-09-08 passed through real provider discovery, AIAgent and the OpenAI SDK (HTTP 200): thinking off/on, streamed tool calls with null continuation fields, and continuation preserving real reasoning/tool-result history. The full repository test suite was not run.

Manual usage with a real key: set `LONGCAT_API_KEY`, select LongCat in `hermes model`, and use `LongCat-2.0`. Use `/reasoning none` to disable thinking.

## Checklist

- [x] Read the Contributing Guide; conventional commit and focused diff.
- [x] Searched existing PRs and described related work above.
- [x] Added and ran behavior tests for the affected paths.
- [ ] Full repository test suite — not run; targeted coverage is listed above.
- [x] Updated provider contract, environment-variable, and configuration documentation.
- [x] No new behavioral config keys, tool schemas, dependencies, or platform-specific operations.

AI assistance: Codex helped implement, review, and test this change.
