### PR TITLE
fix(terminal): don't send a Hermes-host cwd to the ssh peer

### DIFF
--- a/tests/tools/test_ssh_cwd_sanitize.py
+++ b/tests/tools/test_ssh_cwd_sanitize.py
@@ -1,0 +1,272 @@
+"""Host-path cwd sanitization on the ssh backend.
+
+``ssh`` is the one backend whose cwd is resolved by a shell on *another*
+machine. A path taken from this host is not merely useless there: ``cd`` fails
+and the command returns 126 before it runs. The guards that already exist for
+that mistake are all scoped to container backends, and ``ssh`` is not one of
+them -- and the container predicate is the wrong one for it anyway, since a
+container must reject ``/Users/me`` while over ssh that is very likely exactly
+where the caller means to run.
+
+Measured on a Windows host driving a macOS peer, 2026-09-07: a worker exported
+``TERMINAL_CWD`` as its own Windows workspace, and ``sw_vers`` and
+``sysctl -n hw.model`` both came back ``exit 126`` until the caller passed an
+explicit ``workdir``.
+
+There are five places a cwd reaches a command or an environment builder, and
+all five needed the guard:
+
+  1. ``_get_env_config``      TERMINAL_CWD               -> env creation
+  2. ``terminal_tool``        per-task cwd override      -> env creation
+  3. ``_resolve_command_cwd`` session cwd record         -> every command
+  4. ``file_tools``           its own builder            -> its own env
+  5. ``code_execution_tool``  its own builder            -> its own env
+
+Sites 3-5 are the ones that are easy to miss. 3 carries the failure that
+sustains itself: ``cd`` dies before the cwd marker is printed, so the record is
+never corrected and the same value is re-recorded after every command. 4 and 5
+build their own environments and do not route through ``_resolve_command_cwd``.
+"""
+
+import tools.terminal_tool as tt
+import tools.terminal_tool_config as cfg
+
+
+class TestIsUnusableSSHCwd:
+    def test_the_measured_case(self):
+        assert cfg._is_unusable_ssh_cwd(
+            r"D:\agent\workspaces\task") is True
+
+    def test_any_drive_either_slash(self):
+        for p in (r"C:\Users\me", "C:/Users/me", r"D:\work", "d:/work", r"Z:\x"):
+            assert cfg._is_unusable_ssh_cwd(p) is True, p
+
+    def test_relative_paths(self):
+        for p in (".", "..", "src/", "work/project"):
+            assert cfg._is_unusable_ssh_cwd(p) is True, p
+
+    def test_tilde_is_the_peers_own_home(self):
+        assert cfg._is_unusable_ssh_cwd("~") is False
+        assert cfg._is_unusable_ssh_cwd("~/work") is False
+
+    def test_absolute_posix_paths_are_kept(self):
+        # We do not guess whether these exist on the peer; only reject what
+        # cannot work. /Users/me is a host path for a container and a perfectly
+        # good remote path here -- which is why ssh needs its own predicate.
+        for p in ("/Users/me", "/home/joon", "/opt/data", "/"):
+            assert cfg._is_unusable_ssh_cwd(p) is False, p
+
+    def test_empty_is_not_flagged(self):
+        assert cfg._is_unusable_ssh_cwd("") is False
+
+
+class TestSessionRecordIsSanitized:
+    """Site 3 -- the one that carries the self-sustaining failure."""
+
+    def test_host_record_is_dropped_on_ssh(self):
+        tt.record_session_cwd("sess-ssh-rec", r"D:\hermes\workspaces\task")
+        try:
+            assert tt._resolve_command_cwd(
+                workdir=None, default_cwd="~",
+                env_type="ssh", session_key="sess-ssh-rec") == "~"
+        finally:
+            tt.clear_session_cwd("sess-ssh-rec")
+
+    def test_remote_record_is_kept(self):
+        tt.record_session_cwd("sess-ssh-ok", "/Users/me/work")
+        try:
+            assert tt._resolve_command_cwd(
+                workdir=None, default_cwd="~",
+                env_type="ssh", session_key="sess-ssh-ok") == "/Users/me/work"
+        finally:
+            tt.clear_session_cwd("sess-ssh-ok")
+
+    def test_explicit_workdir_still_wins(self):
+        # workdir= is the caller saying where this must run; the guard must not
+        # second-guess it. Passing one is also how the bug was worked around
+        # before the fix existed.
+        tt.record_session_cwd("sess-ssh-wd", r"D:\hermes")
+        try:
+            assert tt._resolve_command_cwd(
+                workdir="/Users/me", default_cwd="~",
+                env_type="ssh", session_key="sess-ssh-wd") == "/Users/me"
+        finally:
+            tt.clear_session_cwd("sess-ssh-wd")
+
+    def test_other_backends_are_untouched(self):
+        tt.record_session_cwd("sess-other", "/workspace/task")
+        try:
+            for backend in ("local", "docker", "modal"):
+                assert tt._resolve_command_cwd(
+                    workdir=None, default_cwd="/root",
+                    env_type=backend, session_key="sess-other") == "/workspace/task", backend
+        finally:
+            tt.clear_session_cwd("sess-other")
+
+
+class TestEnvironmentBuildersAreSanitized:
+    """Sites 1, 2, 4 and 5 -- everything that builds an environment.
+
+    Unit-testing the predicate is not enough: the first version of a fix like
+    this can wire a guard that no test exercises, and the suite stays green.
+    Each of these drives a real builder and asserts on the cwd it hands out.
+    """
+
+    @staticmethod
+    def _config(cwd="~"):
+        return {
+            "env_type": "ssh", "docker_image": "", "singularity_image": "",
+            "modal_image": "", "daytona_image": "",
+            "cwd": cwd, "host_cwd": None, "timeout": 180, "lifetime_seconds": 300,
+            "container_cpu": 1, "container_memory": 5120, "container_disk": 51200,
+            "container_persistent": True, "docker_volumes": [], "docker_env": {},
+            "docker_extra_args": [], "docker_forward_env": [],
+            "docker_run_as_host_user": False, "docker_network": True,
+            "docker_mount_cwd_to_workspace": False, "modal_mode": "auto",
+            "local_persistent": False,
+            "ssh_host": "peer", "ssh_user": "me", "ssh_port": 22, "ssh_key": "",
+        }
+
+    def _patch_builder(self, monkeypatch, captured, config):
+        import tools.terminal_tool_backends as backends
+
+        class _DummyEnv:
+            cwd = config["cwd"]
+
+            def execute(self, *a, **k):
+                captured.setdefault("execute_cwds", []).append(k.get("cwd"))
+                return {"output": "", "exit_code": 0}
+
+        def fake_create_environment(**kwargs):
+            captured["create_cwd"] = kwargs.get("cwd")
+            return _DummyEnv()
+
+        monkeypatch.setattr(tt, "_get_env_config", lambda: config)
+        monkeypatch.setattr(backends, "_create_environment", fake_create_environment)
+        monkeypatch.setattr(tt, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setattr(tt, "_active_environments", {})
+        monkeypatch.setattr(tt, "_last_activity", {})
+
+    def _drive(self, monkeypatch, build, override_cwd, extra_overrides=None):
+        captured = {}
+        config = self._config()
+        self._patch_builder(monkeypatch, captured, config)
+        task_id = "sess-ssh-builder"
+        overrides = {"cwd": override_cwd}
+        overrides.update(extra_overrides or {})
+        tt.register_task_env_overrides(task_id, overrides)
+        try:
+            build(task_id)
+        finally:
+            tt.clear_task_env_overrides(task_id)
+            tt.clear_session_cwd(task_id)
+            tt._active_environments.pop(task_id, None)
+            tt._active_environments.pop("default", None)
+        return captured
+
+    def test_file_tools_builder(self, monkeypatch):
+        import tools.file_tools as ft
+        cap = self._drive(monkeypatch, ft._get_file_ops, r"D:\hermes\workspaces\task")
+        assert cap["create_cwd"] == "~", (
+            f"file_tools built an ssh environment in {cap['create_cwd']!r}; "
+            "every command it runs would die in `cd` with 126.")
+
+    def test_file_tools_keeps_a_remote_path(self, monkeypatch):
+        import tools.file_tools as ft
+        cap = self._drive(monkeypatch, ft._get_file_ops, "/Users/me/work")
+        assert cap["create_cwd"] == "/Users/me/work"
+
+    # execute_code reads overrides under the COLLAPSED container id, so a
+    # CWD-only override never reaches it -- it collapses to the shared
+    # "default" key. An isolation key (env_type / *_image, as RL and benchmark
+    # harnesses register) keeps the raw id, and that is the path on which a
+    # host cwd does reach this builder today. Both cases are pinned.
+    _ISOLATION = {"env_type": "ssh"}
+
+    def test_code_execution_builder(self, monkeypatch):
+        import tools.code_execution_tool as cet
+        cap = self._drive(monkeypatch, cet._get_or_create_env,
+                          r"D:\hermes\workspaces\task", self._ISOLATION)
+        assert cap["create_cwd"] == "~"
+
+    def test_code_execution_keeps_a_remote_path(self, monkeypatch):
+        import tools.code_execution_tool as cet
+        cap = self._drive(monkeypatch, cet._get_or_create_env,
+                          "/Users/me/work", self._ISOLATION)
+        assert cap["create_cwd"] == "/Users/me/work"
+
+    def test_code_execution_cwd_only_override_does_not_reach_it_today(self, monkeypatch):
+        # Documents the collapsed-lookup behaviour this branch does not change:
+        # without an isolation key the override is not seen at all, so the
+        # builder falls back to the config cwd. If that lookup is ever unified
+        # with the terminal and file layers, this test should start failing and
+        # the expectation becomes "/Users/me/work".
+        import tools.code_execution_tool as cet
+        cap = self._drive(monkeypatch, cet._get_or_create_env, "/Users/me/work")
+        assert cap["create_cwd"] == "~"
+
+
+class TestConfigCwdIsSanitized:
+    """Site 1 -- TERMINAL_CWD itself."""
+
+    def test_host_terminal_cwd_falls_back_to_remote_home(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "peer")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "me")
+        monkeypatch.setenv("TERMINAL_CWD", r"D:\hermes\workspaces\task")
+        assert tt._get_env_config()["cwd"] == "~"
+
+    def test_remote_terminal_cwd_is_kept(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "peer")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "me")
+        monkeypatch.setenv("TERMINAL_CWD", "/Users/me/work")
+        assert tt._get_env_config()["cwd"] == "/Users/me/work"
+
+
+class TestPerCallOverrideIsSanitized:
+    """Site 2 -- the per-task override resolved on every terminal call.
+
+    This one is easy to wire and leave untested: the predicate tests and the
+    builder tests all stay green with this guard disabled. Mutation testing is
+    what surfaced that, so it gets its own case.
+    """
+
+    @staticmethod
+    def _plan(monkeypatch, override_cwd, config_cwd="~"):
+        config = {
+            "env_type": "ssh", "docker_image": "", "singularity_image": "",
+            "modal_image": "", "daytona_image": "",
+            "cwd": config_cwd, "host_cwd": None, "timeout": 180,
+            "lifetime_seconds": 300, "container_cpu": 1, "container_memory": 5120,
+            "container_disk": 51200, "container_persistent": True,
+            "docker_volumes": [], "docker_env": {}, "docker_extra_args": [],
+            "docker_forward_env": [], "docker_run_as_host_user": False,
+            "docker_network": True, "docker_mount_cwd_to_workspace": False,
+            "modal_mode": "auto", "local_persistent": False,
+            "ssh_host": "peer", "ssh_user": "me", "ssh_port": 22, "ssh_key": "",
+        }
+        monkeypatch.setattr(tt, "_get_env_config", lambda: config)
+        task_id = "sess-ssh-plan"
+        tt.register_task_env_overrides(task_id, {"cwd": override_cwd})
+        try:
+            plan = tt._plan_execution(
+                "pwd", task_id=task_id, timeout=None,
+                background=False, _host_local=False,
+            )
+        finally:
+            tt.clear_task_env_overrides(task_id)
+            tt.clear_session_cwd(task_id)
+        return plan.cwd
+
+    def test_host_override_is_replaced_by_the_config_cwd(self, monkeypatch):
+        assert self._plan(monkeypatch, r"D:\hermes\workspaces\task") == "~"
+
+    def test_relative_override_is_replaced(self, monkeypatch):
+        assert self._plan(monkeypatch, "src/") == "~"
+
+    def test_remote_override_is_preserved(self, monkeypatch):
+        assert self._plan(monkeypatch, "/Users/me/work") == "/Users/me/work"
+
+    def test_tilde_override_is_preserved(self, monkeypatch):
+        assert self._plan(monkeypatch, "~/work") == "~/work"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -396,6 +396,28 @@ def _call(tool_name, args):
 
 # ---- Remote execution support (file-based RPC via terminal backend) ----
 
