### PR TITLE
fix(computer_use): stop inferring bounds_scale from raw UIA frames on space mismatch

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2503,33 +2503,35 @@ class TestCapturePayloadBudget:
 class TestBoundsSpaceNote:
     def test_note_present_when_bounds_exceed_image(self):
         from tools.computer_use.backend import UIElement
-        from tools.computer_use.tool import _bounds_space_note
+        from tools.computer_use.tool import _bounds_hints
 
         # Live repro: 1455x791 screenshot, element bounds out to x=3840
-        # (native 4K desktop space).
+        # (raw desktop space). The mismatch must stay a warning — no scale
+        # inference, and the note steers back to element indices/screenshot.
         elems = [UIElement(index=0, role="Button", label="Close",
                            bounds=(3771, 0, 69, 60), app="")]
-        note = _bounds_space_note(elems, 1455, 791)
+        note = _bounds_hints(elems, 1455, 791)
         assert note is not None
-        assert "native desktop coordinates" in note
+        assert "cannot be converted to screenshot pixels" in note
+        assert "do not copy, subtract, or scale raw element bounds" in note
 
     def test_no_note_when_spaces_match(self):
         from tools.computer_use.backend import UIElement
-        from tools.computer_use.tool import _bounds_space_note
+        from tools.computer_use.tool import _bounds_hints
 
         elems = [UIElement(index=0, role="Button", label="OK",
                            bounds=(10, 10, 50, 20), app="")]
-        assert _bounds_space_note(elems, 1455, 791) is None
+        assert _bounds_hints(elems, 1455, 791) is None
 
     def test_no_note_for_empty_or_degenerate(self):
         from tools.computer_use.backend import UIElement
-        from tools.computer_use.tool import _bounds_space_note
+        from tools.computer_use.tool import _bounds_hints
 
-        assert _bounds_space_note([], 1455, 791) is None
+        assert _bounds_hints([], 1455, 791) is None
         zero = [UIElement(index=0, role="B", label="x",
                           bounds=(0, 0, 0, 0), app="")]
-        assert _bounds_space_note(zero, 1455, 791) is None
-        assert _bounds_space_note(zero, 0, 0) is None
+        assert _bounds_hints(zero, 1455, 791) is None
+        assert _bounds_hints(zero, 0, 0) is None
 
 
 class TestElementSpillFile:
@@ -2646,28 +2648,49 @@ class TestCaptureScreenshotPersistence:
         assert len(captures) == 2
 
 
-class TestBoundsScaleField:
-    def test_scale_reported_when_spaces_diverge(self, tmp_path, monkeypatch):
+class TestBoundsScaleRemoved:
+    """A raw-bounds/screenshot space mismatch must never expose a bounds_scale: the
+    schema's coordinate= is window-local screenshot pixels and no linear conversion
+    from raw UIA frames exists (offset/clipping/stale geometry also diverge)."""
+    def test_no_scale_reported_when_spaces_diverge(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         from tools.computer_use.backend import CaptureResult, UIElement
         from tools.computer_use.tool import _capture_response
 
-        # Live repro geometry: 1455x791 screenshot, native bounds to 3799.
+        # Live repro geometry: 1455x791 screenshot, raw bounds to 3799. A space
+        # mismatch must not leak a bounds_scale or scale-derived guidance.
         elems = [UIElement(index=0, role="Button", label="Close",
                            bounds=(3730, 0, 69, 60), app="")]
         cap = CaptureResult(mode="som", width=1455, height=791, png_b64=None,
                             elements=elems, app="chrome.exe",
                             window_title="", png_bytes_len=0)
         out = json.loads(_capture_response(cap))
-        assert out["bounds_scale"] == pytest.approx(3799 / 1455, abs=0.01)
-        assert f"~{out['bounds_scale']}x" in out["summary"]
+        assert "bounds_scale" not in out
+        assert "estimated scale" not in out["summary"]
+        assert "cannot be converted to screenshot pixels" in out["summary"]
 
-    def test_no_scale_when_spaces_match(self):
+    def test_multimodal_meta_has_no_scale_when_spaces_diverge(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.computer_use.backend import CaptureResult, UIElement
+        from tools.computer_use import tool as cu_tool
+
+        fake_png = "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nGNgGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+        elems = [UIElement(index=0, role="Button", label="Close",
+                           bounds=(3730, 0, 69, 60), app="")]
+        cap = CaptureResult(mode="som", width=1455, height=791, png_b64=fake_png,
+                            elements=elems, app="chrome.exe",
+                            window_title="", png_bytes_len=100)
+        with patch.object(cu_tool, "_should_route_through_aux_vision", return_value=False):
+            out = cu_tool._capture_response(cap)
+        assert out["_multimodal"] is True
+        assert "bounds_scale" not in out["meta"]
+
+    def test_no_note_when_spaces_match(self):
         from tools.computer_use.backend import UIElement
