### PR TITLE
fix(slack): name scheduled threads from their results

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -217,10 +217,11 @@ def _open_continuable_cron_thread(
     if not callable(create_thread) or loop is None:
         return None
     from agent.title_generator import derive_title
+    from gateway.platforms.helpers import strip_markdown
     # The completed result is already available: use its opening headline, not
     # the recurring job's identity. No additional inference on scheduled wakes.
     headline = next((line.strip() for line in result_text.splitlines() if line.strip()), "")
-    thread_name = derive_title(headline.lstrip("# ").strip("*")) or job.get("name") or "Scheduled result"
+    thread_name = derive_title(strip_markdown(headline)) or job.get("name") or "Scheduled result"
     try:
         from agent.async_utils import safe_schedule_threadsafe
         coro = create_thread(str(chat_id), thread_name)

--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -208,13 +208,19 @@ def _maybe_mirror_cron_delivery(
         )
 
 
-def _open_continuable_cron_thread(job: dict, adapter, chat_id: str, loop) -> Optional[str]:
+def _open_continuable_cron_thread(
+    job: dict, adapter, chat_id: str, loop, *, result_text: str = "",
+) -> Optional[str]:
     """Open a thread for a continuable cron job via ``adapter.create_handoff_thread``. Returns the
     thread_id, or ``None`` (no thread primitive / failed) = caller falls back to the DM mirror."""
     create_thread = getattr(adapter, "create_handoff_thread", None)
     if not callable(create_thread) or loop is None:
         return None
-    thread_name = f"Hermes — {job.get('name') or job.get('id', 'cron')}"
+    from agent.title_generator import derive_title
+    # The completed result is already available: use its opening headline, not
+    # the recurring job's identity. No additional inference on scheduled wakes.
+    headline = next((line.strip() for line in result_text.splitlines() if line.strip()), "")
+    thread_name = derive_title(headline.lstrip("# ").strip("*")) or job.get("name") or "Scheduled result"
     try:
         from agent.async_utils import safe_schedule_threadsafe
         coro = create_thread(str(chat_id), thread_name)
@@ -1613,7 +1619,7 @@ def _prepare_target_delivery(
         and not thread_id  # never override an explicit origin thread/topic
     ):
         opened_thread_id = _open_continuable_cron_thread(
-            job, runtime_adapter, chat_id, loop) or None
+            job, runtime_adapter, chat_id, loop, result_text=mirror_text) or None
         if opened_thread_id:
             thread_id = opened_thread_id
     return _TargetDelivery(

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -1423,7 +1423,7 @@ class GatewayStartupMixin:
         cli_title = row.get("title") or cli_session_id[:8]
         try:
             new_thread_id = await transport.adapter.create_handoff_thread(
-                home_chat_id, f"Hermes — {cli_title}",
+                home_chat_id, cli_title,
             )
         except Exception as exc:
             logger.debug("Handoff: create_handoff_thread raised on %s: %s", platform_name, exc, exc_info=True)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1724,8 +1724,15 @@ class SlackAdapter(BasePlatformAdapter):
             client = self._get_client(parent_chat_id)
             if client is None:
                 return None
-            seed_text = f":thread: Hermes handoff — *{(name or 'session').strip()[:80]}*"
-            result = await client.chat_postMessage(channel=parent_chat_id, text=seed_text)
+            from html import escape
+            title = " ".join((name or "Conversation").split())[:150] or "Conversation"
+            # Titles are content, not Slack markup: never turn a quoted mention
+            # or link into a notification or an action in the channel.
+            result = await client.chat_postMessage(
+                channel=parent_chat_id, text=escape(title, quote=False),
+                mrkdwn=False, parse="none",
+                blocks=[{"type": "header", "text": {"type": "plain_text", "text": title}}],
+            )
             ts = _slack_response_payload(result).get("ts")
             return str(ts) if ts else None
         except Exception as exc:

--- a/tests/cron/test_result_thread_titles.py
+++ b/tests/cron/test_result_thread_titles.py
@@ -1,0 +1,36 @@
+import asyncio
+from concurrent.futures import Future
+from unittest.mock import AsyncMock, patch
+
+from cron.scheduler_delivery import _open_continuable_cron_thread
+
+
+def test_results_from_same_job_open_distinct_content_named_threads():
+    adapter = AsyncMock()
+    adapter.create_handoff_thread.return_value = "123.456"
+
+    def run_now(coro, loop):
+        future = Future()
+        future.set_result(asyncio.run(coro))
+        return future
+
+    job = {"id": "j1", "name": "Claudia manager — stamps-community"}
+    with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=run_now):
+        for headline in ("Search indexing restored", "Newsletter needs your approval"):
+            assert _open_continuable_cron_thread(
+                job, adapter, "C123", object(), result_text=f"## {headline}\n\nDetails",
+            ) == "123.456"
+            assert adapter.create_handoff_thread.call_args.args == ("C123", headline)
+
+
+def test_empty_result_retains_honest_job_name():
+    adapter = AsyncMock()
+
+    def run_now(coro, loop):
+        future = Future()
+        future.set_result(asyncio.run(coro))
+        return future
+
+    with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=run_now):
+        _open_continuable_cron_thread({"name": "Daily brief"}, adapter, "C123", object())
+    assert adapter.create_handoff_thread.call_args.args == ("C123", "Daily brief")