+def _peer_safe_cwd(env_type: str, overrides: Dict[str, Any], config: Dict[str, Any]) -> str:
+    """Resolve the cwd for a freshly built environment, sanitized for ``ssh``.
+
+    A registered cwd override is a host path (a desktop/TUI/ACP session
+    recording its own workspace). Over ``ssh`` it is resolved by a shell on
+    the peer, where ``cd`` fails and every command returns 126 before it runs.
+    The other builders guard their own cwd; this one did not.
+    """
+    from tools.terminal_tool_config import _is_unusable_ssh_cwd
+
+    cwd = overrides.get("cwd") or config["cwd"]
+    if env_type == "ssh" and _is_unusable_ssh_cwd(cwd):
+        if cwd != config["cwd"]:
+            logger.info(
+                "Ignoring host cwd override %r for ssh backend "
+                "(won't resolve on the peer). Using %r instead.",
+                cwd, config["cwd"],
+            )
+        return config["cwd"]
+    return cwd
+
+
 def _get_or_create_env(task_id: str):
     """``(env, env_type)`` — the environment the terminal/file tools share for *task_id*, created on
     first use (same double-checked per-task lock pattern as file_tools._get_file_ops)."""
@@ -433,7 +455,7 @@ def _get_or_create_env(task_id: str):
                      env_type, effective_task_id[:8])
         env = _create_environment(
             env_type=env_type, image=_select_image(env_type, overrides, config),
-            cwd=overrides.get("cwd") or config["cwd"], timeout=config["timeout"],
+            cwd=_peer_safe_cwd(env_type, overrides, config), timeout=config["timeout"],
             ssh_config=_ssh_config_from_config(config) if env_type == "ssh" else None,
             container_config=container_config,
             local_config={"persistent": config.get("local_persistent", False)} if env_type == "local" else None,

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -258,6 +258,7 @@ def _create_terminal_env_for_file_ops(raw_task_id: str, task_id: str):
     from tools.terminal_tool_config import _is_container_backend
     from tools.terminal_tool import (
         _create_configured_env, _get_env_config, _is_unusable_container_cwd,
+        _is_unusable_ssh_cwd,
         _resolve_task_host_cwd, _select_image, get_session_cwd, resolve_task_overrides)
 
     config = _get_env_config()
@@ -283,6 +284,20 @@ def _create_terminal_env_for_file_ops(raw_task_id: str, task_id: str):
                 "Ignoring host/relative cwd override %r for %s backend "
                 "(won't exist in sandbox). Using %r instead.",
                 cwd, env_type, config["cwd"])
