### PR TITLE
feat(tui): make the terminal tab and window titles configurable

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -901,6 +901,18 @@ DEFAULT_CONFIG = {
         "status_bar": {
             "fields": [],
         },
+        # TUI terminal title templates. Empty = the built-in composition:
+        # tab (OSC 1) `{marker} {session}`, window (OSC 2)
+        # `{marker} {session} · {model} · {cwd}`. The tab label deliberately
+        # omits model/cwd — narrow tab bars truncate from the LEFT, so a long
+        # window string would hide the session name.
+        # Tokens: {marker} {session} {session_full} {model} {model_full}
+        # {cwd} {cwd_full}. The short forms are capped/abbreviated
+        # ({session} 28 chars, {model} vendor prefix stripped, {cwd} 24 chars
+        # and $HOME → ~); the *_full forms are verbatim. Unknown {tokens} are
+        # left as written. Empty tokens collapse their ` · ` separators.
+        "tab_title_template": "",
+        "window_title_template": "",
         "copy_shortcut": "auto",  # "auto" (platform default) | ctrl_c | ctrl_shift_c | disabled
         # Petdex animated mascot (github.com/crafter-station/petdex): cosmetic sprite across
         # CLI/TUI/desktop, managed with `hermes pets`. No effect on prompt caching.

--- a/ui-tui/src/__tests__/paths.test.ts
+++ b/ui-tui/src/__tests__/paths.test.ts
@@ -5,6 +5,7 @@ import {
   fmtCwdBranch,
   fmtProjectCwdBranch,
   renderTitleTemplate,
+  resolveTerminalTitle,
   shortCwd,
   shortProject,
   shortSessionName,
@@ -204,6 +205,20 @@ describe('renderTitleTemplate', () => {
     expect(renderTitleTemplate('{marker} {session}', dflt)).toBe(composeTabTitle('✓', 'auth refactor', '', ''))
   })
 
+  it('preserves whitespace inside literal text (no global collapse)', () => {
+    expect(renderTitleTemplate('prefix  literal {marker}', tokens)).toBe('prefix  literal ✓')
+  })
+
+  it('keeps *_full values byte-verbatim, including runs of spaces', () => {
+    const spaced: TitleTokens = { ...tokens, cwdFull: '/tmp/a  b', sessionFull: 'alpha  beta' }
+    expect(renderTitleTemplate('{session_full}', spaced)).toBe('alpha  beta')
+    expect(renderTitleTemplate('{cwd_full}', spaced)).toBe('/tmp/a  b')
+  })
+
+  it('leaves a literal separator run alone when no token was empty', () => {
+    expect(renderTitleTemplate('A · · B {marker}', tokens)).toBe('A · · B ✓')
+  })
+
   it('collapses the separator orphaned by an empty token', () => {
     const noModel: TitleTokens = { ...tokens, model: '', session: 'auth refactor' }
     expect(renderTitleTemplate('{marker} {session} · {model} · {cwd}', noModel)).toBe('✓ auth refactor · ~/proj')
@@ -218,9 +233,51 @@ describe('renderTitleTemplate', () => {
     expect(renderTitleTemplate('{marker} {sesion}', tokens)).toBe('✓ {sesion}')
   })
 
+  it('drops only the space around an empty token, not the neighbours', () => {
+    const noMarker: TitleTokens = { ...tokens, marker: '', session: 'auth refactor' }
+    expect(renderTitleTemplate('{marker} {session}', noMarker)).toBe('auth refactor')
+  })
+
   it('passes literal text through unchanged', () => {
     expect(renderTitleTemplate('hermes: {session_full}', tokens)).toBe(
       'hermes: a very long session name that is not clipped'
     )
+  })
+})
+
+describe('resolveTerminalTitle', () => {
+  const tokens: TitleTokens = {
+    cwd: '~/proj',
+    cwdFull: '/Users/bb/proj',
+    marker: '✓',
+    model: 'opus-4',
+    modelFull: 'anthropic/opus-4',
+    session: 'auth refactor',
+    sessionFull: 'auth refactor'
+  }
+
+  const noModel: TitleTokens = { ...tokens, model: '', modelFull: '' }
+
+  it('falls back to the brand string when nothing is configured and no model is known', () => {
+    expect(resolveTerminalTitle({ tab: '', window: '' }, noModel, 'auth refactor')).toBe('Hermes')
+  })
+
+  it('honors a configured template BEFORE the model arrives', () => {
+    expect(resolveTerminalTitle({ tab: '{session_full}', window: '' }, noModel, 'auth refactor')).toEqual({
+      tab: 'auth refactor',
+      window: '✓ auth refactor · ~/proj'
+    })
+  })
+
+  it('honors a window-only template with no model', () => {
+    const out = resolveTerminalTitle({ tab: '', window: 'hermes: {session_full}' }, noModel, 'auth refactor')
+    expect(out).toEqual({ tab: '✓ auth refactor', window: 'hermes: auth refactor' })
+  })
+
+  it('reproduces the built-in split when no template is set', () => {
+    expect(resolveTerminalTitle({ tab: '', window: '' }, tokens, 'auth refactor')).toEqual({
+      tab: '✓ auth refactor',
+      window: '✓ auth refactor · opus-4 · ~/proj'
+    })
   })
 })

--- a/ui-tui/src/__tests__/paths.test.ts
+++ b/ui-tui/src/__tests__/paths.test.ts
@@ -1,6 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { composeTabTitle, fmtCwdBranch, fmtProjectCwdBranch, shortCwd, shortProject } from '../domain/paths.js'
+import {
+  composeTabTitle,
+  fmtCwdBranch,
+  fmtProjectCwdBranch,
+  renderTitleTemplate,
+  shortCwd,
+  shortProject,
+  shortSessionName,
+  type TitleTokens
+} from '../domain/paths.js'
 
 describe('shortCwd', () => {
   const origHome = process.env.HOME
@@ -140,5 +149,78 @@ describe('composeTabTitle', () => {
     const name = 'b'.repeat(28)
     const out = composeTabTitle('✓', name, 'opus-4', '', 28)
     expect(out).toBe(`✓ ${name} · opus-4`)
+  })
+})
+
+describe('shortSessionName', () => {
+  it('leaves a short name untouched and trims it', () => {
+    expect(shortSessionName('  auth refactor  ')).toBe('auth refactor')
+  })
+
+  it('truncates past the cap with an ellipsis', () => {
+    const out = shortSessionName('a'.repeat(40), 28)
+    expect(out.endsWith('…')).toBe(true)
+    expect(out.length).toBe(28)
+  })
+})
+
+describe('renderTitleTemplate', () => {
+  const tokens: TitleTokens = {
+    cwd: '~/proj',
+    cwdFull: '/Users/bb/very/long/path/to/proj',
+    marker: '✓',
+    model: 'opus-4',
+    modelFull: 'anthropic/opus-4',
+    session: 'a very long session name th…',
+    sessionFull: 'a very long session name that is not clipped'
+  }
+
+  it('returns null for an empty template so the caller keeps its default', () => {
+    expect(renderTitleTemplate('', tokens)).toBeNull()
+    expect(renderTitleTemplate('   ', tokens)).toBeNull()
+  })
+
+  it('substitutes every known token', () => {
+    expect(renderTitleTemplate('{marker} {session} · {model} · {cwd}', tokens)).toBe(
+      '✓ a very long session name th… · opus-4 · ~/proj'
+    )
+  })
+
+  it('renders the full variants verbatim, uncapped', () => {
+    expect(renderTitleTemplate('{session_full}', tokens)).toBe('a very long session name that is not clipped')
+    expect(renderTitleTemplate('{model_full}', tokens)).toBe('anthropic/opus-4')
+    expect(renderTitleTemplate('{cwd_full}', tokens)).toBe('/Users/bb/very/long/path/to/proj')
+  })
+
+  it('reproduces the default window composition when given the default template', () => {
+    const dflt = { ...tokens, session: 'auth refactor' }
+    expect(renderTitleTemplate('{marker} {session} · {model} · {cwd}', dflt)).toBe(
+      composeTabTitle('✓', 'auth refactor', 'opus-4', '~/proj')
+    )
+  })
+
+  it('reproduces the default tab composition when given the default tab template', () => {
+    const dflt = { ...tokens, session: 'auth refactor' }
+    expect(renderTitleTemplate('{marker} {session}', dflt)).toBe(composeTabTitle('✓', 'auth refactor', '', ''))
+  })
+
+  it('collapses the separator orphaned by an empty token', () => {
+    const noModel: TitleTokens = { ...tokens, model: '', session: 'auth refactor' }
+    expect(renderTitleTemplate('{marker} {session} · {model} · {cwd}', noModel)).toBe('✓ auth refactor · ~/proj')
+  })
+
+  it('trims separators left dangling at either end', () => {
+    const bare: TitleTokens = { ...tokens, cwd: '', marker: '', model: '', session: 'auth refactor' }
+    expect(renderTitleTemplate('{marker} {session} · {model} · {cwd}', bare)).toBe('auth refactor')
+  })
+
+  it('keeps an unknown token verbatim so a typo stays visible', () => {
+    expect(renderTitleTemplate('{marker} {sesion}', tokens)).toBe('✓ {sesion}')
+  })
+
+  it('passes literal text through unchanged', () => {
+    expect(renderTitleTemplate('hermes: {session_full}', tokens)).toBe(
+      'hermes: a very long session name that is not clipped'
+    )
   })
 })

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeIndicatorStyle,
   normalizeMouseTracking,
   normalizeStatusBar,
+  normalizeTitleTemplate,
   syncMcpReload
 } from '../app/useConfigSync.js'
 
@@ -117,6 +118,29 @@ describe('applyDisplay', () => {
     expect(s.statusBar).toBe('top')
     expect(s.streaming).toBe(true)
     expect(s.sections).toEqual({})
+    // Empty template = keep the built-in title composition.
+    expect(s.tabTitleTemplate).toBe('')
+    expect(s.windowTitleTemplate).toBe('')
+  })
+
+  it('fans the title templates out to $uiState', () => {
+    const setBell = vi.fn()
+
+    applyDisplay(
+      {
+        config: {
+          display: {
+            tab_title_template: '{session_full}',
+            window_title_template: '{marker} {session_full} · {model_full}'
+          }
+        }
+      },
+      setBell
+    )
+
+    const s = $uiState.get()
+    expect(s.tabTitleTemplate).toBe('{session_full}')
+    expect(s.windowTitleTemplate).toBe('{marker} {session_full} · {model_full}')
   })
 
   it('uses documented mouse_tracking with legacy tui_mouse fallback', () => {
@@ -589,5 +613,20 @@ describe('hydrateFullConfig', () => {
     // display flags (round-2 / round-8 invariant).
     await expect(hydrateFullConfig(gw, setBell)).resolves.toBeTruthy()
     expect(setBell).toHaveBeenCalledWith(true)
+  })
+})
+
+describe('normalizeTitleTemplate', () => {
+  it('keeps a real template verbatim, including its spacing', () => {
+    expect(normalizeTitleTemplate('  {marker} {session_full} ')).toBe('  {marker} {session_full} ')
+  })
+
+  it('collapses blank and non-string values to the default sentinel', () => {
+    expect(normalizeTitleTemplate('')).toBe('')
+    expect(normalizeTitleTemplate('   ')).toBe('')
+    expect(normalizeTitleTemplate(undefined)).toBe('')
+    expect(normalizeTitleTemplate(3)).toBe('')
+    expect(normalizeTitleTemplate(null)).toBe('')
+    expect(normalizeTitleTemplate({ a: 1 })).toBe('')
   })
 })

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -616,6 +616,39 @@ describe('hydrateFullConfig', () => {
   })
 })
 
