### PR TITLE
fix(security): close fork-bomb and kill-all spelling gaps in the hardline floor

### DIFF
--- a/tests/tools/test_hardline_process_kill.py
+++ b/tests/tools/test_hardline_process_kill.py
@@ -1,0 +1,164 @@
+"""Process-destruction spellings on the unconditional hardline floor.
+
+The floor below yolo is only worth the spellings it recognizes, and the two
+process rules each recognized exactly one:
+
+* the fork bomb rule matched a function literally NAMED ``:``, so renaming it
+  (``bomb(){ bomb|bomb& };bomb``) — same bomb, same fork storm — ran under
+  ``--yolo`` / ``approvals.mode: off`` with no prompt at all, and so did the
+  canonical bomb written with a ``;`` before the closing brace;
+* the kill rule read every flag as a single token, so a signal handed over as
+  a SEPARATE token (``kill -s KILL -1``) walked straight past it, and
+  ``killall5`` — whose entire job is signalling every process on the host —
+  was not covered at all.
+
+The same kill rule fired on ``-1`` wherever it appeared, so ``kill -1 1234``
+(signal 1 is SIGHUP: the ordinary "tell the daemon to reload" idiom) was
+hardline-blocked. The floor cannot be approved, so that command could not be
+run at all — while ``kill -HUP 1234``, the exact same syscall, was fine.
+"""
+
+import pytest
+
+from tools.approval import (
+    check_all_command_guards,
+    check_dangerous_command,
+    detect_dangerous_command,
+    detect_hardline_command,
+    disable_session_yolo,
+)
+from tools.approval_context import reset_current_session_key, set_current_session_key
+
+
+# (command, expected description) — every one of these must hit the floor.
+_PROCESS_KILL_BLOCK = [
+    # ---- fork bombs. The NAME is decoration; the self-reference is the bomb.
+    (":(){ :|:& };:", "fork bomb"),
+    (":() { : | : & }; :", "fork bomb"),
+    (":(){ :|:&; };:", "fork bomb"),            # `;` before the closing brace
+    ("bomb(){ bomb|bomb& };bomb", "fork bomb"),
+    ("b() { b | b & }; b", "fork bomb"),
+    ("function bomb { bomb | bomb & }; bomb", "fork bomb"),
+    ("fork(){ fork|fork& }; fork", "fork bomb"),
+    ("bash -c 'bomb(){ bomb|bomb& };bomb'", "fork bomb"),
+    ("true && bomb(){ bomb|bomb& };bomb", "fork bomb"),
+    # ---- kill aimed at pid -1 (every process), signal given as a separate token
+    ("kill -s KILL -1", "kill all processes"),
+    ("kill -s 9 -1", "kill all processes"),
+    ("kill -s SIGKILL -1", "kill all processes"),
+    ("kill -s TERM -1", "kill all processes"),
+    ("kill -n 9 -1", "kill all processes"),
+    ("kill --signal KILL -1", "kill all processes"),
+    ("kill --signal=KILL -1", "kill all processes"),
+    ("sudo kill -s KILL -1", "kill all processes"),
+    ("sh -c 'kill -s KILL -1'", "kill all processes"),
+    # -1 is the target once a signal or `--` came first, whatever follows it.
+    ("kill -- -1", "kill all processes"),
+    ("kill -9 -- -1", "kill all processes"),
+    ("kill -1 -1", "kill all processes"),
+    ("kill -9 -1 1234", "kill all processes"),
+    ("kill -s KILL -1 1234", "kill all processes"),
+    # ---- -1 after other pids is still the pid -1 operand (bash and /bin/kill both read it so)
+    ("kill 1234 -1", "kill all processes"),
+    ("kill -9 1234 -1", "kill all processes"),
+    ("kill -s KILL 1234 -1", "kill all processes"),
+    ("sudo kill -TERM 1234 5678 -1", "kill all processes"),
+    # ---- killall5: "send a signal to all processes" is the whole program
+    ("killall5", "kill all processes"),
+    ("killall5 -9", "kill all processes"),
+    ("killall5 -15", "kill all processes"),
+    ("$(killall5 -9)", "kill all processes"),
+    ("nohup killall5", "kill all processes"),
+    ("sudo /sbin/killall5", "kill all processes"),
+]
+
+# Targeted process commands that must stay runnable: the floor has no approval
+# path, so a false positive here bans the command outright.
+_PROCESS_KILL_ALLOW = [
+    # SIGHUP-to-a-pid reload idiom — signal 1 is HUP, the same thing `-HUP` spells.
+    "kill -1 1234",
+    "kill -1 $(cat /var/run/nginx.pid)",
+    "kill -1 -- 1234",
+    "kill -HUP 1234",
+    "kill -s HUP 1234",
+    "kill -s KILL 1234",
+    "kill -l",
+    "kill 1234 1235",
+    # Whole-token rule: -19 is SIGSTOP, -1234 is a process group — neither is pid -1.
+    "kill -19 1234",
+    "kill -9 -- -1234",
+    # killall/pkill by name are the softer dangerous tier, never the floor.
+    "killall firefox",
+    "killall -9 node",
+    "pkill -HUP nginx",
+    # killall5 named as DATA, not run.
+    'echo "killall5 -9"',
+    "grep killall5 script.sh",
+    # A fork bomb quoted as prose is an argument, not a command (#93392).
+    'echo "bomb(){ bomb|bomb& };bomb"',
+    'git commit -m ":(){ :|:& };:"',
+    # Ordinary shell functions: no self-pipe, or defined and never invoked.
+    "f(){ echo hi; }; f",
+    'retry(){ retry_impl "$@" & }; retry',
+    "a(){ a|b& };a",
+    "g(){ g_helper | g_other & }; g",
+    "x(){ x|x& }",
+]
+
+
+@pytest.mark.parametrize("command,expected", _PROCESS_KILL_BLOCK)
+def test_process_destruction_spellings_are_hardline(command, expected):
+    """Renaming the function or splitting the signal off is not a bypass."""
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"process-kill spelling leaked past the hardline floor: {command!r}"
+    assert desc == expected, f"unexpected description {desc!r} for {command!r}"
+
+
+@pytest.mark.parametrize("command", _PROCESS_KILL_ALLOW)
+def test_targeted_process_commands_are_not_hardline(command):
+    """A targeted signal (or a mention of one) must stay runnable."""
+    is_hl, desc = detect_hardline_command(command)
+    assert not is_hl, (
+        f"targeted process command false-positived the hardline floor: "
+        f"{command!r} (got: {desc})"
+    )
+    assert desc is None
+
+
+@pytest.fixture
+def clean_session(monkeypatch):
+    """Reset session-scoped approval state around each test."""
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    token = set_current_session_key("hardline_process_test")
+    try:
+        disable_session_yolo("hardline_process_test")
+        yield
+    finally:
+        disable_session_yolo("hardline_process_test")
+        reset_current_session_key(token)
+
+
+def test_yolo_cannot_bypass_renamed_process_kills(clean_session, monkeypatch):
+    """HERMES_YOLO_MODE=1 must not bypass the newly recognized spellings."""
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+
+    for cmd in ["bomb(){ bomb|bomb& };bomb", "kill -s KILL -1", "killall5 -9"]:
+        r1 = check_dangerous_command(cmd, "local")
+        assert r1["approved"] is False, f"yolo leaked hardline on {cmd!r} (check_dangerous_command)"
+        assert r1.get("hardline") is True
+
+        r2 = check_all_command_guards(cmd, "local")
+        assert r2["approved"] is False, f"yolo leaked hardline on {cmd!r} (check_all_command_guards)"
+        assert r2.get("hardline") is True
+
+
+def test_dangerous_tier_also_flags_renamed_fork_bomb():
+    """The dangerous-tier duplicate of the rule tracks the same spellings."""
+    for cmd in ["bomb(){ bomb|bomb& };bomb", ":(){ :|:& };:"]:
+        is_dangerous, _, desc = detect_dangerous_command(cmd)
+        assert is_dangerous, f"fork bomb not flagged on the dangerous tier: {cmd!r}"
+        assert desc == "fork bomb"

