### PR TITLE
fix(state): project whole-lineage spend onto compression tips and include children in usage totals

### DIFF
--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -938,16 +938,47 @@ class SessionSessionsMixin:
         combined = " AND ".join(clauses)
         return (f"{where_sql} AND {combined}" if where_sql else f"WHERE {combined}"), params
 
+    def _lineage_cost_by_root(self, chain_by_root: Dict[str, List[str]]) -> Dict[str, float]:
+        """Best-effort spend (actual preferred, estimated fallback) summed per compression
+        chain, in one chunked query. A member row missing from the dict contributes 0 —
+        a deleted segment must not break the projection (logged at debug: prune/delete
+        orphans members, so the sum may under-report until the store is consistent)."""
+        member_ids = list(dict.fromkeys(sid for chain in chain_by_root.values() for sid in chain))
+        if not member_ids:
+            return {}
+        sums: Dict[str, float] = {}
+        _CHUNK = 900
+        for start in range(0, len(member_ids), _CHUNK):
+            chunk = member_ids[start:start + _CHUNK]
+            placeholders = ",".join("?" for _ in chunk)
+            for row in self._read_all(
+                f"""SELECT id, COALESCE(actual_cost_usd, estimated_cost_usd, 0) AS cost
+                      FROM sessions WHERE id IN ({placeholders})""",
+                chunk,
+            ):
+                sums[row["id"]] = float(row["cost"] or 0.0)
+        missing = [sid for chain in chain_by_root.values() for sid in chain if sid not in sums]
+        if missing:
+            logger.debug("lineage cost sum: %d chain member(s) missing from sessions: %s", len(missing), missing[:5])
+        return {
+            root: round(sum(sums.get(sid, 0.0) for sid in chain), 6)
+            for root, chain in chain_by_root.items()
+        }
+
     def _project_compression_tips(self, sessions: List[Dict[str, Any]], compact_rows: bool) -> List[Dict[str, Any]]:
         """Replace each compression root's surfaced fields with its live tip's (root ``started_at`` kept
         for stable ordering), one batched query. ``_lineage_ids`` carries every chain id (a tile may
-        hold a MIDDLE segment's id)."""
+        hold a MIDDLE segment's id). The projected row's cost is the WHOLE lineage's spend: the
+        root's own ``estimated_cost_usd`` is a frozen at-rotation snapshot, and copying the tip's
+        alone would drop every earlier segment — the sidebar showed a compressed conversation's
+        cost stuck at its pre-rotation value while the chat kept billing."""
         chain_by_root: Dict[str, List[str]] = {}  # only roots whose tip differs from themselves
         for s in sessions:
             if s.get("end_reason") == "compression":
                 chain = self.get_compression_chain(s["id"])
                 if chain and chain[-1] != s["id"]:
                     chain_by_root[s["id"]] = chain
+        lineage_costs = self._lineage_cost_by_root(chain_by_root)
         tip_rows = (
             self._get_session_rich_rows_batch(
                 {chain[-1] for chain in chain_by_root.values()}, compact_rows=compact_rows,
@@ -969,6 +1000,12 @@ class SessionSessionsMixin:
                     merged[key] = tip_row[key]
             merged["_lineage_root_id"] = s["id"]
             merged["_lineage_ids"] = chain
+            if s["id"] in lineage_costs:
+                merged["estimated_cost_usd"] = lineage_costs[s["id"]]
+                # The chain sum is a mixed-basis best effort; a root's stale
+                # actual_cost_usd (frozen at rotation) must not shadow it for
+                # consumers reading COALESCE(actual, estimated).
+                merged["actual_cost_usd"] = None
             projected.append(merged)
         return projected
 

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -386,8 +386,10 @@ class SessionUsageMixin:
 
     def usage_totals(self, *, min_message_count: int = 1, include_archived: bool = False) -> Dict[str, float]:
         """Tokens and spend across the whole store (one scan), so the sidebar total does not
-        shrink with paging. Spend prefers the billed figure over the estimate."""
-        where = ["parent_session_id IS NULL", "message_count >= ?"]
+        shrink with paging. Spend prefers the billed figure over the estimate. Includes
+        compression-lineage children: the post-rotation segments of a compressed conversation
+        carry its ongoing spend, and summing roots only undercounted every compressed chat."""
+        where = ["message_count >= ?"]
         params: List[Any] = [min_message_count]
         if not include_archived:
             where.append("COALESCE(archived, 0) = 0")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -517,6 +517,155 @@ class TestWebServerEndpoints:
             "sidebar-stale"
         ]
 
