### PR TITLE
fix(agent): scope learned image costs to the full endpoint

### DIFF
--- a/agent/image_token_cost.py
+++ b/agent/image_token_cost.py
@@ -6,7 +6,7 @@ request that carries it, so the cost is observable: with a fresh usage anchor (r
 the previous response), the residual between the next real ``prompt_tokens`` and
 ``anchor + text-only delta`` is the price of the N images that delta introduced (#70328).
 
-The learned value is kept per ``model@host`` in ``~/.hermes/cache/image_token_costs.json`` so a new
+The learned value is kept per model and endpoint in ``~/.hermes/cache/image_token_costs.json`` so a new
 session starts calibrated, and bound per turn through a ContextVar so every estimator
 (preflight trigger, tail-budget walk, gateway hygiene) prices images the same way.
 """
@@ -14,6 +14,7 @@ session starts calibrated, and bound per turn through a ContextVar so every esti
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import logging
 from contextvars import ContextVar
 from typing import Any, Dict, List, Optional
@@ -37,9 +38,11 @@ def _cache_path():
 
 
 def _key(model: Any, base_url: Any) -> str:
-    from utils import base_url_hostname
-
-    return f"{model or ''}@{base_url_hostname(base_url or '') or ''}"
+    # A host can serve different models behind separate ports or proxy paths.
+    # Hash the full endpoint so URL credentials never enter cache keys or logs.
+    # Legacy host-only entries are ambiguous and must be learned again.
+    endpoint = str(base_url or "").strip().rstrip("/")
+    return f"{model or ''}@sha256:{hashlib.sha256(endpoint.encode()).hexdigest()}"
 
 
 def _load() -> None:
@@ -55,7 +58,7 @@ def _load() -> None:
 
 
 def learned_image_token_cost(model: Any, base_url: Any) -> int:
-    """Learned per-image cost for ``model@host``, else the flat default."""
+    """Learned per-image cost for this model and endpoint, else the flat default."""
     _load()
     return _LEARNED.get(_key(model, base_url), DEFAULT_IMAGE_TOKEN_COST)
 

--- a/tests/agent/test_image_token_cost_endpoint.py
+++ b/tests/agent/test_image_token_cost_endpoint.py
@@ -1,0 +1,67 @@
+"""Learned image prices belong to an endpoint, not every server on its host."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent import image_token_cost as itc
+from agent.model_metadata import estimate_messages_tokens_rough
+from agent.usage_anchor import anchored_context_tokens, capture_usage_anchor
+
+
+@pytest.fixture
+def cost_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(itc, "_LEARNED", {})
+    monkeypatch.setattr(itc, "_LOADED", False)
+    with itc.image_cost_context(None):
+        yield itc._cache_path()
+
+
+def _calibrate(endpoint, price):
+    history = [{"role": "user", "content": "start"}, {"role": "assistant", "content": "ok"}]
+    anchor = capture_usage_anchor(10_000, 5, history)
+    image = {"role": "user", "content": [
+        {"type": "text", "text": "look"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+    ]}
+    history.append(image)
+    with itc.image_cost_context(0):
+        text_only = anchored_context_tokens(history, anchor)
+    agent = SimpleNamespace(_usage_anchor=anchor, model="vision-local", base_url=endpoint)
+    return itc.calibrate_from_usage(agent, history, text_only + price), image
+
+
+@pytest.mark.parametrize("first, second", [
+    ("http://localhost:8080/v1", "http://localhost:8081/v1"),
+    ("https://proxy.example/vision-a/v1", "https://proxy.example/vision-b/v1"),
+    ("http://proxy.example/v1", "https://proxy.example/v1"),
+])
+def test_endpoint_prices_survive_reload_and_bind_to_estimators(cost_cache, monkeypatch, first, second):
+    assert _calibrate(first, 4_000)[0] == 4_000
+    assert itc.learned_image_token_cost("vision-local", second) == itc.DEFAULT_IMAGE_TOKEN_COST
+    learned, image = _calibrate(second, 800)
+    assert learned == 800
+
+    # Reload the real cache file as a new process would, then exercise the turn binding.
+    monkeypatch.setattr(itc, "_LEARNED", {})
+    monkeypatch.setattr(itc, "_LOADED", False)
+    estimates = []
+    for endpoint, price in [(first, 4_000), (second, 800)]:
+        assert itc.learned_image_token_cost("vision-local", endpoint + "/") == price
+        itc.bind_image_token_cost(SimpleNamespace(model="vision-local", base_url=endpoint))
+        estimates.append(estimate_messages_tokens_rough([image]))
+    assert estimates[0] - estimates[1] == 4_000 - 800
+
+
+def test_ambiguous_legacy_host_price_is_relearned_without_persisting_url_secrets(cost_cache):
+    cost_cache.parent.mkdir(parents=True)
+    cost_cache.write_text(json.dumps({"vision-local@localhost": 4_000}), encoding="utf-8")
+    endpoint = "http://user:example-password@localhost:8080/v1?token=example-query-token"
+    assert itc.learned_image_token_cost("vision-local", endpoint) == itc.DEFAULT_IMAGE_TOKEN_COST
+    assert _calibrate(endpoint, 800)[0] == 800
+    assert itc.learned_image_token_cost("vision-local", endpoint) == 800
+    persisted = cost_cache.read_text(encoding="utf-8")
+    assert "example-password" not in persisted
+    assert "example-query-token" not in persisted


### PR DESCRIPTION
## What does this PR do?

Keep learned per-image token costs separate for different API endpoints serving the same model ID. The current key is `model@hostname`, so `localhost:8080` and `localhost:8081`, or two model-serving proxy paths on the same domain, reuse and average each other's observations. Subsequent turns and restarted sessions bind that mixed cost into their context estimators.

Key by the model and a digest of the full endpoint instead. Preserve trailing-slash equivalence, while keeping ports, schemes and paths distinct. The digest avoids putting credentials embedded in a URL into the cache or calibration log. Ambiguous legacy host-only entries are not reused; each endpoint learns again from its own usage.

## Related issue

Found on main `520e63661c8eaa2135ebd60a07192f0d8aa45e6e`, in the calibration feature introduced by #104575 / #70328. Searched open/closed PRs for image-token cache keys, endpoints, ports and same-host collisions. #105067 addresses process-wide state shared between profiles; this fixes endpoint identity within a single profile and leaves that PR's state-scoping change independent.

## Type of change

- [x] Bug fix

## How was this tested?

Two invariant tests use a temporary `HERMES_HOME`, the real usage-anchor/calibration functions and actual JSON cache writes/reloads. Different ports, paths and schemes must retain independent prices; after reload, binding each endpoint must produce the corresponding difference in the real context estimator. A legacy-cache case verifies relearning and absence of URL credentials in the new cache keys.

- Unpatched main: **4 failed** in the new file, all at the wrongly reused-price assertion.
- Patched: **20 passed** across endpoint regressions, existing image calibration, multimodal estimator, compressor, usage logging and context breakdown tests, via `scripts/run_tests.sh` with retries disabled.
- Ruff, `git diff --check` and compatibility-pointer check passed.

Usage readings are deterministic test inputs; no live model calls were made. The full repository suite was not run. Existing installations temporarily use the standard image estimate until a fresh eligible response recalibrates the endpoint.

## Checklist

- [x] Reproduced on current main and verified through persistence and estimator binding.
- [x] Related existing work checked; the patch only changes cache identity and regression tests.
- [x] No new tool, setting, dependency or public API.
