### PR TITLE
fix(security): hardline floor covers macOS disks and disk-wipe tools

### DIFF
--- a/tests/tools/test_hardline_block_devices.py
+++ b/tests/tools/test_hardline_block_devices.py
@@ -1,0 +1,259 @@
+"""Hardline coverage for raw block devices and the disk wipe/format tool family.
+
+The floor exists for "root wipe, raw block device writes, shutdown, DoS", but its
+device rules only knew the Linux SCSI/NVMe spellings and its format rule only knew
+the name `mkfs`. Everything else that destroys a whole disk — macOS `/dev/disk0`,
+device-mapper/LVM, md RAID, loop/nbd, the `/dev/disk/by-*` symlinks, and the
+`wipefs`/`blkdiscard`/`sgdisk`/`shred`/`mke2fs`/`mkswap`/`newfs_*`/`diskutil`
+tools — walked past every guard, so `--yolo` ran them with no prompt at all.
+
+These are behaviour contracts on the classifier: a command that erases a disk with
+no recovery path must hit the unconditional floor, and the tool invocations that
+only PRINT (or that target a file rather than a device) must stay runnable.
+"""
+
+import pytest
+
+from tools.approval import (
+    check_all_command_guards,
+    check_dangerous_command,
+    detect_dangerous_command,
+    detect_hardline_command,
+    disable_session_yolo,
+)
+from tools.approval_context import reset_current_session_key, set_current_session_key
+
+
+# Commands that MUST be hardline-blocked: every one destroys a whole disk.
+_BLOCK_DEVICE_HARDLINE_BLOCK = [
+    # ---- macOS disks: whole disk, slice, and the raw character node -------
+    "cat x > /dev/disk0",
+    "cat x > /dev/disk0s2",
+    "cat x > /dev/rdisk0",
+    "dd if=/dev/zero of=/dev/disk0",
+    "dd if=/dev/zero of=/dev/rdisk2 bs=1m",
+    # ---- device-mapper / LVM, md RAID, loop, network block devices --------
+    "cat x > /dev/dm-0",
+    "cat x > /dev/mapper/vg-root",
+    "cat x > /dev/md0",
+    "cat x > /dev/md127",
+    "cat x > /dev/loop0",
+    "cat x > /dev/nbd0",
+    "dd if=/dev/zero of=/dev/mapper/vg-root",
+    "dd if=/dev/zero of=/dev/dm-0",
+    # ---- udev persistent-name symlinks: the same disks, stable names ------
+    "cat x > /dev/disk/by-id/ata-Samsung_SSD",
+    "cat x > /dev/disk/by-uuid/8e7d1c2a-1111-2222-3333-444455556666",
+    "cat x > /dev/disk/by-path/pci-0000:00:1f.2-ata-1",
+    "cat x > /dev/disk/by-label/DATA",
+    "cat x > /dev/disk/by-partuuid/1a2b3c4d-01",
+    "cat x > /dev/disk/by-partlabel/root",
+    "dd if=/dev/zero of=/dev/disk/by-id/ata-Samsung_SSD",
+    # ---- redirect spellings ----------------------------------------------
+    "cat x >> /dev/disk0",
+    "cat x 1> /dev/rdisk0",
+    "cat x 1>> /dev/mapper/vg-root",
+    "cat x >/dev/loop0",
+    # ---- dd with the operands in either order ----------------------------
+    "dd of=/dev/disk0 if=/dev/zero",
+    "dd of=/dev/md0 bs=4M if=/dev/urandom",
+    # ---- wipe family ------------------------------------------------------
+    "wipefs -a /dev/sda",
+    "wipefs --all /dev/sda",
+    "wipefs -a /dev/disk0",
+    "wipefs /dev/sda -a",  # util-linux permutes flags after operands
+    "wipefs -fa /dev/nvme0n1",
+    "blkdiscard /dev/nvme0n1",
+    "blkdiscard -f /dev/sda",
+    "blkdiscard /dev/disk/by-id/nvme-Samsung",
+    "sgdisk --zap-all /dev/sda",
+    "sgdisk -Z /dev/sda",
+    "sgdisk -o /dev/sda",
+    "sgdisk --clear /dev/nvme0n1",
+    "shred -n 1 -z /dev/sda",
+    "shred /dev/nvme0n1",
+    "shred -vfz -n 3 /dev/disk2",
+    # ---- format family ----------------------------------------------------
+    "mke2fs /dev/sda1",  # mke2fs IS mkfs.ext2/3/4 — same binary
+    "mke2fs -t ext4 /dev/nvme0n1p2",
+    "mkswap /dev/sda1",
+    "mkswap /dev/mapper/vg-swap",
+    "newfs_hfs /dev/disk2",
+    "newfs_apfs /dev/disk2",
+    "newfs_msdos /dev/disk2s1",
+    "newfs_hfs -v Data /dev/rdisk3s2",
+    # ---- macOS diskutil destructive verbs ---------------------------------
+    "diskutil eraseDisk JHFS+ X disk0",
+    "diskutil eraseVolume JHFS+ X disk0s2",
+    "diskutil zeroDisk disk0",
+    "diskutil randomDisk 1 disk0",
+    "diskutil secureErase 0 disk0",
+    "diskutil reformat disk0",
+    "diskutil partitionDisk disk0 GPT JHFS+ Data 100%",
+    "diskutil apfs eraseVolume disk2s1",
+    # ---- command-position variants (separators, wrappers, substitution) ----
+    "true && wipefs -a /dev/sda",
+    "ls; blkdiscard /dev/sda",
+    "echo x | shred -z /dev/sda",
+    "$(blkdiscard /dev/sda)",
+    "`sgdisk -Z /dev/sda`",
+    "sudo diskutil eraseDisk APFS Data /dev/disk2",
+    "sudo wipefs -a /dev/disk0",
+    "env FOO=1 mke2fs /dev/sda1",
+    "nohup blkdiscard /dev/sda",
+    "(wipefs -a /dev/sda)",
+    "{ mke2fs /dev/sda1; }",
+    'bash -c "wipefs -a /dev/sda"',
+    'sh -c "cat f > /dev/disk0"',
+]
+
+
+# Commands that look similar but MUST stay runnable.
+_BLOCK_DEVICE_HARDLINE_ALLOW = [
+    # ---- /dev entries that are not block devices --------------------------
+    "echo test > /dev/null",
+    "cat noisy.log > /dev/null 2>&1",
+    "dd if=/dev/zero of=./image.bin",
+    "head -c 16 /dev/urandom > seed.bin",
+    "cat /dev/random | head -c 4",
+    "echo hi > /dev/stdout",
+    "echo hi > /dev/stderr",
+    "cat < /dev/stdin",
+    "echo hi > /dev/tty",
+    "echo hi > /dev/pts/0",
+    "echo hi > /dev/fd/1",
+    "echo payload > /dev/shm/cache",
+    "echo hi > /dev/full",
+    # ---- reading a device is not writing to one ---------------------------
+    "dd if=/dev/sda of=backup.img",
+    "dd if=/dev/disk0 of=backup.img",
+    "ls /dev/sda",
+    "ls /dev/disk/by-id",
+    "cat /dev/disk/by-id/foo",
+    "lsblk /dev/sda",
+    # ---- wipe-family invocations that only print or target a file ---------
+    "wipefs /dev/sda",
+    "wipefs -n /dev/sda",
+    "wipefs --backup /dev/sda",
+    "sgdisk -p /dev/sda",
+    "sgdisk -n 1:0:+512M /dev/sda",
+    "blkdiscard --help",
+    "shred file.txt",
+    "shred -u secret.txt",
+    "shred -n 3 /tmp/notes.txt",
+    # ---- format-family invocations that target a file, not a device -------
+    "mkswap /swapfile",
+    "mkswap ./swap.img",
+    "newfs_hfs disk.dmg",
+    # ---- diskutil read-only verbs -----------------------------------------
+    "diskutil list",
+    "diskutil info disk0",
+    "diskutil mount disk2s1",
+    "diskutil unmount /dev/disk2s1",
+    "diskutil apfs list",
+    # ---- the trigger words as quoted prose, not as commands ---------------
+    'echo "run diskutil eraseDisk later"',
+    'git commit -m "mke2fs the backup disk"',
+    'echo "wipefs -a /dev/sda destroys the disk"',
+    "grep 'blkdiscard /dev/sda' notes.md",
+    'gh pr create --body "this PR blocks shred /dev/nvme0n1"',
+    "echo 'sgdisk -Z /dev/sda zaps the partition table'",
+    'git commit -m "document dd if=/dev/zero of=/dev/disk0"',
+]
+
+
+@pytest.mark.parametrize("command", _BLOCK_DEVICE_HARDLINE_BLOCK)
+def test_disk_destroying_commands_are_hardline(command):
+    """Every spelling of "erase a whole disk" hits the unconditional floor."""
+    is_hardline, description = detect_hardline_command(command)
+    assert is_hardline, f"disk wipe leaked past the hardline floor: {command!r}"
+    assert description, "hardline match must provide a description"
+
+
+@pytest.mark.parametrize("command", _BLOCK_DEVICE_HARDLINE_ALLOW)
+def test_lookalike_commands_stay_runnable(command):
+    """Reads, print-only tool runs, file targets, and prose must not be blocked."""
+    is_hardline, description = detect_hardline_command(command)
+    assert not is_hardline, (
+        f"legitimate command false-positived the hardline floor: {command!r} "
+        f"(got: {description})"
+    )
+    assert description is None
+
+
+# Ordinary /dev pseudo-devices must not be dragged into the APPROVAL tier
+# either: the block-device fragment is shared with _SENSITIVE_WRITE_TARGET,
+# so `echo x > /dev/null` in a script would start prompting if it over-matched.
+@pytest.mark.parametrize("command", [
+    "echo test > /dev/null",
+    "cat noisy.log > /dev/null 2>&1",
+    "echo hi > /dev/stdout",
+    "echo hi > /dev/stderr",
+    "echo payload > /dev/shm/cache",
+    "echo hi > /dev/fd/1",
+    "cat file | tee /dev/tty",
+])
+def test_pseudo_device_writes_need_no_approval(command):
+    is_dangerous, _, description = detect_dangerous_command(command)
+    assert not is_dangerous, (
+        f"pseudo-device write started requiring approval: {command!r} "
+        f"(got: {description})"
+    )
+
+
+# The dangerous tier carried the same Linux-only spellings, so cp/mv/tee to a
+# non-`sd` device was auto-approved. Yolo may still bypass this tier — the point
+# is that an unattended session no longer writes a disk with no prompt at all.
+@pytest.mark.parametrize("command", [
+    "cp x /dev/nvme0n1",
+    "cp x /dev/disk0",
+    "mv x /dev/vda",
+    "mv x /dev/mapper/vg-root",
+    "tee /dev/disk0 < x",
+    "tee /dev/mapper/vg-root < x",
+    "echo x | tee /dev/nvme0n1",
+])
+def test_copy_and_tee_to_block_device_requires_approval(command):
+    is_dangerous, key, description = detect_dangerous_command(command)
+    assert is_dangerous, f"write to a block device was auto-approved: {command!r}"
+    assert key is not None and description
+
+
+@pytest.fixture
+def clean_session(monkeypatch):
+    """Reset session-scoped approval state around each test."""
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    token = set_current_session_key("hardline_block_device_test")
+    try:
+        disable_session_yolo("hardline_block_device_test")
+        yield
+    finally:
+        disable_session_yolo("hardline_block_device_test")
+        reset_current_session_key(token)
+
+
+def test_yolo_cannot_bypass_disk_wipes(clean_session, monkeypatch):
+    """macOS/dm/wipe spellings stay blocked with HERMES_YOLO_MODE=1.
+
+    They previously reached the approval tier at best (`dd ... of=/dev/disk0`)
+    or no tier at all, and yolo bypasses everything above the floor.
+    """
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+
+    for command in ("dd if=/dev/zero of=/dev/disk0", "cat x > /dev/rdisk0",
+                    "diskutil eraseDisk JHFS+ X disk0", "newfs_apfs /dev/disk2",
+                    "wipefs -a /dev/sda", "blkdiscard /dev/nvme0n1",
+                    "sgdisk -Z /dev/sda", "shred -z /dev/disk2",
+                    "mke2fs /dev/sda1", "cat x > /dev/mapper/vg-root"):
+        first = check_dangerous_command(command, "local")
+        assert first["approved"] is False, f"yolo leaked {command!r} (check_dangerous_command)"
+        assert first.get("hardline") is True
+
+        second = check_all_command_guards(command, "local")
+        assert second["approved"] is False, f"yolo leaked {command!r} (check_all_command_guards)"
+        assert second.get("hardline") is True
+        assert "BLOCKED (hardline)" in second["message"]

