### PR TITLE
fix(tui): avoid UnboundLocalError on pt_key_to_sequence when config import fails (#101757)

### DIFF
--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -2011,6 +2011,10 @@ class CLITuiMixin:
         mid-session.
         """
         from cli import logger
+        # pt_key_to_sequence is a pure helper (no config dependency); import it outside the try so the
+        # Ctrl+B fallback still resolves when the config/normalize imports below fail (#101757) — otherwise
+        # pt_key_to_sequence stays an unbound local and the return raises UnboundLocalError.
+        from hermes_cli.voice import pt_key_to_sequence
         # Voice push-to-talk key: configurable via config.yaml (voice.record_key) Default: Ctrl+B (avoids
         # conflict with Ctrl+R readline reverse-search). Config spellings (ctrl/control/alt/option/opt) are
         # normalized to prompt_toolkit's c-x / a-x format via
@@ -2023,7 +2027,6 @@ class CLITuiMixin:
             from hermes_cli.config import load_config
             from hermes_cli.voice import (
                 normalize_voice_record_key_for_prompt_toolkit,
-                pt_key_to_sequence,
                 voice_record_key_from_config)
             _raw_key = voice_record_key_from_config(load_config())
             _voice_key = normalize_voice_record_key_for_prompt_toolkit(_raw_key)

--- a/tests/hermes_cli/test_tui_voice_record_key_sequence.py
+++ b/tests/hermes_cli/test_tui_voice_record_key_sequence.py
@@ -1,0 +1,55 @@
+"""Regression for #101757: ``CLITuiMixin._tui_voice_record_key_sequence`` must
+fall back to the default Ctrl+B sequence — not raise ``UnboundLocalError`` —
+when the config/normalize imports inside its try block fail.
+
+The method imported ``pt_key_to_sequence`` (a pure helper) inside the same
+``try`` block as the config/normalize helpers. When the packaged
+``hermes_cli.config`` import is broken (as reported in Docker), the
+``except`` clause only restores ``_voice_key`` to the default, leaving
+``pt_key_to_sequence`` an unbound local — so the final
+``return pt_key_to_sequence(_voice_key)`` raised ``UnboundLocalError`` and
+the TUI crashed on startup. ``pt_key_to_sequence`` is a pure function with
+no config dependency, so importing it outside the try block makes the
+fallback path resolve cleanly.
+"""
+
+import logging
+import sys
+import types
+
+
+class TestTuiVoiceRecordKeySequenceFallback:
+    """Regression for #101757 — the Ctrl+B fallback path must not UnboundLocalError."""
+
+    def test_falls_back_to_ctrl_b_when_config_import_fails(self, monkeypatch):
+        # Import first so the module-level imports of cli_tui_mixin resolve
+        # against the real package; we only want the method's *local* import
+        # of `hermes_cli.config` to fail.
+        from hermes_cli.cli_tui_mixin import CLITuiMixin
+
+        # The method does `from cli import logger` at the top; stub it so the
+        # test does not depend on the (heavy) cli module import path.
+        cli_stub = types.ModuleType("cli")
+        cli_stub.logger = logging.getLogger("cli")
+        monkeypatch.setitem(sys.modules, "cli", cli_stub)
+
+        # sys.modules[key] = None makes `from <key> import ...` raise ImportError,
+        # reproducing the broken-packaged-import path that triggers #101757:
+        # the config import inside the try block fails, pt_key_to_sequence never
+        # gets bound there, and (pre-fix) the return raised UnboundLocalError.
+        monkeypatch.setitem(sys.modules, "hermes_cli.config", None)
+
+        class _Self(CLITuiMixin):
+            """Minimal host: the method only touches self.set_voice_record_key_cache."""
+
+            def set_voice_record_key_cache(self, raw_key):
+                self.cached = raw_key
+
+        self_obj = _Self()
+        result = self_obj._tui_voice_record_key_sequence()
+
+        # Ctrl+B default sequence, not UnboundLocalError.
+        assert result == ("c-b",)
+        # The default raw key is cached for the UI label (same value that drives
+        # the prompt_toolkit binding).
+        assert self_obj.cached == "ctrl+b"


### PR DESCRIPTION
## What does this PR do?

Fixes #101757 — the TUI crashed on startup in the packaged Docker image with:

```
UnboundLocalError: cannot access the local variable 'pt_key_to_sequence'
  where it is not associated with a value
  at cli_tui_mixin.py:1992 → return pt_key_to_sequence(_voice_key)
```

`_tui_voice_record_key_sequence` imported `pt_key_to_sequence` **inside the same `try` block** as the config/normalize helpers. Per Python's scoping rules, a `from m import x` anywhere in a function makes `x` a **local** of that function. When the packaged `hermes_cli.config` import is broken (as in the Docker image), the `try` block exits before `pt_key_to_sequence` is ever bound, the `except` only restores `_voice_key = "c-b"`, and the final `return pt_key_to_sequence(_voice_key)` raises `UnboundLocalError` — so `hermes` exits immediately after the welcome banner.

## Related Issue

Fixes #101757

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`hermes_cli/cli_tui_mixin.py` — import `pt_key_to_sequence` **outside the `try` block** (right after `from cli import logger`). It is a pure helper (`voice.py:92`, string processing only, no config/IO dependency), so there is no reason for it to be lazy. The `normalize_voice_record_key_for_prompt_toolkit` and `voice_record_key_from_config` imports stay lazy inside the `try` because they genuinely participate in the config-reading path that can fail.

With this, a broken `hermes_cli.config` import falls back cleanly: `_voice_key = "c-b"`, `return pt_key_to_sequence("c-b")` → `("c-b",)`, and the TUI binds Ctrl+B and continues. No behavior change on the happy path (config imports succeed → same sequence returned); only the broken-import fallback path is repaired.

`tests/hermes_cli/test_tui_voice_record_key_sequence.py` (new) — regression test that poisons `hermes_cli.config` in `sys.modules` (set to `None`, which makes `from hermes_cli.config import ...` raise `ImportError`) to reproduce the broken-packaged-import path.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_tui_voice_record_key_sequence.py`

Post-fix: PASSED. Pre-fix (same test against unmodified `main`): FAILED with the exact `UnboundLocalError` at `return pt_key_to_sequence(_voice_key)`:

```
>       return pt_key_to_sequence(_voice_key)
E       UnboundLocalError: cannot access the local variable 'pt_key_to_sequence' where it is not associated with a value
FAILED tests/hermes_cli/test_tui_voice_record_key_sequence.py::...::test_falls_back_to_ctrl_b_when_config_import_fails
```

Rebuilt on current `main@476a45f4f`. The focused behavioral regression passes 1/1 through the CI-parity runner; Ruff, `py_compile`, and `git diff --check` are clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tui): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] N/A (single-method fix, no doc/architecture change)
