### PR TITLE
fix(claw): preserve long Windows paths in extension archives

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -27,6 +27,18 @@ except Exception:  # pragma: no cover - handled at runtime
     yaml = None
 
 
+def _archive_copy_path(path: Path) -> Path:
+    """Use Windows extended paths for recursive extension archives, without data loss."""
+    if os.name != "nt":
+        return path
+    absolute = os.path.abspath(path)
+    if absolute.startswith("\\\\?\\"):
+        return Path(absolute)
+    if absolute.startswith("\\\\"):
+        return Path("\\\\?\\UNC\\" + absolute[2:])
+    return Path("\\\\?\\" + absolute)
+
+
 ENTRY_DELIMITER = "\n§\n"
 DEFAULT_MEMORY_CHAR_LIMIT = 2200
 DEFAULT_USER_CHAR_LIMIT = 1375
@@ -2348,7 +2360,9 @@ class Migrator:
         if ext_dir.is_dir() and self.archive_dir:
             dest_ext = self.archive_dir / "extensions"
             if self.execute:
-                shutil.copytree(ext_dir, dest_ext, dirs_exist_ok=True)
+                shutil.copytree(
+                    _archive_copy_path(ext_dir), _archive_copy_path(dest_ext), dirs_exist_ok=True
+                )
             self.record("plugins-config", str(ext_dir), str(dest_ext), "archived",
                         "Extensions directory archived")
 

--- a/tests/skills/test_openclaw_extension_longpaths.py
+++ b/tests/skills/test_openclaw_extension_longpaths.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import importlib.util
+import json
+import sys
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py"
+
+@pytest.mark.windows_only
+def test_extension_archive_preserves_dependencies_beyond_max_path(tmp_path):
+    spec = importlib.util.spec_from_file_location("claw_longpath", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "openclaw.json").write_text(json.dumps({"plugins": {"entries": {"demo": {"enabled": True}}}}))
+    relative = Path("demo/node_modules") / ("nested-" + "x" * 70) / ("nested-" + "y" * 70) / "payload.txt"
+    payload = b"dependency content retained\x00\xff"
+    def extended(path):
+        return Path("\\\\?\\" + str(path.resolve()))
+    original = extended(source / "extensions" / relative)
+    original.parent.mkdir(parents=True)
+    original.write_bytes(payload)
+    migrator = module.Migrator(source, tmp_path / ("target-" + "z" * 60), True, None, False, False, None, selected_options={"plugins-config"})
+    migrator.migrate_plugins_config()
+    destination = migrator.archive_dir / "extensions" / relative
+    assert len(str(destination)) > 260
+    assert extended(destination).read_bytes() == original.read_bytes() == payload
+    assert json.loads((migrator.archive_dir / "plugins-config.json").read_text())["entries"]["demo"]["enabled"] is True
+    migrator.migrate_plugins_config()
+    assert extended(destination).read_bytes() == payload


### PR DESCRIPTION
## What does this PR do?

Preserve long Windows paths when archiving OpenClaw extensions during migration.

Problem: a readable extension dependency tree can exceed MAX_PATH after the migration archive prefix is added. Root cause: `migrate_plugins_config()` passes ordinary paths to recursive `shutil.copytree`, which fails on Windows while creating nested destination directories.

The change uses Windows extended-length paths at that copy boundary, including UNC handling. It preserves the complete extension archive, including `node_modules`, instead of silently dropping dependencies. POSIX paths and existing merge/error behavior remain unchanged.

Non-goals: reducing archive size, skipping dependency/build directories, changing system long-path policy, or changing unrelated migration groups.

## Related Issue

Fixes #105649

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py`: normalize only extension-copy I/O paths into Windows extended paths; keep human-facing archive records unchanged.
- `tests/skills/test_openclaw_extension_longpaths.py`: actual Windows filesystem/migrator regression for nested binary dependency content beyond MAX_PATH, config archive and rerun merging. Uses the canonical `windows_only` marker, not a mocked host OS.

## How to Test

Canonical CI entry: `scripts/run_tests.sh tests/skills/test_openclaw_extension_longpaths.py` on Windows.

Executed locally using the existing Windows Python 3.11 venv and direct pytest:
`python -m pytest tests/skills/test_openclaw_extension_longpaths.py -q --tb=short`

- Base `866332bfb52c46e543143b2620a9aeee8bce9c77`: **1 failed** with `shutil.Error` / `WinError 3` at the extension copy.
- Fixed: **1 passed**; archived dependency bytes retained and rerun succeeds.
- `git diff --check`: passed.

The reproduced symptom is a concrete long-path copy failure, not a timed reproduction of the reporter's apparent hang. This fixes the path limit, not the cost of copying a large archive.

Validation completed on head `b494accc76530eea14ce747c98e2feaf9b1b7f36`:

- Full CLI E2E on actual Windows: `python -m hermes_cli.main claw migrate --source <synthetic-source> --preset user-data --yes --no-backup`, with isolated HOME/USERPROFILE/HERMES_HOME and `HERMES_OPTIONAL_SKILLS` pointing to this checkout's optional-skills. Preview and apply completed; an archived dependency path of **362 characters** retained identical binary bytes and the source remained intact. A synthetic skill ensures the preview has an importable item; no production OpenClaw files or credentials are used.
- Adjacent selection: **34 passed, 3 failed**. The identical three existing tests also fail on an isolated unmodified base (**33 passed, 3 failed**), in `backup_existing` for daily-memory/model-config/allowlist paths. Those separate backup paths are unchanged and out of scope.
- Independent Claude Code and Codex exact-diff reviews: **PASS**. Parent executed the recorded tests; reviewer results are not substituted for test execution.
- Remote required checks: **all passed**, including Windows-only tests, Python suite, lints, Docker and Nix.

The script's direct `--include plugins-config --execute --json` entry also passed with a 362-character destination. The top-level CLI check above verifies command routing and preview/apply, not just the helper.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite not run.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — path helper docstring.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — non-Windows paths unchanged.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

## Screenshots / Logs

AI-assisted contribution; real filesystem RED/GREEN, full migration CLI E2E, independent dual-engine review and remote CI results are recorded above.
