### PR TITLE
feat(reasoning): model_overrides opt-in for reasoning on custom-endpoint aliases

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1330,7 +1330,7 @@ def _build_chat_completions_kwargs(agent, api_messages, tools_for_api, reasoning
         request_overrides=request_overrides, session_id=getattr(agent, "session_id", None),
         cache_scope_id=cache_scope_id, ollama_num_ctx=agent._ollama_num_ctx,
         provider_preferences=_prefs or None, openrouter_min_coding_score=agent.openrouter_min_coding_score,
-        supports_reasoning=agent._supports_reasoning_extra_body(),
+        supports_reasoning=agent._supports_reasoning_extra_body(), provider=agent.provider,
         qwen_session_metadata=_qwen_meta)
     if _profile:
         # Profiles handle per-provider quirks via hooks fed the context above.

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -512,7 +512,7 @@ def lookup_models_dev_context(provider: str, model: str, *, allow_network: bool 
 
 # Per-model overrides (config.yaml → model_overrides). Canonical schema (the ONLY key space consumers
 # accept): context_window, supports_tools, supports_vision, supports_reasoning,
-# model_family. ``<provider>.<model_id>`` is an explicit partial patch that always wins over the
+# model_family, canonical_model. ``<provider>.<model_id>`` is an explicit partial patch that always wins over the
 # catalog. ``<provider>._default`` / top-level ``_default`` are FILL-GAP defaults: they apply ONLY to
 # models the catalog does not know and never displace catalog data. Provider keys accept the Hermes
 # or models.dev id; model ids match exactly, then case-insensitively (mirroring catalog lookup).

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -82,11 +82,28 @@ OLLAMA_CLOUD_OVERRIDES: dict[str, str] = {"xhigh": "max"}
 META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 
-def is_astra_model(model: Optional[str]) -> bool:
+def canonical_model_id(model: Optional[str], provider: Optional[str] = None) -> str:
+    """Resolve a router alias to its declared upstream id via ``model_overrides.<provider>.<alias>.canonical_model``.
+    Falls back to *model* unchanged; never raises (config errors fail closed to the raw id)."""
+    raw = (model or "").strip()
+    if provider and raw:
+        try:
+            from agent.models_dev import _explicit_model_override
+            entry = _explicit_model_override(provider, raw) or {}
+            canonical = str(entry.get("canonical_model") or "").strip()
+            if canonical:
+                return canonical
+        except Exception:
+            pass
+    return raw
+
+
+def is_astra_model(model: Optional[str], provider: Optional[str] = None) -> bool:
     """``gpt-6-astra`` or its Hermes-side ``-900k`` picker alias, with or without a ``vendor/`` prefix.
     The single home for the slug set: picker gating, effort vocabulary and the request sanitizer all
-    key off it, so a new Astra alias is one edit."""
-    return (model or "").strip().lower().rsplit("/", 1)[-1] in ASTRA_MODEL_IDS
+    key off it, so a new Astra alias is one edit. With *provider*, a config ``canonical_model`` alias
+    (e.g. a router alias declared as gpt-6-astra) is honoured too."""
+    return canonical_model_id(model, provider).lower().rsplit("/", 1)[-1] in ASTRA_MODEL_IDS
 
 
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:

--- a/agent/reasoning_params.py
+++ b/agent/reasoning_params.py
@@ -51,6 +51,14 @@ class ReasoningParamsMixin:
         """True when reasoning extra_body is safe to send: OpenRouter forwards unknown extra_body upstream and
         some routes 400 on ``reasoning``, so gate to known reasoning-capable families and direct Nous Portal."""
         url = self._base_url_lower
+        # Config opt-in for custom routers: model_overrides.<provider>.<alias>.supports_reasoning: true.
+        # Absent → unchanged behaviour (no reasoning fields sent to arbitrary custom endpoints).
+        try:
+            from agent.models_dev import _explicit_model_override
+            if (_explicit_model_override(self.provider, self.model) or {}).get("supports_reasoning") is True:
+                return True
+        except Exception:
+            pass
         if base_url_host_matches(url, "nousresearch.com") or base_url_host_matches(url, "ai-gateway.vercel.sh"):
             return True
         if base_url_host_matches(url, "models.github.ai") or base_url_host_matches(url, "githubcopilot.com"):

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -109,7 +109,7 @@ def _add_prompt_cache_key(
         api_kwargs["prompt_cache_key"] = cache_key
 
 
-def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> dict | None:
+def _reasoning_config_for_model(model: str, reasoning_config: dict | None, provider: str | None = None) -> dict | None:
     """Clamp Hermes' extended effort set (``ultra``) to the OpenAI-compat wire vocabulary.
 
     Hermes' internal effort set extends the wire vocabulary with ``ultra`` (the /reasoning command documents
@@ -121,8 +121,14 @@ def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> di
     if not isinstance(reasoning_config, dict):
         return reasoning_config
     effort = str(reasoning_config.get("effort") or "").strip().lower()
-    clamped = clamp_effort(effort, OPENAI_COMPAT_WIRE_EFFORTS) if effort else effort
-    return {**reasoning_config, "effort": clamped} if clamped != effort else reasoning_config
+    from agent.reasoning_effort import CODEX_ASTRA_EFFORTS, is_astra_model
+    astra = is_astra_model(model, provider)
+    supported = CODEX_ASTRA_EFFORTS if astra else OPENAI_COMPAT_WIRE_EFFORTS
+    clamped = clamp_effort(effort, supported) if effort else effort
+    result = {**reasoning_config, "effort": clamped} if clamped != effort else reasoning_config
+    if astra and result.get("enabled") is False:
+        return {**result, "enabled": True, "effort": "low"}
+    return result
 
 
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
@@ -377,7 +383,7 @@ class ChatCompletionsTransport(ProviderTransport):
         is_kimi = params.get("is_kimi", False)
         is_lmstudio = params.get("is_lmstudio", False)
         supports_reasoning = params.get("supports_reasoning", False)
-        reasoning_config = _reasoning_config_for_model(model, params.get("reasoning_config"))
+        reasoning_config = _reasoning_config_for_model(model, params.get("reasoning_config"), params.get("provider"))
         _apply_max_tokens(api_kwargs, model, reasoning_config, params)
 
         # Kimi / TokenHub / LM Studio: top-level reasoning_effort (unless thinking disabled).

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1835,13 +1835,18 @@ DEFAULT_CONFIG = {
         "providers": {},
     },
     # Per-model metadata overrides. Fields: context_window, supports_tools,
-    # supports_vision, supports_reasoning, model_family. <provider>.<model_id> wins over
+    # supports_vision, supports_reasoning, model_family, canonical_model. <provider>.<model_id> wins over
     # models.dev/OpenRouter/hardcoded defaults for the fields it sets (chain order in
     # agent/model_metadata.py). <provider>._default and top-level _default fill gaps ONLY for models
     # the catalog does not know, so they never clamp known models. Unknown ids start from safe
     # defaults (200K context, tools on, vision/reasoning off) and get patched. Provider keys: Hermes
     # or models.dev id; model ids match case-insensitively. Example: {"custom:my-local-vllm":
     # {"my-llava-model": {"context_window": 8192}}}
+    # Custom-endpoint aliases (routers/proxies): `supports_reasoning: true` opts the alias into
+    # reasoning extra_body (otherwise custom hosts never send it); `canonical_model` names the
+    # upstream model the alias resolves to, so model-specific rules (e.g. Codex Astra effort clamping)
+    # apply. Example: {"my-router": {"astra-alias": {"canonical_model": "gpt-6-astra",
+    # "supports_reasoning": true}}}
     # Semantics: 1. NOTE: an explicit model.context_length (global) and a custom_providers per-model
     # context_length are user settings at other layers and are consulted in the resolution chain order
     # documented in agent/model_metadata.py. 2. See #84482, #8731.

--- a/tests/agent/test_model_overrides_reasoning_optin.py
+++ b/tests/agent/test_model_overrides_reasoning_optin.py
@@ -1,0 +1,62 @@
+"""Regression coverage: ``model_overrides.<provider>.<alias>`` can declare ``canonical_model`` and
+``supports_reasoning`` so a custom-endpoint alias gets reasoning extra_body and model-specific effort clamping.
+Aliases without an override keep the current fail-closed behaviour."""
+from types import SimpleNamespace
+
+import pytest
+
+from agent import models_dev
+from agent.reasoning_effort import is_astra_model, canonical_model_id
+from agent.reasoning_params import ReasoningParamsMixin
+from agent.transports.chat_completions import ChatCompletionsTransport
+
+BASE = "https://router.example.com/v1"
+
+
+@pytest.fixture
+def overrides(monkeypatch):
+    def _set(section):
+        monkeypatch.setattr(models_dev, "_load_model_overrides", lambda: {"my-router": section})
+    return _set
+
+
+def _agent(model):
+    return SimpleNamespace(model=model, provider="my-router", _base_url_lower=BASE, _is_openrouter_url=lambda: False)
+
+
+def test_canonical_model_override_resolves_alias(overrides):
+    overrides({"astra-alias": {"canonical_model": "gpt-6-astra"}})
+    assert canonical_model_id("astra-alias", "my-router") == "gpt-6-astra"
+    assert is_astra_model("astra-alias", provider="my-router")
+    assert not is_astra_model("astra-alias")  # no provider → no override lookup
+
+
+def test_unregistered_alias_stays_silent(overrides):
+    overrides({})
+    assert not is_astra_model("astra-alias", provider="my-router")
+    assert not ReasoningParamsMixin._supports_reasoning_extra_body(_agent("sol-alias"))
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="sol-alias", messages=[{"role": "user", "content": "hi"}],
+        reasoning_config={"enabled": True, "effort": "xhigh"}, supports_reasoning=False,
+    )
+    assert "reasoning" not in kwargs.get("extra_body", {})
+
+
+def test_supports_reasoning_override_enables_extra_body_for_sol_alias(overrides):
+    overrides({"sol-alias": {"canonical_model": "gpt-5.6-sol", "supports_reasoning": True}})
+    assert ReasoningParamsMixin._supports_reasoning_extra_body(_agent("sol-alias"))
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="sol-alias", messages=[{"role": "user", "content": "hi"}],
+        reasoning_config={"enabled": True, "effort": "ultra"}, supports_reasoning=True, provider="my-router",
+    )
+    assert kwargs["extra_body"]["reasoning"] == {"enabled": True, "effort": "max"}
+
+
+def test_astra_alias_clamps_disabled_effort_to_low_on_chat_wire(overrides):
+    overrides({"astra-alias": {"canonical_model": "gpt-6-astra", "supports_reasoning": True}})
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model="astra-alias", messages=[{"role": "user", "content": "hi"}],
+        reasoning_config={"enabled": False, "effort": "none"}, supports_reasoning=True, provider="my-router",
+    )
+    assert kwargs["extra_body"]["reasoning"] == {"enabled": True, "effort": "low"}
+    assert "prompt_cache_options" not in kwargs


