### PR TITLE
fix: wrap valid non-object JSON MCP sampling tool arguments as {"_raw": ...}

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2367,6 +2367,28 @@ class TestMalformedToolCallArgs:
         assert isinstance(tc, ToolUseContent)
         assert tc.input == {"_raw": "not valid json {{{"}
 
+
+class TestNonObjectToolCallArgs:
+    @pytest.mark.parametrize("raw", ["[]", "null", "42", "true"])
+    def test_non_object_json_wrapped_as_raw(self, raw):
+        """Valid non-object JSON arguments get wrapped in {"_raw": ...} too."""
+        handler = SamplingHandler("mf", {})
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = _make_llm_tool_response(
+            tool_calls_data=[("call_x", "some_tool", raw)]
+        )
+
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=fake_client.chat.completions.create.return_value,
+        ):
+            result = asyncio.run(handler(None, _make_sampling_params()))
+
+        assert isinstance(result, CreateMessageResultWithTools)
+        tc = result.content[0]
+        assert isinstance(tc, ToolUseContent)
+        assert tc.input == {"_raw": raw}
+
 # ---------------------------------------------------------------------------
 # 12. Metrics tracking
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool_sampling.py
+++ b/tools/mcp_tool_sampling.py
@@ -73,14 +73,22 @@ def _convert_sampling_message(msg) -> List[dict]:
 
 def _parse_tool_call_arguments(server_name: str, args) -> dict:
     """LLM tool_calls arguments -> dict; malformed JSON / non-dicts become ``{"_raw": ...}``, not dropped."""
+    parsed = args
     if isinstance(args, str):
         try:
-            return json.loads(args)
+            parsed = json.loads(args)
         except (json.JSONDecodeError, ValueError):
             logger.warning("MCP server '%s': malformed tool_calls arguments from LLM (wrapping as raw): %.100s",
                            server_name, args)
             return {"_raw": args}
-    return args if isinstance(args, dict) else {"_raw": str(args)}
+    if isinstance(parsed, dict):
+        return parsed
+    logger.warning(
+        "MCP server '%s': non-object tool_calls arguments from LLM (wrapping as raw): %.100s",
+        server_name,
+        args,
+    )
+    return {"_raw": args if isinstance(args, str) else str(args)}
 
 
 class SamplingHandler:


### PR DESCRIPTION
## Summary
- `_parse_tool_call_arguments` (`tools/mcp_tool_sampling.py`) returned `json.loads(args)` verbatim for any syntactically valid JSON string. Valid-but-non-object payloads (`[]`, `null`, `42`, `true`) therefore reached `ToolUseContent.input`, which the MCP SDK types as `dict[str, Any]` — the sampling callback raised a Pydantic `ValidationError` and the MCP server never received its tool-use response.
- Now the parsed result goes through the same dict check that already applied to non-string inputs: valid objects pass through unchanged, any valid non-object value is preserved as `{"_raw": <original>}` (consistent with the existing malformed-JSON behavior) with a matching warning log.
- Regression test `TestNonObjectToolCallArgs` covers all four payloads at the callback level, alongside the existing malformed-JSON test.

## Testing
- `pytest --confcutdir=tests/tools tests/tools/test_mcp_tool.py -q` → 105 passed (101 before + 4 new parameterized cases)
- Mutation check: reverting the fix makes exactly the 4 new cases fail (`Input should be a valid dictionary`), existing suite unaffected.
- `ruff check` clean; `ruff format --diff` shows zero new complaints on touched lines.

Fixes #105551