### PR TITLE
fix(memory): preserve surrounding content on partial replace across single and batch paths (#59184)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -151,6 +151,89 @@ class TestMemoryStoreReplace:
         assert "Python 3.12 project" in store.memory_entries
         assert "Python 3.11 project" not in store.memory_entries
 
+    def test_replace_composite_entry_middle_span(self, store):
+        """Fix #59184: replacing a middle clause preserves surrounding prefix and suffix."""
+        store.add("user", "User: Alice. Role: Architect. Stack: Python & Go. Prefers dark mode.")
+        result = store.replace("user", "Stack: Python & Go.", "Stack: Rust & TypeScript.")
+        assert result["success"] is True
+        assert store.user_entries[0] == "User: Alice. Role: Architect. Stack: Rust & TypeScript. Prefers dark mode."
+
+    def test_replace_composite_entry_suffix_span(self, store):
+        """Fix #59184: replacing a trailing clause preserves preceding content."""
+        store.add("user", "User: Bob. City: Bandung. Timezone: WIB. Alert: Slack.")
+        result = store.replace("user", "Alert: Slack.", "Alert: Discord.")
+        assert result["success"] is True
+        assert store.user_entries[0] == "User: Bob. City: Bandung. Timezone: WIB. Alert: Discord."
+
+    def test_replace_composite_entry_prefix_span(self, store):
+        """Fix #59184: replacing a leading clause preserves following content."""
+        store.add("memory", "Status: Staging. DB: PostgreSQL. Cache: Redis.")
+        result = store.replace("memory", "Status: Staging.", "Status: Production.")
+        assert result["success"] is True
+        assert store.memory_entries[0] == "Status: Production. DB: PostgreSQL. Cache: Redis."
+
+    def test_replace_whole_entry_backward_compat(self, store):
+        """When old_text matches the full entry, replacement behaves as whole-card update."""
+        store.add("memory", "Python 3.11 project")
+        result = store.replace("memory", "Python 3.11 project", "Rust 1.75 project")
+        assert result["success"] is True
+        assert store.memory_entries[0] == "Rust 1.75 project"
+
+    def test_replace_punctuation_suffix_not_mistaken_for_whole_entry(self, store):
+        """Fix edge-case: punctuation suffix (e.g. '.') must not trigger whole-card override."""
+        store.add("memory", "Model: GPT-4.")
+        result = store.replace("memory", "GPT-4", "Claude-3")
+        assert result["success"] is True
+        assert store.memory_entries[0] == "Model: Claude-3."
+
+    def test_replace_leading_span_with_full_card_repetition(self, store):
+        """Fix edge-case: when model targets leading clause but repeats full card in content."""
+        store.add("memory", "Status: Staging. Cache: Redis.")
+        result = store.replace("memory", "Status: Staging.", "Status: Staging. Cache: Valkey.")
+        assert result["success"] is True
+        assert store.memory_entries[0] == "Status: Staging. Cache: Valkey."
+
+    def test_replace_at_capacity_shrinkage_consolidation(self, store):
+        """Consolidation shrinkage: replacing full bloated entry with concise summary must shrink cleanly."""
+        store.add("memory", "Detailed Log: " + "x" * 400)
+        result = store.replace("memory", "Detailed Log: " + "x" * 400, "Log: Compacted.")
+        assert result["success"] is True
+        assert store.memory_entries[0] == "Log: Compacted."
+
+    def test_replace_regex_and_special_characters(self, store):
+        """Special characters like brackets, anchors, and carets must not break string matching."""
+        store.add("memory", "Pattern: ^[a-z0-9_-]{3,16}$. Status: Valid.")
+        result = store.replace("memory", "^[a-z0-9_-]{3,16}$", "^[a-zA-Z0-9_-]{3,32}$")
+        assert result["success"] is True
+        assert store.memory_entries[0] == "Pattern: ^[a-zA-Z0-9_-]{3,32}$. Status: Valid."
+
+    def test_replace_multiline_list_formatting(self, store):
+        """Multiline bullet lists and newlines within a card are preserved."""
+        store.add("user", "Section A:\n- item 1\nSection B:\n- item 2")
+        result = store.replace("user", "- item 2", "- item 2\n- item 3")
+        assert result["success"] is True
+        assert store.user_entries[0] == "Section A:\n- item 1\nSection B:\n- item 2\n- item 3"
+
+    def test_replace_composite_multi_sentence_real_world(self, store):
+        """Real-world multi-attribute user profile card preserving surrounding context."""
+        entry = (
+            "User Profile: Alice, AI Researcher at Lab X (advisor: Dr. Y). "
+            "Building agentic systems. UI utilitarian; diagram README WAJIB Mermaid SVG."
+        )
+        store.add("user", entry)
+        result = store.replace(
+            "user",
+            "diagram README WAJIB Mermaid SVG.",
+            "diagram arsitektur & README WAJIB format Mermaid SVG."
+        )
+        assert result["success"] is True
+        res = store.user_entries[0]
+        assert "Alice" in res
+        assert "Lab X" in res
+        assert "advisor: Dr. Y" in res
+        assert "Building agentic systems" in res
+        assert "diagram arsitektur & README WAJIB format Mermaid SVG." in res
+
 
     def test_replace_ambiguous_match(self, store):
         store.add("memory", "server A runs nginx")
@@ -396,6 +479,14 @@ class TestMemoryBatch:
         ))
         assert result["success"] is False
         assert "legit fact" not in store.memory_entries
