### PR TITLE
fix(sessions): stamp archived_at on first archive for Done-today

### DIFF
--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -331,6 +331,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     profile_name TEXT,
     rewind_count INTEGER NOT NULL DEFAULT 0,
     archived INTEGER NOT NULL DEFAULT 0,
+    archived_at REAL,
     pinned INTEGER NOT NULL DEFAULT 0,
     hidden INTEGER NOT NULL DEFAULT 0,
     last_read_at REAL,

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -829,8 +829,50 @@ class SessionSessionsMixin:
         ) > 0
 
     def set_session_archived(self, session_id: str, archived: bool) -> bool:
-        """Soft-hide (or unhide) a session and its compression lineage; messages are kept."""
-        return self._set_lineage_column("archived", session_id, int(archived))
+        """Soft-hide (or unhide) a session and its compression lineage; messages are kept.
+
+        First archive stamps ``archived_at`` (unix seconds) so Done/KPI credit
+        the calendar day of the archive, not last activity. Unarchive clears it.
+        Re-archive of an already-archived row keeps the original stamp.
+        """
+        archived_flag = 1 if archived else 0
+        now = time.time()
+        return self._write_rowcount(
+            """
+            WITH RECURSIVE
+              ancestors(id) AS (
+                SELECT ?
+                UNION
+                SELECT parent.id
+                FROM ancestors a
+                JOIN sessions child ON child.id = a.id
+                JOIN sessions parent ON parent.id = child.parent_session_id
+                WHERE parent.end_reason = 'compression'
+              ),
+              descendants(id) AS (
+                SELECT ?
+                UNION
+                SELECT child.id
+                FROM descendants d
+                JOIN sessions parent ON parent.id = d.id
+                JOIN sessions child ON child.parent_session_id = parent.id
+                WHERE parent.end_reason = 'compression'
+              ),
+              lineage(id) AS (
+                SELECT id FROM ancestors
+                UNION
+                SELECT id FROM descendants
+              )
+            UPDATE sessions
+            SET archived = ?,
+                archived_at = CASE
+                    WHEN ? = 1 THEN COALESCE(archived_at, ?)
+                    ELSE NULL
+                END
+            WHERE id IN (SELECT id FROM lineage)
+            """,
+            (session_id, session_id, archived_flag, archived_flag, now),
+        ) > 0
 
     # Accidental end reasons recovery treats as resumable (also interpolated into
     # the recovery/promotion SQL so literals cannot drift).
@@ -964,6 +1006,7 @@ class SessionSessionsMixin:
             for key in (
                 "id", "ended_at", "end_reason", "message_count", "tool_call_count", "title", "last_active",
                 "preview", "model", "system_prompt", "cwd", "git_branch", "git_repo_root",
+                "archived", "archived_at",
             ):
                 if key in tip_row:
                     merged[key] = tip_row[key]
@@ -1204,6 +1247,13 @@ class SessionSessionsMixin:
             outer_where, id_params = self._chain_search_where(
                 where_sql, (id_query or "").strip().lower(), (search_query or "").strip().lower(),
             )
+            # Archived-only lists order by archive flip time so idle chats
+            # archived today page first instead of burying under stale last_active.
+            order_expr = (
+                "COALESCE(s.archived_at, _effective_last_active)"
+                if archived_only
+                else "_effective_last_active"
+            )
             query = f"""
                 WITH RECURSIVE chain(root_id, cur_id) AS (
                     SELECT s.id, s.id FROM sessions s {where_sql}
@@ -1230,7 +1280,7 @@ class SessionSessionsMixin:
                 LEFT JOIN chain_max cm ON cm.root_id = s.id
                 {prompt_join}
                 {outer_where}
-                ORDER BY _effective_last_active DESC, s.started_at DESC, s.id DESC
+                ORDER BY {order_expr} DESC, s.started_at DESC, s.id DESC
                 LIMIT ? OFFSET ?
             """
             params = params + params + id_params + [limit, offset]  # WHERE binds twice (seed + outer)

--- a/tests/hermes_state/test_session_archiving.py
+++ b/tests/hermes_state/test_session_archiving.py
@@ -48,4 +48,65 @@ def test_unarchiving_compression_tip_unarchives_projected_root(db):
 
     assert db.get_session("root")["archived"] == 0
     assert db.get_session("tip")["archived"] == 0
+    assert db.get_session("tip")["archived_at"] is None
     assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["tip"]
