### PR TITLE
fix(desktop): busy Bot Chat stays current on return (salvage #102474)

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as HermesModule from '@/hermes'
 import { setSessionOwnerHint, setSessions } from '@/store/session'
-import { sessionTileDelegate } from '@/store/session-states'
+import { $sessionTiles, sessionTileDelegate } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
 import { useSessionTileDelegate } from './use-session-tile-delegate'
@@ -230,6 +230,161 @@ describe('useSessionTileDelegate resumeTile', () => {
     const texts = next.messages.flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
 
     expect(texts.some(text => text.includes('cron delivery'))).toBe(true)
+  })
+
+  it('refreshes a retained live tile even when the reverse lookup is absent', async () => {
+    const state = {
+      busy: true,
+      streamId: 'assistant-stream-live',
+      storedSessionId: 'stored-retained',
+      messages: [
+        { id: 'old-user', role: 'user', parts: [{ type: 'text', text: 'earlier prompt' }] },
+        { id: 'old-assistant', role: 'assistant', parts: [{ type: 'text', text: 'Hello earlier answer' }] },
+        { id: 'user-live', role: 'user', parts: [{ type: 'text', text: 'prompt' }] },
+        { id: 'assistant-stream-live', role: 'assistant', pending: true, parts: [{ type: 'text', text: 'Hello' }] }
+      ]
+    }
+
+    const states = { current: new Map([['runtime-retained', state]]) }
+
+    const update = vi.fn((_id, updater) => {
+      const next = updater(states.current.get(_id))
+      states.current.set(_id, next)
+
+      return next
+    })
+
+    setSessions([row({ id: 'stored-retained', profile: 'default' })])
+    $sessionTiles.set([{ storedSessionId: 'stored-retained', runtimeId: 'runtime-retained' }] as never)
+    vi.mocked(getLatestSessionMessages).mockResolvedValueOnce({
+      session_id: 'stored-retained',
+      messages: [
+        { role: 'user', content: 'earlier prompt', timestamp: 0.5 },
+        { role: 'assistant', content: 'Hello earlier answer', timestamp: 0.6 },
+        { role: 'user', content: 'prompt', timestamp: 1 },
+        { role: 'system', content: 'external notice', timestamp: 2 }
+      ]
+    } as never)
+    vi.mocked(requestGatewayForProfile).mockResolvedValueOnce({
+      session_id: 'runtime-retained',
+      info: { running: true }
+    } as never)
+    const request = vi.fn()
+    renderTile(request, { sessionStateByRuntimeIdRef: states, updateSessionState: update })
+
+    try {
+      expect(await sessionTileDelegate()!.resumeTile('stored-retained', { refreshTranscript: true })).toBe(
+        'runtime-retained'
+      )
+      const refreshed = states.current.get('runtime-retained')!
+      expect(JSON.stringify(refreshed.messages)).toContain('external notice')
+      expect(refreshed.messages.find(message => message.id === state.streamId)).toEqual(state.messages[3])
+      expect(refreshed.busy).toBe(true)
+
+      // REST may finish before the next WS delta; keep one, fuller answer.
+      states.current.set('runtime-retained', state)
+      vi.mocked(getLatestSessionMessages).mockResolvedValueOnce({
+        session_id: 'stored-retained',
+        messages: [
+          { role: 'user', content: 'earlier prompt', timestamp: 0.5 },
+          { role: 'assistant', content: 'Hello earlier answer', timestamp: 0.6 },
+          { role: 'user', content: 'prompt', timestamp: 1 },
+          { role: 'assistant', content: 'Hello world', timestamp: 2 }
+        ]
+      } as never)
+      await sessionTileDelegate()!.resumeTile('stored-retained', { refreshTranscript: true })
+      const answers = states.current.get('runtime-retained')!.messages.filter(message => message.role === 'assistant')
+      expect(answers.map(message => message.parts.map(part => part.text).join(''))).toEqual([
+        'Hello earlier answer',
+        'Hello world'
+      ])
+    } finally {
+      vi.mocked(requestGatewayForProfile).mockReset()
+      $sessionTiles.set([])
+    }
+  })
+
+  it('merges delayed refreshes against the latest streaming and completed state', async () => {
+    const initial = {
+      busy: true,
+      streamId: 'assistant-stream-live',
+      storedSessionId: 'stored-delay',
+      messages: [
+        { id: 'user-live', role: 'user', parts: [{ type: 'text', text: 'prompt' }] },
+        { id: 'assistant-stream-live', role: 'assistant', pending: true, parts: [{ type: 'text', text: 'Hello' }] }
+      ]
+    }
+
+    const states = { current: new Map([['runtime-delay', initial]]) }
+
+    const update = vi.fn((_id, updater) => {
+      const next = updater(states.current.get(_id))
+      states.current.set(_id, next)
+
+      return next
+    })
+
+    renderTile(vi.fn(), {
+      runtimeIdByStoredSessionIdRef: { current: new Map([['stored-delay', 'runtime-delay']]) },
+      sessionStateByRuntimeIdRef: states,
+      updateSessionState: update
+    })
+
+    for (const scenario of ['streaming', 'completed', 'compacted']) {
+      const pending = scenario === 'streaming'
+      states.current.set('runtime-delay', initial)
+      let release!: (value: never) => void
+      let started!: () => void
+
+      const fetching = new Promise<void>(resolve => {
+        started = resolve
+      })
+
+      vi.mocked(getLatestSessionMessages).mockImplementationOnce(() => {
+        started()
+
+        return new Promise(resolve => {
+          release = resolve
+        })
+      })
+      const refreshing = sessionTileDelegate()!.resumeTile('stored-delay', { refreshTranscript: true })
+      await fetching
+
+      const current = {
+        ...initial,
+        busy: pending,
+        streamId: pending ? initial.streamId : null,
+        messages: [
+          ...(scenario === 'compacted'
+            ? [{ id: 'old-answer', role: 'assistant', parts: [{ type: 'text', text: 'Hello earlier answer' }] }]
+            : []),
+          initial.messages[0],
+          {
+            ...initial.messages[1],
+            pending,
+            parts: [{ type: 'text', text: pending ? 'Hello newer delta' : 'Hello completed' }]
+          }
+        ]
+      }
+
+      states.current.set('runtime-delay', current as never)
+      release({
+        session_id: 'stored-delay',
+        messages: [
+          { role: 'user', content: 'prompt', timestamp: 1 },
+          { role: 'system', content: 'external notice', timestamp: 2 },
+          ...(scenario === 'compacted' ? [{ role: 'assistant', content: 'Hello completed', timestamp: 3 }] : [])
+        ]
+      } as never)
+      await refreshing
+      const refreshed = states.current.get('runtime-delay')!
+      expect(refreshed.busy).toBe(pending)
+      expect(refreshed.streamId).toBe(current.streamId)
+      expect(refreshed.messages.filter(message => message.role === 'assistant')).toEqual([
+        current.messages[current.messages.length - 1]
+      ])
+      expect(JSON.stringify(refreshed.messages)).toContain('external notice')
+    }
   })
 
   it('falls through to a real resume when the warm binding has no transcript (post-wake empty tile)', async () => {

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -7,7 +7,7 @@ import {
   PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
 } from '@/hermes'
 import { translateNow } from '@/i18n/runtime'
-import { type ChatMessage, toChatMessages } from '@/lib/chat-messages'
+import { type ChatMessage, chatMessageText, toChatMessages } from '@/lib/chat-messages'
 import { notify } from '@/store/notifications'
 import {
   isReadOnlyRuntimeId,
@@ -17,7 +17,12 @@ import {
 import { knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
 import { assertSessionOwnerResolved } from '@/store/session-owner-resolution'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
-import { publishSessionState, sessionTileOwnerRoute, setSessionTileDelegate } from '@/store/session-states'
+import {
+  $sessionTiles,
+  publishSessionState,
+  sessionTileOwnerRoute,
+  setSessionTileDelegate
+} from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
 
 import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
@@ -25,6 +30,7 @@ import { singleFlightSessionResume } from '../../session/hooks/use-prompt-action
 import { markSessionRecentlyInterrupted, withSessionNotFoundResume } from '../../session/hooks/use-prompt-actions/utils'
 import {
   chatMessageArraysEquivalent,
+  preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
   resolveSessionOwner
 } from '../../session/hooks/use-session-actions/utils'
@@ -35,7 +41,8 @@ type SessionStateCache = ReturnType<typeof useSessionStateCache>
 
 function mergeTileTranscript(
   previous: ChatMessage[],
-  prefetchMessages: SessionResumeResponse['messages'] | undefined
+  prefetchMessages: SessionResumeResponse['messages'] | undefined,
+  streamId?: null | string
 ): ChatMessage[] {
   const prefetched = toChatMessages(prefetchMessages ?? [])
 
@@ -45,7 +52,64 @@ function mergeTileTranscript(
 
   const persisted = graftRefreshedTailOntoBackfill(prefetched, previous)
 
-  return reconcileResumeMessages(persisted, previous)
+  // The known stream belongs to this turn even when its text repeats an older
+  // answer; the generic reconnect reconciler only has text/ordinal heuristics.
+  const stream = previous.find(message => message.id === streamId)
+
+  const merged = preserveLocalPendingTurnMessages(
+    reconcileResumeMessages(persisted, previous),
+    stream ? previous.filter(message => message !== stream) : previous
+  )
+
+  if (!stream) {
+    return merged
+  }
+
+  // Compaction shifts global assistant ordinals. Anchor this turn at its user
+  // row instead; an older answer sharing the stream's prefix is not a match.
+  const beforeStream = previous.slice(0, previous.indexOf(stream))
+  const user = beforeStream.findLast(message => message.role === 'user')
+
+  let anchor = user
+    ? persisted.findIndex(
+        message => message.id === user.id || (user.rowId !== undefined && message.rowId === user.rowId)
+      )
+    : -1
+
+  if (user && anchor < 0) {
+    const matches = persisted.filter(
+      message => message.role === 'user' && chatMessageText(message) === chatMessageText(user)
+    )
+
+    anchor = matches.length === 1 ? persisted.indexOf(matches[0]) : -1
+  }
+
+  const turn = anchor < 0 ? [] : persisted.slice(anchor + 1)
+  const nextUser = turn.findIndex(message => message.role === 'user')
+
+  const ordinal = user
+    ? beforeStream.slice(beforeStream.indexOf(user) + 1).filter(message => message.role === 'assistant').length
+    : 0
+
+  const counterpart =
+    persisted.find(
+      message => message.id === stream.id || (stream.rowId !== undefined && message.rowId === stream.rowId)
+    ) ?? (nextUser < 0 ? turn : turn.slice(0, nextUser)).filter(message => message.role === 'assistant')[ordinal]
+
+  const localText = chatMessageText(stream)
+  const storedText = counterpart ? chatMessageText(counterpart) : ''
+
+  if (!counterpart || !(storedText.startsWith(localText) || localText.startsWith(storedText))) {
+    return [...merged, stream]
+  }
+
+  // Keep the stream id for subsequent deltas, but use REST's fuller answer.
+  const reply =
+    storedText.length > localText.length
+      ? { ...reconcileResumeMessages([counterpart], [stream])[0], id: stream.id }
+      : stream
+
+  return merged.map((message, index) => (index === persisted.indexOf(counterpart) ? reply : message))
 }
 
 interface SessionTileDelegateParams {
@@ -203,7 +267,12 @@ export function useSessionTileDelegate({
         )
       },
       resumeTile: async (storedSessionId, options) => {
-        const existing = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
+        // A retained tile can still own its runtime after the primary view drops
+        // its reverse lookup. Reconnect invalidates both bindings.
+        const existing =
+          runtimeIdByStoredSessionIdRef.current.get(storedSessionId) ??
+          $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.runtimeId
+
         const cached = existing ? sessionStateByRuntimeIdRef.current.get(existing) : undefined
         const refreshTranscript = options?.refreshTranscript === true
 
@@ -245,13 +314,16 @@ export function useSessionTileDelegate({
 
         if (existing && cached?.storedSessionId === storedSessionId && (cached.busy || cached.messages.length > 0)) {
           const prefetch = await prefetchPromise
-          const merged = mergeTileTranscript(cached.messages, prefetch?.messages)
+          // Deltas and completion may land while REST is in flight.
+          updateSessionState(
+            existing,
+            state => {
+              const merged = mergeTileTranscript(state.messages, prefetch?.messages, state.streamId ?? cached.streamId)
 
-          if (!chatMessageArraysEquivalent(cached.messages, merged)) {
-            updateSessionState(existing, state => ({ ...state, messages: merged }), storedSessionId)
-          } else {
-            publishSessionState(existing, cached)
-          }
+              return chatMessageArraysEquivalent(state.messages, merged) ? state : { ...state, messages: merged }
+            },
+            storedSessionId
+          )
 
           return existing
         }

--- a/apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
@@ -71,7 +71,7 @@ describe('a row click lands on the canonical chat, never a remembered side tab',
     })
   })
 
-  it('fronting an already-open Bot Chat refreshes its transcript in place', async () => {
+  it('fronting a busy, already-open Bot Chat refreshes its transcript in place', async () => {
     // The front is presentation-only: the pane keeps whatever transcript it
     // last painted, which can predate rows the bot wrote while the user was
     // elsewhere (a cron delivery, a teammate's message_agent, another bot's
@@ -82,11 +82,16 @@ describe('a row click lands on the canonical chat, never a remembered side tab',
       only?.includes('bot-chat-tip') ? 'bot-chat-tip' : null
     ) as never
     $selectedStoredSessionId.set('bot-chat-tip')
+    const busy = vi.spyOn(host.state.busy, 'get').mockReturnValue(true)
 
-    await expect(openRosterBot(canonicalBot)).resolves.toBe(true)
+    try {
+      await expect(openRosterBot(canonicalBot)).resolves.toBe(true)
 
-    expect(openBotCanonicalChat).toHaveBeenCalledWith(canonicalBot, expect.any(Function))
-    $selectedStoredSessionId.set(null)
+      expect(openBotCanonicalChat).toHaveBeenCalledWith(canonicalBot, expect.any(Function))
+    } finally {
+      busy.mockRestore()
+      $selectedStoredSessionId.set(null)
+    }
   })
 
   it('resolves the registry when only a side thread is open', async () => {
@@ -142,5 +147,21 @@ describe('the open Bot Chat follows its session on the gateway', () => {
 
     expect(openBotCanonicalChat).not.toHaveBeenCalled()
     $selectedStoredSessionId.set(null)
+  })
+
+  it('does not re-open a focused Bot Chat from roster activity while its turn is busy', () => {
+    $selectedBot.set('alpha')
+    $selectedStoredSessionId.set('bot-chat-tip')
+    const busy = vi.spyOn(host.state.busy, 'get').mockReturnValue(true)
+
+    try {
+      trackInboundActivity([activeBot(500)])
+      trackInboundActivity([activeBot(600)])
+
+      expect(openBotCanonicalChat).not.toHaveBeenCalled()
+    } finally {
+      busy.mockRestore()
+      $selectedStoredSessionId.set(null)
+    }
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
@@ -116,11 +116,11 @@ export function trackInboundActivity(roster: RosterRow[]) {
  *  session — a group room or another tab owning the center must not be
  *  yanked away by background activity — and never mid-turn, when the
  *  activity is the turn itself, already streaming. */
-function refreshOpenBotChat(bot: RosterRow) {
+function refreshOpenBotChat(bot: RosterRow, { allowWhileBusy = false }: { allowWhileBusy?: boolean } = {}) {
   const canonicalIds = [bot.canonical_session?.id, bot.canonical_session?.resolved_id].filter(Boolean).map(String)
   const focused = String(host.state.focusedStoredSessionId?.get?.() || '')
 
-  if (!focused || !canonicalIds.includes(focused) || host.state.busy.get()) {
+  if (!focused || !canonicalIds.includes(focused) || (!allowWhileBusy && host.state.busy.get())) {
     return
   }
 
@@ -252,7 +252,7 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
     // message_agent). Force a registry open so forceResume re-pulls the
     // latest transcript instead of leaving a stale snapshot until the next
     // user turn (#99393 class; #95600 only covered the not-yet-open path).
-    refreshOpenBotChat(bot)
+    refreshOpenBotChat(bot, { allowWhileBusy: true })
 
     return true
   }


### PR DESCRIPTION
Returning from a group to an already-open, busy Bot Chat now refreshes persisted messages without losing its running reply.

Salvages #102474 from @helix4u; the original contributor commit is preserved separately from the integration fixes discovered during native QA. This addresses the community-reported stale Bot Chat class, not a report from the maintainer's installation.

## Changes
- Explicit bot-row clicks may refresh a busy canonical chat; passive roster activity still leaves busy chats alone.
- Resolve the retained tile's existing runtime when the primary view's reverse lookup is absent, rather than discarding the REST prefetch on a cold-resume path.
- Merge into current state after REST returns, retaining the current reply through streaming/completion; anchor authoritative replies within their user turn so older repeated answers and compaction do not cause duplicate replies.

**Root cause:** the explicit-open path inherited a passive busy guard; removing it exposed a retained-runtime lookup gap and refresh reconciliation that could discard the live tail.

## Improvements during salvage
The contributor's trigger change alone still failed native QA: the persisted notice remained absent even though `forceResume` ran. The separate follow-up fixes that integration gap. Independent review also reproduced duplicate replies when REST was ahead or compaction shifted assistant ordinals; those cases now pass within the same two hook invariants. There are two roster invariant cases and two downstream hook invariant cases, not a new test framework. No new settings or user-facing controls require documentation.

## Validation
**Live repro:** native Electron 40.10.2, production main/preload/renderer and real Python backend, isolated HOME/HERMES_HOME/userData, loopback mock inference. Before: group → retained busy canonical tile leaves the persisted notice absent. After: the ordinary row click shows the notice while retaining the runtime and pending reply, which then completes normally.

| Gate | Actual result |
|---|---|
| Baseline roster regression | 1 expected assertion failure, 6 passed; explicit-open registry calls = 0. Passive busy-poll control remains green. |
| Original salvage, downstream hook | Native missing-notice assertion fails; both new hook invariants fail against the original hook. |
| Final native ordinary return | Persisted notice absent before / visible after; busy remains true, runtime preserved, original stream completes. |
| Final native delayed REST | Original stream completes while genuine IPC response is held; releasing unchanged response shows notice, busy stays false, runtime and completed reply preserved. |
| Review regression tests | Both reported duplicate-answer cases reproduced red before correction and green afterward. |
| Bot plugin directory | 61 files / 576 tests passed. |
| Contrib hook directory | 6 files / 84 tests passed. |
| Static checks | All three Desktop TypeScript projects; hook-directory and changed-roster ESLint; Prettier on hook/test; Windows-footgun, compat-pointer and diff checks passed. |

Live steps: create isolated profiles and canonical chats → retain canonical tile beside a side chat → start a held local SSE reply → open group → append a uniquely marked notice through real SessionDB → click bot row → assert visible notice and unchanged runtime/reply → release reply and assert completion. Repeat with the real REST response delayed until completion.

The external notice is a **real persisted SessionDB fixture**, not a claimed live cron or `message_agent` producer test. Inference is local and deterministic; no paid model calls or real customer configuration were used. Screenshots were captured and visually checked locally. Native receipts are retained under `.busy-live/review-final-{fixed,delayed}/receipt.json` in the isolated QA worktree; temporary harnesses/images are intentionally not committed. Full Desktop suite and non-Linux native platforms were not run locally; remote CI is pending.

## Infographic
![Busy Bot Chat explicit refresh preserves its running reply](https://v3b.fal.media/files/b/0aa98f07/6VqiES1RKUP49-OXlMBeS_rtvafpGL.png)
