### PR TITLE
fix(retry): reject non-finite Retry-After values

### DIFF
--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -4,6 +4,7 @@ Jittered delays (vs. fixed exponential) prevent thundering-herd retry spikes
 when many sessions hit the same rate-limited provider concurrently.
 """
 
+import math
 import random
 import threading
 import time
@@ -28,7 +29,7 @@ _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS = 3
 
 def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
     """Parse a ``Retry-After`` value (numeric / HTTP-date) or a headers mapping (both casings tried) into
-    seconds, clamped at 0.0; None when absent / unparseable."""
+    seconds, clamped at 0.0; None when absent, unparseable or non-finite."""
     raw = value_or_headers
     if raw is not None and not isinstance(raw, (str, int, float)):
         getter = getattr(raw, "get", None)
@@ -43,12 +44,17 @@ def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
     if raw is None or isinstance(raw, bool):
         return None
     if isinstance(raw, (int, float)):
-        return max(0.0, float(raw))
+        try:
+            seconds = float(raw)
+        except OverflowError:
+            return None
+        return max(0.0, seconds) if math.isfinite(seconds) else None
     text = str(raw).strip()
     if not text:
         return None
     try:
-        return max(0.0, float(text))
+        seconds = float(text)
+        return max(0.0, seconds) if math.isfinite(seconds) else None
     except (TypeError, ValueError):
         pass
     # HTTP-date form (RFC 7231): seconds until that instant, clamped at 0.

--- a/tests/agent/test_retry_after_nonfinite.py
+++ b/tests/agent/test_retry_after_nonfinite.py
@@ -1,0 +1,43 @@
+"""Invalid cooldown metadata must not replace the original provider error."""
+
+import io
+import json
+from urllib.error import HTTPError
+
+import pytest
+
+from agent.retry_utils import parse_retry_after_seconds
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("inf", None), ("-Infinity", None), ("NaN", None), ("1e9999", None),
+    (float("inf"), None), (float("-inf"), None), (float("nan"), None),
+    pytest.param(10 ** 400, None, id="overflowing-integer"),
+    ("12.5", 12.5), (12, 12.0), ("-3", 0.0), (0, 0.0),
+    ("Wed, 21 Oct 2015 07:28:00 GMT", 0.0),
+])
+def test_retry_after_is_finite_or_absent(raw, expected):
+    for value in (raw, {"Retry-After": raw}, {"retry-after": raw}):
+        assert parse_retry_after_seconds(value) == expected
+
+
+@pytest.mark.parametrize("header", ["inf", "NaN", "1e9999"])
+def test_invalid_retry_after_preserves_http_error_contract(monkeypatch, header):
+    from hermes_cli import auth_codex, nous_billing
+
+    payload = {"error": "rate_limited", "message": "Try later"}
+    headers = {"Retry-After": header}
+
+    def rate_limited(request, **kwargs):
+        raise HTTPError(request.full_url, 429, "Too Many Requests", headers,
+                        io.BytesIO(json.dumps(payload).encode()))
+
+    monkeypatch.setattr(nous_billing, "_resolve_token_and_base",
+                        lambda **kwargs: ("test-token", "https://billing.example.invalid"))
+    monkeypatch.setattr(nous_billing.urllib.request, "urlopen", rate_limited)
+    with pytest.raises(nous_billing.BillingRateLimited) as caught:
+        nous_billing._request("GET", "/billing/state")
+    assert caught.value.status == 429
+    assert caught.value.payload == payload
+    assert caught.value.retry_after is None
+    assert auth_codex._parse_retry_after_seconds(headers) is None


### PR DESCRIPTION
## What does this PR do?

Ignore non-finite or overflowing numeric values in the shared `parse_retry_after_seconds` parser. Python accepts `Retry-After: inf` / `1e9999` as floating-point infinity, but Codex auth and Nous Billing convert the result to integer seconds. That raises `OverflowError` and hides the original HTTP error. NaN currently turns into an apparent zero-second cooldown; a very large integer body hint can also raise during parsing.

Return `None` for these invalid values, preserving each caller's existing absent-header behavior. Finite delays, clamped negative values and HTTP dates continue to work.

## Related issue

Found on main `6e2b8e070d28b1a3381a3fb290b6b8d6cce13cef`; no issue filed. Checked open/closed parser and non-finite Retry-After PRs. #39809 changes exception-hint precedence in the conversation/Gemini paths; its patch does not change this shared parser or its auth/billing callers.

## Type of change

- [x] Bug fix

## How was this tested?

Two invariant tests cover direct values and both header casings, plus the real billing HTTP-error handling path and Codex auth wrapper. Only the HTTP transport/auth boundary is stubbed; the real `HTTPError`, parser and typed-error mapping execute.

- Unpatched main: **11 failed, 5 passed** in the new file, including the actual `OverflowError` from the HTTP-error path.
- Patched: **43 passed** across the new file, retry utilities, billing request, Codex quota and Signal rate-limit tests via `scripts/run_tests.sh`, with retries disabled.
- Ruff, `git diff --check` and compatibility-pointer check passed.

Tests use temporary Hermes state and no live credentials, billing requests or paid API calls. The full repository suite was not run.

## Checklist

- [x] Reproduced on current main and covered with behavioral regressions.
- [x] Shared parser fixes its callers without adding wrapper-specific guards.
- [x] No new configuration, dependency or API.
