### PR TITLE
perf(agent): avoid quadratic work in tool history pairing

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -499,7 +499,8 @@ def _prune_unanswered_tool_calls(messages: List[Dict]) -> Tuple[List[Dict], int]
             pruned.append(msg)
             continue
         answered: set = set()
-        for follower in messages[i + 1:]:
+        for follower_idx in range(i + 1, len(messages)):
+            follower = messages[follower_idx]
             if not (isinstance(follower, dict) and follower.get("role") == "tool"):
                 break
             tid = (follower.get("tool_call_id") or "").strip()
@@ -2512,10 +2513,10 @@ def _classify_tool_call_orphans(messages: List[Dict[str, Any]]):
     ]
     result_call_ids: set[str] = set().union(*(v for _, v in result_entries))
     orphaned_results = [msg for msg, v in result_entries if v and not (v & surviving_call_ids)]
-    orphaned_ids = {id(msg) for msg in orphaned_results}
-    surviving_result_variants = [v for msg, v in result_entries if v and id(msg) not in orphaned_ids]
+    # Orphan result variants are disjoint from every declared call, so they
+    # cannot contribute a match. Reuse the union instead of scanning each result.
     missing_tool_calls = [
-        tc for tc, v in assistant_call_variants if not any(v & rv for rv in surviving_result_variants)
+        tc for tc, v in assistant_call_variants if not (v & result_call_ids)
     ]
     return surviving_call_ids, result_call_ids, orphaned_results, missing_tool_calls
 

--- a/tests/agent/test_tool_pairing_scaling.py
+++ b/tests/agent/test_tool_pairing_scaling.py
@@ -1,0 +1,85 @@
+"""Bound pairing work by history size without wall-clock timing assertions."""
+
+import pytest
+
+from agent import agent_runtime_helpers as helpers
+
+
+def _exchange(index):
+    call = {
+        "id": f"item_{index}",
+        "call_id": f"call_{index}",
+        "response_item_id": f"fc_{index}",
+        "type": "function",
+        "function": {"name": "read_file", "arguments": "{}"},
+    }
+    return [
+        {"role": "assistant", "content": "", "tool_calls": [call]},
+        {"role": "tool", "tool_call_id": f"call_{index}|fc_{index}", "content": "ok"},
+    ]
+
+
+@pytest.mark.parametrize("pair_count", [64, 256])
+def test_positional_pairing_bounds_history_reads(pair_count):
+    class CountedHistory(list):
+        items_read = 0
+
+        def __iter__(self):
+            for item in super().__iter__():
+                self.items_read += 1
+                yield item
+
+        def __getitem__(self, key):
+            value = super().__getitem__(key)
+            # A slice copies every selected reference before the caller can break.
+            self.items_read += len(value) if isinstance(key, slice) else 1
+            return value
+
+    paired = [msg for i in range(pair_count) for msg in _exchange(i)]
+    displaced_call, displaced_result = _exchange("displaced")
+    boundary = {"role": "user", "content": "next turn"}
+    messages = CountedHistory(paired + [displaced_call, boundary, displaced_result])
+
+    repaired, repairs = helpers._prune_unanswered_tool_calls(messages)
+
+    assert messages.items_read <= 8 * len(messages)
+    assert repairs == 1
+    expected = paired + [boundary, displaced_result]
+    assert repaired == expected
+    assert all(actual is original for actual, original in zip(repaired, expected))
+
+
+@pytest.mark.parametrize("pair_count", [64, 256])
+def test_global_pairing_bounds_id_comparisons(pair_count, monkeypatch):
+    intersections = 0
+    original_variants = helpers.tool_call_id_variants
+
+    class CountedVariants(frozenset):
+        def __and__(self, other):
+            nonlocal intersections
+            intersections += 1
+            return super().__and__(other)
+
+    monkeypatch.setattr(
+        helpers, "tool_call_id_variants",
+        lambda call: CountedVariants(original_variants(call)),
+    )
+    messages = [msg for i in range(pair_count) for msg in _exchange(i)]
+    unanswered, _ = _exchange("missing")
+    missing_call = unanswered["tool_calls"][0]
+    orphan = {"role": "tool", "tool_call_id": "orphan", "content": "unmatched"}
+    messages.extend([unanswered, orphan])
+
+    call_ids, result_ids, orphaned, missing = helpers._classify_tool_call_orphans(messages)
+
+    assert intersections <= 4 * (pair_count + 1)
+    assert orphaned == [orphan] and orphaned[0] is orphan
+    assert missing == [missing_call] and missing[0] is missing_call
+    assert call_ids == set().union(*(
+        original_variants(call)
+        for message in messages for call in message.get("tool_calls", [])
+    ))
+    assert result_ids == set().union(*(
+        helpers.tool_result_id_variants(message["tool_call_id"])
+        for message in messages if message["role"] == "tool"
+    ))


### PR DESCRIPTION
## What does this PR do?

Long tool-heavy histories incur two avoidable quadratic costs during message pairing: positional repair copies the entire remaining history for each assistant call, and compression orphan classification scans result-ID sets again for each declared call. This removes both costs while preserving the existing pairing decisions.

## Related Issue

Found by profiling current main (`fef0e16fe19b79ded929209f87c7434270b03825`); no linked issue. This preserves the positional pairing policy from #97203. I searched open and closed PRs by the helper names and quadratic/tool-pairing terms; the nearby #104454 changes persistence invalidation, not traversal cost.

