### PR TITLE
fix(agent): preserve usage anchors across display-only rewrites

### DIFF
--- a/agent/usage_anchor.py
+++ b/agent/usage_anchor.py
@@ -25,9 +25,8 @@ logger = logging.getLogger(__name__)
 
 USAGE_ANCHOR_MODEL_CONFIG_KEY = "_usage_anchor"
 
-# Identity of a priced message = the provider-visible fields that round-trip the session DB
-# byte-for-byte. Display/persistence metadata (timestamps, row ids, display kinds) is rewritten
-# on reload and would only ever fail the match closed.
+# Identity follows replayed content: persistence may move the same API bytes from
+# content into api_content while replacing the display text.
 _FINGERPRINT_KEYS = ("role", "content", "api_content", "tool_call_id", "tool_calls")
 
 
@@ -35,7 +34,10 @@ def message_fingerprint(msg: Any) -> Optional[str]:
     """Stable digest of one transcript message over its provider-visible, persisted fields."""
     if not isinstance(msg, dict):
         return None
+    from agent.turn_context import substitute_api_content
+
     payload = {k: msg.get(k) for k in _FINGERPRINT_KEYS if msg.get(k) is not None}
+    substitute_api_content(payload)
     try:
         raw = json.dumps(payload, sort_keys=True, default=str, ensure_ascii=True, separators=(",", ":"))
     except (TypeError, ValueError):

--- a/tests/agent/test_usage_anchor_content_identity.py
+++ b/tests/agent/test_usage_anchor_content_identity.py
@@ -1,0 +1,74 @@
+"""An unchanged API message keeps its usage anchor across display-only rewrites."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from agent.memory_manager import build_memory_context_block
+from agent.session_persistence import _db_flush_row
+from agent.turn_context import _preflight_request_tokens, build_api_messages, substitute_api_content
+from agent.usage_anchor import capture_usage_anchor, message_fingerprint, restore_usage_anchor, set_usage_anchor
+from hermes_state import SessionDB
+
+
+def _agent(**attrs):
+    return SimpleNamespace(
+        model="fixture", provider="custom", base_url="https://example.invalid/v1",
+        api_mode="chat_completions", tools=[], ephemeral_system_prompt="",
+        _copy_reasoning_content_for_api=lambda *_: None,
+        _should_sanitize_tool_calls=lambda: False, **attrs,
+    )
+
+
+@pytest.mark.parametrize("rewrite", ["persist_override", "sanitized_display"])
+def test_persisted_display_rewrite_preserves_priced_wire_message(tmp_path, rewrite):
+    sent = "visible question\n\n" + build_memory_context_block("recalled context")
+    messages = [{"role": "user", "content": sent}]
+    original = deepcopy(messages)
+    sid = "wire-identity"
+    db_path = tmp_path / "state.db"
+    with SessionDB(db_path) as db:
+        db.create_session(sid, source="cli")
+        agent = _agent(session_id=sid, _session_db=db,
+                       _persist_user_message_override="visible question" if rewrite == "persist_override" else None)
+        db.append_messages_batch(sid, [_db_flush_row(agent, messages[0], True)])
+        set_usage_anchor(agent, capture_usage_anchor(30_000, 25, messages))
+        assert messages == original
+
+    with SessionDB(db_path) as db:
+        restored = db.get_messages_as_conversation(sid)
+        assert restored[0]["content"] != sent
+        resumed = _agent(session_id=sid, _session_db=db, _usage_anchor=None)
+        wire, _ = build_api_messages(
+            resumed, restored, current_turn_user_idx=None, ext_prefetch_cache="",
+            plugin_user_context="", moa_config=None, active_system_prompt="",
+        )
+        assert wire[0]["content"] == sent
+        restore_usage_anchor(resumed, restored)
+        assert _preflight_request_tokens(resumed, restored, "") == 30_025
+
+        # A real change to replayed content still invalidates the old provider reading.
+        restored[0]["api_content"] += " changed"
+        resumed._usage_anchor = None
+        restore_usage_anchor(resumed, restored)
+        assert resumed._usage_anchor is None
+
+
+@pytest.mark.parametrize("role,sidecar", [
+    ("user", "wire"), ("assistant", "wire"), ("user", ""),
+    ("user", {"text": "ignored"}), ("tool", "ignored"), ("system", "ignored"),
+])
+def test_fingerprint_tracks_replayed_content_without_mutating_message(role, sidecar):
+    message = {"role": role, "content": "display", "api_content": sidecar}
+    original = deepcopy(message)
+    wire = deepcopy(message)
+    substitute_api_content(wire)
+    assert message_fingerprint(message) == message_fingerprint(wire)
+    edited = dict(message, content="new display")
+    wire_edited = deepcopy(edited)
+    substitute_api_content(wire_edited)
+    assert (message_fingerprint(message) == message_fingerprint(edited)) == (wire == wire_edited)
+    if role == "user" and sidecar == "wire":
+        assert message_fingerprint(message) != message_fingerprint(dict(message, api_content="new wire"))
+    assert message == original


### PR DESCRIPTION
## What does this PR do?

Keep a valid usage anchor when transcript persistence changes only the display representation of a priced message. A user-message persist override, or sanitization on reload, can store the original API bytes in `api_content` and clean text in `content`. Replay sends the same bytes, but the current fingerprint hashes both fields separately and rejects the anchor, falling back to a full context estimate.

Fingerprint a copied message through the existing `substitute_api_content` helper before hashing. Actual replay-content changes still invalidate the anchor, and the original transcript is never mutated. Plain-message fingerprints remain unchanged; old anchors with a different sidecar encoding fail closed until fresh usage is recorded.

## Related Issue

No dedicated issue. Reproduced on current main while tracing the persistence and replay contracts from #99585 and #64293. This is independent of #105032, which scopes anchors to the model route; this PR fixes equivalent message representations on the same route. Searched open and closed PRs for fingerprint/api_content, anchor/api_content and anchor/sidecar; no matching repair found.

## Type of Change

- [x] Bug fix

## Changes Made

- Reuse the production sidecar-substitution rules in `agent/usage_anchor.py`.
- Two parameterized behavior tests cover real SessionDB close/reopen, the production persistence row builder and request builder, display overrides, sanitized display content, valid/invalid sidecars and actual replay-content changes.

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_usage_anchor_content_identity.py --file-retries 0 -q
```

- Identical regression file on unmodified main `6e2b8e070d`: **8 failed**; with this fix: **8 passed**.
- **78 related tests passed across 9 files**, including the existing loopback HTTP provider tests that verify next-turn request replay. Retries disabled. The wire-test file was rerun with local socket access after the initial environment denied binding its test server.
- Ruff, `git diff --check`, and `scripts/check_compat_pointers.py` passed.
- Tests use temporary Hermes state and controlled provider inputs; no live vendor API calls. Full repository suite not run.

## Checklist

- [x] Read contribution guidance and checked current main and related PRs.
- [x] One focused bug fix; conventional commit.
- [x] Behavioral regression proven red on base, green with fix.
- [x] Real persistence/replay integration tested on macOS.
- [x] No new config, tools, prompt changes or platform-specific behavior.
