### PR TITLE
fix(cli): retain authenticated pricing keys for cached-only reads

### DIFF
--- a/hermes_cli/models_pricing.py
+++ b/hermes_cli/models_pricing.py
@@ -19,7 +19,7 @@ from hermes_cli.models_reasoning_caps import _seed_reasoning_caps
 
 # Cache: maps model_id → {"prompt": str, "completion": str} per endpoint
 _pricing_cache: dict[str, dict[str, dict[str, str]]] = {}
-# (profile key, provider) → endpoint cache key last fetched, so cached_only reads find the right entry.
+# (profile key, provider) → exact catalog key (including credential fingerprint when authenticated).
 _pricing_provider_cache_keys: dict[tuple[str, str], str] = {}
 
 # A failed fetch caches its empty result too, so an unreachable endpoint isn't re-dialed on every
@@ -373,9 +373,10 @@ def _remember_provider_cache_key(provider: str, cache_key: str) -> None:
 
 
 def _fetch_openrouter_pricing(*, force_refresh: bool = False) -> dict[str, dict[str, Any]]:
-    _remember_provider_cache_key("openrouter", _OPENROUTER_PRICING_BASE)
+    api_key = _resolve_openrouter_api_key()
+    _remember_provider_cache_key("openrouter", _OPENROUTER_PRICING_BASE + _pricing_auth_fingerprint(api_key))
     return fetch_models_with_pricing(
-        api_key=_resolve_openrouter_api_key(),
+        api_key=api_key,
         base_url=_OPENROUTER_PRICING_BASE,
         force_refresh=force_refresh,
     )
