### PR TITLE
fix(cli): keep fresh sessions on their configured custom provider

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -351,6 +351,40 @@ class StartupModelRoute(NamedTuple):
     api_key: str = ""
 
 
+def _configured_provider_declares_model(
+    provider: str,
+    model: str,
+    user_providers: Optional[dict],
+    custom_providers: Optional[list],
+) -> bool:
+    """Whether *model* is an exact catalog member of the configured *provider*."""
+    identity = _clean(provider).lower()
+    target = _clean(model).lower()
+    if not identity or not target:
+        return False
+
+    keyed_entries = user_providers.items() if isinstance(user_providers, dict) else ()
+    entries = [
+        (str(key), entry)
+        for key, entry in keyed_entries
+        if isinstance(entry, dict)
+    ]
+    entries.extend(
+        (str(entry.get("provider_key") or ""), entry)
+        for entry in (custom_providers if isinstance(custom_providers, list) else [])
+        if isinstance(entry, dict)
+    )
+    for provider_key, entry in entries:
+        if identity not in custom_provider_aliases(
+            str(entry.get("name") or ""), provider_key
+        ):
+            continue
+        declared = _declared_model_ids(entry.get("models"))
+        declared.extend([entry.get("model"), entry.get("default_model")])
+        return any(_clean(candidate).lower() == target for candidate in declared)
+    return False
+
+
 def resolve_startup_model_route(
     raw_model: str, *, explicit_provider: str = "", current_provider: str = "",
     user_providers: Optional[dict] = None,
@@ -387,6 +421,13 @@ def resolve_startup_model_route(
         return None
     prefix, model = (part.strip() for part in raw.split("/", 1))
     if not prefix or not model:
+        return None
+
+    # A slash can be part of a proxy-native model ID. Honor an exact declaration on the selected
+    # provider before interpreting the prefix as a different configured provider (#105581).
+    if _configured_provider_declares_model(
+        current_provider, raw, user_providers, custom_providers
+    ):
         return None
 
     if current_provider:

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -86,12 +86,29 @@ class TestMaxTurnsResolution:
         cli = _make_cli(max_turns=25)
         assert cli.max_turns == 25
 
-
-
-
     def test_legacy_root_max_turns_is_used_when_agent_key_exists_without_value(self):
         cli_obj = _make_cli(config_overrides={"agent": {}, "max_turns": 77})
         assert cli_obj.max_turns == 77
+
+
+class TestStartupModelRouting:
+    def test_named_provider_keeps_its_declared_slash_model(self):
+        cli = _make_cli(config_overrides={
+            "model": {
+                "default": "deepseek/deepseek-v4-flash",
+                "provider": "custom:commandcode",
+            },
+            "providers": {
+                "deepseek": {"base_url": "https://api.deepseek.com/v1"},
+                "commandcode": {
+                    "base_url": "https://api.commandcode.ai/provider/v1",
+                    "models": {"deepseek/deepseek-v4-flash": {}},
+                },
+            },
+        })
+
+        assert cli.model == "deepseek/deepseek-v4-flash"
+        assert cli.requested_provider == "custom:commandcode"
 
 
 

--- a/tests/hermes_cli/test_startup_model_routing_87189.py
+++ b/tests/hermes_cli/test_startup_model_routing_87189.py
@@ -60,6 +60,22 @@ def test_startup_route_non_aggregator_current_provider_still_routes(monkeypatch)
     assert route == model_switch.StartupModelRoute("deepseek-v4-pro", "nous", "")
 
 
+def test_startup_route_keeps_named_provider_declared_slash_model(monkeypatch):
+    monkeypatch.setattr(model_switch, "DIRECT_ALIASES", {})
+    route = model_switch.resolve_startup_model_route(
+        "deepseek/deepseek-v4-flash",
+        current_provider="custom:commandcode",
+        user_providers={
+            "deepseek": {"base_url": "https://api.deepseek.com/v1"},
+            "commandcode": {
+                "base_url": "https://api.commandcode.ai/provider/v1",
+                "models": {"deepseek/deepseek-v4-flash": {}},
+            },
+        },
+    )
+    assert route is None
+
+
 def test_startup_route_resolves_dict_alias_and_preserves_endpoint(monkeypatch):
     monkeypatch.setattr(
         model_switch,


### PR DESCRIPTION
## What does this PR do?

Fresh CLI sessions now preserve a configured named custom provider when its exact model ID contains a slash that also matches another configured provider. This prevents traffic intended for a proxy such as `custom:commandcode` from being silently redirected to an official provider endpoint.

### Symptom

With `model.provider: custom:commandcode`, `model.default: deepseek/deepseek-v4-flash`, and both `providers.commandcode` and `providers.deepseek` configured, a fresh CLI session started with model `deepseek-v4-flash` on provider `deepseek`. Switching through `/model` restored the intended `commandcode` route.

### Impact

Affected fresh CLI sessions can send requests to the wrong provider and billing account while persisted session metadata still reports the intended custom provider.

### Bug Cause

**Trigger:** `hermes_cli/model_switch.py:413` / `resolve_startup_model_route`

**Causal chain:**
1. `HermesCLI` supplies the configured model, selected provider, and provider map to startup route resolution.
2. Startup resolution sees the `deepseek/` prefix and selects `providers.deepseek` without first checking whether the selected `custom:commandcode` provider declares the full model ID.
3. The prefix is stripped and the live agent routes `deepseek-v4-flash` to the official DeepSeek provider.

**Why it is wrong:** A slash is not always a provider selector. Named proxies may expose vendor-prefixed model IDs as exact catalog members, and the explicitly configured route owns those IDs.

**Working sibling / contrast:** The interactive `/model` path performs provider-aware catalog resolution, so selecting the same model there keeps the named custom provider.

**Ruled out:** Resume persistence and OAuth fallback do not cause this failure because the route changes during fresh `HermesCLI` construction before either path can select the live provider.

### Fix

Startup routing now checks the selected provider's configured catalog, including keyed and legacy custom provider shapes, before interpreting a slash prefix as a provider switch. An exact declared model remains unchanged on its selected provider; unmatched models retain the existing prefix-routing behavior.

## Related Issue

Closes #105581

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/model_switch.py` - preserve exact slash-bearing model IDs declared by the selected configured provider.
- `tests/hermes_cli/test_startup_model_routing_87189.py` - cover the conflicting provider-prefix resolver case.
- `tests/cli/test_cli_init.py` - cover the complete fresh CLI initialization route.

## How to Test

1. Configure `custom:commandcode` with model `deepseek/deepseek-v4-flash` while also configuring the official `deepseek` provider, then start a fresh CLI session.
2. Confirm the startup model remains `deepseek/deepseek-v4-flash` and the requested provider remains `custom:commandcode`.
3. Automated (26 relevant tests passed locally):

```bash
scripts/run_tests.sh tests/hermes_cli/test_startup_model_routing_87189.py tests/cli/test_cli_init.py -k 'startup_route or StartupModelRouting'
scripts/run_tests.sh tests/cli/test_cli_provider_resolution.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on relevant tests and all relevant tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; this restores documented routing behavior
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the change is platform-independent routing logic
- [x] Tool descriptions and schemas are N/A; no tool behavior changed

## Screenshots / Logs

N/A; automated regressions exercise the resolver and complete fresh CLI initialization path.
