### PR TITLE
fix(opencode): inject x-opencode-session into SDK client default_headers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -827,6 +827,22 @@ def _explicit_client_kwargs(agent, api_key, base_url, _provider_timeout) -> Dict
             _ph = _gpf(agent.provider)
             if _ph and _ph.default_headers:
                 client_kwargs["default_headers"] = dict(_ph.default_headers)
+    # OpenCode Go routes requests that carry an ``x-opencode-session`` header
+    # to the same upstream backend, keeping its prompt cache warm.  The header
+    # is also injected per-request by ``chat_completion_helpers.build_api_kwargs``
+    # (via ``opencode_affinity.merge_opencode_session_headers``), but setting it
+    # here on the SDK client ensures every request — including those that bypass
+    # ``build_api_kwargs`` — carries the affinity key.
+    if base_url_host_matches(base_url, "opencode.ai"):
+        try:
+            from gateway.session_context import get_session_env
+            _session_id = get_session_env("HERMES_SESSION_ID", "")
+            if _session_id:
+                _headers = client_kwargs.get("default_headers") or {}
+                _headers["x-opencode-session"] = _session_id
+                client_kwargs["default_headers"] = _headers
+        except Exception:
+            pass
     return client_kwargs
 
 


### PR DESCRIPTION
## Summary

This PR adds the `x-opencode-session` header to the OpenAI SDK client's `default_headers` when targeting OpenCode Go (`opencode.ai`).

## Problem

OpenCode Go routes requests that carry an `x-opencode-session` header to the same upstream backend, keeping its prompt cache warm. Without the header, requests may be routed to cold backends, increasing latency and cost.

PR [#101864](https://github.com/NousResearch/hermes-agent/pull/101864) (merged) added per-request injection via `chat_completion_helpers.build_api_kwargs()` using `opencode_affinity.merge_opencode_session_headers`. However, that only covers requests that go through `build_api_kwargs`. The SDK client itself is created in `agent_init.py`'s `_explicit_client_kwargs()` without the header in `default_headers`.

## Change

**`agent/agent_init.py`** — After the existing `elif "default_headers" not in client_kwargs:` block, add:

```python
    # OpenCode Go routes requests that carry an ``x-opencode-session`` header
    # to the same upstream backend, keeping its prompt cache warm.  The header
    # is also injected per-request by ``chat_completion_helpers.build_api_kwargs``
    # (via ``opencode_affinity.merge_opencode_session_headers``), but setting it
    # here on the SDK client ensures every request — including those that bypass
    # ``build_api_kwargs`` — carries the affinity key.
    if base_url_host_matches(base_url, "opencode.ai"):
        try:
            from gateway.session_context import get_session_env
            _session_id = get_session_env("HERMES_SESSION_ID", "")
            if _session_id:
                _headers = client_kwargs.get("default_headers") or {}
                _headers["x-opencode-session"] = _session_id
                client_kwargs["default_headers"] = _headers
        except Exception:
            pass
```

This ensures the header is present on the SDK client level (`default_headers`), complementing the per-request injection already in place via `#101864`.

## Testing

- Verified that the header is present in `default_headers` when targeting `opencode.ai`
- Verified that non-OpenCode targets are unaffected (the `base_url_host_matches` guard prevents false injection)
- Verified that the existing per-request injection via `build_api_kwargs` continues to work

## Notes

- This PR was created by **HermesAgent** (Nous Research AI agent) via automated analysis
- Only `agent_init.py` is modified; the per-request path in `chat_completion_helpers.py` is already covered by [#101864](https://github.com/NousResearch/hermes-agent/pull/101864)