### PR TITLE
fix(matrix): treat a present m.mentions block as authoritative and always send one

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1931,8 +1931,8 @@ class MatrixAdapter(BasePlatformAdapter):
         chat_type = "dm" if is_dm else "group"
         thread_id = relates_to.get("event_id") if relates_to.get("rel_type") == "m.thread" else None
         formatted_body = source_content.get("formatted_body")
-        mentions_block = source_content.get("m.mentions") or {}  # MSC3952: authoritative signal
-        mention_user_ids = mentions_block.get("user_ids") if isinstance(mentions_block, dict) else None
+        mentions_block = source_content.get("m.mentions")  # MSC3952: authoritative when present, even if empty
+        mention_user_ids = (mentions_block.get("user_ids") or []) if isinstance(mentions_block, dict) else None
         is_mentioned = self._is_bot_mentioned(body, formatted_body, mention_user_ids)
         if not is_dm:
             # Whitelist first: non-listed rooms are dropped even when @mentioned (DMs exempt).
@@ -2639,9 +2639,9 @@ class MatrixAdapter(BasePlatformAdapter):
     def _build_text_message_content(self, text: str, msgtype: str = "m.text") -> Dict[str, Any]:
         """Build Matrix text content with HTML and outbound mention metadata."""
         msg_content: Dict[str, Any] = {"msgtype": msgtype, "body": text}
-        mention_user_ids = self._extract_outbound_mentions(text)
-        if mention_user_ids:
-            msg_content["m.mentions"] = {"user_ids": mention_user_ids}
+        # Always write the block (MSC3952): an empty one tells other bots in the room that a name in
+        # this prose is not a mention, which is what keeps sibling agents from waking each other.
+        msg_content["m.mentions"] = {"user_ids": self._extract_outbound_mentions(text)}
         if self._allow_room_mentions and self._has_outbound_room_mention(text):
             msg_content.setdefault("m.mentions", {})["room"] = True
         html = self._markdown_to_html(self._inject_outbound_mention_links(text))
@@ -2702,8 +2702,11 @@ class MatrixAdapter(BasePlatformAdapter):
         self, body: str, formatted_body: Optional[str] = None, mention_user_ids: Optional[list] = None) -> bool:
         """True if the bot is mentioned; ``m.mentions.user_ids`` (MSC3952) is authoritative
         even when the body has no ``@bot`` text (pills may live only in formatted_body)."""
-        if mention_user_ids and self._user_id and self._user_id in mention_user_ids:
-            return True
+        if mention_user_ids is not None:
+            # The sender's client wrote an m.mentions block (MSC3952), so it is the whole truth even when
+            # empty: a bare localpart in the prose is a name, not a mention. Several bots sharing one
+            # room depend on this; the body heuristics below serve only clients that send no block.
+            return bool(self._user_id and self._user_id in mention_user_ids)
         if not body and not formatted_body:
             return False
         if self._user_id and self._user_id in body:

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -109,6 +109,26 @@ class TestIsBotMentioned:
             mention_user_ids=["@hermes:example.org"],
         )
 
+    def test_m_mentions_block_present_makes_bare_localpart_prose(self):
+        """A present block is the whole truth: a bare localpart in prose is a name, not a mention."""
+        assert not self.adapter._is_bot_mentioned("hermes can you help?", mention_user_ids=[])
+
+    def test_m_mentions_block_naming_another_user_only(self):
+        """Pill for a sibling bot + this bot's name in prose must not wake this bot."""
+        assert not self.adapter._is_bot_mentioned(
+            "@other ask hermes for the digest", mention_user_ids=["@other:example.org"])
+
+    def test_no_block_keeps_legacy_localpart_heuristic(self):
+        """Clients that send no m.mentions block keep the bare-localpart behaviour."""
+        assert self.adapter._is_bot_mentioned("hermes can you help?", mention_user_ids=None)
+
+    def test_outbound_text_always_carries_mentions_block(self):
+        """Outbound prose always writes m.mentions so sibling bots read it as intentional."""
+        content = self.adapter._build_text_message_content("nahash is idle today")
+        assert content["m.mentions"] == {"user_ids": []}
+        content = self.adapter._build_text_message_content("ping @nahash:example.org")
+        assert content["m.mentions"] == {"user_ids": ["@nahash:example.org"]}
+
 
 class TestStripMention:
     def setup_method(self):

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -124,6 +124,10 @@ MATRIX_ALLOW_ROOM_MENTIONS=false
 Hermes sends structured Matrix user mentions for explicit Matrix IDs such as `@alice:example.org`. Room-wide `@room` notifications are disabled by default; set `MATRIX_ALLOW_ROOM_MENTIONS=true` only in rooms where the bot is allowed to notify everyone.
 :::
 
+:::note Several bots in one room
+When more than one Hermes profile shares a room, only the bot that is actually mentioned should wake. Modern clients attach an `m.mentions` block (MSC3952) to every message; when that block is present Hermes treats it as the whole truth, so a bare bot name in prose ("ask bob for the digest", with no pill) is just a name, even with `require_mention: true`. Hermes also writes an `m.mentions` block on every message it sends, so one bot's reply never wakes a sibling by naming it. Clients that send no block fall back to the text heuristics (`@localpart`, the full user ID, a pill, or the bare localpart).
+:::
+
 :::note
 If you are upgrading from a version that did not have `MATRIX_REQUIRE_MENTION`, the bot previously responded to all messages in rooms. To preserve that behavior, set `MATRIX_REQUIRE_MENTION=false`.
 :::


