### PR TITLE
fix: Telegram outbound 및 gateway update 안전성 강화

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -4,7 +4,9 @@ A cron job that restarts/stops the gateway from inside the gateway (``hermes gat
 ``launchctl kickstart ai.hermes.gateway``, ``systemctl restart hermes-gateway``) kills the process,
 the supervisor revives it, auto-resume re-runs the turn: a SIGTERM-respawn loop.
 ``cron.jobs.create_job`` rejects such specs on every creation path. Patterns are command-shaped —
-anchored on concrete command identifiers — so they cannot fire on prose. Defence-in-depth layer.
+anchored on concrete command identifiers — so they cannot fire on prose. Defence-in-depth layer:
+the updater separately rejects ordinary mutating updates at its own entry point when launched from
+a live gateway descendant, independent of shell syntax.
 """
 
 from __future__ import annotations

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1581,10 +1581,13 @@ _SEND_RETRY_INLINE_WAIT_CAP_SECS = 60.0
 
 # Platform-neutral send-failure kinds for ``SendResult.error_kind``: too_long (size cap),
 # bad_format (markup rejected; plain-text retry fixes), forbidden (the bot CANNOT reach the user),
-# not_found (chat/thread/message gone), rate_limited, transient (connection-level, retry-safe),
-# unknown.
+# not_found (chat/thread/message gone), rate_limited (ordinary flood control, retryable after the
+# declared delay), peer_flood (Telegram per-peer anti-spam — a circuit-breaker signal that must NOT
+# trigger a retry, a plain-text fallback or a failure notice), transient (connection-level,
+# retry-safe), unknown.
 SEND_ERROR_KINDS = frozenset(
-    {"too_long", "bad_format", "forbidden", "not_found", "rate_limited", "transient", "unknown"})
+    {"too_long", "bad_format", "forbidden", "not_found", "rate_limited", "peer_flood", "transient",
+     "unknown"})
 
 # ``not_found`` substrings by blast radius: chat-level = target dead; thread/topic/message-level
 # leaves the parent chat reachable.
@@ -1618,6 +1621,9 @@ _SEND_ERROR_CLASSIFIERS: Tuple[Tuple[str, Callable[[str], bool]], ...] = (
         b, "forbidden", "bot was blocked", "blocked by the user", "user is deactivated",
         "not enough rights", "have no rights", "not a member")),
     ("not_found", lambda b: _any_in(b, *_CHAT_LEVEL_NOT_FOUND_SUBSTRINGS, *_SUBCHAT_NOT_FOUND_SUBSTRINGS)),
+    # Before rate_limited: PEER_FLOOD also contains "flood" but is a per-peer circuit-breaker
+    # signal, not a retry-after-the-delay throttle.
+    ("peer_flood", lambda b: _any_in(b, "peer_flood", "peer flood")),
     ("rate_limited", lambda b: _any_in(b, "flood", "too many requests", "retry after", "rate limit")),
     ("transient", lambda b: _any_in(b, *_RETRYABLE_ERROR_PATTERNS, "connecttimeout")))
 
@@ -3149,6 +3155,16 @@ class BasePlatformAdapter(ABC):
         result = await _send(content)
         if result.success:
             return result
+
+        # Telegram PEER_FLOOD is a per-chat circuit-breaker signal, not a
+        # formatting or ordinary transient failure. The adapter already keeps
+        # the server-requested (or conservative default) cooldown. Retrying,
+        # sending a failure notice, or attempting plain text would all hit the
+        # same peer immediately and amplify the restriction. Return the exact
+        # failure so final-delivery ledger handling records it as failed.
+        if getattr(result, "error_kind", None) == "peer_flood":
+            return result
+
         error_str = result.error or ""
         # A rate-limited / flood-capped send is transient: it should back off
         # (honoring the server's retry_after when present) rather than fall
@@ -3191,6 +3207,8 @@ class BasePlatformAdapter(ABC):
                 result = await _send(content)
                 if result.success:
                     logger.info("[%s] Send succeeded on retry %d", self.name, attempt)
+                    return result
+                if getattr(result, "error_kind", None) == "peer_flood":
                     return result
                 error_str = result.error or ""
                 if result.retry_after is not None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -41,6 +41,11 @@ from agent.turn_context import compression_made_progress
 from agent.session_activity import ActivityProvenance
 from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from gateway.update_contract import (
+    UPDATE_ORPHAN_GRACE_SECONDS,
+    UPDATE_TIMEOUT_SECONDS,
+    acquire_update_helper_probe,
+)
 
 # Per-session AIAgent cache bounds (agents are heavy); see _enforce_agent_cache_cap/_session_housekeeping_watcher.
 _AGENT_CACHE_MAX_SIZE = 128
@@ -4952,6 +4957,11 @@ def _start_gateway_claim_pid_file() -> bool:
         release_gateway_runtime_lock()
         logger.error("PID file race lost to another gateway instance. Exiting.")
         return False
+    # Publish only after the authoritative PID/runtime-lock claims succeed.
+    # Descendants retain this identity even when a routed profile changes
+    # HERMES_HOME or a wrapper strips the legacy _HERMES_GATEWAY marker.
+    from tools.process_registry import GATEWAY_ORIGIN_PID_ENV
+    os.environ[GATEWAY_ORIGIN_PID_ENV] = str(os.getpid())
     atexit.register(remove_pid_file)
     atexit.register(release_gateway_runtime_lock)
     return True

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -11,6 +11,7 @@ import asyncio
 import dataclasses
 import json
 import logging
+import os
 import time
 from contextlib import suppress
 from pathlib import Path
@@ -20,6 +21,7 @@ from gateway.config import Platform, _BUILTIN_PLATFORM_VALUES
 from gateway.platforms.event import MessageEvent, MessageType
 from gateway.session import SessionEntry, SessionSource
 from gateway.run_shutdown import _log_suppressed, _notice_target_key, _send_error, _send_failed
+from gateway.update_contract import UPDATE_ORPHAN_GRACE_SECONDS, UPDATE_TIMEOUT_SECONDS
 
 # Log-record parity with the origin module.
 logger = logging.getLogger("gateway.run")
@@ -55,24 +57,6 @@ class GatewayNotificationsMixin:
     # Coalescing keys: process completions (short-window fan-in) and async delegations (+ parent session).
     _COMPLETION_BATCH_KEY_FIELDS = ("session_key", "platform", "chat_type", "chat_id", "thread_id", "user_id")
     _ASYNC_GROUP_KEY_FIELDS = ("session_key", "parent_session_id", *_COMPLETION_BATCH_KEY_FIELDS[1:])
-
-    @dataclasses.dataclass
-    class _UpdatePaths:
-        """Marker files ``hermes update --gateway`` and its watcher exchange under HERMES_HOME."""
-
-        pending: Path
-        claimed: Path
-        output: Path
-        exit_code: Path
-        prompt: Path
-        response: Path
-
-        def any_pending(self) -> bool:
-            return self.pending.exists() or self.claimed.exists()
-
-        def unlink_all(self) -> None:
-            for p in (self.pending, self.claimed, self.output, self.exit_code, self.prompt, self.response):
-                p.unlink(missing_ok=True)
 
     @dataclasses.dataclass
     class _UpdateTarget:
@@ -364,39 +348,6 @@ class GatewayNotificationsMixin:
         except RuntimeError:
             logger.debug("Skipping update notification watcher: no running event loop")
 
-    @classmethod
-    def _update_paths(cls) -> "GatewayNotificationsMixin._UpdatePaths":
-        from gateway.run import _hermes_home
-        return cls._UpdatePaths(
-            pending=_hermes_home / ".update_pending.json",
-            claimed=_hermes_home / ".update_pending.claimed.json", output=_hermes_home / ".update_output.txt",
-            exit_code=_hermes_home / ".update_exit_code",
-            prompt=_hermes_home / ".update_prompt.json", response=_hermes_home / ".update_response",
-        )
-
-    def _resolve_update_target(self, paths: "_UpdatePaths") -> Optional["_UpdateTarget"]:
-        """Resolve adapter/chat/session for update watcher messages from the pending marker."""
-        for path in (paths.claimed, paths.pending):
-            if not path.exists():
-                continue
-            with suppress(Exception):
-                pending = json.loads(path.read_text(encoding="utf-8"))
-                platform_str = pending.get("platform")
-                chat_id = pending.get("chat_id")
-                session_key = pending.get("session_key")
-                if not (platform_str and chat_id):
-                    continue  # BASE: an incomplete marker falls through to the next path, not "unresolved"
-                platform = Platform(platform_str)
-                adapter = self.adapters.get(platform)
-                if not adapter:
-                    return None
-                metadata = self._pending_marker_metadata(platform, chat_id, pending, adapter)
-                # Fallback session key if not stored (old pending files)
-                return self._UpdateTarget(
-                    adapter, chat_id, session_key or f"{platform_str}:{chat_id}", metadata, platform,
-                )
-        return None
-
     def _pending_marker_metadata(self, platform, chat_id, data: dict, adapter):
         """Thread metadata for a persisted update/restart marker (thread_id/chat_type/message_id keys)."""
         return self._thread_metadata_for_target(
@@ -404,66 +355,36 @@ class GatewayNotificationsMixin:
             reply_to_message_id=data.get("message_id"), adapter=adapter,
         )
 
-    async def _watch_update_completion_only(self, paths: "_UpdatePaths", deadline: float, poll_interval: float) -> None:
-        """Fallback when no adapter/chat can be resolved: wait for the exit code, then notify."""
-        logger.warning("Update watcher: cannot resolve adapter/chat_id, falling back to completion-only")
-        # Poll until _send_update_notification delivers (it returns False while the platform reconnects).
-        loop = asyncio.get_running_loop()
-        while paths.any_pending() and loop.time() < deadline:
-            if paths.exit_code.exists() and await self._send_update_notification():
-                return
-            await asyncio.sleep(poll_interval)
-        if paths.any_pending() and not paths.exit_code.exists():
-            paths.exit_code.write_text("124", encoding="utf-8")
-            await self._send_update_notification()
-
-    @staticmethod
-    def _update_exit_code(paths: "_UpdatePaths") -> int:
-        return int(paths.exit_code.read_text(encoding="utf-8").strip() or "1")
-
-    @staticmethod
-    def _read_update_output_since(path: Path, offset: int) -> tuple[str, int]:
-        """Read update output defensively; logs may contain invalid UTF-8."""
-        try:
-            data = path.read_bytes()
-        except OSError:
-            return "", offset
-        if len(data) <= offset:
-            return "", len(data)
-        return data[offset:].decode("utf-8", errors="replace"), len(data)
-
-    async def _send_update_output(self, target: "_UpdateTarget", text: str) -> None:
-        """Send buffered update output as fenced chunks that fit message limits (Telegram: 4096)."""
-        from tools.ansi_strip import strip_ansi
-        clean = strip_ansi(text).strip()
-        if not clean:
-            return
-        max_chunk = 3500
-        for i in range(0, len(clean), max_chunk):
-            with _log_suppressed(logging.DEBUG, "Update stream send failed: %s"):
-                await target.send(f"```\n{clean[i:i + max_chunk]}\n```")
-
     async def _forward_update_prompt(self, target: "_UpdateTarget", prompt_text: str, default: str) -> None:
         """Forward an update prompt: platform-native buttons first (Discord, Telegram), else text."""
-        sent_buttons = False
+        delivered = False
+        peer_flood_blocked = False
         adapter = target.adapter
         if getattr(type(adapter), "send_update_prompt", None) is not None:
-            with _log_suppressed(logging.DEBUG, "Button-based update prompt failed: %s"):
-                await adapter.send_update_prompt(
+            try:
+                result = await adapter.send_update_prompt(
                     chat_id=target.chat_id, prompt=prompt_text, default=default,
                     session_key=target.session_key, metadata=target.send_metadata(),
                 )
-                sent_buttons = True
-        if not sent_buttons:
+                delivered = not _send_failed(result)
+                peer_flood_blocked = getattr(result, "error_kind", None) == "peer_flood"
+            except Exception as exc:
+                peer_flood_blocked = getattr(exc, "error_kind", None) == "peer_flood"
+                logger.debug("Button-based update prompt failed: %s", exc)
+        if not delivered and not peer_flood_blocked:
             default_hint = f" (default: {default})" if default else ""
             _p = getattr(adapter, "typed_command_prefix", "/")
-            await target.send(
+            result = await target.send(
                 f"⚕ **Update needs your input:**\n\n{prompt_text}{default_hint}\n\n"
                 f"Reply `{_p}approve` (yes) or `{_p}deny` (no), or type your answer directly."
             )
+            delivered = not _send_failed(result)
         # Keep the prompt marker on disk until answered so a restarted watcher can re-forward it.
-        self._session_state(target.session_key).persistent.update_prompt_pending = True
-        logger.info("Forwarded update prompt to %s: %s", target.session_key, prompt_text[:80])
+        self._session_state(target.session_key).persistent.update_prompt_pending = delivered
+        if delivered:
+            logger.info("Forwarded update prompt to %s: %s", target.session_key, prompt_text[:80])
+        else:
+            logger.warning("Update prompt delivery failed for %s", target.session_key)
 
     def _clear_update_markers(self, paths: "_UpdatePaths", session_key: Optional[str]) -> None:
         paths.unlink_all()
@@ -472,142 +393,555 @@ class GatewayNotificationsMixin:
             state.persistent.update_prompt_pending = False
 
     async def _watch_update_progress(
-        self, poll_interval: float = 2.0, stream_interval: float = 4.0, timeout: float = 1800.0
+        self,
+        poll_interval: float = 2.0,
+        stream_interval: float = 4.0,
+        timeout: float = UPDATE_TIMEOUT_SECONDS,
     ) -> None:
         """Watch ``hermes update --gateway``, streaming output + forwarding prompts.
 
-        Polls ``.update_output.txt`` for new content and sends chunks to the user periodically;
-        detects ``.update_prompt.json`` (written when the update process needs input) and forwards it.
+        Polls ``.update_output.txt`` for new content and sends chunks to the
+        user periodically.  Detects ``.update_prompt.json`` (written by the
+        update process when it needs user input) and forwards the prompt to
+        the messenger.  The user's next message is intercepted by
+        ``_handle_message`` and written to ``.update_response``.
         """
-        paths = self._update_paths()
+        from gateway.run import _hermes_home, _non_conversational_metadata
+
+        pending_path = _hermes_home / ".update_pending.json"
+        claimed_path = _hermes_home / ".update_pending.claimed.json"
+        output_path = _hermes_home / ".update_output.txt"
+        exit_code_path = _hermes_home / ".update_exit_code"
+        helper_pid_path = _hermes_home / ".update_helper_pid"
+        prompt_path = _hermes_home / ".update_prompt.json"
+        from hermes_cli.active_sessions import _FileLock
+        update_lock_path = _hermes_home / ".update_pending.lock"
+
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
-        target = self._resolve_update_target(paths)
-        if target is None:
-            await self._watch_update_completion_only(paths, deadline, poll_interval)
+
+        # Resolve the adapter and chat_id for sending messages
+        adapter = None
+        chat_id = None
+        session_key = None
+        metadata = None
+        for path in (claimed_path, pending_path):
+            if path.exists():
+                try:
+                    pending = json.loads(path.read_text(encoding="utf-8"))
+                    platform_str = pending.get("platform")
+                    chat_id = pending.get("chat_id")
+                    chat_type = pending.get("chat_type")
+                    session_key = pending.get("session_key")
+                    thread_id = pending.get("thread_id")
+                    message_id = pending.get("message_id")
+                    if platform_str and chat_id:
+                        platform = Platform(platform_str)
+                        adapter = self.adapters.get(platform)
+                        metadata = self._thread_metadata_for_target(
+                            platform,
+                            chat_id,
+                            thread_id,
+                            chat_type=chat_type,
+                            reply_to_message_id=message_id,
+                            adapter=adapter,
+                        )
+                        # Fallback session key if not stored (old pending files)
+                        if not session_key:
+                            session_key = f"{platform_str}:{chat_id}"
+                    break
+                except Exception:
+                    pass
+
+        if not adapter or not chat_id:
+            logger.warning("Update watcher: cannot resolve adapter/chat_id, falling back to completion-only")
+            # Fall back to completion-only: wait for the exit code and send the
+            # final notification. _send_update_notification re-resolves the
+            # adapter on every call, so when the target platform is still
+            # reconnecting it returns False and keeps the markers. Keep polling
+            # until it actually delivers (returns True) instead of giving up
+            # after the first completion check — otherwise a platform that
+            # reconnects a few seconds after completion never gets notified.
+            while (
+                (pending_path.exists() or claimed_path.exists())
+                and loop.time() < deadline
+            ):
+                if await self._send_update_notification():
+                    return
+                await asyncio.sleep(poll_interval)
+            if pending_path.exists() or claimed_path.exists():
+                await self._send_update_notification()
             return
-        session_key = target.session_key
+
+        target = self._UpdateTarget(
+            adapter, chat_id, session_key, metadata, platform,
+        )
+
+        def _strip_ansi(text: str) -> str:
+            from tools.ansi_strip import strip_ansi
+            return strip_ansi(text)
+
+        def _read_output_since(path: Path, offset: int) -> tuple[str, int]:
+            """Read update output defensively; logs may contain invalid UTF-8."""
+            try:
+                data = path.read_bytes()
+            except OSError:
+                return "", offset
+            if len(data) <= offset:
+                return "", len(data)
+            return data[offset:].decode("utf-8", errors="replace"), len(data)
+
         bytes_sent = 0
         last_stream_time = loop.time()
         buffer = ""
 
         async def _flush_buffer() -> None:
+            """Send buffered output to the user."""
             nonlocal buffer, last_stream_time
-            text, buffer = buffer, ""
-            if text.strip():
-                last_stream_time = loop.time()
-                await self._send_update_output(target, text)
-
-        def _read_new_output() -> None:
-            nonlocal buffer, bytes_sent
-            if paths.output.exists():
-                with suppress(OSError):
-                    chunk, bytes_sent = self._read_update_output_since(paths.output, bytes_sent)
-                    buffer += chunk
+            if not buffer.strip():
+                buffer = ""
+                return
+            # Chunk to fit message limits (Telegram: 4096, others: generous)
+            clean = _strip_ansi(buffer).strip()
+            buffer = ""
+            last_stream_time = loop.time()
+            if not clean:
+                return
+            # Split into chunks if too long
+            max_chunk = 3500
+            chunks = [clean[i:i + max_chunk] for i in range(0, len(clean), max_chunk)]
+            for chunk in chunks:
+                try:
+                    await adapter.send(
+                        chat_id,
+                        f"```\n{chunk}\n```",
+                        metadata=_non_conversational_metadata(metadata, platform=platform),
+                    )
+                except Exception as e:
+                    logger.debug("Update stream send failed: %s", e)
 
         while loop.time() < deadline:
-            if paths.exit_code.exists():
-                _read_new_output()
-                await _flush_buffer()
-                with _log_suppressed(logging.WARNING, "Update final notification failed: %s"):
-                    exit_code = self._update_exit_code(paths)
-                    await target.send(
-                        "✅ Hermes update finished." if exit_code == 0
-                        else "❌ Hermes update failed (exit code {}).".format(exit_code)
-                    )
-                    logger.info("Update finished (exit=%s), notified %s", exit_code, session_key)
-                self._clear_update_markers(paths, session_key)
+            if await self._send_update_notification():
+                _up_done = self._peek_session_state(session_key)
+                if _up_done is not None:
+                    _up_done.persistent.update_prompt_pending = False
                 return
-            _read_new_output()
+
+            # Check for new output
+            if output_path.exists():
+                try:
+                    chunk, bytes_sent = _read_output_since(output_path, bytes_sent)
+                    if chunk:
+                        buffer += chunk
+                except OSError:
+                    pass
+
+            # Flush buffer periodically
             if buffer.strip() and (loop.time() - last_stream_time) >= stream_interval:
                 await _flush_buffer()
-            # Forward a prompt only when none is pending, else every poll re-forwards the same prompt.
-            _pending_state = self._peek_session_state(session_key) if session_key else None
-            if paths.prompt.exists() and session_key and not getattr(
-                getattr(_pending_state, "persistent", None), "update_prompt_pending", False
-            ):
+
+            # Check for prompts — only forward if we haven't already sent
+            # one that's still awaiting a response.  Without this guard the
+            # watcher would re-read the same .update_prompt.json every poll
+            # cycle and spam the user with duplicate prompt messages.
+            _up_pending_state = (
+                self._peek_session_state(session_key) if session_key else None
+            )
+            if (prompt_path.exists() and session_key
+                    and not (
+                        _up_pending_state is not None
+                        and _up_pending_state.persistent.update_prompt_pending
+                    )):
                 try:
-                    prompt_data = json.loads(paths.prompt.read_text(encoding="utf-8"))
+                    prompt_data = json.loads(prompt_path.read_text(encoding="utf-8"))
                     prompt_text = prompt_data.get("prompt", "")
+                    default = prompt_data.get("default", "")
                     if prompt_text:
-                        await _flush_buffer()  # user sees context before the prompt
-                        await self._forward_update_prompt(target, prompt_text, prompt_data.get("default", ""))
+                        # Flush any buffered output first so the user sees
+                        # context before the prompt
+                        await _flush_buffer()
+                        await self._forward_update_prompt(target, prompt_text, default)
                 except (json.JSONDecodeError, OSError) as e:
                     logger.debug("Failed to read update prompt: %s", e)
+
             await asyncio.sleep(poll_interval)
-        if not paths.exit_code.exists():
-            logger.warning("Update watcher timed out after %.0fs", timeout)
-            paths.exit_code.write_text("124", encoding="utf-8")
-            await _flush_buffer()
-            with suppress(Exception):
-                await target.send("❌ Hermes update timed out after 30 minutes.")
-            self._clear_update_markers(paths, session_key)
+
+        # Local watch budget elapsed. The persisted request deadline and helper
+        # lock remain authoritative; one final pass may recover an expired orphan
+        # or deliver a completed request, but never invents completion itself.
+        await _flush_buffer()
+        if await self._send_update_notification():
+            _up_timeout_state = self._peek_session_state(session_key)
+            if _up_timeout_state is not None:
+                _up_timeout_state.persistent.update_prompt_pending = False
 
     async def _send_update_notification(self) -> bool:
         """If an update finished, notify the user.
 