### PR DESCRIPTION
## Summary

Custom OpenAI-compatible endpoints (self-hosted routers/proxies) never receive reasoning `extra_body`: `_supports_reasoning_extra_body()` is host-allowlisted, so an alias such as `astra-alias` on a private router silently drops the configured `reasoning_effort`. Model-specific rules keyed on the model id (Codex Astra effort vocabulary, `enabled: false → low`) also fail to match the alias.

This PR adds two **config-driven, per-alias** keys under the existing `model_overrides` section — fail-closed by default:

```yaml
model_overrides:
  my-router:
    astra-alias:
      canonical_model: gpt-6-astra   # upstream model the alias resolves to
      supports_reasoning: true       # opt this alias into reasoning extra_body
```

- `supports_reasoning: true` → the alias is opted into reasoning `extra_body` on the chat-completions wire.
- `canonical_model` → `is_astra_model(model, provider)` and the chat-completions effort clamp resolve the alias to its upstream model, so Astra-specific clamping (`CODEX_ASTRA_EFFORTS`, `enabled:false → low`) applies.

Aliases **without** an override keep today's behaviour (no reasoning fields sent to arbitrary custom hosts). Registered providers are unaffected.

## Changes
- `agent/reasoning_effort.py` — `canonical_model_id(model, provider)`; `is_astra_model(model, provider=None)` (backwards compatible).
- `agent/reasoning_params.py` — honour `model_overrides.<provider>.<alias>.supports_reasoning`.
- `agent/transports/chat_completions.py` — clamp against the canonical model (accepts optional `provider`).
- `agent/chat_completion_helpers.py` — pass `provider` into the transport (1 line).
- `agent/models_dev.py`, `hermes_cli/config_defaults.py` — document `canonical_model` in the override schema.
- `tests/agent/test_model_overrides_reasoning_optin.py` — 4 regression tests (opt-in on, opt-in absent/fail-closed, Sol-style alias `ultra → max`, Astra-style alias `none → low` + no `prompt_cache_options`).

## Test plan
- [x] `pytest tests/agent/test_model_overrides_reasoning_optin.py tests/agent/test_astra_baseline_runtime.py tests/agent/transports/ tests/hermes_cli/test_config*.py` → 739 passed, 4 skipped
- [x] Live: with the override present, a real agent turn against a self-hosted router now carries `extra_body.reasoning = {"enabled": true, "effort": "xhigh"}` (captured at the httpx layer); without the override the request is unchanged.
- [x] Live A/B on the router: reported `reasoning_tokens` scale with effort (low ≈ 350 → xhigh ≈ 470 for gpt-6-astra; 516 → 860 for gpt-5.6-sol).
