### PR TITLE
fix(gateway): hand root-written stop markers to the HERMES_HOME owner

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1126,6 +1126,9 @@ _TAKEOVER_MARKER_FILENAME = ".gateway-takeover.json"
 _TAKEOVER_MARKER_TTL_S = 60  # Marker older than this is treated as stale
 _PLANNED_STOP_MARKER_FILENAME = ".gateway-planned-stop.json"
 _PLANNED_STOP_MARKER_TTL_S = 60
+# Marker paths already reported as unreadable, so the planned-stop watcher (polls twice a second)
+# logs the diagnostic once per path per process instead of flooding gateway.log.
+_unreadable_marker_paths_warned: set[str] = set()
 
 
 def _get_takeover_marker_path(hermes_home: Optional[Path] = None) -> Path:
@@ -1146,11 +1149,50 @@ def _marker_is_stale(written_at: str, ttl_s: int) -> bool:
         return True
 
 
+def _path_owner(path: Path) -> Optional[tuple[int, int]]:
+    """Owning ``(uid, gid)`` of *path* on POSIX; None on Windows or when the path cannot be
+    stat'ed. Single seam so ownership decisions stay testable without patching ``os.stat``."""
+    if os.name != "posix":
+        return None
+    try:
+        st = path.stat()
+    except OSError:
+        return None
+    return (st.st_uid, st.st_gid)
+
+
+def _warn_once_unreadable_marker(path: Path) -> None:
+    """Warn (once per path per process) that a marker exists but this uid cannot read it.
+
+    ``_read_json_file`` swallows the EACCES, so a marker written by a privileged stopper into an
+    unprivileged gateway's home is silently invisible: the stop is never matched and the gateway
+    reports an unexpected exit instead. Only reachable for an unprivileged reader -- root reads
+    anything. See #91212."""
+    try:
+        if not path.exists() or os.access(path, os.R_OK):
+            return
+    except OSError:
+        return
+    key = os.path.normcase(str(path))
+    if key in _unreadable_marker_paths_warned:
+        return
+    _unreadable_marker_paths_warned.add(key)
+    geteuid = getattr(os, "geteuid", None)
+    owner = _path_owner(path)
+    logger.warning(
+        "Gateway marker %s exists but is not readable by uid %s (file owner uid %s) — it was "
+        "written by a more privileged process (e.g. `sudo hermes gateway stop`, or an s6/docker "
+        "supervisor running as root), so a planned stop cannot be matched and this shutdown will "
+        "be reported as unexpected. Delete the file or chown it to the owner of %s (issue #91212).",
+        path, geteuid() if geteuid else "?", owner[0] if owner else "?", path.parent)
+
+
 def _read_live_pid_marker(path: Path, ttl_s: int) -> Optional[tuple[dict[str, Any], int, Any]]:
     """``(record, target_pid, target_start_time)`` for a usable marker, else None. Malformed/expired
     markers can never match anyone, so they are unlinked here (must not wedge a new instance)."""
     record = _read_json_file(path)
     if not record:
+        _warn_once_unreadable_marker(path)
         return None
     target_pid = _pid_from_record(record, "target_pid")
     if target_pid is None or _marker_is_stale(record.get("written_at") or "", ttl_s):