-        False while the update is still running (caller may retry); True after a definitive send/skip.
+        Returns False while the helper owns its OS lock, when state is partial or
+        request IDs do not match, or when delivery should be retried. Request
+        state is removed only after a matching completion is delivered. The
+        ``.update_helper.lock`` inode is intentionally retained: only ownership
+        of its OS lock is lifecycle authority, and stable lock files avoid
+        unlink-and-recreate races across processes.
         """
-        from gateway.run import _non_conversational_metadata
-        paths = self._update_paths()
-        if not paths.any_pending():
-            return False
-        cleanup = True
-        active_pending_path = paths.claimed
+        from gateway.run import (
+            _hermes_home,
+            _non_conversational_metadata,
+            acquire_update_helper_probe,
+        )
 
-        def _defer(reason: str, *args) -> bool:
-            nonlocal cleanup, active_pending_path
-            logger.info(reason, *args)
-            cleanup = False
-            active_pending_path = paths.pending
-            paths.claimed.replace(paths.pending)
+        pending_path = _hermes_home / ".update_pending.json"
+        claimed_path = _hermes_home / ".update_pending.claimed.json"
+        output_path = _hermes_home / ".update_output.txt"
+        exit_code_path = _hermes_home / ".update_exit_code"
+        helper_pid_path = _hermes_home / ".update_helper_pid"
+        helper_lock_path = _hermes_home / ".update_helper.lock"
+        done_path = _hermes_home / ".update_helper_done.json"
+        from hermes_cli.active_sessions import _FileLock
+        update_lock_path = _hermes_home / ".update_pending.lock"
+
+        if not pending_path.exists() and not claimed_path.exists():
             return False
 
         try:
-            if paths.pending.exists():
-                try:
-                    paths.pending.replace(paths.claimed)
-                except FileNotFoundError:
-                    if not paths.claimed.exists():
-                        return True
-            elif not paths.claimed.exists():
-                return True
-            pending = json.loads(paths.claimed.read_text(encoding="utf-8"))
+            helper_probe = acquire_update_helper_probe(helper_lock_path)
+        except (OSError, RuntimeError):
+            logger.warning("Update notification deferred: helper lock probe failed")
+            return False
+        if helper_probe is None:
+            logger.info("Update notification deferred: update helper lock is held")
+            return False
+
+        cleanup = False
+        delivered = False
+        request_id = None
+        active_pending_path = claimed_path
+        try:
+            with _FileLock(update_lock_path):
+                if pending_path.exists():
+                    try:
+                        pending = json.loads(pending_path.read_text(encoding="utf-8"))
+                    except (OSError, ValueError, TypeError):
+                        logger.info(
+                            "Update notification deferred: pending marker is incomplete"
+                        )
+                        return False
+                    try:
+                        pending_path.replace(claimed_path)
+                    except FileNotFoundError:
+                        if not claimed_path.exists():
+                            return False
+                        try:
+                            pending = json.loads(
+                                claimed_path.read_text(encoding="utf-8")
+                            )
+                        except (OSError, ValueError, TypeError):
+                            return False
+                elif not claimed_path.exists():
+                    return False
+                else:
+                    try:
+                        pending = json.loads(claimed_path.read_text(encoding="utf-8"))
+                    except (OSError, ValueError, TypeError):
+                        logger.info(
+                            "Update notification deferred: claimed marker is incomplete"
+                        )
+                        return False
+
             platform_str = pending.get("platform")
             chat_id = pending.get("chat_id")
-            if not paths.exit_code.exists():
-                return _defer("Update notification deferred: update still running")
-            exit_code = self._update_exit_code(paths)
-            output = paths.output.read_bytes().decode("utf-8", errors="replace") if paths.output.exists() else ""
+            chat_type = pending.get("chat_type")
+            thread_id = pending.get("thread_id")
+            message_id = pending.get("message_id")
+            request_id = pending.get("request_id")
+
+            try:
+                done = json.loads(done_path.read_text(encoding="utf-8"))
+            except FileNotFoundError:
+                done = None
+            except (OSError, ValueError, TypeError):
+                done = "invalid"
+            legacy_request = (
+                "request_id" not in pending
+                and "deadline_epoch" not in pending
+                and "handoff_token_sha256" not in pending
+                and done is None
+            )
+            matching_done = (
+                isinstance(request_id, str)
+                and bool(request_id)
+                and isinstance(done, dict)
+                and done.get("request_id") == request_id
+            )
+            if legacy_request:
+                # Helpers from before the request-id contract wrote only the
+                # pending metadata, output and exit code. The helper OS lock is
+                # still lifecycle authority; PID metadata is deliberately not.
+                if not isinstance(platform_str, str) or not platform_str or not chat_id:
+                    logger.info(
+                        "Update notification deferred: legacy pending target is invalid"
+                    )
+                    return False
+                try:
+                    Platform(platform_str)
+                except (TypeError, ValueError):
+                    logger.info(
+                        "Update notification deferred: legacy pending platform is invalid"
+                    )
+                    return False
+
+                if not exit_code_path.exists():
+                    try:
+                        legacy_started_epoch = active_pending_path.stat().st_mtime
+                    except OSError:
+                        logger.info(
+                            "Update notification deferred: legacy pending age unavailable"
+                        )
+                        return False
+                    legacy_expiry = (
+                        legacy_started_epoch
+                        + UPDATE_TIMEOUT_SECONDS
+                        + UPDATE_ORPHAN_GRACE_SECONDS
+                    )
+                    if time.time() <= legacy_expiry:
+                        logger.info(
+                            "Update notification deferred: legacy helper may still complete"
+                        )
+                        return False
+                    with _FileLock(update_lock_path):
+                        current = json.loads(
+                            claimed_path.read_text(encoding="utf-8")
+                        )
+                        if current != pending or any(
+                            isinstance(candidate, dict) and candidate.get("request_id")
+                            for candidate_path in (pending_path, claimed_path)
+                            if candidate_path.exists()
+                            for candidate in (
+                                json.loads(candidate_path.read_text(encoding="utf-8")),
+                            )
+                        ):
+                            return False
+                        exit_tmp = exit_code_path.with_name(
+                            f"{exit_code_path.name}.legacy.tmp"
+                        )
+                        with open(exit_tmp, "wb") as exit_file:
+                            exit_file.write(b"125")
+                            exit_file.flush()
+                            os.fsync(exit_file.fileno())
+                        exit_tmp.replace(exit_code_path)
+                matching_done = True
+            elif not matching_done:
+                deadline_epoch = pending.get("deadline_epoch")
+                orphan_grace = pending.get("orphan_grace_seconds")
+                recoverable_orphan = (
+                    done is None
+                    and isinstance(request_id, str)
+                    and bool(request_id)
+                    and isinstance(deadline_epoch, (int, float))
+                    and not isinstance(deadline_epoch, bool)
+                    and isinstance(orphan_grace, (int, float))
+                    and not isinstance(orphan_grace, bool)
+                    and orphan_grace >= 0
+                    and time.time() > deadline_epoch + orphan_grace
+                )
+                if recoverable_orphan:
+                    from utils import atomic_json_write
+
+                    with _FileLock(update_lock_path):
+                        current = json.loads(
+                            claimed_path.read_text(encoding="utf-8")
+                        )
+                        if current.get("request_id") != request_id:
+                            cleanup = False
+                            return False
+                        exit_tmp = exit_code_path.with_name(
+                            f"{exit_code_path.name}.{request_id}.tmp"
+                        )
+                        with open(exit_tmp, "wb") as exit_file:
+                            exit_file.write(b"125")
+                            exit_file.flush()
+                            os.fsync(exit_file.fileno())
+                        exit_tmp.replace(exit_code_path)
+                        done = {
+                            "request_id": request_id,
+                            "exit_code": 125,
+                            "status": "helper_crashed",
+                        }
+                        atomic_json_write(done_path, done)
+                    matching_done = True
+                else:
+                    logger.info(
+                        "Update notification deferred: no matching helper completion"
+                    )
+                    cleanup = False
+                    active_pending_path = pending_path
+                    with _FileLock(update_lock_path):
+                        claimed_path.replace(pending_path)
+                    return False
+            if not exit_code_path.exists():
+                logger.info("Update notification deferred: exit code not flushed")
+                cleanup = False
+                active_pending_path = pending_path
+                with _FileLock(update_lock_path):
+                    claimed_path.replace(pending_path)
+                return False
+
+            exit_code_raw = exit_code_path.read_text(encoding="utf-8").strip() or "1"
+            try:
+                exit_code = int(exit_code_raw)
+            except ValueError:
+                logger.info("Update notification deferred: exit code is incomplete")
+                return False
+            if not legacy_request and done.get("exit_code") != exit_code:
+                logger.info("Update notification deferred: exit code does not match completion")
+                return False
+
+            # Read the captured update output
+            output = ""
+            if output_path.exists():
+                output = output_path.read_bytes().decode("utf-8", errors="replace")
+
+            # Resolve adapter
             platform = Platform(platform_str)
             adapter = self.adapters.get(platform)
-            if chat_id and not adapter:
-                # Target platform not reconnected yet (common right after the update's restart): keep the
-                # markers for a later retry instead of silently losing the notification.
-                return _defer("Update notification deferred: %s adapter not connected yet", platform_str)
-            if chat_id:
-                metadata = self._pending_marker_metadata(platform, chat_id, pending, adapter)
+
+            if not adapter and chat_id:
+                # The update finished, but the target platform has not
+                # reconnected yet (common right after the restart that
+                # `hermes update` triggers). Treating "adapter missing" as a
+                # definitive skip would delete the markers and silently lose the
+                # completion notification — the user never learns whether the
+                # update succeeded or timed out. Preserve the markers instead so
+                # a later retry (the watcher poll loop, or the next gateway
+                # startup) can deliver the result once the adapter is back.
+                logger.info(
+                    "Update notification deferred: %s adapter not connected yet",
+                    platform_str,
+                )
+                cleanup = False
+                active_pending_path = pending_path
+                with _FileLock(update_lock_path):
+                    claimed_path.replace(pending_path)
+                return False
+
+            if adapter and chat_id:
+                metadata = self._thread_metadata_for_target(
+                    platform,
+                    chat_id,
+                    thread_id,
+                    chat_type=chat_type,
+                    reply_to_message_id=message_id,
+                    adapter=adapter,
+                )
+                # Strip ANSI escape codes for clean display
                 from tools.ansi_strip import strip_ansi
                 output = strip_ansi(output).strip()
                 if output:
                     if len(output) > 3500:
                         output = "…" + output[-3500:]
-                    status = "✅ Hermes update finished." if exit_code == 0 else "❌ Hermes update failed."
-                    msg = f"{status}\n\n```\n{output}\n```"
+                    if exit_code == 0:
+                        msg = f"✅ Hermes update finished.\n\n```\n{output}\n```"
+                    else:
+                        msg = f"❌ Hermes update failed.\n\n```\n{output}\n```"
+                elif exit_code == 0:
+                    msg = "✅ Hermes update finished successfully."
                 else:
-                    msg = (
-                        "✅ Hermes update finished successfully." if exit_code == 0 else
-                        "❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details."
+                    msg = "❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details."
+                result = await adapter.send(
+                    chat_id,
+                    msg,
+                    metadata=_non_conversational_metadata(metadata, platform=platform),
+                )
+                if result is not None and getattr(result, "success", True) is False:
+                    logger.warning(
+                        "Post-update notification to %s:%s was not delivered: %s",
+                        platform_str,
+                        chat_id,
+                        getattr(result, "error", "send returned success=False"),
                     )
-                await adapter.send(chat_id, msg, metadata=_non_conversational_metadata(metadata, platform=platform))
-                logger.info("Sent post-update notification to %s:%s (exit=%s)", platform_str, chat_id, exit_code)
+                    return False
+                logger.info(
+                    "Sent post-update notification to %s:%s (exit=%s)",
+                    platform_str,
+                    chat_id,
+                    exit_code,
+                )
+                cleanup = True
+                delivered = True
         except Exception as e:
             logger.warning("Post-update notification failed: %s", e)
         finally:
             if cleanup:
-                for p in (active_pending_path, paths.claimed, paths.output, paths.exit_code):
-                    p.unlink(missing_ok=True)
-        return True
+                with _FileLock(update_lock_path):
+                    if legacy_request:
+                        try:
+                            cleanup_pending = json.loads(
+                                active_pending_path.read_text(encoding="utf-8")
+                            )
+                            marker_states = [
+                                json.loads(path.read_text(encoding="utf-8"))
+                                for path in (pending_path, claimed_path)
+                                if path.exists()
+                            ]
+                        except (FileNotFoundError, OSError, ValueError, TypeError):
+                            cleanup_pending = None
+                            marker_states = []
+                        safe_to_clean_legacy = (
+                            cleanup_pending == pending
+                            and "request_id" not in cleanup_pending
+                            and not any(
+                                isinstance(state, dict) and state.get("request_id")
+                                for state in marker_states
+                            )
+                        )
+                        if safe_to_clean_legacy:
+                            for path in (
+                                pending_path,
+                                claimed_path,
+                                output_path,
+                                exit_code_path,
+                                helper_pid_path,
+                                _hermes_home / ".update_prompt.json",
+                                _hermes_home / ".update_response",
+                            ):
+                                path.unlink(missing_ok=True)
+                    else:
+                        try:
+                            cleanup_pending = json.loads(
+                                active_pending_path.read_text(encoding="utf-8")
+                            )
+                            cleanup_done = json.loads(done_path.read_text(encoding="utf-8"))
+                        except (FileNotFoundError, OSError, ValueError, TypeError):
+                            cleanup_pending = cleanup_done = None
+                    if (
+                        not legacy_request
+                        and isinstance(cleanup_pending, dict)
+                        and cleanup_pending.get("request_id") == request_id
+                        and isinstance(cleanup_done, dict)
+                        and cleanup_done.get("request_id") == request_id
+                    ):
+                        for path in (
+                            active_pending_path,
+                            claimed_path,
+                            output_path,
+                            exit_code_path,
+                            helper_pid_path,
+                            done_path,
+                            _hermes_home / ".update_prompt.json",
+                            _hermes_home / ".update_response",
+                        ):
+                            path.unlink(missing_ok=True)
+            elif claimed_path.exists() and not pending_path.exists():
+                try:
+                    with _FileLock(update_lock_path):
+                        if claimed_path.exists() and not pending_path.exists():
+                            claimed_path.replace(pending_path)
+                except (OSError, RuntimeError):
+                    pass
+            helper_probe.release()
+
+        return delivered
 
     async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
         """Notify the chat that initiated /restart that the gateway is back."""

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -29,6 +29,11 @@ from gateway.slash_commands_goals import GatewayGoalCommandsMixin
 from gateway.slash_commands_model import GatewayModelCommandsMixin
 from gateway.slash_commands_session import GatewaySessionCommandsMixin
 from gateway.slash_commands_status import HISTORY_UNREADABLE, GatewayStatusCommandsMixin
+from gateway.update_contract import (
+    UPDATE_ORPHAN_GRACE_SECONDS,
+    UPDATE_TIMEOUT_SECONDS,
+    acquire_update_helper_probe,
+)
 from hermes_cli.config import atomic_config_write, cfg_get
 from utils import atomic_json_write, is_truthy_value
 
@@ -71,16 +76,6 @@ _PLATFORM_USAGE = ("Usage: /platform <list|pause|resume> [name]\n"
                    "  /platform pause <name> — stop retrying a failing platform\n"
                    "  /platform resume <name> — re-queue a paused platform")
 
-_WINDOWS_UPDATE_HELPER = """
-import os, subprocess, sys
-output_path, exit_code_path, cmd = sys.argv[1], sys.argv[2], sys.argv[3:]
-env = dict(os.environ, PYTHONUNBUFFERED="1")
-with open(output_path, "wb") as f:
-    rc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, env=env).wait(timeout=3600)
-with open(exit_code_path, "w", encoding="utf-8") as f:
-    f.write(str(rc))
-""".strip()
-
 
 def _nested_dict(root: dict, *keys: str) -> dict:
     """Walk/create ``root[k1][k2]...`` as dicts, replacing any non-dict value on the path."""
@@ -112,36 +107,6 @@ def _restart_notify_payload(event: MessageEvent) -> dict:
     optional = (("thread_id", source.thread_id), ("message_id", event.message_id))
     data.update({k: v for k, v in optional if v})
     return data
-
-
-def _spawn_detached_update(hermes_cmd, output_path, exit_code_path) -> None:
-    """Spawn ``hermes update --gateway`` detached so it survives the gateway restart it may trigger.
-    setsid is portable (works where ``systemd-run --user`` lacks a D-Bus session); ``--gateway``
-    enables file-based IPC so interactive prompts are forwarded; PYTHONUNBUFFERED lets the gateway
-    stream output live.  Windows has no setsid: an inline helper runs the updater as a module under
-    this interpreter (not venv\\Scripts\\hermes.exe — that shim holds its own file open, and the
-    update must replace it), redirects both outputs to one file and writes the exit code."""
-    import shutil
-    import subprocess
-    if sys.platform == "win32":
-        from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
-        subprocess.Popen(
-            [sys.executable, "-c", _WINDOWS_UPDATE_HELPER, str(output_path), str(exit_code_path),
-             sys.executable, "-m", "hermes_cli.main", "update", "--gateway"],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **windows_detach_popen_kwargs())
-        return
-    hermes_cmd_str = " ".join(shlex.quote(part) for part in hermes_cmd)
-    update_cmd = (
-        f"PYTHONUNBUFFERED=1 {hermes_cmd_str} update --gateway"
-        f" > {shlex.quote(str(output_path))} 2>&1; "
-        # Avoid `status=$?`: `status` is read-only in zsh and this template is reused in
-        # macOS/zsh operator wrappers, so keep it zsh-safe even though bash runs it here.
-        f"rc=$?; printf '%s' \"$rc\" > {shlex.quote(str(exit_code_path))}")
-    # Preferred: setsid creates a new session, fully detached; fallback start_new_session=True
-    # calls os.setsid() in the child.
-    setsid_bin = shutil.which("setsid")
-    argv = [setsid_bin, "bash", "-c", update_cmd] if setsid_bin else ["bash", "-c", update_cmd]
-    subprocess.Popen(argv, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
 
 
 def _home_thread_from_source(source) -> Optional[str]:
@@ -1201,7 +1166,12 @@ class GatewaySlashCommandsMixin(
         """Handle /update — spawn ``hermes update`` detached (``setsid``) so it survives the gateway
         restart it may trigger; marker files let this or the next gateway process notify the user."""
         import json
+        import hashlib
+        import secrets
+        import shutil
+        import subprocess
         from gateway.run import _hermes_home, _resolve_hermes_bin
+        from hermes_cli.active_sessions import _FileLock
         from hermes_cli.config import is_managed, format_managed_message
         # Block non-messaging platforms (API server, webhooks, ACP); plugin platforms with
         # allow_update_command=True are also allowed.
@@ -1222,22 +1192,264 @@ class GatewaySlashCommandsMixin(
         if not hermes_cmd:
             return t("gateway.update.hermes_cmd_not_found")
         pending_path = _hermes_home / ".update_pending.json"
+        claimed_path = _hermes_home / ".update_pending.claimed.json"
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"
-        pending = {
-            "platform": src.platform.value, "chat_id": src.chat_id, "chat_type": src.chat_type,
-            "user_id": src.user_id, "session_key": self._session_key_for_source(src),
-            "timestamp": datetime.now().isoformat()}
-        pending.update({k: v for k, v in (("thread_id", src.thread_id), ("message_id", event.message_id)) if v})
-        _tmp_pending = pending_path.with_suffix(".tmp")
-        _tmp_pending.write_text(json.dumps(pending), encoding="utf-8")
-        _tmp_pending.replace(pending_path)
-        exit_code_path.unlink(missing_ok=True)
+        helper_pid_path = _hermes_home / ".update_helper_pid"
+        helper_lock_path = _hermes_home / ".update_helper.lock"
+        done_path = _hermes_home / ".update_helper_done.json"
+        session_key = self._session_key_for_source(event.source)
+        lock_path = pending_path.with_name(".update_pending.lock")
         try:
-            _spawn_detached_update(hermes_cmd, output_path, exit_code_path)
+            with _FileLock(lock_path):
+                helper_probe = acquire_update_helper_probe(helper_lock_path)
+                if helper_probe is None:
+                    return "An update is already in progress or awaiting notification."
+                helper_probe.release()
+                for active_path in (pending_path, claimed_path):
+                    try:
+                        active = json.loads(active_path.read_text(encoding="utf-8"))
+                    except (FileNotFoundError, OSError, ValueError, TypeError):
+                        continue
+                    if isinstance(active, dict) and active.get("platform") and active.get("chat_id"):
+                        return "An update is already in progress or awaiting notification."
+
+                # Invalid leftovers are not an active update. Clear them only
+                # after the locked active-state check, then publish one matched
+                # metadata/token pair atomically.
+                for stale_path in (
+                    pending_path, claimed_path, output_path,
+                    exit_code_path, helper_pid_path,
+                ):
+                    stale_path.unlink(missing_ok=True)
+                handoff_token = secrets.token_urlsafe(32)
+                request_id = secrets.token_urlsafe(24)
+                pending = {
+                    "request_id": request_id,
+                    "platform": event.source.platform.value,
+                    "chat_id": event.source.chat_id,
+                    "chat_type": event.source.chat_type,
+                    "user_id": event.source.user_id,
+                    "session_key": session_key,
+                    "timestamp": datetime.now().isoformat(),
+                    "deadline_epoch": time.time() + UPDATE_TIMEOUT_SECONDS,
+                    "orphan_grace_seconds": UPDATE_ORPHAN_GRACE_SECONDS,
+                    "handoff_token_sha256": hashlib.sha256(
+                        handoff_token.encode("utf-8")
+                    ).hexdigest(),
+                }
+                if event.source.thread_id:
+                    pending["thread_id"] = event.source.thread_id
+                if event.message_id:
+                    pending["message_id"] = event.message_id
+                atomic_json_write(pending_path, pending)
+        except (OSError, RuntimeError) as exc:
+            return t("gateway.update.start_failed", error=exc)
+
+        # Spawn `hermes update --gateway` detached so it survives gateway restart.
+        # --gateway enables file-based IPC for interactive prompts (stash
+        # restore, config migration) so the gateway can forward them to the
+        # user instead of silently skipping them.
+        # Use setsid for portable session detach (works under system services
+        # where systemd-run --user fails due to missing D-Bus session).
+        # PYTHONUNBUFFERED ensures output is flushed line-by-line so the
+        # gateway can stream it to the messenger in near-real-time.
+        # Spawn `hermes update --gateway` detached so it survives gateway restart.
+        # --gateway enables file-based IPC for interactive prompts (stash
+        # restore, config migration) so the gateway can forward them to the
+        # user instead of silently skipping them.
+        # Use setsid for portable session detach (works under system services
+        # where systemd-run --user fails due to missing D-Bus session).
+        # PYTHONUNBUFFERED ensures output is flushed line-by-line so the
+        # gateway can stream it to the messenger in near-real-time.
+        #
+        # Windows: no bash/setsid chain.  Run `hermes update --gateway`
+        # directly via sys.executable; redirect stdout/stderr to the same
+        # output files via Popen file handles; write the exit code in a
+        # follow-up write.  A tiny Python watcher would be cleaner but
+        # we're already inside gateway/run.py's update path which is async,
+        # so the simplest correct thing is: launch an inline Python helper
+        # that runs the command and writes both outputs.
+        try:
+            import textwrap
+            from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+
+            # The helper receives the capability through an inherited anonymous
+            # stdin pipe, then forwards it to the updater through a second pipe.
+            # It never appears in argv, environment variables, command strings,
+            # or logs. The same helper records the exit code on every platform.
+            helper = textwrap.dedent(
+                """
+                import json, os, subprocess, sys, time
+                from pathlib import Path
+                from gateway.status import get_process_start_time
+                from gateway.update_contract import UpdateHelperLock
+                output_path = sys.argv[1]
+                exit_code_path = sys.argv[2]
+                helper_lock_path = sys.argv[3]
+                done_path = sys.argv[4]
+                request_id = sys.argv[5]
+                timeout = float(sys.argv[6])
+                cmd = sys.argv[7:]
+                helper_pid_path = str(Path(helper_lock_path).with_name(".update_helper_pid"))
+
+                def atomic_write(path, data):
+                    tmp = f"{path}.{os.getpid()}.tmp"
+                    with open(tmp, "wb") as f:
+                        f.write(data)
+                        f.flush()
+                        os.fsync(f.fileno())
+                    os.replace(tmp, path)
+
+                def stop_and_reap(proc):
+                    # Do not return until child termination is positively observed.
+                    while True:
+                        try:
+                            if proc.poll() is not None:
+                                return
+                        except BaseException:
+                            pass
+                        try:
+                            proc.kill()
+                        except BaseException:
+                            try:
+                                proc.terminate()
+                            except BaseException:
+                                pass
+                        try:
+                            proc.communicate(timeout=1.0)
+                        except subprocess.TimeoutExpired:
+                            pass
+                        except BaseException:
+                            try:
+                                proc.wait(timeout=1.0)
+                            except BaseException:
+                                pass
+                        try:
+                            if proc.poll() is not None:
+                                return
+                        except BaseException:
+                            pass
+                        time.sleep(0.1)
+
+                def flush_output(output_file):
+                    # Keep the lifecycle lock if captured output cannot be persisted.
+                    if output_file is None:
+                        return
+                    while True:
+                        try:
+                            output_file.flush()
+                            os.fsync(output_file.fileno())
+                            output_file.close()
+                            return
+                        except BaseException:
+                            time.sleep(0.1)
+
+                helper_exit = 0
+                with UpdateHelperLock(Path(helper_lock_path)):
+                    helper_pid = os.getpid()
+                    identity_bytes = json.dumps(
+                        {
+                            "pid": helper_pid,
+                            "start_time": get_process_start_time(helper_pid),
+                        },
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                    atomic_write(helper_pid_path, identity_bytes)
+                    proc = None
+                    output_file = None
+                    try:
+                        token = sys.stdin.buffer.readline(4097)
+                        env = dict(os.environ)
+                        env["PYTHONUNBUFFERED"] = "1"
+                        output_file = open(output_path, "wb")
+                        proc = subprocess.Popen(
+                            cmd, stdin=subprocess.PIPE, stdout=output_file,
+                            stderr=subprocess.STDOUT, env=env,
+                        )
+                        try:
+                            proc.communicate(input=token, timeout=timeout)
+                            if proc.poll() is None:
+                                stop_and_reap(proc)
+                            rc = proc.returncode
+                            status = "completed"
+                        except subprocess.TimeoutExpired:
+                            stop_and_reap(proc)
+                            rc = 124
+                            status = "timed_out"
+                        except BaseException:
+                            stop_and_reap(proc)
+                            rc = 125
+                            status = "helper_exception"
+                            helper_exit = 125
+                    except BaseException:
+                        if proc is not None:
+                            stop_and_reap(proc)
+                        rc = 125
+                        status = "helper_exception"
+                        helper_exit = 125
+                    flush_output(output_file)
+                    atomic_write(exit_code_path, str(rc).encode("ascii"))
+                    done_bytes = json.dumps(
+                        {
+                            "request_id": request_id,
+                            "exit_code": rc,
+                            "status": status,
+                        },
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                    atomic_write(done_path, done_bytes)
+                raise SystemExit(helper_exit)
+                """
+            ).strip()
+            helper_command = [
+                sys.executable, "-c", helper,
+                str(output_path), str(exit_code_path),
+                str(helper_lock_path), str(done_path), request_id,
+                str(UPDATE_TIMEOUT_SECONDS),
+                sys.executable, "-m", "hermes_cli.main",
+                "update", "--gateway",
+            ]
+            popen_kwargs = {
+                "stdin": subprocess.PIPE,
+                "stdout": subprocess.DEVNULL,
+                "stderr": subprocess.DEVNULL,
+            }
+            if sys.platform == "win32":
+                # Invoke the updater as a module under this interpreter rather
+                # than through hermes_cmd (venv\Scripts\hermes.exe): the shim
+                # launcher holds its own file open for the whole run, and the
+                # update has to replace it. Going through python.exe maps no
+                # shim, so the entry points can be rewritten freely.
+                popen_kwargs.update(windows_detach_popen_kwargs())
+            else:
+                setsid_bin = shutil.which("setsid")
+                if setsid_bin:
+                    helper_command.insert(0, setsid_bin)
+                else:
+                    popen_kwargs["start_new_session"] = True
+            helper_proc = subprocess.Popen(helper_command, **popen_kwargs)
+            assert helper_proc.stdin is not None
+            helper_proc.stdin.write((handoff_token + "\n").encode("utf-8"))
+            helper_proc.stdin.close()
         except Exception as e:
-            pending_path.unlink(missing_ok=True)
-            exit_code_path.unlink(missing_ok=True)
+            try:
+                with _FileLock(lock_path):
+                    current_request_id = None
+                    try:
+                        current_request_id = json.loads(
+                            pending_path.read_text(encoding="utf-8")
+                        ).get("request_id")
+                    except (FileNotFoundError, OSError, ValueError, TypeError):
+                        pass
+                    if current_request_id == request_id:
+                        pending_path.unlink(missing_ok=True)
+                        claimed_path.unlink(missing_ok=True)
+                        output_path.unlink(missing_ok=True)
+                        exit_code_path.unlink(missing_ok=True)
+                        helper_pid_path.unlink(missing_ok=True)
+            except (OSError, RuntimeError):
+                pass
             return t("gateway.update.start_failed", error=e)
         self._schedule_update_notification_watch()
         return t("gateway.update.starting")

--- a/gateway/update_contract.py
+++ b/gateway/update_contract.py
@@ -1,0 +1,92 @@
+"""Shared lifecycle contract for gateway-triggered updates."""
+
+import errno
+import os
+from pathlib import Path
+from typing import Optional
+
+
+UPDATE_TIMEOUT_SECONDS = 3600.0
+UPDATE_ORPHAN_GRACE_SECONDS = 30.0
+
+
+class UpdateHelperLockBusy(RuntimeError):
+    """The live detached update helper owns its lifecycle lock."""
+
+
+class UpdateHelperLock:
+    """Cross-platform OS lock held for the detached helper's whole lifetime."""
+
+    def __init__(self, path: Path, *, blocking: bool = True):
+        self.path = path
+        self.blocking = blocking
+        self._fh = None
+
+    def acquire(self) -> "UpdateHelperLock":
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = open(self.path, "a+b")
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                self._fh.seek(0, os.SEEK_END)
+                if self._fh.tell() == 0:
+                    self._fh.write(b"\0")
+                    self._fh.flush()
+                self._fh.seek(0)
+                mode = msvcrt.LK_LOCK if self.blocking else msvcrt.LK_NBLCK
+                msvcrt.locking(self._fh.fileno(), mode, 1)
+            else:
+                import fcntl
+
+                mode = fcntl.LOCK_EX
+                if not self.blocking:
+                    mode |= fcntl.LOCK_NB
+                fcntl.flock(self._fh.fileno(), mode)
+        except OSError as exc:
+            self._fh.close()
+            self._fh = None
+            if not self.blocking and exc.errno in (errno.EACCES, errno.EAGAIN):
+                raise UpdateHelperLockBusy from exc
+            raise RuntimeError("update helper file lock unavailable") from exc
+        except Exception as exc:
+            self._fh.close()
+            self._fh = None
+            raise RuntimeError("update helper file lock unavailable") from exc
+        return self
+
+    def release(self) -> None:
+        if self._fh is None:
+            return
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                self._fh.seek(0)
+                msvcrt.locking(self._fh.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+        finally:
+            self._fh.close()
+            self._fh = None
+
+    def __enter__(self) -> "UpdateHelperLock":
+        return self.acquire()
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.release()
+
+
+def acquire_update_helper_probe(path: Path) -> Optional[UpdateHelperLock]:
+    """Hold and return the unlocked helper lock, or None when a helper owns it.
+
+    Lock inspection errors are raised so callers can fail closed. Keeping the
+    returned handle held closes the probe-to-cleanup race with a late helper.
+    """
+    lock = UpdateHelperLock(path, blocking=False)
+    try:
+        return lock.acquire()
+    except UpdateHelperLockBusy:
+        return None

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2236,11 +2236,76 @@ def _update_preflight_handled(args) -> bool:
     return False
 
 
+def _consume_gateway_update_handoff(stream=None) -> bool:
+    """Consume one messaging handoff token read from an anonymous pipe."""
+    import hashlib
+    import hmac
+    import json
+
+    if stream is None:
+        stream = getattr(sys.stdin, "buffer", sys.stdin)
+    try:
+        raw = stream.readline(4097)
+    except (OSError, ValueError):
+        return False
+    if isinstance(raw, str):
+        raw = raw.encode("utf-8")
+    if not raw or len(raw) > 4096:
+        return False
+    token = raw.rstrip(b"\r\n")
+    if not token:
+        return False
+
+    try:
+        from hermes_cli.active_sessions import _FileLock
+        from hermes_cli.config import get_hermes_home
+        from utils import atomic_json_write
+
+        pending_path = get_hermes_home() / ".update_pending.json"
+        lock_path = pending_path.with_name(".update_pending.lock")
+        with _FileLock(lock_path):
+            pending = json.loads(pending_path.read_text(encoding="utf-8"))
+            expected = pending.get("handoff_token_sha256")
+            actual = hashlib.sha256(token).hexdigest()
+            if not isinstance(expected, str) or not hmac.compare_digest(expected, actual):
+                return False
+
+            # The lock makes verification plus removal one indivisible claim.
+            # atomic_json_write uses mkstemp, avoiding fixed-name temp races.
+            del pending["handoff_token_sha256"]
+            atomic_json_write(pending_path, pending)
+            return True
+    except (OSError, RuntimeError, ValueError, TypeError, KeyError):
+        return False
+
+
+def _authorize_update_from_context(gateway_mode: bool, stream=None) -> bool:
+    """Allow external updates; require one-shot stdin proof inside a gateway tree."""
+    from tools.process_registry import _is_gateway_descendant_process
+
+    if not _is_gateway_descendant_process():
+        return True
+    return gateway_mode and _consume_gateway_update_handoff(stream)
+
+
 def cmd_update(args):
     """Update Hermes Agent: hangup protection + update lock around ``_cmd_update_impl``."""
     if _update_preflight_handled(args):
         return
     gateway_mode = getattr(args, "gateway", False)
+
+    # A normal updater launched by terminal/execute_code is a child of the gateway it
+    # must stop: it dies with that parent before completion and can strand the install.
+    # Gate at the updater entry point so shell wrappers, variables, PowerShell, cmd and
+    # subprocess forms cannot bypass it. The messaging /update hand-off uses --gateway
+    # and owns its own detach/restart protocol, so that path stays open.
+    if not _authorize_update_from_context(gateway_mode):
+        print(
+            "Blocked: cannot update Hermes from a process launched by the "
+            "running gateway.\nRun `hermes update` from a separate shell "
+            "outside the running gateway, or use messaging `/update`."
+        )
+        sys.exit(1)
 
     _update_io_state = _install_hangup_protection(gateway_mode=gateway_mode)
     # Cross-process mutual exclusion: dashboard Update button, Tauri updater

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -147,7 +147,23 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES, SUPPORTED_IMAGE_DOCUMENT_TYPES, _TEXT_INJECT_EXTENSIONS, utf16_len,
 )
 from gateway.platforms.event import MessageEvent, MessageType, ProcessingOutcome
-from plugins.platforms.telegram.telegram_ids import normalize_telegram_chat_id
+from plugins.platforms.telegram.telegram_ids import normalize_telegram_chat_id, telegram_chat_id_key
+from plugins.platforms.telegram.outbound_circuit import (
+    GLOBAL_CIRCUIT_KEY,
+    open_circuit as persist_peer_flood_circuit,
+    open_circuit_async as persist_peer_flood_circuit_async,
+    remaining as persistent_peer_flood_remaining,
+    remaining_async as persistent_peer_flood_remaining_async,
+)
+from plugins.platforms.telegram.outbound_policy import (
+    GuardedTelegramTarget,
+    TelegramOutboundGateway,
+    TelegramPeerFloodBlocked,
+    deactivate_coupang_urls as _deactivate_coupang_urls,
+    is_peer_flood,
+    peer_flood_delay,
+    prepare_caption,
+)
 from plugins.platforms.telegram.telegram_network import (
     SEED_FALLBACK_IPS, TelegramFallbackTransport, discover_fallback_ips, parse_fallback_ip_env, tcp_keepalive_socket_options)
 from utils import env_float, env_int
@@ -159,6 +175,37 @@ _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 # machinery (delivery ledger, streaming fallback) owns the wait instead of the coroutine pinning its worker
 # — a 97-minute penalty on the boot path froze inbound on every platform (#91969).
 _FLOOD_INLINE_WAIT_CAP_SECS = 5.0
+_CALLBACK_UNKNOWN_CIRCUIT_KEY = "telegram:callback:unknown"
+
+
+
+class _PeerFloodGuardedCallbackQuery:
+    """Apply the chat circuit to every callback answer/edit write."""
+
+    def __init__(self, adapter, query, chat_id: str):
+        self._adapter = adapter
+        self._query = query
+        self._chat_id = chat_id
+
+    def __getattr__(self, name):
+        return getattr(self._query, name)
+
+    async def _call(self, method: str, *args, **kwargs):
+        outbound = GuardedTelegramTarget(
+            self._query,
+            self._adapter._outbound_gateway,
+            target_key=self._chat_id,
+        )
+        try:
+            return await getattr(outbound, method)(*args, **kwargs)
+        except TelegramPeerFloodBlocked:
+            return None
+
+    async def answer(self, *args, **kwargs):
+        return await self._call("answer", *args, **kwargs)
+
+    async def edit_message_text(self, *args, **kwargs):
+        return await self._call("edit_message_text", *args, **kwargs)
 
 
 def _flood_cap_result(wait: float) -> "SendResult":
@@ -383,9 +430,33 @@ class TelegramAdapter(BasePlatformAdapter):
     _RECONNECT_WAIT_SECONDS = 15.0
     _RECONNECT_POLL_INTERVAL = 0.5
 
+    @property
+    def _outbound_gateway(self) -> TelegramOutboundGateway:
+        gateway = getattr(self, "_telegram_outbound_gateway", None)
+        if gateway is None:
+            gateway = TelegramOutboundGateway()
+            self._telegram_outbound_gateway = gateway
+        return gateway
+
+    @property
+    def _outbound(self) -> GuardedTelegramTarget:
+        """Return the sole Bot API write facade; reads continue to use ``_bot``."""
+        return GuardedTelegramTarget(self._bot, self._outbound_gateway)
+
+    def _guard_callback_query(self, query, chat_id: object):
+        if isinstance(query, _PeerFloodGuardedCallbackQuery):
+            return query
+        return _PeerFloodGuardedCallbackQuery(self, query, str(chat_id))
+
+    async def telegram_write(self, chat_id: object, method: str, **kwargs):
+        """Thin public wrapper for Telegram writes owned by gateway orchestration."""
+        return await getattr(
+            GuardedTelegramTarget(self._bot, self._outbound_gateway, target_key=chat_id),
+            method,
+        )(**kwargs)
+
     # edit_message applies MarkdownV2 only on finalize=True; without this flag stream_consumer skips
     # the final edit when raw text is unchanged.
-    # Fixes #25710.
     REQUIRES_EDIT_FINALIZE: bool = True
     FALLBACK_ON_FINAL_EDIT_FLOOD: bool = True  # retrying a final edit burns the same flood budget
     RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK: bool = True  # a failed final edit may leave a partial preview
@@ -442,6 +513,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self._rich_send_disabled = self._rich_draft_disabled = False  # latched after a capability failure
         # Transient sendChatAction failures recur on every keep-typing tick; back off per chat.
         self._telegram_typing_cooldown_until: Dict[str, float] = {}
+        # Per-chat PEER_FLOOD cooldowns (loop clock); mirrors the process-shared SQLite circuit.
+        self._telegram_peer_flood_until: Dict[str, float] = {}
+        self._telegram_peer_flood_until: Dict[str, float] = {}
         self._telegram_typing_cooldown_seconds: float = self._coerce_float_extra(
             "typing_cooldown_seconds", 30.0, min_value=1.0, max_value=300.0)
         # Buffer album/photo bursts into a single MessageEvent instead of self-interrupting turns.
@@ -1418,8 +1492,10 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             # Raw Bot API result: return_type=Message would make PTB deserialize a 10.1 shape it doesn't
             # fully model; a post-delivery parse error ≠ send failure.
-            msg = await self._bot.do_api_request("sendRichMessage", api_kwargs=payload)
+            msg = await self._outbound.do_api_request("sendRichMessage", api_kwargs=payload)
         except Exception as exc:
+            if self._is_peer_flood_error(exc):
+                return await self._open_peer_flood_circuit_async(chat_id, exc)
             if self._rich_rejected(exc, "sendRichMessage", "MarkdownV2"):
                 return None
             # Honor Telegram's flood-control retry_after over the base retry schedule.
@@ -1462,8 +1538,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # No topic routing on edits: message_thread_id/direct_messages_topic_id make Telegram reject it.
         payload = {**self._rich_payload_base(chat_id, content), "message_id": int(message_id)}
         try:
-            await self._bot.do_api_request("editMessageText", api_kwargs=payload)
+            await self._outbound.do_api_request("editMessageText", api_kwargs=payload)
         except Exception as exc:
+            if self._is_peer_flood_error(exc):
+                return await self._open_peer_flood_circuit_async(chat_id, exc)
             # "Message is not modified" = successful no-op; skip the redundant legacy edit.
             if "not modified" in str(exc).lower():
                 if self._is_rich_fallback_error(exc) and self._is_rich_capability_error(exc):
@@ -1484,15 +1562,20 @@ class TelegramAdapter(BasePlatformAdapter):
             and not getattr(self, "_rich_draft_disabled", False)
             and self._rich_content_ok(content))
 
-    async def _try_send_rich_draft(self, chat_id: str, draft_id: int, content: str, metadata: Optional[Dict[str, Any]]) -> bool:
+    async def _try_send_rich_draft(
+        self, chat_id: str, draft_id: int, content: str,
+        metadata: Optional[Dict[str, Any]]) -> "bool | SendResult":
         """Emit one ``sendRichMessageDraft`` frame; True on success. Frames are ephemeral, so any failure
-        returns False and the caller renders the legacy draft; capability failures latch off."""
+        returns False and the caller renders the legacy draft; capability failures latch off. PEER_FLOOD
+        returns the typed SendResult instead - the legacy draft would hit the same restricted peer."""
         payload: Dict[str, Any] = {
             "chat_id": normalize_telegram_chat_id(chat_id), "draft_id": int(draft_id), "rich_message": self._rich_message_payload(content)}
         payload.update(self._thread_kwargs_for_draft(chat_id, metadata))
         try:
-            return bool(await self._bot.do_api_request("sendRichMessageDraft", api_kwargs=payload))
+            return bool(await self._outbound.do_api_request("sendRichMessageDraft", api_kwargs=payload))
         except Exception as exc:
+            if self._is_peer_flood_error(exc):
+                return await self._open_peer_flood_circuit_async(chat_id, exc)
             if self._is_rich_capability_error(exc):
                 self._rich_draft_disabled = True
                 logger.debug(
@@ -1778,7 +1861,7 @@ class TelegramAdapter(BasePlatformAdapter):
         partial adapter, while reconnects recover transient errors in background."""
         if not self._bot:
             return False
-        delete_webhook = getattr(self._bot, "delete_webhook", None)
+        delete_webhook = getattr(self._outbound, "delete_webhook", None)
         if not callable(delete_webhook):
             return True
         try:
@@ -2340,17 +2423,22 @@ class TelegramAdapter(BasePlatformAdapter):
         """Create a forum topic in a private (DM) chat (Bot API 9.4+); message_thread_id or None."""
         if not self._bot:
             return None
+        if await self._peer_flood_circuit_result_async(str(chat_id)) is not None:
+            return None
         try:
             kwargs: Dict[str, Any] = {"chat_id": chat_id, "name": name}
             if icon_color is not None:
                 kwargs["icon_color"] = icon_color
             if icon_custom_emoji_id:
                 kwargs["icon_custom_emoji_id"] = icon_custom_emoji_id
-            topic = await self._bot.create_forum_topic(**kwargs)
+            topic = await self._outbound.create_forum_topic(**kwargs)
             thread_id = topic.message_thread_id
             logger.info("[%s] Created DM topic '%s' in chat %s -> thread_id=%s", self.name, name, chat_id, thread_id)
             return thread_id
         except Exception as e:
+            if self._is_peer_flood_error(e):
+                await self._open_peer_flood_circuit_async(str(chat_id), e)
+                return None
             error_text = str(e).lower()
             # Telegram has no "list topics" API: an existing topic is mapped from incoming messages.
             if "topic_name_duplicate" in error_text or "already" in error_text:
@@ -2420,11 +2508,19 @@ class TelegramAdapter(BasePlatformAdapter):
         """Rename a forum topic in a private (DM) chat."""
         if not self._bot:
             return
+        if await self._peer_flood_circuit_result_async(str(chat_id)) is not None:
+            return
         try:
             chat_id_arg = int(chat_id)
         except (TypeError, ValueError):
             chat_id_arg = chat_id
-        await self._bot.edit_forum_topic(chat_id=chat_id_arg, message_thread_id=int(thread_id), name=name)
+        try:
+            await self._outbound.edit_forum_topic(chat_id=chat_id_arg, message_thread_id=int(thread_id), name=name)
+        except Exception as exc:
+            if self._is_peer_flood_error(exc):
+                await self._open_peer_flood_circuit_async(str(chat_id), exc)
+                return
+            raise
         logger.info("[%s] Renamed DM topic in chat %s thread_id=%s -> '%s'", self.name, chat_id, thread_id, name)
 
     def _persist_dm_topic_thread_id(self, chat_id: int, topic_name: str, thread_id: int, replace_existing: bool = False) -> None:
@@ -2495,9 +2591,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._persist_dm_topic_thread_id(int(chat_id), topic_name, thread_id)
                 # Seed message: Telegram's client hides empty topics until they contain one.
                 try:
-                    await self._bot.send_message(
+                    await self._outbound.send_message(
                         chat_id=normalize_telegram_chat_id(chat_id), message_thread_id=thread_id, text=f"\U0001f4cc {topic_name}")
                 except Exception as seed_err:
+                    if self._is_peer_flood_error(seed_err):
+                        await self._open_peer_flood_circuit_async(str(chat_id), seed_err)
+                        continue
                     logger.debug("[%s] Could not send seed message to topic '%s': %s", self.name, topic_name, seed_err)
 
     async def _bot_identity_refresh_loop(self) -> None:
@@ -2531,13 +2630,20 @@ class TelegramAdapter(BasePlatformAdapter):
         max_commands = telegram_menu_max_commands()
         menu_commands, hidden_count = telegram_menu_commands(max_commands=max_commands)
         bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
+        # Bot-wide scopes have no chat: they ride the shared global circuit key.
+        if await self._peer_flood_circuit_result_async(GLOBAL_CIRCUIT_KEY) is not None:
+            return
         for scope_cls in (BotCommandScopeDefault, BotCommandScopeAllPrivateChats, BotCommandScopeAllGroupChats):
             scope_name = getattr(scope_cls, "__name__", str(scope_cls))
             try:
-                await self._bot.set_my_commands(bot_commands, scope=scope_cls())
+                await self._outbound.set_my_commands(bot_commands, scope=scope_cls())
                 logger.info("[%s] set_my_commands OK for scope %s (%d cmds)", self.name, scope_name, len(bot_commands))
             except Exception as scope_err:
-                logger.warning("[%s] set_my_commands FAILED for scope %s: %s", self.name, scope_name, scope_err)
+                if self._is_peer_flood_error(scope_err):
+                    await self._open_peer_flood_circuit_async(GLOBAL_CIRCUIT_KEY, scope_err)
+                    break
+                logger.warning("[%s] set_my_commands FAILED for scope %s: %s", self.name, scope_name,
+                               _redact_telegram_error_text(scope_err))
         if hidden_count:
             logger.info(
                 "[%s] Telegram menu: %d commands registered, %d hidden (over %d limit). Use /commands for full list.",
@@ -2869,11 +2975,18 @@ class TelegramAdapter(BasePlatformAdapter):
                 "Then register it with Telegram when setting the webhook via setWebhook's secret_token parameter.")
         from urllib.parse import urlparse
         webhook_path = urlparse(webhook_url).path or "/telegram"
-        await self._app.updater.start_webhook(
-            listen=webhook_host, port=webhook_port, url_path=webhook_path, webhook_url=webhook_url,
-            secret_token=webhook_secret, allowed_updates=Update.ALL_TYPES,
+        await self._outbound_gateway.write(
+            GLOBAL_CIRCUIT_KEY,
+            "start_webhook",
+            self._app.updater.start_webhook,
+            listen=webhook_host,
+            port=webhook_port,
+            url_path=webhook_path,
+            webhook_url=webhook_url,
+            secret_token=webhook_secret,
+            allowed_updates=Update.ALL_TYPES,
             drop_pending_updates=not is_reconnect,  # push-based ⇒ practically a no-op; mirrors polling
-       )
+        )
         self._webhook_mode = True
         self._polling_progress_accepting = False
         self._send_path_degraded = False
@@ -3007,7 +3120,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         text = (self._status_online_text if online else self._status_offline_text)[:120]  # Telegram cap
         try:
-            await bot.set_my_short_description(short_description=text)
+            await self._outbound.set_my_short_description(short_description=text)
             logger.info("[%s] Set bot status indicator to %r", self.name, text)
         except Exception as e:
             logger.debug("[%s] Failed to set bot status indicator to %r: %s", self.name, text, _redact_telegram_error_text(e))
@@ -3204,11 +3317,11 @@ class TelegramAdapter(BasePlatformAdapter):
     async def _send_chunk_markdown_or_plain(self, chunk: str, send_kwargs: Dict[str, Any]):
         """MarkdownV2 first; on a parse/markdown rejection resend as stripped plain text."""
         try:
-            return await self._bot.send_message(text=chunk, parse_mode=ParseMode.MARKDOWN_V2, **send_kwargs)
+            return await self._outbound.send_message(text=chunk, parse_mode=ParseMode.MARKDOWN_V2, **send_kwargs)
         except Exception as md_error:
             if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
                 logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
-                return await self._bot.send_message(text=_strip_mdv2(chunk), parse_mode=None, **send_kwargs)
+                return await self._outbound.send_message(text=_strip_mdv2(chunk), parse_mode=None, **send_kwargs)
             raise
 
     async def _send_chunk_with_retries(
@@ -3284,6 +3397,9 @@ class TelegramAdapter(BasePlatformAdapter):
                                self.name, _send_attempt + 1, wait, _redact_telegram_error_text(send_err))
                 await asyncio.sleep(wait)
             except Exception as send_err:
+                # PEER_FLOOD before the RetryAfter ladder: it is a circuit signal, not a wait-and-retry.
+                if self._is_peer_flood_error(send_err):
+                    return await self._open_peer_flood_circuit_async(chat_id, send_err)
                 retry_after = getattr(send_err, "retry_after", None)
                 if retry_after is not None or "retry after" in str(send_err).lower():
                     wait = float(retry_after) if retry_after is not None else 1.0
@@ -3323,6 +3439,102 @@ class TelegramAdapter(BasePlatformAdapter):
         with contextlib.suppress(Exception):
             await self.send_typing(chat_id, metadata=metadata)
 
+    # --- PEER_FLOOD circuit -----------------------------------------------------------------
+    # PEER_FLOOD is Telegram's per-peer anti-spam verdict, not ordinary flood control: retrying,
+    # falling back to plain text or sending a failure notice all hit the same restricted peer and
+    # extend the ban. Every write path checks the circuit first and opens it on the way out. Local
+    # state is the loop clock; the durable half lives in the profile's state.db so a restart and a
+    # standalone `hermes send` observe the same cooldown.
+
+    @staticmethod
+    def _is_peer_flood_error(error: object) -> bool:
+        """Recognize Telegram's per-peer anti-spam server code."""
+        return is_peer_flood(error)
+
+    def _peer_flood_local_remaining(self, chat_id: str) -> tuple:
+        """``(key, now, local_remaining)`` from the in-process map, expiring stale entries."""
+        store = getattr(self, "_telegram_peer_flood_until", None)
+        if store is None:
+            store = {}
+            self._telegram_peer_flood_until = store
+        key = telegram_chat_id_key(chat_id)
+        now = asyncio.get_running_loop().time()
+        local_remaining = None
+        until = store.get(key)
+        if until is not None:
+            local_remaining = until - now
+            if local_remaining <= 0:
+                store.pop(key, None)
+                local_remaining = None
+        return key, now, local_remaining
+
+    def _peer_flood_merge(self, key: str, now: float, local_remaining, durable_remaining):
+        """Fold a durable cooldown into local state; return the longest remaining wait or None."""
+        store = self._telegram_peer_flood_until
+        if durable_remaining is not None:
+            durable_until = now + durable_remaining
+            store[key] = max(store.get(key, durable_until), durable_until)
+        candidates = [v for v in (local_remaining, durable_remaining) if v is not None]
+        return max(candidates) if candidates else None
+
+    @staticmethod
+    def _peer_flood_result(remaining: float) -> SendResult:
+        return SendResult(
+            success=False, error="peer_flood", retryable=False, retry_after=remaining,
+            error_kind="peer_flood")
+
+    def _peer_flood_remaining(self, chat_id: str) -> Optional[float]:
+        key, now, local_remaining = self._peer_flood_local_remaining(chat_id)
+        return self._peer_flood_merge(
+            key, now, local_remaining, persistent_peer_flood_remaining(chat_id))
+
+    def _peer_flood_circuit_result(self, chat_id: str) -> Optional[SendResult]:
+        remaining = self._peer_flood_remaining(chat_id)
+        return None if remaining is None else self._peer_flood_result(remaining)
+
+    async def _peer_flood_circuit_result_async(self, chat_id: str) -> Optional[SendResult]:
+        """Check process-shared SQLite state without blocking the event loop."""
+        key, now, local_remaining = self._peer_flood_local_remaining(chat_id)
+        remaining = self._peer_flood_merge(
+            key, now, local_remaining, await persistent_peer_flood_remaining_async(chat_id))
+        return None if remaining is None else self._peer_flood_result(remaining)
+
+    def _peer_flood_result_from_error(self, chat_id: str, error: Exception) -> Optional[SendResult]:
+        if not self._is_peer_flood_error(error):
+            return None
+        return self._open_peer_flood_circuit(chat_id, error)
+
+    async def _peer_flood_result_from_error_async(self, chat_id: str, error: Exception) -> Optional[SendResult]:
+        if not self._is_peer_flood_error(error):
+            return None
+        return await self._open_peer_flood_circuit_async(chat_id, error)
+
+    def _record_peer_flood(self, chat_id: str, delay: float, durable_remaining: float) -> SendResult:
+        """Latch the longest of the requested and durable cooldowns, then report it."""
+        if not hasattr(self, "_telegram_peer_flood_until"):
+            self._telegram_peer_flood_until = {}
+        now = asyncio.get_running_loop().time()
+        key = telegram_chat_id_key(chat_id)
+        store = self._telegram_peer_flood_until
+        store[key] = max(store.get(key, now + delay), now + delay, now + durable_remaining)
+        remaining = store[key] - now
+        logger.warning(
+            "[%s] Telegram PEER_FLOOD for chat %s; suppressing outbound calls for %.1fs",
+            self.name, chat_id, remaining)
+        return self._peer_flood_result(remaining)
+
+    def _open_peer_flood_circuit(self, chat_id: str, error: Exception) -> SendResult:
+        delay = peer_flood_delay(error)
+        return self._record_peer_flood(chat_id, delay, persist_peer_flood_circuit(chat_id, delay))
+
+    async def _open_peer_flood_circuit_async(self, chat_id: str, error: Exception) -> SendResult:
+        """Open local state immediately and persist without blocking the loop."""
+        delay = peer_flood_delay(error)
+        # A block raised BY the circuit is already persisted — re-persisting would extend it.
+        durable = delay if isinstance(error, TelegramPeerFloodBlocked) else (
+            await persist_peer_flood_circuit_async(chat_id, delay))
+        return self._record_peer_flood(chat_id, delay, durable)
+
     async def send(
         self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
         """Send a message to a Telegram chat."""
@@ -3337,12 +3549,20 @@ class TelegramAdapter(BasePlatformAdapter):
                 return await live.send(chat_id, content, reply_to, metadata)
             if not self._bot:
                 return SendResult(success=False, error="Not connected", retryable=True)
+
+        peer_flood_result = await self._peer_flood_circuit_result_async(chat_id)
+        if peer_flood_result is not None:
+            return peer_flood_result
+
         # getattr() — tests build adapters via object.__new__() (no __init__).
         if getattr(self, "_send_path_degraded", False):
             return SendResult(success=False, error="send_path_degraded", retryable=True)
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+        # Delivery policy: Coupang links must not stay clickable. Applied at the transport
+        # boundary so the rich, legacy and chunked paths all get the same defanged host.
+        content = _deactivate_coupang_urls(content)
         error_types = self._telegram_error_types()
         try:
             # Bot API 10.1 rich fast-path; falls through to legacy MarkdownV2 on permanent/capability
@@ -3377,6 +3597,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 raw_response={
                     "message_ids": message_ids, "requested_thread_id": requested_thread_id, "thread_fallback": used_thread_fallback})
         except Exception as e:
+            if self._is_peer_flood_error(e):
+                return await self._open_peer_flood_circuit_async(chat_id, e)
             safe_error = _redact_telegram_error_text(e)
             logger.error("[%s] Failed to send Telegram message: %s", self.name, safe_error)
             err_str = str(e).lower()
@@ -3422,7 +3644,7 @@ class TelegramAdapter(BasePlatformAdapter):
         kwargs: Dict[str, Any] = {"chat_id": normalize_telegram_chat_id(chat_id), "message_id": int(message_id), "text": text}
         if parse_mode is not None:
             kwargs["parse_mode"] = parse_mode
-        await self._bot.edit_message_text(**kwargs)
+        await self._outbound.edit_message_text(**kwargs)
 
     async def _edit_markdown_or_plain(self, chat_id: str, message_id: str, formatted: str, plain: str, warn_fmt: str) -> bool:
         """MarkdownV2 edit with plain-text fallback. Returns True on a "not modified" no-op (caller may
@@ -3430,6 +3652,8 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             await self._edit_text(chat_id, message_id, formatted, ParseMode.MARKDOWN_V2)
         except Exception as fmt_err:
+            if self._is_peer_flood_error(fmt_err):
+                raise  # the plain-text retry would hit the same restricted peer
             if "not modified" in str(fmt_err).lower():
                 return True
             logger.warning(warn_fmt, self.name, _redact_telegram_error_text(fmt_err))
@@ -3446,6 +3670,10 @@ class TelegramAdapter(BasePlatformAdapter):
         continuations, and return the final chunk's id as the next edit target."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        peer_flood_result = await self._peer_flood_circuit_result_async(chat_id)
+        if peer_flood_result is not None:
+            return peer_flood_result
+        content = _deactivate_coupang_urls(content)
         # Rich finalize (Bot API 10.1): edit the preview IN PLACE via rich_message — no fresh send + delete.
         # Before the 4,096 pre-flight because the rich cap is 32,768; falls back to legacy on rejection.
         # Rich finalize (Bot API 10.1): when the completed content has constructs the legacy MarkdownV2 edit
@@ -3493,6 +3721,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] MarkdownV2 edit failed, falling back to plain text: %s")
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
+            if self._is_peer_flood_error(e):
+                return await self._open_peer_flood_circuit_async(chat_id, e)
             err_str = str(e).lower()
             if "not modified" in err_str:
                 return SendResult(success=True, message_id=message_id)
@@ -3568,17 +3798,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 else:
                     # Degrade to stripped text on finalize (raw ** / ``` would render literally); previews stay raw.
                     text = _strip_mdv2(chunk) if finalize else chunk
-                return await self._bot.send_message(
+                return await self._outbound.send_message(
                     chat_id=normalize_telegram_chat_id(chat_id), text=text, parse_mode=ParseMode.MARKDOWN_V2 if use_markdown else None,
                     reply_to_message_id=reply_to_id, **thread_kwargs, **base)
             except Exception as send_err:
+                if self._is_peer_flood_error(send_err):
+                    raise
                 if "reply message not found" in str(send_err).lower():
                     # Private DM topic fallback needs anchor + topic id together; forum topics keep thread id.
                     retry_thread_kwargs = (
                         {} if self._dm_topic_fallback(metadata)
                         else self._thread_kwargs_for_send(chat_id, thread_id, metadata, reply_to_message_id=None))
                     try:
-                        return await self._bot.send_message(
+                        return await self._outbound.send_message(
                             chat_id=normalize_telegram_chat_id(chat_id), text=_strip_mdv2(chunk) if finalize else chunk,
                             **retry_thread_kwargs, **base)
                     except Exception as _retry_err:
@@ -3608,10 +3840,14 @@ class TelegramAdapter(BasePlatformAdapter):
             else:
                 await self._edit_text(chat_id, message_id, first_chunk)
         except Exception as e:
+            # A flooded peer must surface the typed circuit failure, not a generic edit error:
+            # continuations below would keep writing to the same restricted chat.
+            if self._is_peer_flood_error(e):
+                return await self._open_peer_flood_circuit_async(chat_id, e)
             if "not modified" not in str(e).lower():  # identical first chunk still sends continuations
                 logger.error("[%s] Overflow split: first-chunk edit failed: %s", self.name, _redact_telegram_error_text(e), exc_info=True)
                 return SendResult(success=False, error=_redact_telegram_error_text(e))
-        # Continuations call self._bot.send_message directly to skip self.send's pre-chunking.
+        # Continuations call self._outbound.send_message directly to skip self.send's pre-chunking.
         continuation_ids: list[str] = []
         delivered_chunks = [first_chunk]
         prev_id = message_id
@@ -3619,7 +3855,15 @@ class TelegramAdapter(BasePlatformAdapter):
         for chunk in chunks[1:]:
             reply_to_id = int(prev_id) if prev_id else None
             thread_kwargs = self._thread_kwargs_for_send(chat_id, thread_id, metadata, reply_to_message_id=reply_to_id)
-            sent_msg = await self._send_overflow_continuation(chat_id, chunk, reply_to_id, thread_kwargs, thread_id, metadata, finalize)
+            try:
+                sent_msg = await self._send_overflow_continuation(
+                    chat_id, chunk, reply_to_id, thread_kwargs, thread_id, metadata, finalize)
+            except Exception as cont_err:
+                # PEER_FLOOD propagates out of the continuation sender (no anchorless/plain retry
+                # onto a restricted peer); convert it to the typed circuit failure here.
+                if not self._is_peer_flood_error(cont_err):
+                    raise
+                return await self._open_peer_flood_circuit_async(chat_id, cont_err)
             if sent_msg is None:
                 # Partial delivery: do NOT report success — the consumer would treat it as final delivery.
                 logger.warning("[%s] Overflow split: stopped at %d/%d chunks delivered", self.name, 1 + len(continuation_ids), len(chunks))
@@ -3649,8 +3893,10 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._bot:
             return False
+        if await self._peer_flood_circuit_result_async(chat_id) is not None:
+            return False
         try:
-            await self._bot.delete_message(chat_id=normalize_telegram_chat_id(chat_id), message_id=int(message_id))
+            await self._outbound.delete_message(chat_id=normalize_telegram_chat_id(chat_id), message_id=int(message_id))
             return True
         except Exception as e:
             logger.debug("[%s] Failed to delete Telegram message %s: %s", self.name, message_id, _redact_telegram_error_text(e))
@@ -3668,9 +3914,18 @@ class TelegramAdapter(BasePlatformAdapter):
         ``sendMessageDraft``; reusing ``draft_id`` animates the preview. The caller sends the final text."""
         if not self._bot:
             return SendResult(success=False, error="not_connected")
+        peer_flood_result = await self._peer_flood_circuit_result_async(chat_id)
+        if peer_flood_result is not None:
+            return peer_flood_result
+        content = _deactivate_coupang_urls(content)
         # Rich draft fast-path; any failure degrades to the plain draft below. Drafts have no message_id.
-        if self._should_attempt_rich_draft(content) and await self._try_send_rich_draft(chat_id, draft_id, content, metadata):
-            return SendResult(success=True, message_id=None)
+        # A SendResult means the circuit opened - do not degrade onto the same restricted peer.
+        if self._should_attempt_rich_draft(content):
+            rich_result = await self._try_send_rich_draft(chat_id, draft_id, content, metadata)
+            if isinstance(rich_result, SendResult):
+                return rich_result
+            if rich_result:
+                return SendResult(success=True, message_id=None)
         if not hasattr(self._bot, "send_message_draft"):
             return SendResult(success=False, error="api_unavailable")
         # Drafts share the regular-send UTF-16 length contract.
@@ -3690,7 +3945,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 kwargs["parse_mode"] = ParseMode.MARKDOWN_V2
             kwargs.update(draft_thread_kwargs)
             try:
-                if await self._bot.send_message_draft(**kwargs):
+                if await self._outbound.send_message_draft(**kwargs):
                     return SendResult(success=True, message_id=None)
                 return SendResult(success=False, error="draft_rejected")
             except Exception as e:
@@ -3717,7 +3972,7 @@ class TelegramAdapter(BasePlatformAdapter):
             raise RuntimeError("Not connected")
         message_thread_id = kwargs.get("message_thread_id")
         try:
-            return await self._bot.send_message(**kwargs)
+            return await self._outbound.send_message(**kwargs)
         except Exception as send_err:
             if (message_thread_id is not None and self._is_bad_request_error(send_err) and self._is_thread_not_found_error(send_err)):
                 logger.warning(
@@ -3726,7 +3981,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._prune_stale_dm_topic_binding(kwargs.get("chat_id"), message_thread_id)
                 retry_kwargs = dict(kwargs)
                 retry_kwargs.pop("message_thread_id", None)
-                return await self._bot.send_message(**retry_kwargs)
+                return await self._outbound.send_message(**retry_kwargs)
             raise
 
     async def _send_control_message(
@@ -3749,6 +4004,9 @@ class TelegramAdapter(BasePlatformAdapter):
         SendResult to return as-is), routed send, state hook, redacted failure log."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        peer_flood_result = await self._peer_flood_circuit_result_async(chat_id)
+        if peer_flood_result is not None:
+            return peer_flood_result
         try:
             built = build()
             if isinstance(built, SendResult):
@@ -3761,8 +4019,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 on_sent(msg)
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            if self._is_peer_flood_error(e):
+                return await self._open_peer_flood_circuit_async(chat_id, e)
             logger.warning("[%s] %s failed: %s", self.name, what, _redact_telegram_error_text(e))
-            return SendResult(success=False, error=_redact_telegram_error_text(e))
+            return SendResult(
+                success=False, error=_redact_telegram_error_text(e), error_kind=classify_send_error(e))
 
     @staticmethod
     def _rows_of_two(buttons: list) -> list:
@@ -4188,6 +4449,12 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         from_user = getattr(inline_query, "from_user", None)
         user_id = str(getattr(from_user, "id", "") or "").strip()
+        circuit_id = telegram_chat_id_key(user_id or "inline:unknown")
+        if await self._peer_flood_circuit_result_async(circuit_id) is not None:
+            return
+        outbound = GuardedTelegramTarget(
+            inline_query, self._outbound_gateway, target_key=circuit_id
+        )
         try:
             # No chat context on inline queries — authorize on user identity alone, DM-shaped.
             authorized = bool(user_id) and self._is_callback_user_authorized(
@@ -4198,8 +4465,11 @@ class TelegramAdapter(BasePlatformAdapter):
         if not authorized:
             try:
                 from plugins.platforms.telegram.inline_picker import CACHE_TIME_SECONDS as _deny_cache
-                await inline_query.answer([], cache_time=_deny_cache, is_personal=True)
-            except Exception:
+                await outbound.answer([], cache_time=_deny_cache, is_personal=True)
+            except Exception as exc:
+                if self._is_peer_flood_error(exc):
+                    await self._open_peer_flood_circuit_async(circuit_id, exc)
+                    return
                 logger.debug("[%s] inline picker empty answer failed", self.name, exc_info=True)
             return
         try:
@@ -4214,8 +4484,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 for r in results
            ]
             # is_personal: catalogs differ per user (auth, disabled skills) — never share cached pages.
-            await inline_query.answer(articles, cache_time=_CACHE, is_personal=True, next_offset=next_offset)
-        except Exception:
+            await outbound.answer(articles, cache_time=_CACHE, is_personal=True, next_offset=next_offset)
+        except Exception as exc:
+            if self._is_peer_flood_error(exc):
+                await self._open_peer_flood_circuit_async(circuit_id, exc)
+                return
             logger.debug("[%s] inline picker answer failed", self.name, exc_info=True)
 
     @staticmethod
@@ -4226,6 +4499,16 @@ class TelegramAdapter(BasePlatformAdapter):
         return {
             "chat_id": getattr(query_message, "chat_id", None), "chat_type": getattr(query_chat, "type", None),
             "thread_id": getattr(query_message, "message_thread_id", None), "user_name": getattr(query.from_user, "first_name", None)}
+
+    @staticmethod
+    def _callback_circuit_key(query) -> str:
+        """PEER_FLOOD circuit key for a button tap: its chat, else the tapping user."""
+        query_message = getattr(query, "message", None)
+        chat_id = getattr(query_message, "chat_id", None)
+        if chat_id is not None:
+            return str(chat_id)
+        user_id = getattr(getattr(query, "from_user", None), "id", None)
+        return str(user_id) if user_id is not None else _CALLBACK_UNKNOWN_CIRCUIT_KEY
 
     async def _callback_authorized(self, query, cb: Dict[str, Any], denial_text: str) -> bool:
         """Gate a button tap on the callback allowlist; answers ``denial_text`` when refused."""
@@ -4243,6 +4526,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not query or not query.data:
             return
         data = query.data
+        query = self._guard_callback_query(query, self._callback_circuit_key(query))
         cb = self._callback_ctx(query)
         # Model picker / generic choice picker (/reasoning, /fast) need a chat id.
         for prefixes, handler in (
@@ -4558,8 +4842,10 @@ class TelegramAdapter(BasePlatformAdapter):
             send_fn, {**kwargs, **media_kwargs}, metadata, reply_to_id, media_label, reset_media=reset_media)
 
     @staticmethod
-    def _caption_1024(caption: Optional[str]) -> Optional[str]:
-        return caption[:1024] if caption else None
+    def _prepare_caption(caption: Optional[str]) -> Optional[str]:
+        """The single media-caption chokepoint: apply outbound content policy, then Telegram's
+        1024 UTF-16-unit cap (``prepare_caption`` counts units, not codepoints)."""
+        return prepare_caption(caption)
 
     async def _send_voice_bubble(self, audio_file, chat_id, reply_to, metadata, caption, duration_secs):
         """sendVoice with caption variants: MarkdownV2 when it fits 1024 chars, plain fallback when the
@@ -4576,14 +4862,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     _caption_variants.append((_formatted_caption, ParseMode.MARKDOWN_V2))
             except Exception:
                 logger.debug("[%s] voice caption MarkdownV2 formatting failed; sending plain caption", self.name, exc_info=True)
-            _caption_variants.append((caption[:1024], None))
+            _caption_variants.append((caption, None))
         else:
             _caption_variants.append((None, None))
         _last_parse_error: Optional[Exception] = None
         for _cap_text, _cap_parse_mode in _caption_variants:
             try:
                 return await self._send_media(
-                    self._bot.send_voice, chat_id, reply_to, metadata, "voice", reset_media=lambda: audio_file.seek(0),
+                    self._outbound.send_voice, chat_id, reply_to, metadata, "voice", reset_media=lambda: audio_file.seek(0),
                     voice=audio_file, caption=_cap_text, parse_mode=_cap_parse_mode, duration=duration_secs)
             except Exception as _cap_error:
                 err = str(_cap_error).lower()
@@ -4602,6 +4888,11 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send audio as a native Telegram voice message or audio file."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        peer_flood_result = await self._peer_flood_circuit_result_async(chat_id)
+        if peer_flood_result is not None:
+            return peer_flood_result
+        caption = prepare_caption(caption)
+
         _transcoded_voice_path: Optional[str] = None
         try:
             if not os.path.exists(audio_path):
@@ -4625,13 +4916,16 @@ class TelegramAdapter(BasePlatformAdapter):
                     msg = await self._send_voice_bubble(audio_file, chat_id, reply_to, metadata, caption, _duration_secs)
                 elif ext in {".mp3", ".m4a"}:  # Bot API sendAudio only accepts MP3 / M4A
                     msg = await self._send_media(
-                        self._bot.send_audio, chat_id, reply_to, metadata, "audio", reset_media=lambda: audio_file.seek(0),
-                        audio=audio_file, caption=self._caption_1024(caption), duration=_duration_secs)
+                        self._outbound.send_audio, chat_id, reply_to, metadata, "audio", reset_media=lambda: audio_file.seek(0),
+                        audio=audio_file, caption=self._prepare_caption(caption), duration=_duration_secs)
                 else:  # formats Telegram can't play natively (.wav, .flac, ...)
                     return await self.send_document(
                         chat_id=chat_id, file_path=audio_path, caption=caption, reply_to=reply_to, metadata=metadata)
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            peer_flood_result = await self._peer_flood_result_from_error_async(chat_id, e)
+            if peer_flood_result is not None:
+                return peer_flood_result
             logger.error(
                 "[%s] Failed to send Telegram voice/audio, falling back to base adapter: %s", self.name,
                 _redact_telegram_error_text(e), exc_info=True)
@@ -4647,6 +4941,9 @@ class TelegramAdapter(BasePlatformAdapter):
         media group (need ``send_animation``) so they go via the base per-image path, as does a failed chunk."""
         if not self._bot or not images:
             return
+        if await self._peer_flood_circuit_result_async(chat_id) is not None:
+            return
+
         try:
             from telegram import InputMediaPhoto
         except Exception as exc:  # pragma: no cover - missing SDK
@@ -4678,7 +4975,7 @@ class TelegramAdapter(BasePlatformAdapter):
                             continue
                         source = open(local_path, "rb")
                         opened_files.append(source)
-                    media.append(InputMediaPhoto(media=source, caption=self._caption_1024(alt_text)))
+                    media.append(InputMediaPhoto(media=source, caption=self._prepare_caption(alt_text)))
                 if not media:
                     continue
                 logger.info("[%s] Sending media group of %d photo(s) (chunk %d/%d)", self.name, len(media), chunk_idx + 1, len(chunks))
@@ -4690,9 +4987,11 @@ class TelegramAdapter(BasePlatformAdapter):
                             fh.seek(0)
 
                 await self._send_with_dm_topic_reply_anchor_retry(
-                    self._bot.send_media_group, {**send_kwargs, "media": media}, metadata, reply_to_id,
+                    self._outbound.send_media_group, {**send_kwargs, "media": media}, metadata, reply_to_id,
                     "media group", reset_media=_reset_opened_files)
             except Exception as e:
+                if await self._peer_flood_result_from_error_async(chat_id, e) is not None:
+                    return
                 logger.warning(
                     "[%s] send_media_group failed (chunk %d/%d), falling back to per-image: %s", self.name,
                     chunk_idx + 1, len(chunks), _redact_telegram_error_text(e), exc_info=True)
@@ -4706,6 +5005,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self, chat_id: str, image_path: str, caption: Optional[str] = None, reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None, **kwargs) -> SendResult:
         """Send a local image file natively as a Telegram photo."""
+        peer_flood_result = await self._peer_flood_circuit_result_async(chat_id)
+        if peer_flood_result is not None:
+            return peer_flood_result
+
         async def _photo_failed(e: Exception) -> SendResult:
             error_str = str(e)
             # Dimension errors are expected for valid images Telegram refuses as photos → INFO.
@@ -4727,7 +5030,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 return await super(TelegramAdapter, self).send_image_file(chat_id, image_path, caption, reply_to, metadata=metadata)
         return await self._send_local_file(
             "Image", image_path, chat_id, reply_to, metadata, "photo",
-            lambda f: {"photo": f, "caption": self._caption_1024(caption)}, _photo_failed)
+            lambda f: {"photo": f, "caption": self._prepare_caption(caption)}, _photo_failed)
 
     async def _send_local_file(
         self, label: str, path: str, chat_id, reply_to, metadata, media_key: str, build_kwargs, on_error,
@@ -4736,12 +5039,15 @@ class TelegramAdapter(BasePlatformAdapter):
         ``await on_error(exc)`` on any failure. ``build_kwargs(f)`` supplies the media kwargs."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        peer_flood_result = await self._peer_flood_circuit_result_async(chat_id)
+        if peer_flood_result is not None:
+            return peer_flood_result
         try:
             if not os.path.exists(path):
                 return SendResult(success=False, error=self._missing_media_path_error(label, path))
             with open(path, "rb") as f:
                 msg = await self._send_media(
-                    getattr(self._bot, f"send_{media_key}"), chat_id, reply_to, metadata, media_key,
+                    getattr(self._outbound, f"send_{media_key}"), chat_id, reply_to, metadata, media_key,
                     reset_media=lambda: f.seek(0), **build_kwargs(f))
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -4757,7 +5063,7 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send a document/file natively as a Telegram file attachment."""
         return await self._send_local_file(
             "File", file_path, chat_id, reply_to, metadata, "document",
-            lambda f: {"document": f, "filename": file_name or os.path.basename(file_path), "caption": self._caption_1024(caption)},
+            lambda f: {"document": f, "filename": file_name or os.path.basename(file_path), "caption": self._prepare_caption(caption)},
             lambda e: self._warn_then(
                 "document", e, super(
                     TelegramAdapter, self,
@@ -4769,7 +5075,7 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send a video natively as a Telegram video message."""
         return await self._send_local_file(
             "Video", video_path, chat_id, reply_to, metadata, "video",
-            lambda f: {"video": f, "caption": self._caption_1024(caption)},
+            lambda f: {"video": f, "caption": self._prepare_caption(caption)},
             lambda e: self._warn_then(
                 "video", e, super(TelegramAdapter, self).send_video(chat_id, video_path, caption, reply_to, metadata=metadata),
             ))
@@ -4780,16 +5086,23 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send a URL image as a Telegram photo: URL send (<5MB) → download+upload (≤10MB) → base text."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        peer_flood_result = await self._peer_flood_circuit_result_async(chat_id)
+        if peer_flood_result is not None:
+            return peer_flood_result
+
         from tools.url_safety import is_safe_url
         if not is_safe_url(image_url):
             logger.warning("[%s] Blocked unsafe image URL (SSRF protection)", self.name)
             return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
-        photo_caption = self._caption_1024(caption)
+        photo_caption = self._prepare_caption(caption)
         try:
             msg = await self._send_media(
-                self._bot.send_photo, chat_id, reply_to, metadata, "URL photo", photo=image_url, caption=photo_caption)
+                self._outbound.send_photo, chat_id, reply_to, metadata, "URL photo", photo=image_url, caption=photo_caption)
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            peer_flood_result = await self._peer_flood_result_from_error_async(chat_id, e)
+            if peer_flood_result is not None:
+                return peer_flood_result
             logger.warning(
                 "[%s] URL-based send_photo failed, trying file upload: %s", self.name, _redact_telegram_error_text(e), exc_info=True)
             try:
@@ -4800,7 +5113,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     resp.raise_for_status()
                     image_data = resp.content
                 msg = await self._send_media(
-                    self._bot.send_photo, chat_id, reply_to, metadata, "uploaded photo", photo=image_data, caption=photo_caption)
+                    self._outbound.send_photo, chat_id, reply_to, metadata, "uploaded photo", photo=image_data, caption=photo_caption)
                 return SendResult(success=True, message_id=str(msg.message_id))
             except Exception as e2:
                 logger.error("[%s] File upload send_photo also failed: %s", self.name, e2, exc_info=True)
