### PR TITLE
fix(loop): re-anchor current_turn_user_idx after the alternation repair merges rows

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1392,7 +1392,7 @@ def _run_api_retry_loop(agent, s: _LoopState) -> Optional[Dict[str, Any]]:
     return None
 
 
-def run_conversation(
+def _run_conversation_turn(
     agent,
     user_message: Any,
     system_message: str = None,
@@ -1538,6 +1538,46 @@ def run_conversation(
         # future input can move to a clean session (#98722).
         result.update(error=_COMPRESSION_TIMEOUT_FINAL_RESPONSE, partial=True, compression_exhausted=True)
     return result
+
+
+def run_conversation(
+    agent,
+    user_message: Any,
+    system_message: str = None,
+    conversation_history: List[Dict[str, Any]] = None,
+    task_id: str = None,
+    stream_callback: Optional[callable] = None,
+    persist_user_message: Optional[Any] = None,
+    persist_user_timestamp: Optional[float] = None,
+    persist_user_display_kind: Optional[str] = None,
+    persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+    persist_user_platform_id: Optional[str] = None,
+    moa_config: Optional[dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run one turn (see ``_run_conversation_turn``) and export the current-turn boundary.
+
+    Every envelope that leaves the loop — success, partial/error, interrupt, retry-exhausted,
+    tool-limit, preflight timeout, codex runtime — passes through here, so the
+    ``{turn_id, current_turn_user_idx}`` pair is stamped beside the exact ``messages`` it
+    addresses, after every history rewrite including post-turn micro-compaction.
+    """
+    from agent.turn_context import export_current_turn_boundary
+
+    result = _run_conversation_turn(
+        agent,
+        user_message,
+        system_message=system_message,
+        conversation_history=conversation_history,
+        task_id=task_id,
+        stream_callback=stream_callback,
+        persist_user_message=persist_user_message,
+        persist_user_timestamp=persist_user_timestamp,
+        persist_user_display_kind=persist_user_display_kind,
+        persist_user_display_metadata=persist_user_display_metadata,
+        persist_user_platform_id=persist_user_platform_id,
+        moa_config=moa_config,
+    )
+    return export_current_turn_boundary(agent, result, user_message)
 
 
 __all__ = ["run_conversation"]

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -233,6 +233,44 @@ def reanchor_current_turn_user_idx(messages: List[Any], user_message: Any) -> in
     return fallback
 
 
+def export_current_turn_boundary(agent: Any, result: Any, user_message: Any) -> Any:
+    """Stamp ``{turn_id, current_turn_user_idx}`` on a result envelope, proven against the
+    exact ``result["messages"]`` projection it travels with.
+
+    Hosts that settle their own transcript by index (hermes-webui) must never guess which
+    row is the current user turn after this loop rewrote history (alternation repair,
+    compaction, post-turn micro-compaction): a guessed index or a text match can relabel an
+    identical historical prompt and claim its old answer as this turn's. So the producer
+    exports the coordinate, computed on the final list, only when the addressed row is this
+    turn's user message verbatim. Otherwise the keys are omitted and hosts fail closed.
+    Also mirrors the final index into ``_persist_user_message_idx`` so the persist override
+    targets the surviving row after post-turn micro-compaction.
+    """
+    if not isinstance(result, dict):
+        return result
+    messages = result.get("messages")
+    turn_id = str(getattr(agent, "_current_turn_id", "") or "")
+    if not isinstance(messages, list) or not turn_id or user_message is None:
+        return result
+    idx = reanchor_current_turn_user_idx(messages, user_message)
+    if idx < 0 or idx >= len(messages):
+        return result
+    row = messages[idx]
+    if not (isinstance(row, dict) and row.get("role") == "user"):
+        return result
+    from agent.context_compressor import user_originated_turn_view
+
+    live_view = user_originated_turn_view(row)
+    if row.get("content") != user_message and not (
+        isinstance(live_view, dict) and live_view.get("content") == user_message
+    ):
+        return result  # rewritten (merge-into-tail) row: not a proven boundary
+    result["turn_id"] = turn_id
+    result["current_turn_user_idx"] = idx
+    agent._persist_user_message_idx = idx
+    return result
+
+
 def compression_made_progress(
     orig_len: int, new_len: int, orig_tokens: int, new_tokens: int
 ) -> bool:

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -89,9 +89,12 @@ class IterationPrep:
     action: str
     messages: Any
     request_logger: Any
+    current_turn_user_idx: Any
 
 
-def prepare_iteration(agent: Any,*, messages: Any, api_call_count: Any) -> IterationPrep:
+def prepare_iteration(
+    agent: Any, *, messages: Any, api_call_count: Any, user_message: Any = None, current_turn_user_idx: Any = None,
+) -> IterationPrep:
     """Prepare ``messages`` for this iteration in the original order. Every mutation here is
     cache-safe by construction: steer text lands in the newest tool result, the ghost-row
     filter only drops hidden scaffold placeholders, and repair runs BEFORE the request build."""
@@ -182,7 +185,31 @@ def prepare_iteration(agent: Any,*, messages: Any, api_call_count: Any) -> Itera
             repaired_seq,
             agent.session_id or "-",
         )
-    return IterationPrep(action="fallthrough", messages=messages, request_logger=request_logger)
+        # The repair merges adjacent user rows in place (after a compaction the role=user
+        # summary sits next to the protected first user message), so the list shrinks and
+        # the index recorded at turn start points past this turn's user row. Re-anchor it
+        # like the compression restart path does, and mirror the value into
+        # _persist_user_message_idx, which hosts read when the result carries no index:
+        # a stale anchor injects prefetch into a historical row and makes hosts that settle
+        # their transcript by this index (hermes-webui) write the current turn to the FRONT
+        # of the context, rewriting the prompt's leading messages every turn.
+        _reanchored_idx = (
+            reanchor_current_turn_user_idx(messages, user_message) if user_message is not None
+            else current_turn_user_idx
+        )
+        if _reanchored_idx != current_turn_user_idx:
+            request_logger.info(
+                "Re-anchored current_turn_user_idx %s -> %s after alternation repair (session=%s)",
+                current_turn_user_idx,
+                _reanchored_idx,
+                agent.session_id or "-",
+            )
+            current_turn_user_idx = _reanchored_idx
+            agent._persist_user_message_idx = _reanchored_idx
+    return IterationPrep(
+        action="fallthrough", messages=messages, request_logger=request_logger,
+        current_turn_user_idx=current_turn_user_idx,
+    )
 
 
 def _previous_tool_round(messages: Any) -> list:

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -193,6 +193,11 @@ def prepare_iteration(
         # a stale anchor injects prefetch into a historical row and makes hosts that settle
         # their transcript by this index (hermes-webui) write the current turn to the FRONT
         # of the context, rewriting the prompt's leading messages every turn.
+        # reanchor_current_turn_user_idx scans from the tail: with two identical user
+        # rows it resolves to the LAST one, i.e. this turn, never the historical copy.
+        # Without the message text the index cannot be re-derived; leave it (an
+        # out-of-range index is detectably stale, a clamped one would silently target
+        # a wrong row).
         _reanchored_idx = (
             reanchor_current_turn_user_idx(messages, user_message) if user_message is not None
             else current_turn_user_idx

--- a/tests/run_agent/test_export_current_turn_boundary.py
+++ b/tests/run_agent/test_export_current_turn_boundary.py
@@ -1,0 +1,131 @@
+"""The loop exports ``{turn_id, current_turn_user_idx}`` beside the exact ``messages`` it
+addresses, and only when that row is this turn's user message verbatim.
+
+Hosts that settle a transcript by index (hermes-webui) must not guess the current-turn
+row after the loop rewrote history (alternation repair, compaction, post-turn
+micro-compaction): with a repeated prompt a guessed index or a text match relabels the
+historical copy and claims its old answer. The producer therefore proves the coordinate on
+the final list; when it cannot, the keys are omitted and hosts fail closed.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.turn_context import export_current_turn_boundary
+
+
+class _Agent:
+    def __init__(self, turn_id="session:task:abcd1234"):
+        self._current_turn_id = turn_id
+        self._persist_user_message_idx = None
+
+
+def test_repeated_prompt_resolves_to_the_last_verbatim_row():
+    messages = [
+        {"role": "user", "content": "same question"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "same question"},
+        {"role": "assistant", "content": "new answer"},
+    ]
+    agent = _Agent()
+    result = export_current_turn_boundary(agent, {"messages": messages}, "same question")
+    assert result["current_turn_user_idx"] == 2
+    assert result["turn_id"] == agent._current_turn_id
+    assert agent._persist_user_message_idx == 2
+
+
+def test_missing_current_row_exports_nothing():
+    messages = [
+        {"role": "user", "content": "same question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    agent = _Agent()
+    result = export_current_turn_boundary(agent, {"messages": messages}, "another question")
+    assert "current_turn_user_idx" not in result and "turn_id" not in result
+    assert agent._persist_user_message_idx is None
+
+
+def test_rewritten_row_is_not_a_proven_boundary():
+    # merge-into-tail rewrote the surviving row's content: reanchor would fall back to it,
+    # but the export refuses to claim a row that is not the verbatim message.
+    messages = [
+        {"role": "user", "content": "summary\n\nsame question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    result = export_current_turn_boundary(_Agent(), {"messages": messages}, "same question")
+    assert "current_turn_user_idx" not in result
+
+
+def test_multimodal_content_is_matched_verbatim():
+    content = [{"type": "text", "text": "look"}, {"type": "image_url", "image_url": {"url": "data:x"}}]
+    messages = [{"role": "user", "content": content}, {"role": "assistant", "content": "ok"}]
+    result = export_current_turn_boundary(_Agent(), {"messages": messages}, content)
+    assert result["current_turn_user_idx"] == 0
+
+
+def test_no_turn_id_or_non_dict_result_is_left_alone():
+    assert export_current_turn_boundary(_Agent(turn_id=""), {"messages": [{"role": "user", "content": "q"}]}, "q") == {
+        "messages": [{"role": "user", "content": "q"}]
+    }
+    assert export_current_turn_boundary(_Agent(), None, "q") is None
+
+
+@pytest.fixture()
+def loop_agent():
+    from run_agent import AIAgent
+
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.compression_enabled = False
+        a.save_trajectories = False
+        return a
+
+
+def _stub(content, finish_reason="stop"):
+    from tests.run_agent.test_run_agent import _mock_assistant_msg
+
+    return SimpleNamespace(
+        id="chatcmpl-test",
+        model="test/model",
+        choices=[SimpleNamespace(index=0, message=_mock_assistant_msg(content=content), finish_reason=finish_reason)],
+        usage=None,
+    )
+
+
+def test_run_conversation_exports_the_pair_on_a_success_envelope(loop_agent):
+    loop_agent.client.chat.completions.create.side_effect = [_stub("new answer")]
+    history = [
+        {"role": "user", "content": "same question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    with (
+        patch.object(loop_agent, "_persist_session"),
+        patch.object(loop_agent, "_save_trajectory"),
+        patch.object(loop_agent, "_cleanup_task_resources"),
+    ):
+        result = loop_agent.run_conversation("same question", conversation_history=history)
+
+    assert result["completed"] is True
+    idx = result["current_turn_user_idx"]
+    assert result["messages"][idx]["role"] == "user"
+    assert result["messages"][idx]["content"] == "same question"
+    assert idx > 0  # the historical identical prompt at index 0 is never the export
+    assert result["turn_id"] == loop_agent._current_turn_id
+    assert result["messages"][-1]["content"] == "new answer"

--- a/tests/run_agent/test_repair_reanchors_current_turn_user_idx.py
+++ b/tests/run_agent/test_repair_reanchors_current_turn_user_idx.py
@@ -1,0 +1,50 @@
+"""Regression: ``repair_message_sequence`` merges adjacent rows *before* the current
+turn's user message (a role=user compaction summary next to the protected first
+user message), so the index recorded at turn start drifts past the current row.
+Hosts that settle the transcript by that index (WebUI) then write the current
+user turn to the FRONT of the context. ``run_conversation`` must re-anchor the
+index after a repair that changed the list.
+"""
+from agent.agent_runtime_helpers import repair_message_sequence
+from agent.turn_context import reanchor_current_turn_user_idx
+
+
+class _Agent:
+    session_id = "s"
+
+
+def _history_with_adjacent_users():
+    return [
+        {"role": "assistant", "content": "**Context snapshot**"},
+        {"role": "user", "content": "compaction summary written as a user row"},
+        {"role": "user", "content": "first protected user message"},
+        {"role": "assistant", "content": "ok",
+         "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "t", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "out"},
+        {"role": "user", "content": "NEW question"},
+    ]
+
+
+def test_repair_shifts_recorded_index_and_reanchor_recovers_it():
+    messages = _history_with_adjacent_users()
+    recorded_idx = len(messages) - 1  # what run_conversation records at turn start
+    assert messages[recorded_idx]["content"] == "NEW question"
+    repairs = repair_message_sequence(_Agent(), messages)
+    assert repairs >= 1
+    # the recorded index no longer addresses the current user row
+    assert recorded_idx >= len(messages) or messages[recorded_idx]["content"] != "NEW question"
+    reanchored = reanchor_current_turn_user_idx(messages, "NEW question")
+    assert messages[reanchored]["role"] == "user"
+    assert messages[reanchored]["content"] == "NEW question"
+    assert reanchored == len(messages) - 1
+
+
+def test_repair_without_changes_keeps_index():
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "user", "content": "NEW question"},
+    ]
+    recorded_idx = len(messages) - 1
+    assert repair_message_sequence(_Agent(), messages) == 0
+    assert reanchor_current_turn_user_idx(messages, "NEW question") == recorded_idx


### PR DESCRIPTION
## fix(loop): re-anchor `current_turn_user_idx` after the alternation repair, and export the current-turn boundary on every result envelope

`prepare_iteration()` runs `repair_message_sequence_with_cursor()` before each API call; the repair merges adjacent user rows in place. After a compaction the `role=user` summary sits next to the protected first user message, so the merge shrinks the list and `current_turn_user_idx` (recorded at turn start) now points past the current user row: the per-turn context injection targets the wrong row, and hosts that settle the transcript by this index (hermes-webui) write the current user turn to the **front** of the context — rewriting the prompt's leading messages every turn (0% prefix-cache hits at 200K+ tokens, ~100 s re-prefill per turn, measured on a vLLM backend with a per-call hash probe on `pre_api_request`) and duplicating the user's question.

### Commit 1 — re-anchor after the repair
The in-loop compression restart path already re-anchors (`turn_iteration_prep.py`, `_retry.restart_with_compressed_messages`); do the same after a repair that changed the list: `reanchor_current_turn_user_idx(messages, user_message)` (last user row carrying this turn's text, so a repeated prompt never resolves to its historical copy), return the index through the `IterationPrep` verdict so `_run_phase` copies it into the loop state, and mirror it into `agent._persist_user_message_idx`. The two new `prepare_iteration` parameters default to `None`, so the existing direct callers in `tests/agent/` keep their signature.

### Commit 2 — export `{turn_id, current_turn_user_idx}` beside the exact messages
A host cannot prove which row of `result["messages"]` is the current user turn after this loop rewrote history (alternation repair, compaction, post-turn micro-compaction): the instance-side `_persist_user_message_idx` predates those rewrites, and a text match relabels an identical historical prompt and claims its old answer (nesquena/hermes-webui#7461 review). Only the producer can assert the coordinate against the list it returns.

`run_conversation` now wraps the turn (`_run_conversation_turn`) and stamps the pair via `export_current_turn_boundary` (`agent/turn_context.py`) on every envelope that leaves the loop — success, partial/error, interrupt, retry-exhausted, tool-limit, preflight timeout, codex runtime — computed on the final `messages` after `finalize_turn` and micro-compaction. The pair is exported only when the addressed row is this turn's user message verbatim; a rewritten (merge-into-tail) row exports nothing so hosts fail closed. The final index is mirrored into `_persist_user_message_idx` for the persist override.

### Tests
- `tests/run_agent/test_repair_reanchors_current_turn_user_idx.py`: the recorded index goes out of range after the repair and the re-anchor recovers the row; the no-repair case keeps the index.
- `tests/run_agent/test_export_current_turn_boundary.py`: repeated prompt resolves to the last verbatim row, missing/rewritten row exports nothing, multimodal content matched verbatim, and an end-to-end `run_conversation` with a mocked completion exports the pair on a success envelope with the historical identical prompt never chosen.
- Direct callers of the module (`tests/agent/test_iteration_budget_warning.py`, `test_kanban_budget_checkpoint.py`, `test_prompt_cache_ttl_propagation.py`) plus the loop/turn-context subset and every test file driving `run_conversation`: see the CI run.

Related: nesquena/hermes-webui#7461 (host side: proven coordinates or fail closed). Either half alone stops the front insertion; both together make the boundary explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gp366ijf39n4UUtJhZuMh
