### PR TITLE
fix(update): stop npm lockfile churn from invalidating desktop builds

### DIFF
--- a/hermes_cli/main_web_build.py
+++ b/hermes_cli/main_web_build.py
@@ -363,8 +363,13 @@ def _run_npm_install_deterministic(
     finally:
         if original_lockfile is None:
             lockfile.unlink(missing_ok=True)
-        elif lockfile.read_bytes() != original_lockfile:
-            lockfile.write_bytes(original_lockfile)
+        else:
+            try:
+                current_lockfile = lockfile.read_bytes()
+            except FileNotFoundError:
+                current_lockfile = None
+            if current_lockfile != original_lockfile:
+                lockfile.write_bytes(original_lockfile)
 
 
 def _run_npm_watching_for_engine_failure(

--- a/hermes_cli/main_web_build.py
+++ b/hermes_cli/main_web_build.py
@@ -363,7 +363,7 @@ def _run_npm_install_deterministic(
     finally:
         if original_lockfile is None:
             lockfile.unlink(missing_ok=True)
-        else:
+        elif lockfile.read_bytes() != original_lockfile:
             lockfile.write_bytes(original_lockfile)
 
 

--- a/hermes_cli/main_web_build.py
+++ b/hermes_cli/main_web_build.py
@@ -321,10 +321,10 @@ def _run_npm_install_deterministic(
     the build toolchain and the build dies with ``tsc: not found``. An npm outside
     ``engines.npm`` fails every command, so it gets one engine-repair retry.
 
-    ``--no-save`` on the ``npm install`` fallback keeps it true to this function's contract: never mutate
-    ``package-lock.json``. Without it, an out-of-sync lockfile gets rewritten by the fallback, which drifts
-    the committed lockfile and makes every future ``npm ci`` fail — a self-reinforcing cycle where web
-    devDeps never install and a stale dist is served on every update (PR #65595).
+    ``--no-save`` asks npm not to mutate ``package-lock.json``, but npm versions
+    can still normalize lockfile metadata during both commands. Preserve the
+    exact input bytes so generated churn cannot invalidate build stamps or make
+    every update autostash the same file (PR #65595, issue #105659).
     """
     # CI=1 no-ops unicode-animations' postinstall that animates to /dev/tty.
     run_env = _npm_lifecycle_env(env)
@@ -340,19 +340,31 @@ def _run_npm_install_deterministic(
                 return ci_result
         return _run(["install", "--no-save"])
 
-    result = _attempt(npm)
-    if result.returncode == 0:
-        return result
+    lockfile = cwd / "package-lock.json"
+    try:
+        original_lockfile = lockfile.read_bytes()
+    except FileNotFoundError:
+        original_lockfile = None
 
-    from hermes_cli.npm_engine import maybe_repair_npm_engine
-    repaired_npm = maybe_repair_npm_engine(npm, f"{result.stdout or ''}\n{result.stderr or ''}")
-    if not repaired_npm:
-        return result
-    # A freshly provisioned managed npm resolves `node` from PATH — put the
-    # managed tree first so it finds the managed Node, not a mismatched system one.
-    from hermes_constants import with_hermes_node_path
-    run_env["PATH"] = with_hermes_node_path(run_env)["PATH"]
-    return _attempt(repaired_npm)
+    try:
+        result = _attempt(npm)
+        if result.returncode == 0:
+            return result
+
+        from hermes_cli.npm_engine import maybe_repair_npm_engine
+        repaired_npm = maybe_repair_npm_engine(npm, f"{result.stdout or ''}\n{result.stderr or ''}")
+        if not repaired_npm:
+            return result
+        # A freshly provisioned managed npm resolves `node` from PATH — put the
+        # managed tree first so it finds the managed Node, not a mismatched system one.
+        from hermes_constants import with_hermes_node_path
+        run_env["PATH"] = with_hermes_node_path(run_env)["PATH"]
+        return _attempt(repaired_npm)
+    finally:
+        if original_lockfile is None:
+            lockfile.unlink(missing_ok=True)
+        else:
+            lockfile.write_bytes(original_lockfile)
 
 
 def _run_npm_watching_for_engine_failure(

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -12,6 +12,7 @@ freshness check is a no-op and the OOM rebuild always runs.
 """
 
 import os
+import subprocess
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -44,6 +45,22 @@ def _make_web_dir(tmp_path: Path) -> tuple[Path, Path]:
     (web_dir / "package.json").touch()
     dist_dir = tmp_path / "hermes_cli" / "web_dist"
     return web_dir, dist_dir
+
+
+def test_npm_install_restores_lockfile_rewritten_by_npm(tmp_path):
+    lockfile = tmp_path / "package-lock.json"
+    original = b'{"packages":{"node_modules/example":{"peer":true}}}\n'
+    lockfile.write_bytes(original)
+
+    def npm_ci(*_args, **_kwargs):
+        lockfile.write_bytes(b'{"packages":{"node_modules/example":{}}}\n')
+        return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+    with patch("hermes_cli.main_web_build._run_npm_watching_for_engine_failure", side_effect=npm_ci):
+        result = _run_npm_install_deterministic("npm", tmp_path)
+
+    assert result.returncode == 0
+    assert lockfile.read_bytes() == original
 
 
 class TestWebUIBuildNeeded:

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -63,6 +63,22 @@ def test_npm_install_restores_lockfile_rewritten_by_npm(tmp_path):
     assert lockfile.read_bytes() == original
 
 
+def test_npm_install_restores_lockfile_removed_by_npm(tmp_path):
+    lockfile = tmp_path / "package-lock.json"
+    original = b'{"lockfileVersion":3}\n'
+    lockfile.write_bytes(original)
+
+    def npm_ci(*_args, **_kwargs):
+        lockfile.unlink()
+        return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+    with patch("hermes_cli.main_web_build._run_npm_watching_for_engine_failure", side_effect=npm_ci):
+        result = _run_npm_install_deterministic("npm", tmp_path)
+
+    assert result.returncode == 0
+    assert lockfile.read_bytes() == original
+
+
 def test_npm_install_does_not_rewrite_unchanged_lockfile(tmp_path):
     lockfile = tmp_path / "package-lock.json"
     lockfile.write_bytes(b'{"lockfileVersion":3}\n')

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -63,6 +63,35 @@ def test_npm_install_restores_lockfile_rewritten_by_npm(tmp_path):
     assert lockfile.read_bytes() == original
 
 
+def test_npm_install_does_not_rewrite_unchanged_lockfile(tmp_path):
+    lockfile = tmp_path / "package-lock.json"
+    lockfile.write_bytes(b'{"lockfileVersion":3}\n')
+    install_ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+    with patch(
+        "hermes_cli.main_web_build._run_npm_watching_for_engine_failure",
+        return_value=install_ok,
+    ), patch.object(Path, "write_bytes", side_effect=PermissionError("read-only")) as write_bytes:
+        result = _run_npm_install_deterministic("npm", tmp_path)
+
+    assert result.returncode == 0
+    write_bytes.assert_not_called()
+
+
+def test_npm_install_removes_lockfile_created_by_npm(tmp_path):
+    lockfile = tmp_path / "package-lock.json"
+
+    def npm_install(*_args, **_kwargs):
+        lockfile.write_bytes(b'{"lockfileVersion":3}\n')
+        return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+    with patch("hermes_cli.main_web_build._run_npm_watching_for_engine_failure", side_effect=npm_install):
+        result = _run_npm_install_deterministic("npm", tmp_path)
+
+    assert result.returncode == 0
+    assert not lockfile.exists()
+
+
 class TestWebUIBuildNeeded:
     """Content-hash staleness — replaces the old mtime comparison.
 


### PR DESCRIPTION
## What does this PR do?

Windows users running `hermes update` with npm versions that normalize lockfile metadata can be left with a dirty root `package-lock.json`. That changes the Desktop content hash after a successful build, so verification reports the healthy build as stale and later updates repeatedly autostash the same generated churn.

### Symptom

After an otherwise successful Desktop update, `package-lock.json` remains modified and post-update verification can raise `The updated Desktop build is stale, unstamped, or incomplete`.

### Impact

Affected Windows git installs can report every Desktop update as failed and accumulate redundant `hermes-update-autostash-*` entries even though the packaged application is healthy.

### Bug Cause

**Trigger:** `hermes_cli/main_web_build.py:313` / `_run_npm_install_deterministic`

**Causal chain:**
1. A Desktop or updater dependency install invokes npm against the root workspace lockfile.
2. npm normalizes metadata in `package-lock.json` despite the `npm ci` / `npm install --no-save` intent.
3. The generated bytes no longer match the bytes included in the Desktop build stamp, so verification rejects the fresh build and the next update treats the lockfile as a local edit.

**Why it is wrong:** The shared install helper promises not to mutate the lockfile, but previously relied only on npm flags and did not enforce that postcondition.

**Working sibling / contrast:** npm versions that leave the lockfile byte-identical preserve the stamp and keep the checkout clean, so the failure is version-sensitive.

**Ruled out:** Excluding the root lockfile from the Desktop hash would also hide genuine dependency-resolution changes. Preserving the install input bytes fixes generated churn without weakening rebuild detection.

### Fix

Snapshot the lockfile before the shared deterministic install and restore its exact bytes in a `finally` block after successful, failed, or repaired npm attempts. If the install starts without a lockfile, remove any generated lockfile afterward. This enforces the helper's existing contract for Desktop, Web UI, and updater callers.

## Related Issue

Fixes #105659

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main_web_build.py` - enforce byte-for-byte lockfile preservation around deterministic npm installs.
- `tests/hermes_cli/test_web_ui_build.py` - simulate npm 12 metadata normalization and verify the committed lockfile bytes survive.

## How to Test

1. Run the regression and neighboring deterministic-install contracts:

```bash
scripts/run_tests.sh tests/hermes_cli/test_web_ui_build.py -k 'npm_install_restores_lockfile_rewritten_by_npm or web_install_omits_workspace_and_scrubs_esbuild_override or workspace_root_install_names_update_closure or workspace_root_install_skips_missing_ui_tui'
```

2. Confirm all 4 selected tests pass.
3. On Windows with npm 12, run a Desktop-driven update and confirm `package-lock.json` remains clean and the Desktop build stamp still verifies.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the regression on Windows 11 with a simulated npm metadata rewrite

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A beyond the corrected function contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
