### PR TITLE
fix(kanban): treat kanban_request_review as a terminal board call

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -1,7 +1,8 @@
-"""Turn-end guard for kanban workers, which must end with ``kanban_complete`` or
-``kanban_block``. Some models narrate the next step and stop with no tool calls;
-Hermes treats that as a clean exit → ``rc=0`` → dispatcher ``protocol_violation``.
-Policy-only: return a bounded synthetic nudge so the loop continues instead of exiting.
+"""Turn-end guard for kanban workers, which must end with ``kanban_complete``,
+``kanban_block`` or ``kanban_request_review``. Some models narrate the next step
+and stop with no tool calls; Hermes treats that as a clean exit → ``rc=0`` →
+dispatcher ``protocol_violation``. Policy-only: return a bounded synthetic nudge
+so the loop continues instead of exiting.
 """
 
 from __future__ import annotations
@@ -10,7 +11,7 @@ import os
 from typing import Any, Iterable, Optional
 
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block", "kanban_request_review"})
 
 _DEFAULT_MAX_ATTEMPTS = 2
 
@@ -70,7 +71,8 @@ def build_kanban_stop_nudge(
         "Do this immediately in your next response — do not narrate intent:\n"
         "1. Finish any remaining deliverable (write the required file(s) now).\n"
         "2. Call `kanban_complete(summary=..., artifacts=[...])` if the work "
-        "is done, OR `kanban_block(reason=...)` if you are blocked.\n\n"
+        "is done, `kanban_request_review(...)` if it is ready for review, "
+        "OR `kanban_block(reason=...)` if you are blocked.\n\n"
         "Never end a turn with only a promise of future action. Repeated "
         "protocol violations will block this task and require manual intervention.]"
     )

--- a/agent/turn_stop_gates.py
+++ b/agent/turn_stop_gates.py
@@ -77,8 +77,8 @@ def _pre_verify_nudge(agent, final_response, attempt: int) -> Optional[str]:
 
 
 def _kanban_stop_nudge(agent, messages) -> Optional[str]:
-    """Workers must end with kanban_complete / kanban_block; a narrated stop is recorded
-    as protocol_violation, so nudge once or twice first."""
+    """Workers must end with kanban_complete, kanban_block or kanban_request_review;
+    a narrated stop is recorded as protocol_violation, so nudge once or twice first."""
     try:
         from agent.kanban_stop import build_kanban_stop_nudge
 

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -74,6 +74,32 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+def test_no_nudge_after_kanban_request_review(clear_kanban_env):
+    """A worker that ends its run via request_review has legitimately finished:
+    the run is already terminal (outcome="review_requested"), so nudging it
+    toward kanban_complete only produces a deterministic error and a retry spiral."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_request_review",
+                        "arguments": '{"summary": "ready for review"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "name": "kanban_request_review", "tool_call_id": "1", "content": "ok"},
+    ]
+    assert session_called_kanban_terminal(messages) is True
+    assert build_kanban_stop_nudge(messages=messages) is None
+
+
 
 
 


### PR DESCRIPTION
## Summary

Fixes #105641.

`_TERMINAL_KANBAN_TOOLS` only contained `kanban_complete` and `kanban_block`, so a worker that correctly ended its run with `kanban_request_review` (the documented workflow: *implementation done → request review, never self-complete*) tripped the stop-guard. The nudged `kanban_complete` then deterministically fails — `request_review` already ended the run (`outcome="review_requested"`, `_end_or_synthesize_run` in `hermes_cli/kanban_db.py`) — returning `could not complete ... (unknown id or already terminal)`, which models read as a failure to finish and answer with a diagnose-and-retry spiral until budget/runtime kills the run.

Reporter observed 29 such guard fires over 140 production runs, every one immediately after a successful `request_review`.

## Changes

- `agent/kanban_stop.py`: `kanban_request_review` joins `_TERMINAL_KANBAN_TOOLS`; module docstring and the synthetic nudge text list all three legitimate endings.
- `agent/turn_stop_gates.py`: gate docstring kept in sync.
- `tests/agent/test_kanban_stop.py`: new case — a history whose only board call is `kanban_request_review` satisfies `session_called_kanban_terminal` and must NOT produce a nudge (mirrors the existing `kanban_complete` case).

## Tests

```
tests/agent/test_kanban_stop.py ................. 4 passed (was 3)
tests/agent/ + dispatcher core functionality ..... 39 passed, 1 skipped
```