### PR TITLE
fix(mcp): normalize non-object sampling arguments

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2367,6 +2367,22 @@ class TestMalformedToolCallArgs:
         assert isinstance(tc, ToolUseContent)
         assert tc.input == {"_raw": "not valid json {{{"}
 
+    @pytest.mark.parametrize("raw", ["[]", "null", "42", "true", '"value"'])
+    def test_non_object_json_wrapped_as_raw(self, raw):
+        """Valid JSON scalars and arrays still satisfy ToolUseContent.input's dict contract."""
+        handler = SamplingHandler("mf", {})
+        response = _make_llm_tool_response(
+            tool_calls_data=[("call_x", "some_tool", raw)]
+        )
+
+        with patch("agent.auxiliary_client.call_llm", return_value=response):
+            result = asyncio.run(handler(None, _make_sampling_params()))
+
+        assert isinstance(result, CreateMessageResultWithTools)
+        tc = result.content[0]
+        assert isinstance(tc, ToolUseContent)
+        assert tc.input == {"_raw": raw}
+
 # ---------------------------------------------------------------------------
 # 12. Metrics tracking
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool_sampling.py
+++ b/tools/mcp_tool_sampling.py
@@ -75,11 +75,12 @@ def _parse_tool_call_arguments(server_name: str, args) -> dict:
     """LLM tool_calls arguments -> dict; malformed JSON / non-dicts become ``{"_raw": ...}``, not dropped."""
     if isinstance(args, str):
         try:
-            return json.loads(args)
+            parsed = json.loads(args)
         except (json.JSONDecodeError, ValueError):
             logger.warning("MCP server '%s': malformed tool_calls arguments from LLM (wrapping as raw): %.100s",
                            server_name, args)
             return {"_raw": args}
+        return parsed if isinstance(parsed, dict) else {"_raw": args}
     return args if isinstance(args, dict) else {"_raw": str(args)}
 
 


### PR DESCRIPTION
## What does this PR do?

MCP sampling converts auxiliary-model tool calls into SDK `ToolUseContent` objects. The SDK requires `ToolUseContent.input` to be a dictionary, but Hermes previously returned `json.loads(arguments)` directly for every valid JSON string. Valid non-object JSON such as arrays, null, numbers, booleans, and strings could raise a Pydantic `ValidationError` and abort the sampling callback.

This change keeps decoded JSON objects unchanged and preserves every non-object value as `{"_raw": original_arguments}`, matching the existing malformed-JSON fallback. The change is limited to sampling response normalization and does not alter tool execution or schemas.

## Related Issue

Fixes #105551

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool_sampling.py`: accept decoded arguments only when they are a dictionary; otherwise retain the original JSON text under `_raw`.
- `tests/tools/test_mcp_tool.py`: cover arrays, null, numbers, booleans, and strings through the full sampling callback while preserving existing object and malformed-JSON behavior.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_mcp_tool.py -q`.
2. Confirm all 106 MCP tests pass, including `test_non_object_json_wrapped_as_raw`.

Additional checks run:

- `.venv/bin/ruff check tools/mcp_tool_sampling.py tests/tools/test_mcp_tool.py`
- `.venv/bin/python -m compileall -q tools/mcp_tool_sampling.py tests/tools/test_mcp_tool.py`
- `git diff --check`

All checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched open and closed issues and PRs for duplicates.
- [x] This PR contains only the MCP sampling fix and its regression coverage.
- [x] I ran the canonical test runner for the affected MCP test file: 106 passed.
- [x] I added regression tests for the bug.
- [x] Tested on macOS 26.5.2 with Python 3.11.15 and MCP SDK 2.0.0.

### Documentation & Housekeeping

- [x] Documentation update: N/A; this restores the documented dictionary contract without changing user-facing behavior.
- [x] `cli-config.yaml.example`: N/A; no configuration changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered: pure Python value normalization with no OS-specific behavior.
- [x] Tool descriptions/schemas: N/A; no tool schema changed.

## Screenshots / Logs

N/A
