### PR TITLE
fix(desktop): keep subagent rows visible at rest

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/delegate.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/delegate.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, render } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
+import { I18nProvider } from '@/i18n'
+import { $activeSessionId } from '@/store/session'
+import { $subagentsBySession, clearSessionSubagents, upsertSubagent } from '@/store/subagents'
+import { stubResizeObserver } from '@/test/jsdom'
+
+import { DelegateTool } from './delegate'
+
+stubResizeObserver()
+
+const SESSION = 'sess-delegate'
+
+function view(): SessionView {
+  return {
+    ...({} as SessionView),
+    $runtimeId: atom<null | string>(SESSION),
+    kind: 'primary'
+  }
+}
+
+function renderCard() {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <SessionViewProvider value={view()}>
+        <DelegateTool args={{ tasks: [{ goal: 'Inspect visualOutcome' }] }} result={undefined} toolCallId="call-7" />
+      </SessionViewProvider>
+    </I18nProvider>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  clearSessionSubagents(SESSION)
+  $subagentsBySession.set({})
+  $activeSessionId.set(null)
+})
+
+describe('delegate card fade', () => {
+  // Scaffold opacity opens a stacking context. The activity ticker is a
+  // transformed reel clipped to one line. When the mark sat on the wrapper
+  // around both, Chromium stopped clipping the reel and every old activity
+  // line painted through the current one at 0.67 (or worse, nested). The
+  // mark belongs on the goal row. The ticker stays outside it.
+  it('does not put the activity ticker inside a scaffold fade', () => {
+    $activeSessionId.set(SESSION)
+    upsertSubagent(
+      SESSION,
+      {
+        goal: 'Inspect visualOutcome',
+        status: 'running',
+        subagent_id: 'delegate-tool:call-7:0',
+        task_index: 0,
+        text: 'Thinking about the catalog'
+      },
+      true,
+      'subagent.thinking'
+    )
+    upsertSubagent(
+      SESSION,
+      {
+        subagent_id: 'delegate-tool:call-7:0',
+        task_index: 0,
+        tool_name: 'terminal',
+        preview: 'from pathlib import Path'
+      },
+      false,
+      'subagent.tool'
+    )
+
+    const { container } = renderCard()
+    const ticker = container.querySelector('[data-tool-ticker]')
+    const marked = container.querySelector('[data-conversation-scaffold]')
+
+    expect(ticker).not.toBeNull()
+    expect(marked).not.toBeNull()
+    expect(ticker?.closest('[data-conversation-scaffold]')).toBeNull()
+    expect(container.querySelector('[data-delegate-card]')?.hasAttribute('data-conversation-scaffold')).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/delegate.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/delegate.tsx
@@ -85,9 +85,12 @@ function DelegateRowView({ row }: { row: DelegateRow }) {
   // Only a child that reported its own session id has somewhere to go.
   const open = sessionId ? () => void openSessionInNewWindow(sessionId, { watch: true }) : undefined
 
+  // Mark the goal row, never this wrapper. Opacity on a parent of the ticker
+  // opens a stacking context that lets the transformed reel paint old activity
+  // lines through the one-line window.
   return (
-    <div className="grid min-w-0 max-w-full gap-0.5" data-conversation-scaffold="">
-      <div className="flex min-w-0 max-w-full items-center gap-1.5">
+    <div className="grid min-w-0 max-w-full gap-0.5">
+      <div className="flex min-w-0 max-w-full items-center gap-1.5" data-conversation-scaffold="">
         <span className={SCAFFOLD_GLYPH_CLASS}>{statusGlyph(row.status, statusLabel)}</span>
         <button
           className={cn(

--- a/apps/desktop/src/lib/use-enter-animation.test.tsx
+++ b/apps/desktop/src/lib/use-enter-animation.test.tsx
@@ -47,7 +47,7 @@ describe('useEnterAnimation', () => {
     const played = mountAnimated(true, 'plays-once')
 
     expect(played).toBeDefined()
-    expect(played?.keyframes[0]).toMatchObject({ opacity: 0 })
+    expect(played?.keyframes[0]).toMatchObject({ transform: 'translateY(0.375rem)' })
   })
 
   it('stays out of the way when disabled', () => {
@@ -64,19 +64,21 @@ describe('useEnterAnimation', () => {
   })
 
   /**
-   * The animation fills forwards, so any value in its last keyframe is held in
-   * the animation origin of the cascade for the life of the element — above
-   * the stylesheet. Naming an end opacity therefore doesn't just finish the
-   * fade, it permanently overrules whatever opacity CSS wants the element to
-   * rest at, and transcript scaffolding rests dimmed. Rows that animated in
-   * during the turn stayed bright while their rehydrated neighbours faded, and
-   * no hover could lift the bright ones because the sheet had lost the
-   * argument. Opacity has to be left to CSS at the end.
+   * Opacity on any keyframe, with fill that holds while the document timeline
+   * is paused (alt-tab, HUD hide, an unfocused window), pins the node at that
+   * value. Opening at 0 left subagent rows and thinking blocks invisible.
+   * Closing at 1 left scaffolding too bright for hover to lift. CSS already
+   * rests those surfaces at 0.67. The slide is transform-only, and fill is
+   * backwards so the offset applies on the first frame then the effect
+   * releases instead of holding a compositor layer for the life of the node.
    */
-  it('leaves the resting opacity to the stylesheet', () => {
+  it('never animates opacity, and does not hold a filled transform', () => {
     const played = mountAnimated(true, 'resting-opacity')
 
-    expect(played?.options.fill).toBe('both')
-    expect(played?.keyframes.at(-1)).not.toHaveProperty('opacity')
+    expect(played?.options.fill).toBe('backwards')
+
+    for (const frame of played?.keyframes ?? []) {
+      expect(frame).not.toHaveProperty('opacity')
+    }
   })
 })

--- a/apps/desktop/src/lib/use-enter-animation.ts
+++ b/apps/desktop/src/lib/use-enter-animation.ts
@@ -79,23 +79,20 @@ export function useEnterAnimation(enabled: boolean, animationKey?: string): (el:
       return
     }
 
-    el.animate(
-      [
-        { opacity: 0, transform: 'translateY(0.375rem)' },
-        // No `opacity` on the way out, deliberately. A filled animation holds
-        // its final value in the animation origin of the cascade, which
-        // outranks the stylesheet for as long as the element lives — naming 1
-        // here permanently pinned full opacity onto everything the sheet dims.
-        // Transcript scaffolding is dimmed that way, so a tool row or thinking
-        // header kept whichever opacity it happened to mount with: full if it
-        // animated in during the turn, faded if it was rehydrated or remounted
-        // past its one-shot key. Adjacent identical rows disagreed, and hover
-        // couldn't lift the pinned ones. Left neutral, opacity rises to
-        // whatever CSS says it should be and answers hover afterwards.
-        { transform: 'translateY(0)' }
-      ],
-      { duration: 180, easing: 'cubic-bezier(0.16, 1, 0.3, 1)', fill: 'both' }
-    )
+    // Transform only. Opacity in any keyframe outranks the stylesheet while
+    // the effect applies. fill: 'both' plus opacity: 0 on the opening frame
+    // pinned subagent rows and thinking blocks invisible whenever Chromium
+    // paused the document timeline (alt-tab, HUD hide, an unfocused window).
+    // Naming 1 on the way out pinned scaffolding bright so hover could not
+    // lift it. CSS already rests those surfaces at 0.67. fill is backwards
+    // so the offset applies on the first frame, then the effect releases
+    // instead of holding transform: translateY(0) as a compositor layer that
+    // can stop overflow from clipping a descendant ticker reel.
+    el.animate([{ transform: 'translateY(0.375rem)' }, { transform: 'translateY(0)' }], {
+      duration: 180,
+      easing: 'cubic-bezier(0.16, 1, 0.3, 1)',
+      fill: 'backwards'
+    })
 
     if (key) {
       // In React StrictMode the first mount can be immediately torn down.

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2224,6 +2224,10 @@ button[data-slot='aui_msg-reactions'] svg {
 .tool-ticker {
   height: var(--conversation-line-height);
   overflow: hidden;
+  /* clip beats hidden when an ancestor opacity stacking context would
+     otherwise let the transformed reel paint old rows through the window. */
+  overflow: clip;
+  isolation: isolate;
 }
 
 .tool-ticker__reel {


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Live `delegate_task` cards and Agents panel stream lines sometimes drop to near-zero opacity. Thinking, tool summaries, and subagent activity paint through each other.

`useEnterAnimation` opened at `opacity: 0` with `fill: 'both'`. Chromium pauses the document timeline on alt-tab, HUD hide, or an unfocused window, so the node stays stuck at the opening frame. Naming `1` on the way out was already rejected here, because that pins scaffolding bright and hover cannot lift it. Opacity now stays with CSS. The slide is transform only, fill is backwards, and the effect releases so it does not hold a compositor layer.

The delegate card also marked the wrapper around the activity ticker as scaffolding. `opacity: 0.67` on that parent opens a stacking context, and the ticker reel uses `transform`, so old activity lines paint through the one-line window. The mark is now on the goal row only. The reel uses `overflow: clip`.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #105579

Related: #49174 also hits the paused-timeline case. It force-finishes to opacity 1, which this repo later stopped doing because that pins scaffolding bright.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `apps/desktop/src/lib/use-enter-animation.ts`: transform-only enter animation, `fill: 'backwards'`. No opacity in any keyframe.
- `apps/desktop/src/components/assistant-ui/tool/delegate.tsx`: `data-conversation-scaffold` on the goal row, not the wrapper that holds the ticker.
- `apps/desktop/src/styles.css`: `.tool-ticker` uses `overflow: clip` and `isolation: isolate`.
- `apps/desktop/src/lib/use-enter-animation.test.tsx`: no keyframe has opacity, fill is backwards.
- `apps/desktop/src/components/assistant-ui/tool/delegate.test.tsx`: ticker is not inside a scaffold mark.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. From `apps/desktop`: `npx vitest run src/lib/use-enter-animation.test.tsx src/components/assistant-ui/tool/delegate.test.tsx src/components/assistant-ui/tool/tool-group.test.tsx src/components/assistant-ui/thread/status.test.tsx src/components/assistant-ui/tool/delegate-model.test.ts`
2. `never animates opacity, and does not hold a filled transform` fails on current main: first keyframe has `opacity: 0` and fill is `both`. With the fix, no keyframe has opacity and fill is `backwards`.
3. `does not put the activity ticker inside a scaffold fade` fails on current main: the ticker's closest `[data-conversation-scaffold]` is the row wrapper. With the fix that closest is null, and the goal row is still marked.

Ran on Windows 11:

```
Test Files  5 passed (5)
Tests  37 passed (37)
```

The two new/changed files are 5 passed on their own.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
Before: enter animation first keyframe opacity 0, fill both. Ticker closest scaffold is the wrapper.
After:  no opacity in any keyframe, fill backwards. Ticker closest scaffold is null. Goal row still marked.
```

```
apps/desktop: 5 files, 37 related tests passed
```
