### PR TITLE
fix(cron): decode no_agent script stdout lossily on POSIX like Windows

### DIFF
--- a/cron/scheduler_script.py
+++ b/cron/scheduler_script.py
@@ -341,21 +341,22 @@ def _run_job_script(
         if sys.platform == "win32":
             popen_kwargs = {
                 "creationflags": windows_hide_flags()
-                | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
-                # Lossy UTF-8 decode — locale-mismatched bytes from the STT command must not raise in the
-                # reader threads on non-UTF-8 Windows (#45099).
-                # Lossy UTF-8 decode — locale-mismatched bytes from the TTS command must not raise in the
-                # reader threads on non-UTF-8 Windows (#45099).
-                "encoding": "utf-8",
-                "errors": "replace"}
+                | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)}
         env = build_subprocess_env()
         env.update(env_overlay)
         # Subprocess cwd only (default: scripts-dir parent). NEVER os.chdir() the process.
         # Use the job's workdir as the subprocess cwd when configured, otherwise default to the scripts-dir
         # parent (back-compat). NEVER mutate the Python process cwd — that would leak into concurrent
         # gateway sessions (#69396).
+        # Lossy UTF-8 decode for script stdout on BOTH platforms: a stray non-UTF-8 byte (a chunked
+        # multibyte write, a binary source the watchdog inspects, or locale-mismatched output) must not
+        # raise UnicodeDecodeError in communicate() and silently drop the whole tick's output. Windows
+        # needed this for the command pipes (#45099); POSIX had the same strict-default hole even under a
+        # UTF-8 locale — build_subprocess_env sets PYTHONUTF8=1 so the child writes UTF-8, and
+        # errors="replace" makes the remaining undecodable bytes lossy instead of fatal (#105582).
         proc = subprocess.Popen(
             argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            encoding="utf-8", errors="replace",
             cwd=workdir or str(path.parent), env=env, **popen_kwargs)
         deadline = time.monotonic() + script_timeout
         while True:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -282,7 +282,7 @@ class TestRunJobScript:
         sys.platform == "win32",
         reason="Windows always takes the overlay/creationflags branch",
     )
-    def test_non_windows_script_preserves_default_text_decoding(self, cron_env, monkeypatch):
+    def test_non_windows_script_uses_lossy_utf8_decode(self, cron_env, monkeypatch):
         # No platform patching: the Linux CI host already takes this branch.
         from cron import scheduler as sched_mod
         from cron import scheduler_script as sched_script
@@ -320,8 +320,10 @@ class TestRunJobScript:
         assert captured["argv"] == [sys.executable, str(script.resolve())]
         assert captured["kwargs"]["text"] is True
         assert "creationflags" not in captured["kwargs"]
