### PR TITLE
feat(compression): persist compaction as durable session events (#104099)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1214,6 +1214,96 @@ def _emit_compression_attempt_telemetry(
         logger.info(
             "context compression attempt telemetry: %s", json.dumps(payload, sort_keys=True, separators=(",", ":"))
         )
+        _record_compaction_end(agent, payload)
+
+
+def _compaction_audit_db(agent: Any) -> Any:
+    """Live session store for the audit trail, or None (no db, legacy API)."""
+    with contextlib.suppress(Exception):
+        db = getattr(agent, "_session_db", None)
+        if db is not None and callable(getattr(type(db), "record_compaction_event", None)):
+            return db
+    return None
+
+
+def _record_compaction_start(
+    agent: Any, *, attempt_id: str, message_count: int, approx_tokens: Optional[int],
+) -> bool:
+    """Append the ``start`` bracket; arms the one-shot ``end`` for this attempt.
+
+    Best-effort: False (or a silent skip when no store is bound) never affects
+    the compaction itself. Only attempts that reach this point — past the
+    pre-lease sit-outs — are audited, so lock-contention/breaker no-ops stay
+    out of the table.
+    """
+    db = _compaction_audit_db(agent)
+    if db is None or not attempt_id:
+        return False
+    try:
+        session_id = getattr(agent, "session_id", "") or ""
+        if not session_id:
+            return False
+        compressor = getattr(agent, "context_compressor", None)
+        telemetry = getattr(compressor, "_last_compression_telemetry", None)
+        seed = getattr(compressor, "_compression_telemetry_seed", None)
+        if isinstance(telemetry, dict) and isinstance(telemetry.get("trigger_source"), str):
+            trigger_source: str = telemetry["trigger_source"]
+        elif isinstance(seed, dict) and isinstance(seed.get("trigger_source"), str):
+            trigger_source = seed["trigger_source"]
+        else:
+            trigger_source = "unknown"
+        threshold = getattr(compressor, "threshold_tokens", None)
+        provider = getattr(compressor, "provider", None)
+        model = getattr(compressor, "model", None)
+        payload = {
+            "trigger_source": trigger_source,
+            "message_count": max(0, int(message_count)),
+            "approx_tokens": approx_tokens if isinstance(approx_tokens, (int, float)) else None,
+            "threshold_tokens": threshold if isinstance(threshold, (int, float)) else None,
+            "main_provider": provider if isinstance(provider, str) else (getattr(agent, "provider", "") or ""),
+            "main_model": model if isinstance(model, str) else (getattr(agent, "model", "") or ""),
+        }
+        recorder = getattr(type(db), "record_compaction_event", None)
+        if recorder is None or not recorder(db, session_id, attempt_id, "start", payload):
+            return False
+    except Exception:
+        logger.debug("compaction audit start write failed", exc_info=True)
+        return False
+    with contextlib.suppress(Exception):
+        # Anchor the row identity: rotation rebinds agent.session_id to the
+        # child mid-attempt, so the ``end`` must reuse the *start* session or
+        # the pair splits into a false orphan + a dangling end.
+        agent._compaction_audit_start_written = (attempt_id, session_id)
+    return True
+
+
+def _record_compaction_end(agent: Any, payload: Dict[str, Any]) -> None:
+    """Append the ``end`` bracket when this attempt wrote a ``start``.
+
+    Pre-lease sit-outs (lock contention, breaker gates, codex route) never
+    wrote one, so their telemetry stays log-only — no orphan, no noise row.
+    """
+    try:
+        attempt_id = str(payload.get("attempt_id") or "")
+        marker = getattr(agent, "_compaction_audit_start_written", None)
+        if (
+            not attempt_id
+            or not isinstance(marker, tuple)
+            or len(marker) != 2
+            or marker[0] != attempt_id
+        ):
+            return
+        db = _compaction_audit_db(agent)
+        if db is None:
+            return
+        recorder = getattr(type(db), "record_compaction_event", None)
+        if recorder is None:
+            return
+        if recorder(db, marker[1], attempt_id, "end", payload):
+            with contextlib.suppress(Exception):
+                agent._compaction_audit_start_written = None
+    except Exception:
+        logger.debug("compaction audit end write failed", exc_info=True)
 
 
 def _existing_system_prompt(agent: Any, system_message: str) -> str:
@@ -3203,6 +3293,7 @@ def _candidate_rejected(
             agent._emit_warning(
                 "⚠ Compression returned an empty transcript. No session split was performed; conversation continues unchanged."
             )
+        _emit_aborted_attempt_telemetry(agent, attempt_started_at, "empty_transcript")
         return True
 
     # A newer attempt claiming this compressor supersedes us; discard the late
@@ -3500,6 +3591,11 @@ def _begin_compression_attempt(agent: Any, *, force: bool, defer_notification: b
     agent._last_compression_attempt_recorded = True
     agent._last_compression_attempt_in_place = None
     agent._compression_skipped_due_to_lock = None
+    # A new attempt disarms any prior audit bracket: an out-of-band emit
+    # (pool-saturated refusal outside the worker) must never close a
+    # previous attempt's orphan with a mismatched failure_class.
+    with contextlib.suppress(Exception):
+        agent._compaction_audit_start_written = None
     # Clear the lock-skip signal at the VERY TOP, before the codex route and the breaker gates below can
     # early-return (per-attempt state rule, #58630/#69853). A stale ``True``/holder value from a prior
     # lock-skip must never make a later breaker/codex no-op look like lock contention to the automatic-path
@@ -3646,6 +3742,13 @@ def compress_context(
     if not force and _automatic_compression_gate_blocks(agent, bypass_cooldown, include_cooldown=False):
         lease.release()
         return messages, _existing_system_prompt(agent, system_message)
+
+    # Only attempts past the pre-summary sit-outs are audited; pre-lease
+    # breaker/lock/cooldown no-ops stay log-only and never leave an orphan.
+    _record_compaction_start(
+        agent, attempt_id=getattr(agent, "_compression_attempt_id", "") or "",
+        message_count=len(messages), approx_tokens=approx_tokens,
+    )
 
     # Interrupts/redirects must not tear a summary in half. Use the explicit stop
     # Event (message fields race) + fence timeout so pool slots free promptly.

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -510,6 +510,15 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS compaction_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    attempt_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}'
+);
+
 CREATE TABLE IF NOT EXISTS session_turn_leases (
     conversation_id TEXT PRIMARY KEY,
     holder TEXT NOT NULL,
@@ -562,6 +571,8 @@ CREATE INDEX IF NOT EXISTS idx_messages_assistant_calls_by_session
     ON messages(session_id)
     WHERE role = 'assistant' AND tool_calls IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
+CREATE INDEX IF NOT EXISTS idx_compaction_events_session ON compaction_events(session_id, id);
+CREATE INDEX IF NOT EXISTS idx_compaction_events_attempt ON compaction_events(attempt_id, id);
 CREATE INDEX IF NOT EXISTS idx_session_turn_leases_expires ON session_turn_leases(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -612,6 +612,121 @@ class SessionCompressionMixin:
             "SELECT holder FROM compression_locks WHERE session_id = ? AND expires_at >= ?", (session_id, time.time()))
         return None if row is None else row[0]
 
+    _COMPACTION_EVENT_KINDS = frozenset({"start", "end"})
+    _COMPACTION_EVENT_PAYLOAD_BYTES = 8 * 1024
+    _COMPACTION_EVENT_PATIENCE_S = 2.0
+
+    @staticmethod
+    def _cap_compaction_payload(payload: Dict[str, Any]) -> str:
+        """Content-free payload JSON capped at 8 KiB with a ``truncated`` marker."""
+        try:
+            raw = json.dumps(payload if isinstance(payload, dict) else {}, sort_keys=True, separators=(",", ":"))
+        except (TypeError, ValueError):
+            raw = "{}"
+        if len(raw.encode("utf-8")) <= SessionCompressionMixin._COMPACTION_EVENT_PAYLOAD_BYTES:
+            return raw
+        try:
+            slim = {
+                "truncated": True,
+                "session_id": payload.get("session_id"),
+                "attempt_id": payload.get("attempt_id"),
+                "commit_status": payload.get("commit_status"),
+                "failure_class": payload.get("failure_class"),
+            }
+            raw = json.dumps(slim, sort_keys=True, separators=(",", ":"))
+        except (TypeError, ValueError, AttributeError):
+            raw = '{"truncated":true}'
+        return raw
+
+    def record_compaction_event(
+        self, session_id: str, attempt_id: str, kind: str, payload: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Append one compaction audit row; best-effort, never raises.
+
+        Returns True when the row landed, False otherwise (missing ids,
+        unknown kind, or any store error). Audit writes use a short patience
+        so they can never delay or abort a compaction.
+        """
+        if not session_id or not attempt_id or kind not in self._COMPACTION_EVENT_KINDS:
+            return False
+        body = dict(payload) if isinstance(payload, dict) else {}
+        body.setdefault("session_id", session_id)
+        body.setdefault("attempt_id", attempt_id)
+        encoded = self._cap_compaction_payload(body)
+        try:
+            self._execute_write(
+                lambda conn: conn.execute(
+                    "INSERT INTO compaction_events (session_id, attempt_id, kind, created_at, payload_json)"
+                    " VALUES (?, ?, ?, ?, ?)",
+                    (session_id, attempt_id, kind, time.time(), encoded),
+                ),
+                patience_s=self._COMPACTION_EVENT_PATIENCE_S,
+            )
+            return True
+        except Exception as exc:
+            logger.warning("record_compaction_event(%s) failed: %s", session_id, exc)
+            return False
+
+    def find_orphaned_compaction_starts(self, session_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """``start`` rows with no matching ``end`` (same session + attempt).
+
+        A crash mid-compaction leaves exactly this shape; clean runs always
+        pair. Optional per-session scoping for resume diagnostics.
+        """
+        sql = (
+            "SELECT s.session_id, s.attempt_id, s.created_at, s.payload_json"
+            " FROM compaction_events s"
+            " WHERE s.kind = 'start' AND NOT EXISTS ("
+            "SELECT 1 FROM compaction_events e WHERE e.kind = 'end'"
+            " AND e.session_id = s.session_id AND e.attempt_id = s.attempt_id)"
+        )
+        params: Tuple[Any, ...] = ()
+        if session_id:
+            sql += " AND s.session_id = ?"
+            params = (session_id,)
+        sql += " ORDER BY s.created_at ASC"
+        try:
+            rows = self._read_all(sql, params)
+        except Exception as exc:
+            logger.warning("find_orphaned_compaction_starts failed: %s", exc)
+            return []
+        out = []
+        for row in rows or []:
+            try:
+                payload = json.loads(row[3] or "{}")
+            except (TypeError, ValueError):
+                payload = {}
+            out.append({
+                "session_id": row[0], "attempt_id": row[1], "started_at": row[2], "payload": payload,
+            })
+        return out
+
+    def get_compaction_events(self, session_id: str, *, limit: int = 100) -> List[Dict[str, Any]]:
+        """Newest-first audit rows for one session (reader surface for resume/doctor)."""
+        if not session_id:
+            return []
+        try:
+            bound = max(1, min(int(limit), 1000))
+        except (TypeError, ValueError):
+            bound = 100
+        try:
+            rows = self._read_all(
+                "SELECT attempt_id, kind, created_at, payload_json FROM compaction_events"
+                " WHERE session_id = ? ORDER BY id DESC LIMIT ?",
+                (session_id, bound),
+            )
+        except Exception as exc:
+            logger.warning("get_compaction_events(%s) failed: %s", session_id, exc)
+            return []
+        out = []
+        for row in rows or []:
+            try:
+                payload = json.loads(row[3] or "{}")
+            except (TypeError, ValueError):
+                payload = {}
+            out.append({"attempt_id": row[0], "kind": row[1], "created_at": row[2], "payload": payload})
+        return out
+
     def finalize_orphaned_compression_sessions(self) -> int:
         """Mark orphaned compression continuations (parent ended by compression; child has
         messages, no end_reason/ended_at, api_call_count=0, older than 7 days) as

--- a/hermes_state_maintenance.py
+++ b/hermes_state_maintenance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import time
 from pathlib import Path
@@ -288,6 +289,8 @@ class SessionMaintenanceMixin:
                 ph = _placeholders(chunk)
                 conn.execute(f"UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id IN ({ph})", chunk)
                 conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", chunk)
+                with contextlib.suppress(Exception):
+                    conn.execute(f"DELETE FROM compaction_events WHERE session_id IN ({ph})", chunk)
                 conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", chunk)
                 removed_ids.extend(chunk)
             self._delete_unreferenced_system_prompts(conn)

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -2,6 +2,7 @@
 flags (end/reopen/archive/pin/hide/read), model_config patching, listing and
 counting, delete cascades, and the auto-archive sweep."""
 
+import contextlib
 import json
 import logging
 import re
@@ -1484,6 +1485,8 @@ class SessionSessionsMixin:
                 "UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id = ?", (session_id,),
             )
             conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+            with contextlib.suppress(Exception):
+                conn.execute("DELETE FROM compaction_events WHERE session_id = ?", (session_id,))
             conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
             self._delete_unreferenced_system_prompts(conn)
             removed_ids.append(session_id)
@@ -1540,6 +1543,8 @@ class SessionSessionsMixin:
                     f"UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id IN ({ph})", chunk,
                 )
                 conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", chunk)
+                with contextlib.suppress(Exception):
+                    conn.execute(f"DELETE FROM compaction_events WHERE session_id IN ({ph})", chunk)
                 conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", chunk)
             self._delete_unreferenced_system_prompts(conn)
             removed_ids.extend(existing)
@@ -1578,6 +1583,8 @@ class SessionSessionsMixin:
                 # DELETE FROM messages: a row inserted between the SELECT and here
                 # would otherwise dangle (clean FK state).
                 conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", chunk)
+                with contextlib.suppress(Exception):
+                    conn.execute(f"DELETE FROM compaction_events WHERE session_id IN ({ph})", chunk)
                 conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", chunk)
                 removed_ids.extend(chunk)
             self._delete_unreferenced_system_prompts(conn)

--- a/tests/agent/test_compaction_audit_events.py
+++ b/tests/agent/test_compaction_audit_events.py
@@ -1,0 +1,246 @@
+"""Audit trail for compaction: `compaction_events` start/end bracketing.
+
+Covers #104099. Every attempt that reaches the summary phase writes a ``start``
+row on entry and an ``end`` row via the telemetry emitter; pre-lease sit-outs
+(lock/breaker/cooldown/codex) stay log-only so they never leave an orphan.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.conversation_compression import compress_context, _emit_compression_attempt_telemetry
+from hermes_state import SessionDB
+
+
+def _agent(tmp_path: Path, session_id: str, db: SessionDB | None = None):
+    if db is None:
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id, source="cli")
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._compression_feasibility_checked = True
+    agent.compression_in_place = True
+    agent._cached_system_prompt = "sys"
+    agent.context_compressor.threshold_tokens = 1000
+    return db, agent
+
+
+def _msgs(n=20):
+    return [{"role": "user", "content": f"m{i} " + "x" * 200} for i in range(n)]
+
+
+def _compress_small(messages, **kwargs):
+    # Marker-swept shape compress() normally returns: short head+tail into one summary.
+    return [{"role": "user", "content": "summary of earlier turns"}] + messages[-2:]
+
+
+class TestSchema:
+    def test_compaction_events_table_exists(self, tmp_path):
+        db, _ = _agent(tmp_path, "s-schema")
+        rows = db._read_all("SELECT name FROM sqlite_master WHERE type='table' AND name='compaction_events'")
+        assert len(rows) == 1
+
+
+class TestPairing:
+    def test_committed_path_writes_start_and_end_and_no_orphan(self, tmp_path):
+        db, agent = _agent(tmp_path, "s-pair")
+        msgs = _msgs(20)
+        with patch.object(agent.context_compressor, "compress", side_effect=_compress_small):
+            out, _ = compress_context(agent, msgs, "sys", approx_tokens=50000, force=True)
+            assert len(out) < len(msgs)
+        starts = db._read_all("SELECT kind FROM compaction_events WHERE session_id=? ORDER BY id", ("s-pair",))
+        kinds = [r[0] for r in starts]
+        assert kinds.count("start") == 1
+        assert kinds.count("end") == 1
+        assert db.find_orphaned_compaction_starts("s-pair") == []
+        assert db.find_orphaned_compaction_starts() == []
+
+    def test_wiring_bite_emitter_persists_end(self, tmp_path):
+        """Mutation-check: deleting the recorder call in the emitter must break pairing."""
+        db, agent = _agent(tmp_path, "s-wiring")
+        msgs = _msgs(20)
+        with patch.object(agent.context_compressor, "compress", side_effect=_compress_small):
+            # Normal pairing first.
+            compress_context(agent, msgs, "sys", approx_tokens=50000, force=True)
+        assert len(db._read_all("SELECT 1 FROM compaction_events WHERE kind='end' AND session_id='s-wiring'")) == 1
+        # Sabotage the emitter's DB write (but let the start row through) -> orphan must appear.
+        db2, agent2 = _agent(tmp_path, "s-wiring2")
+        import agent.conversation_compression as cc
+
+        with patch.object(cc, "_record_compaction_end"):
+            with patch.object(agent2.context_compressor, "compress", side_effect=_compress_small):
+                compress_context(agent2, _msgs(20), "sys", approx_tokens=50000, force=True)
+            assert db2.find_orphaned_compaction_starts("s-wiring2") != []
+
+
+class TestOrphans:
+    def test_manual_start_is_orphan_until_end(self, tmp_path):
+        db, _ = _agent(tmp_path, "s-orphan")
+        assert db.find_orphaned_compaction_starts("s-orphan") == []
+        db.record_compaction_event("s-orphan", "a1", "start", {"message_count": 3})
+        orphans = db.find_orphaned_compaction_starts("s-orphan")
+        assert len(orphans) == 1 and orphans[0]["attempt_id"] == "a1"
+        # global scan sees it too
+        assert any(r["attempt_id"] == "a1" for r in db.find_orphaned_compaction_starts())
+        # scoping filters
+        assert db.find_orphaned_compaction_starts("other") == []
+        db.record_compaction_event("s-orphan", "a1", "end", {"commit_status": "committed"})
+        assert db.find_orphaned_compaction_starts("s-orphan") == []
+
+    def test_end_without_start_tolerated(self, tmp_path):
+        db, agent = _agent(tmp_path, "s-no-start")
+        # Emitter without a prior start must not create a row (silent no-op).
+        agent._compression_attempt_id = "late123"
+        agent.context_compressor._last_compression_telemetry = {
+            "attempt_id": "late123",
+            "session_id": "s-no-start",
+            "trigger_source": "auto",
+        }
+        _emit_compression_attempt_telemetry(agent, started_at=time.monotonic(), commit_status="aborted", split_status="aborted", failure_class="no_progress")
+        assert db._read_all("SELECT 1 FROM compaction_events WHERE session_id='s-no-start'") == []
+        assert db.find_orphaned_compaction_starts("s-no-start") == []
+
+
+class TestNoFalseOrphansOnEarlyExits:
+    """Post-lease exits must never leave a false orphan (the #104122 defect)."""
+
+    def test_breaker_under_lock_no_orphan(self, tmp_path):
+        db, agent = _agent(tmp_path, "s-breaker")
+        with patch("agent.conversation_compression._automatic_compression_gate_blocks", side_effect=[False, True]):
+            compress_context(agent, _msgs(12), "sys", approx_tokens=99999, force=False)
+        assert db.find_orphaned_compaction_starts("s-breaker") == []
+
+    def test_cooldown_read_failed_no_orphan(self, tmp_path):
+        db, agent = _agent(tmp_path, "s-cooldown")
+        with patch("agent.conversation_compression._capture_authoritative_cooldown_under_lease", return_value=(False, {})):
+            compress_context(agent, _msgs(12), "sys", approx_tokens=99999, force=False)
+        assert db.find_orphaned_compaction_starts("s-cooldown") == []
+
+    def test_parent_rotated_no_orphan(self, tmp_path):
+        db, agent = _agent(tmp_path, "s-rot")
+        with patch("agent.conversation_compression._session_was_rotated_by_compression", return_value=True):
+            with patch("agent.conversation_compression._adopt_live_compression_child", return_value=None):
+                compress_context(agent, _msgs(12), "sys", approx_tokens=99999, force=False)
+        assert db.find_orphaned_compaction_starts("s-rot") == []
+
+    def test_empty_transcript_no_orphan(self, tmp_path):
+        db, agent = _agent(tmp_path, "s-empty")
+        def _empty(messages, **kw):  # triggers _candidate_rejected empty branch (now emitting)
+            return []
+        with patch.object(agent.context_compressor, "compress", side_effect=_empty):
+            compress_context(agent, _msgs(12), "sys", approx_tokens=99999, force=True)
+        rows = db._read_all("SELECT kind FROM compaction_events WHERE session_id='s-empty' ORDER BY id")
+        kinds = [r[0] for r in rows]
+        # start + end (empty_transcript) paired
+        assert kinds.count("start") == 1 and kinds.count("end") == 1
+        assert db.find_orphaned_compaction_starts("s-empty") == []
+
+    def test_no_progress_pairs(self, tmp_path):
+        # A fence-cancelled dispatch returns the transcript unchanged; the
+        # no_progress emit must still close the bracket (review gate #2 rebuttal).
+        db, agent = _agent(tmp_path, "s-noprog")
+        def _same(messages, **kw):
+            return list(messages)
+        with patch.object(agent.context_compressor, "compress", side_effect=_same):
+            compress_context(agent, _msgs(12), "sys", approx_tokens=99999, force=True)
+        rows = db._read_all("SELECT kind FROM compaction_events WHERE session_id='s-noprog' ORDER BY id")
+        kinds = [r[0] for r in rows]
+        assert kinds.count("start") == 1 and kinds.count("end") == 1
+        end_row = db._read_one(
+            "SELECT payload_json FROM compaction_events WHERE session_id='s-noprog' AND kind='end'")
+        assert json.loads(end_row[0])["failure_class"] == "no_progress"
+        assert db.find_orphaned_compaction_starts("s-noprog") == []
+
+
+class TestPayloadAndGuards:
+    def test_payload_bounding(self, tmp_path):
+        db, _ = _agent(tmp_path, "s-cap")
+        huge = {"attempt_id": "x", "session_id": "s-cap", "blob": "y" * 20000}
+        assert db.record_compaction_event("s-cap", "x", "start", huge)
+        row = db._read_one("SELECT payload_json FROM compaction_events WHERE session_id='s-cap' AND attempt_id='x'")
+        payload = json.loads(row[0])
+        assert payload.get("truncated") is True
+        assert len(row[0].encode("utf-8")) <= 9000
+
+    def test_exploding_store_never_raises(self, tmp_path):
+        db, agent = _agent(tmp_path, "s-boom")
+        orig = db._execute_write
+
+        def _boom(fn, patience_s=None):
+            raise Exception("boom")
+
+        db._execute_write = _boom  # type: ignore[method-assign]
+        # record helper is best-effort
+        assert db.record_compaction_event("s-boom", "a1", "start", {}) is False
+        assert db.find_orphaned_compaction_starts("s-boom") == []
+        # compress must still succeed (audit never blocks)
+        db._execute_write = orig  # restore for the real compaction DB writes
+        with patch.object(agent.context_compressor, "compress", side_effect=_compress_small):
+            out, _ = compress_context(agent, _msgs(12), "sys", approx_tokens=50000, force=True)
+            assert len(out) > 0
+
+    def test_no_op_guards(self, tmp_path):
+        db, _ = _agent(tmp_path, "s-guard")
+        assert db.record_compaction_event("", "a", "start", {}) is False
+        assert db.record_compaction_event("s", "", "start", {}) is False
+        assert db.record_compaction_event("s", "a", "bad_kind", {}) is False
+        # no rows leaked
+        assert db._read_all("SELECT 1 FROM compaction_events WHERE session_id='s-guard'") == []
+
+    def test_reader_surface(self, tmp_path):
+        db, agent = _agent(tmp_path, "s-read")
+        with patch.object(agent.context_compressor, "compress", side_effect=_compress_small):
+            compress_context(agent, _msgs(12), "sys", approx_tokens=50000, force=True)
+        events = db.get_compaction_events("s-read", limit=10)
+        assert any(e["kind"] == "start" for e in events)
+        assert any(e["kind"] == "end" for e in events)
+
+    def test_rotation_pairs_under_parent_session(self, tmp_path):
+        """Rotation rebinds agent.session_id to the child; the pair must stay under the start sid."""
+        db, agent = _agent(tmp_path, "s-rot-pair")
+        agent.compression_in_place = False
+        with patch.object(agent.context_compressor, "compress", side_effect=_compress_small):
+            compress_context(agent, _msgs(20), "sys", approx_tokens=50000, force=True)
+        rows = db._read_all(
+            "SELECT session_id, kind FROM compaction_events WHERE attempt_id IN "
+            "(SELECT attempt_id FROM compaction_events WHERE session_id='s-rot-pair') ORDER BY id"
+        )
+        kinds = [(r[0], r[1]) for r in rows]
+        assert ("s-rot-pair", "start") in kinds
+        assert ("s-rot-pair", "end") in kinds
+        assert db.find_orphaned_compaction_starts() == []
+
+    def test_getter_handles_missing_db_method(self, tmp_path):
+        # Stores without the new method (legacy DB, test double) are a silent no-op, never AttributeError.
+        from types import SimpleNamespace
+
+        from agent.conversation_compression import _compaction_audit_db
+
+        assert _compaction_audit_db(SimpleNamespace()) is None
+        assert _compaction_audit_db(SimpleNamespace(_session_db=object())) is None
+
+    def test_no_store_bound_stays_log_only(self, tmp_path):
+        # No session DB at all: the attempt still compacts, telemetry stays log-only, nothing raises.
+        _, agent = _agent(tmp_path, "s-nodb")
+        agent._session_db = None
+        with patch.object(agent.context_compressor, "compress", side_effect=_compress_small):
+            out, _ = compress_context(agent, _msgs(20), "sys", approx_tokens=50000, force=True)
+            assert len(out) < 20


### PR DESCRIPTION
## What does this PR do?

Persists every compression attempt that reaches the summary phase as two append-only rows (`start`/`end`) in a new `compaction_events` table. A crash mid-compaction leaves an orphaned `start` detectable with one query (`find_orphaned_compaction_starts`, global or per-session) instead of forensic log archaeology. Clean runs always pair.

Refs #104099 (partial: metadata-only audit trail; the issue's `summary` text + `shadowed_range` reconstruction is explicitly out of scope — see Exclusions).

## Related Issue

Refs #104099

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `hermes_state_common.py`: `compaction_events` table + 2 indexes in `SCHEMA_SQL` (DDL-only, no migration; existing installs get it on next open).
- `hermes_state_compression.py`: `record_compaction_event` (best-effort, short patience, never raises), `find_orphaned_compaction_starts`, `get_compaction_events` reader surface. Payloads content-free, capped at 8 KiB with a `truncated` marker.
- `agent/conversation_compression.py`: `start` written post-lease (pre-lease breaker/lock/cooldown sit-outs stay log-only, never orphans); `end` via the single telemetry funnel with a per-attempt `(attempt_id, session_id)` arm; arm reset per attempt; `end` reuses the *start* session so rotation never splits the pair; `empty_transcript` branch now emits (it was the one post-lease exit without telemetry).
- `hermes_state_sessions.py` / `hermes_state_maintenance.py`: audit rows ride the existing session delete/prune paths (no FK onto `sessions`).
- `tests/agent/test_compaction_audit_events.py`: 17 tests — pairing (in-place + rotation), orphan detection + scoping, end-without-start tolerated, 4 no-false-orphan exits (breaker/cooldown/parent-rotated/empty), no_progress pairing, payload bounding, exploding-store never raises, guards, reader surface, no-store log-only.
- No new config surface, no knob, no env var. Prompt-cache invariant untouched (observation only, no context mutation).

## How to Test

- `scripts/run_tests.sh tests/agent/test_compaction_audit_events.py tests/agent/test_compression_attempt_telemetry.py tests/agent/test_compression_attempt_lifecycle.py tests/agent/test_compression_orphan_recovery.py tests/agent/test_compression_rotation_state.py` — 78 passed, 0 failed.
- Broader: 23 compression suites (228 passed) + 38 files incl. `tests/hermes_state/` (328 passed) on the same head family; final head re-ran the 5 directly affected suites green.
- Sabotage-checked: deleting the emitter's recorder call fails `test_committed_path_writes_start_and_end_and_no_orphan`; using the live `session_id` at `end` instead of the anchored start sid fails `test_rotation_pairs_under_parent_session`. Both restored → green.

## Exclusions

- No summary text / `shadowed_range` persistence (would break the intentional content-free telemetry policy); reconstruction of "what the model saw at turn N" stays open in #104099, as do #45117/#48404 consumers.
- Codex-owned compactions write no rows (Codex owns that thread; no truthful boundary to record).
- Pre-lease sit-outs (lock contention, breaker gates, cooldown-read, pool-saturated refusals) stay log-only by design — the table records attempts that did work, not every no-op.
- Known residual: a stall-timeout worker whose late result is discarded behind the poison fence leaves a truthful "started, never settled" orphan (rare; diagnosable, not silent). No retention window yet — cleanup rides session deletes; a time-based prune is follow-up work.
- No reader UI (`hermes sessions`/doctor surface); `get_compaction_events` is the API for it.

## Checklist

- [x] I have read the Contributing Guide
- [x] I follow Conventional Commits (`feat(compression): ... (#104099)`)
- [x] I searched for duplicates (#104122 closed unmerged; revived with the 4-exit fix + rotation anchoring)
- [x] I ran the tests above on the pushed head
- [x] I added regression tests (17, bite-proven by sabotage runs)
- [x] No Spanish characters in committed files (`grep -rnE "[áéíóúñ¿¡]"` clean)
- [x] Platform: Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.0 (v2026.9.7), upstream 6e2b8e0
