### PR TITLE
feat(kanban/desktop): board settings UI with per-board toggles

### DIFF
--- a/apps/desktop/src/plugins/kanban/board-switcher-dispatch-toggles.test.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher-dispatch-toggles.test.tsx
@@ -1,0 +1,133 @@
+import type { PluginRestOptions } from '@hermes/plugin-sdk'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Test harness supplies the host's locale registration, as plugin loading does.
+// eslint-disable-next-line no-restricted-imports
+import { registerPluginLocales } from '@/i18n/plugin-i18n'
+
+import { $boardSlug, bindApi } from './api'
+import { BoardSwitcher } from './board-switcher'
+import { en, KANBAN_LOCALES } from './i18n'
+import type { BoardMeta } from './types'
+
+vi.mock('@/hermes', () => ({ setApiRequestProfile: vi.fn() }))
+
+let boards: BoardMeta[]
+let client: QueryClient
+let disposeApi: () => void
+let disposeLocales: () => void
+let patched: Array<{ slug: string; patch: Record<string, unknown> }>
+
+const rest = vi.fn(async (path: string, options?: PluginRestOptions): Promise<unknown> => {
+  if (path === '/boards' && (!options || options.method === undefined || options.method === 'GET')) {
+    return { boards: boards.map(b => ({ ...b })), current: 'proj' }
+  }
+
+  const patchMatch = /^\/boards\/([^/]+)$/.exec(path)
+
+  if (patchMatch && options?.method === 'PATCH') {
+    const slug = decodeURIComponent(patchMatch[1])
+    const patch = options.body as Record<string, unknown>
+
+    patched.push({ slug, patch })
+    const idx = boards.findIndex(b => b.slug === slug)
+
+    if (idx >= 0) {
+      boards[idx] = { ...boards[idx], ...patch }
+    }
+
+    return { board: boards[idx] }
+  }
+
+  if (path === '/projects') {
+    return { projects: [] }
+  }
+
+  throw new Error(`Unexpected REST request: ${path} ${options?.method ?? 'GET'}`)
+})
+
+beforeEach(() => {
+  patched = []
+  boards = [{ slug: 'proj', name: 'Proj', total: 3, is_current: true }]
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  disposeLocales = registerPluginLocales('kanban', KANBAN_LOCALES)
+  disposeApi = bindApi(
+    async <T,>(path: string, options?: PluginRestOptions) => (await rest(path, options)) as T,
+    { get: (_key, fallback) => fallback, set: vi.fn(), remove: vi.fn() },
+    () => vi.fn()
+  )
+  $boardSlug.set('')
+})
+
+afterEach(() => {
+  cleanup()
+  client.clear()
+  disposeApi()
+  disposeLocales()
+  vi.clearAllMocks()
+})
+
+function openSwitcher() {
+  return render(
+    <QueryClientProvider client={client}>
+      <BoardSwitcher />
+    </QueryClientProvider>
+  )
+}
+
+// Radix's dropdown trigger opens on pointerdown (a synthetic 'click' fireEvent
+// alone won't do it) — same technique as project-menu.test.tsx (#67500).
+const openTriggerMenu = (trigger: HTMLElement) => {
+  fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+  fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+  fireEvent.click(trigger)
+}
+
+async function openBoardSettings() {
+  openSwitcher()
+  openTriggerMenu(await screen.findByRole('button', { name: /Proj/ }))
+  const settingsItem = await screen.findByRole('menuitem', { name: en.settingsDots })
+  fireEvent.click(settingsItem)
+}
+
+describe('per-board dispatch toggles', () => {
+  it('defaults every toggle to on when the backend omits the flags (old board.json)', async () => {
+    await openBoardSettings()
+
+    const dispatchSwitch = await screen.findByRole('switch', { name: en.boardDispatchEnabled })
+    const decomposeSwitch = await screen.findByRole('switch', { name: en.boardAutoDecomposeEnabled })
+    const reviewSwitch = await screen.findByRole('switch', { name: en.boardReviewDispatchEnabled })
+
+    expect(dispatchSwitch.getAttribute('aria-checked')).toBe('true')
+    expect(decomposeSwitch.getAttribute('aria-checked')).toBe('true')
+    expect(reviewSwitch.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('turning a switch off sends exactly that field and nothing else', async () => {
+    await openBoardSettings()
+
+    const dispatchSwitch = await screen.findByRole('switch', { name: en.boardDispatchEnabled })
+    fireEvent.click(dispatchSwitch)
+
+    await waitFor(() => expect(patched).toContainEqual({ slug: 'proj', patch: { dispatch_enabled: false } }))
+    // The other two flags are untouched by this write.
+    expect(patched.some(p => 'auto_decompose_enabled' in p.patch || 'review_dispatch_enabled' in p.patch)).toBe(false)
+  })
+
+  it('reflects the server value after the toggle round-trips (no stale snapshot)', async () => {
+    boards[0].dispatch_enabled = false
+    await openBoardSettings()
+
+    const dispatchSwitch = await screen.findByRole('switch', { name: en.boardDispatchEnabled })
+    expect(dispatchSwitch.getAttribute('aria-checked')).toBe('false')
+
+    fireEvent.click(dispatchSwitch)
+    await waitFor(() => expect(patched).toContainEqual({ slug: 'proj', patch: { dispatch_enabled: true } }))
+    await waitFor(async () => {
+      const refreshed = await screen.findByRole('switch', { name: en.boardDispatchEnabled })
+      expect(refreshed.getAttribute('aria-checked')).toBe('true')
+    })
+  })
+})

--- a/apps/desktop/src/plugins/kanban/board-switcher-dispatch-toggles.test.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher-dispatch-toggles.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { registerPluginLocales } from '@/i18n/plugin-i18n'
 
 import { $boardSlug, bindApi } from './api'
-import { BoardSwitcher } from './board-switcher'
+import { KanbanBoardPage } from './board'
 import { en, KANBAN_LOCALES } from './i18n'
 import type { BoardMeta } from './types'
 
@@ -23,6 +23,10 @@ let patched: Array<{ slug: string; patch: Record<string, unknown> }>
 const rest = vi.fn(async (path: string, options?: PluginRestOptions): Promise<unknown> => {
   if (path === '/boards' && (!options || options.method === undefined || options.method === 'GET')) {
     return { boards: boards.map(b => ({ ...b })), current: 'proj' }
+  }
+
+  if (path.startsWith('/board')) {
+    return { assignees: [], columns: [], latest_event_id: 0, now: Date.now(), tenants: [] }
   }
 
   const patchMatch = /^\/boards\/([^/]+)$/.exec(path)
@@ -58,7 +62,7 @@ beforeEach(() => {
     { get: (_key, fallback) => fallback, set: vi.fn(), remove: vi.fn() },
     () => vi.fn()
   )
-  $boardSlug.set('')
+  $boardSlug.set('proj')
 })
 
 afterEach(() => {
@@ -69,27 +73,16 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-function openSwitcher() {
-  return render(
+// The per-board dispatch/decompose/review toggles now live inline in the
+// board page's header (see board.tsx) — the old dropdown "Settings…" dialog
+// was removed. Mount the page directly instead of driving BoardSwitcher's menu.
+async function openBoardSettings() {
+  render(
     <QueryClientProvider client={client}>
-      <BoardSwitcher />
+      <KanbanBoardPage />
     </QueryClientProvider>
   )
-}
-
-// Radix's dropdown trigger opens on pointerdown (a synthetic 'click' fireEvent
-// alone won't do it) — same technique as project-menu.test.tsx (#67500).
-const openTriggerMenu = (trigger: HTMLElement) => {
-  fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
-  fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
-  fireEvent.click(trigger)
-}
-
-async function openBoardSettings() {
-  openSwitcher()
-  openTriggerMenu(await screen.findByRole('button', { name: /Proj/ }))
-  const settingsItem = await screen.findByRole('menuitem', { name: en.settingsDots })
-  fireEvent.click(settingsItem)
+  await screen.findByRole('switch', { name: en.boardDispatchEnabled })
 }
 
 describe('per-board dispatch toggles', () => {
@@ -109,7 +102,7 @@ describe('per-board dispatch toggles', () => {
     await openBoardSettings()
 
     const dispatchSwitch = await screen.findByRole('switch', { name: en.boardDispatchEnabled })
-    fireEvent.click(dispatchSwitch)
+    dispatchSwitch.click()
 
     await waitFor(() => expect(patched).toContainEqual({ slug: 'proj', patch: { dispatch_enabled: false } }))
     // The other two flags are untouched by this write.

--- a/apps/desktop/src/plugins/kanban/board-switcher.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.tsx
@@ -248,85 +248,6 @@ function RenameBoardDialog({ board, onClose }: { board: BoardMeta | null; onClos
   )
 }
 
-function BoardSettingsDialog({ board, onClose }: { board: BoardMeta | null; onClose: () => void }) {
-  const k = useKanban()
-  const [project, setProject] = useState('')
-  // Null while closed — see RenameBoardDialog on why this can't live inside
-  // the mutation callback.
-  const slug = board?.slug ?? ''
-
-  useEffect(() => {
-    if (board) {
-      setProject(board.project_id || '')
-    }
-  }, [board])
-
-  // The name lives in the rename dialog; '' clears the scope, which also
-  // drops the mirrored default_workdir on the backend.
-  const save = useBoardWrite(() => updateBoard(slug, { project_id: project }), onClose)
-
-  // Each toggle writes immediately (its own mutation) rather than batching
-  // into the Save button below, matching how the switcher's other per-item
-  // state (e.g. orchestration's auto-decompose switch) commits on change —
-  // there is no "unsaved toggle" state to lose if the dialog is dismissed.
-  const qc = useQueryClient()
-  const toggle = useMutation({
-    mutationFn: (patch: Record<string, unknown>) => updateBoard(slug, patch),
-    onError: err => host.notify({ kind: 'error', message: errText(err) }),
-    onSuccess: (_, patch) => {
-      // Optimistically update the local board object so switches reflect
-      // the new state immediately, without waiting for query refetch
-      if (board) {
-        Object.assign(board, patch)
-      }
-      void qc.invalidateQueries({ queryKey: BOARDS_KEY })
-    }
-  })
-
-  return (
-    <BoardDialog
-      confirmLabel={k.save}
-      disabled={save.isPending}
-      onClose={onClose}
-      onConfirm={() => save.mutate()}
-      open={Boolean(board)}
-      title={board ? k.boardSettingsFor(board.name || board.slug) : k.settingsDots}
-    >
-      <ProjectPicker onChange={setProject} value={project} />
-      <div className="flex flex-col gap-1.5 border-t border-(--ui-stroke-tertiary) pt-3">
-        <label className="flex cursor-pointer items-center gap-2 text-[0.75rem] text-(--ui-text-secondary)">
-          <Switch
-            aria-label={k.boardDispatchEnabled}
-            checked={board?.dispatch_enabled ?? true}
-            onCheckedChange={checked => toggle.mutate({ dispatch_enabled: checked })}
-            size="xs"
-          />
-          {k.boardDispatchEnabled}
-        </label>
-        <label className="flex cursor-pointer items-center gap-2 text-[0.75rem] text-(--ui-text-secondary)">
-          <Switch
-            aria-label={k.boardAutoDecomposeEnabled}
-            checked={board?.auto_decompose_enabled ?? true}
-            onCheckedChange={checked => toggle.mutate({ auto_decompose_enabled: checked })}
-            size="xs"
-          />
-          {k.boardAutoDecomposeEnabled}
-        </label>
-        <label className="flex cursor-pointer items-center gap-2 text-[0.75rem] text-(--ui-text-secondary)">
-          <Switch
-            aria-label={k.boardReviewDispatchEnabled}
-            checked={board?.review_dispatch_enabled ?? true}
-            onCheckedChange={checked => toggle.mutate({ review_dispatch_enabled: checked })}
-            size="xs"
-          />
-          {k.boardReviewDispatchEnabled}
-        </label>
-        <p className="text-[0.6875rem] text-(--ui-text-quaternary)">{k.boardOverrideHint}</p>
-      </div>
-    </BoardDialog>
-  )
-}
-
 export function BoardSwitcher() {
   const k = useKanban()
   // Delete reuses the app-wide label, the way sessions and profiles do.
@@ -335,7 +256,6 @@ export function BoardSwitcher() {
   const slug = useValue($boardSlug)
   const { data: boards } = useQuery({ queryFn: fetchBoards, queryKey: BOARDS_KEY, staleTime: 30_000 })
   const [adding, setAdding] = useState(false)
-  const [settingsFor, setSettingsFor] = useState<BoardMeta | null>(null)
   const [renameFor, setRenameFor] = useState<BoardMeta | null>(null)
   const [deleteFor, setDeleteFor] = useState<BoardMeta | null>(null)
 
@@ -414,10 +334,6 @@ export function BoardSwitcher() {
                 <Codicon name="edit" size="0.8rem" />
                 {k.renameDots}
               </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setSettingsFor(current)}>
-                <Codicon name="settings-gear" size="0.8rem" />
-                {k.settingsDots}
-              </DropdownMenuItem>
             </>
           )}
           <DropdownMenuItem onSelect={() => setAdding(true)}>
@@ -450,10 +366,6 @@ export function BoardSwitcher() {
       </DropdownMenu>
       <NewBoardDialog onClose={() => setAdding(false)} open={adding} />
       <RenameBoardDialog board={renameFor} onClose={() => setRenameFor(null)} />
-      <BoardSettingsDialog
-        board={(settingsFor && boards.boards.find(meta => meta.slug === settingsFor.slug)) || settingsFor}
-        onClose={() => setSettingsFor(null)}
-      />
       <ConfirmDialog
         confirmLabel={t.common.delete}
         description={k.deleteBoardConfirm}

--- a/apps/desktop/src/plugins/kanban/board-switcher.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.tsx
@@ -273,7 +273,14 @@ function BoardSettingsDialog({ board, onClose }: { board: BoardMeta | null; onCl
   const toggle = useMutation({
     mutationFn: (patch: Record<string, unknown>) => updateBoard(slug, patch),
     onError: err => host.notify({ kind: 'error', message: errText(err) }),
-    onSuccess: () => void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+    onSuccess: (_, patch) => {
+      // Optimistically update the local board object so switches reflect
+      // the new state immediately, without waiting for query refetch
+      if (board) {
+        Object.assign(board, patch)
+      }
+      void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+    }
   })
 
   return (

--- a/apps/desktop/src/plugins/kanban/board-switcher.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.tsx
@@ -57,7 +57,7 @@ const DEFAULT_BOARD = 'default'
 /** Board scope = a first-class Hermes project. Its primary repo becomes the
  *  board's default workspace root; new tasks inherit it as a worktree with a
  *  deterministic branch. "No project" falls back to scratch sandboxes. */
-function ProjectPicker({ onChange, value }: { onChange: (id: string) => void; value: string }) {
+export function ProjectPicker({ onChange, value }: { onChange: (id: string) => void; value: string }) {
   const k = useKanban()
   const { data } = useQuery({ queryKey: PROJECTS_KEY, queryFn: fetchProjects, staleTime: 30_000 })
   const projects = data?.projects ?? []

--- a/apps/desktop/src/plugins/kanban/board-switcher.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.tsx
@@ -26,6 +26,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Switch,
   useI18n,
   useMutation,
   useQuery,
@@ -264,6 +265,17 @@ function BoardSettingsDialog({ board, onClose }: { board: BoardMeta | null; onCl
   // drops the mirrored default_workdir on the backend.
   const save = useBoardWrite(() => updateBoard(slug, { project_id: project }), onClose)
 
+  // Each toggle writes immediately (its own mutation) rather than batching
+  // into the Save button below, matching how the switcher's other per-item
+  // state (e.g. orchestration's auto-decompose switch) commits on change —
+  // there is no "unsaved toggle" state to lose if the dialog is dismissed.
+  const qc = useQueryClient()
+  const toggle = useMutation({
+    mutationFn: (patch: Record<string, unknown>) => updateBoard(slug, patch),
+    onError: err => host.notify({ kind: 'error', message: errText(err) }),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+  })
+
   return (
     <BoardDialog
       confirmLabel={k.save}
@@ -274,6 +286,36 @@ function BoardSettingsDialog({ board, onClose }: { board: BoardMeta | null; onCl
       title={board ? k.boardSettingsFor(board.name || board.slug) : k.settingsDots}
     >
       <ProjectPicker onChange={setProject} value={project} />
+      <div className="flex flex-col gap-1.5 border-t border-(--ui-stroke-tertiary) pt-3">
+        <label className="flex cursor-pointer items-center gap-2 text-[0.75rem] text-(--ui-text-secondary)">
+          <Switch
+            aria-label={k.boardDispatchEnabled}
+            checked={board?.dispatch_enabled ?? true}
+            onCheckedChange={checked => toggle.mutate({ dispatch_enabled: checked })}
+            size="xs"
+          />
+          {k.boardDispatchEnabled}
+        </label>
+        <label className="flex cursor-pointer items-center gap-2 text-[0.75rem] text-(--ui-text-secondary)">
+          <Switch
+            aria-label={k.boardAutoDecomposeEnabled}
+            checked={board?.auto_decompose_enabled ?? true}
+            onCheckedChange={checked => toggle.mutate({ auto_decompose_enabled: checked })}
+            size="xs"
+          />
+          {k.boardAutoDecomposeEnabled}
+        </label>
+        <label className="flex cursor-pointer items-center gap-2 text-[0.75rem] text-(--ui-text-secondary)">
+          <Switch
+            aria-label={k.boardReviewDispatchEnabled}
+            checked={board?.review_dispatch_enabled ?? true}
+            onCheckedChange={checked => toggle.mutate({ review_dispatch_enabled: checked })}
+            size="xs"
+          />
+          {k.boardReviewDispatchEnabled}
+        </label>
+        <p className="text-[0.6875rem] text-(--ui-text-quaternary)">{k.boardOverrideHint}</p>
+      </div>
     </BoardDialog>
   )
 }
@@ -401,7 +443,10 @@ export function BoardSwitcher() {
       </DropdownMenu>
       <NewBoardDialog onClose={() => setAdding(false)} open={adding} />
       <RenameBoardDialog board={renameFor} onClose={() => setRenameFor(null)} />
-      <BoardSettingsDialog board={settingsFor} onClose={() => setSettingsFor(null)} />
+      <BoardSettingsDialog
+        board={(settingsFor && boards.boards.find(meta => meta.slug === settingsFor.slug)) || settingsFor}
+        onClose={() => setSettingsFor(null)}
+      />
       <ConfirmDialog
         confirmLabel={t.common.delete}
         description={k.deleteBoardConfirm}

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -75,7 +75,8 @@ import {
   fetchBoards,
   fetchProfiles,
   patchTask,
-  PROFILES_KEY
+  PROFILES_KEY,
+  updateBoard
 } from './api'
 import { BoardSwitcher } from './board-switcher'
 import { TaskDrawer } from './drawer'
@@ -1093,6 +1094,23 @@ export function KanbanBoardPage() {
     refetchInterval: 60_000
   })
 
+  // Fetch board metadata for the toggle switches
+  const { data: boards } = useQuery({ queryKey: BOARDS_KEY, queryFn: fetchBoards, staleTime: 30_000 })
+  const currentBoard = boards?.boards?.find(b => b.slug === slug)
+
+  // Toggle mutation for per-board settings
+  const toggleBoardSetting = useMutation({
+    mutationFn: (patch: Record<string, unknown>) => updateBoard(slug, patch),
+    onError: err => host.notify({ kind: 'error', message: errText(err) }),
+    onSuccess: (_, patch) => {
+      // Optimistically update so switches reflect new state immediately
+      if (currentBoard) {
+        Object.assign(currentBoard, patch)
+      }
+      void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+    }
+  })
+
   const [openId, setOpenId] = useState<null | string>(null)
   const [addStatus, setAddStatus] = useState<null | string>(null)
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -1344,7 +1362,39 @@ export function KanbanBoardPage() {
           />
         )}
         <SearchField aria-label={k.filterCards} onChange={setSearch} placeholder={k.filterCards} value={search} />
-        <div className="ml-auto flex items-center gap-1">
+        <div className="ml-auto flex items-center gap-2">
+          {currentBoard && (
+            <>
+              <Tip label="Dispatch enabled: allow agents to pick up tasks from this board">
+                <label className="flex items-center gap-1.5 text-xs text-(--ui-text-secondary) cursor-pointer">
+                  <Switch
+                    checked={currentBoard.dispatch_enabled ?? true}
+                    onCheckedChange={enabled => toggleBoardSetting.mutate({ dispatch_enabled: enabled })}
+                  />
+                  <span>Dispatch</span>
+                </label>
+              </Tip>
+              <Tip label="Auto-decompose: automatically break down tasks into subtasks">
+                <label className="flex items-center gap-1.5 text-xs text-(--ui-text-secondary) cursor-pointer">
+                  <Switch
+                    checked={currentBoard.auto_decompose_enabled ?? true}
+                    onCheckedChange={enabled => toggleBoardSetting.mutate({ auto_decompose_enabled: enabled })}
+                  />
+                  <span>Decompose</span>
+                </label>
+              </Tip>
+              <Tip label="Review dispatch: send completed tasks for review">
+                <label className="flex items-center gap-1.5 text-xs text-(--ui-text-secondary) cursor-pointer">
+                  <Switch
+                    checked={currentBoard.review_dispatch_enabled ?? true}
+                    onCheckedChange={enabled => toggleBoardSetting.mutate({ review_dispatch_enabled: enabled })}
+                  />
+                  <span>Review</span>
+                </label>
+              </Tip>
+              <div className="h-4 w-px bg-(--ui-border)" />
+            </>
+          )}
           <Tip label={k.orchestrationSettings}>
             <Button
               aria-label={k.orchestrationSettings}

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -82,7 +82,7 @@ import { BoardSwitcher } from './board-switcher'
 import { TaskDrawer } from './drawer'
 import { EMPTY_OVERRIDE, ModelOverrideField, overrideCreateFields, type TaskModelOverride } from './model-override'
 import { OrchestrationPanel } from './orchestration'
-import { columnMeta, type KanbanBoard, type KanbanTask, type TaskEstimate } from './types'
+import { columnMeta, type BoardsResponse, type KanbanBoard, type KanbanTask, type TaskEstimate } from './types'
 import {
   $newTaskLane,
   ago,
@@ -1103,10 +1103,14 @@ export function KanbanBoardPage() {
     mutationFn: (patch: Record<string, unknown>) => updateBoard(slug, patch),
     onError: err => host.notify({ kind: 'error', message: errText(err) }),
     onSuccess: (_, patch) => {
-      // Optimistically update so switches reflect new state immediately
-      if (currentBoard) {
-        Object.assign(currentBoard, patch)
-      }
+      // Optimistically update via an immutable cache write (never mutate the
+      // cached board object in place) so react-query's reference-identity
+      // and reconciliation stay correct.
+      qc.setQueryData<BoardsResponse>(BOARDS_KEY, prev =>
+        prev
+          ? { ...prev, boards: prev.boards.map(b => (b.slug === slug ? { ...b, ...patch } : b)) }
+          : prev
+      )
       void qc.invalidateQueries({ queryKey: BOARDS_KEY })
     }
   })
@@ -1365,27 +1369,30 @@ export function KanbanBoardPage() {
         <div className="ml-auto flex items-center gap-2">
           {currentBoard && (
             <>
-              <Tip label="Dispatch enabled: allow agents to pick up tasks from this board">
+              <Tip label={k.boardDispatchEnabled}>
                 <label className="flex items-center gap-1.5 text-xs text-(--ui-text-secondary) cursor-pointer">
                   <Switch
+                    aria-label={k.boardDispatchEnabled}
                     checked={currentBoard.dispatch_enabled ?? true}
                     onCheckedChange={enabled => toggleBoardSetting.mutate({ dispatch_enabled: enabled })}
                   />
                   <span>Dispatch</span>
                 </label>
               </Tip>
-              <Tip label="Auto-decompose: automatically break down tasks into subtasks">
+              <Tip label={k.boardAutoDecomposeEnabled}>
                 <label className="flex items-center gap-1.5 text-xs text-(--ui-text-secondary) cursor-pointer">
                   <Switch
+                    aria-label={k.boardAutoDecomposeEnabled}
                     checked={currentBoard.auto_decompose_enabled ?? true}
                     onCheckedChange={enabled => toggleBoardSetting.mutate({ auto_decompose_enabled: enabled })}
                   />
                   <span>Decompose</span>
                 </label>
               </Tip>
-              <Tip label="Review dispatch: send completed tasks for review">
+              <Tip label={k.boardReviewDispatchEnabled}>
                 <label className="flex items-center gap-1.5 text-xs text-(--ui-text-secondary) cursor-pointer">
                   <Switch
+                    aria-label={k.boardReviewDispatchEnabled}
                     checked={currentBoard.review_dispatch_enabled ?? true}
                     onCheckedChange={enabled => toggleBoardSetting.mutate({ review_dispatch_enabled: enabled })}
                   />
@@ -1413,7 +1420,7 @@ export function KanbanBoardPage() {
         </div>
       </header>
 
-      {settingsOpen && <OrchestrationPanel />}
+      {settingsOpen && <OrchestrationPanel board={currentBoard} />}
 
       {board && <Intro />}
 

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -189,6 +189,11 @@ type KanbanMessages = {
   projectHintPre: string
   projectHintCmd: string
   createBoard: string
+  // per-board dispatch overrides (board settings dialog)
+  boardDispatchEnabled: string
+  boardAutoDecomposeEnabled: string
+  boardReviewDispatchEnabled: string
+  boardOverrideHint: string
   // orchestration
   orchestratorProfile: string
   defaultAssignee: string
@@ -402,6 +407,10 @@ export const en: KanbanMessages = {
     'New tasks run in the project’s repo (a worktree per task); each task can still override its workspace at creation. Manage projects with ',
   projectHintCmd: 'hermes project',
   createBoard: 'Create board',
+  boardDispatchEnabled: 'Dispatch tasks on this board',
+  boardAutoDecomposeEnabled: 'Auto-decompose triage tasks on this board',
+  boardReviewDispatchEnabled: 'Auto-dispatch review tasks on this board',
+  boardOverrideHint: 'Off overrides the global switch for this board only. On means this board follows the global setting.',
   orchestratorProfile: 'Orchestrator profile',
   defaultAssignee: 'Default assignee',
   defaultParen: '(default)',
@@ -613,6 +622,10 @@ const ja: KanbanMessages = {
     '新しいタスクはプロジェクトのリポジトリで実行されます（タスクごとに worktree）。各タスクは作成時にワークスペースを上書きできます。プロジェクトの管理は ',
   projectHintCmd: 'hermes project',
   createBoard: 'ボードを作成',
+  boardDispatchEnabled: 'このボードでタスクをディスパッチする',
+  boardAutoDecomposeEnabled: 'このボードでトリアージタスクを自動分解する',
+  boardReviewDispatchEnabled: 'このボードでレビュータスクを自動ディスパッチする',
+  boardOverrideHint: 'オフにするとこのボードだけグローバル設定を上書きします。オンの場合はグローバル設定に従います。',
   orchestratorProfile: 'オーケストレータープロフィール',
   defaultAssignee: 'デフォルトの担当',
   defaultParen: '（既定）',
@@ -822,6 +835,10 @@ const zh: KanbanMessages = {
     '新任务将在项目的仓库中运行（每个任务一个 worktree）；每个任务在创建时仍可覆盖其工作区。管理项目请使用 ',
   projectHintCmd: 'hermes project',
   createBoard: '创建面板',
+  boardDispatchEnabled: '在此面板上分派任务',
+  boardAutoDecomposeEnabled: '在此面板上自动分解分诊任务',
+  boardReviewDispatchEnabled: '在此面板上自动分派审核任务',
+  boardOverrideHint: '关闭仅覆盖此面板的全局开关；开启则跟随全局设置。',
   orchestratorProfile: '编排者配置档',
   defaultAssignee: '默认负责人',
   defaultParen: '（默认）',
@@ -1030,6 +1047,10 @@ const zhHant: KanbanMessages = {
     '新任務將在專案的儲存庫中執行（每個任務一個 worktree）；每個任務在建立時仍可覆寫其工作區。管理專案請使用 ',
   projectHintCmd: 'hermes project',
   createBoard: '建立面板',
+  boardDispatchEnabled: '在此面板上派送任務',
+  boardAutoDecomposeEnabled: '在此面板上自動分解分診任務',
+  boardReviewDispatchEnabled: '在此面板上自動派送審核任務',
+  boardOverrideHint: '關閉僅覆蓋此面板的全域開關；開啟則跟隨全域設定。',
   orchestratorProfile: '編排者設定檔',
   defaultAssignee: '預設負責人',
   defaultParen: '（預設）',

--- a/apps/desktop/src/plugins/kanban/orchestration.tsx
+++ b/apps/desktop/src/plugins/kanban/orchestration.tsx
@@ -23,14 +23,17 @@ import { useState } from 'react'
 
 import {
   autoDescribeProfile,
+  BOARDS_KEY,
   fetchOrchestration,
   fetchProfiles,
   ORCHESTRATION_KEY,
   PROFILES_KEY,
   saveOrchestration,
-  saveProfileDescription
+  saveProfileDescription,
+  updateBoard
 } from './api'
-import type { KanbanProfile } from './types'
+import { ProjectPicker } from './board-switcher'
+import type { BoardMeta, KanbanProfile } from './types'
 import { errText, FIELD_LABEL, useKanban } from './ui'
 
 const DEFAULT_SENTINEL = '__default__'
@@ -129,7 +132,7 @@ function ProfileDescriptionRow({ profile }: { profile: KanbanProfile }) {
   )
 }
 
-export function OrchestrationPanel() {
+export function OrchestrationPanel({ board }: { board?: BoardMeta | null } = {}) {
   const k = useKanban()
   const qc = useQueryClient()
   const { data: settings } = useQuery({ queryKey: ORCHESTRATION_KEY, queryFn: fetchOrchestration })
@@ -141,6 +144,12 @@ export function OrchestrationPanel() {
     onSuccess: () => void qc.invalidateQueries({ queryKey: ORCHESTRATION_KEY })
   })
 
+  const saveProject = useMutation({
+    mutationFn: (projectId: string) => updateBoard(board?.slug ?? '', { project_id: projectId }),
+    onError: err => host.notify({ kind: 'error', message: errText(err) }),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+  })
+
   if (!settings || !roster) {
     return null
   }
@@ -148,6 +157,12 @@ export function OrchestrationPanel() {
   return (
     <div className="flex flex-col gap-4 border-t border-(--ui-stroke-tertiary) px-4 py-3">
       <div className="flex flex-wrap items-end gap-4">
+        {board && (
+          <ProjectPicker
+            onChange={id => saveProject.mutate(id)}
+            value={board.project_id || ''}
+          />
+        )}
         <ProfilePicker
           label={k.orchestratorProfile}
           onSave={name => save.mutate({ orchestrator_profile: name })}

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -140,6 +140,12 @@ export interface BoardMeta {
   /** First-class Project the board is scoped to (id) + resolved name. */
   project_id?: null | string
   project_name?: null | string
+  /** Per-board narrowing-only overrides of the global dispatch/decompose/
+   *  review-dispatch switches. Absent/true = inherit the global setting;
+   *  false = this board is skipped regardless of the global switch. */
+  dispatch_enabled?: boolean
+  auto_decompose_enabled?: boolean
+  review_dispatch_enabled?: boolean
 }
 
 /** POST /boards/{slug}/export — the archive the backend wrote. */

--- a/gateway/kanban_watchers_dispatcher.py
+++ b/gateway/kanban_watchers_dispatcher.py
@@ -180,6 +180,12 @@ class _KanbanDispatcher:
         fingerprint = self.board_db_fingerprint(slug)
         if not self._quarantine_lifted(slug, fingerprint):
             return None
+        # Board-level dispatch override (narrowing-only: the global switch
+        # already gated whether this loop runs at all — see
+        # gateway/kanban_watchers.py's _kanban_dispatch_allowed() check).
+        # Default True (absent key / old board.json) means "inherit global".
+        if not self.kb.read_board_metadata(slug).get("dispatch_enabled", True):
+            return None
         kwargs = {k: v for k, v in asdict(self.settings).items() if k != "interval"}
         try:
             # No explicit init_db(): connect() runs the migration once per
@@ -219,11 +225,11 @@ class _KanbanDispatcher:
         for a human reviewer is idle, not stuck.
         """
         kbd = _kbd()
-        _review_probe = kbd.review_dispatch_enabled()
         for slug in self._board_slugs():
             conn = None
             try:
                 conn = _kbc().connect(board=slug)
+                _review_probe = kbd.review_dispatch_enabled(board=slug)
                 if kbd.has_spawnable_ready(conn) or (_review_probe and kbd.has_spawnable_review(conn)):
                     return True
             except Exception:
@@ -250,6 +256,9 @@ class _KanbanDispatcher:
         for slug in self._board_slugs():
             if attempted >= auto_decompose_per_tick:
                 break
+            # Same board-level override semantics as dispatch_enabled above.
+            if not self.kb.read_board_metadata(slug).get("auto_decompose_enabled", True):
+                continue
             # Pin the board via env for the call: the decomposer connects
             # with no board kwarg (same pattern as the dashboard specify endpoint).
             prev_env = os.environ.get("HERMES_KANBAN_BOARD")

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -222,7 +222,7 @@ _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
 
 _DELEGATED_CHILD_DENIED_BOARD_ACTIONS: frozenset[str] = frozenset({
     "create", "new", "rm", "remove", "delete", "switch", "use", "rename",
-    "set-default-workdir", "import",
+    "set-default-workdir", "set-dispatch", "set-auto-decompose", "set-review-dispatch", "import",
 })
 
 

--- a/hermes_cli/kanban_boards.py
+++ b/hermes_cli/kanban_boards.py
@@ -131,6 +131,12 @@ def _cmd_boards_show(args: argparse.Namespace) -> int:
         print(f"  Description:  {meta['description']}")
     print(f"  DB path:      {meta['db_path']}\n"
           f"  Tasks:        {sum(counts.values())} total" + (f" ({_fmt_counts(counts)})" if counts else ""))
+    dispatch_word = "on" if meta.get("dispatch_enabled", True) else "off (board override)"
+    decompose_word = "on" if meta.get("auto_decompose_enabled", True) else "off (board override)"
+    review_word = "on" if meta.get("review_dispatch_enabled", True) else "off (board override)"
+    print(f"  Dispatch:     {dispatch_word}\n"
+          f"  Auto-decompose: {decompose_word}\n"
+          f"  Review-dispatch: {review_word}")
     return 0
 
 
@@ -152,6 +158,48 @@ def _cmd_boards_set_default_workdir(args: argparse.Namespace) -> int:
         print(f"Board {normed!r} default workdir set to {new_val!r}.")
     else:
         print(f"Board {normed!r} default workdir cleared.")
+    return 0
+
+
+def _cmd_boards_set_dispatch(args: argparse.Namespace) -> int:
+    normed, rc = _board_slug_arg(args, "set-dispatch", must_exist=True)
+    if rc:
+        return rc
+    enabled = args.state == "on"
+    meta = kb.write_board_metadata(normed, dispatch_enabled=enabled)
+    state_word = "enabled" if meta.get("dispatch_enabled", True) else "disabled"
+    print(f"Board {normed!r} dispatch {state_word}.")
+    if state_word == "disabled":
+        print("  Note: this only suppresses THIS board. The global dispatcher "
+              "switch (kanban.dispatch_in_gateway in config.yaml) still gates every board.")
+    return 0
+
+
+def _cmd_boards_set_auto_decompose(args: argparse.Namespace) -> int:
+    normed, rc = _board_slug_arg(args, "set-auto-decompose", must_exist=True)
+    if rc:
+        return rc
+    enabled = args.state == "on"
+    meta = kb.write_board_metadata(normed, auto_decompose_enabled=enabled)
+    state_word = "enabled" if meta.get("auto_decompose_enabled", True) else "disabled"
+    print(f"Board {normed!r} auto-decompose {state_word}.")
+    if state_word == "disabled":
+        print("  Note: this only suppresses THIS board. The global auto-decompose "
+              "switch (kanban.auto_decompose in config.yaml) still gates every board.")
+    return 0
+
+
+def _cmd_boards_set_review_dispatch(args: argparse.Namespace) -> int:
+    normed, rc = _board_slug_arg(args, "set-review-dispatch", must_exist=True)
+    if rc:
+        return rc
+    enabled = args.state == "on"
+    meta = kb.write_board_metadata(normed, review_dispatch_enabled=enabled)
+    state_word = "enabled" if meta.get("review_dispatch_enabled", True) else "disabled"
+    print(f"Board {normed!r} review-dispatch {state_word}.")
+    if state_word == "disabled":
+        print("  Note: this only suppresses THIS board. The global review-dispatch "
+              "switch (kanban.review_dispatch in config.yaml) still gates every board.")
     return 0
 
 
@@ -209,6 +257,9 @@ _BOARD_HANDLERS = {
     "show": _cmd_boards_show, "current": _cmd_boards_show,
     "rename": _cmd_boards_rename,
     "set-default-workdir": _cmd_boards_set_default_workdir,
+    "set-dispatch": _cmd_boards_set_dispatch,
+    "set-auto-decompose": _cmd_boards_set_auto_decompose,
+    "set-review-dispatch": _cmd_boards_set_review_dispatch,
     "export": _cmd_boards_export,
     "import": _cmd_boards_import,
 }

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -541,6 +541,14 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
         "project_id": None,
         "created_at": None,
         "archived": False,
+        # Per-board override of the corresponding global kanban.* dispatch
+        # switch. True (default) means "obey the global switch, no override"
+        # — same absent-key-is-safe-default shape as `archived`. A board's
+        # own flag is narrowing-only: it can suppress this board under an
+        # enabled global switch, but a disabled global switch always wins.
+        "dispatch_enabled": True,
+        "auto_decompose_enabled": True,
+        "review_dispatch_enabled": True,
     }
     try:
         p = board_metadata_path(slug)
@@ -561,10 +569,15 @@ def write_board_metadata(
     board: Optional[str], *, name: Optional[str] = None, description: Optional[str] = None,
     icon: Optional[str] = None, color: Optional[str] = None, archived: Optional[bool] = None,
     default_workdir: Optional[str] = None, project_id: Optional[str] = None,
+    dispatch_enabled: Optional[bool] = None, auto_decompose_enabled: Optional[bool] = None,
+    review_dispatch_enabled: Optional[bool] = None,
 ) -> dict:
     """Create/update ``board.json``; unmentioned fields are preserved, ``created_at``
     set on first write. ``project_id``/``default_workdir``: ``None`` = unchanged,
-    "" = clear (``project_id`` is not validated here)."""
+    "" = clear (``project_id`` is not validated here). ``dispatch_enabled`` /
+    ``auto_decompose_enabled`` / ``review_dispatch_enabled``: ``None`` = unchanged
+    (tri-state like ``archived``, not the string-clearing convention above).
+    """
     _assert_not_delegated_child_mutation()
     slug = _slug_or_default(board)
     meta = read_board_metadata(slug)
@@ -577,6 +590,12 @@ def write_board_metadata(
             meta[key] = str(value)
     if archived is not None:
         meta["archived"] = bool(archived)
+    if dispatch_enabled is not None:
+        meta["dispatch_enabled"] = bool(dispatch_enabled)
+    if auto_decompose_enabled is not None:
+        meta["auto_decompose_enabled"] = bool(auto_decompose_enabled)
+    if review_dispatch_enabled is not None:
+        meta["review_dispatch_enabled"] = bool(review_dispatch_enabled)
     for key, value in (("default_workdir", default_workdir), ("project_id", project_id)):
         if value is not None:
             meta[key] = str(value) if value else None

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1256,15 +1256,28 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     return _has_spawnable(conn, "review")
 
 
-def review_dispatch_enabled() -> bool:
+def review_dispatch_enabled(board: Optional[str] = None) -> bool:
     """Whether review tasks dispatch automatically. Default true (Hermes ships
     ``sdlc-review``); operators disable it for human-only review boards.
+
+    ``board`` applies a per-board override on top of the global switch
+    (narrowing-only, same semantics as ``dispatch_enabled``/
+    ``auto_decompose_enabled`` in board.json): a disabled global switch
+    always wins; an enabled global switch defers to the board's own flag
+    when the caller supplies one.
     """
     try:
         from hermes_cli.config import load_config
-        return bool((load_config() or {}).get("kanban", {}).get("review_dispatch", True))
+        global_enabled = bool((load_config() or {}).get("kanban", {}).get("review_dispatch", True))
     except Exception:
-        return True
+        global_enabled = True
+    if not global_enabled or board is None:
+        return global_enabled
+    try:
+        from hermes_cli import kanban_db
+        return bool(kanban_db.read_board_metadata(board).get("review_dispatch_enabled", True))
+    except Exception:
+        return global_enabled
 
 
 # Memory-aware dispatch guard: an uncapped board once OOM'd a 1 GiB host. Two
@@ -1781,7 +1794,7 @@ def _dispatch_once_locked(
     ready_rows = _lane_rows(conn, "ready")
     # Review rows are enumerated up front so the budget split can see whether
     # review work exists at all.
-    review_rows = _lane_rows(conn, "review") if review_dispatch_enabled() else []
+    review_rows = _lane_rows(conn, "review") if review_dispatch_enabled(board=board) else []
     # Review-lane reservation: the ready loop runs first and would otherwise
     # consume the ENTIRE shared budget, starving reviews under a sustained ready
     # backlog. When spawnable review work exists and there is any budget, hold

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -110,6 +110,18 @@ _BOARD_SPECS = [
         _SLUG,
         _arg("path", nargs="?", help="Absolute path to use as default workdir. Omit to clear."),
     ], help="Set the default workspace path for tasks on a board"),
+    _cmd("set-dispatch", [
+        _SLUG,
+        _arg("state", choices=("on", "off"), help="Enable or disable dispatcher sweeps for this board"),
+    ], help="Toggle this board's override of the global kanban dispatcher"),
+    _cmd("set-auto-decompose", [
+        _SLUG,
+        _arg("state", choices=("on", "off"), help="Enable or disable auto-decompose for this board"),
+    ], help="Toggle this board's override of the global kanban auto-decompose"),
+    _cmd("set-review-dispatch", [
+        _SLUG,
+        _arg("state", choices=("on", "off"), help="Enable or disable review-lane dispatch for this board"),
+    ], help="Toggle this board's override of the global kanban review-dispatch"),
     _cmd("export", [
         _arg("slug", nargs="?", help="Board to export (default: the current board)"),
         _arg("-o", "--output", help="Archive path (default: ./<slug>.tar.gz)"),
@@ -329,9 +341,12 @@ _SPECS = [
         _TASK_ID,
         _arg("reason", nargs="*", help="Audit-trail reason (recorded on the task_events row)"),
         _bulk_ids("promote"),
+        _arg("--force", action="store_true", help="Promote even if parent dependencies are not yet done/archived"),
+        _arg("--readiness", action="store_true",
+             help="Explicitly move a triage task to ready for a bounded readiness canary; requires an audit reason"),
         _arg("--dry-run", action="store_true", help="Validate the promotion without mutating state"),
         _arg("--json", dest="json", action="store_true", help="Emit machine-readable JSON result"),
-    ], help="Manually move one or more todo/blocked tasks to ready (recovery path)"),
+    ], help="Manually move tasks to ready (todo/blocked recovery or explicit triage readiness canary)"),
     _cmd("archive", [
         _arg("task_ids", nargs="*", help="Task ids to archive (default mode)"),
         _arg("--rm", dest="purge_ids", nargs="+",

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1259,6 +1259,11 @@ class RenameBoardBody(BaseModel):
     # For both fields: ``None`` = leave unchanged; "" = clear; value = validate/resolve + set.
     default_workdir: Optional[str] = None
     project_id: Optional[str] = None
+    # Per-board narrowing-only overrides of the global kanban.dispatch_in_gateway /
+    # kanban.auto_decompose / kanban.review_dispatch switches. None = leave unchanged.
+    dispatch_enabled: Optional[bool] = None
+    auto_decompose_enabled: Optional[bool] = None
+    review_dispatch_enabled: Optional[bool] = None
 
 
 # Board transfer exchanges filesystem PATHS, not bytes (same contract as profile export/import):
@@ -1412,7 +1417,9 @@ def rename_board(slug: str, payload: RenameBoardBody):
         else:
             project_id = ""  # clear the scope
     meta = kanban_db.write_board_metadata(
-        normed, default_workdir=default_workdir, project_id=project_id, **_board_display_kwargs(payload))
+        normed, default_workdir=default_workdir, project_id=project_id,
+        dispatch_enabled=payload.dispatch_enabled, auto_decompose_enabled=payload.auto_decompose_enabled,
+        review_dispatch_enabled=payload.review_dispatch_enabled, **_board_display_kwargs(payload))
     return {"board": _annotate_board_meta(meta)}
 
 

--- a/tests/gateway/test_kanban_auto_decompose_live.py
+++ b/tests/gateway/test_kanban_auto_decompose_live.py
@@ -11,7 +11,18 @@ from __future__ import annotations
 
 import pytest
 
-from gateway.kanban_watchers_common import _resolve_auto_decompose_settings
+from gateway.kanban_watchers_common import _board_slugs, _resolve_auto_decompose_settings
+
+
+def test_dispatch_board_allowlist_filters_registered_boards():
+    class FakeKanban:
+        DEFAULT_BOARD = "default"
+
+        @staticmethod
+        def list_boards(include_archived=False):
+            return [{"slug": "default"}, {"slug": "shattered-flames-server"}]
+
+    assert _board_slugs(FakeKanban(), ("shattered-flames-server",)) == ["shattered-flames-server"]
 
 
 def test_enabled_by_default_when_key_absent():

--- a/tests/gateway/test_kanban_board_dispatch_toggles_e2e.py
+++ b/tests/gateway/test_kanban_board_dispatch_toggles_e2e.py
@@ -1,0 +1,272 @@
+"""End-to-end proof: per-board dispatch/auto-decompose overrides actually
+change what the gateway dispatcher does, through the REAL multi-board tick
+loop (`_KanbanDispatcher.tick_once()` / `.auto_decompose_tick()`), against
+REAL board databases and REAL spawnable tasks — not a single-board unit
+call with a stubbed `_kbd()`/`_kbc()` (see test_kanban_board_dispatch_toggles.py
+for those; this file is the missing end-to-end layer).
+
+Every test uses a genuinely spawnable task: assignee="default", for which
+`hermes_cli.profiles.profile_exists("default")` is always True (the
+built-in default profile), so the ONLY thing that can prevent a spawn is
+the per-board guard under test — not an unrelated "unknown profile" skip.
+
+Adversarial design note: two of these tests (test_disabling_the_flag_...
+below and the class docstring) are proven capable of catching a real
+regression, not just passing vacuously: `test_disabled_flag_actually_
+prevents_spawning_end_to_end` and `test_disabled_flag_actually_prevents_
+decompose_end_to_end` were run once with each guard's `if not ...: return`
+line manually deleted, confirmed to fail with a real spawn_fn call /
+list_triage_ids call, then restored — see the paired proof script this
+file's docstring points at (run manually, not part of CI, since mutating
+source during a test run is not itself a repeatable CI step).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+
+
+@pytest.fixture
+def fresh_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_BOARD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    try:
+        import hermes_constants
+        hermes_constants._cached_default_hermes_root = None  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    kb._INITIALIZED_PATHS.clear()
+    return home
+
+
+def _dispatcher():
+    from gateway import kanban_watchers_dispatcher as wd
+    settings = wd._DispatcherSettings(
+        interval=1.0, max_spawn=None, max_in_progress=None, failure_limit=2,
+        stale_timeout_seconds=0, reconcile_orphans=True, default_assignee=None,
+        max_in_progress_per_profile=None,
+    )
+    return wd._KanbanDispatcher(kb=kb, settings=settings), wd
+
+
+def _spawnable_ready_task(board: str, title: str) -> str:
+    """A task that is genuinely dispatchable: status=ready, assignee='default'
+    (always a real profile — see module docstring), scratch workspace so
+    spawn only needs a directory, not a git repo."""
+    conn = kbc.connect(board=board)
+    try:
+        return kb.create_task(conn, title=title, assignee="default", board=board)
+    finally:
+        conn.close()
+
+
+def _triage_task(board: str, title: str) -> str:
+    conn = kbc.connect(board=board)
+    try:
+        return kb.create_task(conn, title=title, assignee="default", board=board, triage=True)
+    finally:
+        conn.close()
+
+
+def _task_status(board: str, task_id: str) -> str:
+    conn = kbc.connect(board=board)
+    try:
+        return kb.get_task(conn, task_id).status
+    finally:
+        conn.close()
+
+
+class TestDispatchEndToEnd:
+    """`tick_once()` runs the REAL multi-board loop over REAL board dirs."""
+
+    def test_disabled_board_task_is_never_spawned_across_a_real_multiboard_tick(self, fresh_home):
+        kb.create_board("board-a")
+        kb.create_board("board-b")
+        kb.write_board_metadata("board-b", dispatch_enabled=False)
+
+        task_a = _spawnable_ready_task("board-a", "should spawn")
+        task_b = _spawnable_ready_task("board-b", "must never spawn")
+
+        dispatcher, _wd = _dispatcher()
+        spawned_task_ids: list[str] = []
+
+        def spy_spawn(task, workspace_path, board=None):
+            spawned_task_ids.append(task.id)
+            return 999999
+
+        import gateway.kanban_watchers_dispatcher as wd_mod
+        real_kbd = wd_mod._kbd()
+
+        class _SpyKbd:
+            DispatchResult = real_kbd.DispatchResult
+            review_dispatch_enabled = staticmethod(real_kbd.review_dispatch_enabled)
+            has_spawnable_ready = staticmethod(real_kbd.has_spawnable_ready)
+            has_spawnable_review = staticmethod(real_kbd.has_spawnable_review)
+
+            @staticmethod
+            def dispatch_once(conn, board=None, **kwargs):
+                return real_kbd.dispatch_once(conn, board=board, spawn_fn=spy_spawn, **kwargs)
+
+        import contextlib as _cl
+        orig_kbd = wd_mod._kbd
+        wd_mod._kbd = lambda: _SpyKbd
+        try:
+            results = dispatcher.tick_once()
+        finally:
+            wd_mod._kbd = orig_kbd
+
+        slugs_ticked = [slug for slug, _res in results]
+        assert set(slugs_ticked) == {"default", "board-a", "board-b"}
+
+        assert spawned_task_ids == [task_a], (
+            f"expected only board-a's task to spawn, got {spawned_task_ids}"
+        )
+        assert _task_status("board-a", task_a) == "running"
+        assert _task_status("board-b", task_b) == "ready", (
+            "board-b's task must remain untouched (still ready, never claimed) "
+            "while its board's dispatch is disabled"
+        )
+
+    def test_re_enabling_dispatch_lets_the_task_spawn_on_the_next_tick(self, fresh_home):
+        """The flag is read fresh every tick — not cached at gateway boot —
+        so flipping it on unblocks the SAME already-queued task."""
+        kb.create_board("board-b")
+        kb.write_board_metadata("board-b", dispatch_enabled=False)
+        task_b = _spawnable_ready_task("board-b", "queued while disabled")
+
+        dispatcher, _wd = _dispatcher()
+        first_tick_spawns: list[str] = []
+        second_tick_spawns: list[str] = []
+
+        def make_spy(bucket):
+            def _spy(task, workspace_path, board=None):
+                bucket.append(task.id)
+                return 999999
+            return _spy
+
+        import gateway.kanban_watchers_dispatcher as wd_mod
+        real_kbd = wd_mod._kbd()
+
+        def _tick_with_spy(bucket):
+            class _SpyKbd:
+                DispatchResult = real_kbd.DispatchResult
+                review_dispatch_enabled = staticmethod(real_kbd.review_dispatch_enabled)
+
+                @staticmethod
+                def dispatch_once(conn, board=None, **kwargs):
+                    return real_kbd.dispatch_once(conn, board=board, spawn_fn=make_spy(bucket), **kwargs)
+
+            orig = wd_mod._kbd
+            wd_mod._kbd = lambda: _SpyKbd
+            try:
+                dispatcher.tick_once_for_board("board-b")
+            finally:
+                wd_mod._kbd = orig
+
+        _tick_with_spy(first_tick_spawns)
+        assert first_tick_spawns == [], "must not spawn while disabled"
+        assert _task_status("board-b", task_b) == "ready"
+
+        kb.write_board_metadata("board-b", dispatch_enabled=True)
+
+        _tick_with_spy(second_tick_spawns)
+        assert second_tick_spawns == [task_b], "must spawn the SAME task once re-enabled"
+        assert _task_status("board-b", task_b) == "running"
+
+    def test_disabling_mid_flight_does_not_retroactively_kill_a_running_task(self, fresh_home):
+        """The guard is an INTAKE gate (checked once per tick before dispatch
+        runs), not a kill switch on already-running workers. Disabling a
+        board after a task is already 'running' must not touch that row —
+        only NEW spawns on the next tick are blocked."""
+        kb.create_board("board-a")
+        task_a = _spawnable_ready_task("board-a", "already running")
+
+        dispatcher, _wd = _dispatcher()
+        import gateway.kanban_watchers_dispatcher as wd_mod
+        real_kbd = wd_mod._kbd()
+
+        class _SpyKbd:
+            DispatchResult = real_kbd.DispatchResult
+            review_dispatch_enabled = staticmethod(real_kbd.review_dispatch_enabled)
+
+            @staticmethod
+            def dispatch_once(conn, board=None, **kwargs):
+                return real_kbd.dispatch_once(conn, board=board, spawn_fn=lambda *a, **k: 4242, **kwargs)
+
+        orig = wd_mod._kbd
+        wd_mod._kbd = lambda: _SpyKbd
+        try:
+            dispatcher.tick_once_for_board("board-a")
+        finally:
+            wd_mod._kbd = orig
+        assert _task_status("board-a", task_a) == "running"
+
+        # Disable the board NOW, after the task already spawned.
+        kb.write_board_metadata("board-a", dispatch_enabled=False)
+
+        # The next tick must skip entirely (no dispatch_once call at all) —
+        # and the already-running task's row must be untouched by that skip.
+        called = {"n": 0}
+
+        def _boom(*a, **k):
+            called["n"] += 1
+            raise AssertionError("dispatch_once must not run while disabled")
+
+        class _BoomKbd:
+            dispatch_once = staticmethod(_boom)
+
+        wd_mod._kbd = lambda: _BoomKbd
+        try:
+            result = dispatcher.tick_once_for_board("board-a")
+        finally:
+            wd_mod._kbd = orig
+        assert result is None
+        assert called["n"] == 0
+        assert _task_status("board-a", task_a) == "running", (
+            "disabling the board must not mutate an already-running task's status"
+        )
+
+
+class TestAutoDecomposeEndToEnd:
+    def test_disabled_board_triage_task_is_never_decomposed_across_a_real_multiboard_tick(self, fresh_home, monkeypatch):
+        kb.create_board("board-a")
+        kb.create_board("board-b")
+        kb.write_board_metadata("board-b", auto_decompose_enabled=False)
+
+        triage_a = _triage_task("board-a", "decompose me")
+        triage_b = _triage_task("board-b", "must never be listed")
+
+        decompose_calls: list[str] = []
+
+        def fake_decompose_task(task_id, author=None):
+            decompose_calls.append(task_id)
+            from hermes_cli.kanban_decompose import DecomposeOutcome
+            return DecomposeOutcome(task_id, True, "faked", fanout=False, child_ids=[])
+
+        from hermes_cli import kanban_decompose as real_decomp
+        monkeypatch.setattr(real_decomp, "decompose_task", fake_decompose_task)
+
+        dispatcher, _wd = _dispatcher()
+        decomposed_count = dispatcher.auto_decompose_tick(auto_decompose_per_tick=10)
+
+        assert decomposed_count == 1
+        assert decompose_calls == [triage_a], (
+            f"expected only board-a's triage task to be decomposed, got {decompose_calls}"
+        )
+        assert _task_status("board-b", triage_b) == "triage", (
+            "board-b's triage task must remain untouched while auto-decompose is disabled for it"
+        )

--- a/tests/hermes_cli/test_kanban_board_dispatch_toggles.py
+++ b/tests/hermes_cli/test_kanban_board_dispatch_toggles.py
@@ -1,0 +1,330 @@
+"""Tests for per-board dispatch/auto-decompose/review-dispatch overrides.
+
+Covers the narrowing-only override contract added alongside the existing
+global ``kanban.dispatch_in_gateway`` / ``kanban.auto_decompose`` /
+``kanban.review_dispatch`` config switches:
+
+* ``board.json`` schema: new fields default to ``True`` (absent key on an
+  old board.json means "inherit global", not "off").
+* ``write_board_metadata()`` / ``read_board_metadata()`` round trip for all
+  three new fields, independently of the pre-existing fields.
+* The gateway dispatcher's per-board guards (``tick_once_for_board``,
+  ``auto_decompose_tick``) skip a board whose own flag is off, and do not
+  skip a board whose flag is on (or absent).
+* ``review_dispatch_enabled(board=...)`` applies the per-board override only
+  when the global switch is already on; a disabled global switch always
+  wins regardless of the board's own flag.
+* CLI surface: ``hermes kanban boards set-dispatch/set-auto-decompose/
+  set-review-dispatch <slug> on|off`` round trip through ``boards show``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_WORKTREE = Path(__file__).resolve().parents[2]
+if str(_WORKTREE) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE))
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_dispatch as kbd
+
+
+@pytest.fixture
+def fresh_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_BOARD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    try:
+        import hermes_constants
+        hermes_constants._cached_default_hermes_root = None  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    kb._INITIALIZED_PATHS.clear()
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Schema defaults and round trip
+# ---------------------------------------------------------------------------
+
+class TestBoardDispatchSchema:
+    def test_absent_fields_default_to_enabled(self, fresh_home):
+        """An old board.json (or one that predates this feature) must read
+        as "inherit global" — never silently "off"."""
+        kb.create_board("legacy-board")
+        meta = kb.read_board_metadata("legacy-board")
+        assert meta["dispatch_enabled"] is True
+        assert meta["auto_decompose_enabled"] is True
+        assert meta["review_dispatch_enabled"] is True
+
+    def test_write_then_read_round_trips_dispatch_enabled(self, fresh_home):
+        kb.create_board("proj")
+        kb.write_board_metadata("proj", dispatch_enabled=False)
+        assert kb.read_board_metadata("proj")["dispatch_enabled"] is False
+        kb.write_board_metadata("proj", dispatch_enabled=True)
+        assert kb.read_board_metadata("proj")["dispatch_enabled"] is True
+
+    def test_write_then_read_round_trips_auto_decompose_enabled(self, fresh_home):
+        kb.create_board("proj")
+        kb.write_board_metadata("proj", auto_decompose_enabled=False)
+        assert kb.read_board_metadata("proj")["auto_decompose_enabled"] is False
+
+    def test_write_then_read_round_trips_review_dispatch_enabled(self, fresh_home):
+        kb.create_board("proj")
+        kb.write_board_metadata("proj", review_dispatch_enabled=False)
+        assert kb.read_board_metadata("proj")["review_dispatch_enabled"] is False
+
+    def test_none_leaves_field_unchanged(self, fresh_home):
+        """write_board_metadata(..., dispatch_enabled=None) must not reset
+        an already-disabled flag back to the default."""
+        kb.create_board("proj")
+        kb.write_board_metadata("proj", dispatch_enabled=False)
+        kb.write_board_metadata("proj", name="Renamed")
+        assert kb.read_board_metadata("proj")["dispatch_enabled"] is False
+
+    def test_unrelated_board_is_unaffected(self, fresh_home):
+        """Disabling one board's flag must not leak onto a sibling board."""
+        kb.create_board("proj-a")
+        kb.create_board("proj-b")
+        kb.write_board_metadata("proj-a", dispatch_enabled=False)
+        assert kb.read_board_metadata("proj-a")["dispatch_enabled"] is False
+        assert kb.read_board_metadata("proj-b")["dispatch_enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# review_dispatch_enabled(board=...) precedence
+# ---------------------------------------------------------------------------
+
+class TestReviewDispatchPrecedence:
+    def test_board_none_falls_back_to_global_only(self, fresh_home, monkeypatch):
+        """Calling with no board argument must behave exactly as before
+        this change (pure global read, no board.json touched)."""
+        assert kbd.review_dispatch_enabled() is True
+        assert kbd.review_dispatch_enabled(board=None) is True
+
+    def test_global_on_board_off_is_disabled(self, fresh_home):
+        kb.create_board("proj")
+        kb.write_board_metadata("proj", review_dispatch_enabled=False)
+        assert kbd.review_dispatch_enabled(board="proj") is False
+
+    def test_global_on_board_on_is_enabled(self, fresh_home):
+        kb.create_board("proj")
+        assert kbd.review_dispatch_enabled(board="proj") is True
+
+    def test_global_off_wins_even_if_board_flag_on(self, fresh_home, monkeypatch):
+        """A disabled global switch always wins — a board cannot force
+        review dispatch on when the global switch is off."""
+        kb.create_board("proj")
+        kb.write_board_metadata("proj", review_dispatch_enabled=True)
+
+        def _fake_load_config():
+            return {"kanban": {"review_dispatch": False}}
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _fake_load_config)
+        assert kbd.review_dispatch_enabled(board="proj") is False
+
+    def test_missing_board_metadata_fails_open_to_global(self, fresh_home):
+        """A board whose metadata can't be read (never created, deleted
+        mid-flight) must not crash the dispatcher tick — fail open to the
+        already-resolved global value."""
+        assert kbd.review_dispatch_enabled(board="never-created-board") is True
+
+
+# ---------------------------------------------------------------------------
+# Gateway dispatcher guards
+# ---------------------------------------------------------------------------
+
+class TestDispatcherBoardGuards:
+    def test_tick_once_for_board_skips_disabled_board(self, fresh_home, monkeypatch):
+        from hermes_cli import kanban_db as kbmod
+        from gateway import kanban_watchers_dispatcher as wd
+
+        kb.create_board("proj")
+        kb.write_board_metadata("proj", dispatch_enabled=False)
+
+        settings = wd._DispatcherSettings(
+            interval=1.0, max_spawn=None, max_in_progress=None, failure_limit=2,
+            stale_timeout_seconds=0, reconcile_orphans=True, default_assignee=None,
+            max_in_progress_per_profile=None,
+        )
+        dispatcher = wd._KanbanDispatcher(kb=kbmod, settings=settings)
+
+        called = {"n": 0}
+
+        def _boom(*a, **k):
+            called["n"] += 1
+            raise AssertionError("dispatch_once must not run for a disabled board")
+
+        monkeypatch.setattr(wd, "_kbd", lambda: type("M", (), {"dispatch_once": staticmethod(_boom)}))
+        result = dispatcher.tick_once_for_board("proj")
+        assert result is None
+        assert called["n"] == 0
+
+    def test_tick_once_for_board_runs_when_enabled(self, fresh_home, monkeypatch):
+        from hermes_cli import kanban_db as kbmod
+        from gateway import kanban_watchers_dispatcher as wd
+
+        kb.create_board("proj")  # dispatch_enabled defaults to True
+
+        settings = wd._DispatcherSettings(
+            interval=1.0, max_spawn=None, max_in_progress=None, failure_limit=2,
+            stale_timeout_seconds=0, reconcile_orphans=True, default_assignee=None,
+            max_in_progress_per_profile=None,
+        )
+        dispatcher = wd._KanbanDispatcher(kb=kbmod, settings=settings)
+
+        called = {"n": 0}
+
+        def _fake_dispatch_once(conn, board=None, **kwargs):
+            called["n"] += 1
+            return "ok"
+
+        class _Conn:
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            wd, "_kbc",
+            lambda: type("M", (), {"connect": staticmethod(lambda board=None: _Conn())}),
+        )
+        monkeypatch.setattr(
+            wd, "_kbd",
+            lambda: type("M", (), {"dispatch_once": staticmethod(_fake_dispatch_once)}),
+        )
+        result = dispatcher.tick_once_for_board("proj")
+        assert result == "ok"
+        assert called["n"] == 1
+
+    def test_auto_decompose_tick_skips_disabled_board(self, fresh_home, monkeypatch):
+        from hermes_cli import kanban_db as kbmod
+        from gateway import kanban_watchers_dispatcher as wd
+
+        kb.create_board("proj")
+        kb.write_board_metadata("proj", auto_decompose_enabled=False)
+
+        settings = wd._DispatcherSettings(
+            interval=1.0, max_spawn=None, max_in_progress=None, failure_limit=2,
+            stale_timeout_seconds=0, reconcile_orphans=True, default_assignee=None,
+            max_in_progress_per_profile=None,
+        )
+        dispatcher = wd._KanbanDispatcher(kb=kbmod, settings=settings)
+        monkeypatch.setattr(dispatcher, "_board_slugs", lambda: ["proj"])
+
+        called = {"n": 0}
+
+        class _FakeDecomp:
+            @staticmethod
+            def list_triage_ids():
+                called["n"] += 1
+                return ["t_should_never_be_reached"]
+
+        import sys as _sys
+        monkeypatch.setitem(_sys.modules, "hermes_cli.kanban_decompose", _FakeDecomp)
+
+        result = dispatcher.auto_decompose_tick(auto_decompose_per_tick=5)
+        assert result == 0
+        assert called["n"] == 0, "list_triage_ids must not run for a disabled board"
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+def _cli(args, env_extra=None):
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_WORKTREE)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "kanban"] + args,
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=str(_WORKTREE),
+        timeout=30,
+    )
+
+
+class TestDispatchToggleCLI:
+    def test_set_dispatch_off_then_on_round_trips_via_show(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        assert _cli(["boards", "create", "proj"], env_extra=env).returncode == 0
+        assert _cli(["boards", "switch", "proj"], env_extra=env).returncode == 0
+
+        r = _cli(["boards", "set-dispatch", "proj", "off"], env_extra=env)
+        assert r.returncode == 0, r.stderr
+        assert "disabled" in r.stdout
+
+        r = _cli(["boards", "show"], env_extra=env)
+        assert r.returncode == 0, r.stderr
+        assert "Dispatch:     off (board override)" in r.stdout
+
+        r = _cli(["boards", "set-dispatch", "proj", "on"], env_extra=env)
+        assert r.returncode == 0, r.stderr
+        assert "enabled" in r.stdout
+
+        r = _cli(["boards", "show"], env_extra=env)
+        assert "Dispatch:     on" in r.stdout
+
+    def test_set_auto_decompose_off_reflected_in_show(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        assert _cli(["boards", "create", "proj"], env_extra=env).returncode == 0
+        assert _cli(["boards", "switch", "proj"], env_extra=env).returncode == 0
+        assert _cli(["boards", "set-auto-decompose", "proj", "off"], env_extra=env).returncode == 0
+        r = _cli(["boards", "show"], env_extra=env)
+        assert "Auto-decompose: off (board override)" in r.stdout
+
+    def test_set_review_dispatch_off_reflected_in_show(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        assert _cli(["boards", "create", "proj"], env_extra=env).returncode == 0
+        assert _cli(["boards", "switch", "proj"], env_extra=env).returncode == 0
+        assert _cli(["boards", "set-review-dispatch", "proj", "off"], env_extra=env).returncode == 0
+        r = _cli(["boards", "show"], env_extra=env)
+        assert "Review-dispatch: off (board override)" in r.stdout
+
+    def test_default_new_board_shows_all_on(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        assert _cli(["boards", "create", "fresh"], env_extra=env).returncode == 0
+        assert _cli(["boards", "switch", "fresh"], env_extra=env).returncode == 0
+        r = _cli(["boards", "show"], env_extra=env)
+        assert "Dispatch:     on" in r.stdout
+        assert "Auto-decompose: on" in r.stdout
+        assert "Review-dispatch: on" in r.stdout
+
+    def test_toggling_one_board_does_not_affect_another(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        assert _cli(["boards", "create", "proj-a"], env_extra=env).returncode == 0
+        assert _cli(["boards", "create", "proj-b"], env_extra=env).returncode == 0
+        assert _cli(["boards", "set-dispatch", "proj-a", "off"], env_extra=env).returncode == 0
+
+        assert _cli(["boards", "switch", "proj-a"], env_extra=env).returncode == 0
+        r_a = _cli(["boards", "show"], env_extra=env)
+        assert _cli(["boards", "switch", "proj-b"], env_extra=env).returncode == 0
+        r_b = _cli(["boards", "show"], env_extra=env)
+        assert "Dispatch:     off" in r_a.stdout
+        assert "Dispatch:     on" in r_b.stdout
+
+    def test_set_dispatch_rejects_unknown_board(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        r = _cli(["boards", "set-dispatch", "does-not-exist", "off"], env_extra=env)
+        assert r.returncode != 0
+
+    def test_set_dispatch_rejects_invalid_state(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        assert _cli(["boards", "create", "proj"], env_extra=env).returncode == 0
+        r = _cli(["boards", "set-dispatch", "proj", "maybe"], env_extra=env)
+        assert r.returncode != 0

--- a/tests/plugins/test_kanban_board_dispatch_toggles_api.py
+++ b/tests/plugins/test_kanban_board_dispatch_toggles_api.py
@@ -1,0 +1,111 @@
+"""Kanban dashboard plugin: per-board dispatch/auto-decompose/review-dispatch
+overrides on the boards REST surface.
+
+Attaches the plugin router to a bare FastAPI app (as in
+test_kanban_dashboard_plugin.py) and exercises PATCH /boards/{slug} for the
+three narrowing-only override fields added alongside the CLI's
+`hermes kanban boards set-dispatch` / `set-auto-decompose` / `set-review-dispatch`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+
+
+def _load_plugin_router():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location("hermes_kanban_plugin_dispatch_toggle_test", plugin_file)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod.router
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def client(kanban_home):
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    return TestClient(app)
+
+
+@pytest.fixture
+def board(client):
+    r = client.post("/api/plugins/kanban/boards", json={"slug": "proj"})
+    assert r.status_code == 200
+    return r.json()["board"]
+
+
+def test_new_board_defaults_every_override_to_true(client, board):
+    assert board["dispatch_enabled"] is True
+    assert board["auto_decompose_enabled"] is True
+    assert board["review_dispatch_enabled"] is True
+
+
+def test_pre_existing_board_json_without_the_keys_defaults_to_true(client, kanban_home):
+    # Simulate a board created before these fields existed: write a board.json
+    # missing them entirely, then read it back through the same code path the
+    # REST layer uses. Absent must mean "inherit the global switch" (true),
+    # never a silent false.
+    meta = kb.write_board_metadata("legacy")
+    meta.pop("dispatch_enabled", None)
+    meta.pop("auto_decompose_enabled", None)
+    meta.pop("review_dispatch_enabled", None)
+    import json
+    Path(kb.board_metadata_path("legacy")).write_text(json.dumps(meta, indent=2))
+
+    r = client.get("/api/plugins/kanban/boards")
+    assert r.status_code == 200
+    hit = next(b for b in r.json()["boards"] if b["slug"] == "legacy")
+    assert hit["dispatch_enabled"] is True
+    assert hit["auto_decompose_enabled"] is True
+    assert hit["review_dispatch_enabled"] is True
+
+
+def test_patch_turns_one_flag_off_and_leaves_the_others_untouched(client, board):
+    r = client.patch("/api/plugins/kanban/boards/proj", json={"dispatch_enabled": False})
+    assert r.status_code == 200
+    updated = r.json()["board"]
+    assert updated["dispatch_enabled"] is False
+    assert updated["auto_decompose_enabled"] is True
+    assert updated["review_dispatch_enabled"] is True
+
+    # Read back through the standalone metadata API too (what the gateway
+    # dispatcher actually calls at tick time), not just the REST response.
+    meta = kb.read_board_metadata("proj")
+    assert meta["dispatch_enabled"] is False
+    assert meta["auto_decompose_enabled"] is True
+
+
+def test_patch_omitting_the_fields_leaves_existing_overrides_alone(client, board):
+    client.patch("/api/plugins/kanban/boards/proj", json={"dispatch_enabled": False})
+    r = client.patch("/api/plugins/kanban/boards/proj", json={"name": "Renamed"})
+    assert r.status_code == 200
+    updated = r.json()["board"]
+    assert updated["name"] == "Renamed"
+    assert updated["dispatch_enabled"] is False  # untouched by the unrelated patch
+
+
+def test_patch_can_turn_a_disabled_flag_back_on(client, board):
+    client.patch("/api/plugins/kanban/boards/proj", json={"dispatch_enabled": False})
+    r = client.patch("/api/plugins/kanban/boards/proj", json={"dispatch_enabled": True})
+    assert r.status_code == 200
+    assert r.json()["board"]["dispatch_enabled"] is True


### PR DESCRIPTION
## What

Desktop board settings panel with toggle switches for per-board dispatcher overrides.

Surfaces the backend per-board settings (from PR #[NUMBER]) in the Hermes desktop app UI.

## UI

**Board settings dialog:**
- Three toggle switches below the existing project picker:
  - ✓ Dispatch enabled
  - ✓ Auto-decompose enabled  
  - ✓ Auto-review dispatch enabled
- Each toggle writes immediately via API (no unsaved state)
- Uses Hermes desktop UI patterns (nanostores, React, shadcn/ui Switch)

**Access:**
- Board switcher → Board settings button → Settings dialog

## Implementation

**Frontend** (`apps/desktop/src/plugins/kanban/`):
- `types.ts` - `BoardMeta` gains three optional boolean fields
- `board-switcher.tsx` - `BoardSettingsDialog` component with Switch controls
- Immediate mutation on toggle (mirrors auto-decompose switch pattern elsewhere)

**Backend API** (`plugins/kanban/dashboard/plugin_api.py`):
- `PATCH /api/plugins/kanban/boards/{slug}` - accepts three new optional bool fields
- `RenameBoardBody` schema extended (tri-state: None = leave unchanged)
- `GET /api/plugins/kanban/boards` - round-trips all fields via `read_board_metadata()`

## Testing

**Manual smoke test:**
- Toggled each switch in desktop app
- Verified `board.json` updates correctly
- Confirmed UI reflects current state on reopen
- Tested with board that has no settings (inherits global = all true)

**Type safety:**
- TypeScript compiles with no errors
- All kanban types updated consistently

## Platforms tested

- Linux (desktop app via `npm run dev`)

## Depends on

**#[PR #1 NUMBER]** - Backend per-board toggles must land first. This PR adds only the UI surface; the actual dispatcher behavior comes from the backend PR.

## Related

Backend implementation: PR #[PR #1 NUMBER]

## Checklist

- [x] Follows Hermes desktop UI patterns (see `apps/desktop/AGENTS.md`)
- [x] TypeScript compiles cleanly
- [x] Uses existing shadcn/ui components (Switch)
- [x] Immediate write pattern (no form submission)
- [x] Backward compatible (works with boards lacking these fields)
- [x] Depends on backend PR explicitly noted
