### PR TITLE
feat(tools): sync the desktop toolset selection to all platforms

### DIFF
--- a/apps/desktop/src/api/toolsets.ts
+++ b/apps/desktop/src/api/toolsets.ts
@@ -4,7 +4,8 @@ import type {
   TerminalBackendsResponse,
   ToolsetConfig,
   ToolsetInfo,
-  ToolsetModelsResponse
+  ToolsetModelsResponse,
+  ToolsetSyncResponse
 } from '@/types/hermes'
 
 import { capabilityScoped, hermesApi, type ProfileScope, profileScoped } from './client'
@@ -31,6 +32,19 @@ export function setToolsetEnabled(
     path: `/api/tools/toolsets/${encodeURIComponent(name)}`,
     method: 'PUT',
     body: { enabled }
+  })
+}
+
+// Applies the desktop/CLI toolset selection to every other enabled platform —
+// the non-interactive sibling of the CLI's "Configure all platforms (global)"
+// menu entry. Toolsets still missing provider setup come back in
+// `needs_setup` for the caller to surface.
+export function syncToolsetsToPlatforms(profile?: ProfileScope): Promise<ToolsetSyncResponse> {
+  return window.hermesDesktop.api<ToolsetSyncResponse>({
+    ...capabilityScoped(profile),
+    path: '/api/tools/toolsets/sync-platforms',
+    method: 'POST',
+    body: {}
   })
 }
 

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -13,6 +13,7 @@ const getSkills = vi.fn()
 const getToolsets = vi.fn()
 const setSkillEnabled = vi.fn()
 const setToolsetEnabled = vi.fn()
+const syncToolsetsToPlatforms = vi.fn()
 const getToolsetConfig = vi.fn()
 const selectToolsetProvider = vi.fn()
 const getUsageAnalytics = vi.fn()
