### PR TITLE
fix(state): serialize replaced/generation probe with close() in _execute_write (#105567)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -791,10 +791,20 @@ class SessionDB(
         ioerr_begin_retried = False
         while True:
             self._raise_if_db_corrupt()
-            self._raise_if_db_replaced()
+            # NOTE: the replaced/generation live probe runs INSIDE the lock below,
+            # not here. close() mutates _conn and _db_sidecar_identity under that
+            # same lock, ending the WAL generation (SQLite unlinks the -wal/-shm
+            # sidecars on a clean close). A lock-free probe that races close() can
+            # observe the mid-teardown state — sidecars already unlinked while
+            # _db_sidecar_identity is not yet cleared — and misclassify this
+            # process's OWN clean close as an externally deleted generation,
+            # raising a sticky DeletedWalGenerationError that permanently refuses
+            # later writes (#105567). Inside the lock the probe only ever sees the
+            # stable post-close state (identity cleared → adopt / reopen path).
             fn_started = False
             try:
                 with self._lock:
+                    self._raise_if_db_replaced()
                     if self._conn is None:  # close() raced this writer
                         self._reopen_after_close_locked(context="write")
                     self._conn.execute("BEGIN IMMEDIATE")


### PR DESCRIPTION
## Summary

Fixes #105567 — a synthetic close/write race on direct `SessionDB` handles permanently refused later appends with a sticky `DeletedWalGenerationError`. Reproduced on `main` `520e63661c` (100 rounds × 40 writes: ~9 failing rounds, ~360 refused writes).

## Root cause

`_execute_write()` ran its replaced/WAL-generation live probe **lock-free** at the top of the retry loop:

```python
while True:
    self._raise_if_db_corrupt()
    self._raise_if_db_replaced()     # live probe: stats -wal/-shm (no lock)
    try:
        with self._lock:             # close() takes this same lock
            if self._conn is None:
                self._reopen_after_close_locked(...)
```

`close()` (under `_lock`) ends the WAL generation: PASSIVE checkpoint → close connection (SQLite unlinks the `-wal`/`-shm` sidecars) → `_conn = None` → clear `_db_sidecar_identity`. The lock-free probe could run concurrently with that teardown and observe the **mid-teardown state** — sidecars already unlinked while `_db_sidecar_identity` was not yet cleared — so `_wal_generation_was_lost()` judged this process's *own clean close* as an externally deleted generation. The resulting `_db_wal_generation_lost` flag is sticky, permanently refusing every later write on that handle.

Notably, the code already had the right design intent for this exact scenario ("a clean close lets SQLite unlink the sidecars … a teardown-race reopen must re-adopt") — but the lock-free probe ran *before* the locked reopen decision could take the re-adopt path.

## Fix

Move the `_raise_if_db_replaced()` live probe **inside the lock**, ahead of the close-race reopen:

```python
while True:
    self._raise_if_db_corrupt()          # lock-free sticky fast path (unchanged)
    try:
        with self._lock:
            self._raise_if_db_replaced() # now serialized with close()
            if self._conn is None:
                self._reopen_after_close_locked(...)
```

Inside the lock the probe only ever sees the stable post-close state (identity cleared → the existing adopt/reopen path). External file/generation replacement detection is unchanged — just serialized with teardown instead of racing it. The exception-path `_raise_if_db_replaced()` call (already-error diagnosis) is untouched.

## Verification

- Synthetic repro (100 rounds × 40 writes, direct handles): before ~9 failing rounds / ~360 `DeletedWalGenerationError`; after **0 failures, 4000/4000 writes persisted** — stable across repeated runs (60/100-round variants).
- `tests/state/` — **181 passed** (incl. `test_append_message_after_close_94736.py`, `test_writer_conn_thread_safety.py`, `test_state_db_wal_unlink_race.py`, `test_no_more_rows_retry.py`).
- Generation/replaced/corrupt guard suites (`test_deleted_wal_generation_guard.py`, `test_state_db_file_identity.py`, `test_session_db_replaced_fallback.py`, `test_session_db_corrupt_fallback.py`, `test_state_db_corrupt_quarantine.py`, `test_kanban_db_init.py`) — 55 passed.