@@ -4812,12 +5125,18 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send an animated GIF natively as a Telegram animation (auto-plays inline)."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        peer_flood_result = await self._peer_flood_circuit_result_async(chat_id)
+        if peer_flood_result is not None:
+            return peer_flood_result
         try:
             msg = await self._send_media(
-                self._bot.send_animation, chat_id, reply_to, metadata, "animation", animation=animation_url,
-                caption=self._caption_1024(caption))
+                self._outbound.send_animation, chat_id, reply_to, metadata, "animation", animation=animation_url,
+                caption=self._prepare_caption(caption))
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            peer_flood_result = await self._peer_flood_result_from_error_async(chat_id, e)
+            if peer_flood_result is not None:
+                return peer_flood_result
             logger.error(
                 "[%s] Failed to send Telegram animation, falling back to photo: %s", self.name,
                 _redact_telegram_error_text(e), exc_info=True)
@@ -4863,11 +5182,13 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send typing indicator."""
         if not self._bot or self._typing_in_cooldown(chat_id):
             return
+        if await self._peer_flood_circuit_result_async(chat_id) is not None:
+            return
         _is_dm_topic: bool = False
         message_thread_id: Optional[int] = None
 
         async def _action(**kw) -> None:
-            await self._bot.send_chat_action(chat_id=normalize_telegram_chat_id(chat_id), action="typing", **kw)
+            await self._outbound.send_chat_action(chat_id=normalize_telegram_chat_id(chat_id), action="typing", **kw)
             self._telegram_typing_cooldown_until.pop(str(chat_id), None)
         try:
             _is_dm_topic = self._dm_topic_fallback(metadata)
@@ -4881,7 +5202,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     await _action()
                     return
                 except Exception as fallback_exc:
-                    if self._is_transient_typing_error(fallback_exc):
+                    if self._is_peer_flood_error(fallback_exc):
+                        await self._open_peer_flood_circuit_async(chat_id, fallback_exc)
+                    elif self._is_transient_typing_error(fallback_exc):
                         self._record_typing_cooldown(chat_id, fallback_exc)
             elif self._is_transient_typing_error(e):
                 self._record_typing_cooldown(chat_id, e)
@@ -5648,14 +5971,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 chat_id = int(chat.id)
                 if chat_id in self._forum_command_registered:
                     return
+                if await self._peer_flood_circuit_result_async(str(chat_id)) is not None:
+                    return
                 from telegram import BotCommand, BotCommandScopeChat
                 from hermes_cli.commands_platforms import telegram_menu_commands, telegram_menu_max_commands
                 menu_commands, _ = telegram_menu_commands(max_commands=telegram_menu_max_commands())
                 bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
-                await self._bot.set_my_commands(bot_commands, scope=BotCommandScopeChat(chat_id=chat_id))
+                await self._outbound.set_my_commands(bot_commands, scope=BotCommandScopeChat(chat_id=chat_id))
                 self._forum_command_registered.add(chat_id)
                 logger.info("[%s] Lazy-registered %d commands for forum chat %s", self.name, len(bot_commands), chat_id)
             except Exception as e:
+                if self._is_peer_flood_error(e):
+                    await self._open_peer_flood_circuit_async(str(chat_id), e)
+                    return
                 logger.warning("[%s] Forum command lazy-registration failed: %s", self.name, _redact_telegram_error_text(e))
 
     def _effective_update_message(self, update: Update) -> Optional[Message]:
@@ -6323,8 +6651,10 @@ class TelegramAdapter(BasePlatformAdapter):
         """Set a single emoji reaction (``None`` clears all bot-set reactions, the documented Bot API way)."""
         if not self._bot:
             return False
+        if await self._peer_flood_circuit_result_async(chat_id) is not None:
+            return False
         try:
-            await self._bot.set_message_reaction(chat_id=normalize_telegram_chat_id(chat_id), message_id=int(message_id), reaction=emoji)
+            await self._outbound.set_message_reaction(chat_id=normalize_telegram_chat_id(chat_id), message_id=int(message_id), reaction=emoji)
             return True
         except Exception as e:
             if emoji is None:

--- a/plugins/platforms/telegram/outbound_circuit.py
+++ b/plugins/platforms/telegram/outbound_circuit.py
@@ -1,0 +1,170 @@
+"""Small process-shared Telegram PEER_FLOOD circuit.
+
+Only a normalized chat key and wall-clock expiry are stored in the profile's
+existing ``state.db``. Message bodies and credentials never enter this table.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import sqlite3
+import threading
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+from hermes_constants import get_hermes_home
+from plugins.platforms.telegram.telegram_ids import telegram_chat_id_key
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COOLDOWN_SECONDS = 300.0
+MAX_COOLDOWN_SECONDS = 300.0
+DB_BUSY_TIMEOUT_SECONDS = 0.05
+DB_ERROR_COOLDOWN_SECONDS = 5.0
+GLOBAL_CIRCUIT_KEY = "telegram:global"
+_DB_LOCK = threading.Lock()
+_ERROR_STATE_LOCK = threading.Lock()
+_READ_ERROR_UNTIL: dict[tuple[str, str], float] = {}
+_WRITE_ERROR_UNTIL: dict[tuple[str, str], float] = {}
+
+
+def chat_key(chat_id: object) -> str:
+    """Return the canonical key shared by adapter and standalone sender."""
+    return telegram_chat_id_key(str(chat_id).strip())
+
+
+def _db_path():
+    return get_hermes_home() / "state.db"
+
+
+@contextmanager
+def _connection() -> Iterator[sqlite3.Connection]:
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=DB_BUSY_TIMEOUT_SECONDS)
+    try:
+        from hermes_state import apply_wal_with_fallback
+
+        apply_wal_with_fallback(conn, db_label="state.db (telegram outbound circuit)")
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS telegram_peer_flood_circuits (
+                chat_key TEXT PRIMARY KEY,
+                expires_at REAL NOT NULL
+            )"""
+        )
+        with conn:
+            yield conn
+    finally:
+        conn.close()
+
+
+def _bounded_delay(delay: object) -> float:
+    try:
+        value = float(delay)
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError
+    except (TypeError, ValueError):
+        value = DEFAULT_COOLDOWN_SECONDS
+    return min(value, MAX_COOLDOWN_SECONDS)
+
+
+def open_circuit(chat_id: object, delay: object = None) -> float:
+    """Persist a cooldown, preserving a later expiry already opened elsewhere."""
+    bounded = _bounded_delay(delay)
+    expires_at = time.time() + bounded
+    try:
+        if not _DB_LOCK.acquire(timeout=DB_BUSY_TIMEOUT_SECONDS):
+            raise sqlite3.OperationalError("Telegram circuit database lock timed out")
+        try:
+            with _connection() as conn:
+                conn.execute(
+                    """INSERT INTO telegram_peer_flood_circuits(chat_key, expires_at)
+                       VALUES (?, ?)
+                       ON CONFLICT(chat_key) DO UPDATE SET expires_at =
+                           MAX(telegram_peer_flood_circuits.expires_at, excluded.expires_at)""",
+                    (chat_key(chat_id), expires_at),
+                )
+                stored = conn.execute(
+                    "SELECT expires_at FROM telegram_peer_flood_circuits WHERE chat_key=?",
+                    (chat_key(chat_id),),
+                ).fetchone()
+        finally:
+            _DB_LOCK.release()
+        return max(0.0, float(stored[0]) - time.time()) if stored else bounded
+    except (OSError, sqlite3.Error):
+        logger.warning("Could not persist Telegram PEER_FLOOD circuit")
+        failure_key = (str(_db_path()), chat_key(chat_id))
+        with _ERROR_STATE_LOCK:
+            _WRITE_ERROR_UNTIL[failure_key] = max(
+                _WRITE_ERROR_UNTIL.get(failure_key, 0.0),
+                time.monotonic() + DB_ERROR_COOLDOWN_SECONDS,
+            )
+        return bounded
+
+
+async def open_circuit_async(chat_id: object, delay: object = None) -> float:
+    """Persist a cooldown in a worker thread for asynchronous callers."""
+    return await asyncio.to_thread(open_circuit, chat_id, delay)
+
+
+def remaining(chat_id: object) -> float | None:
+    """Return cooldown; DB errors fail closed once for a finite short window.
+
+    After that window one call is allowed through before a persistent error can
+    open another window. This prioritizes PEER_FLOOD suppression without making
+    an unavailable state database an unconditional permanent outage.
+    """
+    now = time.time()
+    path_key = str(_db_path())
+    monotonic_now = time.monotonic()
+    failure_key = (path_key, chat_key(chat_id))
+    with _ERROR_STATE_LOCK:
+        write_error_until = _WRITE_ERROR_UNTIL.get(failure_key)
+        if write_error_until is not None:
+            left = write_error_until - monotonic_now
+            if left > 0:
+                return left
+            _WRITE_ERROR_UNTIL.pop(failure_key, None)
+        error_until = _READ_ERROR_UNTIL.get(failure_key)
+        if error_until is not None:
+            left = error_until - monotonic_now
+            if left > 0:
+                return left
+            _READ_ERROR_UNTIL.pop(failure_key, None)
+            return None
+    try:
+        if not _DB_LOCK.acquire(timeout=DB_BUSY_TIMEOUT_SECONDS):
+            raise sqlite3.OperationalError("Telegram circuit database lock timed out")
+        try:
+            with _connection() as conn:
+                row = conn.execute(
+                    "SELECT expires_at FROM telegram_peer_flood_circuits WHERE chat_key=?",
+                    (chat_key(chat_id),),
+                ).fetchone()
+                if row is None:
+                    return None
+                left = float(row[0]) - now
+                if left <= 0:
+                    conn.execute(
+                        "DELETE FROM telegram_peer_flood_circuits WHERE chat_key=?",
+                        (chat_key(chat_id),),
+                    )
+                    return None
+                return left
+        finally:
+            _DB_LOCK.release()
+    except (OSError, sqlite3.Error):
+        logger.warning("Could not read Telegram PEER_FLOOD circuit")
+        with _ERROR_STATE_LOCK:
+            _READ_ERROR_UNTIL[failure_key] = (
+                time.monotonic() + DB_ERROR_COOLDOWN_SECONDS
+            )
+        return DB_ERROR_COOLDOWN_SECONDS
+
+
+async def remaining_async(chat_id: object) -> float | None:
+    """Read a cooldown in a worker thread for asynchronous callers."""
+    return await asyncio.to_thread(remaining, chat_id)

--- a/plugins/platforms/telegram/outbound_policy.py
+++ b/plugins/platforms/telegram/outbound_policy.py
@@ -1,0 +1,408 @@
+"""Shared Telegram outbound content and PEER_FLOOD policy helpers."""
+
+from __future__ import annotations
+
+import inspect
+import math
+import re
+from collections.abc import Mapping
+from copy import copy
+from datetime import date, datetime, time as datetime_time, timedelta
+from enum import Enum
+from io import IOBase
+from os import PathLike
+from typing import Any, Awaitable, Callable
+from urllib.parse import urlsplit
+
+DEFAULT_PEER_FLOOD_COOLDOWN_SECONDS = 300.0
+MAX_PEER_FLOOD_COOLDOWN_SECONDS = 300.0
+
+_URL_TOKEN_RE = re.compile(
+    r"(?<![a-z0-9_@.-])(?:https?:)?//[^\s<>\[\]{}()'\"`]+",
+    re.IGNORECASE,
+)
+_BARE_COUPANG_HOST_RE = re.compile(
+    r"(?<![a-z0-9_/@.=?#&-])"
+    r"(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*coupang\.com"
+    r"(?:\.)?(?=(?::[0-9]+)?(?:[/\s?#)\]>,;:'\"`]|$))",
+    re.IGNORECASE,
+)
+_PEER_FLOOD_RE = re.compile(r"\bPEER[_ ]FLOOD\b", re.IGNORECASE)
+
+
+def deactivate_coupang_urls(content: str) -> str:
+    """Defang Coupang URL origins without touching another URL's values."""
+    if not content:
+        return content
+
+    def defang_host(value: str) -> str:
+        return re.sub(
+            r"coupang\.com(?=\.?(?::[0-9]+)?(?:[/\\?#]|$))",
+            "coupang[.]com",
+            value,
+            flags=re.IGNORECASE,
+        )
+
+    def defang_url_token(match: re.Match) -> str:
+        token = match.group(0)
+        parsed = urlsplit(token if "://" in token else f"https:{token}")
+        host = (parsed.hostname or "").rstrip(".").lower()
+        if host == "coupang.com" or host.endswith(".coupang.com"):
+            return defang_host(token)
+        return token
+
+    pieces = []
+    cursor = 0
+    for match in _URL_TOKEN_RE.finditer(content):
+        pieces.append(
+            _BARE_COUPANG_HOST_RE.sub(
+                lambda item: defang_host(item.group(0)), content[cursor : match.start()]
+            )
+        )
+        pieces.append(defang_url_token(match))
+        cursor = match.end()
+    pieces.append(
+        _BARE_COUPANG_HOST_RE.sub(
+            lambda item: defang_host(item.group(0)), content[cursor:]
+        )
+    )
+    prepared = "".join(pieces)
+    # Preserve str subclasses such as telegram.constants.ParseMode when the
+    # policy made no change; converting them to plain str breaks caller
+    # contracts and equality-by-identity assumptions in PTB integrations.
+    return content if prepared == content else prepared
+
+
+def prepare_caption(caption: str | None, limit: int = 1024) -> str | None:
+    """Defang Coupang URLs, then truncate to Telegram's UTF-16 unit limit."""
+    if not caption:
+        return None
+    prepared = deactivate_coupang_urls(caption)
+    units = 0
+    end = 0
+    for end, char in enumerate(prepared, start=1):
+        units += len(char.encode("utf-16-le")) // 2
+        if units > limit:
+            return prepared[: end - 1]
+    return prepared
+
+
+def is_peer_flood(value: object) -> bool:
+    """Recognize PEER_FLOOD in exceptions and raw Bot API error responses."""
+    if isinstance(value, dict):
+        text = " ".join(
+            str(value.get(key, "")) for key in ("error", "description", "message")
+        )
+    else:
+        text = str(value or "")
+    return bool(_PEER_FLOOD_RE.search(text))
+
+
+def peer_flood_delay(value: object) -> float:
+    """Return a finite positive cooldown, capped to the shared maximum."""
+    retry_after = getattr(value, "retry_after", None)
+    if retry_after is None and isinstance(value, dict):
+        parameters = value.get("parameters")
+        if isinstance(parameters, dict):
+            retry_after = parameters.get("retry_after")
+        if retry_after is None:
+            retry_after = value.get("retry_after")
+    try:
+        delay = float(retry_after)
+        if not math.isfinite(delay) or delay <= 0:
+            raise ValueError
+    except (TypeError, ValueError):
+        delay = DEFAULT_PEER_FLOOD_COOLDOWN_SECONDS
+    return min(delay, MAX_PEER_FLOOD_COOLDOWN_SECONDS)
+
+
+class TelegramPeerFloodBlocked(RuntimeError):
+    """Raised when the per-target policy circuit blocks a Bot API write."""
+
+    def __init__(self, retry_after: float):
+        super().__init__("Telegram PEER_FLOOD outbound circuit is open")
+        self.retry_after = float(retry_after)
+
+
+class TelegramUnsafeContentBlocked(RuntimeError):
+    """Raised when a payload cannot be inspected safely before transport."""
+
+
+def _copy_with_content_policy(
+    value: Any,
+    *,
+    depth: int,
+    max_depth: int,
+    memo: dict[int, Any],
+    active_tuples: set[int],
+) -> Any:
+    """Copy a supported outbound value and defang every reachable string value."""
+    if depth > max_depth:
+        raise TelegramUnsafeContentBlocked("Telegram payload exceeds safe policy depth")
+    if isinstance(value, str):
+        return deactivate_coupang_urls(value)
+    if value is None or isinstance(value, (bytes, bytearray, int, float, bool)):
+        return value
+
+    identity = id(value)
+    if identity in memo:
+        return memo[identity]
+    if isinstance(value, Mapping):
+        copied: dict[Any, Any] = {}
+        memo[identity] = copied
+        for key, item in value.items():
+            copied_key = _copy_with_content_policy(
+                key,
+                depth=depth + 1,
+                max_depth=max_depth,
+                memo=memo,
+                active_tuples=active_tuples,
+            )
+            try:
+                if copied_key in copied:
+                    raise TelegramUnsafeContentBlocked(
+                        "Telegram payload has a key collision after content policy"
+                    )
+            except TypeError as exc:
+                raise TelegramUnsafeContentBlocked(
+                    "Telegram payload key became unhashable after content policy"
+                ) from exc
+            copied[copied_key] = _copy_with_content_policy(
+                item,
+                depth=depth + 1,
+                max_depth=max_depth,
+                memo=memo,
+                active_tuples=active_tuples,
+            )
+        return copied
+    if isinstance(value, list):
+        copied_list: list[Any] = []
+        memo[identity] = copied_list
+        copied_list.extend(
+            _copy_with_content_policy(
+                item,
+                depth=depth + 1,
+                max_depth=max_depth,
+                memo=memo,
+                active_tuples=active_tuples,
+            )
+            for item in value
+        )
+        return copied_list
+    if isinstance(value, tuple):
+        if identity in active_tuples:
+            raise TelegramUnsafeContentBlocked("Telegram payload contains a tuple cycle")
+        active_tuples.add(identity)
+        try:
+            copied_tuple = tuple(
+                _copy_with_content_policy(
+                    item,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                    memo=memo,
+                    active_tuples=active_tuples,
+                )
+                for item in value
+            )
+        finally:
+            active_tuples.remove(identity)
+        memo[identity] = copied_tuple
+        return copied_tuple
+
+    try:
+        from telegram import TelegramObject
+    except ImportError:
+        TelegramObject = None
+
+    if isinstance(TelegramObject, type) and isinstance(value, TelegramObject):
+        source_bot = getattr(value, "_bot", None)
+        copied_object = copy(value)
+        memo[identity] = copied_object
+        fields: list[str] = []
+        for cls in type(value).mro():
+            slots = getattr(cls, "__slots__", ())
+            if isinstance(slots, str):
+                slots = (slots,)
+            for field in slots:
+                if field.startswith("_") or field in fields or not hasattr(value, field):
+                    continue
+                fields.append(field)
+        value_dict = getattr(value, "__dict__", None)
+        if isinstance(value_dict, dict):
+            for field in value_dict:
+                if field.startswith("_") or field in fields:
+                    continue
+                fields.append(field)
+        with copied_object._unfrozen():
+            for field in fields:
+                setattr(
+                    copied_object,
+                    field,
+                    _copy_with_content_policy(
+                        getattr(value, field),
+                        depth=depth + 1,
+                        max_depth=max_depth,
+                        memo=memo,
+                        active_tuples=active_tuples,
+                    ),
+                )
+        if source_bot is not None:
+            copied_object.set_bot(source_bot)
+        return copied_object
+
+    try:
+        from telegram import InputFile
+    except ImportError:
+        InputFile = None
+    try:
+        from telegram._utils.defaultvalue import DefaultValue
+    except ImportError:
+        DefaultValue = None
+    if isinstance(DefaultValue, type) and isinstance(value, DefaultValue):
+        copied_default = type(value)(
+            _copy_with_content_policy(
+                value.value,
+                depth=depth + 1,
+                max_depth=max_depth,
+                memo=memo,
+                active_tuples=active_tuples,
+            )
+        )
+        memo[identity] = copied_default
+        return copied_default
+    opaque_types = tuple(
+        candidate
+        for candidate in (
+            InputFile,
+            IOBase,
+            PathLike,
+            Enum,
+            date,
+            datetime,
+            datetime_time,
+            timedelta,
+        )
+        if isinstance(candidate, type)
+    )
+    if isinstance(value, opaque_types):
+        return value
+    raise TelegramUnsafeContentBlocked(
+        f"Telegram payload has unsupported payload type: {type(value).__name__}"
+    )
+
+
+class TelegramOutboundGateway:
+    """The single asynchronous policy boundary for Telegram Bot API writes."""
+
+    _TEXT_METHODS = {
+        "answer",
+        "edit_message_text",
+        "send_message",
+        "send_message_draft",
+    }
+    _GLOBAL_METHODS = {
+        "delete_webhook",
+        "set_my_commands",
+        "set_my_description",
+        "set_my_short_description",
+        "set_webhook",
+    }
+    _MAX_CONTENT_DEPTH = 32
+
+    @staticmethod
+    def _key(target_key: object) -> str:
+        from plugins.platforms.telegram.outbound_circuit import chat_key
+
+        return chat_key(target_key)
+
+    @staticmethod
+    def _apply_content_policy(method: str, args: tuple[Any, ...], kwargs: dict[str, Any]):
+        del method
+        memo: dict[int, Any] = {}
+        active_tuples: set[int] = set()
+        args_out = _copy_with_content_policy(
+            args,
+            depth=0,
+            max_depth=TelegramOutboundGateway._MAX_CONTENT_DEPTH,
+            memo=memo,
+            active_tuples=active_tuples,
+        )
+        kwargs_out = _copy_with_content_policy(
+            kwargs,
+            depth=0,
+            max_depth=TelegramOutboundGateway._MAX_CONTENT_DEPTH,
+            memo=memo,
+            active_tuples=active_tuples,
+        )
+        return args_out, kwargs_out
+
+    async def write(
+        self,
+        target_key: object,
+        method: str,
+        operation: Callable[..., Awaitable[Any]],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        from plugins.platforms.telegram import outbound_circuit
+
+        key = self._key(target_key)
+        blocked = await outbound_circuit.remaining_async(key)
+        if blocked is not None:
+            raise TelegramPeerFloodBlocked(blocked)
+        args, kwargs = self._apply_content_policy(method, args, kwargs)
+        try:
+            result = await operation(*args, **kwargs)
+        except Exception as exc:
+            if not is_peer_flood(exc):
+                raise
+            delay = await outbound_circuit.open_circuit_async(key, peer_flood_delay(exc))
+            raise TelegramPeerFloodBlocked(delay) from None
+        if is_peer_flood(result):
+            delay = await outbound_circuit.open_circuit_async(key, peer_flood_delay(result))
+            raise TelegramPeerFloodBlocked(delay)
+        return result
+
+
+class GuardedTelegramTarget:
+    """Verifiably thin dynamic wrapper whose write methods all enter the gateway."""
+
+    def __init__(
+        self,
+        target: object,
+        gateway: TelegramOutboundGateway,
+        *,
+        target_key: object | None = None,
+    ) -> None:
+        self._target = target
+        self._gateway = gateway
+        self._target_key = target_key
+
+    def __getattr__(self, method: str):
+        operation = getattr(self._target, method)
+        if method.startswith("get_") or method in {"initialize", "shutdown"}:
+            return operation
+
+        async def guarded(*args: Any, **kwargs: Any):
+            key = self._target_key
+            if key is None:
+                key = kwargs.get("chat_id")
+            if key is None and isinstance(kwargs.get("api_kwargs"), dict):
+                key = kwargs["api_kwargs"].get("chat_id")
+            if key is None and method == "set_my_commands":
+                scope = kwargs.get("scope")
+                if isinstance(scope, Mapping):
+                    if "chat_id" in scope:
+                        key = scope.get("chat_id")
+                elif inspect.getattr_static(scope, "chat_id", None) is not None:
+                    key = getattr(scope, "chat_id", None)
+            if key is None and method in TelegramOutboundGateway._GLOBAL_METHODS:
+                from plugins.platforms.telegram.outbound_circuit import GLOBAL_CIRCUIT_KEY
+
+                key = GLOBAL_CIRCUIT_KEY
+            if key is None:
+                key = "telegram:user:unknown"
+            return await self._gateway.write(key, method, operation, *args, **kwargs)
+
+        return guarded

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -11,7 +11,13 @@ Verifies that:
 import pytest
 from unittest.mock import AsyncMock, patch
 
-from gateway.platforms.base import BasePlatformAdapter, SendResult, _RETRYABLE_ERROR_PATTERNS
+from gateway.platforms.base import (
+    SEND_ERROR_KINDS,
+    BasePlatformAdapter,
+    SendResult,
+    _RETRYABLE_ERROR_PATTERNS,
+    classify_send_error,
+)
 from gateway.platforms.base import Platform, PlatformConfig
 
 
@@ -62,6 +68,10 @@ class TestIsRetryableError:
 
     def test_permission_error_not_retryable(self):
         assert not _StubAdapter._is_retryable_error("Forbidden: bot was blocked by the user")
+
+    def test_peer_flood_has_documented_machine_readable_kind(self):
+        assert "peer_flood" in SEND_ERROR_KINDS
+        assert classify_send_error(None, "Telegram PEER_FLOOD") == "peer_flood"
 
 
 # ---------------------------------------------------------------------------
@@ -294,3 +304,57 @@ class TestSendWithRetryFailureTypeTransitions:
         assert result.success  # fallback succeeded
         # No delivery-failure notice was sent (this is a formatting fallback, not network exhaustion)
         assert "delivery failed" not in adapter._send_calls[-1][1].lower()
+
+
+# ---------------------------------------------------------------------------
+# _send_with_retry — Telegram PEER_FLOOD (per-peer circuit breaker)
+# ---------------------------------------------------------------------------
+# peer_flood is NOT ordinary flood control: the adapter already holds the
+# cooldown, so a retry, a plain-text fallback or a delivery-failure notice
+# would each hit the same restricted peer and amplify the ban.
+
+class TestSendWithRetryPeerFlood:
+
+    @pytest.mark.asyncio
+    async def test_peer_flood_is_not_retried_or_followed_by_notice_or_fallback(self):
+        """PEER_FLOOD must leave the original final-delivery failure intact."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(
+                success=False,
+                error="peer_flood",
+                retryable=False,
+                retry_after=300.0,
+                error_kind="peer_flood",
+            ),
+        ]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "final answer")
+
+        assert not result.success
+        assert result.error_kind == "peer_flood"
+        assert len(adapter._send_calls) == 1
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_peer_flood_on_retry_stops_notice_and_plain_text_fallback(self):
+        """A retry that hits PEER_FLOOD must become the final result immediately."""
+        adapter = _StubAdapter()
+        peer_flood = SendResult(
+            success=False,
+            error="peer_flood",
+            retryable=False,
+            retry_after=300.0,
+            error_kind="peer_flood",
+        )
+        adapter._send_results = [
+            SendResult(success=False, error="network down", retryable=True),
+            peer_flood,
+        ]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter._send_with_retry("chat1", "final answer")
+
+        assert result is peer_flood
+        assert len(adapter._send_calls) == 2

--- a/tests/gateway/test_telegram_coupang_peer_flood.py
+++ b/tests/gateway/test_telegram_coupang_peer_flood.py
@@ -1,0 +1,680 @@
+"""쿠팡 URL 비활성화와 Telegram PEER_FLOOD 회로 차단 회귀 시험."""
+
+import asyncio
+from types import SimpleNamespace
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import (
+    TelegramAdapter,
+    _deactivate_coupang_urls,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_persistent_circuit(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.outbound_circuit._db_path",
+        lambda: tmp_path / "state.db",
+    )
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    return adapter
+
+
+def test_deactivate_coupang_urls_preserves_product_path_and_other_urls():
+    content = (
+        "상품 https://www.coupang.com/vp/products/123456?itemId=789 와 "
+        "https://example.com/coupang.com 안내"
+    )
+
+    assert _deactivate_coupang_urls(content) == (
+        "상품 https://www.coupang[.]com/vp/products/123456?itemId=789 와 "
+        "https://example.com/coupang.com 안내"
+    )
+
+
+def test_deactivate_coupang_urls_defangs_inline_and_fenced_code_too():
+    content = (
+        "실제 https://link.coupang.com/a/ABC\n"
+        "`curl https://www.coupang.com/vp/products/111`\n"
+        "```python\nurl = 'https://coupang.com/vp/products/222'\n```"
+    )
+
+    assert _deactivate_coupang_urls(content) == (
+        "실제 https://link.coupang[.]com/a/ABC\n"
+        "`curl https://www.coupang[.]com/vp/products/111`\n"
+        "```python\nurl = 'https://coupang[.]com/vp/products/222'\n```"
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("coupang.com/item", "coupang[.]com/item"),
+        ("www.coupang.com:443/item", "www.coupang[.]com:443/item"),
+        ("shop.coupang.com./item", "shop.coupang[.]com./item"),
+        ("COUPANG.COM:8443/item", "coupang[.]com:8443/item"),
+        ("[상품](coupang.com/item)", "[상품](coupang[.]com/item)"),
+        ("[상품](HTTPS://WWW.COUPANG.COM.:443/item)", "[상품](HTTPS://WWW.coupang[.]com.:443/item)"),
+        ("example-coupang.com/item", "example-coupang.com/item"),
+        ("https://example.com/coupang.com/item", "https://example.com/coupang.com/item"),
+    ],
+)
+def test_deactivate_coupang_urls_handles_host_variants_without_false_positives(
+    source, expected
+):
+    assert _deactivate_coupang_urls(source) == expected
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("[상품](//coupang.com/item)", "[상품](//coupang[.]com/item)"),
+        ("//www.coupang.com/item", "//www.coupang[.]com/item"),
+        ("https://EXAMPLE.com/?next=//coupang.com/item", "https://EXAMPLE.com/?next=//coupang.com/item"),
+        ("https://example.com/#https://coupang.com/item", "https://example.com/#https://coupang.com/item"),
+        ("notcoupang.com/item", "notcoupang.com/item"),
+        ("coupang.com.evil.test/item", "coupang.com.evil.test/item"),
+    ],
+)
+def test_deactivate_coupang_urls_handles_protocol_relative_without_query_damage(
+    source, expected
+):
+    assert _deactivate_coupang_urls(source) == expected
+
+
+@pytest.mark.asyncio
+async def test_send_defangs_coupang_url_immediately_before_transport(monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(adapter, "format_message", lambda value: value)
+    adapter._bot.send_message.return_value.message_id = 10
+
+    result = await adapter.send(
+        "123", "상품 https://www.coupang.com/vp/products/123456", metadata={"notify": True}
+    )
+
+    assert result.success
+    assert adapter._bot.send_message.await_args.kwargs["text"] == (
+        "상품 https://www.coupang[.]com/vp/products/123456"
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_defangs_coupang_url_immediately_before_transport():
+    adapter = _make_adapter()
+
+    result = await adapter.edit_message(
+        "123", "10", "상품 https://link.coupang.com/a/ABC", finalize=False
+    )
+
+    assert result.success
+    assert adapter._bot.edit_message_text.await_args.kwargs["text"] == (
+        "상품 https://link.coupang[.]com/a/ABC"
+    )
+
+
+class PeerFloodError(Exception):
+    def __init__(self, retry_after=None):
+        super().__init__("Telegram server error: PEER_FLOOD")
+        self.retry_after = retry_after
+
+
+@pytest.mark.asyncio
+async def test_peer_flood_opens_per_chat_circuit_for_send_edit_and_typing(monkeypatch):
+    adapter = _make_adapter()
+    now = {"value": 100.0}
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.asyncio.get_running_loop",
+        lambda: type("Loop", (), {"time": lambda self: now["value"]})(),
+    )
+    adapter._bot.send_message.side_effect = PeerFloodError()
+
+    first = await adapter.send("123", "첫 발송", metadata={"notify": True})
+    second = await adapter.send("123", "반복 발송", metadata={"notify": True})
+    edit = await adapter.edit_message("123", "10", "수정", finalize=False)
+    await adapter.send_typing("123")
+
+    assert not first.success and first.error_kind == "peer_flood"
+    assert not first.retryable
+    assert not second.success and second.error_kind == "peer_flood"
+    assert not edit.success and edit.error_kind == "peer_flood"
+    assert adapter._bot.send_message.await_count == 1
+    adapter._bot.edit_message_text.assert_not_awaited()
+    adapter._bot.send_chat_action.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_peer_flood_circuit_honors_explicit_retry_after(monkeypatch):
+    adapter = _make_adapter()
+    now = {"value": 100.0}
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.asyncio.get_running_loop",
+        lambda: type("Loop", (), {"time": lambda self: now["value"]})(),
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.outbound_circuit.time.time",
+        lambda: now["value"],
+    )
+    adapter._bot.send_message.side_effect = [
+        PeerFloodError(retry_after=42.0),
+        type("Message", (), {"message_id": 11})(),
+    ]
+
+    failed = await adapter.send("123", "첫 발송", metadata={"notify": True})
+    now["value"] = 141.9
+    blocked = await adapter.send("123", "아직 차단", metadata={"notify": True})
+    now["value"] = 142.1
+    recovered = await adapter.send("123", "차단 해제", metadata={"notify": True})
+
+    assert failed.retry_after == pytest.approx(42.0)
+    assert not blocked.success
+    assert recovered.success
+    assert adapter._bot.send_message.await_count == 2
+
+
+@pytest.mark.parametrize(
+    ("retry_after", "expected"),
+    [
+        (float("nan"), 300.0),
+        (float("inf"), 300.0),
+        (float("-inf"), 300.0),
+        (0.0, 300.0),
+        (-1.0, 300.0),
+        (900.0, 300.0),
+        (42.0, 42.0),
+    ],
+)
+@pytest.mark.asyncio
+async def test_peer_flood_retry_after_uses_only_finite_positive_capped_values(
+    retry_after, expected
+):
+    adapter = _make_adapter()
+
+    result = adapter._open_peer_flood_circuit("123", PeerFloodError(retry_after))
+
+    assert result.retry_after == pytest.approx(expected)
+    remaining = adapter._peer_flood_remaining("123")
+    assert remaining is not None
+    assert expected - 1.0 <= remaining <= expected
+
+
+@pytest.mark.asyncio
+async def test_rich_send_peer_flood_opens_same_chat_circuit(monkeypatch):
+    adapter = _make_adapter()
+    now = {"value": 100.0}
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.asyncio.get_running_loop",
+        lambda: type("Loop", (), {"time": lambda self: now["value"]})(),
+    )
+    adapter._bot.do_api_request.side_effect = PeerFloodError(retry_after=60.0)
+
+    result = await adapter._try_send_rich("123", "표 | 내용", None, None)
+    blocked = await adapter.send("123", "반복", metadata={"notify": True})
+
+    assert result is not None and result.error_kind == "peer_flood"
+    assert not blocked.success and blocked.error_kind == "peer_flood"
+    adapter._bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_final_edit_peer_flood_does_not_plain_text_retry():
+    adapter = _make_adapter()
+    adapter._bot.edit_message_text.side_effect = PeerFloodError(retry_after=30.0)
+
+    result = await adapter.edit_message("123", "10", "최종 응답", finalize=True)
+
+    assert not result.success and result.error_kind == "peer_flood"
+    assert adapter._bot.edit_message_text.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_overflow_edit_peer_flood_opens_same_chat_circuit(monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(adapter, "MAX_MESSAGE_LENGTH", 20)
+    adapter._bot.edit_message_text.side_effect = PeerFloodError(retry_after=30.0)
+
+    result = await adapter.edit_message(
+        "123", "10", "긴 최종 응답 " * 20, finalize=True
+    )
+    blocked = await adapter.send("123", "반복", metadata={"notify": True})
+
+    assert not result.success and result.error_kind == "peer_flood"
+    assert not blocked.success and blocked.error_kind == "peer_flood"
+    adapter._bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_open_peer_flood_circuit_blocks_all_outbound_send_entrypoints(monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.asyncio.get_running_loop",
+        lambda: type("Loop", (), {"time": lambda self: 100.0})(),
+    )
+    adapter._telegram_peer_flood_until["123"] = 200.0
+
+    results = [
+        await adapter.send_voice("123", "missing.ogg"),
+        await adapter.send_image_file("123", "missing.png"),
+        await adapter.send_document("123", "missing.txt"),
+        await adapter.send_video("123", "missing.mp4"),
+        await adapter.send_image("123", "not-a-url"),
+        await adapter.send_animation("123", "not-a-url"),
+        await adapter.send_update_prompt("123", "update?"),
+        await adapter.send_exec_approval("123", "cmd", "session"),
+        await adapter.send_slash_confirm("123", "title", "body", "session", "confirm"),
+        await adapter.send_clarify("123", "question", ["yes"], "clarify", "session"),
+        await adapter.send_model_picker("123", [], "model", "provider", "session", None),
+        await adapter.send_choice_picker("123", "title", [{"value": "x"}], "session", None),
+    ]
+    await adapter.send_multiple_images("123", [("https://example.com/a.png", "a")])
+
+    assert all(result.error_kind == "peer_flood" for result in results)
+    assert all(
+        getattr(adapter._bot, method).await_count == 0
+        for method in (
+            "send_message",
+            "send_voice",
+            "send_audio",
+            "send_media_group",
+            "send_photo",
+            "send_document",
+            "send_video",
+            "send_animation",
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_peer_flood_from_control_prompt_opens_circuit_without_fallback():
+    adapter = _make_adapter()
+    adapter._bot.send_message.side_effect = PeerFloodError(retry_after=60.0)
+
+    result = await adapter.send_exec_approval("123", "cmd", "session")
+    blocked = await adapter.send_choice_picker(
+        "123", "title", [{"value": "x"}], "session", None
+    )
+
+    assert result.error_kind == "peer_flood"
+    assert blocked.error_kind == "peer_flood"
+    assert adapter._bot.send_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_dm_topic_typing_fallback_peer_flood_opens_circuit():
+    adapter = _make_adapter()
+    adapter._bot.send_chat_action.side_effect = [
+        RuntimeError("message thread not found"),
+        PeerFloodError(retry_after=60.0),
+    ]
+
+    await adapter.send_typing(
+        "123",
+        metadata={"thread_id": "99", "telegram_dm_topic_reply_fallback": True},
+    )
+    await adapter.send_typing("123")
+
+    circuit = adapter._peer_flood_circuit_result("123")
+    assert circuit is not None and circuit.error_kind == "peer_flood"
+    assert adapter._bot.send_chat_action.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_peer_flood_from_each_media_send_opens_circuit_without_fallback(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter._probe_voice_duration_seconds",
+        lambda _path: 1,
+    )
+    files = {}
+    for suffix in ("ogg", "png", "txt", "mp4"):
+        path = tmp_path / f"media.{suffix}"
+        path.write_bytes(b"test")
+        files[suffix] = str(path)
+
+    cases = (
+        ("send_voice", (files["ogg"],), "send_voice"),
+        ("send_multiple_images", ([("https://example.com/a.png", "a")],), "send_media_group"),
+        ("send_image_file", (files["png"],), "send_photo"),
+        ("send_document", (files["txt"],), "send_document"),
+        ("send_video", (files["mp4"],), "send_video"),
+        ("send_image", ("https://example.com/a.png",), "send_photo"),
+        ("send_animation", ("https://example.com/a.gif",), "send_animation"),
+    )
+
+    for index, (entrypoint, args, bot_method) in enumerate(cases):
+        adapter = _make_adapter()
+        getattr(adapter._bot, bot_method).side_effect = PeerFloodError(retry_after=60.0)
+        chat_id = str(123 + index)
+
+        await asyncio.wait_for(getattr(adapter, entrypoint)(chat_id, *args), timeout=1.0)
+
+        circuit = adapter._peer_flood_circuit_result(chat_id)
+        assert circuit is not None and circuit.error_kind == "peer_flood", entrypoint
+        assert getattr(adapter._bot, bot_method).await_count == 1, entrypoint
+
+
+@pytest.mark.asyncio
+async def test_rich_draft_peer_flood_does_not_fall_back_to_legacy(monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(adapter, "_should_attempt_rich_draft", lambda _content: True)
+    adapter._bot.do_api_request.side_effect = PeerFloodError(retry_after=60.0)
+
+    result = await adapter.send_draft("123", 7, "표 | 내용")
+
+    assert not result.success and result.error_kind == "peer_flood"
+    adapter._bot.send_message_draft.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_draft_checks_open_circuit_and_defangs_legacy_text(monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(adapter, "_should_attempt_rich_draft", lambda _content: False)
+    adapter._bot.send_message_draft.return_value = True
+
+    delivered = await adapter.send_draft("123", 8, "//www.coupang.com/item")
+    adapter._telegram_peer_flood_until["123"] = asyncio.get_running_loop().time() + 60
+    blocked = await adapter.send_draft("123", 9, "blocked")
+
+    assert delivered.success
+    assert adapter._bot.send_message_draft.await_args_list[0].kwargs["text"] == (
+        r"//www\.coupang\[\.\]com/item"
+    )
+    assert not blocked.success and blocked.error_kind == "peer_flood"
+    assert adapter._bot.send_message_draft.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_open_peer_flood_keeps_later_local_expiry():
+    adapter = _make_adapter()
+    now = asyncio.get_running_loop().time()
+    adapter._telegram_peer_flood_until["123"] = now + 120.0
+
+    adapter._open_peer_flood_circuit("123", PeerFloodError(retry_after=10.0))
+
+    remaining = adapter._peer_flood_remaining("123")
+    assert remaining is not None
+    assert 119.0 <= remaining <= 120.0
+
+
+@pytest.mark.asyncio
+async def test_adapter_reads_circuit_opened_by_other_process(monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.persistent_peer_flood_remaining_async",
+        AsyncMock(return_value=55.0),
+    )
+
+    result = await adapter.send("123", "blocked", metadata={"notify": True})
+
+    assert not result.success and result.error_kind == "peer_flood"
+    assert 54.0 <= result.retry_after <= 55.0
+    adapter._bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dm_topic_seed_and_reaction_peer_flood_open_circuit(monkeypatch):
+    adapter = _make_adapter()
+    adapter._dm_topics_config = [{"chat_id": 123, "topics": [{"name": "General"}]}]
+    adapter._dm_topics = {}
+    monkeypatch.setattr(adapter, "_persist_dm_topic_thread_id", lambda *args, **kwargs: None)
+    adapter._bot.create_forum_topic.return_value.message_thread_id = 9
+    adapter._bot.send_message.side_effect = PeerFloodError(retry_after=60.0)
+
+    await adapter._setup_dm_topics()
+    reacted = await adapter._set_reaction("123", "10", "👍")
+
+    assert not reacted
+    assert adapter._peer_flood_circuit_result("123") is not None
+    adapter._bot.set_message_reaction.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_callback_edit_peer_flood_blocks_callback_fallback_and_answer(monkeypatch):
+    adapter = _make_adapter()
+    adapter._choice_picker_state["123"] = {
+        "choices": [{"value": "x"}],
+        "on_choice_selected": AsyncMock(return_value="done"),
+    }
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *args, **kwargs: True)
+    query = AsyncMock()
+    query.data = "cp:0"
+    query.message.chat_id = 123
+    query.message.chat.type = "private"
+    query.message.message_thread_id = None
+    query.from_user.id = 123
+    query.from_user.first_name = "User"
+    query.edit_message_text.side_effect = PeerFloodError(retry_after=60.0)
+    update = type("Update", (), {"callback_query": query})()
+
+    await adapter._handle_callback_query(update, None)
+
+    assert query.edit_message_text.await_count == 1
+    query.answer.assert_not_awaited()
+    assert adapter._peer_flood_circuit_result("123") is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_message_checks_and_opens_peer_flood_circuit():
+    adapter = _make_adapter()
+    adapter._bot.delete_message.side_effect = PeerFloodError(retry_after=60.0)
+
+    assert not await adapter.delete_message("123", "10")
+    assert not await adapter.delete_message("123", "11")
+
+    assert adapter._bot.delete_message.await_count == 1
+    assert adapter._peer_flood_circuit_result("123") is not None
+
+
+@pytest.mark.asyncio
+async def test_ensure_forum_commands_checks_and_opens_peer_flood_circuit():
+    adapter = _make_adapter()
+    adapter._forum_lock = asyncio.Lock()
+    adapter._forum_command_registered = set()
+    adapter._bot.set_my_commands.side_effect = PeerFloodError(retry_after=60.0)
+    message = SimpleNamespace(chat=SimpleNamespace(is_forum=True, id=123))
+
+    await adapter._ensure_forum_commands(message)
+    await adapter._ensure_forum_commands(message)
+
+    assert adapter._bot.set_my_commands.await_count == 1
+    assert adapter._peer_flood_circuit_result("123") is not None
+
+
+@pytest.mark.parametrize(
+    ("entrypoint", "suffix", "bot_method"),
+    [
+        ("send_voice", "mp3", "send_audio"),
+        ("send_image_file", "png", "send_photo"),
+        ("send_document", "txt", "send_document"),
+        ("send_video", "mp4", "send_video"),
+        ("send_image", None, "send_photo"),
+        ("send_animation", None, "send_animation"),
+        ("send_multiple_images", None, "send_media_group"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_every_media_caption_uses_shared_policy(
+    entrypoint, suffix, bot_method, tmp_path, monkeypatch
+):
+    adapter = _make_adapter()
+    getattr(adapter._bot, bot_method).return_value = SimpleNamespace(message_id=10)
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter._probe_voice_duration_seconds",
+        lambda _path: 1,
+    )
+    monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _url: True)
+
+    class _InputMediaPhoto(dict):
+        def __init__(self, media, caption=None):
+            super().__init__(media=media, caption=caption)
+
+    monkeypatch.setattr("telegram.InputMediaPhoto", _InputMediaPhoto)
+    caption = "https://www.coupang.com/item/1 " + ("😀" * 700)
+
+    if entrypoint == "send_multiple_images":
+        await adapter.send_multiple_images(
+            "123", [("https://example.com/image.png", caption)]
+        )
+        media = adapter._bot.send_media_group.await_args.kwargs["media"]
+        sent_caption = media[0]["caption"]
+    elif entrypoint in {"send_image", "send_animation"}:
+        await getattr(adapter, entrypoint)(
+            "123", "https://example.com/image.png", caption=caption
+        )
+        sent_caption = getattr(adapter._bot, bot_method).await_args.kwargs["caption"]
+    else:
+        media_path = tmp_path / f"media.{suffix}"
+        media_path.write_bytes(b"test")
+        await getattr(adapter, entrypoint)("123", str(media_path), caption=caption)
+        sent_caption = getattr(adapter._bot, bot_method).await_args.kwargs["caption"]
+
+    assert "coupang.com" not in sent_caption.lower(), entrypoint
+    assert "coupang[.]com" in sent_caption.lower(), entrypoint
+    assert len(sent_caption.encode("utf-16-le")) // 2 <= 1024, entrypoint
+
+
+@pytest.mark.asyncio
+async def test_async_peer_flood_open_uses_async_persistence_wrapper(monkeypatch):
+    adapter = _make_adapter()
+    adapter._bot.send_message.side_effect = PeerFloodError(retry_after=60.0)
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.persist_peer_flood_circuit",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("sync DB call")),
+    )
+    async_open = AsyncMock(return_value=60.0)
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.outbound_circuit.open_circuit_async",
+        async_open,
+    )
+
+    result = await adapter.send("123", "hello", metadata={"notify": True})
+
+    assert result.error_kind == "peer_flood"
+    async_open.assert_awaited_once_with("123", 60.0)
+
+
+@pytest.mark.asyncio
+async def test_send_typing_uses_async_circuit_read(monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.persistent_peer_flood_remaining",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("sync DB call")),
+    )
+    async_remaining = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.persistent_peer_flood_remaining_async",
+        async_remaining,
+    )
+
+    await adapter.send_typing("123")
+
+    async_remaining.assert_awaited_once_with("123")
+    adapter._bot.send_chat_action.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_global_command_batch_stops_after_first_peer_flood():
+    from plugins.platforms.telegram import outbound_circuit
+
+    adapter = _make_adapter()
+    adapter._bot.set_my_commands.side_effect = PeerFloodError(retry_after=60.0)
+    adapter._set_status_indicator = AsyncMock()
+    adapter._setup_dm_topics = AsyncMock()
+
+    await adapter._run_post_connect_housekeeping()
+    await adapter._run_post_connect_housekeeping()
+
+    assert adapter._bot.set_my_commands.await_count == 1
+    assert outbound_circuit.remaining(outbound_circuit.GLOBAL_CIRCUIT_KEY) is not None
+
+
+@pytest.mark.asyncio
+async def test_status_indicator_checks_and_opens_global_circuit():
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="test-token", extra={"status_indicator": True})
+    )
+    adapter._bot = AsyncMock()
+    adapter._bot.set_my_short_description.side_effect = PeerFloodError(60.0)
+
+    await adapter._set_status_indicator(online=True)
+    await adapter._set_status_indicator(online=False)
+
+    assert adapter._bot.set_my_short_description.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_inline_answer_uses_normalized_user_circuit_key():
+    adapter = _make_adapter()
+    adapter._is_callback_user_authorized = lambda *_args, **_kwargs: False
+    first = SimpleNamespace(
+        query="",
+        offset="",
+        from_user=SimpleNamespace(id=42, username="tester"),
+        answer=AsyncMock(side_effect=PeerFloodError(60.0)),
+    )
+    second = SimpleNamespace(
+        query="",
+        offset="",
+        from_user=SimpleNamespace(id="042", username="tester"),
+        answer=AsyncMock(),
+    )
+
+    await adapter._handle_inline_query(SimpleNamespace(inline_query=first), None)
+    await adapter._handle_inline_query(SimpleNamespace(inline_query=second), None)
+
+    first.answer.assert_awaited_once()
+    second.answer.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_command_scope_error_log_redacts_bot_token(caplog):
+    adapter = _make_adapter()
+    secret = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"
+    adapter._bot.set_my_commands.side_effect = RuntimeError(f"request token {secret}")
+    adapter._set_status_indicator = AsyncMock()
+    adapter._setup_dm_topics = AsyncMock()
+
+    with caplog.at_level("WARNING"):
+        await adapter._run_post_connect_housekeeping()
+
+    assert secret not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_adapter_write_failure_blocks_next_adapter_call(monkeypatch):
+    from plugins.platforms.telegram import outbound_circuit
+
+    first = _make_adapter()
+    first._bot.send_message.side_effect = PeerFloodError(60.0)
+    real_connection = outbound_circuit._connection
+
+    def broken_connection():
+        raise OSError("disk unavailable")
+
+    async def fail_persist(chat_id, delay):
+        outbound_circuit._connection = broken_connection
+        try:
+            return await outbound_circuit.open_circuit_async(chat_id, delay)
+        finally:
+            outbound_circuit._connection = real_connection
+
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.persist_peer_flood_circuit_async",
+        fail_persist,
+    )
+    failed = await first.send("123", "first", metadata={"notify": True})
+    second = _make_adapter()
+
+    blocked = await second.send("123", "second", metadata={"notify": True})
+
+    assert failed.error_kind == "peer_flood"
+    assert blocked.error_kind == "peer_flood"
+    second._bot.send_message.assert_not_awaited()

--- a/tests/gateway/test_telegram_outbound_circuit.py
+++ b/tests/gateway/test_telegram_outbound_circuit.py
@@ -1,0 +1,705 @@
+"""Telegram 프로세스 간 PEER_FLOOD 발송 회로 시험."""
+
+import asyncio
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from plugins.platforms.telegram import outbound_circuit
+
+
+def test_open_circuit_persists_only_chat_key_and_expiry(tmp_path, monkeypatch):
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: tmp_path / "state.db")
+    monkeypatch.setattr(outbound_circuit.time, "time", lambda: 100.0)
+
+    remaining = outbound_circuit.open_circuit("123", 42.0)
+
+    assert remaining == 42.0
+    assert outbound_circuit.remaining("123") == 42.0
+    with sqlite3.connect(tmp_path / "state.db") as conn:
+        columns = [row[1] for row in conn.execute("PRAGMA table_info(telegram_peer_flood_circuits)")]
+        row = conn.execute("SELECT * FROM telegram_peer_flood_circuits").fetchone()
+    assert columns == ["chat_key", "expires_at"]
+    assert row == ("123", 142.0)
+
+
+def test_open_circuit_preserves_later_existing_expiry(tmp_path, monkeypatch):
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: tmp_path / "state.db")
+    now = {"value": 100.0}
+    monkeypatch.setattr(outbound_circuit.time, "time", lambda: now["value"])
+
+    outbound_circuit.open_circuit("123", 60.0)
+    now["value"] = 110.0
+    outbound_circuit.open_circuit("123", 10.0)
+
+    assert outbound_circuit.remaining("123") == 50.0
+
+
+def test_expired_circuit_is_removed(tmp_path, monkeypatch):
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: tmp_path / "state.db")
+    now = {"value": 100.0}
+    monkeypatch.setattr(outbound_circuit.time, "time", lambda: now["value"])
+    outbound_circuit.open_circuit("123", 10.0)
+
+    now["value"] = 110.1
+
+    assert outbound_circuit.remaining("123") is None
+    with sqlite3.connect(tmp_path / "state.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM telegram_peer_flood_circuits").fetchone()[0] == 0
+
+
+def test_invalid_delay_uses_bounded_default(tmp_path, monkeypatch):
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: tmp_path / "state.db")
+    monkeypatch.setattr(outbound_circuit.time, "time", lambda: 100.0)
+
+    assert outbound_circuit.open_circuit("123", float("nan")) == 300.0
+    assert outbound_circuit.open_circuit("456", 900.0) == 300.0
+
+
+@pytest.mark.parametrize("chat_id", [123, "123", " 123 "])
+def test_chat_key_normalization_is_shared(chat_id):
+    assert outbound_circuit.chat_key(chat_id) == "123"
+
+
+def test_locked_database_returns_finite_safe_block_with_short_latency(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: db_path)
+    outbound_circuit.open_circuit("seed", 1.0)
+    lock = sqlite3.connect(db_path, timeout=0)
+    lock.execute("PRAGMA journal_mode=DELETE")
+    lock.execute("BEGIN EXCLUSIVE")
+    try:
+        started = time.monotonic()
+        result = outbound_circuit.remaining("123")
+        elapsed = time.monotonic() - started
+    finally:
+        lock.rollback()
+        lock.close()
+
+    assert result is not None
+    assert 0 < result <= outbound_circuit.DB_ERROR_COOLDOWN_SECONDS
+    assert elapsed < 0.75
+
+
+def test_repeated_db_read_error_has_finite_block_then_one_release(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    clock = {"value": 100.0}
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: db_path)
+    monkeypatch.setattr(outbound_circuit.time, "monotonic", lambda: clock["value"])
+
+    def broken_connection():
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(outbound_circuit, "_connection", broken_connection)
+
+    assert outbound_circuit.remaining("123") == outbound_circuit.DB_ERROR_COOLDOWN_SECONDS
+    clock["value"] += 2.0
+    assert outbound_circuit.remaining("123") == pytest.approx(3.0)
+    clock["value"] += 3.1
+    assert outbound_circuit.remaining("123") is None
+
+
+def test_open_write_error_fails_closed_for_target_chat(tmp_path, monkeypatch):
+    clock = {"value": 100.0}
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: tmp_path / "state.db")
+    monkeypatch.setattr(outbound_circuit.time, "monotonic", lambda: clock["value"])
+
+    real_connection = outbound_circuit._connection
+
+    def broken_connection():
+        raise sqlite3.OperationalError("disk full")
+
+    monkeypatch.setattr(outbound_circuit, "_connection", broken_connection)
+
+    assert outbound_circuit.open_circuit("00123", 60.0) == 60.0
+    monkeypatch.setattr(outbound_circuit, "_connection", real_connection)
+    blocked = outbound_circuit.remaining("123")
+    assert blocked == pytest.approx(outbound_circuit.DB_ERROR_COOLDOWN_SECONDS)
+    clock["value"] += outbound_circuit.DB_ERROR_COOLDOWN_SECONDS + 0.1
+    assert outbound_circuit.remaining("123") is None
+
+
+@pytest.mark.parametrize(
+    ("sync_name", "async_name", "args"),
+    [
+        ("remaining", "remaining_async", ("123",)),
+        ("open_circuit", "open_circuit_async", ("123", 60.0)),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_wrappers_keep_event_loop_ticking_with_mocked_db_lock(
+    monkeypatch, sync_name, async_name, args
+):
+    release = threading.Event()
+    entered = threading.Event()
+
+    def slow_operation(*_args):
+        entered.set()
+        release.wait(timeout=1.0)
+        return None
+
+    monkeypatch.setattr(outbound_circuit, sync_name, slow_operation)
+    ticks = 0
+
+    async def ticker():
+        nonlocal ticks
+        while not entered.is_set():
+            await asyncio.sleep(0.001)
+        for _ in range(5):
+            await asyncio.sleep(0.01)
+            ticks += 1
+        release.set()
+
+    result, _ = await asyncio.wait_for(
+        asyncio.gather(getattr(outbound_circuit, async_name)(*args), ticker()),
+        timeout=1.5,
+    )
+
+    assert result is None
+    assert ticks == 5
+
+
+@pytest.mark.asyncio
+async def test_adapter_db_lock_check_does_not_stop_event_loop(tmp_path, monkeypatch):
+    import asyncio
+
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: db_path)
+    outbound_circuit.open_circuit("seed", 1.0)
+    lock = sqlite3.connect(db_path, timeout=0)
+    lock.execute("PRAGMA journal_mode=DELETE")
+    lock.execute("BEGIN EXCLUSIVE")
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = type("Bot", (), {})()
+    ticks = 0
+
+    async def ticker():
+        nonlocal ticks
+        for _ in range(20):
+            await asyncio.sleep(0.005)
+            ticks += 1
+
+    try:
+        started = time.monotonic()
+        result, _ = await asyncio.gather(adapter.send("123", "blocked"), ticker())
+        elapsed = time.monotonic() - started
+    finally:
+        lock.rollback()
+        lock.close()
+
+    assert not result.success and result.error_kind == "peer_flood"
+    assert ticks == 20
+    assert elapsed < 0.75
+
+
+@pytest.mark.asyncio
+async def test_single_gateway_applies_policy_to_text_caption_and_edit(monkeypatch):
+    from plugins.platforms.telegram.outbound_policy import TelegramOutboundGateway
+
+    calls = []
+
+    async def operation(**kwargs):
+        calls.append(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(outbound_circuit, "remaining_async", lambda _key: asyncio.sleep(0, result=None))
+    gateway = TelegramOutboundGateway()
+
+    assert await gateway.write(
+        "00123",
+        "send_photo",
+        operation,
+        caption="https://www.coupang.com/vp/products/1",
+    ) == "ok"
+    assert await gateway.write(
+        "123",
+        "edit_message_text",
+        operation,
+        text="see coupang.com now",
+    ) == "ok"
+    assert "coupang[.]com" in calls[0]["caption"]
+    assert "coupang[.]com" in calls[1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_defangs_nested_raw_payload_without_mutating_caller(monkeypatch):
+    from copy import deepcopy
+
+    from plugins.platforms.telegram.outbound_policy import TelegramOutboundGateway
+
+    received = []
+    payload = {
+        "rich_message": {
+            "text": "https://www.coupang.com/p?next=https://example.com/#ok",
+            "rows": ["//link.coupang.com/a/X", ("https://example.com/coupang.com", 7)],
+        }
+    }
+    original = deepcopy(payload)
+
+    async def operation(*args, **kwargs):
+        received.append((args, kwargs))
+        return "ok"
+
+    monkeypatch.setattr(outbound_circuit, "remaining_async", lambda _key: asyncio.sleep(0, result=None))
+
+    result = await TelegramOutboundGateway().write(
+        "123", "do_api_request", operation, "sendRichMessage", api_kwargs=payload
+    )
+
+    assert result == "ok"
+    sent = received[0][1]["api_kwargs"]
+    assert sent["rich_message"]["text"].startswith("https://www.coupang[.]com/")
+    assert sent["rich_message"]["rows"][0] == "//link.coupang[.]com/a/X"
+    assert sent["rich_message"]["rows"][1] == ("https://example.com/coupang.com", 7)
+    assert payload == original
+    assert sent is not payload
+
+
+@pytest.mark.asyncio
+async def test_gateway_rebuilds_supported_ptb_payloads_without_mutating_caller():
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import asyncio
+        from telegram import InlineQueryResultArticle, InputMediaPhoto, InputTextMessageContent
+        from plugins.platforms.telegram import outbound_circuit
+        from plugins.platforms.telegram.outbound_policy import TelegramOutboundGateway
+
+        async def main():
+            outbound_circuit.remaining_async = lambda key: asyncio.sleep(0, result=None)
+            media = InputMediaPhoto("file-id", caption="https://coupang.com/media?x=1#f")
+            article = InlineQueryResultArticle(
+                "id", "title", InputTextMessageContent("https://link.coupang.com/a/inline")
+            )
+            received = []
+
+            async def operation(*args, **kwargs):
+                received.append((args, kwargs))
+                return True
+
+            await TelegramOutboundGateway().write(
+                "123", "answer", operation, [article], api_kwargs={"media": [media]}
+            )
+            sent_article = received[0][0][0][0]
+            sent_media = received[0][1]["api_kwargs"]["media"][0]
+            assert sent_article.input_message_content.message_text == (
+                "https://link.coupang[.]com/a/inline"
+            )
+            assert sent_media.caption == "https://coupang[.]com/media?x=1#f"
+            assert article.input_message_content.message_text == "https://link.coupang.com/a/inline"
+            assert media.caption == "https://coupang.com/media?x=1#f"
+            assert sent_article is not article
+            assert sent_media is not media
+
+        asyncio.run(main())
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_gateway_defangs_default_value_string_before_ptb_serialization():
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import asyncio
+        from telegram import LinkPreviewOptions
+        from telegram._utils.defaultvalue import DefaultValue
+        from plugins.platforms.telegram import outbound_circuit
+        from plugins.platforms.telegram.outbound_policy import TelegramOutboundGateway
+
+        async def main():
+            outbound_circuit.remaining_async = lambda key: asyncio.sleep(0, result=None)
+            preview = LinkPreviewOptions(
+                url=DefaultValue("https://link.coupang.com/a/BYPASS")
+            )
+            received = []
+
+            async def operation(**kwargs):
+                received.append(kwargs)
+                return True
+
+            await TelegramOutboundGateway().write(
+                "123",
+                "send_message",
+                operation,
+                text="safe",
+                link_preview_options=preview,
+            )
+            sent = received[0]["link_preview_options"]
+            assert sent.to_dict()["url"] == "https://link.coupang[.]com/a/BYPASS"
+            assert preview.to_dict()["url"] == "https://link.coupang.com/a/BYPASS"
+
+        asyncio.run(main())
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script], check=False, capture_output=True, text=True
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_gateway_defangs_telegram_subclass_dict_before_ptb_serialization():
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import asyncio
+        from telegram import InlineKeyboardButton, TelegramObject
+        from plugins.platforms.telegram import outbound_circuit
+        from plugins.platforms.telegram.outbound_policy import TelegramOutboundGateway
+
+        class CustomMarkup(TelegramObject):
+            pass
+
+        async def main():
+            outbound_circuit.remaining_async = lambda key: asyncio.sleep(0, result=None)
+            markup = CustomMarkup()
+            markup.inline_keyboard = [
+                [InlineKeyboardButton("open", url="https://link.coupang.com/a/BYPASS")]
+            ]
+            received = []
+
+            async def operation(**kwargs):
+                received.append(kwargs)
+                return True
+
+            await TelegramOutboundGateway().write(
+                "123", "send_message", operation, text="safe", reply_markup=markup
+            )
+            sent = received[0]["reply_markup"]
+            assert sent.to_dict()["inline_keyboard"][0][0]["url"] == (
+                "https://link.coupang[.]com/a/BYPASS"
+            )
+            assert markup.to_dict()["inline_keyboard"][0][0]["url"] == (
+                "https://link.coupang.com/a/BYPASS"
+            )
+            assert sent.inline_keyboard is not markup.inline_keyboard
+
+        asyncio.run(main())
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script], check=False, capture_output=True, text=True
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.asyncio
+async def test_gateway_handles_recursive_payload_cycle_and_depth_fail_closed(monkeypatch):
+    from plugins.platforms.telegram.outbound_policy import (
+        TelegramOutboundGateway,
+        TelegramUnsafeContentBlocked,
+    )
+
+    received = []
+    cycle = ["https://coupang.com/cycle"]
+    cycle.append(cycle)
+
+    async def operation(*args, **kwargs):
+        received.append((args, kwargs))
+        return True
+
+    monkeypatch.setattr(outbound_circuit, "remaining_async", lambda _key: asyncio.sleep(0, result=None))
+    gateway = TelegramOutboundGateway()
+
+    await gateway.write("123", "send_media_group", operation, media=cycle)
+    sent_cycle = received[0][1]["media"]
+    assert sent_cycle[0] == "https://coupang[.]com/cycle"
+    assert sent_cycle[1] is sent_cycle
+    assert cycle[0] == "https://coupang.com/cycle"
+    assert cycle[1] is cycle
+
+    deep = "https://coupang.com/deep"
+    for _ in range(gateway._MAX_CONTENT_DEPTH + 1):
+        deep = [deep]
+    with pytest.raises(TelegramUnsafeContentBlocked):
+        await gateway.write("123", "send_media_group", operation, media=deep)
+    assert len(received) == 1
+
+
+@pytest.mark.asyncio
+async def test_callback_and_control_text_enter_same_policy_gateway(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: tmp_path / "state.db")
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._bot.send_message.return_value = SimpleNamespace(message_id=7)
+
+    control = await adapter.send_exec_approval(
+        "123",
+        "open https://www.coupang.com/item/1",
+        "session",
+    )
+    query = SimpleNamespace(
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+        from_user=SimpleNamespace(id=123),
+        message=SimpleNamespace(chat_id=123, text="callback"),
+    )
+    guarded_query = adapter._guard_callback_query(query, "123")
+    await guarded_query.edit_message_text(
+        text="https://link.coupang.com/a/ABC"
+    )
+
+    assert control.success
+    assert "coupang.com" not in adapter._bot.send_message.await_args.kwargs["text"].lower()
+    assert "coupang[.]com" in adapter._bot.send_message.await_args.kwargs["text"].lower()
+    callback_text = query.edit_message_text.await_args.kwargs["text"].lower()
+    assert "coupang.com" not in callback_text
+    assert "coupang[.]com" in callback_text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("from_user", "expected_key"),
+    [
+        (type("User", (), {"id": 321, "first_name": "User"})(), "321"),
+        (None, "telegram:callback:unknown"),
+    ],
+)
+async def test_message_less_callback_answer_enters_gateway_once(
+    tmp_path, monkeypatch, from_user, expected_key
+):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: tmp_path / "state.db")
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    query = SimpleNamespace(
+        answer=AsyncMock(),
+        data="ea:once:not-an-integer",
+        from_user=from_user,
+        inline_message_id="inline-42",
+        message=None,
+    )
+    gateway = adapter._outbound_gateway
+    original_write = gateway.write
+    gateway.write = AsyncMock(side_effect=original_write)
+
+    await adapter._handle_callback_query(SimpleNamespace(callback_query=query), None)
+
+    query.answer.assert_awaited_once_with(text="Invalid approval data.")
+    gateway.write.assert_awaited_once()
+    assert gateway.write.await_args.args[:2] == (expected_key, "answer")
+
+
+@pytest.mark.asyncio
+async def test_inline_callback_answer_and_edit_each_enter_gateway_once(
+    tmp_path, monkeypatch
+):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+    from tools import approval
+
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: tmp_path / "state.db")
+    monkeypatch.setattr(approval, "resolve_gateway_approval", lambda *_args: 1)
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._approval_state[7] = "session"
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *_args, **_kwargs: True)
+    query = SimpleNamespace(
+        answer=AsyncMock(),
+        data="ea:once:7",
+        edit_message_text=AsyncMock(),
+        from_user=SimpleNamespace(id=321, first_name="User"),
+        inline_message_id="inline-42",
+        message=None,
+    )
+    gateway = adapter._outbound_gateway
+    original_write = gateway.write
+    gateway.write = AsyncMock(side_effect=original_write)
+
+    await adapter._handle_callback_query(SimpleNamespace(callback_query=query), None)
+
+    assert query.answer.await_count == 1
+    assert query.edit_message_text.await_count == 1
+    assert [call.args[:2] for call in gateway.write.await_args_list] == [
+        ("321", "answer"),
+        ("321", "edit_message_text"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_single_gateway_opens_immediately_and_stops_same_batch(monkeypatch):
+    from plugins.platforms.telegram.outbound_policy import (
+        TelegramOutboundGateway,
+        TelegramPeerFloodBlocked,
+    )
+
+    opened = []
+    attempts = 0
+
+    async def remaining(key):
+        return 30.0 if opened and key == "123" else None
+
+    async def open_async(key, delay):
+        opened.append((key, delay))
+        return delay
+
+    async def peer_flood_operation(**_kwargs):
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("Telegram says PEER_FLOOD retry_after=60")
+
+    monkeypatch.setattr(outbound_circuit, "remaining_async", remaining)
+    monkeypatch.setattr(outbound_circuit, "open_circuit_async", open_async)
+    gateway = TelegramOutboundGateway()
+
+    with pytest.raises(TelegramPeerFloodBlocked):
+        await gateway.write("00123", "edit_message_text", peer_flood_operation, text="x")
+    with pytest.raises(TelegramPeerFloodBlocked):
+        await gateway.write("123", "send_message", peer_flood_operation, text="fallback")
+
+    assert attempts == 1
+    assert opened and opened[0][0] == "123"
+
+
+@pytest.mark.asyncio
+async def test_adapter_does_not_record_gateway_peer_flood_twice(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._bot.send_message.side_effect = RuntimeError("PEER_FLOOD")
+    opened = AsyncMock(return_value=30.0)
+    monkeypatch.setattr(outbound_circuit, "open_circuit_async", opened)
+    monkeypatch.setattr(outbound_circuit, "remaining_async", AsyncMock(return_value=None))
+
+    result = await adapter.send("123", "hello", metadata={"notify": True})
+
+    assert not result.success and result.error_kind == "peer_flood"
+    assert result.retry_after == pytest.approx(30.0)
+    opened.assert_awaited_once_with("123", 300.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scope",
+    [
+        {"type": "chat", "chat_id": "00123"},
+        {"type": "chat", "chat_id": 123},
+    ],
+)
+async def test_chat_command_scope_peer_flood_is_persistent_and_not_global(
+    tmp_path, monkeypatch, scope
+):
+    from plugins.platforms.telegram.outbound_policy import (
+        GuardedTelegramTarget,
+        TelegramOutboundGateway,
+        TelegramPeerFloodBlocked,
+    )
+
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: tmp_path / "state.db")
+    calls = []
+
+    class FirstBot:
+        async def set_my_commands(self, *_args, **_kwargs):
+            calls.append("first-chat")
+            error = RuntimeError("PEER_FLOOD")
+            error.retry_after = 42
+            raise error
+
+    with pytest.raises(TelegramPeerFloodBlocked) as opened:
+        await GuardedTelegramTarget(FirstBot(), TelegramOutboundGateway()).set_my_commands(
+            [], scope=scope
+        )
+    assert opened.value.retry_after == pytest.approx(42.0, abs=1.0)
+
+    class NextBot:
+        async def set_my_commands(self, *_args, **_kwargs):
+            calls.append("next")
+            return True
+
+    next_target = GuardedTelegramTarget(NextBot(), TelegramOutboundGateway())
+    with pytest.raises(TelegramPeerFloodBlocked):
+        await next_target.set_my_commands([], scope={"chat_id": "123"})
+    assert await next_target.set_my_commands([], scope={"type": "default"}) is True
+
+    assert calls == ["first-chat", "next"]
+    assert outbound_circuit.remaining("123") == pytest.approx(42.0, abs=1.0)
+    assert outbound_circuit.remaining(outbound_circuit.GLOBAL_CIRCUIT_KEY) is None
+
+
+def test_db_read_error_isolated_by_db_path_and_chat_key(tmp_path, monkeypatch):
+    clock = {"value": 100.0}
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: tmp_path / "state.db")
+    monkeypatch.setattr(outbound_circuit.time, "monotonic", lambda: clock["value"])
+    outbound_circuit._READ_ERROR_UNTIL.clear()
+
+    real_connection = outbound_circuit._connection
+
+    def broken_connection():
+        raise sqlite3.OperationalError("read failed for https://secret.invalid/token")
+
+    monkeypatch.setattr(outbound_circuit, "_connection", broken_connection)
+    assert outbound_circuit.remaining("123") == outbound_circuit.DB_ERROR_COOLDOWN_SECONDS
+    monkeypatch.setattr(outbound_circuit, "_connection", real_connection)
+
+    assert outbound_circuit.remaining("123") == pytest.approx(5.0)
+    assert outbound_circuit.remaining("456") is None
+
+
+def test_production_telegram_writes_use_only_the_policy_gateway():
+    import ast
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    targets = (
+        root / "plugins/platforms/telegram/adapter.py",
+        root / "tools/send_message_tool.py",
+        root / "gateway/run.py",
+    )
+    write_methods = {
+        "answer", "create_forum_topic", "delete_message", "do_api_request",
+        "edit_forum_topic", "edit_message_text", "pin_chat_message",
+        "send_audio", "send_animation", "send_chat_action", "send_document",
+        "send_media_group", "send_message",
+        "send_message_draft", "send_photo", "send_video", "send_voice",
+        "set_message_reaction", "set_my_commands", "set_my_short_description",
+    }
+    violations = []
+    forbidden_receivers = {"self._bot", "bot", "inline_query", "self._query"}
+    for path in targets:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Attribute) or node.attr not in write_methods:
+                continue
+            receiver = ast.unparse(node.value)
+            if receiver in forbidden_receivers:
+                violations.append(f"{path.relative_to(root)}:{node.lineno}:{receiver}.{node.attr}")
+
+    assert violations == []

--- a/tests/gateway/test_telegram_polling_progress.py
+++ b/tests/gateway/test_telegram_polling_progress.py
@@ -116,6 +116,36 @@ def _configure_lifecycle_connect(monkeypatch, adapter, apps):
     return builders
 
 
+@pytest.mark.asyncio
+async def test_delete_webhook_routes_through_global_outbound_gateway():
+    adapter = _make_adapter()
+    adapter._bot = MagicMock()
+    adapter._bot.delete_webhook = AsyncMock(return_value=True)
+    adapter._outbound_gateway.write = AsyncMock(return_value=True)
+
+    assert await adapter._delete_webhook_best_effort() is True
+
+    adapter._outbound_gateway.write.assert_awaited_once()
+    call = adapter._outbound_gateway.write.await_args
+    assert call.args[1] == "delete_webhook"
+
+
+@pytest.mark.asyncio
+async def test_start_webhook_routes_through_global_outbound_gateway(monkeypatch):
+    adapter = _make_adapter()
+    adapter._app = _lifecycle_app()
+    adapter._outbound_gateway.write = AsyncMock(return_value=True)
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "test-secret")
+
+    await adapter._start_webhook_mode(
+        "https://example.test/telegram", is_reconnect=False
+    )
+
+    adapter._outbound_gateway.write.assert_awaited_once()
+    call = adapter._outbound_gateway.write.await_args
+    assert call.args[1] == "start_webhook"
+
+
 async def _cancel_task(task):
     if task is None or task.done():
         return

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -62,11 +62,9 @@ class _FakeInlineKeyboardMarkup:
         self.inline_keyboard = inline_keyboard
 
 
-class _FakeInputMediaPhoto:
+class _FakeInputMediaPhoto(dict):
     def __init__(self, media, caption=None, **kwargs):
-        self.media = media
-        self.caption = caption
-        self.kwargs = kwargs
+        super().__init__(media=media, caption=caption, **kwargs)
 
 
 _fake_telegram = types.ModuleType("telegram")

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -4,7 +4,16 @@ Tests both the _handle_update_command handler (spawns update process) and
 the _send_update_notification startup hook (sends results after restart).
 """
 
+import hashlib
+import asyncio
+import concurrent.futures
 import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
 from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
 
@@ -13,6 +22,7 @@ import pytest
 from gateway.config import Platform
 from gateway.platforms.event import MessageEvent
 from gateway.session import SessionSource
+from gateway.update_contract import UpdateHelperLock, acquire_update_helper_probe
 
 
 def _make_event(text="/update", platform=Platform.TELEGRAM,
@@ -122,8 +132,9 @@ class TestHandleUpdateCommand:
 
         with patch("gateway.run._hermes_home", hermes_home), \
              patch("gateway.run.__file__", fake_file), \
+             patch("gateway.slash_commands.sys.platform", "linux"), \
              patch("shutil.which", side_effect=lambda x: "/usr/bin/hermes" if x == "hermes" else "/usr/bin/setsid"), \
-             patch("subprocess.Popen"):
+             patch("subprocess.Popen") as mock_popen:
             result = await runner._handle_update_command(event)
 
         pending_path = hermes_home / ".update_pending.json"
@@ -134,7 +145,536 @@ class TestHandleUpdateCommand:
         assert data["chat_type"] == "dm"
         assert data["message_id"] == "m-update"
         assert "timestamp" in data
+        assert len(data["handoff_token_sha256"]) == 64
         assert not (hermes_home / ".update_exit_code").exists()
+
+        popen_command = mock_popen.call_args[0][0]
+        popen_kwargs = mock_popen.call_args.kwargs
+        assert all("handoff_token" not in str(arg).lower() for arg in popen_command)
+        assert "HERMES_UPDATE_HANDOFF_TOKEN" not in str(popen_kwargs)
+        assert popen_kwargs["stdin"] is subprocess.PIPE
+        helper_stdin = mock_popen.return_value.stdin
+        written = helper_stdin.write.call_args.args[0]
+        assert isinstance(written, bytes)
+        assert written.endswith(b"\n")
+        helper_stdin.close.assert_called_once_with()
+
+
+    @pytest.mark.asyncio
+    async def test_windows_handoff_passes_token_to_helper(self, tmp_path):
+        runner = _make_runner()
+        event = _make_event()
+        fake_root = tmp_path / "project"
+        (fake_root / ".git").mkdir(parents=True)
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("gateway.slash_commands.sys.platform", "win32"), \
+             patch("shutil.which", return_value="C:/hermes.exe"), \
+             patch("subprocess.Popen") as mock_popen:
+            await runner._handle_update_command(event)
+
+        command = mock_popen.call_args[0][0]
+        popen_kwargs = mock_popen.call_args.kwargs
+        pending = json.loads((hermes_home / ".update_pending.json").read_text())
+        assert all("handoff_token" not in str(arg).lower() for arg in command)
+        assert "HERMES_UPDATE_HANDOFF_TOKEN" not in str(popen_kwargs)
+        assert popen_kwargs["stdin"] is subprocess.PIPE
+        assert len(pending["handoff_token_sha256"]) == 64
+
+    @pytest.mark.asyncio
+    @pytest.mark.live_system_guard_bypass
+    async def test_real_helper_lock_done_release_and_watcher_cleanup(self, tmp_path):
+        runner = _make_runner()
+        runner._schedule_update_notification_watch = MagicMock()
+        adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+        event = _make_event(chat_id="integration-chat")
+        fake_root = tmp_path / "project"
+        (fake_root / ".git").mkdir(parents=True)
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("gateway.slash_commands.sys.platform", "win32"), \
+             patch("shutil.which", return_value="C:/hermes.exe"), \
+             patch("subprocess.Popen") as mocked_popen:
+            await runner._handle_update_command(event)
+
+        pending = json.loads(
+            (hermes_home / ".update_pending.json").read_text(encoding="utf-8")
+        )
+        helper_source = mocked_popen.call_args.args[0][2]
+        lock_path = hermes_home / ".update_helper.lock"
+        done_path = hermes_home / ".update_helper_done.json"
+        output_path = hermes_home / ".update_output.txt"
+        exit_path = hermes_home / ".update_exit_code"
+        helper = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                helper_source,
+                str(output_path),
+                str(exit_path),
+                str(lock_path),
+                str(done_path),
+                pending["request_id"],
+                "5",
+                sys.executable,
+                "-c",
+                "import time; print('fake update child'); time.sleep(0.5)",
+            ],
+            stdin=subprocess.PIPE,
+        )
+        assert helper.stdin is not None
+        helper.stdin.write(b"integration-token\n")
+        helper.stdin.close()
+
+        deadline = time.monotonic() + 5
+        lock_was_held = False
+        while time.monotonic() < deadline:
+            probe = acquire_update_helper_probe(lock_path)
+            if probe is None:
+                lock_was_held = True
+                break
+            probe.release()
+            time.sleep(0.01)
+        assert lock_was_held
+        assert not done_path.exists()
+        assert helper.wait(timeout=5) == 0
+
+        done = json.loads(done_path.read_text(encoding="utf-8"))
+        assert done["request_id"] == pending["request_id"]
+        assert done["exit_code"] == 0
+        assert done["status"] == "completed"
+        assert not list(hermes_home.glob(".update_helper_done.json.*.tmp"))
+        probe = acquire_update_helper_probe(lock_path)
+        assert probe is not None
+        probe.release()
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            await runner._watch_update_progress(
+                poll_interval=0.001,
+                stream_interval=0.001,
+                timeout=1.0,
+            )
+
+        adapter.send.assert_called_once()
+        assert not (hermes_home / ".update_pending.json").exists()
+        assert not done_path.exists()
+        assert not output_path.exists()
+        assert not exit_path.exists()
+
+    @pytest.mark.asyncio
+    @pytest.mark.live_system_guard_bypass
+    async def test_helper_atomically_writes_pid_and_start_time_identity(self, tmp_path):
+        runner = _make_runner()
+        event = _make_event()
+        fake_root = tmp_path / "project"
+        (fake_root / ".git").mkdir(parents=True)
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("gateway.slash_commands.sys.platform", "win32"), \
+             patch("shutil.which", return_value="C:/hermes.exe"), \
+             patch("subprocess.Popen") as mock_popen:
+            await runner._handle_update_command(event)
+
+        helper_command = mock_popen.call_args.args[0]
+        helper_source = helper_command[2]
+        assert "os.replace(" in helper_source
+        assert 'def atomic_write(path, data):' in helper_source
+
+        output_path = tmp_path / "helper-output.bin"
+        exit_code_path = tmp_path / "helper-exit.txt"
+        helper_lock_path = tmp_path / "helper.lock"
+        done_path = tmp_path / "helper-done.json"
+        identity_path = tmp_path / ".update_helper_pid"
+        helper = subprocess.Popen(
+            [
+                sys.executable, "-c", helper_source,
+                str(output_path), str(exit_code_path), str(helper_lock_path),
+                str(done_path), "identity-request", "5",
+                sys.executable, "-c", "raise SystemExit(0)",
+            ],
+            stdin=subprocess.PIPE,
+        )
+        try:
+            deadline = time.monotonic() + 5
+            while not identity_path.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert identity_path.exists()
+
+            from gateway.status import get_process_start_time
+
+            identity = json.loads(identity_path.read_bytes())
+            assert set(identity) == {"pid", "start_time"}
+            assert identity["start_time"] == get_process_start_time(identity["pid"])
+            expected = json.dumps(identity, separators=(",", ":")).encode("utf-8")
+            assert identity_path.read_bytes() == expected
+            assert not list(tmp_path.glob(".update_helper_pid.*.tmp"))
+        finally:
+            assert helper.stdin is not None
+            helper.stdin.write(b"test-token\n")
+            helper.stdin.close()
+            assert helper.wait(timeout=5) == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.live_system_guard_bypass
+    @pytest.mark.parametrize(
+        ("child_args", "helper_exit", "child_exit", "status"),
+        [
+            (["definitely-not-an-executable"], 125, 125, "helper_exception"),
+            (
+                [sys.executable, "-c", "import time; time.sleep(1)"],
+                0,
+                124,
+                "timed_out",
+            ),
+        ],
+    )
+    async def test_real_helper_records_failure_before_unlock(
+        self, tmp_path, child_args, helper_exit, child_exit, status
+    ):
+        runner = _make_runner()
+        fake_root = tmp_path / "project"
+        (fake_root / ".git").mkdir(parents=True)
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", str(fake_root / "gateway" / "run.py")), \
+             patch("gateway.slash_commands.sys.platform", "win32"), \
+             patch("shutil.which", return_value="C:/hermes.exe"), \
+             patch("subprocess.Popen") as mocked_popen:
+            await runner._handle_update_command(_make_event())
+
+        helper_source = mocked_popen.call_args.args[0][2]
+        request_id = json.loads(
+            (hermes_home / ".update_pending.json").read_text(encoding="utf-8")
+        )["request_id"]
+        output_path = hermes_home / ".update_output.txt"
+        exit_path = hermes_home / ".update_exit_code"
+        lock_path = hermes_home / ".update_helper.lock"
+        done_path = hermes_home / ".update_helper_done.json"
+        helper = subprocess.Popen(
+            [
+                sys.executable, "-c", helper_source,
+                str(output_path), str(exit_path), str(lock_path), str(done_path),
+                request_id, "0.05", *child_args,
+            ],
+            stdin=subprocess.PIPE,
+        )
+        assert helper.stdin is not None
+        helper.stdin.write(b"test-token\n")
+        helper.stdin.close()
+        assert helper.wait(timeout=5) == helper_exit
+
+        assert exit_path.read_text(encoding="utf-8") == str(child_exit)
+        assert json.loads(done_path.read_text(encoding="utf-8")) == {
+            "request_id": request_id,
+            "exit_code": child_exit,
+            "status": status,
+        }
+        probe = acquire_update_helper_probe(lock_path)
+        assert probe is not None
+        probe.release()
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.live_system_guard_bypass
+    async def test_helper_reaps_live_child_after_general_communicate_exception(
+        self, tmp_path
+    ):
+        runner = _make_runner()
+        fake_root = tmp_path / "project"
+        (fake_root / ".git").mkdir(parents=True)
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", str(fake_root / "gateway" / "run.py")), \
+             patch("gateway.slash_commands.sys.platform", "win32"), \
+             patch("shutil.which", return_value="C:/hermes.exe"), \
+             patch("subprocess.Popen") as mocked_popen:
+            await runner._handle_update_command(_make_event())
+
+        helper_source = mocked_popen.call_args.args[0][2]
+        helper_source = helper_source.replace(
+            "from gateway.update_contract import UpdateHelperLock",
+            "from gateway.update_contract import UpdateHelperLock\n"
+            "import helper_injection\nhelper_injection.install(subprocess)",
+        )
+        request_id = json.loads(
+            (hermes_home / ".update_pending.json").read_text(encoding="utf-8")
+        )["request_id"]
+        injection = tmp_path / "injection"
+        injection.mkdir()
+        child_pid_path = tmp_path / "child.pid"
+        events_path = tmp_path / "events.txt"
+        (injection / "helper_injection.py").write_text(
+            """import os, subprocess
+_real_popen = subprocess.Popen
+_pid_path = os.environ["HELPER_TEST_CHILD_PID"]
+_events_path = os.environ["HELPER_TEST_EVENTS"]
+def _event(value):
+    with open(_events_path, "a", encoding="utf-8") as stream:
+        stream.write(value + "\\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+class InjectedPopen:
+    def __init__(self, *args, **kwargs):
+        self._proc = _real_popen(*args, **kwargs)
+        with open(_pid_path, "w", encoding="ascii") as stream:
+            stream.write(str(self._proc.pid))
+            stream.flush()
+            os.fsync(stream.fileno())
+        self._first = True
+    def communicate(self, *args, **kwargs):
+        if self._first and kwargs.get("timeout") is not None:
+            self._first = False
+            _event("communicate_error")
+            raise KeyboardInterrupt()
+        _event("communicate_reap")
+        return self._proc.communicate(*args, **kwargs)
+    def kill(self):
+        _event("kill")
+        return self._proc.kill()
+    def terminate(self):
+        _event("terminate")
+        return self._proc.terminate()
+    def wait(self, *args, **kwargs):
+        _event("wait")
+        return self._proc.wait(*args, **kwargs)
+    def poll(self):
+        return self._proc.poll()
+    def __getattr__(self, name):
+        return getattr(self._proc, name)
+def injected_popen(*args, **kwargs):
+    if hasattr(kwargs.get("stdout"), "write") and kwargs.get("stderr") is subprocess.STDOUT:
+        return InjectedPopen(*args, **kwargs)
+    return _real_popen(*args, **kwargs)
+def install(module):
+    module.Popen = injected_popen
+""",
+            encoding="utf-8",
+        )
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(injection) + os.pathsep + env.get("PYTHONPATH", "")
+        env["HELPER_TEST_CHILD_PID"] = str(child_pid_path)
+        env["HELPER_TEST_EVENTS"] = str(events_path)
+        lock_path = hermes_home / ".update_helper.lock"
+        done_path = hermes_home / ".update_helper_done.json"
+        helper = subprocess.Popen(
+            [
+                sys.executable, "-c", helper_source,
+                str(hermes_home / ".update_output.txt"),
+                str(hermes_home / ".update_exit_code"),
+                str(lock_path), str(done_path), request_id, "5",
+                sys.executable, "-c", "import time; time.sleep(30)",
+            ],
+            stdin=subprocess.PIPE,
+            env=env,
+        )
+        assert helper.stdin is not None
+        helper.stdin.write(b"test-token\n")
+        helper.stdin.close()
+        child_pid = None
+        try:
+            assert helper.wait(timeout=8) == 125
+            child_pid = int(child_pid_path.read_text(encoding="ascii"))
+            from gateway.status import _pid_exists
+
+            assert _pid_exists(child_pid) is False
+            assert events_path.read_text(encoding="utf-8").splitlines()[:3] == [
+                "communicate_error", "kill", "communicate_reap",
+            ]
+            assert done_path.stat().st_mtime_ns >= events_path.stat().st_mtime_ns
+            assert json.loads(done_path.read_text(encoding="utf-8")) == {
+                "request_id": request_id,
+                "exit_code": 125,
+                "status": "helper_exception",
+            }
+            probe = acquire_update_helper_probe(lock_path)
+            assert probe is not None
+            probe.release()
+        finally:
+            if child_pid is not None:
+                try:
+                    os.kill(child_pid, signal.SIGTERM)
+                except OSError:
+                    pass
+
+    @pytest.mark.asyncio
+    @pytest.mark.live_system_guard_bypass
+    async def test_helper_keeps_lock_and_withholds_done_when_reap_cannot_be_verified(
+        self, tmp_path
+    ):
+        runner = _make_runner()
+        fake_root = tmp_path / "project"
+        (fake_root / ".git").mkdir(parents=True)
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", str(fake_root / "gateway" / "run.py")), \
+             patch("gateway.slash_commands.sys.platform", "win32"), \
+             patch("shutil.which", return_value="C:/hermes.exe"), \
+             patch("subprocess.Popen") as mocked_popen:
+            await runner._handle_update_command(_make_event())
+
+        helper_source = mocked_popen.call_args.args[0][2]
+        helper_source = helper_source.replace(
+            "from gateway.update_contract import UpdateHelperLock",
+            "from gateway.update_contract import UpdateHelperLock\n"
+            "import helper_injection\nhelper_injection.install(subprocess)",
+        )
+        request_id = json.loads(
+            (hermes_home / ".update_pending.json").read_text(encoding="utf-8")
+        )["request_id"]
+        injection = tmp_path / "injection"
+        injection.mkdir()
+        child_pid_path = tmp_path / "child.pid"
+        (injection / "helper_injection.py").write_text(
+            """import os, subprocess
+_real_popen = subprocess.Popen
+_pid_path = os.environ["HELPER_TEST_CHILD_PID"]
+class InjectedPopen:
+    def __init__(self, *args, **kwargs):
+        self._proc = _real_popen(*args, **kwargs)
+        with open(_pid_path, "w", encoding="ascii") as stream:
+            stream.write(str(self._proc.pid))
+            stream.flush()
+            os.fsync(stream.fileno())
+    def communicate(self, *args, **kwargs):
+        raise OSError("injected communicate failure")
+    def kill(self):
+        raise OSError("injected kill failure")
+    def terminate(self):
+        raise OSError("injected terminate failure")
+    def wait(self, *args, **kwargs):
+        raise OSError("injected wait failure")
+    def poll(self):
+        raise OSError("injected poll failure")
+    def __getattr__(self, name):
+        return getattr(self._proc, name)
+def injected_popen(*args, **kwargs):
+    if hasattr(kwargs.get("stdout"), "write") and kwargs.get("stderr") is subprocess.STDOUT:
+        return InjectedPopen(*args, **kwargs)
+    return _real_popen(*args, **kwargs)
+def install(module):
+    module.Popen = injected_popen
+""",
+            encoding="utf-8",
+        )
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(injection) + os.pathsep + env.get("PYTHONPATH", "")
+        env["HELPER_TEST_CHILD_PID"] = str(child_pid_path)
+        lock_path = hermes_home / ".update_helper.lock"
+        done_path = hermes_home / ".update_helper_done.json"
+        helper = subprocess.Popen(
+            [
+                sys.executable, "-c", helper_source,
+                str(hermes_home / ".update_output.txt"),
+                str(hermes_home / ".update_exit_code"),
+                str(lock_path), str(done_path), request_id, "5",
+                sys.executable, "-c", "import time; time.sleep(30)",
+            ],
+            stdin=subprocess.PIPE,
+            env=env,
+        )
+        assert helper.stdin is not None
+        helper.stdin.write(b"test-token\n")
+        helper.stdin.close()
+        child_pid = None
+        try:
+            deadline = time.monotonic() + 5
+            while not child_pid_path.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            child_pid = int(child_pid_path.read_text(encoding="ascii"))
+            time.sleep(0.2)
+            assert helper.poll() is None
+            assert not done_path.exists()
+            assert not (hermes_home / ".update_exit_code").exists()
+            assert acquire_update_helper_probe(lock_path) is None
+        finally:
+            helper.kill()
+            helper.wait(timeout=5)
+            if child_pid is not None:
+                try:
+                    os.kill(child_pid, signal.SIGTERM)
+                except OSError:
+                    pass
+
+
+    @pytest.mark.asyncio
+    async def test_duplicate_update_is_rejected_without_overwriting_files(self, tmp_path):
+        runner = _make_runner()
+        event = _make_event()
+        fake_root = tmp_path / "project"
+        (fake_root / ".git").mkdir(parents=True)
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        output_path = hermes_home / ".update_output.txt"
+        exit_path = hermes_home / ".update_exit_code"
+        original_pending = json.dumps({"platform": "telegram", "chat_id": "old"})
+        pending_path.write_text(original_pending, encoding="utf-8")
+        output_path.write_text("original output", encoding="utf-8")
+        exit_path.write_text("0", encoding="utf-8")
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("shutil.which", return_value="C:/hermes.exe"), \
+             patch("subprocess.Popen") as mock_popen:
+            result = await runner._handle_update_command(event)
+
+        assert "already" in result.lower()
+        assert pending_path.read_text(encoding="utf-8") == original_pending
+        assert output_path.read_text(encoding="utf-8") == "original output"
+        assert exit_path.read_text(encoding="utf-8") == "0"
+        mock_popen.assert_not_called()
+
+    def test_concurrent_update_requests_have_one_winner(self, tmp_path):
+        """Two real concurrent handlers preserve one request and reject the other."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        barrier_reached = threading.Event()
+        start_barrier = threading.Barrier(2, action=barrier_reached.set)
+
+        def synchronize_admission():
+            start_barrier.wait(timeout=5)
+            return False
+
+        def invoke(chat_id):
+            runner = _make_runner()
+            return asyncio.run(runner._handle_update_command(_make_event(chat_id=chat_id)))
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("hermes_cli.config.is_managed", side_effect=synchronize_admission), \
+             patch("shutil.which", return_value="C:/hermes.exe"), \
+             patch("subprocess.Popen") as popen, \
+             concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(invoke, ("first", "second")))
+
+        assert barrier_reached.is_set()
+        assert sum("starting hermes update" in result.lower() for result in results) == 1
+        assert sum("already" in result.lower() for result in results) == 1
+        assert popen.call_count == 1
+        pending = json.loads(
+            (hermes_home / ".update_pending.json").read_text(encoding="utf-8")
+        )
+        winner_index = next(
+            index for index, result in enumerate(results)
+            if "starting hermes update" in result.lower()
+        )
+        assert pending["chat_id"] == ("first", "second")[winner_index]
 
 
     @pytest.mark.asyncio
@@ -163,18 +703,18 @@ class TestHandleUpdateCommand:
 
         with patch("gateway.run._hermes_home", hermes_home), \
              patch("gateway.run.__file__", fake_file), \
+             patch("gateway.slash_commands.sys.platform", "linux"), \
              patch("shutil.which", side_effect=which_no_setsid), \
              patch("subprocess.Popen", mock_popen):
             result = await runner._handle_update_command(event)
 
-        # Verify plain bash -c fallback (no nohup, no setsid)
+        # Verify the Python helper detaches without the optional setsid binary.
         call_args = mock_popen.call_args[0][0]
-        assert call_args[0] == "bash"
-        assert "nohup" not in call_args[2]
-        assert ".update_exit_code" in call_args[2]
-        # start_new_session=True should be in kwargs
+        assert call_args[0] == sys.executable
+        assert ".update_exit_code" in call_args[4]
         call_kwargs = mock_popen.call_args[1]
         assert call_kwargs.get("start_new_session") is True
+        assert call_kwargs.get("stdin") is subprocess.PIPE
         assert "Starting Hermes update" in result
 
 
@@ -265,6 +805,502 @@ class TestUpdateCommandPlatformGate:
 class TestSendUpdateNotification:
     """Tests for GatewayRunner._send_update_notification."""
 
+    @pytest.mark.asyncio
+    async def test_upgrade_handoff_delivers_legacy_exit_once_and_cleans_legacy_markers(
+        self, tmp_path
+    ):
+        """A new watcher completes an update started by the pre-request-id helper."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        legacy_pending = {
+            "platform": "telegram",
+            "chat_id": "legacy-chat",
+            "session_key": "telegram:legacy-chat",
+            "timestamp": "2026-09-07T12:00:00",
+        }
+        (hermes_home / ".update_pending.json").write_text(
+            json.dumps(legacy_pending), encoding="utf-8"
+        )
+        (hermes_home / ".update_output.txt").write_text(
+            "legacy helper completed", encoding="utf-8"
+        )
+        (hermes_home / ".update_exit_code").write_text("0", encoding="utf-8")
+        (hermes_home / ".update_helper_pid").write_text("999999", encoding="utf-8")
+        (hermes_home / ".update_prompt.json").write_text("{}", encoding="utf-8")
+        (hermes_home / ".update_response").write_text("yes", encoding="utf-8")
+        adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            await runner._watch_update_progress(
+                poll_interval=0.001, stream_interval=0.001, timeout=0.1
+            )
+
+        adapter.send.assert_called_once()
+        assert adapter.send.call_args.args[0] == "legacy-chat"
+        assert "finished" in adapter.send.call_args.args[1].lower()
+        for name in (
+            ".update_pending.json",
+            ".update_pending.claimed.json",
+            ".update_output.txt",
+            ".update_exit_code",
+            ".update_helper_pid",
+            ".update_prompt.json",
+            ".update_response",
+        ):
+            assert not (hermes_home / name).exists()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_watchers_deliver_legacy_exit_exactly_once(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / ".update_pending.json").write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "legacy-chat",
+            "session_key": "telegram:legacy-chat",
+            "timestamp": "2026-09-07T12:00:00",
+        }), encoding="utf-8")
+        (hermes_home / ".update_exit_code").write_text("1", encoding="utf-8")
+        adapter = AsyncMock()
+
+        async def slow_send(*args, **kwargs):
+            await asyncio.sleep(0.05)
+
+        adapter.send.side_effect = slow_send
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            results = await asyncio.gather(
+                runner._send_update_notification(),
+                runner._send_update_notification(),
+            )
+
+        assert adapter.send.call_count == 1
+        assert results.count(True) == 1
+
+    @pytest.mark.asyncio
+    async def test_legacy_orphan_waits_for_mtime_deadline_then_reports_exit_125_once(
+        self, tmp_path
+    ):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        exit_path = hermes_home / ".update_exit_code"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "legacy-chat",
+            "session_key": "telegram:legacy-chat",
+        }), encoding="utf-8")
+        os.utime(pending_path, (1000.0, 1000.0))
+        observed_exit_codes = []
+        adapter = AsyncMock()
+
+        async def observe_exit(*args, **kwargs):
+            observed_exit_codes.append(exit_path.read_text(encoding="utf-8"))
+
+        adapter.send.side_effect = observe_exit
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.time.time", return_value=4629.0):
+            assert await runner._send_update_notification() is False
+        assert pending_path.exists()
+        assert not exit_path.exists()
+        adapter.send.assert_not_called()
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.time.time", return_value=4631.0):
+            assert await runner._send_update_notification() is True
+
+        adapter.send.assert_called_once()
+        assert observed_exit_codes == ["125"]
+        assert not pending_path.exists()
+        assert not exit_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_legacy_cleanup_never_deletes_concurrently_published_request_state(
+        self, tmp_path
+    ):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        done_path = hermes_home / ".update_helper_done.json"
+        exit_path = hermes_home / ".update_exit_code"
+        output_path = hermes_home / ".update_output.txt"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram", "chat_id": "legacy-chat",
+        }), encoding="utf-8")
+        exit_path.write_text("0", encoding="utf-8")
+        output_path.write_text("legacy output", encoding="utf-8")
+        adapter = AsyncMock()
+        new_pending = {
+            "request_id": "new-request",
+            "platform": "telegram",
+            "chat_id": "new-chat",
+            "deadline_epoch": time.time() + 60,
+            "orphan_grace_seconds": 30,
+        }
+        new_done = {"request_id": "new-request", "exit_code": 0}
+
+        async def publish_new_request(*args, **kwargs):
+            pending_path.write_text(json.dumps(new_pending), encoding="utf-8")
+            done_path.write_text(json.dumps(new_done), encoding="utf-8")
+            exit_path.write_text("0", encoding="utf-8")
+            output_path.write_text("new output", encoding="utf-8")
+
+        adapter.send.side_effect = publish_new_request
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            assert await runner._send_update_notification() is True
+
+        assert json.loads(pending_path.read_text(encoding="utf-8")) == new_pending
+        assert json.loads(done_path.read_text(encoding="utf-8")) == new_done
+        assert exit_path.read_text(encoding="utf-8") == "0"
+        assert output_path.read_text(encoding="utf-8") == "new output"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("done_bytes", [
+        json.dumps({"request_id": "another-request", "exit_code": 0}),
+        '{"request_id":"current-request",',
+    ])
+    async def test_mismatched_or_partial_done_is_preserved(self, tmp_path, done_bytes):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        done_path = hermes_home / ".update_helper_done.json"
+        exit_path = hermes_home / ".update_exit_code"
+        output_path = hermes_home / ".update_output.txt"
+        pending_path.write_text(json.dumps({
+            "request_id": "current-request",
+            "platform": "telegram",
+            "chat_id": "111",
+            "deadline_epoch": time.time() + 60,
+            "orphan_grace_seconds": 30,
+        }), encoding="utf-8")
+        done_path.write_text(done_bytes, encoding="utf-8")
+        exit_path.write_text("0", encoding="utf-8")
+        output_path.write_text("request output", encoding="utf-8")
+        adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            assert await runner._send_update_notification() is False
+
+        adapter.send.assert_not_called()
+        assert pending_path.exists()
+        assert done_path.read_text(encoding="utf-8") == done_bytes
+        assert exit_path.exists()
+        assert output_path.exists()
+        assert not (hermes_home / ".update_pending.claimed.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_partial_pending_json_is_preserved_for_atomic_writer_retry(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        pending_bytes = '{"request_id":"not-finished",'
+        pending_path.write_text(pending_bytes, encoding="utf-8")
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            assert await runner._send_update_notification() is False
+
+        assert pending_path.read_text(encoding="utf-8") == pending_bytes
+        assert not (hermes_home / ".update_pending.claimed.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_partial_exit_code_is_preserved_for_atomic_writer_retry(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        request_id = "partial-exit"
+        pending_path = hermes_home / ".update_pending.json"
+        done_path = hermes_home / ".update_helper_done.json"
+        exit_path = hermes_home / ".update_exit_code"
+        pending_path.write_text(json.dumps({
+            "request_id": request_id,
+            "platform": "telegram",
+            "chat_id": "111",
+            "deadline_epoch": time.time() + 60,
+            "orphan_grace_seconds": 30,
+        }), encoding="utf-8")
+        done_path.write_text(json.dumps({
+            "request_id": request_id,
+            "exit_code": 0,
+        }), encoding="utf-8")
+        exit_path.write_text("-", encoding="utf-8")
+        adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            assert await runner._send_update_notification() is False
+
+        adapter.send.assert_not_called()
+        assert pending_path.exists()
+        assert done_path.exists()
+        assert exit_path.read_text(encoding="utf-8") == "-"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_watchers_deliver_matching_request_once(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        request_id = "one-delivery"
+        (hermes_home / ".update_pending.json").write_text(json.dumps({
+            "request_id": request_id,
+            "platform": "telegram",
+            "chat_id": "111",
+            "deadline_epoch": time.time() + 60,
+            "orphan_grace_seconds": 30,
+        }), encoding="utf-8")
+        (hermes_home / ".update_helper_done.json").write_text(json.dumps({
+            "request_id": request_id,
+            "exit_code": 0,
+        }), encoding="utf-8")
+        (hermes_home / ".update_exit_code").write_text("0", encoding="utf-8")
+        adapter = AsyncMock()
+
+        async def slow_send(*args, **kwargs):
+            await asyncio.sleep(0.05)
+
+        adapter.send.side_effect = slow_send
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            results = await asyncio.gather(
+                runner._send_update_notification(),
+                runner._send_update_notification(),
+            )
+
+        assert adapter.send.call_count == 1
+        assert results.count(True) == 1
+
+    @pytest.mark.asyncio
+    async def test_helper_lock_blocks_cleanup_and_second_request(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        request_id = "request-one"
+        pending_path = hermes_home / ".update_pending.json"
+        done_path = hermes_home / ".update_helper_done.json"
+        output_path = hermes_home / ".update_output.txt"
+        exit_path = hermes_home / ".update_exit_code"
+        helper_lock_path = hermes_home / ".update_helper.lock"
+        pending_path.write_text(json.dumps({
+            "request_id": request_id,
+            "platform": "telegram",
+            "chat_id": "111",
+            "deadline_epoch": time.time() + 60,
+            "orphan_grace_seconds": 30,
+        }), encoding="utf-8")
+        done_path.write_text(json.dumps({
+            "request_id": request_id, "exit_code": 0,
+        }), encoding="utf-8")
+        output_path.write_text("not fully flushed", encoding="utf-8")
+        exit_path.write_text("0", encoding="utf-8")
+        adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        fake_root = tmp_path / "project"
+        (fake_root / ".git").mkdir(parents=True)
+        fake_file = str(fake_root / "gateway" / "run.py")
+        with UpdateHelperLock(helper_lock_path):
+            with patch("gateway.run._hermes_home", hermes_home):
+                delivered = await runner._send_update_notification()
+            with patch("gateway.run._hermes_home", hermes_home), \
+                 patch("gateway.run.__file__", fake_file), \
+                 patch("shutil.which", return_value="C:/hermes.exe"), \
+                 patch("subprocess.Popen") as popen:
+                duplicate_result = await runner._handle_update_command(
+                    _make_event(chat_id="222")
+                )
+
+        assert delivered is False
+        adapter.send.assert_not_called()
+        assert pending_path.exists()
+        assert done_path.exists()
+        assert output_path.read_text(encoding="utf-8") == "not fully flushed"
+        assert exit_path.exists()
+        assert "already" in duplicate_result.lower()
+        popen.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_matching_done_and_unlocked_notifies_then_cleans_request(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        request_id = "request-complete"
+        paths = {
+            "pending": hermes_home / ".update_pending.json",
+            "done": hermes_home / ".update_helper_done.json",
+            "output": hermes_home / ".update_output.txt",
+            "exit": hermes_home / ".update_exit_code",
+        }
+        paths["pending"].write_text(json.dumps({
+            "request_id": request_id,
+            "platform": "telegram",
+            "chat_id": "111",
+            "deadline_epoch": time.time() + 60,
+            "orphan_grace_seconds": 30,
+        }), encoding="utf-8")
+        paths["done"].write_text(json.dumps({
+            "request_id": request_id,
+            "exit_code": 0,
+        }), encoding="utf-8")
+        paths["output"].write_text("complete output", encoding="utf-8")
+        paths["exit"].write_text("0", encoding="utf-8")
+        adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            delivered = await runner._send_update_notification()
+
+        assert delivered is True
+        adapter.send.assert_called_once()
+        assert all(not path.exists() for path in paths.values())
+
+    @pytest.mark.asyncio
+    async def test_crashed_helper_is_preserved_until_deadline_then_failed_until_notified(
+        self, tmp_path
+    ):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        request_id = "request-orphan"
+        pending_path = hermes_home / ".update_pending.json"
+        done_path = hermes_home / ".update_helper_done.json"
+        exit_path = hermes_home / ".update_exit_code"
+        output_path = hermes_home / ".update_output.txt"
+        pending_path.write_text(json.dumps({
+            "request_id": request_id,
+            "platform": "telegram",
+            "chat_id": "111",
+            "deadline_epoch": 1000.0,
+            "orphan_grace_seconds": 30.0,
+        }), encoding="utf-8")
+        output_path.write_text("partial child output", encoding="utf-8")
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.time.time", return_value=1029.0):
+            assert await runner._send_update_notification() is False
+
+        assert pending_path.exists()
+        assert not done_path.exists()
+        assert not exit_path.exists()
+        assert output_path.read_text(encoding="utf-8") == "partial child output"
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.time.time", return_value=1031.0):
+            assert await runner._send_update_notification() is False
+
+        assert pending_path.exists()
+        assert json.loads(done_path.read_text(encoding="utf-8")) == {
+            "request_id": request_id,
+            "exit_code": 125,
+            "status": "helper_crashed",
+        }
+        assert exit_path.read_text(encoding="utf-8") == "125"
+        assert output_path.exists()
+
+        adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.time.time", return_value=1032.0):
+            assert await runner._send_update_notification() is True
+
+        adapter.send.assert_called_once()
+        assert not pending_path.exists()
+        assert not done_path.exists()
+        assert not exit_path.exists()
+        assert not output_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_helper_lock_probe_os_error_preserves_every_marker(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        paths = [
+            hermes_home / ".update_pending.json",
+            hermes_home / ".update_helper_done.json",
+            hermes_home / ".update_output.txt",
+            hermes_home / ".update_exit_code",
+        ]
+        paths[0].write_text(json.dumps({
+            "request_id": "request-lock-error",
+            "platform": "telegram",
+            "chat_id": "111",
+        }), encoding="utf-8")
+        paths[1].write_text(json.dumps({
+            "request_id": "request-lock-error", "exit_code": 0,
+        }), encoding="utf-8")
+        paths[2].write_text("done", encoding="utf-8")
+        paths[3].write_text("0", encoding="utf-8")
+        adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch(
+                 "gateway.run.acquire_update_helper_probe",
+                 side_effect=OSError("lock filesystem unavailable"),
+             ):
+            delivered = await runner._send_update_notification()
+
+        assert delivered is False
+        adapter.send.assert_not_called()
+        assert all(path.exists() for path in paths)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("legacy_identity", [
+        "4242",
+        json.dumps({"pid": 4242, "start_time": 100}),
+        json.dumps({"pid": 4242, "start_time": None}),
+    ])
+    async def test_pid_metadata_cannot_extend_expired_orphan_forever(
+        self, tmp_path, legacy_identity
+    ):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        helper_pid_path = hermes_home / ".update_helper_pid"
+        pending_path.write_text(json.dumps({
+            "request_id": "request-expired",
+            "platform": "telegram",
+            "chat_id": "111",
+            "session_key": "telegram:111",
+            "deadline_epoch": 1.0,
+            "orphan_grace_seconds": 0.0,
+        }), encoding="utf-8")
+        helper_pid_path.write_text(legacy_identity, encoding="utf-8")
+        adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.time.time", return_value=2.0), \
+             patch(
+                 "gateway.status._pid_exists",
+                 side_effect=AssertionError("PID must not be cleanup authority"),
+             ), \
+             patch(
+                 "gateway.status.get_process_start_time",
+                 side_effect=AssertionError("start time must not be cleanup authority"),
+             ):
+            await runner._watch_update_progress(
+                poll_interval=0.001,
+                stream_interval=0.001,
+                timeout=0.0,
+            )
+
+        adapter.send.assert_called_once()
+        assert not pending_path.exists()
+        assert not helper_pid_path.exists()
+        assert not (hermes_home / ".update_helper_done.json").exists()
 
     @pytest.mark.asyncio
     async def test_defers_notification_while_update_still_running(self, tmp_path):
@@ -297,11 +1333,16 @@ class TestSendUpdateNotification:
         hermes_home.mkdir()
 
         claimed_path = hermes_home / ".update_pending.claimed.json"
+        request_id = "claimed-request"
         claimed_path.write_text(json.dumps({
+            "request_id": request_id,
             "platform": "telegram", "chat_id": "67890", "user_id": "12345",
         }))
         (hermes_home / ".update_output.txt").write_text("done")
         (hermes_home / ".update_exit_code").write_text("0")
+        (hermes_home / ".update_helper_done.json").write_text(json.dumps({
+            "request_id": request_id, "exit_code": 0,
+        }))
 
         mock_adapter = AsyncMock()
         runner.adapters = {Platform.TELEGRAM: mock_adapter}
@@ -322,6 +1363,7 @@ class TestSendUpdateNotification:
 
         # Write pending marker
         pending = {
+            "request_id": "output-request",
             "platform": "telegram",
             "chat_id": "67890",
             "user_id": "12345",
@@ -332,6 +1374,9 @@ class TestSendUpdateNotification:
             "→ Found 3 new commit(s)\n✓ Code updated!\n✓ Update complete!"
         )
         (hermes_home / ".update_exit_code").write_text("0")
+        (hermes_home / ".update_helper_done.json").write_text(json.dumps({
+            "request_id": "output-request", "exit_code": 0,
+        }))
 
         # Mock the adapter
         mock_adapter = AsyncMock()
@@ -348,8 +1393,8 @@ class TestSendUpdateNotification:
 
 
     @pytest.mark.asyncio
-    async def test_cleans_up_on_error(self, tmp_path):
-        """Files are cleaned up even if notification fails."""
+    async def test_preserves_request_on_notification_error(self, tmp_path):
+        """Files remain retryable if notification delivery fails."""
         runner = _make_runner()
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
@@ -357,11 +1402,16 @@ class TestSendUpdateNotification:
         pending_path = hermes_home / ".update_pending.json"
         output_path = hermes_home / ".update_output.txt"
         exit_code_path = hermes_home / ".update_exit_code"
+        done_path = hermes_home / ".update_helper_done.json"
         pending_path.write_text(json.dumps({
+            "request_id": "send-failure",
             "platform": "telegram", "chat_id": "111", "user_id": "222",
         }))
         output_path.write_text("✓ Done")
         exit_code_path.write_text("0")
+        done_path.write_text(json.dumps({
+            "request_id": "send-failure", "exit_code": 0,
+        }))
 
         # Adapter send raises
         mock_adapter = AsyncMock()
@@ -371,10 +1421,56 @@ class TestSendUpdateNotification:
         with patch("gateway.run._hermes_home", hermes_home):
             await runner._send_update_notification()
 
-        # Files should still be cleaned up (finally block)
-        assert not pending_path.exists()
-        assert not output_path.exists()
-        assert not exit_code_path.exists()
+        assert pending_path.exists()
+        assert output_path.exists()
+        assert exit_code_path.exists()
+        assert done_path.exists()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("legacy", [False, True])
+    async def test_preserves_request_when_notification_returns_unsuccessful(
+        self, tmp_path, legacy
+    ):
+        """A non-raising SendResult failure must remain retryable."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        pending_path = hermes_home / ".update_pending.json"
+        output_path = hermes_home / ".update_output.txt"
+        exit_code_path = hermes_home / ".update_exit_code"
+        done_path = hermes_home / ".update_helper_done.json"
+        pending = {
+            "platform": "telegram",
+            "chat_id": "111",
+            "user_id": "222",
+        }
+        if not legacy:
+            pending["request_id"] = "unsuccessful-send"
+        pending_path.write_text(json.dumps(pending), encoding="utf-8")
+        output_path.write_text("done", encoding="utf-8")
+        exit_code_path.write_text("0", encoding="utf-8")
+        if not legacy:
+            done_path.write_text(
+                json.dumps({"request_id": "unsuccessful-send", "exit_code": 0}),
+                encoding="utf-8",
+            )
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send.return_value = MagicMock(
+            success=False, error="delivery rejected"
+        )
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            delivered = await runner._send_update_notification()
+
+        assert delivered is False
+        assert pending_path.exists()
+        assert output_path.exists()
+        assert exit_code_path.exists()
+        if not legacy:
+            assert done_path.exists()
 
 
     @pytest.mark.asyncio
@@ -428,13 +1524,19 @@ class TestSendUpdateNotification:
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
 
-        pending = {"platform": "discord", "chat_id": "111", "user_id": "222"}
+        pending = {
+            "request_id": "reconnect-request",
+            "platform": "discord", "chat_id": "111", "user_id": "222",
+        }
         pending_path = hermes_home / ".update_pending.json"
         output_path = hermes_home / ".update_output.txt"
         exit_code_path = hermes_home / ".update_exit_code"
         pending_path.write_text(json.dumps(pending))
         output_path.write_text("✓ Update complete!")
         exit_code_path.write_text("0")
+        (hermes_home / ".update_helper_done.json").write_text(json.dumps({
+            "request_id": "reconnect-request", "exit_code": 0,
+        }))
 
         # First pass: target platform (discord) is still offline → defer.
         with patch("gateway.run._hermes_home", hermes_home):
@@ -467,13 +1569,19 @@ class TestSendUpdateNotification:
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
 
-        pending = {"platform": "discord", "chat_id": "111", "user_id": "222"}
+        pending = {
+            "request_id": "invalid-utf8-request",
+            "platform": "discord", "chat_id": "111", "user_id": "222",
+        }
         pending_path = hermes_home / ".update_pending.json"
         output_path = hermes_home / ".update_output.txt"
         exit_code_path = hermes_home / ".update_exit_code"
         pending_path.write_text(json.dumps(pending))
         output_path.write_bytes(b"ok before\ninvalid byte: \x96\ncontinued after\n")
         exit_code_path.write_text("0")
+        (hermes_home / ".update_helper_done.json").write_text(json.dumps({
+            "request_id": "invalid-utf8-request", "exit_code": 0,
+        }))
 
         mock_adapter = AsyncMock()
         runner.adapters = {Platform.DISCORD: mock_adapter}
@@ -524,6 +1632,7 @@ class TestWatchUpdateProgress:
         hermes_home.mkdir()
 
         (hermes_home / ".update_pending.json").write_text(json.dumps({
+            "request_id": "watch-invalid-utf8",
             "platform": "telegram",
             "chat_id": "67890",
             "user_id": "12345",
@@ -532,6 +1641,9 @@ class TestWatchUpdateProgress:
             b"ok before\n\xe2\x9c invalid-continuation: \x96\ncontinued after\n"
         )
         (hermes_home / ".update_exit_code").write_text("0")
+        (hermes_home / ".update_helper_done.json").write_text(json.dumps({
+            "request_id": "watch-invalid-utf8", "exit_code": 0,
+        }))
 
         mock_adapter = AsyncMock()
         runner.adapters = {Platform.TELEGRAM: mock_adapter}

--- a/tests/gateway/test_update_contract.py
+++ b/tests/gateway/test_update_contract.py
@@ -1,0 +1,24 @@
+"""Update-helper lifecycle lock contract tests."""
+
+from gateway.update_contract import UpdateHelperLock, acquire_update_helper_probe
+
+
+def test_probe_returns_held_lock_when_helper_lock_is_free(tmp_path):
+    lock_path = tmp_path / ".update_helper.lock"
+
+    probe = acquire_update_helper_probe(lock_path)
+
+    assert probe is not None
+    assert acquire_update_helper_probe(lock_path) is None
+    probe.release()
+
+
+def test_probe_returns_none_while_helper_owns_lock(tmp_path):
+    lock_path = tmp_path / ".update_helper.lock"
+
+    with UpdateHelperLock(lock_path):
+        assert acquire_update_helper_probe(lock_path) is None
+
+    probe = acquire_update_helper_probe(lock_path)
+    assert probe is not None
+    probe.release()

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -18,6 +18,7 @@ import pytest
 from gateway.config import Platform
 from gateway.platforms.event import MessageEvent
 from gateway.session import SessionSource
+from gateway.update_contract import UpdateHelperLock
 
 
 def _make_event(text="/update", platform=Platform.TELEGRAM,
@@ -151,13 +152,13 @@ class TestUpdateCommandGatewayFlag:
              patch("subprocess.Popen", mock_popen):
             result = await runner._handle_update_command(event)
 
-        # Check the bash command string contains --gateway and PYTHONUNBUFFERED
+        # The detached Python helper carries --gateway and unbuffered output,
+        # and records every platform's exit code without a shell wrapper.
         call_args = mock_popen.call_args[0][0]
-        cmd_string = call_args[-1] if isinstance(call_args, list) else str(call_args)
-        assert "--gateway" in cmd_string
-        assert "PYTHONUNBUFFERED" in cmd_string
-        assert "rc=$?" in cmd_string
-        assert "status=$?" not in cmd_string
+        assert "--gateway" in call_args
+        helper_source = next(part for part in call_args if "PYTHONUNBUFFERED" in part)
+        assert "proc.returncode" in helper_source
+        assert "TimeoutExpired" in helper_source
         assert "stream progress" in result
 
 
@@ -170,13 +171,122 @@ class TestWatchUpdateProgress:
     """Tests for _watch_update_progress() streaming output."""
 
     @pytest.mark.asyncio
+    async def test_default_watcher_preserves_40_minute_update(self, tmp_path):
+        """The shared one-hour helper budget must not be cut off at 30 minutes."""
+        from gateway.update_contract import UPDATE_TIMEOUT_SECONDS
+
+        assert UPDATE_TIMEOUT_SECONDS == 3600.0
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        output_path = hermes_home / ".update_output.txt"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "111",
+            "user_id": "222",
+            "session_key": "agent:main:telegram:dm:111",
+        }))
+        output_path.write_text("still running", encoding="utf-8")
+        runner.adapters = {Platform.TELEGRAM: AsyncMock()}
+
+        class FortyMinutesElapsed(Exception):
+            pass
+
+        class FakeLoop:
+            now = 0.0
+
+            def time(self):
+                return self.now
+
+        loop = FakeLoop()
+
+        async def advance_clock(_seconds):
+            loop.now += 600.0
+            if loop.now >= 2400.0:
+                raise FortyMinutesElapsed
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.asyncio.get_running_loop", return_value=loop), \
+             patch("gateway.run.asyncio.sleep", side_effect=advance_clock):
+            with pytest.raises(FortyMinutesElapsed):
+                await runner._watch_update_progress()
+
+        assert pending_path.exists()
+        assert output_path.exists()
+        assert not (hermes_home / ".update_exit_code").exists()
+
+        duplicate = _make_event(chat_id="222")
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("subprocess.Popen") as popen:
+            result = await runner._handle_update_command(duplicate)
+
+        assert "already" in result.lower()
+        assert json.loads(pending_path.read_text(encoding="utf-8"))["chat_id"] == "111"
+        assert output_path.read_text(encoding="utf-8") == "still running"
+        popen.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_completion_waits_for_helper_process_exit(self, tmp_path):
+        """Matching done is not cleanup authority while the helper lock is held."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        output_path = hermes_home / ".update_output.txt"
+        exit_path = hermes_home / ".update_exit_code"
+        done_path = hermes_home / ".update_helper_done.json"
+        helper_lock_path = hermes_home / ".update_helper.lock"
+        request_id = "locked-helper"
+        pending_path.write_text(json.dumps({
+            "request_id": request_id,
+            "platform": "telegram",
+            "chat_id": "111",
+            "user_id": "222",
+            "session_key": "agent:main:telegram:dm:111",
+        }))
+        output_path.write_text("done", encoding="utf-8")
+        exit_path.write_text("0", encoding="utf-8")
+        done_path.write_text(json.dumps({
+            "request_id": request_id, "exit_code": 0,
+        }), encoding="utf-8")
+        adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        helper_lock = UpdateHelperLock(helper_lock_path).acquire()
+        with patch("gateway.run._hermes_home", hermes_home):
+            watch_task = asyncio.create_task(runner._watch_update_progress(
+                poll_interval=0.001,
+                stream_interval=0.001,
+                timeout=1.0,
+            ))
+            await asyncio.sleep(0.02)
+            sent_while_locked = " ".join(str(call) for call in adapter.send.call_args_list)
+            assert "update finished" not in sent_while_locked.lower()
+            assert pending_path.exists()
+            assert output_path.exists()
+            assert exit_path.exists()
+            assert done_path.exists()
+            helper_lock.release()
+            await watch_task
+
+        adapter.send.assert_called()
+        assert not pending_path.exists()
+        assert not output_path.exists()
+        assert not exit_path.exists()
+        assert not done_path.exists()
+        assert helper_lock_path.exists()
+
+    @pytest.mark.asyncio
     async def test_streams_output_to_adapter(self, tmp_path):
         """New output is sent to the adapter periodically."""
         runner = _make_runner()
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
 
-        pending = {"platform": "telegram", "chat_id": "111", "user_id": "222",
+        request_id = "stream-output"
+        pending = {"request_id": request_id,
+                   "platform": "telegram", "chat_id": "111", "user_id": "222",
                    "session_key": "agent:main:telegram:dm:111"}
         (hermes_home / ".update_pending.json").write_text(json.dumps(pending))
         # Write output
@@ -192,6 +302,10 @@ class TestWatchUpdateProgress:
                 "→ Fetching updates...\n✓ Code updated!\n"
             , encoding="utf-8")
             (hermes_home / ".update_exit_code").write_text("0")
+            (hermes_home / ".update_helper_done.json").write_text(
+                json.dumps({"request_id": request_id, "exit_code": 0}),
+                encoding="utf-8",
+            )
 
         with patch("gateway.run._hermes_home", hermes_home):
             task = asyncio.create_task(write_exit_code())
@@ -221,6 +335,9 @@ class TestWatchUpdateProgress:
 
         mock_adapter = AsyncMock()
         runner.adapters = {Platform.TELEGRAM: mock_adapter}
+        runner._forward_update_prompt = AsyncMock(
+            wraps=runner._forward_update_prompt
+        )
 
         # Write a prompt, then respond and finish
         async def simulate_prompt_cycle():
@@ -247,6 +364,7 @@ class TestWatchUpdateProgress:
         all_sent = [str(c) for c in mock_adapter.send.call_args_list]
         prompt_found = any("Restore local changes" in s for s in all_sent)
         assert prompt_found, f"Prompt not forwarded. Sent: {all_sent}"
+        runner._forward_update_prompt.assert_awaited_once()
         # Check session was marked as having pending prompt
         # (may be cleared by the time we check since update finished)
 
@@ -319,6 +437,91 @@ class TestWatchUpdateProgress:
             if "Restore local changes" in str(call)
         ]
         assert len(prompt_sends) == 1
+
+    @pytest.mark.asyncio
+    async def test_prompt_button_failure_falls_back_to_text(self):
+        """An unsuccessful button result is not treated as delivered."""
+        from gateway.platforms.base import SendResult
+
+        class ButtonAdapter:
+            def __init__(self, text_result):
+                self.send = AsyncMock(return_value=text_result)
+
+            async def send_update_prompt(self, **_kwargs):
+                return SendResult(success=False, error="button send failed")
+
+        runner = _make_runner()
+        adapter = ButtonAdapter(SendResult(success=True))
+        target = runner._UpdateTarget(
+            adapter=adapter,
+            chat_id="111",
+            session_key="agent:main:telegram:dm:111",
+            metadata={},
+            platform=Platform.TELEGRAM,
+        )
+
+        await runner._forward_update_prompt(target, "Continue?", "y")
+
+        adapter.send.assert_awaited_once()
+        assert runner._session_state(target.session_key).persistent.update_prompt_pending is True
+
+    @pytest.mark.asyncio
+    async def test_prompt_all_delivery_failures_do_not_mark_pending(self):
+        """A prompt cannot be pending when no delivery path succeeded."""
+        from gateway.platforms.base import SendResult
+
+        class ButtonAdapter:
+            def __init__(self, text_result):
+                self.send = AsyncMock(return_value=text_result)
+
+            async def send_update_prompt(self, **_kwargs):
+                return SendResult(success=False, error="button send failed")
+
+        runner = _make_runner()
+        adapter = ButtonAdapter(SendResult(success=False, error="text send failed"))
+        target = runner._UpdateTarget(
+            adapter=adapter,
+            chat_id="111",
+            session_key="agent:main:telegram:dm:111",
+            metadata={},
+            platform=Platform.TELEGRAM,
+        )
+
+        await runner._forward_update_prompt(target, "Continue?", "y")
+
+        adapter.send.assert_awaited_once()
+        assert runner._session_state(target.session_key).persistent.update_prompt_pending is False
+
+    @pytest.mark.asyncio
+    async def test_prompt_peer_flood_does_not_attempt_text_fallback(self):
+        """PEER_FLOOD is terminal for the target; never retry via another prompt shape."""
+        from gateway.platforms.base import SendResult
+
+        class ButtonAdapter:
+            def __init__(self):
+                self.send = AsyncMock()
+
+            async def send_update_prompt(self, **_kwargs):
+                return SendResult(
+                    success=False,
+                    error="Telegram PEER_FLOOD",
+                    error_kind="peer_flood",
+                )
+
+        runner = _make_runner()
+        adapter = ButtonAdapter()
+        target = runner._UpdateTarget(
+            adapter=adapter,
+            chat_id="111",
+            session_key="agent:main:telegram:dm:111",
+            metadata={},
+            platform=Platform.TELEGRAM,
+        )
+
+        await runner._forward_update_prompt(target, "Continue?", "y")
+
+        adapter.send.assert_not_awaited()
+        assert runner._session_state(target.session_key).persistent.update_prompt_pending is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1,7 +1,10 @@
 """Tests for cmd_update — branch fallback when remote branch doesn't exist."""
 
 import hashlib
+import io
+import os
 import subprocess
+import threading
 from types import SimpleNamespace
 from unittest.mock import ANY, patch
 
@@ -43,6 +46,166 @@ def mock_args():
     return SimpleNamespace()
 
 
+class TestGatewayDescendantUpdateGuard:
+    """Mutating updates must not run as children of the gateway they stop."""
+
+    @patch("hermes_cli.config.is_managed", return_value=False)
+    def test_mutating_update_refuses_gateway_descendant(
+        self, _managed, monkeypatch, capsys
+    ):
+        from tools import process_registry
+
+        monkeypatch.setattr(
+            process_registry, "_is_gateway_descendant_process", lambda: True
+        )
+        args = SimpleNamespace(plan=False, check=False, gateway=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update(args)
+
+        assert exc_info.value.code == 1
+        assert "outside the running gateway" in capsys.readouterr().out
+
+    @patch("hermes_cli.config.is_managed", return_value=False)
+    @patch("hermes_cli.main._resolve_update_branch", return_value="main")
+    # Patch where production reads: the preflight late-imports _cmd_update_check from
+    # hermes_cli.update_cmd (the Sep-2026 decomposition moved it off hermes_cli.main).
+    @patch("hermes_cli.update_cmd._cmd_update_check")
+    def test_read_only_check_is_allowed(
+        self, check_update, _branch, _managed, monkeypatch
+    ):
+        from tools import process_registry
+
+        monkeypatch.setattr(
+            process_registry, "_is_gateway_descendant_process", lambda: True
+        )
+        args = SimpleNamespace(plan=False, check=True, branch=None, gateway=False)
+
+        cmd_update(args)
+
+        check_update.assert_called_once_with(branch="main", branch_explicit=False)
+
+    @pytest.mark.parametrize("gateway_mode", [False, True])
+    def test_external_updaters_are_allowed_without_environment(
+        self, monkeypatch, gateway_mode
+    ):
+        """Shell and official --gateway updaters need no new environment."""
+        from hermes_cli import main
+        from tools import process_registry
+
+        monkeypatch.delenv("HERMES_GATEWAY_ORIGIN_PID", raising=False)
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        monkeypatch.setattr(
+            process_registry, "_is_gateway_descendant_process", lambda: False
+        )
+
+        assert main._authorize_update_from_context(
+            gateway_mode=gateway_mode, stream=io.BytesIO()
+        )
+
+    def test_gateway_child_cannot_spoof_external_updater_mode(self, monkeypatch):
+        from hermes_cli import main
+        from tools import process_registry
+
+        monkeypatch.setenv("HERMES_UPDATE_MODE", "external" + "-updater")
+        monkeypatch.setenv("HERMES_GATEWAY_ORIGIN_PID", "4242")
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setattr(
+            process_registry, "_is_gateway_descendant_process", lambda: True
+        )
+
+        assert not main._authorize_update_from_context(
+            gateway_mode=True, stream=io.BytesIO(b"not-a-token\n")
+        )
+
+    def test_gateway_handoff_token_matches_pending_hash(self, tmp_path, monkeypatch):
+        """Only the token paired with the pending marker authorizes --gateway."""
+        import hashlib
+        import json
+        from hermes_cli import main
+        from tools import process_registry
+
+        token = "test-one-time-handoff-token"
+        pending = tmp_path / ".update_pending.json"
+        pending.write_text(
+            json.dumps(
+                {"handoff_token_sha256": hashlib.sha256(token.encode()).hexdigest()}
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            process_registry, "_is_gateway_descendant_process", lambda: True
+        )
+
+        assert main._authorize_update_from_context(
+            gateway_mode=True,
+            stream=io.BytesIO((token + "\n").encode()),
+        ) is True
+        assert "handoff_token_sha256" not in json.loads(pending.read_text())
+
+    def test_gateway_handoff_token_is_single_use_under_concurrency(
+        self, tmp_path, monkeypatch
+    ):
+        import json
+        from hermes_cli import main
+
+        token = "one-consumer-only"
+        pending = tmp_path / ".update_pending.json"
+        pending.write_text(
+            json.dumps(
+                {"handoff_token_sha256": hashlib.sha256(token.encode()).hexdigest()}
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: tmp_path)
+        barrier = threading.Barrier(3)
+        results = []
+
+        def consume():
+            barrier.wait()
+            results.append(
+                main._consume_gateway_update_handoff(
+                    io.BytesIO((token + "\n").encode())
+                )
+            )
+
+        threads = [threading.Thread(target=consume) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        assert sorted(results) == [False, True]
+        assert main._consume_gateway_update_handoff(
+            io.BytesIO((token + "\n").encode())
+        ) is False
+
+    def test_gateway_handoff_lock_access_denied_fails_closed(
+        self, tmp_path, monkeypatch
+    ):
+        import json
+        from hermes_cli import active_sessions, main
+
+        token = "must-not-consume-without-lock"
+        pending = tmp_path / ".update_pending.json"
+        expected = hashlib.sha256(token.encode()).hexdigest()
+        pending.write_text(
+            json.dumps({"handoff_token_sha256": expected}), encoding="utf-8"
+        )
+        monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: tmp_path)
+
+        def denied(_self):
+            raise RuntimeError("access denied")
+
+        monkeypatch.setattr(active_sessions._FileLock, "__enter__", denied)
+
+        assert main._consume_gateway_update_handoff(
+            io.BytesIO((token + "\n").encode())
+        ) is False
+        assert json.loads(pending.read_text())["handoff_token_sha256"] == expected
+
 # ---------------------------------------------------------------------------
 # Managed-uv compatibility for tests that patch shutil.which
 # ---------------------------------------------------------------------------
@@ -79,8 +242,18 @@ def _patch_managed_uv(request):
 
 
 @pytest.fixture(autouse=True)
-def _patch_gateway_discovery(isolated_update_runtime):
-    pass
+def _patch_gateway_discovery(isolated_update_runtime, monkeypatch, request):
+    """``isolated_update_runtime`` already keeps gateway discovery off this host.
+
+    Only the new updater admission gate needs handling here: every test in this
+    module models an EXTERNAL shell, so the gateway-descendant probe must read
+    False. Never patch it for the dedicated guard class — its tests must execute
+    the real decision seam or the regression signal disappears.
+    """
+    if request.node.cls is not TestGatewayDescendantUpdateGuard:
+        monkeypatch.setattr(
+            "tools.process_registry._is_gateway_descendant_process", lambda: False
+        )
 
 
 class TestCmdUpdateNpmLockfileCache:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -8,12 +8,27 @@ Covers:
 
 import json
 import os
+import sys
 from argparse import Namespace
+from pathlib import Path
 
 import pytest
 
 from cron.lifecycle_guard import contains_gateway_lifecycle_command as _contains_gateway_lifecycle_command
 from hermes_cli.cron import cron_command
+
+
+class _ShellPath(type(Path())):
+    """Native test path rendered safely inside POSIX shell command strings."""
+
+    def __str__(self):
+        return super().__str__().replace("\\", "/")
+
+
+@pytest.fixture(name="tmp_path")
+def _shell_tmp_path(tmp_path_factory):
+    """Keep shell-script tests independent of the pytest host platform."""
+    return _ShellPath(tmp_path_factory.mktemp("gateway-restart-loop"))
 
 
 # ---------------------------------------------------------------------------
@@ -516,7 +531,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         monkeypatch.setattr(tt, "_task_env_overrides", {})
         monkeypatch.setattr(tt, "_get_env_config", self._minimal_config)
         monkeypatch.setattr(
-            process_registry, "_is_supervised_gateway_process",
+            process_registry, "_is_gateway_runtime_process",
             lambda: inside_gateway,
         )
 
@@ -554,6 +569,27 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
 
+    def test_execute_code_uses_gateway_pid_identity(self, monkeypatch):
+        """A direct Windows gateway must get the execute_code lifecycle guard."""
+        import tools.code_execution_tool as code_tool
+        from tools import process_registry
+
+        monkeypatch.setattr(code_tool, "SANDBOX_AVAILABLE", True)
+        monkeypatch.setattr(
+            process_registry, "_is_gateway_runtime_process", lambda: True
+        )
+        monkeypatch.setattr(
+            process_registry, "_is_supervised_gateway_process", lambda: False
+        )
+
+        result = json.loads(
+            code_tool.execute_code(
+                'import subprocess\nsubprocess.run(["hermes", "gateway", "restart"])'
+            )
+        )
+
+        assert "cannot restart or stop" in result["error"]
+
     def test_blocks_lifecycle_command_hidden_in_referenced_script(
         self, monkeypatch, tmp_path
     ):
@@ -567,6 +603,7 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
         assert "referenced script" in result["error"]
+
 
     def test_blocks_launchctl_submit_inside_gateway(self, monkeypatch, tmp_path):
         import tools.terminal_tool as tt
@@ -633,9 +670,10 @@ class TestTerminalToolGatewayLifecycleGuard:
     @pytest.mark.parametrize("command", [
         "launchctl submit -l com.foo -- /path/gateway",
         "launchctl bootstrap gui/501 /tmp/com.foo.plist",
+        "hermes update --backup --yes",
     ])
-    def test_submit_and_bootstrap_allowed_outside_gateway(self, monkeypatch, command):
-        """The label-independent block applies only inside the gateway process."""
+    def test_lifecycle_commands_allowed_outside_gateway(self, monkeypatch, command):
+        """The hard block applies only inside the gateway process."""
         import tools.terminal_tool as tt
 
         calls = []
@@ -677,7 +715,7 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         # Simulate a CLI agent session: _HERMES_GATEWAY=1 is in the
         # environment (inherited from the gateway), but
-        # _is_supervised_gateway_process() returns False because the
+        # _is_gateway_runtime_process() returns False because the
         # process does not own the gateway PID file.
         self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=False)
         monkeypatch.setenv("_HERMES_GATEWAY", "1")
@@ -801,6 +839,7 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Windows has no os.mkfifo")
     def test_non_regular_referenced_script_fails_closed(self, monkeypatch, tmp_path):
         import tools.terminal_tool as tt
 
@@ -1218,6 +1257,9 @@ class TestLifecycleGuardModule:
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily ops", str(script))
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="symlink creation requires Windows privilege"
+    )
     def test_cloud_backed_symlink_fails_closed_without_opening_target(
         self, tmp_path, monkeypatch
     ):
@@ -1849,7 +1891,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         monkeypatch.setattr(tt, "_task_env_overrides", {})
         monkeypatch.setattr(tt, "_get_env_config", lambda: {"env_type": "local", "cwd": "/tmp", "timeout": 60, "lifetime_seconds": 3600})
         monkeypatch.setattr(
-            process_registry, "_is_supervised_gateway_process",
+            process_registry, "_is_gateway_runtime_process",
             lambda: inside_gateway,
         )
 
@@ -1858,7 +1900,12 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
 
         # Path only exists on the remote backend; locally it is absent, so the
         # guard must fall back to a bounded env.execute('head -c ...') read.
-        script = "/remote/workspace/remote.sh"
+        script = (
+            "Z:/remote/workspace/remote.sh"
+            if sys.platform == "win32"
+            else "/remote/workspace/remote.sh"
+        )
+        resolved_script = str(Path(script))
         calls = []
 
         class _RemoteEnv:
@@ -1866,7 +1913,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
             cwd = str(tmp_path)
             def execute(self, command, **kwargs):
                 calls.append(command)
-                if "head -c" in command and "/remote/workspace/remote.sh" in command:
+                if "head -c" in command and resolved_script in command:
                     return {"output": "#!/bin/bash\nhermes gateway restart\n", "returncode": 0}
                 return {"output": "", "returncode": 0}
 

--- a/tests/hermes_cli/test_update_gateway_modes.py
+++ b/tests/hermes_cli/test_update_gateway_modes.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REMOVED_EXTERNAL_MODE = "external" + "-updater"
+
+
+def test_official_desktop_updaters_need_no_update_mode_environment():
+    sources = [
+        ROOT / "apps/bootstrap-installer/src-tauri/src/update.rs",
+        ROOT / "scripts/desktop-update/posix.sh",
+        ROOT / "scripts/desktop-update/windows.ps1",
+    ]
+
+    for source in sources:
+        text = source.read_text(encoding="utf-8")
+        assert "HERMES_UPDATE_MODE" not in text, source
+        assert REMOVED_EXTERNAL_MODE not in text, source
+
+
+def test_messaging_handoff_never_places_token_in_argv_or_environment():
+    source = (ROOT / "gateway/slash_commands.py").read_text(encoding="utf-8")
+
+    assert "HERMES_UPDATE_HANDOFF_TOKEN" not in source
+    assert "HERMES_UPDATE_MODE" not in source
+    assert "stdin=subprocess.PIPE" in source
+
+
+def test_update_admission_has_no_external_updater_mode():
+    source = (ROOT / "hermes_cli/main.py").read_text(encoding="utf-8")
+
+    assert REMOVED_EXTERNAL_MODE not in source
+    assert "HERMES_UPDATE_MODE" not in source

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1874,6 +1874,227 @@ class TestReaderLoopOrphanedPipe:
 # =========================================================================
 # systemd cgroup isolation for gateway-spawned local executors (#70716)
 # =========================================================================
+class TestGatewayRuntimeIdentity:
+    """The terminal safety guard must recognize every real gateway runtime."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_gateway_environment(self, monkeypatch):
+        monkeypatch.delenv("HERMES_GATEWAY_ORIGIN_PID", raising=False)
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+
+    def test_direct_spawn_gateway_owns_pid_without_supervisor(self, monkeypatch):
+        """Windows login-item gateways have no systemd/launchd supervisor marker."""
+        from tools import process_registry
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: os.getpid(),
+        )
+
+        assert process_registry._is_gateway_runtime_process() is True
+
+    def test_inherited_marker_without_pid_ownership_is_not_gateway(self, monkeypatch):
+        """A terminal child inherits the marker but must not identify as the gateway."""
+        from tools import process_registry
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: os.getpid() + 1,
+        )
+
+        assert process_registry._is_gateway_runtime_process() is False
+
+    def test_inherited_marker_with_live_gateway_identifies_descendant(self, monkeypatch):
+        """An updater spawned by a gateway inherits the marker and sees its live PID."""
+        import sys
+        from types import SimpleNamespace
+        from tools import process_registry
+
+        live_pid = os.getpid() + 100
+
+        class FakeProcess:
+            def __init__(self, _pid):
+                pass
+
+            def parents(self):
+                return [SimpleNamespace(pid=live_pid, cmdline=lambda: ["opaque"])]
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=FakeProcess))
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: live_pid,
+        )
+
+        assert process_registry._is_gateway_descendant_process() is True
+
+    def test_gateway_ancestor_identifies_descendant_without_marker(self, monkeypatch):
+        import sys
+        from types import SimpleNamespace
+        from tools import process_registry
+
+        class FakeProcess:
+            def __init__(self, _pid):
+                pass
+
+            def parents(self):
+                return [
+                    SimpleNamespace(
+                        cmdline=lambda: [
+                            "python.exe",
+                            "-m",
+                            "hermes_cli.main",
+                            "--profile",
+                            "quant",
+                            "gateway",
+                            "run",
+                        ]
+                    )
+                ]
+
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=FakeProcess))
+
+        assert process_registry._is_gateway_descendant_process() is True
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["python", "-m", "gateway.run"],
+            ["python", "cli.py", "--gateway"],
+            ["hermes", "gateway", "run"],
+        ],
+    )
+    def test_gateway_entrypoint_ancestor_shapes(self, monkeypatch, argv):
+        from types import SimpleNamespace
+        from tools import process_registry
+
+        class FakeProcess:
+            def __init__(self, _pid):
+                pass
+
+            def parents(self):
+                return [SimpleNamespace(pid=444, cmdline=lambda: argv)]
+
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_ORIGIN_PID", raising=False)
+        monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=FakeProcess))
+
+        assert process_registry._is_gateway_descendant_process() is True
+
+    def test_external_cli_gateway_run_is_not_gateway_ancestor(self, monkeypatch):
+        """An unrelated CLI reusing ``gateway run`` is not a Hermes entrypoint."""
+        import sys
+        from types import SimpleNamespace
+        from tools import process_registry
+
+        class FakeProcess:
+            def __init__(self, _pid):
+                pass
+
+            def parents(self):
+                return [
+                    SimpleNamespace(
+                        pid=445,
+                        cmdline=lambda: ["external-cli", "gateway", "run"],
+                    )
+                ]
+
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_ORIGIN_PID", raising=False)
+        monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=FakeProcess))
+
+        assert process_registry._is_gateway_descendant_process() is False
+
+    def test_origin_pid_survives_profile_home_change_and_legacy_env_removal(
+        self, monkeypatch
+    ):
+        from types import SimpleNamespace
+        from tools import process_registry
+
+        class FakeProcess:
+            def __init__(self, _pid):
+                pass
+
+            def parents(self):
+                return [SimpleNamespace(pid=777, cmdline=lambda: ["opaque-launcher"])]
+
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        monkeypatch.setenv("HERMES_HOME", "D:/other-profile-home")
+        monkeypatch.setenv("HERMES_PROFILE", "other")
+        monkeypatch.setenv("HERMES_GATEWAY_ORIGIN_PID", "777")
+        monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=FakeProcess))
+
+        assert process_registry._is_gateway_descendant_process() is True
+
+    def test_import_only_external_cli_is_not_gateway_ancestor(self, monkeypatch):
+        from types import SimpleNamespace
+        from tools import process_registry
+
+        class FakeProcess:
+            def __init__(self, _pid):
+                pass
+
+            def parents(self):
+                return [
+                    SimpleNamespace(
+                        pid=888,
+                        cmdline=lambda: ["python", "external_cli.py", "status"],
+                    )
+                ]
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.delenv("HERMES_GATEWAY_ORIGIN_PID", raising=False)
+        monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=FakeProcess))
+
+        assert process_registry._is_gateway_descendant_process() is False
+
+    def test_marker_without_live_gateway_is_not_descendant(self, monkeypatch):
+        from types import SimpleNamespace
+        from tools import process_registry
+
+        class FakeProcess:
+            def __init__(self, _pid):
+                pass
+
+            def parents(self):
+                return []
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.delenv("HERMES_GATEWAY_ORIGIN_PID", raising=False)
+        monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=FakeProcess))
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: None,
+        )
+
+        assert process_registry._is_gateway_descendant_process() is False
+
+    def test_gateway_marker_fails_closed_when_pid_check_errors(self, monkeypatch):
+        import sys
+        from types import SimpleNamespace
+        from tools import process_registry
+
+        class FakeProcess:
+            def __init__(self, _pid):
+                pass
+
+            def parents(self):
+                return []
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=FakeProcess))
+
+        def _raise(*, cleanup_stale=False):
+            raise OSError("state unreadable")
+
+        monkeypatch.setattr("gateway.status.get_running_pid", _raise)
+
+        assert process_registry._is_gateway_descendant_process() is True
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only: systemd scopes")
 class TestSystemdCgroupIsolation:
     """Verify spawn_local wraps the worker in ``systemd-run --user --scope``

--- a/tests/tools/test_send_message_telegram_peer_flood.py
+++ b/tests/tools/test_send_message_telegram_peer_flood.py
@@ -1,0 +1,222 @@
+"""Standalone Telegram outbound policy and shared PEER_FLOOD circuit tests."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram import outbound_circuit
+from plugins.platforms.telegram.adapter import TelegramAdapter, _standalone_send
+from plugins.platforms.telegram.outbound_policy import deactivate_coupang_urls
+from tools.send_message_tool import _send_telegram
+
+
+class PeerFloodError(Exception):
+    def __init__(self, retry_after=None):
+        super().__init__("Telegram server error: PEER_FLOOD")
+        self.retry_after = retry_after
+
+
+@pytest.fixture(autouse=True)
+def _isolated_circuit(tmp_path, monkeypatch):
+    monkeypatch.setattr(outbound_circuit, "_db_path", lambda: tmp_path / "state.db")
+
+
+@pytest.fixture
+def telegram_bot(monkeypatch):
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+    bot.send_photo = AsyncMock(return_value=SimpleNamespace(message_id=2))
+    bot.send_video = AsyncMock(return_value=SimpleNamespace(message_id=3))
+    bot.send_voice = AsyncMock(return_value=SimpleNamespace(message_id=4))
+    bot.send_audio = AsyncMock(return_value=SimpleNamespace(message_id=5))
+    bot.send_document = AsyncMock(return_value=SimpleNamespace(message_id=6))
+    factory = MagicMock(return_value=bot)
+    parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
+    constants = SimpleNamespace(ParseMode=parse_mode)
+    telegram = SimpleNamespace(
+        Bot=factory,
+        MessageEntity=lambda **kwargs: SimpleNamespace(**kwargs),
+        constants=constants,
+    )
+    monkeypatch.setitem(sys.modules, "telegram", telegram)
+    monkeypatch.setitem(sys.modules, "telegram.constants", constants)
+    monkeypatch.setattr(
+        "gateway.platforms.base.resolve_proxy_url", lambda *_args, **_kwargs: None
+    )
+    return bot, factory
+
+
+def _adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    return adapter
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            "상품 https://www.coupang.com/vp/products/1?itemId=2#review",
+            "상품 https://www.coupang[.]com/vp/products/1?itemId=2#review",
+        ),
+        ("//link.coupang.com/a/ABC", "//link.coupang[.]com/a/ABC"),
+        ("coupang.com/item", "coupang[.]com/item"),
+        (
+            "https://example.com/?next=//coupang.com/item#coupang.com",
+            "https://example.com/?next=//coupang.com/item#coupang.com",
+        ),
+    ],
+)
+def test_standalone_defangs_only_coupang_origins(
+    source, expected, telegram_bot, monkeypatch
+):
+    bot, _factory = telegram_bot
+    monkeypatch.setattr(TelegramAdapter, "format_message", lambda _self, value: value)
+
+    result = asyncio.run(_send_telegram("token", "123", source))
+
+    assert deactivate_coupang_urls(source) == expected
+    assert result["success"] is True
+    assert bot.send_message.await_args.kwargs["text"] == expected
+
+
+def test_adapter_opened_circuit_blocks_standalone_with_same_normalized_chat_key(
+    telegram_bot,
+):
+    bot, _factory = telegram_bot
+    pconfig = SimpleNamespace(token="token", extra={})
+
+    async def run():
+        adapter = _adapter()
+        adapter._open_peer_flood_circuit("00123", PeerFloodError(60.0))
+        return await _standalone_send(pconfig, " 123 ", "blocked")
+
+    result = asyncio.run(run())
+
+    assert result["error_kind"] == "peer_flood"
+    assert result["retryable"] is False
+    bot.send_message.assert_not_awaited()
+
+
+def test_standalone_peer_flood_opens_circuit_seen_by_adapter_without_retry(
+    telegram_bot, monkeypatch
+):
+    bot, _factory = telegram_bot
+    bot.send_message.side_effect = PeerFloodError(42.0)
+    sleep = AsyncMock()
+    monkeypatch.setattr("tools.send_message_tool.asyncio.sleep", sleep)
+
+    result = asyncio.run(_send_telegram("token", "00123", "hello"))
+    blocked = asyncio.run(_adapter().send("123", "blocked", metadata={"notify": True}))
+
+    assert result["error_kind"] == "peer_flood"
+    assert result["retryable"] is False
+    assert 0 < result["retry_after"] <= 42.0
+    assert blocked.error_kind == "peer_flood"
+    assert bot.send_message.await_count == 1
+    sleep.assert_not_awaited()
+
+
+def test_standalone_peer_flood_response_opens_circuit(telegram_bot):
+    bot, _factory = telegram_bot
+    bot.send_message.return_value = {
+        "ok": False,
+        "description": "Bad Request: PEER_FLOOD",
+        "parameters": {"retry_after": 30},
+    }
+
+    result = asyncio.run(_send_telegram("token", "123", "hello"))
+
+    assert result["error_kind"] == "peer_flood"
+    assert 0 < result["retry_after"] <= 30.0
+    assert outbound_circuit.remaining("123") is not None
+
+
+def test_media_peer_flood_stops_remaining_media_and_fallback(
+    telegram_bot, tmp_path
+):
+    bot, _factory = telegram_bot
+    first = tmp_path / "first.png"
+    second = tmp_path / "second.png"
+    first.write_bytes(b"png")
+    second.write_bytes(b"png")
+    bot.send_photo.side_effect = [
+        PeerFloodError(60.0),
+        SimpleNamespace(message_id=2),
+    ]
+
+    result = asyncio.run(
+        _send_telegram(
+            "token",
+            "123",
+            "",
+            media_files=[(str(first), False), (str(second), False)],
+        )
+    )
+
+    assert result["error_kind"] == "peer_flood"
+    assert bot.send_photo.await_count == 1
+    bot.send_document.assert_not_awaited()
+
+
+def test_standalone_async_path_uses_async_circuit_wrappers(
+    telegram_bot, monkeypatch
+):
+    bot, _factory = telegram_bot
+    bot.send_message.side_effect = PeerFloodError(60.0)
+    monkeypatch.setattr(
+        outbound_circuit,
+        "remaining",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("sync DB read")),
+    )
+    monkeypatch.setattr(
+        outbound_circuit,
+        "open_circuit",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("sync DB write")),
+    )
+    remaining_async = AsyncMock(return_value=None)
+    open_async = AsyncMock(return_value=60.0)
+    monkeypatch.setattr(outbound_circuit, "remaining_async", remaining_async)
+    monkeypatch.setattr(outbound_circuit, "open_circuit_async", open_async)
+
+    result = asyncio.run(_send_telegram("token", "123", "hello"))
+
+    assert result["error_kind"] == "peer_flood"
+    remaining_async.assert_awaited_once_with("123")
+    open_async.assert_awaited_once_with("123", 60.0)
+
+
+def test_standalone_write_failure_blocks_next_call(
+    telegram_bot, monkeypatch
+):
+    bot, _factory = telegram_bot
+    bot.send_message.side_effect = PeerFloodError(60.0)
+    real_connection = outbound_circuit._connection
+
+    def broken_connection():
+        raise OSError("disk unavailable")
+
+    real_open_async = outbound_circuit.open_circuit_async
+
+    async def fail_persist(chat_id, delay):
+        outbound_circuit._connection = broken_connection
+        try:
+            return await real_open_async(chat_id, delay)
+        finally:
+            outbound_circuit._connection = real_connection
+
+    monkeypatch.setattr(outbound_circuit, "open_circuit_async", fail_persist)
+    failed = asyncio.run(_send_telegram("token", "123", "first"))
+    bot.send_message.side_effect = None
+
+    blocked = asyncio.run(_send_telegram("token", "123", "second"))
+
+    assert failed["error_kind"] == "peer_flood"
+    assert blocked["error_kind"] == "peer_flood"
+    assert bot.send_message.await_count == 1

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -682,15 +682,12 @@ def execute_code(
     if not code or not code.strip():
         return tool_error("No code provided. execute_code requires a non-empty 'code' "
                           "parameter containing Python source. To run shell commands, use terminal(command=...) instead.")
-    # Hard-block gateway-lifecycle commands (mirrors the terminal_tool guard — otherwise
-    # `os.system("launchctl bootout ...")` here bypasses it and SIGTERMs the gateway mid-task).
-    # Gated on PID-file ownership, not the inherited env marker.
     # Hard-block gateway-lifecycle commands, mirroring the terminal_tool guard (#68289): without this,
     # execute_code is a straight bypass — the terminal() path refuses `launchctl bootout ai.hermes.gateway`,
     # but the identical command inside `os.system(...)` / `subprocess.run([...])` here sailed through and
-    # SIGTERM'd the gateway mid-task.
-    from tools.process_registry import _is_supervised_gateway_process
-    if _is_supervised_gateway_process():
+    # SIGTERM'd the gateway mid-task. Gated on PID-file ownership, not the inherited env marker (#92560).
+    from tools.process_registry import _is_gateway_runtime_process
+    if _is_gateway_runtime_process():
         from cron.lifecycle_guard import contains_gateway_lifecycle_command
         if contains_gateway_lifecycle_command(code):
             return tool_error(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -186,18 +186,123 @@ def _systemd_run_user_scope_available() -> bool:
         return available
 
 
+GATEWAY_ORIGIN_PID_ENV = "HERMES_GATEWAY_ORIGIN_PID"
+
+
+def _is_gateway_runtime_process() -> bool:
+    """Return whether this process owns the live Hermes gateway PID file.
+
+    ``_HERMES_GATEWAY`` alone is insufficient because imports and child
+    processes inherit it. PID ownership distinguishes the gateway itself and
+    works for both supervised Unix services and direct-spawn Windows login
+    items.
+    """
+    origin = os.environ.get(GATEWAY_ORIGIN_PID_ENV, "").strip()
+    if origin and origin != str(os.getpid()):
+        return False
+    if not origin and os.environ.get("_HERMES_GATEWAY") != "1":
+        return False
+
+    try:
+        from gateway.status import get_running_pid
+
+        return get_running_pid(cleanup_stale=False) == os.getpid()
+    except Exception as exc:
+        logger.debug("Could not verify gateway process identity: %s", exc)
+        return False
+
+
+def _is_gateway_descendant_process() -> bool:
+    """Return whether this process descends from a currently running gateway.
+
+    Prefer the inherited origin PID and actual process ancestry. Explicit
+    gateway command shapes recover when wrappers remove the environment or
+    switch profiles. The legacy marker is only a fail-closed fallback paired
+    with live gateway state, never sufficient during an ordinary import.
+    """
+    marker = os.environ.get("_HERMES_GATEWAY") == "1"
+    origin_raw = os.environ.get(GATEWAY_ORIGIN_PID_ENV, "").strip()
+    ancestors = None
+    ancestry_error = False
+    try:
+        import psutil
+
+        ancestors = psutil.Process(os.getpid()).parents()
+    except Exception as exc:
+        ancestry_error = True
+        logger.debug("Could not inspect gateway ancestry: %s", exc)
+
+    if ancestors is not None:
+        try:
+            origin_pid = int(origin_raw) if origin_raw else None
+        except ValueError:
+            origin_pid = None
+        ancestor_pids = {getattr(ancestor, "pid", None) for ancestor in ancestors}
+        if origin_pid is not None and origin_pid in ancestor_pids:
+            return True
+
+        for ancestor in ancestors:
+            try:
+                argv = [
+                    str(part).replace("\\", "/").lower()
+                    for part in ancestor.cmdline()
+                ]
+            except Exception:
+                continue
+            executable = argv[0].rsplit("/", 1)[-1].removesuffix(".exe") if argv else ""
+            is_hermes_cli = executable == "hermes" or any(
+                argv[index] == "-m" and argv[index + 1] == "hermes_cli.main"
+                for index in range(len(argv) - 1)
+            )
+            if is_hermes_cli and any(
+                argv[index] == "gateway" and argv[index + 1] == "run"
+                for index in range(len(argv) - 1)
+            ):
+                return True
+            if any(
+                argv[index] == "-m" and argv[index + 1] == "gateway.run"
+                for index in range(len(argv) - 1)
+            ):
+                return True
+            if "--gateway" in argv and any(
+                part.rsplit("/", 1)[-1] == "cli.py" for part in argv
+            ):
+                return True
+
+    if origin_raw and ancestry_error:
+        return True
+    if not marker:
+        return False
+
+    try:
+        from gateway.status import get_running_pid
+
+        live_pid = get_running_pid(cleanup_stale=False)
+    except Exception as exc:
+        logger.debug("Could not verify inherited gateway marker: %s", exc)
+        return True
+
+    if live_pid is None:
+        return False
+    if ancestors is None:
+        return True
+    return live_pid == os.getpid() or any(
+        getattr(ancestor, "pid", None) == live_pid for ancestor in ancestors
+    )
+
+
 def _is_supervised_gateway_process() -> bool:
     """Whether this process is the live, supervised Hermes gateway itself.
     Supervisor markers and ``_HERMES_GATEWAY`` are inherited by every descendant (and
-    importing ``gateway.run`` sets the latter), so also require ownership of the live
-    gateway PID file — scopes are for the gateway, not terminal children or CLIs."""
-    if os.environ.get("_HERMES_GATEWAY") != "1":
+    importing ``gateway.run`` sets the latter), so PID-file ownership is required too
+    — scopes are for the gateway, not terminal children or CLIs. The ownership half
+    now lives in ``_is_gateway_runtime_process`` so both probes share one answer."""
+    if not _is_gateway_runtime_process():
         return False
     try:
         from gateway.restart import is_gateway_supervisor_process
-        from gateway.status import get_running_pid
 
-        return is_gateway_supervisor_process() and get_running_pid(cleanup_stale=False) == os.getpid()
+        return is_gateway_supervisor_process()
     except Exception as exc:
         logger.debug("Could not verify supervised gateway process identity: %s", exc)
         return False

--- a/tools/send_message_senders.py
+++ b/tools/send_message_senders.py
@@ -69,6 +69,13 @@ _TELEGRAM_TRANSIENT_MARKERS = ("bad gateway", "502", "too many requests", "429",
 def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
     """Retry delay in seconds, or None when final: honours ``retry_after``; timeouts are
     never retried (the send may have gone through); 5xx/429 back off exponentially."""
+    try:
+        from plugins.platforms.telegram.outbound_policy import TelegramPeerFloodBlocked
+
+        if isinstance(exc, TelegramPeerFloodBlocked):
+            return None
+    except ImportError:
+        pass
     retry_after = getattr(exc, "retry_after", None)
     if retry_after is not None:
         try:
@@ -238,9 +245,17 @@ def _telegram_format(message):
 
 async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
     """One-shot Telegram Bot API send; parse failures fall back to plain text."""
+    from plugins.platforms.telegram.outbound_policy import (
+        GuardedTelegramTarget,
+        TelegramOutboundGateway,
+        TelegramPeerFloodBlocked,
+    )
+
     try:
         formatted, send_parse_mode, _has_html = _telegram_format(message)
-        bot = _telegram_bot(token)
+        bot = GuardedTelegramTarget(
+            _telegram_bot(token), TelegramOutboundGateway(), target_key=chat_id
+        )
         from plugins.platforms.telegram.telegram_ids import normalize_telegram_chat_id
         from gateway.platforms.base import BasePlatformAdapter, utf16_len
         # Telegram accepts a numeric chat_id OR an @username string; never force-int.
@@ -270,6 +285,8 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             bot, chat_id=int_chat_id, text=_tg_caption, parse_mode=send_parse_mode, **text_kwargs)
                         _tg_caption = None  # delivered — don't re-caption a later file
                     except Exception as _cap_err:
+                        if isinstance(_cap_err, TelegramPeerFloodBlocked):
+                            raise
                         logger.warning("Telegram caption-fallback send failed for missing media: %s",
                                        _sanitize_error_text(_cap_err))
                 continue
@@ -277,12 +294,23 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 last_msg = await _telegram_send_one_media(
                     bot, int_chat_id, media_path, is_voice, caption=_tg_caption, parse_mode=send_parse_mode,
                     has_html=_has_html, thread_kwargs=thread_kwargs, force_document=force_document)
+            except TelegramPeerFloodBlocked:
+                raise
             except Exception as e:
                 warnings.append(_sanitize_error_text(f"Failed to send media {media_path}: {e}"))
                 logger.error(warnings[-1])
         if last_msg is None:
             return {"error": _NO_DELIVERABLE, **({"warnings": warnings} if warnings else {})}
         return _success("telegram", chat_id, warnings, message_id=str(last_msg.message_id))
+    except TelegramPeerFloodBlocked as e:
+        return {
+            "error": "peer_flood",
+            "error_kind": "peer_flood",
+            "retryable": False,
+            "retry_after": e.retry_after,
+            "platform": "telegram",
+            "chat_id": chat_id,
+        }
     except ImportError:
         return {"error": "python-telegram-bot not installed. Run: pip install python-telegram-bot"}
     except Exception as e:

--- a/tools/terminal_tool_guards.py
+++ b/tools/terminal_tool_guards.py
@@ -197,10 +197,10 @@ def gateway_lifecycle_block(
     a self-restart into a respawn loop, so it passes too.
     Returns the JSON error string when blocked, else None.
     """
-    from tools.process_registry import _is_supervised_gateway_process
+    from tools.process_registry import _is_gateway_runtime_process
     from tools.terminal_tool import _resolve_command_cwd, get_session_cwd
 
-    if not _is_supervised_gateway_process():
+    if not _is_gateway_runtime_process():
         return None
     from cron.lifecycle_guard import (
         _MAX_REFERENCED_SCRIPT_BYTES,


### PR DESCRIPTION
## 변경 사항
- Telegram adapter, standalone sender, callback, webhook 쓰기를 단일 outbound 정책 관문으로 통합
- 쿠팡 URL 비활성화와 프로세스 공유 PEER_FLOOD 회로, 재시도/대체 발송 차단 추가
- gateway 내부 update/lifecycle 차단과 메시징 `/update`의 stdin 일회용 토큰, OS lock, request_id/done marker 계약 추가
- 업데이트 완료/승인 안내가 `SendResult.success=False`일 때 상태를 보존하고 실제 전달 성공 전 pending 처리하지 않도록 수정

## 안전성
- handoff token은 argv, 환경변수, 로그에 넣지 않고 stdin으로만 전달
- helper 실행 중 OS lock을 유지하고 request_id, done marker, exit code가 일치할 때만 상태 정리
- Telegram payload의 Mapping 키/값, cycle/alias, TelegramObject, DefaultValue를 복사 검사하며 미지원 타입은 전송 전 차단
- webhook `delete_webhook`, `start_webhook`도 global circuit key를 사용

## 검증
- 독립 보안/논리 검토: 차단 이슈 0건
- Telegram 핵심 회귀: 113 passed
- Telegram polling/webhook: 14 passed
- update 표적 묶음: 115 passed
- gateway lifecycle: 297 passed, 2 skipped
- 광범위 Telegram 회귀: 1059 passed, 6 failed, 5 skipped
  - 실패 6건은 clean upstream/main에서도 동일하게 재현, 신규 실패 0건
- process_registry 전체: clean upstream/main과 동일한 Windows 기준 실패 6건, 신규 identity 시험 12 passed
- Ruff 통과
- `git diff --cached --check` 통과

## 범위
- 활성 설치본과 실행 중 gateway는 변경하거나 재시작하지 않았습니다.
- 작업은 별도 clone에서만 수행했습니다.