### PR TITLE
feat(desktop): file group chats into user-made roster sections

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
@@ -65,7 +65,16 @@ import { openRosterBot } from './roster-actions'
 import { botRosterMeta, botWorkspaceOwnerKey, setBotsWorkspaceOwner } from './routing'
 import { A2A_PREFIX_RE, botCanonicalSessionId, botRowOwnsWorkspace, previewKind, workerActiveAt } from './row-helpers'
 import type { GroupMember, RosterRow, SidebarRowLabels } from './types'
-import { $botSections, $draggingBot, BOT_DRAG_MIME, botSectionId, moveBotsToSection } from './user-sections'
+import {
+  $botSections,
+  $draggingBot,
+  BOT_DRAG_MIME,
+  botSectionId,
+  groupChatSectionId,
+  groupDragKey,
+  moveBotsToSection,
+  moveGroupChatsToSection
+} from './user-sections'
 
 // ── bot row ──────────────────────────────────────────────────────────────────
 
@@ -455,13 +464,17 @@ interface GroupRowProps {
   members: GroupMember[]
   needsYou: boolean
   onDisband: (room: { members: GroupMember[]; name: string }) => void
+  /** Opens the New section dialog; the group is filed into it on create. */
+  onNewSection: (group: string) => void
   onOpen: (group: string) => void
 }
 