+describe('applyDisplay title-template fail-safe', () => {
+  beforeEach(() => {
+    resetUiState()
+  })
+
+  it('preserves live templates when the full-config RPC fails (cfg=null)', () => {
+    const setBell = vi.fn()
+
+    applyDisplay(
+      { config: { display: { tab_title_template: '{session_full}', window_title_template: '{marker} {cwd_full}' } } },
+      setBell
+    )
+
+    // A transient `config.get full` failure must not reset the user's
+    // templates: the mtime poller already advanced, so the clobber would
+    // survive until the next config edit.
+    applyDisplay(null, setBell)
+
+    const s = $uiState.get()
+    expect(s.tabTitleTemplate).toBe('{session_full}')
+    expect(s.windowTitleTemplate).toBe('{marker} {cwd_full}')
+  })
+
+  it('still clears templates when a SUCCESSFUL payload drops the keys', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: { tab_title_template: '{session_full}' } } }, setBell)
+    applyDisplay({ config: { display: {} } }, setBell)
+
+    expect($uiState.get().tabTitleTemplate).toBe('')
+  })
+})
+
 describe('normalizeTitleTemplate', () => {
   it('keeps a real template verbatim, including its spacing', () => {
     expect(normalizeTitleTemplate('  {marker} {session_full} ')).toBe('  {marker} {session_full} ')

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -351,11 +351,17 @@ export interface UiState {
   // the default set).
   statusBarFields: null | ReadonlySet<string>
   streaming: boolean
+  // `display.tab_title_template` — user template for the OSC 1 tab label.
+  // Empty string = use the built-in default composition.
+  tabTitleTemplate: string
   theme: Theme
   // `display.timestamps` — dim [HH:MM] labels on user/assistant transcript
   // rows, the same config key the classic CLI honors (#41531).
   timestamps: boolean
   usage: Usage
+  // `display.window_title_template` — user template for the OSC 2 window
+  // title. Empty string = use the built-in default composition.
+  windowTitleTemplate: string
 }
 
 export interface VirtualHistoryState {

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -35,11 +35,13 @@ const buildUiState = (): UiState => ({
   statusBar: 'top',
   statusBarFields: null,
   streaming: true,
+  tabTitleTemplate: '',
   timestamps: false,
   // Last session's resolved theme paints frame one (flash-free boot, like
   // the desktop's hermes-boot-* keys); DEFAULT_THEME only on first launch.
   theme: bootTheme ?? DEFAULT_THEME,
-  usage: ZERO
+  usage: ZERO,
+  windowTitleTemplate: ''
 })
 
 export const $uiState = atom<UiState>(buildUiState())

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -42,6 +42,18 @@ export const normalizeStatusBarFields = (raw: unknown): null | ReadonlySet<strin
   return cleaned.length ? new Set(cleaned) : null
 }
 
+// `display.tab_title_template` / `display.window_title_template` — raw YAML
+// may hold any scalar. Non-strings and blanks collapse to '' meaning "keep
+// the built-in default composition", so a hand-edited `tab_title_template: 3`
+// cannot blank the title bar.
+export const normalizeTitleTemplate = (raw: unknown): string => {
+  if (typeof raw !== 'string') {
+    return ''
+  }
+
+  return raw.trim() ? raw : ''
+}
+
 const BUSY_MODES = new Set<BusyInputMode>(['interrupt', 'queue', 'steer'])
 
 // TUI defaults to `queue` even though the framework default
@@ -309,9 +321,11 @@ export const applyDisplay = (
     statusBar: normalizeStatusBar(d.tui_statusbar),
     statusBarFields: normalizeStatusBarFields(d.status_bar?.fields),
     streaming: d.streaming !== false,
+    tabTitleTemplate: normalizeTitleTemplate(d.tab_title_template),
     // The SAME key that stamps [HH:MM] on classic-CLI labels (#41531) —
     // no separate TUI knob.
-    timestamps: d.timestamps === true
+    timestamps: d.timestamps === true,
+    windowTitleTemplate: normalizeTitleTemplate(d.window_title_template)
   })
 }
 

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -321,11 +321,19 @@ export const applyDisplay = (
     statusBar: normalizeStatusBar(d.tui_statusbar),
     statusBarFields: normalizeStatusBarFields(d.status_bar?.fields),
     streaming: d.streaming !== false,
-    tabTitleTemplate: normalizeTitleTemplate(d.tab_title_template),
+    // Fail safe, same rule as destructiveSlashConfirm above: a transient
+    // `config.get full` failure (cfg=null) must NOT reset a custom title
+    // template. The mtime poller advances mtimeRef before hydrating, so a
+    // clobber here would persist until the next config edit.
+    ...(cfg
+      ? {
+          tabTitleTemplate: normalizeTitleTemplate(d.tab_title_template),
+          windowTitleTemplate: normalizeTitleTemplate(d.window_title_template)
+        }
+      : {}),
     // The SAME key that stamps [HH:MM] on classic-CLI labels (#41531) —
     // no separate TUI knob.
-    timestamps: d.timestamps === true,
-    windowTitleTemplate: normalizeTitleTemplate(d.window_title_template)
+    timestamps: d.timestamps === true
   })
 }
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -17,9 +17,8 @@ import { RESIZE_COALESCE_MS } from '../config/timing.js'
 import { hasLeadGap, prevRenderedMsg } from '../domain/blockLayout.js'
 import { SECTION_NAMES, sectionMode } from '../domain/details.js'
 import {
-  composeTabTitle,
   fmtProjectCwdBranch,
-  renderTitleTemplate,
+  resolveTerminalTitle,
   shortCwd,
   shortSessionName,
   TITLE_MAX_CWD
@@ -663,15 +662,7 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   useTerminalTitle(
-    model
-      ? {
-          tab:
-            renderTitleTemplate(ui.tabTitleTemplate, titleTokens) ?? composeTabTitle(marker, ui.sessionTitle, '', ''),
-          window:
-            renderTitleTemplate(ui.windowTitleTemplate, titleTokens) ??
-            composeTabTitle(marker, ui.sessionTitle, model, titleTokens.cwd)
-        }
-      : 'Hermes'
+    resolveTerminalTitle({ tab: ui.tabTitleTemplate, window: ui.windowTitleTemplate }, titleTokens, ui.sessionTitle)
   )
 
   useEffect(() => {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -16,7 +16,14 @@ import { WHEEL_SCROLL_STEP } from '../config/limits.js'
 import { RESIZE_COALESCE_MS } from '../config/timing.js'
 import { hasLeadGap, prevRenderedMsg } from '../domain/blockLayout.js'
 import { SECTION_NAMES, sectionMode } from '../domain/details.js'
-import { composeTabTitle, fmtProjectCwdBranch, shortCwd } from '../domain/paths.js'
+import {
+  composeTabTitle,
+  fmtProjectCwdBranch,
+  renderTitleTemplate,
+  shortCwd,
+  shortSessionName,
+  TITLE_MAX_CWD
+} from '../domain/paths.js'
 import { sessionScopedModelArg } from '../domain/slash.js'
 import { type GatewayClient } from '../gatewayClient.js'
 import type {
@@ -630,18 +637,39 @@ export function useMainApp(gw: GatewayClient) {
   }, [gw, ui.sid])
 
   // Tab title: `⚠` waiting on approval/sudo/secret/clarify, `⏳` busy, `✓` idle.
-  // Format: `<marker> <session name> · <model> · <cwd>` — name/cwd omitted when absent.
-  const model = ui.info?.model?.replace(/^.*\//, '') ?? ''
+  // Default format: `<marker> <session name> · <model> · <cwd>` — name/cwd
+  // omitted when absent. `display.tab_title_template` (OSC 1 tab label) and
+  // `display.window_title_template` (OSC 2 window bar) override the two
+  // compositions independently; empty config keeps these defaults.
+  const modelFull = ui.info?.model ?? ''
+
+  const model = modelFull.replace(/^.*\//, '')
 
   const marker = overlay.approval || overlay.sudo || overlay.secret || overlay.clarify ? '⚠' : ui.busy ? '⏳' : '✓'
 
   const tabCwd = ui.info?.cwd
 
+  const titleTokens = useMemo(
+    () => ({
+      cwd: tabCwd ? shortCwd(tabCwd, TITLE_MAX_CWD) : '',
+      cwdFull: tabCwd ?? '',
+      marker,
+      model,
+      modelFull,
+      session: shortSessionName(ui.sessionTitle),
+      sessionFull: ui.sessionTitle.trim()
+    }),
+    [marker, model, modelFull, tabCwd, ui.sessionTitle]
+  )
+
   useTerminalTitle(
     model
       ? {
-          tab: composeTabTitle(marker, ui.sessionTitle, '', ''),
-          window: composeTabTitle(marker, ui.sessionTitle, model, tabCwd ? shortCwd(tabCwd, 24) : '')
+          tab:
+            renderTitleTemplate(ui.tabTitleTemplate, titleTokens) ?? composeTabTitle(marker, ui.sessionTitle, '', ''),
+          window:
+            renderTitleTemplate(ui.windowTitleTemplate, titleTokens) ??
+            composeTabTitle(marker, ui.sessionTitle, model, titleTokens.cwd)
         }
       : 'Hermes'
   )

--- a/ui-tui/src/domain/paths.ts
+++ b/ui-tui/src/domain/paths.ts
@@ -43,6 +43,18 @@ export const fmtProjectCwdBranch = (cwd: string, branch: null | string, projectN
   return `${project}${separator}${fmtCwdBranch(cwd, branch, remaining)}`
 }
 
+/** Default cap on the session-name segment of a composed title. */
+export const TITLE_MAX_NAME = 28
+
+/** Default cap on the cwd segment of a composed title. */
+export const TITLE_MAX_CWD = 24
+
+export const shortSessionName = (sessionName: string, max = TITLE_MAX_NAME): string => {
+  const name = sessionName.trim()
+
+  return name.length > max ? `${name.slice(0, max - 1)}…` : name
+}
+
 /**
  * Compose the terminal titlebar string:
  *   `<marker> <session name> · <model> · <cwd>`
@@ -57,12 +69,79 @@ export const composeTabTitle = (
   sessionName: string,
   model: string,
   cwd: string,
-  maxName = 28
+  maxName = TITLE_MAX_NAME
 ): string => {
-  const name = sessionName.trim()
-  const shortName = name.length > maxName ? `${name.slice(0, maxName - 1)}…` : name
+  const shortName = shortSessionName(sessionName, maxName)
 
   const segments = [shortName, model, cwd].filter(Boolean)
 
   return segments.length ? `${marker} ${segments.join(' · ')}` : marker
+}
+
+/** Values a title template can interpolate. `*_full` variants skip the
+ *  length caps and prefix-stripping that the short forms apply. */
+export interface TitleTokens {
+  cwd: string
+  cwdFull: string
+  marker: string
+  model: string
+  modelFull: string
+  session: string
+  sessionFull: string
+}
+
+// Recognized placeholders. Unknown `{tokens}` are left VERBATIM rather than
+// blanked: a typo stays visible in the title bar instead of silently
+// vanishing, which is the cheaper failure to diagnose.
+const TITLE_TOKEN_PATTERN = /\{(cwd|cwd_full|marker|model|model_full|session|session_full)\}/g
+
+/**
+ * Render a user-supplied title template (`display.tab_title_template` /
+ * `display.window_title_template`).
+ *
+ * Empty/blank template ⇒ `null`, meaning "caller keeps its built-in default".
+ *
+ * Segment separators are part of the template, so a token that resolves to an
+ * empty string would leave a dangling ` · `. We therefore collapse runs of
+ * separator/whitespace left by empty tokens, and trim them from both ends.
+ */
+export const renderTitleTemplate = (template: string, tokens: TitleTokens): null | string => {
+  if (!template.trim()) {
+    return null
+  }
+
+  const substituted = template.replace(TITLE_TOKEN_PATTERN, (_match, name: string) => {
+    switch (name) {
+      case 'cwd':
+        return tokens.cwd
+
+      case 'cwd_full':
+        return tokens.cwdFull
+
+      case 'marker':
+        return tokens.marker
+
+      case 'model':
+        return tokens.model
+
+      case 'model_full':
+        return tokens.modelFull
+
+      case 'session':
+        return tokens.session
+
+      case 'session_full':
+        return tokens.sessionFull
+
+      default:
+        return ''
+    }
+  })
+
+  // Collapse the separators orphaned by empty tokens (`a ·  · b` ⇒ `a · b`),
+  // then strip leading/trailing separators and whitespace.
+  return substituted
+    .replace(/\s*·(?:\s*·)+\s*/g, ' · ')
+    .replace(/^[\s·]+|[\s·]+$/g, '')
+    .replace(/\s{2,}/g, ' ')
 }

--- a/ui-tui/src/domain/paths.ts
+++ b/ui-tui/src/domain/paths.ts
@@ -101,47 +101,108 @@ const TITLE_TOKEN_PATTERN = /\{(cwd|cwd_full|marker|model|model_full|session|ses
  *
  * Empty/blank template ⇒ `null`, meaning "caller keeps its built-in default".
  *
- * Segment separators are part of the template, so a token that resolves to an
- * empty string would leave a dangling ` · `. We therefore collapse runs of
- * separator/whitespace left by empty tokens, and trim them from both ends.
+ * Segment separators live in the template, so a token that resolves to an empty
+ * string would leave a dangling ` · `. Cleanup is driven by WHICH tokens came
+ * back empty rather than by scanning the finished string: a global
+ * whitespace/`·` collapse would also rewrite the user's literal text and the
+ * deliberately verbatim `*_full` values (a cwd or session name holding two
+ * spaces must survive intact). Each empty substitution is marked with a
+ * sentinel that cannot occur in user input, the separator on one side of it is
+ * dropped, then the sentinel is removed.
  */
 export const renderTitleTemplate = (template: string, tokens: TitleTokens): null | string => {
   if (!template.trim()) {
     return null
   }
 
-  const substituted = template.replace(TITLE_TOKEN_PATTERN, (_match, name: string) => {
-    switch (name) {
-      case 'cwd':
-        return tokens.cwd
+  const substituted = template.replace(TITLE_TOKEN_PATTERN, (match, name: string) => {
+    const value = titleTokenValue(name, tokens)
 
-      case 'cwd_full':
-        return tokens.cwdFull
-
-      case 'marker':
-        return tokens.marker
-
-      case 'model':
-        return tokens.model
-
-      case 'model_full':
-        return tokens.modelFull
-
-      case 'session':
-        return tokens.session
-
-      case 'session_full':
-        return tokens.sessionFull
-
-      default:
-        return ''
+    if (value === undefined) {
+      return match
     }
+
+    return value === '' ? EMPTY_TOKEN_SENTINEL : value
   })
 
-  // Collapse the separators orphaned by empty tokens (`a ·  · b` ⇒ `a · b`),
-  // then strip leading/trailing separators and whitespace.
-  return substituted
-    .replace(/\s*·(?:\s*·)+\s*/g, ' · ')
-    .replace(/^[\s·]+|[\s·]+$/g, '')
-    .replace(/\s{2,}/g, ' ')
+  if (!substituted.includes(EMPTY_TOKEN_SENTINEL)) {
+    return substituted.trim()
+  }
+
+  return (
+    substituted
+      // One alternation, not two passes: the match CONSUMES the hole, so a
+      // single hole can never have the separator eaten on both sides. The
+      // following separator is preferred; the leading one covers a trailing
+      // hole. `[^\S\n]` keeps the class to horizontal space only.
+      .replace(SENTINEL_ADJACENT_SEP, EMPTY_TOKEN_SENTINEL)
+      // A hole between plain spaces (`{marker} {session}` with no marker) must
+      // not leave a double space behind.
+      .replace(SENTINEL_BETWEEN_SPACES, ' ')
+      .replaceAll(EMPTY_TOKEN_SENTINEL, '')
+      .trim()
+  )
+}
+
+// A private-use code point: it cannot appear in a YAML scalar, a session title
+// or a path, and unlike U+0000 it is not a control char (no-control-regex).
+const EMPTY_TOKEN_SENTINEL = '\uE000'
+
+const SENTINEL_ADJACENT_SEP = /[^\S\n]*·\s*\uE000|\uE000\s*·[^\S\n]*/g
+const SENTINEL_BETWEEN_SPACES = /[^\S\n]\uE000[^\S\n]/g
+
+/** Token value, or `undefined` for a name the pattern does not cover. */
+const titleTokenValue = (name: string, tokens: TitleTokens): string | undefined => {
+  switch (name) {
+    case 'cwd':
+      return tokens.cwd
+
+    case 'cwd_full':
+      return tokens.cwdFull
+
+    case 'marker':
+      return tokens.marker
+
+    case 'model':
+      return tokens.model
+
+    case 'model_full':
+      return tokens.modelFull
+
+    case 'session':
+      return tokens.session
+
+    case 'session_full':
+      return tokens.sessionFull
+
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Resolve what `useTerminalTitle` should receive: a `{tab, window}` pair, or the
+ * plain brand string when there is nothing session-specific to show yet.
+ *
+ * A CONFIGURED template wins even before the model is known — `{session_full}`
+ * or literal text renders fine with no model, and gating on the model would
+ * ignore the user's config for the whole startup window. The built-in
+ * composition still needs a model, else it degrades to a bare marker.
+ */
+export const resolveTerminalTitle = (
+  templates: { tab: string; window: string },
+  tokens: TitleTokens,
+  sessionName: string
+): string | { tab: string; window: string } => {
+  const tab = renderTitleTemplate(templates.tab, tokens)
+  const window = renderTitleTemplate(templates.window, tokens)
+
+  if (!tab && !window && !tokens.model) {
+    return 'Hermes'
+  }
+
+  return {
+    tab: tab || composeTabTitle(tokens.marker, sessionName, '', ''),
+    window: window || composeTabTitle(tokens.marker, sessionName, tokens.model, tokens.cwd)
+  }
 }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -94,6 +94,9 @@ export interface ConfigDisplayConfig {
    *  Raw YAML: callers must runtime-validate entries. */
   status_bar?: { fields?: unknown }
   streaming?: boolean
+  /** Template for the terminal TAB label (OSC 1). Empty/absent = built-in
+   *  default (`{marker} {session}`). See `renderTitleTemplate`. */
+  tab_title_template?: string
   thinking_mode?: string
   /** Show [HH:MM] timestamps on transcript rows — same key the classic CLI
    *  honors on its user/assistant labels (#41531). */
@@ -118,6 +121,9 @@ export interface ConfigDisplayConfig {
   /** Theme mode pin: 'light' / 'dark' beat background auto-detection; 'auto'
    *  (default) trusts the OSC-11 probe + env signals. */
   tui_theme?: string
+  /** Template for the terminal WINDOW title (OSC 2). Empty/absent = built-in
+   *  default (`{marker} {session} · {model} · {cwd}`). */
+  window_title_template?: string
 }
 
 export interface ConfigVoiceConfig {

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2142,7 +2142,7 @@ Notes:
 
 - An empty string (the default) keeps the built-in composition: `{marker} {session}` for the tab, `{marker} {session} · {model} · {cwd}` for the window.
 - Literal text passes through, so `"hermes: {session}"` works.
-- A token that resolves to nothing collapses its surrounding ` · ` separator, so a template does not leave dangling punctuation when there is no session title yet.
+- A token that resolves to nothing collapses its surrounding ` · ` separator, so a template does not leave dangling punctuation when there is no session title yet. Literal text and `*_full` values are otherwise passed through byte-for-byte, including runs of spaces.
 - Unknown tokens are left verbatim (`{sesion}` renders as `{sesion}`) so a typo is visible instead of silently blanking the title.
 - Display-only: no effect on prompt caching or request payloads. Edits apply live — the TUI re-reads the config without a restart.
 - Your terminal may still truncate the result. Terminal.app clips the active tab's title from the left; if the session name matters most, put it first and drop `{model}`/`{cwd}`.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1988,6 +1988,8 @@ display:
     fields: ["model", "context_pct", "cwd"]
   status_bar:             # CLI/TUI: choose which status-bar fields are visible
     fields: []            # empty = show the default set; see below
+  tab_title_template: ""     # TUI: template for the terminal tab label (OSC 1). Empty = built-in. See below
+  window_title_template: ""  # TUI: template for the terminal window title (OSC 2). Empty = built-in. See below
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   cli_rebuild_scrollback_on_redraw: false  # Classic CLI: also wipe terminal scrollback (CSI 3J) on /redraw / Ctrl+L / width-change resize recovery. Enable when a terminal/tmux stack stamps stale prompt chrome into scrollback on maximize/restore.
@@ -2111,6 +2113,39 @@ Notes:
 - `battery` and `title` visibility here compose with their own toggles (`/battery`, `/title`) — both must be on for the segment to show.
 - The same key also filters the **Ink TUI** status rule (`hermes tui`), where `cache_hit`, `latency`, and `tps` render as width-budgeted tail segments (◎ / ◷ / ↑) on terminals ≥96/104/110 columns respectively.
 - Display-only: no effect on prompt caching or request payloads. Changes take effect on the next session start.
+
+### Terminal title templates (TUI)
+
+The Ink TUI (`hermes --tui`) sets two terminal titles: the **tab label** (OSC 1) and the **window title** (OSC 2). By default the tab shows only the marker and session name, while the window adds the model and cwd — the split exists because narrow tab bars truncate from the *left*, so a long window string would hide the session name.
+
+`display.tab_title_template` and `display.window_title_template` override each composition:
+
+```yaml
+display:
+  tab_title_template: "{session_full}"
+  window_title_template: "{marker} {session_full}"
+```
+
+Available tokens:
+
+| Token | Renders | Example |
+| --- | --- | --- |
+| `{marker}` | Session state: `⚠` awaiting approval, `⏳` busy, `✓` idle | `✓` |
+| `{session}` | Session title, truncated to 28 chars | `auth refactor` |
+| `{session_full}` | Session title, verbatim and uncapped | `auth refactor across the gateway adapters` |
+| `{model}` | Model id with the vendor prefix dropped | `claude-opus-5` |
+| `{model_full}` | Model id as configured | `anthropic/claude-opus-5` |
+| `{cwd}` | Working directory, home-relative, capped at 24 chars | `~/src/hermes` |
+| `{cwd_full}` | Working directory, verbatim | `/Users/you/src/hermes-agent` |
+
+Notes:
+
+- An empty string (the default) keeps the built-in composition: `{marker} {session}` for the tab, `{marker} {session} · {model} · {cwd}` for the window.
+- Literal text passes through, so `"hermes: {session}"` works.
+- A token that resolves to nothing collapses its surrounding ` · ` separator, so a template does not leave dangling punctuation when there is no session title yet.
+- Unknown tokens are left verbatim (`{sesion}` renders as `{sesion}`) so a typo is visible instead of silently blanking the title.
+- Display-only: no effect on prompt caching or request payloads. Edits apply live — the TUI re-reads the config without a restart.
+- Your terminal may still truncate the result. Terminal.app clips the active tab's title from the left; if the session name matters most, put it first and drop `{model}`/`{cwd}`.
 
 ### Runtime-metadata footer (gateway only)
 


### PR DESCRIPTION
## Summary
The TUI terminal title is now user-configurable, with the current composition as the default — previously it was fixed, so the model and cwd could not be dropped and the session name (the only capped segment, at 28 chars) was the part that got clipped on a narrow tab bar.

## Changes
- `ui-tui/src/domain/paths.ts`: `renderTitleTemplate()` + `TitleTokens`; `shortSessionName()` and the `TITLE_MAX_NAME`/`TITLE_MAX_CWD` caps extracted from `composeTabTitle` (behaviour unchanged)
- `ui-tui/src/app/useMainApp.ts`: template consulted first, `?? composeTabTitle(...)` falls back to today's exact output
- `ui-tui/src/app/useConfigSync.ts`: `normalizeTitleTemplate()`, fanned into `$uiState` alongside the other `display.*` knobs
- `uiStore.ts` / `interfaces.ts` / `gatewayTypes.ts`: state fields and wire types
- `hermes_cli/config_defaults.py`: `display.tab_title_template` and `display.window_title_template`, both `""`
- `website/docs/user-guide/configuration.md`: token table + notes

Two keys because the tab (OSC 1) and window (OSC 2) titles already differ deliberately — narrow tab bars truncate from the *left*, so the tab label omits model/cwd to keep the session name visible.

Tokens: `{marker}` `{session}` `{session_full}` `{model}` `{model_full}` `{cwd}` `{cwd_full}`. Short forms keep today's caps and abbreviation; `*_full` are verbatim and uncapped. Empty tokens collapse their orphaned ` · `; unknown `{tokens}` are left verbatim so a typo is visible rather than silently blanking the title; a non-string YAML value falls back to the default.

No `tui_gateway` change: `config.get full` (`methods_config.py:203`) already returns the whole config dict, and the mtime poller re-runs `applyDisplay` (`useConfigSync.ts:409`), so edits apply without a restart.

## Validation
| | Before | After |
|---|---|---|
| `npm run typecheck` (CI gate) | clean | clean |
| `npx vitest run` (full ui-tui) | 1727 passed, 22 failed / 3 files | 1741 passed, **same** 22 failed / 3 files |
| Default config output | `✓ name · model · ~/cwd` | identical (asserted against `composeTabTitle`) |
| `window_title_template: "{marker} {session_full}"` | not possible | `✓ <untruncated session name>` |

The 22 failures are pre-existing and host-specific (`subscriptionOverlay.test.tsx`, `appChromeBlockedTimers.test.tsx`, `ink-backpressure.test.ts`) — verified identical on clean `origin/main` via `git stash`. None touch title, paths, or config-sync. +14 new tests.

Not yet exercised: a live terminal render. The OSC write path (`use-terminal-title.ts`) is untouched, but every check above is static (tsc/vitest) — the template substitution is verified by unit test, not by watching a real tab repaint.
