### PR TITLE
fix(kimi-coding): translate kimi-k3 display ids to the bare k3 slug on the /coding endpoint

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -17,8 +17,8 @@ from agent.anthropic_credentials import _is_oauth_token
 from agent.anthropic_endpoints import (
     _base_url_needs_context_1m_beta, _is_azure_anthropic_endpoint, _is_kimi_coding_endpoint,
     _is_minimax_anthropic_endpoint, _is_nous_portal_endpoint, _is_opencode_endpoint,
-    _is_third_party_anthropic_endpoint, _model_name_is_kimi_family, _normalize_base_url_text,
-    _requires_bearer_auth,
+    _is_third_party_anthropic_endpoint, _kimi_coding_wire_model, _model_name_is_kimi_family,
+    _normalize_base_url_text, _requires_bearer_auth,
 )
 from agent.anthropic_message_convert import (
     convert_messages_to_anthropic, convert_tools_to_anthropic, normalize_model_name,
@@ -536,6 +536,10 @@ def build_anthropic_kwargs(
     # make the model unresolvable there (prefix AND dots kept).
     if not _is_nous_portal_endpoint(base_url):
         model = normalize_model_name(model, preserve_dots=preserve_dots)
+    # Kimi's /coding endpoint serves K3 as the bare ``k3`` slug; the ``kimi-k3`` display ids it
+    # rejects with a non-retryable 401 (#105650) are translated instead of failing every turn.
+    if _is_kimi_coding_endpoint(base_url):
+        model = _kimi_coding_wire_model(model)
     # Non-positive/non-finite values fail locally instead of 400-ing upstream.
     effective_max_tokens = _resolve_anthropic_messages_max_tokens(max_tokens, model, context_length=context_length)
     if context_length and effective_max_tokens > context_length:

--- a/agent/anthropic_endpoints.py
+++ b/agent/anthropic_endpoints.py
@@ -52,6 +52,17 @@ _KIMI_FAMILY_MODEL_PREFIXES = (
 # exact-match so unrelated names sharing the prefix don't match.
 _KIMI_FAMILY_EXACT_SLUGS = frozenset({"k3"})
 
+# Kimi Coding serves K3 under the bare ``k3`` slug only; the ``kimi-k3`` / ``kimi-k3-cot``
+# display ids are rejected by the /coding endpoint with 401 "model id does not exist" (#105650).
+# The Kimi/Moonshot chat endpoints still serve the ``kimi-k3`` name, so translation is scoped
+# to the coding endpoint (see _is_kimi_coding_endpoint), not the provider.
+_KIMI_CODING_MODEL_ALIASES = {"kimi-k3": "k3", "kimi-k3-cot": "k3"}
+
+
+def _kimi_coding_wire_model(model: str) -> str:
+    """Coding-endpoint wire id for ``model``: display aliases map to the bare ``k3`` slug."""
+    return _KIMI_CODING_MODEL_ALIASES.get(model.strip().lower(), model)
+
 
 def _model_name_is_kimi_family(model: str | None) -> bool:
     if not isinstance(model, str):

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -996,6 +996,53 @@ class TestBuildAnthropicKwargs:
         assert _supports_fast_mode("claude-haiku-4-5") is False
         assert _supports_fast_mode("") is False
 
+    def test_kimi_coding_endpoint_translates_k3_display_aliases(self):
+        """Kimi's /coding endpoint serves K3 as the bare ``k3`` slug; the ``kimi-k3`` /
+        ``kimi-k3-cot`` display ids 401 with "model id does not exist" there (#105650)."""
+        for display in ("kimi-k3", "kimi-k3-cot", "Kimi-K3"):
+            kwargs = build_anthropic_kwargs(
+                model=display,
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                max_tokens=64,
+                reasoning_config=None,
+                base_url="https://api.kimi.com/coding",
+            )
+            assert kwargs["model"] == "k3"
+
+    def test_kimi_coding_alias_translation_passes_bare_slug_and_unrelated_models_through(self):
+        kwargs = build_anthropic_kwargs(
+            model="k3",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=64,
+            reasoning_config=None,
+            base_url="https://api.kimi.com/coding",
+        )
+        assert kwargs["model"] == "k3"
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-8",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=64,
+            reasoning_config=None,
+            base_url="https://api.kimi.com/coding",
+        )
+        assert kwargs["model"] == "claude-opus-4-8"
+
+    def test_kimi_coding_alias_translation_is_scoped_to_coding_endpoint(self):
+        """Moonshot/Kimi chat endpoints serve the ``kimi-k3`` name natively — only the
+        /coding endpoint requires the bare ``k3`` slug."""
+        kwargs = build_anthropic_kwargs(
+            model="kimi-k3",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=64,
+            reasoning_config=None,
+            base_url="https://api.moonshot.ai/v1",
+        )
+        assert kwargs["model"] == "kimi-k3"
+
     def test_fable_class_models_route_as_adaptive_thinking(self):
         """Invariant: unknown/new Claude models default to the modern (4.7+)
         contract — adaptive thinking, xhigh-capable, sampling-params-forbidden —


### PR DESCRIPTION
## What does this PR do?

Kimi Coding (`api.kimi.com/coding`, the Anthropic-wire endpoint that `sk-kimi-` coding-plan keys are auto-redirected to) serves K3 under the bare `k3` slug only. A config like `model.default: kimi-k3` + `provider: kimi-coding` reaches the wire verbatim and every turn fails with a non-retryable `HTTP 401 — Your model id does not exist, recognized as other:kimi-k3. Please set model id as 'k3'` (#105650). Nothing translated the display ids before dispatch — this adds that translation.

The fix maps `kimi-k3` / `kimi-k3-cot` (and case variants) to `k3` in `build_anthropic_kwargs` when the base URL is the coding endpoint. That function is the single choke point shared by the main turn path (`chat_completion_helpers`), `transports/anthropic.py`, and the auxiliary client, so all Anthropic-wire dispatches are covered. The `kimi-k3-cot` reasoning variant maps to `k3` too because reasoning on this endpoint is controlled by the `thinking`/`output_config.effort` parameters, not by a separate model id.

Translation is strictly scoped to `_is_kimi_coding_endpoint` (canonical `https://api.kimi.com/coding…` host/path): Moonshot/Kimi chat endpoints still serve the `kimi-k3` name natively, so those requests keep their model id.

Note on the issue's code lead: the `_ENDPOINT_SCOPED_CONTEXT` entry in `agent/model_metadata.py` is a context-length table, not a model-id validator, so it is intentionally left as-is — after translation both the configured id and the wire id resolve to the same 1 MiB context it already records.

## Related Issue

Fixes #105650

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_endpoints.py`: added `_KIMI_CODING_MODEL_ALIASES` (`kimi-k3`/`kimi-k3-cot` → `k3`) and `_kimi_coding_wire_model()` next to the existing coding-endpoint predicate.
- `agent/anthropic_adapter.py`: `build_anthropic_kwargs` now applies the alias translation after model-name normalization when `_is_kimi_coding_endpoint(base_url)` matches.
- `tests/agent/test_anthropic_adapter.py`: 3 regression tests — display aliases (incl. case variant) translate to `k3` on the coding endpoint; bare `k3` and unrelated models pass through unchanged; `kimi-k3` stays verbatim on non-coding Kimi/Moonshot endpoints.

## How to Test

1. `pytest tests/agent/test_anthropic_adapter.py -q` — Observed result: 101 passed (includes the 4 new kimi-slug assertions).
2. With a `sk-kimi-` coding-plan key configured (`model.default: kimi-k3`, `provider: kimi-coding`), any conversation previously failed every turn with `HTTP 401 … Please set model id as 'k3'`; after this change the request body carries `model: "k3"` and the call proceeds. Should pass.
3. `pytest tests/agent/test_anthropic_kimi_signed_thinking_replay.py tests/agent/test_auxiliary_client.py -q` — Observed result: 101 passed across the Kimi replay/aux surfaces (3 pre-existing local-env failures in the broader aux family reproduce identically on a clean `upstream/main` checkout — missing optional anthropic SDK + ordering flakes, unrelated to this change).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
