### PR TITLE
fix(agent): explain guardrail blocker in user-visible halt reply

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1210,11 +1210,22 @@ class AIAgent(
             self._tool_guardrail_halt_decision = decision
 
     def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
+        # User-visible final reply. Must NOT point at "the last tool result" (issue #105404):
+        # messaging surfaces such as Telegram do not render tool results, so that reference is
+        # invisible to the user. Surface only the safely-known, code-derived reason — never raw
+        # arguments, payloads, credentials or private URLs (fail-closed for unknown codes).
+        tool = decision.tool_name or "a tool"
+        if decision.code == "identical_call_streak_halt":
+            reason = f"the same call returned the same result {decision.count} times without progress"
+        elif decision.code == "loop_web_search_cap":
+            reason = f"the per-turn web search limit was reached after {decision.count} searches"
+        elif decision.code == "loop_subagent_cap":
+            reason = f"the per-turn subagent limit was reached after {decision.count} delegations"
+        else:
+            reason = "it made no progress after repeated attempts"
         return (
-            f"I stopped retrying {decision.tool_name or 'a tool'} because it hit the tool-call guardrail "
-            f"({decision.code}) after {decision.count} repeated non-progressing "
-            "attempts. The last tool result explains the blocker; the next step is "
-            "to change strategy instead of repeating the same call."
+            f"I stopped retrying {tool} because {reason}. "
+            "Change the request or use a different approach instead of repeating the same call."
         )
 
     def _append_guardrail_observation(self, tool_name: str, function_args: dict, function_result: str, *,

--- a/tests/agent/test_toolguard_halt_response.py
+++ b/tests/agent/test_toolguard_halt_response.py
@@ -1,0 +1,63 @@
+"""Regression tests for ``AIAgent._toolguard_controlled_halt_response`` (#105404).
+
+The user-visible final reply must explain the safely-known, code-derived
+blocker rather than pointing at the last tool result (invisible on messaging
+surfaces such as Telegram), stay bounded and fail-closed for unknown codes,
+and never copy raw arguments, payloads, credentials or private URLs.
+"""
+import re
+
+import pytest
+
+from agent.tool_guardrails import ToolGuardrailDecision
+from run_agent import AIAgent
+
+
+def _halt(code: str, *, tool_name: str = "example_tool", count: int = 5) -> ToolGuardrailDecision:
+    return ToolGuardrailDecision(
+        action="halt", code=code, tool_name=tool_name, count=count)
+
+
+def _response(code: str, **kw) -> str:
+    agent = AIAgent.__new__(AIAgent)
+    return agent._toolguard_controlled_halt_response(_halt(code, **kw))
+
+
+def test_identical_call_streak_explains_repeated_result():
+    msg = _response("identical_call_streak_halt", count=5)
+    assert "5 times" in msg
+    assert "example_tool" in msg
+
+
+def test_loop_web_search_cap_explains_limit():
+    msg = _response("loop_web_search_cap", count=50)
+    assert "web search limit" in msg
+    assert "50" in msg
+
+
+def test_loop_subagent_cap_explains_limit():
+    msg = _response("loop_subagent_cap", count=10)
+    assert "subagent limit" in msg
+    assert "10" in msg
+
+
+def test_unknown_code_falls_back_to_no_progress():
+    msg = _response("some_future_halt_code", count=3)
+    assert "no progress" in msg
+    # Count is not surfaced for unknown codes (no safe template knows what it means).
+    assert "3" not in msg
+
+
+@pytest.mark.parametrize("code", [
+    "identical_call_streak_halt", "loop_web_search_cap", "loop_subagent_cap", "some_future_code",
+])
+def test_reply_does_not_reference_invisible_tool_result(code):
+    """Regression for #105404: the reply must not point at the last tool result."""
+    assert "last tool result" not in _response(code)
+
+
+@pytest.mark.parametrize("code", [
+    "identical_call_streak_halt", "loop_web_search_cap", "loop_subagent_cap", "some_future_code",
+])
+def test_reply_does_not_claim_completion(code):
+    assert not re.search(r"\bcomplete[ds]?\b", _response(code), re.IGNORECASE)


### PR DESCRIPTION
## Fixes #105404

The controlled tool-loop halt reply (`AIAgent._toolguard_controlled_halt_response`) ended with:

> The last tool result explains the blocker; the next step is to change strategy instead of repeating the same call.

On messaging surfaces such as Telegram the tool result is **not rendered**, so that reference is invisible and the user is left with a guardrail code + retry count and no actionable reason (#105404).

## Change

Surface a **code-derived, safe reason** per halt code instead of the generic reference to the last tool result:

| `decision.code` | user-facing reason |
|---|---|
| `identical_call_streak_halt` | `the same call returned the same result N times without progress` |
| `loop_web_search_cap` | `the per-turn web search limit was reached after N searches` |
| `loop_subagent_cap` | `the per-turn subagent limit was reached after N delegations` |
| unknown | `it made no progress after repeated attempts` (fail-closed; count not surfaced because no safe template knows what it means) |

Every branch surfaces only `tool_name` + `count`/`cap` — never raw arguments, payloads, credentials or private URLs (the safety requirement in the issue). The reply still tells the user to change the request or use a different approach instead of repeating the call, and never claims the deliverable is complete.

The existing `decision.message` is written for the **agent's in-context** guidance (it references in-context tool results like "use the result already provided"), so it is intentionally not echoed verbatim into the user-visible final reply.

## Tests

`tests/agent/test_toolguard_halt_response.py`:
- per-code reason content for all three halt codes,
- fail-closed unknown-code path (count not surfaced),
- regression: the reply never contains "last tool result" (parametrized over all codes incl. unknown),
- regression: the reply never claims completion (`complete[d|s]`).

Manually verified against current `main` (`0d08cd2`) for all four codes.

---

_AI-assisted: this PR's analysis, code, tests, and body were drafted with AI assistance and reviewed by me._
