### PR TITLE
fix(dashboard): explain ended chat recovery

### DIFF
--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -275,6 +275,36 @@ describe("ChatPage", () => {
     expect(maybeReloadForLoopbackWsAuthFailure).toHaveBeenCalledWith(4401);
   });
 
+  it("explains how to recover after the chat process exits", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    await act(async () => {
+      FakeWebSocket.instances[0].onclose?.({
+        code: 4410,
+        reason: "process exited",
+        wasClean: true,
+      });
+    });
+
+    expect(container.textContent).toContain(
+      "The process behind this chat stopped.",
+    );
+    expect(container.textContent).toContain(
+      "Start a new session to continue; you do not need to reload the page.",
+    );
+    expect(
+      container.querySelector('[aria-label="Start a new chat session"]'),
+    ).not.toBeNull();
+  });
+
   it("attaches visualViewport keyboard-inset listeners only while the chat tab is active", async () => {
     // NS-434 follow-up: ChatPage stays mounted (hidden) on every dashboard
     // route. The keyboard-inset/scroll-pin listeners must only be live while

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1881,8 +1881,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               whole page to get a working chat back. */}
           {ptyState === "ended" && (
             <div className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-3 bg-black/60">
-              <div className="text-sm tracking-wide text-white/80">
-                Session ended.
+              <div className="max-w-md px-6 text-center text-sm tracking-wide text-white/80">
+                The process behind this chat stopped. This can happen after the
+                dashboard restarts or when the session exits. Start a new
+                session to continue; you do not need to reload the page.
               </div>
               <Button
                 onClick={startFreshPty}


### PR DESCRIPTION
## What does this PR do?

Clarifies the dashboard overlay shown when the chat process exits with WebSocket close code 4410.

The overlay now explains why the process may have stopped and tells users that they can start a new session without reloading the page. The existing explicit recovery button and session behavior remain unchanged.

## Related Issue

Fixes #105592

## Type of Change

- [x] ✨ New feature

## Changes Made

- Update the ended-chat overlay with clear process and recovery guidance.
- Add regression coverage for the 4410 process-exit state and recovery button.

## How to Test

1. Run `npm test -- --run src/pages/ChatPage.test.tsx` from `web/`.
2. Run `npm run check` from `web/`.
3. Run `npm run build` from `web/`.

## Validation

- Focused ChatPage tests: 7 passed.
- Full web test suite: 296 passed.
- TypeScript type-check: passed.
- ESLint: passed with 0 errors and 27 existing warnings.
- Production build: passed.
- Tested on macOS 26.5.2, Apple Silicon, with Node.js 24.11.0.

## Checklist

- [x] I have read the contributing guide.
- [x] My commit follows Conventional Commits.
- [x] I searched for existing PRs and found no competing implementation.
- [x] The PR contains only changes related to this improvement.
- [x] I added regression coverage.
- [x] Documentation and configuration changes are not applicable.
- [x] I considered cross-platform impact; this is platform-independent UI copy.
