### PR TITLE
feat(dashboard): expose host createPortal to plugins

### DIFF
--- a/web/src/plugins/registry-portal.test.tsx
+++ b/web/src/plugins/registry-portal.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { act, createElement, createContext, useContext } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+import { exposePluginSDK } from "./registry";
+
+it("lets plugin overlays leave their container while retaining React context", async () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  exposePluginSDK();
+  const sdk = window.__HERMES_PLUGIN_SDK__!;
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const Context = createContext("outside");
+  function Overlay() {
+    return createElement("div", { id: "plugin-overlay" }, useContext(Context));
+  }
+  try {
+    await act(async () => {
+      root.render(createElement(Context.Provider, { value: "plugin context" },
+        sdk.createPortal(createElement(Overlay), document.body)));
+    });
+    const overlay = document.getElementById("plugin-overlay")!;
+    expect(overlay.parentElement).toBe(document.body);
+    expect(container.contains(overlay)).toBe(false);
+    expect(overlay.textContent).toBe("plugin context");
+  } finally {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    delete window.__HERMES_PLUGIN_SDK__;
+    delete window.__HERMES_PLUGINS__;
+  }
+  expect(document.getElementById("plugin-overlay")).toBeNull();
+});

--- a/web/src/plugins/registry.ts
+++ b/web/src/plugins/registry.ts
@@ -17,6 +17,7 @@ import React, {
   useContext,
   createContext,
 } from "react";
+import { createPortal } from "react-dom";
 import { api, fetchJSON, authedFetch, buildWsUrl, buildWsAuthParam } from "@/lib/api";
 import { cn, timeAgo, isoTimeAgo } from "@/lib/utils";
 import { Badge } from "@nous-research/ui/ui/components/badge";
@@ -121,6 +122,7 @@ export function exposePluginSDK() {
     sdkVersion: SDK_CONTRACT_VERSION,
     // React core — plugins use these instead of importing react
     React,
+    createPortal,
     hooks: {
       useState,
       useEffect,

--- a/web/src/plugins/sdk.d.ts
+++ b/web/src/plugins/sdk.d.ts
@@ -97,6 +97,12 @@ export interface HermesPluginSDK {
 
   /** React core — use instead of importing/bundling react. */
   React: typeof import("react").default;
+  /**
+   * Render into a supplied DOM container using the host's React DOM instance.
+   * For overlays outside the plugin tab's stacking context, pass document.body.
+   * React context and event propagation still follow the plugin component tree.
+   */
+  createPortal: typeof import("react-dom").createPortal;
   hooks: {
     useState: typeof import("react").useState;
     useEffect: typeof import("react").useEffect;


### PR DESCRIPTION
## What does this PR do?

Expose the host React DOM `createPortal` function to dashboard plugins so their overlays can render into `document.body` instead of remaining trapped inside the plugin tab's stacking context.

Problem: a plugin modal inside the tab cannot out-rank sibling dashboard chrome using z-index alone. Root cause: the SDK exposes React but not React DOM's portal function. This is an additive helper on the existing SDK, not a new modal implementation or another React DOM instance.

Non-goals: changing core dialog styles, building a modal manager, changing plugin loading/auth, or changing the Desktop plugin SDK.

## Related Issue

Fixes #105642

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/plugins/registry.ts`: expose the existing `react-dom` import beside `React`.
- `web/src/plugins/sdk.d.ts`: type/document the helper, including `document.body` as an overlay target.
- `web/src/plugins/registry-portal.test.tsx`: render through the real SDK with React DOM and assert outside-container placement, preserved parent context and unmount cleanup.
- No dependency or SDK version change: the existing contract explicitly permits additive helpers without a version bump.

## How to Test

From `web/`: `npm test -- src/plugins/registry-portal.test.tsx src/plugins/registry.test.ts`.

Current local evidence (Windows): **3 tests passed** using the real registry, React 19.2.7, React DOM 19.2.7 and jsdom 29.1.1. The new test failed on base `fef0e16fe19b79ded929209f87c7434270b03825` with `TypeError: sdk.createPortal is not a function`, then passed with the fix. `git diff --check` passes.

Canonical local verification on the same head now passes: the missing pinned compiler dependencies were installed into an isolated dependency directory through the configured enterprise npm feed. `node ../node_modules/vitest/vitest.mjs run src/plugins/registry-portal.test.tsx src/plugins/registry.test.ts` with the repository's normal config: **3 passed**. `node ../node_modules/vite/bin/vite.js build` using the normal production config: **passed**. Project typecheck passed. Remote JS/TS, Docker and Nix checks and the aggregate required-check gate passed. Full repository tests were not run locally.

Full Dashboard plugin E2E passed twice on Microsoft Edge 152.0.4191.53 at a 390×844 viewport, using the production build above and the real `hermes_cli.web_server.start_server` bound to loopback with isolated HOME/USERPROFILE/HERMES_HOME (no production sessions or credentials). An enabled test plugin is discovered by `/api/dashboard/plugins`, its JS is served from `/dashboard-plugins/portal-e2e/index.js`, and the real Dashboard renders its tab. Browser clicks open and close its SDK-created modal. Assertions cover BODY placement outside the tab, hit-testing above the actual host chrome, preserved React context, cleanup, and reload/reopen. SDK `fetchJSON('/api/dashboard/plugins/hub')` succeeds with the injected session token (200); the same unauthenticated endpoint returns 401. All observed manifest/script requests are 200, and no page errors occurred. This verifies the loopback session-token mode, not external OAuth providers. No test-only source substitutions or mocked API routes were used.

Independent Claude Code and Codex exact-diff reviews both returned PASS on `e52da25fcb98f6fbe27c5127d55a0d3928d272cb`. The coordinating agent executed the tests and browser checks; Codex's review did not rerun tests.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; frontend-only change.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (focused runner caveat above).

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — public SDK doc comment.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — browser DOM API; no OS-specific implementation.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, not a model tool.

## Screenshots / Logs

AI-assisted contribution. Canonical focused tests, typecheck, production build, full Dashboard plugin E2E, both exact-diff reviews and all required CI checks passed as detailed above.
