### PR TITLE
fix(desktop): keep group chat replies visible in arrival order

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "hermes",
   "productName": "Hermes",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Native desktop shell for Hermes Agent.",
   "author": "Nous Research",
   "repository": {

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-timeline.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-timeline.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { translateBots } from './i18n-test-helper'
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { pluginSdkMock, createGroupGateway } = await import('./group-test-utils')
+  const base = await pluginSdkMock(createGroupGateway().host)
+
+  const Button = ({ children, onClick, title }: { children?: ReactNode; onClick?: () => void; title?: string }) => (
+    <button onClick={onClick} title={title}>
+      {children}
+    </button>
+  )
+
+  return {
+    ...base,
+    Button,
+    RowButton: Button,
+    cn: (...values: unknown[]) => values.filter(Boolean).join(' '),
+    Codicon: () => null,
+    CopyButton: () => null,
+    ConfirmDialog: () => null,
+    Dialog: () => null,
+    DialogContent: () => null,
+    DialogDescription: () => null,
+    DialogFooter: () => null,
+    DialogHeader: () => null,
+    DialogTitle: () => null,
+    Input: () => null,
+    Tip: ({ children }: { children: ReactNode }) => children,
+    relativeTime: () => 'now',
+    useI18n: () => ({ t: { common: { cancel: 'Cancel', save: 'Save' } } }),
+    usePluginI18n: () => translateBots
+  }
+})
+vi.mock('./avatar', () => ({ avatarColor: () => '#888', botAppearance: () => ({}), BotFace: () => null }))
+vi.mock('./group-chat-parts', () => ({
+  GroupClarifyCard: () => null,
+  GroupImageControls: () => null,
+  GroupMentionInput: () => null
+}))
+afterEach(cleanup)
+
+it('keeps every public member reply readable in room arrival order across interleaved threads', async () => {
+  Element.prototype.scrollIntoView = vi.fn()
+  const { $groupChats } = await import('./group-chat')
+  const { GroupChatWorkspace } = await import('./group-chat-view')
+
+  const log = [
+    { id: 'u1', thread: 'a', from: { kind: 'user' as const, name: 'You' }, text: 'Build request', at: 1 },
+    { id: 'm1', thread: 'a', from: { kind: 'member' as const, name: 'Builder' }, text: 'Build complete', at: 2 },
+    { id: 'u2', thread: 'b', from: { kind: 'user' as const, name: 'You' }, text: 'Release request', at: 3 },
+    { id: 'm2', thread: 'a', from: { kind: 'member' as const, name: 'Reviewer' }, text: 'QA complete', at: 4 },
+    { id: 'm3', thread: 'b', from: { kind: 'member' as const, name: 'Lead' }, text: 'Release ready', at: 5 }
+  ]
+
+  $groupChats.set({ Room: { log, watermarks: {}, sessions: {} } })
+  const { container } = render(<GroupChatWorkspace group="Room" members={[]} />)
+  const text = container.textContent || ''
+  let previous = -1
+
+  for (const entry of log) {
+    const index = text.indexOf(entry.text)
+    expect(index, `${entry.from.name}: ${entry.text} must remain visible in arrival order`).toBeGreaterThan(previous)
+    expect(text.split(entry.text)).toHaveLength(2)
+    previous = index
+  }
+
+  for (const name of ['Builder', 'Reviewer', 'Lead']) {
+    expect(text).toContain(name)
+  }
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -96,7 +96,7 @@ import type { GroupComposerDraft, GroupDraftSetter } from './group-panes'
 import { sendToGroupChat, stopGroupThread } from './group-rounds'
 import { clearGroupClarify } from './group-turns'
 import { botsText, useBots } from './i18n'
-import { displayName, slugify, stripPreviewMarkdown } from './labels'
+import { displayName, slugify } from './labels'
 import { botRosterMeta, setBotsWorkspaceOwner } from './routing'
 import { bumpBotOpenGeneration, getPluginCtx, ID } from './shared'
 import type { Attachment, BotMeta, GroupChat, GroupMember, GroupMessage, RosterRow } from './types'
@@ -449,13 +449,6 @@ function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }: G
 // work. Member turns are scoped to the thread that triggered them — deltas,
 // watermarks, and responder resolution all key on the thread id.
 
-/** One thread's slice of the room log, with each entry's index in that log. */
-interface GroupThreadBucket {
-  entries: Array<{ entry: GroupMessage; index: number }>
-  id: string
-  startIndex: number
-}
-
 interface GroupChatWorkspaceProps {
   group: string
   members: GroupMember[]
@@ -524,12 +517,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
   // @handle (the roster's name-device form when names collide across
   // connections). Naturally every speaker just shows its display name.
   const [revealedSpeaker, setRevealedSpeaker] = useState<null | string>(null)
-  // Threads, the Slack/Discord shape: entries carry a thread id. The most
-  // recently active thread renders open; older ones collapse to summary rows.
-  // `openThreads` is the user's explicit expand/collapse overrides, and
-  // `replyThread` is the thread whose reply box currently owns the composer
-  // (null = the main composer, which STARTS a new thread).
-  const [openThreads, setOpenThreads] = useState<Record<string, boolean>>({})
+  // Thread replies retain their own draft; the main composer starts a new topic.
   // Pending image attachments per composer: `null` thread key = the main
   // composer, otherwise the reply box of that thread. Data URLs, already
   // downscaled — they ride the send into every responding member's session.
@@ -826,12 +814,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
     // connection fields so their turns route to their own machines.
     const minted = sendToGroupChat(group, memberDescriptors(), text, null, images)
 
-    if (minted) {
-      setOpenThreads(prev => ({
-        ...prev,
-        [minted]: true
-      }))
-    } else {
+    if (!minted) {
       const restored = restoreGroupComposerDraft(composerKeyRef.current, cleared.revision, before)
 
       if (restored) {
@@ -866,12 +849,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
     // scoped to it.
     const sent = sendToGroupChat(group, memberDescriptors(), text, thread, images)
 
-    if (sent) {
-      setOpenThreads(prev => ({
-        ...prev,
-        [thread]: true
-      }))
-    } else {
+    if (!sent) {
       const restored = restoreGroupComposerDraft(composerKeyRef.current, cleared.revision, before)
 
       if (restored) {
@@ -1061,100 +1039,23 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
     )
   }
 
-  // Threads: group entries by thread id (hydration assigned legacy ids, but
-  // guard live pre-thread entries too), ordered by last activity — oldest
-  // first, so the busiest/newest thread sits at the bottom by the composer.
-  // The most recently ACTIVE thread renders open; older ones collapse to a
-  // Slack-style summary row unless explicitly opened. Every open thread gets
-  // its own reply box, which continues THAT thread.
-  const threadsById = new Map<string, GroupThreadBucket>()
-
-  for (let i = 0; i < room.log.length; i++) {
-    const entry = room.log[i]
-    const id = groupThreadOf(entry)
-    let bucket = threadsById.get(id)
-
-    if (!bucket) {
-      bucket = {
-        entries: [],
-        id,
-        startIndex: i
-      }
-      threadsById.set(id, bucket)
-    }
-
-    bucket.entries.push({
-      entry,
-      index: i
-    })
-  }
-
-  const threads = [...threadsById.values()].sort(
-    (a, b) => (a.entries[a.entries.length - 1].entry.at || 0) - (b.entries[b.entries.length - 1].entry.at || 0)
-  )
-
-  const newestThread = threads.length ? threads[threads.length - 1].id : null
+  // The public room is one arrival-ordered conversation. Thread ids scope
+  // replies and prompts, not visibility: a newer topic must never hide a
+  // member's completed answer or move it ahead of intervening messages.
+  const threadEnds = new Map<string, number>()
+  room.log.forEach((entry, index) => threadEnds.set(groupThreadOf(entry), index))
   const logChildren: ReactNode[] = []
-  threads.forEach(threadBucket => {
-    const { entries, id } = threadBucket
-    const head = entries.find(({ entry }) => entry.from.kind === 'user')?.entry || entries[0].entry
-    const isNewest = id === newestThread
-    const expanded = openThreads[id] ?? isNewest
+  room.log.forEach((entry, index) => {
+    logChildren.push(renderEntry(entry, index))
+    const id = groupThreadOf(entry)
 
-    if (!expanded) {
-      const replies = entries.length - 1
-      const headText = stripPreviewMarkdown(head?.text || '').slice(0, 80)
-      logChildren.push(
-        <RowButton
-          className="flex w-full items-center gap-2 rounded-md border border-(--ui-stroke-secondary) px-2 py-1.5 text-left text-xs text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover)"
-          key={`fold:${id}`}
-          onClick={() =>
-            setOpenThreads(prev => ({
-              ...prev,
-              [id]: true
-            }))
-          }
-          title={b.group.openThread}
-        >
-          <Codicon className="shrink-0 text-[0.65rem]" name="chevron-right" />
-          <span className="min-w-0 flex-1 truncate">{headText || b.group.threadFallback}</span>
-          <span className="shrink-0 text-[0.625rem] text-(--ui-text-quaternary)">{`${b.group.replyCount(replies)} · ${relativeTime(entries[entries.length - 1].entry.at)}`}</span>
-        </RowButton>
-      )
-
+    if (threadEnds.get(id) !== index) {
       return
-    }
-
-    // Open thread: a rail-indented block — collapse affordance, its entries,
-    // and its own reply box (Slack's "reply in thread").
-    const threadRows: ReactNode[] = []
-
-    if (!isNewest || openThreads[id] !== undefined) {
-      threadRows.push(
-        <RowButton
-          className="flex w-full items-center gap-1.5 px-2 pt-1 text-left text-[0.65rem] text-(--ui-text-quaternary) transition-colors hover:text-foreground"
-          key={`unfold:${id}`}
-          onClick={() =>
-            setOpenThreads(prev => ({
-              ...prev,
-              [id]: false
-            }))
-          }
-          title={b.group.collapseThreadLabel}
-        >
-          <Codicon className="text-[0.6rem]" name="chevron-down" />
-          {b.group.collapseThread}
-        </RowButton>
-      )
-    }
-
-    for (const { entry, index } of entries) {
-      threadRows.push(renderEntry(entry, index))
     }
 
     // Reply-in-thread: the newest thread's continuation ALSO lives here, so
     // the main composer below can stay "new thread" without ambiguity.
-    threadRows.push(
+    logChildren.push(
       replyThread === id ? (
         <form
           className="grid gap-0 px-2 pb-1"
@@ -1198,11 +1099,6 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
           {b.group.replyInThread}
         </Button>
       )
-    )
-    logChildren.push(
-      <div className="grid gap-1.5 border-l-2 border-(--ui-stroke-secondary) pl-1.5" key={`thread:${id}`}>
-        {threadRows}
-      </div>
     )
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
     },
     "apps/desktop": {
       "name": "hermes",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "@assistant-ui/core": "0.2.23",
         "@assistant-ui/react": "0.14.24",

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -94,6 +94,7 @@ Groups are standalone rows in the same activity-ordered roster as Bot DMs. A Bot
 
 **Open chat** on any group row (2–6 Bots) opens a shared room where the whole group coordinates:
 
+- **One visible conversation.** Public messages and each member's reply stay readable in arrival order, with the speaker's name and timestamp. Starting another topic does not collapse earlier replies. **Reply in thread** continues that topic without reordering the room; **Activity** is a secondary status view, not a replacement for messages. Private Bot Chats remain separate.
 - Your message triggers up to **three serial rounds** of member turns. @-mentioned Bots respond (everyone responds when nobody is mentioned); each Bot replies briefly or passes, and the room settles when a full round stays silent.
 - Bots pull each other in with `@name`, and escalate real judgment calls to you with `@user` — the group row shows a **needs you** badge when that happens.
 - Hard caps (10 messages per send, 3 rounds) keep rooms from spinning.


### PR DESCRIPTION
Bot Mode group chats keep every public member reply visible in arrival order when another topic starts.

- Remove automatic older-thread folding and regrouping from the room transcript.
- Keep speaker attribution, timestamps, thread-scoped reply controls and drafts, with Activity remaining secondary.
- Preserve private Bot Chat isolation; no delivery-engine or DM-history importing changes.
- Document the timeline behavior and bump the bundled Desktop version.

Root cause: the renderer showed only the newest thread by default and sorted entire threads by last activity, hiding earlier replies and reordering interleaved conversation.

## Validation

**Live repro:** baseline `6e2b8e070d28b1a3381a3fb290b6b8d6cce13cef` displayed 4 of 8 public replies; patched source displayed 8 of 8 against the exact same settled room log. Reload retained 8 of 8; continuing the earlier topic yielded 12 of 12 in arrival order.

Native Electron 40.10.2, production main/preload/renderer, real worktree gateway and deterministic loopback inference fixture. No paid inference or model-quality claim. A separate private Bot Chat sentinel was persisted in SQLite and absent from public room log/DOM. This demonstrates the visibility/order defect, not the historical delivery cause of the original cropped report.

Steps: open a two-bot room, submit two public topics, compare identical persisted logs across renderer source legs, reload, then use Reply in thread on the first topic.

| Check | Result |
|---|---|
| Bot Mode plugin tests | 576 passed across 62 files |
| Renderer TypeScript and touched-file ESLint | Passed |
| Windows-footgun and compatibility checks | Passed |
| Regression | Failed on baseline, passed on patch |

### Native Electron before
![Earlier public replies folded](https://files.catbox.moe/v8944o.png)

### Native Electron after
![All public member replies visible](https://files.catbox.moe/1kop21.png)

Screenshots contain clearly labeled deterministic fixture output, not real user conversations.

## Infographic
![Group chat in arrival order](https://v3b.fal.media/files/b/0aa98e96/uBTEj-0ACk2bEGYH42RuX_E2VjmsiK.png)