## Type of Change

- [x] Performance refactor (no behavior change)

## Changes Made

- `agent/agent_runtime_helpers.py`: walk the immediately following tool-result run by index, avoiding eager suffix copies. Stop at the same first non-tool message.
- Reuse the existing union of result-ID variants to find missing calls. An orphan result is disjoint from all declared call IDs, so including it in that union cannot create a match. Alias handling, output ordering, object identity, and the separate positional/global pairing policies stay the same.
- `tests/agent/test_tool_pairing_scaling.py`: two parametrized operation-count contracts (64 and 256 pairs), covering adjacency, composite aliases, missing calls, orphan results, and retained object identity. No wall-clock assertions.

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_tool_pairing_scaling.py tests/run_agent/test_message_sequence_repair.py tests/agent/test_cursor_optimizations_parity.py tests/agent/test_context_compressor.py tests/agent/test_send_path_history_isolation.py --file-retries 0 -j 4 -q --tb=short
```

**218 passed.** Copying just the new test file onto the base produces **4 failures**; this branch passes all 4. At 256 pairs, the base performs 66,821 history reference reads/copies and 33,152 call/result intersections, exceeding the linear budgets.

A separate 1,000-case seeded differential check through the real repair and compression-cleanup callers also preserved repair counts, persistence cursors, serialized transcripts, and retained message identities. Ruff, `git diff --check`, and `scripts/check_compat_pointers.py` pass.

## Performance

macOS 26.6.2 arm64, Python 3.11.15; synthetic histories, 5-run medians after warming existing argument-validation cursors. The small reproduction below was run on the base and this branch with the same venv.

| Messages | Local phase | Base | This PR |
| ---: | --- | ---: | ---: |
| 501 | Per-iteration preparation | 1.66 ms | 1.53 ms |
| 501 | Compression pair cleanup | 2.51 ms | 0.75 ms |
| 6,001 | Per-iteration preparation | 38.78 ms | 17.64 ms |
| 6,001 | Compression pair cleanup | 250.55 ms | 9.02 ms |
| 12,001 | Per-iteration preparation | 124.37 ms | 35.47 ms |
| 12,001 | Compression pair cleanup | 995.41 ms | 19.09 ms |

These measure local phases, excluding model inference, network latency, and summary generation. Short conversations see small absolute savings. Large compression-cleanup inputs are reachable when current-task retention keeps a long tool chain in the tail: with the default lean-tail settings and a 1M-token window, the real boundary/tail helpers retained 12,002 tail messages in a synthetic input estimated at 519,989 tokens. This PR does not change compression thresholds or retention.

<details>
<summary>Benchmark reproduction (run from each checkout root with its dev Python)</summary>

Run the following with `python -` or save it in the checkout root. The outer agent is a minimal stub; the iteration-preparation and compressor methods are real imports. No model request is made. JSON equality checks are outside the timed region.

```python
import gc, json, os, statistics, tempfile, time
from types import SimpleNamespace

with tempfile.TemporaryDirectory(prefix="hermes-pairing-bench-") as bench_home:
    os.environ["HERMES_HOME"] = bench_home
    from agent.agent_runtime_helpers import sanitize_tool_call_arguments
    from agent.context_compressor import ContextCompressor
    from agent.turn_iteration_prep import prepare_iteration

    compressor = object.__new__(ContextCompressor)
    compressor.quiet_mode = True
    for count in (250, 3000, 6000):
        messages = [{"role": "user", "content": "Inspect the repository."}]
        for i in range(count):
            call = {
                "id": f"call_{i}", "call_id": f"logical_{i}",
                "response_item_id": f"fc_{i}", "type": "function",
                "function": {"name": "read_file", "arguments": "{}"},
            }
            messages.extend([
                {"role": "assistant", "content": "", "tool_calls": [call]},
                {"role": "tool", "tool_call_id": f"logical_{i}", "content": "ok"},
            ])
        before = json.dumps(messages)
        agent = SimpleNamespace(
            step_callback=None, _skill_nudge_interval=0, valid_tool_names=set(),
            _adopt_nous_key_before_expiry=lambda: None,
            _drain_pending_steer=lambda: None, session_id="pairing-benchmark",
            _sanitize_tool_call_arguments=sanitize_tool_call_arguments,
            budget_warning_ratio=None, _last_flushed_db_idx=0,
        )
        phases = {
            "prepare_iteration": lambda: prepare_iteration(
                agent, messages=messages, api_call_count=count,
            ).messages,
            "compression_pair_cleanup": lambda: compressor._sanitize_tool_pairs(messages),
        }
        for name, phase in phases.items():
            phase()
            samples = []
            for _ in range(5):
                gc.collect()
                start = time.perf_counter()
                result = phase()
                samples.append(1000 * (time.perf_counter() - start))
                assert json.dumps(result) == before
            print(len(messages), name, round(statistics.median(samples), 3), "ms")
```

</details>

## Checklist

- [x] Read CONTRIBUTING.md and the root/agent development guides.
- [x] Conventional commit; one focused commit with production code and regression tests.
- [x] Searched existing open/closed PRs for duplicates.
- [x] Canonical isolated runner: 218 related tests pass, file retries disabled.
- [ ] Full repository test suite (not run; focused coverage listed above).
- [x] Tested on macOS arm64; changes use host-independent Python list/set operations.
- [x] Documentation/config/tool schemas: N/A; no new settings, dependencies, or user-facing behavior.
