### PR TITLE
fix(agent): persist repaired preflight message sequences

### DIFF
--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -91,6 +91,47 @@ class IterationPrep:
     request_logger: Any
 
 
+def _persist_repaired_sequence(agent: Any, messages: Any, request_logger: Any) -> None:
+    """Make a pre-request sequence repair the canonical active transcript when safe.
+
+    Usage anchors are captured against the list sent to the provider.  An append-only flush
+    cannot represent a merge or drop in that list, so a restarted process would otherwise reload
+    a different cursor and correctly reject the anchor.  Preserve older compaction generations
+    and soft-archive only the superseded active rows.
+
+    A current-turn clean-user override is intentionally left to the regular flush/finalizer: its
+    DB projection differs from the API-facing message and must retain the ``api_content`` sidecar.
+    """
+    session_db = getattr(agent, "_session_db", None)
+    session_id = getattr(agent, "session_id", None)
+    if (
+        getattr(agent, "_persist_disabled", False)
+        or session_db is None
+        or not session_id
+        or getattr(agent, "_persist_user_message_override", None) is not None
+    ):
+        return
+    replace_messages = getattr(session_db, "replace_messages", None)
+    if not callable(replace_messages):
+        return
+    try:
+        replace_messages(session_id, messages, active_only=True, archive_dropped=True)
+    except Exception:
+        request_logger.warning(
+            "Could not durably rewrite repaired message sequence before request (session=%s); "
+            "the resumed usage anchor will fail closed",
+            session_id,
+            exc_info=True,
+        )
+        return
+    from agent.context_compressor import stamp_db_persisted_markers
+
+    stamp_db_persisted_markers(messages)
+    agent._last_flushed_db_idx = len(messages)
+    agent._db_flush_scan_prefix = messages[:]
+    agent._flushed_db_message_ids = set()
+
+
 def prepare_iteration(agent: Any,*, messages: Any, api_call_count: Any) -> IterationPrep:
     """Prepare ``messages`` for this iteration in the original order. Every mutation here is
     cache-safe by construction: steer text lands in the newest tool result, the ghost-row
@@ -177,6 +218,7 @@ def prepare_iteration(agent: Any,*, messages: Any, api_call_count: Any) -> Itera
     from agent.agent_runtime_helpers import repair_message_sequence_with_cursor
     repaired_seq = repair_message_sequence_with_cursor(agent, messages)
     if repaired_seq > 0:
+        _persist_repaired_sequence(agent, messages, request_logger)
         request_logger.info(
             "Repaired %s message-alternation violations before request (session=%s)",
             repaired_seq,

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -9,6 +9,8 @@ providers (violating role alternation), which retriggered the empty-retry
 recovery every turn.
 """
 
+from types import SimpleNamespace
+
 from run_agent import AIAgent
 
 
@@ -471,6 +473,88 @@ def test_cursor_rewinds_when_compaction_happens_before_cursor():
     # min(2, len=2) would leave it at 2 and the flush would skip it.
     assert agent._last_flushed_db_idx == 1
     assert messages[agent._last_flushed_db_idx] is unflushed_assistant
+
+
+def test_preflight_repair_rewrites_active_history_before_anchor_persists(tmp_path):
+    """A repaired preflight transcript must be the durable transcript an anchor resumes against.
+
+    A malformed pair of adjacent user rows is repaired before the next provider request. The
+    following three-result tool batch mirrors the boundary that exposed the production bug:
+    without a durable rewrite, the final tool fingerprint lives at a different DB index and a
+    fresh process rejects its provider-usage anchor.
+    """
+    from agent.turn_iteration_prep import prepare_iteration
+    from agent.usage_anchor import capture_usage_anchor, restore_usage_anchor, set_usage_anchor
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "durable-preflight-repair"
+    db.create_session(session_id, source="cli")
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "second"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": f"call_{index}",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }
+                for index in range(3)
+            ],
+        },
+        *[
+            {"role": "tool", "tool_call_id": f"call_{index}", "content": f"result-{index}"}
+            for index in range(3)
+        ],
+    ]
+    for message in messages:
+        db.append_message(
+            session_id,
+            message["role"],
+            message.get("content"),
+            tool_calls=message.get("tool_calls"),
+            tool_call_id=message.get("tool_call_id"),
+        )
+
+    agent = SimpleNamespace(
+        session_id=session_id,
+        _session_db=db,
+        _persist_disabled=False,
+        _last_flushed_db_idx=len(messages),
+        step_callback=None,
+        _skill_nudge_interval=0,
+        _adopt_nous_key_before_expiry=lambda: None,
+        _drain_pending_steer=lambda: None,
+        run_budget_seconds=None,
+        logger=None,
+        _sanitize_tool_call_arguments=lambda *args, **kwargs: 0,
+    )
+
+    repaired = prepare_iteration(agent, messages=messages, api_call_count=1).messages
+    assert [message["role"] for message in repaired] == ["user", "assistant", "tool", "tool", "tool"]
+    assert all(message.get("_db_persisted") for message in repaired)
+
+    anchor = capture_usage_anchor(12_000, 100, repaired)
+    set_usage_anchor(agent, anchor)
+    fresh = SimpleNamespace(
+        session_id=session_id, _session_db=db, _persist_disabled=False, _usage_anchor=None,
+    )
+    durable = db.get_messages_as_conversation(session_id)
+    restore_usage_anchor(fresh, durable)
+
+    provider_fields = ("role", "content", "tool_call_id", "tool_calls")
+    assert [
+        {field: message.get(field) for field in provider_fields if message.get(field) is not None}
+        for message in durable
+    ] == [
+        {field: message.get(field) for field in provider_fields if message.get(field) is not None}
+        for message in repaired
+    ]
+    assert fresh._usage_anchor == anchor
+    db.close()
 
 
 


### PR DESCRIPTION
## What does this PR do?
Persist repaired preflight message sequences before capturing subsequent provider-usage anchors. An in-memory merge/drop otherwise leaves append-only durable history at a different index, so resume rejects the anchor against the stored transcript.

## Related Issue
No linked issue. Searched existing PRs for sequence repair and usage anchors; no matching fix found.

## Type of Change
- [x] Bug fix

## Changes Made
Use the existing replace_messages API for the active generation only, soft-archive dropped rows, and refresh persistence cursors after success. Skip disabled/missing persistence and current-turn user-message overrides. Database-write failure is logged and leaves resumed-anchor validation fail-closed.

Add a synthetic SQLite regression with adjacent user messages followed by a three-result tool batch. It checks durable transcript equivalence and restoration of the usage anchor on a fresh agent object. This is not a full separate-process restart test.

## How to Test
`scripts/run_tests.sh tests/run_agent/test_message_sequence_repair.py`

New regression fails on upstream 520e63661c8eaa2135ebd60a07192f0d8aa45e6e without the fix; with it, 59 tests pass.

`scripts/run_tests.sh tests/agent/test_usage_anchor.py tests/agent/test_turn_finalizer_final_response_persistence.py tests/agent/test_compression_anti_thrash_persistence.py`

30 additional related tests pass. No live conversation database was modified.

## Checklist
- [x] Read contributing guide; searched existing PRs; focused diff and conventional commit.
- [x] Added regression and tested on macOS / Python 3.11.
- [ ] Full repository test suite (not run; focused suites above).
- [x] Documentation/config/tool schema updates: not applicable.

AI-assisted implementation and testing. No local application integrations, configuration or private conversation data are included.