-export function GroupRow({ active, group, members, needsYou, onOpen, onDisband }: GroupRowProps) {
+export function GroupRow({ active, group, members, needsYou, onOpen, onDisband, onNewSection }: GroupRowProps) {
   const { t } = useI18n()
   const b = useBots()
   const rooms = useValue($groupChats)
+  const sections = useValue($botSections)
+  const currentSectionId = groupChatSectionId(group, rooms)
 
   const room = rooms[group] || {
     log: []
@@ -486,17 +499,30 @@ export function GroupRow({ active, group, members, needsYou, onOpen, onDisband }
   const availableMembers = members.filter(member => botSourceStatus(member).available).length
   const availabilityLabel = `${availableMembers} of ${members.length} available`
 
+  // Same drag contract as a bot row, under the group's own key shape so a
+  // drop zone can tell which kind landed without decoding roster keys.
+  const dragKey = groupDragKey(group)
+  const dragging = useValue($draggingBot) === dragKey
+
   const row = (
     <RowButton
       aria-label={`${group}, ${members.length} bots, ${availabilityLabel}`}
       className={cn(
         'flex w-full min-w-0 max-w-full items-center gap-2.5 overflow-hidden rounded-md px-2 py-2 text-left transition-colors',
         'hover:bg-(--chrome-action-hover)',
-        active && 'bg-(--ui-row-active-background)'
+        active && 'bg-(--ui-row-active-background)',
+        dragging && 'opacity-40'
       )}
+      draggable
       onClick={() => {
         haptic('tap')
         onOpen(group)
+      }}
+      onDragEnd={() => $draggingBot.set(null)}
+      onDragStart={event => {
+        event.dataTransfer.setData(BOT_DRAG_MIME, dragKey)
+        event.dataTransfer.effectAllowed = 'move'
+        $draggingBot.set(dragKey)
       }}
     >
       <div className="relative flex w-[34px] shrink-0 items-center justify-center">
@@ -554,6 +580,35 @@ export function GroupRow({ active, group, members, needsYou, onOpen, onDisband }
       <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem onSelect={() => onOpen(group)}>Open Group Chat</ContextMenuItem>
+        <ContextMenuSeparator />
+        {/* Filing — the same submenu a bot row gets, driving the room-record
+            assignment instead of profile meta. */}
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>{b.sections.moveTo}</ContextMenuSubTrigger>
+          <ContextMenuSubContent>
+            {sections.map(section => (
+              <ContextMenuItem
+                disabled={section.id === currentSectionId}
+                key={section.id}
+                onSelect={() => moveGroupChatsToSection([group], section.id)}
+              >
+                <Codicon className="mr-1.5" name="folder" />
+                {section.name}
+              </ContextMenuItem>
+            ))}
+            {sections.length ? <ContextMenuSeparator /> : null}
+            <ContextMenuItem onSelect={() => onNewSection(group)}>
+              <Codicon className="mr-1.5" name="new-folder" />
+              {b.sections.newSectionEllipsis}
+            </ContextMenuItem>
+            {currentSectionId ? (
+              <ContextMenuItem onSelect={() => moveGroupChatsToSection([group], null)}>
+                <Codicon className="mr-1.5" name="inbox" />
+                {b.sections.removeFromSection}
+              </ContextMenuItem>
+            ) : null}
+          </ContextMenuSubContent>
+        </ContextMenuSub>
         <ContextMenuSeparator />
         <ContextMenuItem
           className="text-destructive focus:text-destructive"

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -749,6 +749,8 @@ export function durableGroupChatRooms(all: Record<string, GroupChat> = $groupCha
       // already carries.
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
       image: room.image || null,
+      // Sidebar filing (user-sections) is room-local; keep it across sync.
+      sectionId: room.sectionId ?? null,
       syncRevision: Math.max(0, Number(room.syncRevision || 0))
     }
   }
@@ -1348,6 +1350,8 @@ export function updateGroupChat(
         roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
         // Room picture (small data URL, same normalization as bot avatars).
         image: room.image || null,
+        // Sidebar filing (user-sections) is room-local; keep it durable.
+        sectionId: room.sectionId ?? null,
         syncRevision: Math.max(0, Number(room.syncRevision || 0))
       }
     }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -246,6 +246,7 @@ export default {
                   members: Array.isArray(room.members) ? room.members : [],
                   roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
                   image: typeof room.image === 'string' && room.image ? room.image : null,
+                  sectionId: room.sectionId ?? null,
                   syncRevision: Math.max(0, Number(room.syncRevision || 0)),
                   epoch: 0,
                   running: false

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -85,9 +85,12 @@ import {
   $draggingBot,
   createBotSection,
   deleteBotSection,
+  groupDragKey,
+  GROUP_DRAG_PREFIX,
   groupRowsBySection,
   moveBotSection,
   moveBotsToSection,
+  moveGroupChatsToSection,
   renameBotSection,
   UNASSIGNED_SECTION_KEY
 } from './user-sections'
@@ -269,9 +272,9 @@ export function BotsPane() {
   useEscapeCancelsBotDrag()
 
   // The one name dialog serves both New section (optionally filing the bot
-  // whose menu opened it) and Rename.
+  // or group whose menu opened it) and Rename.
   const [sectionDialog, setSectionDialog] = useState<
-    null | { bot?: RosterRow; mode: 'create' } | { id: string; mode: 'rename'; name: string }
+    null | { bot?: RosterRow; group?: string; mode: 'create' } | { id: string; mode: 'rename'; name: string }
   >(null)
 
   const [grouping, setGrouping] = useState<null | RosterRow>(null)
@@ -574,6 +577,7 @@ export function BotsPane() {
       members={row.members}
       needsYou={Boolean(groupNeedsYou[row.name])}
       onDisband={setDeletingGroup}
+      onNewSection={target => setSectionDialog({ group: target, mode: 'create' })}
       onOpen={openGroupChat}
     />
   )
@@ -608,7 +612,7 @@ export function BotsPane() {
     }
 
     const nested = Boolean(keyPrefix)
-    const blocks = groupRowsBySection(rows, userSections, allMeta)
+    const blocks = groupRowsBySection(rows, userSections, allMeta, groupRooms)
 
     return (
       blocks
@@ -627,15 +631,23 @@ export function BotsPane() {
           return (
             <SectionDropZone
               isSource={
-                Boolean(dragging) && block.rows.some(row => row.kind !== 'group' && botRosterKey(row.bot) === dragging)
+                Boolean(dragging) &&
+                block.rows.some(row =>
+                  row.kind === 'group' ? groupDragKey(row.name) === dragging : botRosterKey(row.bot) === dragging
+                )
               }
               key={key}
               nested={nested}
               onDropBot={rosterKey => {
+                // `block.id` is null for Unassigned, which is exactly the
+                // value both movers want for "clear the assignment".
+                if (rosterKey.startsWith(GROUP_DRAG_PREFIX)) {
+                  moveGroupChatsToSection([rosterKey.slice(GROUP_DRAG_PREFIX.length)], block.id)
+                  return
+                }
+
                 const bot = roster.find(row => botRosterKey(row) === rosterKey)
 
-                // `block.id` is null for Unassigned, which is exactly the value
-                // moveBotsToSection wants for "clear the assignment".
                 if (bot) {
                   void moveBotsToSection([bot], block.id)
                 }
@@ -705,7 +717,9 @@ export function BotsPane() {
           onToggle={() => toggleRosterSection(sectionId)}
           tip={`${sortedGroupRows.length} global group chat${sortedGroupRows.length === 1 ? '' : 's'}`}
         />
-        {collapsed ? null : <div className="grid min-w-0 gap-0.5">{sortedGroupRows.map(renderGroupRow)}</div>}
+        {collapsed ? null : (
+          <div className="grid min-w-0 gap-0.5">{renderUserSections(sortedGroupRows, 'groups:')}</div>
+        )}
       </div>
     )
   }
@@ -1010,7 +1024,11 @@ export function BotsPane() {
           if (sectionDialog?.mode === 'rename') {
             renameBotSection(sectionDialog.id, name)
           } else {
-            createBotSection(name, sectionDialog?.bot ? [sectionDialog.bot] : [])
+            const section = createBotSection(name, sectionDialog?.bot ? [sectionDialog.bot] : [])
+
+            if (section && sectionDialog?.group) {
+              moveGroupChatsToSection([sectionDialog.group], section.id)
+            }
           }
         }}
         open={Boolean(sectionDialog)}

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -178,6 +178,13 @@ export interface GroupChat {
   tombstone?: boolean
   /** Read when ordering rooms; no write site in the plugin today. */
   pinned?: boolean
+  /** Which user-made sidebar section this group chat is filed under
+   *  (`user-sections.ts`). Like a bot's `sectionId` it is membership on the
+   *  item, but a group's only durable identity is its room record, so the
+   *  field rides the room's plugin-storage persistence — local, like the
+   *  section list itself, and deliberately absent from the bounded gateway
+   *  sync projection, which carries conversations, not sidebar layout. */
+  sectionId?: null | string
   /** How far each `<thread>::<member>` has read into `log`. Required: unlike
    *  the gateway-sourced shapes above, a room record is plugin-owned — every
    *  writer (hydrate, server-sync merge, updateGroupChat, room reset) seeds

--- a/apps/desktop/src/plugins/hermes-bots/user-sections.groups.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/user-sections.groups.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Group chats file into user-made sections exactly like bots — with the one
+ * structural difference the model encodes: a bot's membership is a field on
+ * its profile meta (profile sync carries it), while a group's is a field on
+ * its room record, because that record is the only durable identity a group
+ * has. Filing must ride the room's own durable persistence path, never a
+ * parallel list.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { saveBotMeta, storage } = vi.hoisted(() => ({
+  saveBotMeta: vi.fn<(bot: { name: string }, patch: Record<string, unknown>) => Promise<unknown>>(),
+  storage: new Map<string, unknown>()
+}))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { atom } = await import('nanostores')
+
+  return { atom, host: {} }
+})
+
+vi.mock('./data', async () => {
+  const { atom } = await import('nanostores')
+  const $botMeta = atom<Record<string, { sectionId?: null | string }>>({})
+  const $lastRoster = atom<unknown[]>([])
+
+  saveBotMeta.mockImplementation(async (bot: { name: string }, patch: Record<string, unknown>) => {
+    $botMeta.set({ ...$botMeta.get(), [bot.name]: { ...$botMeta.get()[bot.name], ...patch } })
+
+    return { serverOutcome: 'persisted', serverPersisted: true }
+  })
+
+  return {
+    $botMeta,
+    $lastRoster,
+    botRosterKey: (bot: { connectionId?: string; name?: string }) => `${bot?.connectionId || 'legacy'}::${bot?.name || 'default'}`,
+    saveBotMeta
+  }
+})
+
+vi.mock('./routing', () => ({
+  botRosterMeta: (bot: { name: string }, meta: Record<string, unknown>) => meta[bot.name]
+}))
+
+vi.mock('./shared', () => ({
+  getPluginCtx: () => ({
+    storage: {
+      get: (key: string, fallback: unknown) => (storage.has(key) ? storage.get(key) : fallback),
+      set: (key: string, value: unknown) => storage.set(key, value)
+    }
+  })
+}))
+
+// './group-chat' is deliberately NOT mocked: filing must go through the real
+// room-store path (atom + durable plugin-storage record), with only its
+// externals (sdk, data, routing, shared) faked above.
+import { $botMeta } from './data'
+import { $groupChats } from './group-chat'
+import type { RosterRow } from './types'
+import {
+  $botSections,
+  createBotSection,
+  groupChatSectionId,
+  groupRowsBySection,
+  moveGroupChatsToSection,
+  UNASSIGNED_SECTION_KEY
+} from './user-sections'
+
+const row = (name: string) => ({ bot: { name } as RosterRow, kind: 'bot' as const })
+const groupRow = (name: string) => ({ kind: 'group' as const, name })
+
+beforeEach(() => {
+  storage.clear()
+  $botMeta.set({})
+  $botSections.set([])
+  $groupChats.set({})
+  saveBotMeta.mockClear()
+})
+
+describe('user sections — group chats', () => {
+  it('filing a group writes sectionId on its room record and rides the durable group-chats persistence; clearing returns it to the bucket', () => {
+    const section = createBotSection('XYZ')!
+
+    moveGroupChatsToSection(['Team Chat'], section.id)
+
+    // Membership lives on the room, not on any bot's profile: no bot-meta
+    // write happens for a group filing.
+    expect($groupChats.get()['Team Chat']?.sectionId).toBe(section.id)
+    expect(saveBotMeta).not.toHaveBeenCalled()
+
+    // The durable record in plugin storage carries it — the same record a
+    // reload hydrates rooms from, so the filing survives a restart.
+    const durable = storage.get('group-chats') as Record<string, { sectionId?: null | string }>
+    expect(durable['Team Chat']?.sectionId).toBe(section.id)
+
+    // Unfiling clears the assignment on the room and persists the clear.
+    moveGroupChatsToSection(['Team Chat'], null)
+    expect(groupChatSectionId('Team Chat', $groupChats.get())).toBeNull()
+    expect((storage.get('group-chats') as Record<string, { sectionId?: null | string }>)['Team Chat']?.sectionId).toBeNull()
+  })
+
+  it('grouping seats group rows per their room record section; unfiled or dangling groups fall to Unassigned', () => {
+    const section = createBotSection('XYZ')!
+
+    moveGroupChatsToSection(['Team Chat'], section.id)
+    // A room whose section was deleted keeps a dangling id — it must land in
+    // Unassigned, not vanish (same safety bots get).
+    $groupChats.set({ ...$groupChats.get(), Ghosted: { sectionId: 'sec-deleted' } as never })
+    $botMeta.set({ nanox: { sectionId: section.id } })
+
+    const rows = [row('nanox'), groupRow('Team Chat'), groupRow('Ghosted'), groupRow('Room')]
+
+    const blocks = groupRowsBySection(rows, $botSections.get(), $botMeta.get(), $groupChats.get())
+
+    expect(blocks.map(block => [block.key, block.rows.length])).toEqual([
+      [`section:${section.id}`, 2],
+      [UNASSIGNED_SECTION_KEY, 2]
+    ])
+    // Every row lands exactly once, groups included.
+    expect(blocks.flatMap(block => block.rows)).toHaveLength(rows.length)
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/user-sections.ts
+++ b/apps/desktop/src/plugins/hermes-bots/user-sections.ts
@@ -24,9 +24,10 @@
 import { atom } from 'nanostores'
 
 import { $botMeta, saveBotMeta } from './data'
+import { $groupChats, updateGroupChat } from './group-chat'
 import { botRosterMeta } from './routing'
 import { getPluginCtx } from './shared'
-import type { BotMeta, RosterRow } from './types'
+import type { BotMeta, GroupChat, RosterRow } from './types'
 
 export const UNASSIGNED_SECTION_KEY = 'section:unassigned'
 export const BOT_SECTIONS_KEY = 'bot-sections-v1'
@@ -185,6 +186,52 @@ export function botSectionId(bot: RosterRow, metaByName: Record<string, BotMeta>
   return id ? String(id) : null
 }
 
+// ── group chats ──────────────────────────────────────────────────────────────
+//
+// A group chat files into a section by the same membership-on-the-item rule as
+// a bot, but a group has no profile meta to carry the field — its room record
+// is its only durable identity. So the assignment is a field on the room and
+// rides the room's own persistence (plugin storage), which is also why it is
+// deliberately NOT part of the bounded gateway sync projection: that mirror
+// carries conversations to other clients, not this machine's sidebar layout —
+// the same local scope the section list itself has.
+
+/** The drag payload prefix that marks an in-flight GROUP row (vs a bot's
+ *  roster key). */
+export const GROUP_DRAG_PREFIX = 'group:'
+
+export function groupDragKey(name: string): string {
+  return `${GROUP_DRAG_PREFIX}${name}`
+}
+
+/** A group's section, off the live room record. */
+export function groupChatSectionId(name: string, rooms: Record<string, GroupChat>): null | string {
+  const id = rooms?.[name]?.sectionId
+
+  return id ? String(id) : null
+}
+
+/** File `groups` into a section (`null` clears, back to the group-chat
+ *  bucket). One room write per group whose assignment actually changes,
+ *  through `updateGroupChat` so the durable record and the atom move together. */
+export function moveGroupChatsToSection(groups: string[], sectionId: null | string): void {
+  for (const name of groups || []) {
+    if (!name || groupChatSectionId(name, $groupChats.get()) === (sectionId || null)) {
+      continue
+    }
+
+    updateGroupChat(
+      name,
+      (room: GroupChat) => ({
+        ...room,
+        sectionId: sectionId || null
+      }),
+      // Layout-only: no reason to publish the conversation projection.
+      { sync: false }
+    )
+  }
+}
+
 export interface SectionBlock<TRow> {
   id: null | string
   key: string
@@ -196,12 +243,15 @@ export interface SectionBlock<TRow> {
  * Split roster rows into section blocks, in section order, with Unassigned
  * last. Pure, and returns EVERY row exactly once: a row whose `sectionId`
  * names a section that no longer exists lands in Unassigned rather than
- * vanishing, which is what makes deleting a section safe.
+ * vanishing, which is what makes deleting a section safe. Group rows seat per
+ * their room record's `sectionId` (`rooms`); a group with no room yet is
+ * unassigned.
  */
 export function groupRowsBySection<TRow extends { bot?: RosterRow } | RosterRow>(
   rows: TRow[],
   sections: unknown,
-  metaByName: Record<string, BotMeta>
+  metaByName: Record<string, BotMeta>,
+  groupRooms: Record<string, GroupChat> = {}
 ): SectionBlock<TRow>[] {
   const list = normalizeBotSections(sections)
   const known = new Set(list.map(s => s.id))
@@ -209,8 +259,10 @@ export function groupRowsBySection<TRow extends { bot?: RosterRow } | RosterRow>
   const loose: TRow[] = []
 
   for (const row of rows || []) {
-    const bot = ((row as { bot?: RosterRow })?.bot || row) as RosterRow
-    const id = bot ? botSectionId(bot, metaByName) : null
+    const group = (row as { kind?: string; name?: string })?.kind === 'group' ? row : null
+    const id = group
+      ? groupChatSectionId(String((group as { name?: string }).name || ''), groupRooms)
+      : botSectionId((((row as { bot?: RosterRow })?.bot || row) as RosterRow), metaByName)
 
     if (id && known.has(id)) {
       byId.get(id)!.push(row)


### PR DESCRIPTION
## What does this PR do?

Group chats can now be filed into user-made roster sections exactly like bots: drag the group row onto a section, pick one from its context menu, or create a section straight from the group's menu. Unfiling — drop on Unassigned, "Remove from section", or deleting the section — returns the group to the roster's group-chat bucket. Fixes #105544.

The membership model stays membership-on-the-item, with the one difference the two row kinds force: a bot's `sectionId` is a field on its profile meta (profile sync carries it), while a group has no profile — its room record is its only durable identity — so the assignment is a field on the room and rides the room's own plugin-storage persistence (the durable `group-chats` store), keeping user sections per-connection-scoped the same way bot filing is.

## Related Issue

Fixes #105544

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `user-sections.ts` — `moveGroupChatsToSection(groups, sectionId)`, `groupChatSectionId(name, rooms)`, and `GROUP_DRAG_PREFIX`/`groupDragKey()` so the section model covers group items alongside bots
- `group-chat.ts` / `types.ts` — optional `sectionId: null | string` on the group room record
- `roster-pane.tsx` — group rows participate in section grouping, drag-filing, and the section-aware drop zones; groups with a stale/deleted section id fall back to the group-chat bucket
- `bot-row.tsx` — `GroupRow` is draggable and its context menu gains the same section entries as bot rows (file into section, remove from section, new section from group)
- `plugin.tsx` — wires group filing into the roster actions
- `user-sections.groups.test.ts` — behavior-contract tests: filing writes `sectionId` on the room record and rides the durable `group-chats` persistence; clearing returns the group to the bucket

## How to Test

1. `npx vitest run src/plugins/hermes-bots/user-sections.groups.test.ts --project ui` (from `apps/desktop`) — passes green
2. Manually, in a dev instance (`npm run dev` from `apps/desktop`): create a user section, drag a group chat onto it → it files under the section; right-click the group → "Remove from section" (or drop on Unassigned) → it returns to the group-chat bucket
3. Persistence: file a group, fully restart the dev app → the group is still filed under its section

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the plugin's vitest suite and all tests pass (`src/plugins/hermes-bots/` — 560 passed; the only 2 file failures under full-suite load were pre-existing loaded-runner timeouts in `bot-delete.test.ts`/`hidden-bots.test.ts`, which pass in isolation and are untouched by this PR)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2 (manually verified drag-filing, context menu, unfile, and restart persistence in a dev-worktree instance)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (renderer-only change; drag/context menu are Electron-renderer primitives, no OS-specific code)