--- a/tests/tools/test_hardline_block_devices.py
+++ b/tests/tools/test_hardline_block_devices.py
@@ -415,3 +415,87 @@ def test_yolo_cannot_bypass_an_alternate_executable_position(clean_session, monk
         assert second["approved"] is False, f"yolo leaked {command!r} (check_all_command_guards)"
         assert second.get("hardline") is True
         assert "BLOCKED (hardline)" in second["message"]
+
+
+# ---------------------------------------------------------------------------
+# Second review round: four false-positive classes the first revision's allow
+# list did not reach. Each is a command that RUNS NOTHING destructive, on a
+# floor with no approval path — so matching one bans it outright.
+# ---------------------------------------------------------------------------
+
+_SECOND_ROUND_ALLOW = [
+    # A wrapper's QUERY options do not run the verb. `command -v mkfs` prints a path; the shape
+    # appears 15 times in a 42,222-line corpus of real command lines, and
+    # `_COMMAND_WRAPPER_NON_EXECUTING_OPTIONS` already encodes exactly this.
+    "command -v mkfs",
+    "command -v mkfs.ext4",
+    "command -v mke2fs",
+    "command -V mkfs",
+    "builtin command -v mkfs",
+    "nice -n 10 command -v mkfs",
+    "if command -v mkfs >/dev/null 2>&1; then echo yes; fi",
+    "command -v mkfs.btrfs || apt-get install btrfs-progs",
+    "chrt -p 1234",
+    "taskset -p 1234",
+    "ionice -p 1234",
+    # A directory named `dev` is not /dev. `~/dev/sdk/...` carries `/dev/sd` plus a `k`.
+    "shred -u ~/dev/sdk/token.json",
+    "shred -u /home/user/dev/sdk-token.txt",
+    "shred -n 3 -u /workspace/dev/sdk/keys.pem",
+    "shred -u /opt/dev/mdbook/out.txt",
+    "shred -u /opt/dev/nbdev/notebook.ipynb",
+    "shred -u /src/dev/loopback-tests/creds",
+    "shred -u /src/dev/vdom/token",
+    "shred -u ./dev/hdmi-config.txt",
+    "shred -u /home/ci/dev/dm-cache/pass.txt",
+    "shred -u /var/tmp/dev/disk1-report.txt",
+    "shred -u ../dev/sda-notes",
+    "blkdiscard -v /home/dev/sda-file",
+    "wipefs -a ~/dev/sdk/disk.img",
+    "mkswap /home/user/dev/sdk/swapfile",
+    "mkswap /var/lib/dev/sdk/swap.img",
+    "newfs_hfs ~/dev/sdk/disk.dmg",
+    # The operand lookahead must not read a trailing comment as the operand.
+    "shred -u notes.txt # never do this to /dev/sda",
+    # `-n`/`--no-act` is wipefs doing everything except the write: a diagnostic.
+    "wipefs -n -a /dev/sda",
+    "wipefs --no-act --all /dev/sda",
+    # Quoted words AFTER a quoted redirect target are prose again, not more operands.
+    'cat x > "out.log" "cat y > /dev/sda"',
+    './deploy.sh > "deploy.log" "note: cat img > /dev/sda"',
+    'cat x > "a" ":(){ :|:& };:"',
+    # An EMPTY quoted target leaves no content to move the marker off the `>`, so the quote
+    # character itself has to; otherwise the next quoted word inherits the exception.
+    'cat x > "" "prose about /dev/sda"',
+    'cat x > \'\' \'note: cat y > /dev/sda\'',
+]
+
+
+@pytest.mark.parametrize("command", _SECOND_ROUND_ALLOW)
+def test_the_floor_does_not_reach_commands_that_destroy_nothing(command):
+    is_hardline, description = detect_hardline_command(command)
+    assert not is_hardline, (
+        f"unapprovable floor caught a harmless command: {command!r} (got: {description})"
+    )
+
+
+@pytest.mark.parametrize("command", [
+    # The query-option carve-out must not become a way past the floor.
+    "command mkfs.ext4 /dev/sda1",
+    "command -p mkfs.ext4 /dev/sda1",
+    "chrt -f 1 blkdiscard /dev/sda",
+    "taskset -c 0 dd if=/dev/zero of=/dev/sda",
+    "ionice -c3 blkdiscard /dev/nvme0n1",
+    # A real device path still matches after every boundary that is not a path character.
+    "cat x > /dev/sda",
+    'cat x > "/dev/sda"',
+    "dd if=/dev/zero of=/dev/sda",
+    "wipefs -a /dev/sda",
+    "wipefs -fa /dev/sda",
+    "mkswap /dev/sda1",
+    "shred -n 1 -z /dev/sda",
+])
+def test_the_second_round_carve_outs_do_not_open_the_floor(command):
+    is_hardline, description = detect_hardline_command(command)
+    assert is_hardline, f"carve-out let a disk destroyer through: {command!r}"
+    assert description

--- a/tests/tools/test_hardline_block_devices.py
+++ b/tests/tools/test_hardline_block_devices.py
@@ -257,3 +257,161 @@ def test_yolo_cannot_bypass_disk_wipes(clean_session, monkeypatch):
         assert second["approved"] is False, f"yolo leaked {command!r} (check_all_command_guards)"
         assert second.get("hardline") is True
         assert "BLOCKED (hardline)" in second["message"]
+
+
+# ---------------------------------------------------------------------------
+# Review follow-up: two escape hatches that survived the first revision.
+#
+# Both reproduce on clean main as well, so neither was introduced here — but
+# this change is what claims the non-bypassable floor for these verbs, so it
+# is what has to close them.
+# ---------------------------------------------------------------------------
+
+# #1 — a shell-quoted DEVICE OPERAND is a real target, not prose. `cat x >
+# "/dev/disk0"` performs exactly the write the bare spelling does, but the
+# redirect rule is quote-masked (_QUOTE_MASKED_HARDLINE_DESCRIPTIONS) and the
+# mask blanked the path before the rule saw it; the `dd` rule wanted `of=`
+# followed immediately by an unquoted device. Both landed in the dangerous
+# tier at best, and that is the tier `--yolo` / `approvals.mode: off` exists
+# to skip.
+_QUOTED_OPERAND_HARDLINE_BLOCK = [
+    'cat x > "/dev/disk0"',
+    "cat x > '/dev/disk0'",
+    'cat x > "/dev/sda"',
+    "cat x > '/dev/nvme0n1'",
+    'cat x >"/dev/sda"',
+    'cat x >> "/dev/sda"',
+    'cat x >  "/dev/rdisk0"',
+    'cat x > "/dev/mapper/vg-root"',
+    'cat x > "/dev/disk/by-id/ata-Samsung_SSD"',
+    'dd if=/dev/zero of="/dev/disk0"',
+    "dd if=/dev/zero of='/dev/disk0'",
+    'dd if=/dev/zero of="/dev/sda" bs=1m',
+    "dd if=/dev/zero of='/dev/nvme0n1'",
+]
+
+# #2 — the verb reaching the disk without ever appearing at _CMDPOS: spelled as
+# a path, run behind a scheduling/buffering wrapper, or dispatched by a
+# multicall binary. Measured on clean main, every one of these is BOTH
+# hardline=False and dangerous=False — no tier at all.
+_EXEC_POSITION_HARDLINE_BLOCK = [
+    # absolute and relative paths
+    "/usr/sbin/wipefs -a /dev/sda",
+    "/sbin/mkfs.ext4 /dev/sda1",
+    "/usr/local/bin/shred -n1 /dev/sda",
+    "/sbin/newfs_hfs /dev/disk2",
+    "./wipefs -a /dev/sda",
+    "../sbin/wipefs --all /dev/sda",
+    # scheduling / buffering wrappers
+    "nice blkdiscard /dev/sda",
+    "nice -n 10 sgdisk -Z /dev/sda",
+    "nice mkswap /dev/sda1",
+    "command mke2fs /dev/sda1",
+    "command shred -n 1 -z /dev/sda",
+    "stdbuf -oL dd if=/dev/zero of=/dev/sda",
+    "ionice -c3 blkdiscard /dev/nvme0n1",
+    "taskset -c 0 dd if=/dev/zero of=/dev/sda",
+    "chrt -f 1 blkdiscard /dev/sda",
+    # multicall binaries
+    "busybox dd if=/dev/zero of=/dev/sda",
+    "toybox dd if=/dev/zero of=/dev/sda",
+    "/bin/busybox dd if=/dev/zero of=/dev/sda",
+    # stacked with the wrappers _CMDPOS already peeled
+    "sudo /usr/sbin/wipefs -a /dev/sda",
+    "sudo nice blkdiscard /dev/sda",
+]
+
+# The traps the two widenings could plausibly spring. A path is allowed in
+# front of the verb, so a filename that merely CONTAINS a verb name must not
+# read as a command; a wrapper is peeled, so the wrapper in front of something
+# harmless must stay harmless; a quoted redirect operand is now visible, so an
+# ordinary quoted filename must not start blocking.
+_REVIEW_FOLLOWUP_ALLOW = [
+    # a path that only contains the verb name
+    "\n/opt/mkfs-notes.txt",
+    "\n/var/log/mkfs-notes.txt",
+    "./mkfs-helper.sh --dry-run",
+    "\n/usr/share/doc/wipefs-readme",
+    "\n/etc/init.d/mkfs-cron status",
+    "cat /var/log/dd.log",
+    "tail -f /var/log/shutdown.log",
+    # a peeled wrapper in front of something ordinary
+    "nice make -j4",
+    "nice -n 19 python train.py",
+    "command ls -la",
+    "busybox ls /tmp",
+    "stdbuf -oL grep foo bar.txt",
+    "ionice -c3 rsync a b",
+    # ordinary quoted redirect targets
+    'echo hi > "out.txt"',
+    'printf "%s" > "some file.txt"',
+    'npm run build > "build log.txt"',
+    'cat x > "/dev/null"',
+    # and the prose contract from #93640, restated against the quoted-operand fix
+    'echo "cat x > /dev/disk0"',
+    'echo "cat x > /dev/sda"',
+    "echo 'cat x > /dev/sda'",
+    "git commit -m 'ran dd if=/dev/zero of=/dev/disk0 once'",
+    'git commit -m "dd if=/dev/zero of=/dev/sda is what broke it"',
+]
+
+
+@pytest.mark.parametrize("command", _QUOTED_OPERAND_HARDLINE_BLOCK)
+def test_quoting_the_device_operand_is_not_a_bypass(command):
+    """Shell quoting around the operand must not change the hardline verdict."""
+    is_hardline, description = detect_hardline_command(command)
+    assert is_hardline, f"quoted device operand slipped the floor: {command!r}"
+    assert description
+
+
+@pytest.mark.parametrize("command", _EXEC_POSITION_HARDLINE_BLOCK)
+def test_the_verb_reaches_the_floor_from_any_executable_position(command):
+    """A path, a wrapper or a multicall dispatch is not a way around the floor."""
+    is_hardline, description = detect_hardline_command(command)
+    assert is_hardline, f"verb never reached command position: {command!r}"
+    assert description
+
+
+@pytest.mark.parametrize("command", _REVIEW_FOLLOWUP_ALLOW)
+def test_the_two_widenings_do_not_invent_commands(command):
+    """Neither widening may turn a filename, a wrapper or prose into a block."""
+    is_hardline, description = detect_hardline_command(command)
+    assert not is_hardline, (
+        f"review follow-up false-positived the floor: {command!r} (got: {description})"
+    )
+    assert description is None
+
+
+def test_yolo_cannot_bypass_a_quoted_operand(clean_session, monkeypatch):
+    """The quoted spellings previously reached the dangerous tier at best, and
+    that is exactly the tier yolo skips."""
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    for command in ('cat x > "/dev/disk0"', "cat x > '/dev/sda'",
+                    'dd if=/dev/zero of="/dev/disk0"',
+                    "dd if=/dev/zero of='/dev/nvme0n1'",
+                    'cat x >> "/dev/mapper/vg-root"'):
+        first = check_dangerous_command(command, "local")
+        assert first["approved"] is False, f"yolo leaked {command!r} (check_dangerous_command)"
+        assert first.get("hardline") is True
+
+        second = check_all_command_guards(command, "local")
+        assert second["approved"] is False, f"yolo leaked {command!r} (check_all_command_guards)"
+        assert second.get("hardline") is True
+        assert "BLOCKED (hardline)" in second["message"]
+
+
+def test_yolo_cannot_bypass_an_alternate_executable_position(clean_session, monkeypatch):
+    """These had no tier at all before, so yolo ran them without a prompt."""
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    for command in ("/usr/sbin/wipefs -a /dev/sda", "nice blkdiscard /dev/sda",
+                    "command mke2fs /dev/sda1", "busybox dd if=/dev/zero of=/dev/sda",
+                    "/sbin/mkfs.ext4 /dev/sda1", "nice -n 10 sgdisk -Z /dev/sda",
+                    "sudo /usr/sbin/wipefs -a /dev/sda"):
+        first = check_dangerous_command(command, "local")
+        assert first["approved"] is False, f"yolo leaked {command!r} (check_dangerous_command)"
+        assert first.get("hardline") is True
+
+        second = check_all_command_guards(command, "local")
+        assert second["approved"] is False, f"yolo leaked {command!r} (check_all_command_guards)"
+        assert second.get("hardline") is True
+        assert "BLOCKED (hardline)" in second["message"]

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -34,9 +34,26 @@ _CREDENTIAL_FILES = r'(?:~|\$home|\$\{home\})/\.' r'(?:netrc|pgpass|npmrc|pypirc
 # "/etc/" check. Match both forms.
 _MACOS_PRIVATE_SYSTEM_PATH = r'/private/(?:etc|var|tmp|home)/'
 _SYSTEM_CONFIG_PATH = rf'(?:/etc/|{_MACOS_PRIVATE_SYSTEM_PATH})'
+# A raw block device: writing to one destroys a whole disk (or the volume/array behind it) with no
+# recovery path. Shared by every rule that gates such a write, because the spelling depends on the
+# platform and the storage stack — knowing only the Linux SCSI names left Mac disks unprotected:
+#   sd/hd/vd/xvd/nvme/mmcblk  SATA-SCSI-USB, IDE, virtio, Xen, NVMe, eMMC/SD cards (Linux)
+#   md / dm- / mapper/<name>  md RAID arrays and device-mapper/LVM volumes (Linux)
+#   loop / nbd                loopback and network block devices (Linux)
+#   [r]disk<N>[s<M>]          macOS whole disks, slices, and the raw character node
+#   disk/by-*/<name>          udev persistent-name symlinks — the same disks under stable names
+# The loose `[a-z0-9]*` tail of the original rules is kept so partition/namespace suffixes (sda1,
+# nvme0n1p2) come along; `disk` alone requires a digit because bare /dev/disk is the by-* symlink
+# DIRECTORY, not a device.
+_BLOCK_DEVICE_PATH = (
+    r'/dev/(?:(?:sd|hd|vd|xvd|nvme|mmcblk|md|dm-|loop|nbd)[a-z0-9]*'
+    r'|r?disk[0-9]+[a-z0-9]*'
+    r'|mapper/[^\s;&|<>()"\']+'
+    r'|disk/by-(?:id|uuid|path|label|partuuid|partlabel)/[^\s;&|<>()"\']+)'
+)
 _SENSITIVE_WRITE_TARGET = (
-    rf'(?:{_SYSTEM_CONFIG_PATH}|/dev/sd|{_SSH_SENSITIVE_PATH}|{_HERMES_ENV_PATH}|{_HERMES_CONFIG_PATH}|'
-    rf'{_SHELL_RC_FILES}|{_CREDENTIAL_FILES})'
+    rf'(?:{_SYSTEM_CONFIG_PATH}|{_BLOCK_DEVICE_PATH}|{_SSH_SENSITIVE_PATH}|{_HERMES_ENV_PATH}|'
+    rf'{_HERMES_CONFIG_PATH}|{_SHELL_RC_FILES}|{_CREDENTIAL_FILES})'
 )
 _USER_SENSITIVE_WRITE_TARGET = rf'(?:{_SSH_SENSITIVE_PATH}|{_SHELL_RC_FILES}|{_CREDENTIAL_FILES})'
 _PROJECT_SENSITIVE_WRITE_TARGET = rf'(?:{_PROJECT_ENV_PATH}|{_PROJECT_CONFIG_PATH})'
@@ -94,11 +111,26 @@ HARDLINE_PATTERNS = [
     # Command-name rules (mkfs, dd, kill, shutdown...) are _CMDPOS-anchored so quoted prose
     # (`echo "does this use mkfs?"`) cannot trip the floor.
     # See #93392.
-    (_CMDPOS + r'mkfs(\.[a-z0-9]+)?\b', "format filesystem (mkfs)"),
+    # mke2fs IS mkfs.ext2/3/4 (one binary, three names), so it is unconditional like mkfs. mkswap
+    # and the macOS newfs_<fs> family are gated on a raw block device operand instead, because
+    # `mkswap /swapfile` / `newfs_hfs disk.dmg` write a FILE and must keep working. diskutil is
+    # gated on its destructive verbs — `diskutil list|info|mount|unmount|apfs list` are read-only.
+    (_CMDPOS + r'(?:(?:mkfs(?:\.[a-z0-9]+)?|mke2fs)\b'
+     rf'|(?:mkswap|newfs(?:_[a-z0-9]+)?)\b[^;|&\n]*{_BLOCK_DEVICE_PATH}'
+     r'|diskutil\s+(?:[a-z]+\s+)?(?:erase(?:disk|volume)|zerodisk|randomdisk|secureerase|reformat|partitiondisk)\b)',
+     "format filesystem (mkfs)"),
+    # Whole-device wipes that are neither dd nor a redirect: each erases the partition table or the
+    # raw sectors of the device it is pointed at. Every branch needs BOTH its destructive flag and a
+    # raw block device operand on the same command, so `wipefs /dev/sda` (prints signatures),
+    # `sgdisk -p /dev/sda` (prints the table), `blkdiscard --help` and `shred secret.txt` still run.
+    (_CMDPOS + r'(?:wipefs\b(?=[^;|&\n]*\s(?:-[a-z]*a[a-z]*|--all)\b)'
+     r'|sgdisk\b(?=[^;|&\n]*\s(?:-z|--zap-all|-o|--clear)\b)'
+     r'|blkdiscard\b|shred\b)'
+     rf'(?=[^;|&\n]*{_BLOCK_DEVICE_PATH})', "wipe raw block device"),
     # `dd` is a command-name token, so anchor it to command position like mkfs/rm/shutdown (#93392): quoted
     # prose such as `git commit -m "never dd of=/dev/sda"` is an argument, not a command. The argument tail
     # ([^\n]*of=/dev/...) is kept so flag order doesn't matter.
-    (_CMDPOS + r'dd\b[^\n]*\bof=/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*', "dd to raw block device"),
+    (_CMDPOS + rf'dd\b[^\n]*\bof={_BLOCK_DEVICE_PATH}', "dd to raw block device"),
     # Positionless rules (no command-name token: `>` sits mid-command, the fork bomb is a function
     # definition) are matched against a QUOTE-MASKED variant (_QUOTE_MASKED_HARDLINE_DESCRIPTIONS /
     # _mask_quoted_prose) so quoted prose cannot trip them; sh -c / bash -c / eval payloads still scan raw.
@@ -107,7 +139,7 @@ HARDLINE_PATTERNS = [
     # of the command (see _QUOTE_MASKED_HARDLINE / _mask_quoted_strings) so quoted prose (`echo "cat f >
     # /dev/sda"`) cannot trip it, while shell-carrying wrappers (sh -c / bash -c / eval) still surface their
     # payload as a raw detection variant — quoting is not a bypass (#93392).
-    (r'>\s*/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*\b', "redirect to raw block device"),
+    (rf'>\s*{_BLOCK_DEVICE_PATH}\b', "redirect to raw block device"),
     (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
     # Kill every process on the system — anchor the command-name token so `echo "kill -1 sends SIGHUP to
     # everything"` doesn't trip (#93392).
@@ -262,7 +294,7 @@ DANGEROUS_PATTERNS = [
     # See #93392.
     (_CMDPOS + r'mkfs\b', "format filesystem"),
     (_CMDPOS + r'dd\s+.*if=', "disk copy"),
-    (r'>\s*/dev/sd', "write to block device"),
+    (rf'>\s*{_BLOCK_DEVICE_PATH}', "write to block device"),
     (r'\bDROP\s+(TABLE|DATABASE)\b', "SQL DROP"),
     # [^\n]* not .*: under DOTALL a WHERE on the *next* line would satisfy the lookahead and
     # silently allow DELETE without WHERE.

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -46,7 +46,12 @@ _SYSTEM_CONFIG_PATH = rf'(?:/etc/|{_MACOS_PRIVATE_SYSTEM_PATH})'
 # nvme0n1p2) come along; `disk` alone requires a digit because bare /dev/disk is the by-* symlink
 # DIRECTORY, not a device.
 _BLOCK_DEVICE_PATH = (
-    r'/dev/(?:(?:sd|hd|vd|xvd|nvme|mmcblk|md|dm-|loop|nbd)[a-z0-9]*'
+    # The lookbehind is what makes this a PATH rather than a substring. Without it any
+    # directory called ``dev`` matched: ``~/dev/sdk/token.json`` carries ``/dev/sd`` + ``k``,
+    # so ``shred -u ~/dev/sdk/token.json`` and ``mkswap /home/user/dev/sdk/swapfile`` hit an
+    # unapprovable floor. A real device path is never preceded by a word character, a dot or
+    # a tilde; ``//dev/sda``, ``of=/dev/sda`` and a quoted operand all still match.
+    r'(?<![\w.~-])/dev/(?:(?:sd|hd|vd|xvd|nvme|mmcblk|md|dm-|loop|nbd)[a-z0-9]*'
     r'|r?disk[0-9]+[a-z0-9]*'
     r'|mapper/[^\s;&|<>()"\']+'
     r'|disk/by-(?:id|uuid|path|label|partuuid|partlabel)/[^\s;&|<>()"\']+)'
@@ -94,7 +99,15 @@ _CMDPOS = (
 # every hardline rule here would collide with that work rather than complement it.
 _CMDPOS_EXEC = (
     _CMDPOS
-    + r'(?:(?:command|builtin|nice|ionice|stdbuf|chrt|taskset)\s+(?:-[^\s]+\s+|\d+\s+)*)*'
+    # A wrapper's QUERY options do not run the verb, so they must not peel to it:
+    # ``command -v mkfs`` prints a path, and ``chrt -p``/``taskset -p``/``ionice -p``
+    # interrogate a pid. _COMMAND_WRAPPER_NON_EXECUTING_OPTIONS below is the same list, and
+    # the argv walk already honours it -- peeling them here contradicted it and made the
+    # canonical ``if command -v mkfs >/dev/null; then`` probe unrunnable on a floor with no
+    # approval path. ``command``'s query flag also bundles (``-vp``), matching that walk.
+    + r'(?:(?:command|builtin)\s+(?:-(?![^\s]*[vV])[^\s]+\s+)*'
+    + r'|(?:chrt|taskset|ionice)\s+(?:-(?!p\b|-pid\b|-pgid\b|-uid\b)[^\s]+\s+|\d+\s+)*'
+    + r'|(?:nice|stdbuf)\s+(?:-[^\s]+\s+|\d+\s+)*)*'
     + r'(?:(?:[\w.+-]*/)*(?:busybox|toybox)\s+)?'
     + r'(?:[\w.+-]*/)*'
 )
@@ -132,17 +145,20 @@ HARDLINE_PATTERNS = [
     # `mkswap /swapfile` / `newfs_hfs disk.dmg` write a FILE and must keep working. diskutil is
     # gated on its destructive verbs — `diskutil list|info|mount|unmount|apfs list` are read-only.
     (_CMDPOS_EXEC + r'(?:(?:mkfs(?:\.[a-z0-9]+)?|mke2fs)(?=\s|$|[;|&)])'
-     rf'|(?:mkswap|newfs(?:_[a-z0-9]+)?)\b[^;|&\n]*{_BLOCK_DEVICE_PATH}'
+     rf'|(?:mkswap|newfs(?:_[a-z0-9]+)?)\b[^;|&\n#]*{_BLOCK_DEVICE_PATH}'
      r'|diskutil\s+(?:[a-z]+\s+)?(?:erase(?:disk|volume)|zerodisk|randomdisk|secureerase|reformat|partitiondisk)\b)',
      "format filesystem (mkfs)"),
     # Whole-device wipes that are neither dd nor a redirect: each erases the partition table or the
     # raw sectors of the device it is pointed at. Every branch needs BOTH its destructive flag and a
     # raw block device operand on the same command, so `wipefs /dev/sda` (prints signatures),
     # `sgdisk -p /dev/sda` (prints the table), `blkdiscard --help` and `shred secret.txt` still run.
-    (_CMDPOS_EXEC + r'(?:wipefs\b(?=[^;|&\n]*\s(?:-[a-z]*a[a-z]*|--all)\b)'
+    # ``-n``/``--no-act`` is wipefs doing everything except the write, so it is a diagnostic
+    # and must stay runnable; the destructive-flag lookahead alone matched the ``a`` in
+    # ``-na`` and matched ``--all`` beside ``--no-act``.
+    (_CMDPOS_EXEC + r'(?:wipefs\b(?![^;|&\n]*\s(?:-[a-z]*n[a-z]*|--no-act)\b)(?=[^;|&\n]*\s(?:-[a-z]*a[a-z]*|--all)\b)'
      r'|sgdisk\b(?=[^;|&\n]*\s(?:-z|--zap-all|-o|--clear)\b)'
      r'|blkdiscard\b|shred\b)'
-     rf'(?=[^;|&\n]*{_BLOCK_DEVICE_PATH})', "wipe raw block device"),
+     rf'(?=[^;|&\n#]*{_BLOCK_DEVICE_PATH})', "wipe raw block device"),
     # `dd` is a command-name token, so anchor it to command position like mkfs/rm/shutdown (#93392): quoted
     # prose such as `git commit -m "never dd of=/dev/sda"` is an argument, not a command. The argument tail
     # ([^\n]*of=/dev/...) is kept so flag order doesn't matter.
@@ -207,19 +223,31 @@ def _mask_quoted_prose(command: str) -> str:
     last_significant = ""
     keep_operand = False
     for kind, i, j, quote in _scan_shell(command, subst="q", naive_backtick=True):
+        piece = command[i:j]
         if kind == "quote":
             # `quote` is the state the step was READ in, so None marks the opening quote.
             keep_operand = quote is None and last_significant == ">"
-            out.append(command[i:j])
-            continue
-        if quote is None or kind == "subst" or keep_operand:
-            piece = command[i:j]
             out.append(piece)
-            stripped = piece.rstrip()
-            if stripped and quote is None:
-                last_significant = stripped[-1]
-        else:
+            # The quote character itself is significant: without this the `>` stayed the last
+            # thing seen across the whole operand, so EVERY later quoted word was unmasked too and
+            # `cat x > "out.log" "cat y > /dev/sda"` read the prose as a redirect.
+            last_significant = piece[-1:] or last_significant
+            continue
+        if not (quote is None or kind == "subst" or keep_operand):
             out.append(" " * (j - i))
+            continue  # masked text is prose; it cannot arm the exception either
+        # Inside a kept operand, a `>` is prose, not an operator: a redirect target is a PATH and
+        # paths do not contain one. Blanking it stops a span that normalization only LOOKED like an
+        # operand -- `cat x > '' 'note: cat y > /dev/sda'`, where the empty pair is dropped before
+        # this runs -- from carrying a second redirect. A real `"/dev/disk0"` is untouched.
+        out.append(piece.replace(">", " ") if keep_operand and quote is not None else piece)
+        stripped = piece.rstrip()
+        if stripped:
+            # An ESCAPED `>` is a literal argument, not a redirect operator -- real bash prints
+            # `hello > /dev/disk0` for `echo hello \> "/dev/disk0"` and writes nothing -- so it
+            # must not arm the exception. Recording the backslash keeps it distinct from an
+            # operator without needing a second flag.
+            last_significant = "\\" if kind == "esc" else stripped[-1]
     return "".join(out)
 
 

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -84,6 +84,22 @@ _CMDPOS = (
 )
 
 
+# Executable position for the raw-device floor. _CMDPOS alone peels sudo/env/exec/nohup/setsid/
+# time, so a verb spelled as a path (`/usr/sbin/wipefs -a /dev/sda`), run behind a scheduling or
+# buffering wrapper (`nice blkdiscard`, `nice -n 10 sgdisk -Z`, `command mke2fs`, `stdbuf -oL dd`)
+# or dispatched by a multicall binary (`busybox dd if=/dev/zero of=/dev/sda`) reached the disk with
+# no floor at all — measured on clean main, all four are hardline=False AND dangerous=False.
+# Deliberately scoped to the device/format/wipe rules: the same gap on rm/shutdown belongs to the
+# executable-position lineage in #58643 (paths, wrappers) and #65393 (BusyBox/toybox), and widening
+# every hardline rule here would collide with that work rather than complement it.
+_CMDPOS_EXEC = (
+    _CMDPOS
+    + r'(?:(?:command|builtin|nice|ionice|stdbuf|chrt|taskset)\s+(?:-[^\s]+\s+|\d+\s+)*)*'
+    + r'(?:(?:[\w.+-]*/)*(?:busybox|toybox)\s+)?'
+    + r'(?:[\w.+-]*/)*'
+)
+
+
 # Destructive-path matcher for the rm hardline rules: accept the path fully wrapped in a matching
 # quote pair (`rm -rf "/"`, `rm -rf "$HOME"`) OR bare with a terminator (whitespace, end, or
 # `) ` ; | &` so `$(rm -rf /)` is caught). A bare-token-only anchor lets quoted spellings slip past the floor.
@@ -115,7 +131,7 @@ HARDLINE_PATTERNS = [
     # and the macOS newfs_<fs> family are gated on a raw block device operand instead, because
     # `mkswap /swapfile` / `newfs_hfs disk.dmg` write a FILE and must keep working. diskutil is
     # gated on its destructive verbs — `diskutil list|info|mount|unmount|apfs list` are read-only.
-    (_CMDPOS + r'(?:(?:mkfs(?:\.[a-z0-9]+)?|mke2fs)\b'
+    (_CMDPOS_EXEC + r'(?:(?:mkfs(?:\.[a-z0-9]+)?|mke2fs)(?=\s|$|[;|&)])'
      rf'|(?:mkswap|newfs(?:_[a-z0-9]+)?)\b[^;|&\n]*{_BLOCK_DEVICE_PATH}'
      r'|diskutil\s+(?:[a-z]+\s+)?(?:erase(?:disk|volume)|zerodisk|randomdisk|secureerase|reformat|partitiondisk)\b)',
      "format filesystem (mkfs)"),
@@ -123,14 +139,14 @@ HARDLINE_PATTERNS = [
     # raw sectors of the device it is pointed at. Every branch needs BOTH its destructive flag and a
     # raw block device operand on the same command, so `wipefs /dev/sda` (prints signatures),
     # `sgdisk -p /dev/sda` (prints the table), `blkdiscard --help` and `shred secret.txt` still run.
-    (_CMDPOS + r'(?:wipefs\b(?=[^;|&\n]*\s(?:-[a-z]*a[a-z]*|--all)\b)'
+    (_CMDPOS_EXEC + r'(?:wipefs\b(?=[^;|&\n]*\s(?:-[a-z]*a[a-z]*|--all)\b)'
      r'|sgdisk\b(?=[^;|&\n]*\s(?:-z|--zap-all|-o|--clear)\b)'
      r'|blkdiscard\b|shred\b)'
      rf'(?=[^;|&\n]*{_BLOCK_DEVICE_PATH})', "wipe raw block device"),
     # `dd` is a command-name token, so anchor it to command position like mkfs/rm/shutdown (#93392): quoted
     # prose such as `git commit -m "never dd of=/dev/sda"` is an argument, not a command. The argument tail
     # ([^\n]*of=/dev/...) is kept so flag order doesn't matter.
-    (_CMDPOS + rf'dd\b[^\n]*\bof={_BLOCK_DEVICE_PATH}', "dd to raw block device"),
+    (_CMDPOS_EXEC + rf'dd\b[^\n]*\bof=["\']?{_BLOCK_DEVICE_PATH}', "dd to raw block device"),
     # Positionless rules (no command-name token: `>` sits mid-command, the fork bomb is a function
     # definition) are matched against a QUOTE-MASKED variant (_QUOTE_MASKED_HARDLINE_DESCRIPTIONS /
     # _mask_quoted_prose) so quoted prose cannot trip them; sh -c / bash -c / eval payloads still scan raw.
@@ -139,7 +155,7 @@ HARDLINE_PATTERNS = [
     # of the command (see _QUOTE_MASKED_HARDLINE / _mask_quoted_strings) so quoted prose (`echo "cat f >
     # /dev/sda"`) cannot trip it, while shell-carrying wrappers (sh -c / bash -c / eval) still surface their
     # payload as a raw detection variant — quoting is not a bypass (#93392).
-    (rf'>\s*{_BLOCK_DEVICE_PATH}\b', "redirect to raw block device"),
+    (rf'>\s*["\']?{_BLOCK_DEVICE_PATH}\b', "redirect to raw block device"),
     (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
     # Kill every process on the system — anchor the command-name token so `echo "kill -1 sends SIGHUP to
     # everything"` doesn't trip (#93392).
@@ -180,11 +196,31 @@ def _mask_quoted_prose(command: str) -> str:
     Detection-only rewrite used by the quote-masked hardline rules (redirect-to-block-device, fork bomb):
     text inside single or double quotes is data the shell passes as an argument, so `echo "cat f >
     /dev/sda"` must not trip the unconditional floor (#93392). Unquoted text is untouched.
+
+    One exception, and it is the whole difference between prose and a target: a quoted span opened
+    immediately after an UNQUOTED redirect operator is the redirection's operand, not prose. The
+    shell writes to it either way, so `cat x > "/dev/disk0"` must reach the floor exactly as the
+    bare spelling does. `echo "cat x > /dev/disk0"` keeps its quote opened after `echo`, with the
+    `>` inside the quoted run, so it stays masked and stays allowed.
     """
-    return "".join(
-        command[i:j] if quote is None or kind in ("quote", "subst") else " " * (j - i)
-        for kind, i, j, quote in _scan_shell(command, subst="q", naive_backtick=True)
-    )
+    out: list[str] = []
+    last_significant = ""
+    keep_operand = False
+    for kind, i, j, quote in _scan_shell(command, subst="q", naive_backtick=True):
+        if kind == "quote":
+            # `quote` is the state the step was READ in, so None marks the opening quote.
+            keep_operand = quote is None and last_significant == ">"
+            out.append(command[i:j])
+            continue
+        if quote is None or kind == "subst" or keep_operand:
+            piece = command[i:j]
+            out.append(piece)
+            stripped = piece.rstrip()
+            if stripped and quote is None:
+                last_significant = stripped[-1]
+        else:
+            out.append(" " * (j - i))
+    return "".join(out)
 
 
 # ---- Sudo stdin guard: without SUDO_PASSWORD configured, an explicit "sudo -S" is the LLM piping

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -134,9 +134,14 @@ The blocklist is the floor below `--yolo`. It trips **before** the approval laye
 | `rm -rf /` and obvious variants | Wipes the filesystem root |
 | `rm -rf --no-preserve-root /` | The explicit "yes I mean root" variant |
 | `:(){ :\|:& };:` (bash fork bomb) | Pegs the host until reboot |
-| `mkfs.*` on a mounted root device | Formats the live system |
-| `dd if=/dev/zero of=/dev/sd*` | Zeroes a physical disk |
+| `mkfs.*` / `mke2fs` on a mounted root device | Formats the live system |
+| `mkswap`, `newfs_hfs` / `newfs_apfs` / `newfs_msdos` aimed at a device | Same, for swap and the macOS filesystems (a file target such as `mkswap /swapfile` still runs) |
+| `diskutil eraseDisk` / `eraseVolume` / `zeroDisk` / `randomDisk` / `secureErase` / `reformat` / `partitionDisk` | The macOS spelling of the same disk wipe |
+| `dd of=<device>`, and `>` / `>>` redirects into one | Zeroes a physical disk |
+| `wipefs -a`, `blkdiscard`, `sgdisk -Z` / `-o`, `shred <device>` | Erases the partition table or the raw sectors of the disk |
 | Piping untrusted URLs to `sh` at the rootfs top level | Remote-code-execution attack vector too broad to approve |
+
+`<device>` above means a raw block device under any of its names: Linux `/dev/sd*`, `hd*`, `vd*`, `xvd*`, `nvme*`, `mmcblk*`, `md*`, `dm-*`, `/dev/mapper/*`, `loop*`, `nbd*`; macOS `/dev/disk0`, `/dev/disk0s2`, `/dev/rdisk0`; and the persistent-name symlinks `/dev/disk/by-{id,uuid,path,label,partuuid,partlabel}/*`. Non-device `/dev` entries (`/dev/null`, `/dev/zero` as a source, `/dev/urandom`, `/dev/stdout`, `/dev/tty`, `/dev/shm/*`, ...) are untouched, and so are the read-only runs of these tools: `wipefs` without `-a`, `sgdisk -p`, `blkdiscard --help`, `diskutil list|info|mount|unmount`, `shred secret.txt`, and `dd if=/dev/sda of=backup.img` (reading a disk into a file).
 
 If you hit the blocklist, the tool call returns an explanatory error to the agent and nothing runs. If a legitimate workflow needs one of these commands (you're the operator of a wipe-and-reinstall pipeline, for example), run it outside the agent.
 


### PR DESCRIPTION
## What does this PR do?

The hardline blocklist is the floor below `--yolo`: commands so catastrophic they never run,
regardless of `--yolo` / `/yolo`, `approvals.mode: off`, cron approve mode, or "allow always".
Its own comment scopes it to "root wipe, raw block device writes, shutdown, DoS".

Two of its rules police raw block devices, but both recognise only the Linux SCSI/NVMe
spellings, and the format rule only knows the binary name `mkfs`. Everything else that erases a
whole disk walks past **every** guard — not just the floor, the approval tier too. Measured on
`966637323e` with `detect_hardline_command()` / `detect_dangerous_command()`:

| Command | Verdict before |
|---|---|
| `cat x > /dev/rdisk0` (macOS raw disk) | no guard at all |
| `cat x > /dev/disk0s2` (macOS slice) | no guard at all |
| `cat x > /dev/mapper/vg-root` (LVM) | no guard at all |
| `cat x > /dev/dm-0`, `/dev/md0`, `/dev/loop0`, `/dev/nbd0` | no guard at all |
| `cat x > /dev/disk/by-id/ata-Samsung_SSD` | no guard at all |
| `wipefs -a /dev/sda`, `blkdiscard /dev/nvme0n1`, `sgdisk -Z /dev/sda`, `shred -n 1 -z /dev/sda` | no guard at all |
| `mke2fs /dev/sda1` (mke2fs **is** mkfs.ext2/3/4 — same binary) | no guard at all |
| `mkswap /dev/sda1`, `newfs_hfs /dev/disk2`, `newfs_apfs /dev/disk2` | no guard at all |
| `diskutil eraseDisk JHFS+ X disk0`, `zeroDisk`, `secureErase`, `reformat`, `eraseVolume` | no guard at all |
| `dd if=/dev/zero of=/dev/disk0` | approval tier only ("disk copy") — `--yolo` bypasses it |
| `dd if=/dev/zero of=/dev/sda` (identical command, Linux name) | hardline ✅ |

The dangerous (approval) tier carried the same Linux-only list, so `cp x /dev/nvme0n1`,
`mv x /dev/vda` and `tee /dev/nvme0n1 < x` were auto-approved while the `/dev/sda` spellings
prompted.

macOS is a first-class platform for this project (cross-platform is CONTRIBUTING priority #2),
so in practice the floor protected Linux disks and left Mac disks open.

**Root cause:** three copies of one Linux-only device list —
`tools/approval_detection.py:101` (hardline "dd to raw block device"), `:110` (hardline
"redirect to raw block device") and `:265` (dangerous "write to block device") — plus the bare
`/dev/sd` inside `_SENSITIVE_WRITE_TARGET` at `:38`, and the `mkfs`-only format rule at `:97`
(line numbers on `966637323e`).

**Approach:** one shared regex fragment instead of four hand-maintained copies, and the two
tool families that are literally "raw block device writes" / "format filesystem" brought under
the rules that already exist for them. No new hardline *category* — the list grows by exactly
one entry (12 → 13, cap is 20).

## Related Issue

Fixes #102371

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval_detection.py`
  - New `_BLOCK_DEVICE_PATH` fragment next to the other path constants, with a comment naming
    each device family: Linux `sd|hd|vd|xvd|nvme|mmcblk|md|dm-|loop|nbd` and `mapper/<name>`,
    macOS `[r]disk<N>[s<M>]`, and the udev persistent-name symlinks
    `/dev/disk/by-{id,uuid,path,label,partuuid,partlabel}/<name>`. The existing loose
    `[a-z0-9]*` tail is preserved so partition/namespace suffixes come along; `disk` requires a
    digit because bare `/dev/disk` is the symlink *directory*, not a device.
  - The fragment now backs all four places that gated a block-device write: the hardline `dd`
    rule, the hardline `>` redirect rule, the dangerous-tier "write to block device" rule, and
    `_SENSITIVE_WRITE_TARGET` (which is what gates `cp`/`mv`/`install`/`tee`).
  - Hardline "format filesystem (mkfs)" extended (same description) to `mke2fs`
    (unconditional, like `mkfs` — it is the same binary), to `mkswap` / `newfs_<fs>` **only
    when the operand is a raw block device**, and to the destructive `diskutil` verbs
    (`eraseDisk|eraseVolume|zeroDisk|randomDisk|secureErase|reformat|partitionDisk`),
    verb-gated so the read-only verbs stay usable.
  - One new hardline entry, **"wipe raw block device"**: `wipefs` with `-a`/`--all` (any flag
    order), `blkdiscard`, `sgdisk` with `-Z`/`--zap-all`/`-o`/`--clear`, and `shred` — each
    requiring a raw block device operand in the same command segment.
  - Every new rule is `_CMDPOS`-anchored like the existing `mkfs`/`dd` rules, so quoted prose
    (`echo "run diskutil eraseDisk later"`, `git commit -m "mke2fs the backup disk"`) does not
    trip the floor. `HARDLINE_PATTERNS` is 13 entries (cap 20, enforced by
    `test_hardline_list_is_small`).
- `tests/tools/test_hardline_block_devices.py` (new, 128 tests) — must-block / must-allow /
  dangerous-tier / yolo contracts, see **How to Test**.
- `website/docs/user-guide/security.md` — the hardline table gains rows for `mke2fs`,
  `mkswap`/`newfs_*`, the `diskutil` verbs and the `wipefs`/`blkdiscard`/`sgdisk`/`shred`
  family, plus one paragraph listing which device names count as a device and which
  `/dev` entries and read-only invocations stay untouched.

**Deliberately out of scope** (not added to the floor): `fdisk`, `parted`, `hdparm`,
`nvme-cli`, `osascript`, `diskutil apfs deleteContainer`. They are either interactive, or
partially non-destructive, or a much broader surface than "this command erases a disk right
now"; the floor has no approval path, so a false positive there is unrunnable-by-design.

## How to Test

1. Reproduce on `main` — every one of these returns `(False, None)` today, and
   `dd if=/dev/zero of=/dev/disk0` returns only the yolo-bypassable "disk copy":

   ```python
   from tools.approval_detection import detect_hardline_command
   for cmd in ["cat x > /dev/rdisk0", "cat x > /dev/mapper/vg-root",
               "wipefs -a /dev/sda", "blkdiscard /dev/nvme0n1", "sgdisk -Z /dev/sda",
               "shred -n 1 -z /dev/sda", "mke2fs /dev/sda1", "newfs_apfs /dev/disk2",
               "diskutil eraseDisk JHFS+ X disk0"]:
       print(cmd, detect_hardline_command(cmd))
   ```

2. Run the new file against the unpatched detector to see it red, then with the fix:

   ```bash
   git stash push -- tools/approval_detection.py
   pytest tests/tools/test_hardline_block_devices.py -q   # 78 failed, 50 passed
   git stash pop
   pytest tests/tools/test_hardline_block_devices.py -q   # 128 passed
   ```

3. Confirm nothing legitimate regressed:

   ```bash
   scripts/run_tests.sh tests/tools/test_hardline_block_devices.py \
       tests/tools/test_hardline_blocklist.py tests/tools/test_approval.py \
       tests/tools/test_shell_bypass_denylist.py tests/tools/test_execution_flag_detection.py \
       tests/tools/test_approval_grep_in_substitution.py tests/tools/test_command_guards.py \
       tests/tools/test_approval_deny_rules.py tests/tools/test_yolo_mode.py \
       tests/tools/test_cron_approval_mode.py tests/hermes_cli/test_approvals_test.py \
       tests/hermes_cli/test_approval_transport.py
   ```

   `/dev/null`, `/dev/zero` as a source, `/dev/urandom`, `/dev/stdout`, `/dev/tty`, `/dev/shm/*`,
   `dd if=/dev/sda of=backup.img`, `wipefs -n /dev/sda`, `sgdisk -p /dev/sda`,
   `blkdiscard --help`, `shred secret.txt`, `mkswap /swapfile`, `diskutil list|info|mount` and
   quoted prose mentioning any of them all stay runnable — asserted as parametrized cases.

4. Manual: with `--yolo` on, ask the agent to run `wipefs -a /dev/sda` or
   `diskutil eraseDisk JHFS+ X disk0`; the terminal tool returns `BLOCKED (hardline)` and
   nothing executes. `wipefs -n /dev/sda` still runs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (one commit: detection rules, its tests, and the matching doc rows)
- [x] I've run the approval/guard test suites and they pass — the full suite was not run in this environment
- [x] I've added tests for my changes (new `tests/tools/test_hardline_block_devices.py`, proven red on base)
- [x] I've tested on my platform: Linux (Ubuntu container, Python 3.11). The macOS spellings
      (`/dev/disk0`, `/dev/disk0s2`, `/dev/rdisk0`, `newfs_hfs`/`newfs_apfs`/`newfs_msdos`,
      `diskutil` verbs) are verified by the unit tests, which classify command *text* and are
      host-independent — no macOS host was available, and no test fakes `sys.platform`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/user-guide/security.md` hardline table
- [x] N/A — no config keys added, so `cli-config.yaml.example` is unchanged
- [x] N/A — no architecture or workflow change, so `CONTRIBUTING.md` / `AGENTS.md` are unchanged
- [x] I've considered cross-platform impact — this PR *is* the cross-platform fix (macOS device
      names and macOS-only tools); Windows destructive disk verbs (`Clear-Disk`, `Format-Volume`,
      `diskpart`) already have their own dangerous-tier rules and are untouched
- [x] N/A — no tool description/schema change; only the classifier tables

## Screenshots / Logs

```
$ pytest tests/tools/test_hardline_block_devices.py -q     # unpatched detector
78 failed, 50 passed in 4.47s

$ pytest tests/tools/test_hardline_block_devices.py -q     # with the fix
128 passed in 1.54s

$ pytest tests/tools/test_hardline_blocklist.py -q
246 passed in 2.37s
```
