### PR TITLE
fix(gateway): never label a profile home by its raw basename

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12239,6 +12239,79 @@ def test_session_info_includes_turn_started_at():
     assert server._session_info(agent, session)["turn_started_at"] is None
 
 
+def test_session_info_default_profile_on_named_gateway_labels_default(monkeypatch, tmp_path):
+    """Regression: a session pinned to profile 'default' on a NON-default gateway must
+    report profile_name 'default' — never raise FileNotFoundError("Profile '.hermes'
+    does not exist.").
+
+    The gateway's launch home is a named profile (<root>/profiles/mlperf), so a session
+    pinned to 'default' resolves its profile_home to the ROOT home. Labeling that home
+    by raw basename yields '.hermes' (the root dir's name), which is not a valid profile
+    id and cannot exist on disk; the old labeling crashed session.info with exactly that
+    FileNotFoundError, which the deferred build turned into an agent_init_failed error
+    card plus repeated gateway-crash entries."""
+    root = tmp_path / ".hermes"  # basename '.hermes' mirrors the real ~/.hermes
+    launch_home = root / "profiles" / "mlperf"
+    launch_home.mkdir(parents=True)
+    # A named-profile gateway: HERMES_HOME = <root>/profiles/<name>.
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_hermes_home", str(launch_home))
+
+    def _clear():
+        for session in list(server._sessions.values()):
+            server._teardown_session(session)
+        server._sessions.clear()
+
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+    _clear()
+    try:
+        resp = server._methods["session.create"]("r1", {"profile": "default", "cols": 80})
+        assert "result" in resp, resp
+        sid = resp["result"]["session_id"]
+        # The default-profile pin resolves to the ROOT home on this named gateway.
+        assert server._sessions[sid]["profile_home"] == str(root)
+
+        # Create-time (lazy) label.
+        assert resp["result"]["info"]["profile_name"] == "default"
+
+        # Deferred-build session.info label — the path that used to crash.
+        agent = types.SimpleNamespace(tools=[], model="", provider="")
+        info = server._session_info(agent, server._sessions[sid])
+        assert info["profile_name"] == "default"
+    finally:
+        _clear()
+
+
+def test_response_profile_name_falls_back_on_unresolvable_name(monkeypatch):
+    """_response_profile_name must never raise: a name that resolves to no profile dir
+    ('.hermes' — the default home's basename — or any unknown/deleted id) falls back to
+    the launch profile instead of aborting the caller."""
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "launch-profile")
+    assert server._response_profile_name(".hermes") == "launch-profile"
+    assert server._response_profile_name("definitely-not-a-real-profile-xyz") == "launch-profile"
+    assert server._response_profile_name("") == "launch-profile"
+
+    # A real, existing profile still wins over the fallback.
+    from hermes_constants import get_hermes_home
+    real_home = Path(get_hermes_home())
+    (real_home / "profiles" / "ok").mkdir(parents=True)
+    assert server._response_profile_name("ok") == "ok"
+
+
+def test_profile_name_for_home_never_returns_bare_basename(monkeypatch, tmp_path):
+    """Home-path → profile-name labeling mirrors Hermes' profile semantics: the root
+    home labels 'default' (never its basename, e.g. '.hermes'), <root>/profiles/<name>
+    labels by name, and anything else labels 'custom'."""
+    root = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "mlperf"))
+
+    assert server._profile_name_for_home(str(root)) == "default"
+    assert server._profile_name_for_home(str(root / "profiles" / "it-agent")) == "it-agent"
+    assert server._profile_name_for_home(str(root / "some-overlay")) == "custom"
+
+
 # ---------------------------------------------------------------------------
 # History-mutating commands must reject while session.running is True.
 # Without these guards, prompt.submit's post-run history write either

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -268,7 +268,7 @@ def _seed_branch_row(record: dict, key: str, parent_session_id: str, history: li
                 return
             _persist_branch(db, key, parent_session_id, _branch_title(db, parent_session_id), history,
                             source=source, cwd=record["cwd"],
-                            profile_name=(Path(profile_home).name if profile_home else None), compensate=True)
+                            profile_name=(_profile_name_for_home(profile_home) if profile_home else None), compensate=True)
             record["pending_title"] = None
     except Exception:
         logger.warning("seeded-branch persistence failed for %s; falling back to lazy row creation", key,
@@ -1921,7 +1921,7 @@ def _(rid, params: dict, session: dict) -> dict:
             title = params.get("name", "") or _branch_title(db, old_key)
             home = session.get("profile_home")
             _persist_branch(db, new_key, old_key, title, history, source=source, cwd=_session_cwd(session),
-                            profile_name=Path(home).name if home else _current_profile_name(),
+                            profile_name=_profile_name_for_home(home) if home else _current_profile_name(),
                             copy_fields=_BRANCH_COPY_FIELDS)
         except Exception as e:
             return _err(rid, 5008, f"branch failed: {e}")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -444,9 +444,41 @@ def _profile_db(params: dict | None = None):
 
 
 def _response_profile_name(profile: str | None = None) -> str:
-    """Profile name for session.* payloads: the requested real non-launch profile, else the launch one."""
+    """Profile name for session.* payloads: the requested real non-launch profile, else the launch one.
+
+    Never raises: an unresolvable name (a home-path basename like ``.hermes``, a deleted profile, a
+    client race) falls back to the launch profile instead of aborting the session build."""
     name = (profile or "").strip()
-    return name if name and _profile_home(name) is not None else _current_profile_name()
+    if name:
+        try:
+            if _profile_home(name) is not None:
+                return name
+        except FileNotFoundError:
+            pass
+    return _current_profile_name()
+
+
+def _profile_name_for_home(home: str) -> str:
+    """Profile name a home path serves, mirroring ``resolve_profile_env`` semantics: ``default`` for
+    the root home (``~/.hermes`` or the custom root), ``<name>`` for any ``<root>/profiles/<name>``
+    home, ``custom`` otherwise.
+
+    Never the raw basename: ``Path('~/.hermes').name`` is ``.hermes``, which is not a valid profile
+    id and cannot exist on disk — feeding it back into ``_profile_home`` raises ``Profile '.hermes'
+    does not exist.``"""
+    from hermes_cli import profiles as profiles_mod
+    try:
+        resolved = Path(home).expanduser().resolve()
+        root = profiles_mod.get_profile_dir("default").resolve()
+        if resolved == root:
+            return "default"
+        # Hermes treats ANY ``<root>/profiles/<name>`` home as the named profile ``<name>`` — the
+        # root can be the platform default or a custom deployment root (resolve_profile_env).
+        if resolved.parent.name == "profiles":
+            return resolved.name
+    except (ValueError, OSError):
+        pass
+    return "custom"
 
 
 def _db_unavailable_error(rid, *, code: int):
@@ -2054,7 +2086,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "version": "", "release_date": "", "update_behind": None, "update_command": "",
         "usage": _session_usage_snapshot(session),
         "profile_name": (
-            _response_profile_name(Path(session["profile_home"]).name)
+            _response_profile_name(_profile_name_for_home(session["profile_home"]))
             if isinstance(session, dict) and session.get("profile_home") else _current_profile_name()),
     }
     with contextlib.suppress(Exception):

