### PR TITLE
fix(desktop): repair Windows PowerShell SSH lifecycle

### DIFF
--- a/apps/desktop/electron/windows-remote-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.test.ts
@@ -58,6 +58,8 @@ test('Windows spawn publishes the initial ownership record before releasing the 
 
   assert.match(script, /read-lock/)
   assert.match(script, /write-lock/)
+  assert.ok(script.indexOf('$lock|&') >= 0, 'ownership JSON is piped to write-lock stdin')
+  assert.ok(script.indexOf('$lock|&') < script.indexOf("'write-lock'"))
   assert.ok(script.indexOf('write-lock') < script.indexOf('Unlock'))
 })
 
@@ -69,6 +71,53 @@ test('PowerShell transport uses UTF-16LE encoded commands and literal escaping',
   assert.equal(Buffer.from(encodedPowerShell("'ok'"), 'base64').toString('utf16le'), "'ok'")
   assert.equal(psLiteral("a'b"), "'a''b'")
   assert.match(powerShellCommand('Write-Output ok'), /^powershell\.exe -NoProfile -NonInteractive .* -EncodedCommand /)
+})
+
+test('Windows remote commands keep handlers attached to their try blocks', async () => {
+  const decode = command => Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+  const scripts: Array<[string, string]> = []
+
+  await probeWindowsRemote(
+    sshWith(async command => {
+      scripts.push(['platform probe', decode(command)])
+
+      return JSON.stringify({
+        os: 'Windows',
+        arch: 'AMD64',
+        hermesHome: 'C:\\\\Users\\\\alice\\\\.hermes',
+        hermesPath: 'C:\\\\Hermes\\\\hermes.exe',
+        python: 'C:\\\\Hermes\\\\python.exe'
+      })
+    })
+  )
+
+  await assertWindowsRemoteInstallUpdateClear(
+    sshWith(async command => {
+      scripts.push(['update marker probe', decode(command)])
+
+      return 'CLEAR'
+    }),
+    'C:\\\\Users\\\\alice\\\\.hermes'
+  )
+
+  scripts.push([
+    'atomic spawn',
+    decode(
+      atomicWindowsSpawnCommand({
+        hermesHome: 'C:\\\\Users\\\\alice\\\\.hermes',
+        python: 'C:\\\\Users\\\\alice\\\\.hermes\\\\python.exe'
+      })
+    )
+  ])
+
+  for (const [name, script] of scripts) {
+    assert.doesNotMatch(
+      script,
+      /}\s*;\s*(?:catch|finally)\b/,
+      `${name} separates a PowerShell handler from its try block`
+    )
+    assert.doesNotMatch(script, /\$home\s*=/i, `${name} writes PowerShell's read-only $HOME variable`)
+  }
 })
 
 test('Windows relaunch gate refuses live and uncertain markers before executing the remote runtime', async () => {

--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -19,10 +19,14 @@ function powerShellCommand(script) {
   return `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodedPowerShell(script)}`
 }
 
+function powerShellScript(lines) {
+  return lines.join('\n')
+}
+
 async function probeWindowsRemote(ssh, explicitHermesPath = '') {
   const explicit = psLiteral(explicitHermesPath)
 
-  const script = [
+  const script = powerShellScript([
     '$ErrorActionPreference="Stop"',
     'function Assert-NoReparse([string]$candidate,[bool]$allowMissing=$false){',
     'if([string]::IsNullOrWhiteSpace($candidate)){return}',
@@ -63,13 +67,13 @@ async function probeWindowsRemote(ssh, explicitHermesPath = '') {
     '$python=[IO.Path]::Combine([IO.Path]::GetDirectoryName($hermes), "python.exe")',
     'Assert-NoReparse $python $false',
     '[ordered]@{os="Windows";arch=$env:PROCESSOR_ARCHITECTURE;hermesHome=$hermesHome;hermesPath=$hermes;python=$python}|ConvertTo-Json -Compress'
-  ].join(';')
+  ])
 
   return JSON.parse((await ssh.exec(powerShellCommand(script))).trim())
 }
 
 function windowsUpdateMarkerProbeCommand(hermesHome) {
-  const script = [
+  const script = powerShellScript([
     '$ErrorActionPreference="Stop"',
     `Add-Type -TypeDefinition @'
 using System;
@@ -97,9 +101,9 @@ public static class HermesMarkerNoFollow {
     '$parent=$item.Parent.FullName;if(-not $parent -or $parent -eq $current){break};$current=$parent;$first=$false',
     '}',
     '}',
-    `$home=${psLiteral(hermesHome)}`,
-    '$installRoot=$home',
-    '$parent=Split-Path -Parent $home',
+    `$hermesRoot=${psLiteral(hermesHome)}`,
+    '$installRoot=$hermesRoot',
+    '$parent=Split-Path -Parent $hermesRoot',
     'if((Split-Path -Leaf $parent) -ieq "profiles"){$installRoot=Split-Path -Parent $parent}',
     '$marker=Join-Path $installRoot ".hermes-update-in-progress"',
     '$result="UNCERTAIN"',
@@ -127,7 +131,7 @@ public static class HermesMarkerNoFollow {
     '}',
     '}}catch [IO.FileNotFoundException]{$result="CLEAR"}catch{$result="UNCERTAIN"}finally{if($memory){$memory.Dispose()};if($stream){$stream.Dispose()}}',
     'Write-Output $result'
-  ].join(';')
+  ])
 
   return powerShellCommand(script)
 }
@@ -252,9 +256,9 @@ function atomicWindowsSpawnCommand(runtime, reservation: any = {}) {
 
   const script = [
     '$ErrorActionPreference="Stop"',
-    `$home=${psLiteral(runtime.hermesHome)}`,
-    '$installRoot=$home',
-    '$parent=Split-Path -Parent $home',
+    `$hermesRoot=${psLiteral(runtime.hermesHome)}`,
+    '$installRoot=$hermesRoot',
+    '$parent=Split-Path -Parent $hermesRoot',
     'if((Split-Path -Leaf $parent) -ieq "profiles"){$installRoot=Split-Path -Parent $parent}',
     '$marker=Join-Path $installRoot ".hermes-update-in-progress"',
     '$mutexPath=$marker+".mutex"',
@@ -277,15 +281,13 @@ function atomicWindowsSpawnCommand(runtime, reservation: any = {}) {
       : '  if($LASTEXITCODE -ne 0){exit $LASTEXITCODE}',
     reservation.ownershipId
       ? `  $spawned=$spawnLines[-1]|ConvertFrom-Json; $lock=[ordered]@{schemaVersion=2;protocolVersion=1;ownershipId=${psLiteral(reservation.ownershipId)};spawnNonce=${psLiteral(reservation.spawnNonce)};pid=[int]$spawned.pid;creationTimeNs=[string]$spawned.creationTimeNs;port=0;profile=${psLiteral(reservation.profile)};hermesPath=${psLiteral(reservation.hermesPath)};hermesHome=${psLiteral(reservation.hermesHome)};tokenFingerprint=${psLiteral(reservation.tokenFingerprint)};startedAt=${psLiteral(reservation.startedAt)}}|ConvertTo-Json -Compress; ` +
-        `  & ${helper('write-lock').map(psLiteral).join(' ')} ${psLiteral(reservation.ownershipId)} $lock|Out-Null; if($LASTEXITCODE -ne 0){exit $LASTEXITCODE}; $spawnLines|Write-Output`
+        `  $lock|& ${helper('write-lock').map(psLiteral).join(' ')} ${psLiteral(reservation.ownershipId)}|Out-Null; if($LASTEXITCODE -ne 0){exit $LASTEXITCODE}; $spawnLines|Write-Output`
       : '',
     '  if([IO.File]::Exists($marker)){throw "remote update marker claimed during backend spawn"}',
     '}finally{try{$mutex.Unlock(0,1)}catch{};$mutex.Dispose()}'
-  ]
-    .filter(line => line !== '')
-    .join(';')
+  ].filter(line => line !== '')
 
-  return powerShellCommand(script)
+  return powerShellCommand(powerShellScript(script))
 }
 
 async function atomicWindowsSpawn(ssh, runtime, stdinData, reservation: any = {}) {


### PR DESCRIPTION
## Summary

- Build affected Windows SSH PowerShell scripts with newline delimiters so `catch`/`finally` remain syntactically attached to their `try` blocks.
- Replace generated assignments to PowerShell's case-insensitive, read-only `$HOME` automatic variable with `$hermesRoot`.
- Send the ownership lock JSON to `windows_ssh_runtime write-lock` over stdin, matching the helper's dispatch contract.
- Add regression coverage for generated commands: handler boundaries, `$HOME` safety, and the stdin lock-write shape.

## Reproduction

On a Windows 11 remote using Windows PowerShell 5.1, the current `main` generated `try { ... }; catch { ... }`, which PowerShell rejects with `MissingCatchOrFinally`. After resolving that parse error, generated `$home = ...` assignments fail under `ErrorActionPreference=Stop`, and the atomic wrapper passes lock JSON as an extra native argument instead of stdin.

## Verification

- `npm run test:desktop:platforms -- electron/windows-remote-lifecycle.test.ts` — 15 passed.
- `npm exec eslint -- electron/windows-remote-lifecycle.ts electron/windows-remote-lifecycle.test.ts` — clean.
- `npm run typecheck` — clean.
- Generated commands exercised on a real Windows PowerShell 5.1 host: platform probe returned runtime JSON; update-marker gate returned `CLEAR`; the atomic spawn script, including the `$lock | & write-lock` pipeline, parsed successfully.
- `npm run build` compiled the renderer and Electron main bundle successfully; final native `get-windows` staging was blocked when its upstream binary/header downloads reset, unrelated to this diff.