+
+    def test_batch_replace_composite_middle_span(self, store):
+        """Fix #59184: batch replace in the middle of a multi-sentence card preserves surrounding clauses."""
+        store.add("memory", "Policy: Zero-trust. Session: 8h. MFA: Hardware key.")
+        batch = [{"action": "replace", "old_text": "Session: 8h.", "content": "Session: 12h."}]
+        result = store.apply_batch("memory", batch)
+        assert result["success"] is True
+        assert store.memory_entries[0] == "Policy: Zero-trust. Session: 12h. MFA: Hardware key."
 
 
 # =========================================================================

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -54,6 +54,34 @@ def _read_failed_error(path: Path) -> Dict[str, Any]:
         f"memory, so the write is refused. Nothing was changed — retry in a moment.")
 
 
+def _compute_replacement(entry: str, old_text: str, content: str) -> str:
+    """Compute updated entry preserving surrounding content unless whole-entry replacement was intended."""
+    if content == entry or old_text == entry:
+        return content
+    pos = entry.find(old_text)
+    if pos == -1:
+        return content
+    prefix = entry[:pos]
+    suffix = entry[pos + len(old_text):]
+    
+    p_clean = prefix.strip()
+    s_clean = suffix.strip()
+
+    # 1. Both prefix and suffix exist, and content overlaps both ends (e.g. 'Python 3.11 project' -> 'Python 3.12 project' with old='3.11')
+    if p_clean and s_clean and content.startswith(p_clean) and content.endswith(s_clean):
+        return content
+
+    # 2. Match is at the beginning (prefix empty), but content is substantially longer and repeats the old_text prefix
+    if not p_clean and s_clean and content.startswith(old_text.strip()) and len(content) >= len(entry) * 0.7:
+        return content
+
+    # 3. Match is at the end (suffix empty), but content repeats the prefix of the entry
+    if p_clean and not s_clean and len(p_clean) > 3 and content.startswith(p_clean):
+        return content
+
+    return prefix + content + suffix
+
+
 def _find_unique_match(entries: List[str], old_text: str) -> Tuple[Optional[int], bool]:
     """``(index, ambiguous)`` for entries containing *old_text*. Exact-duplicate
     matches are safe (first wins); distinct matches → ``(None, True)``."""
@@ -261,7 +289,11 @@ class MemoryStore:
                 return self._consolidation_failure(_error(
                     f"No entry matched '{old_text}'. Check current_entries below and retry with the exact text "
                     f"of the entry you want to {'replace' if new_content else 'remove'}.", current_entries=entries))
-            replaced = entries[:idx] + ([] if new_content is None else [new_content]) + entries[idx + 1:]
+            if new_content is not None:
+                computed_entry = _compute_replacement(entries[idx], old_text, new_content)
+                replaced = entries[:idx] + [computed_entry] + entries[idx + 1:]
+            else:
+                replaced = entries[:idx] + entries[idx + 1:]
             if new_content is None:
                 return replaced, "Entry removed."
             new_total = len(ENTRY_DELIMITER.join(replaced))
