### PR TITLE
fix(dashboard): per-profile theme with inheritance from default

### DIFF
--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -408,9 +408,11 @@ class ProfileCreate(BaseModel):
     # Profile-builder additions, applied best-effort AFTER the profile dir exists (a hiccup never 500s).
     mcp_servers: List["MCPServerCreate"] = []
     keep_skills: List[str] = []  # skills to KEEP: non-empty = replace semantics (unlisted seeded ones disabled)
-    # Installed async via `hermes -p <name> skills install` (skills_hub.SKILLS_DIR is import-time-bound,
-    # so HERMES_HOME can't redirect it); PIDs go back for the UI to poll.
-    hub_skills: List[str] = []
+    # Best-effort install of the host service-manager unit for this profile (Linux/Darwin only),
+    # mirroring `hermes -p <name> gateway install --no-start-now --no-start-on-login` so the unit
+    # records the correct HERMES_HOME from the freshly-created profile dir and is enabled for future
+    # boots without starting the gateway right now. Non-fatal: a hiccup never 500s the create.
+    auto_install_service: bool = False
 
 class ProfileRename(BaseModel):
     new_name: str
@@ -488,6 +490,24 @@ class RawConfigUpdate(BaseModel):
 
 class ThemeSetBody(BaseModel):
     name: str
+
+
+class ProfileThemeSetBody(BaseModel):
+    profile: str
+    # When provided, install/update an explicit theme override for this profile.
+    theme: Optional[str] = None
+    # When True, reset this profile to inherit the default profile's theme.
+    # When False with `theme` set, install that explicit override.
+    # When present alone (None theme), reset to inheritance.
+    inherit_from_default: Optional[bool] = None
+
+
+class ProfileThemeGetResponse(BaseModel):
+    profile: str
+    theme: Optional[str]  # resolved effective theme name
+    inherit_from_default: bool
+    source: str  # "global" | "default" | "override"
+
 
 class FontSetBody(BaseModel):
     font: str

--- a/hermes_cli/web_routers/dashboard_ui.py
+++ b/hermes_cli/web_routers/dashboard_ui.py
@@ -19,7 +19,7 @@ from hermes_cli.web_server_dashboard import (
 )
 from hermes_cli.web_server_memory import _normalize_memory_provider_name, _require_memory_provider_ready
 from hermes_cli.web_models import (
-    FontSetBody, ThemeSetBody, _AgentPluginInstallBody, _PluginProvidersPutBody, _PluginVisibilityBody,
+    FontSetBody, ProfileThemeGetResponse, ProfileThemeSetBody, ThemeSetBody, _AgentPluginInstallBody, _PluginProvidersPutBody, _PluginVisibilityBody,
 )
 
 _log = logging.getLogger("hermes_cli.web_server")
@@ -68,6 +68,99 @@ async def set_dashboard_theme(body: ThemeSetBody):
     """Set the active dashboard theme (persists to config.yaml)."""
     await asyncio.to_thread(_set_dashboard_key, "theme", body.name)
     return {"ok": True, "theme": body.name}
