### PR TITLE
feat: attach native clients and retain shared-session input safely

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -296,6 +296,7 @@ import {
 import { createPoolStopper } from './pool-stop'
 import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
+import { registerPreparedSubmissions } from './prepared-submissions'
 import { capturePreviewContents } from './preview-capture'
 import { PreviewReachRegistry } from './preview-reach'
 import {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -354,7 +354,6 @@ import {
   type SecretStoragePolicy,
   writeSecretStoragePolicy
 } from './secret-storage-policy'
-import { registerPreparedSubmissions } from './prepared-submissions'
 import {
   buildInstanceWindowUrl,
   buildSessionWindowUrl,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -354,6 +354,7 @@ import {
   type SecretStoragePolicy,
   writeSecretStoragePolicy
 } from './secret-storage-policy'
+import { registerPreparedSubmissions } from './prepared-submissions'
 import {
   buildInstanceWindowUrl,
   buildSessionWindowUrl,
@@ -15121,6 +15122,8 @@ ipcMain.on('hermes:wake-indicator:set', (_event, state) => {
 // --- Text size (zoom) -------------------------------------------------------
 // The settings UI drives the same clamped zoom scale as the Ctrl/Cmd
 // shortcuts and the View menu. Reads and writes target the asking window.
+registerPreparedSubmissions()
+
 ipcMain.handle('hermes:zoom:get', event => {
   const window = BrowserWindow.fromWebContents(event.sender)
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -296,6 +296,10 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     setDefaultProjectDir: dir => ipcRenderer.invoke('hermes:setting:defaultProjectDir:set', dir),
     pickDefaultProjectDir: () => ipcRenderer.invoke('hermes:setting:defaultProjectDir:pick')
   },
+  preparedSubmissions: {
+    read: () => ipcRenderer.invoke('hermes:prepared-submissions:read'),
+    update: (key, entry) => ipcRenderer.invoke('hermes:prepared-submissions:update', key, entry)
+  },
   zoom: {
     // Current zoom of this window, as { level, percent }.
     get: () => ipcRenderer.invoke('hermes:zoom:get'),

--- a/apps/desktop/electron/prepared-submissions.test.ts
+++ b/apps/desktop/electron/prepared-submissions.test.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { expect, test, vi } from 'vitest'
+vi.mock('electron', () => ({ app: {}, ipcMain: {} }))
+import { preparedJournal } from './prepared-submissions'
+
+test('acknowledged journal mutations survive reopening with exact payload and origin isolation', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'prepared-journal-'))
+
+  try {
+    const origin = 'http://localhost:5174'
+    const key = JSON.stringify(['remote', 'profile-a', 'stored-a'])
+    const entry = { id: 'id-a', text: 'Ω 👩🏽‍💻 e\u0301\n  []', attachments: [{ id: 'asset', path: '/tmp/Ω' }], params: { session_id: 'live-a' } }
+    preparedJournal(dir, origin).update(key, entry)
+    preparedJournal(dir, origin).update('other-profile', { id: 'id-b' })
+    expect(preparedJournal(dir, origin).read()[key]).toEqual(entry)
+    expect(preparedJournal(dir, 'http://other:5174').read()).toEqual({})
+    preparedJournal(dir, origin).update(key, null)
+    expect(preparedJournal(dir, origin).read()).toEqual({ 'other-profile': { id: 'id-b' } })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/apps/desktop/electron/prepared-submissions.ts
+++ b/apps/desktop/electron/prepared-submissions.ts
@@ -1,0 +1,52 @@
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { app, ipcMain } from 'electron'
+
+import { writeSecretFileAtomic } from './hardening'
+
+// Match localStorage's origin isolation; destination keys additionally carry
+// connection/profile/session authority. No renderer-provided filesystem paths.
+export function preparedJournal(userData: string, origin: string) {
+  const file = path.join(userData, `prepared-submissions-${createHash('sha256').update(origin).digest('hex')}.json`)
+
+  const read = (): Record<string, unknown> => {
+    try {
+      return JSON.parse(fs.readFileSync(file, 'utf8'))
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {return {}}
+      throw error
+    }
+  }
+
+  return {
+    read,
+    update(key: string, entry: unknown | null) {
+      const journal = read()
+
+      if (entry === null) {delete journal[key]}
+      else {Object.defineProperty(journal, key, { value: entry, enumerable: true, configurable: true })}
+
+      fs.mkdirSync(userData, { recursive: true })
+      // Same private atomic replacement used for native connection settings.
+      // Return only after write+rename: process termination cannot lose an ACKed
+      // entry to Chromium's deferred localStorage commit. Not a power-loss promise.
+      writeSecretFileAtomic(file, JSON.stringify(journal), { encoding: 'utf8' })
+    }
+  }
+}
+
+export function registerPreparedSubmissions() {
+  const store = (event: Electron.IpcMainInvokeEvent) =>
+    preparedJournal(app.getPath('userData'), new URL(event.senderFrame!.url).origin)
+
+  ipcMain.handle('hermes:prepared-submissions:read', event => JSON.stringify(store(event).read()))
+  ipcMain.handle('hermes:prepared-submissions:update', (event, key: string, entry: string | null) => {
+    if (typeof key !== 'string' || (entry !== null && typeof entry !== 'string')) {
+      throw new Error('Invalid prepared submission')
+    }
+
+    store(event).update(key, entry === null ? null : JSON.parse(entry))
+  })
+}

--- a/apps/desktop/src/app/chat/composer/controls.test.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.test.tsx
@@ -138,10 +138,10 @@ describe('ComposerControls shortcut tooltips', () => {
     await expectShortcutTooltip('Send', '↵')
   })
 
-  it('keeps Send (not Steer) while a turn is running if there is a payload', async () => {
+  it('labels busy Send with the effective configured action', async () => {
     renderControls({ busy: true, busyAction: 'steer' })
 
-    await expectShortcutTooltip('Send', '↵')
+    await expectShortcutTooltip('Steer the current run', '↵')
   })
 
   it('shows Stop only when the composer is empty mid-turn', async () => {
@@ -151,7 +151,7 @@ describe('ComposerControls shortcut tooltips', () => {
   })
 
   it('shows Ctrl+Enter for Queue as the secondary mid-turn action', async () => {
-    renderControls({ busy: true, busyAction: 'queue' })
+    renderControls({ busy: true, busyAction: 'interrupt' })
 
     await expectShortcutTooltip('Queue message', 'Ctrl+↵')
   })

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -46,11 +46,12 @@ export function ComposerControls({
   voiceStatus,
   onDictate,
   onQueue,
+  onSteer,
   onToggleAutoSpeak
 }: {
   autoSpeak: boolean
   busy: boolean
-  busyAction: 'steer' | 'queue' | 'stop'
+  busyAction: 'interrupt' | 'steer' | 'queue' | 'stop'
   canSubmit: boolean
   compactModelPill?: boolean
   conversation: ConversationProps
@@ -62,6 +63,7 @@ export function ComposerControls({
   voiceStatus: VoiceStatus
   onDictate: () => void
   onQueue: () => void
+  onSteer?: () => void
   onToggleAutoSpeak: () => void
 }) {
   const { t } = useI18n()
@@ -76,7 +78,10 @@ export function ComposerControls({
   // Steer is just send: a payload keeps the Send affordance mid-turn. Stop
   // only when the composer is empty and a turn is running.
   const showStop = busy && !hasComposerPayload
-  const showQueueButton = busyAction !== 'stop' && hasComposerPayload
+  const showQueueButton = busy && busyAction !== 'stop' && busyAction !== 'queue' && hasComposerPayload
+  const sendLabel = busy
+    ? { interrupt: c.redirect, queue: c.queueMessage, steer: c.steer, stop: c.stop }[busyAction]
+    : c.send
   // The HUD is a Spotlight bar a few hundred pixels wide, so the four separate
   // voice toggles fold into one menu there and leave the row to the input. A
   // narrow tile hits the same wall from the other direction and folds for the
@@ -111,6 +116,21 @@ export function ComposerControls({
           {voiceControls}
         </>
       )}
+      {busy && busyAction !== 'steer' && onSteer ? (
+        <Tip label={c.steer}>
+          <Button
+            aria-label={c.steer}
+            className={GHOST_ICON_BTN}
+            disabled={disabled}
+            onClick={onSteer}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <Codicon name="debug-step-over" size="0.875rem" />
+          </Button>
+        </Tip>
+      ) : null}
       {showQueueButton ? (
         <Tip label={<TipKeybindLabel actionId="composer.queue" text={c.queueMessage} />}>
           <Button
@@ -148,12 +168,12 @@ export function ComposerControls({
             showStop ? (
               <TipKeybindLabel actionId="composer.send" text={c.stop} />
             ) : (
-              <TipKeybindLabel actionId="composer.send" text={c.send} />
+              <TipKeybindLabel actionId="composer.send" text={sendLabel} />
             )
           }
         >
           <Button
-            aria-label={showStop ? c.stop : c.send}
+            aria-label={showStop ? c.stop : sendLabel}
             className={PRIMARY_ICON_BTN}
             disabled={disabled || !canSubmit}
             type="submit"

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -86,6 +86,9 @@ describe('useComposerQueue park integration', () => {
       }
 
       expect(onSubmit).toHaveBeenCalledTimes(MAX_AUTO_DRAIN_ATTEMPTS)
+      for (const [, options] of onSubmit.mock.calls) {
+        expect(options).toMatchObject({ submission_id: entry.id })
+      }
       await act(async () => {
         await vi.advanceTimersByTimeAsync(300_000)
       })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -221,12 +221,13 @@ export function useComposerQueue({
             attachments: entry.attachments,
             ...(entry.displayText ? { displayText: entry.displayText } : {}),
             fromQueue: true,
+            submission_id: entry.id,
             sessionId: drainRuntimeSessionId,
             storedSessionId: drainQueueSessionKey
           })
         )
 
-        if (accepted === false) {
+        if (accepted !== true) {
           return false
         }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -100,7 +100,7 @@ export function useComposerQueue({
   const [drainRetryTick, setDrainRetryTick] = useState(0)
 
   const beginQueuedEdit = (entry: QueuedPromptEntry) => {
-    if (!activeQueueSessionKey || queueEdit) {
+    if (!activeQueueSessionKey || queueEdit || entry.serverStatus) {
       return
     }
 
@@ -207,7 +207,7 @@ export function useComposerQueue({
 
       const drainQueueSessionKey = activeQueueSessionKey
       const drainRuntimeSessionId = sessionId ?? null
-      const entry = pickEntry(getQueuedPrompts(drainQueueSessionKey))
+      const entry = pickEntry(getQueuedPrompts(drainQueueSessionKey).filter(entry => !entry.serverStatus))
 
       if (!entry) {
         return false
@@ -252,7 +252,7 @@ export function useComposerQueue({
     (entries: QueuedPromptEntry[]) => {
       const skip = queueEditRef.current?.entryId
 
-      return skip ? entries.find(e => e.id !== skip) : entries[0]
+      return entries.find(e => !e.serverStatus && e.id !== skip)
     },
     [queueEditRef] // reads the edit id off a ref so the lock-holder always sees the latest
   )

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -22,6 +22,7 @@ import { useComposerSubmit } from './use-composer-submit'
 interface SubmitHarnessOptions {
   attachments?: ComposerAttachment[]
   busy?: boolean
+  busyInputMode?: 'interrupt' | 'queue' | 'steer' | null
   compacting?: boolean
   inputDisabled?: boolean
   scopeTarget?: ComposerTarget
@@ -37,6 +38,7 @@ let surfaceSequence = 0
 function renderSubmitHook({
   attachments = [],
   busy = false,
+  busyInputMode = 'interrupt',
   compacting = false,
   inputDisabled = false,
   scopeTarget = 'main',
@@ -97,6 +99,7 @@ function renderSubmitHook({
         activeQueueSessionKeyRef: { current: sessionKey },
         attachments,
         busy,
+        busyInputMode,
         compacting,
         clearDraft,
         disabled: false,
@@ -265,6 +268,35 @@ describe('useComposerSubmit external request routing', () => {
 })
 
 describe('useComposerSubmit busy-turn routing', () => {
+  it('honors configured busy mode while explicit steering and queueing override it on every surface', async () => {
+    for (const scopeTarget of ['main', 'tile:stored-session'] as const) {
+      for (const mode of ['interrupt', 'queue', 'steer', null] as const) {
+        const ordinary = renderSubmitHook({ busy: true, busyInputMode: mode, scopeTarget, text: 'change course' })
+        act(() => ordinary.hook.result.current.submitDraft())
+
+        if (mode === 'queue') {
+          expect(ordinary.queueCurrentDraft).toHaveBeenCalledOnce()
+          expect(ordinary.onSteer).not.toHaveBeenCalled()
+        } else if (mode === null) {
+          expect(ordinary.clearDraft).not.toHaveBeenCalled()
+          expect(ordinary.onSteer).not.toHaveBeenCalled()
+          expect(ordinary.queueCurrentDraft).not.toHaveBeenCalled()
+        } else {
+          await waitFor(() => expect(ordinary.onSteer).toHaveBeenCalledWith('change course', mode))
+          expect(ordinary.queueCurrentDraft).not.toHaveBeenCalled()
+        }
+
+        ordinary.hook.unmount()
+        const explicit = renderSubmitHook({ busy: true, busyInputMode: mode, scopeTarget, text: 'explicit guidance' })
+        act(() => explicit.hook.result.current.steerDraft('steer'))
+        await waitFor(() => expect(explicit.onSteer).toHaveBeenCalledWith('explicit guidance', 'steer'))
+        act(() => explicit.hook.result.current.queueDraft())
+        expect(explicit.queueCurrentDraft).toHaveBeenCalledOnce()
+        explicit.hook.unmount()
+      }
+    }
+  })
+
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
@@ -280,7 +312,7 @@ describe('useComposerSubmit busy-turn routing', () => {
       hook.result.current.submitDraft()
     })
 
-    await waitFor(() => expect(onSteer).toHaveBeenCalledWith('change course'))
+    await waitFor(() => expect(onSteer).toHaveBeenCalledWith('change course', 'interrupt'))
     expect(queueCurrentDraft).not.toHaveBeenCalled()
     expect(onCancel).not.toHaveBeenCalled()
     expect(onSubmit).not.toHaveBeenCalled()
@@ -437,7 +469,7 @@ describe('useComposerSubmit with a clarify parked on the session', () => {
       hook.result.current.submitDraft()
     })
 
-    await waitFor(() => expect(onSteer).toHaveBeenCalledWith('change course'))
+    await waitFor(() => expect(onSteer).toHaveBeenCalledWith('change course', 'interrupt'))
     expect(gatewayRequest).toHaveBeenCalledWith('clarify.respond', { request_id: 'req-runtime-session', answer: '' })
   })
 
@@ -545,7 +577,7 @@ describe('useComposerSubmit with a blocking prompt parked on the session', () =>
       hook.result.current.submitDraft()
     })
 
-    await waitFor(() => expect(onSteer).toHaveBeenCalledWith('change course'))
+    await waitFor(() => expect(onSteer).toHaveBeenCalledWith('change course', 'interrupt'))
     expect(queueCurrentDraft).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -3,6 +3,7 @@ import { type RefObject, useLayoutEffect, useRef } from 'react'
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
+import type { BusyInputMode } from '@/store/busy-input-mode'
 import { hasClarifyRequest, skipClarifyRequest } from '@/store/clarify'
 import { clearSessionDraft, type ComposerAttachment } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
@@ -22,6 +23,7 @@ interface UseComposerSubmitArgs {
   activeQueueSessionKeyRef: RefObject<string | null>
   attachments: ComposerAttachment[]
   busy: boolean
+  busyInputMode?: BusyInputMode | null
   compacting: boolean
   clearDraft: () => void
   disabled: boolean
@@ -57,6 +59,7 @@ export function useComposerSubmit({
   activeQueueSessionKeyRef,
   attachments,
   busy,
+  busyInputMode = 'interrupt',
   compacting,
   clearDraft,
   disabled,
@@ -203,10 +206,12 @@ export function useComposerSubmit({
         clearDraft()
         dispatchSubmit(text)
       } else if (!compacting && !blockingPrompt && !attachments.length && text.trim()) {
-        // Cursor-style stop-and-correct: interrupt the live turn and redirect
-        // it with this text. redirect() preserves the shown reasoning/work; if
-        // the turn already ended, steerDraft re-queues so nothing is lost.
-        steerDraft()
+        // Unloaded policy must not turn an intended queue into an interrupt.
+        if (busyInputMode === 'queue') {
+          queueCurrentDraft()
+        } else if (busyInputMode !== null) {
+          steerDraft(busyInputMode)
+        }
       } else if (payloadPresent) {
         // Attachments can't ride a redirect (no tool-result image carriage) —
         // queue the whole payload for the next turn. Same for a turn parked on
@@ -236,7 +241,7 @@ export function useComposerSubmit({
   // Redirect the live turn with a correction. The gateway either restarts the
   // active model request with its displayed context or waits for the current
   // tool boundary. If the turn already ended, queue the words instead.
-  const steerDraft = () => {
+  const steerDraft = (mode: 'interrupt' | 'steer' = 'interrupt') => {
     const text = draftRef.current.trim()
 
     // Guard on live editor state, not the render-lagged `canSteer`: a redirect
@@ -248,7 +253,7 @@ export function useComposerSubmit({
     triggerHaptic('submit')
     clearDraft()
 
-    void Promise.resolve(onSteer(text)).then(accepted => {
+    void Promise.resolve(onSteer(text, mode)).then(accepted => {
       if (!accepted && activeQueueSessionKey) {
         enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments: [] })
       }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -3,7 +3,9 @@ import { useStore } from '@nanostores/react'
 import { type ClipboardEvent, type FormEvent, type KeyboardEvent, useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { useTourMarker } from '@/app/chat/tour-marker'
+import type { GatewayRequester } from '@/app/contrib/types'
 import { useHudComposerDrag } from '@/app/hud/composer-drag'
+import { useBusyInputMode } from '@/app/session/hooks/use-busy-input-mode'
 import { composerFill, composerFloatingStrip, composerSurfaceGlass } from '@/components/chat/composer-dock'
 import { Button } from '@/components/ui/button'
 import { Slot as ContribSlot } from '@/contrib/react/slot'
@@ -175,6 +177,17 @@ export function ChatBar({
   const blockingPrompt = useStore(useMemo(() => sessionBlockingPrompt(sessionId ?? null), [sessionId]))
   const activeQueueSessionKey = queueSessionKey || sessionId || null
 
+  const requestBusyConfig = useCallback<GatewayRequester>(
+    (method, params) => (gateway ? gateway.request(method, params) : Promise.reject(new Error('Gateway unavailable'))),
+    [gateway]
+  )
+
+  const busyInputMode = useBusyInputMode({
+    sessionId: sessionId ?? null,
+    storedSessionId: queueSessionKey ?? null,
+    requestGateway: requestBusyConfig
+  })
+
   // Status items (subagents, background processes) are keyed by the RUNTIME
   // session id — gateway events and process.list both speak that id. Only the
   // queue uses the stored-session fallback key (prompts can queue pre-resume).
@@ -343,7 +356,9 @@ export function ChatBar({
   })
 
   const hasComposerPayload = hasText || attachments.length > 0
-  const canSubmit = busy || hasComposerPayload
+  const canSubmit =
+    (busy || hasComposerPayload) &&
+    !(busy && isSteerableText && attachments.length === 0 && !compacting && !blockingPrompt && busyInputMode === null)
 
   // Steer only makes sense mid-turn, text-only (the gateway can't carry images
   // into a tool result) and never for a slash command (those execute inline).
@@ -351,10 +366,9 @@ export function ChatBar({
   // is parked on the user, so a steer can't reach the model — text queues.
   const canSteer = busy && !compacting && !blockingPrompt && !!onSteer && attachments.length === 0 && isSteerableText
 
-  // While busy: text redirects the live turn (Cursor-style stop-and-correct),
-  // attachments queue for the next turn, an empty composer stops.
-  const busyAction: 'steer' | 'queue' | 'stop' = canSteer
-    ? 'steer'
+  // Ordinary busy Send follows backend policy; attachments queue and empty stops.
+  const busyAction: 'interrupt' | 'steer' | 'queue' | 'stop' = canSteer
+    ? (busyInputMode ?? 'interrupt')
     : compacting || hasComposerPayload
       ? 'queue'
       : 'stop'
@@ -362,6 +376,7 @@ export function ChatBar({
   // The submit engine — the orchestration seam where draft + queue meet. Owns
   // the submit decision tree, the send-with-restore primitive, and steer.
   const { queueDraft, steerDraft, submitDraft } = useComposerSubmit({
+    busyInputMode,
     activeQueueSessionKey,
     activeQueueSessionKeyRef,
     attachments,
@@ -1029,6 +1044,7 @@ export function ChatBar({
       minimal={minimal}
       onDictate={dictate}
       onQueue={queueDraft}
+      onSteer={canSteer ? () => steerDraft('steer') : undefined}
       onToggleAutoSpeak={handleToggleAutoSpeak}
       state={state}
       voiceStatus={voiceStatus}

--- a/apps/desktop/src/app/chat/composer/queue-panel.tsx
+++ b/apps/desktop/src/app/chat/composer/queue-panel.tsx
@@ -86,7 +86,7 @@ export function QueuePanel({
             )}
             key={entry.id}
             trailing={
-              <>
+              !entry.serverStatus && <>
                 <Tip label={c.queueEdit}>
                   <Button
                     aria-label={c.queueEdit}

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -54,7 +54,7 @@ export interface ChatBarProps {
   onPickFolders?: () => void
   onPickImages?: () => void
   onRemoveAttachment?: (id: string) => void
-  onSteer?: (text: string) => Promise<boolean> | boolean
+  onSteer?: (text: string, mode?: 'interrupt' | 'steer') => Promise<boolean> | boolean
   onSubmit: (value: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
   onTranscribeAudio?: (audio: Blob) => Promise<string>
 }

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -101,7 +101,7 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   onPickFolders: () => void
   onPickImages: () => void
   onRemoveAttachment: (id: string) => void
-  onSteer: (text: string) => Promise<boolean> | boolean
+  onSteer: (text: string, mode?: 'interrupt' | 'steer') => Promise<boolean> | boolean
   onSubmit: (text: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
   onThreadMessagesChange: (messages: readonly ThreadMessage[]) => void
   onEdit: (message: AppendMessage) => Promise<void>

--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -188,7 +188,7 @@ describe('useSessionTileActions sleep/wake session recovery', () => {
           throw new Error('session not found')
         }
 
-        return {}
+        return { admission_id: params?.submission_id, status: 'started' }
       }
 
       if (method === 'session.resume') {

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -364,7 +364,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
   }, [bindRecoveredRuntime, copy.stopFailed, requestSessionGateway, update])
 
   const steerPrompt = useCallback(
-    async (rawText: string): Promise<boolean> => {
+    async (rawText: string, mode: 'interrupt' | 'steer' = 'interrupt'): Promise<boolean> => {
       const text = rawText.trim()
       const sessionId = runtimeIdRef.current
 
@@ -384,13 +384,13 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
       // bubble above output the user had already read (#73793), and its
       // last-assistant fallback could land it mid-thread when the stream id
       // was missing or stale (#83151).
-      mutate(state =>
-        appendMidTurnUserMessage(state, {
-          id: messageId,
-          role: 'user' as const,
-          parts: [textPart(text)]
-        })
-      )
+      mutate(state => {
+        const message = { id: messageId, role: 'user' as const, parts: [textPart(text)] }
+
+        return mode === 'interrupt'
+          ? appendMidTurnUserMessage(state, message)
+          : { ...state, messages: [...state.messages, message] }
+      })
 
       const discardOptimisticMessage = () =>
         mutate(state => ({
@@ -411,7 +411,11 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
         const { result } = await withSessionNotFoundResume(
           sessionId,
           storedIdRef.current,
-          liveId => requestSessionGateway<{ status?: string }>('session.redirect', { session_id: liveId, text }),
+          liveId =>
+            requestSessionGateway<{ status?: string }>(mode === 'steer' ? 'session.steer' : 'session.redirect', {
+              session_id: liveId,
+              text
+            }),
           {
             requestGateway: requestSessionGateway,
             onRecovered: bindRecoveredRuntime
@@ -425,7 +429,9 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
         }
 
         if (result?.status === 'queued') {
-          moveOptimisticMessageToEnd()
+          if (mode === 'interrupt') {
+            moveOptimisticMessageToEnd()
+          }
           triggerHaptic('submit')
 
           return true

--- a/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
+++ b/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
@@ -133,7 +133,7 @@ describe('session tile attachment occurrence ownership', () => {
     const original = makeAttachment()
     const attach = deferred<{ attached: boolean; path: string }>()
 
-    requestGateway.mockImplementation(async (method: string) => {
+    requestGateway.mockImplementation(async (method: string, params: Record<string, unknown>) => {
       if (method === 'image.attach_bytes') {
         return attach.promise
       }
@@ -142,7 +142,7 @@ describe('session tile attachment occurrence ownership', () => {
         throw new Error('submit failed after staging')
       }
 
-      return {}
+      return method === 'prompt.submit' ? { admission_id: params.submission_id, status: 'started' } : {}
     })
 
     scope.attachments.add(original)
@@ -179,7 +179,7 @@ describe('session tile attachment occurrence ownership', () => {
     const replacement = makeAttachment()
     const attach = deferred<{ attached: boolean; path: string }>()
 
-    requestGateway.mockImplementation(async (method: string) => {
+    requestGateway.mockImplementation(async (method: string, params: Record<string, unknown>) => {
       if (method === 'image.attach_bytes') {
         return attach.promise
       }
@@ -188,7 +188,7 @@ describe('session tile attachment occurrence ownership', () => {
         throw new Error('submit failed after staging')
       }
 
-      return {}
+      return method === 'prompt.submit' ? { admission_id: params.submission_id, status: 'started' } : {}
     })
 
     scope.attachments.add(original)
@@ -221,12 +221,12 @@ describe('session tile attachment occurrence ownership', () => {
     const replacement = makeAttachment()
     const attach = deferred<{ attached: boolean; path: string }>()
 
-    requestGateway.mockImplementation(async (method: string) => {
+    requestGateway.mockImplementation(async (method: string, params: Record<string, unknown>) => {
       if (method === 'image.attach_bytes') {
         return attach.promise
       }
 
-      return {}
+      return method === 'prompt.submit' ? { admission_id: params.submission_id, status: 'started' } : {}
     })
 
     scope.attachments.add(original)
@@ -258,12 +258,14 @@ describe('session tile attachment occurrence ownership', () => {
     const replacement = makeUrlAttachment('new')
     const submit = deferred<Record<string, never>>()
 
-    requestGateway.mockImplementation(async (method: string) => {
+    requestGateway.mockImplementation(async (method: string, params: Record<string, unknown>) => {
       if (method === 'prompt.submit') {
-        return submit.promise
+        await submit.promise
+
+        return { admission_id: params.submission_id, status: 'started' }
       }
 
-      return {}
+      return method === 'prompt.submit' ? { admission_id: params.submission_id, status: 'started' } : {}
     })
 
     scope.attachments.add(original)
@@ -295,7 +297,7 @@ describe('session tile attachment occurrence ownership', () => {
     const scope = createScope()
     const original = makeFileAttachment()
 
-    requestGateway.mockImplementation(async (method: string) => {
+    requestGateway.mockImplementation(async (method: string, params: Record<string, unknown>) => {
       if (method === 'file.attach') {
         return {
           attached: true,
@@ -304,7 +306,7 @@ describe('session tile attachment occurrence ownership', () => {
         }
       }
 
-      return {}
+      return method === 'prompt.submit' ? { admission_id: params.submission_id, status: 'started' } : {}
     })
 
     scope.attachments.add(original)

--- a/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
+++ b/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
@@ -140,7 +140,7 @@ function answer(socket: MockGateway, method: string, params: Record<string, unkn
   }
 
   if (method === 'prompt.submit') {
-    return { ok: true }
+    return { admission_id: params.submission_id, status: 'started' }
   }
 
   if (method === 'session.resume' || method === 'session.activate') {

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -78,13 +78,14 @@ describe('useBackgroundQueueDrain', () => {
     const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
     const submitText = vi.fn(async () => true)
 
-    enqueueQueuedPrompt('stored-session-a', { text: 'continue in the background', attachments: [] })
+    const entry = enqueueQueuedPrompt('stored-session-a', { text: 'continue in the background', attachments: [] })!
     clearAllSessionStates()
 
     render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
 
     await waitFor(() => {
       expect(submitText).toHaveBeenCalledWith('continue in the background', {
+        submission_id: entry.id,
         attachments: [],
         fromQueue: true,
         sessionId: 'rt-session-a',
@@ -183,12 +184,13 @@ describe('useBackgroundQueueDrain', () => {
     const runtimeMap = { current: new Map<string, string>() }
     const submitText = vi.fn(async () => true)
 
-    enqueueQueuedPrompt('stored-session-a', { text: 'resume then send', attachments: [] })
+    const entry = enqueueQueuedPrompt('stored-session-a', { text: 'resume then send', attachments: [] })!
 
     render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
 
     await waitFor(() => {
       expect(submitText).toHaveBeenCalledWith('resume then send', {
+        submission_id: entry.id,
         attachments: [],
         fromQueue: true,
         sessionId: null,

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -122,12 +122,14 @@ export function useBackgroundQueueDrain({
             submitTextRef.current(liveEntry.text, {
               attachments: liveEntry.attachments,
               fromQueue: true,
+              submission_id: liveEntry.id,
+              ...(liveEntry.displayText ? { displayText: liveEntry.displayText } : {}),
               sessionId: runtimeSessionId,
               storedSessionId: sessionKey
             })
           )
 
-          if (accepted === false) {
+          if (accepted !== true) {
             return false
           }
 

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -112,7 +112,7 @@ export function useBackgroundQueueDrain({
         .then(async () => {
           const liveEntry = getQueuedPrompts(sessionKey).find(candidate => candidate.id === entry.id)
 
-          if (!liveEntry) {
+          if (!liveEntry || liveEntry.serverStatus) {
             return true
           }
 
@@ -181,7 +181,7 @@ export function useBackgroundQueueDrain({
         continue
       }
 
-      const entry = entries[0]
+      const entry = entries.find(candidate => !candidate.serverStatus)
 
       if (!entry || (drainFailuresRef.current.get(entry.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS) {
         continue

--- a/apps/desktop/src/app/session/hooks/use-busy-input-mode.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-busy-input-mode.test.tsx
@@ -1,0 +1,59 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { $busyInputConfig } from '@/store/busy-input-mode'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection, $gatewayState } from '@/store/session'
+
+import { useBusyInputMode } from './use-busy-input-mode'
+
+vi.mock('@/store/session-request-router', () => ({
+  requestForSessionProfile: (
+    _owner: unknown,
+    request: (method: string, params: unknown) => Promise<unknown>,
+    method: string,
+    params: unknown
+  ) => request(method, params)
+}))
+
+afterEach(() => {
+  cleanup()
+  $busyInputConfig.set(null)
+  $activeGatewayProfile.set('default')
+  $gatewayState.set('closed')
+})
+
+it('uses only the current owner config and ignores a late response from the previous profile', async () => {
+  $gatewayState.set('open')
+  let resolveOld!: (value: { value: string }) => void
+
+  const request = vi
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveOld = resolve
+        })
+    )
+    .mockResolvedValue({ value: 'steer' })
+
+  const hook = renderHook(() =>
+    useBusyInputMode({ sessionId: 'runtime', storedSessionId: null, requestGateway: request })
+  )
+
+  expect(hook.result.current).toBeNull()
+  act(() => $activeGatewayProfile.set('other'))
+  await waitFor(() => expect(hook.result.current).toBe('steer'))
+  await act(async () => resolveOld({ value: 'queue' }))
+  expect(hook.result.current).toBe('steer')
+  act(() =>
+    $busyInputConfig.set({
+      owner: JSON.stringify([$connection.get()?.connectionId ?? '', 'other']),
+      connection: $connection.get(),
+      mode: 'queue'
+    })
+  )
+  expect(hook.result.current).toBe('queue')
+  act(() => $busyInputConfig.set({ owner: 'foreign-owner', connection: $connection.get(), mode: 'interrupt' }))
+  expect(hook.result.current).toBe('steer')
+})

--- a/apps/desktop/src/app/session/hooks/use-busy-input-mode.ts
+++ b/apps/desktop/src/app/session/hooks/use-busy-input-mode.ts
@@ -1,0 +1,82 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useState } from 'react'
+
+import type { GatewayRequester } from '@/app/contrib/types'
+import {
+  $busyInputConfig,
+  type BusyInputMode,
+  busyInputOwnerKey,
+  normalizeBusyInputMode
+} from '@/store/busy-input-mode'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection, $gatewayState, knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
+import { requestForSessionProfile } from '@/store/session-request-router'
+import { sessionTileOwnerRoute } from '@/store/session-states'
+
+export function useBusyInputMode({
+  sessionId,
+  storedSessionId,
+  requestGateway
+}: {
+  sessionId: string | null
+  storedSessionId: string | null
+  requestGateway: GatewayRequester
+}): BusyInputMode | null {
+  const config = useStore($busyInputConfig)
+  const connection = useStore($connection)
+  const profile = useStore($activeGatewayProfile)
+  const gatewayState = useStore($gatewayState)
+
+  const route = storedSessionId
+    ? (sessionTileOwnerRoute(storedSessionId) ?? knownSessionOwner(ownerLookupSessionRows(), storedSessionId))
+    : undefined
+
+  const connectionId = route && typeof route === 'object' ? route.connectionId : connection?.connectionId
+  const ownerProfile = route && typeof route === 'object' ? route.profile : route || profile
+  const targetProfile = route && typeof route === 'object' ? route.targetProfile : undefined
+  const owner = busyInputOwnerKey(connectionId, targetProfile || ownerProfile)
+
+  const [loaded, setLoaded] = useState<{ owner: string; connection: typeof connection; mode: BusyInputMode } | null>(
+    null
+  )
+
+  const configured = config?.owner === owner && config.connection === connection ? config.mode : null
+
+  useEffect(() => {
+    if (configured !== null || !sessionId || gatewayState !== 'open') {
+      return
+    }
+    let cancelled = false
+    const ownerRoute = connectionId ? { connectionId, profile: ownerProfile, targetProfile } : ownerProfile
+    void requestForSessionProfile<{ value?: unknown }>(ownerRoute, requestGateway, 'config.get', {
+      key: 'busy',
+      session_id: sessionId
+    })
+      .then(result => {
+        if (!cancelled && result && Object.hasOwn(result, 'value')) {
+          setLoaded({ owner, connection, mode: normalizeBusyInputMode(result.value) })
+        }
+      })
+      .catch(() => undefined)
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    configured,
+    connection,
+    connectionId,
+    gatewayState,
+    owner,
+    ownerProfile,
+    requestGateway,
+    sessionId,
+    targetProfile
+  ])
+
+  if (gatewayState !== 'open') {
+    return null
+  }
+
+  return configured ?? (loaded?.owner === owner && loaded.connection === connection ? loaded.mode : null)
+}

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -24,6 +24,7 @@ import { useHermesConfig } from './use-hermes-config'
 
 vi.mock('@/hermes', () => ({
   getHermesConfig: vi.fn(),
+  setApiRequestProfile: vi.fn(),
   getHermesConfigDefaults: vi.fn().mockResolvedValue({})
 }))
 

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -4,7 +4,10 @@ import { setTerminalFontFamilyFromConfig } from '@/app/right-sidebar/terminal/te
 import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
 import { normalize } from '@/lib/text'
+import { $busyInputConfig, busyInputOwnerKey, normalizeBusyInputMode } from '@/store/busy-input-mode'
 import { setDisplayTimestampsFromConfig } from '@/store/display-timestamps'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection } from '@/store/session'
 import {
   getComposerSelectionGeneration,
   getCurrentModelSource,
@@ -63,6 +66,8 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
 
       const profileRefreshEpoch = profileRefreshEpochRef.current
       const selectionGeneration = getComposerSelectionGeneration()
+      const connection = $connection.get()
+      const profile = $activeGatewayProfile.get()
 
       try {
         const [config, defaults] = await Promise.all([getHermesConfig(), getHermesConfigDefaults().catch(() => ({}))])
@@ -135,6 +140,14 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
 
         if (!canPublish()) {
           return
+        }
+
+        if ($connection.get() === connection && $activeGatewayProfile.get() === profile) {
+          $busyInputConfig.set({
+            owner: busyInputOwnerKey(connection?.connectionId, profile),
+            connection,
+            mode: normalizeBusyInputMode(config.display?.busy_input_mode)
+          })
         }
 
         setDisplayTimestampsFromConfig(config.display?.timestamps)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/execution-authority.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/execution-authority.test.tsx
@@ -1,0 +1,34 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+
+import { renderMessageStream } from './test-harness'
+
+afterEach(cleanup)
+
+it('rejects stale snapshots and terminal frames across generations and owner epochs', () => {
+  const stream = renderMessageStream('authority-session')
+
+  const send = (type: string, execution_epoch: string | undefined, execution_generation: number | undefined, running?: boolean) =>
+    act(() => stream.handleEvent({ type, session_id: 'authority-session', payload: { execution_epoch, execution_generation, running } }))
+
+  send('message.start', 'owner-a', 9)
+  send('session.info', 'owner-a', 8, false)
+  expect(stream.state().busy).toBe(true)
+  send('message.complete', undefined, undefined)
+  expect(stream.state().busy).toBe(true)
+  send('session.info', 'owner-b', 1, true)
+  send('message.complete', 'owner-a', 10)
+  expect(stream.state().busy).toBe(true)
+  send('session.info', 'owner-b', 1, false)
+  expect(stream.state().busy).toBe(false)
+  send('session.info', 'owner-b', 1, true)
+  expect(stream.state().busy).toBe(false)
+})
+
+it('accepts a versioned terminal snapshot before optimistic pre-start grace expires', () => {
+  const stream = renderMessageStream('early-terminal')
+  stream.states.set('early-terminal', { ...stream.state(), busy: true, awaitingResponse: true, turnLive: false, turnStartedAt: Date.now() })
+  act(() => stream.handleEvent({ type: 'session.info', session_id: 'early-terminal', payload: { execution_epoch: 'owner', execution_generation: 1, execution_state: 'error', running: false } }))
+  expect(stream.state().busy).toBe(false)
+  expect(stream.state().awaitingResponse).toBe(false)
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
@@ -2,6 +2,7 @@ import { registryBackendScopeKey } from '@hermes/shared'
 import { useCallback, useEffect, useRef } from 'react'
 
 import type { GatewayEventPayload } from '@/lib/chat-messages'
+import { acceptExecutionEvent } from '@/lib/execution-authority'
 import {
   approvalReplaySessionId,
   resolveGatewayEventSessionId,
@@ -95,6 +96,7 @@ const HANDLERS: GatewayEventHandler[] = [
 
 /** The gateway-event dispatcher, extracted from useMessageStream. */
 export function useGatewayEventHandler(deps: GatewayEventDeps) {
+  const executionAuthorities = useRef(new Map())
   const { activeSessionIdRef, compactedTurnRef, refreshHermesConfig, sessionStateByRuntimeIdRef } = deps
 
   const unscopedStreamSessionIdRef = useRef<string | null>(null)
@@ -170,6 +172,9 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       }
 
       const sessionId = route.sessionId
+      const authorityKey = `${registryBackendScopeKey(event.connectionId ?? null, event.profile ?? null)}\u0000${sessionId}`
+
+      if (sessionId && !acceptExecutionEvent(executionAuthorities.current, authorityKey, event.type, payload)) {return}
 
       // Late stragglers: an unscoped stream event attributed via the
       // active-session fallback (no pin) to a session that has no live turn

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -342,7 +342,10 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
           const withinPreStartGrace =
             typeof armedAt === 'number' && Date.now() - armedAt < PRE_TURN_LIVE_SETTLE_GRACE_MS
 
-          if (state.awaitingResponse && !state.sawAssistantPayload && !state.turnLive && withinPreStartGrace) {
+          const authoritative = typeof (payload as Record<string, unknown>)?.execution_epoch === 'string' &&
+            typeof (payload as Record<string, unknown>)?.execution_generation === 'number'
+
+          if (!authoritative && state.awaitingResponse && !state.sawAssistantPayload && !state.turnLive && withinPreStartGrace) {
             return state
           }
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -3,6 +3,7 @@ import { modelOptionsQueryKey } from '@/lib/model-options'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { reconcileSessionCompacting } from '@/store/compaction'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
+import { reconcilePendingSubmissions } from '@/store/pending-submissions'
 import { followActiveSessionCwd } from '@/store/projects'
 import {
   $activeSessionId,
@@ -150,6 +151,11 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
     // conversation already on screen — if so, re-bind the pane so every
     // subsequent isActiveEvent gate keeps matching (#93942 scenario B).
     const rebound = maybeRebindPaneToRebuiltRuntime(ctx)
+
+    if (sessionId) {
+      const storedId = payload?.stored_session_id ?? sessionStateByRuntimeIdRef.current.get(sessionId)?.storedSessionId ?? sessionId
+      reconcilePendingSubmissions(storedId, (payload as Record<string, unknown>)?.pending_submissions)
+    }
 
     // Apply session-scoped fields when the event targets the active
     // session, OR when it's a global broadcast and we have no session.

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -249,6 +249,35 @@ function Harness({
   return null
 }
 
+describe('durable submit acknowledgement', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    [{}, false],
+    [{ admission_id: 'other', status: 'queued' }, false],
+    [{ admission_id: 'entry-id', status: 'queued' }, true],
+    [{ admission_id: 'entry-id', status: 'started' }, true],
+    [{ admission_id: 'entry-id', status: 'terminal' }, true],
+    [{ admission_id: 'entry-id', status: 'unknown' }, false]
+  ])('requires the matching authoritative receipt: %j', async (receipt, accepted) => {
+    const requestGateway = vi.fn(async () => receipt as never)
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+    const options = { fromQueue: true, submission_id: 'entry-id' }
+    expect(await handle!.submitText('keep this input', options)).toBe(accepted)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      expect.objectContaining({ submission_id: 'entry-id', queued: true }),
+      expect.any(Number)
+    )
+  })
+})
+
 describe('usePromptActions /title', () => {
   beforeEach(() => {
     setSessions(() => [sessionInfo()])

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -250,6 +250,20 @@ function Harness({
 }
 
 describe('durable submit acknowledgement', () => {
+  it('retains a failed slash kickoff and forwards queued admission intent on retry', async () => {
+    $sessions.set([])
+    $connection.set(null)
+    $composerAttachments.set([])
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'slash.exec') return { type: 'skill', name: 'private-skill', message: 'expanded skill' } as never
+      return { admission_id: params?.submission_id, status: 'unknown' } as never
+    })
+    let handle: HarnessHandle | null = null
+    await actRender(<Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />)
+    expect(await handle!.submitText('/private-skill', { fromQueue: true, submission_id: 'queued-skill' })).toBe(false)
+    expect(requestGateway.mock.calls.find(call => call[0] === 'prompt.submit')?.[1]).toMatchObject({ queued: true, submission_id: 'queued-skill' })
+  })
+
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -41,6 +41,7 @@ import { uploadComposerAttachment, usePromptActions } from '.'
 // never-settling in-flight promise from one test into the next.
 beforeEach(() => {
   clearSingleFlightSessionResumeState()
+  window.localStorage.removeItem('hermes.desktop.preparedSubmissions.v1')
 })
 
 vi.mock('@/hermes', () => ({
@@ -124,6 +125,7 @@ function Harness({
   seedMessages,
   seedStreamId,
   seedTurnStartedAt,
+  rawAdmissionReceipts = false,
   selectedStoredSessionIdRef: selectedStoredSessionIdRefProp,
   storedSessionId,
   activeSessionId,
@@ -149,6 +151,7 @@ function Harness({
   seedMessages?: unknown[]
   seedStreamId?: null | string
   seedTurnStartedAt?: null | number
+  rawAdmissionReceipts?: boolean
   selectedStoredSessionIdRef?: MutableRefObject<string | null>
   storedSessionId?: null | string
   activeSessionId?: null | string
@@ -198,7 +201,19 @@ function Harness({
     handleSkinCommand: () => '',
     openMemoryGraph: openMemoryGraph ?? (() => undefined),
     refreshSessions,
-    requestGateway,
+    // Older fixture peers acknowledged successful submits with an empty object.
+    // Keep those peers successful under the durable protocol; receipt tests opt
+    // out so missing/mismatched acknowledgements still exercise production.
+    requestGateway: async (method, params, timeoutMs) => {
+      const result = await (timeoutMs === undefined ? requestGateway(method, params) : requestGateway(method, params, timeoutMs))
+
+      if (!rawAdmissionReceipts && method === 'prompt.submit' && result && typeof result === 'object' &&
+          (Object.keys(result).length === 0 || ('ok' in result && result.ok === true))) {
+        return { admission_id: params?.submission_id, status: 'started' } as never
+      }
+
+      return result as never
+    },
     resumeStoredSession: resumeStoredSession ?? (() => undefined),
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionIdRef,
@@ -254,10 +269,13 @@ describe('durable submit acknowledgement', () => {
     $sessions.set([])
     $connection.set(null)
     $composerAttachments.set([])
+
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
-      if (method === 'slash.exec') return { type: 'skill', name: 'private-skill', message: 'expanded skill' } as never
+      if (method === 'slash.exec') {return { type: 'skill', name: 'private-skill', message: 'expanded skill' } as never}
+
       return { admission_id: params?.submission_id, status: 'unknown' } as never
     })
+
     let handle: HarnessHandle | null = null
     await actRender(<Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />)
     expect(await handle!.submitText('/private-skill', { fromQueue: true, submission_id: 'queued-skill' })).toBe(false)
@@ -280,7 +298,7 @@ describe('durable submit acknowledgement', () => {
     const requestGateway = vi.fn(async () => receipt as never)
     let handle: HarnessHandle | null = null
     await actRender(
-      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+      <Harness onReady={h => (handle = h)} rawAdmissionReceipts refreshSessions={async () => undefined} requestGateway={requestGateway} />
     )
     const options = { fromQueue: true, submission_id: 'entry-id' }
     expect(await handle!.submitText('keep this input', options)).toBe(accepted)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1265,7 +1265,7 @@ describe('usePromptActions exec fallback error reporting', () => {
 
     await handle!.submitText('/status')
 
-    expect(requestGateway).toHaveBeenCalledWith('session.status', expect.anything(), undefined)
+    expect(requestGateway).toHaveBeenCalledWith('session.status', expect.anything())
     expect(requestGateway).toHaveBeenCalledWith('slash.exec', expect.objectContaining({ command: 'status' }))
     expect(renderedSeedTexts(seeds).some(text => text.includes('session status from slash worker'))).toBe(true)
   })
@@ -1391,6 +1391,7 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
     })
     expect(calls[1]?.params).toEqual({
       session_id: RUNTIME_SESSION_ID,
+      submission_id: expect.any(String),
       text: 'write the implementation plan'
     })
 
@@ -1990,7 +1991,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
     expect(await handle!.submitText('continue remotely')).toBe(true)
     expect(ambientRequest).toHaveBeenCalledWith(
       'prompt.submit',
-      { session_id: 'runtime-remote', text: 'continue remotely' },
+      { submission_id: expect.any(String), session_id: 'runtime-remote', text: 'continue remotely' },
       1_800_000
     )
     expect(requestGatewayForAgent).not.toHaveBeenCalled()
@@ -2021,6 +2022,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
       'prompt.submit',
       {
         session_id: RUNTIME_SESSION_ID,
+        submission_id: expect.any(String),
         text: 'hello after a stop'
       },
       1_800_000
@@ -2097,6 +2099,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
       'prompt.submit',
       {
         session_id: RUNTIME_SESSION_ID,
+        submission_id: expect.any(String),
         text: 'stop! rude interruption',
         interrupted: true
       },
@@ -2108,6 +2111,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
       'prompt.submit',
       {
         session_id: RUNTIME_SESSION_ID,
+        submission_id: expect.any(String),
         text: 'follow-up without a barge'
       },
       1_800_000
@@ -2138,6 +2142,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
       {
         queued: true,
         session_id: RUNTIME_SESSION_ID,
+        submission_id: expect.any(String),
         text: 'queued message'
       },
       1_800_000
@@ -2175,6 +2180,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
       {
         queued: true,
         session_id: 'rt-session-a',
+        submission_id: expect.any(String),
         text: 'queued for background session'
       },
       1_800_000
@@ -2230,6 +2236,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
       {
         queued: true,
         session_id: 'rt-session-b',
+        submission_id: expect.any(String),
         text: 'queued for B mid-switch'
       },
       1_800_000
@@ -2274,6 +2281,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
       {
         queued: true,
         session_id: 'rt-session-b-live',
+        submission_id: expect.any(String),
         text: 'queued for B, B already re-bound'
       },
       1_800_000
@@ -2316,6 +2324,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
       'prompt.submit',
       {
         session_id: 'rt-tab',
+        submission_id: expect.any(String),
         text: 'kickoff for the tab'
       },
       1_800_000
@@ -2368,6 +2377,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
       {
         queued: true,
         session_id: 'rt-session-a-rebound',
+        submission_id: expect.any(String),
         text: 'queued for background session'
       },
       1_800_000
@@ -2419,6 +2429,7 @@ describe('usePromptActions submit / queue drain semantics', () => {
       {
         queued: true,
         session_id: RUNTIME_SESSION_ID,
+        submission_id: expect.any(String),
         text: 'please send me'
       },
       1_800_000
@@ -2940,6 +2951,7 @@ describe('usePromptActions file attachment sync', () => {
     })
     expect(calls[1]?.params).toEqual({
       session_id: RUNTIME_SESSION_ID,
+      submission_id: expect.any(String),
       text: '@file:.hermes/desktop-attachments/report.txt\n\nconvert this to epub'
     })
   })
@@ -2994,7 +3006,11 @@ describe('usePromptActions file attachment sync', () => {
     })
     expect(calls[1]).toEqual({
       method: 'prompt.submit',
-      params: { session_id: RUNTIME_SESSION_ID, text: '@file:.hermes/desktop-attachments/report.txt\n\nsummarize' }
+      params: {
+        submission_id: expect.any(String),
+        session_id: RUNTIME_SESSION_ID,
+        text: '@file:.hermes/desktop-attachments/report.txt\n\nsummarize'
+      }
     })
   })
 
@@ -3372,7 +3388,11 @@ describe('usePromptActions file attachment sync', () => {
     expect(calls[0]?.params).not.toHaveProperty('data_url')
     expect(calls[1]).toEqual({
       method: 'prompt.submit',
-      params: { session_id: RUNTIME_SESSION_ID, text: '@file:data/report.txt\n\nsummarize' }
+      params: {
+        submission_id: expect.any(String),
+        session_id: RUNTIME_SESSION_ID,
+        text: '@file:data/report.txt\n\nsummarize'
+      }
     })
   })
 })
@@ -3494,7 +3514,11 @@ describe('usePromptActions sleep/wake session recovery', () => {
     // First submit (stale id) → session.resume (stored id) → retry submit (fresh id).
     expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
     expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop', omit_messages: true })
-    expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'message after wake' })
+    expect(calls[2]?.params).toEqual({
+      submission_id: expect.any(String),
+      session_id: RECOVERED_SESSION_ID,
+      text: 'message after wake'
+    })
   })
 
   it('publishes the recovered runtime binding before retrying through the remote owner router', async () => {
@@ -3544,7 +3568,11 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(await handle!.submitText('remote follow-up after reap')).toBe(true)
     expect(bindingPublished).toBe(true)
     expect(calls.map(call => call.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
-    expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'remote follow-up after reap' })
+    expect(calls[2]?.params).toEqual({
+      submission_id: expect.any(String),
+      session_id: RECOVERED_SESSION_ID,
+      text: 'remote follow-up after reap'
+    })
   })
 
   it('resumes the stored session and retries once when reloadFromMessage (regenerate) reports "session not found"', async () => {
@@ -3762,6 +3790,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls[0]?.params).toEqual({
       queued: true,
       session_id: 'rt-background-stale',
+      submission_id: expect.any(String),
       text: 'queued background message after wake'
     })
     expect(calls[1]?.params).toEqual({
@@ -3772,6 +3801,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls[2]?.params).toEqual({
       queued: true,
       session_id: RECOVERED_SESSION_ID,
+      submission_id: expect.any(String),
       text: 'queued background message after wake'
     })
     expect(handle!.activeSessionIdRef.current).toBe(RUNTIME_SESSION_ID)
@@ -3959,6 +3989,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     })
     expect(calls[2]?.params).toEqual({
       session_id: RECOVERED_SESSION_ID,
+      submission_id: expect.any(String),
       text: 'message during starved loop'
     })
   })
@@ -4080,7 +4111,11 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(createBackendSessionForSend).not.toHaveBeenCalled()
     expect(requestGateway).toHaveBeenCalledWith(
       'prompt.submit',
-      { session_id: RECOVERED_SESSION_ID, text: 'follow-up while the profile route is rebinding' },
+      {
+        submission_id: expect.any(String),
+        session_id: RECOVERED_SESSION_ID,
+        text: 'follow-up while the profile route is rebinding'
+      },
       1_800_000
     )
   })
@@ -4118,7 +4153,11 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(resumeStoredSession).toHaveBeenCalledWith(STORED_SESSION_ID)
     expect(requestGateway).toHaveBeenCalledWith(
       'prompt.submit',
-      { session_id: RECOVERED_SESSION_ID, text: 'stay in the routed profile session' },
+      {
+        submission_id: expect.any(String),
+        session_id: RECOVERED_SESSION_ID,
+        text: 'stay in the routed profile session'
+      },
       1_800_000
     )
   })
@@ -4150,7 +4189,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(resumeStoredSession).not.toHaveBeenCalled()
     expect(requestGateway).toHaveBeenCalledWith(
       'prompt.submit',
-      { session_id: RECOVERED_SESSION_ID, text: 'normal follow-up' },
+      { submission_id: expect.any(String), session_id: RECOVERED_SESSION_ID, text: 'normal follow-up' },
       1_800_000
     )
   })
@@ -4207,7 +4246,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(await handle!.submitText('retry after recovery')).toBe(true)
     expect(requestGateway).toHaveBeenCalledWith(
       'prompt.submit',
-      { session_id: RECOVERED_SESSION_ID, text: 'retry after recovery' },
+      { submission_id: expect.any(String), session_id: RECOVERED_SESSION_ID, text: 'retry after recovery' },
       1_800_000
     )
   })
@@ -4634,7 +4673,7 @@ describe('usePromptActions new-chat first-send delivery (#63078)', () => {
     expect(calls).toEqual([
       {
         method: 'prompt.submit',
-        params: { session_id: NEW_RUNTIME_ID, text: 'first message of a new chat' }
+        params: { submission_id: expect.any(String), session_id: NEW_RUNTIME_ID, text: 'first message of a new chat' }
       }
     ])
   })
@@ -4692,6 +4731,7 @@ describe('usePromptActions new-chat first-send delivery (#63078)', () => {
       'prompt.submit',
       {
         session_id: NEW_RUNTIME_ID,
+        submission_id: expect.any(String),
         text: 'hello'
       },
       1_800_000
@@ -4987,7 +5027,11 @@ describe('usePromptActions busy-gateway churn tolerance (#64327)', () => {
       },
       {
         method: 'prompt.submit',
-        params: { session_id: RESUMED_RUNTIME_ID, text: 'deliver despite lagging local publication' }
+        params: {
+          submission_id: expect.any(String),
+          session_id: RESUMED_RUNTIME_ID,
+          text: 'deliver despite lagging local publication'
+        }
       }
     ])
   })
@@ -5066,7 +5110,12 @@ describe('usePromptActions busy-gateway churn tolerance (#64327)', () => {
       },
       {
         method: 'prompt.submit',
-        params: { session_id: QUEUED_RUNTIME_ID, text: 'queued prompt for C', queued: true }
+        params: {
+          submission_id: expect.any(String),
+          session_id: QUEUED_RUNTIME_ID,
+          text: 'queued prompt for C',
+          queued: true
+        }
       }
     ])
     // No prompt or state write ever touches B, and no foreground

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -734,7 +734,7 @@ export function usePromptActions({
   // completed work intact. During a tool it waits for the safe result boundary.
   // Returns false when the turn raced to completion so the composer can queue.
   const redirectPrompt = useCallback(
-    async (rawText: string): Promise<boolean> => {
+    async (rawText: string, mode: 'interrupt' | 'steer' = 'interrupt'): Promise<boolean> => {
       const text = sanitizeComposerInput(rawText).trim()
       // Ref, not the closure-captured prop — see cancelRun above. A redirect
       // reaches the live model mid-turn, so a stale target delivers the user's
@@ -756,7 +756,9 @@ export function usePromptActions({
         // gateway, in arrival order: sealed already-streamed output above,
         // correction bubble below it, post-redirect deltas below that
         // (#73793, #83151).
-        const messageId = appendSessionTextMessage(id, 'user', text, undefined, { appendAfterActiveReply: true })
+        const messageId = appendSessionTextMessage(id, 'user', text, undefined, {
+          appendAfterActiveReply: mode === 'interrupt'
+        })
 
         const discardOptimisticMessage = () =>
           updateSessionState(id, state => ({
@@ -774,7 +776,10 @@ export function usePromptActions({
           })
 
         try {
-          const result = await requestGateway<SessionRedirectResponse>('session.redirect', { session_id: id, text })
+          const result = await requestGateway<SessionRedirectResponse>(
+            mode === 'steer' ? 'session.steer' : 'session.redirect',
+            { session_id: id, text }
+          )
 
           if (result?.status === 'redirected') {
             triggerHaptic('submit')
@@ -785,7 +790,9 @@ export function usePromptActions({
           if (result?.status === 'queued') {
             // Build-window redirects become the next turn, not part of the
             // active reply, so retain the optimistic row at the tail.
-            moveOptimisticMessageToEnd()
+            if (mode === 'interrupt') {
+              moveOptimisticMessageToEnd()
+            }
             triggerHaptic('submit')
 
             return true

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -636,7 +636,7 @@ export function usePromptActions({
         triggerHaptic('selection')
         // Forward the explicit target (background queue drain, tile) — dropping
         // it ran the command against whatever chat happened to be in front.
-        await executeSlashCommand(visibleText, options?.sessionId ? { sessionId: options.sessionId } : undefined)
+        await executeSlashCommand(visibleText, { sessionId: options?.sessionId ?? undefined, submission_id: options?.submission_id })
 
         return true
       }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -636,9 +636,7 @@ export function usePromptActions({
         triggerHaptic('selection')
         // Forward the explicit target (background queue drain, tile) — dropping
         // it ran the command against whatever chat happened to be in front.
-        await executeSlashCommand(visibleText, { sessionId: options?.sessionId ?? undefined, submission_id: options?.submission_id })
-
-        return true
+        return await executeSlashCommand(visibleText, options)
       }
 
       return await submitPromptText(rawText, options)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -66,6 +66,7 @@ import {
   type SurvivorUserRowIds
 } from './rewind'
 import { useSlashCommand } from './slash'
+import { captureSubmissionDestination } from './submission-destination'
 import { useSubmitPrompt } from './submit'
 import {
   blobToDataUrl,
@@ -131,7 +132,13 @@ export async function uploadComposerAttachment(
     terminalBackend?: string
   }
 ): Promise<ComposerAttachment> {
-  const { backendCwd, remote, requestGateway, storedSessionId, onSessionRecovered, terminalBackend } = opts
+  const { backendCwd, remote, storedSessionId, onSessionRecovered, terminalBackend } = opts
+
+  const requestGateway = captureSubmissionDestination(
+    storedSessionId ?? opts.sessionId,
+    opts.requestGateway
+  ).requestGateway
+
   const path = attachment.path ?? ''
   const label = attachment.label || pathLabel(path)
   const uploadBytes = remote || attachmentPathNeedsUpload(path, backendCwd, terminalBackend)
@@ -336,18 +343,34 @@ export function usePromptActions({
     async (
       sessionId: string,
       attachments: ComposerAttachment[],
-      options: { updateComposerAttachments?: boolean } = {}
+      options: {
+        updateComposerAttachments?: boolean
+        storedSessionId?: string | null
+        requestGateway?: GatewayRequest
+      } = {}
     ): Promise<{ attachments: ComposerAttachment[]; sessionId: string }> => {
       const updateComposerAttachments = options.updateComposerAttachments ?? true
-      const storedSessionId = selectedStoredSessionIdRef.current
+
+      const storedSessionId =
+        options.storedSessionId !== undefined ? options.storedSessionId : selectedStoredSessionIdRef.current
+
+      const uploadRequest =
+        options.requestGateway ??
+        captureSubmissionDestination(storedSessionId ?? sessionId, requestGateway).requestGateway
+
+      const backendCwd = $currentCwd.get()
+      const terminalBackend = $terminalBackend.get()
       const remote = isSessionRemote(storedSessionId ?? sessionId)
       let liveSessionId = sessionId
       const synced: ComposerAttachment[] = []
 
       const onSessionRecovered = (recoveredId: string) => {
         liveSessionId = recoveredId
-        activeSessionIdRef.current = recoveredId
-        setActiveSessionId(recoveredId)
+
+        if (activeSessionIdRef.current === sessionId) {
+          activeSessionIdRef.current = recoveredId
+          setActiveSessionId(recoveredId)
+        }
       }
 
       for (const original of attachments) {
@@ -378,13 +401,13 @@ export function usePromptActions({
 
         if (attachment.kind === 'image' || attachment.kind === 'file') {
           const nextAttachment = await uploadComposerAttachment(attachment, {
-            backendCwd: $currentCwd.get(),
+            backendCwd,
             remote,
-            requestGateway,
+            requestGateway: uploadRequest,
             sessionId: liveSessionId,
             storedSessionId,
             onSessionRecovered,
-            terminalBackend: $terminalBackend.get()
+            terminalBackend
           })
 
           // Update-only: never resurrect a chip the user removed mid-upload.
@@ -793,6 +816,7 @@ export function usePromptActions({
             if (mode === 'interrupt') {
               moveOptimisticMessageToEnd()
             }
+
             triggerHaptic('submit')
 
             return true

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/prepared-submissions.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/prepared-submissions.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, expect, test, vi } from 'vitest'
+
+import { type PreparedSubmission, readPreparedSubmission, removePreparedSubmission, writePreparedSubmission } from './prepared-submissions'
+
+afterEach(() => { vi.unstubAllGlobals(); localStorage.clear() })
+
+test('native preparation waits for acknowledgement and never downgrades a write failure to browser storage', async () => {
+  let ack!: () => void
+  const gate = new Promise<void>(resolve => { ack = resolve })
+  const entry = { id: 'a', text: 'Ω\n  exact', attachments: [], params: { session_id: 'live' } } as unknown as PreparedSubmission
+  const native = { read: vi.fn(async () => JSON.stringify({ key: entry })), update: vi.fn(() => gate) }
+  vi.stubGlobal('hermesDesktop', { preparedSubmissions: native })
+  let finished = false
+  const writing = writePreparedSubmission('key', entry).then(() => { finished = true })
+  await Promise.resolve()
+  expect(finished).toBe(false)
+  expect(native.update).toHaveBeenCalledWith('key', JSON.stringify(entry))
+  ack(); await writing
+  expect(await readPreparedSubmission('key')).toEqual(entry)
+  native.update.mockRejectedValueOnce(new Error('disk full'))
+  await expect(writePreparedSubmission('key', entry)).rejects.toThrow('disk full')
+  expect(localStorage.length).toBe(0)
+  await removePreparedSubmission('key')
+  expect(native.update).toHaveBeenLastCalledWith('key', null)
+  vi.stubGlobal('hermesDesktop', undefined)
+  await writePreparedSubmission('key', entry)
+  expect(await readPreparedSubmission('key')).toEqual(entry)
+  await removePreparedSubmission('key')
+  expect(await readPreparedSubmission('key')).toBeUndefined()
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/prepared-submissions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/prepared-submissions.ts
@@ -1,0 +1,66 @@
+import type { ComposerAttachment } from '@/store/composer'
+import type { SessionOwnerScope } from '@/store/session-request-router'
+
+import type { SubmissionDestination } from './submission-destination'
+import type { SubmitTextOptions } from './utils'
+
+const STORAGE_KEY = 'hermes.desktop.preparedSubmissions.v1'
+
+export interface PreparedSubmission {
+  id: string
+  owner: SessionOwnerScope
+  attachments: ComposerAttachment[]
+  text: string
+  displayText?: string
+  params: Record<string, unknown>
+  legacyAttempted?: boolean
+}
+
+// A journal, not an automatic outbox. Only an explicit retry may reuse an
+// uncertain admission. Read storage each time so a remount cannot lose it.
+function readJournal(): Record<string, PreparedSubmission> {
+  const parsed: unknown = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '{}')
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Invalid prepared submission journal')
+  }
+
+  return parsed as Record<string, PreparedSubmission>
+}
+
+export function preparedSubmissionKey(
+  target: string | null | undefined,
+  destination: SubmissionDestination,
+  rawText: string,
+  attachments: ComposerAttachment[],
+  options?: SubmitTextOptions
+): string {
+  return JSON.stringify([
+    destination.scopeKey,
+    target,
+    options?.retryText ?? rawText,
+    attachments.map(a => a.occurrenceId ?? a.id),
+    options?.displayKind,
+    Boolean(options?.fromQueue),
+    // Slash expands once, then retries the prepared wire payload, not a new
+    // generated ID/expansion. Explicit queue IDs remain distinct intents.
+    options?.retryText && !options.fromQueue ? null : options?.submission_id
+  ])
+}
+
+export function readPreparedSubmission(key: string): PreparedSubmission | undefined {
+  return readJournal()[key]
+}
+
+export function writePreparedSubmission(key: string, entry: PreparedSubmission): void {
+  const journal = readJournal()
+  journal[key] = entry
+  // Fail before sending if persistence fails; never claim a volatile ID is durable.
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(journal))
+}
+
+export function removePreparedSubmission(key: string): void {
+  const journal = readJournal()
+  delete journal[key]
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(journal))
+}

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/prepared-submissions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/prepared-submissions.ts
@@ -18,8 +18,12 @@ export interface PreparedSubmission {
 
 // A journal, not an automatic outbox. Only an explicit retry may reuse an
 // uncertain admission. Read storage each time so a remount cannot lose it.
-function readJournal(): Record<string, PreparedSubmission> {
-  const parsed: unknown = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '{}')
+async function readJournal(): Promise<Record<string, PreparedSubmission>> {
+  const native = window.hermesDesktop?.preparedSubmissions
+
+  const parsed: unknown = JSON.parse(native
+    ? await native.read()
+    : window.localStorage.getItem(STORAGE_KEY) || '{}')
 
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('Invalid prepared submission journal')
@@ -48,19 +52,36 @@ export function preparedSubmissionKey(
   ])
 }
 
-export function readPreparedSubmission(key: string): PreparedSubmission | undefined {
-  return readJournal()[key]
+export async function readPreparedSubmission(key: string): Promise<PreparedSubmission | undefined> {
+  return (await readJournal())[key]
 }
 
-export function writePreparedSubmission(key: string, entry: PreparedSubmission): void {
-  const journal = readJournal()
+export async function writePreparedSubmission(key: string, entry: PreparedSubmission): Promise<void> {
+  const native = window.hermesDesktop?.preparedSubmissions
+
+  if (native) {
+    await native.update(key, JSON.stringify(entry))
+
+    return
+  }
+
+  const journal: Record<string, PreparedSubmission> = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '{}')
   journal[key] = entry
-  // Fail before sending if persistence fails; never claim a volatile ID is durable.
+  // Browser-only clients retain reload recovery, not a process-crash guarantee.
+  // Native write failures never fall back here: sending requires their ACK.
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(journal))
 }
 
-export function removePreparedSubmission(key: string): void {
-  const journal = readJournal()
+export async function removePreparedSubmission(key: string): Promise<void> {
+  const native = window.hermesDesktop?.preparedSubmissions
+
+  if (native) {
+    await native.update(key, null)
+
+    return
+  }
+
+  const journal: Record<string, PreparedSubmission> = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '{}')
   delete journal[key]
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(journal))
 }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/queue-if-busy.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/queue-if-busy.test.ts
@@ -1,0 +1,90 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+import { en } from '@/i18n/en'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import * as queue from '@/store/composer-queue'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection, $sessions } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
+
+import { queueKickoffIfSessionBusy } from './queue-if-busy'
+import { useSlashCommand } from './slash'
+import type { GatewayRequest } from './utils'
+
+beforeEach(() => {
+  $sessions.set([])
+  $connection.set(null)
+  $activeGatewayProfile.set('default')
+  $sessionStates.set({
+    'runtime-a': { ...createClientSessionState(), busy: true, storedSessionId: 'stored-a' }
+  })
+  queue.$queuedPromptsBySession.set({})
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  queue.$queuedPromptsBySession.set({})
+  $sessionStates.set({})
+})
+
+it('forwards kickoff identity to queue admission and leaves idle targets alone', () => {
+  const enqueue = vi.spyOn(queue, 'enqueueQueuedPrompt')
+  const input = { id: 'caller-kickoff', sessionId: 'runtime-a', text: 'expanded skill', displayText: '/work' }
+
+  expect(queueKickoffIfSessionBusy(input)).toBe('queued')
+  expect(enqueue).toHaveBeenCalledWith('stored-a', {
+    id: input.id,
+    text: input.text,
+    displayText: input.displayText,
+    attachments: []
+  })
+  expect(queueKickoffIfSessionBusy({ ...input, sessionId: 'idle-target', foregroundBusy: true })).toBe('idle')
+  expect(enqueue).toHaveBeenCalledTimes(1)
+})
+
+it('keeps caller-provided and generated slash IDs when a busy target queues the expanded skill', async () => {
+  const enqueue = vi.spyOn(queue, 'enqueueQueuedPrompt')
+  const generatedId = 'a6c67295-d5e0-4edb-b6f0-8aeb144efb77'
+  vi.spyOn(crypto, 'randomUUID').mockReturnValue(generatedId)
+  const submitPromptText = vi.fn(async () => true)
+
+  const { result } = renderHook(() =>
+    useSlashCommand({
+      activeSessionIdRef: { current: 'runtime-a' },
+      selectedStoredSessionIdRef: { current: 'stored-a' },
+      busyRef: { current: false },
+      copy: en.desktop,
+      createBackendSessionForSend: async () => null,
+      getRoutedStoredSessionId: () => 'stored-a',
+      getRuntimeIdForStoredSession: () => 'runtime-a',
+      requestGateway: vi.fn(async () => ({ type: 'skill', name: 'work', message: 'expanded skill' })) as GatewayRequest,
+      resumeStoredSession: vi.fn(),
+      updateSessionState: vi.fn((_sid, updater) => updater(createClientSessionState())),
+      submitPromptText,
+      appendSessionTextMessage: vi.fn(),
+      branchCurrentSession: async () => true,
+      handleSkinCommand: () => '',
+      handoffSession: async () => ({ ok: true }),
+      openMemoryGraph: vi.fn(),
+      refreshSessions: async () => undefined,
+      startFreshSessionDraft: vi.fn()
+    })
+  )
+
+  for (const submissionId of ['caller-slash', undefined]) {
+    await act(async () => {
+      await result.current('/work', { submission_id: submissionId })
+    })
+    expect(enqueue).toHaveBeenLastCalledWith(
+      'stored-a',
+      expect.objectContaining({
+        id: submissionId ?? generatedId,
+        text: 'expanded skill'
+      })
+    )
+  }
+
+  expect(submitPromptText).not.toHaveBeenCalled()
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/queue-if-busy.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/queue-if-busy.ts
@@ -5,6 +5,7 @@ import { $sessionStates } from '@/store/session-states'
 import { isTargetSessionBusy } from './utils'
 
 export interface QueueIfBusyInput {
+  id?: string
   /** Runtime session the command was resolved against. */
   sessionId: string
   /** Stored session the composer queue is keyed by; defaults to the runtime id
@@ -28,6 +29,7 @@ export interface QueueIfBusyInput {
 export function queueKickoffIfSessionBusy({
   displayText,
   foregroundBusy = false,
+  id,
   sessionId,
   storedSessionId,
   text
@@ -41,5 +43,5 @@ export function queueKickoffIfSessionBusy({
   const stored = storedSessionId ?? states[sessionId]?.storedSessionId ?? null
   const queueKey = resolveComposerSessionKey(stored, $sessions.get()) || stored || sessionId
 
-  return enqueueQueuedPrompt(queueKey, { attachments: [], displayText, text }) ? 'queued' : 'busy'
+  return enqueueQueuedPrompt(queueKey, { attachments: [], displayText, id, text }) ? 'queued' : 'busy'
 }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -208,7 +208,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       const retryOptions = { ...options, retryText: rawCommand }
 
       try {
-        const prepared = readPreparedSubmission(preparedSubmissionKey(
+        const prepared = await readPreparedSubmission(preparedSubmissionKey(
           resolveComposerSessionKey(initialStoredId ?? initialRuntimeId, $sessions.get()),
           destination, rawCommand, options?.attachments ?? $composerAttachments.get(), retryOptions
         ))

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -364,6 +364,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           const queued = queueKickoffIfSessionBusy({
             displayText,
             foregroundBusy: busyRef.current,
+            id: submissionId,
             sessionId,
             storedSessionId,
             text: message

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -186,16 +186,20 @@ export function useSlashCommand(deps: SlashCommandDeps) {
   const compressInFlightRef = useRef(new Set<string>())
 
   return useCallback(
-    async (rawCommand: string, options?: { sessionId?: string; recordInput?: boolean; submission_id?: string }) => {
+    async (rawCommand: string, options?: SubmitTextOptions & { recordInput?: boolean }) => {
       const initialRuntimeId = options?.sessionId ?? activeSessionIdRef.current
       const initialSelectedId = selectedStoredSessionIdRef.current
       const initialRoutedId = getRoutedStoredSessionId()
 
-      const initialStoredId = options?.sessionId
-        ? ($sessionStates.get()[options.sessionId]?.storedSessionId ?? null)
-        : (initialRoutedId ?? initialSelectedId)
+      let submitted = true
+      const initialStoredId =
+        options?.storedSessionId ??
+        (options?.sessionId
+          ? ($sessionStates.get()[options.sessionId]?.storedSessionId ?? null)
+          : (initialRoutedId ?? initialSelectedId))
 
-      const destination = captureSubmissionDestination(initialStoredId ?? initialRuntimeId, ambientRequestGateway)
+      const destination =
+        options?.destination ?? captureSubmissionDestination(initialStoredId ?? initialRuntimeId, ambientRequestGateway)
       const requestGateway = destination.requestGateway
       const submissionId = options?.submission_id ?? crypto.randomUUID()
 
@@ -361,14 +365,16 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           // rather than re-reading the globals — a session switch between
           // dispatch and this branch would otherwise queue the kickoff on
           // whichever chat is now in front (#63352).
-          const queued = queueKickoffIfSessionBusy({
-            displayText,
-            foregroundBusy: busyRef.current,
-            id: submissionId,
-            sessionId,
-            storedSessionId,
-            text: message
-          })
+          const queued = options?.fromQueue
+            ? 'idle'
+            : queueKickoffIfSessionBusy({
+                displayText,
+                foregroundBusy: busyRef.current,
+                id: submissionId,
+                sessionId,
+                storedSessionId,
+                text: message
+              })
 
           if (queued !== 'idle') {
             renderSlashOutput(
@@ -388,7 +394,8 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           // its kickoff as a user message into whatever conversation was on
           // screen. Every other target the dispatcher serves (tile, background
           // queue drain, a session created by this very call) had the same leak.
-          await submitPromptText(message, {
+          submitted = await submitPromptText(message, {
+            ...options,
             sessionId,
             storedSessionId,
             displayText,
@@ -1235,7 +1242,9 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         }
       }
 
-      await runSlash(rawCommand, options?.sessionId, options?.recordInput ?? true)
+      await runSlash(rawCommand, options?.sessionId ?? undefined, options?.recordInput ?? true)
+
+      return submitted
     },
     [
       activeSessionIdRef,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -61,6 +61,7 @@ import type {
 
 import { queueKickoffIfSessionBusy } from './queue-if-busy'
 import { resolveTargetSessionId } from './resolve-target-session'
+import { captureSubmissionDestination } from './submission-destination'
 import {
   type GatewayRequest,
   isSessionIdCandidate,
@@ -174,7 +175,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
     handoffSession,
     openMemoryGraph,
     refreshSessions,
-    requestGateway,
+    requestGateway: ambientRequestGateway,
     resumeStoredSession,
     selectedStoredSessionIdRef,
     startFreshSessionDraft,
@@ -185,7 +186,19 @@ export function useSlashCommand(deps: SlashCommandDeps) {
   const compressInFlightRef = useRef(new Set<string>())
 
   return useCallback(
-    async (rawCommand: string, options?: { sessionId?: string; recordInput?: boolean }) => {
+    async (rawCommand: string, options?: { sessionId?: string; recordInput?: boolean; submission_id?: string }) => {
+      const initialRuntimeId = options?.sessionId ?? activeSessionIdRef.current
+      const initialSelectedId = selectedStoredSessionIdRef.current
+      const initialRoutedId = getRoutedStoredSessionId()
+
+      const initialStoredId = options?.sessionId
+        ? ($sessionStates.get()[options.sessionId]?.storedSessionId ?? null)
+        : (initialRoutedId ?? initialSelectedId)
+
+      const destination = captureSubmissionDestination(initialStoredId ?? initialRuntimeId, ambientRequestGateway)
+      const requestGateway = destination.requestGateway
+      const submissionId = options?.submission_id ?? crypto.randomUUID()
+
       // Resolve the session this command targets through the SHARED ladder that
       // submit.ts uses. A slash command runs backend commands against a runtime
       // session, and per-session state (`/goal`, `/usage`, `/status`) is keyed by
@@ -197,13 +210,13 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       // goal" for a goal that was live on the real chat.
       const ensureSessionId = async (sessionHint?: string, preview?: null | string) =>
         resolveTargetSessionId({
-          activeRuntimeId: activeSessionIdRef.current,
+          activeRuntimeId: initialRuntimeId,
           createSession: () => createBackendSessionForSend(preview),
           explicitRuntimeId: sessionHint,
           getRuntimeIdForStoredSession,
           requestGateway,
-          routedStoredSessionId: getRoutedStoredSessionId(),
-          selectedStoredSessionId: selectedStoredSessionIdRef.current
+          routedStoredSessionId: initialRoutedId,
+          selectedStoredSessionId: initialSelectedId
         })
 
       // Resolve the target session plus a writer for inline slash output, or
@@ -232,7 +245,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         // to updateSessionState re-keyed the tile's cache entry onto the
         // primary's stored session. Fall back to the selection only for a
         // session with no published state yet (a draft this call just created).
-        const storedSessionId = $sessionStates.get()[sessionId]?.storedSessionId ?? selectedStoredSessionIdRef.current
+        const storedSessionId = $sessionStates.get()[sessionId]?.storedSessionId ?? initialStoredId
 
         // Header carries the command token only. The full invocation would
         // duplicate long args — `/goal <prose>` echoed the whole goal in the
@@ -374,7 +387,13 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           // its kickoff as a user message into whatever conversation was on
           // screen. Every other target the dispatcher serves (tile, background
           // queue drain, a session created by this very call) had the same leak.
-          await submitPromptText(message, { sessionId, storedSessionId, displayText })
+          await submitPromptText(message, {
+            sessionId,
+            storedSessionId,
+            displayText,
+            submission_id: submissionId,
+            destination
+          })
         }
 
         try {
@@ -1230,7 +1249,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       handoffSession,
       openMemoryGraph,
       refreshSessions,
-      requestGateway,
+      ambientRequestGateway,
       resumeStoredSession,
       selectedStoredSessionIdRef,
       startFreshSessionDraft,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -17,7 +17,7 @@ import {
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { openCommandPalettePage } from '@/store/command-palette'
-import { setComposerDraft } from '@/store/composer'
+import { $composerAttachments, setComposerDraft } from '@/store/composer'
 import { applyGoalStatusText } from '@/store/goals'
 import { dismissNotification, notify, notifyError } from '@/store/notifications'
 import { setPetScale } from '@/store/pet-gallery'
@@ -33,6 +33,7 @@ import {
   $connection,
   $sessions,
   $yoloActive,
+  resolveComposerSessionKey,
   setActiveSessionId,
   setCurrentUsage,
   setModelPickerOpen,
@@ -59,6 +60,7 @@ import type {
   SlashExecResponse
 } from '../../../types'
 
+import { preparedSubmissionKey, readPreparedSubmission } from './prepared-submissions'
 import { queueKickoffIfSessionBusy } from './queue-if-busy'
 import { resolveTargetSessionId } from './resolve-target-session'
 import { captureSubmissionDestination } from './submission-destination'
@@ -192,6 +194,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       const initialRoutedId = getRoutedStoredSessionId()
 
       let submitted = true
+
       const initialStoredId =
         options?.storedSessionId ??
         (options?.sessionId
@@ -200,7 +203,29 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
       const destination =
         options?.destination ?? captureSubmissionDestination(initialStoredId ?? initialRuntimeId, ambientRequestGateway)
+
       const requestGateway = destination.requestGateway
+      const retryOptions = { ...options, retryText: rawCommand }
+
+      try {
+        const prepared = readPreparedSubmission(preparedSubmissionKey(
+          resolveComposerSessionKey(initialStoredId ?? initialRuntimeId, $sessions.get()),
+          destination, rawCommand, options?.attachments ?? $composerAttachments.get(), retryOptions
+        ))
+
+        if (prepared) {
+          return await submitPromptText(prepared.text, {
+            ...retryOptions, sessionId: initialRuntimeId ?? undefined,
+            storedSessionId: initialStoredId, displayText: prepared.displayText,
+            submission_id: prepared.id, destination
+          })
+        }
+      } catch (err) {
+        notifyError(err, copy.promptFailed)
+
+        return false
+      }
+
       const submissionId = options?.submission_id ?? crypto.randomUUID()
 
       // Resolve the session this command targets through the SHARED ladder that
@@ -249,7 +274,8 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         // to updateSessionState re-keyed the tile's cache entry onto the
         // primary's stored session. Fall back to the selection only for a
         // session with no published state yet (a draft this call just created).
-        const storedSessionId = $sessionStates.get()[sessionId]?.storedSessionId ?? initialStoredId
+        const storedSessionId = $sessionStates.get()[sessionId]?.storedSessionId ?? initialStoredId ??
+          (!initialRuntimeId && activeSessionIdRef.current === sessionId ? selectedStoredSessionIdRef.current : null)
 
         // Header carries the command token only. The full invocation would
         // duplicate long args — `/goal <prose>` echoed the whole goal in the
@@ -395,7 +421,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           // screen. Every other target the dispatcher serves (tile, background
           // queue drain, a session created by this very call) had the same leak.
           submitted = await submitPromptText(message, {
-            ...options,
+            ...retryOptions,
             sessionId,
             storedSessionId,
             displayText,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.test.tsx
@@ -62,6 +62,7 @@ function setup() {
 }
 
 beforeEach(() => {
+  window.localStorage.clear()
   $sessions.set([])
   $sessionStates.set({})
   $connection.set(null)
@@ -87,6 +88,7 @@ describe('submission intent destinations', () => {
       mode: 'local',
       profile: 'default'
     }
+
     $connection.set(connection as never)
     const request = vi.fn(async () => ({ ok: true }))
     const captured = captureSubmissionDestination(null, request as GatewayRequest)
@@ -104,7 +106,9 @@ describe('submission intent destinations', () => {
       mode: 'local',
       profile: 'default'
     }
+
     const request = vi.fn(async () => ({}))
+
     for (const change of [
       { baseUrl: 'http://other' },
       { wsUrl: 'ws://other/ws' },
@@ -118,28 +122,188 @@ describe('submission intent destinations', () => {
       $connection.set({ ...connection, ...change } as never)
       await expect(captured.requestGateway('prompt.submit')).rejects.toThrow('Submission destination changed')
     }
+
     expect(request).not.toHaveBeenCalled()
   })
   it('reuses a prepared direct submission after ambiguous failure without restaging attachments', async () => {
     const { deps, requestGateway } = setup()
     requestGateway.mockRejectedValueOnce(new Error('connection closed'))
-    const { result, rerender } = renderHook(() => useSubmitPrompt(deps))
+    let hook = renderHook(() => useSubmitPrompt(deps))
     await act(async () => {
-      expect(await result.current('retry me')).toBe(false)
+      expect(await hook.result.current('retry me')).toBe(false)
     })
-    rerender()
+    const journal = window.localStorage.getItem('hermes.desktop.preparedSubmissions.v1')
+    expect(journal).toContain('retry me')
+    hook.unmount()
+    window.localStorage.clear()
+    window.localStorage.setItem('hermes.desktop.preparedSubmissions.v1', journal!)
+    // A same-text send in another profile/session is a different intent; it
+    // must neither reuse nor retire the original uncertain admission.
+    $activeGatewayProfile.set('bob')
+    deps.selectedStoredSessionIdRef.current = 'stored-b'
+    deps.activeSessionIdRef.current = 'runtime-b'
+    deps.runtimeIdByStoredSessionIdRef.current.set('stored-b', 'runtime-b')
+    hook = renderHook(() => useSubmitPrompt(deps))
+    await act(async () => {
+      expect(await hook.result.current('retry me')).toBe(true)
+    })
+    expect(requestGateway.mock.calls[1][1]?.submission_id).not.toBe(requestGateway.mock.calls[0][1]?.submission_id)
+    hook.unmount()
+    $activeGatewayProfile.set('default')
+    deps.selectedStoredSessionIdRef.current = 'stored-a'
+    deps.activeSessionIdRef.current = 'runtime-a'
+    hook = renderHook(() => useSubmitPrompt(deps))
+    const { result } = hook
     await act(async () => {
       expect(await result.current('retry me')).toBe(true)
     })
-    const calls = requestGateway.mock.calls.filter(call => call[0] === 'prompt.submit')
+
+    const calls = requestGateway.mock.calls.filter(
+      call => call[0] === 'prompt.submit' && call[1]?.session_id === 'runtime-a'
+    )
+
     expect(calls).toHaveLength(2)
     expect(calls[1][1]).toEqual(calls[0][1])
-    expect(deps.syncAttachmentsForSubmit).toHaveBeenCalledTimes(1)
+    expect(deps.syncAttachmentsForSubmit).toHaveBeenCalledTimes(2)
     await act(async () => {
       expect(await result.current('retry me')).toBe(true)
     })
-    expect(requestGateway.mock.calls[2][1]?.submission_id).not.toBe(calls[0][1]?.submission_id)
+    expect(requestGateway.mock.calls.at(-1)?.[1]?.submission_id).not.toBe(calls[0][1]?.submission_id)
   })
+
+  it.each([false, true])('keeps new-session %s kickoff identity and expansion across journal reload', async slash => {
+    const { deps, requestGateway } = setup()
+    deps.activeSessionIdRef.current = null
+    deps.selectedStoredSessionIdRef.current = null
+    $connection.set({ connectionId: 'local', profile: 'default', mode: 'local' } as never)
+    deps.createBackendSessionForSend.mockImplementation(async () => {
+      deps.activeSessionIdRef.current = 'runtime-a'
+      deps.selectedStoredSessionIdRef.current = 'stored-a'
+      $sessions.set([{ id: 'stored-a', connection_id: 'local', profile: 'default' }] as never)
+
+      return 'runtime-a' as never
+    })
+    const accepted = new Map<string, Record<string, unknown>>()
+    let loseAck = true
+    let expansions = 0
+    requestGateway.mockImplementation(async (method, params) => {
+      if (method === 'slash.exec') {
+        expansions++
+
+        return {
+          type: 'skill',
+          name: 'private-skill',
+          message: `expanded-${expansions}`,
+          display: '/private-skill'
+        } as never
+      }
+
+      if (method !== 'prompt.submit') {
+        return {} as never
+      }
+
+      const id = String(params?.submission_id)
+      const previous = accepted.get(id)
+
+      if (previous) {
+        expect(params).toEqual(previous)
+      } else {
+        accepted.set(id, params!)
+      }
+
+      if (loseAck) {
+        throw new Error('connection closed')
+      }
+
+      return { admission_id: id, status: 'terminal' } as never
+    })
+    wire.request.mockImplementation((_connection, _profile, method, params) => requestGateway(method, params))
+
+    const mount = () =>
+      renderHook(() => {
+        const submitPromptText = useSubmitPrompt(deps)
+
+        const runSlash = useSlashCommand({
+          ...deps,
+          submitPromptText,
+          appendSessionTextMessage: vi.fn(),
+          branchCurrentSession: async () => true,
+          handleSkinCommand: () => '',
+          handoffSession: async () => ({ ok: true }),
+          openMemoryGraph: vi.fn(),
+          refreshSessions: async () => undefined,
+          startFreshSessionDraft: vi.fn()
+        })
+
+        return slash ? runSlash : submitPromptText
+      })
+
+    const input = slash ? '/private-skill' : 'first prompt'
+    let hook = mount()
+    await act(async () => {
+      expect(await hook.result.current(input)).toBe(false)
+    })
+    const serialized = window.localStorage.getItem('hermes.desktop.preparedSubmissions.v1')
+    expect(serialized).toBeTruthy()
+    expect(Object.values(JSON.parse(serialized!))[0]).toMatchObject({ owner: { connectionId: 'local', profile: 'default' } })
+    hook.unmount()
+    window.localStorage.clear()
+    window.localStorage.setItem('hermes.desktop.preparedSubmissions.v1', serialized!)
+    loseAck = false
+    hook = mount()
+    await act(async () => {
+      expect(await hook.result.current(input)).toBe(true)
+    })
+    expect(accepted.size).toBe(1)
+    expect(deps.createBackendSessionForSend).toHaveBeenCalledTimes(1)
+    expect(deps.syncAttachmentsForSubmit).toHaveBeenCalledTimes(1)
+    expect(expansions).toBe(slash ? 1 : 0)
+  })
+
+  it.each(['missing', 'wrong', 'unknown', '4094', 'lost-legacy'])(
+    'requires a matching receipt or one pre-admission legacy refusal: %s',
+    async mode => {
+      const { deps, requestGateway } = setup()
+      const refusal = Object.assign(new Error('durable admission unsupported'), { code: 4094 })
+      requestGateway.mockImplementation(async (_method, params) => {
+        if (mode === '4094' || mode === 'lost-legacy') {
+          if (params?.submission_id) {
+            throw refusal
+          }
+
+          if (mode === 'lost-legacy') {
+            throw new Error('connection closed')
+          }
+
+          return { ok: true } as never
+        }
+
+        if (mode === 'missing') {
+          return { ok: true } as never
+        }
+
+        return { admission_id: mode === 'wrong' ? 'wrong-id' : params?.submission_id, status: 'unknown' } as never
+      })
+      let hook = renderHook(() => useSubmitPrompt(deps))
+      await act(async () => {
+        expect(await hook.result.current('receipt')).toBe(mode === '4094')
+      })
+      hook.unmount()
+      hook = renderHook(() => useSubmitPrompt(deps))
+
+      if (mode !== '4094') {
+        await act(async () => {
+          expect(await hook.result.current('receipt')).toBe(false)
+        })
+        const attempts = requestGateway.mock.calls.filter(call => call[0] === 'prompt.submit')
+
+        if (mode === 'lost-legacy') { expect(attempts).toHaveLength(2) }
+        const identified = attempts.filter(call => call[1]?.submission_id)
+        expect(new Set(identified.map(call => call[1]?.submission_id)).size).toBe(1)
+        expect(attempts.filter(call => !call[1]?.submission_id)).toHaveLength(mode === 'lost-legacy' ? 1 : 0)
+      }
+    }
+  )
 
   it('assigns one direct ID before preprocessing and keeps it through busy retries', async () => {
     const { deps, requestGateway } = setup()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.test.tsx
@@ -78,6 +78,48 @@ afterEach(() => {
 })
 
 describe('submission intent destinations', () => {
+  it('allows presentation and registry metadata replacement on the same authority', async () => {
+    const connection = {
+      baseUrl: 'http://localhost:1',
+      wsUrl: 'ws://localhost:1/ws',
+      token: 'secret',
+      connectionId: 'local',
+      mode: 'local',
+      profile: 'default'
+    }
+    $connection.set(connection as never)
+    const request = vi.fn(async () => ({ ok: true }))
+    const captured = captureSubmissionDestination(null, request as GatewayRequest)
+    $connection.set({ ...connection, registryScoped: true, isVisible: false } as never)
+    await expect(captured.requestGateway('prompt.submit', { text: 'hello' })).resolves.toEqual({ ok: true })
+    expect(request).toHaveBeenCalledOnce()
+  })
+
+  it('rejects actual endpoint, credential, connection and profile changes', async () => {
+    const connection = {
+      baseUrl: 'http://localhost:1',
+      wsUrl: 'ws://localhost:1/ws',
+      token: 'secret',
+      connectionId: 'local',
+      mode: 'local',
+      profile: 'default'
+    }
+    const request = vi.fn(async () => ({}))
+    for (const change of [
+      { baseUrl: 'http://other' },
+      { wsUrl: 'ws://other/ws' },
+      { token: 'other' },
+      { connectionId: 'other' },
+      { profile: 'other' },
+      { mode: 'remote' }
+    ]) {
+      $connection.set(connection as never)
+      const captured = captureSubmissionDestination(null, request as GatewayRequest)
+      $connection.set({ ...connection, ...change } as never)
+      await expect(captured.requestGateway('prompt.submit')).rejects.toThrow('Submission destination changed')
+    }
+    expect(request).not.toHaveBeenCalled()
+  })
   it('reuses a prepared direct submission after ambiguous failure without restaging attachments', async () => {
     const { deps, requestGateway } = setup()
     requestGateway.mockRejectedValueOnce(new Error('connection closed'))

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.test.tsx
@@ -78,11 +78,34 @@ afterEach(() => {
 })
 
 describe('submission intent destinations', () => {
+  it('reuses a prepared direct submission after ambiguous failure without restaging attachments', async () => {
+    const { deps, requestGateway } = setup()
+    requestGateway.mockRejectedValueOnce(new Error('connection closed'))
+    const { result, rerender } = renderHook(() => useSubmitPrompt(deps))
+    await act(async () => {
+      expect(await result.current('retry me')).toBe(false)
+    })
+    rerender()
+    await act(async () => {
+      expect(await result.current('retry me')).toBe(true)
+    })
+    const calls = requestGateway.mock.calls.filter(call => call[0] === 'prompt.submit')
+    expect(calls).toHaveLength(2)
+    expect(calls[1][1]).toEqual(calls[0][1])
+    expect(deps.syncAttachmentsForSubmit).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      expect(await result.current('retry me')).toBe(true)
+    })
+    expect(requestGateway.mock.calls[2][1]?.submission_id).not.toBe(calls[0][1]?.submission_id)
+  })
+
   it('assigns one direct ID before preprocessing and keeps it through busy retries', async () => {
     const { deps, requestGateway } = setup()
     let attempts = 0
     requestGateway.mockImplementation(async (_method, params) => {
-      if (++attempts === 1) {throw new Error('session busy')}
+      if (++attempts === 1) {
+        throw new Error('session busy')
+      }
 
       return { admission_id: params?.submission_id, status: 'started' } as never
     })
@@ -180,12 +203,16 @@ describe('submission intent destinations', () => {
     wire.request.mockImplementation(async (connection, profile, method) => {
       requests.push([connection, profile, method])
 
-      if (method === 'slash.exec') {return gate.promise}
+      if (method === 'slash.exec') {
+        return gate.promise
+      }
 
       return { type: 'skill', name: 'private-skill', message: 'expanded private skill' }
     })
     deps.requestGateway = vi.fn(async (method: string) => {
-      if (method === 'slash.exec') {return gate.promise}
+      if (method === 'slash.exec') {
+        return gate.promise
+      }
 
       return { type: 'skill', name: 'private-skill', message: 'expanded private skill' }
     }) as GatewayRequest
@@ -205,7 +232,7 @@ describe('submission intent destinations', () => {
       })
     )
 
-    let pending!: Promise<void>
+    let pending!: Promise<boolean>
     await act(async () => {
       pending = result.current('/private-skill')
     })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.test.tsx
@@ -1,0 +1,231 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { en } from '@/i18n/en'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection, $sessions } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
+
+import { useSlashCommand } from './slash'
+import { captureSubmissionDestination } from './submission-destination'
+import { useSubmitPrompt } from './submit'
+import type { GatewayRequest } from './utils'
+
+const wire = vi.hoisted(() => ({ request: vi.fn(), release: vi.fn() }))
+vi.mock('@/store/gateway', async original => ({
+  ...(await original<Record<string, unknown>>()),
+  requestGatewayForAgent: wire.request,
+  requestGatewayForProfile: wire.request,
+  retainGatewayForSessionTurn: vi.fn(async () => wire.release)
+}))
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+function setup() {
+  const activeSessionIdRef = { current: 'runtime-a' as string | null }
+  const selectedStoredSessionIdRef = { current: 'stored-a' as string | null }
+
+  const requestGateway = vi.fn(
+    async (_method: string, params?: Record<string, unknown>) =>
+      ({ admission_id: params?.submission_id, status: 'started' }) as never
+  )
+
+  const busyRef = { current: false }
+  const state = createClientSessionState()
+
+  const deps = {
+    activeSessionIdRef,
+    selectedStoredSessionIdRef,
+    busyRef,
+    copy: en.desktop,
+    createBackendSessionForSend: vi.fn(async () => null),
+    getRoutedStoredSessionId: () => null,
+    getRuntimeIdForStoredSession: () => 'runtime-a',
+    getRouteToken: () => 'same-route',
+    requestGateway: requestGateway as GatewayRequest,
+    runtimeIdByStoredSessionIdRef: { current: new Map([['stored-a', 'runtime-a']]) },
+    resumeStoredSession: vi.fn(),
+    syncAttachmentsForSubmit: vi.fn(async (sessionId: string) => ({ sessionId, attachments: [] })),
+    updateSessionState: vi.fn((_sid, updater) => updater(state))
+  }
+
+  return { deps, requestGateway }
+}
+
+beforeEach(() => {
+  $sessions.set([])
+  $sessionStates.set({})
+  $connection.set(null)
+  $activeGatewayProfile.set('default')
+  wire.request.mockReset()
+  wire.request.mockImplementation(async (_connection, _profile, _method, params) => ({
+    admission_id: params?.submission_id,
+    status: 'started'
+  }))
+})
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('submission intent destinations', () => {
+  it('assigns one direct ID before preprocessing and keeps it through busy retries', async () => {
+    const { deps, requestGateway } = setup()
+    let attempts = 0
+    requestGateway.mockImplementation(async (_method, params) => {
+      if (++attempts === 1) {throw new Error('session busy')}
+
+      return { admission_id: params?.submission_id, status: 'started' } as never
+    })
+    const { result } = renderHook(() => useSubmitPrompt(deps))
+    await act(async () => {
+      expect(await result.current('hello')).toBe(true)
+    })
+    const ids = requestGateway.mock.calls.map(call => call[1]?.submission_id)
+    expect(ids.length).toBeGreaterThan(1)
+    expect(ids[0]).toEqual(expect.any(String))
+    expect(new Set(ids).size).toBe(1)
+  })
+
+  it('pins the exact owner before attachment preprocessing changes connection and profile', async () => {
+    const { deps, requestGateway } = setup()
+    $sessions.set([{ id: 'stored-a', connection_id: 'owner-a', profile: 'alice' }] as never)
+    const gate = deferred<{ sessionId: string; attachments: [] }>()
+    deps.syncAttachmentsForSubmit.mockImplementation(() => gate.promise)
+    const { result } = renderHook(() => useSubmitPrompt(deps))
+    let pending!: Promise<boolean>
+    act(() => {
+      pending = result.current('private text')
+    })
+    $sessions.set([{ id: 'stored-a', connection_id: 'owner-b', profile: 'bob' }] as never)
+    $activeGatewayProfile.set('bob')
+    await act(async () => {
+      gate.resolve({ sessionId: 'runtime-a', attachments: [] })
+      expect(await pending).toBe(true)
+    })
+    expect(deps.syncAttachmentsForSubmit).toHaveBeenCalledWith(
+      'runtime-a',
+      [],
+      expect.objectContaining({
+        storedSessionId: 'stored-a',
+        requestGateway: expect.any(Function)
+      })
+    )
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect(wire.request).toHaveBeenCalledWith(
+      'owner-a',
+      'alice',
+      'prompt.submit',
+      expect.objectContaining({ session_id: 'runtime-a', text: 'private text', submission_id: expect.any(String) }),
+      expect.any(Number),
+      undefined
+    )
+  })
+
+  it('captures an attachment upload owner before native byte reading yields', async () => {
+    const { uploadComposerAttachment } = await import('.')
+    const gate = deferred<string>()
+    const original = window.hermesDesktop
+    window.hermesDesktop = { ...original, readFileDataUrl: vi.fn(() => gate.promise) } as never
+    $sessions.set([{ id: 'stored-a', connection_id: 'owner-a', profile: 'alice' }] as never)
+    wire.request.mockResolvedValue({ attached: true, ref_text: '@file:staged.txt' })
+    const ambient = vi.fn(async () => ({ attached: true, ref_text: '@file:wrong.txt' })) as GatewayRequest
+    const captured = captureSubmissionDestination('stored-a', ambient)
+    $sessions.set([{ id: 'stored-a', connection_id: 'owner-b', profile: 'bob' }] as never)
+
+    try {
+      const pending = uploadComposerAttachment(
+        { id: 'file-a', kind: 'file', label: 'private.txt', path: '/private.txt' },
+        {
+          remote: true,
+          sessionId: 'runtime-a',
+          storedSessionId: 'stored-a',
+          requestGateway: captured.requestGateway
+        }
+      )
+
+      $sessions.set([{ id: 'stored-a', connection_id: 'owner-b', profile: 'bob' }] as never)
+      $activeGatewayProfile.set('bob')
+      gate.resolve('data:text/plain;base64,cHJpdmF0ZQ==')
+      await pending
+      expect(wire.request).toHaveBeenCalledWith(
+        'owner-a',
+        'alice',
+        'file.attach',
+        expect.objectContaining({
+          session_id: 'runtime-a',
+          data_url: 'data:text/plain;base64,cHJpdmF0ZQ=='
+        })
+      )
+      expect(ambient).not.toHaveBeenCalled()
+    } finally {
+      window.hermesDesktop = original
+    }
+  })
+
+  it('pins slash fallback and generated kickoff to the entry owner and stored session', async () => {
+    const { deps } = setup()
+    $sessions.set([{ id: 'stored-a', connection_id: 'owner-a', profile: 'alice' }] as never)
+    const gate = deferred<unknown>()
+    const requests: Array<[string, string, string]> = []
+    wire.request.mockImplementation(async (connection, profile, method) => {
+      requests.push([connection, profile, method])
+
+      if (method === 'slash.exec') {return gate.promise}
+
+      return { type: 'skill', name: 'private-skill', message: 'expanded private skill' }
+    })
+    deps.requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {return gate.promise}
+
+      return { type: 'skill', name: 'private-skill', message: 'expanded private skill' }
+    }) as GatewayRequest
+    const submitPromptText = vi.fn(async () => true)
+
+    const { result } = renderHook(() =>
+      useSlashCommand({
+        ...deps,
+        submitPromptText,
+        appendSessionTextMessage: vi.fn(),
+        branchCurrentSession: async () => true,
+        handleSkinCommand: () => '',
+        handoffSession: async () => ({ ok: true }),
+        openMemoryGraph: vi.fn(),
+        refreshSessions: async () => undefined,
+        startFreshSessionDraft: vi.fn()
+      })
+    )
+
+    let pending!: Promise<void>
+    await act(async () => {
+      pending = result.current('/private-skill')
+    })
+    deps.activeSessionIdRef.current = 'runtime-b'
+    deps.selectedStoredSessionIdRef.current = 'stored-b'
+    $sessions.set([{ id: 'stored-a', connection_id: 'owner-b', profile: 'bob' }] as never)
+    $activeGatewayProfile.set('bob')
+    await act(async () => {
+      gate.resolve({ type: 'skill', name: 'private-skill', message: 'expanded private skill' })
+      await pending
+    })
+    expect(requests).toEqual([['owner-a', 'alice', 'slash.exec']])
+    expect(submitPromptText).toHaveBeenCalledWith(
+      'expanded private skill',
+      expect.objectContaining({
+        sessionId: 'runtime-a',
+        storedSessionId: 'stored-a',
+        submission_id: expect.any(String),
+        destination: expect.any(Object)
+      })
+    )
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.ts
@@ -8,6 +8,7 @@ import type { GatewayRequest } from './utils'
 const capturedRequests = new WeakMap<GatewayRequest, SubmissionDestination>()
 
 export interface SubmissionDestination {
+  readonly scopeKey: string
   readonly owner: SessionOwnerScope
   readonly requestGateway: GatewayRequest
 }
@@ -17,19 +18,23 @@ export interface SubmissionDestination {
  * connection/profile is unchanged; a write must never fall to a new socket. */
 export function captureSubmissionDestination(
   sessionId: string | null | undefined,
-  request: GatewayRequest
+  request: GatewayRequest,
+  restoredOwner?: { owner: SessionOwnerScope }
 ): SubmissionDestination {
   const captured = capturedRequests.get(request)
 
-  if (captured) {
+  if (captured && !restoredOwner) {
     return captured
   }
-  const knownOwner = knownOwnerForSession(sessionId)
+
+  const knownOwner = restoredOwner ? restoredOwner.owner : knownOwnerForSession(sessionId)
   const owner = knownOwner && typeof knownOwner === 'object' ? Object.freeze({ ...knownOwner }) : knownOwner
+
   // Window visibility, logs and registry discovery replace this descriptor.
   // Only transport/auth authority may invalidate an in-flight write.
   const authority = () => {
     const connection = $connection.get()
+
     return (
       connection &&
       JSON.stringify([
@@ -43,6 +48,7 @@ export function captureSubmissionDestination(
       ])
     )
   }
+
   const connectionAuthority = authority()
   const profile = $activeGatewayProfile.get()
 
@@ -54,7 +60,16 @@ export function captureSubmissionDestination(
     return timeoutMs === undefined ? request(method, params) : request(method, params, timeoutMs)
   }
 
+  const connection = $connection.get()
+
+  const scopeKey = JSON.stringify(
+    owner && typeof owner === 'object'
+      ? [owner.connectionId, owner.profile]
+      : [connection?.connectionId ?? connection?.baseUrl ?? null, profile]
+  )
+
   const destination = Object.freeze({
+    scopeKey,
     owner,
     requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) =>
       typeof owner === 'object' && owner !== null

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.ts
@@ -1,0 +1,49 @@
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection } from '@/store/session'
+import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
+import { knownOwnerForSession } from '@/store/session-states'
+
+import type { GatewayRequest } from './utils'
+
+const capturedRequests = new WeakMap<GatewayRequest, SubmissionDestination>()
+
+export interface SubmissionDestination {
+  readonly owner: SessionOwnerScope
+  readonly requestGateway: GatewayRequest
+}
+
+/** Capture before preprocessing, not when the prepared payload finally sends.
+ * Unknown legacy owners may use the existing dispatcher only while its ambient
+ * connection/profile is unchanged; a write must never fall to a new socket. */
+export function captureSubmissionDestination(
+  sessionId: string | null | undefined,
+  request: GatewayRequest
+): SubmissionDestination {
+  const captured = capturedRequests.get(request)
+
+  if (captured) {return captured}
+  const knownOwner = knownOwnerForSession(sessionId)
+  const owner = knownOwner && typeof knownOwner === 'object' ? Object.freeze({ ...knownOwner }) : knownOwner
+  const connection = $connection.get()
+  const profile = $activeGatewayProfile.get()
+
+  const guardedRequest: GatewayRequest = (method, params, timeoutMs) => {
+    if (connection !== $connection.get() || profile !== $activeGatewayProfile.get()) {
+      return Promise.reject(new Error('Submission destination changed; retry from the original session'))
+    }
+
+    return timeoutMs === undefined ? request(method, params) : request(method, params, timeoutMs)
+  }
+
+  const destination = Object.freeze({
+    owner,
+    requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) =>
+      typeof owner === 'object' && owner !== null
+        ? requestForSessionProfile<T>(owner, guardedRequest, method, params, timeoutMs)
+        : guardedRequest<T>(method, params, timeoutMs)
+  })
+
+  capturedRequests.set(destination.requestGateway, destination)
+
+  return destination
+}

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submission-destination.ts
@@ -21,14 +21,33 @@ export function captureSubmissionDestination(
 ): SubmissionDestination {
   const captured = capturedRequests.get(request)
 
-  if (captured) {return captured}
+  if (captured) {
+    return captured
+  }
   const knownOwner = knownOwnerForSession(sessionId)
   const owner = knownOwner && typeof knownOwner === 'object' ? Object.freeze({ ...knownOwner }) : knownOwner
-  const connection = $connection.get()
+  // Window visibility, logs and registry discovery replace this descriptor.
+  // Only transport/auth authority may invalidate an in-flight write.
+  const authority = () => {
+    const connection = $connection.get()
+    return (
+      connection &&
+      JSON.stringify([
+        connection.baseUrl,
+        connection.wsUrl,
+        connection.token,
+        connection.connectionId,
+        connection.mode,
+        connection.profile,
+        connection.authMode
+      ])
+    )
+  }
+  const connectionAuthority = authority()
   const profile = $activeGatewayProfile.get()
 
   const guardedRequest: GatewayRequest = (method, params, timeoutMs) => {
-    if (connection !== $connection.get() || profile !== $activeGatewayProfile.get()) {
+    if (connectionAuthority !== authority() || profile !== $activeGatewayProfile.get()) {
       return Promise.reject(new Error('Submission destination changed; retry from the original session'))
     }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -756,6 +756,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         const submitParams = (targetId: string) => ({
           session_id: targetId,
           text,
+          ...(options?.submission_id !== undefined && { submission_id: options.submission_id }),
           ...(interrupted && { interrupted }),
           // Off-screen widget intent: the gateway types the persisted user
           // row display_kind=hidden so no client renders it as a bubble.
@@ -780,9 +781,9 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         let submitErr: unknown = null
 
         try {
-          const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
+          const recoverStoredSessionId = targetStoredSessionId
 
-          await withSessionNotFoundResume(
+          const { result } = await withSessionNotFoundResume<{ admission_id?: string; status?: string }>(
             sessionId,
             recoverStoredSessionId,
             liveId =>
@@ -816,6 +817,16 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // instead of erroring out and losing the session binding.
             { alsoTimeout: true }
           )
+
+          if (
+            options?.submission_id !== undefined &&
+            (result?.admission_id !== options.submission_id ||
+              !['queued', 'started', 'terminal'].includes(result?.status ?? ''))
+          ) {
+            dropOptimistic(sessionId)
+            releaseBusy()
+            return false
+          }
         } catch (firstErr) {
           if (firstErr instanceof SessionRecoveryAborted) {
             console.warn('[submit-drift-abort]', firstErr.reason, { phase: 'post-resume-retry' })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -312,10 +312,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         captured, rawText, attachments, options
       )
 
-      let retained: ReturnType<typeof readPreparedSubmission>
+      let startingRouteToken = getRouteToken()
+      let retained: Awaited<ReturnType<typeof readPreparedSubmission>>
 
       try {
-        retained = readPreparedSubmission(retryKeyForTarget())
+        retained = await readPreparedSubmission(retryKeyForTarget())
 
         // A legacy send has no deduplication identity. After an ambiguous ACK
         // even an upgraded server cannot safely admit it under the saved ID.
@@ -344,8 +345,6 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // the routed target: an already-stale ref is not evidence that the user
       // switched chats while this submit was in flight.
       let startingSelectedStoredSessionId = selectedStoredSessionId
-
-      let startingRouteToken = getRouteToken()
 
       // Reason string (or null) for why the session context genuinely drifted
       // under this in-flight submit. sessionContextDrift ignores the churn a
@@ -839,7 +838,9 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         }
 
         const retryKey = retryKeyForTarget()
-        writePreparedSubmission(retryKey, prepared)
+        await writePreparedSubmission(retryKey, prepared)
+
+        if (sessionDriftReason()) {return abortForSessionSwitch(liveSessionId)}
 
         // On sleep/wake the gateway's in-memory session may have been cleared
         // while the desktop app still holds the old session ID. The shared
@@ -871,7 +872,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
                   }
 
                   prepared.legacyAttempted = true
-                  writePreparedSubmission(retryKey, prepared)
+                  await writePreparedSubmission(retryKey, prepared)
                   const { submission_id: _id, ...legacyParams } = params
 
                   const result = await requestGateway<{ admission_id?: string; status?: string }>(
@@ -947,7 +948,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           throw submitErr
         }
 
-        removePreparedSubmission(retryKey)
+        await removePreparedSubmission(retryKey)
 
         if (usingComposerAttachments) {
           // A submit owns only the occurrences that actually reached the

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -21,6 +21,7 @@ import {
 import { $hudMode } from '@/store/hud'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { consumePendingCredentialWarning, requestDesktopOnboarding } from '@/store/onboarding'
+import { trackPendingSubmission } from '@/store/pending-submissions'
 import { isStoredTranscriptReadOnly } from '@/store/read-only-transcript'
 import {
   $sessions,
@@ -365,7 +366,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         }
       }
 
-      const optimisticId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      const optimisticId = `user-${submissionId}`
 
       // What the bubble shows. A `/skill` send carries the whole expanded
       // skill body as its text — model-facing scaffolding — so the dispatcher
@@ -762,6 +763,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         rewriteOptimistic(liveSessionId)
         const text = buildContextText(syncedAttachments)
 
+        trackPendingSubmission(targetStoredSessionId ?? liveSessionId, { id: submissionId, text, displayText: options?.displayText })
+
         const submitParams = (targetId: string) => ({
           session_id: targetId,
           text,
@@ -836,6 +839,12 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             releaseBusy()
 
             return false
+          }
+
+          if (result?.admission_id === submissionId) {
+            trackPendingSubmission(targetStoredSessionId ?? liveSessionId, { id: submissionId, text, displayText: options?.displayText, status: result.status })
+
+            if (result.status === 'queued') { dropOptimistic(sessionId) }
           }
         } catch (firstErr) {
           if (firstErr instanceof SessionRecoveryAborted) {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -39,6 +39,7 @@ import { resolveSessionProfile } from '../use-session-actions/utils'
 
 import { finalizeInterruptedMessages } from './rewind'
 import { registerRecoveredRuntime, singleFlightSessionResume, takeRecoveredRuntime } from './single-flight-resume'
+import { captureSubmissionDestination } from './submission-destination'
 import {
   acquireSubmitInFlight,
   type GatewayRequest,
@@ -69,7 +70,7 @@ interface SubmitPromptDeps {
   syncAttachmentsForSubmit: (
     sessionId: string,
     attachments: ComposerAttachment[],
-    options?: { updateComposerAttachments?: boolean }
+    options?: { updateComposerAttachments?: boolean; storedSessionId?: string | null; requestGateway?: GatewayRequest }
   ) => Promise<{ attachments: ComposerAttachment[]; sessionId: string }>
   updateSessionState: (
     sessionId: string,
@@ -109,7 +110,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
     getRuntimeIdForStoredSession,
     getRouteToken,
     onRuntimeRecovered,
-    requestGateway,
+    requestGateway: ambientRequestGateway,
     runtimeIdByStoredSessionIdRef,
     resumeStoredSession,
     selectedStoredSessionIdRef,
@@ -295,6 +296,12 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         targetStoredSessionId = routedStoredSessionId
         targetStartedInCurrentView = true
       }
+
+      const destination =
+        options?.destination ?? captureSubmissionDestination(targetStoredSessionId ?? sessionId, ambientRequestGateway)
+
+      const requestGateway = destination.requestGateway
+      const submissionId = options?.submission_id ?? crypto.randomUUID()
 
       let startingStoredSessionId = routedSessionNeedsResume
         ? routedStoredSessionId
@@ -728,7 +735,9 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // plain text survived sleep/wake but images reported "session not
         // found". The attach path recovers and reports the live id back here.
         const attachResult = await syncAttachmentsForSubmit(sessionId, attachments, {
-          updateComposerAttachments: usingComposerAttachments
+          updateComposerAttachments: usingComposerAttachments,
+          storedSessionId: targetStoredSessionId,
+          requestGateway
         })
 
         const syncedAttachments = attachResult.attachments
@@ -756,7 +765,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         const submitParams = (targetId: string) => ({
           session_id: targetId,
           text,
-          ...(options?.submission_id !== undefined && { submission_id: options.submission_id }),
+          submission_id: submissionId,
           ...(interrupted && { interrupted }),
           // Off-screen widget intent: the gateway types the persisted user
           // row display_kind=hidden so no client renders it as a bubble.
@@ -825,6 +834,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           ) {
             dropOptimistic(sessionId)
             releaseBusy()
+
             return false
           }
         } catch (firstErr) {
@@ -915,7 +925,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       getRuntimeIdForStoredSession,
       getRouteToken,
       onRuntimeRecovered,
-      requestGateway,
+      ambientRequestGateway,
       runtimeIdByStoredSessionIdRef,
       resumeStoredSession,
       scope,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -1,4 +1,4 @@
-import { type MutableRefObject, useCallback } from 'react'
+import { type MutableRefObject, useCallback, useRef } from 'react'
 
 import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import type { Translations } from '@/i18n'
@@ -40,7 +40,7 @@ import { resolveSessionProfile } from '../use-session-actions/utils'
 
 import { finalizeInterruptedMessages } from './rewind'
 import { registerRecoveredRuntime, singleFlightSessionResume, takeRecoveredRuntime } from './single-flight-resume'
-import { captureSubmissionDestination } from './submission-destination'
+import { captureSubmissionDestination, type SubmissionDestination } from './submission-destination'
 import {
   acquireSubmitInFlight,
   type GatewayRequest,
@@ -119,6 +119,19 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
     updateSessionState,
     scope = MAIN_SUBMIT_SCOPE
   } = deps
+
+  const pending = useRef(
+    new Map<
+      string,
+      {
+        id: string
+        destination: SubmissionDestination
+        attachments: ComposerAttachment[]
+        text: string
+        params: Record<string, unknown>
+      }
+    >()
+  )
 
   return useCallback(
     async (rawText: string, options?: SubmitTextOptions) => {
@@ -298,11 +311,22 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         targetStartedInCurrentView = true
       }
 
-      const destination =
+      const captured =
         options?.destination ?? captureSubmissionDestination(targetStoredSessionId ?? sessionId, ambientRequestGateway)
-
+      const retryKey = JSON.stringify([
+        targetStoredSessionId ?? sessionId,
+        captured.owner,
+        rawText,
+        attachments.map(a => a.occurrenceId ?? a.id),
+        options?.displayText,
+        options?.displayKind,
+        options?.fromQueue,
+        options?.submission_id
+      ])
+      const retained = pending.current.get(retryKey)
+      const destination = retained?.destination ?? captured
       const requestGateway = destination.requestGateway
-      const submissionId = options?.submission_id ?? crypto.randomUUID()
+      const submissionId = retained?.id ?? options?.submission_id ?? crypto.randomUUID()
 
       let startingStoredSessionId = routedSessionNeedsResume
         ? routedStoredSessionId
@@ -735,11 +759,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // first and submit's own recovery never runs — that asymmetry is why
         // plain text survived sleep/wake but images reported "session not
         // found". The attach path recovers and reports the live id back here.
-        const attachResult = await syncAttachmentsForSubmit(sessionId, attachments, {
-          updateComposerAttachments: usingComposerAttachments,
-          storedSessionId: targetStoredSessionId,
-          requestGateway
-        })
+        const attachResult = retained
+          ? { sessionId, attachments: retained.attachments }
+          : await syncAttachmentsForSubmit(sessionId, attachments, {
+              updateComposerAttachments: usingComposerAttachments,
+              storedSessionId: targetStoredSessionId,
+              requestGateway
+            })
 
         const syncedAttachments = attachResult.attachments
         // Always a live string; pin it so TS narrows past the outer
@@ -761,9 +787,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // Images keep their inline bounded thumbnail — see optimisticAttachmentRef.
         attachmentRefs = syncedAttachments.map(optimisticAttachmentRef).filter((r): r is string => Boolean(r))
         rewriteOptimistic(liveSessionId)
-        const text = buildContextText(syncedAttachments)
+        const text = retained?.text ?? buildContextText(syncedAttachments)
 
-        trackPendingSubmission(targetStoredSessionId ?? liveSessionId, { id: submissionId, text, displayText: options?.displayText })
+        trackPendingSubmission(targetStoredSessionId ?? liveSessionId, {
+          id: submissionId,
+          text,
+          displayText: options?.displayText
+        })
 
         const submitParams = (targetId: string) => ({
           session_id: targetId,
@@ -785,6 +815,15 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           ...(options?.fromQueue && { queued: true })
         })
 
+        const prepared = retained ?? {
+          id: submissionId,
+          destination,
+          attachments: syncedAttachments,
+          text,
+          params: submitParams(liveSessionId)
+        }
+        pending.current.set(retryKey, prepared)
+
         // On sleep/wake the gateway's in-memory session may have been cleared
         // while the desktop app still holds the old session ID. The shared
         // resolver re-registers the stored session and retries once; every
@@ -800,7 +839,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             recoverStoredSessionId,
             liveId =>
               withSessionBusyRetry(() =>
-                requestGateway('prompt.submit', submitParams(liveId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+                requestGateway(
+                  'prompt.submit',
+                  { ...prepared.params, session_id: liveId },
+                  PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+                )
               ),
             {
               requestGateway,
@@ -831,9 +874,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           )
 
           if (
-            options?.submission_id !== undefined &&
-            (result?.admission_id !== options.submission_id ||
-              !['queued', 'started', 'terminal'].includes(result?.status ?? ''))
+            (options?.submission_id !== undefined || result?.admission_id !== undefined) &&
+            (result?.admission_id !== submissionId || !['queued', 'started', 'terminal'].includes(result?.status ?? ''))
           ) {
             dropOptimistic(sessionId)
             releaseBusy()
@@ -842,9 +884,16 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           }
 
           if (result?.admission_id === submissionId) {
-            trackPendingSubmission(targetStoredSessionId ?? liveSessionId, { id: submissionId, text, displayText: options?.displayText, status: result.status })
+            trackPendingSubmission(targetStoredSessionId ?? liveSessionId, {
+              id: submissionId,
+              text,
+              displayText: options?.displayText,
+              status: result.status
+            })
 
-            if (result.status === 'queued') { dropOptimistic(sessionId) }
+            if (result.status === 'queued') {
+              dropOptimistic(sessionId)
+            }
           }
         } catch (firstErr) {
           if (firstErr instanceof SessionRecoveryAborted) {
@@ -859,6 +908,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         if (submitErr !== null) {
           throw submitErr
         }
+
+        pending.current.delete(retryKey)
 
         if (usingComposerAttachments) {
           // A submit owns only the occurrences that actually reached the

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -1,4 +1,4 @@
-import { type MutableRefObject, useCallback, useRef } from 'react'
+import { type MutableRefObject, useCallback } from 'react'
 
 import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import type { Translations } from '@/i18n'
@@ -32,15 +32,21 @@ import {
   setMessages,
   touchSessionActivity
 } from '@/store/session'
-import { $sessionStates } from '@/store/session-states'
+import { $sessionStates, knownOwnerForSession } from '@/store/session-states'
 
 import type { ClientSessionState } from '../../../types'
 import { sessionContextDrift } from '../session-context-drift'
 import { resolveSessionProfile } from '../use-session-actions/utils'
 
+import {
+  preparedSubmissionKey,
+  readPreparedSubmission,
+  removePreparedSubmission,
+  writePreparedSubmission
+} from './prepared-submissions'
 import { finalizeInterruptedMessages } from './rewind'
 import { registerRecoveredRuntime, singleFlightSessionResume, takeRecoveredRuntime } from './single-flight-resume'
-import { captureSubmissionDestination, type SubmissionDestination } from './submission-destination'
+import { captureSubmissionDestination } from './submission-destination'
 import {
   acquireSubmitInFlight,
   type GatewayRequest,
@@ -119,19 +125,6 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
     updateSessionState,
     scope = MAIN_SUBMIT_SCOPE
   } = deps
-
-  const pending = useRef(
-    new Map<
-      string,
-      {
-        id: string
-        destination: SubmissionDestination
-        attachments: ComposerAttachment[]
-        text: string
-        params: Record<string, unknown>
-      }
-    >()
-  )
 
   return useCallback(
     async (rawText: string, options?: SubmitTextOptions) => {
@@ -313,18 +306,32 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       const captured =
         options?.destination ?? captureSubmissionDestination(targetStoredSessionId ?? sessionId, ambientRequestGateway)
-      const retryKey = JSON.stringify([
-        targetStoredSessionId ?? sessionId,
-        captured.owner,
-        rawText,
-        attachments.map(a => a.occurrenceId ?? a.id),
-        options?.displayText,
-        options?.displayKind,
-        options?.fromQueue,
-        options?.submission_id
-      ])
-      const retained = pending.current.get(retryKey)
-      const destination = retained?.destination ?? captured
+
+      const retryKeyForTarget = () => preparedSubmissionKey(
+        resolveComposerSessionKey(targetStoredSessionId ?? sessionId, $sessions.get()),
+        captured, rawText, attachments, options
+      )
+
+      let retained: ReturnType<typeof readPreparedSubmission>
+
+      try {
+        retained = readPreparedSubmission(retryKeyForTarget())
+
+        // A legacy send has no deduplication identity. After an ambiguous ACK
+        // even an upgraded server cannot safely admit it under the saved ID.
+        if (retained?.legacyAttempted) {
+          return false
+        }
+      } catch (err) {
+        notifyError(err, copy.promptFailed)
+
+        return false
+      }
+
+      const destination = retained
+        ? captureSubmissionDestination(targetStoredSessionId ?? sessionId, ambientRequestGateway, retained)
+        : captured
+
       const requestGateway = destination.requestGateway
       const submissionId = retained?.id ?? options?.submission_id ?? crypto.randomUUID()
 
@@ -815,14 +822,24 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           ...(options?.fromQueue && { queued: true })
         })
 
-        const prepared = retained ?? {
+        // A fresh draft had no session owner at entry. Adopt its published
+        // route only if it is the SAME captured connection/profile authority.
+        const publishedDestination = captureSubmissionDestination(targetStoredSessionId, ambientRequestGateway, {
+          owner: knownOwnerForSession(targetStoredSessionId)
+        })
+
+        const prepared: NonNullable<typeof retained> = retained ?? {
           id: submissionId,
-          destination,
+          owner: destination.owner ??
+            (publishedDestination.scopeKey === destination.scopeKey ? publishedDestination.owner : undefined),
+          displayText: options?.displayText,
           attachments: syncedAttachments,
           text,
           params: submitParams(liveSessionId)
         }
-        pending.current.set(retryKey, prepared)
+
+        const retryKey = retryKeyForTarget()
+        writePreparedSubmission(retryKey, prepared)
 
         // On sleep/wake the gateway's in-memory session may have been cleared
         // while the desktop app still holds the old session ID. The shared
@@ -830,6 +847,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // other session-scoped RPC (attach, /compress, rewind, interrupt) goes
         // through the same helper so one policy covers the whole bug class.
         let submitErr: unknown = null
+        let legacyAccepted = false
 
         try {
           const recoverStoredSessionId = targetStoredSessionId
@@ -838,13 +856,33 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             sessionId,
             recoverStoredSessionId,
             liveId =>
-              withSessionBusyRetry(() =>
-                requestGateway(
-                  'prompt.submit',
-                  { ...prepared.params, session_id: liveId },
-                  PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
-                )
-              ),
+              withSessionBusyRetry(async () => {
+                const params: Record<string, unknown> = { ...prepared.params, session_id: liveId }
+
+                try {
+                  return await requestGateway<{ admission_id?: string; status?: string }>(
+                    'prompt.submit', params, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+                  )
+                } catch (error) {
+                  // 4094 is an explicit PRE-admission capability refusal. Never
+                  // downgrade on a timeout, malformed ACK or an ambiguous retry.
+                  if (!error || typeof error !== 'object' || !('code' in error) || error.code !== 4094 || prepared.legacyAttempted) {
+                    throw error
+                  }
+
+                  prepared.legacyAttempted = true
+                  writePreparedSubmission(retryKey, prepared)
+                  const { submission_id: _id, ...legacyParams } = params
+
+                  const result = await requestGateway<{ admission_id?: string; status?: string }>(
+                    'prompt.submit', legacyParams, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+                  )
+
+                  legacyAccepted = true
+
+                  return result
+                }
+              }),
             {
               requestGateway,
               driftReason: sessionDriftReason,
@@ -874,7 +912,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           )
 
           if (
-            (options?.submission_id !== undefined || result?.admission_id !== undefined) &&
+            !legacyAccepted &&
             (result?.admission_id !== submissionId || !['queued', 'started', 'terminal'].includes(result?.status ?? ''))
           ) {
             dropOptimistic(sessionId)
@@ -909,7 +947,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           throw submitErr
         }
 
-        pending.current.delete(retryKey)
+        removePreparedSubmission(retryKey)
 
         if (usingComposerAttachments) {
           // A submit owns only the occurrences that actually reached the

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -689,6 +689,8 @@ export function visibleUserIndexAtOrdinal(messages: readonly ChatMessage[], targ
 }
 
 export interface SubmitTextOptions {
+  /** Stable caller-owned identity; retain across uncertain admission retries. */
+  submission_id?: string
   attachments?: ComposerAttachment[]
   /** The composer scope key that was actually loaded when this text was
    *  submitted (see use-composer-draft's activeQueueSessionKeyRef). Compared

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -7,6 +7,7 @@ import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import type { ComposerAttachment } from '@/store/composer'
 
 import { registerRecoveredRuntime, singleFlightSessionResume, takeRecoveredRuntime } from './single-flight-resume'
+import type { SubmissionDestination } from './submission-destination'
 
 export type GatewayRequest = <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
 
@@ -689,6 +690,8 @@ export function visibleUserIndexAtOrdinal(messages: readonly ChatMessage[], targ
 }
 
 export interface SubmitTextOptions {
+  /** Captured by slash dispatch before asynchronous expansion. */
+  destination?: SubmissionDestination
   /** Stable caller-owned identity; retain across uncertain admission retries. */
   submission_id?: string
   attachments?: ComposerAttachment[]

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -690,6 +690,8 @@ export function visibleUserIndexAtOrdinal(messages: readonly ChatMessage[], targ
 }
 
 export interface SubmitTextOptions {
+  /** Original slash invocation: retries must not re-expand a prepared prompt. */
+  retryText?: string
   /** Captured by slash dispatch before asynchronous expansion. */
   destination?: SubmissionDestination
   /** Stable caller-owned identity; retain across uncertain admission retries. */

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -7,6 +7,7 @@ import { parseErrorSurface } from '@/lib/error-surface'
 import { isMessagingSource, normalizeSessionSource } from '@/lib/session-source'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
+import { reconcilePendingSubmissions } from '@/store/pending-submissions'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $projectTree } from '@/store/projects'
 import {
@@ -1653,6 +1654,10 @@ export function applyRuntimeInfo(
 ): SessionRuntimeStatePatch | null {
   if (!info) {
     return null
+  }
+
+  if (info.stored_session_id) {
+    reconcilePendingSubmissions(info.stored_session_id, info.pending_submissions)
   }
 
   // App/profile-level reporting is session-independent — a tile's runtime

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -350,6 +350,10 @@ declare global {
         pickDefaultProjectDir: () => Promise<{ canceled: boolean; dir: null | string }>
         setDefaultProjectDir: (dir: null | string) => Promise<{ dir: null | string }>
       }
+      preparedSubmissions?: {
+        read: () => Promise<string>
+        update: (key: string, entry: string | null) => Promise<void>
+      }
       zoom?: {
         get: () => Promise<{ level: number; percent: number }>
         /** Synchronous zoom factor of this window (1 = 100%). */

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1880,6 +1880,7 @@ export const ar = defineLocale({
     openDirective: 'فتح',
     queueMessage: 'إضافة الرسالة للطابور',
     steer: 'توجيه',
+    redirect: 'إعادة توجيه التشغيل الحالي',
     stop: 'إيقاف',
     send: 'إرسال',
     speaking: 'يتحدث',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2548,6 +2548,7 @@ export const en: Translations = {
     openDirective: 'Open',
     queueMessage: 'Queue message',
     steer: 'Steer the current run',
+    redirect: 'Redirect the current run',
     stop: 'Stop',
     send: 'Send',
     speaking: 'Speaking',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2584,6 +2584,7 @@ export const ru = defineLocale({
     openDirective: 'Открыть',
     queueMessage: 'Вставить сообщение в очередь',
     steer: 'Направить текущий запуск',
+    redirect: 'Перенаправить текущий запуск',
     stop: 'Стоп',
     send: 'Отправить',
     speaking: 'Говорит',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2174,6 +2174,7 @@ export interface Translations {
     openDirective: string
     queueMessage: string
     steer: string
+    redirect: string
     stop: string
     send: string
     speaking: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2712,6 +2712,7 @@ export const zh: Translations = {
     openDirective: '打开',
     queueMessage: '排队消息',
     steer: '引导当前运行',
+    redirect: '重新定向当前运行',
     stop: '停止',
     send: '发送',
     speaking: '讲话中',

--- a/apps/desktop/src/lib/execution-authority.ts
+++ b/apps/desktop/src/lib/execution-authority.ts
@@ -1,0 +1,41 @@
+interface ExecutionAuthority {
+  epoch: string
+  generation: number
+  terminal: boolean
+  retiredEpochs: Set<string>
+}
+
+/** Each transport consumer owns its map; epochs are opaque, never ordered. */
+export function acceptExecutionEvent(
+  authorities: Map<string, ExecutionAuthority>,
+  key: string,
+  type: string,
+  payload?: Record<string, unknown>
+): boolean {
+  if (!['session.info', 'message.start', 'message.complete', 'message.error'].includes(type)) {return true}
+  const previous = authorities.get(key)
+  const epoch = payload?.execution_epoch
+  const generation = payload?.execution_generation
+  const versioned = typeof epoch === 'string' && epoch.length > 0 && typeof generation === 'number' && Number.isSafeInteger(generation) && generation >= 0
+
+  if (!versioned) {return !previous}
+  const terminal = type === 'message.complete' || type === 'message.error' || payload?.running === false
+
+  if (previous) {
+    if (previous.retiredEpochs.has(epoch)) {return false}
+
+    if (previous.epoch === epoch) {
+      if (generation < previous.generation) {return false}
+
+      if (generation === previous.generation && previous.terminal && (type === 'message.start' || payload?.running === true)) {return false}
+    } else {
+      // Only an owner snapshot/start can establish a new epoch, not a late finalizer.
+      if (type !== 'session.info' && type !== 'message.start') {return false}
+      previous.retiredEpochs.add(previous.epoch)
+    }
+  }
+
+  authorities.set(key, { epoch, generation, terminal: terminal || Boolean(previous?.epoch === epoch && previous.generation === generation && previous.terminal), retiredEpochs: previous?.retiredEpochs ?? new Set() })
+
+  return true
+}

--- a/apps/desktop/src/store/busy-input-mode.ts
+++ b/apps/desktop/src/store/busy-input-mode.ts
@@ -1,0 +1,16 @@
+import { atom } from 'nanostores'
+
+export type BusyInputMode = 'interrupt' | 'queue' | 'steer'
+
+export function normalizeBusyInputMode(value: unknown): BusyInputMode {
+  const mode = typeof value === 'string' ? value.trim().toLowerCase() : ''
+
+  return mode === 'steer' || mode === 'queue' ? mode : 'interrupt'
+}
+
+export function busyInputOwnerKey(connectionId?: string | null, profile?: string | null): string {
+  return JSON.stringify([connectionId ?? '', profile?.trim() || 'default'])
+}
+
+// A backend config snapshot, never a persisted Desktop-only preference.
+export const $busyInputConfig = atom<{ owner: string; connection: unknown; mode: BusyInputMode } | null>(null)

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -6,6 +6,7 @@ import type { ComposerAttachment } from './composer'
 
 export interface QueuedPromptEntry {
   id: string
+  serverStatus?: string
   text: string
   /** What the queue panel and the sent bubble show, when it differs from the
    *  text the agent receives. A queued `/skill` invocation carries the whole
@@ -18,10 +19,10 @@ export interface QueuedPromptEntry {
 /** Whether a queued entry can ride a mid-turn redirect: text-only, non-empty,
  *  not a slash command — the same gate `steerDraft` applies to the live draft
  *  (attachments can't ride a redirect; slash commands execute, not steer). */
-export const isSteerableEntry = (entry: Pick<QueuedPromptEntry, 'attachments' | 'text'>): boolean => {
+export const isSteerableEntry = (entry: Pick<QueuedPromptEntry, 'attachments' | 'text' | 'serverStatus'>): boolean => {
   const text = entry.text.trim()
 
-  return Boolean(text) && entry.attachments.length === 0 && !SLASH_COMMAND_RE.test(text)
+  return !entry.serverStatus && Boolean(text) && entry.attachments.length === 0 && !SLASH_COMMAND_RE.test(text)
 }
 
 type QueueState = Record<string, QueuedPromptEntry[]>
@@ -88,7 +89,7 @@ const setParked = (sid: string, parked: boolean) => {
   $parkedQueueSessions.set(next)
 }
 
-const writeSession = (sid: string, queue: QueuedPromptEntry[]) => {
+export const writeSessionQueue = (sid: string, queue: QueuedPromptEntry[]) => {
   const current = $queuedPromptsBySession.get()
   const next = { ...current }
 
@@ -125,7 +126,7 @@ export const getQueuedPrompts = (key: string | null | undefined): QueuedPromptEn
 
 export const enqueueQueuedPrompt = (
   key: string | null | undefined,
-  payload: { text: string; attachments: ComposerAttachment[]; displayText?: string }
+  payload: { id?: string; text: string; attachments: ComposerAttachment[]; displayText?: string }
 ): null | QueuedPromptEntry => {
   const sid = sidOf(key)
 
@@ -134,14 +135,14 @@ export const enqueueQueuedPrompt = (
   }
 
   const entry: QueuedPromptEntry = {
-    id: nextId(),
+    id: payload.id ?? nextId(),
     text: payload.text,
     ...(payload.displayText ? { displayText: payload.displayText } : {}),
     attachments: cloneAttachments(payload.attachments),
     queuedAt: Date.now()
   }
 
-  writeSession(sid, [...queueFor(sid), entry])
+  writeSessionQueue(sid, [...queueFor(sid), entry])
   // Queueing a new prompt is fresh intent to keep the conversation moving —
   // a park from an earlier Stop must not hold this (or the entries ahead of
   // it) back.
@@ -163,7 +164,7 @@ export const dequeueQueuedPrompt = (key: string | null | undefined): null | Queu
     return null
   }
 
-  writeSession(sid, rest)
+  writeSessionQueue(sid, rest)
 
   return head
 }
@@ -176,13 +177,13 @@ export const removeQueuedPrompt = (key: string | null | undefined, id: string): 
   }
 
   const queue = queueFor(sid)
-  const next = queue.filter(e => e.id !== id)
+  const next = queue.filter(e => e.id !== id || e.serverStatus)
 
   if (next.length === queue.length) {
     return false
   }
 
-  writeSession(sid, next)
+  writeSessionQueue(sid, next)
 
   return true
 }
@@ -202,7 +203,7 @@ export const promoteQueuedPrompt = (key: string | null | undefined, id: string):
   }
 
   const entry = queue[index]!
-  writeSession(sid, [entry, ...queue.slice(0, index), ...queue.slice(index + 1)])
+  writeSessionQueue(sid, [entry, ...queue.slice(0, index), ...queue.slice(index + 1)])
 
   return true
 }
@@ -246,7 +247,7 @@ export const updateQueuedPrompt = (
     return false
   }
 
-  writeSession(sid, next)
+  writeSessionQueue(sid, next)
 
   return true
 }
@@ -261,7 +262,7 @@ export const clearQueuedPrompts = (key: string | null | undefined) => {
     return
   }
 
-  writeSession(sid, [])
+  writeSessionQueue(sid, [])
 }
 
 /**

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1224,8 +1224,11 @@ export async function retainGatewayForAgent(connectionId: null | string, profile
   return release
 }
 
+import { acceptExecutionEvent } from '@/lib/execution-authority'
+
 const turnLeaseKey = (scope: string, sessionId: string): string => `${scope}\u0000${sessionId}`
 const TURN_LEASE_SETTLE_DELAY_MS = 500
+const turnExecutionAuthorities = new Map()
 
 function cancelTurnLeaseRelease(key: string): void {
   const timer = g.turnLeaseReleaseTimers.get(key)
@@ -1319,7 +1322,9 @@ function releaseTerminalTurnLease(scope: string, event: GatewayEvent): void {
 
   const key = turnLeaseKey(scope, sessionId)
 
-  if (event.type === 'message.start') {
+  if (!acceptExecutionEvent(turnExecutionAuthorities, key, event.type, event.payload as Record<string, unknown> | undefined)) {return}
+
+  if (event.type === 'message.start' || (event.type === 'session.info' && (event.payload as Record<string, unknown>)?.running === true)) {
     // The gateway emits settled session.info before immediately chaining a
     // queued/goal follow-up. Keep the same route alive for that next turn.
     cancelTurnLeaseRelease(key)

--- a/apps/desktop/src/store/pending-submissions.test.ts
+++ b/apps/desktop/src/store/pending-submissions.test.ts
@@ -11,17 +11,34 @@ beforeEach(() => {
 it('reconciles server queue by identity without replaying or duplicating local entries', () => {
   enqueueQueuedPrompt('chat', { id: 'one', text: 'same', attachments: [] })
   enqueueQueuedPrompt('chat', { id: 'local', text: 'same', attachments: [] })
-  const snapshot = [{ admission_id: 'one', status: 'queued', text: 'same' }]
+  const snapshot = [{ admission_id: 'one', status: 'queued', user: 'same' }]
   reconcilePendingSubmissions('chat', snapshot)
   reconcilePendingSubmissions('chat', snapshot)
   expect(getQueuedPrompts('chat').map(entry => entry.id)).toEqual(['one', 'local'])
   expect(getQueuedPrompts('chat')[0]?.serverStatus).toBe('queued')
   reconcilePendingSubmissions('chat', [{ ...snapshot[0], status: 'started' }])
   expect(getQueuedPrompts('chat').map(entry => entry.id)).toEqual(['local'])
-  reconcilePendingSubmissions('chat', [{ admission_id: 'unknown', status: 'unknown', text: 'interrupted' }])
+  reconcilePendingSubmissions('chat', [{ admission_id: 'unknown', status: 'unknown', user: 'interrupted' }])
   expect(getQueuedPrompts('chat').find(entry => entry.id === 'unknown')?.serverStatus).toBe('unknown')
   reconcilePendingSubmissions('chat', [])
   expect(getQueuedPrompts('chat').map(entry => entry.id)).toEqual(['local'])
+})
+
+it('recovers remote pending text into the queue and journal without a local submission', () => {
+  const snapshot = [
+    { admission_id: 'remote-queued', status: 'queued', user: 'queued elsewhere' },
+    { admission_id: 'remote-unknown', status: 'unknown', user: 'interrupted elsewhere' }
+  ]
+
+  reconcilePendingSubmissions('chat', snapshot)
+  reconcilePendingSubmissions('chat', snapshot)
+  expect(getQueuedPrompts('chat').map(({ id, text, serverStatus }) => ({ id, text, serverStatus })))
+    .toEqual(snapshot.map(({ admission_id, user, status }) => ({ id: admission_id, text: user, serverStatus: status })))
+  const journal = JSON.parse(window.localStorage.getItem('hermes.desktop.pendingSubmissions.v1')!)
+
+  for (const receipt of snapshot) {
+    expect(journal.chat[receipt.admission_id].text).toBe(receipt.user)
+  }
 })
 
 it('persists identified direct submissions independently of the automatic local queue', () => {

--- a/apps/desktop/src/store/pending-submissions.test.ts
+++ b/apps/desktop/src/store/pending-submissions.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, expect, it } from 'vitest'
+
+import { $queuedPromptsBySession, enqueueQueuedPrompt, getQueuedPrompts } from './composer-queue'
+import { reconcilePendingSubmissions, trackPendingSubmission } from './pending-submissions'
+
+beforeEach(() => {
+  window.localStorage.clear()
+  $queuedPromptsBySession.set({})
+})
+
+it('reconciles server queue by identity without replaying or duplicating local entries', () => {
+  enqueueQueuedPrompt('chat', { id: 'one', text: 'same', attachments: [] })
+  enqueueQueuedPrompt('chat', { id: 'local', text: 'same', attachments: [] })
+  const snapshot = [{ admission_id: 'one', status: 'queued', text: 'same' }]
+  reconcilePendingSubmissions('chat', snapshot)
+  reconcilePendingSubmissions('chat', snapshot)
+  expect(getQueuedPrompts('chat').map(entry => entry.id)).toEqual(['one', 'local'])
+  expect(getQueuedPrompts('chat')[0]?.serverStatus).toBe('queued')
+  reconcilePendingSubmissions('chat', [{ ...snapshot[0], status: 'started' }])
+  expect(getQueuedPrompts('chat').map(entry => entry.id)).toEqual(['local'])
+  reconcilePendingSubmissions('chat', [{ admission_id: 'unknown', status: 'unknown', text: 'interrupted' }])
+  expect(getQueuedPrompts('chat').find(entry => entry.id === 'unknown')?.serverStatus).toBe('unknown')
+  reconcilePendingSubmissions('chat', [])
+  expect(getQueuedPrompts('chat').map(entry => entry.id)).toEqual(['local'])
+})
+
+it('persists identified direct submissions independently of the automatic local queue', () => {
+  trackPendingSubmission('chat', { id: 'direct', text: 'hello' })
+  const stored = JSON.parse(window.localStorage.getItem('hermes.desktop.pendingSubmissions.v1')!)
+  expect(stored.chat.direct).toMatchObject({ id: 'direct', text: 'hello' })
+  expect(getQueuedPrompts('chat')).toEqual([])
+})

--- a/apps/desktop/src/store/pending-submissions.test.ts
+++ b/apps/desktop/src/store/pending-submissions.test.ts
@@ -1,11 +1,31 @@
 import { beforeEach, expect, it } from 'vitest'
 
+import { applyRuntimeInfo } from '@/app/session/hooks/use-session-actions/utils'
+import { isSteerableEntry } from '@/store/composer-queue'
+
 import { $queuedPromptsBySession, enqueueQueuedPrompt, getQueuedPrompts } from './composer-queue'
 import { reconcilePendingSubmissions, trackPendingSubmission } from './pending-submissions'
 
 beforeEach(() => {
   window.localStorage.clear()
   $queuedPromptsBySession.set({})
+})
+
+it('projects resumed runtime pending receipts under durable identity without making them sendable', () => {
+  const info = {
+    stored_session_id: 'durable',
+    pending_submissions: [
+      { admission_id: 'remote', status: 'queued', user: 'queued exact Ω' },
+      { admission_id: 'uncertain', status: 'unknown', user: 'unknown exact Ω' }
+    ]
+  }
+
+  applyRuntimeInfo(info)
+  applyRuntimeInfo(info)
+  expect(getQueuedPrompts('durable').map(({ id, text, serverStatus }) => ({ id, text, serverStatus })))
+    .toEqual(info.pending_submissions.map(({ admission_id, user, status }) => ({ id: admission_id, text: user, serverStatus: status })))
+  expect(getQueuedPrompts('durable').every(entry => !isSteerableEntry(entry))).toBe(true)
+  expect(getQueuedPrompts('runtime')).toEqual([])
 })
 
 it('reconciles server queue by identity without replaying or duplicating local entries', () => {

--- a/apps/desktop/src/store/pending-submissions.ts
+++ b/apps/desktop/src/store/pending-submissions.ts
@@ -25,7 +25,7 @@ export function reconcilePendingSubmissions(key: string, value: unknown): void {
   for (const raw of value) {
     if (!raw || typeof raw.admission_id !== 'string' || !['queued', 'started', 'unknown'].includes(raw.status)) { continue }
     const id = raw.admission_id
-    receipts.set(id, { ...known[id], id, text: typeof raw.text === 'string' ? raw.text : known[id]?.text ?? '', status: raw.status })
+    receipts.set(id, { ...known[id], id, text: typeof raw.user === 'string' ? raw.user : known[id]?.text ?? '', status: raw.status })
   }
 
   const current = getQueuedPrompts(key)
@@ -52,7 +52,7 @@ export function reconcilePendingSubmissions(key: string, value: unknown): void {
   }
 
   for (const raw of value) {
-    if (typeof raw?.admission_id === 'string') { known[raw.admission_id] = { ...known[raw.admission_id], id: raw.admission_id, text: raw.text ?? known[raw.admission_id]?.text ?? '', status: raw.status } }
+    if (typeof raw?.admission_id === 'string') { known[raw.admission_id] = { ...known[raw.admission_id], id: raw.admission_id, text: raw.user ?? known[raw.admission_id]?.text ?? '', status: raw.status } }
   }
 
   journal[key] = known

--- a/apps/desktop/src/store/pending-submissions.ts
+++ b/apps/desktop/src/store/pending-submissions.ts
@@ -1,0 +1,62 @@
+import { getQueuedPrompts, type QueuedPromptEntry, writeSessionQueue } from './composer-queue'
+
+const STORAGE_KEY = 'hermes.desktop.pendingSubmissions.v1'
+interface PendingSubmission { id: string; text: string; displayText?: string; status?: string }
+type Journal = Record<string, Record<string, PendingSubmission>>
+
+const readJournal = (): Journal => {
+  try { return JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '{}') as Journal }
+  catch { return {} }
+}
+
+// Not an outbox: an uncertain accepted input must never be replayed automatically.
+export function trackPendingSubmission(key: string, entry: PendingSubmission): void {
+  const journal = readJournal()
+  journal[key] = { ...journal[key], [entry.id]: entry }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(journal))
+}
+
+export function reconcilePendingSubmissions(key: string, value: unknown): void {
+  if (!Array.isArray(value)) { return }
+  const journal = readJournal()
+  const known = journal[key] ?? {}
+  const receipts = new Map<string, PendingSubmission>()
+
+  for (const raw of value) {
+    if (!raw || typeof raw.admission_id !== 'string' || !['queued', 'started', 'unknown'].includes(raw.status)) { continue }
+    const id = raw.admission_id
+    receipts.set(id, { ...known[id], id, text: typeof raw.text === 'string' ? raw.text : known[id]?.text ?? '', status: raw.status })
+  }
+
+  const current = getQueuedPrompts(key)
+  const next: QueuedPromptEntry[] = []
+
+  for (const entry of current) {
+    const receipt = receipts.get(entry.id)
+
+    if (receipt) {
+      if (receipt.status !== 'started') { next.push({ ...entry, serverStatus: receipt.status }) }
+      receipts.delete(entry.id)
+    } else if (!entry.serverStatus) { next.push(entry) }
+  }
+
+  for (const receipt of receipts.values()) {
+    if (receipt.status !== 'started') {
+      next.push({ id: receipt.id, text: receipt.text, displayText: receipt.displayText, attachments: [], queuedAt: Date.now(), serverStatus: receipt.status })
+    }
+  }
+
+  // Only observed server records may be retired by their later absence.
+  for (const [id, entry] of Object.entries(known)) {
+    if (entry.status && !value.some(raw => raw?.admission_id === id)) { delete known[id] }
+  }
+
+  for (const raw of value) {
+    if (typeof raw?.admission_id === 'string') { known[raw.admission_id] = { ...known[raw.admission_id], id: raw.admission_id, text: raw.text ?? known[raw.admission_id]?.text ?? '', status: raw.status } }
+  }
+
+  journal[key] = known
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(journal))
+
+  if (JSON.stringify(current) !== JSON.stringify(next)) { writeSessionQueue(key, next) }
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -346,6 +346,7 @@ export interface HermesConfig {
     personality?: string
     skin?: string
     interim_assistant_messages?: boolean
+    busy_input_mode?: string
     timestamps?: boolean
   }
   desktop?: {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -717,6 +717,8 @@ export interface SessionResumeResponse {
 }
 
 export interface SessionRuntimeInfo {
+  stored_session_id?: string
+  pending_submissions?: unknown
   approval_mode?: 'manual' | 'off' | 'smart'
   branch?: string
   config_warning?: string

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1660,6 +1660,24 @@ def cmd_chat(args):
 
     _resolve_chat_session_args(args, use_tui)
 
+    # Attach-only clients borrow the owner's provider and lease, never initialize
+    # a second agent (including when this profile has no local credentials).
+    if getattr(args, "resume", None):
+        from hermes_cli.shared_session_attach import discover_attach_url
+        try:
+            attach_url = discover_attach_url(args.resume)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            raise SystemExit(1) from None
+        if attach_url:
+            if getattr(args, "query", None) or getattr(args, "query_file", None):
+                print("Live shared sessions require interactive attachment; omit --query/--query-file.", file=sys.stderr)
+                raise SystemExit(2)
+            if use_tui:
+                return _launch_tui(args.resume, tui_dev=getattr(args, "tui_dev", False), attach_url=attach_url)
+            from hermes_cli.shared_session_cli import run_attached_cli
+            return run_attached_cli(attach_url, args.resume)
+
     _warn_retired_xai_models()
 
     # First-run guard: check if any provider is configured before launching

--- a/hermes_cli/main_tui_launch.py
+++ b/hermes_cli/main_tui_launch.py
@@ -714,7 +714,8 @@ def _launch_tui(
     provider: Optional[str] = None, toolsets: object = None, skills: object = None,
     verbose: Optional[bool] = None, quiet: bool = False, query: Optional[str] = None,
     image: Optional[str] = None, worktree: bool = False, checkpoints: bool = False,
-    pass_session_id: bool = False, max_turns: Optional[int] = None, accept_hooks: bool = False):
+    pass_session_id: bool = False, max_turns: Optional[int] = None, accept_hooks: bool = False,
+    attach_url: Optional[str] = None):
     """Replace current process with the TUI."""
     from hermes_cli.main import PROJECT_ROOT
     tui_dir = PROJECT_ROOT / "ui-tui"
@@ -724,6 +725,10 @@ def _launch_tui(
     # the single factory; keep secrets (the TUI/agent needs provider creds).
     from tools.environments.local import build_subprocess_env
     env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=True)
+    # Preserve the already-authorized endpoint: rediscovery could observe owner
+    # exit and silently fall back to spawning a new backend.
+    if attach_url:
+        env["HERMES_TUI_GATEWAY_URL"] = attach_url
     from hermes_cli.shared_session_attach import configure_tui_attachment
     try:
         configure_tui_attachment(env, resume_session_id)

--- a/hermes_cli/shared_session_attach.py
+++ b/hermes_cli/shared_session_attach.py
@@ -38,14 +38,15 @@ def _authorization(home: Path, endpoint: str) -> str:
     try:
         if os.name != "posix" or directory.resolve() != directory:
             raise ValueError("Private owner discovery is unavailable.")
+        uid = os.getuid()  # windows-footgun: ok — POSIX-only branch above
         info = directory.lstat()
-        if not stat.S_ISDIR(info.st_mode) or info.st_mode & 0o077 or info.st_uid != os.getuid():
+        if not stat.S_ISDIR(info.st_mode) or info.st_mode & 0o077 or info.st_uid != uid:
             raise ValueError("Private owner discovery directory is not private.")
         fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
         with os.fdopen(fd, "r", encoding="utf-8") as stream:
             info = os.fstat(stream.fileno())
             if (not stat.S_ISREG(info.st_mode) or info.st_mode & 0o077
-                    or info.st_uid != os.getuid() or info.st_size > 65536):
+                    or info.st_uid != uid or info.st_size > 65536):
                 raise ValueError("Private owner credential is not private.")
             record = json.load(stream)
         if (record.get("shared_runtime_url") != endpoint or record.get("profile_home") != str(home)

--- a/hermes_cli/shared_session_attach.py
+++ b/hermes_cli/shared_session_attach.py
@@ -5,8 +5,11 @@ registry entry is discovery information, not authority to mint a credential.
 """
 from __future__ import annotations
 
+import hashlib
 import ipaddress
 import json
+import os
+import stat
 from pathlib import Path
 from urllib.parse import urlencode, urlsplit
 
@@ -27,6 +30,32 @@ def _local_origin(url: str, scheme: str) -> tuple[str, int]:
             or parts.password is not None or parts.fragment or not parts.port):
         raise ValueError("Shared runtime endpoint must be an explicit loopback address and port.")
     return host, parts.port
+
+
+def _authorization(home: Path, endpoint: str) -> str:
+    directory = home / "runtime" / "session-attach"
+    path = directory / (hashlib.sha256(endpoint.encode()).hexdigest() + ".json")
+    try:
+        if os.name != "posix" or directory.resolve() != directory:
+            raise ValueError("Private owner discovery is unavailable.")
+        info = directory.lstat()
+        if not stat.S_ISDIR(info.st_mode) or info.st_mode & 0o077 or info.st_uid != os.getuid():
+            raise ValueError("Private owner discovery directory is not private.")
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        with os.fdopen(fd, "r", encoding="utf-8") as stream:
+            info = os.fstat(stream.fileno())
+            if (not stat.S_ISREG(info.st_mode) or info.st_mode & 0o077
+                    or info.st_uid != os.getuid() or info.st_size > 65536):
+                raise ValueError("Private owner credential is not private.")
+            record = json.load(stream)
+        if (record.get("shared_runtime_url") != endpoint or record.get("profile_home") != str(home)
+                or not isinstance(record.get("authorization"), str)
+                or not record["authorization"].startswith("Bearer ")
+                or any(c in record["authorization"] for c in "\r\n")):
+            raise ValueError("Private owner credential identity does not match.")
+        return record["authorization"]
+    except (OSError, json.JSONDecodeError, AttributeError) as exc:
+        raise ValueError("Private owner credential is unavailable; owner left intact.") from exc
 
 
 def discover_attach_url(session_id: str, *, registry_home: str | Path | None = None) -> str | None:
@@ -58,7 +87,8 @@ def discover_attach_url(session_id: str, *, registry_home: str | Path | None = N
         # Ignore proxy env and redirects: local discovery must stay on the
         # advertised endpoint, including on machines with corporate proxies.
         with httpx.Client(trust_env=False, follow_redirects=False, timeout=3.0) as client:
-            with client.stream("GET", endpoint.rstrip("/") + "/api/session-attach?" + query) as response:
+            with client.stream("GET", endpoint.rstrip("/") + "/api/session-attach?" + query,
+                               headers={"Authorization": _authorization(home, endpoint)}) as response:
                 response.raise_for_status()
                 body = bytearray()
                 for chunk in response.iter_bytes():

--- a/hermes_cli/shared_session_cli.py
+++ b/hermes_cli/shared_session_cli.py
@@ -1,0 +1,213 @@
+"""Small prompt_toolkit/Rich viewer for an existing cooperative RPC owner.
+
+This module never imports the agent, acquires a lease, or writes a transcript.
+The authenticated owner remains the sole authority for admission and approvals.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+
+
+class AttachedCLI:
+    def __init__(self, url, session_id, output):
+        self.url, self.session_id, self.output = url, session_id, output
+        self._pending = {}
+        self._next_id = 0
+        self._seq = 0
+        self._ready = False
+        self._buffer = []
+        self._stream = ""
+        self.closed = asyncio.Event()
+
+    async def __aenter__(self):
+        import aiohttp
+        self._http = aiohttp.ClientSession(trust_env=False)
+        try:
+            self._ws = await self._http.ws_connect(self.url, max_msg_size=16 * 1024 * 1024)
+        except BaseException:
+            await self._http.close()
+            raise
+        self._reader = asyncio.create_task(self._receive())
+        return self
+
+    async def __aexit__(self, *exc):
+        # Closing a viewer must not call session.close or session.interrupt.
+        await self._ws.close()
+        await self._reader
+        await self._http.close()
+
+    async def _receive(self):
+        try:
+            async for frame in self._ws:
+                if not isinstance(frame.data, str):
+                    continue
+                for line in frame.data.splitlines():
+                    msg = json.loads(line)
+                    future = self._pending.get(msg.get("id"))
+                    if future is not None and not future.done():
+                        if "error" in msg:
+                            future.set_exception(ValueError(str(msg["error"].get("message", "Request rejected"))))
+                        else:
+                            future.set_result(msg.get("result", {}))
+                    if msg.get("method") == "event":
+                        event = msg.get("params", {})
+                        if self._ready:
+                            self.event(event)
+                        else:
+                            self._buffer.append(event)
+        finally:
+            self.closed.set()
+            for future in self._pending.values():
+                if not future.done():
+                    future.set_exception(ConnectionError("Owner disconnected; viewer detached."))
+
+    async def rpc(self, method, **params):
+        self._next_id += 1
+        rid = self._next_id
+        future = asyncio.get_running_loop().create_future()
+        self._pending[rid] = future
+        try:
+            await self._ws.send_json({"jsonrpc": "2.0", "id": rid, "method": method,
+                                      "params": {"session_id": self.session_id, **params}})
+            return await asyncio.wait_for(future, timeout=30)
+        finally:
+            self._pending.pop(rid, None)
+
+    async def attach(self):
+        snapshot = await self.rpc("session.resume")
+        self.session_id = snapshot["session_id"]
+        self.output("Attached to shared session. /exit detaches; /interrupt stops the shared turn.")
+        for message in snapshot.get("messages", []):
+            self.output(f"{message.get('role', 'message')}: {message.get('text', message.get('content', ''))}")
+        inflight = snapshot.get("inflight") or {}
+        if inflight.get("user"):
+            self.output("user: " + inflight["user"])
+        self._stream = inflight.get("assistant") or ""
+        if self._stream:
+            self.output("assistant: " + self._stream)
+        for key in ("pending_approval", "pending_clarify"):
+            if snapshot.get(key):
+                self.output(key + ": " + json.dumps(snapshot[key], ensure_ascii=False))
+        if snapshot.get("queued"):
+            self.output("queued: " + json.dumps(snapshot["queued"], ensure_ascii=False))
+        await self.replay(initial=True)
+        self._ready = True
+        for event in self._buffer:
+            self.event(event)
+        self._buffer.clear()
+
+    async def replay(self, *, initial=False):
+        result = await self.rpc("session.events.since", last_seen=self._seq)
+        if result.get("truncated") and not initial:
+            self.output("Replay window expired; /exit and resume to reload the transcript.")
+        for event in result.get("events", []):
+            # The initial transcript/inflight snapshot already renders message text.
+            # Replay still restores tool activity and pending control events.
+            live_seqs = {frame.get("seq") for frame in self._buffer}
+            self.event(event, skip_messages=initial and event.get("seq") not in live_seqs)
+        self._seq = max(self._seq, result.get("latest_seq", 0))
+
+    def event(self, event, *, skip_messages=False):
+        if event.get("session_id") != self.session_id:
+            return
+        seq = event.get("seq", 0)
+        if seq and seq <= self._seq:
+            return
+        self._seq = max(self._seq, seq)
+        kind, payload = event.get("type", ""), event.get("payload") or {}
+        if kind == "message.delta":
+            if not skip_messages:
+                text = payload.get("delta", payload.get("text", ""))
+                self._stream += text
+                self.output(text)
+            return
+        if kind == "message.complete":
+            if not skip_messages:
+                text = payload.get("text", "")
+                if text and not self._stream:
+                    self.output("assistant: " + text)
+                self.output("[turn complete]")
+                self._stream = ""
+            return
+        if kind.startswith(("tool.", "approval.", "clarify.", "session.", "prompt.")):
+            self.output(kind + ": " + json.dumps(payload, ensure_ascii=False))
+
+    async def submit(self, text):
+        command, _, arg = text.strip().partition(" ")
+        if command in ("/exit", "/quit", "/detach"):
+            return False
+        if command == "/help":
+            self.output("Text sends to owner. /steer TEXT, /queue TEXT, /interrupt, /replay, "
+                        "/approve REQUEST_ID, /deny REQUEST_ID, /clarify REQUEST_ID ANSWER, /exit")
+            return True
+        if command == "/replay":
+            await self.replay()
+            return True
+        if command in ("/approve", "/deny"):
+            if not arg.strip():
+                self.output("An exact approval request ID is required.")
+                return True
+            result = await self.rpc("approval.respond", request_id=arg.strip(),
+                                    choice="once" if command == "/approve" else "deny", all=False)
+            self.output("Approval accepted." if result.get("resolved") else "Approval not accepted (already resolved or stale).")
+            return True
+        if command == "/clarify":
+            request_id, _, answer = arg.partition(" ")
+            result = await self.rpc("clarify.respond", request_id=request_id, answer=answer)
+        else:
+            routes = {"/steer": ("session.steer", {"text": arg}),
+                      "/queue": ("prompt.submit", {"text": arg, "queued": True}),
+                      "/interrupt": ("session.interrupt", {})}
+            if command.startswith("/") and command not in routes:
+                self.output("Unknown viewer command. /help lists supported commands.")
+                return True
+            method, params = routes.get(command, ("prompt.submit", {"text": text, "queued": False}))
+            result = await self.rpc(method, **params)
+        self.output(json.dumps(result, ensure_ascii=False))
+        return True
+
+
+async def _run(url, session_id):
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.patch_stdout import patch_stdout
+    from rich.console import Console
+
+    console = Console()
+    prompt = PromptSession()
+    with patch_stdout():
+        async with AttachedCLI(url, session_id, lambda text: console.print(text, markup=False, highlight=False)) as viewer:
+            await viewer.attach()
+            while not viewer.closed.is_set():
+                read = asyncio.create_task(prompt.prompt_async("shared> "))
+                disconnected = asyncio.create_task(viewer.closed.wait())
+                try:
+                    done, _ = await asyncio.wait((read, disconnected), return_when=asyncio.FIRST_COMPLETED)
+                    if disconnected in done:
+                        console.print("Owner disconnected; viewer detached.")
+                        break
+                    text = read.result()
+                    if text.strip() and not await viewer.submit(text):
+                        break
+                except KeyboardInterrupt:
+                    await viewer.submit("/interrupt")
+                except EOFError:
+                    break
+                except ValueError as exc:
+                    console.print(str(exc), markup=False)
+                finally:
+                    for task in (read, disconnected):
+                        if not task.done():
+                            task.cancel()
+                            with contextlib.suppress(asyncio.CancelledError):
+                                await task
+
+
+def run_attached_cli(url, session_id):
+    try:
+        asyncio.run(_run(url, session_id))
+    except (OSError, TimeoutError, ValueError):
+        # Transport exceptions may contain the credential-bearing URL.
+        print("Could not attach to the live owner; its session was left intact.")
+        raise SystemExit(1) from None

--- a/hermes_cli/shared_session_cli.py
+++ b/hermes_cli/shared_session_cli.py
@@ -205,9 +205,10 @@ async def _run(url, session_id):
 
 
 def run_attached_cli(url, session_id):
+    from aiohttp import ClientError
     try:
         asyncio.run(_run(url, session_id))
-    except (OSError, TimeoutError, ValueError):
+    except (OSError, TimeoutError, ValueError, ClientError):
         # Transport exceptions may contain the credential-bearing URL.
         print("Could not attach to the live owner; its session was left intact.")
         raise SystemExit(1) from None

--- a/hermes_cli/web_routers/chat_ws.py
+++ b/hermes_cli/web_routers/chat_ws.py
@@ -542,6 +542,9 @@ async def pty_ws(ws: WebSocket) -> None:
 async def gateway_ws(ws: WebSocket) -> None:
     if not await _close_unless_sidecar_allowed(ws):
         return
+    from tui_gateway.session_attach import allow_upgrade
+    if not await allow_upgrade(ws):
+        return
     from tui_gateway.ws import handle_ws
 
     # The authenticated identity (ticket / internal credential) stamped by

--- a/hermes_cli/web_routers/chat_ws.py
+++ b/hermes_cli/web_routers/chat_ws.py
@@ -554,6 +554,7 @@ async def gateway_ws(ws: WebSocket) -> None:
         ws,
         auth_identity=getattr(ws, "_hermes_auth_identity", None),
         subprotocol=getattr(ws, "_hermes_ws_subprotocol", None),
+        dispatch=getattr(ws, "_hermes_attach_fence", None),
     )
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -651,6 +651,9 @@ async def _token_auth_seam(request: Request, call_next):
     routes pass through untouched.
     """
     from hermes_cli.dashboard_auth.token_auth import token_auth_middleware
+    from tui_gateway.session_attach import ATTACH_PATH, handshake
+    if request.url.path == ATTACH_PATH:
+        return await handshake(request)
     return await token_auth_middleware(request, call_next)
 
 

--- a/tests/hermes_cli/test_shared_session_attach.py
+++ b/tests/hermes_cli/test_shared_session_attach.py
@@ -20,6 +20,7 @@ def test_discovery_uses_exact_profile_and_owner_handshake(tmp_path):
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self):
             requests.append(self.path)
+            assert self.headers.get('Authorization') == 'Bearer private-credential'
             payload = json.dumps(reply).encode()
             self.send_response(200)
             self.end_headers()
@@ -32,6 +33,13 @@ def test_discovery_uses_exact_profile_and_owner_handshake(tmp_path):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     origin = f"http://127.0.0.1:{server.server_port}"
+    import hashlib
+    directory = home / 'runtime' / 'session-attach'
+    directory.mkdir(parents=True, mode=0o700)
+    credential = directory / (hashlib.sha256(origin.encode()).hexdigest() + '.json')
+    credential.write_text(json.dumps({'shared_runtime_url': origin, 'profile_home': str(home.resolve()),
+                                      'authorization': 'Bearer private-credential'}))
+    credential.chmod(0o600)
     lease, error = try_acquire_active_session(
         session_id="same-id", surface="desktop", config={}, registry_home=home,
         metadata={"live_session_id": "live", "shared_runtime_url": origin},
@@ -48,6 +56,20 @@ def test_discovery_uses_exact_profile_and_owner_handshake(tmp_path):
         env = {"HERMES_TUI_GATEWAY_URL": "   "}
         configure_tui_attachment(env, "same-id", registry_home=home)
         assert env["HERMES_TUI_GATEWAY_URL"] == reply["websocket_url"]
+        request_count = len(requests)
+        credential.chmod(0o644)
+        with pytest.raises(ValueError, match="not private"):
+            discover_attach_url("same-id", registry_home=home)
+        assert len(requests) == request_count
+        credential.chmod(0o600)
+        record = json.loads(credential.read_text())
+        record['profile_home'] = str(other.resolve())
+        credential.write_text(json.dumps(record))
+        with pytest.raises(ValueError, match="identity"):
+            discover_attach_url("same-id", registry_home=home)
+        assert len(requests) == request_count
+        record['profile_home'] = str(home.resolve())
+        credential.write_text(json.dumps(record))
         reply["profile_home"] = str(other.resolve())
         with pytest.raises(ValueError, match="identity"):
             discover_attach_url("same-id", registry_home=home)

--- a/tests/hermes_cli/test_shared_session_cli.py
+++ b/tests/hermes_cli/test_shared_session_cli.py
@@ -1,0 +1,74 @@
+"""Cooperative viewers never initialize an agent or close the owner."""
+import argparse
+import asyncio
+import json
+
+import pytest
+
+
+@pytest.mark.parametrize("tui", [False, True])
+def test_live_resume_bypasses_provider_setup(monkeypatch, tui):
+    from hermes_cli import main, shared_session_attach
+    from hermes_cli import shared_session_cli
+
+    args = argparse.Namespace(resume="stored", tui=tui)
+    for name in ("_apply_safe_mode", "_apply_user_config_bypass", "_guard_noninteractive_user_config",
+                 "_resolve_chat_session_args"):
+        monkeypatch.setattr(main, name, lambda *a: None)
+    monkeypatch.setattr(main, "_resolve_use_tui", lambda a: tui)
+    monkeypatch.setattr(main, "_has_any_provider_configured", lambda: pytest.fail("provider guard reached"))
+    monkeypatch.setattr(shared_session_attach, "discover_attach_url", lambda sid: "ws://127.0.0.1:123/api/ws?token=test")
+    launches = []
+    monkeypatch.setattr(shared_session_cli, "run_attached_cli", lambda url, sid: launches.append((url, sid)))
+    monkeypatch.setattr(main, "_launch_tui", lambda sid, **kw: launches.append(("tui", sid)))
+    main.cmd_chat(args)
+    assert launches and launches[0][1] == "stored"
+
+
+def test_rpc_viewer_replays_routes_commands_and_only_detaches():
+    from aiohttp import web
+    from hermes_cli.shared_session_cli import AttachedCLI
+
+    async def scenario():
+        requests, output = [], []
+        async def socket(request):
+            ws = web.WebSocketResponse()
+            await ws.prepare(request)
+            async for frame in ws:
+                msg = json.loads(frame.data)
+                requests.append(msg)
+                method = msg["method"]
+                result = {"status": "queued"}
+                if method == "session.resume":
+                    result = {"session_id": "live", "messages": [{"role": "user", "text": "history"}],
+                              "pending_approval": {"request_id": "approve-one", "command": "inert"}}
+                if method == "session.events.since":
+                    result = {"events": [{"session_id": "live", "seq": 1, "type": "tool.start",
+                                          "payload": {"name": "test-tool"}}], "latest_seq": 1}
+                if method == "approval.respond":
+                    result = {"resolved": len([r for r in requests if r["method"] == method]) == 1}
+                await ws.send_json({"jsonrpc": "2.0", "id": msg["id"], "result": result})
+            return ws
+        app = web.Application()
+        app.router.add_get("/api/ws", socket)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, "127.0.0.1", 0)
+        await site.start()
+        port = site._server.sockets[0].getsockname()[1]
+        try:
+            async with AttachedCLI(f"ws://127.0.0.1:{port}/api/ws", "stored", output.append) as viewer:
+                await viewer.attach()
+                for command in ("hello", "/steer focus", "/queue later", "/interrupt", "/approve approve-one", "/approve approve-one"):
+                    await viewer.submit(command)
+                assert await viewer.submit("/exit") is False
+        finally:
+            await runner.cleanup()
+        methods = [msg["method"] for msg in requests]
+        assert methods == ["session.resume", "session.events.since", "prompt.submit", "session.steer",
+                           "prompt.submit", "session.interrupt", "approval.respond", "approval.respond"]
+        assert requests[4]["params"]["queued"] is True
+        assert requests[6]["params"] == {"session_id": "live", "request_id": "approve-one", "choice": "once", "all": False}
+        assert "history" in "\n".join(output) and "test-tool" in "\n".join(output)
+        assert "not accepted" in "\n".join(output)
+    asyncio.run(scenario())

--- a/tests/hermes_cli/test_shared_session_cli.py
+++ b/tests/hermes_cli/test_shared_session_cli.py
@@ -72,3 +72,15 @@ def test_rpc_viewer_replays_routes_commands_and_only_detaches():
         assert "history" in "\n".join(output) and "test-tool" in "\n".join(output)
         assert "not accepted" in "\n".join(output)
     asyncio.run(scenario())
+
+
+def test_rejected_upgrade_does_not_print_authenticated_url(monkeypatch, capsys):
+    import aiohttp
+    from hermes_cli import shared_session_cli
+    async def rejected(*args):
+        raise aiohttp.ClientError("ws://127.0.0.1/api/ws?token=private-secret")
+    monkeypatch.setattr(shared_session_cli, "_run", rejected)
+    with pytest.raises(SystemExit) as exc:
+        shared_session_cli.run_attached_cli("unused", "stored")
+    assert exc.value.code == 1
+    assert "private-secret" not in capsys.readouterr().out

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -715,7 +715,6 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
             }
 
     fixed_info = {"model": "gold-model", "provider": "gold-provider", "usage": {"total": 15}}
-    usage = server._get_usage(_Agent())
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
     monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
@@ -728,7 +727,7 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
 
     def run_flag_off():
         events = []
-        monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: events.append((event, sid, payload)))
+        monkeypatch.setattr(server, "write_json", lambda frame: events.append(frame["params"]))
         monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": False}})
         server._sessions["sid"] = _session(
             agent=_Agent(), model_override={"model": "gold-model", "provider": "gold-provider"}
@@ -744,29 +743,33 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
 
     def run_flag_on():
         events = []
-        monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: events.append((event, sid, payload)))
+        monkeypatch.setattr(server, "write_json", lambda frame: events.append(frame["params"]))
         monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+
+        from tui_gateway.compute_host import ComputeHost
+
+        # Exercise the real child turn/event producer instead of hand-writing an
+        # obsolete transcript. Only agent construction and process IPC are faked.
+        host = ComputeHost(heartbeat_secs=0)
+        child = _session(agent=_Agent(), model_override={
+            "model": "gold-model", "provider": "gold-provider"})
+        monkeypatch.setattr(host, "_ensure_server_session", lambda _server, _frame: child)
 
         class _FakeSupervisor:
             def submit_turn(self, frame, *, on_complete=None):
                 sid = frame["sid"]
-                server._emit("message.start", sid)
-                server._emit("message.delta", sid, {"text": "hi"})
-                server._emit("message.complete", sid, {"text": "hi", "usage": usage, "status": "complete"})
-                server._emit("session.info", sid, dict(fixed_info))
+                parent = server._sessions[sid]
+                frames = []
+                monkeypatch.setattr(host, "emit", frames.append)
+                server._sessions[sid] = child
+                try:
+                    host._run_real_turn(frame)
+                finally:
+                    server._sessions[sid] = parent
+                    host.close()
+                assert [f["type"] for f in frames] == ["turn.started", "turn.end"]
                 if on_complete is not None:
-                    on_complete(
-                        {
-                            "type": "turn.end",
-                            "sid": sid,
-                            "request_id": frame["request_id"],
-                            "session_key": "session-key",
-                            "history_version": 1,
-                            "message_count": 2,
-                            "session_info": dict(fixed_info),
-                            "session_info_emitted": True,
-                        }
-                    )
+                    on_complete(frames[-1])
                 return frame["request_id"]
 
         monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _FakeSupervisor())
@@ -787,7 +790,31 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
         finally:
             server._sessions.pop("sid", None)
 
-    assert run_flag_on() == run_flag_off()
+    def normalized(events):
+        start = next(event["payload"] for event in events if event["type"] == "message.start")
+        complete = next(event["payload"] for event in events if event["type"] == "message.complete")
+        settled = next(event["payload"] for event in events
+                       if event["type"] == "session.info" and "execution_state" in event["payload"])
+        assert start["execution_epoch"]
+        assert start["execution_generation"] > 0
+        assert start["execution_state"] == "running" and start["running"] is True
+        assert settled["execution_state"] == "complete" and settled["running"] is False
+        for payload in (complete, settled):
+            assert payload["execution_epoch"] == start["execution_epoch"]
+            assert payload["execution_generation"] == start["execution_generation"]
+        assert complete["text"] == "hi" and complete["status"] == "complete"
+        assert complete["usage"] == server._get_usage(_Agent())
+        # Epochs identify processes and generations identify executions, not
+        # snapshot literals. Compare the full transcript after rebinding them.
+        return [
+            {**event, "payload": {
+                key: ("<epoch>" if key == "execution_epoch" else
+                      "<generation>" if key == "execution_generation" else value)
+                for key, value in event.get("payload", {}).items()
+            }} for event in events
+        ]
+
+    assert normalized(run_flag_on()) == normalized(run_flag_off())
 
 
 def test_session_context_explicit_cwd_for_ephemeral_task(monkeypatch, tmp_path):
@@ -16784,7 +16811,7 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
-    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(server, "_session_info", lambda agent, session=None: {"model": agent.model})
 
     def _emit(event, sid, payload=None):
         if event == "message.complete":
@@ -16851,7 +16878,7 @@ def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
     that copy without leaking the transport object.
     """
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "queue")
-    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(server, "_session_info", lambda agent, session=None: {"model": agent.model})
     agent = types.SimpleNamespace(model="model-live")
     session = _session(
         agent=agent,
@@ -16884,7 +16911,7 @@ def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
 
 
 def test_session_activate_switches_live_session_without_closing_siblings(monkeypatch):
-    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(server, "_session_info", lambda agent, session=None: {"model": agent.model})
     server._sessions["sid-a"] = _session(
         agent=types.SimpleNamespace(model="model-a"),
         history=[{"role": "user", "content": "old"}],
@@ -16921,7 +16948,7 @@ def test_session_activate_switches_live_session_without_closing_siblings(monkeyp
 
 
 def test_session_activate_can_omit_duplicate_desktop_transcript(monkeypatch):
-    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(server, "_session_info", lambda agent, session=None: {"model": agent.model})
     server._sessions["sid-large"] = _session(
         agent=types.SimpleNamespace(model="model-large"),
         history=[
@@ -21859,7 +21886,10 @@ def test_prompt_submit_consecutive_rewinds_with_returned_survivor_row_ids(
         db._conn.commit()
     original_row_ids = [m["_row_id"] for m in msgs]
 
-    sess = _session(history=[dict(m) for m in msgs], session_key=session_key)
+    sess = _session(
+        history=[dict(m) for m in msgs], session_key=session_key,
+        _compute_host_active=turn_isolation,
+    )
     sid = "real-db-consec-rewind-sid"
     server._sessions[sid] = sess
     monkeypatch.setattr(server, "_get_db", lambda: db)
@@ -21874,7 +21904,10 @@ def test_prompt_submit_consecutive_rewinds_with_returned_survivor_row_ids(
         lambda *_args, **_kwargs: server._ok("host", {"status": "streaming"}),
     )
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
-    monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
+    # Truncation is synchronous, but inline execution now owns a second thread.
+    # Stop at the actual runner seam, not the unrelated inflight projection.
+    run_prompt = Mock(return_value=True)
+    monkeypatch.setattr(server, "_run_prompt_submit", run_prompt)
 
     try:
         # Rewind 1: cut before "third" (last user turn). Survivors: turns
@@ -21912,6 +21945,14 @@ def test_prompt_submit_consecutive_rewinds_with_returned_survivor_row_ids(
             str(original_row_ids[5]): None,
         }
         assert "999999" not in row_id_map
+        if not turn_isolation:
+            sess["_run_thread"].join(timeout=2)
+            assert not sess["_run_thread"].is_alive()
+            assert run_prompt.call_args.args[:4] == ("1", sid, sess, "rewound third")
+        active_prefix = db.get_messages_as_conversation(session_key, include_row_ids=True)
+        assert [m["_row_id"] for m in active_prefix] == [
+            m["_row_id"] for m in sess["history"]
+        ]
         sess["running"] = False
 
         # Rewind 2a: the STALE pre-rewind id for "second" must fail closed.
@@ -21931,6 +21972,7 @@ def test_prompt_submit_consecutive_rewinds_with_returned_survivor_row_ids(
         assert stale_resp.get("error") is not None
         assert stale_resp["error"]["code"] == 4018
         assert len(sess["history"]) == 4  # nothing cut
+        assert db.get_messages_as_conversation(session_key, include_row_ids=True) == active_prefix
 
         # Rewind 2b: the RETURNED survivor id for "second" must succeed.
         resp2 = server.handle_request(
@@ -21954,8 +21996,19 @@ def test_prompt_submit_consecutive_rewinds_with_returned_survivor_row_ids(
         # And the second response rebinds again: one surviving user turn.
         survivors2 = resp2["result"].get("survivor_user_row_ids")
         assert isinstance(survivors2, list) and len(survivors2) == 1
+        assert survivors2 == [sess["history"][0]["_row_id"]]
+        assert set(survivors2).isdisjoint(survivors)
+        if not turn_isolation:
+            sess["_run_thread"].join(timeout=2)
+            assert not sess["_run_thread"].is_alive()
+            assert run_prompt.call_count == 2
+        else:
+            run_prompt.assert_not_called()
     finally:
+        if (worker := sess.get("_run_thread")) is not None:
+            worker.join(timeout=2)
         server._sessions.pop(sid, None)
+        db.close()
 
 
 def test_prompt_submit_rebind_map_clears_active_row_hidden_by_sequence_repair(

--- a/tests/tui_gateway/fixtures/durable_prompt_owner.py
+++ b/tests/tui_gateway/fixtures/durable_prompt_owner.py
@@ -1,0 +1,74 @@
+"""Disposable real owner/SQLite/process-death probe; only model/config edges are inert."""
+import json
+import os
+from pathlib import Path
+import sys
+import threading
+from types import SimpleNamespace
+
+root, phase = Path(sys.argv[1]), sys.argv[2]
+home = root
+os.environ["HERMES_HOME"] = str(home)
+from tui_gateway import server
+from hermes_state import SessionDB
+server._db = SessionDB(db_path=home / "state.db")
+
+entered = threading.Event()
+finished = threading.Event()
+calls = []
+
+def model(message, **kwargs):
+    calls.append(message)
+    if phase == "accept":
+        entered.set()
+        threading.Event().wait(30)
+    return {"final_response": "done", "messages": [{"role": "user", "content": message},
+                                                    {"role": "assistant", "content": "done"}]}
+
+agent = SimpleNamespace(session_id="conversation", run_conversation=model, clear_interrupt=lambda: None)
+ready = threading.Event()
+ready.set()
+session = dict(agent=agent, session_key="conversation", profile_home=str(home),
+               history=[], history_lock=threading.RLock(), history_version=0, running=False,
+               attached_images=[], image_counter=0, cols=80, slash_worker=None,
+               show_reasoning=False, tool_progress_mode="all", inflight_turn=None,
+               agent_ready=ready, title="Probe", source="tui")
+server._sessions["ui"] = session
+# Keep real owner acquisition, prompt handler, queue, run thread, and SQLite.
+server._load_cfg = lambda: {}
+server._load_busy_input_mode = lambda: "queue"
+server._wire_callbacks = lambda *a: None
+server._sync_agent_model_with_config = lambda *a: None
+server._session_cwd = lambda *a: str(home)
+server._register_session_cwd = lambda *a: None
+server._tts_stream_begin = lambda: None
+server._get_usage = lambda *a: {}
+server._session_info = lambda agent, session: {"running": session["running"]}
+
+def emit(event, sid, payload=None):
+    if event == "session.info" and payload and payload.get("execution_state") in {"complete", "error"} and len(calls) == 2:
+        finished.set()
+server._emit = emit
+
+if phase == "accept":
+    initial = server._methods["prompt.submit"]("one", dict(session_id="ui", text="active", submission_id="active", queued=True))
+    assert entered.wait(10), (initial, session)
+    ack = server._methods["prompt.submit"]("two", dict(session_id="ui", text="later", submission_id="later", queued=True))
+    assert ack.get("result", {}).get("status") == "queued", ack
+    assert ack["result"].get("admission_id") == "later", ack
+    from tui_gateway.prompt_admission import admission_snapshot
+    third = server._methods["prompt.submit"]("three", dict(session_id="ui", text="last", submission_id="last", queued=True))
+    assert third["result"]["status"] == "queued"
+    assert session["active_session_lease"] is not None
+    result = dict(ack=ack, snapshot=admission_snapshot(session), calls=calls, running=session["running"], generation=session.get("_execution_generation"))
+    (root / "accepted.json").write_text(json.dumps(result))
+    os._exit(0)  # No finally, queue serialization, graceful close, or manual restore.
+else:
+    from tui_gateway.prompt_admission import admission_snapshot
+    server._maybe_schedule_auto_continue("ui", session, "conversation")
+    assert finished.wait(10), session
+    session["_run_thread"].join(5)
+    result = dict(snapshot=admission_snapshot(session), calls=calls, running=session["running"],
+                  generation=session.get("_execution_generation"))
+    (root / "resumed.json").write_text(json.dumps(result))
+    server._release_active_session_slot(session)

--- a/tests/tui_gateway/test_prompt_admission.py
+++ b/tests/tui_gateway/test_prompt_admission.py
@@ -30,6 +30,18 @@ def submit(text="later", submission_id="stable", **kw):
                     submission_id=submission_id, queued=True, **kw))
 
 
+def test_busy_admission_publishes_pending_snapshot_for_other_viewers(monkeypatch, tmp_path):
+    session = owner(monkeypatch, tmp_path)
+    events = []
+    monkeypatch.setattr(server, "_emit", lambda *args: events.append(args))
+    response = submit(text="queued elsewhere Ω")["result"]
+    snapshots = [payload for kind, sid, payload in events if kind == "session.info" and sid == "ui"]
+    assert snapshots
+    assert snapshots[-1]["stored_session_id"] == session["session_key"]
+    assert [(r["admission_id"], r["status"], r["user"]) for r in snapshots[-1]["pending_submissions"]] == [
+        (response["admission_id"], "queued", "queued elsewhere Ω")]
+
+
 def test_busy_admission_is_durable_before_ack_and_restart_reconstructs_fifo(monkeypatch, tmp_path):
     session = owner(monkeypatch, tmp_path)
     session["attached_images"] = ["/owned/image.png"]

--- a/tests/tui_gateway/test_prompt_admission.py
+++ b/tests/tui_gateway/test_prompt_admission.py
@@ -65,6 +65,36 @@ print(json.dumps({"snapshot":admission_snapshot(s),"queue":[s["queued_prompt"],*
     assert submit()["error"]["code"] == 4093
 
 
+@pytest.mark.parametrize("stop_after_claim", [False, True])
+def test_next_admission_resets_only_prior_stop(monkeypatch, tmp_path, stop_after_claim):
+    _interrupt_session_turn = server._interrupt_session_turn
+
+    session = owner(monkeypatch, tmp_path, running=False)
+    _interrupt_session_turn("ui", session)
+    stopped_generation = session["_queued_prompt_generation"]
+    calls = []
+    monkeypatch.setattr(server, "_restart_completed_failed_agent_build", lambda *a: True)
+
+    def ready(*args):
+        if stop_after_claim:
+            _interrupt_session_turn("ui", session)
+        return None
+
+    def run(*args, **kwargs):
+        calls.append((args[3], kwargs["queued_prompt_generation"]))
+        session["running"] = False
+
+    monkeypatch.setattr(server, "_wait_agent_for_prompt", ready)
+    monkeypatch.setattr(server, "_run_prompt_submit", run)
+    response = submit()
+    session["_run_thread"].join(5)
+    assert response["result"]["admission_id"] == "stable"
+    assert not session["_run_thread"].is_alive()
+    assert calls == ([] if stop_after_claim else [("later", stopped_generation)])
+    assert session["_turn_cancel_requested"] is stop_after_claim
+    assert session["_queued_prompt_generation"] == stopped_generation + int(stop_after_claim)
+
+
 def test_deferred_dispatch_failure_cannot_release_newer_owner(monkeypatch, tmp_path):
     from tui_gateway.prompt_admission import run_queued_admission, claim_admission
     from tui_gateway.prompt_execution import begin_execution

--- a/tests/tui_gateway/test_prompt_admission.py
+++ b/tests/tui_gateway/test_prompt_admission.py
@@ -1,0 +1,175 @@
+"""Durable human admission through the existing busy owner and real restart."""
+import json
+import os
+import subprocess
+import sys
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from tui_gateway import server
+
+
+def owner(monkeypatch, home, *, key="conversation", running=True):
+    session = dict(profile_home=str(home), session_key=key, history_lock=threading.RLock(),
+                   running=running, attached_images=[], history=[], agent=SimpleNamespace(),
+                   history_version=0, cols=80, title="")
+    monkeypatch.setattr(server, "_sess_nowait", lambda *a: (session, None))
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *a: None)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a: False)
+    monkeypatch.setattr(server, "_reattach_refusal", lambda *a: None)
+    monkeypatch.setattr(server, "_typed_stop_phrase_response", lambda *a: None)
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "queue")
+    monkeypatch.setattr(server, "_persist_session_row_for_submit", lambda *a: None)
+    return session
+
+
+def submit(text="later", submission_id="stable", **kw):
+    return server._methods["prompt.submit"]("r", dict(session_id="ui", text=text,
+                    submission_id=submission_id, queued=True, **kw))
+
+
+def test_busy_admission_is_durable_before_ack_and_restart_reconstructs_fifo(monkeypatch, tmp_path):
+    session = owner(monkeypatch, tmp_path)
+    session["attached_images"] = ["/owned/image.png"]
+    first = submit()["result"]
+    assert first.get("admission_id") == "stable"
+    session["attached_images"] = ["/owned/next.png"]
+    assert submit()["result"] == first
+    assert session["attached_images"] == ["/owned/next.png"]
+    assert submit(text="conflict")["error"]["code"] == 4093
+    server._enqueue_prompt(session, "legacy callback envelope", object())
+    assert submit(submission_id="second")["result"]["status"] == "queued"
+    assert [e.get("admission_id") for e in [session["queued_prompt"], *session["queued_prompts"]]] == ["stable", None, "second"]
+    from tui_gateway.prompt_admission import admission_snapshot, cancel_admission
+    # This is another interpreter: nothing from the owner's in-memory queue survives.
+    script = '''import json, threading, sys
+from tui_gateway.prompt_admission import admission_snapshot, restore_pending
+s=dict(profile_home=sys.argv[1],session_key="conversation",history_lock=threading.RLock(),running=False)
+restore_pending(s)
+print(json.dumps({"snapshot":admission_snapshot(s),"queue":[s["queued_prompt"],*s.get("queued_prompts",[])]}), file=sys.__stdout__)
+'''
+    p = subprocess.run([sys.executable, "-c", script, str(tmp_path)], capture_output=True,
+                       text=True, check=True, stdin=subprocess.DEVNULL, env=dict(os.environ))
+    recovered = json.loads(p.stdout)
+    assert [e["admission_id"] for e in recovered["queue"]] == ["stable", "second"]
+    assert all("transport" not in e for e in recovered["queue"])
+    assert cancel_admission(session, "stable")["outcome"] == "cancelled"
+    assert [r["admission_id"] for r in admission_snapshot(session)["pending_submissions"]] == ["second"]
+    # An ID in another profile is not evidence this profile accepted anything.
+    other = owner(monkeypatch, tmp_path / "other")
+    assert admission_snapshot(other)["pending_submissions"] == []
+    assert submit(text="independent")["result"]["status"] == "queued"
+    owner(monkeypatch, tmp_path, key="wrong-session")
+    assert submit()["error"]["code"] == 4093
+
+
+def test_deferred_dispatch_failure_cannot_release_newer_owner(monkeypatch, tmp_path):
+    from tui_gateway.prompt_admission import run_queued_admission, claim_admission
+    from tui_gateway.prompt_execution import begin_execution
+    session = owner(monkeypatch, tmp_path)
+    submit()
+    claim_admission(session, "stable")
+    monkeypatch.setattr(server, "_restart_completed_failed_agent_build", lambda *a: True)
+    def newer(*a, **kw):
+        begin_execution(session)
+        session["_run_thread"] = "newer-owner"
+        raise RuntimeError("old dispatcher failed")
+    monkeypatch.setattr(server, "_run_after_agent_ready", newer)
+    class Inline:
+        def __init__(self, target, **kw):
+            self.target = target
+        def start(self):
+            self.target()
+    monkeypatch.setattr(threading, "Thread", Inline)
+    with pytest.raises(RuntimeError, match="old dispatcher"):
+        run_queued_admission("r", "ui", session, {"text": "later", "admission_id": "stable"}, {})
+    assert session["running"] is True
+    assert session["_run_thread"] == "newer-owner"
+
+
+def test_compression_tip_recovers_original_target_but_branch_cannot_retarget(monkeypatch, tmp_path):
+    from hermes_state import SessionDB
+    from tui_gateway.prompt_admission import admission_snapshot, restore_pending
+    with SessionDB(db_path=tmp_path / "state.db") as db:
+        db.create_session("conversation", source="tui")
+        session = owner(monkeypatch, tmp_path)
+        original = submit()["result"]
+        db.end_session("conversation", "compression")
+        db.create_session("tip", source="tui", parent_session_id="conversation")
+        db.create_session("branch", source="tui", parent_session_id="conversation", model_config={"_branched_from": "conversation"})
+    tip = owner(monkeypatch, tmp_path, key="tip")
+    restore_pending(tip)
+    assert tip["queued_prompt"]["admission_id"] == "stable"
+    assert submit()["result"] == original
+    branch = owner(monkeypatch, tmp_path, key="branch")
+    assert admission_snapshot(branch)["pending_submissions"] == []
+    assert submit()["error"]["code"] == 4093
+
+
+@pytest.mark.parametrize("accepted", [True, False])
+def test_durable_steer_keeps_explicit_correction_and_queue_fallback(monkeypatch, tmp_path, accepted):
+    session = owner(monkeypatch, tmp_path)
+    calls = []
+    def steer(text):
+        calls.append(text)
+        return accepted
+    session["agent"] = SimpleNamespace(steer=steer)
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "steer")
+    response = server._methods["prompt.submit"]("r", dict(session_id="ui", text="correct", submission_id="steer"))["result"]
+    assert calls == ["correct"]
+    assert response["status"] == ("terminal" if accepted else "queued")
+    assert bool(session.get("queued_prompt")) is (not accepted)
+    retry = server._methods["prompt.submit"]("r2", dict(session_id="ui", text="correct", submission_id="steer"))
+    assert retry["result"]["status"] == response["status"]
+    assert calls == ["correct"]
+
+
+def test_real_owner_crash_recovers_queued_not_started(tmp_path):
+    from pathlib import Path
+    probe = Path(__file__).parent / "fixtures" / "durable_prompt_owner.py"
+    env = dict(os.environ, PYTHONPATH=str(Path.cwd()), HERMES_HOME=str(tmp_path))
+    for phase in ("accept", "resume"):
+        p = subprocess.run([sys.executable, str(probe), str(tmp_path), phase], env=env,
+                           capture_output=True, text=True, stdin=subprocess.DEVNULL, timeout=25)
+        assert p.returncode == 0, p.stdout + p.stderr
+    accepted = json.loads((tmp_path / "accepted.json").read_text())
+    resumed = json.loads((tmp_path / "resumed.json").read_text())
+    assert accepted["running"] is True
+    assert accepted["ack"]["result"]["admission_id"] == "later"
+    assert len(resumed["calls"]) == 2
+    assert "later" in resumed["calls"][0] and "last" in resumed["calls"][1]
+    assert resumed["running"] is False
+    assert resumed["generation"] > accepted["generation"]
+    assert [(r["admission_id"], r["status"]) for r in resumed["snapshot"]["pending_submissions"]] == [("active", "unknown")]
+
+
+def test_started_admission_is_not_replayed_and_runtime_objects_are_not_serialized(monkeypatch, tmp_path):
+    session = owner(monkeypatch, tmp_path)
+    receipt = submit()["result"]
+    assert receipt.get("admission_id") == "stable"
+    from tui_gateway.prompt_admission import claim_admission, restore_pending, admission_snapshot
+    assert claim_admission(session, "stable")
+    from tui_gateway.prompt_admission import bind_admission_generation, finish_admission
+    bind_admission_generation(session, "stable", 2)
+    finish_admission(session, "stable", "error", 1)
+    assert admission_snapshot(session)["pending_submissions"][0]["status"] == "started"
+    restarted = owner(monkeypatch, tmp_path, running=False)
+    restore_pending(restarted)
+    assert not restarted.get("queued_prompt")
+    script = """import json, sys, threading
+from tui_gateway.prompt_admission import admission_snapshot, restore_pending
+s=dict(profile_home=sys.argv[1],session_key="conversation",history_lock=threading.RLock(),running=False)
+restore_pending(s)
+assert not s.get("queued_prompt")
+print(json.dumps(admission_snapshot(s)), file=sys.__stdout__)
+"""
+    p = subprocess.run([sys.executable, "-c", script, str(tmp_path)], capture_output=True,
+                       text=True, check=True, stdin=subprocess.DEVNULL)
+    assert json.loads(p.stdout)["pending_submissions"][0]["status"] == "unknown"
+    # The existing callback-bearing automation envelope is retained by reference.
+    callback = lambda: None
+    restarted["queued_prompt"] = {"text": "automation", "transport": object(), "callback": callback}
+    restore_pending(restarted)
+    assert restarted["queued_prompt"]["callback"] is callback

--- a/tests/tui_gateway/test_prompt_execution.py
+++ b/tests/tui_gateway/test_prompt_execution.py
@@ -1,0 +1,95 @@
+"""Execution terminal authority survives failures outside the conversation loop."""
+import contextvars
+import logging
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from tui_gateway import prompt_turn
+from tui_gateway.method_ctx import rebind
+
+
+@pytest.mark.parametrize("failure", ["success", "marker", "prepare", "cleanup", "interrupt", "stale", "snapshot", "generation"])
+def test_outermost_turn_settles_even_when_setup_or_cleanup_fails(failure, monkeypatch):
+    agent = SimpleNamespace(session_id="chat")
+    session = dict(agent=agent, session_key="chat", history_lock=threading.RLock(), running=True)
+    events, receipts, followups = [], [], []
+    def noop(*args, **kwargs):
+        return None
+    def fail(*args, **kwargs):
+        raise RuntimeError(failure)
+    def invoke(sid, session, st, *args):
+        st.result = {"interrupted": failure == "interrupt"}
+    def finish(*args):
+        if failure == "stale":
+            from tui_gateway.prompt_execution import begin_execution
+            begin_execution(session)
+            agent.interim_assistant_callback = "new callback"
+            session["inflight_turn"] = {"text": "new turn"}
+        elif failure == "cleanup":
+            fail()
+    env = {
+        "threading": threading, "time": time, "logger": logging.getLogger(__name__),
+        "_sessions_lock": threading.RLock(), "_sessions": {},
+        "_admit_prompt_turn": lambda *args: ([], agent),
+        "_emit": lambda event, sid, payload=None: events.append((event, payload)),
+        "bind_transport": noop, "reset_transport": noop,
+        "_current_runtime_session_record": contextvars.ContextVar("execution_test"),
+        "_TurnRun": prompt_turn._TurnRun,
+        "_record_turn_marker": fail if failure == "marker" else lambda *a, **k: "marker",
+        "_prepare_turn_input": fail if failure == "prepare" else lambda *a: ("hi", "hi", 80, None),
+        "_invoke_agent": invoke, "_absorb_turn_result": noop,
+        "_complete_turn_payload": lambda *a: ({}, "ok", "interrupted" if failure == "interrupt" else "complete"),
+        "_goal_followup_after_turn": noop, "_after_complete_turn": noop,
+        "_publish_session_control_snapshot": noop,
+        "_recover_turn_exception": lambda sid, session, st, exc: receipts.append(str(exc)),
+        "_finish_turn": finish,
+        "_clear_inflight_turn": noop, "_retire_turn_marker": noop,
+        "_emit_settled_session_info": fail if failure == "snapshot" else noop,
+        "_run_post_turn_followups": lambda *a: followups.append(True),
+        "_result_status": prompt_turn._result_status,
+    }
+    submit = rebind(prompt_turn._run_prompt_submit, env)
+    if failure == "generation":
+        from tui_gateway import prompt_admission
+        monkeypatch.setattr(prompt_admission, "next_generation", fail)
+        with pytest.raises(RuntimeError, match="generation"):
+            submit(None, "live", session, "hi")
+        assert session["running"] is False
+        assert events[-1][1]["execution_state"] == "error"
+        return
+    assert submit(None, "live", session, "hi")
+    session["_run_thread"].join(5)
+    assert not session["_run_thread"].is_alive()
+    if failure == "stale":
+        assert session["running"] is True
+        assert session["_execution_state"] == "running"
+        assert agent.interim_assistant_callback == "new callback"
+        assert session["inflight_turn"] == {"text": "new turn"}
+        assert not any(event == "session.info" for event, _ in events)
+        return
+    assert session["running"] is False
+    assert followups == [True]
+    state = "complete" if failure in {"success", "snapshot"} else "interrupted" if failure == "interrupt" else "error"
+    assert session["_execution_state"] == state
+    info = [payload for event, payload in events if event == "session.info"][-1]
+    assert info["execution_generation"] == session["_execution_generation"]
+    assert info["execution_state"] == state
+    assert info["running"] is False
+
+
+def test_stale_generation_cannot_settle_a_newer_execution():
+    from tui_gateway import prompt_execution
+    session = {"history_lock": threading.RLock(), "running": True, "_execution_state": "complete"}
+    assert prompt_execution.execution_snapshot(session)["execution_state"] == "running"
+    first = prompt_execution.begin_execution(session)
+    second = prompt_execution.begin_execution(session)
+    assert second > first
+    assert not prompt_execution.settle_execution(session, first, "error")
+    assert session["running"] is True
+    assert prompt_execution.execution_snapshot(session) == {
+        "execution_generation": second, "execution_state": "running", "running": True}
+    assert prompt_execution.settle_execution(session, second, "complete")
+    assert session["running"] is False

--- a/tests/tui_gateway/test_prompt_execution.py
+++ b/tests/tui_gateway/test_prompt_execution.py
@@ -90,6 +90,7 @@ def test_stale_generation_cannot_settle_a_newer_execution():
     assert not prompt_execution.settle_execution(session, first, "error")
     assert session["running"] is True
     assert prompt_execution.execution_snapshot(session) == {
-        "execution_generation": second, "execution_state": "running", "running": True}
+        "execution_generation": second, "execution_state": "running", "running": True,
+        "execution_epoch": prompt_execution.execution_snapshot(session)["execution_epoch"]}
     assert prompt_execution.settle_execution(session, second, "complete")
     assert session["running"] is False

--- a/tests/tui_gateway/test_session_attach_handshake.py
+++ b/tests/tui_gateway/test_session_attach_handshake.py
@@ -1,0 +1,122 @@
+"""The private owner handshake uses real registry, HTTP gates, and WS admission."""
+import hashlib
+import json
+import threading
+from urllib.parse import urlencode, urlsplit
+
+import pytest
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+
+pytestmark = pytest.mark.linux_only  # Private POSIX mode contract exercised on the real host.
+
+
+@pytest.fixture
+def owner(tmp_path, monkeypatch):
+    from hermes_cli import web_server as web
+    from tui_gateway import server
+    from hermes_cli.active_sessions import active_session_registry_snapshot
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_sessions", {})
+    monkeypatch.setattr(web.app.state, "bound_host", "127.0.0.1", raising=False)
+    monkeypatch.setattr(web.app.state, "bound_port", 18765, raising=False)
+    monkeypatch.setattr(web.app.state, "trusted_public_hosts", frozenset(), raising=False)
+    monkeypatch.setattr(web.app.state, "auth_required", True, raising=False)
+    monkeypatch.setattr(server, "resolve_skin", lambda: {})
+    lease, error = server._claim_active_session_slot(
+        "durable-owner", live_session_id="live-owner", profile_home=home)
+    assert error is None
+    session = {"session_key": "durable-owner", "profile_home": str(home),
+               "active_session_lease": lease, "history_lock": threading.RLock()}
+    server._sessions["live-owner"] = session
+    client = TestClient(web.app, base_url="http://127.0.0.1:18765", client=("127.0.0.1", 50000))
+    yield web, server, home, lease, client, active_session_registry_snapshot
+    lease.release()
+    client.close()
+
+
+def test_private_advertisement_auth_and_identity_fences(owner, monkeypatch):
+    web, server, home, lease, client, snapshot = owner
+    row = snapshot(home, strict=True)[0]
+    origin = row["metadata"].get("shared_runtime_url")
+    assert origin == "http://127.0.0.1:18765"
+    path = home / "runtime" / "session-attach" / (hashlib.sha256(origin.encode()).hexdigest() + ".json")
+    record = json.loads(path.read_text())
+    assert path.stat().st_mode & 0o077 == 0
+    assert path.parent.stat().st_mode & 0o077 == 0
+    assert record["authorization"] not in json.dumps(row)
+    assert record["profile_home"] == str(home)
+    pins = {"session_id": "durable-owner", "lease_id": lease.lease_id, "profile_home": str(home)}
+    headers = {"Authorization": record["authorization"]}
+    route = "/api/session-attach"
+    assert client.get(route, params=pins).status_code == 401
+    assert client.get(route, params=pins, headers={"Authorization": "Bearer " + web._SESSION_TOKEN}).status_code == 401
+    assert client.get(route, params=pins, headers={**headers, "Origin": origin}).status_code == 403
+    assert client.get(route, params=pins, headers={**headers, "Host": "evil.example"}).status_code == 403
+    assert client.post(route, params=pins, headers=headers).status_code == 405
+    remote = TestClient(web.app, base_url=origin, client=("192.0.2.1", 50000))
+    assert remote.get(route, params=pins, headers=headers).status_code == 403
+    remote.close()
+    for field, bad in [("lease_id", "stale"), ("session_id", "other"), ("profile_home", str(home.parent))]:
+        assert client.get(route, params={**pins, field: bad}, headers=headers).status_code == 409
+    response = client.get(route, params=pins, headers=headers)
+    assert response.status_code == 200, response.text
+    assert response.headers["cache-control"] == "no-store"
+    reply = response.json()
+    assert all(reply[key] == value for key, value in pins.items())
+    assert urlsplit(reply["websocket_url"]).netloc == urlsplit(origin).netloc
+    assert snapshot(home, strict=True)[0]["lease_id"] == lease.lease_id
+    # Legacy bearer must not gain authority on any other gated route.
+    assert client.get("/api/sessions", headers=headers).status_code in (401, 403)
+    session = server._sessions.pop("live-owner")
+    assert client.get(route, params=pins, headers=headers).status_code == 409
+    server._sessions["live-owner"] = session
+    assert server._transfer_active_session_slot("live-owner", session, new_session_id="compressed-owner")
+    session["session_key"] = "compressed-owner"
+    assert snapshot(home, strict=True)[0]["metadata"]["shared_runtime_url"] == origin
+    assert client.get(route, params=pins, headers=headers).status_code == 409
+    assert client.get(route, params={**pins, "session_id": "compressed-owner"}, headers=headers).status_code == 200
+    monkeypatch.setattr(web.app.state, "bound_host", "192.0.2.1")
+    from tui_gateway.session_attach import owner_metadata
+    assert "shared_runtime_url" not in owner_metadata("another-live", home)
+
+
+@pytest.mark.parametrize("gated, bind_host", [(False, "127.0.0.1"), (True, "127.0.0.1"), (True, "0.0.0.0")])
+def test_upgrade_rechecks_owner_after_handshake(owner, monkeypatch, gated, bind_host):
+    web, server, home, lease, client, snapshot = owner
+    monkeypatch.setattr(web.app.state, "auth_required", gated)
+    monkeypatch.setattr(web.app.state, "bound_host", bind_host)
+    # Claim another owner after changing auth mode, exercising credential publication.
+    second, error = server._claim_active_session_slot(
+        "second-owner", live_session_id="second-live", profile_home=home)
+    assert error is None
+    server._sessions["second-live"] = {**server._sessions["live-owner"],
+        "session_key": "second-owner", "active_session_lease": second}
+    try:
+        origin = snapshot(home, strict=True)[0]["metadata"].get("shared_runtime_url")
+        assert origin
+        record = json.loads((home / "runtime" / "session-attach" /
+            (hashlib.sha256(origin.encode()).hexdigest() + ".json")).read_text())
+        pins = {"session_id": "second-owner", "lease_id": second.lease_id, "profile_home": str(home)}
+        response = client.get("/api/session-attach?" + urlencode(pins),
+                              headers={"Authorization": record["authorization"]})
+        assert response.status_code == 200, response.text
+        url = response.json()["websocket_url"]
+        with client.websocket_connect(url) as ws:
+            frame = json.loads(ws.receive_text())
+            assert frame["params"]["type"] == "gateway.ready"
+        # A stale URL must not connect even though its process credential remains valid.
+        second.release()
+        with pytest.raises(WebSocketDisconnect) as caught:
+            with client.websocket_connect(url):
+                pass
+        assert caught.value.code == 4409
+        assert client.get("/api/session-attach", params=pins,
+                          headers={"Authorization": record["authorization"]}).status_code == 409
+    finally:
+        second.release()

--- a/tests/tui_gateway/test_session_attach_handshake.py
+++ b/tests/tui_gateway/test_session_attach_handshake.py
@@ -23,6 +23,10 @@ def owner(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(server, "_load_cfg", lambda: {})
     monkeypatch.setattr(server, "_sessions", {})
+    from hermes_state import SessionDB
+    db = SessionDB(home / "state.db")
+    db.create_session("durable-owner", source="tui")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
     monkeypatch.setattr(web.app.state, "bound_host", "127.0.0.1", raising=False)
     monkeypatch.setattr(web.app.state, "bound_port", 18765, raising=False)
     monkeypatch.setattr(web.app.state, "trusted_public_hosts", frozenset(), raising=False)
@@ -38,6 +42,7 @@ def owner(tmp_path, monkeypatch):
     yield web, server, home, lease, client, active_session_registry_snapshot
     lease.release()
     client.close()
+    db.close()
 
 
 def test_private_advertisement_auth_and_identity_fences(owner, monkeypatch):
@@ -120,3 +125,71 @@ def test_upgrade_rechecks_owner_after_handshake(owner, monkeypatch, gated, bind_
                           headers={"Authorization": record["authorization"]}).status_code == 409
     finally:
         second.release()
+
+
+def rpc(ws, method, **params):
+    ws.send_json({"jsonrpc": "2.0", "id": method, "method": method, "params": params})
+    while True:
+        frame = json.loads(ws.receive_text())
+        if frame.get("id") == method:
+            return frame
+
+
+def attach_url(home, lease, client):
+    record = json.loads(next((home / "runtime/session-attach").glob("*.json")).read_text())
+    response = client.get("/api/session-attach", params={
+        "session_id": "durable-owner", "lease_id": lease.lease_id, "profile_home": str(home)},
+        headers={"Authorization": record["authorization"]})
+    assert response.status_code == 200
+    return response.json()["websocket_url"]
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("lost", ["released", "replaced", "removed"])
+def test_resume_after_upgrade_never_recreates_or_reclaims_owner(owner, lost):
+    _, server, home, lease, client, snapshot = owner
+    original = server._sessions["live-owner"]
+    with client.websocket_connect(attach_url(home, lease, client)) as ws:
+        ws.receive_text()
+        if lost == "released":
+            lease.release()
+        elif lost == "replaced":
+            server._sessions["live-owner"] = dict(original)
+        else:
+            server._sessions.pop("live-owner")
+        before = snapshot(home, strict=True)
+        result = rpc(ws, "session.resume", session_id="durable-owner", lazy=True, force=True)
+        assert result.get("error", {}).get("code") == 4409, result
+        assert snapshot(home, strict=True) == before
+        assert len(server._sessions) == (0 if lost == "removed" else 1)
+
+
+@pytest.mark.linux_only
+def test_same_socket_follows_own_compression_but_not_a_replacement_lease(owner):
+    _, server, home, lease, client, snapshot = owner
+    original = server._sessions["live-owner"]
+    original.update(history=[], agent=None, running=False)
+    with client.websocket_connect(attach_url(home, lease, client)) as ws:
+        ws.receive_text()
+        first = rpc(ws, "session.resume", session_id="durable-owner", lazy=True)
+        assert first.get("result", {}).get("session_id") == "live-owner", first
+        assert server._transfer_active_session_slot("live-owner", original, new_session_id="compressed")
+        original["session_key"] = "compressed"
+        resumed = rpc(ws, "session.resume", session_id="durable-owner", lazy=True)
+        assert resumed.get("result", {}).get("session_id") == "live-owner", resumed
+        assert resumed["result"]["resumed"] == "compressed"
+        lease.release()
+        replacement, error = server._claim_active_session_slot(
+            "compressed", live_session_id="live-owner", profile_home=home)
+        assert error is None
+        original["active_session_lease"] = replacement
+        try:
+            before = snapshot(home, strict=True)
+            refused = rpc(ws, "session.resume", session_id="compressed", lazy=True, force=True)
+            assert refused.get("error", {}).get("code") == 4409, refused
+            assert rpc(ws, "prompt.submit", session_id="live-owner", prompt="not admitted").get(
+                "error", {}).get("code") == 4409
+            assert snapshot(home, strict=True) == before
+            assert server._sessions["live-owner"] is original
+        finally:
+            replacement.release()

--- a/tests/tui_gateway/test_shared_session_projection.py
+++ b/tests/tui_gateway/test_shared_session_projection.py
@@ -1,0 +1,26 @@
+import threading
+
+from tui_gateway import prompt_execution, server
+
+
+def test_projection_under_owned_nonreentrant_lock(monkeypatch):
+    session = dict(history_lock=threading.Lock(), running=True, _execution_generation=4)
+    with session["history_lock"]:
+        info = prompt_execution.execution_snapshot(session)
+    assert info["execution_epoch"]
+    assert info["execution_generation"] == 4
+    monkeypatch.setattr(server, "_resolve_model", lambda: "fixture")
+    monkeypatch.setattr(server, "_session_cwd", lambda s: "/tmp")
+    info = server._fallback_session_info(session)
+    assert info["execution_epoch"]
+    assert info["pending_submissions"] == []
+
+
+def test_turn_frames_retain_captured_authority():
+    from tui_gateway.prompt_execution import event_authority
+    token = event_authority.set({"execution_epoch": "old", "execution_generation": 4})
+    try:
+        frame = server._event_frame("message.complete", "sid", {"status": "complete"})
+        assert frame["params"]["payload"]["execution_epoch"] == "old"
+    finally:
+        event_authority.reset(token)

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -465,7 +465,7 @@ def _persist_session_row_for_submit(rid, session):
     return None
 
 
-def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_terminal_callback):
+def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_terminal_callback, **turn_kwargs):
     """Turn thread body: patient wait for a deferred build (a slow build must not eat the
     accepted in-flight message), then run."""
     # The wait delivers the prompt when the still-running build completes, honors a cancel promptly, notices
@@ -495,7 +495,7 @@ def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_termina
             return
     _run_prompt_submit(
         rid, sid, session, text, display_kind=display_kind,
-        terminal_callback=hosted_terminal_callback)
+        terminal_callback=hosted_terminal_callback, **turn_kwargs)
 
 
 _TRUNCATION_PARAMS = (
@@ -580,6 +580,22 @@ def _(rid, params: dict) -> dict:
         if (t := current_transport()) is not None:
             _attach_session_transport(session, t)
             _cancel_ws_orphan_reap(sid)
+    if "submission_id" in params:
+        from tui_gateway.prompt_admission import AdmissionConflict, submit_admission
+        if internal_hosted_submit or turn_isolation or has_truncation:
+            return _err(rid, 4094, "durable admission requires an ordinary in-process human prompt")
+        if not session.get("running"):
+            if (err := _persist_session_row_for_submit(rid, session)) is not None:
+                return err
+        try:
+            return submit_admission(rid, sid, session, params, text, t or session.get("transport"))
+        except AdmissionConflict as exc:
+            return _err(rid, 4093, str(exc))
+        except (TypeError, ValueError) as exc:
+            return _err(rid, 4004, str(exc))
+        except Exception as exc:
+            logger.exception("durable prompt admission failed")
+            return _err(rid, 5071, f"prompt storage unavailable: {exc}")
     # Claim the turn against a possibly-running session (busy/queued reply, else fall
     # through once ``running`` is observed False).  The provider interrupt happens after
     # history_lock is released (a non-interruptible tool may hold it); if the old turn
@@ -635,6 +651,25 @@ def _(rid, params: dict) -> dict:
     session["_run_thread"] = run_thread
     run_thread.start()
     return _ok(rid, {"status": "streaming", **survivor_fields})
+
+
+@method("prompt.pending")
+def _(rid, params: dict) -> dict:
+    from tui_gateway.prompt_admission import admission_snapshot
+    session, err = _sess_nowait(params, rid)
+    return err if err else _ok(rid, admission_snapshot(session))
+
+
+@method("prompt.cancel")
+def _(rid, params: dict) -> dict:
+    from tui_gateway.prompt_admission import cancel_admission
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    try:
+        return _ok(rid, cancel_admission(session, params.get("admission_id")))
+    except ValueError as exc:
+        return _err(rid, 4004, str(exc))
 
 
 # ── attachments ─────────────────────────────────────────────────────────────

--- a/tui_gateway/prompt_admission.py
+++ b/tui_gateway/prompt_admission.py
@@ -1,0 +1,242 @@
+"""Profile-scoped human input ledger; persist identity/payload, never live transports.
+
+The owner queue is the executor. A claim is irreversible: a dead owner's started
+row is ambiguous, not permission to repeat arbitrary tool effects.
+"""
+from contextlib import contextmanager
+import json
+from pathlib import Path
+import sqlite3
+import uuid
+
+_PROCESS = uuid.uuid4().hex
+
+
+class AdmissionConflict(ValueError):
+    pass
+
+
+def _home(session):
+    from hermes_constants import get_hermes_home
+    return Path(session.get("profile_home") or get_hermes_home()).resolve()
+
+
+@contextmanager
+def _ledger(session):
+    home = _home(session)
+    home.mkdir(parents=True, exist_ok=True, mode=0o700)
+    db = sqlite3.connect(home / "prompt-admissions.db", timeout=10)
+    db.row_factory = sqlite3.Row
+    try:
+        db.execute("""CREATE TABLE IF NOT EXISTS admissions (
+            seq INTEGER PRIMARY KEY AUTOINCREMENT, admission_id TEXT UNIQUE NOT NULL,
+            target_session_id TEXT NOT NULL, root TEXT NOT NULL, lineage TEXT NOT NULL,
+            payload TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'queued',
+            outcome TEXT, owner TEXT, generation INTEGER)""")
+        with db:
+            yield db
+    finally:
+        db.close()
+
+
+def _target(session):
+    key = str(session.get("session_key") or "")
+    if not key:
+        raise ValueError("durable admission requires a stored session identity")
+    from . import server
+    with server._session_db(session) as db:
+        lineage = db.get_compression_lineage(key) if db is not None else []
+    lineage = lineage or [key]
+    return key, lineage[0], lineage
+
+
+def _receipt(session, row):
+    state = row["status"]
+    if state == "started" and row["owner"] != _PROCESS:
+        state = "unknown"
+    return dict(admission_id=row["admission_id"], status=state, outcome=row["outcome"],
+                target_session_id=row["target_session_id"], target_profile_home=str(_home(session)))
+
+
+def accept_admission(session, admission_id, payload):
+    if not isinstance(admission_id, str) or not admission_id or len(admission_id) > 200:
+        raise ValueError("submission_id must be a nonempty string of at most 200 characters")
+    key, root, lineage = _target(session)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    with _ledger(session) as db:
+        db.execute("BEGIN IMMEDIATE")
+        row = db.execute("SELECT * FROM admissions WHERE admission_id=?", (admission_id,)).fetchone()
+        if row is not None:
+            # Attached media was captured at first admission, not repasted on retry.
+            prior = json.loads(row["payload"])
+            retry = dict(payload, image_paths=prior.get("image_paths", []))
+            if row["root"] != root or prior != retry:
+                raise AdmissionConflict("submission_id already belongs to different input or target")
+            return _receipt(session, row), False
+        db.execute("INSERT INTO admissions(admission_id,target_session_id,root,lineage,payload) VALUES(?,?,?,?,?)",
+                   (admission_id, key, root, json.dumps(lineage), encoded))
+        row = db.execute("SELECT * FROM admissions WHERE admission_id=?", (admission_id,)).fetchone()
+        receipt = _receipt(session, row)
+    return receipt, True  # context manager committed before any acknowledgement
+
+
+def next_generation(session, floor):
+    """Persist epochs once a session has opted into durable admission."""
+    if not (_home(session) / "prompt-admissions.db").exists():
+        return floor + 1
+    _, root, _ = _target(session)
+    with _ledger(session) as db:
+        db.execute("CREATE TABLE IF NOT EXISTS executions (root TEXT PRIMARY KEY, generation INTEGER NOT NULL)")
+        db.execute("BEGIN IMMEDIATE")
+        db.execute("INSERT INTO executions(root,generation) VALUES(?,?) ON CONFLICT(root) DO UPDATE SET generation=MAX(generation,?)+1",
+                   (root, floor + 1, floor))
+        return db.execute("SELECT generation FROM executions WHERE root=?", (root,)).fetchone()[0]
+
+
+def claim_admission(session, admission_id):
+    _, root, _ = _target(session)
+    with _ledger(session) as db:
+        return db.execute("UPDATE admissions SET status='started',owner=? WHERE admission_id=? AND root=? AND status='queued'",
+                          (_PROCESS, admission_id, root)).rowcount == 1
+
+
+def bind_admission_generation(session, admission_id, generation):
+    with _ledger(session) as db:
+        db.execute("UPDATE admissions SET generation=? WHERE admission_id=? AND owner=? AND status='started' AND generation IS NULL",
+                   (generation, admission_id, _PROCESS))
+
+
+def finish_admission(session, admission_id, status, generation):
+    with _ledger(session) as db:
+        db.execute("UPDATE admissions SET status='terminal',outcome=?,generation=? WHERE admission_id=? AND owner=? AND status='started' AND (generation IS NULL OR generation=?)",
+                   (status, generation, admission_id, _PROCESS, generation))
+
+
+def cancel_admission(session, admission_id):
+    _, root, _ = _target(session)
+    with _ledger(session) as db:
+        db.execute("UPDATE admissions SET status='terminal',outcome='cancelled' WHERE admission_id=? AND root=? AND status='queued'",
+                   (admission_id, root))
+        row = db.execute("SELECT * FROM admissions WHERE admission_id=? AND root=?", (admission_id, root)).fetchone()
+        if row is None:
+            raise ValueError("admission not found in this session")
+        return _receipt(session, row)
+
+
+def _pending(session):
+    if not (_home(session) / "prompt-admissions.db").exists():
+        return []
+    _, root, _ = _target(session)
+    with _ledger(session) as db:
+        return list(db.execute("SELECT * FROM admissions WHERE root=? AND status!='terminal' ORDER BY seq", (root,)))
+
+
+def admission_snapshot(session):
+    return {"pending_submissions": [dict(_receipt(session, row), user=json.loads(row["payload"])["text"])
+                                    for row in _pending(session)]}
+
+
+def restore_pending(session):
+    """Rebuild only never-started work; preserve opaque legacy envelopes by reference."""
+    if not (_home(session) / "prompt-admissions.db").exists():
+        return
+    rows = _pending(session)
+    with session["history_lock"]:
+        old = ([session["queued_prompt"]] if session.get("queued_prompt") else []) + list(session.get("queued_prompts") or [])
+        pending = {r["admission_id"]: r for r in rows if r["status"] == "queued"}
+        # Preserve mixed legacy/durable FIFO and runtime-only callbacks by reference.
+        entries = [e for e in old if not e.get("admission_id") or e["admission_id"] in pending]
+        present = {e.get("admission_id") for e in entries}
+        entries.extend(dict(json.loads(r["payload"]), admission_id=aid)
+                       for aid, r in pending.items() if aid not in present)
+        session["queued_prompt"] = entries[0] if entries else None
+        session["queued_prompts"] = entries[1:]
+
+
+def run_queued_admission(rid, sid, session, queued, kwargs):
+    from . import server
+    import threading
+
+    admission_id = queued["admission_id"]
+
+    def run():
+        try:
+            if not server._restart_completed_failed_agent_build(sid, session, session.get("agent_ready")):
+                server._start_agent_build(sid, session)
+            server._run_after_agent_ready(
+                rid, sid, session, queued["text"], queued.get("display_kind"), None,
+                admission_id=admission_id, **kwargs)
+        except BaseException:
+            # The build dispatcher stops owning lifecycle after handing off its thread.
+            with session["history_lock"]:
+                owns_dispatch = session.get("_run_thread") is thread
+                if owns_dispatch:
+                    session.update(running=False, _execution_state="error")
+            try:
+                finish_admission(session, admission_id, "error", session.get("_execution_generation", 0))
+            finally:
+                if owns_dispatch:
+                    from .prompt_execution import execution_snapshot
+                    server._emit("session.info", sid, execution_snapshot(session))
+            raise
+        else:
+            if not session.get("running"):
+                finish_admission(session, admission_id, "error", session.get("_execution_generation", 0))
+
+    thread = threading.Thread(target=run, daemon=True)
+    session["_run_thread"] = thread
+    thread.start()
+
+
+def submit_admission(rid, sid, session, params, text, transport):
+    """Existing prompt.submit's opt-in durable branch, sharing its owner drain."""
+    from . import server
+    mode = "queue" if params.get("queued") else server._load_busy_input_mode()
+    with session["history_lock"]:
+        images = list(session.get("attached_images") or [])
+        payload = dict(text=text, image_paths=images, display_kind="hidden" if params.get("display_kind") == "hidden" else None,
+                       intent=mode)
+        # Attachment retry does not consume a later paste or require repasting accepted media.
+        receipt, fresh = accept_admission(session, params["submission_id"], payload)
+        if not fresh:
+            return server._ok(rid, receipt)
+        session["attached_images"] = []
+        busy = bool(session.get("running"))
+    if busy and mode != "queue" and not images:
+        # The durable started marker precedes steer/redirect. Crash here is unknown,
+        # not a synthetic next-turn replay of a possibly already consumed correction.
+        agent = session.get("agent")
+        plain = server._coerce_message_text(text).strip() if server._is_text_only_busy_payload(text) else ""
+        method, status = {"steer": ("steer", "steered"), "interrupt": ("redirect", "redirected")}.get(mode, (None, None))
+        supported = method and agent is not None and hasattr(agent, method)
+        if mode == "interrupt":
+            supported = supported and getattr(agent, "_supports_active_turn_redirect", False) is True
+        if plain and supported and claim_admission(session, receipt["admission_id"]):
+            try:
+                accepted = getattr(agent, method)(plain)
+            except Exception:
+                # The correction may have been consumed before an implementation raised.
+                finish_admission(session, receipt["admission_id"], "correction_unknown", session.get("_execution_generation", 0))
+                return server._ok(rid, dict(receipt, status="terminal", outcome="correction_unknown"))
+            if accepted:
+                with session["history_lock"]:
+                    server._record_inflight_correction(session, plain)
+                    server._drop_queued_duplicates_of_inflight_user(session)
+                finish_admission(session, receipt["admission_id"], status, session.get("_execution_generation", 0))
+                return server._ok(rid, dict(receipt, status="terminal", outcome=status))
+            # A concrete refusal proves no correction was admitted. Preserve the
+            # configured safe-boundary fallback (unlike a crash/exception ambiguity).
+            with _ledger(session) as db:
+                db.execute("UPDATE admissions SET status='queued',owner=NULL WHERE admission_id=? AND owner=? AND status='started'",
+                           (receipt["admission_id"], _PROCESS))
+    restore_pending(session)
+    with session["history_lock"]:
+        entries = ([session["queued_prompt"]] if session.get("queued_prompt") else []) + session.get("queued_prompts", [])
+        for entry in entries:
+            if entry.get("admission_id") == receipt["admission_id"]:
+                entry["transport"] = transport
+    if busy and mode == "interrupt" and not images:
+        server._interrupt_busy_session(sid, session, session.get("agent"))
+    # Recheck at the boundary: the busy turn may have settled while SQLite committed.
+    server._drain_queued_prompt(rid, sid, session)
+    return server._ok(rid, receipt)

--- a/tui_gateway/prompt_admission.py
+++ b/tui_gateway/prompt_admission.py
@@ -239,4 +239,10 @@ def submit_admission(rid, sid, session, params, text, transport):
         server._interrupt_busy_session(sid, session, session.get("agent"))
     # Recheck at the boundary: the busy turn may have settled while SQLite committed.
     server._drain_queued_prompt(rid, sid, session)
+    # The submit ACK reaches only its sender; every attached viewer needs the
+    # durable queue, even while the owner is blocked inside a model/tool call.
+    server._emit("session.info", sid, {
+        "stored_session_id": session.get("session_key") or sid,
+        **admission_snapshot(session),
+    })
     return server._ok(rid, receipt)

--- a/tui_gateway/prompt_execution.py
+++ b/tui_gateway/prompt_execution.py
@@ -1,0 +1,34 @@
+"""Generation-fenced authority for in-process prompt executions.
+
+Only explicit turn completion releases running; elapsed time is not ownership.
+These helpers retain their own globals rather than the gateway facade's bindings.
+"""
+
+
+def begin_execution(session: dict) -> int:
+    from .prompt_admission import next_generation
+    with session["history_lock"]:
+        try:
+            generation = next_generation(session, int(session.get("_execution_generation", 0)))
+        except BaseException:
+            session.update(_execution_state="error", running=False)
+            raise
+        session.update(_execution_generation=generation, _execution_state="running", running=True)
+        return generation
+
+
+def settle_execution(session: dict, generation: int, status: str) -> bool:
+    with session["history_lock"]:
+        if session.get("_execution_generation") != generation:
+            return False
+        session.update(_execution_state=status, running=False)
+        return True
+
+
+def execution_snapshot(session: dict) -> dict:
+    with session["history_lock"]:
+        return {
+            "execution_generation": int(session.get("_execution_generation", 0)),
+            "execution_state": "running" if session.get("running") else session.get("_execution_state", "idle"),
+            "running": bool(session.get("running")),
+        }

--- a/tui_gateway/prompt_execution.py
+++ b/tui_gateway/prompt_execution.py
@@ -8,7 +8,7 @@ from contextvars import ContextVar
 import uuid
 
 _EPOCH = uuid.uuid4().hex
-event_authority = ContextVar("prompt_event_authority", default=None)
+event_authority: ContextVar[dict | None] = ContextVar("prompt_event_authority", default=None)
 
 
 def begin_execution(session: dict) -> int:

--- a/tui_gateway/prompt_execution.py
+++ b/tui_gateway/prompt_execution.py
@@ -4,6 +4,12 @@ Only explicit turn completion releases running; elapsed time is not ownership.
 These helpers retain their own globals rather than the gateway facade's bindings.
 """
 
+from contextvars import ContextVar
+import uuid
+
+_EPOCH = uuid.uuid4().hex
+event_authority = ContextVar("prompt_event_authority", default=None)
+
 
 def begin_execution(session: dict) -> int:
     from .prompt_admission import next_generation
@@ -26,9 +32,17 @@ def settle_execution(session: dict, generation: int, status: str) -> bool:
 
 
 def execution_snapshot(session: dict) -> dict:
-    with session["history_lock"]:
-        return {
-            "execution_generation": int(session.get("_execution_generation", 0)),
-            "execution_state": "running" if session.get("running") else session.get("_execution_state", "idle"),
-            "running": bool(session.get("running")),
-        }
+    # Copy the dictionary once: projections also run inside an already-owned
+    # non-reentrant history lock. Writers publish authority with dict.update.
+    state = session.copy()
+    return {
+        "execution_epoch": _EPOCH,
+        "execution_generation": int(state.get("_execution_generation", 0)),
+        "execution_state": "running" if state.get("running") else state.get("_execution_state", "idle"),
+        "running": bool(state.get("running")),
+    }
+
+
+def session_authority(session: dict) -> dict:
+    from .prompt_admission import admission_snapshot
+    return {**admission_snapshot(session), **execution_snapshot(session)}

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -875,7 +875,10 @@ def _run_prompt_submit(
         return goal_followup
 
     def run():
+        from tui_gateway.prompt_execution import event_authority
         nonlocal execution_status
+        token = event_authority.set({"execution_epoch": execution_snapshot(session)["execution_epoch"],
+                                     "execution_generation": generation})
         goal_followup = None
         try:
             goal_followup = run_turn()
@@ -887,7 +890,10 @@ def _run_prompt_submit(
             except Exception:
                 logger.exception("outer turn recovery failed")
         finally:
-            settled = settle(execution_status)
+            try:
+                settled = settle(execution_status)
+            finally:
+                event_authority.reset(token)
         if settled:
             try:
                 _emit_settled_session_info(sid, session, st.agent)
@@ -897,7 +903,7 @@ def _run_prompt_submit(
                 _run_post_turn_followups(rid, sid, session, st.result, goal_followup)
 
     try:
-        _emit("message.start", sid)
+        _emit("message.start", sid, execution_snapshot(session))
         run_thread = threading.Thread(target=run, daemon=True)
         with _sessions_lock:
             registered = _sessions.get(sid)

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -751,7 +751,10 @@ def _run_prompt_submit(
     rid, sid: str, session: dict, text: Any, *, display_kind: str | None = None,
     display_metadata: dict | None = None, image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
-    terminal_callback: Callable[[dict[str, Any]], None] | None = None) -> bool:
+    terminal_callback: Callable[[dict[str, Any]], None] | None = None,
+    admission_id: str | None = None) -> bool:
+    from tui_gateway.prompt_execution import begin_execution, settle_execution, execution_snapshot
+
     admitted = _admit_prompt_turn(sid, session, text, image_paths, queued_prompt_generation)
     if admitted is None:
         return False
@@ -770,21 +773,44 @@ def _run_prompt_submit(
         "kind=%s chars=%s images=%d",
         sid, session.get("session_key") or "", getattr(agent, "session_id", "") or "",
         display_kind or "user", len(text) if isinstance(text, str) else "-", len(images))
-    _emit("message.start", sid)
+    try:
+        generation = begin_execution(session)
+    except BaseException:
+        _emit("session.info", sid, execution_snapshot(session))
+        raise
 
-    def run():
+    def settle(status):
+        settled = settle_execution(session, generation, status)
+        try:
+            if admission_id is not None:
+                from tui_gateway.prompt_admission import finish_admission
+                finish_admission(session, admission_id, status, generation)
+        finally:
+            if settled:
+                _emit("session.info", sid, execution_snapshot(session))
+        return settled
+
+    st = _TurnRun(
+        agent, session.pop("one_turn_model_restore", None), terminal_callback,
+        receipt_committed=terminal_callback is None)
+    execution_status = "error"
+    dispatch_followups = True
+
+    def run_turn():
+        nonlocal execution_status, dispatch_followups
         # RPC-dispatcher ContextVars do not follow onto this thread: rebind the transport
         # before any tool can commission a child (delegate_task captures it as authority).
         transport_token = bind_transport(session.get("transport"))
         runtime_session_token = _current_runtime_session_record.set(session)
-        st = _TurnRun(
-            session["agent"], session.pop("one_turn_model_restore", None), terminal_callback,
-            receipt_committed=terminal_callback is None)
-        st.marker_key = _record_turn_marker(session, text, auto_continue=terminal_callback is None)
         goal_followup = None
         try:
+            if admission_id is not None:
+                from tui_gateway.prompt_admission import bind_admission_generation
+                bind_admission_generation(session, admission_id, generation)
+            st.marker_key = _record_turn_marker(session, text, auto_continue=terminal_callback is None and admission_id is None)
             prepared = _prepare_turn_input(sid, session, st, text, images)
             if prepared is None:
+                dispatch_followups = False
                 if st.terminal_callback is not None and not st.receipt_attempted:
                     st.receipt_attempted = True
                     st.terminal_callback({
@@ -798,6 +824,7 @@ def _run_prompt_submit(
             status_note = _absorb_turn_result(
                 sid, session, st, text, display_kind, display_metadata)
             payload, raw, status = _complete_turn_payload(session, st, status_note, cols)
+            execution_status = status
             _emit("message.complete", sid, payload)
             goal_followup = _goal_followup_after_turn(sid, session, st.result, status, raw)
             if status == "complete":
@@ -806,15 +833,21 @@ def _run_prompt_submit(
             # structured control snapshot now so the Desktop card never paints the pre-judge turn count.
             _publish_session_control_snapshot(sid, session, only_if_present=True)
         except Exception as e:
+            execution_status = "error"
             _recover_turn_exception(sid, session, st, e)
         finally:
-            _finish_turn(sid, session, st)
-            _current_runtime_session_record.reset(runtime_session_token)
-            reset_transport(transport_token)
-            # A stale interim closure must not fire during a later turn.
-            st.agent.interim_assistant_callback = None
+            try:
+                _finish_turn(sid, session, st)
+            finally:
+                try:
+                    _current_runtime_session_record.reset(runtime_session_token)
+                finally:
+                    reset_transport(transport_token)
+            # A stale interim closure must not clear the newer turn's callback.
             with session["history_lock"]:
-                session["running"] = False
+                if session.get("_execution_generation") != generation:
+                    return None
+                st.agent.interim_assistant_callback = None
                 session["last_active"] = time.time()
                 if not st.error_retained:
                     _clear_inflight_turn(session)
@@ -839,19 +872,45 @@ def _run_prompt_submit(
                         session.pop("_active_turn_marker_key", None)
                     session.pop("_hosted_room_task", None)
             session.pop("_auto_continue_scheduled", None)
-            _emit_settled_session_info(sid, session, st.agent)
-        _run_post_turn_followups(rid, sid, session, st.result, goal_followup)
-    run_thread = threading.Thread(target=run, daemon=True)
-    with _sessions_lock:
-        registered = _sessions.get(sid)
-        can_start = not session.get("_closing") and (registered is None or registered is session)
-        if can_start:
-            session["_run_thread"] = run_thread
-            run_thread.start()
-    if not can_start:
-        with session["history_lock"]:
-            session["running"] = False
-    return can_start
+        return goal_followup
+
+    def run():
+        nonlocal execution_status
+        goal_followup = None
+        try:
+            goal_followup = run_turn()
+        except BaseException as exc:
+            execution_status = "interrupted" if isinstance(exc, (KeyboardInterrupt, SystemExit)) else "error"
+            try:
+                if session.get("_execution_generation") == generation:
+                    _recover_turn_exception(sid, session, st, exc)
+            except Exception:
+                logger.exception("outer turn recovery failed")
+        finally:
+            settled = settle(execution_status)
+        if settled:
+            try:
+                _emit_settled_session_info(sid, session, st.agent)
+            except Exception:
+                logger.exception("settled session projection failed")
+            if dispatch_followups:
+                _run_post_turn_followups(rid, sid, session, st.result, goal_followup)
+
+    try:
+        _emit("message.start", sid)
+        run_thread = threading.Thread(target=run, daemon=True)
+        with _sessions_lock:
+            registered = _sessions.get(sid)
+            can_start = not session.get("_closing") and (registered is None or registered is session)
+            if can_start:
+                session["_run_thread"] = run_thread
+                run_thread.start()
+        if not can_start:
+            settle("interrupted")
+        return can_start
+    except BaseException:
+        settle("error")
+        raise
 
 
 def register(server) -> None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -571,6 +571,10 @@ def write_json(obj: dict) -> bool:
 
 
 def _event_frame(event: str, sid: str, payload: dict | None = None) -> dict:
+    from .prompt_execution import event_authority
+    authority = event_authority.get()
+    if authority and event in {"message.start", "message.complete", "message.error"}:
+        payload = {**(payload or {}), **authority}
     params: dict = {"type": event, "session_id": sid, **({"payload": payload} if payload is not None else {})}
     return {"jsonrpc": "2.0", "method": "event", "params": params}
 
@@ -2092,6 +2096,9 @@ def _session_info(agent, session: dict | None = None) -> dict:
         info["update_command"] = recommended_update_command()
     if live_agent and (warn := _probe_credentials(agent)):
         info["credential_warning"] = warn
+    if session is not None:
+        from .prompt_execution import session_authority
+        info.update(session_authority(session))
     return info
 
 
@@ -2626,7 +2633,7 @@ def _find_live_session_by_key(session_key: str, profile_home=_ANY_PROFILE) -> tu
 def _fallback_session_info(session: dict) -> dict:
     agent = session.get("agent")
     if agent is not None:
-        return _session_info(agent)
+        return _session_info(agent, session)
     # The SESSION's own workspace, not the launch dir (wrong project in the desktop Files pane). `branch` is
     # always emitted ("" outside git) so a stale label clears; `desktop_contract` missing reads as "out of date".
     # Reporting `_default_session_cwd()` here told a lazily-resumed session's client that its workspace was
@@ -2635,7 +2642,9 @@ def _fallback_session_info(session: dict) -> dict:
     # so a client can clear a stale label instead of retaining it — the same contract `_lazy_session_info`
     # above already follows.
     cwd = _session_cwd(session)
+    from .prompt_execution import session_authority
     return {
+        **session_authority(session),
         "cwd": cwd, "branch": git_probe.branch(cwd), "project": _project_info_for_cwd(cwd), "lazy": True,
         "model": _resolve_model(), "skills": {}, "tools": {}, "desktop_contract": DESKTOP_BACKEND_CONTRACT,
     }

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -573,7 +573,7 @@ def write_json(obj: dict) -> bool:
 def _event_frame(event: str, sid: str, payload: dict | None = None) -> dict:
     from .prompt_execution import event_authority
     authority = event_authority.get()
-    if authority and event in {"message.start", "message.complete", "message.error"}:
+    if authority and event in {"message.start", "message.complete", "message.error", "error"}:
         payload = {**(payload or {}), **authority}
     params: dict = {"type": event, "session_id": sid, **({"payload": payload} if payload is not None else {})}
     return {"jsonrpc": "2.0", "method": "event", "params": params}

--- a/tui_gateway/session_attach.py
+++ b/tui_gateway/session_attach.py
@@ -1,0 +1,159 @@
+"""Private same-user discovery on the existing serve listener.
+
+Registry metadata locates the runtime but never authorizes access. Only a native
+client holding its profile's private copy of the existing runtime credential can
+complete the handshake; browser and non-loopback callers cannot use this route.
+"""
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import logging
+import stat
+import sys
+from pathlib import Path
+from urllib.parse import urlencode, urlsplit
+
+from hermes_constants import get_hermes_home
+
+_log = logging.getLogger(__name__)
+ATTACH_PATH = "/api/session-attach"
+
+
+def _loopback(host: str) -> bool:
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _origin(web) -> str | None:
+    host = getattr(web.app.state, "bound_host", "") or ""
+    port = getattr(web.app.state, "bound_port", None)
+    # Wildcard listeners also serve loopback; never advertise their public address.
+    host = {"localhost": "127.0.0.1", "0.0.0.0": "127.0.0.1", "::": "::1"}.get(host, host)
+    if not _loopback(host) or not isinstance(port, int) or not 0 < port < 65536:
+        return None
+    authority = f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
+    return f"http://{authority}"
+
+
+def _credential(web) -> tuple[str, str]:
+    if getattr(web.app.state, "auth_required", False):
+        from hermes_cli.dashboard_auth.ws_tickets import internal_ws_credential
+        return "internal", internal_ws_credential()
+    return "token", web._SESSION_TOKEN
+
+
+def owner_metadata(live_session_id: str, profile_home=None) -> dict:
+    metadata = {"live_session_id": live_session_id, "bot_live_delivery_consumer": True}
+    # A standalone stdio backend must not import/start a dashboard to advertise.
+    web = sys.modules.get("hermes_cli.web_server")
+    if web is None or (origin := _origin(web)) is None:
+        return metadata
+    home = Path(profile_home or get_hermes_home()).resolve()
+    directory = home / "runtime" / "session-attach"
+    try:
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        info = directory.lstat()
+        if (not stat.S_ISDIR(info.st_mode) or info.st_mode & 0o077
+                or directory.resolve() != directory):
+            raise OSError("private discovery directory is not private")
+        from utils import atomic_json_write
+        _, credential = _credential(web)
+        atomic_json_write(directory / (hashlib.sha256(origin.encode()).hexdigest() + ".json"),
+                          {"shared_runtime_url": origin, "profile_home": str(home),
+                           "authorization": f"Bearer {credential}"}, mode=0o600)
+    except OSError:
+        # Discovery is optional; a filesystem problem must not prevent the owner
+        # working, nor publish an endpoint the next local client cannot authorize.
+        _log.warning("Could not publish private session attachment discovery")
+        return metadata
+    metadata["shared_runtime_url"] = origin
+    return metadata
+
+
+def _owner_matches(session_id: str, lease_id: str, profile_home: str) -> bool:
+    from tui_gateway import server
+    from hermes_cli.active_sessions import active_session_registry_snapshot
+
+    if not session_id or not lease_id or not profile_home:
+        return False
+    # Match an already-open profile before touching a client-supplied path.
+    with server._sessions_lock:
+        matches = [session for session in server._sessions.values()
+                   if session.get("session_key") == session_id
+                   and str(Path(session.get("profile_home") or get_hermes_home()).resolve()) == profile_home
+                   and not session.get("_closing") and not session.get("_finalized")]
+        if len(matches) != 1:
+            return False
+        lease = matches[0].get("active_session_lease")
+        if (lease is None or lease.lease_id != lease_id or lease.released
+                or not lease.enabled or lease.session_id != session_id):
+            return False
+        try:
+            owners = [row for row in active_session_registry_snapshot(profile_home, strict=True)
+                      if row.get("session_id") == session_id]
+        except Exception:
+            _log.warning("Could not verify session attachment ownership")
+            return False
+        return len(owners) == 1 and owners[0].get("lease_id") == lease_id
+
+
+def _local_native(request, web) -> bool:
+    from hermes_cli.web_server import _is_accepted_host
+    origin = _origin(web)
+    return bool(origin and request.client and _loopback(request.client.host)
+                and "origin" not in request.headers
+                and _is_accepted_host(request.headers.get("host", ""), urlsplit(origin).hostname or "", frozenset()))
+
+
+async def handshake(request):
+    """Exact-path HTTP auth seam; never sets an auth bypass flag for other routes."""
+    import asyncio
+    from fastapi.responses import JSONResponse
+    from hermes_cli import web_server as web
+
+    def reply(status, content):
+        return JSONResponse(content, status_code=status, headers={"Cache-Control": "no-store"})
+
+    origin = _origin(web)
+    if origin is None or not _local_native(request, web):
+        return reply(403, {"detail": "Local native attachment only"})
+    if request.method != "GET":
+        return reply(405, {"detail": "GET required"})
+    auth = request.headers.get("authorization", "")
+    if getattr(web.app.state, "auth_required", False):
+        from hermes_cli.dashboard_auth.ws_tickets import TicketInvalid, consume_internal_credential
+        try:
+            consume_internal_credential(auth.removeprefix("Bearer ") if auth.startswith("Bearer ") else "")
+        except TicketInvalid:
+            return reply(401, {"detail": "Unauthorized"})
+    elif not web._has_valid_session_token(request):
+        return reply(401, {"detail": "Unauthorized"})
+    fields = ("session_id", "lease_id", "profile_home")
+    pins = {key: request.query_params.get(key, "") for key in fields}
+    if (any(len(request.query_params.getlist(key)) != 1 for key in fields)
+            or not await asyncio.to_thread(_owner_matches, **pins)):
+        return reply(409, {"detail": "Session owner changed or unavailable"})
+    key, credential = _credential(web)
+    qs = {key: credential, **{f"attach_{key}": value for key, value in pins.items()}}
+    return reply(200, {**pins, "websocket_url": origin.replace("http://", "ws://", 1)
+                      + "/api/ws?" + urlencode(qs)})
+
+
+async def allow_upgrade(ws) -> bool:
+    """Fence a discovered URL again after normal WS authentication, before accept."""
+    import asyncio
+    from hermes_cli import web_server as web
+
+    fields = ("session_id", "lease_id", "profile_home")
+    if not any(f"attach_{key}" in ws.query_params for key in fields):
+        return True
+    pins = {key: ws.query_params.get(f"attach_{key}", "") for key in fields}
+    if (not _local_native(ws, web)
+            or any(len(ws.query_params.getlist(f"attach_{key}")) != 1 for key in fields)
+            or not await asyncio.to_thread(_owner_matches, **pins)):
+        await ws.close(code=4409, reason="session owner changed or unavailable")
+        return False
+    return True

--- a/tui_gateway/session_attach.py
+++ b/tui_gateway/session_attach.py
@@ -152,8 +152,93 @@ async def allow_upgrade(ws) -> bool:
         return True
     pins = {key: ws.query_params.get(f"attach_{key}", "") for key in fields}
     if (not _local_native(ws, web)
-            or any(len(ws.query_params.getlist(f"attach_{key}")) != 1 for key in fields)
-            or not await asyncio.to_thread(_owner_matches, **pins)):
+            or any(len(ws.query_params.getlist(f"attach_{key}")) != 1 for key in fields)):
         await ws.close(code=4409, reason="session owner changed or unavailable")
         return False
+    fence = await asyncio.to_thread(_capture_owner, pins)
+    if fence is None:
+        await ws.close(code=4409, reason="session owner changed or unavailable")
+        return False
+    ws._hermes_attach_fence = fence
     return True
+
+
+def _capture_owner(pins):
+    from tui_gateway import server
+
+    with server._sessions_lock:
+        if not _owner_matches(**pins):
+            return None
+        sid, session = next((sid, session) for sid, session in server._sessions.items()
+                            if session.get("session_key") == pins["session_id"]
+                            and str(Path(session.get("profile_home") or get_hermes_home()).resolve())
+                            == pins["profile_home"])
+        return _OwnerFence(pins, sid, session, session["active_session_lease"])
+
+
+class _OwnerFence:
+    """A discovered socket subscribes to one live record, never the cold-resume path.
+
+    Retain object identity as well as the published lease ID: compression transfers
+    the SAME lease; releasing/reclaiming or replacing the runtime is not migration.
+    """
+
+    def __init__(self, pins, sid, session, lease):
+        self.pins, self.sid, self.session, self.lease = pins, sid, session, lease
+
+    def valid(self):
+        from tui_gateway import server
+
+        with server._sessions_lock:
+            return (server._sessions.get(self.sid) is self.session
+                    and self.session.get("active_session_lease") is self.lease
+                    and _owner_matches(str(self.session.get("session_key") or ""),
+                                       self.pins["lease_id"], self.pins["profile_home"]))
+
+    def __call__(self, req, transport):
+        import contextvars
+        from tui_gateway import server
+        from tui_gateway.transport import bind_transport, reset_transport
+
+        normalized = server._normalize_request(req)
+        if isinstance(normalized, dict):
+            return normalized
+        transport.attach_fence = self
+        token = bind_transport(transport)
+        try:
+            if normalized[1] not in server._LONG_HANDLERS:
+                return self._handle(req)
+            ctx = contextvars.copy_context()
+
+            def run():
+                try:
+                    response = self._handle(req)
+                except Exception:
+                    _log.exception("attached session request failed")
+                    response = server._err(normalized[0], -32603, "internal error")
+                if response is not None:
+                    transport.write(response)
+
+            server._pool.submit(lambda: ctx.run(run))
+            return None
+        finally:
+            reset_transport(token)
+
+    def _handle(self, req):
+        from tui_gateway import server
+
+        rid, method, params = server._normalize_request(req)
+        # Check in the executing worker, not just before it queues. Resume must
+        # stay on this record even if the transcript's profile/name lookup differs.
+        with server._session_resume_lock:
+            if not self.valid():
+                return server._err(rid, 4409, "session owner changed or unavailable")
+            if method == "session.resume":
+                target = params.get("session_id") or params.get("id")
+                if target not in (self.pins["session_id"], self.session["session_key"], self.sid):
+                    return server._err(rid, 4409, "session owner changed or unavailable")
+                ctx = server._Resume(rid, params, self.session["session_key"])
+                return server._resume_reuse_live_locked(ctx, self.sid, self.session)
+            if method == "session.create":
+                return server._err(rid, 4409, "attachment requires the existing session owner")
+        return server.handle_request(req)

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -62,6 +62,13 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     # its execution generation and duplicate work.
     if session.get("source") == "bot_room":
         return None
+    from tui_gateway.prompt_admission import restore_pending, admission_snapshot
+    restore_pending(session)
+    pending = admission_snapshot(session)["pending_submissions"]
+    if pending:
+        if any(row["status"] == "queued" for row in pending):
+            _drain_queued_prompt("__admission_resume__", sid, session)
+        return None  # Started/unknown human work is never generic auto-continue input.
     home = _session_home(session)
     if (marker := read_turn_marker(home, session_key)) is None:
         return None
@@ -141,7 +148,7 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any, image_paths: list[
     queued = {"text": text, "transport": transport, **({"image_paths": image_paths} if image_paths else {})}
     existing = session.get("queued_prompt")
     if (existing and text_only and isinstance(existing.get("text"), str)
-            and not existing.get("image_paths") and not session.get("queued_prompts")):
+            and not existing.get("image_paths") and not existing.get("admission_id") and not session.get("queued_prompts")):
         prev = existing["text"]
         existing["text"] = f"{prev}\n\n{text}" if prev and text else (prev or text)
     elif existing:
@@ -161,6 +168,8 @@ def _sanitize_queued_entry_vs_inflight_user(entry: Any, original: str) -> dict |
     """
     if not isinstance(entry, dict):
         return None
+    if entry.get("admission_id"):
+        return entry  # Identity, not text equality, defines accepted human work.
     text = entry.get("text")
     if not original or entry.get("image_paths") or not isinstance(text, str):
         return entry
@@ -281,6 +290,8 @@ def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any,
 def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     """Fire a queued next-turn prompt if one is waiting and the session is idle. True when dispatched: the caller
     skips lower-priority follow-ups this cycle (the user's message wins)."""
+    from tui_gateway.prompt_admission import restore_pending, claim_admission
+    restore_pending(session)
     with session["history_lock"]:
         if session.get("_closing") or not (queued := session.get("queued_prompt")) or session.get("running"):
             return False
@@ -309,7 +320,14 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         kwargs["image_paths"] = queued["image_paths"]
     dispatch_failed = False
     try:
-        if not use_compute_host:
+        if queued.get("admission_id"):
+            from tui_gateway.prompt_admission import run_queued_admission
+            if not claim_admission(session, queued["admission_id"]):
+                with session["history_lock"]:
+                    session["running"] = False
+                return _drain_queued_prompt(rid, sid, session)
+            run_queued_admission(rid, sid, session, queued, kwargs)
+        elif not use_compute_host:
             _run_prompt_submit(rid, sid, session, queued["text"], **kwargs)
         elif (resp := _submit_prompt_to_compute_host(rid, sid, session, queued["text"], **kwargs)).get("error"):
             with session["history_lock"]:

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -298,6 +298,9 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         queue_generation = int(session.get("_queued_prompt_generation", 0))
         _ac_set_queue(session, session.get("queued_prompts") or [])
         session["running"] = True
+        # Reset only the previous turn's Stop while claiming the next turn. A
+        # later Stop still latches cancellation and invalidates queue_generation.
+        session["_turn_cancel_requested"] = False
         queued_transport = queued.get("transport")
         # The queuer's transport is pinned so the drained turn reaches the client that sent it — but
         # ATTACHED, not rebound: a mid-turn prompt from a second client used to silence the first for the

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -459,6 +459,9 @@ def _reattach_refusal(rid, sid: str, session: dict) -> dict | None:
     """Under ``_session_resume_lock``: why a reattaching RPC (resume/activate/prompt.submit) must NOT rebind
     ``session`` — it is stale, or a client-gone interrupt is still settling and the reap Timer must keep
     polling. None when the reattach may proceed."""
+    fence = getattr(current_transport(), "attach_fence", None)
+    if fence is not None and (session is not fence.session or not fence.valid()):
+        return _err(rid, 4409, "session owner changed or unavailable")
     if _sessions.get(sid) is not session:
         return _err(rid, 4007, "session no longer live; retry resume")
     if session.get("_client_gone_interrupt_requested"):

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -29,9 +29,10 @@ def _claim_active_session_slot(
 ) -> tuple[Any, str | None]:
     try:
         from hermes_cli.active_sessions import try_acquire_active_session
+        from tui_gateway.session_attach import owner_metadata
         return try_acquire_active_session(
             session_id=session_key, surface=surface, config=_load_cfg(), registry_home=profile_home,
-            metadata={"live_session_id": live_session_id, "bot_live_delivery_consumer": True},
+            metadata=owner_metadata(live_session_id, profile_home),
             track_liveness=str(surface or "").strip().lower() == "desktop")
     except Exception as exc:
         logger.warning("Failed to claim active session slot: %s", exc)
@@ -138,8 +139,9 @@ def _transfer_active_session_slot(sid: str, session: dict, *, new_session_id: st
         return True
     try:
         from hermes_cli.active_sessions import transfer_active_session
-        if transfer_active_session(lease, session_id=new_session_id, metadata={
-                "live_session_id": sid, "bot_live_delivery_consumer": True}):
+        from tui_gateway.session_attach import owner_metadata
+        if transfer_active_session(lease, session_id=new_session_id,
+                                   metadata=owner_metadata(sid, session.get("profile_home"))):
             return True
     except Exception:
         logger.debug("Failed to transfer active session slot", exc_info=True)

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -236,7 +236,8 @@ class _SendFailed(Exception):
     """Raised by handle_ws._reply when a reply could not be written: ends the read loop."""
 
 
-async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: str | None = None) -> None:
+async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: str | None = None,
+                    dispatch=None) -> None:
     """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``. *auth_identity* is the server-minted
     ``{user_id, provider}`` recorded at WS-upgrade auth, stored as ``WSTransport.auth_identity`` (the only identity
     authority for browser-controller registration); callers that omit it (harnesses, embedded TUI child) get None."""
@@ -330,7 +331,7 @@ async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: 
             # writes the response itself via transport.write (a separate thread, so that is the safe
             # path). Inline handlers return the response dict, written here from the loop.
             try:
-                resp = await asyncio.to_thread(server.dispatch, req, transport)
+                resp = await asyncio.to_thread(dispatch or server.dispatch, req, transport)
             except Exception:
                 dispatch_crashes += 1
                 _log.exception("ws dispatch crash peer=%s id=%s method=%s", peer, req_id, req_method)

--- a/ui-tui/src/__tests__/composerDestinationRenderer.test.tsx
+++ b/ui-tui/src/__tests__/composerDestinationRenderer.test.tsx
@@ -1,0 +1,120 @@
+import { PassThrough } from 'node:stream'
+
+import { renderSync, Text } from '@hermes/ink'
+import React from 'react'
+import { expect, it, vi } from 'vitest'
+
+import { patchUiState, resetUiState } from '../app/uiStore.js'
+import { useComposerState } from '../app/useComposerState.js'
+import { readClipboardText } from '../lib/clipboard.js'
+
+vi.mock('../lib/clipboard.js', () => ({
+  readClipboardText: vi.fn(),
+  isUsableClipboardText: (text: unknown) => typeof text === 'string' && text.length > 0
+}))
+
+function deferred() {
+  let resolve!: (value: any) => void
+
+  const promise = new Promise<any>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+function mount(request: any) {
+  resetUiState()
+  patchUiState({ sid: 'owner', pasteCollapseChars: 5 })
+  let composer!: ReturnType<typeof useComposerState>
+  const sys = vi.fn()
+
+  function Harness() {
+    composer = useComposerState({ gw: { request } as any, submitRef: { current: () => {} }, sys })
+
+    return <Text>{composer.state.input}</Text>
+  }
+
+  const instance = renderSync(<Harness />, {
+    stdin: new PassThrough() as any,
+    stdout: Object.assign(new PassThrough(), { columns: 80, rows: 20, isTTY: false }) as any,
+    stderr: new PassThrough() as any,
+    patchConsole: false
+  })
+
+  return {
+    get composer() {
+      return composer
+    },
+    sys,
+    close() {
+      instance.unmount()
+      resetUiState()
+    }
+  }
+}
+
+it('captures hotkey destination before reading the clipboard, while preserving current-owner pastes', async () => {
+  vi.stubEnv('SSH_CONNECTION', '')
+  vi.stubEnv('SSH_CLIENT', '')
+  vi.stubEnv('SSH_TTY', '')
+  const request = vi.fn(async () => ({ name: 'shot', path: '/shot.png' }))
+  const h = mount(request)
+
+  try {
+    const gate = deferred()
+    vi.mocked(readClipboardText).mockReturnValueOnce(gate.promise)
+    const pending = h.composer.actions.handleTextPaste({ hotkey: true, text: '', value: '', cursor: 0 })
+    patchUiState({ sid: 'other' })
+    gate.resolve('/shot.png')
+    expect(await pending).toBeNull()
+    expect(request).not.toHaveBeenCalled()
+    expect(h.composer.refs.tokensRef.current).toEqual([])
+    vi.mocked(readClipboardText).mockResolvedValueOnce('/shot.png')
+    expect(await h.composer.actions.handleTextPaste({ hotkey: true, text: '', value: '', cursor: 0 })).toMatchObject({
+      value: '[[ Image 1 ]]'
+    })
+    expect(request).toHaveBeenCalledWith('image.attach', { path: '/shot.png', session_id: 'other' })
+  } finally {
+    h.close()
+    vi.unstubAllEnvs()
+  }
+})
+
+it('discards stale image, drop fallback and collapse completions without changing the new composer', async () => {
+  for (const mode of ['image', 'clipboard', 'drop', 'collapse']) {
+    const gate = deferred()
+    const request = vi.fn((method: string) => (method.startsWith('complete.') ? Promise.resolve({}) : gate.promise))
+    const h = mount(request)
+
+    try {
+      let pending: unknown
+
+      if (mode === 'image') {h.composer.actions.attachImagePath('/shot.png')}
+      else if (mode === 'clipboard') {h.composer.actions.attachClipboardImage()}
+      else
+        {pending = h.composer.actions.handleTextPaste({
+          text: mode === 'drop' ? '/file.txt' : 'long paste',
+          value: '',
+          cursor: 0
+        })}
+
+      await Promise.resolve()
+      const tokens = h.composer.refs.tokensRef.current.map(t => ({ ...t }))
+      patchUiState({ sid: 'other' })
+      h.composer.actions.setInput('new draft')
+      h.composer.actions.setComposerTokens(tokens)
+      gate.resolve(
+        mode === 'drop' ? { matched: true, text: 'wrong' } : { name: 'shot', attached: true, path: '/old-path' }
+      )
+      await pending
+      await new Promise<void>(resolve => setImmediate(resolve))
+      expect(h.composer.refs.tokensRef.current).toEqual(tokens)
+      expect(h.composer.state.input).toBe('new draft')
+      expect(request.mock.calls.filter(([method]) => method === 'input.detect_drop')).toHaveLength(0)
+      expect(h.sys).not.toHaveBeenCalled()
+    } finally {
+      h.close()
+    }
+  }
+})

--- a/ui-tui/src/__tests__/composerFreshnessRenderer.test.tsx
+++ b/ui-tui/src/__tests__/composerFreshnessRenderer.test.tsx
@@ -1,0 +1,45 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
+import { renderSync, Text } from '@hermes/ink'
+import React from 'react'
+import { expect, it, vi } from 'vitest'
+import { useComposerState } from '../app/useComposerState.js'
+import { patchUiState, resetUiState } from '../app/uiStore.js'
+
+it('does not restore stale same-session paste results after editing away and back', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'ink-composer-freshness-'))
+  vi.stubEnv('HERMES_HOME', home)
+  resetUiState()
+  patchUiState({ sid: 'session' })
+  let finish!: (value: unknown) => void
+  const request = vi.fn((method: string) => method === 'clipboard.paste'
+    ? new Promise(resolve => { finish = resolve }) : Promise.resolve({}))
+  let composer!: ReturnType<typeof useComposerState>
+  function Harness() {
+    composer = useComposerState({ gw: { request }, submitRef: { current: vi.fn() }, sys: vi.fn() } as any)
+    return <Text>composer</Text>
+  }
+  const instance = renderSync(<Harness />, { stdin: new PassThrough() as any,
+    stdout: Object.assign(new PassThrough(), { columns: 80, rows: 20, isTTY: false }) as any,
+    stderr: new PassThrough() as any, patchConsole: false })
+  try {
+    composer.actions.setInput('old')
+    const pending = composer.actions.handleTextPaste({ bracketed: true, hotkey: false, text: '', value: 'old', cursor: 3 })
+    composer.actions.setInput('new')
+    composer.actions.setInput('old')
+    finish({ attached: true, name: 'image', path: '/tmp/owned-image.png' })
+    expect(await pending).toBeNull()
+    expect(composer.refs.tokensRef.current).toEqual([])
+    const fresh = composer.actions.handleTextPaste({ bracketed: true, hotkey: false, text: '', value: 'old', cursor: 3 })
+    finish({ attached: true, name: 'image', path: '/tmp/owned-image.png' })
+    expect(await fresh).toEqual(expect.objectContaining({ value: expect.stringContaining('Image') }))
+    expect(composer.refs.tokensRef.current).toHaveLength(1)
+  } finally {
+    instance.unmount()
+    resetUiState()
+    vi.unstubAllEnvs()
+    rmSync(home, { recursive: true, force: true })
+  }
+})

--- a/ui-tui/src/__tests__/composerFreshnessRenderer.test.tsx
+++ b/ui-tui/src/__tests__/composerFreshnessRenderer.test.tsx
@@ -2,11 +2,13 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
+
 import { renderSync, Text } from '@hermes/ink'
 import React from 'react'
 import { expect, it, vi } from 'vitest'
-import { useComposerState } from '../app/useComposerState.js'
+
 import { patchUiState, resetUiState } from '../app/uiStore.js'
+import { useComposerState } from '../app/useComposerState.js'
 
 it('does not restore stale same-session paste results after editing away and back', async () => {
   const home = mkdtempSync(join(tmpdir(), 'ink-composer-freshness-'))
@@ -14,16 +16,22 @@ it('does not restore stale same-session paste results after editing away and bac
   resetUiState()
   patchUiState({ sid: 'session' })
   let finish!: (value: unknown) => void
+
   const request = vi.fn((method: string) => method === 'clipboard.paste'
     ? new Promise(resolve => { finish = resolve }) : Promise.resolve({}))
+
   let composer!: ReturnType<typeof useComposerState>
+
   function Harness() {
     composer = useComposerState({ gw: { request }, submitRef: { current: vi.fn() }, sys: vi.fn() } as any)
+
     return <Text>composer</Text>
   }
+
   const instance = renderSync(<Harness />, { stdin: new PassThrough() as any,
     stdout: Object.assign(new PassThrough(), { columns: 80, rows: 20, isTTY: false }) as any,
     stderr: new PassThrough() as any, patchConsole: false })
+
   try {
     composer.actions.setInput('old')
     const pending = composer.actions.handleTextPaste({ bracketed: true, hotkey: false, text: '', value: 'old', cursor: 3 })

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -90,6 +90,24 @@ describe('createGatewayEventHandler', () => {
     expect(getUiState().status).toBe('ready')
     expect(getOverlayState().approval).toBeNull()
     expect(getTurnState().tools).toEqual([])
+    onEvent({
+      session_id: 'focused',
+      payload: { ...snapshot, running: true, execution_generation: 2 },
+      type: 'session.info'
+    } as any)
+    onEvent({
+      session_id: 'focused',
+      payload: { running: false, execution_generation: 1 },
+      type: 'session.info'
+    } as any)
+    expect(getUiState().busy).toBe(true)
+    onEvent({
+      session_id: 'focused',
+      payload: { running: false, execution_generation: 2 },
+      type: 'session.info'
+    } as any)
+    expect(getUiState().busy).toBe(false)
+    expect(getUiState().info?.model).toBe('test')
   })
 
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -67,6 +67,42 @@ describe('createGatewayEventHandler', () => {
     patchUiState({ showReasoning: true })
   })
 
+  it('fences restarted owner lifecycle events until resume establishes the new epoch', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    const info = { model: 'test', skills: {}, tools: {}, running: true,
+      execution_epoch: 'old-owner', execution_generation: 9 }
+
+    patchUiState({ sid: 'focused', info, busy: true })
+    const emit = (type: string, payload: any) => onEvent({ type, payload, session_id: 'focused' } as any)
+    emit('session.info', { execution_epoch: 'new-owner', execution_generation: 1, running: false })
+    expect(getUiState().busy).toBe(true)
+    // session.resume replaces info with the authoritative attachment snapshot.
+    patchUiState({ info: { ...info, execution_epoch: 'new-owner', execution_generation: 1 } })
+
+    for (const payload of [{}, { execution_epoch: 'old-owner', execution_generation: 99 },
+      { execution_epoch: 'new-owner', execution_generation: 0 }]) {
+      emit('message.complete', { ...payload, text: 'stale' })
+      emit('error', { ...payload, message: 'stale' })
+      emit('session.info', { ...payload, running: false })
+      expect(getUiState().busy).toBe(true)
+    }
+
+    expect(appended).toEqual([])
+    emit('message.complete', { execution_epoch: 'new-owner', execution_generation: 1, text: 'fresh' })
+    expect(getUiState().busy).toBe(false)
+    expect(appended.some(m => m.text === 'fresh')).toBe(true)
+    emit('message.start', { execution_epoch: 'new-owner', execution_generation: 2 })
+    emit('message.complete', { execution_epoch: 'new-owner', execution_generation: 1, text: 'late' })
+    expect(getUiState().busy).toBe(true)
+    expect(getUiState().info?.execution_generation).toBe(2)
+    emit('message.complete', { execution_epoch: 'new-owner', execution_generation: 4, text: 'missed start' })
+    emit('message.start', { execution_epoch: 'new-owner', execution_generation: 3 })
+    expect(getUiState().busy).toBe(false)
+    expect(getUiState().info?.execution_generation).toBe(4)
+  })
+
   it('heals missed completion and blocking prompts only from the focused authoritative idle snapshot', () => {
     patchUiState({ sid: 'focused' })
     const onEvent = createGatewayEventHandler(buildCtx([]))

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -67,6 +67,18 @@ describe('createGatewayEventHandler', () => {
     patchUiState({ showReasoning: true })
   })
 
+  it('displays generic errors without settling versioned execution', () => {
+    const ctx = buildCtx([])
+    const onEvent = createGatewayEventHandler(ctx)
+    patchUiState({ sid: 'owner', busy: true, status: 'running…', info: { model: 'test', tools: {}, skills: {}, execution_epoch: 'owner-epoch', execution_generation: 2 } })
+    onEvent({ type: 'error', session_id: 'owner', payload: { message: 'build failed' } } as any)
+    expect(ctx.system.sys).toHaveBeenCalledWith('error: build failed')
+    expect(getUiState()).toMatchObject({ busy: true, status: 'running…' })
+    onEvent({ type: 'error', session_id: 'owner', payload: { message: 'turn failed', execution_epoch: 'owner-epoch', execution_generation: 2 } } as any)
+    expect(ctx.system.sys).toHaveBeenCalledWith('error: turn failed')
+    expect(getUiState().busy).toBe(false)
+  })
+
   it('fences restarted owner lifecycle events until resume establishes the new epoch', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -33,6 +33,18 @@ describe('createSlashHandler', () => {
     envState.dashboardTuiMode = false
   })
 
+  it('does not execute a stale fallback command after switching destinations', async () => {
+    patchUiState({ sid: 'owner' })
+    const ctx = buildCtx()
+    let reject!: (error: unknown) => void
+    ctx.gateway.gw.request.mockReturnValueOnce(new Promise((_, fail) => { reject = fail }))
+    createSlashHandler(ctx)('/unknown-command')
+    patchUiState({ sid: 'other' })
+    reject(new Error('worker failed'))
+    await new Promise(resolve => setImmediate(resolve))
+    expect(ctx.gateway.gw.request).toHaveBeenCalledTimes(1)
+  })
+
   it('opens the unified sessions overlay for /resume', () => {
     const ctx = buildCtx()
 

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -583,7 +583,7 @@ describe('createSlashHandler', () => {
       createSlashHandler(ctx)('/compress')
       const current = { ...source, ...change }
       patchUiState({ info: current, busy: current.running, usage: { calls: 8, input: 8, output: 8, total: 16 } })
-      resolve({ info: source, messages: [{ role: 'assistant', content: 'old summary' }], usage: { total: 1 } })
+      resolve({ info: source, messages: [{ role: 'assistant', text: 'old summary' }], usage: { total: 1 } })
       await flush()
       expect(getUiState().info).toEqual(current)
       expect(getUiState().usage.total).toBe(16)
@@ -606,7 +606,7 @@ describe('createSlashHandler', () => {
     const ctx = buildCtx({ gateway: { ...buildGateway(), rpc: vi.fn(() => new Promise<any>(done => { resolve = done })) } })
     createSlashHandler(ctx)('/compress')
     patchUiState({ info: { ...source, model: 'refreshed' } })
-    resolve({ info: { execution_epoch: 'owner', execution_generation: 2 }, messages: [{ role: 'assistant', content: 'fresh summary' }] })
+    resolve({ info: { execution_epoch: 'owner', execution_generation: 2 }, messages: [{ role: 'assistant', text: 'fresh summary' }] })
     await flush()
     expect(getUiState().info).toMatchObject({ ...source, model: 'refreshed' })
     expect(ctx.transcript.setHistoryItems).toHaveBeenCalledWith(expect.arrayContaining([

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -546,7 +546,7 @@ describe('createSlashHandler', () => {
     expect(ctx.session.newSession).toHaveBeenCalledWith('new session started', undefined)
   })
 
-  it('keeps visible scrollback when branching a TUI session', async () => {
+  it('hydrates a branch through session resume without prematurely replacing source state', async () => {
     patchUiState({ sid: 'sid-parent' })
     const rpc = vi.fn(() => Promise.resolve({ session_id: 'sid-branch', title: 'branch title' }))
     const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
@@ -555,10 +555,63 @@ describe('createSlashHandler', () => {
 
     expect(rpc).toHaveBeenCalledWith('session.branch', { name: 'branch title', session_id: 'sid-parent' })
     await vi.waitFor(() => {
-      expect(getUiState().sid).toBe('sid-branch')
+      expect(ctx.session.resumeById).toHaveBeenCalledWith('sid-branch')
       expect(ctx.transcript.sys).toHaveBeenCalledWith('branched → branch title')
     })
+    expect(getUiState().sid).toBe('sid-parent')
+    expect(ctx.session.closeSession).not.toHaveBeenCalled()
     expect(ctx.transcript.setHistoryItems).not.toHaveBeenCalled()
+  })
+
+  it('only applies compression snapshots while execution authority is fresh', async () => {
+    const source = {
+      model: 'test', tools: {}, skills: {}, execution_epoch: 'owner', execution_generation: 2,
+      execution_state: 'idle', running: false, stored_session_id: 'stored-source'
+    }
+    const flush = () => new Promise(resolve => setImmediate(resolve))
+
+    for (const change of [
+      { execution_generation: 3, execution_state: 'running', running: true },
+      { execution_epoch: 'replacement', execution_generation: 0 },
+      { execution_state: 'complete' },
+      { stored_session_id: 'other' }
+    ]) {
+      patchUiState({ sid: 'source', info: source, busy: false })
+      let resolve!: (value: any) => void
+      const rpc = vi.fn(() => new Promise<any>(done => { resolve = done }))
+      const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+      createSlashHandler(ctx)('/compress')
+      const current = { ...source, ...change }
+      patchUiState({ info: current, busy: current.running, usage: { calls: 8, input: 8, output: 8, total: 16 } })
+      resolve({ info: source, messages: [{ role: 'assistant', content: 'old summary' }], usage: { total: 1 } })
+      await flush()
+      expect(getUiState().info).toEqual(current)
+      expect(getUiState().usage.total).toBe(16)
+      expect(ctx.transcript.setHistoryItems).not.toHaveBeenCalled()
+    }
+
+    // Stale/missing snapshot versions cannot erase established authority either.
+    for (const info of [undefined, { ...source, execution_generation: 1 }, { ...source, execution_epoch: 'old' }]) {
+      patchUiState({ sid: 'source', info: source, busy: false })
+      const ctx = buildCtx({ gateway: { ...buildGateway(), rpc: vi.fn(async () => ({ info, messages: [] })) } })
+      createSlashHandler(ctx)('/compress')
+      await flush()
+      expect(getUiState().info).toEqual(source)
+      expect(ctx.transcript.setHistoryItems).not.toHaveBeenCalled()
+    }
+
+    // Ordinary metadata refresh is not a new execution; fresh partial info merges.
+    patchUiState({ sid: 'source', info: source, busy: false })
+    let resolve!: (value: any) => void
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc: vi.fn(() => new Promise<any>(done => { resolve = done })) } })
+    createSlashHandler(ctx)('/compress')
+    patchUiState({ info: { ...source, model: 'refreshed' } })
+    resolve({ info: { execution_epoch: 'owner', execution_generation: 2 }, messages: [{ role: 'assistant', content: 'fresh summary' }] })
+    await flush()
+    expect(getUiState().info).toMatchObject({ ...source, model: 'refreshed' })
+    expect(ctx.transcript.setHistoryItems).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({ role: 'assistant', text: 'fresh summary' })
+    ]))
   })
 
   it('reloads skills in the live gateway and refreshes the catalog', async () => {

--- a/ui-tui/src/__tests__/orchestratorPromptSession.test.ts
+++ b/ui-tui/src/__tests__/orchestratorPromptSession.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import { startPromptLiveSession } from '../app/useMainApp.js'
 import { patchUiState } from '../app/uiStore.js'
+import { startPromptLiveSession } from '../app/useMainApp.js'
 
 describe('startPromptLiveSession', () => {
   it('keeps the created target through a delayed model switch without publishing into the new focus', async () => {
@@ -9,6 +9,7 @@ describe('startPromptLiveSession', () => {
     let finish!: (value: { value: string }) => void
     const dispatched: unknown[] = []
     const notices: string[] = []
+
     const pending = startPromptLiveSession({
       dispatchSubmission: (text, destination) => dispatched.push({ text, destination }),
       maybeWarn: () => notices.push('warn'),
@@ -19,6 +20,7 @@ describe('startPromptLiveSession', () => {
       rpc: () => new Promise(resolve => { finish = resolve }),
       sys: text => notices.push(text)
     })
+
     await Promise.resolve()
     patchUiState({ sid: 'other' })
     finish({ value: 'chosen' })
@@ -38,6 +40,7 @@ describe('startPromptLiveSession', () => {
         calls.push(['new', { message, title }])
 
         patchUiState({ sid: 'abc123' })
+
         return 'abc123'
       },
       onModelSwitched: (value, result) => calls.push(['model-switched', { result, value }]),
@@ -77,6 +80,7 @@ describe('startPromptLiveSession', () => {
         calls.push('new')
 
         patchUiState({ sid: 'abc123' })
+
         return 'abc123'
       },
       prompt: '   ',

--- a/ui-tui/src/__tests__/orchestratorPromptSession.test.ts
+++ b/ui-tui/src/__tests__/orchestratorPromptSession.test.ts
@@ -1,8 +1,32 @@
 import { describe, expect, it } from 'vitest'
 
 import { startPromptLiveSession } from '../app/useMainApp.js'
+import { patchUiState } from '../app/uiStore.js'
 
 describe('startPromptLiveSession', () => {
+  it('keeps the created target through a delayed model switch without publishing into the new focus', async () => {
+    patchUiState({ sid: 'created' })
+    let finish!: (value: { value: string }) => void
+    const dispatched: unknown[] = []
+    const notices: string[] = []
+    const pending = startPromptLiveSession({
+      dispatchSubmission: (text, destination) => dispatched.push({ text, destination }),
+      maybeWarn: () => notices.push('warn'),
+      modelArg: 'chosen',
+      newLiveSession: async () => 'created',
+      onModelSwitched: () => notices.push('model'),
+      prompt: 'private prompt',
+      rpc: () => new Promise(resolve => { finish = resolve }),
+      sys: text => notices.push(text)
+    })
+    await Promise.resolve()
+    patchUiState({ sid: 'other' })
+    finish({ value: 'chosen' })
+    await pending
+    expect(dispatched).toEqual([{ text: 'private prompt', destination: expect.objectContaining({ sid: 'created' }) }])
+    expect(notices).toEqual([])
+  })
+
   it('starts a kept-live session with generated id/title, applies selected model, then dispatches the prompt', async () => {
     const calls: Array<[string, unknown]> = []
 
@@ -13,6 +37,7 @@ describe('startPromptLiveSession', () => {
       newLiveSession: async (message, title) => {
         calls.push(['new', { message, title }])
 
+        patchUiState({ sid: 'abc123' })
         return 'abc123'
       },
       onModelSwitched: (value, result) => calls.push(['model-switched', { result, value }]),
@@ -51,6 +76,7 @@ describe('startPromptLiveSession', () => {
       newLiveSession: async () => {
         calls.push('new')
 
+        patchUiState({ sid: 'abc123' })
         return 'abc123'
       },
       prompt: '   ',

--- a/ui-tui/src/__tests__/pendingMigrationRenderer.test.tsx
+++ b/ui-tui/src/__tests__/pendingMigrationRenderer.test.tsx
@@ -1,0 +1,118 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
+
+import { renderSync, Text } from '@hermes/ink'
+import React from 'react'
+import { expect, it, vi } from 'vitest'
+
+import { captureDestination, isCurrentDestination } from '../app/submissionDestination.js'
+import { patchUiState, resetUiState } from '../app/uiStore.js'
+import { useQueue } from '../hooks/useQueue.js'
+import * as pending from '../lib/pendingInputs.js'
+
+it('moves compression queues across cached successors without changing attempted receipts or losing settlement', () => {
+  const home = mkdtempSync(join(tmpdir(), 'ink-migrate-'))
+  vi.stubEnv('HERMES_HOME', home)
+  resetUiState()
+  patchUiState({ sid: 'old', info: { model: 'test', profile_name: 'alpha', skills: {}, tools: {} } })
+  let queue!: ReturnType<typeof useQueue>
+
+  function Harness() {
+    queue = useQueue()
+
+    return <Text>{queue.queuedDisplay.join('|')}</Text>
+  }
+
+  const options = {
+    stdin: new PassThrough() as any,
+    stdout: Object.assign(new PassThrough(), { columns: 80, rows: 20, isTTY: false }) as any,
+    stderr: new PassThrough() as any,
+    patchConsole: false
+  }
+
+  let instance = renderSync(<Harness />, options)
+
+  try {
+    const original = captureDestination()
+    const attempted = queue.stage('attempted')
+    const settle = attempted.settle
+    const waiting = queue.enqueue('waiting')
+    queue.setQueueEdit(1)
+    patchUiState({ sid: 'next' })
+    expect(queue.queueRef.current).toEqual([]) // cache successor before migration
+    const ownNext = queue.enqueue('already next')
+    patchUiState({ sid: 'old' })
+    pending.migratePendingInputs(original, 'next')
+    patchUiState({ sid: 'next' })
+    expect(queue.queueRef.current).toEqual([attempted, waiting, ownNext])
+    expect(queue.queueRef.current[0]).toBe(attempted)
+    expect(attempted.destination).toEqual(original)
+    expect(attempted.settle).toBe(settle)
+    expect(waiting.destination?.sid).toBe('next')
+    expect(queue.queueEditRef.current).toBe(1)
+    expect(pending.loadPendingInputs(original)).toEqual([])
+    expect(pending.loadPendingInputs(captureDestination())).toHaveLength(3)
+    const next = captureDestination()
+    pending.migratePendingInputs(next, 'last')
+    patchUiState({ sid: 'last' })
+    // Late completion must find the migrated queue even before a getter/render.
+    settle!(false)
+    expect(queue.queueRef.current[0]).toBe(attempted)
+    expect(queue.dequeue()).toBeUndefined()
+    instance.unmount()
+    instance = renderSync(<Harness />, options)
+    const restored = queue.queueRef.current[0]
+    expect(restored).toMatchObject({ destination: original, failed: true, submissionId: attempted.submissionId })
+    expect(queue.dequeue()).toBeUndefined()
+    queue.dequeue(true)!.settle!(true)
+    expect(queue.queueRef.current.map(item => item.text)).toEqual(['waiting', 'already next'])
+    expect(pending.loadPendingInputs(captureDestination())).toHaveLength(2)
+    const live = queue.stage('late success')
+    pending.migratePendingInputs(captureDestination(), 'later')
+    patchUiState({ sid: 'later' })
+    pending.migratePendingInputs(captureDestination(), 'latest')
+    patchUiState({ sid: 'latest' })
+    live.settle!(true)
+    expect(live.destination?.sid).toBe('last')
+    expect(queue.queueRef.current.map(item => item.text)).toEqual(['waiting', 'already next'])
+
+    patchUiState({ sid: 'unrelated' })
+    expect(queue.queueRef.current).toEqual([])
+    queue.enqueue('cold source')
+    const cold = captureDestination()
+    instance.unmount()
+    patchUiState({ sid: 'cold successor' })
+    instance = renderSync(<Harness />, options)
+    expect(queue.queueRef.current).toEqual([])
+    pending.migratePendingInputs(cold, 'cold successor')
+    expect(queue.queueRef.current.map(item => item.text)).toEqual(['cold source'])
+  } finally {
+    instance.unmount()
+    resetUiState()
+    vi.unstubAllEnvs()
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+it('uses the canonical profile home through symlinks, including a missing descendant', () => {
+  const root = mkdtempSync(join(tmpdir(), 'ink-home-'))
+  const real = join(root, 'real')
+  const alias = join(root, 'alias')
+  mkdirSync(real)
+  symlinkSync(real, alias, 'junction')
+
+  try {
+    vi.stubEnv('HERMES_HOME', alias)
+    const captured = captureDestination()
+    expect(captured.profileHome).toBe(realpathSync(real))
+    vi.stubEnv('HERMES_HOME', real)
+    expect(isCurrentDestination(captured)).toBe(true)
+    vi.stubEnv('HERMES_HOME', join(alias, 'missing', 'nested'))
+    expect(captureDestination().profileHome).toBe(join(realpathSync(real), 'missing', 'nested'))
+  } finally {
+    vi.unstubAllEnvs()
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/ui-tui/src/__tests__/promptResponseFreshness.test.ts
+++ b/ui-tui/src/__tests__/promptResponseFreshness.test.ts
@@ -1,0 +1,24 @@
+import { expect, it } from 'vitest'
+import { capturePromptResponseGuard, patchOverlayState } from '../app/overlayStore.js'
+import { patchUiState, resetUiState } from '../app/uiStore.js'
+
+it('allows only the original prompt in the original execution to publish a response', () => {
+  resetUiState()
+  const info = { model: 'test', tools: {}, skills: {}, execution_epoch: 'owner', execution_generation: 1 }
+  patchUiState({ sid: 'original', info })
+  for (const key of ['approval', 'clarify', 'sudo', 'secret'] as const) {
+    const prompt = { requestId: 'same-id' } as any
+    patchOverlayState({ [key]: prompt })
+    const fresh = capturePromptResponseGuard(key, prompt)
+    expect(fresh()).toBe(true)
+    patchUiState({ sid: 'other' })
+    expect(fresh()).toBe(false)
+    patchUiState({ sid: 'original', info: { ...info, execution_generation: 2 } })
+    expect(fresh()).toBe(false)
+    patchUiState({ info })
+    patchOverlayState({ [key]: { ...prompt } })
+    expect(fresh()).toBe(false)
+    patchOverlayState({ [key]: null })
+  }
+  resetUiState()
+})

--- a/ui-tui/src/__tests__/promptResponseFreshness.test.ts
+++ b/ui-tui/src/__tests__/promptResponseFreshness.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from 'vitest'
+
 import { capturePromptResponseGuard, patchOverlayState } from '../app/overlayStore.js'
 import { patchUiState, resetUiState } from '../app/uiStore.js'
 
@@ -6,6 +7,7 @@ it('allows only the original prompt in the original execution to publish a respo
   resetUiState()
   const info = { model: 'test', tools: {}, skills: {}, execution_epoch: 'owner', execution_generation: 1 }
   patchUiState({ sid: 'original', info })
+
   for (const key of ['approval', 'clarify', 'sudo', 'secret'] as const) {
     const prompt = { requestId: 'same-id' } as any
     patchOverlayState({ [key]: prompt })
@@ -20,5 +22,6 @@ it('allows only the original prompt in the original execution to publish a respo
     expect(fresh()).toBe(false)
     patchOverlayState({ [key]: null })
   }
+
   resetUiState()
 })

--- a/ui-tui/src/__tests__/queueScopeRenderer.test.tsx
+++ b/ui-tui/src/__tests__/queueScopeRenderer.test.tsx
@@ -1,8 +1,11 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
 
 import { renderSync, Text } from '@hermes/ink'
 import React from 'react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { patchUiState, resetUiState } from '../app/uiStore.js'
 import { useQueue } from '../hooks/useQueue.js'
@@ -16,6 +19,8 @@ describe('pending input destination', () => {
     { profile: 'alpha', sid: 'other-session' },
     { profile: 'beta', sid: 'same-session' }
   ])('does not drain or edit another destination: $profile/$sid', async destination => {
+    const home = mkdtempSync(join(tmpdir(), 'ink-pending-'))
+    vi.stubEnv('HERMES_HOME', home)
     patchUiState({ info: null, sid: null })
     let queue!: ReturnType<typeof useQueue>
 
@@ -32,17 +37,31 @@ describe('pending input destination', () => {
       output += String(chunk)
     })
 
-    const instance = renderSync(<Harness />, {
+    const renderOptions = {
       patchConsole: false,
       stdin: new PassThrough() as unknown as NodeJS.ReadStream,
       stdout: stdout as unknown as NodeJS.WriteStream,
       stderr: new PassThrough() as unknown as NodeJS.WriteStream
-    })
+    }
+
+    let instance = renderSync(<Harness />, renderOptions)
 
     try {
       queue.enqueue('startup payload')
       patchUiState({ info: info('alpha'), sid: 'same-session' })
-      expect(queue.dequeue()).toBe('startup payload')
+      const pending = queue.dequeue()!
+      expect(pending).toMatchObject({ text: 'startup payload', submissionId: expect.any(String) })
+      expect(queue.queueRef.current).toContain(pending)
+      expect(queue.dequeue()).toBeUndefined()
+      pending.settle!(false)
+      expect(queue.dequeue()).toBeUndefined() // no automatic ambiguous replay
+      instance.unmount()
+      instance = renderSync(<Harness />, renderOptions)
+      expect(queue.dequeue()).toBeUndefined()
+      const restored = queue.dequeue(true)!
+      expect(restored).toMatchObject({ submissionId: pending.submissionId, text: pending.text })
+      restored.settle!(true)
+      expect(queue.queueRef.current).not.toContain(pending)
       queue.enqueue('private payload', 'private preview')
       queue.setQueueEdit(0)
       patchUiState({ info: info(destination.profile), sid: destination.sid })
@@ -55,12 +74,14 @@ describe('pending input destination', () => {
       expect(output).not.toContain('private preview|destination payload')
       patchUiState({ info: info('alpha'), sid: 'same-session' })
       expect(queue.queueEditRef.current).toBe(0)
-      expect(queue.takeQ(0)).toEqual({ display: 'private preview', text: 'private payload' })
+      expect(queue.takeQ(0)).toMatchObject({ display: 'private preview', text: 'private payload' })
       patchUiState({ info: info(destination.profile), sid: destination.sid })
-      expect(queue.dequeue()).toBe('destination payload')
+      expect(queue.dequeue()).toMatchObject({ text: 'destination payload' })
       expect(queue.dequeue()).toBeUndefined()
     } finally {
       instance.unmount()
+      vi.unstubAllEnvs()
+      rmSync(home, { recursive: true, force: true })
     }
   })
 })

--- a/ui-tui/src/__tests__/resumeEpochRenderer.test.tsx
+++ b/ui-tui/src/__tests__/resumeEpochRenderer.test.tsx
@@ -1,0 +1,59 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
+
+import { renderSync, Text } from '@hermes/ink'
+import React from 'react'
+import { expect, it, vi } from 'vitest'
+
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
+import { useSessionLifecycle } from '../app/useSessionLifecycle.js'
+import { useQueue } from '../hooks/useQueue.js'
+
+it('resumes a successor with a reset epoch while retaining original attempted admission targets', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'ink-resume-epoch-'))
+  vi.stubEnv('HERMES_HOME', home)
+  resetUiState()
+  const info = { model: 'test', skills: {}, tools: {}, execution_epoch: 'old', execution_generation: 9, running: true }
+  patchUiState({ sid: 'old-session', info, busy: true })
+  let queue!: ReturnType<typeof useQueue>
+  let lifecycle!: ReturnType<typeof useSessionLifecycle>
+
+  const request = vi.fn(async () => ({ session_id: 'successor', resumed: 'successor', info: {
+    ...info, execution_epoch: 'new', execution_generation: 0, running: false
+  }, running: false, messages: [] }))
+
+  function Harness() {
+    queue = useQueue()
+    lifecycle = useSessionLifecycle({ colsRef: { current: 80 }, composerActions: { setComposerTokens: vi.fn() },
+      gw: { request }, rpc: async () => ({}), scrollRef: { current: null }, panel: vi.fn(), sys: vi.fn(),
+      setHistoryItems: vi.fn(), setLastUserMsg: vi.fn(), setSessionStartedAt: vi.fn(), setStickyPrompt: vi.fn(),
+      setVoiceProcessing: vi.fn(), setVoiceRecording: vi.fn() } as any)
+
+    return <Text>{queue.queuedDisplay.join('|')}</Text>
+  }
+
+  const instance = renderSync(<Harness />, { stdin: new PassThrough() as any,
+    stdout: Object.assign(new PassThrough(), { columns: 80, rows: 20, isTTY: false }) as any,
+    stderr: new PassThrough() as any, patchConsole: false })
+
+  try {
+    const attempted = queue.stage('ambiguous')
+    attempted.settle!(false)
+    const waiting = queue.enqueue('not attempted')
+    lifecycle.resumeById('old-session')
+    await vi.waitFor(() => expect(getUiState().sid).toBe('successor'))
+    expect(getUiState().info?.execution_epoch).toBe('new')
+    expect(getUiState().busy).toBe(false)
+    expect(queue.queueRef.current.map(item => item.submissionId)).toEqual([attempted.submissionId, waiting.submissionId])
+    expect(queue.queueRef.current[0]?.destination?.sid).toBe('old-session')
+    expect(queue.queueRef.current[1]?.destination?.sid).toBe('successor')
+    expect(queue.dequeue()).toBeUndefined()
+  } finally {
+    instance.unmount()
+    resetUiState()
+    vi.unstubAllEnvs()
+    rmSync(home, { recursive: true, force: true })
+  }
+})

--- a/ui-tui/src/__tests__/resumeEpochRenderer.test.tsx
+++ b/ui-tui/src/__tests__/resumeEpochRenderer.test.tsx
@@ -15,12 +15,12 @@ it('resumes a successor with a reset epoch while retaining original attempted ad
   const home = mkdtempSync(join(tmpdir(), 'ink-resume-epoch-'))
   vi.stubEnv('HERMES_HOME', home)
   resetUiState()
-  const info = { model: 'test', skills: {}, tools: {}, execution_epoch: 'old', execution_generation: 9, running: true }
+  const info = { model: 'test', skills: {}, tools: {}, stored_session_id: 'stored-old', execution_epoch: 'old', execution_generation: 9, running: true }
   patchUiState({ sid: 'old-session', info, busy: true })
   let queue!: ReturnType<typeof useQueue>
   let lifecycle!: ReturnType<typeof useSessionLifecycle>
 
-  const request = vi.fn(async () => ({ session_id: 'successor', resumed: 'successor', info: {
+  const request = vi.fn(async () => ({ session_id: 'successor', session_key: 'stored-successor', resumed: 'stored-successor', info: {
     ...info, execution_epoch: 'new', execution_generation: 0, running: false
   }, running: false, messages: [] }))
 
@@ -49,6 +49,9 @@ it('resumes a successor with a reset epoch while retaining original attempted ad
     expect(queue.queueRef.current.map(item => item.submissionId)).toEqual([attempted.submissionId, waiting.submissionId])
     expect(queue.queueRef.current[0]?.destination?.sid).toBe('old-session')
     expect(queue.queueRef.current[1]?.destination?.sid).toBe('successor')
+    expect(queue.queueRef.current[0]?.destination?.storedSid).toBe('stored-old')
+    expect(queue.queueRef.current[1]?.destination?.storedSid).toBe('stored-successor')
+    expect(getUiState().info?.stored_session_id).toBe('stored-successor')
     expect(queue.dequeue()).toBeUndefined()
   } finally {
     instance.unmount()

--- a/ui-tui/src/__tests__/resumeEpochRenderer.test.tsx
+++ b/ui-tui/src/__tests__/resumeEpochRenderer.test.tsx
@@ -11,6 +11,56 @@ import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import { useSessionLifecycle } from '../app/useSessionLifecycle.js'
 import { useQueue } from '../hooks/useQueue.js'
 
+it('only the newest attachment request may replace session authority', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'ink-attachment-order-'))
+  vi.stubEnv('HERMES_HOME', home)
+  resetUiState()
+  patchUiState({ sid: 'source' })
+  const pending: Array<{ method: string; resolve: (value: any) => void }> = []
+  const request = vi.fn((method: string) => new Promise(resolve => pending.push({ method, resolve })))
+  let lifecycle!: ReturnType<typeof useSessionLifecycle>
+
+  function Harness() {
+    lifecycle = useSessionLifecycle({ colsRef: { current: 80 }, composerActions: { setComposerTokens: vi.fn() },
+      gw: { request }, rpc: request, scrollRef: { current: null }, panel: vi.fn(), sys: vi.fn(),
+      setHistoryItems: vi.fn(), setLastUserMsg: vi.fn(), setSessionStartedAt: vi.fn(), setStickyPrompt: vi.fn(),
+      setVoiceProcessing: vi.fn(), setVoiceRecording: vi.fn() } as any)
+
+    return <Text>session</Text>
+  }
+
+  const instance = renderSync(<Harness />, { stdin: new PassThrough() as any,
+    stdout: Object.assign(new PassThrough(), { columns: 80, rows: 20, isTTY: false }) as any,
+    stderr: new PassThrough() as any, patchConsole: false })
+
+  const flush = () => new Promise(resolve => setImmediate(resolve))
+
+  const result = (sid: string) => ({ session_id: sid, messages: [], info: {
+    model: 'test', tools: {}, skills: {}, stored_session_id: sid, execution_epoch: sid, execution_generation: 0 } })
+
+  try {
+    for (const start of [() => lifecycle.resumeById('old'), () => void lifecycle.newLiveSession(), () => lifecycle.activateLiveSession('old')]) {
+      start()
+      const old = pending.shift()!
+      lifecycle.activateLiveSession('new')
+      pending.shift()!.resolve(result('new'))
+      await flush()
+      expect(getUiState().sid).toBe('new')
+      old.resolve(old.method === 'setup.status' ? {} : result('old'))
+      await flush()
+      // Stale setup must not even dispatch a create/resume/close operation.
+      expect(pending).toHaveLength(0)
+      expect(getUiState().sid).toBe('new')
+      expect(getUiState().info?.execution_epoch).toBe('new')
+    }
+  } finally {
+    instance.unmount()
+    resetUiState()
+    vi.unstubAllEnvs()
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
 it('resumes a successor with a reset epoch while retaining original attempted admission targets', async () => {
   const home = mkdtempSync(join(tmpdir(), 'ink-resume-epoch-'))
   vi.stubEnv('HERMES_HOME', home)

--- a/ui-tui/src/__tests__/slashSessionAuthority.test.tsx
+++ b/ui-tui/src/__tests__/slashSessionAuthority.test.tsx
@@ -1,0 +1,78 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
+
+import { renderSync, Text } from '@hermes/ink'
+import React from 'react'
+import { expect, it, vi } from 'vitest'
+
+import { createSlashHandler } from '../app/createSlashHandler.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
+import { useSessionLifecycle } from '../app/useSessionLifecycle.js'
+
+it('branch hydration replaces source authority only after a successful destination attachment', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'ink-slash-branch-'))
+  vi.stubEnv('HERMES_HOME', home)
+  vi.stubEnv('HERMES_TUI_ACTIVE_SESSION_FILE', join(home, 'active'))
+  resetUiState()
+  const source = { model: 'test', skills: {}, tools: {}, stored_session_id: 'stored-source',
+    execution_epoch: 'source-owner', execution_generation: 9, running: true }
+  patchUiState({ sid: 'source', info: source, busy: true })
+  const pending: Array<{ method: string; resolve: (value: any) => void }> = []
+  const request = vi.fn((method: string) => method === 'session.close'
+    ? Promise.resolve({}) : new Promise(resolve => pending.push({ method, resolve })))
+  const setHistoryItems = vi.fn()
+  const sys = vi.fn()
+  let slash!: (command: string) => boolean
+
+  function Harness() {
+    const lifecycle = useSessionLifecycle({ colsRef: { current: 80 }, composerActions: { setComposerTokens: vi.fn() },
+      gw: { request }, rpc: request, scrollRef: { current: null }, panel: vi.fn(), sys,
+      setHistoryItems, setLastUserMsg: vi.fn(), setSessionStartedAt: vi.fn(), setStickyPrompt: vi.fn(),
+      setVoiceProcessing: vi.fn(), setVoiceRecording: vi.fn() } as any)
+    slash = createSlashHandler({ slashFlightRef: { current: 0 }, gateway: { gw: { request }, rpc: request },
+      local: {}, session: { ...lifecycle, setSessionStartedAt: vi.fn() }, transcript: { sys, setHistoryItems } } as any)
+    return <Text>branch</Text>
+  }
+
+  const instance = renderSync(<Harness />, { stdin: new PassThrough() as any,
+    stdout: Object.assign(new PassThrough(), { columns: 80, rows: 20, isTTY: false }) as any,
+    stderr: new PassThrough() as any, patchConsole: false })
+  const flush = () => new Promise(resolve => setImmediate(resolve))
+
+  try {
+    slash('/branch child')
+    pending.shift()!.resolve({ session_id: 'branch', title: 'child' })
+    await flush()
+    expect(getUiState().sid).toBe('source')
+    expect(request).not.toHaveBeenCalledWith('session.close', expect.anything())
+    expect(pending[0]?.method).toBe('setup.status')
+    pending.shift()!.resolve({ provider_configured: true })
+    await flush()
+    expect(pending[0]?.method).toBe('session.resume')
+    pending.shift()!.resolve({ session_id: 'branch', stored_session_id: 'stored-branch', running: false,
+      info: { ...source, stored_session_id: 'stored-branch', execution_epoch: 'branch-owner', execution_generation: 0, running: false },
+      messages: [{ role: 'user', content: 'inherited history' }] })
+    await flush()
+    expect(getUiState()).toMatchObject({ sid: 'branch', busy: false, info: {
+      stored_session_id: 'stored-branch', execution_epoch: 'branch-owner', execution_generation: 0 } })
+    expect(setHistoryItems).toHaveBeenLastCalledWith(expect.arrayContaining([
+      expect.objectContaining({ role: 'user', text: 'inherited history' })
+    ]))
+    expect(request).toHaveBeenCalledWith('session.close', { session_id: 'source' })
+
+    // A branch response for a destination the user has left must not attach.
+    slash('/branch stale')
+    patchUiState({ sid: 'other' })
+    pending.shift()!.resolve({ session_id: 'late-branch' })
+    await flush()
+    expect(pending).toHaveLength(0)
+    expect(getUiState().sid).toBe('other')
+  } finally {
+    instance.unmount()
+    resetUiState()
+    vi.unstubAllEnvs()
+    rmSync(home, { recursive: true, force: true })
+  }
+})

--- a/ui-tui/src/__tests__/slashSessionAuthority.test.tsx
+++ b/ui-tui/src/__tests__/slashSessionAuthority.test.tsx
@@ -53,7 +53,7 @@ it('branch hydration replaces source authority only after a successful destinati
     expect(pending[0]?.method).toBe('session.resume')
     pending.shift()!.resolve({ session_id: 'branch', stored_session_id: 'stored-branch', running: false,
       info: { ...source, stored_session_id: 'stored-branch', execution_epoch: 'branch-owner', execution_generation: 0, running: false },
-      messages: [{ role: 'user', content: 'inherited history' }] })
+      messages: [{ role: 'user', text: 'inherited history' }] })
     await flush()
     expect(getUiState()).toMatchObject({ sid: 'branch', busy: false, info: {
       stored_session_id: 'stored-branch', execution_epoch: 'branch-owner', execution_generation: 0 } })

--- a/ui-tui/src/__tests__/submissionCore.test.ts
+++ b/ui-tui/src/__tests__/submissionCore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { isSessionBusyError, markSubmitting, submitPrompt, type SubmitPromptDeps } from '../app/submissionCore.js'
+import { captureDestination } from '../app/submissionDestination.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import type { GatewayClient } from '../gatewayClient.js'
 
@@ -148,6 +149,50 @@ describe('submissionCore.submitPrompt — literal submissions (startup -q querie
 
     expect(submitted).toEqual(['/model $(rm -rf ~)'])
   })
+})
+
+it('keeps the submit destination across preprocessing and never mutates the newly focused session', async () => {
+  resetUiState()
+  patchUiState({ sid: 'original' })
+  const { gw, resolveDrop } = makeDeferredGateway()
+  const deps = makeDeps(gw)
+  submitPrompt('private', deps)
+  patchUiState({ sid: 'other', busy: false, status: 'other ready' })
+  resolveDrop()
+  await Promise.resolve()
+  await Promise.resolve()
+  expect(gw.request).toHaveBeenCalledWith(
+    'prompt.submit',
+    expect.objectContaining({ session_id: 'original', text: 'private' })
+  )
+  expect(deps.appendMessage).not.toHaveBeenCalled()
+  expect(getUiState()).toMatchObject({ sid: 'other', busy: false, status: 'other ready' })
+})
+
+it('retains a queued submission on ambiguous response and retries the exact identity until durable acknowledgement', async () => {
+  resetUiState()
+  patchUiState({ sid: 'owner' })
+  const settle = vi.fn()
+  const item = { text: 'private', display: 'private', submissionId: 'stable-id', settle }
+
+  const request = vi.fn().mockResolvedValueOnce({ status: 'streaming' }).mockResolvedValueOnce({
+    admission_id: 'stable-id',
+    target_session_id: 'owner',
+    target_profile_home: captureDestination().profileHome,
+    status: 'queued'
+  })
+
+  const deps = makeDeps({ request } as unknown as GatewayClient)
+  submitPrompt(item.text, deps, true, undefined, { skipDetectDrop: true, queueItem: item })
+  await Promise.resolve()
+  expect(settle).toHaveBeenLastCalledWith(false)
+  submitPrompt(item.text, deps, true, undefined, { skipDetectDrop: true, queueItem: item })
+  await Promise.resolve()
+  expect(request.mock.calls.map(call => call[1])).toEqual([
+    { session_id: 'owner', text: 'private', submission_id: 'stable-id', queued: true },
+    { session_id: 'owner', text: 'private', submission_id: 'stable-id', queued: true }
+  ])
+  expect(settle).toHaveBeenLastCalledWith(true)
 })
 
 describe('submissionCore.markSubmitting', () => {

--- a/ui-tui/src/__tests__/submissionCore.test.ts
+++ b/ui-tui/src/__tests__/submissionCore.test.ts
@@ -171,13 +171,13 @@ it('keeps the submit destination across preprocessing and never mutates the newl
 
 it('retains a queued submission on ambiguous response and retries the exact identity until durable acknowledgement', async () => {
   resetUiState()
-  patchUiState({ sid: 'owner' })
+  patchUiState({ sid: 'owner', info: { model: 'test', tools: {}, skills: {}, stored_session_id: 'stored-owner' } })
   const settle = vi.fn()
   const item = { text: 'private', display: 'private', submissionId: 'stable-id', settle }
 
   const request = vi.fn().mockResolvedValueOnce({ status: 'streaming' }).mockResolvedValueOnce({
     admission_id: 'stable-id',
-    target_session_id: 'owner',
+    target_session_id: 'stored-owner',
     target_profile_home: captureDestination().profileHome,
     status: 'queued'
   })
@@ -193,6 +193,14 @@ it('retains a queued submission on ambiguous response and retries the exact iden
     { session_id: 'owner', text: 'private', submission_id: 'stable-id', queued: true }
   ])
   expect(settle).toHaveBeenLastCalledWith(true)
+  for (const stored_session_id of [undefined, 'wrong-target']) {
+    patchUiState({ info: { model: 'test', tools: {}, skills: {}, stored_session_id } })
+    request.mockResolvedValueOnce({ admission_id: 'stable-id', target_session_id: 'owner',
+      target_profile_home: captureDestination().profileHome, status: 'queued' })
+    submitPrompt(item.text, deps, true, undefined, { skipDetectDrop: true, queueItem: item })
+    await Promise.resolve()
+    expect(settle).toHaveBeenLastCalledWith(false)
+  }
 })
 
 describe('submissionCore.markSubmitting', () => {

--- a/ui-tui/src/__tests__/submissionCore.test.ts
+++ b/ui-tui/src/__tests__/submissionCore.test.ts
@@ -193,6 +193,7 @@ it('retains a queued submission on ambiguous response and retries the exact iden
     { session_id: 'owner', text: 'private', submission_id: 'stable-id', queued: true }
   ])
   expect(settle).toHaveBeenLastCalledWith(true)
+
   for (const stored_session_id of [undefined, 'wrong-target']) {
     patchUiState({ info: { model: 'test', tools: {}, skills: {}, stored_session_id } })
     request.mockResolvedValueOnce({ admission_id: 'stable-id', target_session_id: 'owner',
@@ -200,6 +201,43 @@ it('retains a queued submission on ambiguous response and retries the exact iden
     submitPrompt(item.text, deps, true, undefined, { skipDetectDrop: true, queueItem: item })
     await Promise.resolve()
     expect(settle).toHaveBeenLastCalledWith(false)
+  }
+})
+
+it('preserves legacy isolated submission after explicit unsupported admission without repeating preprocessing', async () => {
+  resetUiState()
+  patchUiState({ sid: 'owner' })
+  const settle = vi.fn()
+  const item = { text: 'private', display: 'private', submissionId: 'unsupported-id', queued: true, settle }
+  let reject!: (error: unknown) => void
+
+  const request = vi.fn().mockReturnValueOnce(new Promise((_, fail) => { reject = fail }))
+    .mockResolvedValueOnce({ status: 'queued' })
+
+  const deps = makeDeps({ request } as unknown as GatewayClient)
+  submitPrompt(item.text, deps, true, undefined, { skipDetectDrop: true, queueItem: item })
+  patchUiState({ sid: 'other', busy: false, status: 'other ready' })
+  reject(Object.assign(new Error('unsupported'), { code: 4094 }))
+  await vi.waitFor(() => expect(settle).toHaveBeenLastCalledWith(true))
+  expect(request.mock.calls.map(call => call[1])).toEqual([
+    { session_id: 'owner', text: 'private', submission_id: 'unsupported-id', queued: true },
+    { session_id: 'owner', text: 'private', queued: true }
+  ])
+  expect(deps.appendMessage).toHaveBeenCalledTimes(1)
+  expect(getUiState()).toMatchObject({ sid: 'other', busy: false, status: 'other ready' })
+})
+
+it('never downgrades ambiguous or conflicting durable submissions to legacy delivery', async () => {
+  for (const code of [undefined, 4093, 5071]) {
+    resetUiState()
+    patchUiState({ sid: 'owner' })
+    const settle = vi.fn()
+    const item = { text: 'private', display: 'private', submissionId: 'retained-id', settle }
+    const request = vi.fn().mockRejectedValue(Object.assign(new Error('not admitted'), { code }))
+    submitPrompt(item.text, makeDeps({ request } as unknown as GatewayClient), true, undefined,
+      { skipDetectDrop: true, queueItem: item })
+    await vi.waitFor(() => expect(settle).toHaveBeenLastCalledWith(false))
+    expect(request).toHaveBeenCalledTimes(1)
   }
 })
 

--- a/ui-tui/src/__tests__/submissionDestinationRenderer.test.tsx
+++ b/ui-tui/src/__tests__/submissionDestinationRenderer.test.tsx
@@ -15,7 +15,7 @@ it('submits interpolated queued input only to its captured owner and removes it 
   const home = mkdtempSync(join(tmpdir(), 'ink-submit-'))
   vi.stubEnv('HERMES_HOME', home)
   resetUiState()
-  const info = { model: 'test', profile_name: 'alpha', skills: {}, tools: {} }
+  const info = { model: 'test', profile_name: 'alpha', stored_session_id: 'stored-owner', skills: {}, tools: {} }
   patchUiState({ sid: 'owner', info })
   let resolveShell!: (value: unknown) => void
   let resolveSubmit!: (value: unknown) => void
@@ -85,7 +85,7 @@ it('submits interpolated queued input only to its captured owner and removes it 
     expect(queue.queueRef.current).toContain(item)
     resolveSubmit({
       admission_id: item.submissionId,
-      target_session_id: 'owner',
+      target_session_id: 'stored-owner',
       target_profile_home: home,
       status: 'queued'
     })

--- a/ui-tui/src/__tests__/submissionDestinationRenderer.test.tsx
+++ b/ui-tui/src/__tests__/submissionDestinationRenderer.test.tsx
@@ -1,0 +1,99 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
+
+import { renderSync, Text } from '@hermes/ink'
+import React from 'react'
+import { expect, it, vi } from 'vitest'
+
+import { patchUiState, resetUiState } from '../app/uiStore.js'
+import { useSubmission } from '../app/useSubmission.js'
+import { useQueue } from '../hooks/useQueue.js'
+
+it('submits interpolated queued input only to its captured owner and removes it only after the matching receipt', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'ink-submit-'))
+  vi.stubEnv('HERMES_HOME', home)
+  resetUiState()
+  const info = { model: 'test', profile_name: 'alpha', skills: {}, tools: {} }
+  patchUiState({ sid: 'owner', info })
+  let resolveShell!: (value: unknown) => void
+  let resolveSubmit!: (value: unknown) => void
+
+  const request = vi.fn((method: string) => {
+    if (method === 'shell.exec') {
+      return new Promise(resolve => {
+        resolveShell = resolve
+      })
+    }
+
+    if (method === 'input.detect_drop') {
+      return Promise.resolve({ matched: false })
+    }
+
+    return new Promise(resolve => {
+      resolveSubmit = resolve
+    })
+  })
+
+  let queue!: ReturnType<typeof useQueue>
+  let submission!: ReturnType<typeof useSubmission>
+  const appended = vi.fn()
+
+  function Harness() {
+    queue = useQueue()
+    submission = useSubmission({
+      appendMessage: appended,
+      composerActions: { ...queue, prependQueue: queue.prependQ, takeQueue: queue.takeQ } as any,
+      composerRefs: { queueRef: queue.queueRef, queueEditRef: queue.queueEditRef, tokensRef: { current: [] } } as any,
+      composerState: { input: '', inputBuf: [], completions: [] } as any,
+      gw: { request } as any,
+      setLastUserMsg: vi.fn(),
+      slashRef: { current: () => true },
+      submitRef: { current: () => {} },
+      sys: vi.fn()
+    })
+
+    return <Text>{queue.queuedDisplay.join('|')}</Text>
+  }
+
+  const stdout = Object.assign(new PassThrough(), { columns: 80, rows: 20, isTTY: false })
+
+  const instance = renderSync(<Harness />, {
+    stdin: new PassThrough() as any,
+    stdout: stdout as any,
+    stderr: new PassThrough() as any,
+    patchConsole: false
+  })
+
+  try {
+    queue.enqueue('private {!printf data}')
+    const item = queue.dequeue()!
+    submission.sendQueued(item)
+    patchUiState({ sid: 'other', busy: false })
+    resolveShell({ stdout: 'data', code: 0 })
+    await expect.poll(() => request.mock.calls.filter(call => call[0] === 'prompt.submit').length).toBe(1)
+    expect(request).toHaveBeenCalledWith('prompt.submit', {
+      session_id: 'owner',
+      text: 'private data',
+      submission_id: item.submissionId,
+      queued: true
+    })
+    expect(appended).not.toHaveBeenCalled()
+    expect(queue.queueRef.current).toEqual([])
+    patchUiState({ sid: 'owner' })
+    expect(queue.queueRef.current).toContain(item)
+    resolveSubmit({
+      admission_id: item.submissionId,
+      target_session_id: 'owner',
+      target_profile_home: home,
+      status: 'queued'
+    })
+    await expect.poll(() => queue.queueRef.current.length).toBe(0)
+  } finally {
+    instance.unmount()
+    resetUiState()
+    vi.unstubAllEnvs()
+    rmSync(home, { recursive: true, force: true })
+  }
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -770,6 +770,28 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       return
     }
 
+    // Lifecycle authority is local to an owner epoch. Only attachment RPC
+    // snapshots replace that epoch; delayed push events cannot reset it.
+    const current = getUiState().info
+    const lifecycle = ['session.info', 'message.start', 'message.complete', 'error'].includes(ev.type)
+
+    if (lifecycle && current?.execution_generation !== undefined) {
+      const incoming = (ev.payload ?? {}) as { execution_epoch?: string; execution_generation?: number }
+
+      if (
+        incoming.execution_epoch !== current.execution_epoch ||
+        typeof incoming.execution_generation !== 'number' ||
+        !Number.isSafeInteger(incoming.execution_generation) ||
+        incoming.execution_generation < current.execution_generation
+      ) {
+        return
+      }
+
+      if (ev.type !== 'session.info') {
+        patchUiState({ info: { ...current, execution_generation: incoming.execution_generation } })
+      }
+    }
+
     switch (ev.type) {
       case 'gateway.ready':
         handleReady(ev.payload?.skin)
@@ -787,13 +809,6 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         const incoming = ev.payload
 
         if (incoming.profile_name && current?.profile_name && incoming.profile_name !== current.profile_name) {
-          return
-        }
-
-        if (
-          current?.execution_generation !== undefined &&
-          (incoming.execution_generation === undefined || incoming.execution_generation < current.execution_generation)
-        ) {
           return
         }
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -29,6 +29,7 @@ import { applyDelegationStatus, getDelegationState } from './delegationStore.js'
 import type { GatewayEventHandlerContext } from './interfaces.js'
 import { getOverlayState, patchOverlayState } from './overlayStore.js'
 import { flashGoodVibes, flashPet } from './petFlashStore.js'
+import { captureDestination, isCurrentDestination } from './submissionDestination.js'
 import { turnController } from './turnController.js'
 import { getTurnState } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
@@ -431,7 +432,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
   }
 
   const { appendMessage, panel, setHistoryItems } = ctx.transcript
-  const { setInput } = ctx.composer
+  const { setInput, enqueue } = ctx.composer
   const { submitLiteralRef, submitRef } = ctx.submission
   const { setProcessing: setVoiceProcessing, setRecording: setVoiceRecording, setVoiceEnabled } = ctx.voice
 
@@ -782,11 +783,29 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
       case 'session.info': {
-        const info = ev.payload
+        const current = getUiState().info
+        const incoming = ev.payload
+
+        if (incoming.profile_name && current?.profile_name && incoming.profile_name !== current.profile_name) {
+          return
+        }
+
+        if (
+          current?.execution_generation !== undefined &&
+          (incoming.execution_generation === undefined || incoming.execution_generation < current.execution_generation)
+        ) {
+          return
+        }
+
+        const info = { ...current, ...incoming }
 
         // A replayed snapshot can be the only terminal signal after reconnect.
         // Missing running on older gateways must not clear a live turn.
-        if (info.running === false) {
+        if (incoming.running === true) {
+          patchUiState({ busy: true, status: 'running…' })
+        }
+
+        if (incoming.running === false) {
           turnController.clearStatusTimer()
           turnController.idle()
           setStatus('ready')
@@ -1021,7 +1040,14 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           return
         }
 
+        const destination = captureDestination()
         void getFullConfigOnce().then(cfg => {
+          if (!isCurrentDestination(destination)) {
+            enqueue?.(text, text, destination)
+
+            return
+          }
+
           const submitMode = normalizeVoiceSubmitMode(cfg?.config?.voice?.submit_mode)
 
           if (submitMode === 'draft') {
@@ -1034,7 +1060,13 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           // is committed before submit reads it; invalid config also falls
           // back to this established direct-submit behavior.
           setInput('')
-          setTimeout(() => submitRef.current(text), 0)
+          setTimeout(() => {
+            if (isCurrentDestination(destination)) {
+              submitRef.current(text)
+            } else {
+              enqueue?.(text, text, destination)
+            }
+          }, 0)
         })
 
         return

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -773,7 +773,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
     // Lifecycle authority is local to an owner epoch. Only attachment RPC
     // snapshots replace that epoch; delayed push events cannot reset it.
     const current = getUiState().info
-    const lifecycle = ['session.info', 'message.start', 'message.complete', 'error'].includes(ev.type)
+    const execution = (ev.payload ?? {}) as { execution_epoch?: string; execution_generation?: number }
+    const genericError = ev.type === 'error' &&
+      execution.execution_epoch === undefined && execution.execution_generation === undefined
+    const lifecycle = !genericError && ['session.info', 'message.start', 'message.complete', 'error'].includes(ev.type)
 
     if (lifecycle && current?.execution_generation !== undefined) {
       const incoming = (ev.payload ?? {}) as { execution_epoch?: string; execution_generation?: number }
@@ -1557,6 +1560,13 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       }
 
       case 'error':
+        // Build/RPC failures are not authority to settle a versioned turn.
+        if (genericError && current?.execution_generation !== undefined) {
+          sys(`error: ${String(ev.payload?.message || 'unknown error')}`)
+
+          return
+        }
+
         turnController.recordError()
         flashPet('failed')
 

--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -170,6 +170,7 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
         long ? page(text, parsed.name[0]!.toUpperCase() + parsed.name.slice(1)) : sys(text)
       })
       .catch(() => {
+        if (stale()) {return}
         gw.request('command.dispatch', { arg: parsed.arg, name: parsed.name, session_id: sid })
           .then((raw: unknown) => {
             if (stale()) {

--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -8,6 +8,7 @@ import type { SlashHandlerContext } from './interfaces.js'
 import { scoreSlashMenuItem } from './slash/fuzzyScore.js'
 import { findSlashCommand } from './slash/registry.js'
 import type { SlashRunCtx } from './slash/types.js'
+import { captureDestination, isCurrentDestination } from './submissionDestination.js'
 import { getUiState } from './uiStore.js'
 
 export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => boolean {
@@ -19,10 +20,11 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
     const flight = ++ctx.slashFlightRef.current
     const ui = getUiState()
     const sid = ui.sid
+    const destination = captureDestination()
     const parsed = parseSlashCommand(cmd)
     const argTail = parsed.arg ? ` ${parsed.arg}` : ''
 
-    const stale = () => flight !== ctx.slashFlightRef.current || getUiState().sid !== sid
+    const stale = () => flight !== ctx.slashFlightRef.current || !isCurrentDestination(destination)
 
     const guarded =
       <T>(fn: (r: T) => void) =>

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -32,6 +32,8 @@ import type {
   Usage
 } from '../types.js'
 
+import type { SubmissionDestination } from './submissionDestination.js'
+
 export interface StateSetter<T> {
   (value: SetStateAction<T>): void
 }
@@ -380,11 +382,12 @@ export interface ComposerActions {
   /** Attach an image by path in as a token. */
   attachImagePath: (path: string) => void
   clearIn: () => void
-  dequeue: () => string | undefined
-  enqueue: (text: string, display?: string) => void
+  stage?: (text: string, display?: string, destination?: SubmissionDestination) => QueueItem
+  dequeue: (retry?: boolean) => QueueItem | undefined
+  enqueue: (text: string, display?: string, destination?: SubmissionDestination) => void
   handleTextPaste: (event: PasteEvent) => MaybePromise<ComposerPasteResult | null>
   openEditor: () => Promise<void>
-  prependQueue: (item: QueueItem) => void
+  prependQueue: (item: QueueItem, destination?: SubmissionDestination) => void
   pushHistory: (text: string) => void
   removeQueue: (index: number) => void
   setCompIdx: StateSetter<number>
@@ -435,7 +438,7 @@ export interface InputHandlerActions {
   answerClarify: (answer: string) => void
   appendMessage: (msg: Msg) => void
   die: () => void
-  dispatchSubmission: (full: string) => void
+  dispatchSubmission: (full: string | QueueItem) => void
   guardBusySessionSwitch: (what?: string) => boolean
   newSession: (msg?: string, title?: string) => void
   sys: (text: string) => void
@@ -474,6 +477,7 @@ export interface InputHandlerResult {
 
 export interface GatewayEventHandlerContext {
   composer: {
+    enqueue?: ComposerActions['enqueue']
     setInput: StateSetter<string>
   }
   gateway: GatewayServices

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -1,8 +1,8 @@
 import { atom, computed } from 'nanostores'
 
 import type { OverlayState } from './interfaces.js'
-import { $uiState } from './uiStore.js'
 import { captureDestination, isCurrentDestination } from './submissionDestination.js'
+import { $uiState } from './uiStore.js'
 
 export function capturePromptResponseGuard<K extends 'approval' | 'clarify' | 'sudo' | 'secret'>(
   key: K,

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -2,6 +2,20 @@ import { atom, computed } from 'nanostores'
 
 import type { OverlayState } from './interfaces.js'
 import { $uiState } from './uiStore.js'
+import { captureDestination, isCurrentDestination } from './submissionDestination.js'
+
+export function capturePromptResponseGuard<K extends 'approval' | 'clarify' | 'sudo' | 'secret'>(
+  key: K,
+  prompt: OverlayState[K]
+): () => boolean {
+  const destination = captureDestination()
+  const info = $uiState.get().info
+
+  return () => Boolean(prompt) && isCurrentDestination(destination) &&
+    $uiState.get().info?.execution_epoch === info?.execution_epoch &&
+    $uiState.get().info?.execution_generation === info?.execution_generation &&
+    $overlayState.get()[key] === prompt
+}
 
 const buildOverlayState = (): OverlayState => ({
   agents: false,

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -247,7 +247,7 @@ export const sessionCommands: SlashCommand[] = [
         .then(
           ctx.guarded<SessionCompressResponse>(r => {
             const current = getUiState()
-            const authorityKeys = ['execution_epoch', 'execution_generation', 'execution_state', 'running'] as const
+            const authorityKeys = ['stored_session_id', 'execution_epoch', 'execution_generation', 'execution_state', 'running'] as const
 
             // Compression is not attachment: a delayed reply cannot replace a
             // newer turn/owner, nor replace its transcript with an old snapshot.

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -17,7 +17,7 @@ import type { PanelSection } from '../../../types.js'
 import { applyConfiguredTuiTheme } from '../../createGatewayEventHandler.js'
 import { DEFAULT_INDICATOR_STYLE, INDICATOR_STYLES, type IndicatorStyle } from '../../interfaces.js'
 import { patchOverlayState } from '../../overlayStore.js'
-import { patchUiState } from '../../uiStore.js'
+import { getUiState, patchUiState } from '../../uiStore.js'
 import type { SlashCommand } from '../types.js'
 
 const USAGE_CTA = 'Run /subscription to change plan · /topup to add to your balance'
@@ -246,14 +246,37 @@ export const sessionCommands: SlashCommand[] = [
         })
         .then(
           ctx.guarded<SessionCompressResponse>(r => {
+            const current = getUiState()
+            const authorityKeys = ['execution_epoch', 'execution_generation', 'execution_state', 'running'] as const
+
+            // Compression is not attachment: a delayed reply cannot replace a
+            // newer turn/owner, nor replace its transcript with an old snapshot.
+            if (
+              current.busy !== ctx.ui.busy ||
+              authorityKeys.some(key => current.info?.[key] !== ctx.ui.info?.[key])
+            ) {
+              return
+            }
+
+            if (
+              current.info?.execution_generation !== undefined &&
+              (r.info?.execution_epoch !== current.info.execution_epoch ||
+                !Number.isSafeInteger(r.info?.execution_generation) ||
+                (r.info?.execution_generation ?? -1) < current.info.execution_generation)
+            ) {
+              return
+            }
+
+            const info = r.info ? { ...current.info, ...r.info } : current.info
+
             if (Array.isArray(r.messages)) {
               const rows = toTranscriptMessages(r.messages)
 
-              ctx.transcript.setHistoryItems(r.info ? [introMsg(r.info), ...rows] : rows)
+              ctx.transcript.setHistoryItems(info ? [introMsg(info), ...rows] : rows)
             }
 
             if (r.info) {
-              patchUiState({ info: r.info })
+              patchUiState({ info })
             }
 
             if (r.usage) {
@@ -294,17 +317,15 @@ export const sessionCommands: SlashCommand[] = [
     help: 'branch the session',
     name: 'branch',
     run: (arg, ctx) => {
-      const prevSid = ctx.sid
-
       ctx.gateway.rpc<SessionBranchResponse>('session.branch', { name: arg, session_id: ctx.sid }).then(
         ctx.guarded<SessionBranchResponse>(r => {
           if (!r.session_id) {
             return
           }
 
-          void ctx.session.closeSession(prevSid)
-          patchUiState({ sid: r.session_id })
-          ctx.session.setSessionStartedAt(Date.now())
+          // Resume hydrates destination authority/history before closing the
+          // source; changing only sid would inherit the source owner's epoch.
+          ctx.session.resumeById(r.session_id)
           ctx.transcript.sys(`branched → ${r.title ?? ''}`)
         })
       )

--- a/ui-tui/src/app/submissionCore.ts
+++ b/ui-tui/src/app/submissionCore.ts
@@ -119,7 +119,42 @@ export function submitPrompt(
           patchUiState({ busy: false, status: 'ready' })
         }
       })
-      .catch((e: Error) => {
+      .catch(async (e: Error & { code?: number }) => {
+        // 4094 is a pre-admission refusal, not an ambiguous write. Special
+        // compute modes still support legacy submit; retry only this refusal,
+        // keeping the prepared payload, destination and queue mode unchanged.
+        if (item && e.code === 4094) {
+          if (focused()) {deps.sys('durable admission unavailable for this session — using legacy delivery')}
+
+          try {
+            const r = await deps.gw.request<PromptSubmitResponse>('prompt.submit', {
+              session_id: sid,
+              text: item.preparedText ?? submitText,
+              queued: item.queued !== false
+            })
+
+            const accepted = Boolean(r?.voice_stopped || ['streaming', 'queued', 'steered', 'redirected'].includes(r?.status ?? ''))
+            item.settle?.(accepted)
+
+            if (focused()) {
+              if (r?.voice_stopped) {patchUiState({ busy: false, status: 'ready' })}
+              else if (!accepted) {
+                deps.sys('legacy delivery unconfirmed — input retained; retry may duplicate execution')
+                patchUiState({ status: 'delivery unconfirmed' })
+              }
+            }
+          } catch (error) {
+            item.settle?.(false)
+
+            if (focused()) {
+              deps.sys(`legacy delivery unconfirmed: ${error instanceof Error ? error.message : String(error)} — input retained; retry may duplicate execution`)
+              patchUiState({ status: 'delivery unconfirmed' })
+            }
+          }
+
+          return
+        }
+
         if (item) {
           item.settle?.(false)
 
@@ -141,6 +176,7 @@ export function submitPrompt(
           if (!focused()) {
             return
           }
+
           patchUiState({ busy: true, status: 'queued for next turn' })
 
           return deps.sys(`queued: "${submitText.slice(0, 50)}${submitText.length > 50 ? '…' : ''}"`)
@@ -149,6 +185,7 @@ export function submitPrompt(
         if (!focused()) {
           return
         }
+
         deps.sys(`error: ${e.message}`)
         patchUiState({ busy: false, status: 'ready' })
       })

--- a/ui-tui/src/app/submissionCore.ts
+++ b/ui-tui/src/app/submissionCore.ts
@@ -99,7 +99,8 @@ export function submitPrompt(
         if (item) {
           const accepted =
             r?.admission_id === item.submissionId &&
-            r?.target_session_id === sid &&
+            Boolean(destination.storedSid) &&
+            r?.target_session_id === destination.storedSid &&
             r?.target_profile_home === destination.profileHome &&
             ['queued', 'started', 'terminal', 'unknown'].includes(r?.status ?? '')
 

--- a/ui-tui/src/app/submissionCore.ts
+++ b/ui-tui/src/app/submissionCore.ts
@@ -1,9 +1,12 @@
 import type { GatewayClient } from '../gatewayClient.js'
 import type { InputDetectDropResponse, PromptSubmitResponse } from '../gatewayTypes.js'
+import type { QueueItem } from '../hooks/useQueue.js'
+import { savePendingInput } from '../lib/pendingInputs.js'
 import type { Msg } from '../types.js'
 
+import { captureDestination, isCurrentDestination, type SubmissionDestination } from './submissionDestination.js'
 import { turnController } from './turnController.js'
-import { getUiState, patchUiState } from './uiStore.js'
+import { patchUiState } from './uiStore.js'
 
 const SESSION_BUSY_RE = /session busy|waiting for model response/i
 
@@ -11,7 +14,7 @@ export const isSessionBusyError = (e: unknown) => e instanceof Error && SESSION_
 
 export interface SubmitPromptDeps {
   appendMessage: (msg: Msg) => void
-  enqueue: (text: string) => void
+  enqueue: (text: string, display?: string, destination?: SubmissionDestination) => void
   expand: (text: string) => string
   gw: GatewayClient
   setLastUserMsg: (value: string) => void
@@ -50,57 +53,101 @@ export function submitPrompt(
   deps: SubmitPromptDeps,
   showUserMessage = true,
   displayOverride?: string,
-  opts: { skipDetectDrop?: boolean } = {}
+  opts: { skipDetectDrop?: boolean; destination?: SubmissionDestination; queueItem?: QueueItem } = {}
 ): void {
-  const sid = getUiState().sid
+  const destination = opts.destination ?? captureDestination()
+  const { sid } = destination
+  const focused = () => isCurrentDestination(destination)
 
   if (!sid) {
     return deps.sys('session not ready yet')
   }
 
   // Close the async-busy gap up front, before the detect_drop round-trip.
-  markSubmitting()
+  if (focused()) {
+    markSubmitting()
+  }
 
   const startSubmit = (displayText: string, submitText: string, show = true) => {
-    const liveSid = getUiState().sid
+    if (focused()) {
+      turnController.clearStatusTimer()
+      deps.setLastUserMsg(text)
 
-    if (!liveSid) {
-      return deps.sys('session not ready yet')
+      if (show) {
+        deps.appendMessage({ role: 'user', text: displayOverride || displayText })
+      }
+
+      patchUiState({ busy: true, status: 'running…' })
+      turnController.bufRef = ''
+      turnController.interrupted = false
     }
 
-    turnController.clearStatusTimer()
-    deps.setLastUserMsg(text)
+    const item = opts.queueItem
 
-    if (show) {
-      deps.appendMessage({ role: 'user', text: displayOverride || displayText })
+    if (item) {
+      item.preparedText ??= submitText
+      savePendingInput(item)
     }
-
-    patchUiState({ busy: true, status: 'running…' })
-    turnController.bufRef = ''
-    turnController.interrupted = false
 
     deps.gw
-      .request<PromptSubmitResponse>('prompt.submit', { session_id: liveSid, text: submitText })
+      .request<PromptSubmitResponse>('prompt.submit', {
+        session_id: sid,
+        text: item?.preparedText ?? submitText,
+        ...(item ? { submission_id: item.submissionId, queued: item.queued !== false } : {})
+      })
       .then(r => {
+        if (item) {
+          const accepted =
+            r?.admission_id === item.submissionId &&
+            r?.target_session_id === sid &&
+            r?.target_profile_home === destination.profileHome &&
+            ['queued', 'started', 'terminal', 'unknown'].includes(r?.status ?? '')
+
+          item.settle?.(accepted)
+
+          if (!accepted && focused()) {
+            deps.sys('admission not confirmed — input retained; use Alt+K to retry with the same identity')
+            patchUiState({ status: 'admission unconfirmed' })
+          }
+        }
+
         // The gateway consumed a typed voice stop phrase server-side (voice
         // chat ended, no turn started) — release the busy latch; the
         // voice.transcript {stop_phrase} event handles the mode flags + notice.
-        if (r?.voice_stopped) {
+        if (r?.voice_stopped && focused()) {
           patchUiState({ busy: false, status: 'ready' })
         }
       })
       .catch((e: Error) => {
+        if (item) {
+          item.settle?.(false)
+
+          if (focused()) {
+            deps.sys(`input retained: ${e.message} — Alt+K retries the same submission`)
+            patchUiState({ status: 'admission unconfirmed' })
+          }
+
+          return
+        }
+
         // Defensive: prompt.submit no longer rejects a mid-turn send with
         // "session busy" (the gateway queues it and returns success), but keep
         // the re-queue path as a safety net for any future/legacy gateway that
         // still errors, so a message is never silently dropped.
         if (isSessionBusyError(e)) {
-          deps.enqueue(submitText)
+          deps.enqueue(submitText, displayOverride, destination)
+
+          if (!focused()) {
+            return
+          }
           patchUiState({ busy: true, status: 'queued for next turn' })
 
           return deps.sys(`queued: "${submitText.slice(0, 50)}${submitText.length > 50 ? '…' : ''}"`)
         }
 
+        if (!focused()) {
+          return
+        }
         deps.sys(`error: ${e.message}`)
         patchUiState({ busy: false, status: 'ready' })
       })
@@ -115,6 +162,10 @@ export function submitPrompt(
   // shows as an `[[ Image N ]]` token, and a matched non-image path is rewritten
   // in place. Announcing it a second time above the status bar was the old
   // out-of-band attachment UI.
+  if (opts.queueItem?.preparedText !== undefined) {
+    return startSubmit(text, opts.queueItem.preparedText, showUserMessage)
+  }
+
   if (opts.skipDetectDrop) {
     return startSubmit(text, deps.expand(text), showUserMessage)
   }

--- a/ui-tui/src/app/submissionDestination.ts
+++ b/ui-tui/src/app/submissionDestination.ts
@@ -6,6 +6,7 @@ import { getUiState } from './uiStore.js'
 
 export interface SubmissionDestination {
   readonly sid: string | null
+  readonly storedSid?: string | null
   readonly profile: string
   readonly profileHome: string
 }
@@ -30,6 +31,7 @@ export function captureDestination(): SubmissionDestination {
 
   return Object.freeze({
     sid,
+    storedSid: info?.stored_session_id || null,
     profile: info?.profile_name || 'default',
     profileHome: canonicalHome(resolve(process.env.HERMES_HOME ?? join(homedir(), '.hermes')))
   })

--- a/ui-tui/src/app/submissionDestination.ts
+++ b/ui-tui/src/app/submissionDestination.ts
@@ -1,0 +1,30 @@
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { getUiState } from './uiStore.js'
+
+export interface SubmissionDestination {
+  readonly sid: string | null
+  readonly profile: string
+  readonly profileHome: string
+}
+
+export function captureDestination(): SubmissionDestination {
+  const { sid, info } = getUiState()
+
+  return Object.freeze({
+    sid,
+    profile: info?.profile_name || 'default',
+    profileHome: resolve(process.env.HERMES_HOME ?? join(homedir(), '.hermes'))
+  })
+}
+
+export function isCurrentDestination(destination: SubmissionDestination): boolean {
+  const current = captureDestination()
+
+  return (
+    current.sid === destination.sid &&
+    current.profile === destination.profile &&
+    current.profileHome === destination.profileHome
+  )
+}

--- a/ui-tui/src/app/submissionDestination.ts
+++ b/ui-tui/src/app/submissionDestination.ts
@@ -1,5 +1,6 @@
+import { realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 
 import { getUiState } from './uiStore.js'
 
@@ -9,13 +10,28 @@ export interface SubmissionDestination {
   readonly profileHome: string
 }
 
+// Resolve existing ancestors too: a new profile may not have been created yet.
+function canonicalHome(path: string): string {
+  try {
+    return realpathSync(path)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+
+    const parent = dirname(path)
+
+    return parent === path ? path : join(canonicalHome(parent), basename(path))
+  }
+}
+
 export function captureDestination(): SubmissionDestination {
   const { sid, info } = getUiState()
 
   return Object.freeze({
     sid,
     profile: info?.profile_name || 'default',
-    profileHome: resolve(process.env.HERMES_HOME ?? join(homedir(), '.hermes'))
+    profileHome: canonicalHome(resolve(process.env.HERMES_HOME ?? join(homedir(), '.hermes')))
   })
 }
 

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -28,6 +28,7 @@ import type {
   UseComposerStateResult
 } from './interfaces.js'
 import { $isBlocked } from './overlayStore.js'
+import { captureDestination, isCurrentDestination } from './submissionDestination.js'
 import { getUiState } from './uiStore.js'
 
 const TOKEN_MAX_COUNT = 32
@@ -129,6 +130,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   const { querier } = useStdin() as { querier: Parameters<typeof readOsc52Clipboard>[0] }
 
   const {
+    stage,
     queueRef,
     queueEditRef,
     queuedDisplay,
@@ -389,6 +391,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   )
 
   const openEditor = useCallback(async () => {
+    const destination = captureDestination()
     const dir = mkdtempSync(join(tmpdir(), 'hermes-'))
     const file = join(dir, 'prompt.md')
     const [cmd, ...args] = resolveEditor()
@@ -412,19 +415,26 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
         return
       }
 
+      if (!isCurrentDestination(destination)) {
+        enqueue(text, text, destination)
+
+        return
+      }
+
       setInput('')
       setInputBuf([])
       submitRef.current(text)
     } finally {
       rmSync(dir, { force: true, recursive: true })
     }
-  }, [input, inputBuf, setInput, submitRef])
+  }, [enqueue, input, inputBuf, setInput, submitRef])
 
   const actions = useMemo(
     () => ({
       attachClipboardImage,
       attachImagePath,
       clearIn,
+      stage,
       dequeue,
       enqueue,
       handleTextPaste,
@@ -445,6 +455,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
       attachClipboardImage,
       attachImagePath,
       clearIn,
+      stage,
       dequeue,
       enqueue,
       handleTextPaste,

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -108,7 +108,12 @@ export function looksLikeDroppedPath(text: string): boolean {
 
 export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions): UseComposerStateResult {
   const [input, setInputState] = useState('')
-  const [inputBuf, setInputBuf] = useState<string[]>([])
+  const [inputBuf, setInputBufState] = useState<string[]>([])
+  const composerRevision = useRef(0)
+  const setInputBuf = useCallback<StateSetter<string[]>>(next => {
+    composerRevision.current++
+    setInputBufState(next)
+  }, [])
   const [tokens, setTokens] = useState<ComposerToken[]>([])
   // Tokens and the input line are read from keystroke handlers that run several
   // times before React re-renders, so the refs — not the state — are the source
@@ -117,6 +122,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   const tokensRef = useRef<ComposerToken[]>([])
 
   const setInput = useCallback<StateSetter<string>>(next => {
+    composerRevision.current++
     inputRef.current = typeof next === 'function' ? next(inputRef.current) : next
     setInputState(inputRef.current)
   }, [])
@@ -153,7 +159,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
     setQueueEdit(null)
     setHistoryIdx(null)
     historyDraftRef.current = ''
-  }, [historyDraftRef, setComposerTokens, setHistoryIdx, setInput, setQueueEdit])
+  }, [historyDraftRef, setComposerTokens, setHistoryIdx, setInput, setInputBuf, setQueueEdit])
 
   /**
    * Deleting an `[[ Image N ]]` token IS how you unattach the image — there is
@@ -210,6 +216,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   const pasteClipboardImage = useCallback(
     async (value: string, cursor: number, quiet: boolean): Promise<ComposerPasteResult | null> => {
       const destination = captureDestination()
+      const revision = composerRevision.current
       const { sid } = destination
 
       if (!sid) {
@@ -220,7 +227,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
         .request<ClipboardPasteResponse & { path?: string }>('clipboard.paste', { session_id: sid })
         .catch(() => null)
 
-      if (!isCurrentDestination(destination)) {return null}
+      if (!(isCurrentDestination(destination) && revision === composerRevision.current)) {return null}
 
       if (r?.attached) {
         return attachImageToken(r, value, cursor)
@@ -238,6 +245,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   const handleResolvedPaste = useCallback(
     async ({ bracketed, cursor, text, value }: Omit<PasteEvent, 'hotkey'>): Promise<ComposerPasteResult | null> => {
       const destination = captureDestination()
+      const revision = composerRevision.current
       const cleanedText = stripTrailingPasteNewlines(text)
 
       if (!cleanedText || !/[^\n]/.test(cleanedText)) {
@@ -253,7 +261,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
             session_id: sid
           })
 
-          if (!isCurrentDestination(destination)) {return null}
+          if (!(isCurrentDestination(destination) && revision === composerRevision.current)) {return null}
 
           if (attached?.name) {
             // Drop an `[[ Image N ]]` token where the path was typed. The old
@@ -266,7 +274,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
           // Fall back to generic file-drop detection below.
         }
 
-        if (!isCurrentDestination(destination)) {return null}
+        if (!(isCurrentDestination(destination) && revision === composerRevision.current)) {return null}
 
         try {
           const dropped = await gw.request<InputDetectDropResponse>('input.detect_drop', {
@@ -274,7 +282,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
             text: cleanedText
           })
 
-          if (!isCurrentDestination(destination)) {return null}
+          if (!(isCurrentDestination(destination) && revision === composerRevision.current)) {return null}
 
           if (dropped?.matched && dropped.text) {
             return insertAtCursor(value, cursor, dropped.text)
@@ -284,7 +292,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
         }
       }
 
-      if (!isCurrentDestination(destination)) {return null}
+      if (!(isCurrentDestination(destination) && revision === composerRevision.current)) {return null}
 
       const lineCount = cleanedText.split('\n').length
       const pasteCollapseLines = getUiState().pasteCollapseLines
@@ -302,7 +310,8 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
       const label = pasteTokenLabel(cleanedText, lineCount)
       const inserted = insertAtCursor(value, cursor, label)
 
-      setComposerTokens(prev => trimTokens([...prev, { kind: 'paste', label, text: cleanedText }]))
+      const token: ComposerToken = { kind: 'paste', label, text: cleanedText }
+      setComposerTokens(prev => trimTokens([...prev, token]))
 
       void gw
         .request<{ path?: string }>('paste.collapse', { text: cleanedText })
@@ -313,7 +322,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
             return
           }
 
-          setComposerTokens(prev => prev.map(t => (t.label === label ? { ...t, path } : t)))
+          setComposerTokens(prev => prev.map(t => (t === token ? { ...t, path } : t)))
         })
         .catch(() => {})
 
@@ -326,6 +335,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
     ({ bracketed, cursor, hotkey, text, value }: PasteEvent): MaybePromise<ComposerPasteResult | null> => {
       // Clipboard reads can outlive a focus change, before any gateway RPC starts.
       const destination = captureDestination()
+      const revision = composerRevision.current
 
       if (hotkey) {
         const preferOsc52 = isRemoteShellSession(process.env)
@@ -347,7 +357,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
             })
 
         return readPreferredText.then(async preferredText => {
-          if (!isCurrentDestination(destination)) {return null}
+          if (!(isCurrentDestination(destination) && revision === composerRevision.current)) {return null}
 
           if (isUsableClipboardText(preferredText)) {
             return handleResolvedPaste({ bracketed: false, cursor, text: preferredText, value })
@@ -370,10 +380,11 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   const appendAttachment = useCallback(
     (attach: (value: string, cursor: number) => Promise<ComposerPasteResult | null>) => {
       const destination = captureDestination()
+      const revision = composerRevision.current
       const current = inputRef.current
 
       void attach(current, current.length).then(next => {
-        if (next && isCurrentDestination(destination)) {
+        if (next && (isCurrentDestination(destination) && revision === composerRevision.current)) {
           setInput(next.value)
         }
       })
@@ -390,6 +401,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
     (path: string) =>
       appendAttachment(async (value, cursor) => {
         const destination = captureDestination()
+        const revision = composerRevision.current
         const { sid } = destination
 
         if (!sid || !path.trim()) {
@@ -399,18 +411,19 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
         const attached = await gw
           .request<ImageAttachResponse & { path?: string }>('image.attach', { path, session_id: sid })
           .catch((e: Error) => {
-            if (isCurrentDestination(destination)) {sys(`error: ${e.message}`)}
+            if ((isCurrentDestination(destination) && revision === composerRevision.current)) {sys(`error: ${e.message}`)}
 
             return null
           })
 
-        return isCurrentDestination(destination) && attached?.name ? attachImageToken(attached, value, cursor) : null
+        return (isCurrentDestination(destination) && revision === composerRevision.current) && attached?.name ? attachImageToken(attached, value, cursor) : null
       }),
     [appendAttachment, attachImageToken, gw, sys]
   )
 
   const openEditor = useCallback(async () => {
     const destination = captureDestination()
+    const revision = composerRevision.current
     const dir = mkdtempSync(join(tmpdir(), 'hermes-'))
     const file = join(dir, 'prompt.md')
     const [cmd, ...args] = resolveEditor()
@@ -434,7 +447,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
         return
       }
 
-      if (!isCurrentDestination(destination)) {
+      if (!(isCurrentDestination(destination) && revision === composerRevision.current)) {
         enqueue(text, text, destination)
 
         return
@@ -446,7 +459,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
     } finally {
       rmSync(dir, { force: true, recursive: true })
     }
-  }, [enqueue, input, inputBuf, setInput, submitRef])
+  }, [enqueue, input, inputBuf, setInput, setInputBuf, submitRef])
 
   const actions = useMemo(
     () => ({
@@ -488,6 +501,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
       setInput,
       setQueueEdit,
       takeQ,
+      setInputBuf,
       syncTokens
     ]
   )

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -209,7 +209,8 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
    */
   const pasteClipboardImage = useCallback(
     async (value: string, cursor: number, quiet: boolean): Promise<ComposerPasteResult | null> => {
-      const sid = getUiState().sid
+      const destination = captureDestination()
+      const { sid } = destination
 
       if (!sid) {
         return null
@@ -218,6 +219,8 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
       const r = await gw
         .request<ClipboardPasteResponse & { path?: string }>('clipboard.paste', { session_id: sid })
         .catch(() => null)
+
+      if (!isCurrentDestination(destination)) {return null}
 
       if (r?.attached) {
         return attachImageToken(r, value, cursor)
@@ -234,6 +237,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
 
   const handleResolvedPaste = useCallback(
     async ({ bracketed, cursor, text, value }: Omit<PasteEvent, 'hotkey'>): Promise<ComposerPasteResult | null> => {
+      const destination = captureDestination()
       const cleanedText = stripTrailingPasteNewlines(text)
 
       if (!cleanedText || !/[^\n]/.test(cleanedText)) {
@@ -249,6 +253,8 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
             session_id: sid
           })
 
+          if (!isCurrentDestination(destination)) {return null}
+
           if (attached?.name) {
             // Drop an `[[ Image N ]]` token where the path was typed. The old
             // path printed a notice above the status bar and left the composer
@@ -260,11 +266,15 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
           // Fall back to generic file-drop detection below.
         }
 
+        if (!isCurrentDestination(destination)) {return null}
+
         try {
           const dropped = await gw.request<InputDetectDropResponse>('input.detect_drop', {
             session_id: sid,
             text: cleanedText
           })
+
+          if (!isCurrentDestination(destination)) {return null}
 
           if (dropped?.matched && dropped.text) {
             return insertAtCursor(value, cursor, dropped.text)
@@ -273,6 +283,8 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
           // Fall through to normal text paste behavior.
         }
       }
+
+      if (!isCurrentDestination(destination)) {return null}
 
       const lineCount = cleanedText.split('\n').length
       const pasteCollapseLines = getUiState().pasteCollapseLines
@@ -297,7 +309,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
         .then(r => {
           const path = r?.path
 
-          if (!path) {
+          if (!path || !isCurrentDestination(destination)) {
             return
           }
 
@@ -312,6 +324,9 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
 
   const handleTextPaste = useCallback(
     ({ bracketed, cursor, hotkey, text, value }: PasteEvent): MaybePromise<ComposerPasteResult | null> => {
+      // Clipboard reads can outlive a focus change, before any gateway RPC starts.
+      const destination = captureDestination()
+
       if (hotkey) {
         const preferOsc52 = isRemoteShellSession(process.env)
 
@@ -332,6 +347,8 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
             })
 
         return readPreferredText.then(async preferredText => {
+          if (!isCurrentDestination(destination)) {return null}
+
           if (isUsableClipboardText(preferredText)) {
             return handleResolvedPaste({ bracketed: false, cursor, text: preferredText, value })
           }
@@ -352,10 +369,11 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
    */
   const appendAttachment = useCallback(
     (attach: (value: string, cursor: number) => Promise<ComposerPasteResult | null>) => {
+      const destination = captureDestination()
       const current = inputRef.current
 
       void attach(current, current.length).then(next => {
-        if (next) {
+        if (next && isCurrentDestination(destination)) {
           setInput(next.value)
         }
       })
@@ -371,7 +389,8 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   const attachImagePath = useCallback(
     (path: string) =>
       appendAttachment(async (value, cursor) => {
-        const sid = getUiState().sid
+        const destination = captureDestination()
+        const { sid } = destination
 
         if (!sid || !path.trim()) {
           return null
@@ -380,12 +399,12 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
         const attached = await gw
           .request<ImageAttachResponse & { path?: string }>('image.attach', { path, session_id: sid })
           .catch((e: Error) => {
-            sys(`error: ${e.message}`)
+            if (isCurrentDestination(destination)) {sys(`error: ${e.message}`)}
 
             return null
           })
 
-        return attached?.name ? attachImageToken(attached, value, cursor) : null
+        return isCurrentDestination(destination) && attached?.name ? attachImageToken(attached, value, cursor) : null
       }),
     [appendAttachment, attachImageToken, gw, sys]
   )

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -728,7 +728,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (isAction(key, ch, 'k') && cRefs.queueRef.current.length && live.sid) {
-      const next = cActions.dequeue()
+      const next = cActions.dequeue(true)
 
       if (next) {
         cActions.setQueueEdit(null)

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -25,7 +25,7 @@ import {
   type InputHandlerResult,
   type OverlayState
 } from './interfaces.js'
-import { $isBlocked, $overlayState, patchOverlayState } from './overlayStore.js'
+import { $isBlocked, $overlayState, capturePromptResponseGuard, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { patchTurnState } from './turnStore.js'
 import { getUiState } from './uiStore.js'
@@ -218,9 +218,13 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (overlay.approval) {
+      const fresh = capturePromptResponseGuard('approval', overlay.approval)
+      if (!fresh()) {
+        return
+      }
       return gateway
         .rpc<ApprovalRespondResponse>('approval.respond', { choice: 'deny', session_id: getUiState().sid })
-        .then(r => r && (patchOverlayState({ approval: null }), patchTurnState({ outcome: 'denied' })))
+        .then(r => r && fresh() && (patchOverlayState({ approval: null }), patchTurnState({ outcome: 'denied' })))
     }
 
     if (overlay.sudo || overlay.secret) {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -846,7 +846,7 @@ export function useMainApp(gw: GatewayClient) {
   const onEvent = useMemo(
     () =>
       createGatewayEventHandler({
-        composer: { setInput: composerActions.setInput },
+        composer: { setInput: composerActions.setInput, enqueue: composerActions.enqueue },
         gateway,
         session: {
           STARTUP_RESUME_ID,
@@ -871,6 +871,7 @@ export function useMainApp(gw: GatewayClient) {
       appendMessage,
       bellOnComplete,
       bellOnPrompt,
+      composerActions.enqueue,
       composerActions.setInput,
       gateway,
       panel,

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -51,9 +51,10 @@ import { createSlashHandler } from './createSlashHandler.js'
 import { planGatewayRecovery } from './gatewayRecovery.js'
 import { getInputSelection } from './inputSelectionStore.js'
 import { type GatewayRpc, type StateSetter, type TranscriptRow } from './interfaces.js'
-import { $overlayState, patchOverlayState } from './overlayStore.js'
+import { $overlayState, capturePromptResponseGuard, patchOverlayState } from './overlayStore.js'
 import { $goodVibesTick } from './petFlashStore.js'
 import { scrollWithSelectionBy } from './scroll.js'
+import { captureDestination, isCurrentDestination, type SubmissionDestination } from './submissionDestination.js'
 import { turnController } from './turnController.js'
 import { patchTurnState, useTurnSelector } from './turnStore.js'
 import { $uiState, getUiState, patchUiState } from './uiStore.js'
@@ -86,7 +87,7 @@ const statusColorOf = (status: string, t: { error: string; muted: string; ok: st
 }
 
 export interface PromptLiveSessionOptions {
-  dispatchSubmission: (full: string) => void
+  dispatchSubmission: (full: string, destination: SubmissionDestination) => void
   maybeWarn: (value: unknown) => void
   modelArg?: string
   newLiveSession: (msg?: string, title?: string) => Promise<null | string> | null | string | void
@@ -124,6 +125,7 @@ export async function startPromptLiveSession({
     return null
   }
 
+  const destination = Object.freeze({ ...captureDestination(), sid })
   const requestedModel = modelArg ? sessionScopedModelArg(modelArg) : ''
 
   if (requestedModel) {
@@ -135,12 +137,14 @@ export async function startPromptLiveSession({
       return sid
     }
 
-    sys(`model → ${result.value}`)
-    maybeWarn(result)
-    onModelSwitched?.(result.value, result)
+    if (isCurrentDestination(destination)) {
+      sys(`model → ${result.value}`)
+      maybeWarn(result)
+      onModelSwitched?.(result.value, result)
+    }
   }
 
-  dispatchSubmission(trimmed)
+  dispatchSubmission(trimmed, destination)
 
   return sid
 }
@@ -687,13 +691,17 @@ export function useMainApp(gw: GatewayClient) {
         return
       }
 
+      const fresh = capturePromptResponseGuard('clarify', clarify)
+      if (!fresh()) {
+        return
+      }
       const label = toolTrailLabel('clarify')
 
       turnController.turnTools = turnController.turnTools.filter(line => !sameToolTrailGroup(label, line))
       patchTurnState({ turnTrail: turnController.turnTools })
 
       rpc<ClarifyRespondResponse>('clarify.respond', { answer, request_id: clarify.requestId }).then(r => {
-        if (!r) {
+        if (!r || !fresh()) {
           return
         }
 
@@ -736,12 +744,16 @@ export function useMainApp(gw: GatewayClient) {
         return
       }
 
+      const fresh = capturePromptResponseGuard('clarify', clarify)
+      if (!fresh()) {
+        return
+      }
       rpc<ClarifyRespondResponse & { remaining?: string[] }>('clarify.respond', {
         answer,
         question_id: qid,
         request_id: clarify.requestId
       }).then(r => {
-        if (!r) {
+        if (!r || !fresh()) {
           return
         }
 
@@ -1004,13 +1016,21 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   const answerApproval = useCallback(
-    (choice: string) =>
-      respondWith('approval.respond', { choice, session_id: ui.sid }, () => {
+    (choice: string) => {
+      const fresh = capturePromptResponseGuard('approval', overlay.approval)
+      if (!fresh()) {
+        return
+      }
+      return respondWith('approval.respond', { choice, session_id: ui.sid }, () => {
+        if (!fresh()) {
+        return
+      }
         patchOverlayState({ approval: null })
         patchTurnState({ outcome: choice === 'deny' ? 'denied' : `approved (${choice})` })
         patchUiState({ status: 'running…' })
-      }),
-    [respondWith, ui.sid]
+      })
+    },
+    [overlay.approval, respondWith, ui.sid]
   )
 
   const answerSudo = useCallback(
@@ -1019,6 +1039,10 @@ export function useMainApp(gw: GatewayClient) {
         return
       }
 
+      const fresh = capturePromptResponseGuard('sudo', overlay.sudo)
+      if (!fresh()) {
+        return
+      }
       const requestId = overlay.sudo.requestId
 
       if (!pw) {
@@ -1026,6 +1050,9 @@ export function useMainApp(gw: GatewayClient) {
       }
 
       return respondWith('sudo.respond', { password: pw, request_id: requestId }, () => {
+        if (!fresh()) {
+        return
+      }
         patchOverlayState({ sudo: null })
         patchUiState({ status: 'running…' })
       })
@@ -1039,6 +1066,10 @@ export function useMainApp(gw: GatewayClient) {
         return
       }
 
+      const fresh = capturePromptResponseGuard('secret', overlay.secret)
+      if (!fresh()) {
+        return
+      }
       const requestId = overlay.secret.requestId
 
       if (!value) {
@@ -1046,6 +1077,9 @@ export function useMainApp(gw: GatewayClient) {
       }
 
       return respondWith('secret.respond', { request_id: requestId, value }, () => {
+        if (!fresh()) {
+        return
+      }
         patchOverlayState({ secret: null })
         patchUiState({ status: 'running…' })
       })
@@ -1081,7 +1115,7 @@ export function useMainApp(gw: GatewayClient) {
   const newPromptSession = useCallback(
     (prompt: string, modelArg?: string) => {
       void startPromptLiveSession({
-        dispatchSubmission,
+        dispatchSubmission: (text, destination) => send(text, true, text, value => value, { destination }),
         maybeWarn,
         modelArg,
         newLiveSession: session.newLiveSession,
@@ -1095,7 +1129,7 @@ export function useMainApp(gw: GatewayClient) {
         sys
       })
     },
-    [dispatchSubmission, maybeWarn, rpc, session.newLiveSession, sys]
+    [send, maybeWarn, rpc, session.newLiveSession, sys]
   )
 
   const hasReasoning = useTurnSelector(state => Boolean(state.reasoning.trim()))

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -210,7 +210,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
         return null
       }
 
-      const info = r.info ?? null
+      const info = r.info ? { ...r.info, stored_session_id: r.stored_session_id || r.info.stored_session_id } : null
       const requestedTitle = title?.trim() ?? ''
 
       resetSession()
@@ -301,8 +301,9 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
             return patchUiState({ status: 'ready' })
           }
 
-          const info = r.info ?? null
+          const info = r.info ? { ...r.info, stored_session_id: r.stored_session_id || r.info.stored_session_id } : null
           const running = Boolean(r.running || r.status === 'working' || r.status === 'waiting')
+          if (info) info.stored_session_id = r.session_key || info.stored_session_id
 
           resetSession()
           setSessionStartedAt(r.started_at ? r.started_at * 1000 : Date.now())
@@ -330,7 +331,9 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
 
   const resumeById = useCallback(
     (id: string) => {
-      const destination = { ...captureDestination(), sid: id }
+      const current = captureDestination()
+      const destination = current.sid === id || current.storedSid === id
+        ? current : { ...current, sid: id, storedSid: id }
       patchOverlayState({ sessions: false })
       patchUiState({ status: 'resuming…' })
 
@@ -354,12 +357,13 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
               return patchUiState({ status: 'ready' })
             }
 
-            const info = r.info ?? null
+            const info = r.info ? { ...r.info, stored_session_id: r.stored_session_id || r.info.stored_session_id } : null
             const running = Boolean(r.running || r.status === 'working' || r.status === 'waiting')
+            if (info) info.stored_session_id = r.session_key || info.stored_session_id || r.resumed
 
             // A successful resume authorizes the requested source → canonical
             // successor mapping; ordinary focus changes never migrate input.
-            migratePendingInputs(destination, r.session_id)
+            migratePendingInputs(destination, r.session_id, info?.stored_session_id)
             resetSession()
             setSessionStartedAt(r.started_at ? r.started_at * 1000 : Date.now())
 

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -143,6 +143,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
   )
 
   const cancelResumeScrollRef = useRef<null | (() => void)>(null)
+  const attachmentFlight = useRef(0)
 
   const resetSession = useCallback(() => {
     cancelResumeScrollRef.current?.()
@@ -162,6 +163,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
 
   useEffect(
     () => () => {
+      attachmentFlight.current++
       cancelResumeScrollRef.current?.()
       cancelResumeScrollRef.current = null
     },
@@ -187,7 +189,11 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
 
   const startNewSession = useCallback(
     async (msg?: string, title?: string, keepCurrent = false) => {
+      const flight = ++attachmentFlight.current
+      const previousSid = getUiState().sid
       const setup = await rpc<SetupStatusResponse>('setup.status', {})
+
+      if (flight !== attachmentFlight.current) {return null}
 
       if (setup?.provider_configured === false) {
         panel(SETUP_REQUIRED_TITLE, buildSetupRequiredSections())
@@ -196,13 +202,15 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
         return null
       }
 
-      const previousSid = getUiState().sid
-
       if (!keepCurrent) {
         await closeSession(previousSid)
+
+        if (flight !== attachmentFlight.current) {return null}
       }
 
       const r = await rpc<SessionCreateResponse>('session.create', { cols: colsRef.current })
+
+      if (flight !== attachmentFlight.current) {return null}
 
       if (!r) {
         patchUiState({ status: 'ready' })
@@ -288,11 +296,13 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
 
   const activateLiveSession = useCallback(
     (id: string) => {
+      const flight = ++attachmentFlight.current
       patchOverlayState({ sessions: false })
       patchUiState({ status: 'switching session…' })
 
       gw.request<SessionActivateResponse>('session.activate', { session_id: id })
         .then(raw => {
+          if (flight !== attachmentFlight.current) {return}
           const r = asRpcResult<SessionActivateResponse>(raw)
 
           if (!r) {
@@ -303,7 +313,8 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
 
           const info = r.info ? { ...r.info, stored_session_id: r.stored_session_id || r.info.stored_session_id } : null
           const running = Boolean(r.running || r.status === 'working' || r.status === 'waiting')
-          if (info) info.stored_session_id = r.session_key || info.stored_session_id
+
+          if (info) {info.stored_session_id = r.session_key || info.stored_session_id}
 
           resetSession()
           setSessionStartedAt(r.started_at ? r.started_at * 1000 : Date.now())
@@ -322,6 +333,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
           cancelResumeScrollRef.current = scheduleResumeScrollToBottom(scrollRef)
         })
         .catch((e: Error) => {
+          if (flight !== attachmentFlight.current) {return}
           sys(`error: ${e.message}`)
           patchUiState({ status: 'ready' })
         })
@@ -331,13 +343,19 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
 
   const resumeById = useCallback(
     (id: string) => {
+      const flight = ++attachmentFlight.current
       const current = captureDestination()
+      const previousSid = current.sid
+
       const destination = current.sid === id || current.storedSid === id
         ? current : { ...current, sid: id, storedSid: id }
+
       patchOverlayState({ sessions: false })
       patchUiState({ status: 'resuming…' })
 
       rpc<SetupStatusResponse>('setup.status', {}).then(setup => {
+        if (flight !== attachmentFlight.current) {return}
+
         if (setup?.provider_configured === false) {
           panel(SETUP_REQUIRED_TITLE, buildSetupRequiredSections())
           patchUiState({ status: 'setup required' })
@@ -345,10 +363,9 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
           return
         }
 
-        const previousSid = getUiState().sid
-
         gw.request<SessionResumeResponse>('session.resume', { cols: colsRef.current, session_id: id })
           .then(raw => {
+            if (flight !== attachmentFlight.current) {return}
             const r = asRpcResult<SessionResumeResponse>(raw)
 
             if (!r) {
@@ -359,7 +376,8 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
 
             const info = r.info ? { ...r.info, stored_session_id: r.stored_session_id || r.info.stored_session_id } : null
             const running = Boolean(r.running || r.status === 'working' || r.status === 'waiting')
-            if (info) info.stored_session_id = r.session_key || info.stored_session_id || r.resumed
+
+            if (info) {info.stored_session_id = r.session_key || info.stored_session_id || r.resumed}
 
             // A successful resume authorizes the requested source → canonical
             // successor mapping; ordinary focus changes never migrate input.
@@ -387,6 +405,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
             }
           })
           .catch((e: Error) => {
+            if (flight !== attachmentFlight.current) {return}
             sys(`error: ${e.message}`)
             patchUiState({ status: 'ready' })
           })

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -17,12 +17,14 @@ import type {
   SessionTitleResponse,
   SetupStatusResponse
 } from '../gatewayTypes.js'
+import { migratePendingInputs } from '../lib/pendingInputs.js'
 import { asRpcResult } from '../lib/rpc.js'
 import type { Msg, PanelSection, SessionInfo, Usage } from '../types.js'
 
 import type { ComposerActions, GatewayRpc, StateSetter } from './interfaces.js'
 import { patchOverlayState } from './overlayStore.js'
 import { scheduleResumeScrollToBottom } from './sessionResumeView.js'
+import { captureDestination } from './submissionDestination.js'
 import { turnController } from './turnController.js'
 import { patchTurnState } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
@@ -328,6 +330,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
 
   const resumeById = useCallback(
     (id: string) => {
+      const destination = { ...captureDestination(), sid: id }
       patchOverlayState({ sessions: false })
       patchUiState({ status: 'resuming…' })
 
@@ -354,6 +357,9 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
             const info = r.info ?? null
             const running = Boolean(r.running || r.status === 'working' || r.status === 'waiting')
 
+            // A successful resume authorizes the requested source → canonical
+            // successor mapping; ordinary focus changes never migrate input.
+            migratePendingInputs(destination, r.session_id)
             resetSession()
             setSessionStartedAt(r.started_at ? r.started_at * 1000 : Date.now())
 

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -4,7 +4,7 @@ import { TYPING_IDLE_MS } from '../config/timing.js'
 import { expandTokens } from '../domain/attachments.js'
 import { completionToApplyOnSubmit, looksLikeSlashCommand, parseSlashCommand } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
-import type { SessionSteerResponse, ShellExecResponse } from '../gatewayTypes.js'
+import type { ShellExecResponse } from '../gatewayTypes.js'
 import { queueItem, type QueueItem } from '../hooks/useQueue.js'
 import { asRpcResult } from '../lib/rpc.js'
 import { hasInterpolation, INTERPOLATION_RE } from '../protocol/interpolation.js'
@@ -12,6 +12,7 @@ import type { Msg } from '../types.js'
 
 import type { ComposerActions, ComposerRefs, ComposerState, ComposerToken } from './interfaces.js'
 import { submitPrompt } from './submissionCore.js'
+import { captureDestination, isCurrentDestination, type SubmissionDestination } from './submissionDestination.js'
 import { turnController } from './turnController.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
@@ -102,11 +103,16 @@ export function useSubmission(opts: UseSubmissionOptions) {
       showUserMessage = true,
       displayText?: string,
       expandOverride?: (value: string) => string,
-      submitOpts: { skipDetectDrop?: boolean } = {}
+      submitOpts: { skipDetectDrop?: boolean; destination?: SubmissionDestination; queueItem?: QueueItem } = {}
     ) => {
       // Read tokens off the ref, not render state: a paste immediately followed
       // by Enter submits before React has re-rendered with the new token.
       const expand = expandOverride ?? expandTokens(composerRefs.tokensRef.current)
+
+      const destination = submitOpts.destination ?? captureDestination()
+
+      const item =
+        submitOpts.queueItem ?? (destination.sid ? composerActions.stage?.(text, displayText, destination) : undefined)
 
       submitPrompt(
         text,
@@ -120,20 +126,26 @@ export function useSubmission(opts: UseSubmissionOptions) {
         },
         showUserMessage,
         displayText,
-        submitOpts
+        { ...submitOpts, destination, queueItem: item }
       )
     },
     [appendMessage, composerActions, composerRefs, gw, setLastUserMsg, sys]
   )
 
   const shellExec = useCallback(
-    (cmd: string) => {
+    (cmd: string, destination = captureDestination(), item?: QueueItem) => {
+      const focused = () => isCurrentDestination(destination)
       appendMessage({ role: 'user', text: `!${cmd}` })
       patchUiState({ busy: true, status: 'running…' })
 
-      gw.request<ShellExecResponse>('shell.exec', { command: cmd })
+      gw.request<ShellExecResponse>('shell.exec', { command: cmd, session_id: destination.sid })
         .then(raw => {
           const r = asRpcResult<ShellExecResponse>(raw)
+          item?.settle?.(Boolean(r))
+
+          if (!focused()) {
+            return
+          }
 
           if (!r) {
             return sys('error: invalid response: shell.exec')
@@ -149,21 +161,31 @@ export function useSubmission(opts: UseSubmissionOptions) {
             sys(`exit ${r.code}`)
           }
         })
-        .catch((e: Error) => sys(`error: ${e.message}`))
-        .finally(() => patchUiState({ busy: false, status: 'ready' }))
+        .catch((e: Error) => {
+          item?.settle?.(false)
+
+          if (focused()) {
+            sys(`error: ${e.message}`)
+          }
+        })
+        .finally(() => {
+          if (focused()) {
+            patchUiState({ busy: false, status: 'ready' })
+          }
+        })
     },
     [appendMessage, gw, sys]
   )
 
   const interpolate = useCallback(
-    (text: string, then: (result: string) => void) => {
+    (text: string, then: (result: string) => void, destination = captureDestination()) => {
       patchUiState({ status: 'interpolating…' })
       const matches = [...text.matchAll(new RegExp(INTERPOLATION_RE.source, 'g'))]
 
       Promise.all(
         matches.map(m =>
           gw
-            .request<ShellExecResponse>('shell.exec', { command: m[1]! })
+            .request<ShellExecResponse>('shell.exec', { command: m[1]!, session_id: destination.sid })
             .then(raw => {
               const r = asRpcResult<ShellExecResponse>(raw)
 
@@ -177,18 +199,30 @@ export function useSubmission(opts: UseSubmissionOptions) {
   )
 
   const sendQueued = useCallback(
-    (text: string) => {
+    (input: string | QueueItem) => {
+      const item = typeof input === 'string' ? undefined : input
+      const text = item?.preparedText ?? (typeof input === 'string' ? input : input.text)
+      const destination = item?.destination ?? captureDestination()
+
+      if (item?.preparedText !== undefined) {
+        return send(text, true, item.display, value => value, { destination, queueItem: item, skipDetectDrop: true })
+      }
+
       if (text.startsWith('!')) {
-        return shellExec(text.slice(1).trim())
+        return shellExec(text.slice(1).trim(), destination, item)
       }
 
       if (hasInterpolation(text)) {
         patchUiState({ busy: true })
 
-        return interpolate(text, send)
+        return interpolate(
+          text,
+          result => send(result, true, undefined, value => value, { destination, queueItem: item }),
+          destination
+        )
       }
 
-      send(text)
+      send(text, true, undefined, value => value, { destination, queueItem: item })
     },
     [interpolate, send, shellExec]
   )
@@ -207,50 +241,41 @@ export function useSubmission(opts: UseSubmissionOptions) {
   const handleBusyInput = useCallback(
     (item: QueueItem, opts: { fallbackToFront?: boolean } = {}) => {
       const live = getUiState()
+      const destination = captureDestination()
       const mode = live.busyInputMode
 
       const enqueueText = () => {
         if (opts.fallbackToFront) {
-          composerActions.prependQueue(item)
+          composerActions.prependQueue(item, destination)
         } else {
-          composerActions.enqueue(item.text, item.display)
+          composerActions.enqueue(item.text, item.display, destination)
         }
-      }
-
-      const fallback = (note: string) => {
-        enqueueText()
-        sys(note)
       }
 
       if (mode === 'queue') {
         return enqueueText()
       }
 
-      if (mode === 'steer' && live.sid) {
-        gw.request<SessionSteerResponse>('session.steer', { session_id: live.sid, text: item.text })
-          .then(raw => {
-            const r = asRpcResult<SessionSteerResponse>(raw)
-
-            if (r?.status !== 'queued') {
-              fallback('steer rejected — message queued for next turn')
-            }
-          })
-          .catch(() => fallback('steer failed — message queued for next turn'))
-
-        return
+      if (item.settle) {
+        item.queued = false
       }
 
       // The gateway owns the atomic redirect decision because it knows whether
       // the agent is in model generation, tool execution, or an older runtime.
       // Reuse the normal submit pipeline so the correction gets its user bubble
       // and file-drop interpolation exactly once.
-      send(item.text)
+      send(item.text, true, item.display, value => value, { destination, queueItem: item.settle ? item : undefined })
     },
-    [composerActions, gw, send, sys]
+    [composerActions, send]
   )
 
   const dispatchSubmission = useCallback(
-    (full: string) => {
+    (input: string | QueueItem) => {
+      if (typeof input !== 'string') {
+        return sendQueued(input)
+      }
+      const full = input
+
       if (!full.trim()) {
         return
       }
@@ -260,6 +285,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
       // nothing — a detached image can't be re-attached by recalling the text.
       // Idempotent on token-free text, so re-submitting a recalled entry is
       // stable.
+      const destination = captureDestination()
       const submissionTokens = [...composerRefs.tokensRef.current]
       const submission = prepareSubmission(full, submissionTokens)
       const toHistory = submission.text
@@ -297,7 +323,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
       if (!live.sid) {
         composerActions.pushHistory(toHistory)
-        composerActions.enqueue(full)
+        composerActions.enqueue(submission.text, submission.display)
         composerActions.clearIn()
 
         return
@@ -325,20 +351,28 @@ export function useSubmission(opts: UseSubmissionOptions) {
           return handleBusyInput(picked, { fallbackToFront: true })
         }
 
-        return sendQueued(picked.text)
+        return sendQueued(picked)
       }
 
       composerActions.pushHistory(toHistory)
 
       if (getUiState().busy) {
-        return handleBusyInput(queueItem(full))
+        return handleBusyInput(queueItem(submission.text, submission.display))
       }
 
       if (shouldInterpolateSubmission(full)) {
         patchUiState({ busy: true })
 
-        return interpolate(full, text =>
-          send(prepareSubmission(text, submissionTokens).text, true, text, value => value)
+        const item = composerActions.stage?.(submission.text, submission.display, destination)
+
+        return interpolate(
+          full,
+          text =>
+            send(prepareSubmission(text, submissionTokens).text, true, text, value => value, {
+              destination,
+              queueItem: item
+            }),
+          destination
         )
       }
 
@@ -384,7 +418,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
         }
 
         if (doubleTap && live.sid && composerRefs.queueRef.current.length) {
-          const next = composerActions.dequeue()
+          const next = composerActions.dequeue(true)
 
           if (next) {
             composerActions.setQueueEdit(null)

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -182,11 +182,14 @@ export interface SystemBatteryResponse {
 // ── Session lifecycle ────────────────────────────────────────────────
 
 export interface SessionCreateResponse {
+  stored_session_id?: string
   info?: SessionInfo & { config_warning?: string; credential_warning?: string }
   session_id: string
 }
 
 export interface SessionResumeResponse {
+  stored_session_id?: string
+  session_key?: string
   inflight?: null | SessionInflightTurn
   info?: SessionInfo
   message_count?: number
@@ -224,6 +227,7 @@ export interface SessionInflightTurn {
 }
 
 export interface SessionActivateResponse {
+  stored_session_id?: string
   inflight?: null | SessionInflightTurn
   info?: SessionInfo
   message_count?: number

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -342,6 +342,11 @@ export interface SessionSteerResponse {
 // ── Prompt / submission ──────────────────────────────────────────────
 
 export interface PromptSubmitResponse {
+  status?: string
+  admission_id?: string
+  target_session_id?: string
+  target_profile_home?: string
+  outcome?: string | null
   ok?: boolean
   /** Set when the submitted text was a bare voice stop phrase consumed
    *  server-side to end the voice chat instead of starting a turn. */

--- a/ui-tui/src/hooks/useQueue.ts
+++ b/ui-tui/src/hooks/useQueue.ts
@@ -1,11 +1,23 @@
-import { useStore } from '@nanostores/react'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { randomUUID } from 'node:crypto'
 
+import { useStore } from '@nanostores/react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { captureDestination, type SubmissionDestination } from '../app/submissionDestination.js'
 import { $uiState, getUiState } from '../app/uiStore.js'
+import { loadPendingInputs, removePendingInput, savePendingInput } from '../lib/pendingInputs.js'
 
 export interface QueueItem {
   display: string
   text: string
+  queued?: boolean
+  createdAt?: number
+  submissionId?: string
+  destination?: SubmissionDestination
+  inFlight?: boolean
+  failed?: boolean
+  preparedText?: string
+  settle?: (accepted: boolean) => void
 }
 
 export const queueItem = (text: string, display = text): QueueItem => ({ display, text })
@@ -25,10 +37,9 @@ export function takeQueueItem(queue: QueueItem[], index: number, editedDisplay?:
     return item
   }
 
-  return {
-    display: editedDisplay,
-    text: editedDisplay.includes(item.display) ? editedDisplay.replace(item.display, item.text) : editedDisplay
-  }
+  const text = editedDisplay.includes(item.display) ? editedDisplay.replace(item.display, item.text) : editedDisplay
+
+  return text === item.text ? { ...item, display: editedDisplay } : { display: editedDisplay, text }
 }
 
 // Mutates `arr` in place; returned reference is the same input array, kept
@@ -49,23 +60,23 @@ interface PendingQueue {
 }
 
 export function useQueue() {
-  useStore($uiState)
+  const ui = useStore($uiState)
   const queues = useRef(new Map<string, PendingQueue>())
   const unbound = useRef<PendingQueue>({ edit: null, items: [] })
   const [, refresh] = useState(0)
 
-  const getQueue = useCallback(() => {
-    const { sid, info } = getUiState()
+  const getQueue = useCallback((destination = captureDestination()) => {
+    const { sid, profile } = destination
 
     if (!sid) {
       return unbound.current
     }
 
-    const key = JSON.stringify([info?.profile_name || 'default', sid])
+    const key = JSON.stringify([profile, sid])
     let queue = queues.current.get(key)
 
     if (!queue) {
-      queue = { edit: null, items: [] }
+      queue = { edit: null, items: loadPendingInputs(destination) }
       queues.current.set(key, queue)
     }
 
@@ -73,7 +84,12 @@ export function useQueue() {
     // unlike a bound session's queue, which must never migrate on navigation.
     if (unbound.current.items.length) {
       const offset = queue.items.length
-      queue.items.push(...unbound.current.items)
+
+      for (const item of unbound.current.items) {
+        item.destination = destination
+        savePendingInput(item)
+        queue.items.push(item)
+      }
 
       if (unbound.current.edit !== null) {
         queue.edit = offset + unbound.current.edit
@@ -108,7 +124,11 @@ export function useQueue() {
     [getQueue]
   )
 
-  const queuedDisplay = queueRef.current.map(item => item.display)
+  const queuedDisplay = [
+    ...queueRef.current.map(item => `${item.failed ? '[unconfirmed · Alt+K retry] ' : ''}${item.display}`),
+    ...(ui.info?.pending_submissions ?? []).map(item => `[${item.status} · ${item.admission_id}] ${item.user}`)
+  ]
+
   const queueEditIdx = queueEditRef.current
   const syncQueue = useCallback(() => refresh(version => version + 1), [])
 
@@ -121,50 +141,168 @@ export function useQueue() {
   )
 
   const enqueue = useCallback(
-    (text: string, display = text) => {
-      queueRef.current.push(queueItem(text, display))
-      syncQueue()
-    },
-    [queueRef, syncQueue]
-  )
+    (text: string, display = text, destination?: SubmissionDestination) => {
+      const owner = destination ?? captureDestination()
+      const queue = getQueue(owner)
 
-  const prependQ = useCallback(
-    (item: QueueItem) => {
-      prependQueueItem(queueRef.current, item)
-      syncQueue()
-    },
-    [queueRef, syncQueue]
-  )
-
-  const dequeue = useCallback(() => {
-    const head = queueRef.current.shift()?.text
-    syncQueue()
-
-    return head
-  }, [queueRef, syncQueue])
-
-  const takeQ = useCallback(
-    (i: number, editedDisplay?: string) => {
-      const item = takeQueueItem(queueRef.current, i, editedDisplay)
-
-      if (item) {
-        syncQueue()
+      const item = {
+        ...queueItem(text, display),
+        submissionId: randomUUID(),
+        destination: owner,
+        createdAt: Math.max(Date.now(), (queue.items.at(-1)?.createdAt ?? 0) + 1)
       }
+
+      savePendingInput(item)
+      queue.items.push(item)
+      syncQueue()
 
       return item
     },
-    [queueRef, syncQueue]
+    [getQueue, syncQueue]
+  )
+
+  const prependQ = useCallback(
+    (item: QueueItem, destination?: SubmissionDestination) => {
+      const queue = getQueue(destination)
+      item.inFlight = false
+      item.submissionId ??= randomUUID()
+      item.destination ??= destination ?? captureDestination()
+      savePendingInput(item)
+
+      if (!queue.items.includes(item)) {
+        prependQueueItem(queue.items, item)
+      }
+      syncQueue()
+    },
+    [getQueue, syncQueue]
+  )
+
+  const claim = useCallback(
+    (queue: PendingQueue, item: QueueItem) => {
+      item.submissionId ??= randomUUID()
+      item.destination ??= captureDestination()
+      item.inFlight = true
+      item.failed = false
+      savePendingInput(item)
+      let confirmed = false
+
+      item.settle = accepted => {
+        if (confirmed) {
+          return
+        }
+        confirmed = accepted
+        item.inFlight = false
+        item.failed = !accepted
+
+        if (accepted) {
+          removePendingInput(item)
+          removeAtInPlace(queue.items, queue.items.indexOf(item))
+        } else {
+          savePendingInput(item)
+        }
+
+        syncQueue()
+      }
+
+      syncQueue()
+
+      return item
+    },
+    [syncQueue]
+  )
+
+  useEffect(() => {
+    const queue = getQueue()
+
+    for (const receipt of getUiState().info?.pending_submissions ?? []) {
+      const item = queue.items.find(
+        item =>
+          item.submissionId === receipt.admission_id &&
+          item.destination?.sid === receipt.target_session_id &&
+          item.destination?.profileHome === receipt.target_profile_home
+      )
+
+      if (!item) {
+        continue
+      }
+
+      if (item.settle) {
+        item.settle(true)
+      } else {
+        removePendingInput(item)
+        removeAtInPlace(queue.items, queue.items.indexOf(item))
+        syncQueue()
+      }
+    }
+  }, [ui.info, getQueue, syncQueue])
+
+  const stage = useCallback(
+    (text: string, display = text, destination = captureDestination()) => {
+      const item = enqueue(text, display, destination)
+      item.queued = false
+
+      return claim(getQueue(destination), item)
+    },
+    [enqueue, claim, getQueue]
+  )
+
+  const dequeue = useCallback(
+    (retry = false) => {
+      const queue = getQueue()
+      const item = queue.items[0]
+
+      if (!item || item.inFlight || (item.failed && !retry)) {
+        return undefined
+      }
+
+      return claim(queue, item)
+    },
+    [getQueue, claim]
+  )
+
+  const takeQ = useCallback(
+    (i: number, editedDisplay?: string) => {
+      const queue = getQueue()
+
+      if (queue.items[i]?.inFlight) {
+        return undefined
+      }
+      const previous = queue.items[i]
+      const item = takeQueueItem(queue.items, i, editedDisplay)
+
+      if (!item) {
+        return undefined
+      }
+
+      if (previous && previous.submissionId !== item.submissionId) {
+        removePendingInput(previous)
+      }
+      queue.items.splice(i, 0, item)
+
+      return claim(queue, item)
+    },
+    [getQueue, claim]
   )
 
   const removeQ = useCallback(
     (i: number) => {
-      takeQ(i)
+      if (queueRef.current[i]?.inFlight) {
+        return
+      }
+      const item = queueRef.current[i]
+
+      if (item) {
+        removePendingInput(item)
+      }
+      removeAtInPlace(queueRef.current, i)
+      syncQueue()
     },
-    [takeQ]
+    [queueRef, syncQueue]
   )
 
   return {
     dequeue,
+    stage,
     enqueue,
     prependQ,
     queueEditIdx,

--- a/ui-tui/src/hooks/useQueue.ts
+++ b/ui-tui/src/hooks/useQueue.ts
@@ -277,7 +277,8 @@ export function useQueue() {
       const item = queue.items.find(
         item =>
           item.submissionId === receipt.admission_id &&
-          item.destination?.sid === receipt.target_session_id &&
+          Boolean(item.destination?.storedSid) &&
+          item.destination?.storedSid === receipt.target_session_id &&
           item.destination?.profileHome === receipt.target_profile_home
       )
 

--- a/ui-tui/src/hooks/useQueue.ts
+++ b/ui-tui/src/hooks/useQueue.ts
@@ -5,7 +5,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { captureDestination, type SubmissionDestination } from '../app/submissionDestination.js'
 import { $uiState, getUiState } from '../app/uiStore.js'
-import { loadPendingInputs, removePendingInput, savePendingInput } from '../lib/pendingInputs.js'
+import {
+  loadPendingInputs,
+  pendingDestinationKey,
+  pendingInputOwner,
+  pendingInputRevision,
+  removePendingInput,
+  savePendingInput
+} from '../lib/pendingInputs.js'
 
 export interface QueueItem {
   display: string
@@ -14,6 +21,7 @@ export interface QueueItem {
   createdAt?: number
   submissionId?: string
   destination?: SubmissionDestination
+  ownerDestination?: SubmissionDestination
   inFlight?: boolean
   failed?: boolean
   preparedText?: string
@@ -55,6 +63,8 @@ export function removeAtInPlace<T>(arr: T[], i: number): T[] {
 }
 
 interface PendingQueue {
+  revision?: number
+  destination?: SubmissionDestination
   edit: number | null
   items: QueueItem[]
 }
@@ -66,18 +76,58 @@ export function useQueue() {
   const [, refresh] = useState(0)
 
   const getQueue = useCallback((destination = captureDestination()) => {
-    const { sid, profile } = destination
+    // Apply compression before resolving a queue, including through stale callbacks.
+    for (const [oldKey, source] of queues.current) {
+      const owner = pendingInputOwner(source.destination!)
+      const newKey = pendingDestinationKey(owner)
+
+      if (newKey === oldKey) {
+        continue
+      }
+
+      const target = queues.current.get(newKey) ?? { destination: owner, edit: null, items: [] }
+      const edited = source.edit === null ? undefined : source.items[source.edit]
+
+      for (const item of source.items) {
+        item.ownerDestination = owner
+
+        if (!item.inFlight && !item.failed) {
+          item.destination = owner
+        }
+      }
+
+      const retained = new Map([...target.items, ...source.items].map(item => [item.submissionId, item]))
+      target.items = loadPendingInputs(owner).map(item => retained.get(item.submissionId) ?? item)
+
+      if (edited) {
+        target.edit = target.items.indexOf(edited)
+      }
+
+      queues.current.delete(oldKey)
+      queues.current.set(newKey, target)
+    }
+
+    destination = pendingInputOwner(destination)
+    const { sid } = destination
 
     if (!sid) {
       return unbound.current
     }
 
-    const key = JSON.stringify([profile, sid])
+    const key = pendingDestinationKey(destination)
     let queue = queues.current.get(key)
 
     if (!queue) {
-      queue = { edit: null, items: loadPendingInputs(destination) }
+      queue = { destination, edit: null, items: loadPendingInputs(destination) }
       queues.current.set(key, queue)
+    }
+
+    if (queue.revision !== pendingInputRevision) {
+      const retained = new Map(queue.items.map(item => [item.submissionId, item]))
+      const edited = queue.edit === null ? undefined : queue.items[queue.edit]
+      queue.items = loadPendingInputs(destination).map(item => retained.get(item.submissionId) ?? item)
+      queue.edit = edited ? queue.items.indexOf(edited) : null
+      queue.revision = pendingInputRevision
     }
 
     // Input typed before any session exists belongs to the next attachment,
@@ -142,7 +192,7 @@ export function useQueue() {
 
   const enqueue = useCallback(
     (text: string, display = text, destination?: SubmissionDestination) => {
-      const owner = destination ?? captureDestination()
+      const owner = pendingInputOwner(destination ?? captureDestination())
       const queue = getQueue(owner)
 
       const item = {
@@ -172,6 +222,7 @@ export function useQueue() {
       if (!queue.items.includes(item)) {
         prependQueueItem(queue.items, item)
       }
+
       syncQueue()
     },
     [getQueue, syncQueue]
@@ -190,12 +241,20 @@ export function useQueue() {
         if (confirmed) {
           return
         }
+
+        // Resolve migrations while the attempted state still protects the receipt target.
+        getQueue()
         confirmed = accepted
         item.inFlight = false
         item.failed = !accepted
 
         if (accepted) {
           removePendingInput(item)
+
+          for (const pending of queues.current.values()) {
+            removeAtInPlace(pending.items, pending.items.indexOf(item))
+          }
+
           removeAtInPlace(queue.items, queue.items.indexOf(item))
         } else {
           savePendingInput(item)
@@ -208,7 +267,7 @@ export function useQueue() {
 
       return item
     },
-    [syncQueue]
+    [getQueue, syncQueue]
   )
 
   useEffect(() => {
@@ -267,6 +326,7 @@ export function useQueue() {
       if (queue.items[i]?.inFlight) {
         return undefined
       }
+
       const previous = queue.items[i]
       const item = takeQueueItem(queue.items, i, editedDisplay)
 
@@ -277,6 +337,7 @@ export function useQueue() {
       if (previous && previous.submissionId !== item.submissionId) {
         removePendingInput(previous)
       }
+
       queue.items.splice(i, 0, item)
 
       return claim(queue, item)
@@ -289,11 +350,13 @@ export function useQueue() {
       if (queueRef.current[i]?.inFlight) {
         return
       }
+
       const item = queueRef.current[i]
 
       if (item) {
         removePendingInput(item)
       }
+
       removeAtInPlace(queueRef.current, i)
       syncQueue()
     },

--- a/ui-tui/src/lib/pendingInputs.ts
+++ b/ui-tui/src/lib/pendingInputs.ts
@@ -45,7 +45,7 @@ export function pendingInputOwner(destination: SubmissionDestination): Submissio
   return current
 }
 
-// Only the authorized compression event calls this, never ordinary navigation.
+// Resume authorizes the source → successor mapping; navigation alone does not.
 export function migratePendingInputs(previous: SubmissionDestination, successorSid: string): void {
   if (!previous.sid || !successorSid || previous.sid === successorSid) {
     return

--- a/ui-tui/src/lib/pendingInputs.ts
+++ b/ui-tui/src/lib/pendingInputs.ts
@@ -46,12 +46,12 @@ export function pendingInputOwner(destination: SubmissionDestination): Submissio
 }
 
 // Resume authorizes the source → successor mapping; navigation alone does not.
-export function migratePendingInputs(previous: SubmissionDestination, successorSid: string): void {
-  if (!previous.sid || !successorSid || previous.sid === successorSid) {
+export function migratePendingInputs(previous: SubmissionDestination, successorSid: string, successorStoredSid?: string): void {
+  if (!previous.sid || !successorSid || (previous.sid === successorSid && previous.storedSid === successorStoredSid)) {
     return
   }
 
-  const successor = Object.freeze({ ...previous, sid: successorSid })
+  const successor = Object.freeze({ ...previous, sid: successorSid, storedSid: successorStoredSid ?? null })
 
   for (const item of loadPendingInputs(previous)) {
     item.ownerDestination = successor

--- a/ui-tui/src/lib/pendingInputs.ts
+++ b/ui-tui/src/lib/pendingInputs.ts
@@ -20,11 +20,58 @@ const directory = (home?: string) =>
   join(home ?? process.env.HERMES_HOME ?? join(homedir(), '.hermes'), 'tui-pending-inputs')
 
 const recordName = /^[0-9a-f-]{36}\.json$/
+const successors = new Map<string, SubmissionDestination>()
+export let pendingInputRevision = 0
+
+export const pendingDestinationKey = (destination: SubmissionDestination) =>
+  JSON.stringify([destination.profileHome, destination.profile, destination.sid])
+
+export function pendingInputOwner(destination: SubmissionDestination): SubmissionDestination {
+  let current = destination
+  const seen = new Set<string>()
+
+  while (!seen.has(pendingDestinationKey(current))) {
+    const key = pendingDestinationKey(current)
+    seen.add(key)
+    const next = successors.get(key)
+
+    if (!next) {
+      break
+    }
+
+    current = next
+  }
+
+  return current
+}
+
+// Only the authorized compression event calls this, never ordinary navigation.
+export function migratePendingInputs(previous: SubmissionDestination, successorSid: string): void {
+  if (!previous.sid || !successorSid || previous.sid === successorSid) {
+    return
+  }
+
+  const successor = Object.freeze({ ...previous, sid: successorSid })
+
+  for (const item of loadPendingInputs(previous)) {
+    item.ownerDestination = successor
+
+    if (!item.failed) {
+      item.destination = successor
+    }
+
+    savePendingInput(item)
+  }
+
+  successors.set(pendingDestinationKey(previous), successor)
+  pendingInputRevision++
+}
 
 function syncDirectory(dir: string) {
   if (process.platform === 'win32') {
     return
   }
+
   const fd = openSync(dir, 'r')
 
   try {
@@ -39,16 +86,20 @@ export function savePendingInput(item: QueueItem): void {
   if (!item.submissionId || !item.destination?.sid) {
     return
   }
+
   const dir = directory(item.destination?.profileHome)
   mkdirSync(dir, { recursive: true, mode: 0o700 })
   const path = join(dir, `${item.submissionId}.json`)
   const temporary = `${path}.${process.pid}.tmp`
-  const { submissionId, destination, display, text, preparedText, inFlight, failed, createdAt, queued } = item
+  const ownerDestination = pendingInputOwner(item.ownerDestination ?? item.destination)
+  const { submissionId, display, text, preparedText, inFlight, failed, createdAt, queued } = item
+  const destination = inFlight || failed ? item.destination : ownerDestination
   writeFileSync(
     temporary,
     JSON.stringify({
       submissionId,
       destination,
+      ownerDestination,
       display,
       text,
       preparedText,
@@ -66,11 +117,13 @@ export function removePendingInput(item: QueueItem): void {
   if (!item.submissionId) {
     return
   }
+
   const dir = directory(item.destination?.profileHome)
 
   if (!existsSync(dir)) {
     return
   }
+
   rmSync(join(dir, `${item.submissionId}.json`), { force: true })
   syncDirectory(dir)
 }
@@ -94,6 +147,7 @@ export function loadPendingInputs(destination: SubmissionDestination): QueueItem
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
           return []
         }
+
         throw error
       }
 
@@ -107,7 +161,9 @@ export function loadPendingInputs(destination: SubmissionDestination): QueueItem
         throw new Error(`Invalid pending input record: ${name}`)
       }
 
-      if (record.destination?.sid !== destination.sid || record.destination?.profile !== destination.profile) {
+      const owner = record.ownerDestination ?? record.destination
+
+      if (owner?.sid !== destination.sid || owner?.profile !== destination.profile) {
         return []
       }
 

--- a/ui-tui/src/lib/pendingInputs.ts
+++ b/ui-tui/src/lib/pendingInputs.ts
@@ -1,0 +1,117 @@
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import type { SubmissionDestination } from '../app/submissionDestination.js'
+import type { QueueItem } from '../hooks/useQueue.js'
+
+const directory = (home?: string) =>
+  join(home ?? process.env.HERMES_HOME ?? join(homedir(), '.hermes'), 'tui-pending-inputs')
+
+const recordName = /^[0-9a-f-]{36}\.json$/
+
+function syncDirectory(dir: string) {
+  if (process.platform === 'win32') {
+    return
+  }
+  const fd = openSync(dir, 'r')
+
+  try {
+    fsyncSync(fd)
+  } finally {
+    closeSync(fd)
+  }
+}
+
+// Separate files avoid read/modify/write loss between two native clients.
+export function savePendingInput(item: QueueItem): void {
+  if (!item.submissionId || !item.destination?.sid) {
+    return
+  }
+  const dir = directory(item.destination?.profileHome)
+  mkdirSync(dir, { recursive: true, mode: 0o700 })
+  const path = join(dir, `${item.submissionId}.json`)
+  const temporary = `${path}.${process.pid}.tmp`
+  const { submissionId, destination, display, text, preparedText, inFlight, failed, createdAt, queued } = item
+  writeFileSync(
+    temporary,
+    JSON.stringify({
+      submissionId,
+      destination,
+      display,
+      text,
+      preparedText,
+      createdAt,
+      queued,
+      attempted: inFlight || failed
+    }),
+    { mode: 0o600, flush: true }
+  )
+  renameSync(temporary, path)
+  syncDirectory(dir)
+}
+
+export function removePendingInput(item: QueueItem): void {
+  if (!item.submissionId) {
+    return
+  }
+  const dir = directory(item.destination?.profileHome)
+
+  if (!existsSync(dir)) {
+    return
+  }
+  rmSync(join(dir, `${item.submissionId}.json`), { force: true })
+  syncDirectory(dir)
+}
+
+export function loadPendingInputs(destination: SubmissionDestination): QueueItem[] {
+  const dir = directory(destination.profileHome)
+
+  if (!existsSync(dir)) {
+    return []
+  }
+
+  return readdirSync(dir)
+    .filter(name => recordName.test(name))
+    .flatMap(name => {
+      // A missing record is a concurrent client's acknowledgement, not corruption.
+      let raw: string
+
+      try {
+        raw = readFileSync(join(dir, name), 'utf8')
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          return []
+        }
+        throw error
+      }
+
+      const record = JSON.parse(raw)
+
+      if (
+        record.submissionId + '.json' !== name ||
+        typeof record.text !== 'string' ||
+        typeof record.display !== 'string'
+      ) {
+        throw new Error(`Invalid pending input record: ${name}`)
+      }
+
+      if (record.destination?.sid !== destination.sid || record.destination?.profile !== destination.profile) {
+        return []
+      }
+
+      return [{ ...record, inFlight: false, failed: Boolean(record.attempted) }]
+    })
+    .sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0))
+}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -188,6 +188,7 @@ export interface ProjectInfo {
 }
 
 export interface SessionInfo {
+  stored_session_id?: string
   cwd?: string
   fast?: boolean
   install_warning?: string

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -197,6 +197,16 @@ export interface SessionInfo {
   profile_name?: string
   project?: null | ProjectInfo
   reasoning_effort?: string
+  pending_submissions?: Array<{
+    admission_id: string
+    target_session_id: string
+    target_profile_home: string
+    status: string
+    user: string
+    outcome?: string | null
+  }>
+  execution_generation?: number
+  execution_state?: string
   running?: boolean
   release_date?: string
   service_tier?: string

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -205,6 +205,7 @@ export interface SessionInfo {
     user: string
     outcome?: string | null
   }>
+  execution_epoch?: string
   execution_generation?: number
   execution_state?: string
   running?: boolean

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -59,6 +59,57 @@ terminal.resize         clipboard.paste         image.attach
 
 Within one authenticated gateway, resuming or activating a live session attaches another event subscriber rather than replacing the previous connection. Streaming and terminal events go to all attached clients; disconnecting one client does not end a session another client is viewing. Existing submit exclusivity and configured busy-input policy remain in force. Attached clients can steer the session's subagents; browser-controller results still require the connection that registered that controller. This does not enable independent gateway processes to write the same session, nor does it imply durable prompt admission across an owner restart.
 
+### Durable human prompt admission
+
+In-process `prompt.submit` accepts an optional `submission_id`: a nonempty string
+of at most 200 characters, chosen once per human submission and retained on retry.
+The profile-scoped SQLite inbox commits before acknowledging input. Results include:
+
+```json
+{"admission_id":"client-generated-id","status":"queued","outcome":null,
+ "target_session_id":"stored-session-id","target_profile_home":"/profile/home"}
+```
+
+`status` is `queued`, `started`, or `terminal`; retries of work started by a previous
+owner report `unknown`. Identical retries return the original receipt, not a second
+admission. Reusing an ID for another payload, intent, or session returns error
+`4093`. The original stored target and compression lineage are immutable; its
+canonical compression successor can recover the queue, but a branch cannot.
+IDs are isolated by profile: an acceptance in another profile is not an acceptance
+here. Attached image paths are captured at first acceptance; retries neither
+require repasting them nor consume a later paste.
+
+`queued: true` forces the existing safe-boundary queue. Otherwise the configured
+busy-input mode still applies: accepted steer/redirect uses the live agent's
+correction mechanism, never a synthetic user turn inserted mid-loop. A concrete
+correction refusal falls back to the queue; an exception with uncertain correction
+consumption is terminal with `outcome: "correction_unknown"`, not automatically
+retried. Runtime-only automation callbacks and transports remain in memory and
+are never JSON-serialized into the human inbox.
+
+- `prompt.pending({session_id})` returns `pending_submissions`, with the receipt
+  fields above plus `user` (the submitted text/content).
+- `prompt.cancel({session_id, admission_id})` returns the receipt. Only `queued`
+  work becomes `terminal` / `cancelled`; already-started/unknown work is not
+  restarted or cancelled by this operation. Use the explicit session interrupt
+  operation for an active execution.
+- Resume reconstructs only never-started submissions, in FIFO order, through the
+  existing owner queue. Started work left by process death remains inspectable as
+  `unknown`, even if a crash marker exists. This is **exactly-once admission**, not
+  a promise of exactly-once arbitrary tool effects.
+
+Terminal `session.info` authority includes integer `execution_generation`,
+`execution_state` (`complete`, `error`, or `interrupted`), and `running: false`.
+Generations for durable sessions advance across owner restarts. Stale finalizers
+cannot release a newer generation, and ordinary cleanup failures do not prevent
+terminal settlement. No elapsed-time heuristic clears an active execution.
+
+Omitting `submission_id` preserves the legacy behavior. Durable IDs currently
+require ordinary human, in-process turns: hosted internal callbacks, isolated
+compute workers, and rewind/truncation requests are refused with `4094` rather
+than falsely claiming durable admission. Storage failures return `5071` (or the
+existing session-storage errors); malformed IDs return `4004`.
+
 ### Rewinding history on `prompt.submit`
 
 A rewind / edit / regenerate is a `prompt.submit` that drops part of the stored transcript before running the new turn. Because that write is a destructive rewrite of the session's durable rows, the gateway honors it only when the client states its intent:

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -61,6 +61,15 @@ Within one authenticated gateway, resuming or activating a live session attaches
 
 ### Durable human prompt admission
 
+Native Desktop saves the prepared ID, exact text, attachment references, and
+captured destination in an origin-scoped private file under Electron userData,
+using the same atomic replacement mechanism as native connection settings.
+It waits for the main-process write acknowledgement before sending. An immediate
+Desktop process termination therefore retains the retry identity; this is not a
+power-loss or attachment-file backup guarantee. Browser-only clients retain a
+localStorage journal for reload recovery, without the native process-crash
+guarantee. Neither client automatically sends uncertain submissions on startup.
+
 In-process `prompt.submit` accepts an optional `submission_id`: a nonempty string
 of at most 200 characters, chosen once per human submission and retained on retry.
 The profile-scoped SQLite inbox commits before acknowledging input. Results include:

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -953,3 +953,12 @@ hermes sessions prune --older-than 30 --yes
 :::tip
 The database grows slowly (typical: 10-15 MB for hundreds of sessions) and session history powers `session_search` recall across past conversations, so auto-prune ships disabled. Enable it if you're running a heavy gateway/cron workload where `state.db` is meaningfully affecting performance (observed failure mode: 384 MB state.db with ~1000 sessions slowing down FTS5 inserts and `/resume` listing). Use `hermes sessions prune` for one-off cleanup without turning on the automatic sweep.
 :::
+
+
+### Attach to a local Desktop or serve owner
+
+On POSIX systems, `hermes --resume SESSION_ID` (or `--cli`) can attach a lightweight classic prompt_toolkit/Rich viewer to a live local Desktop/serve session. `hermes --tui --resume SESSION_ID` uses the existing Ink WebSocket transport. Both retain the owner’s provider and writer lease; the viewer does not need a separately configured provider.
+
+The classic attached viewer supports ordinary messages, `/steer TEXT`, `/queue TEXT`, `/interrupt`, `/replay`, `/approve REQUEST_ID`, `/deny REQUEST_ID`, and `/clarify REQUEST_ID ANSWER`. `/help` lists its limited command set; this is not a second full standalone CLI runtime. `/exit` only detaches this viewer. Interrupting deliberately affects the shared turn.
+
+Discovery stays within the selected profile and existing loopback listener. A private `runtime/session-attach` credential authorizes the handshake; public lease metadata contains no token. Missing credentials, unsupported owners, incorrect profile or changed leases fail closed. Windows private-file ACL discovery is not yet supported. Do not copy or publish discovery credentials or authenticated WebSocket URLs.


### PR DESCRIPTION
Desktop, classic CLI, and Ink can share one live session owner, with recoverable identified input and authoritative execution state.

## Changes
- Authenticated profile/lease-fenced local attachment reuses the existing owner rather than starting a competing writer.
- Identified submissions are durably admitted with conflict detection, pending recovery, and generation-safe completion. Ambiguous started admissions remain unknown and are not automatically dispatched again.
- Desktop prepares retry identity/content through acknowledged native journal writes before network submission. Browser-only fallback guarantees reload recovery, not native crash durability.
- Explicit input modes, destination capture, session-scoped queues, and recovered pending rows preserve user intent across navigation, retries, and restart.

## Live validation
Inference used an explicit loopback stub; no real-provider billing or cache-hit-rate claims. Tests used real native Electron windows, classic CLI/Ink PTYs, production transports, SQLite, and owned subprocesses.

| Surface | Verified behavior |
| --- | --- |
| Four simultaneous clients | Two native Desktop windows, classic CLI and Ink send busy/idle inputs into the same session exactly once |
| Approval | All clients observe the request; racing responses resolve once and stale responses are rejected |
| Owner crash | Actual SIGKILL/restart recovers acknowledged pending FIFO; started admission remains unknown, not redispatched |
| Prepared/retry crash | Native hardkill before send and after lost real ACK retains exact ID, Unicode text and nonempty attachment payload; retry deduplicates |
| Queue projection | Second native window displays exact queued text in expanded queue-row DOM; queued and unknown rows survive restart without becoming auto-sendable |
| Ownership | Correct profile succeeds; same-ID wrong-profile attach rejects without changing isolated storage |
| Controls | Stop then fresh input, error/abort, reconnect, queue navigation, and prior-message/system/tools wire stability |
| Automation regression | Production cron delivery/dedup/busy queue, local DM runner, real delegated child and once-only completion notice |

The final projection fix passed two red/green invariants and native two-window hardkill/retry/profile probes. Earlier full campaigns ran at their recorded implementation heads; the final rebase applied cleanly. Current-head CI is rerunning.

## Limits
- Private automatic owner discovery is POSIX-only; unsupported Windows discovery fails closed.
- Identified admission rejects isolated-compute, hosted-callback and rewind modes before acceptance (4094); clients retain explicit legacy fallback for that rejection only, never for ambiguous delivery failure.
- Unknown started work can leave unfinished user text in conversation context. Not redispatching an admission does not guarantee exactly-once external tool side effects.
- Automation probes cover delivery paths, not scheduler timing or remote DM peer authorization. No live-provider cache/billing benchmark claimed.

Root cause: client-local ownership and queues could diverge from the live execution owner, losing terminal events, accepted input, or its visible state.

Merge remains subject to Teknium approval for this follow-up; approval of merged #105571 does not apply here.