--- a/tests/cron/test_result_thread_titles.py
+++ b/tests/cron/test_result_thread_titles.py
@@ -18,7 +18,8 @@ def test_results_from_same_job_open_distinct_content_named_threads():
     with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=run_now):
         for headline in ("Search indexing restored", "Newsletter needs your approval"):
             assert _open_continuable_cron_thread(
-                job, adapter, "C123", object(), result_text=f"## {headline}\n\nDetails",
+                job, adapter, "C123", object(),
+                result_text=f"## **[{headline}](https://github.com/example/repo/issues/42)**\n\nDetails",
             ) == "123.456"
             assert adapter.create_handoff_thread.call_args.args == ("C123", headline)
 

--- a/tests/gateway/test_slack_sdk_response.py
+++ b/tests/gateway/test_slack_sdk_response.py
@@ -265,8 +265,14 @@ class TestHandoffThread:
             return_value=make_response({"ok": True, "ts": "1700000000.000100"})
         )
         adapter._get_client = lambda *_a, **_kw: client
-        thread_id = asyncio.run(adapter.create_handoff_thread("C_GEN", "review"))
+        title = "Newsletter approval <@U123> & release"
+        thread_id = asyncio.run(adapter.create_handoff_thread("C_GEN", title))
         assert thread_id == "1700000000.000100"
+        payload = client.chat_postMessage.call_args.kwargs
+        assert payload["blocks"][0]["text"] == {"type": "plain_text", "text": title}
+        assert payload["text"] == "Newsletter approval &lt;@U123&gt; &amp; release"
+        assert payload["mrkdwn"] is False
+        assert payload["parse"] == "none"
 
     def test_unreadable_response_yields_no_thread(self):
         """Callers must still see a clean ``None`` for genuinely opaque replies."""


### PR DESCRIPTION
## Summary
Scheduled Slack threads repeat the runtime and job identity, making different results indistinguishable in a channel. Use the completed result opening headline through the existing deterministic title helper; fall back to the job name when empty. Remove redundant transport branding from handoff titles. Render Slack roots as native plain-text headers with escaped fallback text to prevent mention interpretation.

No extra model calls, changed cadence, delivery routing, or subscriber prompt workaround.

## Verification
- New cron regressions fail on base and pass on this head.
- 144 tests pass through scripts/run_tests.sh: result titles, real Slack delivery response shapes, profile handoff routing, and scheduler delivery.
- Self-reviewed; existing explicit thread routing and session anchoring preserved.