### PR TITLE
fix(mcp): fail fast with actionable error when mcp SDK missing (salvage of #34245)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -269,6 +269,19 @@ def _probe_single_server(
     from tools.mcp_tool_discovery import _connect_server
     from tools.mcp_tool_lifecycle import _stop_mcp_loop_if_idle
     from tools.mcp_tool_common import _parse_boolish
+    from tools.mcp_tool import _MCP_AVAILABLE
+
+    # Fail fast before event loop + connect retry/timeout bury the SDK ImportError (#34220).
+    if not _MCP_AVAILABLE:
+        raise ImportError(
+            "The 'mcp' Python SDK is required for 'hermes mcp' commands but "
+            "is not installed. Install with:\n"
+            "  pip install 'hermes-agent[mcp]'\n"
+            "or, for pipx installs:\n"
+            "  pipx inject hermes-agent mcp\n"
+            "or, for the full install:\n"
+            "  pip install 'hermes-agent[all]'"
+        )
 
     config = _resolve_mcp_server_config(config)
     if connect_timeout is None:

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -845,3 +845,30 @@ class TestMcpReauth:
         cmd_mcp_reauth(_make_args(name="ghost", all=False))
         out = capsys.readouterr().out
         assert "not found" in out
+
+class TestProbeSingleServerMcpMissing:
+    """#34220: fail fast when mcp SDK missing."""
+
+    def test_probe_raises_importerror_fast_when_mcp_missing(self, monkeypatch):
+        from hermes_cli import mcp_config
+        import tools.mcp_tool as mcp_tool
+        monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", False, raising=False)
+        with pytest.raises(ImportError) as exc_info:
+            mcp_config._probe_single_server(
+                "ghost-server",
+                {"command": "echo", "args": ["hi"]},
+                connect_timeout=5,
+            )
+        msg = str(exc_info.value)
+        assert "mcp" in msg.lower()
+        assert "hermes-agent[mcp]" in msg
+
+    def test_probe_actionable_error_mentions_pipx_inject(self, monkeypatch):
+        from hermes_cli import mcp_config
+        import tools.mcp_tool as mcp_tool
+        monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", False, raising=False)
+        with pytest.raises(ImportError) as exc_info:
+            mcp_config._probe_single_server(
+                "ghost-server", {"command": "echo"}, connect_timeout=5
+            )
+        assert "pipx inject" in str(exc_info.value)


### PR DESCRIPTION
Fixes #34220 (still present on current main for `hermes mcp` probe paths).

Salvage of #34245 onto current `origin/main`. Original PR is CONFLICTING after MCP module split (`tools.mcp_tool_loop` / discovery / lifecycle).

## Problem
When the optional `mcp` SDK is not installed, `_probe_single_server` still starts the event loop + connect path. The inner ImportError can be buried under retries/timeouts.

Transport-level ImportError exists (`tools/mcp_tool_transport.py`), but CLI probe does not fail fast before looping.

## Fix
Check `_MCP_AVAILABLE` at the top of `_probe_single_server` and raise a synchronous ImportError with pip / pipx / `[all]` install hints.

## Tests
`TestProbeSingleServerMcpMissing` in `tests/hermes_cli/test_mcp_config.py`.

```
pytest tests/hermes_cli/test_mcp_config.py
40 passed
```