### PR TITLE
fix(desktop-update): verify Windows build from install root

### DIFF
--- a/apps/desktop/src/app/profiles/create-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/create-profile-dialog.tsx
@@ -28,7 +28,7 @@ export function isValidProfileName(name: string): boolean {
 
 // Self-contained create flow (name + clone toggle + optional SOUL.md). Owns the
 // createProfile/updateProfileSoul calls so every caller just refreshes/selects
-// via onCreated. A new profile is blank by default; cloning is an explicit choice.
+// via onCreated. SOUL left blank keeps the cloned/blank persona untouched.
 export function CreateProfileDialog({
   onClose,
   onCreated,
@@ -43,7 +43,7 @@ export function CreateProfileDialog({
   const { t } = useI18n()
   const p = t.profiles
   const [name, setName] = useState('')
-  const [cloneFrom, setCloneFrom] = useState<null | string>(null)
+  const [cloneFrom, setCloneFrom] = useState<null | string>('default')
   const [soul, setSoul] = useState('')
   const [status, setStatus] = useState<'done' | 'idle' | 'saving'>('idle')
   const [error, setError] = useState<null | string>(null)
@@ -54,7 +54,7 @@ export function CreateProfileDialog({
     }
 
     setName('')
-    setCloneFrom(null)
+    setCloneFrom('default')
     setSoul('')
     setError(null)
     setStatus('idle')

--- a/apps/desktop/src/app/profiles/create-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/create-profile-dialog.tsx
@@ -28,7 +28,7 @@ export function isValidProfileName(name: string): boolean {
 
 // Self-contained create flow (name + clone toggle + optional SOUL.md). Owns the
 // createProfile/updateProfileSoul calls so every caller just refreshes/selects
-// via onCreated. SOUL left blank keeps the cloned/blank persona untouched.
+// via onCreated. A new profile is blank by default; cloning is an explicit choice.
 export function CreateProfileDialog({
   onClose,
   onCreated,
@@ -43,7 +43,7 @@ export function CreateProfileDialog({
   const { t } = useI18n()
   const p = t.profiles
   const [name, setName] = useState('')
-  const [cloneFrom, setCloneFrom] = useState<null | string>('default')
+  const [cloneFrom, setCloneFrom] = useState<null | string>(null)
   const [soul, setSoul] = useState('')
   const [status, setStatus] = useState<'done' | 'idle' | 'saving'>('idle')
   const [error, setError] = useState<null | string>(null)
@@ -54,7 +54,7 @@ export function CreateProfileDialog({
     }
 
     setName('')
-    setCloneFrom('default')
+    setCloneFrom(null)
     setSoul('')
     setError(null)
     setStatus('idle')

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1606,8 +1606,21 @@ try {
 
     # A zero-exit update is not proof that the runtime survived the update.
     if ($res.Code -eq 0 -and -not $desktopBuildFailed) {
-        $verifyCode = "import hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path.cwd())"
-        $verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode) "verify"
+        # Invoke-HermesStep inherits the hand-off host's working directory,
+        # which is not guaranteed to be the Hermes checkout. Path.cwd() made
+        # the verifier inspect the wrong tree and report a false missing exe.
+        $verifyRoot = $InstallRoot -replace '\\', '/'
+        $verifyCode = "import hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path(r'$verifyRoot'))"
+        $verify = $null
+        for ($attempt = 1; $attempt -le 15; $attempt++) {
+            $verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode) "verify"
+            if ($verify.Code -eq 0) { break }
+            if ($verify.Output -notmatch "updated Desktop executable is missing|updated Desktop archive or main entry is invalid") { break }
+            if ($attempt -lt 15) {
+                Write-HandoffLog "desktop verification not ready yet (attempt $attempt/15); retrying in 2s"
+                Start-Sleep -Seconds 2
+            }
+        }
         if ($verify.Code -ne 0) {
             $finalCode = 8
             $finalMsg = "The updated Hermes runtime or Desktop build failed verification. Repair the installation and review antivirus quarantine before retrying."

--- a/tests/test_desktop_update_windows_python_handoff.py
+++ b/tests/test_desktop_update_windows_python_handoff.py
@@ -124,3 +124,19 @@ def test_desktop_relaunch_waits_for_an_in_place_rebuild() -> None:
     assert "if ((Get-Date) -ge $relaunchDeadline)" in body
     assert "Start-Sleep -Milliseconds 500" in body
     assert "[System.Windows.Forms.Application]::DoEvents()" in body
+
+
+def test_desktop_verification_uses_install_root_not_process_cwd() -> None:
+    source = _read()
+
+    assert "$verifyRoot = $InstallRoot -replace" in source
+    assert "verify_windows_desktop_update(Path(r'$verifyRoot'))" in source
+    assert "verify_windows_desktop_update(Path.cwd())" not in source
+
+
+def test_desktop_verification_retries_transient_publication_failures() -> None:
+    source = _read()
+
+    assert "for ($attempt = 1; $attempt -le 15; $attempt++)" in source
+    assert "desktop verification not ready yet" in source
+    assert "Start-Sleep -Seconds 2" in source


### PR DESCRIPTION
## Problem\nThe Windows desktop handoff verified with Path.cwd(). The handoff process can inherit a different working directory, so a valid pps/desktop/release/win-unpacked/Hermes.exe was reported as missing after a successful update.\n\n## Fix\n- pass the explicit $InstallRoot to the verifier\n- retry transient publication/visibility failures\n- add regression coverage\n\n## Validation\n13 targeted tests pass.

<img width="560" height="187" alt="Screenshot 2026-09-08 034611" src="https://github.com/user-attachments/assets/5aa07fc5-4597-467a-8359-7ebdabc1d919" />
