### PR TITLE
fix(gateway): preserve shared MCP visibility across profile reloads

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2271,7 +2271,7 @@ class GatewayTurnMixin:
         try:
             from tools.mcp_tool_lifecycle import shutdown_mcp_servers
             from tools.mcp_tool_discovery import discover_mcp_tools
-            from tools.mcp_tool import _servers, _lock, _server_scope_keys
+            from tools.mcp_tool import _servers, _lock, _server_visible_in_scope
             from tools.mcp_tool_agent import reprobe_tool_availability
             from tools.registry import registry
 
@@ -2281,7 +2281,7 @@ class GatewayTurnMixin:
                 with _lock:
                     return {
                         name for name in _servers
-                        if reload_scope is None or _server_scope_keys.get(name) == reload_scope
+                        if _server_visible_in_scope(name, reload_scope)
                     }
 
             old_servers = _scoped_server_names()

--- a/tests/gateway/test_multiplex_mcp_discovery.py
+++ b/tests/gateway/test_multiplex_mcp_discovery.py
@@ -179,6 +179,109 @@ def test_scope_visibility_rejects_a_foreign_server_route(
     assert mcp_tool._server_tool_scopes["shared"] == {launch_scope}
 
 
+def test_shared_server_tools_are_callable_and_removed_on_non_owner_reload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from agent.secret_scope import set_multiplex_active
+    from hermes_constants import (
+        hermes_home_key,
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    from tools import mcp_tool
+    from tools import mcp_tool_config as _mcp_config
+    from tools import mcp_tool_discovery as _mcp_discovery
+    from tools.registry import registry
+
+    worker_home = tmp_path / "profiles" / "worker"
+    launch_home = tmp_path / "default"
+    worker_home.mkdir(parents=True)
+    launch_home.mkdir()
+    worker_token = set_hermes_home_override(worker_home)
+    previous_multiplex = set_multiplex_active(True)
+    worker_scope = hermes_home_key()
+    launch_scope = hermes_home_key(launch_home)
+    tool = SimpleNamespace(
+        name="echo",
+        description="Echo a value",
+        inputSchema={"type": "object", "properties": {}},
+        annotations=None,
+    )
+    server = SimpleNamespace(
+        name="shared",
+        session=object(),
+        _tools=[tool],
+        tool_timeout=30,
+        _registered_tool_names=[],
+        _config={},
+        initialize_result=None,
+    )
+    owner_tool_name = "mcp__shared__echo"
+    registry.register(
+        owner_tool_name,
+        "mcp-shared",
+        {"name": owner_tool_name, "description": "Echo a value", "type": "object"},
+        lambda **_kwargs: None,
+        scope=launch_scope,
+    )
+    registry.register_toolset_alias("shared", "mcp-shared")
+    server._registered_tool_names = [owner_tool_name]
+    with mcp_tool._lock:
+        saved = {
+            "_servers": dict(mcp_tool._servers),
+            "_server_scope_keys": dict(mcp_tool._server_scope_keys),
+            "_server_tool_scopes": dict(mcp_tool._server_tool_scopes),
+            "_mcp_tool_server_names": dict(mcp_tool._mcp_tool_server_names),
+        }
+        mcp_tool._servers.clear()
+        mcp_tool._server_scope_keys.clear()
+        mcp_tool._server_tool_scopes.clear()
+        mcp_tool._mcp_tool_server_names.clear()
+        mcp_tool._servers["shared"] = server
+        mcp_tool._server_scope_keys["shared"] = launch_scope
+        mcp_tool._server_tool_scopes["shared"] = {launch_scope}
+
+    try:
+        monkeypatch.setattr(mcp_tool, "_ensure_mcp_sdk", lambda: True)
+        monkeypatch.setattr(_mcp_config, "_filter_suspicious_mcp_servers", lambda servers: servers)
+        assert _mcp_discovery.register_mcp_servers({"shared": {}})
+        tool_names = registry.get_tool_names_for_toolset("mcp-shared")
+        assert tool_names
+        assert callable(registry.get_entry(tool_names[0]).handler)
+
+        # Changing the worker route removes only the worker overlay; the shared
+        # live connection and launch owner remain intact.
+        assert _mcp_discovery.register_mcp_servers(
+            {"shared": {"url": "https://worker.example/mcp"}}
+        ) == []
+        assert registry.get_tool_names_for_toolset("mcp-shared") == []
+        with mcp_tool._lock:
+            assert mcp_tool._server_scope_keys["shared"] == launch_scope
+            assert mcp_tool._server_tool_scopes["shared"] == {launch_scope}
+            assert mcp_tool._servers["shared"] is server
+        assert registry.snapshot_registration(owner_tool_name, scope=launch_scope) is not None
+        assert registry.get_toolset_alias_target("shared") == "mcp-shared"
+
+        # Removing the server from the worker config has the same scoped cleanup.
+        assert _mcp_discovery.register_mcp_servers({}) == []
+        assert registry.get_tool_names_for_toolset("mcp-shared") == []
+        with mcp_tool._lock:
+            assert mcp_tool._server_scope_keys["shared"] == launch_scope
+            assert mcp_tool._server_tool_scopes["shared"] == {launch_scope}
+            assert mcp_tool._servers["shared"] is server
+    finally:
+        for tool_name in list(registry.get_tool_names_for_toolset("mcp-shared")):
+            registry.deregister(tool_name, scope=worker_scope)
+        registry.deregister(owner_tool_name, scope=launch_scope)
+        with mcp_tool._lock:
+            for name, value in saved.items():
+                target = getattr(mcp_tool, name)
+                target.clear()
+                target.update(value)
+        set_multiplex_active(previous_multiplex)
+        reset_hermes_home_override(worker_token)
+
+
 def test_deregister_scope_kwarg_targets_overlay_and_keeps_plugin_confinement() -> None:
     from tools.registry import ToolRegistry
 

--- a/tests/gateway/test_multiplex_mcp_discovery.py
+++ b/tests/gateway/test_multiplex_mcp_discovery.py
@@ -102,6 +102,83 @@ async def test_reload_mcp_only_touches_requesting_profile(
     assert "default-srv" not in result
 
 
+@pytest.mark.asyncio
+async def test_reload_mcp_reports_a_shared_server_to_a_non_owner_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A shared connection remains visible when its peer profile reloads MCP."""
+    from gateway.run import GatewayRunner
+    from tools import mcp_tool
+    from tools import mcp_tool_discovery as _mcp_discovery
+    from tools import mcp_tool_lifecycle as _mcp_lifecycle
+
+    worker_home = tmp_path / "profiles" / "worker"
+    worker_home.mkdir(parents=True)
+    worker_scope = hermes_home_key(worker_home)
+    launch_scope = hermes_home_key(tmp_path / "default")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner._resolve_profile_home_for_source = MagicMock(return_value=worker_home)
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._async_session_store = SimpleNamespace(
+        get_or_create_session=MagicMock(side_effect=RuntimeError("skip transcript")),
+    )
+
+    live_server = SimpleNamespace(session=object(), _config={})
+    monkeypatch.setattr(mcp_tool, "_servers", {"shared": live_server})
+    monkeypatch.setattr(mcp_tool, "_server_scope_keys", {"shared": launch_scope})
+    monkeypatch.setattr(mcp_tool, "_server_tool_scopes", {"shared": {launch_scope}}, raising=False)
+    monkeypatch.setattr(mcp_tool, "_server_connecting", set())
+    monkeypatch.setattr(mcp_tool, "_server_connect_errors", {})
+    monkeypatch.setattr(mcp_tool, "_lazy_server_configs", {})
+    monkeypatch.setattr(mcp_tool, "_mcp_registry_scope", lambda: worker_scope)
+
+    def fake_discover() -> list[str]:
+        _mcp_discovery._select_new_servers({"shared": {}})
+        return ["mcp__shared__tool"]
+
+    monkeypatch.setattr(_mcp_lifecycle, "shutdown_mcp_servers", lambda **_kwargs: None)
+    monkeypatch.setattr(_mcp_discovery, "discover_mcp_tools", fake_discover)
+
+    event = MessageEvent(
+        text="/reload-mcp", message_id="m1",
+        source=SessionSource(
+            platform=Platform.TELEGRAM, user_id="u1", chat_id="c1",
+            chat_type="dm", profile="worker",
+        ),
+    )
+    result = await runner._execute_mcp_reload(event)
+
+    assert "No MCP servers connected." not in result
+    assert "shared" in result
+    assert mcp_tool._server_scope_keys["shared"] == launch_scope
+    assert mcp_tool._server_tool_scopes["shared"] == {launch_scope, worker_scope}
+
+
+def test_scope_visibility_rejects_a_foreign_server_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tools import mcp_tool
+    from tools import mcp_tool_discovery as _mcp_discovery
+
+    worker_scope = hermes_home_key(tmp_path / "worker")
+    launch_scope = hermes_home_key(tmp_path / "default")
+    live_server = SimpleNamespace(session=object(), _config={"url": "https://default.example/mcp"})
+    monkeypatch.setattr(mcp_tool, "_servers", {"shared": live_server})
+    monkeypatch.setattr(mcp_tool, "_server_scope_keys", {"shared": launch_scope})
+    monkeypatch.setattr(mcp_tool, "_server_tool_scopes", {"shared": {launch_scope}}, raising=False)
+    monkeypatch.setattr(mcp_tool, "_server_connecting", set())
+    monkeypatch.setattr(mcp_tool, "_server_connect_errors", {})
+    monkeypatch.setattr(mcp_tool, "_lazy_server_configs", {})
+    monkeypatch.setattr(mcp_tool, "_mcp_registry_scope", lambda: worker_scope)
+
+    _mcp_discovery._select_new_servers({"shared": {"url": "https://worker.example/mcp"}})
+
+    assert mcp_tool._server_tool_scopes["shared"] == {launch_scope}
+
+
 def test_deregister_scope_kwarg_targets_overlay_and_keeps_plugin_confinement() -> None:
     from tools.registry import ToolRegistry
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -401,6 +401,9 @@ _servers: Dict[str, MCPServerTask] = {}
 # Profile registry scope per live connection (None outside multiplex) so a multiplexed
 # /reload-mcp tears down only its own profile's servers.
 _server_scope_keys: Dict[str, Optional[str]] = {}
+# Registry scopes that have adopted a live server connection. The owning scope above remains
+# authoritative for connection teardown; this set preserves visibility for shared connections.
+_server_tool_scopes: Dict[str, set] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
 # Lazy startup: servers registered from the schema cache without connecting; popped on
@@ -625,6 +628,14 @@ def _server_registry_scope(name: str) -> Optional[str]:
     if name in _server_scope_keys:
         return _server_scope_keys[name]
     return _mcp_registry_scope()
+
+
+def _server_visible_in_scope(name: str, scope: Optional[str]) -> bool:
+    """Whether a live server is visible from ``scope`` without changing its teardown owner."""
+    if scope is None:
+        return True
+    return (_server_scope_keys.get(name) == scope
+            or scope in _server_tool_scopes.get(name, ()))
 
 
 # Cross-process discovery guard: advisory file lock so gateway + CLI + TUI don't all discover.

--- a/tools/mcp_tool_discovery.py
+++ b/tools/mcp_tool_discovery.py
@@ -168,10 +168,8 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
     # The cached manifest may advertise tools the live server no longer serves.
     phantom_names = [n for n in cached_names if n not in live_names]
     if phantom_names:
-        from tools.registry import registry
         for tool_name in phantom_names:
-            registry.deregister(tool_name, scope=_core._server_registry_scope(server_name))
-            _registration._forget_mcp_tool_server(tool_name)
+            _registration._deregister_mcp_tool_all_scopes(server_name, tool_name)
         logger.info("MCP server '%s': deregistered %d phantom cached tool(s) not served live (stale schema-cache "
                     "fingerprint %s): %s", server_name, len(phantom_names), stale_fingerprint, ", ".join(phantom_names))
     return server is not None and server.session is not None
@@ -375,10 +373,13 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         logger.debug("MCP SDK not available -- skipping explicit MCP registration")
         return []
     servers = _config._filter_suspicious_mcp_servers(servers)
+    scoped_healed = _registration.register_connected_into_current_scope(servers)
     if not servers:
         logger.debug("No explicit MCP servers provided")
-        return []
+        return _registration._existing_tool_names() if _core._mcp_registry_scope() is not None else []
     new_servers = _select_new_servers(servers)
+    if scoped_healed:
+        logger.info("MCP: registered %d already-connected server(s) into this profile scope", scoped_healed)
     if not new_servers:
         return _registration._existing_tool_names()
     new_servers, lazy_registered, lazy_server_count = _register_lazy_from_cache(new_servers)

--- a/tools/mcp_tool_discovery.py
+++ b/tools/mcp_tool_discovery.py
@@ -249,6 +249,19 @@ def _select_new_servers(servers: Dict[str, dict]) -> Dict[str, dict]:
         for srv_name in new_servers:
             _core._server_scope_keys[srv_name] = current_scope
             _core._server_connect_errors.pop(srv_name, None)
+        # A shared connection can already be owned by another profile. Record the current
+        # profile's visibility separately so its scoped reload sees the connection without
+        # moving teardown ownership away from the profile that opened it.
+        if current_scope is not None:
+            from tools.mcp_schema_cache import config_fingerprint
+            for srv_name, srv_cfg in servers.items():
+                if not _enabled(srv_cfg):
+                    continue
+                server = _core._servers.get(srv_name)
+                if (server is not None and getattr(server, "session", None) is not None
+                        and config_fingerprint(getattr(server, "_config", {}) or {})
+                        == config_fingerprint(srv_cfg)):
+                    _core._server_tool_scopes.setdefault(srv_name, set()).add(current_scope)
         # Track which servers opt-in to parallel tool calls (idempotent).
         for srv_name, srv_cfg in servers.items():
             if _parse_boolish(srv_cfg.get("supports_parallel_tool_calls", False), default=False):
@@ -468,7 +481,7 @@ def get_mcp_status(configured: Optional[Dict[str, dict]] = None, *, include_runt
             # Runtime state belongs to the profile that adopted it; under a multiplexer only that
             # profile's view may show it, and ``include_runtime=False`` hides the launch profile's
             # servers from a status read scoped to a different profile.
-            return include_runtime and _core._server_scope_keys.get(name, None) == current_scope
+            return include_runtime and _core._server_visible_in_scope(name, current_scope)
 
         active_servers = {n: s for n, s in _core._servers.items() if visible(n)}
         connecting = {n for n in _core._server_connecting if visible(n)}

--- a/tools/mcp_tool_health.py
+++ b/tools/mcp_tool_health.py
@@ -9,7 +9,6 @@ import time
 from typing import Iterable, Optional
 from tools.mcp_tool_errors import _is_method_not_found_error, _unwrap_exception_group
 from tools.mcp_tool_schema import mcp_prefixed_tool_name
-from tools.mcp_tool_registration import _forget_mcp_tool_server
 from tools.mcp_tool_common import _core
 from tools import mcp_tool_registration as _registration
 
@@ -128,8 +127,7 @@ class MCPServerHealthMixin:
         from tools.registry import registry
         for tool_name in tool_names:
             if registry.get_toolset_for_tool(tool_name) == f"mcp-{self.name}":
-                registry.deregister(tool_name, scope=_core._server_registry_scope(self.name))
-                _forget_mcp_tool_server(tool_name)
+                _registration._deregister_mcp_tool_all_scopes(self.name, tool_name)
 
     async def _refresh_tools(self):
         """Re-fetch tools on ``tools/list_changed`` and update the registry. The lock serializes rapid-fire

--- a/tools/mcp_tool_lifecycle.py
+++ b/tools/mcp_tool_lifecycle.py
@@ -107,6 +107,7 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
         servers_snapshot = [_core._servers[name] for name in selected]
         selected_status = (
             set(_core._servers) | set(_core._server_scope_keys)
+            | set(_core._server_tool_scopes)
             | set(_core._server_connecting) | set(_core._server_connect_errors)
             if scope is None else {
                 name for name, owner in _core._server_scope_keys.items() if owner == scope
@@ -118,6 +119,7 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
         for name in selected_status:
             _core._server_connect_errors.pop(name, None)
             _core._server_scope_keys.pop(name, None)
+            _core._server_tool_scopes.pop(name, None)
 
     # Fast path: nothing to shut down. The connect-cooldown maps can still be populated here — a server that
     # failed to connect is never recorded in ``_servers`` (that is the very premise of the #50394 cooldown),

--- a/tools/mcp_tool_registration.py
+++ b/tools/mcp_tool_registration.py
@@ -4,6 +4,7 @@ resolution and the schema-cache write-through. Both entry points (``_register_se
 live, ``_register_from_cache_sync`` lazy) build ``_Candidate`` records for ``_register_candidates``."""
 
 import logging
+import threading
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional
@@ -20,6 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from tools.mcp_tool import MCPServerTask
 
 logger = logging.getLogger("tools.mcp_tool")
+_SCOPE_REFRESH_LOCKS = tuple(threading.RLock() for _ in range(16))
 
 _UTILITY_ORIGIN_PREFIX = "generated utility "
 # Utility tool key -> handler factory; each takes (server_name, tool_timeout).
@@ -68,6 +70,51 @@ def _forget_mcp_tool_server(tool_name: str) -> None:
         _core._mcp_tool_server_names.pop(tool_name, None)
 
 
+def _deregister_mcp_tool_all_scopes(server_name: str, tool_name: str) -> None:
+    """Deregister one server tool from every profile overlay that owns it."""
+    from tools.registry import registry
+
+    with _core._lock:
+        scopes = set(_core._server_tool_scopes.get(server_name, ()))
+        if not scopes:
+            scopes = {_core._server_registry_scope(server_name)}
+    for scope in scopes:
+        registry.deregister(tool_name, scope=scope)
+    _forget_mcp_tool_server(tool_name)
+    _restore_server_toolset_alias(server_name)
+
+
+def _restore_server_toolset_alias(server_name: str) -> None:
+    """Keep the process-global alias while any profile still owns this server's tools."""
+    from tools.registry import registry
+
+    with _core._lock:
+        server = _core._servers.get(server_name)
+        scopes = set(_core._server_tool_scopes.get(server_name, ()))
+        tool_names = list(getattr(server, "_registered_tool_names", ()) if server is not None else ())
+    if any(
+        registry.snapshot_registration(tool_name, scope=scope) is not None
+        for scope in scopes for tool_name in tool_names
+    ):
+        registry.register_toolset_alias(server_name, f"mcp-{server_name}")
+
+
+def _remove_server_scope(server_name: str, scope: str) -> None:
+    """Remove one profile's MCP overlay for a shared live connection."""
+    from tools.registry import registry
+
+    for tool_name in registry.get_tool_names_for_toolset(f"mcp-{server_name}"):
+        registry.deregister(tool_name, scope=scope)
+    with _core._lock:
+        scopes = set(_core._server_tool_scopes.get(server_name, ()))
+        scopes.discard(scope)
+        if scopes:
+            _core._server_tool_scopes[server_name] = scopes
+        else:
+            _core._server_tool_scopes.pop(server_name, None)
+    _restore_server_toolset_alias(server_name)
+
+
 def _select_utility_schemas(server_name: str, server: "MCPServerTask", config: dict) -> List[dict]:
     """Utility schemas allowed by config (``tools.resources``/``tools.prompts``) and advertised
     capabilities. ``initialize_result.capabilities`` is the truth (sub-object non-None iff the
@@ -99,6 +146,25 @@ def _select_utility_schemas(server_name: str, server: "MCPServerTask", config: d
 
 def _existing_tool_names() -> List[str]:
     """Tool names for all connected servers plus lazy (cache-registered) servers, whose tools live only in the registry."""
+    scope = _core._mcp_registry_scope()
+    if scope is not None:
+        from tools.registry import registry
+
+        with _core._lock:
+            server_names = [
+                name for name in _core._servers
+                if _core._server_visible_in_scope(name, scope)
+            ]
+            server_names.extend(
+                name for name in _core._lazy_server_tool_names
+                if name not in _core._servers
+            )
+        return sorted({
+            tool_name
+            for server_name in server_names
+            for tool_name in registry.get_tool_names_for_toolset(f"mcp-{server_name}")
+        })
+
     names: List[str] = []
     for server in _core._servers.values():
         names.extend(server._registered_tool_names if hasattr(server, "_registered_tool_names")
@@ -228,6 +294,7 @@ def _register_candidates(name: str, candidates: List[_Candidate], *, check_fn: C
     from tools.registry import registry
     toolset_name = f"mcp-{name}"
     registered: List[str] = []
+    scope_value = scope()
     for c in candidates:
         existing_toolset = registry.get_toolset_for_tool(c.registry_name)
         if existing_toolset and existing_toolset != toolset_name:  # foreign owner: skip, preserve it
@@ -244,9 +311,12 @@ def _register_candidates(name: str, candidates: List[_Candidate], *, check_fn: C
             continue
         registry.register(
             name=c.registry_name, toolset=toolset_name, schema=c.schema, handler=c.handler, check_fn=check_fn,
-            is_async=False, description=c.schema.get("description") or "", scope=scope())
+            is_async=False, description=c.schema.get("description") or "", scope=scope_value)
         if registry.get_toolset_for_tool(c.registry_name) == toolset_name:
             _track_mcp_tool_server(c.registry_name, name)
+            if scope_value is not None:
+                with _core._lock:
+                    _core._server_tool_scopes.setdefault(name, set()).add(scope_value)
             registered.append(c.registry_name)
         elif not lazy:
             logger.error("MCP server '%s': registration of %s as '%s' was rejected by the registry; "
@@ -300,6 +370,79 @@ def _register_server_tools(name: str, server: "MCPServerTask", config: dict) -> 
     if registered:
         _write_schema_cache(name, server, config, should_register)
     return registered
+
+
+def _server_enabled(config: dict) -> bool:
+    return _parse_boolish(config.get("enabled", True), default=True)
+
+
+def _same_server_route(server: Any, config: dict) -> bool:
+    from tools.mcp_schema_cache import config_fingerprint
+
+    return config_fingerprint(getattr(server, "_config", {}) or {}) == config_fingerprint(config)
+
+
+def register_connected_into_current_scope(servers: dict) -> int:
+    """Serialize shared-scope reconciliation and registration for one discovery pass."""
+    scope = _core._mcp_registry_scope()
+    if scope is None:
+        return 0
+    with _SCOPE_REFRESH_LOCKS[hash(scope) % len(_SCOPE_REFRESH_LOCKS)]:
+        return _register_connected_into_current_scope(servers)
+
+
+def _register_connected_into_current_scope(servers: dict) -> int:
+    """Heal the current profile's MCP overlay from already-connected shared servers.
+
+    A shared live connection remains owned by the profile that opened it, but a profile with the
+    same route must still receive its callable tool entries. The current profile's config is the
+    allowlist, and route fingerprints prevent borrowing a differently-authenticated connection.
+    Missing or changed config entries remove only this profile's overlay.
+    """
+    from tools.registry import registry
+
+    scope = _core._mcp_registry_scope()
+    if scope is None:
+        return 0
+
+    from tools.mcp_schema_cache import config_fingerprint
+
+    with _core._lock:
+        stale = []
+        for name, scopes in _core._server_tool_scopes.items():
+            if scope not in scopes:
+                continue
+            server = _core._servers.get(name)
+            config = servers.get(name)
+            if (config is None or not _server_enabled(config) or server is None
+                    or getattr(server, "session", None) is None
+                    or config_fingerprint(getattr(server, "_config", {}) or {}) != config_fingerprint(config)):
+                stale.append(name)
+    for name in stale:
+        _remove_server_scope(name, scope)
+
+    registered_servers = 0
+    for name, config in servers.items():
+        if not _server_enabled(config):
+            continue
+        with _core._lock:
+            server = _core._servers.get(name)
+        if server is None or getattr(server, "session", None) is None or not _same_server_route(server, config):
+            continue
+        if registry.get_tool_names_for_toolset(f"mcp-{name}"):
+            continue
+        candidates = _tool_candidates(name, server._tools, _make_tool_filter(name, config), server.tool_timeout)
+        candidates += _utility_candidates(
+            name, _select_utility_schemas(name, server, config), server.tool_timeout)
+        names = _register_candidates(
+            name, _resolve_name_collisions(name, candidates),
+            check_fn=_make_check_fn(name), scope=lambda: scope, lazy=False)
+        if names:
+            registered_servers += 1
+            with _core._lock:
+                server._registered_tool_names = sorted(
+                    set(getattr(server, "_registered_tool_names", []) or ()) | set(names))
+    return registered_servers
 
 
 def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]:

--- a/tools/mcp_tool_server_run.py
+++ b/tools/mcp_tool_server_run.py
@@ -413,8 +413,6 @@ class MCPServerRunMixin:
     def _deregister_tools(self) -> None:
         """Drop this server's tools from the registry (idempotent); on shutdown AND budget
         exhaustion, so a dead server never leaves phantom tools in the prompt."""
-        from tools.registry import registry
         for tool_name in list(getattr(self, "_registered_tool_names", [])):
-            registry.deregister(tool_name, scope=_core._server_registry_scope(self.name))
-            _registration._forget_mcp_tool_server(tool_name)
+            _registration._deregister_mcp_tool_all_scopes(self.name, tool_name)
         self._registered_tool_names = []


### PR DESCRIPTION
## Summary

Fixes #105396.

In a multiplexed gateway, MCP discovery runs once per served profile while live connections are process-wide. When a secondary profile configures the same server as the launch profile, name-keyed discovery correctly reuses the live connection, but the secondary profile originally received neither the visibility record nor the callable tool entries in its registry overlay. `/reload-mcp` therefore reported `No MCP servers connected.` and the profile could not invoke the shared server's tools.

This change separates connection ownership from profile visibility and tool registration. The profile that opened a connection remains the teardown owner; every profile with an enabled, live, fingerprint-matching view receives its own callable registry overlay. Removing or changing that profile's configuration removes only its overlay.

## Investigation and reproduction

The issue was reproduced on the checked-out `origin/main` baseline with deterministic gateway regressions:

1. Seed one live `shared` MCP connection owned by the launch/default profile.
2. Run discovery and `/reload-mcp` from a multiplexed `worker` profile whose config declares the same server and route.
3. The baseline filters the existing name as not new, leaves `_server_scope_keys` owner-only, and does not materialize callable MCP entries in the worker registry overlay.
4. The worker consequently reports no connected server/tools even though the live connection exists.

The relevant paths were:

- `tools/mcp_tool_discovery.py::_select_new_servers`: existing name-keyed connections were not adopted into the requesting scope.
- `tools/mcp_tool_registration.py::_register_candidates`: only the connection's original registration scope received tool entries.
- `gateway/run_turn.py::_execute_mcp_reload`: reporting uses scoped visibility and must not infer visibility from connection ownership.
- `tools/mcp_tool_lifecycle.py::shutdown_mcp_servers`: scoped teardown intentionally uses the connection owner and must not kill a peer profile's shared connection.

The new regression test exercises the real `register_mcp_servers()` path and verifies callable registry entries, route-change cleanup, removed-config cleanup, owner preservation, and toolset-alias preservation.

## Root cause

`_server_scope_keys` serves connection ownership, while `/reload-mcp` and registry resolution need multi-profile visibility. Name-keyed discovery treated those concepts as one. A secondary profile's already-connected server was not newly selected, so it never acquired visibility or tool registrations.

A second bug remained after visibility was tracked: returning the process-wide `_registered_tool_names` list could expose the owner profile's tool names to a peer after that peer's scoped overlay had been removed.

## Implementation

- Keep `_server_scope_keys` as the singular connection owner.
- Use `_server_tool_scopes` as the set of profile scopes that currently own registry overlays for a live server.
- Add `register_connected_into_current_scope()` to adopt matching live servers into the requesting profile's registry overlay without opening a duplicate connection.
- Register the actual callable handlers under the current profile scope and track those scopes only after registry acceptance.
- Reconcile the current scope before each discovery pass: disabled, removed, disconnected, or fingerprint-mismatched entries remove only that profile's overlay.
- Make `_existing_tool_names()` scope-aware in multiplex mode so `/reload-mcp` and agent refreshes cannot return another profile's owner-only tool names.
- Deregister server tools across every tracked scope during health refresh, phantom-cache cleanup, and server teardown; restore the process-global toolset alias while another profile still owns tools.
- Serialize reconciliation per lock stripe rather than with one process-wide discovery lock, keeping concurrent profiles independent while avoiding stale-remove/register races.
- Preserve the configuration-fingerprint gate so a same-name route with different credentials or transport settings cannot borrow the peer connection.

The implementation remains O(N) per discovery pass for N configured servers, with O(S) scope state for S profile overlays and average O(1) visibility lookup. It adds no network, subprocess, or filesystem I/O.

## Related work and scope

PR #104534 addresses composite connection identity and divergent same-name connection paths. This PR closes the remaining adoption/visibility/registry-overlay gap for an already-connected, fingerprint-matching shared connection. Divergent routes still fail closed here rather than borrowing another profile's connection. Related work: #91654 and #104534.

## Six blocking reviews completed

1. Registry/tool-call review: fixed missing callable worker overlays; added a real scoped `registry` regression.
2. Reload/config review: fixed stale worker overlays when a server is removed, disabled, or its route changes; owner connection remains live.
3. Security review: retained route/config fingerprint validation and credential-isolation coverage; foreign routes are not adopted.
4. Lifecycle review: extended teardown/health/phantom cleanup to all tracked scopes and preserved aliases for remaining owners.
5. Concurrency/performance review: replaced a global reconciliation lock with striped scope locks and exercised concurrent profile discovery.
6. API/regression review: made existing-tool return values scope-aware and preserved the non-multiplex path; reran the related gateway, TUI, lifecycle, and MCP suites.

## Tests and verification

Focused canonical runner:

- `HERMES_PYTHON=C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe scripts/run_tests.sh tests/gateway/test_multiplex_mcp_discovery.py -q` — 6 passed.
- `HERMES_PYTHON=C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe scripts/run_tests.sh tests/gateway/test_multiplex_mcp_discovery.py tests/gateway/test_mcp_reload_refreshes_cached_agents.py tests/tui_gateway/test_mcp_profile_rpcs.py tests/gateway/test_multiplex_credential_isolation.py tests/tools/test_mcp_initial_connect_shutdown.py tests/tools/test_mcp_bridge_single_failure.py tests/tools/test_mcp_register_wakes_stale.py tests/tools/test_refresh_agent_mcp_tools.py -q` — 52 passed, 2 skipped.
- `python -m compileall -q` on all changed Python files — passed.
- `ruff check` on all changed Python files — passed.
- `git diff --check` — passed.

Stress harness: 3 consecutive rounds, each with 32 worker profiles, 6,400 concurrent discovery/adoption calls, 33 tracked scopes including the owner, all profile tool overlays present, owner preserved, zero errors:

- Round 1: 5.5741 seconds, 1,148.17 calls/second, 218,162 peak traced bytes.
- Round 2: 7.8307 seconds, 817.30 calls/second, 232,189 peak traced bytes.
- Round 3: 7.4788 seconds, 855.75 calls/second, 224,652 peak traced bytes.

All three rounds passed consecutively. The earlier 16,000-call discovery stress receipt from the original PR also remains green.

Graphify was rerun after the final source edit and completed successfully: 221,386 nodes and 486,122 edges. It reported four pre-existing syntax-warning files outside this change; no changed-file syntax warning was reported.

## Known environment limitations

- `tests/tools/test_mcp_tool.py` still cannot collect in this checkout because the installed optional MCP SDK does not expose `CreateMessageResultWithTools`; the collection error reproduces on the baseline and is unrelated to this change.
- `npm run check` is not applicable to these Python-only files and remains blocked in this checkout by missing workspace dependencies/type definitions. No JavaScript files were changed.
- `ruff format --check` reports pre-existing formatting differences in large touched facade files; no formatter rewrite was applied because it would add unrelated churn.

## Risk

The owner map remains unchanged for teardown and single-profile behavior remains unchanged. The new visibility and registry overlay state is populated only for live, enabled, configuration-fingerprint-matching connections. A profile with a different route cannot borrow or expose the peer connection through this fix.

Fixes #105396