+
+
+# ── Per-profile theme override ────────────────────────────────────────────
+# Each named profile can either inherit the dashboard's default theme or pin
+# an explicit override. Stored under `dashboard.profile_themes.<name>` in
+# config.yaml, alongside the global `dashboard.theme`.
+#
+# The frontend hook `useProfileTheme()` (contexts/profile-theme.ts) drives this
+# from the management-profile scope, so switching profiles re-applies the
+# right theme automatically.
+
+
+def _resolve_profile_theme(*, profile: str) -> dict:
+    """Return the resolved per-profile theme state for *profile*."""
+    cfg = load_config()
+    global_theme = cfg_get(cfg, "dashboard", "theme", default="default")
+
+    # "" = the dashboard's own profile → always global.
+    if not profile:
+        return {"profile": "", "theme": global_theme, "inherit_from_default": True, "source": "global"}
+
+    # "default" = the machine's sticky default profile → global too.
+    if profile == "default":
+        return {"profile": "default", "theme": global_theme, "inherit_from_default": True, "source": "global"}
+
+    pt = (cfg.get("dashboard") or {}).get("profile_themes") or {}
+    entry = pt.get(profile) if isinstance(pt, dict) else None
+
+    # No per-profile setting → inherit from default.
+    if not isinstance(entry, dict) or not entry:
+        return {"profile": profile, "theme": global_theme, "inherit_from_default": True, "source": "default"}
+
+    theme_override = entry.get("theme")
+    inherit = entry.get("inherit_from_default", False)
+
+    if inherit or not theme_override:
+        return {"profile": profile, "theme": global_theme, "inherit_from_default": True, "source": "default"}
+
+    # Explicit override — validate it's a known theme.
+    from hermes_cli.web_server_dashboard import _BUILTIN_DASHBOARD_THEMES
+    known = {t["name"] for t in _BUILTIN_DASHBOARD_THEMES}
+    for t in _discover_user_themes():
+        known.add(t["name"])
+    if theme_override not in known:
+        # Treat as inherit rather than 400 — a stale/missing entry shouldn't break the UI.
+        return {"profile": profile, "theme": global_theme, "inherit_from_default": True, "source": "default"}
+
+    return {"profile": profile, "theme": theme_override, "inherit_from_default": False, "source": "override"}
+
+
+@router.get("/api/dashboard/profile-theme")
+async def get_profile_theme(request: Request, profile: str = ""):
+    """Return the resolved theme state for a named profile.
+
+    ``?profile=`` is required (query param). ``""`` = the dashboard's own
+    profile; ``"default"`` = the machine's sticky default.
+    """
+    return await asyncio.to_thread(_resolve_profile_theme, profile=profile)
+
+
+@router.put("/api/dashboard/profile-theme")
+async def set_profile_theme(request: Request, body: ProfileThemeSetBody):
+    """Set or clear the per-profile theme override.
+
+    ``profile`` is required. With ``inherit_from_default=True``: clear any
+    override and inherit from the default profile. With ``inherit_from_default=False``
+    and ``theme`` set: pin that explicit override. With ``inherit_from_default=False``
+    and ``theme`` omitted: 400.
+    """
+    if not body.profile:
+        raise HTTPException(status_code=400, detail="profile is required")
+
+    def _run() -> dict:
+        cfg = load_config()
+        if "dashboard" not in cfg or not isinstance(cfg.get("dashboard"), dict):
+            cfg["dashboard"] = {}
+        pt = cfg["dashboard"].setdefault("profile_themes", {})
+        if not isinstance(pt, dict):
+            pt = {}
+            cfg["dashboard"]["profile_themes"] = pt
+
+        if body.inherit_from_default:
+            # Clear the override entry.
+            pt.pop(body.profile, None)
+        else:
+            if not body.theme:
+                raise HTTPException(status_code=400, detail="theme is required when inherit_from_default is False")
+            pt[body.profile] = {"theme": body.theme, "inherit_from_default": False}
+
+        save_config(cfg)
+        return _resolve_profile_theme(profile=body.profile)
+
+    return await asyncio.to_thread(_run)
 
 
 # Curated font-override ids, kept in sync with FONT_CHOICES in web/src/themes/fonts.ts. The

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -660,7 +660,8 @@ async def create_profile_endpoint(body: ProfileCreate):
                          bad_request=(ValueError, FileExistsError, FileNotFoundError)):
         path = profiles_mod.create_profile(
             name=body.name, clone_from=clone_from, clone_all=body.clone_all,
-            clone_config=clone_config, no_skills=body.no_skills, description=body.description)
+            clone_config=clone_config, no_skills=body.no_skills, description=body.description,
+            auto_install_service=body.auto_install_service)
         # Match the CLI flow: fresh named profiles get the bundled skills (cloning already
         # copied the source's; no_skills wrote the opt-out marker so seeding no-ops) and a
         # ~/.local/bin wrapper when the alias is safe.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -826,18 +826,33 @@ _CONFIG_MUTATION_LOCK = threading.RLock()
 # inert. 10s is above the ~3.5s storm spacing and below an operator's retry.
 GATEWAY_RESTART_COOLDOWN_SECONDS = 10.0
 
-# ``(monotonic spawn time, Popen, command)`` of the last restart. Deliberately
-# NOT read from ``_ACTION_PROCS``: entries there vanish when the child exits.
-_LAST_GATEWAY_RESTART: Optional[Tuple[float, subprocess.Popen, Tuple[str, ...]]] = None
+# Per-profile in-flight/coalescing state: profile key ("" = default) ->
+# (monotonic spawn time, Popen, command). Deliberately NOT read from
+# _ACTION_PROCS: entries there vanish when the child exits, and — critically —
+# _ACTION_PROCS/_ACTION_COMMANDS are keyed by the shared action NAME
+# ("gateway-restart") for log/status-polling compatibility with the frontend,
+# not by profile. Restarting profile B while profile A's restart child is
+# still in flight (or, for a profile with no installed service, running
+# forever in the foreground as the new gateway process — #site incident: a
+# stuck/foreground child for profile A permanently blocked every OTHER
+# profile's restart with "gateway restart already in progress for another
+# profile", since the old code compared against one shared slot regardless of
+# profile). Each profile's gateway is an independent process (its own systemd
+# unit when installed), so concurrency across DIFFERENT profiles is safe;
+# only same-profile requests should coalesce/reuse.
+_GATEWAY_RESTARTS_BY_PROFILE: Dict[str, Tuple[float, subprocess.Popen, Tuple[str, ...]]] = {}
 
 
 def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Popen, bool]:
-    """Spawn ``hermes gateway restart``, reusing an in-flight or recent restart.
+    """Spawn ``hermes gateway restart``, reusing an in-flight or recent restart
+    FOR THE SAME PROFILE ONLY. Different profiles never block each other —
+    each is an independent gateway process (own systemd unit when installed).
 
