### PR TITLE
fix(terminal): don't send a Hermes-host cwd to the ssh peer

### DIFF
--- a/tests/tools/test_session_cwd_store.py
+++ b/tests/tools/test_session_cwd_store.py
@@ -182,6 +182,7 @@ class TestCommandCwdReadsTheRecord:
         resolved = tt._resolve_command_cwd(
             workdir=None,
             default_cwd="/config/default",
+            env_type="local",
             session_key="sess-a",
         )
         assert resolved == "/my/worktree"
@@ -191,6 +192,7 @@ class TestCommandCwdReadsTheRecord:
         resolved = tt._resolve_command_cwd(
             workdir="/explicit/place",
             default_cwd="/config/default",
+            env_type="local",
             session_key="sess-a",
         )
         assert resolved == "/explicit/place"
@@ -199,6 +201,7 @@ class TestCommandCwdReadsTheRecord:
         resolved = tt._resolve_command_cwd(
             workdir=None,
             default_cwd="/config/default",
+            env_type="local",
             session_key="sess-a",
         )
         assert resolved == "/config/default"
@@ -208,6 +211,7 @@ class TestCommandCwdReadsTheRecord:
         resolved = tt._resolve_command_cwd(
             workdir=None,
             default_cwd="/config/default",
+            env_type="local",
             session_key="sess-a",
         )
         assert resolved == "/config/default"

