### PR TITLE
fix(process): list refreshes no longer leave exited children running (salvage #60506, #81385)

### DIFF
--- a/tests/tools/test_process_registry_list_exit.py
+++ b/tests/tools/test_process_registry_list_exit.py
@@ -1,0 +1,119 @@
+"""List refresh observes the child, not its descendants' capture-pipe lifetime."""
+
+import ctypes
+import json
+import os
+from pathlib import Path
+import shlex
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+
+@pytest.mark.linux_only
+def test_list_reconciles_real_exit_without_consuming_owned_result(tmp_path):
+    # A disposable subreaper owns even the orphaned writer; no global pytest
+    # process state is changed, and every fixture child is reaped on failure.
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), "probe", str(tmp_path)],
+        cwd=Path(__file__).resolve().parents[2],
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[2])},
+        stdin=subprocess.DEVNULL, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def _probe(root):
+    import tools.process_registry as module
+
+    assert ctypes.CDLL(None).prctl(36, 1, 0, 0, 0) == 0  # PR_SET_CHILD_SUBREAPER
+    module._SYSTEMD_SCOPE_AVAILABLE = False  # Own the test process tree, not a host service.
+    registry = module.ProcessRegistry()
+    sessions = []
+    command = f"exec {shlex.quote(sys.executable)} {shlex.quote(__file__)}"
+    try:
+        for name in ("owner", "sibling"):
+            session = registry.spawn_local(
+                f"{command} child {shlex.quote(str(root / name))}",
+                cwd=str(root), task_id=name + "-task", owner_task_id=name + "-owner",
+                session_key=name + "-session",
+            )
+            sessions.append(session)
+            session.notify_on_complete = True
+        owner, sibling = sessions
+        deadline = time.monotonic() + 5
+        while not all(s.output_buffer for s in sessions):
+            assert time.monotonic() < deadline, "writers did not become ready"
+            time.sleep(0.01)
+        assert all(s.process.poll() is None for s in sessions)
+        (root / "owner-exit").touch()
+        assert owner.process.wait(timeout=5) == 0
+        assert owner._reader_thread.is_alive()  # Writer is still producing output.
+        started = time.monotonic()
+        listed = registry.list_sessions(session_key="owner-session")
+        elapsed = time.monotonic() - started
+        print(json.dumps({"direct_child": owner.process.returncode, "listed": listed,
+                          "elapsed": elapsed, "reader_alive": owner._reader_thread.is_alive()}), flush=True)
+        assert elapsed < 2, "list waited for the descendant's pipe lifetime"
+        assert [entry["session_id"] for entry in listed] == [owner.id]
+        assert listed[0]["status"] == "exited"
+        assert listed[0]["exit_code"] == 0
+        event = registry.completion_queue.get(timeout=2)
+        assert (event["session_id"], event["session_key"], event["task_id"], event["owner_task_id"]) == (
+            owner.id, "owner-session", "owner-task", "owner-owner")
+        assert event["exit_code"] == 0 and "owner-output" in event["output"]
+        assert registry.unread_completions_owned_by("owner-owner") == [owner]
+        assert registry.unread_completions_owned_by("sibling-owner") == []
+        for _ in range(3):
+            assert registry.list_sessions(session_key="owner-session")[0]["status"] == "exited"
+            foreign = registry.list_sessions(session_key="sibling-session")
+            assert [(row["session_id"], row["status"]) for row in foreign] == [(sibling.id, "running")]
+        assert sibling.process.poll() is None
+        (root / "owner-stop").touch()
+        owner._reader_thread.join(timeout=5)
+        assert not owner._reader_thread.is_alive()
+        assert registry.completion_queue.empty(), "reader and list emitted duplicate completions"
+        assert not registry.is_completion_consumed(owner.id)
+        assert "owner-output" in registry.read_log(owner.id)["output"]
+        assert registry.is_completion_consumed(owner.id)
+        print("PASS: list-only exit; one exact-owner event; running sibling isolated; unread output retained", flush=True)
+    finally:
+        for name in ("owner", "sibling"):
+            (root / (name + "-stop")).touch()
+            (root / (name + "-exit")).touch()
+        for session in sessions:
+            try:
+                os.killpg(session.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            session.process.wait(timeout=5)
+            session._reader_thread.join(timeout=5)
+        # This subprocess contains only our two child trees.
+        while True:
+            try:
+                os.waitpid(-1, 0)
+            except ChildProcessError:
+                break
+
+
+def _child(gate):
+    subprocess.Popen(
+        [sys.executable, __file__, "writer", str(gate)], stdin=subprocess.DEVNULL,
+    )
+    deadline = time.monotonic() + 15
+    while not Path(str(gate) + "-exit").exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+
+def _writer(gate):
+    deadline = time.monotonic() + 15
+    while not Path(str(gate) + "-stop").exists() and time.monotonic() < deadline:
+        print(gate.name + "-output", flush=True)
+        time.sleep(0.02)
+
+
+if __name__ == "__main__":
+    {"probe": _probe, "child": _child, "writer": _writer}[sys.argv[1]](Path(sys.argv[2]))

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1939,6 +1939,9 @@ class ProcessRegistry(ProcessCheckpointMixin):
             ]
         result = []
         for s in all_sessions:
