### PR TITLE
fix(account-usage): preserve Anthropic utilization percent points

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -510,7 +510,7 @@ def _fetch_anthropic_account_usage(
     payload = _get_json("https://api.anthropic.com/api/oauth/usage", headers, timeout=15.0)
     windows = _usage_windows(
         payload, (("five_hour", "Current session"), ("seven_day", "Current week"), ("seven_day_opus", "Opus week"),
-                  ("seven_day_sonnet", "Sonnet week")), "utilization", "resets_at", fraction=True,
+                  ("seven_day_sonnet", "Sonnet week")), "utilization", "resets_at",
     )
     details: list[str] = []
     extra = payload.get("extra_usage") or {}

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -169,7 +169,7 @@ def test_anthropic_usage_keeps_provider_percent_points(monkeypatch):
         "seven_day": {"utilization": 20.0, "resets_at": "2026-09-10T21:00:00Z"},
     }
     calls = []
-    monkeypatch.setattr(account_usage, "resolve_anthropic_token", lambda: "sk-ant-oat-test-token")
+    monkeypatch.setattr(account_usage, "resolve_anthropic_token", lambda: "synthetic-oauth-token")
     monkeypatch.setattr(account_usage, "_is_oauth_token", lambda token: True)
     monkeypatch.setattr(
         account_usage.httpx,

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -162,6 +162,27 @@ def test_codex_usage_account_id_read_failure_keeps_singleton_token(monkeypatch, 
     assert "ChatGPT-Account-Id" not in calls[0]["headers"]
 
 
+def test_anthropic_usage_keeps_provider_percent_points(monkeypatch):
+    """Anthropic's usage API reports utilization as percent points, not a fraction."""
+    payload = {
+        "five_hour": {"utilization": 1.0, "resets_at": "2026-09-05T21:30:00Z"},
+        "seven_day": {"utilization": 20.0, "resets_at": "2026-09-10T21:00:00Z"},
+    }
+    calls = []
+    monkeypatch.setattr(account_usage, "resolve_anthropic_token", lambda: "sk-ant-oat-test-token")
+    monkeypatch.setattr(account_usage, "_is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [window.used_percent for window in snapshot.windows] == [1.0, 20.0]
+
+
 
 
 # ── Banked rate-limit reset credits (`/usage reset`) ─────────────────────────


### PR DESCRIPTION
## What does this PR do?
Fix Anthropic account-usage normalization: utilization is already in percentage points. Passing fraction=True turned 1.0 into 100.0, incorrectly reporting a fully used window.

## Related Issue
No linked issue. Searched existing PRs. Related #54467 handles nonnumeric input and #51913 hardens rendering; neither fixes this unit conversion.

## Type of Change
- [x] Bug fix

## Changes Made
Remove the fraction conversion only for Anthropic and add a mocked regression for 1.0 and 20.0. No credential selection, OAuth, provider request or configuration changes.

## How to Test
`scripts/run_tests.sh tests/agent/test_account_usage.py`

On upstream 520e63661c8eaa2135ebd60a07192f0d8aa45e6e with only the new regression applied: expected [1.0, 20.0], got [100.0, 20.0]. With the fix: 5 passed.

## Checklist
- [x] Read contributing guide; checked related PRs; focused diff and conventional commit.
- [x] Added regression and tested on macOS / Python 3.11.
- [ ] Full repository test suite (not run; focused suite above).
- [x] Documentation/config/tool schema updates: not applicable.

AI-assisted implementation and testing. All test inputs are synthetic; no live account or credential data is included.
