### PR TITLE
test(desktop): make the Electron suite pass on Windows

### DIFF
--- a/apps/desktop/electron/desktop-installation.test.ts
+++ b/apps/desktop/electron/desktop-installation.test.ts
@@ -38,7 +38,12 @@ test('loadOrCreateInstallationId persists and reuses one installation ID', () =>
       loadOrCreateInstallationId(filePath, () => ID_B),
       ID_A
     )
-    assert.equal(fs.statSync(filePath).mode & 0o777, 0o600)
+    // POSIX mode bits only: Windows has none, so `chmod` maps to the
+    // read-only bit and 0600 reads back as 0666. The persistence contract
+    // above is the platform-independent half and always runs.
+    if (process.platform !== 'win32') {
+      assert.equal(fs.statSync(filePath).mode & 0o777, 0o600)
+    }
   }))
 
 test('loadOrCreateInstallationId tightens an existing identity file', () =>

--- a/apps/desktop/electron/git-repo-scan.test.ts
+++ b/apps/desktop/electron/git-repo-scan.test.ts
@@ -74,7 +74,17 @@ describe('scanGitRepos', () => {
   })
 })
 
-describe('macOS TCC-protected media exclusions (issue #57611 salvage)', () => {
+/**
+ * These cases inject a POSIX `platform` while building fixtures with the
+ * REAL filesystem. On Windows that combination is self-contradictory: the
+ * scanner switches to `path.posix` and then cannot normalize the `C:\…`
+ * fixture paths, so every scan returns empty for a reason that has nothing
+ * to do with the TCC exclusions under test.
+ *
+ * The exclusion logic itself is platform-pure and stays covered on CI (Linux)
+ * and on macOS. Skipping beats asserting a falsehood or mocking the scan.
+ */
+describe.skipIf(process.platform === 'win32')('macOS TCC-protected media exclusions (issue #57611 salvage)', () => {
   it('finds a normal repo but skips root-level media folders on darwin', async () => {
     const root = tempDir()
     const dev = makeRepoAt(root, 'dev', 'proj')

--- a/apps/desktop/electron/git-worktree-ops.test.ts
+++ b/apps/desktop/electron/git-worktree-ops.test.ts
@@ -16,6 +16,30 @@ import {
   switchBranch
 } from './git-worktree-ops'
 
+/**
+ * Windows keeps brief handles on files a just-exited `git` touched (AV,
+ * search indexer), so an immediate recursive delete throws EPERM and fails
+ * an otherwise-passing test. Retry briefly, then leave the temp dir to the
+ * OS — cleanup is housekeeping, never the assertion.
+ */
+/**
+ * `fs.realpathSync` leaves Windows 8.3 short names (`C:\Users\ADMINI~1\…`)
+ * intact, while `git` reports the expanded long form — so comparing a git
+ * path against a plain-realpath temp dir fails on the alias, not the
+ * behaviour. Only the `.native` variant resolves both to one spelling.
+ */
+function canonicalPath(target: string): string {
+  return fs.realpathSync.native(target)
+}
+
+function removeTempDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { force: true, maxRetries: 5, recursive: true, retryDelay: 20 })
+  } catch {
+    // best-effort: a leaked temp dir must not turn into a test failure
+  }
+}
+
 test('sanitizeBranch: spaces → hyphens, forbidden chars dropped, edges trimmed', () => {
   assert.equal(sanitizeBranch('beach vibes'), 'beach-vibes')
   assert.equal(sanitizeBranch('feat/cool thing'), 'feat/cool-thing')
@@ -74,7 +98,7 @@ test('ensureGitRepo: inits a plain dir with a root commit so worktrees branch', 
     await ensureGitRepo('git', dir)
     assert.equal(git('rev-list', '--count', 'HEAD'), '1')
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -90,7 +114,7 @@ test('switchBranch: switches a normal checkout branch', async () => {
 
     assert.equal(git('branch', '--show-current'), 'feature')
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -109,12 +133,12 @@ test('listBranches: lists locals and flags the checked-out branch', async () => 
     // The repo's own checkout is flagged; the unused branch is convertible.
     assert.equal(branches.find(b => b.name === current).checkedOut, true)
     assert.equal(branches.find(b => b.name === current).isDefault, true)
-    assert.equal(fs.realpathSync(branches.find(b => b.name === current).worktreePath), fs.realpathSync(dir))
+    assert.equal(canonicalPath(branches.find(b => b.name === current).worktreePath), canonicalPath(dir))
     assert.equal(branches.find(b => b.name === 'feature').checkedOut, false)
     assert.equal(branches.find(b => b.name === 'feature').isDefault, false)
     assert.equal(branches.find(b => b.name === 'feature').worktreePath, null)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -134,7 +158,7 @@ test('listBranches: flags a free default branch as default, not checked out', as
     assert.equal(defaultBranch.isDefault, true)
     assert.equal(defaultBranch.worktreePath, null)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -154,7 +178,7 @@ test('listBranches: a branch claimed by a worktree is flagged checked out', asyn
 
     assert.equal(branches.find(b => b.name === 'feature').checkedOut, true)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -164,7 +188,7 @@ test('listBranches: empty on a non-repo path', async () => {
   try {
     assert.deepEqual(await listBranches(dir, 'git'), [])
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -189,7 +213,7 @@ test('addWorktree: existingBranch checks the branch out without a new branch', a
       'cool/feature'
     )
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -205,11 +229,11 @@ test('addWorktree: existing default branch switches the main checkout, not .work
     const result = await addWorktree(dir, { existingBranch: trunk }, 'git')
 
     assert.equal(result.branch, trunk)
-    assert.equal(fs.realpathSync(result.path), fs.realpathSync(dir))
+    assert.equal(canonicalPath(result.path), canonicalPath(dir))
     assert.equal(git('branch', '--show-current'), trunk)
     assert.equal(fs.existsSync(path.join(dir, '.worktrees', trunk)), false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -235,7 +259,7 @@ test('listBaseBranches: lists local branches and flags the default', async () =>
     assert.equal(branches.find(b => b.name === trunk).isDefault, true)
     assert.equal(branches.find(b => b.name === 'feature').isDefault, false)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -245,7 +269,7 @@ test('listBaseBranches: empty on a non-repo path', async () => {
   try {
     assert.deepEqual(await listBaseBranches(dir, 'git'), [])
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -266,7 +290,7 @@ test('addWorktree: base param branches off a specified local branch', async () =
     assert.equal(result.branch, 'new-from-staging')
     assert.equal(git('-C', result.path, 'merge-base', 'HEAD', 'staging').length > 0, true)
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -428,7 +452,7 @@ test('addWorktree: a remote default branch gets its own worktree, not a home swi
     // "switch home" applies to a local default branch. A remote ref always gets
     // a new worktree, so the main checkout stays where the user put it.
     assert.equal(result.branch, 'main')
-    assert.notEqual(fs.realpathSync(result.path), fs.realpathSync(cloneDir))
+    assert.notEqual(canonicalPath(result.path), canonicalPath(cloneDir))
     assert.equal(git('branch', '--show-current'), 'rawr')
   } finally {
     fs.rmSync(remoteDir, { recursive: true, force: true })
@@ -447,7 +471,7 @@ test('switchBranch: non-repo dir short-circuits instead of throwing', async () =
 
     assert.deepEqual(result, { branch: null })
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })
 
@@ -467,6 +491,6 @@ test('switchBranch: repo dir still validates the branch name and switches', asyn
     const result = await switchBranch(dir, 'main', 'git')
     assert.deepEqual(result, { branch: 'main' })
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true })
+    removeTempDir(dir)
   }
 })

--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -39,9 +39,29 @@ function withTempDir(run: (dir: string) => void) {
   try {
     run(dir)
   } finally {
-    fs.rmSync(dir, { force: true, recursive: true })
+    // Windows holds briefly-open handles (indexer, AV) that make an immediate
+    // recursive delete throw EPERM and fail an otherwise-green test. The temp
+    // dir is disposable, so retry a little and then leave it to the OS.
+    try {
+      fs.rmSync(dir, { force: true, maxRetries: 5, recursive: true, retryDelay: 20 })
+    } catch {
+      // best-effort cleanup: never fail a test over temp-dir removal
+    }
   }
 }
+
+/**
+ * POSIX mode bits are the subject of these assertions, and Windows has none:
+ * Node maps `chmod` to the read-only bit, so `0600` reads back as `0666` and
+ * every owner-only assertion fails for a reason that says nothing about the
+ * code. `tightenSecretFileMode` returns early on win32 BY DESIGN (see
+ * hardening.ts) and that contract is covered by the injected-platform tests
+ * below, which DO run everywhere.
+ *
+ * So: skip the on-disk mode tests off POSIX rather than assert a falsehood or
+ * mock away the very thing under test.
+ */
+const posixOnly = process.platform === 'win32' ? test.skip : test
 
 function modeOf(filePath: string) {
   return fs.statSync(filePath).mode & 0o777
@@ -154,7 +174,7 @@ test('encryptDesktopSecret stores safeStorage base64 payload', () => {
 
 // ─── Owner-only credential files (connection.json) ─────────────────────────
 
-test('writeSecretFileAtomic creates the file owner-only, not at the 0644 umask default', () => {
+posixOnly('writeSecretFileAtomic creates the file owner-only, not at the 0644 umask default', () => {
   withTempDir(dir => {
     const target = path.join(dir, 'connection.json')
     const payload = JSON.stringify({ remote: { token: { encoding: SAFE_STORAGE_ENCODING, value: 'BLOB' } } })
@@ -381,7 +401,7 @@ test('resolvePersistedRemoteToken keeps the existing token when no new token is 
   assert.equal(called, false, 'an empty incoming token must not re-encrypt anything')
 })
 
-test('writeSecretFileAtomic does not inherit loose bits from a stale temp file', () => {
+posixOnly('writeSecretFileAtomic does not inherit loose bits from a stale temp file', () => {
   // renameSync keeps the TEMP file's permissions, and writeFileSync's `mode`
   // is ignored when the path already exists — so a temp left by a crashed
   // earlier write would otherwise hand 0644 straight to the target.
@@ -409,7 +429,7 @@ function fsWith(overrides: Record<string, unknown>) {
   return { ...fs, ...overrides } as any
 }
 
-test('the written file is owner-only even where chmod does nothing', () => {
+posixOnly('the written file is owner-only even where chmod does nothing', () => {
   // Windows, and any mount that refuses chmod. The create-time `mode` is what
   // covers this — there is no second chance to tighten.
   withTempDir(dir => {
@@ -434,7 +454,7 @@ test('the written file is owner-only even where chmod does nothing', () => {
   })
 })
 
-test('the written file is owner-only even when a stale temp cannot be removed', () => {
+posixOnly('the written file is owner-only even when a stale temp cannot be removed', () => {
   // The unlink is best-effort; if the stale temp survives, writeFileSync's
   // `mode` is ignored on an existing path and only the chmod before the rename
   // can still fix the bits.
@@ -449,7 +469,7 @@ test('the written file is owner-only even when a stale temp cannot be removed', 
   })
 })
 
-test('writeSecretFileAtomic cannot be redirected through a symlink planted at the temp path', () => {
+posixOnly('writeSecretFileAtomic cannot be redirected through a symlink planted at the temp path', () => {
   // A stale temp path is attacker-controllable in a shared temp/userData dir.
   // Following it would write the token into the victim file AND then rename the
   // link over connection.json, so every later write leaks too.
@@ -478,7 +498,7 @@ test('writeSecretFileAtomic cannot be redirected through a symlink planted at th
   })
 })
 
-test('tightenSecretFileMode tightens a pre-existing world-readable config in place', () => {
+posixOnly('tightenSecretFileMode tightens a pre-existing world-readable config in place', () => {
   // The upgrade path: a connection.json written by an older build sits at 0644
   // with a real (encrypted) token in it. Tightening must change the mode and
   // nothing else — the token has to stay readable or the user loses their
@@ -505,7 +525,7 @@ test('tightenSecretFileMode tightens a pre-existing world-readable config in pla
   })
 })
 
-test('tightenSecretFileMode leaves a non-safeStorage token payload readable', () => {
+posixOnly('tightenSecretFileMode leaves a non-safeStorage token payload readable', () => {
   // A hand-edited config (or one from a pre-release build) can hold a
   // non-safeStorage token payload, which decryptDesktopSecret still reads
   // verbatim on purpose. Tightening the mode must not disturb that fallback —
@@ -527,7 +547,7 @@ test('tightenSecretFileMode leaves a non-safeStorage token payload readable', ()
   })
 })
 
-test('tightenSecretFileMode is idempotent and never throws on an unusable path', () => {
+posixOnly('tightenSecretFileMode is idempotent and never throws on an unusable path', () => {
   withTempDir(dir => {
     const target = path.join(dir, 'connection.json')
     writeSecretFileAtomic(target, '{}')
@@ -542,7 +562,7 @@ test('tightenSecretFileMode is idempotent and never throws on an unusable path',
   })
 })
 
-test('tightenSecretFileMode refuses to chmod a symlink instead of following it to its target', () => {
+posixOnly('tightenSecretFileMode refuses to chmod a symlink instead of following it to its target', () => {
   // Matches readInstallationId in desktop-installation.ts. Without the lstat
   // guard a link planted at the config path sends the chmod to whatever it
   // resolves to — someone else's file gets its mode rewritten.
@@ -566,7 +586,7 @@ test('tightenSecretFileMode refuses to chmod a symlink instead of following it t
   })
 })
 
-test('tightenSecretFileMode only touches a regular file the current user owns', () => {
+posixOnly('tightenSecretFileMode only touches a regular file the current user owns', () => {
   // Directories, sockets, fifos and files owned by another account are all
   // "not ours to chmod". Injected lstat so the foreign-owner branch is
   // reachable without a second OS account.

--- a/apps/desktop/electron/managed-ssh-update.test.ts
+++ b/apps/desktop/electron/managed-ssh-update.test.ts
@@ -26,6 +26,15 @@ import {
   waitForManagedSshBootstrapFence,
   waitForManagedUpdateOperations
 } from './managed-ssh-update'
+
+/**
+ * These cases execute the managed launcher through a real POSIX shell and
+ * assert POSIX remote-path semantics (`/…` or `~/…`). Windows has no
+ * `/bin/sh`, and a Windows temp dir is not a valid remote path, so the
+ * failures describe the host rather than the launcher. Green on CI (Linux)
+ * and macOS, which is where this code ships.
+ */
+const posixShellOnly = process.platform === 'win32' ? test.skip : test
 import { createBootstrapCoordinator } from './ssh-bootstrap-coordinator'
 
 const CORRELATION = '12345678-1234-4678-9234-567812345678'
@@ -280,7 +289,7 @@ test('POSIX managed launcher is detached, correlation-scoped, and never publishe
   assert.match(command, /while \[ ! -e/)
 })
 
-test('POSIX managed launcher executes the updater command and atomically publishes its status', async () => {
+posixShellOnly('POSIX managed launcher executes the updater command and atomically publishes its status', async () => {
   const home = await mkdtemp(path.join(os.tmpdir(), 'hermes-managed-launch-'))
 
   try {
@@ -359,7 +368,7 @@ test('remote observation rejects a receipt for another correlation', () => {
   )
 })
 
-test('POSIX observer reads the exact correlation receipt and terminal marker from disk', async () => {
+posixShellOnly('POSIX observer reads the exact correlation receipt and terminal marker from disk', async () => {
   const home = await mkdtemp(path.join(os.tmpdir(), 'hermes-managed-update-'))
 
   try {
@@ -401,7 +410,7 @@ test('POSIX observer reads the exact correlation receipt and terminal marker fro
   }
 })
 
-test('managed observer unwraps a named profile home for the install-wide marker', async () => {
+posixShellOnly('managed observer unwraps a named profile home for the install-wide marker', async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'hermes-managed-profile-marker-'))
   const profileHome = path.join(root, 'profiles', 'research')
 

--- a/apps/desktop/electron/ssh-config.test.ts
+++ b/apps/desktop/electron/ssh-config.test.ts
@@ -26,6 +26,17 @@ test('parseSshConfigIncludes extracts include tokens', () => {
   assert.deepEqual(parseSshConfigIncludes(cfg), ['~/.ssh/config.d/*', 'work_hosts', 'personal_hosts'])
 })
 
+/**
+ * The fixtures below are keyed by POSIX paths, but `collectSshConfigHosts`
+ * joins Include targets with `path.join`, which emits backslashes on Windows.
+ * Normalizing separators inside the fake reader keeps the fixtures readable
+ * and tests the traversal logic itself on every platform, instead of the
+ * host's path spelling.
+ */
+function fakeReader(files: Record<string, string>) {
+  return (candidate: string) => files[candidate.split('\\').join('/')] ?? null
+}
+
 test('collectSshConfigHosts follows Include directives (read-only)', () => {
   const files = {
     '/home/u/.ssh/config': 'Host main\nInclude work\nInclude ~/abs_inc',
@@ -36,7 +47,7 @@ test('collectSshConfigHosts follows Include directives (read-only)', () => {
 
   const hosts = collectSshConfigHosts('/home/u/.ssh/config', {
     homeDir: '/home/u',
-    readFile: p => files[p] ?? null
+    readFile: fakeReader(files)
   })
 
   assert.deepEqual(hosts.sort(), ['deep', 'home-abs', 'main', 'work-box'].sort())
@@ -54,7 +65,7 @@ test('collectSshConfigHosts does not loop on a self-include cycle', () => {
 
   const hosts = collectSshConfigHosts('/home/u/.ssh/config', {
     homeDir: '/home/u',
-    readFile: p => files[p] ?? null
+    readFile: fakeReader(files)
   })
 
   assert.deepEqual(hosts.sort(), ['a', 'b'])
@@ -69,9 +80,13 @@ test('collectSshConfigHosts expands globbed includes via injected globSync', () 
 
   const hosts = collectSshConfigHosts('/home/u/.ssh/config', {
     homeDir: '/home/u',
-    readFile: p => files[p] ?? null,
+    readFile: fakeReader(files),
     globSync: pattern =>
-      pattern.endsWith('config.d/*') ? ['/home/u/.ssh/config.d/10-work', '/home/u/.ssh/config.d/20-home'] : [pattern]
+      // Same separator caveat as fakeReader: the pattern arrives with the
+      // host's separators, the fixture keys are POSIX.
+      pattern.split('\\').join('/').endsWith('config.d/*')
+        ? ['/home/u/.ssh/config.d/10-work', '/home/u/.ssh/config.d/20-home']
+        : [pattern]
   })
 
   assert.deepEqual(hosts.sort(), ['home', 'root', 'work'].sort())

--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -27,6 +27,15 @@ import {
   validateSshTarget
 } from './ssh-connection'
 
+/**
+ * ControlMaster multiplexing does not exist in Win32 OpenSSH, so
+ * `SshConnection` deliberately runs mux-less there (see the `_mux` default in
+ * ssh-connection.ts). These cases assert the POSIX mux contract — socket
+ * paths, `-O` control commands, control-dir permissions — none of which the
+ * Windows path even attempts. They stay green on CI (Linux) and macOS.
+ */
+const posixMuxOnly = process.platform === 'win32' ? test.skip : test
+
 test('redactSecrets scrubs the spawn-time session token env var', () => {
   const line = 'setsid env HERMES_DASHBOARD_SESSION_TOKEN=abc123deadbeef HERMES_DESKTOP=1 hermes dashboard'
   const out = redactSecrets(line)
@@ -80,7 +89,7 @@ test('redactSecrets leaves legitimate ssh target logging untouched', () => {
   )
 })
 
-test('controlSocketPath is stable, short, and host-distinct', () => {
+posixMuxOnly('controlSocketPath is stable, short, and host-distinct', () => {
   const a = controlSocketPath('me', 'box1', 22, '/tmp/d')
   const a2 = controlSocketPath('me', 'box1', 22, '/tmp/d')
   const b = controlSocketPath('me', 'box2', 22, '/tmp/d')
@@ -264,7 +273,7 @@ function scriptedSpawn(scripts) {
   return fn
 }
 
-test('open() establishes the master when not already alive', async () => {
+posixMuxOnly('open() establishes the master when not already alive', async () => {
   // `-O check` fails first (not alive) → master opens (code 0). Track which
   // ssh ops ran rather than re-probing with the same always-failing check.
   const ops: string[] = []
@@ -302,7 +311,7 @@ test('open() abort kills an in-flight SSH child instead of waiting for timeout',
   assert.equal(child._killed, true)
 })
 
-test('open() is a no-op when the master is already alive and execs verify', async () => {
+posixMuxOnly('open() is a no-op when the master is already alive and execs verify', async () => {
   const ops: string[] = []
 
   const spawnFn = scriptedSpawn(args => {
@@ -316,7 +325,7 @@ test('open() is a no-op when the master is already alive and execs verify', asyn
   assert.deepEqual(ops, ['check', 'verify'], 'alive master is exec-verified, then trusted without reopening')
 })
 
-test('open() evicts a wedged master (check passes, exec hangs) and dials fresh', async () => {
+posixMuxOnly('open() evicts a wedged master (check passes, exec hangs) and dials fresh', async () => {
   // The macOS mode-switch wedge: ControlPersist master answers -O check but
   // every exec through it hangs. open() must verify, evict (-O exit), and
   // establish a fresh master instead of trusting the corpse.
@@ -356,7 +365,7 @@ test('open() evicts a wedged master (check passes, exec hangs) and dials fresh',
   )
 })
 
-test('close() removes the control socket when -O exit fails', async () => {
+posixMuxOnly('close() removes the control socket when -O exit fails', async () => {
   const dir = path.join(os.tmpdir(), `hermes-ssh-close-${process.pid}-${Date.now()}`)
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
 
@@ -380,7 +389,7 @@ test('close() removes the control socket when -O exit fails', async () => {
   fs.rmSync(dir, { recursive: true, force: true })
 })
 
-test('open() creates the control-socket directory if it does not exist', async () => {
+posixMuxOnly('open() creates the control-socket directory if it does not exist', async () => {
   const dir = path.join(os.tmpdir(), `hermes-ssh-test-${process.pid}-${Date.now()}`)
   assert.ok(!fs.existsSync(dir), 'precondition: control dir absent')
   const spawnFn = scriptedSpawn(args => (args.includes('check') ? { code: 255 } : { code: 0 }))
@@ -449,7 +458,7 @@ test('exec() treats a hung ssh as a timeout (half-open connection)', async () =>
   )
 })
 
-test('forward() issues -O forward with a loopback-bound -L spec', async () => {
+posixMuxOnly('forward() issues -O forward with a loopback-bound -L spec', async () => {
   const spawnFn = scriptedSpawn([{ code: 0 }])
   const conn = new SshConnection({ host: 'box', user: 'me' }, { spawnFn, controlDir: '/tmp/d' })
   await conn.forward(5000, 6000)
@@ -459,7 +468,7 @@ test('forward() issues -O forward with a loopback-bound -L spec', async () => {
   assert.ok(args.includes('127.0.0.1:5000:127.0.0.1:6000'))
 })
 
-test('lifecycle logging passes through redaction', async () => {
+posixMuxOnly('lifecycle logging passes through redaction', async () => {
   const logs: string[] = []
   const spawnFn = scriptedSpawn(args => (args.includes('check') ? { code: 255 } : { code: 0 }))
 
@@ -920,7 +929,7 @@ test('runSsh delivers stdinData to the child and does not log it', async () => {
   assert.equal(stdinWritten, 'secret-token-value', 'stdinData must be written to child.stdin')
 })
 
-test('open() rejects a control-dir that is a symlink', async () => {
+posixMuxOnly('open() rejects a control-dir that is a symlink', async () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ssh-test-'))
   const real = path.join(tmp, 'real')
   const link = path.join(tmp, 'link')
@@ -998,7 +1007,7 @@ test('control socket identity separates installation scope and key identity', ()
   )
 })
 
-test('closing one scope addresses only that scope control master', async () => {
+posixMuxOnly('closing one scope addresses only that scope control master', async () => {
   const firstSpawn = scriptedSpawn({ code: 0 })
   const secondSpawn = scriptedSpawn({ code: 0 })
 
@@ -1031,7 +1040,7 @@ test('closing one scope addresses only that scope control master', async () => {
   assert.equal(second._opened, true)
 })
 
-test('failed ControlMaster close disowns the master instead of retrying it', async () => {
+posixMuxOnly('failed ControlMaster close disowns the master instead of retrying it', async () => {
   // Old contract kept _opened=true for a retry — which left wedged ControlPersist
   // masters trusted and reattachable (the macOS mode-switch livelock). New
   // contract: a master that refuses -O exit is disowned — socket dropped,

--- a/apps/desktop/electron/windows-hermes-path.test.ts
+++ b/apps/desktop/electron/windows-hermes-path.test.ts
@@ -196,11 +196,17 @@ test('getVenvSitePackagesEntries: returns empty on Windows when site-packages do
 test('getVenvSitePackagesEntries: reads pyvenv.cfg version on POSIX and resolves lib/pythonX.Y/site-packages', () => {
   const result = getVenvSitePackagesEntries('/venv', {
     isWindows: false,
-    directoryExists: p => p === '/venv/lib/python3.12/site-packages',
+    // `isWindows: false` selects the POSIX layout, but the join still uses
+    // the host separator, so compare on a normalized spelling rather than
+    // letting a backslash fail a POSIX-layout assertion.
+    directoryExists: p => p.split('\\').join('/') === '/venv/lib/python3.12/site-packages',
     readFile: () => 'version_info = 3.12.1\n'
   })
 
-  assert.deepEqual(result, ['/venv/lib/python3.12/site-packages'])
+  assert.deepEqual(
+    result.map(entry => entry.split('\\').join('/')),
+    ['/venv/lib/python3.12/site-packages']
+  )
 })
 
 test('getVenvSitePackagesEntries: returns empty on POSIX when pyvenv.cfg is missing', () => {

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -594,7 +594,12 @@ test('darwin staging ships the Swift helper executable and the rewritten windows
 
     stageGetWindowsInto(srcRoot, destRoot, { platform: 'darwin' })
 
-    assert.equal(fs.statSync(join(destRoot, 'main')).mode & 0o777, 0o755)
+    // The 0755 exec bit is a POSIX property; Windows has no mode bits and
+    // reports 0666 regardless. The staging behaviour under test (which files
+    // land, and the windows.js rewrite) is asserted below on every platform.
+    if (process.platform !== 'win32') {
+      assert.equal(fs.statSync(join(destRoot, 'main')).mode & 0o777, 0o755)
+    }
     const staged = fs.readFileSync(join(destRoot, 'lib', 'windows.js'), 'utf8')
     assert.match(staged, /Rewritten by stage-native-deps\.mjs/)
     assert.ok(!staged.includes('node-pre-gyp'), 'pre-gyp loader must not survive staging')

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -25,7 +25,11 @@ const electronNative: TestProjectConfiguration = {
     // ignores the same pattern so they run in exactly one runner.
     include: ['electron/**/*.test.ts', 'scripts/**.test.{ts,mjs}', 'e2e/**/*.unit.test.ts'],
     // These use node:test and have dedicated npm scripts, not Vitest suites.
-    exclude: ['scripts/run-short-session-hang-repro.test.mjs', 'scripts/tasks-scroll.test.mjs']
+    exclude: ['scripts/run-short-session-hang-repro.test.mjs', 'scripts/tasks-scroll.test.mjs'],
+    // Several suites here shell out to real `git` many times per test. Process
+    // spawn on Windows costs far more than on POSIX, so the 5s default times
+    // out work that is progressing normally rather than hung.
+    testTimeout: 30_000
   }
 }
 


### PR DESCRIPTION
## Problem

On Windows, `npx vitest run --project electron` fails ~38 tests across 10 files. None are product bugs — every one is a test that assumes a POSIX host.

Measured on `main` @ 866332bfb5, Windows 11 AMD64, Node v24.19.0, three consecutive runs:

```
run 1   Tests  38 failed | 2101 passed | 6 skipped (2145)
run 2   Tests  38 failed | 2101 passed | 6 skipped (2145)
run 3   Tests  40 failed | 2099 passed | 6 skipped (2145)
```

**37 of those failures are deterministic** (identical in all three runs). The count moves because of one genuinely flaky test, `pool-spawn-coordinator`, which is unrelated to platform assumptions — see the last section.

Deterministic failures by file:

```
11  electron/ssh-connection.test.ts
10  electron/hardening.test.ts
 5  electron/git-repo-scan.test.ts
 3  electron/ssh-config.test.ts
 3  electron/managed-ssh-update.test.ts
 2  electron/git-worktree-ops.test.ts
 1  electron/desktop-installation.test.ts
 1  electron/windows-hermes-path.test.ts
 1  scripts/stage-native-deps.test.mjs
```

## Causes

**POSIX mode bits** — `hardening.test.ts`, `stage-native-deps.test.mjs` assert `mode & 0o777 === 0o755`. Windows has no mode bits and reports `0o666`. `tightenSecretFileMode` already returns early on win32 *by design*, so these assert a contract that does not exist on the platform.

**POSIX path/shell semantics** — `ssh-config.test.ts`, `ssh-connection.test.ts` assert remote-path forms (`/…`, `~/…`), `/bin/sh`, and ControlMaster multiplexing, which Win32 OpenSSH does not implement. Several build their *expected* value with `path.join`, so a backslash fails a POSIX-layout assertion before the Windows path is even exercised.

**Windows file locking** — `git-worktree-ops.test.ts` recursively deletes a temp dir immediately after `git` exits. Windows keeps brief handles on those files (AV, search indexer), so the delete throws `EPERM` and fails an otherwise-green test.

**Process spawn cost** — several suites shell out to real `git` many times per test. Spawn on Windows is far slower than on POSIX, so Vitest's 5s default kills work that is progressing normally rather than hung.

## Fix

Follows the conventions already in these files: `describe.skipIf(process.platform === 'win32')` and `const posixOnly = process.platform === 'win32' ? test.skip : test` for platform-specific contracts, a short retry around the Windows unlink, and `testTimeout: 30_000` for the `electron` project.

Every skip carries a comment explaining why the assertion is POSIX-only. **No assertion is weakened on Linux or macOS** — the skips are `win32`-gated, so CI behaviour is unchanged.

## Result

Three consecutive runs on the same machine:

```
run 1   Tests  1 failed | 2109 passed | 35 skipped (2145)
run 2   Tests  1 failed | 2109 passed | 35 skipped (2145)
run 3   Tests  1 failed | 2109 passed | 35 skipped (2145)
```

All 37 deterministic failures are resolved, and the result is now stable across runs. The 35 skips are the POSIX-only assertions, skipped only on win32. Runtime is about 90s — the 30s timeout is a ceiling, not a delay.

## Out of scope: one pre-existing flaky test

`pool-spawn-coordinator.test.ts` — "100 real child processes never exceed twelve simultaneous local slots" — fails intermittently on clean `main` (6 of 7 full runs, observed 94/96/98/99 distinct PIDs against an expected 100). It asserts PID *uniqueness*, which Windows does not guarantee because it recycles PIDs promptly as the coordinator's 12 slots turn over.

That is a flaw in the test's own assumption rather than a POSIX-vs-Windows portability issue, so this PR leaves it alone; filed separately as #105685. It is the one failure still visible in the "after" runs above.

## Verification

Three full `--project electron` runs before and three after (plus one earlier confirming run), on the same machine and Node version, to separate deterministic failures from flakes rather than trusting a single run.

Two tests initially looked flaky and turned out to be fixed by this PR, which is worth stating explicitly since it affects the counts above:

- `git-worktree-ops.test.ts` "listBranches: empty on a non-repo path" — `EPERM` from deleting the temp dir immediately after `git` exits; resolved by the retrying `removeTempDir` helper.
- `update-handoff-marker.test.ts` "PowerShell hand-off preserves the Desktop marker acquisition time" — needs ~8s and was dying at the 5s default; resolved by `testTimeout: 30_000`.

Neither has failed in the four runs since.
