### PR TITLE
fix(tui): tolerate kitty CSI-u colon sub-parameters in keypress parser (#103885)

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress-csi-u-subparams.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress-csi-u-subparams.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { INITIAL_STATE, parseMultipleKeypresses } from './parse-keypress.js'
+
+// Regression for #103885: kitty CSI-u sequences carrying colon sub-parameters
+// (progressive-enhancement flags above 1) must still resolve to a keypress,
+// not be swallowed by the CSI-u branch with an empty name. The parser skips
+// the sub-parameter and consumes only the leading number of each field,
+// mirroring hermes_cli/curses_ui.py::_parse_csi_u_key so the TS and Python
+// input paths agree.
+describe('CSI-u tolerates kitty colon sub-parameters (#103885)', () => {
+  it.each([
+    // Standard Shift+a (codepoint 97 = 'a', modifier 2 = shift) — must keep working.
+    { seq: '\x1b[97;2u', name: 'a', shift: true },
+    // Alternate-key sub-parameter on the codepoint: ESC[97:65;2u — drop :65.
+    { seq: '\x1b[97:65;2u', name: 'a', shift: true },
+    // Event-type sub-parameter on the modifier: ESC[97;2:1u — drop :1.
+    { seq: '\x1b[97;2:1u', name: 'a', shift: true },
+    // Sub-parameter on the codepoint with no modifier field: ESC[97:65u.
+    { seq: '\x1b[97:65u', name: 'a', shift: false }
+  ])('parses $seq as name=$name shift=$shift', ({ seq, name, shift }) => {
+    const [keys] = parseMultipleKeypresses(INITIAL_STATE, seq)
+
+    expect(keys).toHaveLength(1)
+    expect(keys[0]).toMatchObject({ name, shift, meta: false, ctrl: false, super: false })
+  })
+
+  it('still parses plain CSI-u without sub-parameters (no regression)', () => {
+    const [keys] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[13;2u')
+
+    expect(keys).toEqual([expect.objectContaining({ name: 'return', shift: true })])
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -19,8 +19,16 @@ const FN_KEY_RE =
 // CSI u (kitty keyboard protocol): ESC [ codepoint [; modifier] u
 // Example: ESC[13;2u = Shift+Enter, ESC[27u = Escape (no modifiers)
 // Modifier is optional - when absent, defaults to 1 (no modifiers)
+//
+// Each parameter may carry a colon sub-parameter once kitty progressive-enhancement
+// flags rise above 1: an alternate key on the codepoint (ESC[97:65;2u) or an event
+// type on the modifier (ESC[97;2:1u). We only consume the leading number of each
+// field and skip the sub-parameter, mirroring the Python path
+// (hermes_cli/curses_ui.py::_parse_csi_u_key) so the two input parsers agree —
+// otherwise the sequence fails to match, name comes back empty, and the CSI-u
+// branch in input-event.ts silently swallows the keystroke (#103885).
 // eslint-disable-next-line no-control-regex
-const CSI_U_RE = /^\x1b\[(\d+)(?:;(\d+))?u/
+const CSI_U_RE = /^\x1b\[(\d+)(?::\d+)?(?:;(\d+)(?::\d+)?)?u/
 
 // xterm modifyOtherKeys: ESC [ 27 ; modifier ; keycode ~
 // Example: ESC[27;2;13~ = Shift+Enter. Emitted by Ghostty/tmux/xterm when


### PR DESCRIPTION
## What

Fixes #103885 — the Ink TUI silently swallowed **every keystroke** once a kitty keyboard sequence carried a colon sub-parameter. No character, no error, no log.

## Root cause

`CSI_U_RE` in `ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts` only matched `ESC[<codepoint>[;<modifier>]u`:

```ts
const CSI_U_RE = /^\x1b\[(\d+)(?:;(\d+))?u/
```

The kitty keyboard protocol allows **colon sub-parameters** on both fields once progressive-enhancement flags rise above 1 — an alternate key on the codepoint (`ESC[97:65;2u`) and an event type on the modifier (`ESC[97;2:1u`). Neither matches `\d+`, so `parseKeypress` falls through every branch with `name: ""`, and the CSI-u branch in `input-event.ts` discards the empty-name key. The keystroke is gone.

**Reachability.** Hermes only ever pushes `CSI >1u` (flag 1), so these normally cannot arrive — except through a **multiplexer without passthrough**: the push never reaches the real terminal, which keeps whatever flags a previous application left on its stack. The Python side (`hermes_cli/curses_ui.py::_parse_csi_u_key`) already tolerates this, so the two input paths disagreed.

## Fix

Consume only the **leading number** of each field and skip the sub-parameter, mirroring the Python path:

```ts
const CSI_U_RE = /^\x1b\[(\d+)(?::\d+)?(?:;(\d+)(?::\d+)?)?u/
```

- `(\d+)` — codepoint (group 1)
- `(?::\d+)?` — skip the codepoint's colon sub-parameter
- `(?:;(\d+)(?::\d+)?)?` — optional modifier: `;` + leading number (group 2) + skip its colon sub-parameter

The TS parser does not use the event-type sub-parameter (only codepoint + modifier), so it is dropped, exactly as the Python path's `parts[1].split(":")[0]` keeps the leading modifier.

Result: `ESC[97:65;2u` and `ESC[97;2:1u` now parse as Shift+a just like the standard `ESC[97;2u`.

## Test

Adds `parse-keypress-csi-u-subparams.test.ts` — the reporter's three repro sequences (`ESC[97;2u`, `ESC[97:65;2u`, `ESC[97;2:1u`) plus a no-modifier-field case (`ESC[97:65u`) and a no-regression guard for plain `ESC[13;2u`. Verified the new tests **fail on `main`** (3 failed — exactly the sub-parameter cases) and pass after the fix.

```
$ npx vitest run packages/hermes-ink/src/ink/parse-keypress-csi-u-subparams.test.ts
Test Files  1 passed (1)
Tests  5 passed (5)
```

Full hermes-ink suite (29 files) still green: **230 passed**. `tsc --noEmit` clean; `prettier --check` clean.

## Scope

One regex + an explanatory comment in `parse-keypress.ts` + one new test file. No behavior change on the happy path (standard CSI-u without sub-parameters matches identically); only the sub-parameter path is repaired.

---

*Investigation and fix authored with AI assistance (Claude); the reporter's own root-cause trace and repro made the fix path straightforward to verify.*
