### PR TITLE
fix(acp): inherit reasoning config from config.yaml and add /reasoning command

### DIFF
--- a/acp_adapter/commands.py
+++ b/acp_adapter/commands.py
@@ -48,6 +48,11 @@ class SlashCommandsMixin:
             "Show current model and provider, or switch models",
             "model name to switch to",
         ),
+        "reasoning": (
+            "Show or change reasoning effort",
+            "Show or change reasoning effort",
+            "none|minimal|low|medium|high|xhigh|max|ultra [--global]",
+        ),
         "tools": ("List available tools", "List available tools with descriptions", None),
         "context": ("Show conversation context info", "Show conversation message counts by role", None),
         "reset": ("Clear conversation history", "Clear conversation history", None),
@@ -129,6 +134,53 @@ class SlashCommandsMixin:
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider or "openrouter"
         logger.info("Session %s: model switched to %s", state.session_id, new_model)
         return f"Model switched to: {new_model}\nProvider: {provider_label}"
+
+    def _cmd_reasoning(self, args: str, state: SessionState) -> str:
+        """``/reasoning [none|minimal|low|medium|high|xhigh|max|ultra [--global]]`` — show or set
+        the session's reasoning effort (CLI parity; session-scoped unless ``--global``)."""
+        from hermes_constants import VALID_REASONING_EFFORTS, parse_reasoning_effort
+
+        parts = args.split()
+        global_scope = "--global" in parts
+        raw = " ".join(p for p in parts if p != "--global").strip().lower()
+
+        if not raw:  # show current state
+            rc = getattr(state.agent, "reasoning_config", None)
+            level = ("medium (default)" if rc is None
+                     else "none (disabled)" if rc.get("enabled") is False
+                     else rc.get("effort", "medium"))
+            return "\n".join([
+                f"Reasoning effort:  {level}",
+                "Usage: /reasoning <none|minimal|low|medium|high|xhigh|max|ultra> [--global]",
+            ])
+
+        parsed = parse_reasoning_effort(raw)
+        if parsed is None:
+            return "\n".join([
+                f"(._.) Unknown argument: {raw}",
+                f"Valid levels: none, {', '.join(VALID_REASONING_EFFORTS)}",
+                "Scope:        session-scoped by default, --global to persist",
+            ])
+
+        state.agent.reasoning_config = parsed
+        # Keep the persisted session row honest for resume (agent_init records the init config).
+        init_cfg = getattr(state.agent, "_session_init_model_config", None)
+        if isinstance(init_cfg, dict):
+            init_cfg["reasoning_config"] = parsed
+        self.session_manager.save_session(state.session_id)
+
+        outcome = "for this session"
+        if global_scope:
+            try:
+                from cli import save_config_value
+
+                saved = bool(save_config_value("agent.reasoning_effort", raw))
+            except Exception:
+                logger.warning("ACP /reasoning --global persist failed", exc_info=True)
+                saved = False
+            outcome = "saved to config" if saved else "applied for this session (persist failed; see logs)"
+        effort_label = "none (disabled)" if parsed.get("enabled") is False else parsed.get("effort", "medium")
+        return f"✓ Reasoning effort set to '{effort_label}' ({outcome})"
 
     def _cmd_tools(self, args: str, state: SessionState) -> str:
         try:

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -388,10 +388,22 @@ class SessionManager:
             name for name, cfg in (config.get("mcp_servers") or {}).items()
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
+        effective_model = model or default_model
+        # Same chokepoint as CLI/TUI/gateway/cron (per-model override > global
+        # agent.reasoning_effort). Without it, ACP sessions silently pinned to
+        # medium and ignored user config.
+        try:
+            from hermes_constants import resolve_reasoning_config
+
+            reasoning_config = resolve_reasoning_config(config, effective_model)
+        except Exception:
+            logger.debug("Could not resolve reasoning config for ACP session", exc_info=True)
+            reasoning_config = None
         kwargs = {
             "platform": "acp", "quiet_mode": True, "session_id": session_id, "session_db": self._get_db(),
             "enabled_toolsets": _expand_acp_enabled_toolsets(["hermes-acp"], mcp_server_names=configured_mcp_servers),
-            "model": model or default_model,
+            "model": effective_model,
+            "reasoning_config": reasoning_config,
         }
         try:
             runtime = resolve_runtime_provider(requested=requested_provider or config_provider)

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -167,3 +167,85 @@ async def test_acp_cancel_publishes_hard_stop_while_holding_runtime_lock():
 
 
 