@@ -1215,13 +1257,48 @@ def write_takeover_marker(
         return False
 
 
+def _hand_marker_to_home_owner(path: Path) -> None:
+    """Hand a marker root just wrote to the owner of the HERMES_HOME directory it lives in.
+
+    Markers are written by whoever STOPS or REPLACES a gateway, and that process is routinely more
+    privileged than the gateway itself: ``sudo hermes gateway stop`` for a system-scope unit whose
+    ``User=`` is a login account, and ``docker exec`` into the container, where s6 runs as root
+    while the gateway runs under ``s6-setuidgid hermes``. ``atomic_json_write`` creates a NEW file
+    as its writer, so the marker lands root:root 0600 in a home the gateway user owns; the gateway
+    then reads EACCES, never matches the marker, and reports the deliberate SIGTERM as an
+    unexpected exit (non-zero status, shutdown forensics, failure alerts) — while the unreadable
+    file stays in ``~/.hermes``
+    forever, because the stale/malformed cleanup path cannot parse it either (issue #91212).
+
+    Same remedy as ``cron.jobs._preserve_file_ownership`` for #68483, keyed on the home directory
+    rather than the file's previous owner because a marker is normally created fresh. Best-effort:
+    a failed chown is logged, never raised — the marker itself was written."""
+    geteuid = getattr(os, "geteuid", None)
+    chown = getattr(os, "chown", None)
+    if os.name != "posix" or geteuid is None or chown is None or geteuid() != 0:
+        return  # Windows, or an unprivileged writer whose marker already suits the home
+    home_owner = _path_owner(path.parent)
+    if home_owner is None or home_owner[0] == 0 or _path_owner(path) == home_owner:
+        return  # root's own home has nobody to hand it to; equal ownership needs no chown
+    try:
+        chown(path, home_owner[0], home_owner[1])
+    except OSError as e:
+        logger.warning(
+            "Could not hand %s to uid=%s gid=%s (owner of %s): %s — a gateway running as that "
+            "user cannot read the marker, so its planned stop will be reported as an unexpected "
+            "exit instead of a clean shutdown (see issue #91212).",
+            path, home_owner[0], home_owner[1], path.parent, e)
+
+
 def _write_marker(path: Path, record: dict[str, Any]) -> bool:
-    """Atomically write a marker record; False (never raise) on OS failure."""
+    """Atomically write a marker record; False (never raise) on OS failure. A root writer hands
+    the marker to the HERMES_HOME owner so an unprivileged gateway can still read it (#91212)."""
     try:
         _write_json_file(path, record)
-        return True
     except OSError:
         return False
+    _hand_marker_to_home_owner(path)
+    return True
 
 
 def consume_takeover_marker_for_self() -> bool:

--- a/tests/gateway/test_planned_stop_marker_owner.py
+++ b/tests/gateway/test_planned_stop_marker_owner.py
@@ -1,0 +1,282 @@
+"""Regression tests for issue #91212.
+
+The CLI that *stops* a gateway writes ``.gateway-planned-stop.json`` so the gateway's shutdown
+handler can classify the SIGTERM as operator-initiated (exit 0, ``gateway_state=stopped``) instead
+of an unexpected exit (non-zero status, shutdown forensics, failure alerts). That stopper is routinely more privileged than
+the gateway: ``sudo hermes gateway stop`` for a system unit whose ``User=`` is a login account, and
+``docker exec`` into the container, where s6 runs as root while the gateway runs under
+``s6-setuidgid hermes``. ``atomic_json_write`` creates the marker as its writer, so it landed
+root:root 0600 inside a home owned by the gateway user — unreadable by the gateway, so the stop was
+misclassified and the file stayed in ``~/.hermes`` forever (the reported symptom).
+
+Two behaviour contracts are pinned here:
+
+1. Hand-over: a privileged (euid 0) marker writer gives the file to the owner of the HERMES_HOME
+   directory it lives in; unprivileged writers and root-owned homes chown nothing, and a failed
+   chown is logged rather than turned into a write failure.
+2. Reader-side diagnosis: a marker that exists but cannot be read by this uid says so in the log
+   exactly once per path, so a misclassified stop is explainable after the fact.
+"""
+
+import contextlib
+import json
+import logging
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from gateway import status
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX-only: uid/gid ownership semantics"
+)
+
+
+@pytest.fixture()
+def marker_home(tmp_path, monkeypatch):
+    """An isolated HERMES_HOME for the markers under test."""
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _clear_unreadable_marker_warnings():
+    """The once-per-path warn ledger is module state; keep it from leaking between tests."""
+    status._unreadable_marker_paths_warned.clear()
+    yield
+    status._unreadable_marker_paths_warned.clear()
+
+
+def _owners(mapping):
+    """Replacement for ``status._path_owner`` backed by a ``{path: (uid, gid)}`` dict.
+
+    Patching the seam instead of ``os.stat`` keeps the fake scoped to the ownership decision — a
+    global ``os.stat`` fake also reaches the atomic write itself.
+    """
+    return lambda path: mapping.get(str(path))
+
+
+def _record_chowns(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        status.os, "chown", lambda path, uid, gid: calls.append((str(path), uid, gid))
+    )
+    return calls
+
+
+def _refuse_chown(monkeypatch):
+    def _fail(*args, **kwargs):
+        raise AssertionError(f"unexpected chown{args}")
+
+    monkeypatch.setattr(status.os, "chown", _fail)
+
+
+class TestRootWrittenMarkerOwnership:
+    def test_root_writer_hands_marker_to_home_owner(self, marker_home, monkeypatch):
+        """euid 0 + a home owned by the gateway user => the marker follows the home's owner."""
+        marker = status._get_planned_stop_marker_path()
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 42)
+        monkeypatch.setattr(status.os, "geteuid", lambda: 0)
+        monkeypatch.setattr(
+            status, "_path_owner", _owners({str(marker_home): (1000, 1000), str(marker): (0, 0)})
+        )
+        calls = _record_chowns(monkeypatch)
+
+        assert status.write_planned_stop_marker(target_pid=12345) is True
+
+        assert calls == [(str(marker), 1000, 1000)], (
+            "a root-written planned-stop marker must be handed to the HERMES_HOME owner, "
+            "otherwise the unprivileged gateway cannot read it (#91212)"
+        )
+        assert json.loads(marker.read_text(encoding="utf-8"))["target_pid"] == 12345
+
+    def test_unprivileged_writer_never_chowns(self, marker_home, monkeypatch):
+        """A same-uid writer already produced a readable marker; chown would only raise EPERM."""
+        marker = status._get_planned_stop_marker_path()
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 42)
+        monkeypatch.setattr(status.os, "geteuid", lambda: 1000)
+        monkeypatch.setattr(
+            status, "_path_owner", _owners({str(marker_home): (1000, 1000), str(marker): (0, 0)})
+        )
+        _refuse_chown(monkeypatch)
+
+        assert status.write_planned_stop_marker(target_pid=12345) is True
+        assert marker.exists()
+
+    def test_root_owned_home_is_left_alone(self, marker_home, monkeypatch):
+        """A root-owned HERMES_HOME (root gateway, root stopper) has nobody to hand the marker to."""
+        marker = status._get_planned_stop_marker_path()
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 42)
+        monkeypatch.setattr(status.os, "geteuid", lambda: 0)
+        monkeypatch.setattr(
+            status, "_path_owner", _owners({str(marker_home): (0, 0), str(marker): (0, 0)})
+        )
+        _refuse_chown(monkeypatch)
+
+        assert status.write_planned_stop_marker(target_pid=12345) is True
+        assert marker.exists()
+
+    def test_chown_failure_keeps_the_write_successful_and_warns(
+        self, marker_home, monkeypatch, caplog
+    ):
+        """The marker WAS written; a hand-over failure is a diagnosable warning, not a failure."""
+        marker = status._get_planned_stop_marker_path()
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 42)
+        monkeypatch.setattr(status.os, "geteuid", lambda: 0)
+        monkeypatch.setattr(
+            status, "_path_owner", _owners({str(marker_home): (1000, 1000), str(marker): (0, 0)})
+        )
+
+        def _boom(*args, **kwargs):
+            raise PermissionError("simulated chown failure")
+
+        monkeypatch.setattr(status.os, "chown", _boom)
+
+        with caplog.at_level(logging.WARNING, logger="gateway.status"):
+            assert status.write_planned_stop_marker(target_pid=12345) is True
+
+        assert marker.exists()
+        warnings = [r.getMessage() for r in caplog.records if "#91212" in r.getMessage()]
+        assert len(warnings) == 1, "a failed hand-over must be reported once, with the issue ref"
+        assert str(marker) in warnings[0] and "1000" in warnings[0]
+
+    def test_takeover_marker_into_another_home_is_handed_over_too(self, tmp_path, monkeypatch):
+        """``--replace`` routes a takeover marker into the TARGET's home; same hand-over applies."""
+        target_home = tmp_path / "target-home"
+        target_home.mkdir()
+        marker = status._get_takeover_marker_path(target_home)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "replacer-home"))
+        monkeypatch.setattr(status.os, "geteuid", lambda: 0)
+        monkeypatch.setattr(
+            status, "_path_owner", _owners({str(marker.parent): (1000, 1000), str(marker): (0, 0)})
+        )
+        calls = _record_chowns(monkeypatch)
+
+        assert status.write_takeover_marker(
+            4242, target_home=target_home, target_start_time=7
+        ) is True
+
+        assert calls == [(str(marker), 1000, 1000)]
+        assert json.loads(marker.read_text(encoding="utf-8"))["target_pid"] == 4242
+
+
+class TestUnreadableMarkerDiagnostics:
+    def test_unreadable_marker_warns_exactly_once_per_path(
+        self, marker_home, monkeypatch, caplog
+    ):
+        """The planned-stop watcher polls twice a second: the diagnosis must not become a flood."""
+        marker = status._get_planned_stop_marker_path()
+        marker.write_text('{"target_pid": 4321}', encoding="utf-8")
+        # What an EACCES read looks like from the reader's side: _read_json_file swallows it.
+        monkeypatch.setattr(status, "_read_json_file", lambda path, **kwargs: None)
+        real_access = os.access
+        monkeypatch.setattr(
+            status.os, "access",
+            lambda path, mode, **kwargs: (
+                False if str(path) == str(marker) else real_access(path, mode, **kwargs)
+            ),
+        )
+        monkeypatch.setattr(status, "_path_owner", _owners({str(marker): (0, 0)}))
+
+        with caplog.at_level(logging.WARNING, logger="gateway.status"):
+            assert status.planned_stop_marker_targets_self() is False
+            assert status.planned_stop_marker_targets_self() is False
+
+        warnings = [r.getMessage() for r in caplog.records if "#91212" in r.getMessage()]
+        assert len(warnings) == 1, "one warning per marker path per process, not one per poll"
+        assert str(marker) in warnings[0]
+
+    def test_readable_marker_is_never_reported_as_unreadable(self, marker_home, caplog):
+        """A plain absent/stale marker is the normal case and must stay silent."""
+        with caplog.at_level(logging.WARNING, logger="gateway.status"):
+            assert status.planned_stop_marker_targets_self() is False
+
+        assert not [r for r in caplog.records if "#91212" in r.getMessage()]
+
+
+def _unprivileged_account():
+    """``(uid, gid)`` of a real non-root account to hand a marker to, or None."""
+    import pwd
+
+    with contextlib.suppress(KeyError):
+        entry = pwd.getpwnam("nobody")
+        return (entry.pw_uid, entry.pw_gid)
+    entry = next(
+        (e for e in sorted(pwd.getpwall(), key=lambda e: e.pw_uid) if e.pw_uid >= 1000), None
+    )
+    return (entry.pw_uid, entry.pw_gid) if entry else None
+
+
+def _target_pid_read_as(uid: int, gid: int, marker: Path) -> str:
+    """Parse ``target_pid`` out of *marker* in a child process running as ``(uid, gid)``."""
+    read_fd, write_fd = os.pipe()
+    child = os.fork()  # windows-footgun: ok — linux_only real-uid probe
+    if child == 0:  # pragma: no cover - child process
+        code = 1
+        try:
+            os.close(read_fd)
+            os.setgroups([])
+            os.setgid(gid)
+            os.setuid(uid)
+            os.write(write_fd, str(json.loads(marker.read_text(encoding="utf-8"))["target_pid"]).encode())
+            code = 0
+        except BaseException as exc:  # reported to the parent through the pipe
+            with contextlib.suppress(OSError):
+                os.write(write_fd, f"ERROR {type(exc).__name__}: {exc}".encode())
+        finally:
+            os._exit(code)
+    os.close(write_fd)
+    with os.fdopen(read_fd, "rb") as pipe:
+        output = pipe.read().decode()
+    _, wait_status = os.waitpid(child, 0)
+    assert os.waitstatus_to_exitcode(wait_status) == 0, f"reader child failed: {output}"
+    return output
+
+
+@pytest.mark.linux_only
+def test_root_written_marker_is_readable_by_the_real_home_owner(monkeypatch):
+    """End-to-end with real uids: root stops a gateway whose HERMES_HOME belongs to someone else.
+
+    No patched ownership seams — the marker is written by this (root) process into a directory
+    owned by an unprivileged account, and a process running AS that account reads it back. This is
+    the shape of ``sudo hermes gateway stop`` and of the s6 supervisor stopping the container's
+    ``s6-setuidgid hermes`` gateway.
+    """
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None or geteuid() != 0:
+        pytest.skip("needs a real root writer")
+    account = _unprivileged_account()
+    if account is None:
+        pytest.skip("no unprivileged account available to hand the marker to")
+    uid, gid = account
+
+    # Not tmp_path: the unprivileged child must be able to traverse every parent directory, and
+    # pytest's temp root is 0700 root-owned.
+    workdir = Path(tempfile.mkdtemp(prefix="hermes-marker-owner-"))
+    try:
+        os.chmod(workdir, 0o755)
+        home = workdir / "hermes-home"
+        home.mkdir()
+        os.chown(home, uid, gid)
+        os.chmod(home, 0o700)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        marker = status._get_planned_stop_marker_path()
+
+        assert status.write_planned_stop_marker(os.getpid()) is True
+
+        marker_stat = marker.stat()
+        assert (marker_stat.st_uid, marker_stat.st_gid) == (uid, gid), (
+            "a root-written marker inside a user-owned HERMES_HOME must end up owned by that "
+            "user, not root:root (#91212)"
+        )
+        assert _target_pid_read_as(uid, gid, marker) == str(os.getpid()), (
+            "the account the gateway runs as must be able to parse the marker"
+        )
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)


