### PR TITLE
fix(gateway): guard display config reads against present-but-null values

### DIFF
--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1176,7 +1176,9 @@ class TurnRunner:
                 if pdc is not None:
                     pdc[ctx.session_key] = bg_release
         # display.memory_notifications: off | on (generic "💾 Memory updated", default) | verbose.
-        mem_notif = ctx.user_config.get("display", {}).get("memory_notifications")
+        # `display:` present-but-null yields None, not the {} default (same `or {}` guard as
+        # display_config.py / runtime_footer.py).
+        mem_notif = (ctx.user_config.get("display") or {}).get("memory_notifications")
         if isinstance(mem_notif, bool):
             mem_notif = "on" if mem_notif else "off"
         agent.memory_notifications = str(mem_notif).lower() if mem_notif else "on"

--- a/tests/gateway/test_display_null_turn_wiring.py
+++ b/tests/gateway/test_display_null_turn_wiring.py
@@ -1,0 +1,68 @@
+"""A profile config with `display: null` must not crash turn wiring.
+
+`user_config.get("display", {})` returns None when the key is present but null
+(bare `display:` in YAML), so the chained `.get("memory_notifications")` raised
+AttributeError on every real gateway turn (#105674). Oneshot turns bypass
+`_wire_turn_agent_callbacks`, which masked the regression during smoke tests.
+"""
+
+from __future__ import annotations
+
+import types
+
+from gateway.run_turn_runner import TurnRunner
+
+
+def _wire(user_config):
+    """Run `_wire_turn_agent_callbacks` over minimal fakes; return the agent."""
+    agent = types.SimpleNamespace()
+    ctx = types.SimpleNamespace(
+        progress_callback=None,
+        native_tool_start_callback=None,
+        voice_ack_callback=None,
+        _voice_ack_guild=[None],
+        _native_slack_task_cards=False,
+        native_tool_complete_callback=None,
+        _step_callback_sync=None,
+        _hooks_ref=types.SimpleNamespace(loaded_hooks=[]),
+        _status_callback_sync=None,
+        _event_callback_sync=None,
+        _status_adapter=None,
+        session_key="",
+        user_config=user_config,
+        _thinking_enabled=False,
+        agent_holder=[None],
+        tools_holder=[None],
+        process_task_id=None,
+        process_baseline=None,
+        run_generation=0,
+    )
+    holder = types.SimpleNamespace(
+        _ctx=ctx,
+        _runner=types.SimpleNamespace(
+            _service_tier=None,
+            _consume_pending_turn_sidecar_notes=lambda key: [],
+        ),
+        _make_bg_review_callbacks=lambda: (lambda message: None, lambda: None),
+        _merge_turn_request_overrides=TurnRunner._merge_turn_request_overrides,
+        _clarify_callback_sync=lambda *a, **k: None,
+        _notice_callback_sync=lambda *a, **k: None,
+        _attach_session_title_callback=lambda agent, ctx: None,
+    )
+    TurnRunner._wire_turn_agent_callbacks(holder, agent, {}, None, None, None, False)
+    return agent
+
+
+def test_present_but_null_display_falls_back_to_on():
+    agent = _wire({"display": None})
+    assert agent.memory_notifications == "on"
+
+
+def test_missing_display_falls_back_to_on():
+    agent = _wire({})
+    assert agent.memory_notifications == "on"
+
+
+def test_memory_notifications_setting_still_applies():
+    agent = _wire({"display": {"memory_notifications": "verbose"}})
+    assert agent.memory_notifications == "verbose"


### PR DESCRIPTION
## What does this PR do?

Fixes an `AttributeError: 'NoneType' object has no attribute 'get'` crash on every real gateway turn (Discord / cron) when the profile `config.yaml` contains a bare `display:` key (present-but-null).

`user_config.get("display", {})` only returns the `{}` default when the key is **missing**; when the key is present with a null value (YAML bare `display:`), it returns `None`, so the chained `.get("memory_notifications")` in `_wire_turn_agent_callbacks` raised. Oneshot (`-z`) turns bypass this wiring, which masked the crash during smoke tests.

The fix applies the same `or {}` guard the other gateway display readers (`display_config.py:87`, `runtime_footer.py:50`) already use, falling back to the documented default `"on"`.

## Related Issue

Fixes #105674

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run_turn_runner.py`: `_wire_turn_agent_callbacks` now reads `(ctx.user_config.get("display") or {}).get("memory_notifications")` instead of `ctx.user_config.get("display", {}).get("memory_notifications")` — one line, plus a comment noting the present-but-null YAML pitfall.
- `tests/gateway/test_display_null_turn_wiring.py`: new regression tests covering present-but-null `display`, missing `display`, and the normal `display.memory_notifications` path.

## How to Test

1. `pytest tests/gateway/test_display_null_turn_wiring.py -v` — 3 passed.
2. `pytest tests/gateway/test_subagent_failure_notice.py tests/gateway/test_compression_session_id_persistence.py tests/gateway/test_decline_fallback_suppression.py tests/gateway/test_stream_final_adoption_gate.py tests/gateway/test_approval_prompt_redaction.py tests/gateway/test_restart_drain_recovery_dedup.py tests/gateway/test_turn_context.py tests/gateway/test_session_title_rename_lane.py tests/gateway/test_display_null_turn_wiring.py` — 63 passed (surrounding `run_turn_runner` tests, no regressions).
3. Observed result: wiring a profile config with `display: null` no longer raises; `agent.memory_notifications` falls back to `"on"`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python dict access, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```
$ pytest tests/gateway/test_display_null_turn_wiring.py -v
tests/gateway/test_display_null_turn_wiring.py::test_present_but_null_display_falls_back_to_on PASSED
tests/gateway/test_display_null_turn_wiring.py::test_missing_display_falls_back_to_on PASSED
tests/gateway/test_display_null_turn_wiring.py::test_memory_notifications_setting_still_applies PASSED
3 passed
```