-        from tools.computer_use.tool import _bounds_scale
+        from tools.computer_use.tool import _bounds_hints
 
         elems = [UIElement(index=0, role="Button", label="OK",
                            bounds=(10, 10, 50, 20), app="")]
-        assert _bounds_scale(elems, 1455, 791) is None
-        assert _bounds_scale([], 1455, 791) is None
-        assert _bounds_scale(elems, 0, 0) is None
+        assert _bounds_hints(elems, 1455, 791) is None
+        assert _bounds_hints([], 1455, 791) is None
+        assert _bounds_hints(elems, 0, 0) is None

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -472,13 +472,14 @@ def _format_elements(elements: List[UIElement], max_lines: int = 40) -> List[str
            + (f" [{e.app}]" if e.app else "") for e in elements[:max_lines]]
     return out + ([f"  ... +{len(elements) - max_lines} more (call capture with app= to narrow)"] if len(elements) > max_lines else [])
 
-def _bounds_hints(elements: List[UIElement], image_width: int, image_height: int) -> Tuple[Optional[float], Optional[str]]:
-    """(scale, note) when element bounds live in a different coordinate space than the screenshot, else (None, None).
-    On HiDPI displays AX bounds are native while the screenshot is downscaled, so coordinate= clicks read off the
-    screenshot miss by the scale factor. 5% slack: window chrome can hang a few px past the captured frame without
-    implying a different space. Scale heuristic: larger axis ratio wins."""
+def _bounds_hints(elements: List[UIElement], image_width: int, image_height: int) -> Optional[str]:
+    """Warning note when element bounds live in a different coordinate space than the screenshot, else None.
+    A mismatch proves only that raw bounds are not directly usable (desktop/window offset, clipping, stale
+    geometry, or a different DPI space) — it does not establish any conversion to screenshot pixels, so no
+    scale is inferred and the note steers the model back to element indices / the screenshot itself.
+    5% slack: window chrome can hang a few px past the captured frame without implying a different space."""
     if not elements or image_width <= 0 or image_height <= 0:
-        return None, None
+        return None
     max_x = max_y = 0
     for e in elements:
         try:
@@ -487,14 +488,11 @@ def _bounds_hints(elements: List[UIElement], image_width: int, image_height: int
             continue
         max_x, max_y = max(max_x, int(x) + int(w)), max(max_y, int(y) + int(h))
     if max_x <= image_width * 1.05 and max_y <= image_height * 1.05:
-        return None, None
-    note = (f"element bounds are in native desktop coordinates (extend to ~{max_x}x{max_y}), "
-            f"NOT screenshot pixels ({image_width}x{image_height}). coordinate= clicks expect the native "
-            "space — derive click points from element bounds, or scale screenshot positions up accordingly")
-    return round(max(max_x / image_width, max_y / image_height), 2), note
-
-_bounds_scale = lambda elements, image_width, image_height: _bounds_hints(elements, image_width, image_height)[0]  # noqa: E731
-_bounds_space_note = lambda elements, image_width, image_height: _bounds_hints(elements, image_width, image_height)[1]  # noqa: E731
+        return None
+    return (f"element bounds are in a different coordinate space than the screenshot (extend to ~{max_x}x{max_y} "
+            f"vs {image_width}x{image_height}) and cannot be converted to screenshot pixels. coordinate= expects "
+            "window-local screenshot pixels — use a fresh element index or pick the point from the screenshot; "
+            "do not copy, subtract, or scale raw element bounds")
 
 def _capture_view(cap: CaptureResult, max_elements: int) -> SimpleNamespace:
     """One capture's derived facts, computed once for every response branch: ``visible`` is the capped element list,
@@ -503,13 +501,13 @@ def _capture_view(cap: CaptureResult, max_elements: int) -> SimpleNamespace:
     with contextlib.suppress(Exception):  # (width, height) of the inline PNG/JPEG screenshot, else the backend's
         dims = image_dimensions_from_bytes(base64.b64decode(cap.png_b64, validate=False)) if cap.png_b64 else None
     width, height = dims or (cap.width, cap.height)
-    scale, note = _bounds_hints(visible, width, height)
+    note = _bounds_hints(visible, width, height)
     # Capped labels / capped element array: spill the complete tree for on-demand reads.
     lost_detail = len(cap.elements) > len(visible) or any(len(e.label) > _MAX_ELEMENT_LABEL_CHARS for e in visible)
     too_small = bool(dims) and min(dims) < _MIN_PROVIDER_IMAGE_DIMENSION
     has_image = bool(cap.png_b64) and cap.mode != "ax" and not too_small
     return SimpleNamespace(cap=cap, visible=visible, total=len(cap.elements), width=width, height=height,
-                           truncated=len(cap.elements) - len(visible), bounds_scale=scale, bounds_note=note,
+                           truncated=len(cap.elements) - len(visible), bounds_note=note,
                            elements_file=_spill_elements_to_file(cap) if lost_detail else None,
                            screenshot_path=_persist_capture_image(cap) if has_image else None,
                            dims_omitted=dims if too_small else None, has_image=has_image)
@@ -518,8 +516,7 @@ def _capture_summary_lines(v: SimpleNamespace) -> List[str]:
     """Human-readable capture summary; line ORDER is contract. Lists only what `elements` surfaces, otherwise the
     summary names indices the model can't find."""
     notes = (
-        v.bounds_note and v.bounds_note + (f"; estimated scale ~{v.bounds_scale}x (screenshot position x "
-                                           f"{v.bounds_scale} ≈ native coordinate)" if v.bounds_scale else ""),
+        v.bounds_note,
         v.screenshot_path and f"shareable screenshot saved to {v.screenshot_path}",
         v.cap.note,
         v.elements_file and (f"full element tree with untruncated labels saved to {v.elements_file} — "
@@ -542,8 +539,7 @@ def _text_capture_payload(v: SimpleNamespace, summary: str, extra: Optional[Dict
         "mode": v.cap.mode, "width": v.width, "height": v.height, "app": v.cap.app, "window_title": v.cap.window_title,
         "elements": [_element_to_dict(e) for e in v.visible], "total_elements": v.total, "summary": summary,
         **(extra or {}),
-        **_present(truncated_elements=v.truncated, elements_file=v.elements_file, screenshot_path=v.screenshot_path,
-                   bounds_scale=v.bounds_scale),
+        **_present(truncated_elements=v.truncated, elements_file=v.elements_file, screenshot_path=v.screenshot_path),
     })
 
 def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEMENTS) -> Any:
@@ -560,7 +556,7 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
                             {"type": "image_url", "image_url": {"url": f"data:{_capture_image_format(cap)[0]};base64,{cap.png_b64}"}}],
                 "text_summary": summary,
                 "meta": {"mode": cap.mode, "width": v.width, "height": v.height, "elements": v.total, "png_bytes": cap.png_bytes_len,
-                         **_present(screenshot_path=v.screenshot_path, elements_file=v.elements_file, bounds_scale=v.bounds_scale)},
+                         **_present(screenshot_path=v.screenshot_path, elements_file=v.elements_file)},
             }
         # Decide whether to hand the screenshot to the auxiliary.vision pipeline (text-only result) or keep
         # the multimodal envelope (main model handles vision natively). Issue #24015: previously the
