### PR TITLE
feat(moa): make the advisory tool-result budget config-driven per preset

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -637,7 +637,9 @@ _ADVISORY_INSTRUCTION = (
 )
 
 
-def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _reference_messages(
+    messages: list[dict[str, Any]], *, tool_result_budget: int = _REFERENCE_TOOL_RESULT_BUDGET,
+) -> list[dict[str, Any]]:
     """Build the advisory (reference-model) view of the conversation.
 
     Plain user/assistant TEXT turns only: system prompt dropped, tool_calls rendered
@@ -673,7 +675,7 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         elif role == "tool":
             # Fold the tool result into the preceding assistant turn as text (a leading
             # tool result with no assistant turn opens one).
-            block = f"[tool result: {_truncate_tool_result(text)}]"
+            block = f"[tool result: {_truncate_tool_result(text, budget=tool_result_budget)}]"
             if rendered and rendered[-1].get("role") == "assistant":
                 rendered[-1]["content"] = rendered[-1]["content"] + "\n" + block
             else:
@@ -720,6 +722,26 @@ def _preset_temperature(preset: dict[str, Any], key: str) -> float | None:
     except (TypeError, ValueError):
         logger.warning("ignoring non-numeric %s=%r in MoA preset", key, value)
         return None
+
+
+def _preset_tool_result_budget(preset: Any) -> int:
+    """Per-tool-result advisory budget from a preset, clamped; falls back to the module default.
+
+    Config-driven (``moa.presets.<name>.reference_tool_result_budget``) so PDF/vision-heavy
+    tool loops can widen the advisory view without editing this source file, which a
+    ``hermes update`` (git pull) would overwrite.
+    """
+    if not isinstance(preset, dict):
+        return _REFERENCE_TOOL_RESULT_BUDGET
+    raw = preset.get("reference_tool_result_budget")
+    if raw is None:
+        return _REFERENCE_TOOL_RESULT_BUDGET
+    try:
+        from hermes_cli.moa_config import _coerce_reference_tool_result_budget
+        return _coerce_reference_tool_result_budget(raw)
+    except Exception:  # pragma: no cover - bad config must not break MoA
+        logger.debug("MoA reference_tool_result_budget coercion failed for %r", raw)
+        return _REFERENCE_TOOL_RESULT_BUDGET
 
 
 def _hash_messages(msgs: list[dict[str, Any]]) -> str:
@@ -781,6 +803,7 @@ def aggregate_moa_context(
     aggregator: dict[str, Any], temperature: float | None = None, aggregator_temperature: float | None = None,
     reference_max_tokens: int | None = None, reference_timeout: float | None = None,
     degraded_reference_policy: str = "loud", agent: Any = None,
+    reference_tool_result_budget: int = _REFERENCE_TOOL_RESULT_BUDGET,
 ) -> str:
     """Run configured reference models and synthesize their advice (one-shot /moa).
 
