### PR TITLE
feat(skills): add optional evidence-led deep researcher

### DIFF
--- a/optional-skills/research/deep-researcher/SKILL.md
+++ b/optional-skills/research/deep-researcher/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: deep-researcher
+description: Track research claims and resume evidence dossiers.
+version: 1.0.0
+author: Brent Wilkins (BrentWilkins)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [research, web-search, web-extraction, evidence, citations]
+    category: research
+    related_skills: [grounded-citations, research-paper-writing, arxiv, blogwatcher]
+---
+
+# Deep Researcher Skill
+
+Search discovers candidates; retrieved passages support claims; the ledger controls synthesis.
+Never use search snippets or model memory to fill a missing source-backed conclusion.
+Use native `web_search`, `web_extract`, `browser_navigate`, `read_file`,
+`write_file`, and `patch` tools. Do not type tool calls
+into a terminal or substitute direct search-engine scraping. Scripts below are local
+bookkeeping helpers, not alternative retrieval backends.
+
+## When to Use
+
+Use for substantive multi-source investigations and comparisons requiring
+persistent claims, contradiction analysis, or work across sessions. Simple
+lookups, single-claim checks, and synthesis of supplied documents usually need
+a smaller workflow such as `grounded-citations`.
+
+## Prerequisites
+
+Python 3.10+ for the standard-library bookkeeping scripts, `terminal` for running
+them, and native retrieval tools configured in Hermes. No extra Python packages,
+API keys, or research-access plugin are required by this skill itself. Retrieval
+services may have their own setup requirements.
+
+## How to Run
+
+Invoke the commands below through `terminal`. Replace SKILL with this skill's
+absolute directory and RUN with a new dedicated research directory; quote paths
+containing spaces. Use the available Python interpreter (`python3` below).
+
+```sh
+python3 SKILL/scripts/research_run.py init RUN --question "Research question" --scope "Audience, timeframe, exclusions" --mode standard
+python3 SKILL/scripts/evidence_ledger.py init RUN/evidence.json --topic "Topic" --question "Q1: Question"
+```
+
+## Quick Reference
+
+- `research_run.py init|checkpoint|status`: initialize, save progress, or resume.
+- `evidence_ledger.py add-source|add-claim`: record passages and linked claims.
+- `evidence_ledger.py check|brief`: validate references and derive a compact brief.
+- `audit_report.py REPORT --ledger LEDGER --no-live`: offline citation audit.
+- `research_run.py archive|restore`: verified lossless archival and recovery.
+
+All helpers live under `scripts/`; each command supports `--help`.
+Read [run management](references/run-management.md) for lifecycle commands.
+
+## Procedure
+
+### 1. Frame and budget
+
+Establish the decision, audience, scope, timeframe, and exclusions. Ask only when an
+unresolved choice materially changes the task; otherwise record assumptions and proceed.
+Decompose into focused questions, including material counterarguments or failure modes.
+Define what evidence would answer each question and which source types can establish it.
+
+Use a new dedicated run directory. Resolve this skill's directory and the run directory
+to absolute paths; commands below use SKILL and RUN as placeholders, not persistent shell
+variables. Read [run management](references/run-management.md) when initializing, resuming,
+or archiving a run.
+
+Planning defaults (override to match the task and record the effective values):
+- Quick: 4 search calls, about 4–6 useful sources.
+- Standard: 8 search calls, about 8–15 useful sources.
+- Deep: 12 search calls, about 15–25 useful sources.
+- Stop after four search/extraction/gap-analysis iterations by default. An explicit zero
+  removes the iteration ceiling only; search, context, and storage budgets still apply.
+- Reserve at most two additional searches for a specific high-impact gap after extraction.
+- Reserve roughly one quarter of available context for synthesis and audit. Extract at
+  most 8,000 characters per page initially; read relevant cached sections as needed.
+  Keep raw excerpts in context below roughly 35% of the available window and discovery/tool
+  overhead near 10%; reduce collection further when the session already has substantial history.
+- Use a 64 MiB warning budget for registered working artifacts, configurable at initialization.
+  This is a collection guideline, not a downloader quota or an OS disk limit.
+
+Counts are ceilings or planning estimates, never success targets. Stop once material
+questions are adequately answered or further collection is unlikely to change the result.
+Expose unresolved gaps when the budget is exhausted.
+In quick mode, a decisive claim needs a strong primary source or independent corroboration.
+In standard/deep modes, seek two independently assessed origins per major claim and label
+single-source exceptions. Deep mode also requires a counter-evidence search per major theme.
+
+### 2. Discover and retrieve
+
+1. Search before extraction unless URLs were supplied. Start each evidence gap with one
+   concise query. Try a materially broader query after an empty result; stop that gap
+   after a second empty result. Stop discovery after four empty responses across the report.
+   Before each follow-up, compare its evidence gap and candidate URLs with prior queries;
+   a reworded query is not a new evidence need. Stop discovery after two searches add no new
+   credible canonical URLs. Synthesize or report the gap; do not silently raise budgets to
+   avoid stopping. Record user-requested scope/budget changes in the run state.
+2. Keep a compact search log: query, gap, outcome, newly shortlisted URLs. Do not retain
+   repeated snippets as evidence. Favor primary evidence for facts and independent work
+   for interpretation. Popularity and domain suffix are not quality scores.
+   Assess directness, author authority, methodological transparency, independence, recency,
+   and incentives/conflicts. Do not compare options on dimensions lacking comparable evidence.
+3. Extract at most three promising canonical URLs per batch. Record actual citation identity,
+   retrieval date, relevant passages, coverage, and limitations. Never invent metadata.
+4. A successful HTTP response containing a cookie wall, challenge, or empty body is a
+   retrieval failure. For permitted sites, try an available native browser session or an
+   authoritative alternative (canonical page, print/PDF, original study, official API, or
+   repository copy). Use at most one browser fallback per failed URL and two consent interactions,
+   preferring necessary-only consent, then record persistent blocks. Respect site
+   access policies; tool availability does not authorize paid services or new accounts.
+5. Abstract-only retrieval cannot establish unreported full-paper methods or results.
+   Full-text availability does not establish study quality, and cached but unread sections
+   have not been reviewed. For clinical claims, follow secondary leads to underlying
+   studies, reviews, guidelines, or regulator documents.
+   If the underlying clinical claim cannot be verified, omit it from clinical conclusions
+   or explicitly label it unverified. Record retrieval method, timestamp, and article identifiers
+   when available. Keep extracted, failed, considered, and cited sources distinct.
+6. Deduplicate by source identity as well as URL. Copies, syndicated reports, and articles
+   relying on the same study share an origin group even on different domains.
+
+Native retrieval tools own extraction; do not bypass them with terminal
+Firecrawl calls, inline Python, or generated extraction scripts. Invoke the
+bundled bookkeeping scripts through `terminal`.
+
+### 3. Record evidence and checkpoint
+
+Initialize the run manifest first, then the ledger:
+
+```sh
+python3 SKILL/scripts/evidence_ledger.py init RUN/evidence.json --topic "Topic" --question "Q1: Question"
+```
+
+After each extraction batch, add concise source records and atomic claims using
+`evidence_ledger.py add-source` and `add-claim`. See `--help` and the
+[worked example](references/worked-example.md) for paired passages and locators.
+
+- Use repeatable `--evidence '{"excerpt":"Exact short passage","locator":"Section/page/paragraph"}'`
+  on sources. Locators may include a registered run-relative cache path and line numbers.
+  Record a separate excerpt/locator pair for each passage.
+- Link claims with `--evidence S1E1` and the corresponding `--source 1` or
+  `--counter-source 1`. Evidence IDs remain stable within the ledger.
+- Independence starts unverified. Set both `--independence-group` and
+  `--independence-note` only after tracing the underlying data or origin. Group IDs are
+  assessments, not proof; the script cannot establish semantic independence.
+- Keep excerpts short and relevant (usually one to three per source). Prefer source
+  locators over entire page copies; retain a single local text copy only when needed for
+  audit or offline reproducibility. Do not collect browser profiles, cookies, or credentials.
+- Checkpoint completed work, current gaps, the next action, and artifact paths after each
+  batch or before context compaction. Register every retained run artifact. Resume from
+  the manifest and compact brief, opening only the passages needed for the next decision.
+
+Older ledgers remain readable. Legacy domain-based groups count as unverified until an
+explicit assessment and note are recorded. Do not infer independence while migrating.
+For corrections, use the native file editor on the ledger and rerun its checks.
+
+### 4. Check gaps and synthesize
+
+Run `evidence_ledger.py check RUN/evidence.json` and
+`evidence_ledger.py brief RUN/evidence.json`; save the brief as RUN/evidence-brief.md.
+Checks warn about missing corroboration and locators; they do not prove truth.
+The brief defaults to at most 24,000 characters. If it reports truncation, read relevant
+ledger records before synthesis; use `--max-chars` only when the context budget allows.
+Seek counter-evidence for decisive claims and inspect conflicts in definitions, populations,
+dates, methods, and incentives. Sources repeating one origin do not supply independent support.
+After each batch, check unanswered questions, interested-party-only support, stale evidence,
+disputed claims without counter-evidence, and recommendations missing tradeoffs or downsides.
+Resolve the most consequential gap first. Formulate the strongest plausible contrary claim
+before searching for evidence that would support it.
+
+Draft from the brief and ledger using [the dossier template](references/dossier-template.md),
+adapting its length and sections to the user's request. Keep these distinctions visible:
+sourced fact, interpretation, analyst inference, recommendation, and unresolved gap.
+Place citations next to the exact claims they support. Summarize uncertainty and what would
+change the conclusion. Count only successfully retrieved sources actually used in the report.
+Each paragraph-end citation must support the whole paragraph; otherwise split the claims.
+List excluded and failed candidates separately. Calibrate confidence per finding:
+- High: direct evidence with independent corroboration and no serious unresolved contradiction.
+- Medium: credible evidence with limitations in independence, coverage, recency, or methods.
+- Low: sparse, indirect, disputed, or materially uncertain evidence.
+
+### 5. Audit and finish
+
+Run `audit_report.py RUN/report.md --ledger RUN/evidence.json` (use `--no-live` for
+offline structural checking). Review warnings and inspect each major claim's exact scope,
+tense, supporting passage, opposing evidence, and independence assessment. A reachable URL
+or a clean script result does not establish semantic support.
+Fix structural errors, explain unresolved warnings, and remember that a blocked live link alone
+does not invalidate a source already retrieved. Revise once for accuracy and once for usefulness.
+
+Check the executive summary against the findings, revise, and mark the run complete only
+after the requested report and audit are finished. Then offer or perform lossless archiving
+when requested, using [run management](references/run-management.md). Keep report.md readable.
+Compression reduces disk storage, not token usage; read selectively rather than inflating
+an archive into model context. Never archive an active run or prune unregistered artifacts.
+
+## Pitfalls
+
+- Different hostnames do not establish independent evidence.
+- Ledger checks validate structure, not truth or verbatim passage accuracy;
+  compare recorded excerpts with retrieved text during the semantic audit.
+- Archives are not encrypted backups. Never include credentials or browser state.
+- Compression saves disk space, not context; the storage budget is a warning,
+  not a hard quota. Missing optional codecs fall back without installing packages.
+
+## Verification
+
+After writing the report, run this offline check through `terminal`:
+
+```sh
+python3 SKILL/scripts/audit_report.py RUN/report.md --ledger RUN/evidence.json --no-live
+```
+
+Fix structural errors and review every material claim against its supporting
+passages; a clean exit does not certify the report's conclusions.
+
+Maintained at [BrentWilkins/research-skills](https://github.com/BrentWilkins/research-skills).
+Related design references: [SkillMedev's deep-research skill](https://github.com/SkillMedev/skills/blob/main/skills/deep-research/SKILL.md)
+(scope and examples) and [LovStudio's deep-research skill](https://github.com/lovstudio/deep-research-skill/blob/main/SKILL.md)
+(evidence locators and run manifests).

--- a/optional-skills/research/deep-researcher/references/dossier-template.md
+++ b/optional-skills/research/deep-researcher/references/dossier-template.md
@@ -1,0 +1,91 @@
+# [Research title]
+
+> **Mode:** [quick / standard / deep] | **Sources analyzed:** [successfully extracted and cited N] | **Completed:** [YYYY-MM-DD, timezone]
+
+## Research scope
+
+- **Decision or question:** [What this report is intended to resolve]
+- **Audience:** [Who will use it]
+- **Timeframe/geography:** [Relevant bounds]
+- **Key definitions:** [Terms whose meaning affects the answer]
+- **Assumptions:** [Material assumptions made without user clarification]
+
+## Executive summary
+
+**Bottom line:** [Direct answer in one or two sentences, with citations.]
+
+- **[Finding]:** [Decision-relevant takeaway] [N], [N]. **Confidence: High/Medium/Low.**
+- **[Finding]:** [Decision-relevant takeaway] [N], [N]. **Confidence: High/Medium/Low.**
+- **[Risk or contradiction]:** [What could change the conclusion] [N]. **Confidence: ...**
+
+**Recommendation:** [If requested and supported. State conditions under which it changes.]
+
+## Findings by research question
+
+### Q1. [Question]
+
+**Answer:** [Concise answer with immediate citations.] [N], [N]
+
+| Finding | Evidence | Confidence | Why |
+|---|---|---|---|
+| [Atomic claim] [N], [N] | [Primary/secondary evidence and independence] | High/Medium/Low | [Calibration rationale] |
+
+**Analysis:** [Connect the evidence. Explicitly label material inference: “Analyst inference: ...”]
+
+**Counter-evidence and limits:** [Strongest contrary evidence, methodological weaknesses, boundary conditions, or “None found after targeted search.”]
+
+### Q2. [Question]
+
+[Repeat the Q1 structure.]
+
+## Options or comparison
+
+[Include only when the topic requires a choice. Do not compare dimensions for which comparable evidence was not found.]
+
+| Criterion | Option A | Option B | Implication |
+|---|---|---|---|
+| [Criterion] | [Evidence-backed assessment] [N] | [Evidence-backed assessment] [N] | [Decision consequence] |
+
+## Contradictions and uncertainty
+
+| Issue | Evidence on one side | Counter-evidence | Likely explanation | Resolution |
+|---|---|---|---|---|
+| [Dispute] | [Claim and citations] | [Claim and citations] | [Definitions, timeframe, method, incentives, etc.] | Resolved / partly resolved / unresolved |
+
+### Information gaps
+
+- [Question that remains unanswered and why it matters]
+- [Evidence that was unavailable, incomparable, stale, or methodologically weak]
+
+### What would change the conclusion
+
+- [Specific future evidence, threshold, event, or assumption that would reverse or materially alter the result]
+
+## Sources analyzed
+
+| # | Source | Type | Date | Independence group | Used for | Limitations |
+|---:|---|---|---|---|---|---|
+| 1 | [Title] | Primary/Secondary/Commentary/Community | YYYY-MM-DD | [Origin/dataset/organization] | Q1, claim C001 | [Conflict, method, access, age] |
+
+### Citation Links
+
+1. [Title](https://example.com/source)
+2. [Title](https://example.org/source)
+
+## Methodology
+
+- **Search strategy:** [Queries and source targets]
+- **Extraction:** [Successfully extracted N; failed N; relevant date range]
+- **Evidence standard:** [How primary evidence, independence, and counter-evidence were assessed]
+- **Context controls:** [Batch/character limits and use of evidence ledger]
+- **Audit:** [Deterministic audit result and semantic claim-audit summary]
+
+### Considered but excluded or failed
+
+| Source/URL | Status | Reason not used |
+|---|---|---|
+| [Candidate] | Failed / duplicate / low relevance / superseded | [Reason] |
+
+---
+
+*Prepared with the Hermes Deep Researcher workflow. Citations establish provenance; confidence reflects evidence directness, independence, recency, and methodological transparency.*

--- a/optional-skills/research/deep-researcher/references/run-management.md
+++ b/optional-skills/research/deep-researcher/references/run-management.md
@@ -1,0 +1,80 @@
+# Run state, storage, and recovery
+
+Use a new dedicated directory per run, outside the skill package. Replace SKILL and RUN
+with actual absolute paths; do not assume shell variables survive across tool calls.
+
+```sh
+python3 SKILL/scripts/research_run.py init RUN --question "Research question" --scope "Audience, timeframe, exclusions" --mode standard --storage-mb 64
+```
+
+The manifest records assumptions, effective search/storage budgets, completed work, gaps,
+next action, and an explicit artifact inventory. `--search-budget` overrides the mode's
+default; repeat `--assumption` as needed. It contains no automatic environment/config dump.
+
+After initializing the ledger and collecting evidence:
+
+```sh
+python3 SKILL/scripts/research_run.py checkpoint RUN --artifact evidence.json --artifact evidence-brief.md --completed "Q1 evidence collected" --gaps "Q2 lacks independent evidence" --next-action "Retrieve the original Q2 study"
+python3 SKILL/scripts/research_run.py status RUN
+```
+
+Artifact arguments refer to existing individual files relative to RUN, not directories,
+globs, external tool caches, or symlinks. Repeat `--artifact` for any intentionally retained
+source text or search log. Completed/gaps arguments replace their respective lists;
+omitting them preserves the previous state. `--clear-gaps` clears resolved gaps.
+Use the native file editor to revise scope, assumptions, or budgets in the manifest.
+
+To resume, read status and the brief first, then the ledger only as needed. Inspect whether
+time-sensitive evidence needs refreshing. Reuse completed work; do not rerun all searches.
+The manifest is a checkpoint, not an automatic search scheduler or spending meter.
+
+## Prevent accumulation
+
+- Record compact facts once. The ledger is authoritative; the brief is a small derived view.
+- Brief output is capped at 24,000 characters by default, with an explicit truncation notice.
+  Truncation never changes stored evidence. Read omitted relevant records before drawing conclusions.
+- Keep one working report and one brief. Use a final report plus archive for retention rather
+  than appending a new full report after every iteration.
+- Default to excerpts and locators. Retain full raw text only when it serves verification;
+  avoid downloaded media, screenshots, PDFs, and duplicate HTML unless the task needs them.
+- Check registered storage after each batch. The 64 MiB default is a warning threshold,
+  not a hard cap. It does not include unregistered files or backend-managed caches.
+- Do not delete host caches or other research runs. Their retention is separately managed.
+- Store runs outside the distributable repository; do not commit reports or archives by default.
+
+## Complete and archive
+
+Finish the semantic and structural report audit before marking complete. Run completion
+checks that report.md is nonempty; it cannot verify that a human/agent performed the audit.
+
+```sh
+python3 SKILL/scripts/research_run.py checkpoint RUN --status complete --artifact report.md --artifact evidence.json --artifact evidence-brief.md
+python3 SKILL/scripts/research_run.py archive RUN --prune
+```
+
+This creates artifacts.zip using lossless LZMA compression when available. If the Python build
+lacks LZMA, it uses deflate; if neither codec is available, it stores files in an uncompressed ZIP.
+No dependency installation is needed. The command reports the chosen method. Restoring an
+archive on another machine requires support for the codec that created it.
+Text-heavy evidence often compresses well; PDFs, images, and already compressed files may
+shrink little or grow. Actual byte counts are printed. No lossy rewriting of evidence occurs.
+
+The archive includes all registered files, including a copy of the report and manifest.
+Each archived member is decompressed and SHA-256 checked against its source before pruning.
+`--prune` removes only registered, verified working files; report.md and run_manifest.json
+remain readable. Unregistered files remain untouched. Without `--prune`, all originals
+remain, so the operation adds storage rather than reclaiming it.
+
+Use this only on an inactive, completed run. Existing archives are never overwritten.
+The outer manifest records the archive checksum and member hashes. Keep it with the archive.
+If a failure interrupts archiving, inspect the reported error and surviving files before retrying;
+do not remove source artifacts to force a retry.
+
+```sh
+python3 SKILL/scripts/research_run.py restore RUN NEW_RUN
+python3 SKILL/scripts/research_run.py checkpoint NEW_RUN --status active --next-action "Review the unresolved evidence gap"
+```
+
+Restore verifies checksums and requires a fresh destination. It restores original file bytes,
+including the complete-state manifest. This is archival compression, not encryption or backup
+to another device. Keep the readable report, manifest, and archive together in your backup.

--- a/optional-skills/research/deep-researcher/references/worked-example.md
+++ b/optional-skills/research/deep-researcher/references/worked-example.md
@@ -1,0 +1,23 @@
+# Example: shared origins and unresolved evidence
+
+This is a synthetic illustration, not a real study or a factual performance claim.
+Replace SKILL and RUN with absolute paths. Initialize a run before these commands.
+
+```sh
+python3 SKILL/scripts/evidence_ledger.py init RUN/evidence.json --topic "Synthetic pilot evaluation" --question "Q1: Did the pilot reduce processing time?" --question "Q2: Does this generalize?"
+python3 SKILL/scripts/evidence_ledger.py add-source RUN/evidence.json --url https://example.com/pilot --title "Synthetic pilot report" --source-type primary --question "Q1: Did the pilot reduce processing time?" --independence-group pilot-dataset --independence-note "Original pilot dataset; self-reported by its operator" --summary "The operator reports a shorter median in its pilot." --evidence '{"excerpt":"Median processing time fell from 10 to 8 minutes in this pilot.","locator":"Results, paragraph 2"}' --limitation "Self-reported; no independent replication"
+python3 SKILL/scripts/evidence_ledger.py add-source RUN/evidence.json --url https://example.org/news --title "Synthetic news coverage" --source-type secondary --question "Q1: Did the pilot reduce processing time?" --independence-group pilot-dataset --independence-note "This article repeats the first report; no new data" --summary "Coverage repeats the pilot result." --evidence '{"excerpt":"The operator reports a reduction from 10 to 8 minutes.","locator":"Paragraph 4; cites the pilot report"}'
+python3 SKILL/scripts/evidence_ledger.py add-claim RUN/evidence.json --text "The pilot operator reports that median processing time fell from 10 to 8 minutes." --question "Q1: Did the pilot reduce processing time?" --status single-source --source 1,2 --evidence S1E1 --evidence S2E1 --reasoning "Both publications depend on the same pilot dataset." --caveat "This does not establish general effectiveness."
+python3 SKILL/scripts/evidence_ledger.py add-claim RUN/evidence.json --text "The pilot result generalizes to other organizations." --question "Q2: Does this generalize?" --status unsupported --caveat "No independent replication was retrieved."
+python3 SKILL/scripts/evidence_ledger.py check RUN/evidence.json
+python3 SKILL/scripts/evidence_ledger.py brief RUN/evidence.json
+```
+
+Expected interpretation: the first narrow claim has direct passage support but only one
+origin group. The checker warns about insufficient independent support. The second is an
+unresolved gap, not a report conclusion. Two hostnames do not turn one study into two studies.
+For an unassessed source, omit both independence arguments; it contributes no verified group.
+For a counterargument, use `--counter-source` with its corresponding `--evidence` passage.
+
+Report wording: “The operator reported a shorter median in its pilot [1]. News coverage [2]
+repeats the same dataset. Independent replication was not found; generalizability is unresolved.”

--- a/optional-skills/research/deep-researcher/scripts/audit_report.py
+++ b/optional-skills/research/deep-researcher/scripts/audit_report.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Audit a deep-research report's citation structure, coverage, and links."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections import Counter
+from pathlib import Path
+from typing import NamedTuple
+from urllib.parse import urlsplit
+
+BIBLIOGRAPHY_HEADING = re.compile(
+    r"^#{2,4}\s+(?:Citation Links|References|Bibliography)\s*$", re.IGNORECASE
+)
+CITATION_MARKER = re.compile(r"\[([0-9][0-9,\-–\s]*)\]")
+NUMBERED_ENTRY = re.compile(r"^(\d+)\.\s+(.*)$")
+MARKDOWN_URL = re.compile(r"\]\((https?://[^)]+)\)")
+BARE_URL = re.compile(r"(https?://\S+)")
+FACT_SIGNAL = re.compile(
+    r"(?:\b(?:18|19|20)\d{2}\b|\b\d+(?:\.\d+)?%\b|\$\s?\d|"
+    r"\b\d+(?:\.\d+)?\s*(?:million|billion|trillion|percent|users?|stars?|days?|years?)\b|"
+    r"\b(?:increased|decreased|launched|released|founded|acquired|outperform(?:s|ed)?|"
+    r"largest|smallest|fastest|slowest|leading|only)\b)",
+    re.IGNORECASE,
+)
+
+
+class LinkResult(NamedTuple):
+    number: int
+    url: str
+    severity: str
+    message: str
+
+
+def split_document(text: str) -> tuple[str, list[str]]:
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if BIBLIOGRAPHY_HEADING.match(line.strip()):
+            return "\n".join(lines[:index]), lines[index + 1 :]
+    return text, []
+
+
+def analytical_body(text: str) -> str:
+    """Exclude source inventories and methodology from heuristic claim checks."""
+    return re.split(
+        r"^##\s+(?:Sources analyzed|Methodology|Appendix|Considered but excluded or failed)\s*$",
+        text,
+        maxsplit=1,
+        flags=re.IGNORECASE | re.MULTILINE,
+    )[0]
+
+
+def expand_citation_group(group: str) -> set[int]:
+    result: set[int] = set()
+    for part in re.split(r"\s*,\s*", group.replace("–", "-")):
+        if not part:
+            continue
+        if "-" in part:
+            left, right = part.split("-", 1)
+            if left.strip().isdigit() and right.strip().isdigit():
+                start, end = int(left), int(right)
+                if 0 < start <= end <= start + 100:
+                    result.update(range(start, end + 1))
+        elif part.strip().isdigit():
+            result.add(int(part))
+    return result
+
+
+def citations_in(text: str) -> set[int]:
+    result: set[int] = set()
+    for match in CITATION_MARKER.finditer(text):
+        result.update(expand_citation_group(match.group(1)))
+    return result
+
+
+def bibliography_entries(lines: list[str]) -> tuple[dict[int, str], list[str]]:
+    entries: dict[int, str] = {}
+    errors: list[str] = []
+    for raw in lines:
+        stripped = raw.strip()
+        match = NUMBERED_ENTRY.match(stripped)
+        if not match:
+            continue
+        number = int(match.group(1))
+        url_match = MARKDOWN_URL.search(match.group(2)) or BARE_URL.search(
+            match.group(2)
+        )
+        if not url_match:
+            errors.append(f"Bibliography entry [{number}] has no HTTP(S) URL.")
+            continue
+        if number in entries:
+            errors.append(f"Bibliography entry [{number}] is duplicated.")
+        entries[number] = url_match.group(1).rstrip(".,")
+    return entries, errors
+
+
+def candidate_factual_lines(body: str) -> list[tuple[int, str]]:
+    warnings: list[tuple[int, str]] = []
+    in_fence = False
+    for number, raw in enumerate(body.splitlines(), start=1):
+        stripped = raw.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence or not stripped or stripped.startswith(("#", ">")):
+            continue
+        if stripped.startswith("|") and stripped.endswith("|"):
+            continue
+        if re.fullmatch(r"\|?[\s:|-]+\|?", stripped):
+            continue
+        if FACT_SIGNAL.search(stripped) and not citations_in(stripped):
+            warnings.append((number, stripped[:180]))
+    return warnings
+
+
+def uncited_analytical_rows(body: str) -> list[tuple[int, str]]:
+    rows: list[tuple[int, str]] = []
+    for number, raw in enumerate(body.splitlines(), start=1):
+        stripped = raw.strip()
+        if not (stripped.startswith("|") and stripped.endswith("|")):
+            continue
+        if re.fullmatch(r"\|?[\s:|-]+\|?", stripped):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) < 3 or all(len(cell.split()) <= 3 for cell in cells):
+            continue
+        if not citations_in(stripped) and not any(
+            cell.lower() in {"source", "sources"} for cell in cells
+        ):
+            rows.append((number, stripped[:180]))
+    return rows
+
+
+def check_url(item: tuple[int, str], timeout: int) -> LinkResult:
+    number, url = item
+    request = urllib.request.Request(url, method="GET")
+    request.add_header("User-Agent", "HermesDeepResearchAudit/2.0")
+    request.add_header("Range", "bytes=0-1023")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            response.read(1)
+            status = getattr(response, "status", 200)
+            return LinkResult(number, url, "ok", f"HTTP {status}")
+    except urllib.error.HTTPError as exc:
+        if exc.code in {404, 410}:
+            return LinkResult(number, url, "error", f"HTTP {exc.code} (not found)")
+        if exc.code in {401, 403, 405, 408, 425, 429} or 500 <= exc.code < 600:
+            return LinkResult(
+                number, url, "warning", f"HTTP {exc.code} (blocked or transient)"
+            )
+        return LinkResult(number, url, "warning", f"HTTP {exc.code}")
+    except Exception as exc:  # noqa: BLE001
+        return LinkResult(number, url, "warning", f"unverified: {str(exc)[:100]}")
+
+
+def ledger_urls(path: Path) -> set[str]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        source.get("canonical_url") or source.get("url")
+        for source in data.get("sources", [])
+    }
+
+
+def normalize_for_match(url: str) -> str:
+    parts = urlsplit(url)
+    path = (parts.path or "/").rstrip("/") or "/"
+    return f"{parts.scheme.lower()}://{parts.netloc.lower()}{path}"
+
+
+def run(args: argparse.Namespace) -> int:
+    path = Path(args.report).expanduser()
+    if not path.exists():
+        print(f"ERROR: report not found: {path}")
+        return 1
+    body, bibliography_lines = split_document(path.read_text(encoding="utf-8"))
+    cited = citations_in(body)
+    entries, parse_errors = bibliography_entries(bibliography_lines)
+    errors = list(parse_errors)
+    warnings: list[str] = []
+
+    if not bibliography_lines:
+        errors.append(
+            "No 'Citation Links', 'References', or 'Bibliography' section found."
+        )
+    if not cited:
+        errors.append("No numbered citations were found in the report body.")
+    missing = sorted(cited - set(entries))
+    unused = sorted(set(entries) - cited)
+    for number in missing:
+        errors.append(
+            f"Citation [{number}] is used in the body but missing from the bibliography."
+        )
+    for number in unused:
+        warnings.append(
+            f"Bibliography entry [{number}] is never cited in the report body."
+        )
+    if entries:
+        expected = set(range(1, max(entries) + 1))
+        gaps = sorted(expected - set(entries))
+        if gaps:
+            warnings.append(f"Bibliography numbering has gaps: {gaps}.")
+
+    domains = Counter(urlsplit(url).hostname or "" for url in entries.values())
+    if len(entries) >= 5 and domains:
+        domain, count = domains.most_common(1)[0]
+        if count / len(entries) > 0.5:
+            warnings.append(
+                f"Source concentration: {count}/{len(entries)} bibliography entries are from {domain}."
+            )
+    duplicate_urls: dict[str, list[int]] = {}
+    for number, url in entries.items():
+        duplicate_urls.setdefault(normalize_for_match(url), []).append(number)
+    for url, numbers in duplicate_urls.items():
+        if len(numbers) > 1:
+            errors.append(f"Duplicate bibliography URL in entries {numbers}: {url}")
+
+    analysis_text = analytical_body(body)
+    factual = candidate_factual_lines(analysis_text)
+    for line_number, preview in factual[: args.max_heuristic_warnings]:
+        warnings.append(
+            f"Possibly uncited factual claim at line {line_number}: {preview}"
+        )
+    if len(factual) > args.max_heuristic_warnings:
+        warnings.append(
+            f"{len(factual) - args.max_heuristic_warnings} additional possibly uncited lines suppressed."
+        )
+    for line_number, preview in uncited_analytical_rows(analysis_text)[
+        : args.max_heuristic_warnings
+    ]:
+        warnings.append(
+            f"Possibly uncited analytical table row at line {line_number}: {preview}"
+        )
+
+    if args.ledger:
+        try:
+            evidence_urls = {
+                normalize_for_match(url)
+                for url in ledger_urls(Path(args.ledger).expanduser())
+                if url
+            }
+            for number, url in entries.items():
+                if normalize_for_match(url) not in evidence_urls:
+                    errors.append(
+                        f"Bibliography entry [{number}] is absent from the evidence ledger."
+                    )
+        except (OSError, json.JSONDecodeError, TypeError) as exc:
+            errors.append(f"Could not read evidence ledger: {exc}")
+
+    link_results: list[LinkResult] = []
+    if not args.no_live and entries:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=min(args.workers, len(entries))
+        ) as executor:
+            link_results = sorted(
+                executor.map(
+                    lambda item: check_url(item, args.timeout), entries.items()
+                ),
+                key=lambda item: item.number,
+            )
+        for result in link_results:
+            message = f"Link [{result.number}] {result.message}: {result.url}"
+            if result.severity == "error":
+                errors.append(message)
+            elif result.severity == "warning":
+                warnings.append(message)
+
+    print(f"Report audit: {path.name}")
+    print(f"  Body citations: {len(cited)} unique")
+    print(f"  Bibliography:   {len(entries)} entries across {len(domains)} domain(s)")
+    if link_results:
+        print(
+            f"  Live links:     {sum(item.severity == 'ok' for item in link_results)}/{len(link_results)} verified"
+        )
+    for message in errors:
+        print(f"ERROR: {message}")
+    for message in warnings:
+        print(f"WARN: {message}")
+    if not errors and not warnings:
+        print("PASS: all deterministic report checks passed.")
+    elif not errors:
+        print(f"PASS WITH WARNINGS: {len(warnings)} item(s) require review.")
+    else:
+        print(f"FAIL: {len(errors)} error(s), {len(warnings)} warning(s).")
+    return 1 if errors else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", help="Markdown report to audit")
+    parser.add_argument("--ledger", help="Optional evidence-ledger JSON to cross-check")
+    parser.add_argument("--no-live", action="store_true", help="Skip HTTP checks")
+    parser.add_argument(
+        "--timeout", type=int, default=10, help="Per-link timeout in seconds"
+    )
+    parser.add_argument("--workers", type=int, default=8, help="Concurrent link checks")
+    parser.add_argument("--max-heuristic-warnings", type=int, default=12)
+    return parser
+
+
+def main() -> None:
+    sys.exit(run(build_parser().parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/research/deep-researcher/scripts/evidence_ledger.py
+++ b/optional-skills/research/deep-researcher/scripts/evidence_ledger.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""Create and validate a compact evidence ledger for deep research."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+SOURCE_TYPES = ("primary", "secondary", "commentary", "community")
+CLAIM_STATUSES = ("supported", "disputed", "single-source", "unsupported")
+TRACKING_KEYS = {
+    "fbclid",
+    "gclid",
+    "mc_cid",
+    "mc_eid",
+    "ref",
+    "source",
+}
+
+
+def canonical_url(value: str) -> str:
+    """Normalize a URL enough to catch common duplicate-source entries."""
+    parts = urlsplit(value.strip())
+    if parts.scheme not in {"http", "https"} or not parts.netloc:
+        raise ValueError(f"Expected an absolute HTTP(S) URL: {value}")
+    host = parts.hostname.lower() if parts.hostname else ""
+    port = parts.port
+    if port and not (
+        (parts.scheme == "http" and port == 80)
+        or (parts.scheme == "https" and port == 443)
+    ):
+        host = f"{host}:{port}"
+    query = urlencode(
+        sorted(
+            (key, val)
+            for key, val in parse_qsl(parts.query, keep_blank_values=True)
+            if not key.lower().startswith("utm_") and key.lower() not in TRACKING_KEYS
+        )
+    )
+    path = re.sub(r"/{2,}", "/", parts.path or "/")
+    if path != "/":
+        path = path.rstrip("/")
+    return urlunsplit((parts.scheme.lower(), host, path, query, ""))
+
+
+def read_ledger(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SystemExit(f"ERROR: ledger does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"ERROR: invalid ledger JSON: {exc}") from exc
+    if not isinstance(data, dict) or data.get("version") != 1:
+        raise SystemExit("ERROR: unsupported or malformed evidence ledger")
+    return data
+
+
+def write_ledger(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    handle, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as temp:
+            json.dump(data, temp, indent=2, ensure_ascii=False)
+            temp.write("\n")
+        os.replace(temp_name, path)
+    except Exception:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def cmd_init(args: argparse.Namespace) -> None:
+    path = Path(args.ledger).expanduser()
+    if path.exists() and not args.force:
+        raise SystemExit(
+            f"ERROR: ledger already exists: {path} (use --force to replace)"
+        )
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    data = {
+        "version": 1,
+        "topic": args.topic,
+        "created_at": now,
+        "updated_at": now,
+        "research_questions": args.question,
+        "sources": [],
+        "claims": [],
+    }
+    write_ledger(path, data)
+    print(f"Initialized {path} with {len(args.question)} research question(s).")
+
+
+def cmd_add_source(args: argparse.Namespace) -> None:
+    path = Path(args.ledger).expanduser()
+    data = read_ledger(path)
+    normalized = canonical_url(args.url)
+    for source in data["sources"]:
+        if source["canonical_url"] == normalized:
+            raise SystemExit(
+                f"ERROR: duplicate source URL already has ID {source['id']}"
+            )
+    source_id = max((item["id"] for item in data["sources"]), default=0) + 1
+    source = {
+        "id": source_id,
+        "url": args.url,
+        "canonical_url": normalized,
+        "title": args.title,
+        "publisher": args.publisher or urlsplit(normalized).hostname,
+        "author": args.author or "",
+        "published_date": args.published_date or "",
+        "accessed_date": args.accessed_date
+        or datetime.now(timezone.utc).date().isoformat(),
+        "source_type": args.source_type,
+        "independence_group": args.independence_group or None,
+        "independence_assessed": bool(args.independence_group and args.independence_note),
+        "independence_note": args.independence_note or "",
+        "questions": args.question,
+        "extraction_status": args.extraction_status,
+        "summary": args.summary or "",
+        "excerpts": args.excerpt,
+        "limitations": args.limitation,
+        "evidence": [],
+    }
+    for index, value in enumerate(args.evidence, 1):
+        try:
+            item = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"ERROR: invalid evidence JSON: {exc}") from exc
+        if not isinstance(item, dict) or any(
+            not isinstance(item.get(key), str) or not item[key].strip()
+            for key in ("excerpt", "locator")
+        ):
+            raise SystemExit("ERROR: evidence needs nonempty excerpt and locator strings")
+        source["evidence"].append({
+            "id": f"S{source_id}E{index}",
+            "excerpt": item["excerpt"], "locator": item["locator"],
+        })
+    data["sources"].append(source)
+    write_ledger(path, data)
+    print(f"Added source [{source_id}] {args.title}")
+
+
+def parse_source_ids(values: list[str]) -> list[int]:
+    result: list[int] = []
+    for value in values:
+        for item in value.split(","):
+            item = item.strip()
+            if item:
+                result.append(int(item))
+    return sorted(set(result))
+
+
+def cmd_add_claim(args: argparse.Namespace) -> None:
+    path = Path(args.ledger).expanduser()
+    data = read_ledger(path)
+    claim_number = (
+        max(
+            (
+                int(item["id"][1:])
+                for item in data["claims"]
+                if re.fullmatch(r"C\d+", item["id"])
+            ),
+            default=0,
+        )
+        + 1
+    )
+    claim = {
+        "id": f"C{claim_number:03d}",
+        "text": args.text,
+        "question": args.question,
+        "importance": args.importance,
+        "status": args.status,
+        "source_ids": parse_source_ids(args.source),
+        "counter_source_ids": parse_source_ids(args.counter_source),
+        "reasoning": args.reasoning or "",
+        "caveat": args.caveat or "",
+        "evidence_ids": args.evidence,
+    }
+    data["claims"].append(claim)
+    write_ledger(path, data)
+    print(f"Added claim {claim['id']} ({claim['status']})")
+
+
+def validate(data: dict[str, Any]) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    source_ids = [source.get("id") for source in data.get("sources", [])]
+    source_id_set = set(source_ids)
+    if len(source_ids) != len(source_id_set):
+        errors.append("Duplicate source IDs exist.")
+    canonical_seen: dict[str, int] = {}
+    for source in data.get("sources", []):
+        if source.get("source_type") not in SOURCE_TYPES:
+            errors.append(
+                f"Source [{source.get('id', '?')}] has invalid source_type {source.get('source_type')!r}."
+            )
+        try:
+            normalized = canonical_url(source.get("url", ""))
+        except ValueError as exc:
+            errors.append(f"Source [{source.get('id', '?')}]: {exc}")
+            continue
+        if normalized in canonical_seen:
+            errors.append(
+                f"Sources [{canonical_seen[normalized]}] and [{source.get('id')}] duplicate {normalized}."
+            )
+        canonical_seen[normalized] = source.get("id")
+        if source.get("extraction_status") != "extracted":
+            warnings.append(
+                f"Source [{source.get('id')}] was not successfully extracted."
+            )
+        if not source.get("summary"):
+            warnings.append(
+                f"Source [{source.get('id')}] has no compact evidence summary."
+            )
+        elif len(source["summary"]) > 1200:
+            warnings.append(
+                f"Source [{source.get('id')}] summary exceeds 1,200 characters; compact it."
+            )
+        if any(len(excerpt) > 500 for excerpt in source.get("excerpts", [])):
+            warnings.append(
+                f"Source [{source.get('id')}] has an excerpt over 500 characters; retain only decisive wording."
+            )
+    question_set = set(data.get("research_questions", []))
+    question_sources = {question: set() for question in question_set}
+    for source in data.get("sources", []):
+        for question in source.get("questions", []):
+            if question not in question_set:
+                warnings.append(
+                    f"Source [{source.get('id')}] references unknown question {question!r}."
+                )
+            else:
+                question_sources[question].add(source.get("id"))
+    for question, ids in question_sources.items():
+        if len(ids) < 2:
+            warnings.append(
+                f"Research question {question!r} has fewer than two extracted sources."
+            )
+    claim_ids = [claim.get("id") for claim in data.get("claims", [])]
+    if len(claim_ids) != len(set(claim_ids)):
+        errors.append("Duplicate claim IDs exist.")
+    source_by_id = {source.get("id"): source for source in data.get("sources", [])}
+    for claim in data.get("claims", []):
+        claim_id = claim.get("id", "?")
+        supporting = set(claim.get("source_ids", []))
+        counter = set(claim.get("counter_source_ids", []))
+        missing = (supporting | counter) - source_id_set
+        if missing:
+            errors.append(
+                f"Claim {claim_id} references missing source IDs: {sorted(missing)}."
+            )
+            continue
+        if claim.get("question") not in question_set:
+            errors.append(
+                f"Claim {claim_id} references unknown question {claim.get('question')!r}."
+            )
+        if claim.get("status") not in CLAIM_STATUSES:
+            errors.append(
+                f"Claim {claim_id} has invalid status {claim.get('status')!r}."
+            )
+        if supporting & counter:
+            errors.append(
+                f"Claim {claim_id} lists source IDs as both support and counter-evidence: "
+                f"{sorted(supporting & counter)}."
+            )
+        unusable = {
+            source_id
+            for source_id in supporting | counter
+            if source_by_id[source_id].get("extraction_status") != "extracted"
+        }
+        if unusable:
+            errors.append(
+                f"Claim {claim_id} cites sources that were not extracted: {sorted(unusable)}."
+            )
+        if claim.get("status") == "unsupported" and supporting:
+            warnings.append(
+                f"Claim {claim_id} is unsupported but lists supporting sources."
+            )
+        if claim.get("status") != "unsupported" and not supporting:
+            errors.append(
+                f"Claim {claim_id} has status {claim.get('status')!r} but no supporting source."
+            )
+        groups = {
+            source.get("independence_group")
+            for source in data.get("sources", [])
+            if source.get("id") in supporting
+            and source.get("independence_assessed") is True
+            and source.get("independence_note", "").strip()
+            and source.get("independence_group")
+        }
+        if claim.get("importance") == "major" and len(groups) < 2:
+            warnings.append(
+                f"Major claim {claim_id} lacks two independent supporting sources."
+            )
+        if claim.get("status") == "disputed" and not counter:
+            warnings.append(
+                f"Disputed claim {claim_id} has no counter-evidence source."
+            )
+    evidence_by_id = {}
+    for source in data.get("sources", []):
+        if source.get("independence_assessed") is not True:
+            warnings.append(f"Source [{source.get('id')}] independence is unverified.")
+        for item in source.get("evidence", []):
+            evidence_id = item.get("id")
+            if not evidence_id or evidence_id in evidence_by_id:
+                errors.append(f"Missing or duplicate evidence ID: {evidence_id!r}.")
+            evidence_by_id[evidence_id] = source.get("id")
+            if not item.get("excerpt") or not item.get("locator"):
+                errors.append(f"Evidence {evidence_id} needs an excerpt and locator.")
+            if len(item.get("excerpt", "")) > 500:
+                warnings.append(f"Evidence {evidence_id} exceeds 500 characters; keep only the relevant passage.")
+    for claim in data.get("claims", []):
+        cited_sources = set(claim.get("source_ids", []) + claim.get("counter_source_ids", []))
+        if cited_sources and not claim.get("evidence_ids"):
+            warnings.append(f"Claim {claim.get('id')} has no precise evidence links.")
+        for evidence_id in claim.get("evidence_ids", []):
+            if evidence_id not in evidence_by_id or evidence_by_id[evidence_id] not in cited_sources:
+                errors.append(f"Claim {claim.get('id')} references unknown or unrelated evidence {evidence_id}.")
+        located_sources = {evidence_by_id[item] for item in claim.get("evidence_ids", []) if item in evidence_by_id}
+        if cited_sources - located_sources:
+            warnings.append(f"Claim {claim.get('id')} lacks precise passages for sources {sorted(cited_sources - located_sources)}.")
+    return errors, warnings
+
+
+def cmd_check(args: argparse.Namespace) -> None:
+    data = read_ledger(Path(args.ledger).expanduser())
+    errors, warnings = validate(data)
+    print(
+        f"Ledger: {len(data.get('sources', []))} source(s), "
+        f"{len(data.get('claims', []))} claim(s), "
+        f"{len(data.get('research_questions', []))} question(s)"
+    )
+    for message in errors:
+        print(f"ERROR: {message}")
+    for message in warnings:
+        print(f"WARN: {message}")
+    if not errors and not warnings:
+        print("PASS: ledger structure and evidence coverage checks passed.")
+    raise SystemExit(1 if errors else 0)
+
+
+def render_brief(args: argparse.Namespace) -> None:
+    data = read_ledger(Path(args.ledger).expanduser())
+    sources = {source["id"]: source for source in data.get("sources", [])}
+    print(f"# Evidence brief: {data.get('topic', '')}\n")
+    for question in data.get("research_questions", []):
+        print(f"## {question}")
+        matching = [
+            claim
+            for claim in data.get("claims", [])
+            if claim.get("question") == question
+        ]
+        if not matching:
+            print("- GAP: no claims recorded")
+        for claim in matching:
+            refs = (
+                ", ".join(f"[{item}]" for item in claim.get("source_ids", [])) or "none"
+            )
+            counter = ", ".join(
+                f"[{item}]" for item in claim.get("counter_source_ids", [])
+            )
+            suffix = f"; counter: {counter}" if counter else ""
+            print(
+                f"- {claim['id']} ({claim['status']}, {claim['importance']}): {claim['text']} — {refs}{suffix}"
+            )
+            if claim.get("caveat"):
+                print(f"  Caveat: {claim['caveat']}")
+            if claim.get("evidence_ids"):
+                print(f"  Evidence: {', '.join(claim['evidence_ids'])}")
+        print()
+    print("## Source notes")
+    for source_id in sorted(sources):
+        source = sources[source_id]
+        print(
+            f"- [{source_id}] {source['title']} ({source['source_type']}): {source.get('summary') or 'NO SUMMARY'}"
+        )
+        print(f"  Independence: {source.get('independence_group') if source.get('independence_assessed') else 'unverified'}")
+        for limitation in source.get("limitations", []):
+            print(f"  Limitation: {limitation}")
+        for item in source.get("evidence", []):
+            if any(item.get("id") in claim.get("evidence_ids", []) for claim in data.get("claims", [])):
+                print(f"  {item['id']} @ {item['locator']}: {item['excerpt']}")
+
+
+def cmd_brief(args: argparse.Namespace) -> None:
+    if args.max_chars <= 0:
+        raise SystemExit("ERROR: --max-chars must be positive")
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        render_brief(args)
+    text = output.getvalue()
+    if len(text) <= args.max_chars:
+        print(text, end="")
+    else:
+        notice = "\n[BRIEF TRUNCATED: read relevant ledger records before synthesis.]\n"
+        if args.max_chars < len(notice):
+            raise SystemExit(f"ERROR: --max-chars must be at least {len(notice)} when truncation is needed")
+        print(text[:args.max_chars - len(notice)] + notice, end="")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init = subparsers.add_parser("init", help="Create a new ledger")
+    init.add_argument("ledger")
+    init.add_argument("--topic", required=True)
+    init.add_argument("--question", action="append", required=True)
+    init.add_argument("--force", action="store_true")
+    init.set_defaults(func=cmd_init)
+
+    source = subparsers.add_parser("add-source", help="Add an extracted source")
+    source.add_argument("ledger")
+    source.add_argument("--url", required=True)
+    source.add_argument("--title", required=True)
+    source.add_argument("--publisher")
+    source.add_argument("--author")
+    source.add_argument("--published-date")
+    source.add_argument("--accessed-date")
+    source.add_argument("--source-type", choices=SOURCE_TYPES, required=True)
+    source.add_argument("--independence-group")
+    source.add_argument("--independence-note", help="Why this source belongs to the stated origin group")
+    source.add_argument("--evidence", action="append", default=[], help='JSON with excerpt and locator; repeatable')
+    source.add_argument("--question", action="append", default=[])
+    source.add_argument(
+        "--extraction-status",
+        choices=("pending", "extracted", "failed"),
+        default="extracted",
+    )
+    source.add_argument("--summary")
+    source.add_argument("--excerpt", action="append", default=[])
+    source.add_argument("--limitation", action="append", default=[])
+    source.set_defaults(func=cmd_add_source)
+
+    claim = subparsers.add_parser(
+        "add-claim", help="Add a claim and its evidence links"
+    )
+    claim.add_argument("ledger")
+    claim.add_argument("--text", required=True)
+    claim.add_argument("--question", required=True)
+    claim.add_argument("--importance", choices=("major", "minor"), default="major")
+    claim.add_argument("--status", choices=CLAIM_STATUSES, required=True)
+    claim.add_argument("--source", action="append", default=[])
+    claim.add_argument("--counter-source", action="append", default=[])
+    claim.add_argument("--reasoning")
+    claim.add_argument("--caveat")
+    claim.add_argument("--evidence", action="append", default=[], help="Supporting or opposing evidence ID; repeatable")
+    claim.set_defaults(func=cmd_add_claim)
+
+    check = subparsers.add_parser(
+        "check", help="Validate evidence structure and coverage"
+    )
+    check.add_argument("ledger")
+    check.set_defaults(func=cmd_check)
+
+    brief = subparsers.add_parser(
+        "brief", help="Render a context-efficient evidence brief"
+    )
+    brief.add_argument("ledger")
+    brief.add_argument("--max-chars", type=int, default=24000, help="Maximum brief characters, including truncation notice")
+    brief.set_defaults(func=cmd_brief)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/research/deep-researcher/scripts/research_run.py
+++ b/optional-skills/research/deep-researcher/scripts/research_run.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Checkpoint research and losslessly archive explicitly registered run artifacts."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+
+KIND = "deep-research-run-v1"
+MANIFEST = "run_manifest.json"
+DEFAULTS = {"quick": 4, "standard": 8, "deep": 12}
+
+
+def now():
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def positive(value):
+    number = int(value)
+    if number <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return number
+
+
+def safe_path(root, name):
+    """Accept only portable relative file paths; never follow symlinks."""
+    relative = PurePosixPath(name)
+    if (not name or relative.is_absolute() or "\\" in name or ":" in name
+            or any(part in {"", ".", ".."} for part in name.split("/"))):
+        raise ValueError(f"Unsafe artifact path: {name!r}")
+    path = root
+    for part in relative.parts:
+        path = path / part
+        if path.is_symlink():
+            raise ValueError(f"Symlink artifact refused: {name}")
+    if path.exists() and not path.is_file():
+        raise ValueError(f"Artifact must be a file: {name}")
+    return path
+
+
+def digest(path):
+    checksum = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            checksum.update(block)
+    return checksum.hexdigest()
+
+
+def save(root, data):
+    target = safe_path(root, MANIFEST)
+    data["updated_at"] = now()
+    handle, temporary = tempfile.mkstemp(prefix=".manifest-", dir=root)
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as stream:
+            json.dump(data, stream, indent=2, ensure_ascii=False)
+            stream.write("\n")
+        os.replace(temporary, target)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def load(root):
+    if root.is_symlink():
+        raise ValueError("Run directory must not be a symlink")
+    data = json.loads(safe_path(root, MANIFEST).read_text(encoding="utf-8"))
+    if data.get("kind") != KIND:
+        raise ValueError("Not a managed research run")
+    for name in data["artifacts"]:
+        safe_path(root, name)
+    safe_path(root, data["report"])
+    return data
+
+
+def init(args):
+    root = Path(args.run).expanduser()
+    # New, dedicated directory: never adopt a workspace or personal directory.
+    root.mkdir(parents=True, exist_ok=False)
+    data = {
+        "kind": KIND, "created_at": now(), "status": "active",
+        "question": args.question, "scope": args.scope, "mode": args.mode,
+        "assumptions": args.assumption,
+        "budgets": {"search_calls": args.search_budget or DEFAULTS[args.mode],
+                    "storage_bytes": args.storage_mb * 1024 * 1024},
+        "completed": [], "gaps": [], "next_action": "Frame questions and initialize evidence.json",
+        "artifacts": [MANIFEST], "report": "report.md",
+    }
+    save(root, data)
+    print(f"Created {root}")
+
+
+def checkpoint(args):
+    root = Path(args.run).expanduser()
+    data = load(root)
+    if data["status"] == "archived":
+        raise ValueError("Restore the archive to a new directory before resuming")
+    for name in args.artifact:
+        path = safe_path(root, name)
+        if not path.is_file():
+            raise ValueError(f"Artifact does not exist: {name}")
+        if name not in data["artifacts"]:
+            data["artifacts"].append(name)
+    if args.status:
+        data["status"] = args.status
+    if args.next_action is not None:
+        data["next_action"] = args.next_action
+    for key in ("completed", "gaps"):
+        value = getattr(args, key)
+        if value is not None:
+            data[key] = value
+    if args.clear_gaps:
+        data["gaps"] = []
+    if data["status"] == "complete":
+        report = safe_path(root, data["report"])
+        if not report.is_file() or not report.stat().st_size:
+            raise ValueError("Completion requires a nonempty report.md")
+        if data["report"] not in data["artifacts"]:
+            data["artifacts"].append(data["report"])
+        data["next_action"] = ""
+    save(root, data)
+    status(args)
+
+
+def status(args):
+    root = Path(args.run).expanduser()
+    data = load(root)
+    total = sum(safe_path(root, name).stat().st_size
+                for name in data["artifacts"] if safe_path(root, name).exists())
+    print(json.dumps({key: data[key] for key in
+                     ("question", "scope", "mode", "status", "budgets", "completed", "gaps", "next_action")}, indent=2))
+    print(f"Registered working artifacts: {total} bytes")
+    if total > data["budgets"]["storage_bytes"]:
+        print("WARN: storage budget exceeded; stop retaining raw pages and review registered artifacts.")
+
+
+def verify(archive, expected):
+    with zipfile.ZipFile(archive) as bundle:
+        if len(bundle.namelist()) != len(expected) or set(bundle.namelist()) != set(expected):
+            raise ValueError("Archive inventory mismatch")
+        for name, checksum in expected.items():
+            value = hashlib.sha256()
+            with bundle.open(name) as stream:
+                for block in iter(lambda: stream.read(1024 * 1024), b""):
+                    value.update(block)
+            if value.hexdigest() != checksum:
+                raise ValueError(f"Archive verification failed: {name}")
+
+
+def archive(args):
+    root = Path(args.run).expanduser()
+    data = load(root)
+    if data["status"] != "complete":
+        raise ValueError("Only completed, inactive runs can be archived")
+    report = safe_path(root, data["report"])
+    if not report.is_file() or not report.stat().st_size:
+        raise ValueError("A nonempty final report is required")
+    names = sorted(set(data["artifacts"]))
+    if MANIFEST not in names or data["report"] not in names:
+        raise ValueError("Register manifest and report before archiving")
+    target = safe_path(root, "artifacts.zip")
+    if target.exists() or "artifacts.zip" in names:
+        raise ValueError("Archive already exists or is registered as an input")
+    files = {name: safe_path(root, name) for name in names}
+    hashes = {name: digest(path) for name, path in files.items()}
+    raw_bytes = sum(path.stat().st_size for path in files.values())
+    handle, temporary = tempfile.mkstemp(prefix=".archive-", suffix=".zip", dir=root)
+    os.close(handle)
+    try:
+        # Optional standard-library codecs may be absent in a custom Python build.
+        if zipfile.lzma is not None:
+            compression, method = zipfile.ZIP_LZMA, "lzma"
+        elif zipfile.zlib is not None:
+            compression, method = zipfile.ZIP_DEFLATED, "deflate"
+        else:
+            compression, method = zipfile.ZIP_STORED, "stored"
+        with zipfile.ZipFile(temporary, "w", compression=compression) as bundle:
+            for name, path in files.items():
+                bundle.write(path, name)
+        verify(temporary, hashes)
+        for name, path in files.items():
+            if digest(safe_path(root, name)) != hashes[name]:
+                raise ValueError(f"Artifact changed during archive: {name}")
+        # Exclusive publication prevents replacing an existing archive.
+        with target.open("xb") as output, open(temporary, "rb") as source:
+            for block in iter(lambda: source.read(1024 * 1024), b""):
+                output.write(block)
+        verify(target, hashes)
+    finally:
+        os.unlink(temporary)
+    data["status"] = "archived"
+    data["archive"] = {"path": target.name, "sha256": digest(target), "members": hashes,
+                       "raw_bytes": raw_bytes, "archive_bytes": target.stat().st_size,
+                       "compression": method}
+    save(root, data)
+    removed = []
+    if args.prune:
+        for name in names:
+            if name in {MANIFEST, data["report"]}:
+                continue
+            path = safe_path(root, name)
+            if digest(path) != hashes[name]:
+                raise ValueError(f"Changed artifact retained: {name}; verified archive is available")
+            path.unlink()
+            removed.append(name)
+    print(f"Verified lossless archive ({method}): {raw_bytes} -> {target.stat().st_size} bytes ({target})")
+    print(f"Removed {len(removed)} registered working files; report and manifest retained."
+          if args.prune else "Working files retained; no disk reclamation requested.")
+    if removed:
+        print("Recover with restore into a new directory: " + ", ".join(removed))
+
+
+def restore(args):
+    root = Path(args.run).expanduser()
+    data = load(root)
+    record = data.get("archive")
+    if not record:
+        raise ValueError("Run has no archive record")
+    bundle_path = safe_path(root, record["path"])
+    if digest(bundle_path) != record["sha256"]:
+        raise ValueError("Archive checksum mismatch")
+    verify(bundle_path, record["members"])
+    destination = Path(args.destination).expanduser()
+    if destination.exists() or destination.is_symlink():
+        raise ValueError("Restore destination must be a new directory")
+    for name in record["members"]:
+        safe_path(destination, name)
+    destination.mkdir(parents=True, exist_ok=False)
+    with zipfile.ZipFile(bundle_path) as bundle:
+        for name in record["members"]:
+            target = safe_path(destination, name)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with bundle.open(name) as source, target.open("xb") as output:
+                for block in iter(lambda: source.read(1024 * 1024), b""):
+                    output.write(block)
+    print(f"Restored completed run to {destination}; checkpoint --status active to resume.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(required=True)
+    command = commands.add_parser("init")
+    command.add_argument("run")
+    command.add_argument("--question", required=True)
+    command.add_argument("--scope", required=True)
+    command.add_argument("--mode", choices=DEFAULTS, default="standard")
+    command.add_argument("--assumption", action="append", default=[])
+    command.add_argument("--search-budget", type=positive)
+    command.add_argument("--storage-mb", type=positive, default=64)
+    command.set_defaults(func=init)
+    command = commands.add_parser("checkpoint")
+    command.add_argument("run")
+    command.add_argument("--status", choices=("active", "complete"))
+    command.add_argument("--artifact", action="append", default=[])
+    command.add_argument("--completed", action="append")
+    command.add_argument("--gaps", action="append")
+    command.add_argument("--clear-gaps", action="store_true")
+    command.add_argument("--next-action")
+    command.set_defaults(func=checkpoint)
+    command = commands.add_parser("status")
+    command.add_argument("run")
+    command.set_defaults(func=status)
+    command = commands.add_parser("archive")
+    command.add_argument("run")
+    command.add_argument("--prune", action="store_true", help="Remove only verified archived working files; keep report and manifest")
+    command.set_defaults(func=archive)
+    command = commands.add_parser("restore")
+    command.add_argument("run")
+    command.add_argument("destination")
+    command.set_defaults(func=restore)
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    except (ValueError, OSError, KeyError, zipfile.BadZipFile) as exc:
+        parser.exit(1, f"ERROR: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/research/deep-researcher/scripts/validate_citations.py
+++ b/optional-skills/research/deep-researcher/scripts/validate_citations.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Backward-compatible entry point for the stronger report audit."""
+
+from audit_report import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/test_deep_researcher_skill.py
+++ b/tests/skills/test_deep_researcher_skill.py
@@ -1,0 +1,229 @@
+"""Behavioral tests for evidence provenance and lossless run lifecycle."""
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+import contextlib
+import io
+import pytest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "optional-skills/research/deep-researcher/scripts"
+
+
+def module(name):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    result = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(result)
+    return result
+
+
+ledger = module("evidence_ledger")
+run = module("research_run")
+
+
+class ResearchTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.base = Path(self.temp.name)
+        self.root = self.base / "run"
+
+    def cli(self, script, *args, success=True):
+        result = subprocess.run([sys.executable, str(SCRIPTS / script), *map(str, args)],
+                                capture_output=True, text=True)
+        if success:
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        else:
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+        return result
+
+    def init_run(self):
+        self.cli("research_run.py", "init", self.root, "--question", "Synthetic question",
+                 "--scope", "Synthetic fixtures", "--storage-mb", "1")
+
+    def complete_run(self):
+        self.init_run()
+        (self.root / "report.md").write_text("# Final report\nA synthetic finding.\n", encoding="utf-8")
+        (self.root / "evidence.json").write_text(json.dumps({"fixture": "evidence " * 10000}), encoding="utf-8")
+        self.cli("research_run.py", "checkpoint", self.root, "--status", "complete",
+                 "--artifact", "evidence.json")
+
+    def init_ledger(self):
+        self.path = self.base / "evidence.json"
+        self.cli("evidence_ledger.py", "init", self.path, "--topic", "Fixture", "--question", "Q1")
+
+    def add_source(self, url, *args):
+        return self.cli("evidence_ledger.py", "add-source", self.path, "--url", url,
+                        "--title", "Fixture", "--source-type", "primary", "--question", "Q1",
+                        "--summary", "A test finding", *args)
+
+    def claim(self, *args):
+        return self.cli("evidence_ledger.py", "add-claim", self.path, "--text", "Narrow claim",
+                        "--question", "Q1", "--status", "supported", "--source", "1,2", *args)
+
+    def test_domains_are_not_independence(self):
+        self.init_ledger()
+        self.add_source("https://example.com/a")
+        self.add_source("https://example.org/b")
+        self.claim()
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        self.assertIsNone(data["sources"][0]["independence_group"])
+        errors, warnings = ledger.validate(data)
+        self.assertFalse(errors)
+        self.assertTrue(any("lacks two independent" in item for item in warnings))
+        # Legacy hostname defaults must also remain unverified.
+        for index, source in enumerate(data["sources"]):
+            source.pop("independence_assessed")
+            source["independence_group"] = f"legacy-host-{index}"
+        self.assertTrue(any("lacks two independent" in item for item in ledger.validate(data)[1]))
+
+    def test_assessed_origins_and_locators(self):
+        self.init_ledger()
+        for index, host in enumerate(("example.com", "example.org")):
+            self.add_source(f"https://{host}/a", "--independence-group", f"dataset-{index}",
+                            "--independence-note", "Distinct original dataset reviewed",
+                            "--evidence", json.dumps({"excerpt": "A short finding", "locator": "Results, p. 3"}))
+        self.claim("--evidence", "S1E1", "--evidence", "S2E1", "--caveat", "Limited population")
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        self.assertEqual(ledger.validate(data), ([], []))
+        brief = self.cli("evidence_ledger.py", "brief", self.path).stdout
+        self.assertIn("Results, p. 3", brief)
+        self.assertIn("Limited population", brief)
+        data["sources"][1]["independence_group"] = "dataset-0"
+        self.assertTrue(any("lacks two independent" in item for item in ledger.validate(data)[1]))
+        data["claims"][0]["evidence_ids"].append("S99E1")
+        self.assertTrue(any("unknown or unrelated" in item for item in ledger.validate(data)[0]))
+        data["claims"][0]["evidence_ids"] = ["S2E1"]
+        data["claims"][0]["source_ids"] = [1]
+        self.assertTrue(any("unknown or unrelated" in item for item in ledger.validate(data)[0]))
+
+    def test_invalid_evidence_does_not_write_source(self):
+        self.init_ledger()
+        before = self.path.read_bytes()
+        self.cli("evidence_ledger.py", "add-source", self.path, "--url", "https://example.com",
+                 "--title", "Bad", "--source-type", "primary", "--evidence", '{"excerpt":"Missing location"}', success=False)
+        self.assertEqual(self.path.read_bytes(), before)
+
+    def test_brief_budget_does_not_discard_stored_evidence(self):
+        self.init_ledger()
+        self.add_source("https://example.com/a", "--evidence",
+                        json.dumps({"excerpt": "finding " * 1000, "locator": "Section 1"}))
+        self.cli("evidence_ledger.py", "add-claim", self.path, "--text", "Claim", "--question", "Q1",
+                 "--status", "single-source", "--source", "1", "--evidence", "S1E1")
+        before = self.path.read_bytes()
+        brief = self.cli("evidence_ledger.py", "brief", self.path, "--max-chars", "300").stdout
+        self.assertLessEqual(len(brief), 300)
+        self.assertIn("BRIEF TRUNCATED", brief)
+        self.assertEqual(self.path.read_bytes(), before)
+
+    def test_existing_report_audit_offline(self):
+        self.init_ledger()
+        self.add_source("https://example.com/a")
+        report = self.base / "report.md"
+        report.write_text("# Fixture\n\n## Findings\nThe source reports a result. [1]\n\n## Citation Links\n\n1. [Fixture](https://example.com/a)\n", encoding="utf-8")
+        self.cli("audit_report.py", report, "--ledger", self.path, "--no-live")
+
+    def test_checkpoint_and_resume_state(self):
+        self.init_run()
+        self.cli("research_run.py", "checkpoint", self.root, "--completed", "Q1",
+                 "--gaps", "Q2", "--next-action", "Retrieve original")
+        data = run.load(self.root)
+        self.assertEqual(data["next_action"], "Retrieve original")
+        self.assertEqual(data["gaps"], ["Q2"])
+        self.cli("research_run.py", "checkpoint", self.root, "--clear-gaps")
+        self.assertEqual(run.load(self.root)["completed"], ["Q1"])
+        self.assertEqual(run.load(self.root)["gaps"], [])
+        self.cli("research_run.py", "checkpoint", self.root, "--status", "complete", success=False)
+        self.cli("research_run.py", "archive", self.root, "--prune", success=False)
+
+    def test_archive_prune_restore_exact_bytes(self):
+        self.complete_run()
+        (self.root / "unregistered.txt").write_text("Leave me alone", encoding="utf-8")
+        before = {name: (self.root / name).read_bytes() for name in run.load(self.root)["artifacts"]}
+        self.cli("research_run.py", "archive", self.root, "--prune")
+        self.assertFalse((self.root / "evidence.json").exists())
+        self.assertEqual((self.root / "report.md").read_bytes(), before["report.md"])
+        self.assertTrue((self.root / "unregistered.txt").exists())
+        self.assertLess((self.root / "artifacts.zip").stat().st_size, len(before["evidence.json"]))
+        destination = self.base / "restored"
+        self.cli("research_run.py", "restore", self.root, destination)
+        for name, content in before.items():
+            self.assertEqual((destination / name).read_bytes(), content)
+        self.cli("research_run.py", "checkpoint", destination, "--status", "active", "--next-action", "Continue")
+        self.assertEqual(run.load(destination)["status"], "active")
+        self.cli("research_run.py", "restore", self.root, destination, success=False)
+        self.cli("research_run.py", "archive", self.root, success=False)
+
+    def test_archive_without_prune_retains_files(self):
+        self.complete_run()
+        self.cli("research_run.py", "archive", self.root)
+        self.assertTrue((self.root / "evidence.json").exists())
+
+    def test_archive_without_optional_compression_modules(self):
+        for omit_zlib, method in ((False, "deflate"), (True, "stored")):
+            with self.subTest(method=method):
+                self.root = self.base / method
+                self.complete_run()
+                original = (self.root / "evidence.json").read_bytes()
+                args = type("Args", (), {"run": str(self.root), "prune": True,
+                                         "destination": str(self.base / (method + "-restored"))})()
+                with contextlib.ExitStack() as stack:
+                    stack.enter_context(patch.object(run.zipfile, "lzma", None))
+                    if omit_zlib:
+                        stack.enter_context(patch.object(run.zipfile, "zlib", None))
+                    stack.enter_context(contextlib.redirect_stdout(io.StringIO()))
+                    run.archive(args)
+                    self.assertEqual(run.load(self.root)["archive"]["compression"], method)
+                    run.restore(args)
+                self.assertEqual((Path(args.destination) / "evidence.json").read_bytes(), original)
+
+    def test_verification_failure_never_prunes(self):
+        self.complete_run()
+        args = type("Args", (), {"run": str(self.root), "prune": True})()
+        with patch.object(run, "verify", side_effect=ValueError("Simulated corruption")):
+            with self.assertRaises(ValueError):
+                run.archive(args)
+        self.assertTrue((self.root / "evidence.json").exists())
+        self.assertFalse((self.root / "artifacts.zip").exists())
+        self.assertEqual(run.load(self.root)["status"], "complete")
+
+    def test_corruption_blocks_restore(self):
+        self.complete_run()
+        self.cli("research_run.py", "archive", self.root)
+        with (self.root / "artifacts.zip").open("ab") as stream:
+            stream.write(b"corrupted")
+        destination = self.base / "bad-restore"
+        self.cli("research_run.py", "restore", self.root, destination, success=False)
+        self.assertFalse(destination.exists())
+
+    def test_unsafe_paths_and_existing_directory(self):
+        self.init_run()
+        self.cli("research_run.py", "init", self.root, "--question", "Q", "--scope", "S", success=False)
+        outside = self.base / "private.txt"
+        outside.write_text("Private fixture", encoding="utf-8")
+        for name in ("../private.txt", str(outside), "a/../private.txt", "C:/private.txt"):
+            self.cli("research_run.py", "checkpoint", self.root, "--artifact", name, success=False)
+        self.assertEqual(outside.read_text(encoding="utf-8"), "Private fixture")
+
+    @pytest.mark.linux_only
+    def test_symlink_artifact_is_rejected(self):
+        self.init_run()
+        outside = self.base / "private.txt"
+        outside.write_text("Private fixture", encoding="utf-8")
+        (self.root / "link").symlink_to(outside)
+        self.cli("research_run.py", "checkpoint", self.root, "--artifact", "link", success=False)
+        self.assertEqual(outside.read_text(encoding="utf-8"), "Private fixture")
+
+    def test_storage_warning_is_explicit(self):
+        self.init_run()
+        (self.root / "large.txt").write_bytes(b"x" * (1024 * 1024 + 1))
+        result = self.cli("research_run.py", "checkpoint", self.root, "--artifact", "large.txt")
+        self.assertIn("storage budget exceeded", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -219,6 +219,7 @@ hermes skills uninstall <skill-name>
 | [**bioinformatics**](/docs/user-guide/skills/optional/research/research-bioinformatics) | Gateway to 400+ genomics and computational biology skills. |
 | [**blogwatcher**](/docs/user-guide/skills/optional/research/research-blogwatcher) | Monitor blogs and RSS/Atom feeds via blogwatcher-cli tool. |
 | [**darwinian-evolver**](/docs/user-guide/skills/optional/research/research-darwinian-evolver) | Evolve prompts/regex/SQL/code with Imbue's evolution loop. |
+| [**deep-researcher**](/docs/user-guide/skills/optional/research/research-deep-researcher) | Track research claims and resume evidence dossiers. |
 | [**domain-intel**](/docs/user-guide/skills/optional/research/research-domain-intel) | Passive recon of subdomains, SSL certs, WHOIS, and DNS. |
 | [**drug-discovery**](/docs/user-guide/skills/optional/research/research-drug-discovery) | Drug discovery: ChEMBL search, drug-likeness, interactions. |
 | [**duckduckgo-search**](/docs/user-guide/skills/optional/research/research-duckduckgo-search) | Free keyless web, news, and image search via ddgs. |

--- a/website/docs/user-guide/skills/optional/research/research-deep-researcher.md
+++ b/website/docs/user-guide/skills/optional/research/research-deep-researcher.md
@@ -1,0 +1,242 @@
+---
+title: "Deep Researcher — Track research claims and resume evidence dossiers"
+sidebar_label: "Deep Researcher"
+description: "Track research claims and resume evidence dossiers"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Deep Researcher
+
+Track research claims and resume evidence dossiers.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/research/deep-researcher` |
+| Path | `optional-skills/research/deep-researcher` |
+| Version | `1.0.0` |
+| Author | Brent Wilkins (BrentWilkins) |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `research`, `web-search`, `web-extraction`, `evidence`, `citations` |
+| Related skills | `grounded-citations`, `research-paper-writing`, `arxiv`, `blogwatcher` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Deep Researcher Skill
+
+Search discovers candidates; retrieved passages support claims; the ledger controls synthesis.
+Never use search snippets or model memory to fill a missing source-backed conclusion.
+Use native `web_search`, `web_extract`, `browser_navigate`, `read_file`,
+`write_file`, and `patch` tools. Do not type tool calls
+into a terminal or substitute direct search-engine scraping. Scripts below are local
+bookkeeping helpers, not alternative retrieval backends.
+
+## When to Use
+
+Use for substantive multi-source investigations and comparisons requiring
+persistent claims, contradiction analysis, or work across sessions. Simple
+lookups, single-claim checks, and synthesis of supplied documents usually need
+a smaller workflow such as `grounded-citations`.
+
+## Prerequisites
+
+Python 3.10+ for the standard-library bookkeeping scripts, `terminal` for running
+them, and native retrieval tools configured in Hermes. No extra Python packages,
+API keys, or research-access plugin are required by this skill itself. Retrieval
+services may have their own setup requirements.
+
+## How to Run
+
+Invoke the commands below through `terminal`. Replace SKILL with this skill's
+absolute directory and RUN with a new dedicated research directory; quote paths
+containing spaces. Use the available Python interpreter (`python3` below).
+
+```sh
+python3 SKILL/scripts/research_run.py init RUN --question "Research question" --scope "Audience, timeframe, exclusions" --mode standard
+python3 SKILL/scripts/evidence_ledger.py init RUN/evidence.json --topic "Topic" --question "Q1: Question"
+```
+
+## Quick Reference
+
+- `research_run.py init|checkpoint|status`: initialize, save progress, or resume.
+- `evidence_ledger.py add-source|add-claim`: record passages and linked claims.
+- `evidence_ledger.py check|brief`: validate references and derive a compact brief.
+- `audit_report.py REPORT --ledger LEDGER --no-live`: offline citation audit.
+- `research_run.py archive|restore`: verified lossless archival and recovery.
+
+All helpers live under `scripts/`; each command supports `--help`.
+Read [run management](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/research/deep-researcher/references/run-management.md) for lifecycle commands.
+
+## Procedure
+
+### 1. Frame and budget
+
+Establish the decision, audience, scope, timeframe, and exclusions. Ask only when an
+unresolved choice materially changes the task; otherwise record assumptions and proceed.
+Decompose into focused questions, including material counterarguments or failure modes.
+Define what evidence would answer each question and which source types can establish it.
+
+Use a new dedicated run directory. Resolve this skill's directory and the run directory
+to absolute paths; commands below use SKILL and RUN as placeholders, not persistent shell
+variables. Read [run management](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/research/deep-researcher/references/run-management.md) when initializing, resuming,
+or archiving a run.
+
+Planning defaults (override to match the task and record the effective values):
+- Quick: 4 search calls, about 4–6 useful sources.
+- Standard: 8 search calls, about 8–15 useful sources.
+- Deep: 12 search calls, about 15–25 useful sources.
+- Stop after four search/extraction/gap-analysis iterations by default. An explicit zero
+  removes the iteration ceiling only; search, context, and storage budgets still apply.
+- Reserve at most two additional searches for a specific high-impact gap after extraction.
+- Reserve roughly one quarter of available context for synthesis and audit. Extract at
+  most 8,000 characters per page initially; read relevant cached sections as needed.
+  Keep raw excerpts in context below roughly 35% of the available window and discovery/tool
+  overhead near 10%; reduce collection further when the session already has substantial history.
+- Use a 64 MiB warning budget for registered working artifacts, configurable at initialization.
+  This is a collection guideline, not a downloader quota or an OS disk limit.
+
+Counts are ceilings or planning estimates, never success targets. Stop once material
+questions are adequately answered or further collection is unlikely to change the result.
+Expose unresolved gaps when the budget is exhausted.
+In quick mode, a decisive claim needs a strong primary source or independent corroboration.
+In standard/deep modes, seek two independently assessed origins per major claim and label
+single-source exceptions. Deep mode also requires a counter-evidence search per major theme.
+
+### 2. Discover and retrieve
+
+1. Search before extraction unless URLs were supplied. Start each evidence gap with one
+   concise query. Try a materially broader query after an empty result; stop that gap
+   after a second empty result. Stop discovery after four empty responses across the report.
+   Before each follow-up, compare its evidence gap and candidate URLs with prior queries;
+   a reworded query is not a new evidence need. Stop discovery after two searches add no new
+   credible canonical URLs. Synthesize or report the gap; do not silently raise budgets to
+   avoid stopping. Record user-requested scope/budget changes in the run state.
+2. Keep a compact search log: query, gap, outcome, newly shortlisted URLs. Do not retain
+   repeated snippets as evidence. Favor primary evidence for facts and independent work
+   for interpretation. Popularity and domain suffix are not quality scores.
+   Assess directness, author authority, methodological transparency, independence, recency,
+   and incentives/conflicts. Do not compare options on dimensions lacking comparable evidence.
+3. Extract at most three promising canonical URLs per batch. Record actual citation identity,
+   retrieval date, relevant passages, coverage, and limitations. Never invent metadata.
+4. A successful HTTP response containing a cookie wall, challenge, or empty body is a
+   retrieval failure. For permitted sites, try an available native browser session or an
+   authoritative alternative (canonical page, print/PDF, original study, official API, or
+   repository copy). Use at most one browser fallback per failed URL and two consent interactions,
+   preferring necessary-only consent, then record persistent blocks. Respect site
+   access policies; tool availability does not authorize paid services or new accounts.
+5. Abstract-only retrieval cannot establish unreported full-paper methods or results.
+   Full-text availability does not establish study quality, and cached but unread sections
+   have not been reviewed. For clinical claims, follow secondary leads to underlying
+   studies, reviews, guidelines, or regulator documents.
+   If the underlying clinical claim cannot be verified, omit it from clinical conclusions
+   or explicitly label it unverified. Record retrieval method, timestamp, and article identifiers
+   when available. Keep extracted, failed, considered, and cited sources distinct.
+6. Deduplicate by source identity as well as URL. Copies, syndicated reports, and articles
+   relying on the same study share an origin group even on different domains.
+
+Native retrieval tools own extraction; do not bypass them with terminal
+Firecrawl calls, inline Python, or generated extraction scripts. Invoke the
+bundled bookkeeping scripts through `terminal`.
+
+### 3. Record evidence and checkpoint
+
+Initialize the run manifest first, then the ledger:
+
+```sh
+python3 SKILL/scripts/evidence_ledger.py init RUN/evidence.json --topic "Topic" --question "Q1: Question"
+```
+
+After each extraction batch, add concise source records and atomic claims using
+`evidence_ledger.py add-source` and `add-claim`. See `--help` and the
+[worked example](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/research/deep-researcher/references/worked-example.md) for paired passages and locators.
+
+- Use repeatable `--evidence '{"excerpt":"Exact short passage","locator":"Section/page/paragraph"}'`
+  on sources. Locators may include a registered run-relative cache path and line numbers.
+  Record a separate excerpt/locator pair for each passage.
+- Link claims with `--evidence S1E1` and the corresponding `--source 1` or
+  `--counter-source 1`. Evidence IDs remain stable within the ledger.
+- Independence starts unverified. Set both `--independence-group` and
+  `--independence-note` only after tracing the underlying data or origin. Group IDs are
+  assessments, not proof; the script cannot establish semantic independence.
+- Keep excerpts short and relevant (usually one to three per source). Prefer source
+  locators over entire page copies; retain a single local text copy only when needed for
+  audit or offline reproducibility. Do not collect browser profiles, cookies, or credentials.
+- Checkpoint completed work, current gaps, the next action, and artifact paths after each
+  batch or before context compaction. Register every retained run artifact. Resume from
+  the manifest and compact brief, opening only the passages needed for the next decision.
+
+Older ledgers remain readable. Legacy domain-based groups count as unverified until an
+explicit assessment and note are recorded. Do not infer independence while migrating.
+For corrections, use the native file editor on the ledger and rerun its checks.
+
+### 4. Check gaps and synthesize
+
+Run `evidence_ledger.py check RUN/evidence.json` and
+`evidence_ledger.py brief RUN/evidence.json`; save the brief as RUN/evidence-brief.md.
+Checks warn about missing corroboration and locators; they do not prove truth.
+The brief defaults to at most 24,000 characters. If it reports truncation, read relevant
+ledger records before synthesis; use `--max-chars` only when the context budget allows.
+Seek counter-evidence for decisive claims and inspect conflicts in definitions, populations,
+dates, methods, and incentives. Sources repeating one origin do not supply independent support.
+After each batch, check unanswered questions, interested-party-only support, stale evidence,
+disputed claims without counter-evidence, and recommendations missing tradeoffs or downsides.
+Resolve the most consequential gap first. Formulate the strongest plausible contrary claim
+before searching for evidence that would support it.
+
+Draft from the brief and ledger using [the dossier template](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/research/deep-researcher/references/dossier-template.md),
+adapting its length and sections to the user's request. Keep these distinctions visible:
+sourced fact, interpretation, analyst inference, recommendation, and unresolved gap.
+Place citations next to the exact claims they support. Summarize uncertainty and what would
+change the conclusion. Count only successfully retrieved sources actually used in the report.
+Each paragraph-end citation must support the whole paragraph; otherwise split the claims.
+List excluded and failed candidates separately. Calibrate confidence per finding:
+- High: direct evidence with independent corroboration and no serious unresolved contradiction.
+- Medium: credible evidence with limitations in independence, coverage, recency, or methods.
+- Low: sparse, indirect, disputed, or materially uncertain evidence.
+
+### 5. Audit and finish
+
+Run `audit_report.py RUN/report.md --ledger RUN/evidence.json` (use `--no-live` for
+offline structural checking). Review warnings and inspect each major claim's exact scope,
+tense, supporting passage, opposing evidence, and independence assessment. A reachable URL
+or a clean script result does not establish semantic support.
+Fix structural errors, explain unresolved warnings, and remember that a blocked live link alone
+does not invalidate a source already retrieved. Revise once for accuracy and once for usefulness.
+
+Check the executive summary against the findings, revise, and mark the run complete only
+after the requested report and audit are finished. Then offer or perform lossless archiving
+when requested, using [run management](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/research/deep-researcher/references/run-management.md). Keep report.md readable.
+Compression reduces disk storage, not token usage; read selectively rather than inflating
+an archive into model context. Never archive an active run or prune unregistered artifacts.
+
+## Pitfalls
+
+- Different hostnames do not establish independent evidence.
+- Ledger checks validate structure, not truth or verbatim passage accuracy;
+  compare recorded excerpts with retrieved text during the semantic audit.
+- Archives are not encrypted backups. Never include credentials or browser state.
+- Compression saves disk space, not context; the storage budget is a warning,
+  not a hard quota. Missing optional codecs fall back without installing packages.
+
+## Verification
+
+After writing the report, run this offline check through `terminal`:
+
+```sh
+python3 SKILL/scripts/audit_report.py RUN/report.md --ledger RUN/evidence.json --no-live
+```
+
+Fix structural errors and review every material claim against its supporting
+passages; a clean exit does not certify the report's conclusions.
+
+Maintained at [BrentWilkins/research-skills](https://github.com/BrentWilkins/research-skills).
+Related design references: [SkillMedev's deep-research skill](https://github.com/SkillMedev/skills/blob/main/skills/deep-research/SKILL.md)
+(scope and examples) and [LovStudio's deep-research skill](https://github.com/lovstudio/deep-research-skill/blob/main/SKILL.md)
+(evidence locators and run manifests).

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -555,6 +555,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/research/research-bioinformatics',
                     'user-guide/skills/optional/research/research-blogwatcher',
                     'user-guide/skills/optional/research/research-darwinian-evolver',
+                    'user-guide/skills/optional/research/research-deep-researcher',
                     'user-guide/skills/optional/research/research-domain-intel',
                     'user-guide/skills/optional/research/research-drug-discovery',
                     'user-guide/skills/optional/research/research-duckduckgo-search',


### PR DESCRIPTION
## What does this PR do?

Adds `deep-researcher` as an official optional research skill, with a catalog entry and generated documentation page. It guides substantial multi-source investigations using native Hermes retrieval tools, a persistent claim/evidence ledger, explicit collection budgets, and resumable research runs.

The skill is maintained at https://github.com/BrentWilkins/research-skills. This contribution includes only the core skill and its standard-library helpers. The separately installable research-access plugin is not included or required. No core tools, model configuration, dependency manifests, or user settings change.

## Why a separate optional skill?

`grounded-citations` already covers source registration, citation rendering, and evidence-backed answers. This skill is for the larger research lifecycle: question-specific atomic claims and counter-sources, explicitly assessed shared-origin groups, source coverage limitations, bounded gap discovery, progress checkpoints, and verified archive/restore. It points simple lookups and single-claim checks toward a smaller workflow. It does not replace `grounded-citations` or claim to verify semantic truth automatically.

The existing researcher-now proposal (#47932) integrates a hosted research service; this skill uses Hermes's configured native retrieval tools and local bookkeeping, with no additional research service or model calls introduced by its helpers.

## Type of Change

- [x] New skill (official optional)

## Changes Made

- `optional-skills/research/deep-researcher/`: instructions, dossier template, synthetic worked example, run-management reference, and ledger/audit/archive helpers.
- `tests/skills/test_deep_researcher_skill.py`: behavioral tests for evidence links, shared origins, brief truncation, report auditing, checkpoints, storage warnings, safe paths, codec fallbacks, and byte-exact archive/prune/restore.
- Optional-skills catalog, generated skill page, and sidebar entry.

Archives retain the readable report and recovery manifest. Pruning is opt-in and limited to registered files after verification. Compression falls back from LZMA to deflate to uncompressed ZIP without installing dependencies. The storage budget is a warning, not a hard quota.

## How to Test

```sh
scripts/run_tests.sh tests/skills/test_deep_researcher_skill.py tests/website/test_generate_skill_docs.py -q
scripts/run_tests.sh tests/skills/test_authoring_standards.py -k deep-researcher -q
python scripts/check-windows-footguns.py --diff origin/main
```

On Linux / Python 3.11: 14 research tests, 7 documentation-generator tests, and 6 skill-specific authoring checks pass. Hermes's skill scanner reports `safe` with no findings. The staged Windows-footgun check and `git diff --check` pass. Tests use temporary synthetic artifacts and no live network calls. The symlink test is Linux-marked; portable path checks remain cross-platform.

For a manual skill exercise, use the synthetic example in `references/worked-example.md`, then audit a report, mark the run complete, archive/prune, restore into a fresh directory, and resume. After merge, install with `hermes skills install official/research/deep-researcher`.

## Validation limits

The full Hermes suite, full Docusaurus build, and a new live-model research session were not run for this PR. macOS and Windows execution are not yet verified. Script checks establish structural invariants, not source truth, semantic independence, or research-quality equivalence.

## Checklist

- [x] Read the contribution guide and skill authoring instructions.
- [x] Conventional commit; searched existing research skill PRs.
- [x] Focused optional skill, supporting tests, and documentation only.
- [x] Standard Hermes metadata, native tool names, and explicit human attribution.
- [x] No new dependencies; cross-platform impact considered.
- [x] Focused tests and skill scanner pass.
- [ ] Full test suite and live-model end-to-end exercise.
