### PR TITLE
ActivePieces as a first-class gateway platform (thin WebhookAdapter subclass)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -581,6 +581,12 @@ _LOCAL_CRON_DELIVERY_NOTE = (
 )
 
 PLATFORM_HINTS = {
+    "activepieces": (
+        "You are reacting to an ActivePieces automation event (a trigger such as a new email or "
+        "webhook fired a flow). No human is waiting synchronously: finish the task autonomously, "
+        "be concise, and remember your reply is delivered back to the automation that woke you "
+        "(or read aloud at the next conversation). Plain text; no interactive formatting."
+    ),
     "whatsapp": (
         "You are on WhatsApp. Standard markdown auto-converts to WhatsApp syntax (*bold*, _italic_, ~strike~, "
         "monospace) \u2014 write markdown freely, bullets included. No tables \u2014 use bullets or labeled lines. "

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -478,7 +478,8 @@ class GatewayAuthorizationMixin:
         ``GATEWAY_ALLOW_ALL_USERS``, default deny.
         """
         # HA events are system-generated (HASS_TOKEN); webhook events are HMAC-verified.
-        if source.platform in {Platform.HOMEASSISTANT, Platform.WEBHOOK}:
+        # AP flow events are secret-verified at intake (bearer/HMAC), same trust as webhook HMAC.
+        if source.platform in {Platform.HOMEASSISTANT, Platform.WEBHOOK, Platform.ACTIVEPIECES}:
             return True
 
         adapter_profile = self._adapter_profile_for_source(source)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -214,6 +214,7 @@ class Platform(Enum):
     API_SERVER = "api_server"
     WEBHOOK = "webhook"
     MSGRAPH_WEBHOOK = "msgraph_webhook"
+    ACTIVEPIECES = "activepieces"
     FEISHU = "feishu"
     WECOM = "wecom"
     WECOM_CALLBACK = "wecom_callback"
@@ -520,6 +521,7 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
     Platform.API_SERVER: lambda cfg: _has_usable_api_server_key(cfg.extra.get("key") if cfg else None),
     Platform.WEBHOOK: lambda cfg: True,
     Platform.MSGRAPH_WEBHOOK: lambda cfg: bool(str(cfg.extra.get("client_state") or "").strip()),
+    Platform.ACTIVEPIECES: lambda cfg: True,
     Platform.BLUEBUBBLES: _needs_extra("server_url", "password"),
     Platform.QQBOT: _needs_extra("app_id", "client_secret"),
     Platform.YUANBAO: _needs_extra("app_id", "app_secret"),

--- a/gateway/platforms/activepieces.py
+++ b/gateway/platforms/activepieces.py
@@ -1,0 +1,144 @@
+"""ActivePieces platform adapter: AP automation triggers wake the agent.
+
+ActivePieces (self-hosted AP, e.g. the meeting pod's in-pod instance) runs
+flows whose triggers — Gmail new email, generic webhooks, Twilio SMS — must
+wake the agent exactly like a Telegram message. Rather than duplicating the
+webhook receiver's pipeline, this adapter REUSES it: subclass of
+:class:`WebhookAdapter` (auth → rate-limit → parse → event/payload filters →
+route script → prompt render → skills attach → agent dispatch → delivery,
+``gateway/platforms/webhook.py::_handle_webhook``), registered as its own
+first-class ``Platform.ACTIVEPIECES`` the same way
+:class:`~gateway.platforms.msgraph_webhook.MSGraphWebhookAdapter` is.
+
+Only the ActivePieces-specific edges live here:
+
+- **Bearer auth.** An AP flow's HTTP-request piece sets STATIC headers; it
+  cannot compute an HMAC. ``Authorization: Bearer <secret>`` is compared
+  timing-safely against the route (or global) secret; the inherited HMAC
+  schemes still work for flows that use a code piece. No secret → the route
+  never starts (inherited fail-closed validation).
+- **Reply delivery — ``deliver: "activepieces"``.** The agent's final
+  response is POSTed as ``{delivery_id, flow, reply}`` to the route's
+  ``deliver_extra.url`` (trusted route config, never payload-derived) with
+  optional static ``deliver_extra.headers``. That URL is the AP-native
+  reply channel: a Webhook-Response/HTTP step in the flow's reply leg.
+- **Loopback default.** AP events arrive over the pod's control-doc bridge
+  (session-api control event → app task_loop → loopback POST), so the
+  listener binds 127.0.0.1 unless ``extra.host`` says otherwise.
+
+Envelope contract (shared with the cold-start/Twilio consumers): the POST
+body is ``{source: "activepieces", piece, trigger, project_id, event: <raw
+trigger payload>}``; per-flow skills attach via the route's ``skills`` key
+and pieces are distinguished with payload filters (``source``/``piece``).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+try:
+    from aiohttp import ClientSession, ClientTimeout
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:  # pragma: no cover - aiohttp is a hard requirement, same as the base
+    AIOHTTP_AVAILABLE = False
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.webhook import WebhookAdapter, _hmac_str_equal
+from gateway.response_filters import is_autonomous_silence_response
+
+logger = logging.getLogger(__name__)
+
+#: Pod-loopback by default: AP reaches this adapter through the app's
+#: control-doc bridge, never from a public network.
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8647
+_DELIVER_TYPE = "activepieces"
+_REPLY_TIMEOUT_SECONDS = 15
+
+
+def check_activepieces_requirements() -> bool:
+    """Check if ActivePieces adapter dependencies are available."""
+    return AIOHTTP_AVAILABLE
+
+
+class ActivePiecesAdapter(WebhookAdapter):
+    """Receive ActivePieces flow events and surface them to the agent."""
+
+    _session_id_prefix = "activepieces"
+    _source_label = "activepieces"
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.ACTIVEPIECES)
+        extra = config.extra
+        # Flows use the same route schema as webhook routes (secret, events,
+        # filters, script, prompt, skills, toolsets, deliver, deliver_extra)
+        # keyed by the AP flow name; static-only — AP flows are provisioned
+        # alongside the config, not agent-created subscriptions.
+        flows = extra.get("flows", {})
+        self._static_routes: Dict[str, dict] = {str(k): v for k, v in flows.items()} if isinstance(flows, dict) else {}
+        self._routes: Dict[str, dict] = dict(self._static_routes)
+        self._host: Optional[str] = str(extra.get("host") or DEFAULT_HOST)
+        self._port: int = int(extra.get("port", DEFAULT_PORT))
+
+    def _validate_signature(self, request, body: bytes, secret: str) -> bool:
+        """Bearer first (what AP flows can actually send), then the inherited HMAC schemes."""
+        auth = request.headers.get("Authorization", "") or ""
+        if auth.startswith("Bearer "):
+            return _hmac_str_equal(auth[len("Bearer "):].strip(), secret)
+        return super()._validate_signature(request, body, secret)
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None,
+                   metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        """Agent-mode delivery: ``deliver: activepieces`` POSTs the reply back into AP."""
+        if is_autonomous_silence_response(content):
+            logger.info("[activepieces] Response for %s is a silence marker — not delivering", chat_id)
+            return SendResult(success=True)
+        delivery = self._delivery_info.get(chat_id, {})
+        if delivery.get("deliver") == _DELIVER_TYPE:
+            return await self._deliver_activepieces(content, delivery, chat_id)
+        return await super().send(chat_id, content, reply_to, metadata)
+
+    def _validate_route(self, name: str, route: dict) -> None:
+        """Inherited secret checks, plus: ``deliver: activepieces`` needs an http(s) URL."""
+        super()._validate_route(name, route)
+        if route.get("deliver") == _DELIVER_TYPE:
+            url = str((route.get("deliver_extra") or {}).get("url", "")).strip()
+            if not url.startswith(("http://", "https://")):
+                raise ValueError(
+                    f"[activepieces] Flow '{name}' sets deliver='{_DELIVER_TYPE}' but deliver_extra.url "
+                    f"is not an http(s) URL: {url!r}")
+
+    async def _direct_deliver(self, content: str, delivery: dict) -> SendResult:
+        """deliver_only parity for the activepieces target."""
+        if delivery.get("deliver") == _DELIVER_TYPE:
+            return await self._deliver_activepieces(
+                content, delivery, f"{self._session_id_prefix}:{delivery.get('route', '')}:"
+                                   f"{delivery.get('delivery_id', '')}")
+        return await super()._direct_deliver(content, delivery)
+
+    async def _deliver_activepieces(self, content: str, delivery: dict, chat_id: str) -> SendResult:
+        """POST the agent reply to the flow's reply URL ({delivery_id, flow, reply})."""
+        extra = delivery.get("deliver_extra", {})
+        url = str(extra.get("url", "")).strip()
+        if not url.startswith(("http://", "https://")):
+            logger.error("[activepieces] Reply URL missing or not http(s) for %s", chat_id)
+            return SendResult(success=False, error="Reply URL not configured")
+        headers = {str(k): str(v) for k, v in (extra.get("headers") or {}).items()}
+        body = {"delivery_id": chat_id.rsplit(":", 1)[-1], "flow": delivery.get("route", ""), "reply": content}
+        try:
+            async with ClientSession(timeout=ClientTimeout(total=_REPLY_TIMEOUT_SECONDS)) as session:
+                async with session.post(url, json=body, headers=headers) as resp:
+                    if 200 <= resp.status < 300:
+                        logger.info("[activepieces] Reply delivered for %s -> %s (HTTP %d)",
+                                    chat_id, url, resp.status)
+                        return SendResult(success=True)
+                    detail = (await resp.text())[:200]
+                    logger.warning("[activepieces] Reply target rejected %s -> %s (HTTP %d): %s",
+                                   chat_id, url, resp.status, detail)
+                    return SendResult(success=False, error=f"HTTP {resp.status}")
+        except Exception as e:  # a dead reply target must never fail the completed run
+            logger.warning("[activepieces] Reply delivery failed for %s -> %s: %s", chat_id, url, e)
+            return SendResult(success=False, error=str(e))

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -154,8 +154,14 @@ class WebhookAdapter(BasePlatformAdapter):
     # emitting an interactive acknowledgement that abandons the task (#57056).
     interactive_resume: bool = False
 
-    def __init__(self, config: PlatformConfig):
-        super().__init__(config, Platform.WEBHOOK)
+    # Session/source identity label. Subclass platforms that reuse this
+    # transport (ActivePieces) override BOTH so sessions, logs and
+    # toolset routing carry their own platform value instead of "webhook".
+    _session_id_prefix: str = "webhook"
+    _source_label: str = "webhook"
+
+    def __init__(self, config: PlatformConfig, platform: Platform = Platform.WEBHOOK):
+        super().__init__(config, platform)
         extra = config.extra
         # Empty string / null host normalises to None ("bind all families").
         self._host: Optional[str] = extra.get("host", DEFAULT_HOST) or None
@@ -316,7 +322,7 @@ class WebhookAdapter(BasePlatformAdapter):
         deliberately NOT settable via `hermes webhook subscribe`, so an agent-created subscription
         cannot self-grant tools)."""
         parts = str(getattr(source, "chat_id", "") or "").split(":", 2)
-        if len(parts) < 2 or parts[0] != "webhook":
+        if len(parts) < 2 or parts[0] != self._session_id_prefix:
             return None
         route_config = self._routes.get(parts[1])
         toolsets = route_config.get("toolsets") if isinstance(route_config, dict) else None
@@ -452,7 +458,8 @@ class WebhookAdapter(BasePlatformAdapter):
         """deliver_only: the rendered prompt IS the message — skip the agent, reuse the same
         auth/rate-limit/idempotency/template pipeline."""
         delivery = {"deliver": route_config.get("deliver", "log"), "payload": payload,
-                    "deliver_extra": self._render_delivery_extra(route_config.get("deliver_extra", {}), payload)}
+                    "deliver_extra": self._render_delivery_extra(route_config.get("deliver_extra", {}), payload),
+                    "delivery_id": delivery_id}
         logger.info("[webhook] direct-deliver event=%s route=%s target=%s msg_len=%d delivery=%s", event_type,
                     route_name, delivery["deliver"], len(prompt), delivery_id)
         failed = {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id}
@@ -564,15 +571,17 @@ class WebhookAdapter(BasePlatformAdapter):
                             event_type: str, delivery_id: str, now: float) -> "web.Response":
         """Record delivery info, spawn the agent run, and return 202 immediately."""
         # delivery_id in the session key → concurrent webhooks on one route get independent runs.
-        session_chat_id = f"webhook:{route_name}:{delivery_id}"
+        session_chat_id = f"{self._session_id_prefix}:{route_name}:{delivery_id}"
         self._delivery_info[session_chat_id] = {
             "deliver": route_config.get("deliver", "log"),
-            "deliver_extra": self._render_delivery_extra(route_config.get("deliver_extra", {}), payload)}
+            "deliver_extra": self._render_delivery_extra(route_config.get("deliver_extra", {}), payload),
+            "route": route_name}
         self._delivery_info_created[session_chat_id] = now
         self._delivery_info_order.append((now, session_chat_id))
         self._prune_delivery_info(now)
-        source = self.build_source(chat_id=session_chat_id, chat_name=f"webhook/{route_name}", chat_type="webhook",
-                                   user_id=f"webhook:{route_name}", user_name=route_name)
+        source = self.build_source(chat_id=session_chat_id, chat_name=f"{self._source_label}/{route_name}",
+                                   chat_type=self._source_label,
+                                   user_id=f"{self._source_label}:{route_name}", user_name=route_name)
         if profile and isinstance(profile, str):
             source.profile = profile
         event = MessageEvent(text=prompt, message_type=MessageType.TEXT, source=source, raw_message=payload,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -355,7 +355,7 @@ def _gateway_compression_progress_notices_enabled() -> bool:
     return False
 
 # Surfaces consuming gateway text programmatically must keep RAW status/error text; unknown/empty -> chat.
-_GATEWAY_RAW_TEXT_PLATFORMS = frozenset({"local", "api_server", "webhook", "msgraph_webhook"})
+_GATEWAY_RAW_TEXT_PLATFORMS = frozenset({"local", "api_server", "webhook", "msgraph_webhook", "activepieces"})
 
 
 def _gateway_surface_passes_raw_text(platform: Any) -> bool:
@@ -3191,6 +3191,8 @@ _BUILTIN_ADAPTERS: dict[Platform, tuple[str, str, str, str]] = {
                        "Webhook: aiohttp not installed"),
     Platform.MSGRAPH_WEBHOOK: ("msgraph_webhook", "MSGraphWebhookAdapter", "check_msgraph_webhook_requirements",
                                "MSGraph webhook: aiohttp not installed"),
+    Platform.ACTIVEPIECES: ("activepieces", "ActivePiecesAdapter", "check_activepieces_requirements",
+                            "ActivePieces: aiohttp not installed"),
     Platform.BLUEBUBBLES: ("bluebubbles", "BlueBubblesAdapter", "check_bluebubbles_requirements",
                            "BlueBubbles: aiohttp/httpx missing or BLUEBUBBLES_SERVER_URL/BLUEBUBBLES_PASSWORD not configured"),
     Platform.QQBOT: ("qqbot", "QQAdapter", "check_qq_requirements",

--- a/tests/gateway/test_activepieces.py
+++ b/tests/gateway/test_activepieces.py
@@ -1,0 +1,228 @@
+"""Integration tests for the ActivePieces platform adapter.
+
+Exercises the AP-specific edges over the inherited webhook pipeline:
+1. Bearer-authenticated AP-shaped POST → agent MessageEvent (right platform,
+   right session prefix, skills lane attached)
+2. Wrong / missing bearer → 401; secretless flow fails closed
+3. ``deliver: activepieces`` POSTs the agent reply {delivery_id, flow, reply}
+   to the flow's reply URL
+4. Flow validation: deliver=activepieces without an http(s) URL is rejected
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.event import MessageEvent
+from gateway.platforms.activepieces import ActivePiecesAdapter
+
+AP_SECRET = "ap-flow-secret"
+#: The envelope AP flows POST (contract shared with cold-start/Twilio consumers).
+AP_PAYLOAD = {
+    "source": "activepieces",
+    "piece": "gmail",
+    "trigger": "new_email_received",
+    "project_id": 42,
+    "event": {
+        "subject": "Invoice attached",
+        "from": "billing@example.com",
+        "body": "See the attached invoice for September.",
+    },
+}
+
+
+def _make_adapter(flows, **extra_kw) -> ActivePiecesAdapter:
+    extra = {"host": "127.0.0.1", "port": 0, "flows": flows}
+    extra.update(extra_kw)
+    return ActivePiecesAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: ActivePiecesAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_post("/activepieces/{route_name}", adapter._handle_webhook)
+    return app
+
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+class TestAPEventReachesAgent:
+
+    @pytest.mark.asyncio
+    async def test_bearer_post_triggers_agent_with_skills(self):
+        """A bearer-authenticated AP envelope wakes the agent run with the
+        route's skill injected and the ActivePieces source identity."""
+        flows = {
+            "gmail_new_email": {
+                "secret": AP_SECRET,
+                "prompt": "New email from {event.from}: {event.subject}",
+                "skills": ["email-triage"],
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(flows)
+        captured: list[MessageEvent] = []
+
+        async def _capture(event: MessageEvent):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+        skill_content = "TRIAGE SKILL — work the email: New email from billing@example.com: Invoice attached"
+
+        with patch(
+            "agent.skill_commands.build_skill_invocation_message",
+            return_value=skill_content,
+        ) as mock_build, patch(
+            "agent.skill_commands.get_skill_commands",
+            return_value={"/email-triage": {"name": "email-triage"}},
+        ):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/activepieces/gmail_new_email",
+                    data=json.dumps(AP_PAYLOAD),
+                    headers={**_bearer(AP_SECRET), "X-Request-ID": "ap-delivery-001"},
+                )
+                assert resp.status == 202
+                data = await resp.json()
+                assert data["status"] == "accepted"
+                assert data["route"] == "gmail_new_email"
+
+            await asyncio.sleep(0.05)
+            mock_build.assert_called_once()
+
+        assert len(captured) == 1
+        event = captured[0]
+        # The skills lane: the prompt is the skill invocation, not the raw render.
+        assert "TRIAGE SKILL" in event.text
+        assert "Invoice attached" in event.text
+        assert event.source.platform == Platform.ACTIVEPIECES
+        assert event.source.chat_type == "activepieces"
+        assert event.source.chat_id.startswith("activepieces:gmail_new_email:")
+        assert event.message_id == "ap-delivery-001"
+
+    @pytest.mark.asyncio
+    async def test_global_secret_bearer_accepted(self):
+        """A flow without its own secret uses the platform-level secret."""
+        adapter = _make_adapter(
+            {"webhook_in": {"deliver": "log"}}, secret=AP_SECRET)
+        captured: list[MessageEvent] = []
+
+        async def _capture(event: MessageEvent):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/activepieces/webhook_in", json=AP_PAYLOAD, headers=_bearer(AP_SECRET))
+            assert resp.status == 202
+        await asyncio.sleep(0.05)
+        assert len(captured) == 1
+
+    @pytest.mark.asyncio
+    async def test_wrong_bearer_rejected(self):
+        adapter = _make_adapter({"gmail_new_email": {"secret": AP_SECRET, "deliver": "log"}})
+        adapter.handle_message = AsyncMock()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/activepieces/gmail_new_email", json=AP_PAYLOAD, headers=_bearer("wrong-secret"))
+            assert resp.status == 401
+            resp2 = await cli.post("/activepieces/gmail_new_email", json=AP_PAYLOAD)
+            assert resp2.status == 401  # no auth header at all → fail closed
+        await asyncio.sleep(0.05)
+        assert adapter.handle_message.await_count == 0
+
+
+class TestSecretlessFlowFailsClosed:
+
+    def test_secretless_flow_rejected_at_validation(self):
+        adapter = _make_adapter({"open_flow": {"deliver": "log"}})
+        with pytest.raises(ValueError, match="no HMAC secret"):
+            adapter._validate_route("open_flow", adapter._routes["open_flow"])
+
+    def test_defaults_are_loopback_and_own_port(self):
+        adapter = ActivePiecesAdapter(PlatformConfig(enabled=True, extra={"flows": {}}))
+        assert adapter._host == "127.0.0.1"
+        assert adapter._port == 8647
+        assert adapter._source_label == "activepieces"
+
+
+class TestAPReplyDelivery:
+
+    @pytest.mark.asyncio
+    async def test_reply_posted_to_flow_url(self):
+        """deliver=activepieces POSTs {delivery_id, flow, reply} to the reply URL."""
+        received: list[dict] = []
+        received_headers: list[dict] = []
+
+        async def _reply_target(request: "web.Request") -> "web.Response":
+            received.append(await request.json())
+            received_headers.append(dict(request.headers))
+            return web.json_response({"ok": True})
+
+        target = web.Application()
+        target.router.add_post("/reply", _reply_target)
+        async with TestClient(TestServer(target)) as target_cli:
+            reply_url = str(target_cli.server.make_url("/reply"))
+            flows = {
+                "gmail_new_email": {
+                    "secret": AP_SECRET,
+                    "deliver": "activepieces",
+                    "deliver_extra": {"url": reply_url, "headers": {"X-AP-Flow": "gmail_new_email"}},
+                }
+            }
+            adapter = _make_adapter(flows)
+            adapter.handle_message = AsyncMock()
+
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/activepieces/gmail_new_email", json=AP_PAYLOAD,
+                    headers={**_bearer(AP_SECRET), "X-Request-ID": "ap-delivery-77"})
+                assert resp.status == 202
+
+            chat_id = "activepieces:gmail_new_email:ap-delivery-77"
+            assert chat_id in adapter._delivery_info
+            assert adapter._delivery_info[chat_id]["deliver"] == "activepieces"
+
+            result = await adapter.send(chat_id, "Filed the invoice and drafted a reply.")
+            assert result.success is True
+
+        assert len(received) == 1
+        assert received[0] == {
+            "delivery_id": "ap-delivery-77",
+            "flow": "gmail_new_email",
+            "reply": "Filed the invoice and drafted a reply.",
+        }
+        assert received_headers[0].get("X-AP-Flow") == "gmail_new_email"
+
+    @pytest.mark.asyncio
+    async def test_reply_target_down_reports_failure(self):
+        flows = {
+            "gmail_new_email": {
+                "secret": AP_SECRET,
+                "deliver": "activepieces",
+                "deliver_extra": {"url": "http://127.0.0.1:9/nope"},
+            }
+        }
+        adapter = _make_adapter(flows)
+        result = await adapter._deliver_activepieces(
+            "hello", {"deliver_extra": flows["gmail_new_email"]["deliver_extra"], "route": "gmail_new_email"},
+            "activepieces:gmail_new_email:d1")
+        assert result.success is False
+        assert result.error
+
+    def test_deliver_activepieces_without_url_rejected(self):
+        adapter = _make_adapter({"gmail_new_email": {"secret": AP_SECRET, "deliver": "activepieces"}})
+        with pytest.raises(ValueError, match="http\\(s\\) URL"):
+            adapter._validate_route("gmail_new_email", adapter._routes["gmail_new_email"])

--- a/toolsets.py
+++ b/toolsets.py
@@ -223,6 +223,9 @@ TOOLSETS = {
     },
     "hermes-sms": _bundle("SMS bot toolset - interact with Hermes via SMS (Twilio)"),
     "hermes-webhook": _ts("Webhook toolset - receive and process external webhook events", _HERMES_WEBHOOK_SAFE_TOOLS),
+    "hermes-activepieces": _ts(
+        "ActivePieces toolset - react to ActivePieces automation trigger events",
+        _HERMES_WEBHOOK_SAFE_TOOLS),
     "hermes-gateway": _ts(
         "Gateway toolset - union of all messaging platform tools",
         [],
@@ -231,7 +234,7 @@ TOOLSETS = {
             "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email",
             "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk",
             "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin",
-            "hermes-qqbot", "hermes-webhook", "hermes-yuanbao",
+            "hermes-qqbot", "hermes-webhook", "hermes-activepieces", "hermes-yuanbao",
         ],
     ),
 }


