### PR TITLE
fix(auth): keep a callable key_cmd credential in the api_key branch

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4680,8 +4680,17 @@ def _resolve_api_key_branch(req: _ResolveRequest, pconfig: Any, resolve_creds: C
     api_key = str(creds.get("api_key", "")).strip()
     # Explicit api_key override (fallback_model / custom_providers entry) lets callers
     # authenticate where no built-in credential is registered for this alias.
+    # A ``key_cmd`` credential arrives as a CALLABLE token provider
+    # (``CommandTokenSource``), which the wire clients invoke per request so a
+    # short-lived bearer is always fresh. ``.strip()`` on it raises
+    # AttributeError and takes the whole auxiliary call down (#88667). Pass a
+    # callable through untouched; only strings get normalised.
     if req.explicit_api_key:
-        api_key = req.explicit_api_key.strip() or api_key
+        api_key = (
+            req.explicit_api_key
+            if callable(req.explicit_api_key)
+            else (req.explicit_api_key.strip() or api_key)
+        )
     raw_base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
     if req.explicit_base_url:
         raw_base_url = req.explicit_base_url.strip().rstrip("/")

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -347,3 +347,44 @@ class TestAuxiliaryResolverHonoursKeyCmd:
         assert self._resolve(
             monkeypatch, {**self.BASE, "key_cmd": "   "}
         ) == "no-key-required"
+
+
+class TestApiKeyBranchHonoursCallable:
+    """``_resolve_api_key_branch`` must not ``.strip()`` a callable credential.
+
+    This is the sibling of the ``custom`` arm covered by #88668: a registered
+    ``api_key`` provider (an alias whose base credential comes from
+    PROVIDER_REGISTRY) reached through an explicit override. A ``key_cmd``
+    credential arrives here as a ``CommandTokenSource``, and the unguarded
+    ``.strip()`` raised ``AttributeError: 'CommandTokenSource' object has no
+    attribute 'strip'`` — killing the auxiliary call. The user sees
+    "Auxiliary title generation failed"; the chat turn itself is unaffected,
+    which is why it reads as cosmetic rather than as a credential bug.
+    """
+
+    @staticmethod
+    def _resolve(monkeypatch, explicit_api_key):
+        """Resolve through the api_key branch; return the key handed to the client."""
+        import agent.auxiliary_client as ac
+
+        seen = {}
+
+        def _spy(*, api_key, base_url, **kw):
+            seen["api_key"] = api_key
+            return SimpleNamespace(api_key=api_key, base_url=base_url)
+
+        monkeypatch.setattr(ac, "_create_openai_client", _spy)
+        ac.resolve_provider_client("openai-api", explicit_api_key=explicit_api_key)
+        return seen.get("api_key", "__unset__")
+
+    def test_callable_survives_resolution(self, monkeypatch):
+        source = build_command_token_provider("printf minted-token", "gw")
+        api_key = self._resolve(monkeypatch, source)
+        assert callable(api_key), (
+            "a key_cmd credential was stringified or dropped; the auxiliary "
+            "call cannot re-mint and the request goes out unauthenticated"
+        )
+        assert api_key() == "minted-token"
+
+    def test_string_key_is_still_stripped(self, monkeypatch):
+        assert self._resolve(monkeypatch, "  sk-static  ") == "sk-static"


### PR DESCRIPTION
## What does this PR do?

`_resolve_api_key_branch()` in `agent/auxiliary_client.py` calls `.strip()` on `req.explicit_api_key` unguarded. A `key_cmd` credential is a **callable** `CommandTokenSource` — the wire clients invoke it per request so a short-lived bearer is always fresh — so any auxiliary call routed at a `key_cmd` provider dies with:

```
AttributeError: 'CommandTokenSource' object has no attribute 'strip'
```

The user-visible symptom is `Auxiliary title generation failed`. The chat turn itself succeeds, which is why this reads as a cosmetic wart rather than a credential bug — but everything on the auxiliary path is affected: title generation, context compression, vision, and embedding.

Measured on a LiteLLM gateway behind Entra ID OIDC: **28** occurrences in `agent.log` / `errors.log` before the fix, **0** after.

## Related Issue

Fixes #88667 (in part — see below)

## Relationship to the other open PRs

#88667 reports this AttributeError at two distinct sites in the same file, and a commenter confirmed it still reproduces on v0.21.0 from a second direction (`vision_analyze`, tracked as #79121).

- **#88668** fixes the `custom` arm (`custom_key = (explicit_api_key or "").strip() ...`).
- **This PR** fixes `_resolve_api_key_branch` — a separate function reached when the provider is a registered `api_key` provider with an explicit override.

I checked #88668's diff: it has two hunks and does not touch this branch. The two are **additive, not competing** — merging #88668 alone leaves this path crashing. Happy to fold this into #88668 instead if the maintainers prefer one PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` — `_resolve_api_key_branch()` passes a callable credential through untouched and normalises only strings. Static-key setups are unchanged.
- `tests/agent/test_command_token_source.py` — `TestApiKeyBranchHonoursCallable`, two cases: a callable survives resolution and still mints, and a string key is still stripped.

## How to Test

```bash
pytest tests/agent/test_command_token_source.py -k ApiKeyBranchHonoursCallable -q
```

Verified the tests actually bite: with the guard reverted, `test_callable_survives_resolution` fails with the exact `AttributeError` from the issue; with it, both pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — found four touching this area and documented the relationship above
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see note
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.6.0), Python 3.11.16

**On the suite:** `pytest tests/agent/ -k "auxiliary or command_token"` gives **449 passed, 21 failed** on this branch — and a **byte-identical** 21 failures on a clean checkout with the change stashed. All are missing optional dev dependencies in my environment (the `anthropic` package, `pytest-asyncio`). This branch introduces zero new failures.

`scripts/check-windows-footguns.py` is clean on the changed file.

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing surface change)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (no platform-specific behaviour; `check-windows-footguns.py` clean)
