### PR TITLE
feat(providers): add API Route

### DIFF
--- a/plugins/model-providers/api-route/__init__.py
+++ b/plugins/model-providers/api-route/__init__.py
@@ -1,0 +1,18 @@
+"""API Route provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+api_route = ProviderProfile(
+    name="api-route",
+    aliases=("api_route", "apiroute"),
+    env_vars=("API_ROUTE_API_KEY",),
+    display_name="API Route",
+    description="API Route — unified OpenAI-compatible API",
+    signup_url="https://www.api-route.com",
+    base_url="https://global.api-route.com/v1",
+    models_url="https://global.api-route.com/v1/models",
+)
+
+register_provider(api_route)

--- a/plugins/model-providers/api-route/plugin.yaml
+++ b/plugins/model-providers/api-route/plugin.yaml
@@ -1,0 +1,5 @@
+name: api-route-provider
+kind: model-provider
+version: 1.0.0
+description: API Route OpenAI-compatible API
+author: API Route


### PR DESCRIPTION
## What does this PR do?

Adds API Route as a first-class OpenAI-compatible model provider. Hermes can discover it in the provider picker, authenticate with `API_ROUTE_API_KEY`, and load the account's current models from the standard `/v1/models` endpoint.

## Related Issue

None.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Added `plugins/model-providers/api-route/__init__.py` with the provider profile, aliases, endpoint, and credential variable.
- Added `plugins/model-providers/api-route/plugin.yaml` for plugin discovery.

## How to Test

1. Run `uvx --with PyYAML pytest tests/providers/test_plugin_discovery.py -q`.
2. Confirm `get_provider_profile("api-route")` returns the API Route profile.
3. Confirm the `api_route` and `apiroute` aliases resolve to the same profile.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (the existing generic provider-discovery tests cover this profile)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update — N/A; the provider is surfaced through plugin discovery metadata
- [x] `cli-config.yaml.example` update — N/A; no config keys added
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture changes
- [x] I've considered cross-platform impact; the profile is declarative and platform-independent
- [x] Tool descriptions/schemas update — N/A; no tool behavior changed

## Screenshots / Logs

```text
...                                                                      [100%]
3 passed in 0.72s
```