### PR TITLE
fix(ssh): detach the closed tar pipe before communicate() drains stderr

### DIFF
--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -265,3 +265,100 @@ class TestSSHBulkUploadEdgeCases:
 
         mock_tar.kill.assert_called_once()
         mock_tar.wait.assert_called_once()
+
+
+class TestSSHBulkUploadWindowsPipes:
+    """`communicate()` must not be handed a stdout we already closed.
+
+    The bulk upload closes tar's stdout so tar sees SIGPIPE if ssh exits
+    early, then calls `communicate()` to drain tar's stderr so a large error
+    stream can't deadlock the pipe. Both intents are right; the combination is
+    only accidentally safe on POSIX.
+
+    CPython's `communicate()` differs by platform. The POSIX branch guards
+    with `not self.stdout.closed` and skips the stream. The Windows branch
+    starts one reader thread per non-None stream with no such check, and that
+    thread calls `fh.read()` on the closed pipe -- `ValueError: read of closed
+    file`.
+
+    The exception dies inside the reader thread, so the upload still succeeds
+    and tar still exits 0. What it produces is a traceback on every bulk
+    upload plus a dead thread: noise that buries the real failure the next
+    time something actually breaks. Measured on a Windows host driving a macOS
+    peer, 2026-09-07 -- nine tracebacks in a single run.
+
+    The existing tests here cannot catch this: their pipes are plain
+    MagicMocks, which have no notion of being closed. This one models the
+    close and makes `communicate()` behave the way CPython does on Windows.
+    """
+
+    def test_tar_stdout_is_detached_before_communicate(self, mock_env, tmp_path):
+        f1 = tmp_path / "a.txt"
+        f1.write_text("aaa")
+        files = [(str(f1), "/home/testuser/.hermes/skills/a.txt")]
+
+        mock_run = MagicMock(return_value=subprocess.CompletedProcess([], 0))
+        procs = []
+
+        def make_proc(cmd, **kwargs):
+            m = MagicMock()
+            stdout = MagicMock()
+            stdout.closed = False
+
+            def _close():
+                stdout.closed = True
+
+            stdout.close.side_effect = _close
+            m.stdout = stdout
+            m.returncode = 0
+            m.poll.return_value = 0
+            m.stderr = MagicMock()
+            m.stderr.read.return_value = b""
+
+            def _communicate(*a, **k):
+                # What CPython does on Windows: a reader thread is started for
+                # any non-None stream, and reading a closed pipe raises.
+                if m.stdout is not None and getattr(m.stdout, "closed", False):
+                    raise ValueError("read of closed file")
+                return (b"", b"")
+
+            m.communicate.side_effect = _communicate
+            procs.append(m)
+            return m
+
+        with patch.object(subprocess, "run", mock_run), \
+             patch.object(subprocess, "Popen", side_effect=make_proc):
+            mock_env._ssh_bulk_upload(files)
+
+        tar_proc = procs[0]
+        assert tar_proc.stdout is None, (
+            "tar's stdout was closed but still referenced when communicate() "
+            "ran; on Windows that starts a reader thread against a closed pipe."
+        )
+
+    def test_the_pipe_is_still_closed_so_tar_can_see_sigpipe(self, mock_env, tmp_path):
+        """Detaching must not replace closing -- the original intent stands."""
+        f1 = tmp_path / "a.txt"
+        f1.write_text("aaa")
+        files = [(str(f1), "/home/testuser/.hermes/skills/a.txt")]
+
+        closed = []
+        mock_run = MagicMock(return_value=subprocess.CompletedProcess([], 0))
+
+        def make_proc(cmd, **kwargs):
+            m = MagicMock()
+            stdout = MagicMock()
+            stdout.close.side_effect = lambda: closed.append(True)
+            m.stdout = stdout
+            m.returncode = 0
+            m.poll.return_value = 0
+            m.communicate.return_value = (b"", b"")
+            m.stderr = MagicMock()
+            m.stderr.read.return_value = b""
+            return m
+
+        with patch.object(subprocess, "run", mock_run), \
+             patch.object(subprocess, "Popen", side_effect=make_proc):
+            mock_env._ssh_bulk_upload(files)
+
+        assert closed, "tar's stdout must still be closed, not merely detached"

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -214,6 +214,23 @@ class SSHEnvironment(BaseEnvironment):
                 tar_proc.wait()
                 raise
             tar_proc.stdout.close()  # let tar_proc receive SIGPIPE if ssh_proc exits early
