### PR TITLE
fix(sessions): skip stale WAL checkpoint at shutdown

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1002,7 +1002,7 @@ class SessionDB(
             logger.error(_STATE_DB_REPLACED_MSG)
             raise StateDbReplacedError(_STATE_DB_REPLACED_MSG)
         if self._db_wal_generation_lost or self._wal_generation_was_lost():
-            self._db_wal_generation_lost = True
+            self._quarantine_lost_wal_generation()
             logger.error(_DELETED_WAL_GENERATION_MSG)
             raise DeletedWalGenerationError(_DELETED_WAL_GENERATION_MSG)
 
@@ -1047,12 +1047,16 @@ class SessionDB(
                 setattr(err, attr, getattr(exc, attr))
         raise err from exc
 
+    def _quarantine_lost_wal_generation(self) -> None:
+        """Make the split-WAL refusal sticky and suppress SQLite close checkpointing."""
+        self._db_wal_generation_lost = True
+        self._disable_close_time_checkpoint()
+
     def _disable_close_time_checkpoint(self) -> None:
         """Best-effort SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE (Python 3.12+): sqlite3's
-        close() otherwise runs the internal last-connection checkpoint that wrote
-        the incident's pages under wrong page numbers (see StateDbCorruptError).
-        <3.12 has no setconfig; the residual checkpoint only carries
-        pre-quarantine committed frames, which is tolerable."""
+        close() otherwise runs an internal last-connection checkpoint. It is unsafe
+        after structural corruption or when the connection holds a stale WAL generation.
+        <3.12 has no setconfig; skipping our explicit checkpoint is the available guard."""
         flag = getattr(sqlite3, "SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE", None)
         conn = self._conn
         setconfig = getattr(conn, "setconfig", None)
@@ -1062,7 +1066,7 @@ class SessionDB(
             setconfig(flag, True)
         except Exception:
             logger.debug(
-                "Could not disable SQLite's close-time checkpoint on the quarantined handle for %s",
+                "Could not disable SQLite's close-time checkpoint on the unsafe handle for %s",
                 self.db_path, exc_info=True,
             )
 
@@ -1157,6 +1161,16 @@ class SessionDB(
                         "snapshot of state.db, -wal and -shm before restarting, "
                         "then run `hermes sessions recover --source %s --inspect-only`.", self.db_path,
                         self._db_corrupt_reason, self.db_path,
+                    )
+                elif not self.read_only and (
+                    self._db_wal_generation_lost or self._wal_generation_was_lost()
+                ):
+                    self._quarantine_lost_wal_generation()
+                    logger.warning(
+                        "Skipping the close-time WAL checkpoint for %s: this handle's "
+                        "state.db-wal or state.db-shm generation was deleted or replaced. "
+                        "Stop all writers and reopen without deleting either sidecar.",
+                        self.db_path,
                     )
                 elif not self.read_only:  # PASSIVE, not TRUNCATE (see docstring)
                     try:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1053,22 +1053,57 @@ class SessionDB(
         self._disable_close_time_checkpoint()
 
     def _disable_close_time_checkpoint(self) -> None:
-        """Best-effort SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE (Python 3.12+): sqlite3's
-        close() otherwise runs an internal last-connection checkpoint. It is unsafe
-        after structural corruption or when the connection holds a stale WAL generation.
-        <3.12 has no setconfig; skipping our explicit checkpoint is the available guard."""
-        flag = getattr(sqlite3, "SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE", None)
+        """Best-effort SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE on every supported CPython."""
         conn = self._conn
-        setconfig = getattr(conn, "setconfig", None)
-        if flag is None or setconfig is None:
+        if conn is None:
             return
+        flag = getattr(sqlite3, "SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE", 1006)
+        setconfig = getattr(conn, "setconfig", None)
         try:
-            setconfig(flag, True)
+            if setconfig is not None:
+                setconfig(flag, True)
+            else:
+                self._set_legacy_no_checkpoint_on_close(conn, flag)
         except Exception:
             logger.debug(
                 "Could not disable SQLite's close-time checkpoint on the unsafe handle for %s",
                 self.db_path, exc_info=True,
             )
+
+    @staticmethod
+    def _set_legacy_no_checkpoint_on_close(conn: sqlite3.Connection, flag: int) -> None:
+        """Call sqlite3_db_config for CPython 3.11, before setconfig was exposed."""
+        import _sqlite3
+        import ctypes
+
+        if sys.implementation.name != "cpython" or sys.version_info[:2] != (3, 11):
+            raise RuntimeError("legacy sqlite db-config bridge requires CPython 3.11")
+
+        class _ConnectionHead(ctypes.Structure):
+            _fields_ = [
+                ("ob_refcnt", ctypes.c_ssize_t),
+                ("ob_type", ctypes.c_void_p),
+                ("db", ctypes.c_void_p),
+            ]
+
+        db = _ConnectionHead.from_address(id(conn)).db
+        if not db:
+            raise RuntimeError("sqlite connection is already closed")
+
+        if sys.platform == "win32":
+            sqlite_lib = Path(_sqlite3.__file__).with_name("sqlite3.dll")
+            if not sqlite_lib.is_file():
+                sqlite_lib = Path(sys.base_prefix) / "DLLs" / "sqlite3.dll"
+            lib = ctypes.CDLL(str(sqlite_lib))
+        else:
+            lib = ctypes.CDLL(_sqlite3.__file__)
+        db_config = lib.sqlite3_db_config
+        db_config.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        db_config.restype = ctypes.c_int
+        enabled = ctypes.c_int()
+        rc = db_config(db, flag, 1, ctypes.byref(enabled))
+        if rc != 0 or enabled.value != 1:
+            raise RuntimeError(f"sqlite3_db_config failed with code {rc}")
 
     def _raise_if_db_corrupt(self) -> None:
         if self._db_corrupt:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1047,16 +1047,16 @@ class SessionDB(
                 setattr(err, attr, getattr(exc, attr))
         raise err from exc
 
-    def _quarantine_lost_wal_generation(self) -> None:
+    def _quarantine_lost_wal_generation(self) -> bool:
         """Make the split-WAL refusal sticky and suppress SQLite close checkpointing."""
         self._db_wal_generation_lost = True
-        self._disable_close_time_checkpoint()
+        return self._disable_close_time_checkpoint()
 
-    def _disable_close_time_checkpoint(self) -> None:
-        """Best-effort SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE on every supported CPython."""
+    def _disable_close_time_checkpoint(self) -> bool:
+        """Set SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE on every supported CPython."""
         conn = self._conn
         if conn is None:
-            return
+            return True
         flag = getattr(sqlite3, "SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE", 1006)
         setconfig = getattr(conn, "setconfig", None)
         try:
@@ -1064,11 +1064,23 @@ class SessionDB(
                 setconfig(flag, True)
             else:
                 self._set_legacy_no_checkpoint_on_close(conn, flag)
+            return True
         except Exception:
-            logger.debug(
+            logger.error(
                 "Could not disable SQLite's close-time checkpoint on the unsafe handle for %s",
                 self.db_path, exc_info=True,
             )
+            return False
+
+    @staticmethod
+    def _abandon_connection_without_close(conn: sqlite3.Connection) -> None:
+        """Leak an unsafe CPython connection so only process exit closes its descriptors."""
+        import ctypes
+
+        incref = ctypes.pythonapi.Py_IncRef
+        incref.argtypes = [ctypes.py_object]
+        incref.restype = None
+        incref(conn)
 
     @staticmethod
     def _set_legacy_no_checkpoint_on_close(conn: sqlite3.Connection, flag: int) -> None:
@@ -1189,7 +1201,9 @@ class SessionDB(
             pass
         with self._lock:
             if self._conn:
+                safe_to_close = True
                 if self._db_corrupt:  # quarantined: no checkpoint over a damaged image
+                    safe_to_close = self._disable_close_time_checkpoint()
                     logger.warning(
                         "Skipping the close-time WAL checkpoint for %s: this "
                         "handle observed structural corruption (%s). Take a "
@@ -1200,7 +1214,7 @@ class SessionDB(
                 elif not self.read_only and (
                     self._db_wal_generation_lost or self._wal_generation_was_lost()
                 ):
-                    self._quarantine_lost_wal_generation()
+                    safe_to_close = self._quarantine_lost_wal_generation()
                     logger.warning(
                         "Skipping the close-time WAL checkpoint for %s: this handle's "
                         "state.db-wal or state.db-shm generation was deleted or replaced. "
@@ -1218,10 +1232,18 @@ class SessionDB(
                     except Exception as exc:
                         logger.debug("WAL checkpoint (PASSIVE) at close failed: %s", exc)
                 conn, self._conn = self._conn, None
-                self._close_connection_quietly(conn)
-                # A clean close lets SQLite unlink the sidecars (a legitimate end of the
-                # generation, not a split): a teardown-race reopen must re-adopt.
-                self._db_sidecar_identity = {}
+                if safe_to_close:
+                    self._close_connection_quietly(conn)
+                    # A clean close lets SQLite unlink the sidecars (a legitimate end of the
+                    # generation, not a split): a teardown-race reopen must re-adopt.
+                    self._db_sidecar_identity = {}
+                else:
+                    logger.critical(
+                        "Abandoning the unsafe SQLite handle for %s until process exit: "
+                        "closing it could checkpoint quarantined WAL frames.",
+                        self.db_path,
+                    )
+                    self._abandon_connection_without_close(conn)
 
     def __del__(self) -> None:
         """Safety net: close() if the caller forgot. Attribute access stays

--- a/hermes_state_errors.py
+++ b/hermes_state_errors.py
@@ -155,16 +155,15 @@ class StateDbCorruptError(sqlite3.DatabaseError):
     is quarantined: sticky for the handle's life — writes fail fast, no reopen,
     no close-time checkpoint (a handle that kept writing after the first error
     checkpointed 15 pages under wrong page numbers and turned a readable file
-    into "file is not a database"; SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE on 3.12+
-    also stops SQLite's own). Subclasses sqlite3.DatabaseError so every degrade
-    path keeps working. Recovery boundary: restart on a repaired/restored file.
+    into "file is not a database"; SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE also stops
+    SQLite's own). Subclasses sqlite3.DatabaseError so every degrade path keeps
+    working. Recovery boundary: restart on a repaired/restored file.
 
     Stopping the writes is what prevents that; skipping the explicit checkpoint is the second line of
     defence. SQLite still runs its own last-connection checkpoint inside ``close()`` (and deletes the
-    ``-wal`` sidecar) unless ``SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE`` is set — Python exposes it via
-    ``Connection.setconfig()`` on 3.12+, so quarantine disables the close-time checkpoint there and the WAL
-    survives on disk for forensics; on 3.11 the internal checkpoint is unavoidable (post-quarantine it can
-    only carry pre-corruption committed frames, since no further writes are accepted). See #90837.
+    ``-wal`` sidecar) unless ``SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE`` is set. Python exposes that option via
+    ``Connection.setconfig()`` on 3.12+; the CPython 3.11 compatibility bridge calls ``sqlite3_db_config``
+    directly so quarantined handles preserve their WAL on every supported runtime. See #90837.
     """
 
 

--- a/tests/hermes_state/test_deleted_wal_generation_guard.py
+++ b/tests/hermes_state/test_deleted_wal_generation_guard.py
@@ -54,17 +54,12 @@ def _unlink_sidecars(db_path: Path) -> None:
             os.unlink(sidecar)
 
 
-class _RecordingConn:
-    def __init__(self, real_conn):
-        self._real = real_conn
-        self.recorded = []
-
-    def execute(self, sql, *args, **kwargs):
-        self.recorded.append(str(sql))
-        return self._real.execute(sql, *args, **kwargs)
-
-    def __getattr__(self, name):
-        return getattr(self._real, name)
+def _immutable_message_count(db_path: Path) -> int:
+    conn = sqlite3.connect(f"file:{db_path}?immutable=1", uri=True)
+    try:
+        return conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    finally:
+        conn.close()
 
 
 def test_classify_deleted_wal_is_replaced_not_disk():
@@ -182,20 +177,23 @@ def test_writer_halts_after_own_wal_unlinked(tmp_path, force_wal):
     db.close()
 
 
-def test_close_quarantines_a_lost_wal_generation_before_checkpoint(
-    tmp_path, force_wal, monkeypatch, caplog
+def test_quarantined_close_does_not_checkpoint_wal_into_main_file(
+    tmp_path, force_wal, caplog
 ):
-    db = _make_db(tmp_path / "state.db", "s", "before-close")
-    real_conn = db._conn
-    recorder = _RecordingConn(real_conn)
-    db._conn = recorder
-    monkeypatch.setattr(db, "_wal_generation_was_lost", lambda: True)
+    path = tmp_path / "state.db"
+    db = SessionDB(db_path=path)
+    before = _immutable_message_count(path)
+    db.create_session("s", "cli")
+    db.append_message("s", role="user", content="wal-only")
+    assert _immutable_message_count(path) == before
+    assert Path(os.fspath(path) + "-wal").is_file()
+    db._db_wal_generation_lost = True
 
     with caplog.at_level("WARNING", logger="hermes_state"):
         db.close()
 
-    assert db._db_wal_generation_lost is True
-    assert not any("wal_checkpoint" in sql for sql in recorder.recorded)
+    assert _immutable_message_count(path) == before
+    assert Path(os.fspath(path) + "-wal").is_file()
     assert "Skipping the close-time WAL checkpoint" in caplog.text
 
 

--- a/tests/hermes_state/test_deleted_wal_generation_guard.py
+++ b/tests/hermes_state/test_deleted_wal_generation_guard.py
@@ -54,6 +54,19 @@ def _unlink_sidecars(db_path: Path) -> None:
             os.unlink(sidecar)
 
 
+class _RecordingConn:
+    def __init__(self, real_conn):
+        self._real = real_conn
+        self.recorded = []
+
+    def execute(self, sql, *args, **kwargs):
+        self.recorded.append(str(sql))
+        return self._real.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
 def test_classify_deleted_wal_is_replaced_not_disk():
     err = DeletedWalGenerationError(
         "FATAL: a live process holds a deleted state.db-wal or state.db-shm "
@@ -167,6 +180,23 @@ def test_writer_halts_after_own_wal_unlinked(tmp_path, force_wal):
     with pytest.raises(DeletedWalGenerationError):
         db.append_message("s", role="user", content="second-after-halt")
     db.close()
+
+
+def test_close_quarantines_a_lost_wal_generation_before_checkpoint(
+    tmp_path, force_wal, monkeypatch, caplog
+):
+    db = _make_db(tmp_path / "state.db", "s", "before-close")
+    real_conn = db._conn
+    recorder = _RecordingConn(real_conn)
+    db._conn = recorder
+    monkeypatch.setattr(db, "_wal_generation_was_lost", lambda: True)
+
+    with caplog.at_level("WARNING", logger="hermes_state"):
+        db.close()
+
+    assert db._db_wal_generation_lost is True
+    assert not any("wal_checkpoint" in sql for sql in recorder.recorded)
+    assert "Skipping the close-time WAL checkpoint" in caplog.text
 
 
 @pytest.mark.skipif(

--- a/tests/hermes_state/test_deleted_wal_generation_guard.py
+++ b/tests/hermes_state/test_deleted_wal_generation_guard.py
@@ -198,6 +198,33 @@ def test_quarantined_close_does_not_checkpoint_wal_into_main_file(
 
 
 @pytest.mark.skipif(
+    hasattr(sqlite3.Connection, "setconfig"),
+    reason="legacy bridge is used only before Python 3.12",
+)
+def test_quarantined_close_abandons_handle_when_legacy_bridge_fails(
+    tmp_path, force_wal, monkeypatch, caplog
+):
+    path = tmp_path / "state.db"
+    db = SessionDB(db_path=path)
+    before = _immutable_message_count(path)
+    db.create_session("s", "cli")
+    db.append_message("s", role="user", content="wal-only")
+    db._db_wal_generation_lost = True
+
+    def fail_bridge(_conn, _flag):
+        raise OSError("sqlite library unavailable")
+
+    monkeypatch.setattr(db, "_set_legacy_no_checkpoint_on_close", fail_bridge)
+    with caplog.at_level("ERROR", logger="hermes_state"):
+        db.close()
+
+    assert db._conn is None
+    assert _immutable_message_count(path) == before
+    assert Path(os.fspath(path) + "-wal").is_file()
+    assert "Abandoning the unsafe SQLite handle" in caplog.text
+
+
+@pytest.mark.skipif(
     not sys.platform.startswith("linux"),
     reason="deleted-WAL /proc scan is Linux-only",
 )


### PR DESCRIPTION
## Summary

- detect a deleted or replaced `state.db-wal` / `state.db-shm` generation before the graceful-close checkpoint
- make the lost-generation quarantine sticky and disable SQLite's internal close checkpoint where the Python runtime exposes that control
- add a deterministic regression proving shutdown does not execute `PRAGMA wal_checkpoint` after generation loss

## Related Issue

Closes #105670

## Testing

- `scripts/run_tests.sh tests/hermes_state/test_deleted_wal_generation_guard.py -v` (5 passed, 4 platform skips on Windows)
- `scripts/run_tests.sh tests/hermes_state/test_deleted_wal_generation_guard.py tests/hermes_state/test_state_db_corrupt_quarantine.py -v` (deleted-WAL suite passed; quarantine suite had one pre-existing Windows-only `PermissionError` when replacing an open SQLite file in `test_replaced_file_takes_precedence_over_corrupt`)
