### PR TITLE
fix: continue interrupted tasks after gateway recovery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -967,27 +967,30 @@ def build_resume_recovery_note(
     reason: Optional[str], message: str = "", *, interactive: bool = True) -> str:
     """Build the resume-pending recovery system note for an interrupted turn (empty ``message`` = auto-resume).
 
-    Interactive platforms report the restore and ask what next; non-interactive ones finish the work.
-
-    On non-interactive event platforms (webhook, API server — adapters with ``interactive_resume = False``)
-    nobody can answer; the resumed turn must instead complete the interrupted work, or the task is silently
-    abandoned behind a "restored" acknowledgement that goes nowhere (#57056).
+    An empty message is a synthesized auto-resume turn, so every platform continues
+    the interrupted work. ``interactive`` only controls whether a brief recovery
+    acknowledgement is appropriate; it never changes continuation semantics.
     """
     reason_phrase = (
         "a gateway restart" if reason == "restart_timeout"
         else "a gateway shutdown" if reason == "shutdown_timeout" else "a gateway interruption")
     if message:
         resume_guidance = (
-            "Address the user's NEW message below FIRST and focus on what the user is asking now.")
+            "Address the user's NEW message below FIRST. If it is compatible with, asks about, "
+            "or asks to resume the interrupted task, continue that task from where it stopped. "
+            "If it supersedes or cancels the old task, follow the new message instead.")
         tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any unfinished work from the conversation history."
+            "Do NOT re-run tool calls whose results already appear in the history — resume from "
+            "the first incomplete step when continuation is appropriate."
         )
     elif interactive:
         resume_guidance = (
-            "Report to the user that the session was restored "
-            "successfully and ask what they would like to do next.")
+            "Briefly mention that the session was restored if useful, then review the conversation "
+            "history and CONTINUE the interrupted task to completion. Ask the user only when a "
+            "genuine missing decision prevents progress.")
         tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any unfinished work from the conversation history."
+            "Do NOT re-run tool calls whose results already appear in the history — resume from "
+            "the first step that has no recorded result."
         )
     else:
         resume_guidance = (

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -315,6 +315,15 @@ class TestResumePendingSystemNote:
         # But still guards against re-running already-recorded tool calls.
         assert "already appear in the history" in note
 
+    def test_empty_message_interactive_note_continues_task(self):
+        """Interactive recovery should resume work rather than abandon it behind
+        a restore acknowledgement and a needless 'what next?' round trip."""
+        note = build_resume_recovery_note("restart_timeout", "", interactive=True)
+        assert "CONTINUE the interrupted task" in note
+        assert "ask what they would like to do next" not in note
+        assert "skip any unfinished work" not in note
+        assert "first step that has no recorded result" in note
+
 
     def test_resume_note_is_persisted_instead_of_original_empty_message(self):
         """The auto-resume note must not leave an empty row in state.db."""
@@ -350,6 +359,8 @@ class TestResumePendingSystemNote:
         assert message != persisted
         assert "what were we doing?" in message
         assert "[System note:" in message
+        assert "continue that task from where it stopped" in message
+        assert "skip any unfinished work" not in message
 
 
     def test_resume_pending_fires_without_tool_tail(self):


### PR DESCRIPTION
## Problem

Interactive gateway recovery currently instructs the model to ask what the user wants next and to skip unfinished work. That abandons the task that the restart interrupted and forces an unnecessary round trip. A real Telegram recovery reproduced this behavior.

## Change

- auto-resume interrupted work on interactive platforms, just as event platforms already do
- when a real user message arrives, continue compatible interrupted work while allowing the new message to supersede or cancel it
- never rerun tool calls whose results are already recorded

## Test

- `scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py`
- 40 passed