### PR DESCRIPTION
## What does this PR do?

`hermes gateway stop` (and restart, orphan reaping, and the s6 supervisor's stop) writes
`.gateway-planned-stop.json` into the target's `HERMES_HOME` **before** signalling, so the
gateway's shutdown handler classifies that SIGTERM as operator-initiated — exit 0,
`gateway_state=stopped` — instead of an unexpected exit.

In two real deployments the process writing that marker is **root** while the gateway is not:

* a **system-scope unit** whose `User=` is a login account, stopped with `sudo hermes gateway stop`;
* the **container**, where s6 runs as root (`hermes_cli/service_manager.py:552`) while the gateway
  runs under `s6-setuidgid hermes` (`docker/main-wrapper.sh`).

`_write_marker` → `_write_json_file` → `utils.atomic_json_write` creates a **new** file as its
writer (`utils.py:186` preserves the owner only of an *existing* file), so the marker lands
`root:root` `0600` inside a home owned by the gateway user. The gateway's read then fails with
EACCES, `_read_json_file` (`gateway/status.py:462`) swallows it and returns `None`, so
`planned_stop_marker_targets_self()` and `consume_planned_stop_marker_for_self()` both return
`False`. Consequences:

1. the deliberate stop is logged as an `UNKNOWN` exit and exits non-zero, so it surfaces as a
   crash (`failed` unit state, shutdown forensics, failure alerts) — exactly what the marker
   exists to prevent;
2. the root-owned file stays in `~/.hermes` forever (the symptom in the issue) — the
   stale/malformed cleanup inside `_read_live_pid_marker` never runs because there is no parsed
   record to act on;
3. nothing in the log explains any of it.

**The fix** is applied in `_write_marker`, so every marker written through it is covered — the
planned-stop marker and the takeover marker, including a takeover routed into another profile's
home via `target_home`. After a successful write, `_hand_marker_to_home_owner()` chowns the marker
to the owner of the `HERMES_HOME` **directory** it lives in. It is POSIX-only, runs only when the
writer's effective uid is 0, and only when that directory belongs to a non-root uid — a root-owned
home is left alone because there is nobody to hand it to. A failed chown logs a WARNING naming the
path and the target uid/gid and never turns the write into a failure; the marker itself was
written, so `_write_marker` still returns `True`.

This is the same remedy as `cron/jobs.py:538` `_preserve_file_ownership`, added for the same bug
class in #68483 (a root CLI write against the unprivileged gateway's `jobs.json` locked the ticker
out). It is keyed on the home directory rather than the file's previous owner because a marker is
normally created fresh, so there is no previous owner to restore.

