### PR TITLE
feat(gateway): configurable min-interval rate limit for interim assistant messages

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -21,6 +21,9 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "streaming": None,  # None = follow top-level streaming config
     # Gateway-only assistant/status chatter; mobile platforms opt down to final-answer-first.
     "interim_assistant_messages": True,
+    # Gateway: minimum seconds between interim assistant commentary messages (0 = unrestricted).
+    # Rate-limits non-urgent mid-turn chatter for mobile gateways with send limits (#44926).
+    "interim_assistant_min_interval_seconds": 0,
     "long_running_notifications": True,
     "busy_ack_detail": True,
     "busy_steer_ack_enabled": True,  # busy_input_mode=steer echo; the text still lands in the run
@@ -147,11 +150,20 @@ def _norm_int(value: Any) -> int:
         return 0
 
 
+def _norm_nonneg_seconds(value: Any) -> int:
+    """Seconds normaliser: ints pass, junk → 0, negatives clamp to 0 (off)."""
+    try:
+        return max(0, int(float(value)))
+    except (TypeError, ValueError):
+        return 0
+
+
 _NORMALISERS: dict[str, Any] = {
     "tool_progress": _norm_tristate("all", "off", {"off", "new", "all", "verbose", "log"}),
     "show_reasoning": _norm_bool,
     "streaming": _norm_bool,
     "interim_assistant_messages": _norm_bool,
+    "interim_assistant_min_interval_seconds": _norm_nonneg_seconds,
     "long_running_notifications": _norm_long_running,
     "busy_ack_detail": _norm_bool,
     "busy_steer_ack_enabled": _norm_bool,

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -151,10 +151,12 @@ def _norm_int(value: Any) -> int:
 
 
 def _norm_nonneg_seconds(value: Any) -> int:
-    """Seconds normaliser: ints pass, junk → 0, negatives clamp to 0 (off)."""
+    """Seconds normaliser: ints pass, junk → 0, negatives clamp to 0 (off); fractional values truncate (1.9 → 1)."""
+    if isinstance(value, bool):
+        return 0
     try:
         return max(0, int(float(value)))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return 0
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4338,6 +4338,7 @@ class GatewayRunner(
         log_mode_enabled: Any = None
         log_queue: Any = None
         interim_assistant_messages_enabled: Any = None
+        interim_assistant_min_interval_seconds: Any = 0
         _thinking_enabled: Any = None
         _native_slack_task_cards: Any = None
         needs_progress_queue: Any = None

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2660,6 +2660,10 @@ class GatewayTurnMixin:
             "interim_assistant_messages", default=True, require_platform_override_for={Platform.MATTERMOST},
         )
         interim_assistant_messages_enabled = not is_webhook and interim_assistant_messages_mode != "off"
+        # Rate limit for non-urgent interim commentary (issue #44926): 0 = unrestricted.
+        interim_assistant_min_interval_seconds = resolve_display_setting(
+            user_config, platform_key, "interim_assistant_min_interval_seconds", 0,
+        )
         _thinking_enabled = _display_surface_mode(
             "thinking_progress", default=False, require_platform_override_for={Platform.MATTERMOST},
         ) != "off"
@@ -2683,6 +2687,7 @@ class GatewayTurnMixin:
             _live_status_adapter=_live_status_adapter, log_mode_enabled=log_mode_enabled,
             log_queue=queue.Queue() if log_mode_enabled else None,
             interim_assistant_messages_enabled=interim_assistant_messages_enabled,
+            interim_assistant_min_interval_seconds=interim_assistant_min_interval_seconds,
             _thinking_enabled=_thinking_enabled, _native_slack_task_cards=_native_slack_task_cards,
             needs_progress_queue=tool_progress_enabled or _thinking_enabled or _native_slack_task_cards,
             _generic_status_phrase=_generic_status_phrase,
@@ -2694,6 +2699,7 @@ class GatewayTurnMixin:
         "progress_grouping", "tool_progress_enabled", "log_queue", "resolve_display_setting",
         "user_config", "enabled_toolsets", "disabled_toolsets", "log_mode_enabled",
         "interim_assistant_messages_enabled", "needs_progress_queue", "_native_slack_task_cards",
+        "interim_assistant_min_interval_seconds",
     )
 
     def _run_agent_build_turn_context(

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -67,7 +67,12 @@ class _InterimRateGate:
         return self._min_interval > 0
 
     def allow(self, text: Any) -> bool:
-        """True if this commentary may send now; records the send when allowed."""
+        """True if this commentary may send now; records the send when allowed.
+
+        ``text`` is accepted but not consumed: every message routed here is
+        non-urgent by construction (approvals, errors and finals never reach
+        this gate), so urgency has no bearing on admission.
+        """
         if not self.enabled:
             return True
         with self._lock:

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -45,6 +45,38 @@ class _ExecApprovalDeclined(RuntimeError):
     """
 
 
+class _InterimRateGate:
+    """Per-session cooldown for interim assistant commentary (issue #44926).
+
+    0/disabled passes everything. Approval, final-response and error paths never
+    route through the gated callback, so urgent messages are exempt by construction.
+    Suppressed messages are dropped, not queued — replaying them after the window
+    would deliver stale commentary.
+    """
+
+    def __init__(self, min_interval_seconds: Any) -> None:
+        try:
+            self._min_interval = max(0.0, float(min_interval_seconds or 0))
+        except (TypeError, ValueError):
+            self._min_interval = 0.0
+        self._last_emit = 0.0  # monotonic timestamp of the last admitted send; 0 = none yet
+        self._lock = threading.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        return self._min_interval > 0
+
+    def allow(self, text: Any) -> bool:
+        """True if this commentary may send now; records the send when allowed."""
+        if not self.enabled:
+            return True
+        now = time.monotonic()
+        with self._lock:
+            if self._last_emit and (now - self._last_emit) < self._min_interval:
+                return False
+            self._last_emit = now
+            return True
+
 class TurnRunner:
     """Per-turn collaborator carrying ``GatewayRunner._run_agent_inner``'s tool-progress callbacks."""
 
@@ -852,6 +884,7 @@ class TurnRunner:
             scfg.enabled and scfg.transport != "off" if plat_streaming is None else bool(plat_streaming)
         )
         want_interim_messages = ctx.interim_assistant_messages_enabled
+        interim_rate_gate = _InterimRateGate(getattr(ctx, "interim_assistant_min_interval_seconds", 0) or 0)
         if want_stream_deltas or want_interim_messages:
             try:
                 from gateway.stream_consumer import GatewayStreamConsumer
@@ -883,6 +916,10 @@ class TurnRunner:
 
         def interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
             if not ctx._run_still_current():
+                return
+            # Non-urgent commentary only (issue #44926): approvals, errors and finals
+            # never route through here. Fresh gate per turn → first message always passes.
+            if interim_rate_gate.enabled and not interim_rate_gate.allow(text):
                 return
             if stream_consumer is not None:
                 stream_consumer.on_segment_break() if already_streamed else stream_consumer.on_commentary(text)

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -59,7 +59,7 @@ class _InterimRateGate:
             self._min_interval = max(0.0, float(min_interval_seconds or 0))
         except (TypeError, ValueError):
             self._min_interval = 0.0
-        self._last_emit = 0.0  # monotonic timestamp of the last admitted send; 0 = none yet
+        self._last_emit: Optional[float] = None  # monotonic timestamp of last admitted send
         self._lock = threading.Lock()
 
     @property
@@ -70,9 +70,9 @@ class _InterimRateGate:
         """True if this commentary may send now; records the send when allowed."""
         if not self.enabled:
             return True
-        now = time.monotonic()
         with self._lock:
-            if self._last_emit and (now - self._last_emit) < self._min_interval:
+            now = time.monotonic()
+            if self._last_emit is not None and (now - self._last_emit) < self._min_interval:
                 return False
             self._last_emit = now
             return True

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -62,6 +62,7 @@ class TurnContext:
     disabled_toolsets: Any = None
     log_mode_enabled: bool = False
     interim_assistant_messages_enabled: bool = False
+    # Min seconds between non-urgent interim commentary messages (issue #44926); 0 = unrestricted.
     interim_assistant_min_interval_seconds: int = 0
     needs_progress_queue: bool = False
     AIAgent: Any = None

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -62,6 +62,7 @@ class TurnContext:
     disabled_toolsets: Any = None
     log_mode_enabled: bool = False
     interim_assistant_messages_enabled: bool = False
+    interim_assistant_min_interval_seconds: int = 0
     needs_progress_queue: bool = False
     AIAgent: Any = None
     resolve_display_setting: Any = None

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -843,6 +843,9 @@ DEFAULT_CONFIG = {
         # Gateway: natural mid-turn assistant status messages. Desktop: keep mid-turn narration
         # between tool calls instead of collapsing to the final message.
         "interim_assistant_messages": True,
+        # Gateway: minimum seconds between interim assistant commentary messages (0 = unrestricted).
+        # Per-platform override supported; finals/approvals are never delayed (#44926).
+        "interim_assistant_min_interval_seconds": 0,
         # Codex Responses commentary channel: true delivers completed commentary as mid-turn interim
         # updates; false routes it to reasoning (visible only with show_reasoning).
         "show_commentary": True,

--- a/tests/gateway/test_interim_rate_limit.py
+++ b/tests/gateway/test_interim_rate_limit.py
@@ -1,0 +1,214 @@
+"""Tests for the interim assistant message rate limit (issue #44926).
+
+Covers: display-config resolution/normalisation of
+``display.interim_assistant_min_interval_seconds`` (with per-platform overrides),
+the ``_InterimRateGate`` unit behaviour, and the end-to-end gating of
+``TurnRunner._setup_stream_consumer``'s ``interim_assistant_cb`` (second rapid
+commentary within the window is dropped; finals are untouched by construction —
+they never route through the callback).
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.display_config import resolve_display_setting
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+class TestMinIntervalResolution:
+    """display.interim_assistant_min_interval_seconds resolves per the standard order."""
+
+    def test_default_is_zero_unrestricted(self):
+        assert resolve_display_setting({}, "telegram", "interim_assistant_min_interval_seconds") == 0
+
+    def test_global_setting(self):
+        config = {"display": {"interim_assistant_min_interval_seconds": 120}}
+        assert resolve_display_setting(config, "telegram", "interim_assistant_min_interval_seconds") == 120
+
+    def test_platform_override_wins(self):
+        config = {
+            "display": {
+                "interim_assistant_min_interval_seconds": 120,
+                "platforms": {"weixin": {"interim_assistant_min_interval_seconds": 90}},
+            }
+        }
+        assert resolve_display_setting(config, "weixin", "interim_assistant_min_interval_seconds") == 90
+        # Other platforms keep the global value.
+        assert resolve_display_setting(config, "telegram", "interim_assistant_min_interval_seconds") == 120
+
+    def test_string_value_normalised_to_int(self):
+        config = {"display": {"interim_assistant_min_interval_seconds": "120"}}
+        assert resolve_display_setting(config, "weixin", "interim_assistant_min_interval_seconds") == 120
+
+    @pytest.mark.parametrize("bad", [-5, "-5", "abc", None])
+    def test_invalid_values_normalise_to_zero(self, bad):
+        config = {"display": {"interim_assistant_min_interval_seconds": bad}}
+        assert resolve_display_setting(config, "weixin", "interim_assistant_min_interval_seconds") == 0
+
+    def test_key_is_platform_overrideable(self):
+        from gateway.display_config import OVERRIDEABLE_KEYS
+
+        assert "interim_assistant_min_interval_seconds" in OVERRIDEABLE_KEYS
+
+
+# ---------------------------------------------------------------------------
+# _InterimRateGate unit behaviour
+# ---------------------------------------------------------------------------
+
+class TestInterimRateGate:
+    @staticmethod
+    def _gate(interval):
+        from gateway.run_turn_runner import _InterimRateGate
+
+        return _InterimRateGate(interval)
+
+    def test_disabled_gate_always_allows(self):
+        gate = self._gate(0)
+        for _ in range(3):
+            assert gate.allow("msg") is True
+        assert gate.enabled is False
+
+    def test_first_message_always_passes(self):
+        gate = self._gate(120)
+        assert gate.allow("first") is True
+
+    def test_second_message_within_window_suppressed(self):
+        gate = self._gate(120)
+        assert gate.allow("first") is True
+        assert gate.allow("second") is False
+
+    def test_message_after_window_passes(self, monkeypatch):
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
+        gate = self._gate(120)
+        assert gate.allow("first") is True
+        clock["t"] += 30
+        assert gate.allow("second") is False
+        clock["t"] += 91  # 121s after the first send
+        assert gate.allow("third") is True
+
+    def test_suppressed_message_does_not_consume_window(self, monkeypatch):
+        """A dropped message must not extend the cooldown (no starvation under spam)."""
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
+        gate = self._gate(60)
+        assert gate.allow("first") is True
+        for _ in range(50):
+            clock["t"] += 1
+            assert gate.allow("spam") is False
+        clock["t"] += 10  # 61s after first (loop only advanced 50s)
+        assert gate.allow("after-window") is True
+
+    def test_concurrent_calls_admit_at_most_one(self):
+        gate = self._gate(300)
+        admitted = []
+        lock = threading.Lock()
+        barrier = threading.Barrier(8)
+
+        def contender():
+            barrier.wait()
+            if gate.allow("racer"):
+                with lock:
+                    admitted.append(True)
+
+        threads = [threading.Thread(target=contender) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(admitted) == 1
+
+    def test_non_positive_intervals_disable(self):
+        assert self._gate(-10).enabled is False
+        assert self._gate(None).enabled is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: interim_assistant_cb honours the gate
+# ---------------------------------------------------------------------------
+
+class _RecordingConsumer:
+    def __init__(self):
+        self.commentary = []
+        self.segment_breaks = 0
+
+    def on_commentary(self, text):
+        self.commentary.append(text)
+
+    def on_segment_break(self):
+        self.segment_breaks += 1
+
+
+def _build_interim_cb(monkeypatch, min_interval):
+    """Build the real interim_assistant_cb via TurnRunner._setup_stream_consumer.
+
+    Stub TurnContext + runner carry only the attributes the wiring reads; the
+    GatewayStreamConsumer symbol is swapped for a recording sink so no real
+    transports start. Returns (callback, recording_consumer).
+    """
+    import gateway.stream_consumer as sc_mod
+    from gateway.run_turn_runner import TurnRunner
+
+    consumer = _RecordingConsumer()
+    ctx = SimpleNamespace(
+        streaming_tts_consumer_holder=[None],
+        resolve_display_setting=lambda *a, **k: None,
+        user_config={},
+        interim_assistant_messages_enabled=True,
+        interim_assistant_min_interval_seconds=min_interval,
+        source=SimpleNamespace(chat_id="chat-1"),
+        _status_thread_metadata=None,
+        event_message_id=None,
+        progress_queue=None,
+        stream_consumer_holder=[None],
+        _run_still_current=lambda: True,
+        _status_adapter=None,
+    )
+    runner_stub = SimpleNamespace(
+        config=SimpleNamespace(streaming=None),
+        _adapter_for_source=lambda source: object(),
+        _build_stream_consumer_config=lambda *a, **k: (object(), False),
+    )
+    turn_runner = TurnRunner(runner_stub, ctx)
+    monkeypatch.setattr(sc_mod, "GatewayStreamConsumer", lambda *a, **k: consumer)
+
+    _, _, interim_cb, want_interim = turn_runner._setup_stream_consumer("weixin")
+    assert want_interim is True
+    return interim_cb, consumer
+
+
+class TestInterimCallbackGating:
+    def test_rapid_second_message_suppressed(self, monkeypatch):
+        cb, consumer = _build_interim_cb(monkeypatch, 120)
+        cb("progress one")
+        cb("progress two")
+        assert consumer.commentary == ["progress one"]
+
+    def test_interval_zero_delivers_both(self, monkeypatch):
+        cb, consumer = _build_interim_cb(monkeypatch, 0)
+        cb("one")
+        cb("two")
+        assert consumer.commentary == ["one", "two"]
+
+    def test_already_streamed_commentary_also_gated(self, monkeypatch):
+        cb, consumer = _build_interim_cb(monkeypatch, 120)
+        cb("streamed one", already_streamed=True)
+        cb("streamed two", already_streamed=True)
+        assert consumer.commentary == []
+        assert consumer.segment_breaks == 1
+
+    def test_fresh_gate_per_turn_first_message_free(self, monkeypatch):
+        """Each turn builds its own gate: turn 2's first commentary passes immediately."""
+        cb1, consumer1 = _build_interim_cb(monkeypatch, 120)
+        cb1("turn one")
+        cb1("suppressed")
+        cb2, consumer2 = _build_interim_cb(monkeypatch, 120)
+        cb2("turn two first")
+        assert consumer1.commentary == ["turn one"]
+        assert consumer2.commentary == ["turn two first"]

--- a/tests/gateway/test_interim_rate_limit.py
+++ b/tests/gateway/test_interim_rate_limit.py
@@ -128,6 +128,21 @@ class TestInterimRateGate:
         assert self._gate(-10).enabled is False
         assert self._gate(None).enabled is False
 
+    def test_admission_at_monotonic_zero_still_gates(self, monkeypatch):
+        """A send at monotonic t=0.0 must not leave the gate unset (0.0 is falsy)."""
+        clock = {"t": 0.0}
+        monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
+        gate = self._gate(120)
+        assert gate.allow("at-zero") is True
+        assert gate.allow("within-window") is False
+        clock["t"] += 121
+        assert gate.allow("after-window") is True
+
+    @pytest.mark.parametrize("junk", [".inf", "-.inf", True, False])
+    def test_yaml_edge_values_normalise_to_zero(self, junk):
+        config = {"display": {"interim_assistant_min_interval_seconds": junk}}
+        assert resolve_display_setting(config, "weixin", "interim_assistant_min_interval_seconds") == 0
+
 
 # ---------------------------------------------------------------------------
 # End-to-end: interim_assistant_cb honours the gate

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1963,6 +1963,7 @@ display:
   focus_view: false       # CLI focus view (/focus) — reduced output, display-only
   platforms: {}           # Per-platform display overrides (see below)
   interim_assistant_messages: true  # Gateway: send natural mid-turn assistant updates as separate messages
+  interim_assistant_min_interval_seconds: 0  # Gateway: minimum seconds between interim assistant updates (0 = unrestricted; per-platform override supported)
   show_commentary: true   # Codex models: deliver commentary-channel progress narration as visible mid-turn updates
   skin: default           # Built-in or custom CLI skin (see user-guide/features/skins)
   personality: ""         # Legacy cosmetic field still surfaced in some summaries
@@ -2167,6 +2168,8 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
+
+`interim_assistant_min_interval_seconds` (default `0`, unrestricted) rate-limits those interim updates on busy mobile gateways: set it to e.g. `120` to deliver at most one interim assistant message every two minutes. Configure it globally under `display` or per platform via `display.platforms.<platform>.interim_assistant_min_interval_seconds`. It applies only to non-urgent commentary — final responses, approval prompts, and error notices are never delayed — and an update dropped by the cooldown is discarded rather than queued (a stale progress replay after the window would be more confusing than helpful). This matters on platforms like WeChat/Weixin or Telegram where frequent messages can hit platform send limits or bury the conversation (issue [#44926](https://github.com/NousResearch/hermes-agent/issues/44926)).
 
 `show_commentary` (default `true`) controls Codex Responses models' commentary channel — the polished progress narration these models produce alongside their private reasoning. When enabled, each completed commentary message is delivered as a visible mid-turn update (on the gateway this also requires `interim_assistant_messages`). Set it to `false` if the extra narration annoys you: commentary then falls back to the reasoning channel and is only shown when `show_reasoning` is enabled.
 


### PR DESCRIPTION
# feat(gateway): configurable min-interval rate limit for interim assistant messages

Closes #44926.

Adds `display.interim_assistant_min_interval_seconds` (default `0` = unrestricted, per-platform override supported), which rate-limits non-urgent interim assistant commentary on messaging gateways:

```yaml
display:
  interim_assistant_min_interval_seconds: 120

display:
  platforms:
    weixin:
      interim_assistant_min_interval_seconds: 120
```

## Behavior

- Applies **only** to interim assistant commentary. The gate lives in the single choke point every interim message already flows through (`interim_assistant_cb` in `TurnRunner._setup_stream_consumer`). Final responses (stream consumer `finish()` / finalize path), approval prompts (`close_for_approval_prompt` boundary + runner dispatch), error notices (status/error channels), busy-acks (`run_busy.py`), and `long_running_notifications` heartbeats never route through that callback, so they are exempt by construction.
- A fresh gate is created per turn, so the **first** interim message of every turn always passes — the cooldown only spreads subsequent commentary.
- An update dropped by the cooldown is **discarded, not queued**: replaying stale progress narration after the window would desync it from what the agent is actually doing.
- `0` (default) keeps existing behavior byte-identical; desktop/CLI is unaffected (gateway-only key).

## Config plumbing

The key joins `gateway/display_config.py`'s resolver, so `display.platforms.<platform>.…` overrides, YAML normalisation (string numbers, junk → 0, negatives → 0, `.inf` → 0, bools → 0), and `hermes config set` platform redirection all come from the existing machinery.

## Tests

New `tests/gateway/test_interim_rate_limit.py` (26 tests): resolver order + normalisation edge cases, gate units (window expiry, drop-doesn't-consume-window, 8-thread concurrency admits exactly 1, admission at monotonic `t=0.0` still gates), and end-to-end callback gating through the real `_setup_stream_consumer` wiring (rapid second message suppressed; `already_streamed` commentary gated; fresh gate per turn).

```
pytest tests/gateway/test_interim_rate_limit.py tests/gateway/test_display_config.py \
  tests/tui_gateway/test_interim_assistant_callback.py tests/hermes_cli/test_config_set_platforms_redirect.py
→ 60 passed
```

Broader lanes (`scripts/run_tests.sh tests/gateway/ tests/tui_gateway/ tests/hermes_cli/test_config.py`): the only failures reproduce identically on a pristine `origin/main` baseline worktree (macOS-specific: Unix abstract sockets, long-path pathlib) — no regressions. `tests/gateway/test_stream_final_contract.py` (mutation-checked streaming contract) passes.

## Notes

- Cross-vendor review: Gemini 3.8 Flash (High) + GPT-OSS 120B, two rounds — round 1 approved with hardening findings (monotonic-zero sentinel, `OverflowError` on `.inf`, bool → 0, clock-in-lock), all fixed in the second commit with regression tests; round 2 re-reviewed the incremental diff.

**Open question:** the issue suggests a practical mobile-gateway default of 120s. This PR ships `0` (opt-in) to avoid changing behavior for existing users, with per-platform overrides for the mobile case. If maintainers prefer a shipped default, tier defaults for mobile platforms (e.g. `weixin`/`whatsapp_cloud`) would be a small follow-up in `_PLATFORM_DEFAULTS`.
