### PR TITLE
fix(kanban): clarify kanban_create parents are prerequisites, not ownership

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1161,3 +1161,31 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# kanban_create schema wording — prerequisites vs. ownership (#105573)
+# ---------------------------------------------------------------------------
+
+
+def test_kanban_create_schema_clarifies_parents_are_prerequisites():
+    """The create wording must separate continuations from decomposition.
+
+    A continuation may list the current task in ``parents`` (it starts after
+    that task is done), but a child the current task waits on must not list
+    it — a root held open until its children deliver would deadlock. The
+    schema is model-facing guidance, so the clarification lives in the
+    description strings.
+    """
+    from tools.kanban_tools_schemas import KANBAN_CREATE_SCHEMA
+
+    desc = KANBAN_CREATE_SCHEMA["description"]
+    assert "continuation of the current one" in desc
+    assert "prerequisites, not ownership" in desc
+    assert "waiting on this new one" in desc
+    assert "body for traceability" in desc
+
+    parents = KANBAN_CREATE_SCHEMA["parameters"]["properties"]["parents"]["description"]
+    assert parents.startswith("Prerequisite task ids.")
+    assert "Continuations may list the current task" in parents
+    assert "waiting on the new one" in parents

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -351,12 +351,17 @@ KANBAN_ATTACHMENTS_SCHEMA = _schema(
 KANBAN_CREATE_SCHEMA = _schema(
     "kanban_create",
     (
-        "Create a new kanban task, optionally as a child of the current "
-        "one (pass the current task id in ``parents``). Used by "
-        "orchestrator workers to fan out — decompose work into child "
-        "tasks with specific assignees, link them into a pipeline, "
-        "then complete your own task. The dispatcher picks up the new "
-        "tasks on its next tick and spawns the assigned profiles."
+        "Create a new kanban task, optionally as a continuation of the "
+        "current one (pass the current task id in ``parents`` — the new "
+        "task only starts after that task is done). Used by orchestrator "
+        "workers to fan out — decompose work into child tasks with "
+        "specific assignees, link them into a pipeline, then complete "
+        "your own task. ``parents`` are prerequisites, not ownership: "
+        "never list a task that is waiting on this new one (a root held "
+        "open until its children deliver would deadlock) — mention its "
+        "id in the body for traceability instead. The dispatcher picks "
+        "up the new tasks on its next tick and spawns the assigned "
+        "profiles."
     ),
     {
         "title": _prop("string", "Short task title (required)."),
@@ -375,9 +380,11 @@ KANBAN_CREATE_SCHEMA = _schema(
             "type": "array",
             "items": {"type": "string"},
             "description": (
-                "Parent task ids. The new task stays in 'todo' "
+                "Prerequisite task ids. The new task stays in 'todo' "
                 "until every parent reaches 'done'; then it "
-                "auto-promotes to 'ready'. Typical fan-in: list "
+                "auto-promotes to 'ready'. Continuations may list the "
+                "current task; a task that is waiting on the new one "
+                "must not be listed (deadlock). Typical fan-in: list "
                 "all the researcher task ids when creating a "
                 "synthesizer task."
             ),


### PR DESCRIPTION
## What does this PR do?

Clarifies the `kanban_create` tool's model-facing wording so that `parents` is understood as **prerequisites, not task ownership**, separating two usage patterns the old text conflated:

- **Continuation** — work that should start after the current task completes. Listing the current task id in `parents` is correct here.
- **Root-task decomposition** — an orchestrator keeps the root open until the work it creates is delivered and accepted. The old guidance ("pass the current task id in `parents`", "then complete your own task") pushed implementation children into depending on a root that was waiting on them, so the child sat in `'todo'` forever waiting for a parent that could never reach `'done'` (deadlock).

The reworded description states that a task waiting on the new one must never be listed in `parents`, and that the root id can be referenced in the task body for traceability instead. Dependency semantics are unchanged — this is a wording-only fix, exactly as scoped in the issue.

## Related Issue

Fixes #105573

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `tools/kanban_tools_schemas.py` — reworded `KANBAN_CREATE_SCHEMA`'s tool description ("continuation of the current one … only starts after that task is done", "``parents`` are prerequisites, not ownership", deadlock warning, body-for-traceability guidance)
- `tools/kanban_tools_schemas.py` — reworded the `parents` property description ("Prerequisite task ids", "Continuations may list the current task; a task that is waiting on the new one must not be listed")
- `tests/tools/test_kanban_tools.py` — added `test_kanban_create_schema_clarifies_parents_are_prerequisites` regression test pinning the clarified wording

## How to Test

1. Run the regression test:
   `python -m pytest tests/tools/test_kanban_tools.py::test_kanban_create_schema_clarifies_parents_are_prerequisites -q`
   Observed result: 1 passed.
2. Run the full kanban tool surface plus the schema consumer in the gateway poller:
   `python -m pytest tests/tools/test_kanban_tools.py tests/tui_gateway/test_kanban_notify_poller.py -q`
   Observed result: 47 passed.
3. `ruff check tools/kanban_tools_schemas.py tests/tools/test_kanban_tools.py` — Observed result: All checks passed.
4. Confirm no behavior change: the diff touches only description strings inside `tools/kanban_tools_schemas.py`; no handler or dispatcher logic is modified. Dependency semantics should stay exactly as before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
