### PR TITLE
fix: native Gemini tool calls survive nullable and union parameters (salvage #55643)

### DIFF
--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import math
 from typing import Any, Dict
 
+from tools.schema_sanitizer import _normalize_type_array
+
 # Gemini's ``FunctionDeclaration.parameters`` accepts only a subset of OpenAPI 3.0 /
 # JSON Schema (the ``Schema`` object); everything else is stripped.
 _GEMINI_SCHEMA_ALLOWED_KEYS = {
@@ -30,6 +32,7 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
     if not isinstance(schema, dict):
         return {}
     cleaned: Dict[str, Any] = {}
+    type_array: Any = None
     for key, value in schema.items():
         if key not in _GEMINI_SCHEMA_ALLOWED_KEYS:
             continue
@@ -41,8 +44,27 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
         elif key == "anyOf":
             if isinstance(value, list):
                 cleaned[key] = [sanitize_gemini_schema(item) for item in value if isinstance(item, dict)]
+        elif key == "type" and isinstance(value, list):
+            type_array = value  # normalized after the loop, so the derived ``nullable`` wins
         else:
             cleaned[key] = value
+
+    # JSON Schema allows an array ``type`` (``["string", "null"]``, ``["string", "integer"]``).
+    # Gemini's ``Schema`` accepts only a single string, and the enum check below would evaluate
+    # ``[...] in {...}`` -> TypeError: unhashable type: 'list', aborting translation of the WHOLE
+    # tool catalog. Reuse the sanitizer's normalization so a multi-type array becomes an ``anyOf``
+    # of single-type branches (no branch dropped) rather than keeping only the first.
+    if type_array is not None:
+        derived: Dict[str, Any] = {}
+        _normalize_type_array(type_array, derived)
+        if "anyOf" in derived:
+            cleaned["anyOf"] = derived["anyOf"]
+        else:
+            cleaned["type"] = derived["type"]
+        if derived.get("nullable"):
+            # Derived from "null" in the array. Set AFTER the loop so it beats an input
+            # ``nullable: false`` regardless of which key the producer emitted first.
+            cleaned["nullable"] = True
 
     # Gemini requires every ``enum`` entry to be a string even for
     # integer/number/boolean types; the declared type stays intact and Gemini

--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -16,6 +16,12 @@ _GEMINI_SCHEMA_ALLOWED_KEYS = {
 }
 
 
+_GEMINI_STRUCTURAL_KEYS = {
+    "array": {"items", "minItems", "maxItems"},
+    "object": {"properties", "required", "minProperties", "maxProperties", "propertyOrdering"},
+}
+
+
 def _stringify_enum_value(item: Any) -> Any:
     """Gemini-safe string for a scalar enum entry, or None to drop it."""
     if isinstance(item, bool):
@@ -25,6 +31,30 @@ def _stringify_enum_value(item: Any) -> Any:
     return item if isinstance(item, str) else None
 
 
+def _normalize_gemini_type_array(type_array: list, cleaned: Dict[str, Any]) -> None:
+    """Keep union alternatives and their branch-local structural constraints."""
+    derived: Dict[str, Any] = {}
+    _normalize_type_array(type_array, derived)
+    if "anyOf" in derived:
+        constraints = {"anyOf": cleaned["anyOf"]} if "anyOf" in cleaned else {}
+        # Gemini requires items/properties on the typed branch itself, not
+        # its typeless parent. Keep required paired with those properties.
+        structural = {key: cleaned.pop(key) for keys in _GEMINI_STRUCTURAL_KEYS.values()
+                      for key in keys if key in cleaned}
+        cleaned["anyOf"] = [
+            sanitize_gemini_schema({**branch, **constraints, **{
+                key: value for key, value in structural.items()
+                if key in _GEMINI_STRUCTURAL_KEYS.get(branch["type"], ())
+            }}) for branch in derived["anyOf"]
+        ]
+    else:
+        cleaned["type"] = derived["type"]
+    if derived.get("nullable"):
+        # Derived from "null" in the array. Set AFTER the loop so it beats an input
+        # ``nullable: false`` regardless of which key the producer emitted first.
+        cleaned["nullable"] = True
+
+
 def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
     """Gemini-compatible copy of a tool parameter schema: keeps only the documented subset
     (drops e.g. ``$schema`` / ``additionalProperties``) and recursively sanitizes nested
@@ -32,7 +62,6 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
     if not isinstance(schema, dict):
         return {}
     cleaned: Dict[str, Any] = {}
-    type_array: Any = None
     for key, value in schema.items():
         if key not in _GEMINI_SCHEMA_ALLOWED_KEYS:
             continue
@@ -44,33 +73,21 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
         elif key == "anyOf":
             if isinstance(value, list):
                 cleaned[key] = [sanitize_gemini_schema(item) for item in value if isinstance(item, dict)]
-        elif key == "type" and isinstance(value, list):
-            type_array = value  # normalized after the loop, so the derived ``nullable`` wins
         else:
             cleaned[key] = value
 
-    # JSON Schema allows an array ``type`` (``["string", "null"]``, ``["string", "integer"]``).
-    # Gemini's ``Schema`` accepts only a single string, and the enum check below would evaluate
-    # ``[...] in {...}`` -> TypeError: unhashable type: 'list', aborting translation of the WHOLE
-    # tool catalog. Reuse the sanitizer's normalization so a multi-type array becomes an ``anyOf``
-    # of single-type branches (no branch dropped) rather than keeping only the first.
-    if type_array is not None:
-        derived: Dict[str, Any] = {}
-        _normalize_type_array(type_array, derived)
-        if "anyOf" in derived:
-            cleaned["anyOf"] = derived["anyOf"]
-        else:
-            cleaned["type"] = derived["type"]
-        if derived.get("nullable"):
-            # Derived from "null" in the array. Set AFTER the loop so it beats an input
-            # ``nullable: false`` regardless of which key the producer emitted first.
-            cleaned["nullable"] = True
+    type_array = cleaned.get("type")
+    if isinstance(type_array, list):
+        cleaned.pop("type")
+        _normalize_gemini_type_array(type_array, cleaned)
 
     # Gemini requires every ``enum`` entry to be a string even for
     # integer/number/boolean types; the declared type stays intact and Gemini
     # still emits typed tool arguments at runtime. dict.fromkeys = ordered dedupe.
     enum_val = cleaned.get("enum")
-    if isinstance(enum_val, list) and cleaned.get("type") in {"integer", "number", "boolean"}:
+    if isinstance(enum_val, list) and (
+        isinstance(type_array, list) or cleaned.get("type") in {"integer", "number", "boolean"}
+    ):
         if stringified := list(dict.fromkeys(v for v in map(_stringify_enum_value, enum_val) if v is not None)):
             cleaned["enum"] = stringified
         else:

--- a/contributors/emails/272618364+MaxFreedomPollard@users.noreply.github.com
+++ b/contributors/emails/272618364+MaxFreedomPollard@users.noreply.github.com
@@ -1,0 +1,2 @@
+MaxFreedomPollard
+# PR #55643

--- a/evals/gemini_type_array_probe.py
+++ b/evals/gemini_type_array_probe.py
@@ -1,0 +1,120 @@
+"""Offline A/B native adapter + Google SDK schema validation (no API calls).
+
+Run with httpx and google-genai==1.47.0 installed:
+    python evals/gemini_type_array_probe.py --base origin/main
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import importlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+import types
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class WireCapture(BaseHTTPRequestHandler):
+    requests = []
+
+    def do_POST(self):
+        size = int(self.headers["Content-Length"])
+        self.requests.append(json.loads(self.rfile.read(size)))
+        # Intentionally stop at the wire boundary; never fake a model response.
+        self.send_response(418)
+        self.end_headers()
+        self.wfile.write(b"Local schema capture only")
+
+    def log_message(self, *_):
+        pass
+
+
+def wire_translate(adapter, tools):
+    server = ThreadingHTTPServer(("127.0.0.1", 0), WireCapture)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with adapter.GeminiNativeClient(
+            api_key="local-probe-not-a-secret",
+            base_url=f"http://127.0.0.1:{server.server_port}/v1beta",
+        ) as client:
+            try:
+                client.chat.completions.create(
+                    model="gemini-2.5-flash", tools=tools,
+                    messages=[{"role": "user", "content": "Schema validation probe"}],
+                )
+            except adapter.GeminiAPIError as exc:
+                assert exc.status_code == 418
+        return WireCapture.requests.pop()["tools"]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def probe(label, translate):
+    from google.genai.types import FunctionDeclaration
+
+    cases = {
+        "nullable": {"type": ["number", "null"]},
+        "nullable_enum": {"type": ["integer", "null"], "enum": [1, 2]},
+        "union_enum": {"type": ["string", "integer"], "enum": ["one", 2]},
+        "nested_items": {"type": "array", "items": {"type": ["string", "null"]}},
+        "nested_anyof": {"anyOf": [{"type": ["string", "integer"]}, {"type": "boolean"}]},
+        "constrained_union": {"type": ["string", "integer"], "anyOf": [{"enum": ["one"]}, {"enum": ["two"]}]},
+        "structural_union": {"type": ["array", "object", "string"], "items": {"type": "integer"}, "properties": {"name": {"type": "string"}}, "required": ["name"]},
+        "scalar_control": {"type": "number"},
+    }
+    results = {}
+    for name, node in cases.items():
+        parameters = {"type": "object", "properties": {"value": node}}
+        original = copy.deepcopy(parameters)
+        try:
+            wire = translate([{"type": "function", "function": {"name": "probe", "parameters": parameters}}])
+            declaration = wire[0]["functionDeclarations"][0]
+            # Validate the actual adapter declaration, not a reconstructed schema.
+            FunctionDeclaration.model_validate(json.loads(json.dumps(declaration)))
+            results[name] = "accepted"
+        except (TypeError, ValueError) as exc:
+            results[name] = f"{type(exc).__name__}: {str(exc).splitlines()[0]}"
+        assert parameters == original, name
+    print(json.dumps({"label": label, "results": results}, indent=2))
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main")
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(root))
+    for name in list(sys.modules):
+        if name == "agent" or name.startswith(("agent.", "tools", "hermes")):
+            del sys.modules[name]
+    with tempfile.TemporaryDirectory(prefix="gemini-schema-home-") as home:
+        os.environ["HERMES_HOME"] = home
+        adapter = importlib.import_module("agent.gemini_native_adapter")
+        baseline = types.ModuleType("baseline_gemini_schema")
+        source = subprocess.check_output(
+            ["git", "show", f"{args.base}:agent/gemini_schema.py"], cwd=root, text=True,
+        )
+        exec(compile(source, f"{args.base}:agent/gemini_schema.py", "exec"), baseline.__dict__)
+        fixed = adapter.sanitize_gemini_tool_parameters
+        adapter.sanitize_gemini_tool_parameters = baseline.sanitize_gemini_tool_parameters
+        before = probe(args.base, lambda tools: wire_translate(adapter, tools))
+        adapter.sanitize_gemini_tool_parameters = fixed
+        after = probe("worktree", lambda tools: wire_translate(adapter, tools))
+        assert before["scalar_control"] == "accepted"
+        assert all(result != "accepted" for name, result in before.items() if name != "scalar_control")
+        assert all(result == "accepted" for result in after.values())
+        print(f"PASS: {len(before) - 1} failing base cases repaired; scalar control and inputs preserved.")
+        print("LOCAL SDK VALIDATION ONLY: no Google API call or Windows Desktop exercise.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_gemini_schema.py
+++ b/tests/agent/test_gemini_schema.py
@@ -1,7 +1,5 @@
 """Tests for agent.gemini_schema — OpenAI→Gemini tool parameter translation."""
 
-import pytest
-
 from agent.gemini_schema import (
     sanitize_gemini_schema,
     sanitize_gemini_tool_parameters,
@@ -169,75 +167,3 @@ class TestSanitizeGeminiToolParameters:
         assert "1440" in aad["description"]
         # And the string-enum sibling is untouched.
         assert cleaned["properties"]["action"]["enum"] == ["create_thread"]
-
-
-class TestArrayTypeNormalization:
-    """JSON Schema allows an array ``type``; Gemini's ``Schema`` accepts one string.
-
-    The enum-compatibility check evaluated ``[...] in {...}`` on that list and raised
-    ``TypeError: unhashable type: 'list'``, aborting translation of the WHOLE tool
-    catalog, not just the offending tool. #55645
-    """
-
-    def test_nullable_form_collapses_and_keeps_the_enum(self):
-        cleaned = sanitize_gemini_schema({"type": ["string", "null"], "enum": ["low", "high"]})
-        assert cleaned["type"] == "string"
-        assert cleaned["nullable"] is True
-        assert cleaned["enum"] == ["low", "high"]
-
-    def test_nullable_form_without_enum(self):
-        cleaned = sanitize_gemini_schema({"type": ["integer", "null"]})
-        assert cleaned["type"] == "integer"
-        assert cleaned["nullable"] is True
-
-    def test_real_union_becomes_anyof_with_every_branch_kept(self):
-        """No branch may be dropped. ``tools/schema_sanitizer._normalize_type_array``
-        is the canonical behaviour and is reused here rather than reimplemented."""
-        cleaned = sanitize_gemini_schema({"type": ["string", "integer"]})
-        assert "type" not in cleaned
-        assert cleaned["anyOf"] == [{"type": "string"}, {"type": "integer"}]
-        assert "nullable" not in cleaned
-
-    def test_three_way_union_keeps_all_three(self):
-        cleaned = sanitize_gemini_schema({"type": ["string", "integer", "boolean"]})
-        assert cleaned["anyOf"] == [
-            {"type": "string"}, {"type": "integer"}, {"type": "boolean"}]
-
-    @pytest.mark.parametrize("schema", [
-        {"nullable": False, "type": ["string", "null"]},   # nullable emitted first
-        {"type": ["string", "null"], "nullable": False},   # nullable emitted last
-    ])
-    def test_derived_nullable_beats_an_input_nullable_either_order(self, schema):
-        """The array says null is permitted, so an input ``nullable: false`` is wrong.
-
-        Deriving inside the key loop made this order-dependent: whichever key the
-        producer emitted last won.
-        """
-        cleaned = sanitize_gemini_schema(schema)
-        assert cleaned["nullable"] is True
-        assert cleaned["type"] == "string"
-
-    def test_all_null_array_becomes_the_null_type(self):
-        assert sanitize_gemini_schema({"type": ["null"]})["type"] == "null"
-
-    def test_empty_type_array_falls_back_to_object(self):
-        assert sanitize_gemini_schema({"type": []})["type"] == "object"
-
-    def test_integer_union_still_stringifies_its_enum(self):
-        cleaned = sanitize_gemini_schema({"type": ["integer", "null"], "enum": [1, 2, 3]})
-        assert cleaned["type"] == "integer"
-        assert cleaned["enum"] == ["1", "2", "3"]
-
-    def test_nested_property_is_normalized_too(self):
-        cleaned = sanitize_gemini_schema({
-            "type": "object",
-            "properties": {"color": {"type": ["string", "null"], "enum": ["red", "green"]}},
-        })
-        color = cleaned["properties"]["color"]
-        assert color["type"] == "string" and color["nullable"] is True
-        assert color["enum"] == ["red", "green"]
-
-    def test_plain_string_type_is_untouched(self):
-        """Control: the non-array path must be unchanged."""
-        cleaned = sanitize_gemini_schema({"type": "string", "enum": ["a"]})
-        assert cleaned == {"type": "string", "enum": ["a"]}

--- a/tests/agent/test_gemini_schema.py
+++ b/tests/agent/test_gemini_schema.py
@@ -1,5 +1,7 @@
 """Tests for agent.gemini_schema — OpenAI→Gemini tool parameter translation."""
 
+import pytest
+
 from agent.gemini_schema import (
     sanitize_gemini_schema,
     sanitize_gemini_tool_parameters,
@@ -167,3 +169,75 @@ class TestSanitizeGeminiToolParameters:
         assert "1440" in aad["description"]
         # And the string-enum sibling is untouched.
         assert cleaned["properties"]["action"]["enum"] == ["create_thread"]
+
+
+class TestArrayTypeNormalization:
+    """JSON Schema allows an array ``type``; Gemini's ``Schema`` accepts one string.
+
+    The enum-compatibility check evaluated ``[...] in {...}`` on that list and raised
+    ``TypeError: unhashable type: 'list'``, aborting translation of the WHOLE tool
+    catalog, not just the offending tool. #55645
+    """
+
+    def test_nullable_form_collapses_and_keeps_the_enum(self):
+        cleaned = sanitize_gemini_schema({"type": ["string", "null"], "enum": ["low", "high"]})
+        assert cleaned["type"] == "string"
+        assert cleaned["nullable"] is True
+        assert cleaned["enum"] == ["low", "high"]
+
+    def test_nullable_form_without_enum(self):
+        cleaned = sanitize_gemini_schema({"type": ["integer", "null"]})
+        assert cleaned["type"] == "integer"
+        assert cleaned["nullable"] is True
+
+    def test_real_union_becomes_anyof_with_every_branch_kept(self):
+        """No branch may be dropped. ``tools/schema_sanitizer._normalize_type_array``
+        is the canonical behaviour and is reused here rather than reimplemented."""
+        cleaned = sanitize_gemini_schema({"type": ["string", "integer"]})
+        assert "type" not in cleaned
+        assert cleaned["anyOf"] == [{"type": "string"}, {"type": "integer"}]
+        assert "nullable" not in cleaned
+
+    def test_three_way_union_keeps_all_three(self):
+        cleaned = sanitize_gemini_schema({"type": ["string", "integer", "boolean"]})
+        assert cleaned["anyOf"] == [
+            {"type": "string"}, {"type": "integer"}, {"type": "boolean"}]
+
+    @pytest.mark.parametrize("schema", [
+        {"nullable": False, "type": ["string", "null"]},   # nullable emitted first
+        {"type": ["string", "null"], "nullable": False},   # nullable emitted last
+    ])
+    def test_derived_nullable_beats_an_input_nullable_either_order(self, schema):
+        """The array says null is permitted, so an input ``nullable: false`` is wrong.
+
+        Deriving inside the key loop made this order-dependent: whichever key the
+        producer emitted last won.
+        """
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["nullable"] is True
+        assert cleaned["type"] == "string"
+
+    def test_all_null_array_becomes_the_null_type(self):
+        assert sanitize_gemini_schema({"type": ["null"]})["type"] == "null"
+
+    def test_empty_type_array_falls_back_to_object(self):
+        assert sanitize_gemini_schema({"type": []})["type"] == "object"
+
+    def test_integer_union_still_stringifies_its_enum(self):
+        cleaned = sanitize_gemini_schema({"type": ["integer", "null"], "enum": [1, 2, 3]})
+        assert cleaned["type"] == "integer"
+        assert cleaned["enum"] == ["1", "2", "3"]
+
+    def test_nested_property_is_normalized_too(self):
+        cleaned = sanitize_gemini_schema({
+            "type": "object",
+            "properties": {"color": {"type": ["string", "null"], "enum": ["red", "green"]}},
+        })
+        color = cleaned["properties"]["color"]
+        assert color["type"] == "string" and color["nullable"] is True
+        assert color["enum"] == ["red", "green"]
+
+    def test_plain_string_type_is_untouched(self):
+        """Control: the non-array path must be unchanged."""
+        cleaned = sanitize_gemini_schema({"type": "string", "enum": ["a"]})
+        assert cleaned == {"type": "string", "enum": ["a"]}

--- a/tests/agent/test_gemini_type_arrays.py
+++ b/tests/agent/test_gemini_type_arrays.py
@@ -1,0 +1,55 @@
+"""Native tool translation must preserve union alternatives at every depth."""
+import copy
+
+import pytest
+
+from agent.gemini_native_adapter import _translate_tools_to_gemini
+
+
+@pytest.mark.parametrize("types", [["string", "null"], ["integer", "null"], ["string", "integer"], ["string", "integer", "boolean", "null"], ["array", "object", "string"], ["null"], [], "string"])
+@pytest.mark.parametrize("location", ["properties", "items", "anyOf"])
+@pytest.mark.parametrize("nullable_first", [False, True])
+@pytest.mark.parametrize("constrained", [False, True])
+def test_native_type_arrays_preserve_alternatives(types, location, nullable_first, constrained):
+    node = {"nullable": False, "type": types} if nullable_first else {"type": types, "nullable": False}
+    node["description"] = "Keep this guidance"
+    if "array" in types:
+        node.update(items={"type": "integer"}, minItems=1)
+    if "object" in types:
+        node.update(properties={"name": {"type": "string"}}, required=["name", "undefined"])
+    if constrained:
+        node["anyOf"] = [{"enum": ["one"]}, {"enum": ["two"]}]
+    wrapper = {"properties": {"value": node}} if location == "properties" else {location: node if location == "items" else [node]}
+    params = {"type": "object", "properties": {"nested": wrapper}}
+    original = copy.deepcopy(params)
+    tools = [{"type": "function", "function": {"name": "probe", "parameters": params}}]
+    out = _translate_tools_to_gemini(tools)[0]["functionDeclarations"][0]["parameters"]["properties"]["nested"][location]
+    out = out["value"] if location == "properties" else out[0] if location == "anyOf" else out
+    expected = {t for t in types if t != "null"} if isinstance(types, list) else {types}
+    branches = out["anyOf"] if "type" not in out else [out]
+    actual = {branch["type"] for branch in branches}
+    for branch in branches:
+        if branch["type"] == "array":
+            assert branch["items"] == node["items"]
+            assert branch["minItems"] == node["minItems"]
+        if branch["type"] == "object" and "object" in types:
+            assert branch["properties"] == node["properties"]
+            assert branch["required"] == ["name"]
+        if "array" in types and branch["type"] != "array":
+            assert "items" not in branch
+    if constrained:
+        assert all(branch["anyOf"] == node["anyOf"] for branch in branches)
+    assert actual == (expected or {"null" if "null" in types else "object"})
+    assert not isinstance(out.get("type"), list)
+    if isinstance(types, list) and "null" in types and expected:
+        assert out["nullable"] is True
+    assert out["description"] == node["description"]
+    assert params == original
+
+
+@pytest.mark.parametrize("types,enum", [(["integer", "null"], [1, 2]), (["string", "integer"], ["one", 2]), (["boolean", "string"], [True, "other"])])
+def test_native_type_array_enums_remain_wire_strings(types, enum):
+    params = {"type": "object", "properties": {"value": {"type": types, "enum": enum}}}
+    tools = [{"type": "function", "function": {"name": "probe", "parameters": params}}]
+    node = _translate_tools_to_gemini(tools)[0]["functionDeclarations"][0]["parameters"]["properties"]["value"]
+    assert node["enum"] == [str(v).lower() if isinstance(v, bool) else str(v) for v in enum]

--- a/website/docs/guides/google-gemini.md
+++ b/website/docs/guides/google-gemini.md
@@ -76,6 +76,11 @@ Hermes detects this endpoint and creates its native Gemini adapter. Internally, 
 - tool results → Gemini `functionResponse` parts
 - streaming responses → OpenAI-shaped stream chunks for the Hermes loop
 
+Tool parameter type arrays such as `"type": ["number", "null"]` are translated
+into Gemini's scalar type plus `nullable` form. Multi-type unions keep every
+alternative through `anyOf`, including nested properties and array items. This
+happens automatically; no MCP server or provider configuration change is needed.
+
 :::note Gemini 3 thought signatures
 For Gemini 3 tool use, Hermes preserves the `thoughtSignature` values attached to function-call parts and replays them on the next tool turn. That covers the validation-critical path for multi-step agent workflows.
 


### PR DESCRIPTION
Native Gemini tool requests no longer crash or send list-valued schema types when a tool declares nullable or multi-type parameters.

## Changes
- Salvages #55643 by @MaxFreedomPollard on fresh main, preserving the original author commit and contributor attribution.
- Reuses the shared type-array normalizer; preserves every union alternative and derives `nullable` after processing the node, independent of key order.
- Completes the class: mixed-union enum metadata stays string-valued, existing `anyOf` constraints survive, and array `items` / object `properties` and filtered `required` travel with their typed branches.
- Replaces the source PR's extra tests with two parameterized native-adapter invariants and includes a reproducible loopback/SDK A/B harness.

Root cause: native `FunctionDeclaration.parameters.type` is an enum, not a JSON Schema type array; the old translation forwarded lists unchanged and its enum conversion could also raise `TypeError`.

## Validation
**Live repro:** real local native-client HTTP serialization plus Google SDK validation: seven failing base cases become accepted declarations; the scalar control passes both ways. This is **not** live Google API or Windows Desktop validation.

| Check | Result |
|---|---|
| Base nullable and mixed enum arrays | `TypeError: unhashable type: 'list'` |
| Base nullable / nested / constrained / structural unions without enum | Google SDK rejects the actual outgoing declaration |
| Fixed loopback + `google-genai==1.47.0` model validation | All seven repaired cases accepted; scalar control and input immutability preserved |
| Initial regression RED | 39 failed, 6 scalar controls passed on base |
| Class-completeness RED | Source salvage still failed mixed-union enums and existing `anyOf`; structural-union expansion separately failed for missing branch-local `items` |
| Final focused suite | 137 passed, including 99 parameter rows in two new invariants |
| `scripts/run_tests.sh -j 8 tests/agent/` | 519 files; 6,603 passed, 0 failed, 26 skipped |
| Ruff, Windows footguns, compat pointers, subprocess stdin, diff whitespace | Passed |
| Independent final review | No remaining blocker in the scoped fix |

Reproduce without API spend: install `httpx` and `google-genai==1.47.0` in an isolated environment, then run `python evals/gemini_type_array_probe.py --base origin/main`. The local capture endpoint deliberately returns HTTP 418; it never fabricates model output.

**Validation limitation (accepted by maintainer):** neither `GOOGLE_API_KEY` nor `GEMINI_API_KEY` was present in the execution environment. No personal configuration was inspected, no live model request was made, and Windows Desktop was not exercised. Teknium explicitly approved proceeding without live Google API validation; SDK/loopback evidence and CI are the acceptance gates for this fix.

## Cluster scope
- Fixes #55645; salvages #55643. #55666 only guards the local hash error, leaving the invalid wire type.
- #104840 fixes payload-size estimation, not native schema translation.
- #98928 covers this symptom through a broader full-JSON-Schema migration, but its current reference inliner rewrites literal defaults and overwrites conjunctive `$ref` sibling constraints; it is not safe unchanged reuse. #89673 and #99462 address separate schema constructs and do not resolve this type-array path.

## Infographic
![Tool schemas without crashes](https://v3b.fal.media/files/b/0aa98d5f/FS0J_BVuKRgrA1L6r38Lt_Gv63czyI.png)