+
+
+def test_set_session_archived_stamps_archived_at(db):
+    before = time.time()
+    db.create_session("old", source="cli")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'old'",
+        (before - 86400 * 40,),
+    )
+    db._conn.commit()
+
+    assert db.set_session_archived("old", True) is True
+    row = db.get_session("old")
+    assert row["archived"] == 1
+    assert row["archived_at"] is not None
+    assert float(row["archived_at"]) >= before
+
+    listed = db.list_sessions_rich(order_by_last_active=True, archived_only=True)
+    assert [s["id"] for s in listed] == ["old"]
+    assert listed[0]["archived_at"] is not None
+
+    assert db.set_session_archived("old", False) is True
+    assert db.get_session("old")["archived_at"] is None
+
+
+def test_rearchive_keeps_original_archived_at(db):
+    db.create_session("s", source="cli")
+    assert db.set_session_archived("s", True) is True
+    first = float(db.get_session("s")["archived_at"])
+    kept = first - 100
+    db._conn.execute("UPDATE sessions SET archived_at = ? WHERE id = 's'", (kept,))
+    db._conn.commit()
+
+    assert db.set_session_archived("s", True) is True
+    assert db.get_session("s")["archived_at"] == pytest.approx(kept)
+
+
+def test_archived_only_list_orders_by_archived_at_not_last_active(db):
+    now = time.time()
+    db.create_session("stale_activity", source="cli")
+    db.create_session("fresh_activity", source="cli")
+    db._conn.execute(
+        "UPDATE sessions SET last_activity_at = ?, message_count = 1 WHERE id = 'stale_activity'",
+        (now - 86400 * 40,),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET last_activity_at = ?, message_count = 1 WHERE id = 'fresh_activity'",
+        (now,),
+    )
+    db._conn.commit()
+    db.set_session_archived("fresh_activity", True)
+    db._conn.execute(
+        "UPDATE sessions SET archived_at = ? WHERE id = 'fresh_activity'",
+        (now - 100,),
+    )
+    db._conn.commit()
+    db.set_session_archived("stale_activity", True)
+
+    listed = db.list_sessions_rich(order_by_last_active=True, archived_only=True)
+    assert [s["id"] for s in listed] == ["stale_activity", "fresh_activity"]


### PR DESCRIPTION
## Result

Soft-archive now stamps `sessions.archived_at` on the first flip credits the calendar day of the archive, not last activity. Unarchive clears the stamp. Re-archive of an already-archived row keeps the original day.

This restores the behavior from `ca96d604df` that the later `_set_lineage_column("archived", …)` refactor dropped. Idle Desktop/CLI archives were hiding from Recents (`archived=1`) while Focus KPI and Archived page 1 still used `last_active`.

Column add is SCHEMA_SQL + `_reconcile_columns` (no SCHEMA_VERSION bump). Archived-only `list_sessions_rich(order_by_last_active=True)` orders by `COALESCE(s.archived_at, _effective_last_active)`. Compression-tip projection copies `archived` / `archived_at`.

## Before → After

- Before: `set_session_archived(True)` set `archived=1` only. Focus `archivedAt ?? lastActive` landed on last activity. Old chats archived today did not increment Done today and sorted off page 1 of Archived.
- After: first archive writes unix `archived_at`; unarchive nulls it; COALESCE keeps the original stamp on a no-op re-archive. Archived-only lists put today's idle archives first.

## Proof

- [x] `test_set_session_archived_stamps_archived_at` — stamp ≥ now, list carries it, unarchive clears
- [x] `test_rearchive_keeps_original_archived_at` — COALESCE does not rewrite the day
- [x] `test_archived_only_list_orders_by_archived_at_not_last_active` — stale last_active + newer archive sorts first
- [x] Fail-on-revert: restoring `_set_lineage_column("archived", …)` fails those 3; restore passes 5/5
- [x] `scripts/run_tests.sh tests/hermes_state/` — 298 passed, 7 skipped

## Tests run

```
scripts/run_tests.sh tests/hermes_state/test_session_archiving.py
scripts/run_tests.sh tests/hermes_state/
```

## Risks

Running `hermes serve` must restart (or otherwise reload SessionDB) before Desktop/CLI archives stamp. Existing NULL `archived_at` rows are not backfilled (legacy still falls back to last activity). Do not backfill `archived_at = last_active`.