--- a/tests/tools/test_ssh_cwd_sanitize.py
+++ b/tests/tools/test_ssh_cwd_sanitize.py
@@ -1,0 +1,178 @@
+"""Regression tests for host-path cwd sanitization on the ssh backend.
+
+``ssh`` is the one backend whose cwd is resolved by a shell on *another*
+machine, so a path taken from the Hermes host is not merely useless there --
+``cd`` fails and the command returns 126 before it ever runs.
+
+``tools/terminal_tool.py`` already guards two code paths against exactly this
+shape of mistake, but both were scoped to ``_CONTAINER_BACKENDS`` and ``ssh``
+is not one of them:
+
+  1. ``_get_env_config()`` sanitizes the ``TERMINAL_CWD``-derived ``config["cwd"]``.
+  2. ``terminal_tool()`` re-applies the guard to a *per-task cwd override*,
+     which wins over ``config["cwd"]``.
+
+Measured on SSJOON 2026-09-07: the kanban worker sets ``TERMINAL_CWD`` to its
+own Windows workspace (``D:\\hermes\\kanban\\...\\workspaces\\<task_id>``) while
+the ssh peer is a Mac.  ``sw_vers`` and ``sysctl -n hw.model`` both came back
+``exit 126`` until the caller passed an explicit workdir.  ``_HOST_CWD_PREFIXES``
+would not have caught it either -- it lists only the ``C:`` drive.
+
+These tests pin ``_is_unusable_ssh_cwd()`` so neither path can regress, and
+pin the two things it must *not* reject: ``~`` (the peer's own home, which
+``_is_ssh_remote_tilde_cwd`` deliberately leaves for the remote shell) and
+absolute POSIX paths that may well exist on the peer.
+"""
+
+import tools.terminal_tool as tt
+
+
+class TestIsUnusableSSHCwd:
+    def test_the_measured_case_windows_workspace_path(self):
+        # The exact value the kanban worker exported on SSJOON.
+        assert tt._is_unusable_ssh_cwd(
+            r"D:\hermes\kanban\boards\hermes-multinode\workspaces\t_27e56ac3"
+        ) is True
+
+    def test_any_drive_letter_not_just_c(self):
+        # _HOST_CWD_PREFIXES only lists C:, which is why the measured D: path
+        # slipped through every existing guard.
+        for path in (r"C:\Users\me", "C:/Users/me", r"D:\hermes", "d:/hermes", r"Z:\x"):
+            assert tt._is_unusable_ssh_cwd(path) is True, path
+
+    def test_backslash_anywhere_is_rejected(self):
+        # A separator the peer's shell does not use.
+        assert tt._is_unusable_ssh_cwd(r"\\server\share") is True
+        assert tt._is_unusable_ssh_cwd(r"some\relative") is True
+
+    def test_relative_paths_rejected(self):
+        for path in (".", "..", "src/", "work/uservice"):
+            assert tt._is_unusable_ssh_cwd(path) is True, path
+
+    def test_tilde_is_kept(self):
+        # The remote shell expands these itself; see _is_ssh_remote_tilde_cwd.
+        assert tt._is_unusable_ssh_cwd("~") is False
+        assert tt._is_unusable_ssh_cwd("~/work/uservice/teamwork") is False
+
+    def test_absolute_posix_paths_are_kept(self):
+        # We do not guess whether these exist on the peer -- only reject what
+        # cannot possibly work.
+        for path in ("/Users/ftfuture", "/home/joon", "/opt/data", "/"):
+            assert tt._is_unusable_ssh_cwd(path) is False, path
+
+    def test_empty_is_not_flagged(self):
+        assert tt._is_unusable_ssh_cwd("") is False
+
+
+class TestSSHCwdGuardIsWiredIn:
+    """The helper is only worth having if both call sites use it."""
+
+    def test_config_path_falls_back_to_remote_home(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "m5")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "ftfuture")
+        monkeypatch.setenv(
+            "TERMINAL_CWD",
+            r"D:\hermes\kanban\boards\hermes-multinode\workspaces\t_27e56ac3",
+        )
+        config = tt._get_env_config()
+        assert config["env_type"] == "ssh"
+        assert config["cwd"] == "~"
+
+    def test_config_path_keeps_a_legitimate_remote_path(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "m5")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "ftfuture")
+        monkeypatch.setenv("TERMINAL_CWD", "/Users/ftfuture/work/uservice/teamwork")
+        config = tt._get_env_config()
+        assert config["cwd"] == "/Users/ftfuture/work/uservice/teamwork"
+
+    def test_container_guard_is_untouched(self):
+        # This change must not widen or narrow the container behaviour.
+        assert tt._is_unusable_container_cwd(r"C:\Users\me") is True
+        assert tt._is_unusable_container_cwd("/workspace") is False
+
+
+class TestOverrideCwdSanitizedForSSH:
+    """E2E pin for the *second* code path.
+
+    A per-task cwd override wins over ``config["cwd"]``, so sanitizing only the
+    config path leaves the hole open.  Mutation testing proved this is not
+    theoretical: with the override guard disabled, every unit test above still
+    passed.  These drive ``terminal_tool()`` and assert on the cwd that
+    actually reaches the environment builder.
+    """
+
+    def _run_and_capture_cwd(self, monkeypatch, override_cwd, config_cwd="~"):
+        captured = {}
+
+        config = {
+            "env_type": "ssh",
+            "ssh_config": {"host": "m5", "user": "ftfuture", "port": 22, "key": ""},
+            "docker_image": "",
+            "cwd": config_cwd,
+            "host_cwd": None,
+            "timeout": 180,
+            "lifetime_seconds": 300,
+            "container_cpu": 1,
+            "container_memory": 5120,
+            "container_disk": 51200,
+            "container_persistent": True,
+            "docker_volumes": [],
+            "docker_env": {},
+            "docker_extra_args": [],
+            "docker_mount_cwd_to_workspace": False,
+            "docker_run_as_host_user": False,
+            "docker_forward_env": [],
+            "modal_mode": "auto",
+        }
+
+        class _DummyEnv:
+            cwd = config_cwd
+
+            def execute(self, *a, **k):
+                return {"output": "", "exit_code": 0}
+
+        def fake_create_environment(env_type, image, cwd, timeout, **kwargs):
+            captured["cwd"] = cwd
+            return _DummyEnv()
+
+        monkeypatch.setattr(tt, "_get_env_config", lambda: config)
+        monkeypatch.setattr(tt, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setattr(tt, "_check_all_guards", lambda *a, **k: {"approved": True})
+        monkeypatch.setattr(tt, "_create_environment", fake_create_environment)
+        monkeypatch.setattr(tt, "_active_environments", {})
+        monkeypatch.setattr(tt, "_last_activity", {})
+
+        task_id = "sess-ssh-host-cwd"
+        tt.register_task_env_overrides(task_id, {"cwd": override_cwd})
+        try:
+            tt.terminal_tool(command="pwd", task_id=task_id)
+        finally:
+            tt.clear_task_env_overrides(task_id)
+            tt._active_environments.pop(task_id, None)
+            tt._active_environments.pop("default", None)
+        return captured.get("cwd")
+
+    def test_the_measured_case_does_not_reach_the_peer(self, monkeypatch):
+        # The kanban worker's own Windows workspace, registered as an override.
+        cwd = self._run_and_capture_cwd(
+            monkeypatch,
+            r"D:\hermes\kanban\boards\hermes-multinode\workspaces\t_27e56ac3",
+        )
+        assert cwd == "~", (
+            f"Host cwd override leaked to the ssh peer: {cwd!r}. "
+            "Every command would fail in `cd` with exit 126 before running."
+        )
+
+    def test_relative_override_does_not_reach_the_peer(self, monkeypatch):
+        assert self._run_and_capture_cwd(monkeypatch, "src/") == "~"
+
+    def test_absolute_remote_override_is_preserved(self, monkeypatch):
+        # A real directory on the peer must still win — that is what overrides
+        # are for.
+        cwd = self._run_and_capture_cwd(monkeypatch, "/Users/ftfuture/work/uservice/teamwork")
+        assert cwd == "/Users/ftfuture/work/uservice/teamwork"
+
+    def test_tilde_override_is_preserved(self, monkeypatch):
+        assert self._run_and_capture_cwd(monkeypatch, "~/work") == "~/work"

--- a/tests/tools/test_ssh_cwd_sanitize.py
+++ b/tests/tools/test_ssh_cwd_sanitize.py
@@ -284,3 +284,138 @@ class TestMeasuredBugDoesNotReachExecute(TestOverrideCwdSanitizedForSSH):
                 f"Host cwd reached the peer's shell as {got!r}. "
                 "`cd` fails there and the command returns 126 before it runs."
             )
