### PR TITLE
fix(desktop): name the OAuth/basic-auth mismatch instead of pointing back at Sign in

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10086,7 +10086,10 @@ async function buildRemoteConnection(
 
       throw gatewayTicketFailure(
         error,
-        oauthTicketFailureAuthMessage(hasNativeSession(baseUrl)),
+        oauthTicketFailureAuthMessage(
+          hasNativeSession(baseUrl),
+          await gatewayAuthProviders(baseUrl, remoteHeaders)
+        ),
         'Could not reach the remote Hermes gateway while refreshing its WebSocket ticket. Try reconnecting.'
       )
     }

--- a/apps/desktop/electron/native-auth-decisions.test.ts
+++ b/apps/desktop/electron/native-auth-decisions.test.ts
@@ -155,6 +155,37 @@ test('oauthTicketFailureAuthMessage is expired only with a decryptable native se
   assert.match(oauthTicketFailureAuthMessage(false), /not signed in/)
 })
 
+test('oauthTicketFailureAuthMessage names the auth-mode mismatch for password-only backends', () => {
+  // OAuth auth mode + a backend that only offers a password provider can
+  // never persist: sign-in succeeds against the password gate but nothing
+  // OAuth-redeemable is stored, so the next boot loops to "not signed in".
+  // The message must break that loop by pointing at the auth-mode switch,
+  // regardless of whether a password-gate session "decrypts".
+  const passwordOnly = [{ name: 'basic', supports_password: true }]
+  const mismatch = /only offers username\/password sign-in[\s\S]*Session token/
+
+  assert.match(oauthTicketFailureAuthMessage(true, passwordOnly), mismatch)
+  assert.match(oauthTicketFailureAuthMessage(false, passwordOnly), mismatch)
+  // Status-shaped bare-string providers count too (`/api/status` lists "basic").
+  assert.match(oauthTicketFailureAuthMessage(false, ['basic']), mismatch)
+})
+
+test('oauthTicketFailureAuthMessage keeps the existing copy when providers are missing or mixed', () => {
+  // No probe result (undefined / empty list) or a mixed provider list keeps
+  // the strict OAuth messages — a wrong "switch auth mode" hint on a genuine
+  // OAuth outage would be worse than the loop.
+  assert.match(oauthTicketFailureAuthMessage(false, undefined), /not signed in/)
+  assert.match(oauthTicketFailureAuthMessage(false, []), /not signed in/)
+  assert.match(
+    oauthTicketFailureAuthMessage(false, [
+      { name: 'basic', supports_password: true },
+      { name: 'oauth', supports_password: false }
+    ]),
+    /not signed in/
+  )
+  assert.match(oauthTicketFailureAuthMessage(true, undefined), /session has expired/)
+})
+
 // --- 6. gated download auth (guards the Files-panel 401 on cookieless native) ---
 
 test('resolveGatedDownloadAuth matches oauth REST: bearer first, then cookie', () => {

--- a/apps/desktop/electron/native-auth-decisions.ts
+++ b/apps/desktop/electron/native-auth-decisions.ts
@@ -145,6 +145,16 @@ const OAUTH_NOT_SIGNED_IN_MESSAGE =
   'Remote Hermes gateway uses OAuth, but you are not signed in. ' +
   'Open Settings → Gateway and click "Sign in", or switch back to Local.'
 
+// A connection whose auth mode is OAuth but whose backend only offers a
+// password provider can never persist an OAuth session — every sign-in
+// succeeds against the password gate, yet nothing OAuth-redeemable is stored,
+// so the next boot loops straight back to "not signed in". Pointing the user
+// at "Sign in" again re-triggers that loop; the fix is switching the
+// connection's auth mode, so the message must say so.
+const OAUTH_PASSWORD_BACKEND_MESSAGE =
+  'The remote gateway only offers username/password sign-in, which cannot persist an OAuth-mode connection. ' +
+  'Open Settings → Gateways, edit this connection, and switch its authentication to Session token.'
+
 const OAUTH_SESSION_EXPIRED_MESSAGE =
   'Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.'
 
@@ -202,7 +212,20 @@ export function normalizeAdvertisedAuthProviders(providers: unknown): Advertised
  * an unreadable keychain otherwise look like a live oauth session and the
  * ticket mint 401s — that must send the user to Sign in, not "expired".
  */
-export function oauthTicketFailureAuthMessage(hasDecryptableNativeSession: boolean): string {
+export function oauthTicketFailureAuthMessage(
+  hasDecryptableNativeSession: boolean,
+  advertisedProviders?: unknown
+): string {
+  // Password-only backends mis-sign-in (see OAUTH_PASSWORD_BACKEND_MESSAGE), so
+  // they need the mismatch copy even before the expired-vs-unsigned choice —
+  // a native session that "decrypts" here is a password gate session, not an
+  // OAuth one. Mixed/unknown provider lists keep the existing messages: the
+  // caller's probe is best-effort, and a wrong "switch auth mode" hint on a
+  // genuine OAuth outage would be worse than the loop.
+  if (advertisedProviders !== undefined && !oauthGuardMayHardFail(advertisedProviders)) {
+    return OAUTH_PASSWORD_BACKEND_MESSAGE
+  }
+
   return hasDecryptableNativeSession ? OAUTH_SESSION_EXPIRED_MESSAGE : OAUTH_NOT_SIGNED_IN_MESSAGE
 }
 

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -368,7 +368,22 @@ Side-by-side routing is live: each registered gateway dials its own backends and
 
 The connection has two halves: on the backend you protect it with an **auth provider**, and in the app you enter the backend's URL and sign in. Binding the backend to a non-loopback address automatically engages its auth gate, and the provider you configure is what lets the desktop app through.
 
-**Pick a provider based on where the backend lives:**
+:::note Which connection kind / auth mode should I choose?
+The connection kind (Remote gateway vs SSH) and, for a Remote gateway, the auth mode (OAuth vs Session token) are separate choices — and only some combinations persist across app restarts:
+
+| Connection | Requires on the backend | Persists across relaunches? |
+| --- | --- | --- |
+| Remote gateway · **OAuth** auth mode | A configured **OAuth provider** (Nous Portal or self-hosted OIDC) | ✅ — the OAuth session is stored and refreshed |
+| Remote gateway · **Session token** auth mode | Any gated backend (works with a username/password provider) | ✅ — the token is stored (OS keyring) and reused |
+| Remote gateway · OAuth mode **against a basic-auth-only backend** | — | ❌ — sign-in succeeds against the password gate, but nothing OAuth-redeemable is stored; every relaunch fails with *"not signed in"* and asks you to sign in again |
+| **SSH** kind | An SSH key for the remote user | ✅ — the app opens the tunnel on demand and adopts a dashboard token; no recurring sign-in at all |
+
+Two practical consequences:
+
+- If your backend only offers username/password auth, set the connection's auth mode to **Session token** (or sign in via the password form and let the app keep that session) — **not** OAuth. The OAuth mode against a password-only backend is the re-sign-in loop above: every step reports success, yet nothing persists.
+- For the "two personal machines" case (your laptop → your own desktop/Mini), the **SSH** connection kind is usually the best fit: no auth provider configuration, no exposed ports, no recurring sign-in — the app tunnels in with your SSH key and starts the dashboard for you. See [Adding a connection → SSH](./multi-connection-desktop.md#adding-a-connection-step-by-step) for the fields.
+
+Which provider a Remote gateway backend should use:
 
 - **OAuth (Nous Portal) — preferred for anything reachable beyond your own machine.** Logins are verified against your Nous account, so this is the option suitable for a VPS, a public host, or any remote backend. Register the dashboard with `hermes dashboard register` (or the Portal [`/local-dashboards`](https://portal.nousresearch.com/local-dashboards) page) to provision its OAuth client, then sign in from the app with **Sign in with Nous Research**. A self-hosted OIDC provider works the same way if you run your own identity provider.
 - **Username/password — local / trusted-network use only.** The simplest option when the backend is on the same trusted LAN or reachable only over a VPN (e.g. Tailscale). It protects a single shared credential with no external identity provider, so **do not use it for a dashboard exposed to the public internet** — reach for OAuth there instead.
@@ -427,6 +442,7 @@ The remote gateway host is configured per [profile](./profiles.md), so each prof
 - **Sign-in fails with 401 / "Invalid credentials"** — the username or password doesn't match the backend's `HERMES_DASHBOARD_BASIC_AUTH_USERNAME` / `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD`. The backend returns the same generic error for an unknown user and a wrong password (no enumeration oracle), so double-check both. Confirm the gate is on with `curl -s http://<host>:9119/api/status | jq '.auth_required, .auth_providers'` — it should report `true` and include `"basic"`.
 - **No "Sign in" button — it asks for a session token instead** — the backend's username/password provider isn't active. `/api/status` won't list `"basic"` in `auth_providers`. Make sure both the username and a password (or password hash) are set in `~/.hermes/.env` and that the dashboard process actually loaded them.
 - **Signed out on every restart** — set `HERMES_DASHBOARD_BASIC_AUTH_SECRET` to a stable value. Without it the token-signing key is regenerated per boot, invalidating all sessions.
+- **"Remote Hermes gateway uses OAuth, but you are not signed in" on every relaunch (basic-auth backend)** — the connection's auth mode is OAuth but the backend only offers the username/password provider, so no OAuth session can ever be stored. Sign-in succeeds against the password gate each time, then the next launch is unsigned again. Fix: edit the connection in **Settings → Gateways** and switch its auth mode to **Session token** (or sign in via the password form and let the app persist that session). Newer builds name this mismatch directly in the failure message.
 - **Connection refused / times out** — the backend bound to `127.0.0.1` (the default) or a firewall/VPN is blocking the port. Bind to `0.0.0.0` or the tailscale IP and open the port to your trusted network.
 
 For the same setup from the web-dashboard angle, see [Web Dashboard → Connecting Hermes Desktop to a remote backend](./features/web-dashboard.md#connecting-hermes-desktop-to-a-remote-backend); the env vars are catalogued under [Environment Variables → Web Dashboard & Hermes Desktop](../reference/environment-variables.md#web-dashboard--hermes-desktop).


### PR DESCRIPTION
## Summary
- **The loop:** a connection with auth mode **OAuth** against a backend that only offers the username/password provider signs in "successfully" (basic-provider `login_success` + a ws ticket) but never persists anything OAuth-redeemable — the next launch fails with *"Remote Hermes gateway uses OAuth, but you are not signed in. Open Settings → Gateway and click "Sign in"…"*, and clicking Sign in re-triggers the same non-persisting flow.
- **The fix (electron):** `oauthTicketFailureAuthMessage` now takes the advertised auth providers and, when every provider is password-based (the existing `oauthGuardMayHardFail` shape, already probed and cached via `gatewayAuthProviders`), returns a message that names the mismatch and the actual escape hatch: *switch the connection's auth mode to Session token* — instead of pointing back at the button that provably loops. Unknown/mixed provider lists keep the existing expired/unsigned copy (the probe is best-effort; a wrong "switch auth mode" hint on a genuine OAuth outage would be worse than the loop).
- **The fix (docs):** `desktop.md` gains a *"Which connection kind / auth mode should I choose"* table covering what each combination requires and what actually persists across relaunches (including the OAuth-vs-basic ❌ row), plus a troubleshooting entry for this exact symptom and a pointer to the **SSH** connection kind (key + adopted token, no recurring sign-in) for the two-personal-machines case it solves.

Closes #105632 (docs + failure-message UX; the save/test-time mismatch warning from the report can layer on later — this PR removes the misleading guidance and documents the behavior end-to-end).

## Testing
- `npx vitest run --project electron` — new tests pin the three-way choice: password-only → mismatch copy (both with and without a decryptable "native" session, since a password-gate session is not an OAuth one); undefined/empty/mixed providers keep the existing messages. Mutational RED confirmed (disabling the new branch fails all 3 new assertions).
- `npx tsc --build tsconfig.electron.json` — clean.
- Full electron suite: 2140 passed; the single `managed-ssh-update.test.ts` failure (127 !== 0) is pre-existing on a clean checkout of main, untouched by this diff.
- `website`: `python3 scripts/extract-skills.py` + `npm run build:fast` — success (the two `/docs/llms*.txt` broken-link warnings are pre-existing, generated only by the deploy workflow).
