### PR TITLE
fix(memory): guard MemoryStore against 0-byte wipe on failed replace (#105684)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -592,7 +592,8 @@ class TestUnreadableFileDoesNotWipeMemory:
         second read as "no drift" — a read failure between the checked reload
         and the drift check let `replace` rewrite the file from a stale view,
         discarding externally added entries. Pin the invariant structurally:
-        one mutation, one read.
+        one mutation, two reads at most (initial + atomic CAS re-read before
+        write, issue #105684); the CAS read must not swallow failures.
         """
         store.add("memory", "Only entry.")
         path = store._path_for("memory")
@@ -609,9 +610,9 @@ class TestUnreadableFileDoesNotWipeMemory:
         result = store.replace("memory", "Only entry", "Replaced entry.")
 
         assert result["success"] is True
-        assert counts["n"] == 1, (
-            f"replace() read the memory file {counts['n']} times; drift "
-            f"detection must reuse the single checked-read snapshot"
+        assert counts["n"] == 2, (
+            f"replace() read the memory file {counts['n']} times; expected 2 "
+            f"(initial checked-read + atomic CAS re-read before write, issue #105684)"
         )
 
 
@@ -777,8 +778,6 @@ class TestBatchRefusesToEmptyNonEmptyStore:
         assert seed not in store._entries_for(target)
         assert "replacement entry here" in store._entries_for(target)
 
-
-# =========================================================================
 # Background-review delete gate (#105921)
 # =========================================================================
 
@@ -869,3 +868,96 @@ class TestBackgroundReviewDeleteGate:
             reset_current_write_origin(token)
         assert result["success"] is True
         assert "rewritten by refine" in store._entries_for("memory")
+# =========================================================================
+# Wipe guard for failed replace + shrink/CAS (issue #105684)
+#
+# A single failed replace (no old_text match) must never wipe MEMORY.md /
+# USER.md, even when the mutation path later gained defensive checks.
+# The shrink guard also prevents any successful mutation that would
+# collapse a substantially sized file to near-empty in one step.
+# =========================================================================
+
+
+class TestWipeGuard105684:
+    def test_failed_replace_does_not_emit_empty_persist(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=5000, user_char_limit=5000)
+        store.load_from_disk()
+        # Pre-populate with 13 lines ~1.8KB like the reported incident.
+        for i in range(13):
+            assert store.add("memory", f"fact {i:02d}: " + "x" * 120)["success"] is True
+        path = store._path_for("memory")
+        original_bytes = path.read_bytes()
+        assert len(original_bytes) > 200
+
+        result = store.replace("memory", "no-such-thing", "x")
+        assert result["success"] is False
+        assert "No entry matched" in result["error"]
+        # INVARIANT: disk must not have shrunk to 0 / near-0
+        assert path.read_bytes() == original_bytes
+
+    def test_failed_replace_preserves_disk_for_user_target(self, store):
+        store.add("user", "Name: Alice — developer, loves hermes")
+        store.add("user", "Prefers concise replies")
+        path = store._path_for("user")
+        before = path.read_bytes()
+        result = store.replace("user", "no-such-thing", "new entry")
+        assert result["success"] is False
+        assert path.read_bytes() == before
+
+    def test_shrink_guard_refuses_near_empty_write_and_preserves_disk(self, tmp_path, monkeypatch):
+        """A mutation that would collapse a >200-byte file to <50 bytes is refused."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=5000, user_char_limit=5000)
+        store.load_from_disk()
+        for i in range(5):
+            store.add("memory", f"entry {i} " + "y" * 80)
+        path = store._path_for("memory")
+        assert len(path.read_bytes()) > 200
+
+        # Simulate a buggy mutate that returns a near-empty list.
+        def _buggy(entries, limit):
+            return [], "buggy wipe"
+
+        result = store._mutate("memory", _buggy)
+        assert result["success"] is False
+        assert "Refusing to persist near-empty" in result["error"]
+        # File untouched
+        assert len(path.read_bytes()) > 200
+
+    def test_single_remove_last_entry_still_allowed_when_only_one_entry(self, tmp_path, monkeypatch):
+        """Deliberate wipe via single remove() of the last entry must still succeed."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=5000, user_char_limit=5000)
+        store.load_from_disk()
+        store.add("memory", "only entry")
+        path = store._path_for("memory")
+        result = store.remove("memory", "only entry")
+        assert result["success"] is True
+        assert path.read_text(encoding="utf-8") == ""
+        assert len(store.memory_entries) == 0
+
+    def test_cas_aborts_when_file_changes_between_read_and_write(self, tmp_path, monkeypatch):
+        """Atomic CAS: if file changes externally between read and write, abort."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=5000, user_char_limit=5000)
+        store.load_from_disk()
+        store.add("memory", "original entry one")
+        store.add("memory", "original entry two")
+        path = store._path_for("memory")
+        before = path.read_text(encoding="utf-8")
+
+        def _mutate_with_external_change(entries, limit):
+            # Simulate concurrent external writer appending directly (bypassing lock).
+            path.write_text(before + "\n§\nexternally added entry", encoding="utf-8")
+            return entries + ["new entry"], "added"
+
+        result = store._mutate("memory", _mutate_with_external_change)
+        # CAS should detect drift and refuse to overwrite external change.
+        assert result["success"] is False
+        assert "drift_backup" in result or "Refusing to write" in result["error"]
+        # External addition must survive (not overwritten by our stale write).
+        assert "externally added entry" in path.read_text(encoding="utf-8")
+        # Our new entry was not persisted.
+        assert "new entry" not in path.read_text(encoding="utf-8")
+

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -200,22 +200,60 @@ class MemoryStore:
         on an existing-but-unreadable file (even append-only ``add`` rewrites the whole
         file) and, unless *skip_drift*, on external drift (flushing would discard
         un-roundtrippable content). Drift check and parse use the SAME raw snapshot —
-        a failed second read used to count as "no drift"."""
+        a failed second read used to count as "no drift". The write is guarded by a
+        near-empty shrink check and an atomic CAS re-read (issue #105684)."""
         path = self._path_for(target)
         with self._file_lock(path):
-            raw, read_ok = self._read_raw_checked(path)
+            raw_initial, read_ok = self._read_raw_checked(path)
             if not read_ok:
                 return _read_failed_error(path)
-            bak = None if skip_drift else self._detect_external_drift(target, raw)
-            self._set_entries(target, list(dict.fromkeys(self._parse_entries(raw))))
+            bak = None if skip_drift else self._detect_external_drift(target, raw_initial)
+            parsed_before = list(dict.fromkeys(self._parse_entries(raw_initial)))
+            self._set_entries(target, parsed_before)
             if bak:
                 return _drift_error(path, bak)
             result = mutate(self._entries_for(target), self._char_limit(target))
             if isinstance(result, dict):
                 return result
-            self._set_entries(target, result[0])
+            new_entries = result[0]
+            # Defensive shrink guard (issue #105684): refuse a write that would
+            # shrink MEMORY.md/USER.md past a sane floor unless the caller is
+            # the explicit single-remove-last-entry path.
+            new_serialized = ENTRY_DELIMITER.join(new_entries)
+            prev_bytes = len(raw_initial.encode("utf-8"))
+            new_bytes = len(new_serialized.encode("utf-8"))
+            if prev_bytes > 200 and new_bytes < 50:
+                # Explicit single-remove of the last entry is the deliberate-wipe
+                # path (batch emptying is already refused elsewhere); allow only
+                # that exact 1->0 shape.
+                if not (len(parsed_before) == 1 and len(new_entries) == 0):
+                    return _error(
+                        f"Refusing to persist near-empty {path.name} after mutation: "
+                        f"previous size was {prev_bytes} bytes, new size would be "
+                        f"{new_bytes} bytes. This guard prevents accidental wipe of "
+                        f"{path.name} (issue #105684). If you intended to empty the "
+                        f"file, remove entries one by one with single remove() calls."
+                    )
+            # Atomic CAS: re-read before write; if file changed between initial
+            # read and now, abort before touching disk (issue #105684 bullet 2).
+            if not skip_drift:
+                raw_current, read_ok2 = self._read_raw_checked(path)
+                if not read_ok2:
+                    return _read_failed_error(path)
+                if raw_current != raw_initial:
+                    bak2 = self._detect_external_drift(target, raw_current)
+                    if bak2 is None:
+                        bak2 = path.with_suffix(path.suffix + f".bak.{int(time.time())}")
+                        try:
+                            bak2.write_text(raw_current, encoding="utf-8")
+                        except OSError:
+                            bak2 = str(bak2) + " (BACKUP FAILED — file unchanged on disk)"
+                        else:
+                            bak2 = str(bak2)
+                    return _drift_error(path, bak2)
+            self._set_entries(target, new_entries)
             path.parent.mkdir(parents=True, exist_ok=True)
-            self._write_file(path, result[0])
+            self._write_file(path, new_entries)
             return self._success_response(target, result[1])
 
     def add(self, target: str, content: str) -> Dict[str, Any]:


### PR DESCRIPTION
## What does this PR do?

Hardens `MemoryStore._mutate()` against a 0-byte wipe of `MEMORY.md`/`USER.md`, implementing the two defensive measures recommended in #105684:

- **Shrink guard:** refuses a write that would collapse a previously substantial file (`>200 bytes`) to near-empty (`<50 bytes`) in one successful mutation, exempting only the deliberate `single remove()` of the last entry (the `1 → 0` shape). Batch emptying is already refused elsewhere (#103419).
- **Atomic CAS:** re-reads the file before committing the write; if it changed externally between the initial read and the write, aborts with a drift backup instead of overwriting it. This makes the drift check atomic with the write.

On current `main` the `replace` no-match path already returns an error dict before `_write_file()` is reached (confirmed by triage on #105684), so a single failed `replace` does not wipe today. This PR keeps that behavior and adds defense-in-depth so a future regression or a sibling mutation that returns a near-empty list cannot silently empty the store. The observed `ca384c3` wipe (2026-08-29) predates #104151, which fixed the batch emptying path — this guard would have caught either shape.

## Related Issue

Fixes #105684

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue) — hardening

## Changes Made

- `tools/memory_tool_store.py` (`MemoryStore._mutate`): capture `raw_initial` + `parsed_before`, add shrink guard (`prev_bytes >200 && new_bytes <50` → error unless `len(parsed_before)==1 && len(new_entries)==0`), add atomic compare-and-swap re-read before `_write_file()` (skip when `skip_drift=True`), create `.bak.<ts>` on CAS mismatch.
- `tests/tools/test_memory_tool.py`: update `TestUnreadableFileDoesNotWipeMemory::test_mutations_read_the_file_exactly_once` from `1` to `2` reads (initial + CAS) and add `TestWipeGuard105684` with 5 tests: failed `replace` preserves disk (memory + user), shrink guard refusal, single-remove-last still allowed, CAS aborts on external change.

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_memory_tool.py -q` — 50 passed (including 5 new).
2. Sabotage check: `git checkout origin/main -- tools/memory_tool_store.py && .venv/bin/python -m pytest tests/tools/test_memory_tool.py::TestWipeGuard105684::test_shrink_guard_refuses_near_empty_write_and_preserves_disk tests/tools/test_memory_tool.py::TestWipeGuard105684::test_cas_aborts_when_file_changes_between_read_and_write -v` — both FAIL (guard needed), then `git checkout HEAD -- tools/memory_tool_store.py` restores PASS.

Reproduction from issue on a build with this PR:
```python
store.add("memory", "real fact")
original = path.read_bytes()
result = store.replace("memory", "no-such-thing", "x")
assert result["success"] is False
assert path.read_bytes() == original
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(memory): ... (#105684)`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (search `MemoryStore`/`memory wipe` — covering batch fix is #104151; no open PR covers #105684)
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/tools/test_memory_tool.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.1 (v2026.9.7), upstream 866332b

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (no user-facing config change)
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — yes, file lock + UTF-8 handling unchanged, CAS uses same `_read_raw_checked` path
- [x] I've updated tool descriptions/schemas — or N/A
