### PR TITLE
fix(mattermost): report media_delivered in standalone send

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -642,7 +642,8 @@ async def _standalone_send(pconfig, chat_id: str, message: str, *, thread_id: Op
                     body = await resp.text()
                     return {"error": f"Mattermost API error ({resp.status}): {body[:400]}"}
                 data = await resp.json()
-            return {"success": True, "platform": "mattermost", "chat_id": chat_id, "message_id": data.get("id")}
+            return {"success": True, "platform": "mattermost", "chat_id": chat_id, "message_id": data.get("id"),
+                    "media_delivered": bool(file_ids)}
     except aiohttp.ClientError as exc:
         return {"error": f"Mattermost send failed (network): {exc}"}
     except Exception as exc:  # noqa: BLE001

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -709,3 +709,60 @@ class TestMultiplexProfileScope:
             # os.environ.
             assert "MATTERMOST_REQUIRE_MENTION" not in os.environ
 
+
+# ---------------------------------------------------------------------------
+# Standalone send: media_delivered reporting
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_standalone_send_reports_media_delivered(tmp_path):
+    """_standalone_send uploads media and attaches file_ids to the post, so its
+    success result must carry media_delivered=True. send_message_tool relies
+    on that key to decide whether to warn about omitted attachments; without
+    it, mattermost (not on the tool's hardcoded media-platform list) is
+    reported as having dropped attachments that were actually delivered."""
+    from types import SimpleNamespace
+
+    from plugins.platforms.mattermost.adapter import _standalone_send
+
+    audio = tmp_path / "note.ogg"
+    audio.write_bytes(b"FAKEOGG")
+
+    pconfig = SimpleNamespace(
+        token="mm-tok",
+        extra={"url": "https://mm.example.com"},
+    )
+
+    import gateway.platforms.base as base_mod
+    with patch.object(base_mod, "resolve_proxy_url", return_value=None), \
+         patch.object(base_mod, "proxy_kwargs_for_aiohttp", return_value=({}, {})), \
+         patch("aiohttp.ClientSession") as _Session:
+        session = AsyncMock()
+        upload_cm = AsyncMock()
+        up_resp = AsyncMock()
+        up_resp.status = 200
+        up_resp.json = AsyncMock(return_value={"file_infos": [{"id": "F1"}]})
+        up_resp.text = AsyncMock(return_value="")
+        upload_cm.__aenter__ = AsyncMock(return_value=up_resp)
+        upload_cm.__aexit__ = AsyncMock(return_value=False)
+        post_cm = AsyncMock()
+        post_resp = AsyncMock()
+        post_resp.status = 200
+        post_resp.json = AsyncMock(return_value={"id": "post9"})
+        post_resp.text = AsyncMock(return_value="")
+        post_cm.__aenter__ = AsyncMock(return_value=post_resp)
+        post_cm.__aexit__ = AsyncMock(return_value=False)
+        session.post = MagicMock(side_effect=[upload_cm, post_cm])
+        _Session.return_value.__aenter__ = AsyncMock(return_value=session)
+        _Session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await _standalone_send(
+            pconfig,
+            "ch_1",
+            "hello",
+            media_files=[{"path": str(audio)}],
+        )
+
+    assert result.get("success") is True
+    assert result.get("media_delivered") is True
+    assert result.get("message_id") == "post9"
+


### PR DESCRIPTION
## What
`_standalone_send` uploads files and attaches `file_ids` to the post, but its return dict omitted `media_delivered`. `send_message_tool.py` keeps a hardcoded platform list for media support (mattermost not included) and therefore emits a spurious `MEDIA attachments were omitted for mattermost` warning **even though the attachment was actually delivered**. This returns `"media_delivered": bool(file_ids)` so the tool result is truthful.

## Why
`hermes send --to mattermost:<user> "...MEDIA:<file>"` reported success but warned that attachments were omitted, which led to the wrong conclusion that Mattermost doesn't support media via the tool. Verified server-side: the post carries `file_ids` and the file size matches locally.

## Scope
Deliberately **one change**: the `(path, is_voice)` tuple normalization in earlier revisions of this PR duplicates the existing open cluster #86606 (earliest) / #90407 / #101953 (bundled in #47593) for issue #90403, and is removed here to avoid adding a 5th duplicate. If #86606 lands first this PR remains valid untouched (no conflict).

## Verification
- New test `test_standalone_send_reports_media_delivered` (mock aiohttp): asserts `success=true`, `media_delivered=true`, `message_id` set.
- `pytest tests/gateway/test_mattermost.py` → 26 passed.
- Live: `hermes send --to mattermost:zswll2` with `MEDIA:` → returns `"media_delivered": true`, no warning; server post `file_ids` present, file 1,385,994 bytes = local.