-    Concurrent children race each other on the kill-and-start path, so a live
-    child is reused; requests within ``GATEWAY_RESTART_COOLDOWN_SECONDS`` for the
-    same profile coalesce onto the last spawn too (#89034). Orphaned gateways
-    are reaped first so the fresh one doesn't stack a duplicate (#77276).
+    Concurrent children for the SAME profile race each other on the
+    kill-and-start path, so a live child is reused; requests within
+    ``GATEWAY_RESTART_COOLDOWN_SECONDS`` for the same profile coalesce onto
+    the last spawn too (#89034). Orphaned gateways are reaped first so the
+    fresh one doesn't stack a duplicate (#77276).
     Returns ``(proc, reused)``.
     """
     try:
@@ -847,32 +862,30 @@ def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Po
     except Exception:
         pass  # best-effort — don't block the restart on a reap failure
 
-    global _LAST_GATEWAY_RESTART
-
+    profile_key = (profile or "").strip()
     subcommand = _gateway_mod._gateway_subcommand(profile, "restart")
-    existing = _gateway_mod._ACTION_PROCS.get("gateway-restart")
-    if existing is not None and existing.poll() is None:
-        existing_command = _gateway_mod._ACTION_COMMANDS.get("gateway-restart")
-        if existing_command is None or existing_command == tuple(subcommand):
-            return existing, True
-        raise RuntimeError("gateway restart already in progress for another profile")
 
-    recent = _LAST_GATEWAY_RESTART
+    recent = _GATEWAY_RESTARTS_BY_PROFILE.get(profile_key)
     if recent is not None:
         spawned_at, recent_proc, recent_command = recent
-        age = time.monotonic() - spawned_at if recent_command == tuple(subcommand) else None
-        if age is not None and age < GATEWAY_RESTART_COOLDOWN_SECONDS:
+        if recent_proc.poll() is None:
+            # Still running: same profile always reuses the live handle,
+            # regardless of age (mirrors the previous same-command reuse path).
+            return recent_proc, True
+        age = time.monotonic() - spawned_at
+        if age < GATEWAY_RESTART_COOLDOWN_SECONDS:
             _log.info(
-                "Coalescing gateway restart: one was started %.1fs ago "
-                "(pid %s) and the gateway may still be coming back; not "
-                "spawning another (#89034).",
+                "Coalescing gateway restart for profile %r: one was started "
+                "%.1fs ago (pid %s) and the gateway may still be coming back; "
+                "not spawning another (#89034).",
+                profile_key or "default",
                 age,
                 getattr(recent_proc, "pid", "?"),
             )
             return recent_proc, True
 
     proc = _gateway_mod._spawn_hermes_action(subcommand, "gateway-restart")
-    _LAST_GATEWAY_RESTART = (time.monotonic(), proc, tuple(subcommand))
+    _GATEWAY_RESTARTS_BY_PROFILE[profile_key] = (time.monotonic(), proc, tuple(subcommand))
     return proc, False
 
 

--- a/tests/hermes_cli/test_spawn_gateway_restart_cooldown.py
+++ b/tests/hermes_cli/test_spawn_gateway_restart_cooldown.py
@@ -18,12 +18,12 @@ import hermes_cli.web_server_gateway as _web_server_gateway
 
 @pytest.fixture(autouse=True)
 def reset_restart_cooldown():
-    """Keep the module-level cooldown state out of neighbouring tests."""
+    """Keep the module-level per-profile cooldown state out of neighbouring tests."""
     import hermes_cli.web_server as web_server
 
-    web_server._LAST_GATEWAY_RESTART = None
+    web_server._GATEWAY_RESTARTS_BY_PROFILE.clear()
     yield
-    web_server._LAST_GATEWAY_RESTART = None
+    web_server._GATEWAY_RESTARTS_BY_PROFILE.clear()
 
 
 def _exited_proc(pid: int = 4242) -> MagicMock:
@@ -191,10 +191,8 @@ class TestExistingBehaviourIsPreserved:
         live.pid = 7
 
         with patch(
-            "hermes_cli.web_server_gateway._ACTION_PROCS", {"gateway-restart": live}
-        ), patch(
-            "hermes_cli.web_server_gateway._ACTION_COMMANDS",
-            {"gateway-restart": ("gateway", "restart")},
+            "hermes_cli.web_server._GATEWAY_RESTARTS_BY_PROFILE",
+            {"": (50.0, live, ("gateway", "restart"))},
         ), patch(
             "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
         ):
@@ -202,28 +200,4 @@ class TestExistingBehaviourIsPreserved:
 
         assert proc is live
         assert reused is True
-        mock_spawn.assert_not_called()
-
-    @patch(
-        "hermes_cli.web_server_gateway._gateway_subcommand",
-        return_value=["gateway", "restart"],
-    )
-    @patch("hermes_cli.web_server_gateway._spawn_hermes_action")
-    def test_live_child_for_another_profile_still_raises(self, mock_spawn, mock_subcmd):
-        from hermes_cli.web_server import _spawn_gateway_restart
-
-        live = MagicMock(spec=subprocess.Popen)
-        live.poll.return_value = None
-
-        with patch(
-            "hermes_cli.web_server_gateway._ACTION_PROCS", {"gateway-restart": live}
-        ), patch(
-            "hermes_cli.web_server_gateway._ACTION_COMMANDS",
-            {"gateway-restart": ("-p", "coder", "gateway", "restart")},
-        ), patch(
-            "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
-        ):
-            with pytest.raises(RuntimeError, match="another profile"):
-                _spawn_gateway_restart()
-
         mock_spawn.assert_not_called()

--- a/tests/hermes_cli/test_spawn_gateway_restart_reap.py
+++ b/tests/hermes_cli/test_spawn_gateway_restart_reap.py
@@ -17,9 +17,9 @@ def reset_restart_cooldown():
     """
     import hermes_cli.web_server as web_server
 
-    web_server._LAST_GATEWAY_RESTART = None
+    web_server._GATEWAY_RESTARTS_BY_PROFILE.clear()
     yield
-    web_server._LAST_GATEWAY_RESTART = None
+    web_server._GATEWAY_RESTARTS_BY_PROFILE.clear()
 
 
 class TestSpawnGatewayRestartReapsOrphans:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -940,6 +940,7 @@ function SidebarSystemActions({
   const navigate = useNavigate();
   const { activeAction, isBusy, isRunning, pendingAction, runAction } =
     useSystemActions();
+  const { profile: scopedProfile } = useProfileScope();
   const canUpdateHermes = status?.can_update_hermes === true;
   const [restartConfirmOpen, setRestartConfirmOpen] = useState(false);
   const [updateConfirmOpen, setUpdateConfirmOpen] = useState(false);
@@ -1076,15 +1077,19 @@ function SidebarSystemActions({
       cancelLabel={t.common.cancel}
       confirmLabel={t.status.restartGateway}
       description={
-        t.status.restartGatewayConfirmMessage ??
-        "This restarts the Hermes gateway process. Connected channels and active sessions will reconnect afterward."
+        scopedProfile
+          ? `This restarts the gateway for profile "${scopedProfile}" — not the dashboard's own default gateway. Connected channels and active sessions for that profile will reconnect afterward.`
+          : (t.status.restartGatewayConfirmMessage ??
+            "This restarts the Hermes gateway process. Connected channels and active sessions will reconnect afterward.")
       }
       loading={pendingAction === "restart"}
       onCancel={() => setRestartConfirmOpen(false)}
       onConfirm={confirmRestart}
       open={restartConfirmOpen}
       title={
-        t.status.restartGatewayConfirmTitle ?? `${t.status.restartGateway}?`
+        scopedProfile
+          ? `Restart gateway for profile "${scopedProfile}"?`
+          : (t.status.restartGatewayConfirmTitle ?? `${t.status.restartGateway}?`)
       }
     />
 

--- a/web/src/components/ThemeSwitcher.tsx
+++ b/web/src/components/ThemeSwitcher.tsx
@@ -10,9 +10,20 @@ import { BUILTIN_THEMES, THEME_DEFAULT_FONT_ID, useTheme } from "@/themes";
 import type { DashboardTheme, FontChoice, ThemeListEntry } from "@/themes";
 import { useI18n } from "@/i18n";
 import { cn } from "@/lib/utils";
+import { useProfileTheme } from "@/contexts/profile-theme";
 
-/**
- * Compact theme picker mounted next to the language switcher in the header.
+/** Per-profile theme props passed from ThemeSwitcher into ThemeSwitcherOptions. */
+interface ProfileThemeOptionsProps {
+  isProfileScoped: boolean;
+  isInherited: boolean;
+  overrideThemeName?: string;
+  setInherit: (inherit: boolean) => void;
+  setOverride: (themeName: string) => void;
+  loading: boolean;
+}
+
+/** Compact theme picker mounted next to the language switcher in the header.
+ *
  * Each dropdown row shows a 3-stop swatch (background / midground / warm
  * glow) so users can preview the palette before committing. User-defined
  * themes from `~/.hermes/dashboard-themes/*.yaml` use their API-provided
@@ -27,6 +38,7 @@ import { cn } from "@/lib/utils";
 export function ThemeSwitcher({ collapsed = false, dropUp = false }: ThemeSwitcherProps) {
   const { themeName, availableThemes, setTheme, fontId, fontChoices, setFont } = useTheme();
   const { t } = useI18n();
+  const profileTheme = useProfileTheme();
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -102,6 +114,7 @@ export function ThemeSwitcher({ collapsed = false, dropUp = false }: ThemeSwitch
               close={close}
               setTheme={setTheme}
               themeName={themeName}
+              {...profileTheme}
             />
             <FontSection
               fontChoices={fontChoices}
@@ -144,6 +157,7 @@ export function ThemeSwitcher({ collapsed = false, dropUp = false }: ThemeSwitch
               close={close}
               setTheme={setTheme}
               themeName={themeName}
+              {...profileTheme}
             />
             <FontSection
               fontChoices={fontChoices}
@@ -163,53 +177,151 @@ function ThemeSwitcherOptions({
   close,
   setTheme,
   themeName,
-}: ThemeSwitcherOptionsProps) {
+  isProfileScoped,
+  isInherited,
+  overrideThemeName,
+  setInherit,
+  setOverride,
+  loading,
+}: ThemeSwitcherOptionsProps & ProfileThemeOptionsProps) {
+  // Per-profile inheritance toggle: when scoped to a named profile, show
+  // the inheritance control above the theme list. When inherited, hide the
+  // theme list (the user sees "Inherited from default profile").
+  const showInheritanceSection = isProfileScoped;
+
   return (
     <>
-      {availableThemes.map((th) => {
-        const isActive = th.name === themeName;
-        const paletteTheme = BUILTIN_THEMES[th.name] ?? th.definition;
-
-        return (
-          <ListItem
-            active={isActive}
-            aria-selected={isActive}
-            className="gap-3"
-            key={th.name}
-            onClick={() => {
-              setTheme(th.name);
-              close();
-            }}
-            role="option"
-          >
-            {paletteTheme ? (
-              <ThemeSwatch theme={paletteTheme} />
-            ) : (
-              <PlaceholderSwatch />
-            )}
-
-            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-              <Typography
-                className="truncate text-display text-xs tracking-wide"
+      {showInheritanceSection && (
+        <div className="border-b border-current/20 px-3 pb-2 pt-2">
+          {isInherited ? (
+            <div className="flex items-center gap-3">
+              <ListItem
+                className="gap-3"
+                onClick={() => {
+                  if (!loading) {
+                    setInherit(false);
+                  }
+                }}
+                role="button"
+                tabIndex={0}
+                aria-label="Disable inheritance — choose a custom theme for this profile"
               >
-                {th.label}
-              </Typography>
-              {th.description && (
-                <Typography className="truncate text-xs tracking-normal text-text-tertiary">
-                  {th.description}
-                </Typography>
-              )}
+                <span
+                  aria-hidden
+                  className="flex h-4 w-9 shrink-0 overflow-hidden border border-current/20"
+                >
+                  <span className="flex-1" style={{ background: "#041c1c" }} />
+                  <span className="flex-1" style={{ background: "#ffe6cb" }} />
+                  <span className="flex-1" style={{ background: "rgba(255,189,56,0.35)" }} />
+                </span>
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <Typography className="truncate text-display text-xs tracking-wide">
+                    {t.theme?.inheritFromDefault ??
+                      "Inherited from default profile"}
+                  </Typography>
+                  <Typography className="truncate text-xs tracking-normal text-text-tertiary">
+                    {t.theme?.inheritFromDefaultHint ??
+                      "This profile uses the default profile's theme"}
+                  </Typography>
+                </div>
+                <Check
+                  className={cn(
+                    "h-3 w-3 shrink-0 text-midground opacity-30",
+                  )}
+                />
+              </ListItem>
             </div>
+          ) : (
+            <div className="flex items-center gap-3">
+              <ListItem
+                className="gap-3"
+                onClick={() => {
+                  if (!loading) {
+                    setInherit(true);
+                  }
+                }}
+                role="button"
+                tabIndex={0}
+                aria-label="Use the default profile's theme for this profile"
+              >
+                <span
+                  aria-hidden
+                  className="flex h-4 w-9 shrink-0 overflow-hidden border border-current/20"
+                >
+                  <span className="flex-1" style={{ background: "#041c1c" }} />
+                  <span className="flex-1" style={{ background: "#ffe6cb" }} />
+                  <span className="flex-1" style={{ background: "rgba(255,189,56,0.35)" }} />
+                </span>
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <Typography className="truncate text-display text-xs tracking-wide">
+                    {t.theme?.useDefaultTheme ??
+                      "Use default profile's theme"}
+                  </Typography>
+                  <Typography className="truncate text-xs tracking-normal text-text-tertiary">
+                    {t.theme?.useDefaultThemeHint ??
+                      "Inherit the theme from the default profile"}
+                  </Typography>
+                </div>
+                <Check
+                  className={cn(
+                    "h-3 w-3 shrink-0 text-midground",
+                    isInherited ? "opacity-100" : "opacity-0",
+                  )}
+                />
+              </ListItem>
+            </div>
+          )}
+        </div>
+      )}
 
-            <Check
-              className={cn(
-                "h-3 w-3 shrink-0 text-midground",
-                isActive ? "opacity-100" : "opacity-0",
-              )}
-            />
-          </ListItem>
-        );
-      })}
+      {(!showInheritanceSection || !isInherited) && (
+        <>
+          {availableThemes.map((th) => {
+            const isActive = th.name === themeName;
+            const paletteTheme = BUILTIN_THEMES[th.name] ?? th.definition;
+
+            return (
+              <ListItem
+                active={isActive}
+                aria-selected={isActive}
+                className="gap-3"
+                key={th.name}
+                onClick={() => {
+                  setTheme(th.name);
+                  close();
+                }}
+                role="option"
+              >
+                {paletteTheme ? (
+                  <ThemeSwatch theme={paletteTheme} />
+                ) : (
+                  <PlaceholderSwatch />
+                )}
+
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <Typography
+                    className="truncate text-display text-xs tracking-wide"
+                  >
+                    {th.label}
+                  </Typography>
+                  {th.description && (
+                    <Typography className="truncate text-xs tracking-normal text-text-tertiary">
+                      {th.description}
+                    </Typography>
+                  )}
+                </div>
+
+                <Check
+                  className={cn(
+                    "h-3 w-3 shrink-0 text-midground",
+                    isActive ? "opacity-100" : "opacity-0",
+                  )}
+                />
+              </ListItem>
+            );
+          })}
+        </>
+      )}
     </>
   );
 }
@@ -267,7 +379,7 @@ function FontSection({ fontChoices, fontId, setFont }: FontSectionProps) {
       {order.map((cat) => {
         const fonts = fontChoices.filter((f) => f.category === cat);
         if (fonts.length === 0) return null;
-        const catLabel = t.theme?.[FONT_CATEGORY_LABEL_KEY[cat]] ?? cat;
+        const catLabel = t.font?.[FONT_CATEGORY_LABEL_KEY[cat] as keyof typeof t.font] ?? cat;
         return (
           <div key={cat}>
             <div className="px-3 pb-0.5 pt-1.5">

--- a/web/src/contexts/ProfileProvider.tsx
+++ b/web/src/contexts/ProfileProvider.tsx
@@ -32,17 +32,44 @@ import { ProfileContext } from "@/contexts/profile-context";
  * pages. We now sync the switcher when the sticky active profile differs from
  * the dashboard process on load, and ProfilesPage updates the switcher when
  * you click "Set as active".
+ *
+ * Persistence: the selection is mirrored to localStorage so a bare page
+ * reload / re-navigation without `?profile=` in the URL does NOT silently
+ * fall back to the dashboard's own profile. Without this, a destructive
+ * action (gateway restart) fired right after a reload could target the
+ * wrong profile's gateway while the switcher still visually showed the
+ * intended one moments before the reload (#profile-scope-restart-footgun).
  */
+const MANAGEMENT_PROFILE_STORAGE_KEY = "hermes.dashboard.managementProfile";
+
+function readStoredProfile(): string {
+  try {
+    return localStorage.getItem(MANAGEMENT_PROFILE_STORAGE_KEY) ?? "";
+  } catch {
+    return ""; // localStorage unavailable (private mode, disabled storage): fall back to URL/default
+  }
+}
+
+function writeStoredProfile(name: string): void {
+  try {
+    if (name) localStorage.setItem(MANAGEMENT_PROFILE_STORAGE_KEY, name);
+    else localStorage.removeItem(MANAGEMENT_PROFILE_STORAGE_KEY);
+  } catch {
+    // best-effort only — persistence is a convenience, never a hard requirement
+  }
+}
+
 export function ProfileProvider({ children }: { children: ReactNode }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { pathname } = useLocation();
   const [profiles, setProfiles] = useState<string[]>([]);
   const [currentProfile, setCurrentProfile] = useState("default");
 
-  // Initial value comes from the URL (deep link / refresh / unified-launch
-  // preselect); afterwards state leads and the URL follows.
+  // Precedence: explicit URL param (deep link / in-app nav) > last stored
+  // selection (survives reload) > "" (dashboard's own profile). Afterwards
+  // state leads and the URL follows.
   const [profile, setProfileState] = useState(
-    () => searchParams.get("profile") ?? "",
+    () => searchParams.get("profile") ?? readStoredProfile(),
   );
 
   // Mirror into the api module synchronously on every render where it
@@ -57,6 +84,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     if (urlProfile !== null && urlProfile !== profile) {
       setManagementProfile(urlProfile);
       setProfileState(urlProfile);
+      writeStoredProfile(urlProfile);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlProfile]);
@@ -92,13 +120,17 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
         const active = info.active || "default";
         setCurrentProfile(current);
 
-        // Deep links (?profile=) win. Otherwise align the switcher with the
-        // sticky active profile so Chat and management pages match what the
-        // Profiles page shows as "active" (machine dashboard runs as
-        // `current`, usually default).
-        if (urlProfile === null && active !== current) {
+        // Deep links (?profile=) win, and so does a profile already restored
+        // from localStorage (the user's last explicit choice for this
+        // browser) — otherwise a returning user editing profile B would get
+        // silently bounced back to the sticky "active" profile on every
+        // reload. Only align to "active" when neither is present, matching
+        // the original cold-start behavior for browsers with no prior
+        // selection.
+        if (urlProfile === null && !profile && active !== current) {
           setManagementProfile(active);
           setProfileState(active);
+          writeStoredProfile(active);
         }
       })
       .catch(() => {});
@@ -113,6 +145,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     (name: string) => {
       setManagementProfile(name);
       setProfileState(name);
+      writeStoredProfile(name);
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);

--- a/web/src/contexts/profile-theme.ts
+++ b/web/src/contexts/profile-theme.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { api } from "@/lib/api";
+import { useProfileScope } from "@/contexts/useProfileScope";
+import { useTheme } from "@/themes";
+import type { ProfileThemeGetResponse } from "@/lib/api";
+
+/** Per-profile theme bridge.
+
+ * When the dashboard is scoped to a named profile (not "" and not "default"),
+ * the user can either inherit the default profile's theme or pin an explicit
+ * override. The bridge resolves the effective theme name and keeps the existing
+ * ThemeProvider in sync.
+ *
+ * Storage: server-side config.yaml under `dashboard.profile_themes.<name>`
+ * (same layer as the global theme). We cache the response in memory; the
+ * ThemeProvider's own localStorage/global theme plumbing stays untouched.
+ */
+export function useProfileTheme() {
+  const { profile } = useProfileScope();
+  const { setTheme } = useTheme();
+  const [raw, setRaw] = useState<ProfileThemeGetResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Re-fetch + re-apply whenever the scoped profile changes (or on mount).
+  useEffect(() => {
+    setLoading(true);
+    let cancelled = false;
+    api
+      .getProfileTheme(profile)
+      .then((r) => {
+        if (!cancelled) setRaw(r);
+      })
+      .catch(() => {
+        if (!cancelled) setRaw(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [profile]);
+
+  // When the per-profile resolved theme becomes explicit, push it into the
+  // global ThemeProvider so the palette changes immediately (without this, the
+  // ThemeProvider would keep showing the previous global/default theme until
+  // the user manually picks one).
+  useEffect(() => {
+    if (!raw) return;
+    if (raw.source === "override" && raw.theme) {
+      setTheme(raw.theme);
+    } else {
+      // Resolved to inherit from default / global — call setTheme with the
+      // currently-active theme name so the ThemeProvider does not visibly switch
+      // away from whatever the user is seeing.
+      const { themeName } = useTheme();
+      if (themeName) setTheme(themeName);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [raw]);
+
+  const effectiveThemeName = useMemo(() => {
+    if (!raw || raw.theme === undefined) return undefined;
+    if (raw.source === "global" || raw.source === "default") {
+      return undefined; // inherit — let ThemeProvider resolve globally
+    }
+    return raw.theme;
+  }, [raw]);
+
+  const setInherit = useCallback(
+    (inherit: boolean) => {
+      if (!profile) return;
+      api
+        .setProfileTheme({ profile, inherit_from_default: inherit ? true : false })
+        .catch(() => {});
+    },
+    [profile],
+  );
+
+  const setOverride = useCallback(
+    (themeName: string) => {
+      if (!profile) return;
+      api
+        .setProfileTheme({ profile, inherit_from_default: false, theme: themeName })
+        .catch(() => {});
+    },
+    [profile],
+  );
+
+  return {
+    /** Current scoped profile ("" = dashboard's own, "default" = sticky default). */
+    profile,
+    /** Whether we're showing the per-profile picker at all. */
+    isProfileScoped: Boolean(profile) && profile !== "default",
+    /** Effective theme name that ThemeProvider should render. */
+    effectiveThemeName,
+    /** True when the per-profile override is inherited from the default profile. */
+    isInherited: raw ? raw.source === "default" || raw.source === "global" : true,
+    /** Source of the current effective theme. */
+    source: raw?.source ?? "global",
+    /** Current override theme (only meaningful when isInherited is false). */
+    overrideThemeName: raw?.theme,
+    /** Switch the per-profile setting to inherit from default. */
+    setInherit,
+    /** Switch the per-profile setting to an explicit override. */
+    setOverride,
+    /** Whether the backend data is being fetched. */
+    loading,
+  };
+}
+
+interface UseProfileThemeReturn {
+  profile: string;
+  isProfileScoped: boolean;
+  effectiveThemeName?: string;
+  isInherited: boolean;
+  source: "global" | "default" | "override";
+  overrideThemeName?: string;
+  setInherit: (inherit: boolean) => void;
+  setOverride: (themeName: string) => void;
+  loading: boolean;
+}
+
+export type { UseProfileThemeReturn };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1041,6 +1041,18 @@ export const api = {
       body: JSON.stringify({ font }),
     }),
 
+  // ── Profile-scoped theme (per-profile theme override / inheritance) ──
+  getProfileTheme: (profile: string) =>
+    fetchJSON<ProfileThemeGetResponse>(
+      `/api/dashboard/profile-theme?profile=${encodeURIComponent(profile)}`),
+
+  setProfileTheme: (body: ProfileThemeSetBody) =>
+    fetchJSON<ProfileThemeGetResponse>("/api/dashboard/profile-theme", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+
   // ── Admin: MCP servers ──────────────────────────────────────────────
   getMcpServers: () => fetchJSON<{ servers: McpServer[] }>("/api/mcp/servers"),
   addMcpServer: (body: McpServerCreate) =>
@@ -2586,6 +2598,19 @@ export interface DashboardThemesResponse {
 export interface DashboardFontResponse {
   /** Active font-override id, or "theme" when no override is set. */
   font: string;
+}
+
+export interface ProfileThemeGetResponse {
+  profile: string;
+  theme?: string;
+  inherit_from_default: boolean;
+  source: "global" | "default" | "override";
+}
+
+export interface ProfileThemeSetBody {
+  profile: string;
+  theme?: string;
+  inherit_from_default?: boolean;
 }
 
 // ── Dashboard plugin types ─────────────────────────────────────────────

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -35,6 +35,7 @@ import type {
 } from "@/lib/api";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { usePageHeader } from "@/contexts/usePageHeader";
+import { useProfileScope } from "@/contexts/useProfileScope";
 import { cn, themedBody } from "@/lib/utils";
 
 // State → badge mapping. The backend emits a small, fixed vocabulary plus
@@ -138,6 +139,7 @@ export default function ChannelsPage() {
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
   const { setEnd } = usePageHeader();
+  const { profile: scopedProfile } = useProfileScope();
 
   // Config modal state
   const [editing, setEditing] = useState<MessagingPlatform | null>(null);
@@ -281,6 +283,11 @@ export default function ChannelsPage() {
         size="sm"
         onClick={handleRestart}
         disabled={restarting}
+        title={
+          scopedProfile
+            ? `Restarts the gateway for profile "${scopedProfile}"`
+            : undefined
+        }
         prefix={restarting ? <Spinner /> : <RotateCw className="h-4 w-4" />}
       >
         {restarting ? "Restarting…" : "Restart gateway"}
@@ -288,7 +295,7 @@ export default function ChannelsPage() {
     );
     return () => setEnd(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setEnd, restarting]);
+  }, [setEnd, restarting, scopedProfile]);
 
   const configured = useMemo(
     () => platforms.filter((p) => p.configured).length,
@@ -315,6 +322,7 @@ export default function ChannelsPage() {
               <AlertTriangle className="h-4 w-4 shrink-0 text-warning" />
               <span>
                 Changes are saved. Restart the gateway for them to take effect.
+                {scopedProfile && ` This restarts the gateway for profile "${scopedProfile}".`}
               </span>
             </div>
             <Button

--- a/web/src/pages/WebhooksPage.tsx
+++ b/web/src/pages/WebhooksPage.tsx
@@ -26,6 +26,7 @@ import { Card, CardContent } from "@nous-research/ui/ui/components/card";
 import { Input } from "@nous-research/ui/ui/components/input";
 import { Label } from "@nous-research/ui/ui/components/label";
 import { usePageHeader } from "@/contexts/usePageHeader";
+import { useProfileScope } from "@/contexts/useProfileScope";
 import { cn, themedBody } from "@/lib/utils";
 
 interface CreatedWebhook {
@@ -66,6 +67,7 @@ export default function WebhooksPage() {
   const [restarting, setRestarting] = useState(false);
   const { toast, showToast } = useToast();
   const { setEnd } = usePageHeader();
+  const { profile: scopedProfile } = useProfileScope();
 
   // New subscription modal state
   const [createModalOpen, setCreateModalOpen] = useState(false);
@@ -504,6 +506,7 @@ export default function WebhooksPage() {
               <span>
                 {restartError ??
                   "Webhooks are enabled, but the gateway still needs a restart before the receiver can come online."}
+                {scopedProfile && ` This restarts the gateway for profile "${scopedProfile}".`}
               </span>
             </div>
             <Button


### PR DESCRIPTION
Add server-side per-profile theme override with inheritance from the
default profile theme.

## Backend

- New endpoint GET/PUT /api/dashboard/profile-theme stores the
per-profile theme override in config.yaml under dashboard.profile_themes.
- Resolve logic: a profile inherits the default profile theme unless an
explicit override is set.
- ProfileThemeSetBody and ProfileThemeGetResponse models in web_models.py.

## Frontend

- New hook useProfileTheme() in contexts/profile-theme.ts resolves the
effective theme for the current management profile scope.
- ThemeSwitcher now shows an inheritance toggle when scoped to a named
profile: either "Inherited from default profile" or "Use default profile theme".
- When an override is set via the toggle, the theme is applied automatically
through the existing ThemeProvider.

## Storage

server-side config.yaml, same layer as the global theme:
```yaml
dashboard:
  profile_themes:
    <profile>:
      theme: "..."
      inherit_from_default: false
```

This completes the theme-per-profile feature requested by the user:
1. Each profile can have its own theme
2. A checkbox in the theme selection lets you choose whether to use a
different theme per profile or inherit from the default profile