+            # List-only refreshes must observe child exit even while descendants
+            # keep the capture pipe open; retain the existing completion owner.
+            self._reconcile_local_exit(s)
             entry = {
                 "session_id": s.id,
                 "command": s.command[:200],


### PR DESCRIPTION
Background-process list refreshes now report an exited direct child even while its descendant keeps stdout open.

## Changes
- Reuse the existing direct-child reconciliation in `ProcessRegistry.list_sessions()` **after** task/session filtering: one production call plus its explanatory comment (+3 lines).
- Preserve the existing idempotent completion path, exact notification owner, and unread output. No new threads, joins, timers, PID inference, cross-session display, or RPCs.
- Add one Linux-native invariant test using real processes, a gated continuing writer, a running sibling, and a disposable subreaper with owned process-group cleanup.

The cause is a missing list-path reconciliation: the child can have exited while the capture reader is still active, leaving the cached status running.

## Live repro and validation
**Live repro:** on fresh `main` `6e2b8e070d28b1a3381a3fb290b6b8d6cce13cef`, the direct child returned **0**, the reader remained alive, and list returned **running**. The new test failed at the required `exited` assertion before production was edited. After the three-line change, that same test passed.

| Executed check | Result |
| --- | --- |
| RED then GREEN through `scripts/run_tests.sh -j 1 tests/tools/test_process_registry_list_exit.py` | 1 failed before; 1 passed after |
| Five fresh-interpreter, temporary HOME/HERMES_HOME real-process replays | 5/5 passed; list returned in 0.029–0.037 seconds while the reader was still alive |
| Owner invariants | Exactly one completion event with the original session/task/owner; no second event after repeated lists and reader teardown |
| Negative controls | Real running sibling remains running and absent from owner-scoped results; listing does not consume unread output; log retrieval still works |
| Six process/notification test files via the serial canonical runner | 129 passed, 0 failed, 7 skipped |
| Ruff; Windows-footgun scan; compatibility-pointer scan; subprocess-stdin scan; diff whitespace | Passed |
| Independent read-only review | No blocking findings |

The six files were `test_process_registry.py`, `test_process_registry_list_exit.py`, `test_process_registry_windows_live.py`, `test_process_registry_write_stdin_surrogates.py`, `test_process_wait_clarity.py`, and `test_notify_on_complete.py` under `tests/tools/`.

## Salvage and scope
Earliest list-reconciliation credit: **@indigokarasu, #60506**, commit `2a96ae2cbf806ccdc3e9b584911774f32622f421`; **@fangliquanflq, #81385**, commit `50ffd243d92627e4a03a3ee8427ad0f5e090c3ab`, supplied the later focused list/completion fix. This is a minimal carve, preserving Indigo's authorship and Fang's co-author credit—not a wholesale cherry-pick of either broader historical diff.

Read both full discussions/reviews, including #60506's cross-session disclosure/PID-identity concerns. Related sweep also covered #34711, #75771, #86511, #75162, #97433, and #103516. Their polling-loop, pipe-EOF, handle-release, readiness-event, and cross-gateway work is not silently included here.

Related to #81114 and #48339. This does **not** resolve every delivery/turn-compaction symptom in those threads: it proves producer enqueue, not native Desktop rendering or gateway delivery. Native Windows/macOS were not run; the complete repository suite was not run. Existing pipe drain/decoder semantics are unchanged; this is not a claim that every historical stdout race is solved. No user configuration or tool schema changes, and no frontend/CLI changes.

## Infographic
![Background list refresh observes direct-child exit without changing ownership](https://v3b.fal.media/files/b/0aa98db8/Ivajjl_Tub-n5TFoEupvP_wT7LFFAA.png)
