### PR TITLE
test(desktop): count spawns instead of distinct pids in the pool coordinator test

### DIFF
--- a/apps/desktop/electron/pool-spawn-coordinator.test.ts
+++ b/apps/desktop/electron/pool-spawn-coordinator.test.ts
@@ -114,7 +114,11 @@ test('100 real child processes never exceed twelve simultaneous local slots', as
   const limit = 12
   const coordinator = new LocalBackendSpawnCoordinator(limit)
   const livePids = new Set<number>()
-  const seenPids = new Set<number>()
+  // Count spawns rather than collecting distinct pids: the coordinator releases
+  // each slot once its child has exited, so later waves can legitimately be
+  // handed a pid the OS just freed. Windows recycles pids promptly enough that
+  // a Set of them lands below 100 on most runs.
+  let spawned = 0
   let maxLive = 0
 
   await Promise.all(
@@ -128,7 +132,7 @@ test('100 real child processes never exceed twelve simultaneous local slots', as
 
         assert.ok(child.pid)
         livePids.add(child.pid)
-        seenPids.add(child.pid)
+        spawned += 1
         maxLive = Math.max(maxLive, livePids.size)
 
         await new Promise<void>((resolve, reject) => {
@@ -149,7 +153,7 @@ test('100 real child processes never exceed twelve simultaneous local slots', as
     })
   )
 
-  assert.equal(seenPids.size, 100)
+  assert.equal(spawned, 100)
   assert.equal(maxLive, limit)
   assert.equal(livePids.size, 0)
   assert.equal(coordinator.activeCount, 0)


### PR DESCRIPTION
Fixes #105685.

## Problem

```js
seenPids.add(child.pid)
…
assert.equal(seenPids.size, 100)
```

This requires the OS to hand out 100 *distinct* pids across the run. Nothing guarantees that.

The coordinator holds 12 slots and releases each only after its child has exited, so the 100 children run in waves — and later waves can legitimately be handed a pid the OS just freed. Windows recycles pids promptly enough that the `Set` collapses below 100 on most runs.

Measured on `main` @ 866332bfb5, Windows 11 AMD64, Node v24.19.0 — **6 failures in 7** full `--project electron` runs:

```
94 !== 100
96 !== 100   (x2)
98 !== 100   (x2)
99 !== 100
```

Different almost every run, and one run passed, so this is not a stable threshold that could just be lowered.

## Fix

Count spawns instead of collecting distinct pids. `livePids` stays — the concurrency bookkeeping genuinely needs a set — only the unsound `seenPids.size` assertion goes away.

Pid uniqueness is an OS scheduling detail, not a property of `LocalBackendSpawnCoordinator`. The assertions that pin the real contract are untouched: `maxLive === limit`, `livePids.size === 0`, and the drained `activeCount` / `queuedCount`.

## Verification

5 consecutive runs of the suite on Windows, all green:

```
run 1-5   Tests  21 passed (21)
```

**The test still catches real regressions.** With the coordinator mutated to admit `limit + 3`, it fails as it should:

```
AssertionError: Expected values to be strictly equal:
15 !== 12        ← maxLive === limit
```

So this removes a false alarm without removing the test's teeth.

## Notes

Found while making the `electron` suite pass on Windows (#105677). This is the single failure still visible after that PR, and it is independent of it — the fix here applies to clean `main` and needs nothing from #105677. The two PRs touch different files and can land in either order.
