### PR TITLE
fix(desktop): exclude expired Windows CAs and deduplicate trust roots

### DIFF
--- a/apps/desktop/electron/windows-system-ca.test.ts
+++ b/apps/desktop/electron/windows-system-ca.test.ts
@@ -1,6 +1,36 @@
 import assert from 'node:assert/strict'
 
-import { test } from 'vitest'
+import { test, vi } from 'vitest'
+
+vi.mock('node:crypto', () => ({
+  X509Certificate: class {
+    fingerprint256: string
+    validToDate: Date
+    validTo = 'not a parseable display date'
+
+    constructor(pem: string) {
+      if (!pem.startsWith('cert:')) throw new Error('unparseable certificate')
+      const [, fingerprint, expiry] = pem.split(':')
+      this.fingerprint256 = fingerprint
+      this.validToDate = new Date(Number(expiry))
+    }
+  }
+}))
+
+test('excludes expired system roots and deduplicates by fingerprint with defaults first', () => {
+  const future = Date.now() + 86_400_000
+  const past = Date.now() - 86_400_000
+  const bundled = `cert:shared:${future}`
+  const privateRoot = `cert:private:${future}`
+  const tlsApi = fakeTlsApi(
+    [bundled, 'unparseable-default'],
+    [`cert:expired:${past}`, `${bundled}:alternate-pem`, privateRoot, privateRoot, 'unparseable-system']
+  )
+  const result = installWindowsSystemCaTrust(tlsApi, 'win32')
+  assert.deepEqual(tlsApi.installed, [[bundled, 'unparseable-default', privateRoot, 'unparseable-system']])
+  assert.equal(result.systemCertificateCount, 2)
+  assert.equal(result.totalCertificateCount, 4)
+})
 
 import { installWindowsSystemCaTrust, type NodeTlsCaApi } from './windows-system-ca'
 

--- a/apps/desktop/electron/windows-system-ca.ts
+++ b/apps/desktop/electron/windows-system-ca.ts
@@ -1,3 +1,5 @@
+import { X509Certificate } from 'node:crypto'
+
 interface NodeTlsCaApi {
   getCACertificates(type?: 'default' | 'system'): string[]
   setDefaultCACertificates(certificates: string[]): void
@@ -31,12 +33,28 @@ function installWindowsSystemCaTrust(tlsApi: NodeTlsCaApi, platform = process.pl
       }
     }
 
-    const certificates = [...defaultCertificates, ...systemCertificates]
+    // Prefer existing defaults. Expired Windows roots can divert OpenSSL onto
+    // an expired chain even when a valid bundled trust path exists.
+    const seen = new Set<string>()
+    const now = Date.now()
+    const keepCertificate = (pem: string): boolean => {
+      try {
+        const certificate = new X509Certificate(pem)
+        if (certificate.validToDate.getTime() <= now || seen.has(certificate.fingerprint256)) return false
+        seen.add(certificate.fingerprint256)
+      } catch {
+        // Leave PEM acceptability to Node if its X.509 parser cannot inspect it.
+      }
+      return true
+    }
+    const filteredDefaults = defaultCertificates.filter(keepCertificate)
+    const filteredSystem = systemCertificates.filter(keepCertificate)
+    const certificates = [...filteredDefaults, ...filteredSystem]
     tlsApi.setDefaultCACertificates(certificates)
 
     return {
       applied: true,
-      systemCertificateCount: systemCertificates.length,
+      systemCertificateCount: filteredSystem.length,
       totalCertificateCount: certificates.length
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
Fixes #105532.

- Filter expired roots using `X509Certificate.validToDate` before installing the merged Windows/default trust list.
- Deduplicate by `fingerprint256`, keeping default certificates ahead of equivalent Windows roots.
- Preserve valid additional system/private roots and existing Node handling of certificates the X.509 parser cannot inspect.
- Report retained system/total certificate counts and add a behavioral regression test.

TLS verification remains enabled. This does not modify the Windows certificate store, gateway credentials, or timeout UI.

## Root cause / real-path verification
The unchanged current-main implementation concatenates default and system roots. On an affected Windows 11 machine (Electron 40.10.2 / Node 24.15.0 / Chromium 144.0.7559.236), 145 default + 207 system certificates reproduced `CERT_HAS_EXPIRED` although Windows curl verified TLS and returned HTTP 200 and the server leaf remained valid.

With expiry filtering and fingerprint deduplication, 52 additional Windows roots remained (197 total); Electron HTTPS returned HTTP 200 with `authorized: true`, and the saved-token secure WebSocket received `params.type: gateway.ready`. The packaged fixed Electron main policy also passed the HTTPS and authenticated WebSocket checks. No hostname, token, local path, or raw log is included here.

## Validation
- [x] Fetched upstream main; both touched files remain unchanged from this fix's base, and branch is up to date with that fetch.
- [x] Fresh focused Vitest run: **1 file, 5 tests passed** using a minimal Node-environment config and existing dependencies in an isolated scratch checkout.
- [x] `git diff --check` passed.
- [x] Earlier implementation validation completed focused tests, typechecking, build, and Claude code review; full build was not repeated for publication.
- [x] Actual packaged-policy HTTPS + authenticated WebSocket validation described above.
- [ ] Upstream CI: workflows currently report `action_required` (CI, Docker Build/Test/Publish, and Nix flake check); no test check results are reported yet. Maintainer action/approval is needed before CI can validate this fork contribution.

The normal desktop Vitest project config could not initialize with the reused dependency installation because `@rolldown/plugin-babel` was unavailable; the focused CA suite was rerun successfully with an isolated minimal config. That temporary config is not part of this PR.

## Scope
Only the Windows CA helper and its colocated test change. More actionable generic timeout UI is a separate follow-up. Updating can remove a local workaround and expose this bug again; the updater is not the original TLS failure's cause.