### PR DESCRIPTION
## Draft — NOT for merge yet (app-side integration lands in parallel; coordinator merges)

ActivePieces automation triggers (Gmail new email, generic webhooks, Twilio SMS) wake the agent exactly like a Telegram message. Per `gateway/platforms/ADDING_A_PLATFORM.md`, this is a **first-class platform**: `Platform.ACTIVEPIECES`, adapter in the builtin factory table — the same posture as `MSGraphWebhookAdapter`. The transport is **reused, not duplicated**: `gateway/platforms/activepieces.py` subclasses the generic webhook receiver, so AP inherits the full `event → auth → rate-limit → parse → filters → skills → agent dispatch → delivery` pipeline (`gateway/platforms/webhook.py::_handle_webhook`).

### The AP-specific edges (no wrappers)

1. **Bearer auth** — an AP flow's HTTP-request piece sets static headers; it cannot compute an HMAC. `Authorization: Bearer <secret>` is compared timing-safely against the route/global secret (fail-closed: secretless flows never start, inherited validation). Inherited HMAC schemes still work for flows with a code piece.
2. **Reply delivery — `deliver: "activepieces"`** — the agent's final response is POSTed as `{delivery_id, flow, reply}` to the route's `deliver_extra.url` (trusted route config, never payload-derived) with optional static headers — the AP-native reply channel (Webhook-Response/HTTP step in the flow's reply leg).
3. **Loopback-only default bind** (`127.0.0.1:8647`) — in the pod deployment, AP events reach this adapter through the app's control-doc bridge (session-api control event wakes the session → task_loop → loopback POST), never from a public network.

### Core-file footprint (kept minimal + backward compatible)

- `gateway/platforms/webhook.py`: `__init__` gains a `platform: Platform = Platform.WEBHOOK` kwarg; the session-id prefix / source label are class attributes (`_session_id_prefix`, `_source_label`) so subclasses own their identity; delivery info carries the route name and direct-deliver the delivery id.
- Enum + connected check (`gateway/config.py`), builtin factory entry + raw-text set (`gateway/run.py`), transport-authenticated authz exemption (`gateway/authz_mixin.py` — AP events are secret-verified at intake, same trust class as webhook HMAC), `PLATFORM_HINTS` (`agent/prompt_builder.py`), `hermes-activepieces` toolset + composite (`toolsets.py`).
- No cron/send_message standalone sender: receiver platforms don't participate in those maps (same as `WEBHOOK`/`MSGRAPH_WEBHOOK`).

### Envelope contract

AP flows POST `{source: "activepieces", piece, trigger, project_id, event: <raw trigger payload>}`; per-flow skills attach via the route's `skills` key; pieces are distinguished with payload filters (`source`/`piece`).

### Proof (local, red-first)

`tests/gateway/test_activepieces.py` — 8 passed:

- bearer-authenticated AP-shaped POST → agent `MessageEvent` with route skill injected, `Platform.ACTIVEPIECES` source, `activepieces:<flow>:<delivery>` session key
- global-secret bearer accepted; wrong/missing bearer → 401; secretless flow fails closed at validation
- `deliver: activepieces` POSTs the exact reply body + static headers to the flow's reply URL; dead target → honest failure, run unaffected; missing URL rejected at validation

Webhook regression: `test_webhook_integration/adapter/signature_rate_limit/dynamic_routes/deliver_only/offloop_delivery`, `test_msgraph_webhook`, `test_config` — 127 passed. One pre-existing env failure on clean `main` in this sandbox interpreter (`test_routed_profile_skills_resolve_under_that_profile` needs `python-dotenv`, ModuleNotFoundError; the sibling `test_webhook_route_toolsets.py` collection error is the same class). `ruff check` clean on all touched files.
