### PR TITLE
fix(terminal): host-independent container cwd verdict, and guard execute_code's cwd

### DIFF
--- a/tests/tools/test_code_execution_cwd_override.py
+++ b/tests/tools/test_code_execution_cwd_override.py
@@ -1,0 +1,98 @@
+"""execute_code's environment builder: override lookup and container cwd.
+
+Two defects, and fixing either alone is wrong.
+
+The lookup read only the COLLAPSED container id. A CWD-only override is
+registered under the RAW session id and deliberately collapses so sessions
+share one container, so this builder silently dropped it while the terminal
+and file layers -- both of which go through ``resolve_task_overrides`` --
+honoured it.
+
+The builder also had no cwd guard, unlike every other one. That looked
+harmless only because of the first defect. It was not: an override carrying an
+isolation key (``env_type`` or ``*_image``, as RL and benchmark harnesses
+register) keeps the raw id, so a host path already reached
+``docker run -w <host path>`` on exactly the rollouts that ask for their own
+sandbox -- and the container fails to start with exit 125.
+
+Fixing the lookup alone would widen that leak, since the builder would start
+finding host paths it used to miss.
+"""
+
+import tools.code_execution_tool as cet
+import tools.terminal_tool as tt
+
+
+def _config(env_type="docker", cwd="/root"):
+    return {
+        "env_type": env_type, "docker_image": "pytorch/pytorch:latest",
+        "singularity_image": "", "modal_image": "", "daytona_image": "",
+        "cwd": cwd, "timeout": 180, "lifetime_seconds": 300,
+        "container_cpu": 1, "container_memory": 5120, "container_disk": 51200,
+        "container_persistent": True, "docker_volumes": [], "docker_env": {},
+        "docker_extra_args": [], "docker_forward_env": [],
+        "docker_run_as_host_user": False, "docker_network": True,
+        "docker_mount_cwd_to_workspace": False, "modal_mode": "auto",
+        "local_persistent": False, "host_cwd": None,
+        "ssh_host": "", "ssh_user": "", "ssh_port": 22, "ssh_key": "",
+    }
+
+
+def _build(monkeypatch, task_id, overrides, env_type="docker", config_cwd="/root"):
+    captured = {}
+    cfg = _config(env_type, config_cwd)
+
+    class _DummyEnv:
+        cwd = config_cwd
+
+    def fake_create_environment(**kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return _DummyEnv()
+
+    import tools.terminal_tool_backends as backends
+    monkeypatch.setattr(tt, "_get_env_config", lambda: cfg)
+    monkeypatch.setattr(backends, "_create_environment", fake_create_environment)
+    monkeypatch.setattr(tt, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(tt, "_active_environments", {})
+    monkeypatch.setattr(tt, "_last_activity", {})
+
+    tt.register_task_env_overrides(task_id, overrides)
+    try:
+        cet._get_or_create_env(task_id)
+    finally:
+        tt.clear_task_env_overrides(task_id)
+        tt._active_environments.pop(task_id, None)
+        tt._active_environments.pop("default", None)
+    return captured.get("cwd")
+
+
+class TestOverrideLookupMatchesTheOtherLayers:
+    def test_cwd_only_override_is_found(self, monkeypatch):
+        # Collapses to "default"; the old lookup missed it entirely.
+        assert _build(monkeypatch, "sess-cwd-only",
+                      {"cwd": "/workspace/task42"}) == "/workspace/task42"
+
+
+class TestHostCwdDoesNotReachTheContainerBuilder:
+    def test_cwd_only_host_override_is_sanitized(self, monkeypatch):
+        # Newly reachable because of the lookup fix, and therefore newly
+        # dangerous without the guard.
+        assert _build(monkeypatch, "sess-host", {"cwd": r"C:\Users\someuser"}) == "/root"
+
+    def test_isolation_keyed_host_override_is_sanitized(self, monkeypatch):
+        # Reachable even before the lookup fix: an isolation key keeps the raw
+        # id. This is the half that was already leaking.
+        assert _build(monkeypatch, "sess-iso",
+                      {"cwd": "/home/someuser/project", "docker_image": "alpine"}) == "/root"
+
+    def test_drive_path_override_is_sanitized(self, monkeypatch):
+        assert _build(monkeypatch, "sess-drive", {"cwd": r"D:\work"}) == "/root"
+
+    def test_valid_container_override_passes_through(self, monkeypatch):
+        assert _build(monkeypatch, "sess-ok",
+                      {"cwd": "/workspace/task42"}) == "/workspace/task42"
+
+    def test_non_container_backend_is_untouched(self, monkeypatch):
+        # The guard is container-scoped; local resolution must not narrow.
+        assert _build(monkeypatch, "sess-local", {"cwd": "/home/someuser"},
+                      env_type="local", config_cwd="/home/hermes") == "/home/someuser"

--- a/tests/tools/test_container_cwd_host_independence.py
+++ b/tests/tools/test_container_cwd_host_independence.py
@@ -1,0 +1,64 @@
+"""The container cwd verdict must not depend on the host Hermes runs on.
+
+``_is_unusable_container_cwd`` ended its check with ``os.path.isabs``, and
+``os.path`` is ``posixpath`` or ``ntpath`` depending on the machine. The same
+string therefore got different verdicts on different hosts.
+
+Host paths -- including every Windows drive -- are already handled by
+``_is_host_cwd`` (``_WINDOWS_DRIVE_RE``), so the drive families were never the
+problem here. The problem is the other direction: CPython 3.13 changed
+``ntpath.isabs`` to return False for a rooted path with no drive, so on a
+Windows host running 3.13+ the guard would begin rejecting ``/workspace`` and
+``/root`` -- discarding exactly the values it exists to let through, and
+sending every such session to ``default_cwd`` instead of its sandbox
+workspace.
+
+Asking for a leading ``/`` is the rule the sandbox actually imposes and gives
+the same answer on every host and every Python.
+"""
+
+import ntpath
+import posixpath
+
+import tools.terminal_tool_config as cfg
+
+
+class TestVerdictIsTheSameOnEveryHost:
+    REJECT = [
+        r"C:\Users\me", "C:/Users/me",       # host, via the drive regex
+        r"D:\hermes", "d:/hermes", r"Z:\x",  # any drive, either slash
+        "/home/me", "/Users/me",             # host, via the prefixes
+        ".", "..", "src/", "work/uservice",  # relative
+    ]
+    KEEP = ["/workspace", "/workspace/task42", "/root", "/", "/opt/data"]
+
+    def test_rejected_families(self):
+        for p in self.REJECT:
+            assert cfg._is_unusable_container_cwd(p) is True, p
+
+    def test_kept_families(self):
+        for p in self.KEEP:
+            assert cfg._is_unusable_container_cwd(p) is False, p
+
+    def test_verdict_does_not_consult_os_path(self, monkeypatch):
+        # Swap the module's os.path for the other flavour and demand identical
+        # answers. This is the property the old implementation lacked, and the
+        # one that breaks on Windows + CPython 3.13.
+        for flavour in (ntpath, posixpath):
+            monkeypatch.setattr(cfg.os, "path", flavour)
+            for p in self.REJECT:
+                assert cfg._is_unusable_container_cwd(p) is True, (flavour.__name__, p)
+            for p in self.KEEP:
+                assert cfg._is_unusable_container_cwd(p) is False, (flavour.__name__, p)
+
+    def test_the_flavours_really_disagree_about_a_rooted_path(self):
+        # Keeps the property test from going vacuous. On 3.13+ these differ;
+        # on older Pythons they agree, and the property must hold either way,
+        # so assert the shape rather than a version-specific value.
+        assert posixpath.isabs("/workspace") is True
+        assert ntpath.isabs("/workspace") in (True, False)
+        assert ntpath.isabs(r"D:\x") is True
+        assert posixpath.isabs(r"D:\x") is False
+
+    def test_empty_is_not_flagged(self):
+        assert cfg._is_unusable_container_cwd("") is False

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -396,13 +396,43 @@ def _call(tool_name, args):
 
 # ---- Remote execution support (file-based RPC via terminal backend) ----
 
+def _sandbox_safe_cwd(env_type: str, overrides: Dict[str, Any], config: Dict[str, Any]) -> str:
+    """Resolve the cwd for a freshly built environment, sanitized like the
+    terminal and file layers do it.
+
+    A registered cwd override is a host path (a desktop/TUI/ACP session
+    recording its own workspace). On a container backend that reaches
+    ``docker run -w <host path>`` and the container fails to start (exit 125).
+    Every other builder already re-applies this guard; this one did not.
+
+    It looked harmless while the lookup above read only the collapsed
+    container id, because a CWD-only override never reached here. It was not:
+    an override carrying an isolation key (``env_type`` or ``*_image``, as RL
+    and benchmark harnesses register) keeps the raw id, so the host path came
+    through on exactly the rollouts that ask for their own sandbox.
+    """
+    from tools.terminal_tool_config import _is_container_backend, _is_unusable_container_cwd
+
+    cwd = overrides.get("cwd") or config["cwd"]
+    if _is_container_backend(env_type) and _is_unusable_container_cwd(cwd):
+        if cwd != config["cwd"]:
+            logger.info(
+                "Ignoring host/relative cwd override %r for %s backend "
+                "(won't exist in sandbox). Using %r instead.",
+                cwd, env_type, config["cwd"],
+            )
+        return config["cwd"]
+    return cwd
+
+
 def _get_or_create_env(task_id: str):
     """``(env, env_type)`` — the environment the terminal/file tools share for *task_id*, created on
     first use (same double-checked per-task lock pattern as file_tools._get_file_ops)."""
     from tools.terminal_tool_backends import _container_config_from_config, _create_environment, _ssh_config_from_config
     from tools.terminal_tool import (
         _active_environments, _env_lock, _get_env_config, _last_activity,
-        _start_cleanup_thread, _creation_locks, _creation_locks_lock, _task_env_overrides,
+        _start_cleanup_thread, _creation_locks, _creation_locks_lock,
+        resolve_task_overrides,
         _resolve_container_task_id, _resolve_task_host_cwd, _is_container_backend, _select_image,
     )
     effective_task_id = _resolve_container_task_id(task_id)
@@ -423,7 +453,11 @@ def _get_or_create_env(task_id: str):
             return env, _get_env_config()["env_type"]
         config = _get_env_config()
         env_type = config["env_type"]
-        overrides = _task_env_overrides.get(effective_task_id, {})
+        # Raw key first, then the collapsed container id -- the same lookup the
+        # terminal and file layers use. Reading only the collapsed id dropped
+        # CWD-only overrides, which are registered under the raw session id and
+        # deliberately collapse so sessions share one container.
+        overrides = resolve_task_overrides(task_id)
         container_config = None
         if _is_container_backend(env_type):
             # Shared shaper: execute_code's own key subset dropped docker_extra_args / docker_forward_env /
@@ -433,7 +467,7 @@ def _get_or_create_env(task_id: str):
                      env_type, effective_task_id[:8])
         env = _create_environment(
             env_type=env_type, image=_select_image(env_type, overrides, config),
-            cwd=overrides.get("cwd") or config["cwd"], timeout=config["timeout"],
+            cwd=_sandbox_safe_cwd(env_type, overrides, config), timeout=config["timeout"],
             ssh_config=_ssh_config_from_config(config) if env_type == "ssh" else None,
             container_config=container_config,
             local_config={"persistent": config.get("local_persistent", False)} if env_type == "local" else None,

--- a/tools/terminal_tool_config.py
+++ b/tools/terminal_tool_config.py
@@ -98,9 +98,19 @@ def _get_plugin_env_provider(env_type: str):
 def _is_unusable_container_cwd(cwd: str) -> bool:
     """True if *cwd* is a host or relative path that can't be a container
     workdir: ``docker run -w`` needs an absolute in-sandbox path, otherwise the
-    container fails to start (exit 125). Windows drive paths aren't ``isabs``
-    on POSIX, so they're caught by the prefix check."""
-    return bool(cwd) and (_is_host_cwd(cwd) or not os.path.isabs(cwd))
+    container fails to start (exit 125). Host paths (including any Windows
+    drive) are caught by :func:`_is_host_cwd`; what is left is the requirement
+    that the path be absolute *inside the sandbox*, which is POSIX.
+
+    That last check must not be ``os.path.isabs``. ``os.path`` is ``posixpath``
+    or ``ntpath`` depending on the machine Hermes runs on, so the same string
+    gets different verdicts on different hosts -- and CPython 3.13 changed
+    ``ntpath.isabs`` to return False for a rooted path with no drive. On a
+    Windows host running 3.13+ this would start rejecting ``/workspace`` and
+    ``/root``: discarding exactly the values the guard exists to let through.
+    Asking for a leading ``/`` is the rule the sandbox actually imposes, and it
+    is the same answer everywhere."""
+    return bool(cwd) and (_is_host_cwd(cwd) or not cwd.startswith("/"))
 
 
 def _tenv(name: str, default: str = "") -> str:


### PR DESCRIPTION
Two independent defects around the container working directory. They are in the same neighbourhood and the second one's fix depends on the first being right, so they land together.

## 1. The verdict depended on the host Hermes runs on

`_is_unusable_container_cwd` ended with `os.path.isabs`, and `os.path` is `posixpath` or `ntpath` depending on the machine. The same string got different verdicts on different hosts.

Windows drives are **not** the problem here — `_is_host_cwd` already catches every drive via `_WINDOWS_DRIVE_RE`. The problem is the other direction. CPython 3.13 changed `ntpath.isabs` to return `False` for a rooted path with no drive:

```python
# CPython 3.13+
>>> ntpath.isabs("/workspace")
False
```

So on a Windows host running 3.13+, this guard begins rejecting `/workspace` and `/root` — discarding exactly the values it exists to let through, and sending those sessions to `default_cwd` instead of their sandbox workspace.

Measured with `os.path` swapped to each flavour:

| cwd | host path? | posixpath | ntpath |
|---|---|---|---|
| `/workspace` | no | usable | **rejected** |
| `/root` | no | usable | **rejected** |
| `C:\Users\me`, `D:/hermes`, `Z:\x` | yes | rejected | rejected |
| `.`, `src/` | no | rejected | rejected |

Asking for a leading `/` is the rule the sandbox actually imposes, and it gives the same answer on every host and every Python.

> **Scope of "host-independent".** This makes the **absoluteness** half of the verdict host-independent. The **host-detection** half (`_is_host_cwd` — two POSIX prefixes plus a drive regex) is unchanged here. That half is not flavour-dependent either, but it is an enumeration rather than a rule, so a host path shape outside that table is still not recognised. Raised by an independent Windows review; recorded here so the fix isn't read as broader than it is.

## 2. `execute_code`'s builder read the wrong overrides and had no cwd guard

The lookup used the **collapsed** container id. A CWD-only override is registered under the **raw** session id and deliberately collapses so sessions share one container, so this builder silently dropped it while the terminal and file layers — both of which go through `resolve_task_overrides` — honoured it.

The builder also skipped the cwd guard every other builder applies. That looked harmless only because of the lookup defect. It was not: an override carrying an isolation key (`env_type` or `*_image`, as RL and benchmark harnesses register) keeps the raw id, so a host path already reached `docker run -w <host path>` on exactly the rollouts that ask for their own sandbox — and the container fails to start with exit 125.

Fixing the lookup alone would widen that leak, since the builder would start finding host paths it used to miss.

## Tests

11 added.

One swaps the module's `os.path` for the other flavour and demands identical verdicts — the property the old code lacked. Another asserts the two flavours really do disagree about these strings, so that property test cannot quietly go vacuous on an older Python.

All four mutations fail the suite: restoring the `isabs` rule, dropping the host check, reverting the lookup, and bypassing the new guard. Sources were restored and verified by hash afterwards.

## Regression

`tests/tools -k "code_exec or container or cwd or terminal or file_tool"`, with the two new files excluded, gives exactly `main`'s result: the same 5 pre-existing failures, 747 passed.

With the new files included, one of those pre-existing failures stops firing (`test_tool_search_emits_one_terminal_hook`). That test passes in isolation on both `main` and this branch — it is collection-order sensitivity in an unrelated test, not something this change fixes. Noting it so the passed count difference (759 vs 747, rather than 747 + 11) is not mistaken for something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

