### PR TITLE
fix(update): preserve lockfile across npm installs

### DIFF
--- a/hermes_cli/main_web_build.py
+++ b/hermes_cli/main_web_build.py
@@ -326,6 +326,17 @@ def _run_npm_install_deterministic(
     the committed lockfile and makes every future ``npm ci`` fail — a self-reinforcing cycle where web
     devDeps never install and a stale dist is served on every update (PR #65595).
     """
+    # npm 12 can rewrite peer/optional metadata even during ``npm ci``. Preserve
+    # the caller's exact lockfile bytes so generated churn cannot dirty the
+    # checkout or invalidate a build stamp written earlier in the update.
+    lockfile = cwd / "package-lock.json"
+    preserve_lockfile = True
+    try:
+        original_lockfile = lockfile.read_bytes() if lockfile.exists() else None
+    except OSError:
+        preserve_lockfile = False
+        original_lockfile = None
+
     # CI=1 no-ops unicode-animations' postinstall that animates to /dev/tty.
     run_env = _npm_lifecycle_env(env)
 
@@ -334,25 +345,35 @@ def _run_npm_install_deterministic(
             return _run_npm_watching_for_engine_failure(
                 [npm_exe, *args, "--include=dev", *extra_args], cwd=cwd, env=run_env, capture_output=capture_output,
             )
-        if (cwd / "package-lock.json").exists():
+        if lockfile.exists():
             ci_result = _run(["ci"])
             if ci_result.returncode == 0:
                 return ci_result
         return _run(["install", "--no-save"])
 
-    result = _attempt(npm)
-    if result.returncode == 0:
-        return result
+    try:
+        result = _attempt(npm)
+        if result.returncode == 0:
+            return result
 
-    from hermes_cli.npm_engine import maybe_repair_npm_engine
-    repaired_npm = maybe_repair_npm_engine(npm, f"{result.stdout or ''}\n{result.stderr or ''}")
-    if not repaired_npm:
-        return result
-    # A freshly provisioned managed npm resolves `node` from PATH — put the
-    # managed tree first so it finds the managed Node, not a mismatched system one.
-    from hermes_constants import with_hermes_node_path
-    run_env["PATH"] = with_hermes_node_path(run_env)["PATH"]
-    return _attempt(repaired_npm)
+        from hermes_cli.npm_engine import maybe_repair_npm_engine
+        repaired_npm = maybe_repair_npm_engine(npm, f"{result.stdout or ''}\n{result.stderr or ''}")
+        if not repaired_npm:
+            return result
+        # A freshly provisioned managed npm resolves `node` from PATH — put the
+        # managed tree first so it finds the managed Node, not a mismatched system one.
+        from hermes_constants import with_hermes_node_path
+        run_env["PATH"] = with_hermes_node_path(run_env)["PATH"]
+        return _attempt(repaired_npm)
+    finally:
+        if preserve_lockfile:
+            try:
+                if original_lockfile is None:
+                    lockfile.unlink(missing_ok=True)
+                elif not lockfile.is_file() or lockfile.read_bytes() != original_lockfile:
+                    lockfile.write_bytes(original_lockfile)
+            except OSError as exc:
+                logger.warning("Could not restore package-lock.json after npm install: %s", exc)
 
 
 def _run_npm_watching_for_engine_failure(

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -94,6 +94,22 @@ class TestWebUIBuildNeeded:
         assert h1 == h2
         assert len(h1) == 64
 
+    def test_npm_install_restores_lockfile_metadata_churn(self, tmp_path, monkeypatch):
+        lockfile = tmp_path / "package-lock.json"
+        original = b'{"packages":{"node_modules/example":{"peer":true}}}\n'
+        lockfile.write_bytes(original)
+
+        def run_npm(*_args, **_kwargs):
+            lockfile.write_bytes(b'{"packages":{"node_modules/example":{}}}\n')
+            return __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+
+        monkeypatch.setattr("hermes_cli.main_web_build._run_npm_watching_for_engine_failure", run_npm)
+
+        result = _run_npm_install_deterministic("npm", tmp_path)
+
+        assert result.returncode == 0
+        assert lockfile.read_bytes() == original
+
     def test_write_stamp_creates_file_with_hash(self, tmp_path):
         import json as _json
         web_dir, _ = _make_web_dir(tmp_path)


### PR DESCRIPTION
## Summary

`npm ci` can rewrite optional peer metadata under npm 12 even though Hermes treats the deterministic install helper as lockfile-preserving. That left `package-lock.json` dirty after updates and invalidated Desktop build stamps written before the dependency refresh. This change preserves the caller's exact lockfile bytes across every deterministic npm attempt, including fallback and engine-repair paths, while retaining lockfile changes as valid rebuild inputs.

---

## Changes

- `hermes_cli/main_web_build.py`: snapshot and restore `package-lock.json` around deterministic npm installs so npm-generated metadata churn cannot dirty the checkout or stale Desktop stamps.
- `tests/hermes_cli/test_web_ui_build.py`: add one regression test reproducing npm 12-style removal of `peer: true` and asserting exact byte restoration.

## How to Test

```text
TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0 venv/bin/python -m pytest tests/hermes_cli/test_web_ui_build.py tests/hermes_cli/test_desktop_update_verify.py tests/hermes_cli/test_update_desktop_stale_warning.py -q
# 40 passed

TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0 venv/bin/python -m pytest tests/hermes_cli/test_cmd_update.py tests/test_install_lockfile_churn.py -q
# 50 passed

ruff check .
# All checks passed (three pre-existing invalid-noqa warnings)

venv/bin/python scripts/check-windows-footguns.py --diff upstream/main
# No Windows footguns found
```

The canonical runner is blocked by `PermissionError(13)` in this Termux sandbox. A direct full-suite collection also stops on missing environment dependencies (`tzdata`, `snowballstemmer`); the targeted update/Desktop suites above are green.

## Checklist

- [x] Regression test fails before the fix and passes after it
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] Profile-safe paths preserved
- [x] No non-credential `.env` settings added

## Risk & Impact

Low. The helper restores only the lockfile state that existed immediately before its own npm subprocesses; dependency installation behavior and build-stamp hashing remain unchanged.

Type: Bug fix

Closes #105659