### PR DESCRIPTION
## What does this PR do?

Several Hermes profiles sharing one Matrix room wake each other. Pill bot A and write bot B's name in the prose, and B works the request too; A's reply that names B wakes B again.

On current `main`, `_is_bot_mentioned` (`plugins/platforms/matrix/adapter.py:2699-2712`) consults `m.mentions.user_ids` first but not exclusively, then falls through to a case-insensitive `\b<localpart>\b` search of the body. A message whose client wrote an MSC3952 block naming only A therefore still wakes B whenever B's localpart appears as a word. On the outbound side, `_build_text_message_content` (`:2637-2650`) omits the block when the reply pills nobody, so a reply that merely names a sibling reads as a mention to it.

Two changes, no new config surface:

- **A present `m.mentions` block decides, even when empty.** Per MSC3952 (Matrix v1.7), a message that carries the key has intentional mentions, and an empty set means none. The call site in `_resolve_message_context` now passes `[]` for "block present but empty" and `None` for "no block". The body heuristics (`@localpart`, the full user ID, a pill in `formatted_body`, the bare localpart) serve only clients that send no block, so the single-bot contract and its existing tests are unchanged.
- **Outbound text always writes an `m.mentions` block**, empty when nothing is pilled, so bot prose never wakes a sibling by naming it.

This is complementary to the two open PRs on the same symptom, not a duplicate of either. #74616 adds a configurable loose/strict mention mode and filters URLs and foreign MXIDs out of the loose fallback, but keeps the block non-exclusive unless strict mode is switched on. #101366 makes the block exclusive only when it is non-empty, fixes the hyphen word boundary, and ships alongside a history-backfill feature. Neither treats an empty block as authoritative and neither writes the block on outbound messages. Either composes with this change; this one is the minimal contract fix a room with two bots needs under default configuration.

## Related Issue

Related: #74567 (the sibling-bot half of it). Deliberately not `Fixes`: the URL and homeserver-domain false positives that issue also reports are #74616's territory.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/matrix/adapter.py`
  - `_is_bot_mentioned`: `if mention_user_ids is not None: return bool(self._user_id in mention_user_ids)`; the heuristics below it are untouched.
  - `_resolve_message_context` call site: `mention_user_ids = (block.get("user_ids") or []) if the block is a dict else None`.
  - `_build_text_message_content`: `msg_content["m.mentions"] = {"user_ids": self._extract_outbound_mentions(text)}` unconditionally.
- `tests/gateway/test_matrix_mention.py` — four behavior contracts in `TestIsBotMentioned`: a present-but-empty block makes a bare localpart prose; a block naming another user plus this bot's name in the prose does not wake it; no block keeps the legacy localpart heuristic; outbound text always carries the block (empty, and with an explicit ID). The existing `test_require_mention_m_mentions_other_user_ignored` uses a body that does not contain the bot's name, so it never exercised this path.
- `website/docs/user-guide/messaging/matrix.md` — a "Several bots in one room" note under Mention and Threading Configuration. The zh-Hans mirror is untouched.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_matrix_mention.py -q` on this branch: **21 passed**. The same test file against unpatched `main`: **3 failed, 18 passed** — `test_m_mentions_block_present_makes_bare_localpart_prose`, `test_m_mentions_block_naming_another_user_only`, `test_outbound_text_always_carries_mentions_block` are red; `test_no_block_keeps_legacy_localpart_heuristic` is green on both by design, it pins the contract this change preserves.
2. Every `tests/gateway/test_matrix*.py` file (13 files), each in its own pytest process with the runner's pins (`TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0`): **192 passed, 0 failed**, including `test_matrix.py` (112) and `TestOutboundMentions`.
3. Live, on the reporter's fleet: three profiles as three Matrix users in one encrypted room on a self-hosted homeserver, `MATRIX_REQUIRE_MENTION=true`, messages sent from a desktop client that emits `m.mentions` (the post-patch result below is only possible if it does). Before: pill A with B's name bare in the prose → both react and reply; A's reply naming B and C → both react before the allowed-user gate drops them. After, gateways restarted on this patch: pill A with B and C bare in the prose → A alone reacts and replies, B and C silent. Observed from a fourth account's read of the room timeline (event types and senders only; nothing decrypted).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#74616 and #101366 found and cited above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not the full suite**: the mention file through `scripts/run_tests.sh` and all 13 gateway Matrix files per-file, as listed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 / Python 3.11 (live fleet, v0.21.0 + this patch); tests against `main` on Linux / Python 3.11 venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the Matrix user guide note above
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, pure-Python control flow, no I/O

## Authorship

This PR was written by Claude Fable 5.1 (Anthropic) working with the operator who hit the bug on his own fleet. He found the reproduction and ran the live validation; the model root-caused it, wrote the change, the tests, and this description. Stated for the record, not as a caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
