### PR TITLE
fix(desktop): pass the checkout root to the Windows update verify step

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1606,8 +1606,8 @@ try {
 
     # A zero-exit update is not proof that the runtime survived the update.
     if ($res.Code -eq 0 -and -not $desktopBuildFailed) {
-        $verifyCode = "import hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path.cwd())"
-        $verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode) "verify"
+        $verifyCode = "import sys; import hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path(sys.argv[1]))"
+        $verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode, $InstallRoot) "verify"
         if ($verify.Code -ne 0) {
             $finalCode = 8
             $finalMsg = "The updated Hermes runtime or Desktop build failed verification. Repair the installation and review antivirus quarantine before retrying."

--- a/tests/test_desktop_update_windows_python_handoff.py
+++ b/tests/test_desktop_update_windows_python_handoff.py
@@ -124,3 +124,45 @@ def test_desktop_relaunch_waits_for_an_in_place_rebuild() -> None:
     assert "if ((Get-Date) -ge $relaunchDeadline)" in body
     assert "Start-Sleep -Milliseconds 500" in body
     assert "[System.Windows.Forms.Application]::DoEvents()" in body
+
+
+def test_verify_step_receives_the_checkout_explicitly() -> None:
+    """The verify subprocess must not trust its inherited cwd.
+
+    The hand-off host is spawned via ``cmd start /min`` from the Desktop
+    updater, so the verify step's working directory is not the checkout.
+    ``Path.cwd()`` therefore resolved to the updater host's directory and
+    ``verify_windows_desktop_update`` reported a freshly built Desktop
+    executable as missing. The checkout is known here as ``$InstallRoot``
+    and is passed as an explicit argument.
+    """
+    source = _handoff_source()
+
+    assert "verify_windows_desktop_update(Path.cwd())" not in source, (
+        "The Windows hand-off verify step still resolves the project root "
+        "from Path.cwd(); the verify subprocess inherits the updater host's "
+        "directory, not the checkout, so a healthy update fails verification."
+    )
+    assert "verify_windows_desktop_update(Path(sys.argv[1]))" in source, (
+        "The verify step should take its project root from an explicit "
+        "argv[1] passed by the hand-off."
+    )
+    assert '@("-c", $verifyCode, $InstallRoot)' in source, (
+        "The verify invocation must pass $InstallRoot so the project root "
+        "does not depend on the subprocess working directory."
+    )
+
+    # The inline program must actually be runnable: sys.argv needs its import,
+    # and the whole string has to compile as Python before it ships.
+    program = re.search(
+        r'\$verifyCode = "(.*?verify_windows_desktop_update\(Path\(sys\.argv\[1\]\)\))"',
+        source,
+    )
+    assert program is not None, (
+        "Expected the verify step inline program to resolve its project root "
+        "from sys.argv."
+    )
+    assert program.group(1).startswith("import sys;"), (
+        "The verify inline program uses sys.argv and must import sys itself."
+    )
+    compile(program.group(1), "<verifyCode>", "exec")


### PR DESCRIPTION
## What does this PR do?

Fixes #105587.

`scripts/desktop-update/windows.ps1` step 5 (truthful completion) ran the verify subprocess as:

```
python -c "...verify_windows_desktop_update(Path.cwd())"
```

`Invoke-HermesStep` never sets `ProcessStartInfo.WorkingDirectory` (the only `-WorkingDirectory` in the script is the Desktop relaunch), so the verify subprocess inherits the hand-off host's cwd — the host is spawned via `cmd start /min` from the Desktop updater, not from the checkout. With cwd ≠ repo root, `_desktop_packaged_executable(<cwd>/apps/desktop)` returns `None` and `verify_windows_desktop_update` raises `RuntimeError: The updated Desktop executable is missing` on **every** GUI-triggered update that otherwise exits 0 — exactly the reporter's log (`update exit code: 0` then `verify! RuntimeError`).

## The fix

The checkout is already known to the hand-off as `$InstallRoot` (it builds `$pythonExe` from it at lines 1448/1542). The verify now takes the project root from an explicit argument instead of the inherited environment:

```powershell
$verifyCode = "import sys; import hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path(sys.argv[1]))"
$verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode, $InstallRoot) "verify"
```

No implicit environment dependency remains: even if the host's cwd drifts, verification resolves the packaged executable inside the actual checkout.

## Verification

- New source-level regression guard `test_verify_step_receives_the_checkout_explicitly` in `tests/test_desktop_update_windows_python_handoff.py` (same source-level pattern the file already uses for the python.exe hand-off invariant, runnable on the Linux CI lane):
  - asserts `Path.cwd()` is gone from the verify step and `$InstallRoot` is passed explicitly;
  - asserts the inline program imports `sys` (it uses `sys.argv`) and `compile()`s the extracted program, so the step cannot ship a NameError;
  - mutation check (reverting to `Path.cwd()` + dropping the argument) turns the test red, the fixed tree is green.
- Local: `pytest tests/test_desktop_update_windows_python_handoff.py` → 5 passed; the full Windows-updater source-level suite (`progress`, `ui_delivery`, `pipe_drain`, `timestamp`, `python_handoff`, `desktop_update_verify`) → 18 passed, 5 skipped; `ruff check` + `ruff format --check` clean.

## Changes
- `scripts/desktop-update/windows.ps1` — verify step passes `$InstallRoot` explicitly.
- `tests/test_desktop_update_windows_python_handoff.py` — regression guard for the explicit checkout root.