### PR TITLE
fix(agent): preserve Unicode offsets in streaming scrubbers

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -17,6 +17,7 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider, PRE_COMPRESS_CHECKPOINT_API_VERSION
+from agent.message_content import ascii_lower
 from agent.skill_commands import extract_user_instruction_from_skill_message
 from tools.hook_output_spill import get_spill_config, spill_if_oversized
 from tools.registry import tool_error
@@ -210,14 +211,14 @@ class StreamingContextScrubber:
         while buf:
             if self._in_span:
                 tag = self._CLOSE_TAG
-                idx = buf.lower().find(tag)
+                idx = ascii_lower(buf).find(tag)
                 held = self._max_partial_suffix(buf, tag)  # potential partial close tag
             else:
                 tag = self._OPEN_TAG
                 idx = self._find_boundary_open_tag(buf)
                 # A complete boundary tag at the buffer end is held until the next char confirms it.
                 n = len(tag)
-                pending = n if buf.lower().endswith(tag) and self._ends_at_block_boundary(buf[:-n]) else 0
+                pending = n if ascii_lower(buf).endswith(tag) and self._ends_at_block_boundary(buf[:-n]) else 0
                 held = pending or self._max_partial_suffix(buf, tag)
             if idx == -1:
                 # Hold back the possible partial tag; inside a span the rest is dropped.
@@ -242,13 +243,13 @@ class StreamingContextScrubber:
     @staticmethod
     def _max_partial_suffix(buf: str, tag: str) -> int:
         """Length of the longest buf-suffix that is a (case-insensitive) prefix of ``tag``, else 0."""
-        tag_lower, buf_lower = tag.lower(), buf.lower()
+        tag_lower, buf_lower = tag.lower(), ascii_lower(buf)
         span = range(min(len(buf_lower), len(tag_lower) - 1), 0, -1)
         return next((i for i in span if tag_lower.startswith(buf_lower[-i:])), 0)
 
     def _find_boundary_open_tag(self, buf: str) -> int:
         """Find an opening fence only when it starts a block-like span (own line, newline after)."""
-        buf_lower, tag_len = buf.lower(), len(self._OPEN_TAG)
+        buf_lower, tag_len = ascii_lower(buf), len(self._OPEN_TAG)
         idx = buf_lower.find(self._OPEN_TAG)
         while idx != -1:
             after_idx = idx + tag_len

--- a/agent/message_content.py
+++ b/agent/message_content.py
@@ -6,6 +6,16 @@ from typing import Any
 
 _NON_TEXT_PART_TYPES = {"image", "image_url", "input_image", "audio", "input_audio"}
 _TEXT_KEYS = ("text", "content", "input_text", "output_text", "summary_text")
+_ASCII_LOWER_TABLE = str.maketrans("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")
+
+
+def ascii_lower(text: str) -> str:
+    """Fold ASCII tags without shifting offsets into the original Unicode text.
+
+    Unicode lowercasing can expand a character (İ -> i + combining dot), so its
+    search offsets cannot safely be used to slice the original stream buffer.
+    """
+    return text.translate(_ASCII_LOWER_TABLE)
 
 
 def _field(value: Any, key: str) -> Any:

--- a/agent/think_scrubber.py
+++ b/agent/think_scrubber.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import re
 from typing import Tuple
 
+from agent.message_content import ascii_lower
+
 __all__ = ["StreamingThinkScrubber"]
 
 
@@ -115,13 +117,13 @@ class StreamingThinkScrubber:
     @staticmethod
     def _find_first_tag(buf: str, tags: Tuple[str, ...]) -> Tuple[int, int]:
         """Return (earliest_index, tag_length) over *tags* (case-insensitive), or (-1, 0)."""
-        buf_lower = buf.lower()
+        buf_lower = ascii_lower(buf)
         hits = [(idx, len(tag)) for tag in tags if (idx := buf_lower.find(tag)) != -1]
         return min(hits) if hits else (-1, 0)
 
     def _find_earliest_closed_pair(self, buf: str):
         """(start_idx, end_idx) of the earliest ``<tag>...</tag>`` pair (non-greedy, case-insensitive), else None."""
-        buf_lower = buf.lower()
+        buf_lower = ascii_lower(buf)
         pairs = []
         for open_tag, close_tag in zip(self._OPEN_TAGS, self._CLOSE_TAGS):
             open_idx = buf_lower.find(open_tag)
@@ -132,7 +134,7 @@ class StreamingThinkScrubber:
 
     def _find_open_at_boundary(self, buf: str, already_emitted: list[str]) -> Tuple[int, int]:
         """Return the earliest block-boundary open-tag (idx, len), or (-1, 0)."""
-        buf_lower = buf.lower()
+        buf_lower = ascii_lower(buf)
         hits = []
         for tag in self._OPEN_TAGS:
             idx = buf_lower.find(tag)