--- a/tui_gateway/session_workdir.py
+++ b/tui_gateway/session_workdir.py
@@ -275,7 +275,7 @@ def _ensure_session_db_row(session: dict) -> bool:
                 # #94724 legacy-owner backfill exists to repair, and rows minted AFTER that one-shot
                 # backfill ran stayed NULL forever: profile-keyed matching then drops them from the sidebar
                 # and deep links can't resolve them (#99222).
-                profile_name=Path(profile_home).name if profile_home else _current_profile_name())
+                profile_name=_profile_name_for_home(profile_home) if profile_home else _current_profile_name())
             # Born hidden (session.create hidden=true, or set_hidden before the row existed): apply the deferred intent.
             if session.get("pending_hidden"):
                 try:


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway crash where a session pinned to the **default** profile on a **named-profile** backend (e.g. `hermes --profile it-agent serve`) fails to initialize with `FileNotFoundError: Profile '.hermes' does not exist.`

The session's `profile_home` resolves to the root home (`~/.hermes`). `_session_info` labeled it with `Path(profile_home).name` — `.hermes` — and fed that name back into profile resolution. `.hermes` is not a valid profile id (they must match `[a-z0-9][a-z0-9_-]{0,63}`), so resolution raised, the deferred build recorded it as `agent_error`, and users saw an `agent_init_failed` error card plus repeated `[gateway-crash] ... Profile '.hermes' does not exist.` log entries.

## Related Issue

Fixes #105590

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `_response_profile_name` no longer raises on unresolvable profile names; it falls back to the launch profile.
- New `_profile_name_for_home()`: root home → `default`, any `<root>/profiles/<name>` → name, otherwise `custom`. Used by `session.info` and by session-row/branch `profile_name` stamping (`methods_session.py`, `session_workdir.py`) so `state.db` never records the invalid `.hermes` label.
- Regression tests: a default-on-named-gateway session labels `default` without raising; `_response_profile_name` falls back on unresolvable names; `_profile_name_for_home` never returns a bare basename.

## How to Test

1. `pytest tests/test_tui_gateway_server.py -q` — 640 passed.
2. Start a named-profile gateway (`hermes --profile <name> serve`), create a session pinned to profile `default`, send a message; `session.info` reports `profile_name: "default"` and no `Profile '.hermes'` error.
3. Regression proof: reverting to the old labeling makes `test_session_info_default_profile_on_named_gateway_labels_default` fail with the exact production error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): ...`)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_tui_gateway_server.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] N/A — no docs/config/tool-description changes required