Reader side, so an install already in this state is diagnosable instead of silent:
`_read_live_pid_marker` now warns **once per path per process** (the planned-stop watcher polls
twice a second) when the marker exists but `os.access(path, os.R_OK)` is `False`, naming the
reader's uid and the file's owner uid. `_read_json_file` is unchanged, and the branch is only
reachable for an unprivileged reader — root reads anything.

No public signature changes: `write_planned_stop_marker` and `write_takeover_marker` keep their
current parameters (an open PR adds a `target_home` kwarg to the former; this PR does not touch
those lines).

## Related Issue

Fixes #91212

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/status.py`
  - `_path_owner(path)` — owning `(uid, gid)` on POSIX, `None` elsewhere. One seam, so ownership
    decisions are testable without a global `os.stat` fake.
  - `_hand_marker_to_home_owner(path)` — the root → HERMES_HOME-owner hand-over described above;
    best-effort, warns on failure with the issue reference.
  - `_write_marker()` — calls the hand-over after a successful write; still returns `True` when
    only the chown failed.
  - `_warn_once_unreadable_marker(path)` + the `_unreadable_marker_paths_warned` ledger, called
    from `_read_live_pid_marker` when the record is unusable and the file is unreadable.
- `tests/gateway/test_planned_stop_marker_owner.py` (new) — 8 tests, described below.

## How to Test

Reproduction on `main` (Debian container; root stopper, uid-1000 gateway, one shared
`HERMES_HOME` at mode 0700 owned by uid 1000):

1. `mkdir -p /tmp/h/home && chown 1000:1000 /tmp/h/home && chmod 700 /tmp/h/home`
2. As the unprivileged user, start a process with `HERMES_HOME=/tmp/h/home` that publishes its PID
   and then polls `gateway.status.planned_stop_marker_targets_self()` — this is what the
   planned-stop watcher does.
3. As root, with the same `HERMES_HOME`, call `gateway.status.write_planned_stop_marker(<that pid>)`
   — this is what `sudo hermes gateway stop` / the s6 stop does.

On `main`:

```
[root stop] write_planned_stop_marker(31774) -> True; marker owner uid=0 gid=0 mode=0o600
[gateway] marker owner uid=0 gid=0 mode=0o600
[gateway] read_text -> PermissionError: [Errno 13] Permission denied: '/tmp/h/home/.gateway-planned-stop.json'
[gateway] _read_json_file -> None
[gateway] planned_stop_marker_targets_self() -> False
[gateway] consume_planned_stop_marker_for_self() -> False   (=> misclassified as an unexpected exit)
[gateway] marker left on disk? True
```

With this PR:

```
[root stop] write_planned_stop_marker(31782) -> True; marker owner uid=1000 gid=1000 mode=0o600
[gateway] marker owner uid=1000 gid=1000 mode=0o600
[gateway] read_text OK
[gateway] _read_json_file -> {'target_pid': 31782, 'target_start_time': 220522, 'stopper_pid': 31781, ...}
[gateway] planned_stop_marker_targets_self() -> True
[gateway] consume_planned_stop_marker_for_self() -> True    (=> exit 0 / gateway_state=stopped)
[gateway] marker left on disk? False
```

And for an install that already has a root-owned marker sitting in `~/.hermes` (written by an
unpatched build), the gateway now says so, once:

```
WARNING gateway.status: Gateway marker /tmp/h/home/.gateway-planned-stop.json exists but is not
readable by uid 1000 (file owner uid 0) — it was written by a more privileged process (e.g. `sudo
hermes gateway stop`, or an s6/docker supervisor running as root), so a planned stop cannot be
matched and this shutdown will be reported as unexpected. Delete the file or chown it to the owner
of /tmp/h/home (issue #91212).
```

Automated:

```bash
scripts/run_tests.sh tests/gateway/test_planned_stop_marker_owner.py tests/gateway/test_status.py
```

The new file covers: root writer hands over to the home's uid/gid; an unprivileged writer never
chowns; a root-owned home is left alone; a `PermissionError` from `chown` still reports the write
as successful and logs a `#91212` warning; a takeover marker written into another home via
`target_home` takes the same path; the reader warns exactly once across two watcher polls (and
stays silent for a normal absent marker); plus a real-uid `@pytest.mark.linux_only` E2E — skipped
unless running as root with a non-root account available — that chowns a temp `HERMES_HOME` to
that account, writes the marker as root, asserts the marker's `st_uid`/`st_gid`, and reads
`target_pid` back from a child process running as that account. That E2E uses no patched seams and
fails on `main` with `assert (0, 0) == (65534, 65534)`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #91212 has no PR; the closest prior art is #68483, whose fix this mirrors
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the affected areas, not the full suite:
      `tests/gateway/` (7840 passed, 49 skipped, 1 pre-existing failure — `test_webhook_adapter.py`
      dual-stack IPv6 bind, which fails identically on unmodified `main` in this container because
      it has no IPv6), `tests/hermes_cli/test_gateway.py` (37 passed), the other files matching
      `planned_stop|takeover_marker|_write_marker` under `tests/` (103 passed), and
      `tests/cron/test_jobs_file_ownership.py`, the #68483 precedent (9 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian-family Linux container (Python 3.11), including a real
      root → uid-1000 hand-over. Not exercised on macOS or Windows hardware.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the new and
      changed functions carry the why; no user-facing docs describe marker file ownership
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS): the helper returns immediately when
      `os.name != "posix"` or `os.chown`/`os.geteuid` are missing, so **Windows behaviour is
      unchanged**; the unit tests are skipped on Windows (uid/gid semantics) and the real-uid E2E
      is `@pytest.mark.linux_only`. On macOS the logic is the same as Linux; the ownership unit
      tests run there, the real-uid E2E skips unless the run is root.
      `scripts/check-windows-footguns.py` is clean on both changed files.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tools touched

## Screenshots / Logs

See the before/after transcripts and the reader-side warning under **How to Test**.