### PR TITLE
fix(cron): run pre-inference gate in job workdir

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2054,7 +2054,8 @@ def _prepare_job_prompt(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path, cancel_event=cancel_event)
+        prerun_script = _run_job_script_with_claim_heartbeat(
+            job, script_path, workdir=job.get("workdir"), cancel_event=cancel_event)
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info("Job '%s' (ID: %s): wakeAgent=false, skipping agent run", job_name, job_id)

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -17,6 +17,30 @@ import json
 import pytest
 
 
+def test_wake_script_uses_job_workdir_before_loading_prompt(tmp_path, monkeypatch):
+    from hermes_constants import get_hermes_home
+    from cron import scheduler
+
+    scripts = get_hermes_home() / 'scripts'
+    scripts.mkdir(parents=True, exist_ok=True)
+    workdir = tmp_path / 'repository'
+    workdir.mkdir()
+    script = scripts / 'cwd-gate.py'
+    script.write_text(
+        "import os, json\n"
+        f"print(json.dumps({{'wakeAgent': os.getcwd() != {str(workdir)!r}}}))\n"
+    )
+    def unexpected(*args, **kwargs):
+        raise AssertionError('Empty gate must not build the prompt')
+    monkeypatch.setattr(scheduler, '_build_job_prompt', unexpected)
+    early, prompt = scheduler._prepare_job_prompt(
+        {'prompt': 'unused', 'script': str(script), 'workdir': str(workdir)},
+        'test', 'test', None, None)
+    assert early[0] is True
+    assert early[2] == scheduler.SILENT_MARKER
+    assert prompt is None
+
+
 @pytest.fixture()
 def tmp_cron_dir(tmp_path, monkeypatch):
     """Isolate cron job storage into a temp dir so tests don't stomp on real jobs."""


### PR DESCRIPTION
## Summary
Pass the native job workdir into the pre-inference script runner, matching no-agent script jobs. Previously the wake gate ran in the profile scripts directory, so repository checks could not inspect the configured repository.

## Verification
A real subprocess gate checks its cwd and returns wakeAgent=false. The regression failed before the fix and passes after it, proving prompt assembly is bypassed. Native runner: 121 tests pass across cron workdir and scheduler suites. Self-reviewed; no new settings.