--- a/tests/tools/test_hardline_process_kill.py
+++ b/tests/tools/test_hardline_process_kill.py
@@ -75,6 +75,15 @@ _PROCESS_KILL_BLOCK = [
 # Targeted process commands that must stay runnable: the floor has no approval
 # path, so a false positive here bans the command outright.
 _PROCESS_KILL_ALLOW = [
+    # Multi-line scripts. A newline is a command separator (see `_CMDPOS`), so a `-1` on a LATER
+    # line is that line's flag, never this `kill`'s operand. Nothing here is approvable — the floor
+    # has no approval path — so matching one of these bans an ordinary script outright.
+    "kill 4242\nls -1",
+    "kill 1234\ngit log -1",
+    "kill -0 $PID\nhead -1 /tmp/state",
+    "pkill -f worker\nkill 4242\nhead -1 out.txt",
+    "kill $(cat app.pid)\nsleep 2\ntail -1 /var/log/app.log",
+    "kill 4242\ncut -d: -f1 /etc/passwd\nuniq -c -1",
     # SIGHUP-to-a-pid reload idiom — signal 1 is HUP, the same thing `-HUP` spells.
     "kill -1 1234",
     "kill -1 $(cat /var/run/nginx.pid)",
@@ -162,3 +171,29 @@ def test_dangerous_tier_also_flags_renamed_fork_bomb():
         is_dangerous, _, desc = detect_dangerous_command(cmd)
         assert is_dangerous, f"fork bomb not flagged on the dangerous tier: {cmd!r}"
         assert desc == "fork bomb"
+
+
+# The floor is scanned synchronously by `_floor_block` before every terminal command, and
+# `_MAX_DETECTION_COMMAND_CHARS` (128_000) is the budget that keeps that bounded. A pattern that
+# backtracks quadratically turns the budget into a stall: measured, a bare `(?<!\w)` in front of a
+# NAME group that accepts `.` and `-` cost 1697 ms at 8 KB and over seven minutes at the limit,
+# and a `\s+` token run that crosses newlines cost 6344 ms on 28 KB of `kill 1` lines. The bounds
+# below sit ~25x above the healthy timings, so they cannot flake on a slow runner, while the
+# quadratic versions miss them by 3x and more. Sized deliberately: at half this input the
+# broken pattern still finishes inside two seconds and the test would pass while blind.
+@pytest.mark.parametrize("command,budget_s", [
+    ("echo hi\ncurl https://ex.com/" + "a-" * 8000, 2.0),
+    ("echo hi\ncurl https://ex.com/" + "a." * 8000, 2.0),
+    ("kill 1\n" * 4000, 3.0),
+])
+def test_the_floor_scan_stays_linear_on_adversarial_input(command, budget_s):
+    """A hardline pattern may not backtrack quadratically on attacker-shaped text."""
+    import time
+
+    started = time.perf_counter()
+    detect_hardline_command(command)
+    elapsed = time.perf_counter() - started
+    assert elapsed < budget_s, (
+        f"hardline scan took {elapsed:.1f}s on {len(command)} chars (budget {budget_s}s) — "
+        f"a pattern is backtracking; at _MAX_DETECTION_COMMAND_CHARS this is a multi-minute stall"
+    )

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -83,6 +83,30 @@ _HARDLINE_SYSTEM_DIRS = (r'/home|/home/\*|/root|/root/\*|/etc|/etc/\*|/usr|/usr/
 # must be an actual command word — "rm -rf /" as DATA in `git commit -m "…rm -rf /…"` must not trip the floor.
 _RM_FLAG_PREFIX = _CMDPOS + r'rm\s+(-[^\s]*\s+)*'
 
+# Fork bomb: a function whose body pipes itself into itself, backgrounds the pair, and is then
+# invoked. `:` is only the canonical NAME — `bomb(){ bomb|bomb& };bomb` forks exactly as hard — so the
+# name is CAPTURED and back-referenced instead of hardcoded. The self-reference IS the bomb, which is
+# why `a(){ a|b& };a` and `g(){ g_helper|g_other& };g` (and a definition that is never invoked) stay
+# off the floor. Positionless — a definition carries no command-name token to anchor — so it matches
+# the quote-masked variant like the block-device redirect (_QUOTE_MASKED_HARDLINE_DESCRIPTIONS).
+# Each optional part hangs off a literal, never between two `\s*` runs: an ambiguous whitespace split
+# is what turns a failing match into quadratic backtracking.
+_FORK_BOMB = (r'(?<!\w)(?:function\s+)?(:|[a-z_][a-z0-9_.-]*)\s*(?:\(\s*\)\s*)?'
+              r'\{\s*\1\s*\|\s*\1\s*&\s*(?:;\s*)?\}[^\S\n]*[;\n]\s*\1(?!\w)')
+
+# `-1` (every process) as a kill TARGET. Where it sits decides what it means. As the FIRST token after
+# `kill` it is a signal: `kill -1 1234` is the SIGHUP reload idiom (signal 1 = HUP) that `kill -HUP 1234`
+# spells longhand, and the floor cannot be approved, so blocking it leaves no way to run it at all. Any
+# LATER token `-1` is the pid operand -1, i.e. everything: after a signal (`kill -9 -1`), after a flag
+# whose value is a separate token (`kill -s KILL -1` — the old `(-[^\s]+\s+)*` rule consumed `-s` and
+# read `KILL` as the target, which is how that spelling walked past the floor), after `--`, or after
+# other pids (`kill 1234 -1`, which the old rule missed too). Bare `kill -1` with no operand stays on
+# the floor as before. `-1` must be a whole token, so `kill -19 1234` (SIGSTOP) and `kill -- -1234` (a
+# process group) are not read as `-1`. Tokens are whitespace-delimited, so a failing match has one
+# parse per token and cannot backtrack quadratically.
+_KILL_ALL_TARGET = (r'(?:[^\s;&|]+\s+)+-1(?=[\s;&|)`<>#]|$)'
+                    r'|-1(?=\s*(?:[;&|)`<>#]|$))')
+
 HARDLINE_PATTERNS = [
     # Root path: any root-anchored path whose components collapse to "/" in the shell ("/", "//",
     # "/.", "/./", "/../..", optional trailing glob). Each inter-slash segment must be exactly "."
@@ -108,10 +132,11 @@ HARDLINE_PATTERNS = [
     # /dev/sda"`) cannot trip it, while shell-carrying wrappers (sh -c / bash -c / eval) still surface their
     # payload as a raw detection variant — quoting is not a bypass (#93392).
     (r'>\s*/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*\b', "redirect to raw block device"),
-    (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
-    # Kill every process on the system — anchor the command-name token so `echo "kill -1 sends SIGHUP to
-    # everything"` doesn't trip (#93392).
-    (_CMDPOS + r'kill\s+(-[^\s]+\s+)*-1\b', "kill all processes"),
+    (_FORK_BOMB, "fork bomb"),
+    # Kill every process on the system: `kill` aimed at pid -1, plus killall5, whose entire job is
+    # signaling every process. Command-name anchored so `echo "kill -1 sends SIGHUP to everything"`
+    # doesn't trip (#93392); killall5 lives in /sbin, often off PATH, so an explicit path is anchored too.
+    (_CMDPOS + rf'(?:kill\s+(?:{_KILL_ALL_TARGET})|(?:[\w./-]*/)?killall5\b)', "kill all processes"),
     (_CMDPOS + r'(shutdown|reboot|halt|poweroff)\b', "system shutdown/reboot"),
     (_CMDPOS + r'init\s+[06]\b', "init 0/6 (shutdown/reboot)"),
     (_CMDPOS + r'systemctl\s+(poweroff|reboot|halt|kexec)\b', "systemctl poweroff/reboot"),
@@ -277,7 +302,7 @@ DANGEROUS_PATTERNS = [
     (r'\bkillall\s+(-[^\s]*\s+)*-(9|KILL|SIGKILL)\b', "force kill processes (killall -KILL)"),
     (r'\bkillall\s+(-[^\s]*\s+)*-s\s+(KILL|SIGKILL|9)\b', "force kill processes (killall -s KILL)"),
     (r'\bkillall\s+(-[^\s]*\s+)*-r\b', "kill processes by regex (killall -r)"),
-    (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
+    (_FORK_BOMB, "fork bomb"),
     # Shell -c is parsed structurally by _execution_flag_findings(); a regex searching a dash-token
     # for "c" also matched --norc/--rcfile/--restricted.
     (r'\b(curl|wget)\b.*\|\s*(?:[/\w]*/)?(?:ba)?sh(?:\s|$|-c)', "pipe remote content to shell"),

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -91,7 +91,17 @@ _RM_FLAG_PREFIX = _CMDPOS + r'rm\s+(-[^\s]*\s+)*'
 # the quote-masked variant like the block-device redirect (_QUOTE_MASKED_HARDLINE_DESCRIPTIONS).
 # Each optional part hangs off a literal, never between two `\s*` runs: an ambiguous whitespace split
 # is what turns a failing match into quadratic backtracking.
-_FORK_BOMB = (r'(?<!\w)(?:function\s+)?(:|[a-z_][a-z0-9_.-]*)\s*(?:\(\s*\)\s*)?'
+# The lookbehind excludes ``.`` and ``-`` as well as word characters, because the NAME group
+# accepts both. With a bare ``(?<!\w)`` every character after a dot or a dash inside a run
+# like ``a-a-a-...`` is a fresh viable start; each start eats the rest of the run and gives it
+# back one character at a time, and the scan goes quadratic. Measured end-to-end through
+# detect_hardline_command on ``"echo hi\ncurl https://ex.com/" + "a-" * n``: 121 / 428 /
+# 1697 ms at n = 1000 / 2000 / 4000 -- 4x per doubling, against a flat 16-38 ms for the rule
+# this replaces. _MAX_DETECTION_COMMAND_CHARS is 128_000, so the budget that exists to bound
+# the scan became a multi-minute synchronous stall in _floor_block, which every terminal
+# command pays. A NAME is a shell identifier, so a dotted or kebab run cannot start one
+# part-way through anyway and nothing matchable is given up.
+_FORK_BOMB = (r'(?<![\w.-])(?:function\s+)?(:|[a-z_][a-z0-9_.-]*)\s*(?:\(\s*\)\s*)?'
               r'\{\s*\1\s*\|\s*\1\s*&\s*(?:;\s*)?\}[^\S\n]*[;\n]\s*\1(?!\w)')
 
 # `-1` (every process) as a kill TARGET. Where it sits decides what it means. As the FIRST token after
@@ -104,7 +114,14 @@ _FORK_BOMB = (r'(?<!\w)(?:function\s+)?(:|[a-z_][a-z0-9_.-]*)\s*(?:\(\s*\)\s*)?'
 # the floor as before. `-1` must be a whole token, so `kill -19 1234` (SIGSTOP) and `kill -- -1234` (a
 # process group) are not read as `-1`. Tokens are whitespace-delimited, so a failing match has one
 # parse per token and cannot backtrack quadratically.
-_KILL_ALL_TARGET = (r'(?:[^\s;&|]+\s+)+-1(?=[\s;&|)`<>#]|$)'
+# The separator between operand tokens is HORIZONTAL whitespace. _CMDPOS treats a newline as a
+# command separator (its own comment says so), so letting ``\s+`` cross one had two costs. It read
+# a ``-1`` on a LATER line as this ``kill``'s operand -- ``kill 4242\nls -1``,
+# ``kill 1234\ngit log -1`` and ``kill -0 $PID\nhead -1 /tmp/state`` are ordinary scripts, and
+# this floor has no approval path, so matching them banned them outright. And it made the run walk
+# the whole remaining input from every start: 505 / 1753 / 6459 ms on ``"kill 1\n" * n`` at
+# n = 1000 / 2000 / 4000, against 154-568 ms for the rule this replaces.
+_KILL_ALL_TARGET = (r'(?:[^\s;&|]+[^\S\n]+)+-1(?=[\s;&|)`<>#]|$)'
                     r'|-1(?=\s*(?:[;&|)`<>#]|$))')
 
 HARDLINE_PATTERNS = [

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -133,7 +133,8 @@ The blocklist is the floor below `--yolo`. It trips **before** the approval laye
 |---|---|
 | `rm -rf /` and obvious variants | Wipes the filesystem root |
 | `rm -rf --no-preserve-root /` | The explicit "yes I mean root" variant |
-| `:(){ :\|:& };:` (bash fork bomb) | Pegs the host until reboot |
+| `:(){ :\|:& };:` (fork bomb, under any function name) | Pegs the host until reboot |
+| `kill -1` / `kill -9 -1` / `killall5` | Signals every process on the host |
 | `mkfs.*` on a mounted root device | Formats the live system |
 | `dd if=/dev/zero of=/dev/sd*` | Zeroes a physical disk |
 | Piping untrusted URLs to `sh` at the rootfs top level | Remote-code-execution attack vector too broad to approve |

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -134,7 +134,7 @@ The blocklist is the floor below `--yolo`. It trips **before** the approval laye
 | `rm -rf /` and obvious variants | Wipes the filesystem root |
 | `rm -rf --no-preserve-root /` | The explicit "yes I mean root" variant |
 | `:(){ :\|:& };:` (fork bomb, under any function name) | Pegs the host until reboot |
-| `kill -1` / `kill -9 -1` / `killall5` | Signals every process on the host |
+| `kill -9 -1` / `kill -s KILL -1` / `killall5` | Signals every process on the host. `-1` as the *target* means everything; `kill -1 <pid>` is the SIGHUP reload idiom and stays allowed |
 | `mkfs.*` on a mounted root device | Formats the live system |
 | `dd if=/dev/zero of=/dev/sd*` | Zeroes a physical disk |
 | Piping untrusted URLs to `sh` at the rootfs top level | Remote-code-execution attack vector too broad to approve |


### PR DESCRIPTION
## What does this PR do?

The hardline floor is the one guard with no override — no `--yolo`, no `approvals.mode: off`, no
"allow always". Its two process-destruction rules policed exactly one spelling each, so renaming a
function or moving a signal into its own token walked straight past the floor with no prompt at all.
The same `kill` rule then fired on `-1` wherever it appeared, hardline-blocking the ordinary
`kill -1 <pid>` SIGHUP reload — a command the floor cannot approve, so it could not be run at all.

All three were reproduced on `main` (966637323e) with `detect_hardline_command`:

**1. Fork bombs only counted when the function was named `:`** — `tools/approval_detection.py:111`,
`HARDLINE_PATTERNS`, `r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:'`. The rule hardcodes the name, but
the name is decoration; the self-reference is the bomb. Measured on `main`, every one of these
returns `(False, None)` and runs under `--yolo`:

```
bomb(){ bomb|bomb& };bomb
b() { b | b & }; b
function bomb { bomb | bomb & }; bomb
fork(){ fork|fork& }; fork
:(){ :|:&; };:              # the canonical bomb with a `;` before the brace
bash -c 'bomb(){ bomb|bomb& };bomb'
```

The identical regex is duplicated in `DANGEROUS_PATTERNS` (`tools/approval_detection.py:280`), so a
renamed bomb was not even approval-gated.

**2. `kill` read every flag as one token** — `tools/approval_detection.py:114`,
`_CMDPOS + r'kill\s+(-[^\s]+\s+)*-1\b'`. `(-[^\s]+\s+)*` consumes `-s` but not its value, so the
value lands where the rule expects the target. `kill -SIGKILL -1` and `kill -9 -1` were blocked while
these returned `(False, None)`:

```
kill -s KILL -1        kill -s 9 -1       kill -s SIGKILL -1
kill -s TERM -1        kill -n 9 -1       kill --signal KILL -1
sudo kill -s KILL -1   kill -s KILL -1 1234
kill 1234 -1           kill -9 1234 -1    # -1 after a pid is still pid -1 (bash and /bin/kill agree)
```

`killall5` — the SysV "send a signal to all processes" binary — was not covered at all:
`killall5`, `killall5 -9`, `killall5 -15`, `$(killall5 -9)`, `nohup killall5` all returned
`(False, None)`.

**3. False positive in the same rule.** `-1\b` matched anywhere, so signal 1 (SIGHUP) sent to a pid
was read as "kill all processes":

```
kill -1 1234                          -> (True, 'kill all processes')
kill -1 $(cat /var/run/nginx.pid)     -> (True, 'kill all processes')
kill -1 -- 1234                       -> (True, 'kill all processes')
```

That is the standard daemon-reload idiom, and `kill -HUP 1234` / `kill -s HUP 1234` — the same
syscall, spelled differently — were already allowed. Since the hardline floor has no approval path,
this made the command unrunnable through the agent rather than merely prompting.

### The fix

- `_FORK_BOMB`: one module constant, used by both the hardline and dangerous-tier entries. The
  function name is **captured and back-referenced** (`\1`) instead of hardcoded, with an optional
  `function` keyword, optional `()`, an optional `;` before the closing brace, and `;`-or-newline
  before the invocation. Exact-match back-references keep the rule narrow: `a(){ a|b& };a` and
  `g(){ g_helper|g_other& };g` recurse into something else and stay off the floor, and `x(){ x|x& }`
  (defined, never invoked) keeps the existing "invocation required" contract.
- The kill rule now keys on **position** instead of flag shape. `-1` as the first token after
  `kill` is the signal (HUP), so `kill -1 1234` is allowed again. `-1` as any later token is the pid
  operand -1: after a signal (`kill -9 -1`), after a separate-value flag (`kill -s KILL -1`), after
  `--` (`kill -- -1`), or after other pids (`kill 1234 -1`, which the old rule missed as well, since a
  pid is not a flag token). Bare `kill -1` with no operand stays on the floor as before, and `-1` must
  be a whole token, so `kill -19 1234` (SIGSTOP) and `kill -- -1234` (a process group) are untouched.
  `killall5` joins the same rule under the same "kill all processes" description.
- Both descriptions are unchanged — "fork bomb" is a key in `_QUOTE_MASKED_HARDLINE_DESCRIPTIONS`,
  which is what keeps `echo "bomb(){ bomb|bomb& };bomb"` runnable while `bash -c '<payload>'` is
  still scanned raw (#93392).
- Each optional part of the fork-bomb regex hangs off a literal rather than sitting between two
  `\s*` runs, and the kill rule's tokens are whitespace-delimited with exactly one parse each, so a
  failing match cannot backtrack quadratically/exponentially.

No new `HARDLINE_PATTERNS` entries — `killall5` folds into the existing kill rule, so the "keep the
list tiny" contract (`test_hardline_list_is_small`) is untouched.

## Related Issue

No issue filed — found by exercising the guard directly against `detect_hardline_command` on `main`.

Fixes #

Adjacent but distinct open work on the same floor (no overlap in rules touched): #58643
(leading-wrapper / path bypass) and #65393 (busybox/toybox applet verbs). I found no open or merged
PR covering fork-bomb naming, `kill -s KILL -1`, `killall5`, or the `kill -1 <pid>` false positive.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval_detection.py` — new `_FORK_BOMB` constant (name-agnostic, back-referenced) shared
  by the hardline and dangerous-tier fork-bomb entries; rewritten `kill` hardline rule
  (`_KILL_ALL_TARGET`) that reads `-1` as the target by position rather than by flag shape, and adds
  `killall5`.
- `tests/tools/test_hardline_process_kill.py` — new file: 33 must-block spellings (with the expected
  description) and 22 must-allow commands, plus a yolo-cannot-bypass test and a dangerous-tier test.
- `website/docs/user-guide/security.md` — hardline table: fork bombs "under any function name", new
  `kill -1` / `kill -9 -1` / `killall5` row.

## How to Test

1. Reproduce on `main` (`966637323e`):
   ```python
   from tools.approval_detection import detect_hardline_command as d
   d("bomb(){ bomb|bomb& };bomb")   # (False, None)  <- runs under --yolo
   d("kill -s KILL -1")             # (False, None)
   d("killall5 -9")                 # (False, None)
   d("kill 1234 -1")                # (False, None)  <- pid -1 after another pid
   d("kill -1 1234")                # (True, 'kill all processes')  <- false positive
   ```
2. Check the new file out on unpatched code — 31 failed, 26 passed:
   ```
   PYTHONPATH=. python -m pytest tests/tools/test_hardline_process_kill.py -q
   ```
3. With the fix applied, the same file is 57 passed, and the surrounding suites stay green:
   ```
   PYTHONPATH=. python -m pytest tests/tools/test_hardline_process_kill.py \
     tests/tools/test_hardline_blocklist.py tests/tools/test_approval.py \
     tests/tools/test_shell_bypass_denylist.py tests/tools/test_execution_flag_detection.py \
     tests/tools/test_approval_grep_in_substitution.py \
     tests/hermes_cli/test_approvals_test.py tests/hermes_cli/test_approval_transport.py \
     tests/hermes_cli/test_cmd_update.py -q
   ```
   -> 640 passed, 3 failed, 1 skipped.
   (`test_approval.py::TestSensitiveRedirectPattern::test_redirect_to_sensitive_target` and the two
   `test_execution_flag_detection.py::…[man-args4/5]` cases fail identically on unpatched `main` in
   this container — environment-dependent, not from this change.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the approval/hardline suites listed above
      plus every test file matching `fork bomb|kill all processes|kill -1`, not the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Debian, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `website/docs/user-guide/security.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the rules are POSIX-shell shapes and
      are unchanged in kind; `killall5` and `kill -1` simply do not exist on Windows shells
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (approval-key
      descriptions are deliberately unchanged, so stored allowlist entries keep working)

## Screenshots / Logs

```
$ PYTHONPATH=. python -m pytest tests/tools/test_hardline_process_kill.py -q     # before the fix
31 failed, 26 passed in 1.36s

$ PYTHONPATH=. python -m pytest tests/tools/test_hardline_process_kill.py -q     # after
57 passed in 1.19s
```