@@ -796,7 +819,7 @@ def aggregate_moa_context(
     """
     reference_models = [slot for slot in reference_models if slot.get("enabled", True)]
     reference_outputs = _run_references_parallel(
-        reference_models, _reference_messages(api_messages), temperature=temperature,
+        reference_models, _reference_messages(api_messages, tool_result_budget=reference_tool_result_budget), temperature=temperature,
         max_tokens=reference_max_tokens, reference_timeout=reference_timeout, agent=agent,
     )
     privacy_full = False
@@ -1302,7 +1325,9 @@ class MoAChatCompletions:
         if aggregator_temperature is None and api_kwargs.get("temperature") is not None:
             aggregator_temperature = api_kwargs.get("temperature")
 
-        ref_messages = _reference_messages(messages)
+        ref_messages = _reference_messages(
+            messages, tool_result_budget=_preset_tool_result_budget(preset)
+        )
         cache_key = self._fanout_cache_key(preset, ref_messages, reference_models)
         if cache_key == self._ref_cache_key and self._ref_cache_outputs:
             # HIT: already ran and accounted. Do NOT zero pending totals (a late

--- a/agent/turn_request_assembly.py
+++ b/agent/turn_request_assembly.py
@@ -42,7 +42,11 @@ def _append_moa_context(agent: Any, api_messages: Any, moa_config: Any, original
     message (as a trailing text part on multimodal turns). Fail-open."""
     try:
         from agent.message_content import flatten_message_text as _flatten_mt
-        from agent.moa_loop import _preset_temperature, aggregate_moa_context
+        from agent.moa_loop import (
+            _preset_temperature,
+            _preset_tool_result_budget,
+            aggregate_moa_context,
+        )
 
         _moa_context = aggregate_moa_context(
             user_prompt=(
@@ -67,6 +71,7 @@ def _append_moa_context(agent: Any, api_messages: Any, moa_config: Any, original
             degraded_reference_policy=str(
                 moa_config.get("degraded_reference_policy") or "loud"
             ),
+            reference_tool_result_budget=_preset_tool_result_budget(moa_config),
             agent=agent,
         )
         if not _moa_context:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3192,6 +3192,12 @@ _DYNAMIC_TOP_LEVEL_KEYS = frozenset({
 # both top-level and under ``gateway``; anything below the name is accepted (open ``extra``).
 _PLATFORM_CONTAINER_KEYS = frozenset({"platforms"})
 
+# Containers whose immediate child is user-named but whose descendants follow the schema of a
+# template child in DEFAULT_CONFIG. This keeps dynamic names open without making their fields open.
+_DYNAMIC_SCHEMA_TEMPLATES = {
+    ("moa", "presets"): "default",
+}
+
 
 # Top-level keys whose sub-keys are accepted without deep checking.
 _OPEN_SUBKEY_TOP_LEVEL_KEYS = _OPEN_DICT_TOP_LEVEL_KEYS | _DYNAMIC_TOP_LEVEL_KEYS | _SCHEMA_DEFINED_DICT_KEYS
@@ -3246,6 +3252,11 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     for seg in segments[1:]:
         if seg in _PLATFORM_CONTAINER_KEYS or not isinstance(node, dict):
             return True, None
+        template_key = _DYNAMIC_SCHEMA_TEMPLATES.get(tuple(consumed))
+        if template_key is not None:
+            node = node.get(template_key)
+            consumed.append(seg)
+            continue
         if seg not in node:
             sibling = _suggest_closest_key(seg, set(node.keys()))
             return False, ".".join(consumed + [sibling]) if sibling is not None else None

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1314,7 +1314,9 @@ DEFAULT_CONFIG = {
                     {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"},
                 ],
                 "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
-
+                # Max characters retained from each tool result in the advisory view.
+                # Applied as a head+tail preview; normalization clamps to [1000, 32000].
+                "reference_tool_result_budget": 4000,
                 "enabled": True,
             }
         },

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -6,6 +6,7 @@ import base64
 import json
 import math
 from copy import deepcopy
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 MOA_MARKER_PREFIX = "__HERMES_MOA_TURN_V1__"
@@ -19,6 +20,37 @@ DEFAULT_MOA_AGGREGATOR: dict[str, str] = {
     "provider": "openrouter", "model": "anthropic/claude-opus-4.8"}
 
 DEFAULT_MOA_REFERENCE_TIMEOUT: float | None = None
+
+# Per-tool-result char budget for the advisory (reference-model) view. Config-driven so a preset
+# can widen it (e.g. for PDF/vision-heavy tool loops) without editing agent/moa_loop.py source,
+# which would not survive `hermes update` (git pull). Clamped to [1000, 32000]: too low loses all
+# tool-result context, too high risks flooding a reference model's window across many tool calls
+# in one advisory turn (per-result budget, not a per-turn total).
+DEFAULT_MOA_REFERENCE_TOOL_RESULT_BUDGET = 4000
+_MIN_REFERENCE_TOOL_RESULT_BUDGET = 1000
+_MAX_REFERENCE_TOOL_RESULT_BUDGET = 32000
+
+
+def _coerce_reference_tool_result_budget(value: Any) -> int:
+    """Normalize a positive numeric budget, or use 4000 for invalid/non-finite input.
+
+    Finite values are truncated toward zero, then clamped to [1000, 32000]. Decimal parsing keeps
+    huge finite strings distinct from infinities, so they safely clamp to the upper bound.
+    """
+    if isinstance(value, bool):  # bool is an int subclass: True would clamp to the minimum
+        return DEFAULT_MOA_REFERENCE_TOOL_RESULT_BUDGET
+    try:
+        number = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return DEFAULT_MOA_REFERENCE_TOOL_RESULT_BUDGET
+    if not number.is_finite() or number <= 0:
+        return DEFAULT_MOA_REFERENCE_TOOL_RESULT_BUDGET
+    if number >= _MAX_REFERENCE_TOOL_RESULT_BUDGET:
+        return _MAX_REFERENCE_TOOL_RESULT_BUDGET
+    result = int(number)
+    if result <= 0:
+        return DEFAULT_MOA_REFERENCE_TOOL_RESULT_BUDGET
+    return max(_MIN_REFERENCE_TOOL_RESULT_BUDGET, min(result, _MAX_REFERENCE_TOOL_RESULT_BUDGET))
 
 
 def _default_reference_models() -> list[dict[str, Any]]:
@@ -227,6 +259,10 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # Failed-advisor disclosure policy; unknown values fail loud.
         "degraded_reference_policy": policy if policy in {"loud", "silent"} else "loud",
 
+        # Per-tool-result char budget for the advisory view (head+tail preview); config-driven
+        # so PDF/vision-heavy tool loops can widen it without editing moa_loop.py source.
+        "reference_tool_result_budget": _coerce_reference_tool_result_budget(raw.get("reference_tool_result_budget")),
+
         # "user_turn" (default, cheapest): advisors run ONCE per user turn; "per_iteration": every
         # tool iteration; "every_n:<N>": first iteration of each turn and every Nth after.
         "fanout": _coerce_fanout(raw.get("fanout"))}
@@ -235,7 +271,7 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
 _FLAT_PRESET_KEYS = (
     "reference_models", "aggregator", "reference_temperature", "aggregator_temperature",
     "reference_timeout", "degraded_reference_policy",
-    "fanout", "enabled")
+    "fanout", "enabled", "reference_tool_result_budget")
 
 
 # When the reference fan-out runs. "user_turn" (default) runs the advisors ONCE per user turn (the original

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -7,6 +7,11 @@ from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, SecretStr, StrictBool, field_validator
 
+from hermes_cli.moa_config import (
+    DEFAULT_MOA_REFERENCE_TOOL_RESULT_BUDGET,
+    _coerce_reference_tool_result_budget,
+)
+
 
 class ConfigUpdate(BaseModel):
     config: dict
@@ -115,6 +120,7 @@ class MoaModelSlot(BaseModel):
 class _MoaReferenceControls(BaseModel):
     # None = no per-preset override; inherits auxiliary.moa_reference.timeout (900s default).
     reference_timeout: Optional[float] = None
+    reference_tool_result_budget: int = DEFAULT_MOA_REFERENCE_TOOL_RESULT_BUDGET
     degraded_reference_policy: Literal["loud", "silent"] = "loud"
 
     @field_validator("reference_timeout", mode="before")
@@ -130,6 +136,11 @@ class _MoaReferenceControls(BaseModel):
         if not math.isfinite(timeout) or timeout <= 0:
             raise ValueError("reference_timeout must be a finite positive number")
         return timeout
+
+    @field_validator("reference_tool_result_budget", mode="before")
+    @classmethod
+    def _normalize_reference_tool_result_budget(cls, value: Any) -> int:
+        return _coerce_reference_tool_result_budget(value)
 
 class MoaPresetPayload(_MoaReferenceControls):
     reference_models: list[MoaModelSlot] = []

--- a/hermes_cli/web_routers/models.py
+++ b/hermes_cli/web_routers/models.py
@@ -228,7 +228,7 @@ def get_moa_models(profile: Optional[str] = None):
 
 _MOA_PRESET_FIELDS = (
     "reference_temperature", "aggregator_temperature", "reference_timeout",
-    "degraded_reference_policy", "fanout", "enabled",
+    "reference_tool_result_budget", "degraded_reference_policy", "fanout", "enabled",
 )
 
 

--- a/tests/agent/test_moa_tool_result_budget.py
+++ b/tests/agent/test_moa_tool_result_budget.py
@@ -1,0 +1,142 @@
+"""Regression coverage for the config-driven MoA tool-result budget."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent import moa_loop
+from agent.turn_request_assembly import _append_moa_context
+from hermes_cli.config import _validate_config_key
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+from hermes_cli.moa_config import (
+    _coerce_reference_tool_result_budget,
+    normalize_moa_config,
+    resolve_moa_preset,
+)
+
+
+def _tool_transcript(size: int = 50_000) -> list[dict]:
+    return [
+        {"role": "user", "content": "inspect"},
+        {"role": "assistant", "content": "", "tool_calls": []},
+        {"role": "tool", "tool_call_id": "c1", "content": "X" * size},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, 4000),
+        (True, 4000),
+        (0, 4000),
+        (-1, 4000),
+        (500, 1000),
+        (12_000, 12_000),
+        (99_999, 32_000),
+        ("12000", 12_000),
+        ("bad", 4000),
+    ],
+)
+def test_reference_tool_result_budget_normalization(raw, expected):
+    cfg = normalize_moa_config({"reference_tool_result_budget": raw})
+    assert cfg["reference_tool_result_budget"] == expected
+    assert cfg["presets"]["default"]["reference_tool_result_budget"] == expected
+
+
+def test_default_config_declares_budget_as_known_key():
+    assert DEFAULT_CONFIG["moa"]["presets"]["default"]["reference_tool_result_budget"] == 4000
+    assert _validate_config_key("moa.presets.default.reference_tool_result_budget") == (True, None)
+
+
+def test_config_validation_accepts_custom_preset_budget_key():
+    assert _validate_config_key("moa.presets.review.reference_tool_result_budget") == (True, None)
+
+
+def test_config_validation_rejects_unknown_custom_preset_field():
+    is_known, suggestion = _validate_config_key(
+        "moa.presets.review.reference_tool_result_budge"
+    )
+
+    assert not is_known
+    assert suggestion == "moa.presets.review.reference_tool_result_budget"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [float("inf"), float("-inf"), float("nan"), "inf", "-inf", "nan"],
+    ids=["positive-infinity", "negative-infinity", "nan", "string-inf", "string-neg-inf", "string-nan"],
+)
+def test_non_finite_reference_tool_result_budgets_fall_back(raw):
+    assert _coerce_reference_tool_result_budget(raw) == 4000
+
+
+@pytest.mark.parametrize("raw", ["1e1000000", "9" * 5000], ids=["huge-exponent", "huge-integer"])
+def test_huge_finite_reference_tool_result_budgets_clamp(raw):
+    assert _coerce_reference_tool_result_budget(raw) == 32_000
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [(12_000.9, 12_000), ("12000.9", 12_000), (999.9, 1000), (0.9, 4000)],
+)
+def test_fractional_reference_tool_result_budgets_truncate_toward_zero(raw, expected):
+    assert _coerce_reference_tool_result_budget(raw) == expected
+
+
+def test_reference_messages_honors_custom_budget():
+    view = moa_loop._reference_messages(_tool_transcript(), tool_result_budget=12_000)
+    rendered = "\n".join(str(message.get("content") or "") for message in view)
+    assert rendered.count("X") == 12_000
+    assert "chars omitted" in rendered
+
+
+def test_persistent_moa_create_uses_preset_budget(monkeypatch):
+    preset = resolve_moa_preset(
+        {
+            "presets": {
+                "review": {
+                    "reference_models": [],
+                    "aggregator": {"provider": "openrouter", "model": "aggregator"},
+                    "reference_tool_result_budget": 12_000,
+                }
+            },
+            "default_preset": "review",
+        },
+        "review",
+    )
+    monkeypatch.setattr(moa_loop, "_resolve_preset_cached", lambda _name: (preset, {}))
+    captured = {}
+
+    facade = moa_loop.MoAChatCompletions("review")
+
+    def fake_run_fanout(_preset, ref_messages, *_args):
+        captured["messages"] = ref_messages
+        return []
+
+    monkeypatch.setattr(facade, "_run_fanout", fake_run_fanout)
+    facade.prepare(_tool_transcript())
+
+    rendered = "\n".join(str(message.get("content") or "") for message in captured["messages"])
+    assert rendered.count("X") == 12_000
+
+
+def test_one_shot_path_forwards_preset_budget(monkeypatch):
+    captured = {}
+
+    def fake_aggregate_moa_context(**kwargs):
+        captured.update(kwargs)
+        return ""
+
+    monkeypatch.setattr(moa_loop, "aggregate_moa_context", fake_aggregate_moa_context)
+    _append_moa_context(
+        SimpleNamespace(),
+        [{"role": "user", "content": "inspect"}],
+        {
+            "reference_models": [],
+            "aggregator": {},
+            "reference_tool_result_budget": 12_000,
+        },
+        "inspect",
+    )
+
+    assert captured["reference_tool_result_budget"] == 12_000

--- a/tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py
+++ b/tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from hermes_cli.moa_config import normalize_moa_config
 from hermes_cli.web_models import MoaConfigPayload, MoaModelSlot, MoaPresetPayload
 from hermes_cli.web_routers.models import set_moa_models
 
@@ -80,5 +81,51 @@ class TestSetMoaModelsPreservesUndeclaredKeys:
         assert moa.get("trace_dir") == "/custom/traces", (
             "trace_dir was dropped by set_moa_models"
         )
+
+
+def _put_payload(payload: MoaConfigPayload) -> tuple[dict, dict]:
+    saved_cfg = {}
+
+    def fake_save_config(cfg):
+        saved_cfg.update(cfg)
+
+    with (
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("hermes_cli.config.save_config", side_effect=fake_save_config),
+        patch("hermes_cli.web_server_profiles._profile_scope"),
+    ):
+        response = set_moa_models(payload)
+    return response, saved_cfg
+
+
+def test_named_preset_put_round_trip_preserves_reference_tool_result_budget():
+    get_response = normalize_moa_config({
+        "default_preset": "review",
+        "presets": {
+            "review": {
+                "reference_models": [{"provider": "openai-codex", "model": "gpt-5.5"}],
+                "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                "reference_tool_result_budget": 12_000,
+            },
+        },
+    })
+
+    response, saved_cfg = _put_payload(MoaConfigPayload(**get_response))
+
+    assert response["presets"]["review"]["reference_tool_result_budget"] == 12_000
+    assert saved_cfg["moa"]["presets"]["review"]["reference_tool_result_budget"] == 12_000
+
+
+def test_legacy_flat_put_round_trip_preserves_reference_tool_result_budget():
+    payload = MoaConfigPayload(
+        reference_models=[MoaModelSlot(provider="openai-codex", model="gpt-5.5")],
+        aggregator=MoaModelSlot(provider="openrouter", model="anthropic/claude-opus-4.8"),
+        reference_tool_result_budget=12_000,
+    )
+
+    response, saved_cfg = _put_payload(payload)
+
+    assert response["reference_tool_result_budget"] == 12_000
+    assert saved_cfg["moa"]["presets"]["default"]["reference_tool_result_budget"] == 12_000
 
 


### PR DESCRIPTION
## Summary

MoA reference models (the advisors fanned out to before the aggregator acts)
only ever see a hardcoded 4000-character head+tail preview of each tool
result — `_REFERENCE_TOOL_RESULT_BUDGET` in `agent/moa_loop.py`. For
CJK-heavy or document-analysis workloads (e.g. reviewing a patent PDF via
tool calls), 4000 chars is roughly 2000–3000 effective Chinese characters
once punctuation/ASCII overhead is factored in — often too little for a
reference model to say anything useful about what a tool actually returned.

This PR makes that budget configurable per MoA preset, with a safe
fallback, instead of requiring a source edit that `hermes update` would
overwrite on the next pull.

## What changed

- **`hermes_cli/moa_config.py`**: new `_coerce_reference_tool_result_budget()`
  — normalizes to an int in `[1000, 32000]`; every invalid/missing/non-finite
  input (`None`, `False`/`True`, `0`, negative, `"bad"`, `inf`, `-inf`, `nan`,
  absurdly large numeric strings, fractional values) falls back to `4000`
  rather than raising. Field is added to `_normalize_preset()` and
  `_FLAT_PRESET_KEYS`.
- **`hermes_cli/config_defaults.py`**: `DEFAULT_CONFIG["moa"]["presets"]["default"]`
  declares `reference_tool_result_budget: 4000` so the key is documented and
  recognized out of the box.
- **`agent/moa_loop.py`**:
  - `_reference_messages()` accepts a `tool_result_budget` kwarg (was
    hardcoded via the module constant).
  - New `_preset_tool_result_budget(preset)` helper resolves + clamps the
    preset's value, falling back to the module constant on any failure.
  - `MoAChatCompletions.create()` (the persistent MoA loop) and
    `aggregate_moa_context()` (the one-shot `/moa <prompt>` path) both now
    thread the preset's budget through to `_reference_messages`.
- **`agent/turn_request_assembly.py`**: `_append_moa_context()` passes
  `_preset_tool_result_budget(moa_config)` into `aggregate_moa_context()`.
- **`hermes_cli/config.py`**: `_validate_config_key()` previously only
  recognized sub-keys under the literal `moa.presets.default.*` path — a
  user-named preset (`moa.presets.review.*`) would incorrectly warn as an
  unrecognized key. Added `_DYNAMIC_SCHEMA_TEMPLATES` so any preset name
  under `moa.presets.<name>` is validated against the `default` preset's
  schema, while genuine typos (`reference_tool_result_budge`) are still
  rejected with a suggestion.
- **`hermes_cli/web_models.py`** / **`hermes_cli/web_routers/models.py`**:
  `_MoaReferenceControls` (and therefore both `MoaPresetPayload` and the
  legacy flat `MoaConfigPayload`) declares `reference_tool_result_budget`
  with the same coercion/clamping validator, and it's added to
  `_MOA_PRESET_FIELDS` — so a dashboard `PUT /api/model/moa` round-trip no
  longer silently drops the setting for either named-preset or legacy
  payload shapes.

## Why per-preset config instead of just raising the constant

A hardcoded bump would still be lost on every `hermes update` (git pull)
and requires editing agent internals to tune. This exposes it exactly like
`fanout`, `reference_timeout`, etc. — a normal `moa.presets.<name>.*` knob,
settable via `hermes config set` or the dashboard, without touching source.

## Backward compatibility

- Default/fallback value is unchanged at `4000` — existing configs and
  presets that never set this key behave identically to before.
- This is purely additive: no existing field was renamed or removed.

## Testing

- `tests/agent/test_moa_tool_result_budget.py` (new): budget normalization
  boundaries (missing/bool/zero/negative/huge/string/non-finite/fractional
  inputs), CLI validation for both the default and a custom preset name
  (plus typo rejection), `_reference_messages` truncation at a custom
  budget, and that both the persistent (`MoAChatCompletions.create`) and
  one-shot (`aggregate_moa_context` via `_append_moa_context`) paths
  actually forward the preset's configured value.
- `tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py` (extended):
  PUT round-trip preserves `reference_tool_result_budget` for both a named
  preset payload and the legacy flat payload shape.
- `scripts/run_tests.sh tests/agent/test_moa_tool_result_budget.py tests/hermes_cli/test_moa_config.py tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py tests/hermes_cli/test_set_config_value.py` → **129 passed**
  (re-verified again with `tests/run_agent/test_moa_loop_mode.py` included → **156 passed** on a clean shared clone of this branch).
- `ruff check` on all touched files → clean.
- Two independent review passes (fresh-context code review) run against the
  diff; first pass caught three gaps (custom-preset CLI validation,
  non-finite input crash, API round-trip drop), all fixed and re-verified;
  second pass: no remaining logic or security issues found.

## Not in scope

- No change to the `fanout` modes (`user_turn` / `per_iteration` /
  `every_n:<N>`) themselves — this PR only affects the per-tool-result
  character budget.
- No UI/dashboard form field was added for this setting in this PR (it's
  settable via `hermes config set` and preserved correctly if set via a
  raw API payload, but no new dashboard input control is included).