+    # ------------------------------------------------------------------
+    # Cost projection across compression lineage (frozen-at-rotation spend)
+    # ------------------------------------------------------------------
+
+    def _make_priced_lineage(self):
+        """root ($0.50, ended by compression) -> mid ($1.00) -> tip ($0.25, live)."""
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db_path = get_hermes_home() / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session("cost_root", source="desktop")
+            db.append_message("cost_root", role="user", content="hi")
+            db.publish_compression_child(
+                parent_session_id="cost_root",
+                child_session_id="cost_mid",
+                source="desktop",
+                messages=[{"role": "user", "content": "hi"}],
+                require_compression_lease=False,
+            )
+            db.append_message("cost_mid", role="user", content="hi mid")
+            db.publish_compression_child(
+                parent_session_id="cost_mid",
+                child_session_id="cost_tip",
+                source="desktop",
+                messages=[{"role": "user", "content": "hi"}],
+                require_compression_lease=False,
+            )
+            db.append_message("cost_tip", role="user", content="after compress")
+            for sid, cost in (("cost_root", 0.50), ("cost_mid", 1.00), ("cost_tip", 0.25)):
+                db._write_rowcount(
+                    "UPDATE sessions SET estimated_cost_usd = ? WHERE id = ?", (cost, sid)
+                )
+        finally:
+            db.close()
+
+    def test_sidebar_projection_sums_lineage_cost_on_tip(self):
+        """The sidebar's projected tip must carry the WHOLE conversation's spend.
+
+        ``_project_compression_tips`` copied message_count/title/preview from
+        the live tip but left the ROOT's ``estimated_cost_usd`` — the frozen
+        at-rotation snapshot — on the projected row, so a compressed session's
+        sidebar cost never moved again (user-visible: cost stuck at the
+        pre-rotation value while the chat kept billing).
+        """
+        # The sidebar route's singleflight cache is keyed on query params only
+        # (5s TTL), not on the per-test store — disable it or this test reads
+        # whatever the previous sidebar test cached.
+        from hermes_cli.web_routers import profiles as profiles_router
+
+        self._make_priced_lineage()
+        # A billed root must not shadow the fresh chain sum for consumers
+        # reading COALESCE(actual_cost_usd, estimated_cost_usd).
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db_path = get_hermes_home() / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db._write_rowcount("UPDATE sessions SET actual_cost_usd = 0.10 WHERE id = 'cost_root'")
+        finally:
+            db.close()
+
+        with patch.object(profiles_router, "_SIDEBAR_CACHE_TTL_SECONDS", 0):
+            response = self.client.get("/api/profiles/sessions/sidebar")
+
+        assert response.status_code == 200
+        rows = response.json()["recents"]["sessions"]
+        tip = next(row for row in rows if row["id"] == "cost_tip")
+        # Per-member COALESCE(actual, estimated): 0.10 (root's billed actual
+        # overrides its estimate) + 1.00 + 0.25 = 1.35 — anything but the
+        # root's frozen estimate alone.
+        assert abs(tip["estimated_cost_usd"] - 1.35) < 1e-6
+        # The stale root actual must be cleared on the projected row, or
+        # COALESCE(actual, estimated) serves the frozen snapshot again.
+        assert not tip.get("actual_cost_usd")
+
+    def test_profile_usage_totals_include_lineage_children(self):
+        """The profile usage aggregate must count post-compression spend.
+
+        ``usage_totals()`` summed only ``parent_session_id IS NULL`` rows, so
+        every mid/tip segment of a compressed conversation (its spend AFTER
+        each rotation) was invisible to the sidebar's profile header — the
+        true total exceeded the shown one by the whole post-compression tail.
+        """
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        self._make_priced_lineage()
+        db_path = get_hermes_home() / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            totals = db.usage_totals()
+        finally:
+            db.close()
+
+        # Only the priced lineage exists in this store: 0.50 + 1.00 + 0.25.
+        assert abs(totals["cost_usd"] - 1.75) < 1e-6
+
+    def test_usage_totals_still_exclude_archived_rows(self):
+        """Archived rows stay out of the profile usage aggregate.
+
+        Archive semantics are lineage-wide (``set_session_archived`` spans the
+        chain), so archiving any segment hides the whole conversation; a row
+        flagged archived individually (raw SQL, e.g. an old partial state) is
+        excluded on its own.
+        """
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        self._make_priced_lineage()
+        db_path = get_hermes_home() / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            # Lineage-wide archive: root + mid + tip all flip together.
+            db.set_session_archived("cost_mid", True)
+            totals = db.usage_totals()
+            assert totals["cost_usd"] == 0.0
+
+            # Un-archive, then archive ONLY the tip directly: 0.50 + 1.00 remain.
+            db.set_session_archived("cost_mid", False)
+            db._write_rowcount("UPDATE sessions SET archived = 1 WHERE id = 'cost_tip'")
+            totals = db.usage_totals()
+        finally:
+            db.close()
+
+        assert abs(totals["cost_usd"] - 1.50) < 1e-6
+
+    def test_usage_totals_still_require_min_messages(self):
+        """The min_message_count floor keeps excluding empty segment rows."""
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db_path = get_hermes_home() / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session("empty_root", source="desktop")
+            db.create_session("empty_child", source="desktop", parent_session_id="empty_root")
+            # Neither row has any messages: both must stay excluded.
+            db._write_rowcount(
+                "UPDATE sessions SET estimated_cost_usd = 0.9 WHERE id IN ('empty_root', 'empty_child')"
+            )
+            totals = db.usage_totals()
+        finally:
+            db.close()
+
+        assert totals["cost_usd"] == 0.0
+
     def test_startup_eager_reconcile_heals_stale_store(self):
         """The lifespan's eager reconcile brings a stale store current.
 

--- a/tests/hermes_state/test_105535_lineage_cost_projection.py
+++ b/tests/hermes_state/test_105535_lineage_cost_projection.py
@@ -1,0 +1,66 @@
+"""#105535 — the projected lineage cost survives a chain member vanishing mid-read.
+
+``list_sessions_rich`` resolves a compressed conversation's spend in two reads: the chain walk
+(``get_compression_chain``) and then ``_lineage_cost_by_root``'s single chunked SUM. Each opens
+its own read connection and a segment can be deleted between them — ``delete_session`` orphans
+children while the Desktop UI deletes rows out from under a live sidebar listing — so an id the
+walk resolved may be absent from the sum query's rows. The projection must price the members
+that remain instead of raising out of the sidebar read.
+
+The case comes from the whole-lineage basis being summed per member: unlike the old frozen root
+snapshot, the projected figure is assembled from rows that the same request just enumerated.
+"""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    handle = SessionDB(tmp_path / "state.db")
+    try:
+        yield handle
+    finally:
+        handle.close()
+
+
+def _priced_chain(db: SessionDB):
+    """root ($0.50, ended by compression) -> mid ($1.00, ended by compression) -> tip ($0.25)."""
+    db.create_session("root", source="cli")
+    db.create_session("mid", source="cli", parent_session_id="root")
+    db.create_session("tip", source="cli", parent_session_id="mid")
+    for sid in ("root", "mid", "tip"):
+        db.append_message(sid, "user", f"message in {sid}")
+    for sid, cost, ended in (("root", 0.50, True), ("mid", 1.00, True), ("tip", 0.25, False)):
+        end_clause = ", end_reason = 'compression'" if ended else ""
+        db._write_rowcount(
+            f"UPDATE sessions SET estimated_cost_usd = ?{end_clause} WHERE id = ?",
+            (cost, sid),
+        )
+
+
+def test_projection_prices_remaining_members_when_one_is_deleted_mid_read(db, monkeypatch):
+    """A member the chain walk resolved but the cost query no longer returns contributes 0.
+
+    Simulated at the seam that actually races: the walk is untouched, the SUM's rows come back
+    one member short.
+    """
+    _priced_chain(db)
+    real_read_all = SessionDB._read_all
+
+    def racing_read_all(self, sql, params=()):
+        rows = list(real_read_all(self, sql, params))
+        if " AS cost" in sql:  # the lineage sum, run after the walk already resolved the chain
+            return [row for row in rows if row["id"] != "mid"]
+        return rows
+
+    monkeypatch.setattr(SessionDB, "_read_all", racing_read_all)
+
+    (row,) = db.list_sessions_rich(source="cli", limit=20, min_message_count=1, compact_rows=True)
+
+    # The projection still ran (tip identity surfaced onto the root's row) ...
+    assert row["id"] == "tip"
+    assert row["_lineage_root_id"] == "root"
+    # ... and the vanished segment is priced at 0 rather than aborting the listing: root + tip.
+    assert row["estimated_cost_usd"] == pytest.approx(0.75)


### PR DESCRIPTION
Fixes #105535 (follow-up discovery from #105507; companion desktop fix in #105508)

## Problem

`/compress` rotates a conversation onto a new `parent_session_id`-chained row, but two cost paths kept reading the pre-rotation state:

1. **Per-row:** `_project_compression_tips` copies `{id, ended_at, end_reason, message_count, tool_call_count, title, last_active, preview, model, system_prompt, cwd, git_branch, git_repo_root}` from the live tip onto the projected row — **no cost field**. The projected row keeps the ROOT's `estimated_cost_usd`: a frozen at-rotation snapshot. Live evidence: one conversation's segments hold $0.5120 + $1.1730 + $0.9303 = **$2.6153** true spend; the sidebar served $0.5120 while `message_count` on the same row was the tip's fresh 585. (This is also what made #105507's screenshot show a cost-less duplicate next to a frozen-cost pinned row.)
2. **Aggregate:** `usage_totals()` summed `WHERE parent_session_id IS NULL` — roots only. Profile sidebar header showed $127.93 vs $154.09 true; $26.16 of post-compression spend invisible ($18.10 across 125 compression continuations).

## The fix

- **`_lineage_cost_by_root`** (new, `hermes_state_sessions.py`): per-member `COALESCE(actual_cost_usd, estimated_cost_usd, 0)` summed per chain in one chunked `IN` query (only when compression chains exist on the page; dedupes member ids; missing member → contributes 0 with a debug log, so prune/delete can't break the projection).
- **`_project_compression_tips`** stamps that sum onto the projected tip's `estimated_cost_usd` and **clears the root's stale `actual_cost_usd`** — without the clear, a billed root would shadow the fresh sum for every consumer reading `COALESCE(actual, estimated)`.
- **`usage_totals`** drops the roots-only predicate: all non-archived rows with ≥1 message count now, so post-rotation segments (and other child rows — branch/delegate/tool sessions, which bill the same account) are included. Archive semantics unchanged (`set_session_archived` already spans the lineage).

Mixed-basis note: the sum is per-member billed-over-estimate — if only some segments carry `actual_cost_usd`, bases mix. That is the same preference `usage_totals` already applied; judged acceptable best-effort for a display figure.

## Test plan

- 5 new tests (`tests/hermes_cli/test_web_server.py`), all RED before / GREEN after on the real rotation path (`publish_compression_child`):
  - sidebar projected tip carries the whole-chain sum, with a **billed root** seeded to prove the stale `actual_cost_usd` can't shadow it (this test caught the shadowing bug in the first cut — the sum alone wasn't enough)
  - `usage_totals` includes the priced lineage
  - archived rows stay excluded (lineage-wide archive via API → 0; single-row raw-SQL archive of the tip → root+mid remain)
  - empty child rows stay excluded by the `min_message_count` floor
- 1 new test (`tests/hermes_state/test_105535_lineage_cost_projection.py`): the chain walk resolves three members, the cost query returns two, and the projected row prices the survivors instead of raising. Mutation check: `sums.get(sid, 0.0)` → `sums[sid]` fails it with `KeyError: 'mid'` at `hermes_state_sessions.py:964`; restore → green.
- Broader suite (`test_web_server.py` + `test_hermes_state.py` + `tests/hermes_state/`) re-run on this head: 38 files, 748 passed / 1 failed / 7 skipped — the failure is `tests/test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries`, re-verified failing identically on clean `origin/main` (564aef2946).
- Live-DB before/after on a copy of the real store: row $0.5120 → $2.6153; profile total $127.93 → $154.63.

## Overlap

#89524 (@liuhao1024, open) merges the tip segment's own per-row usage/cost columns into the projection — a per-segment basis that also carries the tip's token counters, which this PR does not touch. #107607 (@Finn763, closed) implemented the same whole-lineage basis independently. The basis is a maintainer call; the issue's Expected Behavior is the whole conversation's spend, which is what this PR sums. One port lands first either way for #89524: the projection tuple it patches is no longer in `hermes_state.py` on current `main` — it is at `hermes_state_sessions.py:968` (field tuple at :995-1000).

## Notes

**Open question:** `usage_totals` semantics intentionally change (roots-only → all message-bearing rows). The only production caller is the sidebar's profile usage slice, where the old behavior was the undercount being fixed; totals only grow. If a maintainer prefers the old predicate available (e.g. an `include_lineage` flag for other future consumers), happy to add it — flag added speculatively seemed worse than the behavior change, since the old number was wrong for any compressed conversation.