-        assert "encoding" not in captured["kwargs"]
-        assert "errors" not in captured["kwargs"]
+        # After #105582: POSIX now matches Windows — script stdout is decoded as
+        # UTF-8 with errors="replace" so a stray non-UTF-8 byte no longer crashes the tick.
+        assert captured["kwargs"]["encoding"] == "utf-8"
+        assert captured["kwargs"]["errors"] == "replace"
 
     def test_non_overlay_branch_keeps_plain_argv(self, cron_env, monkeypatch):
         """When the Windows uv-venv overlay is NOT active, the invocation must
@@ -383,8 +385,9 @@ class TestRunJobScript:
     def test_invalid_utf8_stdout_does_not_raise(self, cron_env):
         """Truncated/invalid UTF-8 in script stdout must never escape as an
         exception (#47393) — a raised UnicodeDecodeError higher up would
-        silently drop the whole delivery (#42384). The run may fail, but it
-        must fail as a (False, message) result the scheduler can deliver.
+        silently drop the whole delivery (#42384). After #105582 the run no
+        longer fails either: the undecodable bytes are lossily replaced, so
+        the decodable prefix survives as output and the alert is delivered.
         """
         from cron.scheduler_script import _run_job_script
 
@@ -399,9 +402,12 @@ class TestRunJobScript:
 
         success, output = _run_job_script("bad_bytes.py")  # must not raise
 
-        assert isinstance(success, bool)
+        # Before #105582 this returned (False, "Script execution failed: ...")
+        # and the alert bytes were dropped. Now the run succeeds and the
+        # decodable prefix survives as lossy output.
+        assert success is True
         assert isinstance(output, str)
-        assert output  # a message is always produced, never a silent drop
+        assert "partial" in output
 
 
 class TestBuildJobPromptWithScript:


### PR DESCRIPTION
## Summary

Fixes #105582 — a no_agent cron job whose script emits a single non-UTF-8 byte to stdout silently fails the whole tick on POSIX (`UnicodeDecodeError` is swallowed into `(False, "Script execution failed: ...")` and the alert output is **lost**), instead of decoding lossily the way Windows already does.

## Root cause

`cron/scheduler_script.py` `_run_job_script` runs the script via `subprocess.Popen(..., text=True, **popen_kwargs)`. The Windows branch set `encoding="utf-8", errors="replace"` (so undecodable bytes became `U+FFFD`); the POSIX branch left `popen_kwargs = {"start_new_session": True}` — no `errors=` — so `text=True` defaulted to `errors="strict"`. One stray byte (a truncated multibyte write, a binary source the watchdog inspects, a gzip-rotated log tailed as text) made `communicate()` raise `UnicodeDecodeError`. The `except Exception` at the bottom caught it and returned `(False, "Script execution failed: 'utf-8' codec can't decode byte 0x80...")` — the script's actual output never reached the delivery path. For an alerting/watchdog job this is the worst-case outcome: the watchdog itself dies silently.

@foma-agent confirmed this against `origin/main` (520e6366): a child writing `b'alert ok \x80 leftover'` returns `(False, "Script execution failed: ...")`; the alert bytes never become output.

## Fix

Hoist `encoding="utf-8", errors="replace"` out of the Windows-only `popen_kwargs` into the shared `Popen(...)` call, so both platforms decode stdout lossily:

```python
proc = subprocess.Popen(
    argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
    encoding="utf-8", errors="replace",
    cwd=workdir or str(path.parent), env=env, **popen_kwargs)
```

`build_subprocess_env` already sets `PYTHONUTF8=1` (so the spawned Python child writes UTF-8); `errors="replace"` makes the remaining undecodable bytes lossy instead of fatal. The Windows branch keeps only its `creationflags`. This is exactly what the issue asks for ("align the POSIX path with the Windows branch") and matches the existing pattern elsewhere in the codebase (`tools/environments/local.py:787` uses the same `text=True, encoding="utf-8", errors="replace"`).

## Why a fresh PR (not a +1 on an existing one)

Two open PRs address this, **both edit `cron/scheduler.py`** — but the `Popen` call was refactored into `cron/scheduler_script.py` `_run_job_script`, so neither patch reaches the current code:

- #86967 (`@S-Claw`, opened 2026-08-15, `mergeable: None`) — `errors="replace"` without `encoding` on POSIX, edits `cron/scheduler.py`.
- #96673 (`@Rodkillah`, opened 2026-08-27, `mergeable: False`) — `utf-8` + `replace` on all platforms, edits `cron/scheduler.py`.

@foma-agent flagged exactly this: *"Open PRs still patch the old file."* Neither author has updated in 2–3 weeks. This PR patches the file the code actually lives in today. Happy to close this in favor of either one if a maintainer prefers I rebase #86967 / #96673 onto `scheduler_script.py` instead — I went with a fresh branch only because both are stale, conflicting, and by other new contributors.

## Test changes (`tests/cron/test_cron_script.py`)

- `test_non_windows_script_preserves_default_text_decoding` → renamed to `test_non_windows_script_uses_lossy_utf8_decode`. It previously **pinned the bug** (`assert "encoding" not in kwargs`, `assert "errors" not in kwargs`); now asserts both are present and equal `"utf-8"` / `"replace"`.
- `test_invalid_utf8_stdout_does_not_raise` strengthened: previously asserted only `isinstance(success, bool)` + `output` truthy (it passed because the `UnicodeDecodeError` was caught into a `(False, message)` result). Now asserts `success is True` and `"partial" in output` — the decodable prefix survives instead of the whole output being dropped.

`test_emoji_stdout_round_trips_through_script_capture` (valid UTF-8 emoji) is unchanged and unaffected.

## Verification

`pytest` isn't available in my sandbox, so I replicated the `cron_env` fixture in a standalone runner (`/tmp/hermes-verify-105582.py`) and exercised `_run_job_script` against three real scripts on this macOS host (POSIX branch):

| script | before fix | after fix |
|---|---|---|
| `ok.py` (`print("ok")`) | `(True, "ok")` | `(True, "ok")` |
| `emoji.py` (valid UTF-8 🎉日次) | `(True, "backup done 🎉 日次")` | `(True, "backup done 🎉 日次")` |
| `bad_bytes.py` (`b'partial \xe6\x97'`) | `(False, "Script execution failed: 'utf-8' codec can't decode byte 0xe6 in position 8...")` | **`(True, 'partial ')`** ← the alert prefix survives |

7/7 assertions pass. New contributor — glad to rename, fold into an existing PR, or adjust the fix shape (e.g. `errors="replace"` without forcing `encoding`, to preserve the POSIX locale-derived encoding) if a maintainer prefers that.