@@ -31,6 +32,7 @@ vi.mock('@/hermes', async importOriginal => ({
   setSkillEnabled: (name: string, enabled: boolean, profile?: null | string) => setSkillEnabled(name, enabled, profile),
   setToolsetEnabled: (name: string, enabled: boolean, profile?: null | string) =>
     setToolsetEnabled(name, enabled, profile),
+  syncToolsetsToPlatforms: (profile?: null | string) => syncToolsetsToPlatforms(profile),
   getToolsetConfig: (name: string, profile?: null | string) => getToolsetConfig(name, profile),
   selectToolsetProvider: (toolset: string, provider: string) => selectToolsetProvider(toolset, provider),
   getUsageAnalytics: (days: number, profile?: null | string) => getUsageAnalytics(days, profile),
@@ -96,6 +98,13 @@ beforeEach(() => {
   getSkills.mockResolvedValue([])
   getToolsets.mockResolvedValue([toolset()])
   setToolsetEnabled.mockResolvedValue({ ok: true, name: 'web', enabled: false })
+  syncToolsetsToPlatforms.mockResolvedValue({
+    ok: true,
+    source_platform: 'cli',
+    platforms: ['telegram'],
+    synced: [{ platform: 'telegram', changed: true, enabled: ['web'], added: ['web'], removed: [] }],
+    needs_setup: []
+  })
   getToolsetConfig.mockResolvedValue({ has_category: true, active_provider: null, providers: [] })
   getUsageAnalytics.mockResolvedValue({ tools: [] })
   getOfficialSkills.mockResolvedValue({ skills: [] })
@@ -196,6 +205,24 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
 
     // Toolsets refetch scoped to the picked profile.
     await waitFor(() => expect(getToolsets).toHaveBeenCalledWith('researcher'))
+  })
+
+  it('syncs the CLI toolset selection to all platforms from the kebab menu', async () => {
+    await renderSkills()
+
+    // The kebab opens with pointerDown (Radix), not click.
+    const menuButton = await screen.findByRole('button', { name: 'Tools' })
+    await act(async () => {
+      fireEvent.pointerDown(menuButton, { button: 0 })
+    })
+    const item = await screen.findByRole('menuitem', { name: 'Sync to all platforms' })
+    await act(async () => {
+      fireEvent.click(item)
+    })
+
+    await waitFor(() => expect(syncToolsetsToPlatforms).toHaveBeenCalled())
+    // A changed platform invalidates the toolsets query so rows reflect the sync.
+    await waitFor(() => expect(getToolsets).toHaveBeenCalledTimes(2))
   })
 
   it('scopes the Skills tab (and skill toggles) to the profile chosen in the selector', async () => {

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -25,7 +25,8 @@ import {
   type ProfileScope,
   profileScopeKey,
   setSkillEnabled,
-  setToolsetEnabled
+  setToolsetEnabled,
+  syncToolsetsToPlatforms
 } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { isDesktopToolsetVisible } from '@/lib/desktop-toolsets'
@@ -363,6 +364,7 @@ export function SkillsView({
   const skillsSortDesc = useStore($skillsSortDesc)
   const toolsetsSortDesc = useStore($toolsetsSortDesc)
   const [bulkBusy, setBulkBusy] = useState(false)
+  const [syncBusy, setSyncBusy] = useState(false)
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null)
   // Catalog selection is separate from installed-skill selection: identifiers
   // (official/<category>/<name>) vs names. Non-null wins the detail pane.
@@ -640,6 +642,42 @@ export function SkillsView({
 
   const allSkillsEnabled = bulkSkills.length > 0 && bulkSkills.every(s => s.enabled)
   const allToolsetsEnabled = bulkToolsets.length > 0 && bulkToolsets.every(ts => ts.enabled)
+
+  // Applies the desktop/CLI selection to every other enabled platform in one
+  // call — the sync the CLI's "Configure all platforms (global)" menu entry
+  // performs interactively. Toolsets left without provider setup are named in
+  // the completion toast instead of being prompted for (no TTY here).
+  async function syncToolsets() {
+    if (syncBusy) {
+      return
+    }
+
+    setSyncBusy(true)
+
+    try {
+      const res = await syncToolsetsToPlatforms(scopeProfile)
+      const changed = res.synced.filter(entry => entry.changed)
+
+      if (changed.length === 0) {
+        notify({ kind: 'info', title: t.skills.syncAllNoChange, message: '' })
+      } else if (res.needs_setup.length > 0) {
+        notify({
+          kind: 'info',
+          title: t.skills.syncAllUpdated(changed.length),
+          message: t.skills.syncAllNeedsSetup(res.needs_setup.join(', '))
+        })
+      } else {
+        notify({ kind: 'success', title: t.skills.syncAllUpdated(changed.length), message: '' })
+      }
+
+      refreshToolsets()
+    } catch (err) {
+      notifyError(err, t.skills.failedToUpdate(t.skills.tabToolsets))
+    } finally {
+      invalidateSlashCompletions()
+      setSyncBusy(false)
+    }
+  }
 
   const sortButton = (desc: boolean, flip: () => void) => (
     <ListStripButton onClick={flip}>{desc ? t.skills.sortMostUsedDesc : t.skills.sortLeastUsedAsc}</ListStripButton>
@@ -996,7 +1034,13 @@ export function SkillsView({
                   header={
                     <ListStrip
                       left={sortButton(toolsetsSortDesc, () => $toolsetsSortDesc.set(!$toolsetsSortDesc.get()))}
-                      right={<ListStripMenu label={t.skills.tabToolsets} toggle={bulkSwitch(allToolsetsEnabled)} />}
+                      right={
+                        <ListStripMenu
+                          items={[{ disabled: syncBusy || bulkBusy, label: t.skills.syncAll, onSelect: () => void syncToolsets() }]}
+                          label={t.skills.tabToolsets}
+                          toggle={bulkSwitch(allToolsetsEnabled)}
+                        />
+                      }
                     />
                   }
                 >

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1066,7 +1066,11 @@ export const ar = defineLocale({
     toolsetEnabled: 'تم تفعيل مجموعة الأدوات',
     toolsetDisabled: 'تم تعطيل مجموعة الأدوات',
     appliesToNewSessions: name => `ينطبق على الجلسات الجديدة في ${name}`,
-    failedToUpdate: name => `فشل تحديث ${name}`
+    failedToUpdate: name => `فشل تحديث ${name}`,
+    syncAll: 'مزامنة إلى جميع المنصات',
+    syncAllUpdated: platforms => `تمت المزامنة مع ${platforms} ${platforms === 1 ? 'منصة' : 'منصات'}.`,
+    syncAllNoChange: 'المنصات الأخرى تطابق هذا الاختيار بالفعل.',
+    syncAllNeedsSetup: toolsets => `لا تزال بحاجة إلى إعداد: ${toolsets}.`
   },
   agents: {
     close: 'إغلاق الوكلاء',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1481,6 +1481,10 @@ export const en: Translations = {
     disableUnused: 'Disable unused',
     bulkUpdated: count => `Updated ${count} ${count === 1 ? 'item' : 'items'} for new sessions.`,
     bulkNoChange: 'Nothing to change.',
+    syncAll: 'Sync to all platforms',
+    syncAllUpdated: platforms => `Synced to ${platforms} ${platforms === 1 ? 'platform' : 'platforms'}.`,
+    syncAllNoChange: 'Other platforms already match this selection.',
+    syncAllNeedsSetup: toolsets => `Still needing setup: ${toolsets}.`,
     usageCount: count => `used ${count}×`,
     provenance: {
       agent: 'Learned',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1360,6 +1360,10 @@ export const ja = defineLocale({
     disableUnused: '未使用を無効化',
     bulkUpdated: count => `${count} 件を新しいセッション向けに更新しました。`,
     bulkNoChange: '変更するものはありません。',
+    syncAll: 'すべてのプラットフォームに同期',
+    syncAllUpdated: platforms => `${platforms} 個のプラットフォームに同期しました。`,
+    syncAllNoChange: '他のプラットフォームはすでにこの選択と一致しています。',
+    syncAllNeedsSetup: toolsets => `まだ設定が必要です: ${toolsets}。`,
     usageCount: count => `${count} 回使用`,
     provenance: {
       agent: '学習済み',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -1560,6 +1560,10 @@ export const ru = defineLocale({
     disableUnused: 'Отключить неиспользуемые',
     bulkUpdated: count => `Обновлено ${count} ${RU_NOUN(count, 'элемент', 'элемента', 'элементов')} для новых сеансов.`,
     bulkNoChange: 'Менять нечего.',
+    syncAll: 'Синхронизировать на все платформы',
+    syncAllUpdated: platforms => `Синхронизировано с ${platforms === 1 ? 'платформой' : 'платформами'} (${platforms}).`,
+    syncAllNoChange: 'Другие платформы уже соответствуют этому выбору.',
+    syncAllNeedsSetup: toolsets => `Всё ещё требуют настройки: ${toolsets}.`,
     usageCount: count => `использован ${count}×`,
     provenance: {
       agent: 'Научен',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1302,6 +1302,10 @@ export interface Translations {
     disableUnused: string
     bulkUpdated: (count: number) => string
     bulkNoChange: string
+    syncAll: string
+    syncAllUpdated: (platforms: number) => string
+    syncAllNoChange: string
+    syncAllNeedsSetup: (toolsets: string) => string
     usageCount: (count: number | string) => string
     provenance: Record<'agent' | 'bundled' | 'hub', string>
     emptyNoneFound: (noun: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1307,6 +1307,10 @@ export const zhHant = defineLocale({
     disableUnused: '停用未使用',
     bulkUpdated: count => `已為新工作階段更新 ${count} 項。`,
     bulkNoChange: '沒有需要變更的內容。',
+    syncAll: '同步到所有平台',
+    syncAllUpdated: platforms => `已同步到 ${platforms} 個平台。`,
+    syncAllNoChange: '其他平台已與此選擇一致。',
+    syncAllNeedsSetup: toolsets => `仍需設定：${toolsets}。`,
     usageCount: count => `已使用 ${count} 次`,
     provenance: {
       agent: '已學習',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1655,6 +1655,10 @@ export const zh: Translations = {
     disableUnused: '禁用未使用',
     bulkUpdated: count => `已为新会话更新 ${count} 项。`,
     bulkNoChange: '没有需要更改的内容。',
+    syncAll: '同步到所有平台',
+    syncAllUpdated: platforms => `已同步到 ${platforms} 个平台。`,
+    syncAllNoChange: '其他平台已与此选择一致。',
+    syncAllNeedsSetup: toolsets => `仍需配置：${toolsets}。`,
     usageCount: count => `已使用 ${count} 次`,
     provenance: {
       agent: '习得',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1076,6 +1076,25 @@ export interface ToolsetInfo {
   tools: string[]
 }
 
+/** Per-platform outcome of a sync: what the platform's list looked like after
+ *  the cli selection was applied (empty added/removed = already in sync). */
+export interface ToolsetSyncPlatform {
+  platform: string
+  changed: boolean
+  enabled: string[]
+  added: string[]
+  removed: string[]
+}
+
+/** Shape of `POST /api/tools/toolsets/sync-platforms`. */
+export interface ToolsetSyncResponse {
+  ok: boolean
+  source_platform: string
+  platforms: string[]
+  synced: ToolsetSyncPlatform[]
+  needs_setup: string[]
+}
+
 export interface ToolEnvVar {
   key: string
   prompt: string

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -459,6 +459,9 @@ class ToolsetToggle(BaseModel):
     enabled: bool
     profile: Optional[str] = None
 
+class ToolsetSync(BaseModel):
+    profile: Optional[str] = None
+
 class ToolsetProviderSelect(BaseModel):
     provider: str
     # Web-only scope 'search' | 'extract'; omitted → whole-provider (legacy web.backend path).

--- a/hermes_cli/web_routers/tools.py
+++ b/hermes_cli/web_routers/tools.py
@@ -18,7 +18,7 @@ from hermes_cli.web_server_profiles import _plugin_terminal_backend_rows
 from starlette.concurrency import run_in_threadpool
 from hermes_cli.web_models import (
     TerminalBackendSelect, ToolsetEnvUpdate, ToolsetModelSelect, ToolsetPostSetup,
-    ToolsetProviderSelect, ToolsetToggle)
+    ToolsetProviderSelect, ToolsetSync, ToolsetToggle)
 from hermes_cli.web_routers._common import (
     _CONFIG_MUTATION_LOCK, _profile_cli_args, _profile_scope, _spawn_hermes_action,
     config_write_scope, log as _log, scoped_to_thread, spawn_profile_action)
@@ -323,6 +323,100 @@ async def toggle_toolset(name: str, body: ToolsetToggle, profile: Optional[str] 
     return {
         "ok": True, "name": name, "platform": target_platform, "enabled": body.enabled,
         "post_setup_started": post_setup_started}
+
+
+@router.post("/api/tools/toolsets/sync-platforms")
+async def sync_toolsets_to_platforms(body: ToolsetSync, profile: Optional[str] = None):
+    """Apply the desktop/CLI toolset selection to every enabled platform.
+
+    The interactive counterpart is ``hermes tools`` → "Configure all platforms
+    (global)" (``_configure_platforms(..., all_platforms=True)``): one checklist
+    saved via ``_save_platform_tools`` over ``_get_enabled_platforms()``. There
+    is no TTY here, so the checklist is replaced by the already-persisted
+    ``cli`` selection and the key prompts by ``needs_setup`` in the response —
+    newly enabled toolsets still missing provider/API-key setup are reported
+    instead of interactively configured.
+
+    Per-platform saves re-read the platform's list first: reconciling
+    ``agent.disabled_toolsets`` for one platform can change what the next
+    platform resolves to (same reason ``_configure_platforms`` re-reads inside
+    its loop). A platform restricted away from every toolset in the source
+    selection (e.g. telegram and the discord-only toolsets) is reported as
+    unchanged instead of being emptied.
+    """
+    from hermes_cli.tools_config import (
+        _CONFIG_ONLY_TOOLSETS,
+        _get_enabled_platforms,
+        _get_platform_tools,
+        _save_platform_tools,
+        _toolset_allowed_for_platform,
+        _toolset_configuration_platform,
+        _toolsets_needing_setup,
+    )
+
+    scope_profile = body.profile or profile
+
+    def _run():
+        platforms: List[str] = []
+        synced: List[Dict[str, Any]] = []
+        needs_setup: List[str] = []
+        with config_write_scope(scope_profile):
+            config = load_config()
+            source_platform = "cli"
+            source = _get_platform_tools(
+                config, source_platform, include_default_mcp_servers=False
+            )
+            for platform in _get_enabled_platforms():
+                if platform == source_platform:
+                    continue
+                platforms.append(platform)
+                # Re-read per platform: the previous save's disabled-toolsets
+                # reconciliation changes what this platform resolves to.
+                prev = _get_platform_tools(
+                    config, platform, include_default_mcp_servers=False
+                )
+                target = {
+                    ts for ts in source if _toolset_allowed_for_platform(ts, platform)
+                }
+                if target == prev:
+                    synced.append({
+                        "platform": platform,
+                        "changed": False,
+                        "enabled": sorted(prev),
+                        "added": [],
+                        "removed": [],
+                    })
+                    continue
+                _save_platform_tools(config, platform, target)
+                config = load_config()
+                added = sorted(target - prev)
+                synced.append({
+                    "platform": platform,
+                    "changed": True,
+                    "enabled": sorted(target),
+                    "added": added,
+                    "removed": sorted(prev - target),
+                })
+            if any(entry["changed"] for entry in synced):
+                config = load_config()
+                needs_setup = _toolsets_needing_setup(
+                    {
+                        ts
+                        for ts in source
+                        if ts not in _CONFIG_ONLY_TOOLSETS
+                        and _toolset_configuration_platform(ts) == "cli"
+                    },
+                    config,
+                )
+        return {
+            "ok": True,
+            "source_platform": source_platform,
+            "platforms": platforms,
+            "synced": synced,
+            "needs_setup": needs_setup,
+        }
+
+    return await asyncio.to_thread(_run)
 
 
 @router.get("/api/tools/toolsets/{name}/config")

--- a/tests/hermes_cli/test_web_routers_tools_sync_platforms.py
+++ b/tests/hermes_cli/test_web_routers_tools_sync_platforms.py
@@ -1,0 +1,142 @@
+"""Sync-to-all-platforms endpoint (dashboard/desktop).
+
+``POST /api/tools/toolsets/sync-platforms`` applies the desktop/CLI toolset
+selection to every other enabled platform — the non-interactive sibling of the
+``hermes tools`` "Configure all platforms (global)" menu entry
+(``_configure_platforms(..., all_platforms=True)``). Platform restrictions
+(``discord``/``discord_admin`` are discord-only) filter the selection per
+platform, and toolsets still missing provider/API-key setup are reported as
+``needs_setup`` instead of interactively prompted.
+"""
+
+import pytest
+import hermes_cli.web_server_gateway as _web_server_gateway
+
+
+class TestSyncToolsetsToPlatforms:
+    @pytest.fixture(autouse=True)
+    def _setup(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(
+            hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db"
+        )
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        self.monkeypatch = monkeypatch
+
+    def _set_platforms(self, platforms):
+        import hermes_cli.tools_config as tools_config
+
+        monkeypatch_targets = [
+            (tools_config, "_get_enabled_platforms", lambda: platforms)]
+        self.monkeypatch.setattr(*monkeypatch_targets[0])
+
+    def test_sync_applies_cli_selection_to_other_platforms(self, monkeypatch):
+        import hermes_cli.tools_config as tools_config
+        from hermes_cli.config import load_config
+
+        # cli has web enabled; telegram starts from an explicitly empty list.
+        monkeypatch.setattr(tools_config, "_get_enabled_platforms", lambda: ["cli", "telegram"])
+        from hermes_cli.config import save_config
+        config = load_config()
+        config["platform_toolsets"] = {"cli": ["web"], "telegram": []}
+        save_config(config)
+
+        resp = self.client.post("/api/tools/toolsets/sync-platforms", json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["source_platform"] == "cli"
+        assert data["platforms"] == ["telegram"]
+        assert len(data["synced"]) == 1
+        entry = data["synced"][0]
+        assert entry["platform"] == "telegram"
+        assert entry["changed"] is True
+        assert "web" in entry["added"]
+
+        # The saved telegram list now matches the cli selection.
+        saved = load_config()["platform_toolsets"]["telegram"]
+        assert "web" in saved
+
+    def test_sync_reports_platform_restrictions(self, monkeypatch):
+        import hermes_cli.tools_config as tools_config
+        from hermes_cli.config import load_config, save_config
+
+        # discord-only toolsets must not leak into the telegram list.
+        monkeypatch.setattr(tools_config, "_get_enabled_platforms", lambda: ["cli", "telegram"])
+        config = load_config()
+        config["platform_toolsets"] = {"cli": ["web", "discord"], "telegram": []}
+        save_config(config)
+
+        resp = self.client.post("/api/tools/toolsets/sync-platforms", json={})
+        assert resp.status_code == 200
+        entry = resp.json()["synced"][0]
+        assert entry["changed"] is True
+        assert "web" in entry["added"]
+        assert "discord" not in entry["enabled"]
+
+    def test_sync_reports_needs_setup_for_unconfigured_toolsets(self, monkeypatch):
+        import hermes_cli.tools_config as tools_config
+        from hermes_cli.config import load_config, save_config
+
+        monkeypatch.setattr(tools_config, "_get_enabled_platforms", lambda: ["cli", "telegram"])
+        config = load_config()
+        config["platform_toolsets"] = {"cli": ["web"], "telegram": []}
+        save_config(config)
+
+        # No provider configured for web → it lands in needs_setup after a sync.
+        monkeypatch.setattr(
+            tools_config, "_toolset_needs_configuration_prompt",
+            lambda ts_key, config, force_fresh=False: ts_key == "web")
+
+        resp = self.client.post("/api/tools/toolsets/sync-platforms", json={})
+        assert resp.status_code == 200
+        assert resp.json()["needs_setup"] == ["web"]
+
+    def test_sync_without_other_platforms_is_a_noop(self, monkeypatch):
+        import hermes_cli.tools_config as tools_config
+        from hermes_cli.config import load_config, save_config
+
+        monkeypatch.setattr(tools_config, "_get_enabled_platforms", lambda: ["cli"])
+        config = load_config()
+        config["platform_toolsets"] = {"cli": ["web"]}
+        save_config(config)
+
+        resp = self.client.post("/api/tools/toolsets/sync-platforms", json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["platforms"] == []
+        assert data["synced"] == []
+
+    def test_sync_unchanged_platform_reported_without_resave(self, monkeypatch):
+        import hermes_cli.tools_config as tools_config
+        from hermes_cli.config import load_config, save_config
+
+        monkeypatch.setattr(tools_config, "_get_enabled_platforms", lambda: ["cli", "telegram"])
+        config = load_config()
+        config["platform_toolsets"] = {"cli": ["web"], "telegram": ["web"]}
+        save_config(config)
+
+        saves = []
+        real_save = tools_config._save_platform_tools
+
+        def _counting_save(cfg, platform, enabled):
+            saves.append(platform)
+            return real_save(cfg, platform, enabled)
+
+        monkeypatch.setattr(tools_config, "_save_platform_tools", _counting_save)
+
+        resp = self.client.post("/api/tools/toolsets/sync-platforms", json={})
+        assert resp.status_code == 200
+        entry = resp.json()["synced"][0]
+        assert entry["changed"] is False
+        assert entry["added"] == []
+        assert saves == []


### PR DESCRIPTION
## Summary

The desktop Toolsets view toggles write `platform_toolsets.cli` only (`PUT /api/tools/toolsets/{name}` resolves the toolset's *configuration platform* and saves that one list). Telegram, Discord, the API server and every other messaging platform keep their own separate lists, so a change made on desktop never reaches them — the gap #105616 describes. The CLI already has the global path (`hermes tools` → "Configure all platforms (global)", `_configure_platforms(..., all_platforms=True)` in `hermes_cli/tools_config.py`), but it's interactive and has no REST surface.

**Backend** (`hermes_cli/web_routers/tools.py`): new `POST /api/tools/toolsets/sync-platforms` — reads the current `cli` selection and applies it to every *other* enabled platform via the same `_save_platform_tools` the CLI uses, so the saved lists are byte-identical to what `hermes tools` would write:
- re-reads config per platform (the disabled-toolsets reconciliation in `_save_platform_tools` can change what the next platform resolves to — same reason `_configure_platforms` re-reads inside its loop);
- platform restrictions (`discord`/`discord_admin` are discord-only) filter the selection per platform instead of being silently dropped by the save helper;
- a platform already in sync is reported `changed: false` and not re-saved;
- there is no TTY, so the interactive key prompts are replaced by a `needs_setup` list in the response — toolsets newly enabled but still missing provider/API-key configuration.

**Frontend** (`apps/desktop`): a "Sync to all platforms" item in the Toolsets tab's kebab menu (`ListStripMenu` items — first use of that prop). The toast reports how many platforms changed, or surfaces `needs_setup` toolsets by name; the toolsets query is invalidated so rows reflect the sync. New API client fn + response types.

## Testing

- `pytest tests/hermes_cli/test_web_routers_tools_sync_platforms.py tests/hermes_cli/test_web_routers_tools_install_on_enable.py` — 10 passed (5 new: applies selection across platforms, honors platform restrictions, reports `needs_setup`, no-op without other platforms, unchanged platform not re-saved; mutation-checked: dropping the `needs_setup` computation turns one test red).
- `npx tsc -p . --noEmit` (apps/desktop) — clean.
- `npx vitest run src/app/skills/index.test.tsx --project ui` — 13 passed (1 new: opens the kebab, clicks "Sync to all platforms", asserts the call + query refetch; mutation-checked: removing the post-sync invalidation turns it red).
- `npx vitest run src/hermes-parity.test.ts --project ui` — 12 passed.
- `ruff check` clean; `ruff format --diff` raises no complaints on the new lines (the file carries pre-existing formatter drift that is untouched).
- New i18n keys landed in all five complete desktop locales (en/ru/zh/zh-hant/ja) + ar partial, per the parity invariant.

Fixes #105616