+
+
+# ---- /reasoning (CLI parity: config inheritance + session command) ----------
+
+
+def test_acp_make_agent_inherits_reasoning_config(monkeypatch):
+    """ACP builds agents with the shared resolve_reasoning_config chokepoint,
+    so agent.reasoning_effort / per-model overrides are not silently dropped."""
+    captured = {}
+
+    class CapturingAgent(FakeAgent):
+        def __init__(self, **kwargs):
+            super().__init__()
+            captured.update(kwargs)
+
+    def mod(name, **attrs):
+        module = ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=CapturingAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod("hermes_cli.config", load_config=lambda: {
+            "model": {"default": "m", "provider": "p"},
+            "agent": {"reasoning_effort": "high"},
+        }),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod("hermes_cli.runtime_provider", resolve_runtime_provider=lambda **_kwargs: {
+            "provider": "p", "api_mode": "chat_completions", "base_url": "u",
+            "api_key": "k", "command": None, "args": [],
+        }),
+    )
+
+    manager = SessionManager(db=NoopDb())
+    manager._make_agent(session_id="acp-session", cwd=".")
+
+    assert captured["reasoning_config"] == {"enabled": True, "effort": "high"}
+
+
+def test_reasoning_command_show_and_set():
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    fake.reasoning_config = None
+
+    show = acp_agent._handle_slash_command("/reasoning", state)
+    assert "Reasoning effort:" in show and "medium (default)" in show
+
+    out = acp_agent._handle_slash_command("/reasoning high", state)
+    assert "high" in out and "this session" in out
+    assert fake.reasoning_config == {"enabled": True, "effort": "high"}
+
+    out = acp_agent._handle_slash_command("/reasoning none", state)
+    assert "none" in out
+    assert fake.reasoning_config == {"enabled": False}
+
+    out = acp_agent._handle_slash_command("/reasoning banana", state)
+    assert "Unknown argument" in out
+    assert fake.reasoning_config == {"enabled": False}  # unchanged by invalid input
+
+    show = acp_agent._handle_slash_command("/reasoning", state)
+    assert "none (disabled)" in show
+
+
+def test_reasoning_command_global_scope_persists(monkeypatch):
+    import cli as cli_module
+
+    saved = {}
+    monkeypatch.setattr(
+        cli_module, "save_config_value",
+        lambda key, value: saved.setdefault(key, value) or True,
+    )
+    acp_agent, state, fake, _conn = make_agent_and_state()
+
+    out = acp_agent._handle_slash_command("/reasoning xhigh --global", state)
+    assert "saved to config" in out
+    assert saved == {"agent.reasoning_effort": "xhigh"}
+    assert fake.reasoning_config == {"enabled": True, "effort": "xhigh"}


### PR DESCRIPTION
## Problem

ACP sessions are the only agent surface that ignores the user's reasoning configuration:

1. `acp_adapter/session.py::_make_agent()` never passes `reasoning_config` to `AIAgent`, so `agent.reasoning_effort` and per-model `reasoning_overrides` are silently dropped — every ACP chat pins to `medium` (per the `agent_init` docstring: `reasoning_config: None → {"enabled": True, "effort": "medium"} on OpenRouter`).
2. There is no `/reasoning` slash command in the headless ACP command set, so chat-mode clients (Paseo mobile, Zed, etc.) have no way to inspect or change reasoning effort.

CLI/TUI/gateway/cron all resolve reasoning through the shared chokepoint `hermes_constants.resolve_reasoning_config()` (added in #21256). This PR brings ACP in line.

## Changes

- **`acp_adapter/session.py`** — `_make_agent()` now resolves `reasoning_config` via `resolve_reasoning_config(config, effective_model)` (per-model override > global `agent.reasoning_effort`, YAML `false` = disabled), best-effort with a debug log on failure so a malformed config can't break session creation.
- **`acp_adapter/commands.py`** — new `/reasoning [none|minimal|low|medium|high|xhigh|max|ultra] [--global]` command, mirroring the CLI semantics minus the display toggles (display is the client's job in headless mode):
  - bare `/reasoning` shows current effort (`medium (default)` / explicit level / `none (disabled)`) + usage
  - setting a level mutates `state.agent.reasoning_config` in place (the wire builders read `agent.reasoning_config` per-request, so the change takes effect on the next turn without an agent rebuild) and syncs `_session_init_model_config` so the persisted session row stays honest for resume
  - `--global` persists via `cli.save_config_value("agent.reasoning_effort", ...)` — the same pattern `tui_gateway` already uses
  - invalid levels are rejected without touching current config; unrecognized command args fall through to the LLM like the other commands
  - advertised in `available_commands_update` so ACP clients show it with the input hint

## Tests

- `test_acp_make_agent_inherits_reasoning_config` — real `_make_agent` path captures `reasoning_config={"enabled": True, "effort": "high"}` from a config with `agent.reasoning_effort: high` (fails on main: KeyError/None).
- `test_reasoning_command_show_and_set` — show/`high`/`none`/invalid-arg round trip.
- `test_reasoning_command_global_scope_persists` — `--global` calls `save_config_value("agent.reasoning_effort", "xhigh")`.
- Full local runs: `tests/acp_adapter/` 22 passed; `pytest tests/ -k reasoning` 756 passed; `ruff check` clean on touched files.

Closes #105651