@@ -400,7 +401,7 @@ def _fetch_nous_pricing_for_provider(*, force_refresh: bool = False) -> dict[str
     api_key, base_url = _resolve_nous_pricing_credentials()
     if not base_url:
         return {}
-    _remember_provider_cache_key("nous", base_url.rstrip("/"))
+    _remember_provider_cache_key("nous", base_url.rstrip("/") + _pricing_auth_fingerprint(api_key))
     return _fetch_nous_pricing(api_key, base_url, force_refresh=force_refresh)
 
 
@@ -465,7 +466,9 @@ def pricing_cache_scope(provider: str, *, current_provider: str = "", current_ba
         persisted_base = get_cached_nous_inference_base_url()
         if persisted_base:
             return persisted_base
-        return _pricing_provider_cache_keys.get((_pricing_profile_key(), normalized), _DEFAULT_NOUS_INFERENCE_BASE)
+        cache_key = _pricing_provider_cache_keys.get((_pricing_profile_key(), normalized), _DEFAULT_NOUS_INFERENCE_BASE)
+        # Prewarm scopes are endpoint identities, not authenticated payload keys.
+        return cache_key.partition(_PRICING_AUTH_KEY_PREFIX)[0]
     return ""
 
 

--- a/tests/hermes_cli/test_pricing_cache_auth_key.py
+++ b/tests/hermes_cli/test_pricing_cache_auth_key.py
@@ -132,6 +132,57 @@ def test_force_refresh_replaces_only_its_own_entry(catalog):
     assert len(catalog) == 3, "the anonymous entry should have survived"
 
 
+@pytest.mark.parametrize("provider", ["nous", "openrouter"])
+@pytest.mark.parametrize("api_key", ["sk-test", ""])
+def test_provider_cached_only_reads_its_fetched_catalog(monkeypatch, catalog, provider, api_key):
+    monkeypatch.setattr(models_pricing, "_pricing_provider_cache_keys", {})
+    monkeypatch.setattr(models_pricing, "_resolve_openrouter_api_key", lambda: api_key)
+    monkeypatch.setattr(models_pricing, "_resolve_nous_pricing_credentials", lambda: (api_key, BASE))
+    fetched = models_pricing.get_pricing_for_provider(provider)
+    assert sorted(fetched) == sorted(_FILTERED if api_key else _FULL)
+    if provider == "nous":
+        monkeypatch.setattr("hermes_cli.auth._nous_inference_env_override", lambda: None)
+        monkeypatch.setattr(models_pricing, "get_cached_nous_inference_base_url", lambda: "")
+        assert models_pricing.pricing_cache_scope(provider) == BASE
+
+    def unexpected_auth():
+        pytest.fail("cached-only reads must not resolve or refresh credentials")
+
+    monkeypatch.setattr(models_pricing, "_resolve_openrouter_api_key", unexpected_auth)
+    monkeypatch.setattr(models_pricing, "_resolve_nous_pricing_credentials", unexpected_auth)
+    assert models_pricing.get_pricing_for_provider(provider, cached_only=True) == fetched
+    assert len(catalog) == 1
+    if provider == "nous":
+        now = models_pricing.time.monotonic()
+        monkeypatch.setattr(models_pricing.time, "monotonic", lambda: now + 301)
+        assert models_pricing.get_pricing_for_provider(provider, cached_only=True) == {}
+        assert len(catalog) == 1
+
+
+@pytest.mark.parametrize("provider", ["nous", "openrouter"])
+def test_provider_cached_only_keeps_profile_ownership(monkeypatch, tmp_path, per_org_catalog, provider):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    monkeypatch.setattr(models_pricing, "_pricing_provider_cache_keys", {})
+    expected = {}
+    for profile in ("a", "b"):
+        token = set_hermes_home_override(tmp_path / profile)
+        try:
+            monkeypatch.setattr(models_pricing, "_resolve_openrouter_api_key", lambda: f"tok-{profile}")
+            monkeypatch.setattr(models_pricing, "_resolve_nous_pricing_credentials", lambda: (f"tok-{profile}", BASE))
+            expected[profile] = models_pricing.get_pricing_for_provider(provider)
+        finally:
+            reset_hermes_home_override(token)
+    assert expected["a"] != expected["b"]
+    for profile in ("a", "b"):
+        token = set_hermes_home_override(tmp_path / profile)
+        try:
+            assert models_pricing.get_pricing_for_provider(provider, cached_only=True) == expected[profile]
+        finally:
+            reset_hermes_home_override(token)
+    assert len(per_org_catalog) == 2
+
+
 class TestPeekCachedPricing:
     def test_returns_empty_when_nothing_cached(self):
         assert peek_cached_pricing(BASE) == {}


### PR DESCRIPTION
## What does this PR do?

After an authenticated Nous or OpenRouter pricing fetch succeeds, a subsequent `get_pricing_for_provider(..., cached_only=True)` returns an empty catalogue. The provider reference stores the bare endpoint, but the fetched payload is cached under the endpoint plus a credential fingerprint.

Record the exact authenticated payload key using the credential already resolved for the fetch. Keep the Nous prewarm scope endpoint-only by removing the fingerprint from its fallback reference. Cached-only reads still perform no network requests or credential refreshes, and retain catalogue expiry and profile-specific references.

## Related Issue

Follow-up to the cached-only picker path introduced in #101685. Reproduced on upstream `866332bfb52c46e543143b2620a9aeee8bce9c77`.

## Type of Change

- [x] Bug fix

## How to Test

`scripts/run_tests.sh tests/hermes_cli/test_pricing_cache_auth_key.py tests/hermes_cli/test_inventory_pricing.py tests/hermes_cli/test_sale_pricing.py -q -j 3 --file-retries 0`

Native Windows: 39 passed. Before the fix, the new authenticated round-trip and profile-ownership cases failed for both providers (4 failures); both anonymous cases passed. The tests use synthetic HTTP responses and credentials with the real catalogue parsing and cache paths under isolated HERMES_HOME. They also check that cached-only reads do not resolve credentials or issue another request, expired Nous entries are not returned, and prewarm scope remains an endpoint URL.

`ruff check hermes_cli/models_pricing.py tests/hermes_cli/test_pricing_cache_auth_key.py --select E9,F63,F7,F82` with Ruff 0.15.10 and `git diff --check` passed.

## Checklist

- [x] Read the contributing guide; conventional commit; searched existing PRs.
- [x] Only the focused fix and two parametrised regression tests are included.
- [x] Tested on native Windows with the canonical test runner.
- [ ] Full repository suite and live provider/UI testing (not run).

No dependencies, configuration or public interfaces change. No platform-specific behaviour is introduced.
