### PR TITLE
fix(model_metadata): solar-mini4 is a 1M family, not a solar-mini variant

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -369,6 +369,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     "kimi-k3": 1_048_576, "kimi": 262144,
     # Upstage Solar — /v1/models returns no context_length; dated variants resolve via prefix.
     "solar-open2": 262144, "solar-pro3": 131072, "solar-pro2": 65536, "solar-mini": 32768,
+    # solar-mini4 is its own 1M family, not a solar-mini dated variant — without this key the
+    # longest-match lands on solar-mini (32K) and trips MINIMUM_CONTEXT_LENGTH.
+    "solar-mini4": 1_048_576,
     # Tencent Hunyuan (262144 = 256 × 1024, aligned with OpenRouter live metadata)
     "hy4-preview": 1_048_576, "hy3-preview": 262144, "hy3": 262144,
     # "Ox Alpha" stealth model (OpenCode Zen / OpenRouter slugs); NVIDIA Nemotron (128K

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -20,6 +20,7 @@ from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
     DEFAULT_FALLBACK_CONTEXT,
+    MINIMUM_CONTEXT_LENGTH,
     _strip_provider_prefix,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
@@ -217,6 +218,29 @@ class TestEstimateRequestTokensRough:
 # =========================================================================
 
 class TestDefaultContextLengths:
+    def test_solar_mini4_is_not_a_solar_mini_variant(self):
+        """solar-mini4 is a 1M family, not a solar-mini (32K) dated variant.
+
+        api.upstage.ai is a known provider, so the live /models probe is skipped and
+        resolution lands on DEFAULT_CONTEXT_LENGTHS. Without its own key solar-mini4
+        matched the solar-mini catch-all and returned 32,768 — under
+        MINIMUM_CONTEXT_LENGTH, so Hermes refused the session outright instead of
+        running at the model's real 1M window.
+        """
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=None):
+            upstage = dict(provider="upstage", base_url="https://api.upstage.ai/v1")
+            for model in ("solar-mini4", "solar-mini4-preview"):
+                context = get_model_context_length(model, **upstage)
+                assert context == 1_048_576, model
+                assert context >= MINIMUM_CONTEXT_LENGTH, model
+            # The 32K family it used to be confused with keeps its window.
+            for model in ("solar-mini", "solar-mini-250422"):
+                assert get_model_context_length(model, **upstage) == 32_768, model
+
     def test_nvidia_deepseek_v4_pro_context_is_endpoint_scoped(self):
         """NVIDIA's 262K NIM window must not lower DeepSeek V4 globally."""
         with patch("agent.model_metadata.get_cached_context_length", return_value=None), \


### PR DESCRIPTION
## What does this PR do?

Upstage's `solar-mini4` (1M context) is resolved as a 32,768-token model, which is under `MINIMUM_CONTEXT_LENGTH`, so Hermes refuses the session outright:

> Auxiliary compression model solar-mini4 has a context window of 32,768 tokens, which is below the minimum 64,000 required by Hermes Agent.

`api.upstage.ai` is a known provider (`_URL_TO_PROVIDER`, auto-extended from the Upstage profile hostname), so `get_model_context_length` skips the live `/models` probe at step 2 and falls through to `DEFAULT_CONTEXT_LENGTHS` at step 8. There `_longest_key_match` does substring matching, and with no `solar-mini4` key the longest match is `solar-mini` (32768) — a different, older family.

This PR adds the explicit key. Longest-first matching then also covers the dated `solar-mini4-preview` id, and `solar-mini` keeps its 32K window.

`1048576` is the deployment's `--max-model-len`, and matches what the gateway advertises for the model.

## Related Issue

No issue filed — reproduction is below. Same resolver path as #84482.

Note for reviewers: #84487 and #84493 (both open) add `solar-pro4` / `syn-pro` to the same table. This PR deliberately leaves the existing Solar line byte-identical and appends only the `solar-mini4` key, so it does not compete with either — `solar-mini4` postdates both and neither covers it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`: add `"solar-mini4": 1_048_576` to `DEFAULT_CONTEXT_LENGTHS`
- `tests/agent/test_model_metadata.py`: `TestDefaultContextLengths::test_solar_mini4_is_not_a_solar_mini_variant` — asserts the 1M window for `solar-mini4` / `solar-mini4-preview`, that it clears `MINIMUM_CONTEXT_LENGTH`, and that `solar-mini` / `solar-mini-250422` still resolve to 32K

## How to Test

Before (on `main`):

```
$ python3 -c "
from agent.model_metadata import get_model_context_length as G
U = dict(provider='upstage', base_url='https://api.upstage.ai/v1')
print('solar-mini4        ', G('solar-mini4', **U))
print('solar-mini4-preview', G('solar-mini4-preview', **U))"
solar-mini4         32768
solar-mini4-preview 32768
```

After this PR both return `1048576`.

End to end: with the Upstage provider configured, selecting `solar-mini4` on `main` fails at session start with the gateway error above; with this change the session starts and compression uses the real window.

```
$ pytest tests/agent/test_model_metadata.py -q
122 passed
```

The new test fails on `main` (`AssertionError: solar-mini4`) and passes with the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the note under Related Issue
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] `pytest tests/agent -q` — **6517 passed, 16 failed**, against **6516 passed, 16 failed** on a clean checkout of the same base commit (`fef0e16fe1`). Identical failure set both runs (auxiliary provider resolution, nous portal wire, skill commands, vision routing — pre-existing in my environment); the one extra pass is the test added here. Also green: `tests/agent/test_models_dev.py`, `tests/plugins/model_providers/test_upstage_profile.py`, `tests/run_agent/test_compression_feasibility.py`. Two files fail to *collect* here for unrelated missing deps (`tests/plugins/dashboard_auth/test_opaque_bearer_not_unreachable.py`, `tests/plugins/test_a2a_schema_registration.py`), before and after alike
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (a constant in a lookup table)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