+        cwd = config["cwd"]
+    elif env_type == "ssh" and _is_unusable_ssh_cwd(cwd):
+        # file_tools builds its own environment and does not route through
+        # _resolve_command_cwd, so the terminal guards do not cover it -- and
+        # it reads BOTH sources above, the registered override and the session
+        # record. Over ssh the cost is not an empty search result but a shell
+        # that dies in `cd` with 126 before the tool's command runs, so a file
+        # tool arriving before any terminal command is enough to break a
+        # session outright.
+        if cwd != config["cwd"]:
+            logger.info(
+                "Ignoring host cwd override %r for ssh backend "
+                "(won't resolve on the peer). Using %r instead.",
+                cwd, config["cwd"])
         cwd = config["cwd"]
     logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
     terminal_env = _create_configured_env(

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -44,7 +44,8 @@ from tools.terminal_tool_lifecycle import (
     _evict_environment_for_task, cleanup_all_environments, ensure_task_env,
 )
 from tools.terminal_tool_config import (
-    _is_container_backend, _is_host_cwd, _is_unusable_container_cwd, _parse_env_var,
+    _is_container_backend, _is_host_cwd, _is_unusable_container_cwd,
+    _is_unusable_ssh_cwd, _parse_env_var,
     _plugin_env_flag, _quiet, _safe_getcwd, _tenv, _tenv_bool,
 )
 from tools.terminal_tool_backends import (
@@ -591,6 +592,11 @@ def _resolve_config_cwd(env_type: str, mount_docker_cwd: bool) -> tuple:
                     "(host/relative path won't work in sandbox). Using %r instead.",
                     cwd, env_type, default_cwd)
         cwd = default_cwd
+    elif env_type == "ssh" and cwd and _is_unusable_ssh_cwd(cwd) and cwd != default_cwd:
+        logger.info("Ignoring TERMINAL_CWD=%r for ssh backend "
+                    "(host path won't resolve on the peer). Using %r instead.",
+                    cwd, default_cwd)
+        cwd = default_cwd
     return cwd, host_cwd
 
 
@@ -781,6 +787,19 @@ def _resolve_command_cwd(
             recorded, env_type, default_cwd,
         )
         return default_cwd
+    if recorded and env_type == "ssh" and _is_unusable_ssh_cwd(recorded):
+        # register_task_env_overrides writes a registered override straight
+        # into the record, so a host path lands here even when the two
+        # env-creation guards did their job -- and the failure then sustains
+        # itself: `cd` dies before the cwd marker is printed, so the record is
+        # never corrected and the same value is re-recorded after every
+        # command.
+        logger.info(
+            "Ignoring recorded session cwd %r for ssh backend "
+            "(won't resolve on the peer). Using %r instead.",
+            recorded, default_cwd,
+        )
+        return default_cwd
     return recorded or default_cwd
 
 
@@ -948,6 +967,16 @@ def _plan_execution(
                 cwd, env_type, remapped,
             )
         cwd = remapped
+    elif env_type == "ssh" and _is_unusable_ssh_cwd(cwd):
+        # No /workspace remap here: there is no mount on the peer, so the only
+        # safe value is the already-sanitized config cwd.
+        if cwd != config["cwd"]:
+            logger.info(
+                "Ignoring host cwd override %r for ssh backend "
+                "(won't resolve on the peer). Using %r instead.",
+                cwd, config["cwd"],
+            )
+        cwd = config["cwd"]
     # Reject non-positive timeouts before deadline math: ``timeout or
     # default`` would silently turn 0 into the default, and a negative
     # value is truthy and would fire an immediate "-Ns" timeout.

--- a/tools/terminal_tool_config.py
+++ b/tools/terminal_tool_config.py
@@ -103,6 +103,27 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return bool(cwd) and (_is_host_cwd(cwd) or not os.path.isabs(cwd))
 
 
+def _is_unusable_ssh_cwd(cwd: str) -> bool:
+    """True if *cwd* can't be a working directory on the SSH peer.
+
+    ``ssh`` is the one backend whose cwd is resolved by a shell on *another*
+    machine, so a path taken from this host is not merely useless there --
+    ``cd`` fails and the command returns 126 before it runs.
+
+    It needs its own predicate rather than the container one. A container must
+    reject ``/Users/me`` because that path is absent inside the sandbox; over
+    ``ssh`` that is very likely exactly where the caller means to run. What
+    cannot work is a path that is not a POSIX path at all: a Windows drive, or
+    anything relative. ``~`` and ``~/...`` are the peer's own home and are left
+    for the remote shell to expand (see ``_is_ssh_remote_tilde_cwd``).
+    """
+    if not cwd:
+        return False
+    if cwd == "~" or cwd.startswith("~/"):
+        return False
+    return not cwd.startswith("/")
+
+
 def _tenv(name: str, default: str = "") -> str:
     """Scope-aware read of a ``TERMINAL_*`` variable. Every terminal setting
     must go through this: under gateway multiplexing the active profile's


### PR DESCRIPTION
`ssh` is the one backend whose working directory is resolved by a shell on **another machine**. A path taken from this host is not merely useless there: `cd` fails and the command returns 126 before it runs.

```
sw_vers             15.3s [exit 126]
sysctl -n hw.model   5.1s [exit 126]
(with an explicit workdir)
sw_vers              5.1s  ok
sysctl -n hw.model   5.3s  ok
```

Measured on a Windows host driving a macOS peer (2026-09-07): a worker exported `TERMINAL_CWD` as its own Windows workspace, and every command without an explicit `workdir` died in `cd`.

## Why ssh needs its own predicate

The guards that already exist for this class of mistake are all scoped to container backends, and `ssh` is not one of them. Widening them would be wrong: a container **must** reject `/Users/me` because that path is absent inside the sandbox, while over ssh that is very likely exactly where the caller means to run.

So `_is_unusable_ssh_cwd` is one rule — a remote cwd must be `~`, `~/...`, or an absolute POSIX path. It rejects only what *cannot* work (`D:\x`, `d:/x`, `.`, `src/`) and does not try to guess whether a plausible POSIX path exists on the peer.

## Five sites

| # | where | reaches |
|---|---|---|
| 1 | `_get_env_config` — `TERMINAL_CWD` | environment creation |
| 2 | `_plan_execution` — per-task cwd override | every terminal call |
| 3 | `_resolve_command_cwd` — session cwd record | every command |
| 4 | `file_tools` | its own builder |
| 5 | `code_execution_tool` | its own builder |

Sites 3–5 are the ones easy to miss.

**Site 3 carries a failure that sustains itself.** `register_task_env_overrides` writes a registered override straight into the session record, and `cd` dies before the shell prints the cwd marker — so the record is never corrected, and the same bad value is re-recorded after every command. Once a session is poisoned it stays poisoned.

**Sites 4 and 5 build their own environments** and never route through `_resolve_command_cwd`, so guarding the terminal path alone leaves them open. `file_tools` also reads *both* sources — the registered override and the session record.

At site 2 the container branch remaps a mounted host workspace to `/workspace`. The ssh branch does not: there is no mount on the peer, so the only safe value is the already-sanitized config cwd.

## Tests

21, covering the predicate and all five sites.

The four cases that drive `_plan_execution` exist for a specific reason: mutation testing showed site 2's guard could be disabled with **every other test still green**. Wiring a guard no test exercises is the failure mode this whole change is about, so it seemed worth not repeating it here.

All eight mutations now fail the suite — the five guards, the tilde exemption, and both verdict inversions — with the sources restored and verified by hash afterwards.

One test documents behaviour this PR does **not** change: `execute_code` reads overrides under the collapsed container id, so a CWD-only override never reaches it without an isolation key. If that lookup is ever unified with the terminal and file layers, that test is the one that should start failing.

## Regression

`tests/tools -k "ssh or cwd or terminal or file_tool or code_exec or container"`, with the new file excluded, gives exactly `main`'s result: the same 5 pre-existing failures, 808 passed on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
