### PR TITLE
fix(kanban): honor auto_subscribe_on_create for dashboard-created tasks

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -368,15 +368,47 @@ class CreateTaskBody(BaseModel):
     provider_override: Optional[str] = None
     reasoning_effort: Optional[str] = None  # none|minimal|…|ultra; None inherits the profile's level
     project_id: Optional[str] = None  # None inherits the board's scoped project (if any)
+    subscribe_platforms: Optional[list[str]] = None  # None=auto per config, []=opt out, explicit=subset
 
 
 @router.post("/tasks")
 def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
     with _board_conn(board) as (board, conn), _value_error_400():
         # CreateTaskBody field names match create_task's keyword parameters.
-        task_id = kanban_db.create_task(conn, created_by="dashboard", board=board, **payload.model_dump())
+        body_kwargs = payload.model_dump()
+        subscribe_platforms = body_kwargs.pop("subscribe_platforms")
+        task_id = kanban_db.create_task(
+            conn, created_by="dashboard", board=board, **body_kwargs
+        )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
+        # Terminal events must not stay silent for dashboard/API-created tasks: with
+        # kanban.auto_subscribe_on_create (the same gate /kanban create honours), write
+        # the notify_subs rows home-subscribe would — one per configured home channel,
+        # unless the request narrows (list) or opts out (empty list).
+        if task:
+            try:
+                homes = _configured_home_channels()
+                if subscribe_platforms is not None:
+                    wanted = {p.strip() for p in subscribe_platforms if str(p).strip()}
+                    unknown = wanted - {h["platform"] for h in homes}
+                    if unknown:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=f"no home channel configured for platform(s): {', '.join(sorted(unknown))}",
+                        )
+                    homes = [h for h in homes if h["platform"] in wanted]
+                elif not _auto_subscribe_enabled():
+                    homes = []
+                subscribed = _subscribe_homes(conn, task_id, homes)
+                if subscribed:
+                    body["subscribed_platforms"] = subscribed
+            except HTTPException:
+                raise
+            except Exception as exc:
+                log.warning(
+                    "auto-subscribe after dashboard task create failed: %r", exc
+                )
         # Dispatcher-presence warning so the UI can banner a ready+assigned task that would
         # otherwise sit idle (no gateway / dispatch_in_gateway=false); triage/todo are expected
         # to wait, unassigned tasks can't dispatch anyway. Probe the request's active home: the
@@ -1109,6 +1141,40 @@ def _home_for_platform(platform: str, detail: str) -> dict:
     if not home:
         raise HTTPException(status_code=404, detail=detail)
     return home