+            # Detach the pipe we just closed. `communicate()` below drains
+            # tar's stderr, and on Windows CPython starts one reader thread per
+            # non-None stream without checking whether it is closed
+            # (`subprocess.py::_readerthread` -> `fh.read()`), which raises
+            # `ValueError: read of closed file` inside that thread. The POSIX
+            # branch guards with `not self.stdout.closed`; the Windows branch
+            # has no such check. That is why this never surfaces on macOS or
+            # Linux.
+            #
+            # Scope of the damage: the exception does not reach the caller. It
+            # kills only the reader thread, and the upload itself still
+            # succeeds (tar exits 0). What it does is print a traceback on
+            # every bulk upload and leave a dead thread behind. Measured on a
+            # Windows host driving a macOS peer, 2026-09-07: nine tracebacks in
+            # one run, none of them fatal, all of them noise that buries the
+            # real failure when something else goes wrong.
+            tar_proc.stdout = None
             try:
                 _, ssh_stderr = ssh_proc.communicate(timeout=120)
                 # communicate() (not wait()) drains stderr so tar can't deadlock on >PIPE_BUF errors.


### PR DESCRIPTION
`_ssh_bulk_upload` closes tar's stdout so tar sees `SIGPIPE` if ssh exits early, then calls `communicate()` so a large stderr stream can't deadlock the pipe. Both intents are right. The combination is only accidentally safe on POSIX.

CPython's `communicate()` differs by platform:

| | guard | result |
|---|---|---|
| POSIX (`subprocess.py`, `_communicate`) | `if self.stdout and not self.stdout.closed` | closed stream is skipped |
| Windows (`subprocess.py`, `_communicate`) | `if self.stdout and not hasattr(self, "_stdout_buff")` | starts `_readerthread` → `fh.read()` |

So on Windows the reader thread reads the pipe we just closed:

```
Traceback (most recent call last):
  ...
  File "subprocess.py", line ..., in _readerthread
    buffer.append(fh.read())
ValueError: read of closed file
```

That is why this has never surfaced on macOS or Linux.

### Scope of the damage

The exception does **not** reach the caller — it dies inside the reader thread, so the upload still completes and `tar` still exits 0. What it produces is a traceback on every bulk upload plus a dead thread.

Measured on a Windows host driving a macOS peer (2026-09-07): nine tracebacks in a single run, none of them fatal, all of them noise that buried the real cause when that run later failed for an unrelated reason. That is the actual cost — not a broken upload, but a log you can no longer read.

### The change

One line: set `stdout` to `None` after closing it.

Both original intents survive. The pipe is still closed, so tar still sees `SIGPIPE`. `communicate()` still drains stderr, so the deadlock the comment warns about is still prevented. It simply no longer starts a thread against a stream that is gone.

Alternatives considered and rejected:

- **Move the close after `communicate()`** — tar can then block forever writing to a pipe nobody reads.
- **Use `wait()` plus a direct `stderr.read()`** — reintroduces exactly the `PIPE_BUF` deadlock `communicate()` is there to avoid.

### Tests

The existing tests in this file could not catch it: their pipes are plain `MagicMock`s, which have no notion of being closed. Two tests are added.

- One models the close and makes `communicate()` raise the way CPython does on Windows, then asserts `tar_proc.stdout is None`.
- The other pins the opposite direction: removing the `close()` and keeping only the detach fails the suite, so the `SIGPIPE` intent cannot be dropped by accident later.

Both mutations were verified to fail the suite, with the source restored and checked by hash afterwards.

Regression check: `tests/tools -k "ssh or environment or file_sync"` on this branch and on `main` — the same 2 pre-existing failures with identical node ids on both, and `passed` 310 vs 308, a difference of exactly the 2 tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
