### PR TITLE
fix(cli): stop flagging documented timeouts.* keys as unrecognized in config set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3169,7 +3169,11 @@ def _default_value_for_key(dotted_key: str):
 _OPEN_DICT_TOP_LEVEL_KEYS = frozenset({
     "providers", "credential_pool_strategies", "mcp_servers", "hooks", "quick_commands",
     "personalities", "command_allowlist", "model_catalog", "channel_prompts", "server_actions",
-    "secrets", "goals", "loops"})
+    "secrets", "goals", "loops",
+    # Dynamic dotted-key namespace resolved by agent/deadline.py resolve_timeout(); keys are
+    # documented in cli-config.yaml.example, not enumerated in DEFAULT_CONFIG (already accepted
+    # as a root by _EXTRA_KNOWN_ROOT_KEYS for structure validation).
+    "timeouts"})
 
 # Top-level keys whose sub-keys are partially schema-defined (e.g. a PlatformConfig dataclass) but
 # where users may add fields DEFAULT_CONFIG doesn't enumerate: validate the FIRST segment only.

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -547,11 +547,22 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        "timeouts.tools.sequential_call",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key
         is_known, _ = _validate_config_key(key)
         assert is_known, f"Expected {key!r} to validate as known"
+
+    def test_timeouts_keys_do_not_suggest_timezone(self):
+        """``timeouts.*`` is a dynamic dotted-key namespace (agent/deadline.py resolve_timeout),
+        documented in cli-config.yaml.example but not enumerated in DEFAULT_CONFIG — it must be
+        accepted as an open dict, not flagged as unknown with the difflib ``timezone.*`` near-miss
+        (the misleading warning from #105628)."""
+        from hermes_cli.config import _validate_config_key
+        is_known, suggestion = _validate_config_key("timeouts.tools.concurrent_batch")
+        assert is_known, "timeouts.* paths must validate as known (open dict root)"
+        assert suggestion is None, f"Known key must not carry a suggestion, got {suggestion!r}"
 
     @pytest.mark.parametrize("key,expected_in_suggestion", [
         ("gateway.discord.gateway_restart_notification", None),  # no close suggestion


### PR DESCRIPTION
## What does this PR do?

`timeouts.*` is a dynamic dotted-key namespace resolved at runtime by `agent/deadline.py::resolve_timeout()` (raw `timeouts:` section → legacy env var → default) and documented in `cli-config.yaml.example:259-266`, but it was absent from the `hermes config set` key validator. Every legitimate set printed a false "not a recognized config key" warning plus a misleading difflib suggestion:

```
$ hermes config set timeouts.tools.sequential_call 3600
✓ Set timeouts.tools.sequential_call = 3600 in .../config.yaml
⚠ 'timeouts.tools.sequential_call' is not a recognized config key — it was saved anyway,
  but Hermes may not read it.
  Did you mean: timezone.tools.sequential_call
```

The fix adds `"timeouts"` to `_OPEN_DICT_TOP_LEVEL_KEYS` in `hermes_cli/config.py` — the same open-dict root shape as `hooks`/`goals`/`secrets` (schema declares the dict, the user populates arbitrary dotted paths). This also aligns the config-set validation surface with config *structure* validation, which already accepts the root via `_EXTRA_KNOWN_ROOT_KEYS` (`hermes_cli/config.py:1069`, "unified timeout resolution section") — the two surfaces were inconsistent.

Runtime timeout resolution is untouched: `resolve_timeout()` reads values from the raw config `timeouts:` section and never consults `DEFAULT_CONFIG`, so registering the root only in the validator cannot change any resolved deadline. As a bonus, a genuine typo like `timeots.tools.sequential_call` now suggests `timeouts.*` instead of the nonsensical `timezone.*`.

## Related Issue

Fixes #105628 (secondary finding — the primary delegate_task 420s defect was already fixed by 903b9bf187; the `timeouts.*` schema-registration gap reported in the same issue remained open)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: added `"timeouts"` to `_OPEN_DICT_TOP_LEVEL_KEYS` with a comment noting it is the dynamic dotted-key namespace consumed by `agent/deadline.py` and already accepted by `_EXTRA_KNOWN_ROOT_KEYS` for structure validation.
- `tests/hermes_cli/test_set_config_value.py`: added `timeouts.tools.sequential_call` to the known-keys parametrize list and a dedicated regression test asserting known `timeouts.*` paths carry no suggestion (pinning the exact symptom from the issue).

## How to Test

1. Before the fix: `_validate_config_key("timeouts.tools.sequential_call")` returns `(False, 'timezone.tools.sequential_call')` — reproduced on a clean `upstream/main` checkout.
2. After the fix: it returns `(True, None)`; `timeouts.delegation.child` also passes; a real typo `timeots.tools.sequential_call` now suggests `timeouts.tools.sequential_call`.
3. `pytest tests/hermes_cli/test_set_config_value.py -q` — should pass: 95 passed (includes the two new regression assertions).
4. `pytest tests/hermes_cli/test_timeouts.py tests/agent/test_deadline.py -q` — should pass: 57 passed, 1 skipped (runtime resolution unaffected).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4 (darwin 25.4.0, arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no keys added; `timeouts.*` was already documented there)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