@@ -293,7 +325,10 @@ class MemoryStore:
             return f"{pos}: '{old_text}' matched multiple distinct entries -- be more specific."
         if idx is None:
             return f"{pos}: no entry matched '{old_text}'."
-        working[idx:idx + 1] = [content] if act == "replace" else []
+        if act == "replace":
+            working[idx] = _compute_replacement(working[idx], old_text, content)
+        else:
+            working[idx:idx + 1] = []
         return None
 
     def apply_batch(self, target: str, operations: List[Dict[str, Any]]) -> Dict[str, Any]:


### PR DESCRIPTION
### Summary

Resolves #59184 and supersedes stale PR #66321.

When updating composite multi-sentence memory entries (delimited by `\n§\n`), models frequently pass a partial clause in `old_text` and its updated replacement in `content` / `new_text`. 

Previously, both single `_edit` and batch `_apply_batch_op` paths unconditionally performed whole-slot overwrites (`replaced = entries[:idx] + [new_content] + entries[idx + 1:]`). This silently wiped unmodified sibling clauses (e.g. user profile attributes, environment constraints) while reporting false-positive success (`{"success": true, "message": "Entry replaced."}`).

---

### Root Cause & Why Earlier PRs Stalled

Earlier PR attempts (#66321, #59206) attempted a naive substring replacement:
```python
entry[:pos] + new_content + entry[pos + len(old_text):]
```
While this worked for simple sentences, it introduced a **critical regression** on whole-card replacements and the canonical unit test in `tests/tools/test_memory_tool.py`:
- Existing test: `store.replace("memory", "3.11", "Python 3.12 project")` against `"Python 3.11 project"`.
- Naive replacement produced: `"Python Python 3.12 project project"` (corrupted duplicate text).
- As noted in maintainer review on #66321, those PRs either failed existing unit tests or attempted to modify upstream test expectations to mask the regression.

---

### Proposed Fix

This PR introduces a robust, edge-case-hardened `_compute_replacement(entry, old_text, content)` in `tools/memory_tool_store.py`:
1. **Context-Aware Intent Detection:**
   - **Full & Identical Match:** If `old_text == entry` or `content == entry`, updates whole card directly.
   - **Two-Sided Overlap (Canonical Upstream Pattern):** When both prefix and suffix exist, and `content` overlaps both (`content.startswith(prefix.strip()) and content.endswith(suffix.strip())`), recognizes full-entry replacement intent and prevents duplicate word corruption (`"Python 3.12 project"`).
   - **Punctuation Suffix Protection:** Single punctuation characters (e.g. trailing `.`) do NOT trigger whole-card overrides, allowing span replacements like `"Model: GPT-4."` -> `"Model: Claude-3."`.
   - **Boundary Card Repetitions:** If a model targets a leading/trailing span but emits the full updated card text, safely adopts the full card without duplicating sibling clauses.
   - **Targeted Span Replacement:** Otherwise, cleanly substitutes the matched span in-place, preserving unmodified prefix and suffix.
2. **Covers All Execution Paths:**
   - Single operation: `MemoryStore._edit` (line 279)
   - Batch operation: `MemoryStore._apply_batch_op` (line 325)
3. **Rebased on Main:** Rebased cleanly onto the latest `origin/main` architecture where `MemoryStore` resides in `tools/memory_tool_store.py`.

---

### Concrete Evidence: Before vs After Test Matrix

Here is how each real-world case and edge-case behaves under current `main` vs this branch:

| Scenario / Test Case | Baseline `main` | Naive PR #66321 | This PR (`_compute_replacement`) | Status |
| :--- | :---: | :---: | :---: | :---: |
| **TC1: Canonical upstream test**<br>`"Python 3.11 project"` with `old="3.11"`, `new="Python 3.12 project"` | `"Python 3.12 project"` | `"Python Python 3.12 project project"` (CORRUPT) | `"Python 3.12 project"` | **PASSED (Zero Regression)** |
| **TC2: Whole-entry match**<br>`"Python 3.11 project"` with `old="Python 3.11 project"`, `new="Rust 1.75"` | `"Rust 1.75"` | `"Rust 1.75"` | `"Rust 1.75"` | **PASSED** |
| **TC3: Composite middle clause**<br>`"User: A. Stack: Go. Mode: dark."` with `old="Stack: Go."`, `new="Stack: Rust."` | `"Stack: Rust."`<br>(SILENT DATA LOSS) | `"User: A. Stack: Rust. Mode: dark."` | `"User: A. Stack: Rust. Mode: dark."` | **PASSED (Surrounding Preserved)** |
| **TC4: Composite trailing clause**<br>`"User: Bob. City: BDG. Alert: Slack."` with `old="Alert: Slack."`, `new="Alert: Discord."` | `"Alert: Discord."`<br>(SILENT DATA LOSS) | `"User: Bob. City: BDG. Alert: Discord."` | `"User: Bob. City: BDG. Alert: Discord."` | **PASSED (Surrounding Preserved)** |
| **TC5: Composite leading clause**<br>`"Env: Staging. DB: PG. Cache: Redis."` with `old="Env: Staging."`, `new="Env: Prod."` | `"Env: Prod."`<br>(SILENT DATA LOSS) | `"Env: Prod. DB: PG. Cache: Redis."` | `"Env: Prod. DB: PG. Cache: Redis."` | **PASSED (Surrounding Preserved)** |
| **TC6: Punctuation suffix span**<br>`"Model: GPT-4."` with `old="GPT-4"`, `new="Claude-3"` | `"Claude-3"`<br>(SILENT DATA LOSS) | `"Model: Claude-3."` | `"Model: Claude-3."` | **PASSED (Punctuation Protected)** |
| **TC7: Leading match with full card repetition**<br>`"Env: Dev. Cache: Redis."` with `old="Env: Dev."`, `new="Env: Dev. Cache: Valkey."` | `"Env: Dev. Cache: Valkey."` | `"Env: Dev. Cache: Valkey. Cache: Redis."` (DUPLICATE) | `"Env: Dev. Cache: Valkey."` | **PASSED (Boundary Protected)** |
| **TC8: Consolidation shrinkage at capacity**<br>Bloated 400-char card replaced with 15-char summary | PASSED | PASSED | PASSED | **PASSED (Clean Shrinkage)** |
| **TC9: Special characters and regex syntax**<br>`"^[a-z0-9_-]{3,16}$"` -> `"^[a-zA-Z0-9_-]{3,32}$"` | SILENT DATA LOSS | PASSED | PASSED | **PASSED (Syntax Preserved)** |
| **TC10: Multiline bullet list formatting**<br>Preserving indentation and newlines within card | SILENT DATA LOSS | PASSED | PASSED | **PASSED (Format Preserved)** |
| **TC11: Real-world multi-attribute user profile**<br>Multi-sentence identity + stack card preserving context | SILENT DATA LOSS | PASSED | PASSED | **PASSED (Context Preserved)** |
| **TC12: Batch composite middle span**<br>`apply_batch` targeting middle clause of multi-sentence card | SILENT DATA LOSS | PASSED | PASSED | **PASSED** |

---

### Complete Regression Tests Added (11 Invariant Unit Tests)

Added 11 new targeted tests directly to `tests/tools/test_memory_tool.py`:
1. `test_replace_composite_entry_middle_span`
2. `test_replace_composite_entry_suffix_span`
3. `test_replace_composite_entry_prefix_span`
4. `test_replace_whole_entry_backward_compat`
5. `test_replace_punctuation_suffix_not_mistaken_for_whole_entry`
6. `test_replace_leading_span_with_full_card_repetition`
7. `test_replace_at_capacity_shrinkage_consolidation`
8. `test_replace_regex_and_special_characters`
9. `test_replace_multiline_list_formatting`
10. `test_replace_composite_multi_sentence_real_world`
11. `test_batch_replace_composite_middle_span`

### Verification

```bash
pytest -v tests/tools/test_memory_tool.py
# 56 passed in 1.96s
```

Fixes #59184
Closes #66321
