### PR TITLE
fix(image_gen): make Codex Responses host model retargetable (gpt-5.5 EOL)

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -22,8 +22,8 @@ from typing import Any, Dict, List, Optional, Tuple
 from agent.image_gen_provider import DEFAULT_ASPECT_RATIO, resolve_aspect_ratio, save_b64_image, success_response
 from plugins.image_gen._common import (
     GPT_IMAGE_2_API_MODEL as API_MODEL, GPT_IMAGE_2_DEFAULT as DEFAULT_MODEL, GPT_IMAGE_2_TIERS,
-    StaticImageGenProvider, collect_source_images, error_factory, prompt_required_error,
-    resolve_static_model, size_for)
+    StaticImageGenProvider, collect_source_images, error_factory, load_image_gen_config,
+    prompt_required_error, resolve_static_model, size_for)
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,8 @@ logger = logging.getLogger(__name__)
 # so it stays diagnosable. See issues #19505, #49008 and #31335.
 _MAX_ERROR_BODY_CHARS = 500
 
-# Hosts the ``image_generation`` tool call; ``API_MODEL`` does the image work.
+# Default host model for the Codex Responses image lane; ``API_MODEL`` does the image work.
+# Retargetable without a release via ``_resolve_codex_chat_model`` (env / config) — see #105398.
 _CODEX_CHAT_MODEL = "gpt-5.5"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_INSTRUCTIONS = (
@@ -77,6 +78,34 @@ def _summarize_error_body(body: str) -> str:
 def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return resolve_static_model(
         GPT_IMAGE_2_TIERS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai-codex")
+
+
+def _resolve_codex_chat_model() -> str:
+    """Host model for the Codex Responses image lane (the model that hosts the
+    ``image_generation`` tool call; ``API_MODEL`` does the actual image work).
+
+    Defaults to ``gpt-5.5`` but honours, in order:
+      1. ``OPENAI_CODEX_CHAT_MODEL`` env var,
+      2. ``image_gen.openai-codex.chat_model`` config,
+      3. top-level ``image_gen.codex_chat_model`` config.
+
+    The id is intentionally *not* constrained to a catalog — host model
+    availability is per-account (e.g. gpt-5.5 was removed from a cohort of
+    ChatGPT accounts on 2026-09-07), so operators must be able to retarget
+    the host without waiting for a release (#105398).
+    """
+    env_override = os.environ.get("OPENAI_CODEX_CHAT_MODEL")
+    if env_override and env_override.strip():
+        return env_override.strip()
+    cfg = load_image_gen_config()
+    scoped = cfg.get("openai-codex")
+    scoped_model = scoped.get("chat_model") if isinstance(scoped, dict) else None
+    if isinstance(scoped_model, str) and scoped_model.strip():
+        return scoped_model.strip()
+    top = cfg.get("codex_chat_model")
+    if isinstance(top, str) and top.strip():
+        return top.strip()
+    return _CODEX_CHAT_MODEL
 
 
 def _read_codex_access_token() -> Optional[str]:
@@ -181,7 +210,7 @@ def _build_responses_payload(
     nudged by ``instructions``."""
     content: List[Dict[str, Any]] = [{"type": "input_text", "text": prompt}, *(input_images or [])]
     return {
-        "model": _CODEX_CHAT_MODEL,
+        "model": _resolve_codex_chat_model(),
         "store": False,
         "instructions": _CODEX_INSTRUCTIONS,
         "input": [{"type": "message", "role": "user", "content": content}],

--- a/tests/plugins/image_gen/test_codex_chat_model.py
+++ b/tests/plugins/image_gen/test_codex_chat_model.py
@@ -1,0 +1,77 @@
+"""Regression tests for #105398.
+
+The Codex Responses image lane pinned its host model to a hardcoded
+``_CODEX_CHAT_MODEL = "gpt-5.5"``. When OpenAI removed ``gpt-5.5`` from a cohort
+of ChatGPT accounts, every ``image_generate`` call 404'd permanently with no
+way to retarget the host without a release.
+
+``_resolve_codex_chat_model`` lets operators retarget via env var / config.
+"""
+
+import importlib
+
+import pytest
+
+CODEX_MOD = "plugins.image_gen.openai-codex"
+
+
+@pytest.fixture
+def codex_mod(monkeypatch):
+    mod = importlib.import_module(CODEX_MOD)
+    # load_image_gen_config is imported into the codex module's namespace, so
+    # patch it there to avoid touching the real config.yaml.
+    monkeypatch.setattr(mod, "load_image_gen_config", lambda sub=None: {})
+    return mod
+
+
+def test_codex_chat_model_default(codex_mod, monkeypatch):
+    """With no env var and no config, the host model stays gpt-5.5 (the documented
+    default) so existing installs keep working (#105398)."""
+    monkeypatch.delenv("OPENAI_CODEX_CHAT_MODEL", raising=False)
+    assert codex_mod._resolve_codex_chat_model() == "gpt-5.5"
+
+
+def test_codex_chat_model_env_override(codex_mod, monkeypatch):
+    """OPENAI_CODEX_CHAT_MODEL wins over the default — lets an operator whose
+    account lost gpt-5.5 retarget to a live model without a release (#105398)."""
+    monkeypatch.setenv("OPENAI_CODEX_CHAT_MODEL", "gpt-5.6-luna")
+    assert codex_mod._resolve_codex_chat_model() == "gpt-5.6-luna"
+
+
+def test_codex_chat_model_env_override_blank_falls_through(codex_mod, monkeypatch):
+    """A blank env var must not be treated as a set value (would 404 on empty)."""
+    monkeypatch.setenv("OPENAI_CODEX_CHAT_MODEL", "   ")
+    assert codex_mod._resolve_codex_chat_model() == "gpt-5.5"
+
+
+def test_codex_chat_model_config_scoped(codex_mod, monkeypatch):
+    """image_gen.openai-codex.chat_model retargets when no env var is set."""
+    monkeypatch.delenv("OPENAI_CODEX_CHAT_MODEL", raising=False)
+    codex_mod.load_image_gen_config = lambda sub=None: {"openai-codex": {"chat_model": "gpt-5.6"}}
+    assert codex_mod._resolve_codex_chat_model() == "gpt-5.6"
+
+
+def test_codex_chat_model_config_top_level(codex_mod, monkeypatch):
+    """image_gen.codex_chat_model (top-level) retargets when neither env nor scoped
+    config is set."""
+    monkeypatch.delenv("OPENAI_CODEX_CHAT_MODEL", raising=False)
+    codex_mod.load_image_gen_config = lambda sub=None: {"codex_chat_model": "gpt-5.7"}
+    assert codex_mod._resolve_codex_chat_model() == "gpt-5.7"
+
+
+def test_codex_chat_model_env_beats_config(codex_mod, monkeypatch):
+    """Env var has the highest precedence so operators can override config without
+    editing config.yaml (useful for a temporary retarget during an outage)."""
+    monkeypatch.setenv("OPENAI_CODEX_CHAT_MODEL", "gpt-5.6-luna")
+    codex_mod.load_image_gen_config = lambda sub=None: {"openai-codex": {"chat_model": "gpt-5.6"}}
+    assert codex_mod._resolve_codex_chat_model() == "gpt-5.6-luna"
+
+
+def test_build_responses_payload_uses_resolved_model(codex_mod, monkeypatch):
+    """The Responses request body must carry the resolved host model, not the
+    hardcoded constant (#105398)."""
+    monkeypatch.setenv("OPENAI_CODEX_CHAT_MODEL", "gpt-5.6-luna")
+    payload = codex_mod._build_responses_payload(
+        prompt="a cat", size="1024x1024", quality="high", input_images=None
+    )
+    assert payload["model"] == "gpt-5.6-luna"


### PR DESCRIPTION
Fixes #105398

## Summary

`_CODEX_CHAT_MODEL = "gpt-5.5"` was hardcoded, so when OpenAI removed `gpt-5.5` from a cohort of ChatGPT accounts (2026-09-07), every `image_generate` call 404'd permanently — the host model was not configurable and did not track the active chat model. Chat recovered when the user switched agent model, but the image lane never followed.

## Changes

- `plugins/image_gen/openai-codex/__init__.py`: add `_resolve_codex_chat_model()` with precedence **env → scoped config → top-level config → default `gpt-5.5`**, mirroring the existing `_resolve_model` / `resolve_static_model` pattern. The resolved value now flows into `_build_responses_payload`'s `"model"` field.
  - `OPENAI_CODEX_CHAT_MODEL` env var (highest precedence — temporary retarget during an outage)
  - `image_gen.openai-codex.chat_model` config
  - `image_gen.codex_chat_model` (top-level) config
  - `gpt-5.5` default (existing installs keep working)
- The id is intentionally **not** constrained to a catalog — host model availability is per-account, so operators must be able to retarget to any live model (e.g. `gpt-5.6-luna`) without a release.
- `tests/plugins/image_gen/test_codex_chat_model.py`: 7 regression tests covering every precedence path, blank-env fall-through, env-beats-config, and the payload wiring (`_build_responses_payload` carries the resolved model, not the constant).

## Verification

Locally confirmed all 7 cases pass: default `gpt-5.5`, env override, blank env falls through, scoped config, top-level config, env beats config, and `_build_responses_payload["model"]` reflects the resolved value.

---

*This PR was prepared with AI assistance. I reviewed every changed line and verified the fix against the current `main`.*