@@ -156,7 +158,7 @@ class StreamingThinkScrubber:
     @classmethod
     def _max_partial_suffix(cls, buf: str, tags: Tuple[str, ...]) -> int:
         """Longest buf-suffix that is a strict prefix of any tag (full matches are real tags, handled elsewhere)."""
-        buf_lower = buf.lower()
+        buf_lower = ascii_lower(buf)
         for i in range(min(len(buf_lower), cls._MAX_TAG_LEN - 1), 0, -1):
             suffix = buf_lower[-i:]
             if any(len(tag) > i and tag.startswith(suffix) for tag in tags):

--- a/tests/agent/test_stream_scrubber_unicode.py
+++ b/tests/agent/test_stream_scrubber_unicode.py
@@ -1,0 +1,50 @@
+"""Tag filtering must preserve Unicode prose regardless of stream chunking."""
+
+import pytest
+
+from agent.memory_manager import StreamingContextScrubber
+from agent.stream_delivery import StreamDeliveryMixin
+from agent.think_scrubber import StreamingThinkScrubber
+
+
+@pytest.mark.parametrize("tag", [
+    "memory-context", "think", "thinking", "reasoning", "thought", "REASONING_SCRATCHPAD",
+])
+@pytest.mark.parametrize("prefix, hidden", [
+    ("İstanbul\n", "private context"),
+    ("Visible\n", "İzmir İstanbul"),
+    ("İİİ\n", "İİİ"),
+])
+def test_unicode_prose_is_independent_of_tag_chunk_boundaries(tag, prefix, hidden):
+    factory = StreamingContextScrubber if tag == "memory-context" else StreamingThinkScrubber
+    suffix = "Yanıt: doğru."
+    text = f"{prefix}<{tag.upper()}>\n{hidden}</{tag.upper()}>{suffix}"
+    partitions = [[text], list(text)]
+    partitions.extend([text[:cut], text[cut:]] for cut in range(1, len(text)))
+
+    for chunks in partitions:
+        scrubber = factory()
+        visible = "".join(scrubber.feed(chunk) for chunk in chunks) + scrubber.flush()
+        assert visible == prefix + suffix, chunks
+
+
+@pytest.mark.parametrize("chunk_size", [None, 1, 11])
+def test_unicode_stream_reaches_display_and_tts_without_hidden_blocks(chunk_size):
+    agent = StreamDeliveryMixin()
+    agent._stream_think_scrubber = StreamingThinkScrubber()
+    agent._stream_context_scrubber = StreamingContextScrubber()
+    display, speech = [], []
+    agent.stream_delta_callback = display.append
+    agent._stream_callback = speech.append
+    agent._current_streamed_assistant_text = ""
+    text = (
+        "İstanbul\n<THINK>\nİzmir\n</THINK>"
+        "<memory-context>\nİzmit\n</memory-context>Yanıt: doğru."
+    )
+    size = chunk_size or len(text)
+    for start in range(0, len(text), size):
+        agent._fire_stream_delta(text[start:start + size])
+    agent._reset_stream_delivery_tracking()
+
+    assert "".join(display) == "İstanbul\nYanıt: doğru."
+    assert "".join(speech) == "".join(display)


### PR DESCRIPTION
## What does this PR do?

Fixes Unicode-dependent corruption in streamed assistant text. Both streaming scrubbers search `buf.lower()` but slice the original buffer with those offsets. `İ` lowercases to two code points, so a tag after it is located at the wrong position: memory context can reach the display/TTS callback and normal answer characters can be deleted. The result also changes with provider chunk boundaries.

Use a shared ASCII-only fold for the ASCII tag grammar, preserving offsets into the original text in both the reasoning and memory scrubbers. Visible Unicode text is unchanged. Existing boundary, partial-tag and flush behavior stays intact.

## Related issue

Found by tracing the current streaming callback path on main `6e2b8e070d28b1a3381a3fb290b6b8d6cce13cef`. Searched open/closed PRs for the scrubbers, Unicode, Turkish and dotted-I handling; no matching fix found. This concerns stream filtering, not memory prompt wording or provenance.

## Type of change

- [x] Bug fix

## How was this tested?

Two invariant tests: all supported fence types with Unicode before/inside spans, every two-chunk split and character-at-a-time delivery; plus the real `StreamDeliveryMixin` pipeline with both display and TTS callbacks.

- Unpatched main: **19 failed, 2 passed** in the new file.
- Patched: **190 passed** across the new file, both scrubber suites, memory-provider tests and Codex Responses integration tests, using `scripts/run_tests.sh` with file retries disabled.
- Ruff, `git diff --check` and `scripts/check_compat_pointers.py` passed.

No live provider credentials or paid API calls were used. The full repository suite was not run.

## Checklist

- [x] The bug reproduces on current main and the regression tests pass with this change.
- [x] Related call paths are covered in the same fix.
- [x] No new tool schema, setting, dependency or prompt mutation.
