### PR TITLE
feat(mcp-catalog): add Fidelis Memory

### DIFF
--- a/optional-mcps/fidelis/manifest.yaml
+++ b/optional-mcps/fidelis/manifest.yaml
@@ -1,0 +1,55 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: fidelis
+description: Local-first, zero-LLM memory recall (BM25 + dense + RRF) for Codex, Claude Code, and other agents.
+source: https://github.com/hermes-labs-ai/fidelis
+
+# Published to PyPI as `fidelis-memory` (the bare `fidelis` PyPI name belongs to
+# an unrelated project — see the package's own README). `uvx --from` fetches and
+# runs the pinned release without a local clone; the console-script entry point
+# inside the package is also named `fidelis`. No install: block needed — uvx IS
+# the install, same convention as npx-launched stdio servers elsewhere in this
+# catalog.
+transport:
+  type: stdio
+  command: uvx
+  args:
+    - "--from"
+    - "fidelis-memory==0.0.95"
+    - "fidelis"
+    - "mcp"
+    - "serve"
+
+# No credentials required: the four tools below only need a locally reachable
+# `fidelis-server` (see post_install) — no API key or OAuth token.
+auth:
+  type: none
+
+post_install: |
+  Fidelis exposes 4 read-only tools (fidelis_recall, fidelis_query,
+  fidelis_health, fidelis_orient), all enabled by default. Recall, query, and
+  orientation can return locally stored memories to the model in the current
+  Hermes session. Install them only where that matches your host and model
+  data-sharing policy, or prune them with `hermes mcp configure fidelis`.
+
+  These tools talk to a separate local `fidelis-server` process (default
+  http://localhost:19420), which in turn needs a running Ollama daemon
+  (default http://localhost:11434) with the `nomic-embed-text` model pulled.
+  This MCP entry does not start or manage either for you. Until they're
+  running, tool calls return a clean "fidelis-server unreachable" error
+  instead of failing the connection — the server still installs and its
+  tools still list normally.
+
+  One-time setup on the host running Hermes:
+    ollama serve &
+    ollama pull nomic-embed-text
+    python3 -m pip install "fidelis-memory==0.0.95"
+    fidelis init      # installs a launchd (macOS) / systemd --user (Linux)
+                       # background service for fidelis-server
+
+  Start a new Hermes session after both are up to use the tools.
+
+  Fidelis is marked pre-release by its maintainers (Hermes Labs); review its
+  README before relying on it for anything you can't afford to lose.

--- a/optional-mcps/fidelis/manifest.yaml
+++ b/optional-mcps/fidelis/manifest.yaml
@@ -17,7 +17,7 @@ transport:
   command: uvx
   args:
     - "--from"
-    - "fidelis-memory==0.0.95"
+    - "fidelis-memory==0.0.97"
     - "fidelis"
     - "mcp"
     - "serve"
@@ -45,7 +45,7 @@ post_install: |
   One-time setup on the host running Hermes:
     ollama serve &
     ollama pull nomic-embed-text
-    python3 -m pip install "fidelis-memory==0.0.95"
+    python3 -m pip install "fidelis-memory==0.0.97"
     fidelis init      # installs a launchd (macOS) / systemd --user (Linux)
                        # background service for fidelis-server
 


### PR DESCRIPTION
## Summary

- add Fidelis Memory to the maintained optional MCP catalog
- launch the official MCP Registry/PyPI release through a version-pinned `uvx` command
- document the separate Ollama + local daemon bootstrap, absent-daemon behavior, pre-release status, and memory data-sharing boundary

## Current-reality audit

- MCP Registry server: `io.github.hermes-labs-ai/fidelis-memory` v0.0.95 (active/latest)
- PyPI package and console command: `fidelis-memory==0.0.95` / `fidelis mcp serve`
- exact catalog transport exercised live: `uvx --from fidelis-memory==0.0.95 fidelis mcp serve`
- tools/list succeeds without the daemon and returns the four published tools
- tool calls without a reachable daemon return a clean `fidelis-server unreachable` result
- `fidelis init` remains the explicit host setup step for launchd on macOS or systemd --user on Linux; the catalog install does not mutate host services

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py` (35 passed)
- `hermes-gate fast` (pass)
- `hermes-gate review` (pass, 0 findings)

No core, installer, or parallel integration path is added.

<!-- hermes-labs:attribution:begin -->
**Affiliation:** `Fidelis Memory` is maintained by Hermes Labs; Rolando Bosch is the founder of Hermes Labs.

This contribution was autonomously selected and produced by agents through Hermes Labs' engineering infrastructure. Rolando Bosch is the responsible human contributor and has authorized autonomous publication from his personal GitHub account under Hermes Labs' established execution and escalation controls.
<!-- hermes-labs:attribution:end -->
