### PR TITLE
fix(terminal): bind sandbox env partials by env_type keyword (TypeError double-bind)

### DIFF
--- a/tests/tools/test_terminal_sandbox_env_binding.py
+++ b/tests/tools/test_terminal_sandbox_env_binding.py
@@ -1,0 +1,102 @@
+"""Regression tests for #105414.
+
+The sandbox env builders are ``functools.partial``-bound closures over
+``_build_sandbox_env``, and ``_create_environment`` invokes every builder with
+``env_type=<type>`` by keyword. When the partial bound ``env_type`` positionally
+the keyword collided, raising::
+
+    TypeError: _build_sandbox_env() got multiple values for argument 'env_type'
+
+and breaking the Singularity / Daytona / Vercel terminal backends on every
+terminal and file-tool call.
+"""
+
+import functools
+
+import tools.terminal_tool_backends as ttb
+
+
+def test_sandbox_env_builders_bind_env_type_by_keyword():
+    """The partial builders must bind ``env_type`` by keyword so the caller's
+    ``env_type=`` keyword does not collide (#105414)."""
+    cases = [
+        (ttb._build_singularity_env, "singularity"),
+        (ttb._build_daytona_env, "daytona"),
+        (ttb._build_vercel_env, "vercel_sandbox"),
+    ]
+    for builder, expected in cases:
+        assert isinstance(builder, functools.partial), f"{builder!r} is not a functools.partial"
+        assert builder.args == (), (
+            f"_build_sandbox_env partial must not bind env_type positionally "
+            f"(args={builder.args!r}); positional binding collides with the "
+            f"env_type= keyword passed by _create_environment (#105414)."
+        )
+        assert builder.keywords == {"env_type": expected}, (
+            f"{builder!r} must bind env_type by keyword "
+            f"(got keywords={builder.keywords!r}); only env_type should be bound."
+        )
+
+
+def test_create_environment_singularity_does_not_raise_typeerror(monkeypatch):
+    """_create_environment(env_type='singularity') must invoke the sandbox builder
+    without ``TypeError: multiple values for argument 'env_type'`` (#105414)."""
+
+    class _FakeEnv:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    # Replace the singularity row so no real SingularityEnvironment is needed.
+    monkeypatch.setitem(
+        ttb._SANDBOX_ROWS,
+        "singularity",
+        (lambda: _FakeEnv, True, lambda cc, kw: {}),
+    )
+    monkeypatch.setattr(ttb, "_resources", lambda cc: {})
+
+    env = ttb._create_environment(
+        env_type="singularity",
+        image="img",
+        cwd="/tmp",
+        timeout=30,
+        container_config={},
+        task_id="t",
+    )
+
+    assert isinstance(env, _FakeEnv)
+    # singularity row has with_image=True, so image must reach the environment.
+    assert env.kwargs.get("image") == "img"
+    assert env.kwargs.get("cwd") == "/tmp"
+
+
+def test_create_environment_daytona_and_vercel_do_not_raise_typeerror(monkeypatch):
+    """Same partial-binding regression for Daytona and Vercel sandbox (#105414)."""
+
+    class _FakeEnv:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(ttb, "_resources", lambda cc: {})
+    monkeypatch.setitem(
+        ttb._SANDBOX_ROWS,
+        "daytona",
+        (lambda: _FakeEnv, True, lambda cc, kw: {"cpu": int(kw["cpu"])}),
+    )
+    monkeypatch.setitem(
+        ttb._SANDBOX_ROWS,
+        "vercel_sandbox",
+        (lambda: _FakeEnv, False, lambda cc, kw: {"runtime": cc.get("vercel_runtime") or None}),
+    )
+
+    daytona = ttb._create_environment(
+        env_type="daytona", image="img", cwd="/tmp", timeout=30,
+        container_config={"container_cpu": 2}, task_id="t",
+    )
+    assert isinstance(daytona, _FakeEnv)
+    assert daytona.kwargs.get("cpu") == 2
+
+    vercel = ttb._create_environment(
+        env_type="vercel_sandbox", image="ignored", cwd="/tmp", timeout=30,
+        container_config={"vercel_runtime": "nodejs20"}, task_id="t",
+    )
+    assert isinstance(vercel, _FakeEnv)
+    assert vercel.kwargs.get("runtime") == "nodejs20"

--- a/tools/terminal_tool_backends.py
+++ b/tools/terminal_tool_backends.py
@@ -168,9 +168,12 @@ def _build_sandbox_env(env_type, *, image, cwd, timeout, cc, task_id, **_):
     return cls()(**kwargs)
 
 
-_build_singularity_env = functools.partial(_build_sandbox_env, "singularity")
-_build_daytona_env = functools.partial(_build_sandbox_env, "daytona")
-_build_vercel_env = functools.partial(_build_sandbox_env, "vercel_sandbox")
+# Bind env_type by keyword: _create_environment invokes every builder with
+# ``env_type=<type>`` by keyword, so a positional partial collides and raises
+# ``TypeError: _build_sandbox_env() got multiple values for argument 'env_type'`` (#105414).
+_build_singularity_env = functools.partial(_build_sandbox_env, env_type="singularity")
+_build_daytona_env = functools.partial(_build_sandbox_env, env_type="daytona")
+_build_vercel_env = functools.partial(_build_sandbox_env, env_type="vercel_sandbox")
 
 
 def _build_ssh_env(*, cwd, timeout, ssh_config, probe_only=False, **_):


### PR DESCRIPTION
Fixes #105414

## Summary

The Singularity / Daytona / Vercel sandbox env builders were `functools.partial`-bound with `env_type` **positionally**, but `_create_environment` invokes every builder with `env_type=<type>` **by keyword**, so the two collided:

```
TypeError: _build_sandbox_env() got multiple values for argument 'env_type'
```

This broke the Singularity (and structurally Daytona / Vercel) terminal backends on every terminal and file-tool call — the model kept working, but configured sandbox tools failed immediately.

## Changes

- `tools/terminal_tool_backends.py`: bind `env_type` by **keyword** in the three `functools.partial` builders so the caller's `env_type=` keyword overrides cleanly instead of colliding. (This is the fix proposed in the issue body, verified locally.)
- `tests/tools/test_terminal_sandbox_env_binding.py`: regression tests covering all three sandbox backends — a structural assertion that the partials bind `env_type` by keyword (catches a regression to positional binding), plus behavior tests that `_create_environment(env_type=...)` invokes the builder without raising `TypeError` for singularity, daytona, and vercel_sandbox.

## Note on authorship

The bug analysis and the proposed fix are from @hajromero in #105414 (who marked "I'd like to fix this myself"). I did not see a linked PR after a day, so I opened this one to keep a P1 from sitting — if @hajromero opens their own PR I'm happy to close this in favor of theirs.

## Verification

Locally confirmed the old positional partial raises `TypeError: ... got multiple values for argument 'env_type'` and the keyword-bound partial + `_create_environment(env_type="singularity", ...)` returns the environment without error. All three regression tests pass.

---

*This PR was prepared with AI assistance. I reviewed every changed line and verified the fix against the current `main`.*