@@ -742,7 +738,7 @@ def _route_capture_through_aux_vision(cap: CaptureResult, summary: str, *, visib
     # exactly for non-vision main models. Dimensions are the backend's on this branch.
     view = SimpleNamespace(cap=cap, visible=cap.elements if visible_elements is None else visible_elements,
                            total=len(cap.elements), width=cap.width, height=cap.height, truncated=truncated_elements,
-                           elements_file=elements_file, screenshot_path=screenshot_path, bounds_scale=None)
+                           elements_file=elements_file, screenshot_path=screenshot_path)
     return _text_capture_payload(view, summary, {"vision_analysis": analysis_text,
                                                  "vision_analysis_routed_via": "auxiliary.vision"})
 


### PR DESCRIPTION
## What does this PR do?

On Windows, when raw UIA element bounds exceed the captured screenshot's dimensions, `_bounds_hints()` in `tools/computer_use/tool.py` inferred a "native desktop" coordinate space, emitted a `bounds_scale` factor, and told the model that `coordinate=` clicks expect the native space — "derive click points from element bounds, or scale screenshot positions up accordingly".

That guidance contradicts Hermes's own schema: `coordinate` is defined as *"Pixel coordinates [x, y] relative to the captured window screenshot (top-left origin)"* (`tools/computer_use/schema.py`). A raw-bounds/screenshot mismatch can be a desktop/window offset, clipping, stale geometry, or a different DPI space — it proves only that the raw bounds are not directly usable; it does not establish a linear conversion. In the issue's repro, the real relationship was an offset (window origin `(128, 81)`), so the suggested scaling sent clicks to the wrong global position.

This PR makes the mismatch a conservative warning instead: keep the observed geometry facts (raw extent vs screenshot size), drop the scale factor entirely, and steer the model back to safe paths — a fresh element index, or a point picked directly from the screenshot. `bounds_scale` is removed from every capture response branch (text payload, multimodal `meta`, aux-vision view) along with the `_bounds_scale`/`_bounds_space_note` lambdas.

## Related Issue

Fixes #105560

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/tool.py` — `_bounds_hints()` now returns only `Optional[str]` (the warning note); no scale is computed or returned on a space mismatch, and the note explicitly forbids copying/subtracting/scaling raw bounds.
- `tools/computer_use/tool.py` — removed the `_bounds_scale` / `_bounds_space_note` lambdas and the dead "estimated scale ~Xx" summary suffix; dropped `bounds_scale` from `_capture_view`, `_capture_summary_lines`, `_text_capture_payload`, the multimodal envelope `meta`, and the aux-vision routed view.
- `tests/tools/test_computer_use.py` — `TestBoundsSpaceNote` asserts the new note text (no scale-derived guidance); `TestBoundsScaleField` becomes `TestBoundsScaleRemoved` asserting `bounds_scale` is absent from both the text payload and the multimodal `meta` after a mismatched raw frame.

## How to Test

1. `pytest tests/tools/test_computer_use.py -q` — Observed result: 101 passed (baseline 100 + 1 new multimodal regression).
2. `pytest tests/tools/test_computer_use.py -q -k "TestBoundsSpaceNote or TestBoundsScaleRemoved"` — Observed result: 6 passed; the mismatch note contains "cannot be converted to screenshot pixels" / "do not copy, subtract, or scale raw element bounds" and neither the text payload nor the multimodal `meta` exposes `bounds_scale`.
3. `ruff check tools/computer_use/tool.py tests/tools/test_computer_use.py` — Observed result: All checks passed.

The full flow is unit-tested via `CaptureResult` fixtures (the issue's 230x156-screenshot vs desktop-bounds geometry class); no live Windows session is needed to verify the response-contract assertions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the changed code path is platform-neutral (Windows-specific geometry is covered by fixtures)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] N/A — I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] N/A — I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the bug is Windows-reported; the fix removes incorrect cross-platform guidance and the note wording is platform-neutral
- [ ] N/A — I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — text-only capture metadata change; see the test assertions for the before/after contract.
