### PR TITLE
fix(sessions): include descendants when filtering by filesystem root

### DIFF
--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -53,10 +53,13 @@ def _cwd_prefix_clause(cwd_prefix: str) -> Tuple[str, List[str]]:
     prefix = cwd_prefix.rstrip("/\\") or cwd_prefix
     # ``_``/``%`` are LIKE wildcards but ordinary path characters: unescaped, a
     # prefix also matches sibling directories. The ``=`` arm keeps the raw prefix.
-    esc = _escape_like(prefix)
+    # A filesystem root already ends with its separator: adding another would
+    # search for //repo (or \\repo) instead of its direct descendants.
+    children = [_escape_like(prefix if prefix.endswith(sep) else prefix + sep) + "%"
+                for sep in ("/", "\\")]
     return (
         "(s.cwd = ? OR s.cwd LIKE ? ESCAPE '\\' OR s.cwd LIKE ? ESCAPE '\\')",
-        [prefix, f"{esc}/%", f"{esc}\\\\%"],
+        [prefix, *children],
     )
 
 

--- a/tests/test_session_root_cwd_filter.py
+++ b/tests/test_session_root_cwd_filter.py
@@ -1,0 +1,46 @@
+"""Root and ordinary directory filters share exact directory-boundary semantics."""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.mark.parametrize("prefix, descendants, outside", [
+    ("/", ["/", "/repo", "/repo/src"], ["relative", "C:\\repo"]),
+    ("\\", ["\\", "\\repo", "\\repo\\src"], ["relative", "/repo"]),
+    ("C:\\", ["C:\\", "C:\\repo", "C:\\repo\\src"], ["D:\\repo", "relative"]),
+    ("/work/a_%/", ["/work/a_%", "/work/a_%/src"], ["/work/aXX/src", "/work/a_%other"]),
+])
+@pytest.mark.parametrize("order_by_last_active", [False, True])
+def test_directory_filter_agrees_across_list_count_and_resume(
+    tmp_path, prefix, descendants, outside, order_by_last_active,
+):
+    # These are stored path strings, not a simulated host OS or real directories.
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        for index, cwd in enumerate(descendants + outside):
+            db.create_session(f"s{index}", source="cli", cwd=cwd)
+        expected = {f"s{i}" for i in range(len(descendants))}
+        rows = db.list_sessions_rich(cwd_prefix=prefix, order_by_last_active=order_by_last_active)
+        assert {row["id"] for row in rows} == expected
+        assert db.session_count(cwd_prefix=prefix) == len(expected)
+        assert {row["id"] for row in db.search_sessions(workspace_key=prefix)} == expected
+    finally:
+        db.close()
+
+
+def test_root_prune_matches_its_preview_and_preserves_outside_rows(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        for sid, cwd in [("root", "/"), ("child", "/repo/src"), ("outside", "relative")]:
+            db.create_session(sid, source="cli", cwd=cwd)
+            db.append_message(sid, role="user", content=sid)
+            db.end_session(sid, end_reason="completed")
+        candidates = db.list_prune_candidates(cwd_prefix="/")
+        assert {row["id"] for row in candidates} == {"root", "child"}
+        assert db.count_prune_matches(cwd_prefix="/") == len(candidates)
+        assert db.prune_sessions(older_than_days=None, cwd_prefix="/") == len(candidates)
+        assert {row["id"] for row in db.search_sessions()} == {"outside"}
+        assert db.get_messages("outside")[0]["content"] == "outside"
+    finally:
+        db.close()


### PR DESCRIPTION
## What does this PR do?

A `cwd_prefix="/"` filter currently matches the root session but misses sessions under `/repo` or `/repo/src`: `_cwd_prefix_clause` appends another separator and produces the SQL LIKE pattern `//%`. A stored backslash root has the same issue. The shared predicate affects rich session lists, counts, workspace resume and prune previews/actions.

Append a separator only when the prefix does not already end in that separator, then apply the existing LIKE escaping. Ordinary paths, drive roots, and literal `%`/`_` characters keep their existing behavior.

## Related issue

Found on main `6e2b8e070d28b1a3381a3fb290b6b8d6cce13cef`. No matching issue. Checked existing PRs around `_cwd_prefix_clause`, root filters and workspace filtering. #78927 fixed wildcard escaping; this preserves that fix and handles the remaining root-directory boundary case.

## Type of change

- [x] Bug fix

## How was this tested?

Two invariant tests use real temporary `SessionDB` files. Listing in both order modes, counts and workspace resume must select the same directory and descendants. Pruning must agree with its preview and preserve out-of-scope rows and messages. Windows-style paths are database values; the tests do not fake the host OS.

- Unpatched main: **5 failed, 4 passed** in the new regression file.
- Patched: **61 passed** across the new file, workspace-binding and CLI-listing suites, plus relevant prune/list/resume tests from `test_hermes_state.py`, via `scripts/run_tests.sh` with retries disabled.
- Ruff, `git diff --check` and compatibility-pointer check passed.

A broader `test_hermes_state.py` run exposed an existing FTS query-count assertion failure, reproduced unchanged on the unpatched base. Its separate process-inspection sandbox error passed outside the sandbox. No live session database was modified; the full repository suite was not run.

## Checklist

- [x] Reproduced on current main; focused regressions pass after the fix.
- [x] Shared caller behavior covered; existing wildcard isolation retained.
- [x] No new setting, schema, dependency or public API.