+
+
+def _subscribe_homes(
+    conn: sqlite3.Connection, task_id: str, homes: list[dict]
+) -> list[str]:
+    """Write the notify_subs rows ``home-subscribe`` would for each *homes* entry;
+    returns the platforms actually registered (deduped, config order)."""
+    profile = _active_profile_name()
+    subscribed: list[str] = []
+    for home in homes:
+        kbn.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform=home["platform"],
+            chat_id=home["chat_id"],
+            thread_id=home["thread_id"] or None,
+            notifier_profile=profile,
+        )
+        if home["platform"] not in subscribed:
+            subscribed.append(home["platform"])
+    return subscribed
+
+
+def _auto_subscribe_enabled() -> bool:
+    """``kanban.auto_subscribe_on_create`` — the same gate ``/kanban create`` uses;
+    unreadable config keeps the default (True)."""
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        return bool(
+            cfg_get(load_config(), "kanban", "auto_subscribe_on_create", default=True)
+        )
+    except Exception:
+        return True
 
 
 @router.get("/home-channels")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1069,6 +1069,107 @@ def test_home_channels_lists_only_platforms_with_home(client, with_home_channels
 
 
 # ---------------------------------------------------------------------------
+# POST /tasks honors kanban.auto_subscribe_on_create via home channels
+# ---------------------------------------------------------------------------
+
+
+def _notify_subs(task_id: str) -> list[tuple[str, str]]:
+    conn = kbc.connect()
+    try:
+        rows = conn.execute(
+            "SELECT platform, chat_id FROM kanban_notify_subs WHERE task_id = ?",
+            (task_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [(p, c) for p, c in rows]
+
+
+@pytest.fixture
+def auto_subscribe_enabled(tmp_path, monkeypatch):
+    (Path(os.environ["HERMES_HOME"]) / "config.yaml").write_text(
+        "kanban:\n  auto_subscribe_on_create: true\n"
+    )
+    yield
+    (Path(os.environ["HERMES_HOME"]) / "config.yaml").unlink(missing_ok=True)
+
+
+def test_create_task_auto_subscribes_home_channels(
+    client, with_home_channels, auto_subscribe_enabled
+):
+    r = client.post("/api/plugins/kanban/tasks", json={"title": "notify me"})
+    assert r.status_code == 200, r.text
+    task_id = r.json()["task"]["id"]
+    assert sorted(r.json().get("subscribed_platforms", [])) == ["discord", "telegram"]
+    assert sorted(_notify_subs(task_id)) == [
+        ("discord", "9999999"),
+        ("telegram", "1234567"),
+    ]
+
+
+def test_create_task_subscribe_platforms_filter(
+    client, with_home_channels, auto_subscribe_enabled
+):
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "tg only", "subscribe_platforms": ["telegram"]},
+    )
+    assert r.status_code == 200, r.text
+    task_id = r.json()["task"]["id"]
+    assert r.json()["subscribed_platforms"] == ["telegram"]
+    assert _notify_subs(task_id) == [("telegram", "1234567")]
+
+
+def test_create_task_subscribe_platforms_opt_out(
+    client, with_home_channels, auto_subscribe_enabled
+):
+    r = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "quiet", "subscribe_platforms": []}
+    )
+    assert r.status_code == 200, r.text
+    task_id = r.json()["task"]["id"]
+    assert "subscribed_platforms" not in r.json()
+    assert _notify_subs(task_id) == []
+
+
+def test_create_task_auto_subscribe_disabled_by_config(
+    client, with_home_channels, tmp_path
+):
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text("kanban:\n  auto_subscribe_on_create: false\n")
+    try:
+        r = client.post("/api/plugins/kanban/tasks", json={"title": "gated"})
+        assert r.status_code == 200, r.text
+        task_id = r.json()["task"]["id"]
+        assert "subscribed_platforms" not in r.json()
+        assert _notify_subs(task_id) == []
+    finally:
+        (home / "config.yaml").unlink(missing_ok=True)
+
+
+def test_create_task_subscribe_platforms_unknown_400(
+    client, with_home_channels, auto_subscribe_enabled
+):
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "bad", "subscribe_platforms": ["telegram", "irc"]},
+    )
+    assert r.status_code == 400
+    assert "irc" in r.json()["detail"]
+
+
+def test_create_task_auto_subscribes_without_config_file(client, with_home_channels):
+    """No config.yaml at all: the flag defaults to True, so homes still subscribe."""
+    r = client.post("/api/plugins/kanban/tasks", json={"title": "default on"})
+    assert r.status_code == 200, r.text
+    task_id = r.json()["task"]["id"]
+    assert sorted(_notify_subs(task_id)) == [
+        ("discord", "9999999"),
+        ("telegram", "1234567"),
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Recovery endpoints (reclaim + reassign) and warnings field
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Dashboard/API-created kanban tasks stayed silent on terminal events: `POST /api/plugins/kanban/tasks` wrapped `kanban_db.create_task` and returned, while the agent/gateway path additionally calls `_maybe_auto_subscribe` (`tools/kanban_tools.py`) gated by `kanban.auto_subscribe_on_create`. A dashboard request has no session context, so no notify_subs row was ever written unless someone toggled the per-task home-subscribe afterwards (fixes #105565).

Fix: after the task row lands, when `kanban.auto_subscribe_on_create` is enabled (default true), the endpoint writes exactly the notify_subs rows `POST /tasks/{id}/home-subscribe/{platform}` writes — one per configured gateway home channel (`_configured_home_channels()`), with the active profile as owner. This reuses the dashboard's own subscription primitive, so the gateway notifier needs no new plumbing.

The create body also accepts an optional `subscribe_platforms` field: `null` (default) follows the config flag, `[]` opts out, an explicit list subscribes only those platforms (unknown platform → 400). The response surfaces `subscribed_platforms` when any subscription was written.

Subscription failures are logged and swallowed — bookkeeping must never fail the create (same policy as `_maybe_auto_subscribe`).

## Testing

- `pytest tests/plugins/test_kanban_dashboard_plugin.py` — 44 passed (6 new: auto-subscribe happy path, explicit filter, opt-out, config-gate-off, unknown-platform 400, no-config-file default-on)
- Mutation check: reverting the plugin change fails 4 of the 6 new tests on clean main
- `ruff check` clean on both files; `ruff format --diff` shows zero new complaints vs the pre-existing baseline drift
- Full `tests/plugins/` suite: same 19 pre-existing failures with and without the diff (video/fal env-dependent), no regressions