### PR TITLE
fix(plugins): expose native MCP calls to memory providers

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -16,7 +16,7 @@ import logging
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 from hermes_cli.config import cfg_get
 from plugins import plugin_loader as _loader
@@ -315,6 +315,17 @@ class _ProviderCollector:
 
     def register_memory_provider(self, provider):
         self.provider = provider
+
+    def call_mcp(
+        self, server: str, tool: str, arguments: Optional[Dict[str, Any]] = None,
+        timeout: float = 30,
+    ) -> Dict[str, Any]:
+        """Use the lifecycle-owned context's MCP connection and per-plugin grants.
+
+        Unlike secondary registration failures, denied or failed calls must reach
+        the provider so it cannot mistake a failed memory operation for success.
+        """
+        return self._plugin_context().call_mcp(server, tool, arguments, timeout=timeout)
 
     def register_skill(self, *args, **kwargs):
         """Forward skills to the plugin registry, tracking qualified name + path so

--- a/tests/plugins/test_memory_provider_call_mcp.py
+++ b/tests/plugins/test_memory_provider_call_mcp.py
@@ -1,0 +1,43 @@
+"""Exclusive memory providers share the native plugin MCP capability gate."""
+
+import pytest
+
+from plugins.memory import load_memory_provider
+
+
+def test_loaded_provider_uses_native_mcp_context(tmp_path, monkeypatch):
+    from tools import mcp_tool_handlers
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "memory:\n  provider: native-memory\n"
+        "plugins:\n  entries:\n    native-memory:\n"
+        "      mcp_allowlist: [memory-server]\n",
+        encoding="utf-8",
+    )
+    plugin = tmp_path / "plugins" / "native-memory"
+    plugin.mkdir(parents=True)
+    plugin.joinpath("__init__.py").write_text(
+        "from types import SimpleNamespace\n"
+        "def register(ctx):\n"
+        "    ctx.register_memory_provider(SimpleNamespace(call=ctx.call_mcp))\n",
+        encoding="utf-8",
+    )
+    calls = []
+
+    def make_handler(server, tool, timeout):
+        def handler(arguments):
+            calls.append((server, tool, timeout, arguments))
+            return '{"result": "stored"}'
+        return handler
+
+    monkeypatch.setattr(mcp_tool_handlers, "_make_tool_handler", make_handler)
+    provider = load_memory_provider("native-memory")
+    assert provider is not None
+    assert provider.call("memory-server", "write_note", {"title": "Remember"}, timeout=42) == {
+        "ok": True, "result": "stored",
+    }
+    assert calls == [("memory-server", "write_note", 42.0, {"title": "Remember"})]
+    with pytest.raises(PermissionError, match="native-memory.mcp_allowlist"):
+        provider.call("ungranted-server", "write_note")
+    assert len(calls) == 1


### PR DESCRIPTION
## Why

An exclusive memory provider that binds `ctx.call_mcp` during `register(ctx)` fails to load: `_ProviderCollector` exposes registration methods but raises `AttributeError` for this existing `PluginContext` capability. Basic Memory is migrating its recall and capture policy to Hermes's native MCP runtime (https://github.com/basicmachines-co/basic-memory/issues/1475), so it needs the same connection lifecycle and per-plugin grants as general plugins.

## Change

Explicitly forward `call_mcp(server, tool, arguments, timeout)` through the collector's existing cached `PluginContext`. Permission and operational errors propagate to the provider. No new transport, tool schema, configuration key, or permission bypass is introduced.

## Validation

The new test loads a temporary external memory provider through real discovery and real configuration, verifies an allowed call reaches the native handler with its arguments and timeout, and verifies an ungranted server is denied before transport. The transport handler is mocked; this PR does not claim a live remote MCP test.

- New regression fails on unmodified main because the provider cannot bind `ctx.call_mcp` and loads as `None`.
- `scripts/run_tests.sh tests/plugins/test_memory_provider_call_mcp.py tests/hermes_cli/test_plugin_call_mcp.py tests/hermes_cli/test_plugin_cli_registration.py tests/plugins/test_memory_hook_registration.py -q`: **24 passed** using the runner's `HERMES_PYTHON` override with an existing development environment.
- `git diff --check`: passed.

The downstream integration will require a supported Hermes release containing this forwarding method before switching its transport.
