### PR TITLE
feat(codex): configure app-server per session

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2291,6 +2291,13 @@ def init_agent(
     except Exception:
         _agent_cfg = {}
 
+    _model_cfg = _agent_cfg.get("model") if isinstance(_agent_cfg, dict) else None
+    _codex_cfg = _model_cfg.get("codex_app_server") if isinstance(_model_cfg, dict) else None
+    agent._codex_app_server_config = {
+        key: list(value) if isinstance(value, list) else value
+        for key, value in (_codex_cfg.items() if isinstance(_codex_cfg, dict) else ())
+    }
+
     _apply_display_config(agent, _agent_cfg, platform)
     _init_memory(agent, _agent_cfg, skip_memory, platform)
     _apply_agent_section(agent, _agent_cfg)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2159,6 +2159,15 @@ def switch_model(
     # short-circuiting the freshly selected healthy provider.
     from agent.chat_completion_helpers import _reset_stale_streak
     _reset_stale_streak(agent)
+    if (
+        getattr(agent, "_codex_session", None) is not None
+        and (
+            old_model != agent.model
+            or old_provider != agent.provider
+            or snapshot.get("api_mode") != agent.api_mode
+        )
+    ):
+        agent._close_codex_session()
     agent._primary_runtime = _build_primary_runtime_snapshot(agent, api_mode)
     _finish_switch(agent, new_provider, old_norm, new_norm)
     logger.info(

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -405,6 +405,7 @@ def _ensure_codex_session(agent) -> None:
     # narrower item/started-only bridge from #38835.
     agent._codex_session = CodexAppServerSession(
         cwd=getattr(agent, "session_cwd", None) or str(resolve_agent_cwd()), approval_callback=approval_callback,
+        model=agent.model, config=getattr(agent, "_codex_app_server_config", None),
         request_routing=_ServerRequestRouting(auto_approve_exec=auto_approve_requests, auto_approve_apply_patch=auto_approve_requests),
         on_event=make_codex_app_server_event_bridge(agent),
     )

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -21,6 +21,89 @@ from tools.environments.local import hermes_subprocess_env
 
 MIN_CODEX_VERSION = (0, 125, 0)
 
+_VALID_SANDBOX_MODES = {"read-only", "workspace-write", "danger-full-access"}
+_VALID_APPROVAL_POLICIES = {"untrusted", "on-request", "never"}
+_VALID_REASONING_EFFORTS = {"minimal", "low", "medium", "high", "xhigh"}
+
+
+def _optional_choice(config: dict[str, Any], key: str, choices: set[str]) -> str:
+    if key not in config:
+        return ""
+    value = config[key]
+    normalized = value.strip().lower() if isinstance(value, str) else ""
+    if normalized not in choices:
+        raise ValueError(
+            f"model.codex_app_server.{key} must be one of: {', '.join(sorted(choices))}"
+        )
+    return normalized
+
+
+def resolve_codex_app_server_args(
+    *, model: str, config: Optional[dict[str, Any]] = None,
+    kanban_root: Optional[str] = None,
+) -> list[str]:
+    """Validate and resolve session-local Codex ``-c`` overrides."""
+    cfg = config if isinstance(config, dict) else {}
+    overrides: list[tuple[str, Any]] = []
+    if model:
+        overrides.append(("model", model))
+
+    effort = _optional_choice(cfg, "model_reasoning_effort", _VALID_REASONING_EFFORTS)
+    if effort:
+        overrides.append(("model_reasoning_effort", effort))
+
+    configured_sandbox_mode = _optional_choice(
+        cfg, "sandbox_mode", _VALID_SANDBOX_MODES
+    )
+    sandbox_mode = "workspace-write" if kanban_root else configured_sandbox_mode
+    if sandbox_mode:
+        overrides.append(("sandbox_mode", sandbox_mode))
+
+    approval = _optional_choice(cfg, "ask_for_approval", _VALID_APPROVAL_POLICIES)
+    if approval:
+        overrides.append(("approval_policy", approval))
+
+    if sandbox_mode == "workspace-write":
+        if (
+            not kanban_root
+            and "network_access" in cfg
+            and not isinstance(cfg["network_access"], bool)
+        ):
+            raise ValueError("model.codex_app_server.network_access must be a boolean")
+        if "network_access" in cfg or kanban_root:
+            overrides.append((
+                "sandbox_workspace_write.network_access",
+                False if kanban_root else cfg["network_access"],
+            ))
+
+        configured_roots = [] if kanban_root else cfg.get("writable_roots", [])
+        if not isinstance(configured_roots, list) or any(
+            not isinstance(root, str) or not os.path.isabs(root)
+            for root in configured_roots
+        ):
+            raise ValueError(
+                "model.codex_app_server.writable_roots must contain only absolute paths"
+            )
+        roots: list[str] = []
+        seen_roots: set[str] = set()
+        for candidate in [*configured_roots, kanban_root]:
+            if not candidate:
+                continue
+            dedupe_key = os.path.normcase(os.path.normpath(candidate))
+            if dedupe_key not in seen_roots:
+                seen_roots.add(dedupe_key)
+                roots.append(candidate)
+        if roots:
+            overrides.append(("sandbox_workspace_write.writable_roots", roots))
+
+    args: list[str] = []
+    for key, value in overrides:
+        args.extend((
+            "-c",
+            f"{key}={json.dumps(value, ensure_ascii=False, separators=(',', ':'))}",
+        ))
+    return args
+
 
 @dataclass
 class CodexAppServerError(RuntimeError):
@@ -45,6 +128,7 @@ class CodexAppServerClient:
     def __init__(
         self, codex_bin: str = "codex", codex_home: Optional[str] = None,
         extra_args: Optional[list[str]] = None, env: Optional[dict[str, str]] = None,
+        model: str = "", config: Optional[dict[str, Any]] = None,
     ) -> None:
         self._codex_bin = codex_bin
         # codex needs LLM provider creds but must not receive Tier-1 Hermes secrets (gateway/GitHub/infra tokens).
@@ -62,7 +146,6 @@ class CodexAppServerClient:
         if codex_home:
             spawn_env["CODEX_HOME"] = codex_home
 
-        cmd = [codex_bin, "app-server", *(extra_args or [])]
         from agent.delegation_context import (
             DELEGATED_CHILD_ENV_MARKER, KANBAN_ENV_KEYS,
             delegated_child_subprocess_env, is_dispatcher_owned_worker_context,
@@ -71,23 +154,24 @@ class CodexAppServerClient:
         # endpoint acts for this worker; grant it scope via its existing per-server
         # environment, never by granting the whole executor process ownership.
         owned_task = os.environ.get("HERMES_KANBAN_TASK") and is_dispatcher_owned_worker_context()
+        managed_args: list[str] = []
         if owned_task:
             for key in (*KANBAN_ENV_KEYS, "HERMES_KANBAN_DB", "HERMES_KANBAN_BOARD"):
                 if key in os.environ:
-                    cmd += ["-c", f"mcp_servers.hermes-mcp.env.{key}={json.dumps(os.environ[key])}"]
-            cmd += ["-c", f'mcp_servers.hermes-mcp.env.{DELEGATED_CHILD_ENV_MARKER}=""']
+                    managed_args += ["-c", f"mcp_servers.hermes-mcp.env.{key}={json.dumps(os.environ[key])}"]
+            managed_args += ["-c", f'mcp_servers.hermes-mcp.env.{DELEGATED_CHILD_ENV_MARKER}=""']
         spawn_env = delegated_child_subprocess_env(spawn_env)
-        # Kanban workers must write handoff/status to the board DB outside the
-        # workspace: keep the sandbox on, add the Kanban root as writable.
+        kanban_root = None
         if owned_task:
             kanban_db = spawn_env.get("HERMES_KANBAN_DB")
             default_root = os.path.join(spawn_env.get("HERMES_HOME", os.path.expanduser("~/.hermes")), "kanban")
             kanban_root = os.path.dirname(kanban_db) if kanban_db else spawn_env.get("HERMES_KANBAN_ROOT", default_root)
-            cmd += [
-                "-c", 'sandbox_mode="workspace-write"',
-                "-c", f'sandbox_workspace_write.writable_roots=["{kanban_root}"]',
-                "-c", "sandbox_workspace_write.network_access=false",
-            ]
+        cmd = [
+            codex_bin, "app-server",
+            *(extra_args or []),
+            *managed_args,
+            *resolve_codex_app_server_args(model=model, config=config, kanban_root=kanban_root),
+        ]
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.
         spawn_env.setdefault("RUST_LOG", "warn")
 

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -151,6 +151,7 @@ class CodexAppServerSession:
     def __init__(
         self, *, cwd: Optional[str] = None, codex_bin: str = "codex",
         codex_home: Optional[str] = None, permission_profile: Optional[str] = None,
+        model: str = "", config: Optional[dict[str, Any]] = None,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
@@ -159,6 +160,8 @@ class CodexAppServerSession:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
         self._codex_home = codex_home
+        self._model = model
+        self._config = dict(config or {})
         self._permission_profile = permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(
             os.environ.get("HERMES_TERMINAL_SECURITY_MODE", "auto"), "workspace-write"
         )
@@ -182,7 +185,10 @@ class CodexAppServerSession:
         if self._thread_id is not None:
             return self._thread_id
         if self._client is None:
-            self._client = self._client_factory(codex_bin=self._codex_bin, codex_home=self._codex_home)
+            self._client = self._client_factory(
+                codex_bin=self._codex_bin, codex_home=self._codex_home,
+                model=self._model, config=self._config,
+            )
         self._client.initialize(client_name="hermes", client_title="Hermes Agent", client_version=_get_hermes_version())
         # Permissions are NOT sent on thread/start: codex gates ``thread/start.permissions``
         # behind experimentalApi + a matching ``[permissions]`` table in ~/.codex/config.toml.

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -320,7 +320,8 @@ class TestBridgeWiredInRuntime:
     a future refactor from dropping the bridge wiring and silently
     regressing Discord/Telegram live progress visibility."""
 
-    def test_session_constructor_receives_on_event(self, monkeypatch):
+    @pytest.mark.parametrize("model", ["gpt-5.6-codex", "gpt-5.7-codex"])
+    def test_session_constructor_receives_on_event(self, monkeypatch, model):
         from agent import codex_runtime
 
         captured: dict = {}
@@ -350,6 +351,8 @@ class TestBridgeWiredInRuntime:
         # Minimal stub agent — the runtime only touches a handful of
         # attributes and we mock the heavy ones to keep the test fast.
         agent = SimpleNamespace(
+            model=model,
+            _codex_app_server_config={"model_reasoning_effort": "high"},
             session_cwd=None,
             _codex_session=None,
             tool_progress_callback=MagicMock(),
@@ -388,6 +391,8 @@ class TestBridgeWiredInRuntime:
         assert callable(captured["on_event"]), (
             "on_event must be the bridge callable, not None or a sentinel"
         )
+        assert captured["model"] == model
+        assert captured["config"] == {"model_reasoning_effort": "high"}
 
         # And the bridge must actually drive the agent's callbacks when
         # fed a representative notification.

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -93,6 +93,97 @@ class TestCodexAppServerModule:
     """Module-surface tests for the JSON-RPC speaker. Don't require codex CLI."""
 
 
+    @pytest.mark.parametrize(
+        "config,kanban_root,expected",
+        [
+            (
+                {},
+                None,
+                ['model="gpt-5.6-codex"'],
+            ),
+            (
+                {
+                    "model_reasoning_effort": "high",
+                    "sandbox_mode": "workspace-write",
+                    "ask_for_approval": "on-request",
+                    "network_access": True,
+                    "writable_roots": ["/work", "/work", "/tmp/😀"],
+                },
+                "/kanban",
+                [
+                    'model="gpt-5.6-codex"',
+                    'model_reasoning_effort="high"',
+                    'sandbox_mode="workspace-write"',
+                    'approval_policy="on-request"',
+                    'sandbox_workspace_write.network_access=false',
+                    'sandbox_workspace_write.writable_roots=["/kanban"]',
+                ],
+            ),
+            (
+                {
+                    "sandbox_mode": "danger-full-access",
+                    "network_access": False,
+                    "writable_roots": ["/ignored"],
+                },
+                "/kanban",
+                [
+                    'model="gpt-5.6-codex"',
+                    'sandbox_mode="workspace-write"',
+                    'sandbox_workspace_write.network_access=false',
+                    'sandbox_workspace_write.writable_roots=["/kanban"]',
+                ],
+            ),
+            (
+                {
+                    "sandbox_mode": "danger-full-access",
+                    "network_access": True,
+                    "writable_roots": ["/work"],
+                },
+                None,
+                ['model="gpt-5.6-codex"', 'sandbox_mode="danger-full-access"'],
+            ),
+            (
+                {},
+                "/kanban",
+                [
+                    'model="gpt-5.6-codex"',
+                    'sandbox_mode="workspace-write"',
+                    "sandbox_workspace_write.network_access=false",
+                    'sandbox_workspace_write.writable_roots=["/kanban"]',
+                ],
+            ),
+        ],
+    )
+    def test_launch_config_resolves_session_scoped_overrides_without_conflicts(
+        self, config, kanban_root, expected
+    ) -> None:
+        from agent.transports.codex_app_server import resolve_codex_app_server_args
+
+        args = resolve_codex_app_server_args(
+            model="gpt-5.6-codex",
+            config=config,
+            kanban_root=kanban_root,
+        )
+
+        assert args == [part for value in expected for part in ("-c", value)]
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {"model_reasoning_effort": "extreme"},
+            {"sandbox_mode": "host-write"},
+            {"ask_for_approval": "always"},
+            {"sandbox_mode": "workspace-write", "network_access": "yes"},
+            {"sandbox_mode": "workspace-write", "writable_roots": ["relative/path"]},
+        ],
+    )
+    def test_launch_config_rejects_invalid_values(self, config) -> None:
+        from agent.transports.codex_app_server import resolve_codex_app_server_args
+
+        with pytest.raises(ValueError, match="model.codex_app_server"):
+            resolve_codex_app_server_args(model="gpt-5.6-codex", config=config)
+
+
 
 
     def test_check_binary_handles_missing_executable(self) -> None:
@@ -213,7 +304,7 @@ class TestSpawnEnvIsolation:
         """Codex-runtime Kanban workers need to write board state outside
         their scratch/worktree workspace, but should not fall back to
         danger-full-access. Hermes passes a narrow app-server config override
-        for the Kanban root only.
+        for the Kanban root only and keeps it authoritative over legacy args.
         """
         import subprocess
         from agent.transports import codex_app_server as cas
@@ -251,18 +342,19 @@ class TestSpawnEnvIsolation:
             "/users/alice/.hermes/kanban/boards/smoke/kanban.db",
         )
 
-        client = cas.CodexAppServerClient(codex_bin="codex")
+        client = cas.CodexAppServerClient(
+            codex_bin="codex",
+            extra_args=["-c", 'sandbox_mode="danger-full-access"'],
+        )
         client._closed = True
 
         cmd = captured["cmd"]
         assert cmd[:2] == ["codex", "app-server"]
-        assert 'sandbox_mode="workspace-write"' in cmd
-        assert (
-            'sandbox_workspace_write.writable_roots=["/users/alice/.hermes/kanban/boards/smoke"]'
-            in cmd
-        )
-        assert "sandbox_workspace_write.network_access=false" in cmd
-        assert all("danger" not in part for part in cmd)
+        assert cmd[-6:] == [
+            "-c", 'sandbox_mode="workspace-write"',
+            "-c", 'sandbox_workspace_write.network_access=false',
+            "-c", 'sandbox_workspace_write.writable_roots=["/users/alice/.hermes/kanban/boards/smoke"]',
+        ]
 
 
 class TestSpawnEnvSecretStripping:

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -26,9 +26,14 @@ class FakeClient:
     """Stand-in for CodexAppServerClient that records calls and lets the test
     drive the notification / server-request streams synchronously."""
 
-    def __init__(self, *, codex_bin: str = "codex", codex_home=None) -> None:
+    def __init__(
+        self, *, codex_bin: str = "codex", codex_home=None,
+        model: str = "", config=None,
+    ) -> None:
         self.codex_bin = codex_bin
         self.codex_home = codex_home
+        self.model = model
+        self.config = config
         self.requests: list[tuple[str, dict]] = []
         self.notifications_responses: list[dict] = []
         self.responses: list[tuple[Any, dict]] = []
@@ -152,6 +157,30 @@ class TestTurnInputCoercion:
 # ---- lifecycle ----
 
 class TestLifecycle:
+    def test_ensure_started_passes_session_launch_config_to_client(self):
+        captured = {}
+        client = FakeClient()
+
+        def factory(**kwargs):
+            captured.update(kwargs)
+            return client
+
+        session = CodexAppServerSession(
+            cwd="/tmp",
+            model="gpt-5.6-codex",
+            config={"model_reasoning_effort": "high"},
+            client_factory=factory,  # type: ignore[arg-type]
+        )
+
+        session.ensure_started()
+
+        assert captured == {
+            "codex_bin": "codex",
+            "codex_home": None,
+            "model": "gpt-5.6-codex",
+            "config": {"model_reasoning_effort": "high"},
+        }
+
     def test_ensure_started_is_idempotent(self):
         client = FakeClient()
         s = make_session(client)

--- a/tests/run_agent/test_stream_stale_breaker_reset.py
+++ b/tests/run_agent/test_stream_stale_breaker_reset.py
@@ -103,11 +103,32 @@ def test_switch_model_resets_stale_streak():
     assert agent._consecutive_stale_streams == 0
 
 
+def test_switch_model_closes_stale_codex_app_server_session():
+    agent = _make_agent_openrouter()
+    codex_session = MagicMock()
+    setattr(agent, "_codex_session", codex_session)
+    agent._create_openai_client = MagicMock(return_value=MagicMock(name="NewClient"))
+
+    with patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None):
+        agent.switch_model(
+            new_model="openai/gpt-5",
+            new_provider="openrouter",
+            api_key="or-key-new",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+        )
+
+    assert codex_session.close.call_count == 1
+    assert agent._codex_session is None
+
+
 def test_switch_model_failure_does_not_reset_streak():
     """A failed swap rolls back — the agent is still on the wedged provider,
     so the breaker must stay latched (reset happens after the rebuild)."""
     agent = _make_agent_openrouter()
     agent._consecutive_stale_streams = 7
+    codex_session = MagicMock()
+    setattr(agent, "_codex_session", codex_session)
 
     def boom(*_a, **_kw):
         raise RuntimeError("simulated client build failure")
@@ -127,6 +148,8 @@ def test_switch_model_failure_does_not_reset_streak():
             pass
 
     assert agent._consecutive_stale_streams == 7
+    assert codex_session.close.call_count == 0
+    assert agent._codex_session is codex_session
 
 
 def test_fallback_activation_resets_stale_streak():

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -194,8 +194,36 @@ To check current state without changing anything:
 You can also set it manually in `~/.hermes/config.yaml`:
 ```yaml
 model:
+  default: gpt-5.3-codex
   openai_runtime: codex_app_server   # default is "auto" (= Hermes runtime)
+  codex_app_server:                  # all fields are optional
+    model_reasoning_effort: high     # minimal | low | medium | high | xhigh
+    sandbox_mode: workspace-write    # read-only | workspace-write | danger-full-access
+    ask_for_approval: on-request     # untrusted | on-request | never
+    network_access: true             # workspace-write only
+    writable_roots:                  # workspace-write only; absolute paths
+      - /absolute/path/to/artifacts
 ```
+
+Hermes always passes the model already resolved for this session as a
+process-local `codex app-server -c 'model="<model>"'` override. The existing
+`model.default` remains the only model source; there is no separate
+`codex_app_server.model`. This keeps profiles independent when they select
+different defaults.
+
+The optional `model.codex_app_server` values are validated and passed as
+additional `-c key=value` arguments for that app-server process only. Hermes
+does not write them to `~/.codex/config.toml`. If the block is absent, no
+reasoning, sandbox, approval, network, or writable-root override is added.
+The Hermes field `ask_for_approval` maps to Codex's `approval_policy` key.
+`network_access` and `writable_roots` apply only with `workspace-write`, and
+every writable root must be absolute.
+
+Kanban workers retain their existing managed boundary regardless of the generic
+profile settings: `workspace-write`, network access disabled, and only the Kanban
+root authorized by the dispatcher writable. Profile-level `sandbox_mode`,
+`network_access`, and `writable_roots` therefore cannot widen a dispatcher-owned
+worker's sandbox.
 
 ## Self-improvement loop (memory + skill nudges)
 


### PR DESCRIPTION
## Summary

- pass the model already resolved for the Hermes session to `codex app-server` as a process-local `-c model=...` override
- add validated, optional `model.codex_app_server` overrides for reasoning effort, sandbox mode, approval policy, network access, and writable roots
- preserve the dispatcher-owned Kanban worker boundary independently of generic session preferences

## Behavior

- `model.default` remains the only configured model source; no `codex_app_server.model` key is introduced
- overrides apply only to the spawned App Server process and do not modify `~/.codex/config.toml`
- configurations without the optional block retain the prior non-Kanban sandbox/approval behavior
- ordinary workspace-write roots must be absolute and are deduplicated
- dispatcher-owned Kanban workers always use `workspace-write`, deny network access, and admit only the dispatcher-authorized Kanban root
- an in-place Hermes model switch retires the existing App Server session so the next process uses the newly resolved model

## Validation

- `scripts/run_tests.sh` over the affected App Server, session, event bridge, persistence, model-switch, and agent-init tests — 110 passed
- Ruff passed for every changed Python file
- Python compilation, `git diff --check`, and `scripts/check_compat_pointers.py` passed
- Codex CLI 0.153.2 accepted the generated override keys and TOML values with `--strict-config`
- independent review of exact head found no security or logic errors

Closes #30731