+
+
+class TestFileToolsCwdSanitizedForSSH:
+    """The *fourth* path: tools/file_tools.py builds its own environment.
+
+    It does not route through ``_resolve_command_cwd``, so guarding the three
+    terminal paths leaves it open.  It also reads BOTH leak sources -- the
+    registered override and the session record -- so a file tool arriving
+    before any terminal command in a fresh process is enough: the reviewer
+    measured one ``read_file`` executing four times in a host cwd.
+    """
+
+    def _build_env_and_capture_cwd(self, monkeypatch, override_cwd, config_cwd="~"):
+        import tools.file_tools as ft
+
+        captured = {}
+
+        config = {
+            "env_type": "ssh",
+            "ssh_host": "m5", "ssh_user": "ftfuture", "ssh_port": 22, "ssh_key": "",
+            "docker_image": "", "singularity_image": "", "modal_image": "",
+            "daytona_image": "",
+            "cwd": config_cwd, "host_cwd": None, "timeout": 180,
+            "lifetime_seconds": 300, "container_cpu": 1, "container_memory": 5120,
+            "container_disk": 51200, "container_persistent": True,
+            "docker_volumes": [], "docker_env": {}, "docker_extra_args": [],
+            "docker_mount_cwd_to_workspace": False, "docker_run_as_host_user": False,
+            "docker_forward_env": [], "docker_network": True, "modal_mode": "auto",
+        }
+
+        class _DummyEnv:
+            cwd = config_cwd
+
+            def execute(self, *a, **k):
+                captured.setdefault("execute_cwds", []).append(k.get("cwd"))
+                return {"output": "", "exit_code": 0}
+
+        def fake_create_environment(env_type, image, cwd, timeout, **kwargs):
+            captured["create_cwd"] = cwd
+            return _DummyEnv()
+
+        monkeypatch.setattr(tt, "_get_env_config", lambda: config)
+        monkeypatch.setattr(tt, "_create_environment", fake_create_environment)
+        monkeypatch.setattr(tt, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setattr(tt, "_active_environments", {})
+        monkeypatch.setattr(tt, "_last_activity", {})
+
+        task_id = "sess-filetools-ssh"
+        tt.register_task_env_overrides(task_id, {"cwd": override_cwd})
+        try:
+            ft._get_file_ops(task_id)
+        finally:
+            tt.clear_task_env_overrides(task_id)
+            tt.clear_session_cwd(task_id)
+            tt._active_environments.pop(task_id, None)
+            tt._active_environments.pop("default", None)
+        return captured
+
+    def test_host_override_does_not_reach_the_peer(self, monkeypatch):
+        cap = self._build_env_and_capture_cwd(
+            monkeypatch,
+            r"D:\hermes\kanban\boards\hermes-multinode\workspaces\t_27e56ac3",
+        )
+        assert cap["create_cwd"] == "~", (
+            f"file_tools built an ssh environment in {cap['create_cwd']!r}. "
+            "Every command it runs would die in `cd` with 126."
+        )
+
+    def test_remote_override_is_preserved(self, monkeypatch):
+        cap = self._build_env_and_capture_cwd(monkeypatch, "/Users/ftfuture/work")
+        assert cap["create_cwd"] == "/Users/ftfuture/work"
+
+
+class TestCodeExecutionCwdSanitizedForSSH:
+    """The *fifth* path: tools/code_execution_tool.py, which had no guard at all.
+
+    Not even the container one.  The container case is only accidentally safe
+    (a CWD-only override collapses to the shared ``default`` id and is not
+    found); an isolation key keeps the raw id and the host path flows through.
+    This branch fixes the ssh half only -- see the comment at the call site.
+    """
+
+    def _build_env_and_capture_cwd(self, monkeypatch, override_cwd, config_cwd="~"):
+        import tools.code_execution_tool as cet
+
+        captured = {}
+        config = {
+            "env_type": "ssh",
+            "ssh_host": "m5", "ssh_user": "ftfuture", "ssh_port": 22, "ssh_key": "",
+            "docker_image": "", "singularity_image": "", "modal_image": "",
+            "daytona_image": "",
+            "cwd": config_cwd, "timeout": 180, "lifetime_seconds": 300,
+            "container_cpu": 1, "container_memory": 5120, "container_disk": 51200,
+            "container_persistent": True, "docker_volumes": [],
+            "docker_run_as_host_user": False, "docker_network": True,
+            "modal_mode": "auto",
+        }
+
+        class _DummyEnv:
+            cwd = config_cwd
+
+        def fake_create_environment(env_type, image, cwd, timeout, **kwargs):
+            captured["create_cwd"] = cwd
+            return _DummyEnv()
+
+        monkeypatch.setattr(tt, "_get_env_config", lambda: config)
+        monkeypatch.setattr(tt, "_create_environment", fake_create_environment)
+        monkeypatch.setattr(tt, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setattr(tt, "_active_environments", {})
+        monkeypatch.setattr(tt, "_last_activity", {})
+
+        # An isolation key keeps the RAW task id, which is what makes the
+        # override reachable here at all.
+        task_id = "sess-codeexec-ssh"
+        tt.register_task_env_overrides(
+            task_id, {"cwd": override_cwd, "env_type": "ssh"}
+        )
+        try:
+            cet._get_or_create_env(task_id)
+        finally:
+            tt.clear_task_env_overrides(task_id)
+            tt.clear_session_cwd(task_id)
+            tt._active_environments.pop(task_id, None)
+            tt._active_environments.pop("default", None)
+        return captured
+
+    def test_host_override_does_not_reach_the_peer(self, monkeypatch):
+        cap = self._build_env_and_capture_cwd(
+            monkeypatch, r"D:\hermes\kanban\workspaces\t_27e56ac3"
+        )
+        assert cap["create_cwd"] == "~"
+
+    def test_remote_override_is_preserved(self, monkeypatch):
+        cap = self._build_env_and_capture_cwd(monkeypatch, "/Users/ftfuture/work")
+        assert cap["create_cwd"] == "/Users/ftfuture/work"

--- a/tests/tools/test_ssh_cwd_sanitize.py
+++ b/tests/tools/test_ssh_cwd_sanitize.py
@@ -131,9 +131,14 @@ class TestOverrideCwdSanitizedForSSH:
             cwd = config_cwd
 
             def execute(self, *a, **k):
+                # The cwd that actually reaches the peer's shell. The builder's
+                # cwd only seeds the environment; every command resolves its
+                # own, so this is the value that decides whether `cd` succeeds.
+                captured.setdefault("execute_cwds", []).append(k.get("cwd"))
                 return {"output": "", "exit_code": 0}
 
         def fake_create_environment(env_type, image, cwd, timeout, **kwargs):
+            captured["create_cwd"] = cwd
             captured["cwd"] = cwd
             return _DummyEnv()
 
@@ -152,27 +157,130 @@ class TestOverrideCwdSanitizedForSSH:
             tt.clear_task_env_overrides(task_id)
             tt._active_environments.pop(task_id, None)
             tt._active_environments.pop("default", None)
-        return captured.get("cwd")
+        return captured
 
     def test_the_measured_case_does_not_reach_the_peer(self, monkeypatch):
         # The kanban worker's own Windows workspace, registered as an override.
-        cwd = self._run_and_capture_cwd(
+        cap = self._run_and_capture_cwd(
             monkeypatch,
             r"D:\hermes\kanban\boards\hermes-multinode\workspaces\t_27e56ac3",
         )
-        assert cwd == "~", (
-            f"Host cwd override leaked to the ssh peer: {cwd!r}. "
-            "Every command would fail in `cd` with exit 126 before running."
+        assert cap["create_cwd"] == "~", (
+            f"Host cwd override leaked to the environment builder: "
+            f"{cap['create_cwd']!r}."
         )
 
     def test_relative_override_does_not_reach_the_peer(self, monkeypatch):
-        assert self._run_and_capture_cwd(monkeypatch, "src/") == "~"
+        assert self._run_and_capture_cwd(monkeypatch, "src/")["create_cwd"] == "~"
 
     def test_absolute_remote_override_is_preserved(self, monkeypatch):
         # A real directory on the peer must still win — that is what overrides
         # are for.
-        cwd = self._run_and_capture_cwd(monkeypatch, "/Users/ftfuture/work/uservice/teamwork")
-        assert cwd == "/Users/ftfuture/work/uservice/teamwork"
+        cap = self._run_and_capture_cwd(monkeypatch, "/Users/ftfuture/work/uservice/teamwork")
+        assert cap["create_cwd"] == "/Users/ftfuture/work/uservice/teamwork"
+        assert cap["execute_cwds"] == ["/Users/ftfuture/work/uservice/teamwork"]
 
     def test_tilde_override_is_preserved(self, monkeypatch):
-        assert self._run_and_capture_cwd(monkeypatch, "~/work") == "~/work"
+        cap = self._run_and_capture_cwd(monkeypatch, "~/work")
+        assert cap["create_cwd"] == "~/work"
+        assert cap["execute_cwds"] == ["~/work"]
+
+
+class TestSessionRecordCwdSanitizedForSSH:
+    """The *third* code path -- the one the first version of this fix missed.
+
+    ``register_task_env_overrides`` writes a registered override straight into
+    the session cwd record, and every command without an explicit ``workdir``
+    resolves against that record.  Guarding ``config["cwd"]`` and the override
+    at the environment builder is therefore not enough: the builder gets a
+    clean ``~`` while ``env.execute`` still receives the host path, and the
+    measured bug reproduces with both of the other guards active.
+
+    The failure is also self-sustaining.  ``cd`` fails before the shell prints
+    the cwd marker, so the record is never corrected, and the same bad value is
+    re-recorded after each command.
+
+    Independent review of d33681f72 found this and supplied a repro; these
+    tests are that repro, pinned.
+    """
+
+    def test_resolver_drops_a_host_record_on_ssh(self):
+        tt.record_session_cwd(
+            "sess-ssh-record",
+            r"D:\hermes\kanban\boards\hermes-multinode\workspaces\t_27e56ac3",
+        )
+        try:
+            resolved = tt._resolve_command_cwd(
+                workdir=None, default_cwd="~",
+                env_type="ssh", session_key="sess-ssh-record",
+            )
+        finally:
+            tt.clear_session_cwd("sess-ssh-record")
+        assert resolved == "~"
+
+    def test_resolver_keeps_a_remote_record_on_ssh(self):
+        tt.record_session_cwd("sess-ssh-ok", "/Users/ftfuture/work")
+        try:
+            resolved = tt._resolve_command_cwd(
+                workdir=None, default_cwd="~",
+                env_type="ssh", session_key="sess-ssh-ok",
+            )
+        finally:
+            tt.clear_session_cwd("sess-ssh-ok")
+        assert resolved == "/Users/ftfuture/work"
+
+    def test_explicit_workdir_still_wins_on_ssh(self):
+        # workdir= is the caller saying "I know where this must run". The guard
+        # must not second-guess it -- that is how the measured bug was worked
+        # around before the fix existed.
+        tt.record_session_cwd("sess-ssh-wd", r"D:\hermes\kanban")
+        try:
+            resolved = tt._resolve_command_cwd(
+                workdir="/Users/ftfuture", default_cwd="~",
+                env_type="ssh", session_key="sess-ssh-wd",
+            )
+        finally:
+            tt.clear_session_cwd("sess-ssh-wd")
+        assert resolved == "/Users/ftfuture"
+
+    def test_other_backends_keep_their_record_untouched(self):
+        # The guard is ssh-only; local/container resolution must not change.
+        tt.record_session_cwd("sess-local", r"D:\hermes\kanban")
+        try:
+            for backend in ("local", "docker", "modal"):
+                assert tt._resolve_command_cwd(
+                    workdir=None, default_cwd="/root",
+                    env_type=backend, session_key="sess-local",
+                ) == r"D:\hermes\kanban", backend
+        finally:
+            tt.clear_session_cwd("sess-local")
+
+    def test_env_type_is_required(self):
+        # A new call site that forgets env_type must fail at the call, not
+        # silently skip the guard. That silence is how this path stayed
+        # unguarded while the other two were fixed.
+        import pytest
+        with pytest.raises(TypeError):
+            tt._resolve_command_cwd(workdir=None, default_cwd="~")
+
+
+class TestMeasuredBugDoesNotReachExecute(TestOverrideCwdSanitizedForSSH):
+    """End-to-end: the host path must not reach ``env.execute`` either.
+
+    Inherits the harness above. The earlier version of these tests asserted
+    only on the environment builder's cwd, which is exactly why the leak
+    survived them.
+    """
+
+    def test_execute_never_sees_the_host_path(self, monkeypatch):
+        cap = self._run_and_capture_cwd(
+            monkeypatch,
+            r"D:\hermes\kanban\boards\hermes-multinode\workspaces\t_27e56ac3",
+        )
+        assert cap["create_cwd"] == "~"
+        assert cap["execute_cwds"], "the command never reached env.execute"
+        for got in cap["execute_cwds"]:
+            assert got == "~", (
+                f"Host cwd reached the peer's shell as {got!r}. "
+                "`cd` fails there and the command returns 126 before it runs."
+            )

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -195,7 +195,8 @@ def test_registering_cwd_override_updates_session_record(monkeypatch):
     # … and the session record — what commands actually resolve against — too.
     assert terminal_tool.get_session_cwd(task_id) == "/workspace/new"
     assert terminal_tool._resolve_command_cwd(
-        workdir=None, default_cwd="/workspace/config", session_key=task_id
+        workdir=None, default_cwd="/workspace/config", env_type="local",
+        session_key=task_id
     ) == "/workspace/new"
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -716,6 +716,7 @@ def _get_or_create_env(task_id: str):
         _get_env_config, _last_activity, _start_cleanup_thread,
         _creation_locks, _creation_locks_lock, _task_env_overrides,
         _resolve_container_task_id,
+        _is_unusable_ssh_cwd,
     )
 
     effective_task_id = _resolve_container_task_id(task_id)
@@ -754,6 +755,29 @@ def _get_or_create_env(task_id: str):
             image = ""
 
         cwd = overrides.get("cwd") or config["cwd"]
+        if env_type == "ssh" and _is_unusable_ssh_cwd(cwd):
+            # A registered cwd override is a Hermes-host path; on ssh it is
+            # resolved by a shell on the peer, where `cd` fails and the command
+            # returns 126 before it runs. terminal_tool and file_tools guard
+            # their own cwd paths; this is the fifth, and it had no guard at
+            # all -- not even the container one.
+            #
+            # The container case here is only *accidentally* safe: a CWD-only
+            # override collapses to the shared "default" id and is not found.
+            # Add an isolation key (env_type/*_image, as RL and benchmark
+            # harnesses do) and the raw id survives, so the same host path
+            # reaches _create_environment. That half, and switching this lookup
+            # to resolve_task_overrides(), change container behaviour and are
+            # deliberately left to the follow-up card (t_e4c0a0b2); this branch
+            # is scoped to the ssh leak and leaves every other backend byte for
+            # byte as it was.
+            if cwd != config["cwd"]:
+                logger.info(
+                    "Ignoring host cwd override %r for ssh backend "
+                    "(won't resolve on the peer). Using %r instead.",
+                    cwd, config["cwd"],
+                )
+            cwd = config["cwd"]
 
         container_config = None
         if env_type in {"docker", "singularity", "modal", "daytona"}:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -766,11 +766,14 @@ def _get_or_create_env(task_id: str):
             # override collapses to the shared "default" id and is not found.
             # Add an isolation key (env_type/*_image, as RL and benchmark
             # harnesses do) and the raw id survives, so the same host path
-            # reaches _create_environment. That half, and switching this lookup
-            # to resolve_task_overrides(), change container behaviour and are
-            # deliberately left to the follow-up card (t_e4c0a0b2); this branch
-            # is scoped to the ssh leak and leaves every other backend byte for
-            # byte as it was.
+            # reaches _create_environment for a container backend too.
+            #
+            # Two things are deliberately NOT done here: adding the container
+            # guard, and reading the override through resolve_task_overrides()
+            # (which finds the raw key first, so it would also start finding
+            # overrides this site currently misses). Both change container
+            # behaviour, and this change is scoped to the ssh leak -- every
+            # other backend is byte for byte as it was.
             if cwd != config["cwd"]:
                 logger.info(
                     "Ignoring host cwd override %r for ssh backend "

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -947,6 +947,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _creation_locks_lock,
         _resolve_container_task_id,
         _is_unusable_container_cwd,
+        _is_unusable_ssh_cwd,
         _CONTAINER_BACKENDS,
     )
     import time
@@ -1037,6 +1038,24 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                         "Ignoring host/relative cwd override %r for %s backend "
                         "(won't exist in sandbox). Using %r instead.",
                         cwd, env_type, config["cwd"],
+                    )
+                cwd = config["cwd"]
+            elif env_type == "ssh" and _is_unusable_ssh_cwd(cwd):
+                # Same guard, other backend. ssh is not in _CONTAINER_BACKENDS,
+                # so both sources read above -- the registered override and the
+                # session record -- reached the peer unchecked. There the cost
+                # is not an empty search result but a shell that dies in `cd`:
+                # `cd -- 'D:\...' || exit 126` before the tool's command runs.
+                # A file tool arriving before any terminal command in a fresh
+                # process was enough: one read_file executed four times in a
+                # host cwd. terminal_tool guards its own three paths; this is
+                # the fourth, and file_tools does not route through
+                # _resolve_command_cwd, so it needs its own.
+                if cwd != config["cwd"]:
+                    logger.info(
+                        "Ignoring host cwd override %r for ssh backend "
+                        "(won't resolve on the peer). Using %r instead.",
+                        cwd, config["cwd"],
                     )
                 cwd = config["cwd"]
             logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2126,6 +2126,7 @@ def _resolve_command_cwd(
     *,
     workdir: Optional[str],
     default_cwd: str,
+    env_type: str,
     session_key: Optional[str] = None,
 ) -> str:
     """Return the cwd for a command. Explicit ``workdir=`` overrides everything.
@@ -2136,10 +2137,30 @@ def _resolve_command_cwd(
     ``cd`` lands in another record and can't affect us. A session with no
     record yet (first command) runs in ``default_cwd`` (config/override cwd),
     which is also what seeds a fresh environment.
+
+    The record is the *third* way a cwd reaches a command, and it needs the
+    same sanity check as the other two.  ``register_task_env_overrides``
+    writes a registered override straight into the record, so on the ``ssh``
+    backend a Hermes-host path lands here even when the config and override
+    guards both did their job -- and then every command without an explicit
+    ``workdir`` dies in ``cd`` with 126 before it runs.  Worse, the failure is
+    self-sustaining: ``cd`` fails before the marker is printed, so the record
+    is never corrected and the same bad value is re-recorded after each
+    command.
+
+    ``env_type`` is required rather than optional on purpose.  A new call site
+    that forgets it fails loudly at the call rather than silently skipping the
+    guard, which is exactly how this path came to be unguarded.
     """
     if workdir:
         return workdir
-    return get_session_cwd(session_key) or default_cwd
+    recorded = get_session_cwd(session_key)
+    if recorded and env_type == "ssh" and _is_unusable_ssh_cwd(recorded):
+        logger.info("Ignoring recorded session cwd %r for ssh backend "
+                    "(won't resolve on the peer). Using %r instead.",
+                    recorded, default_cwd)
+        return default_cwd
+    return recorded or default_cwd
 
 
 def terminal_tool(
@@ -2519,6 +2540,7 @@ def terminal_tool(
             effective_cwd = _resolve_command_cwd(
                 workdir=workdir,
                 default_cwd=cwd,
+                env_type=env_type,
                 session_key=session_key,
             )
             try:
@@ -2779,6 +2801,7 @@ def terminal_tool(
                     command_cwd = _resolve_command_cwd(
                         workdir=workdir,
                         default_cwd=cwd,
+                        env_type=env_type,
                         session_key=session_key,
                     )
                     execute_kwargs = {

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1305,12 +1305,49 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return False
 
 
+def _is_unusable_ssh_cwd(cwd: str) -> bool:
+    """Return True if *cwd* cannot be a working directory on the SSH peer.
+
+    ``ssh`` differs from every other backend: the cwd is resolved by a shell on
+    *another machine*, so a path taken from the Hermes host is not merely
+    useless there -- ``cd`` fails and the command returns 126 before it runs.
+    ``_get_env_config`` already discards such paths for the container backends
+    and ``terminal_tool`` re-applies that guard to the per-task override, but
+    both were scoped to ``_CONTAINER_BACKENDS`` and ``ssh`` is not one of them.
+
+    Measured on SSJOON 2026-09-07: the kanban worker exports ``TERMINAL_CWD``
+    as its own Windows workspace
+    (``D:\\hermes\\kanban\\...\\workspaces\\<task_id>``) while the peer is a
+    Mac, so ``sw_vers`` and ``sysctl -n hw.model`` both returned 126 until the
+    caller passed an explicit workdir.  ``_HOST_CWD_PREFIXES`` would not have
+    caught it either -- it lists only the ``C:`` drive.
+
+    The rule is deliberately one line: a remote cwd must be ``~``, ``~/...``
+    (the peer's own home -- see :func:`_is_ssh_remote_tilde_cwd`), or an
+    absolute POSIX path.  Everything else -- ``D:\\x``, ``d:/x``, ``.``,
+    ``src/`` -- cannot name a directory on the peer.
+
+    An earlier draft also rejected any path containing a backslash and matched
+    drive letters with a regex.  Mutation testing showed both branches were
+    unreachable behind this one, and the backslash rule was worse than
+    redundant: ``/Users/me\\weird`` is a legal POSIX path on the peer, so the
+    rule would have rejected a directory that works.
+
+    This only rejects what *cannot* work; it does not try to guess whether an
+    otherwise-plausible POSIX path exists on the peer.
+    """
+    if not cwd:
+        return False
+    if cwd == "~" or cwd.startswith("~/"):
+        return False
+    return not cwd.startswith("/")
+
+
 # One-shot guard for the config-fallback bridge below.  Purely an
 # optimization: after the first attempt either TERMINAL_ENV is set (bridge
 # succeeded — merged config always carries terminal.backend) or the import
 # failed and retrying every call would be wasted work.
 _terminal_config_bridge_attempted = False
-
 
 def _ensure_terminal_env_bridged() -> None:
     """Backfill TERMINAL_* env vars from config.yaml when no launcher did.
@@ -1414,6 +1451,14 @@ def _get_env_config() -> Dict[str, Any]:
             logger.info("Ignoring TERMINAL_CWD=%r for %s backend "
                         "(host/relative path won't work in sandbox). Using %r instead.",
                         cwd, env_type, default_cwd)
+            cwd = default_cwd
+    elif env_type == "ssh" and cwd:
+        # The cwd is resolved by a shell on the peer, so a path from this host
+        # is not just useless there -- it fails in `cd` before the command runs.
+        if _is_unusable_ssh_cwd(cwd) and cwd != default_cwd:
+            logger.info("Ignoring TERMINAL_CWD=%r for ssh backend "
+                        "(host path won't resolve on the peer). Using %r instead.",
+                        cwd, default_cwd)
             cwd = default_cwd
 
     return {
@@ -2201,6 +2246,18 @@ def terminal_tool(
                     "Ignoring host/relative cwd override %r for %s backend "
                     "(won't exist in sandbox). Using %r instead.",
                     cwd, env_type, config["cwd"],
+                )
+            cwd = config["cwd"]
+        elif env_type == "ssh" and _is_unusable_ssh_cwd(cwd):
+            # Same bypass, other backend: the override skips the guard that
+            # _get_env_config() applies to config["cwd"]. Over ssh the cost is
+            # not a container that fails to start but a `cd` that fails on the
+            # peer, so every command returns 126 before it runs.
+            if cwd != config["cwd"]:
+                logger.info(
+                    "Ignoring host cwd override %r for ssh backend "
+                    "(won't resolve on the peer). Using %r instead.",
+                    cwd, config["cwd"],
                 )
             cwd = config["cwd"]
         default_timeout = config["timeout"]


### PR DESCRIPTION
`ssh` is the one backend whose working directory is resolved by a shell on **another machine**. A path taken from this host is not merely useless there: `cd` fails and the command returns 126 before it runs.

```
sw_vers             15.3s [exit 126]
sysctl -n hw.model   5.1s [exit 126]
(with an explicit workdir)
sw_vers              5.1s  ok
sysctl -n hw.model   5.3s  ok
```

Measured on a Windows host driving a macOS peer (2026-09-07): a worker exported `TERMINAL_CWD` as its own Windows workspace, and every command without an explicit `workdir` died in `cd`.

## Why ssh needs its own predicate

The guards that already exist for this class of mistake are all scoped to container backends, and `ssh` is not one of them. Widening them would be wrong: a container **must** reject `/Users/me` because that path is absent inside the sandbox, while over ssh that is very likely exactly where the caller means to run.

So `_is_unusable_ssh_cwd` is one rule — a remote cwd must be `~`, `~/...`, or an absolute POSIX path. It rejects only what *cannot* work (`D:\x`, `d:/x`, `.`, `src/`) and does not try to guess whether a plausible POSIX path exists on the peer.

## Five sites

| # | where | reaches |
|---|---|---|
| 1 | `_get_env_config` — `TERMINAL_CWD` | environment creation |
| 2 | `_plan_execution` — per-task cwd override | every terminal call |
| 3 | `_resolve_command_cwd` — session cwd record | every command |
| 4 | `file_tools` | its own builder |
| 5 | `code_execution_tool` | its own builder |

Sites 3–5 are the ones easy to miss.

**Site 3 carries a failure that sustains itself.** `register_task_env_overrides` writes a registered override straight into the session record, and `cd` dies before the shell prints the cwd marker — so the record is never corrected, and the same bad value is re-recorded after every command. Once a session is poisoned it stays poisoned.

**Sites 4 and 5 build their own environments** and never route through `_resolve_command_cwd`, so guarding the terminal path alone leaves them open. `file_tools` also reads *both* sources — the registered override and the session record.

At site 2 the container branch remaps a mounted host workspace to `/workspace`. The ssh branch does not: there is no mount on the peer, so the only safe value is the already-sanitized config cwd.

## Tests

21, covering the predicate and all five sites.

The four cases that drive `_plan_execution` exist for a specific reason: mutation testing showed site 2's guard could be disabled with **every other test still green**. Wiring a guard no test exercises is the failure mode this whole change is about, so it seemed worth not repeating it here.

All eight mutations now fail the suite — the five guards, the tilde exemption, and both verdict inversions — with the sources restored and verified by hash afterwards.

One test documents behaviour this PR does **not** change: `execute_code` reads overrides under the collapsed container id, so a CWD-only override never reaches it without an isolation key. If that lookup is ever unified with the terminal and file layers, that test is the one that should start failing.

## Regression

`tests/tools -k "ssh or cwd or terminal or file_tool or code_exec or container"`, with the new file excluded, gives exactly `main`'s result: the same 5 pre-existing failures, 808 passed on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
