### PR TITLE
docs: add OrcaReplay to the Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ scripts/run_tests.sh
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🔌 [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) — Record a Hermes run and replay it offline with the network off, from the terminal or through its MCP server. Nothing is installed into Hermes: it terminates TLS for that one run, with a CA it deletes when the run ends.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds one line to the `## Community` section for [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay), which records a Hermes run and replays it offline.

**Disclosure first: I work on OrcaReplay.** It is Apache-2.0 and free; there is no paid tier and nothing to sign up for.

I read [32c3f06](https://github.com/NousResearch/hermes-agent/commit/32c3f06a) before opening this — hermes-eval and MemPalace were removed the day after they landed, because *"README links from us implicitly endorse community projects; the Community section should have a minimum activity bar before we link to a repo, not just 'the contributor opened a PR.'"* That is the right rule, so here is the evidence rather than a request to take my word for it. If the bar is still higher than this, closing it is a fair answer and I would rather you did that than carry a link you have to revisit.

| | ⭐ | forks | created |
|---|--:|--:|---|
| computer-use-linux *(listed)* | 502 | 55 | 2026-05-13 |
| HermesClaw *(listed)* | 729 | 73 | 2026-04-10 |
| MemPalace *(removed)* | 6 | 0 | 2026-05-16 |
| **OrcaReplay** | **173** | **57** | **2026-08-29** |

Fewer stars than either listed project and more forks than one of them, at ten days old rather than four months. Not a single-commit personal repo: Apache-2.0, ~1,700 tests, a trace-format conformance suite, published to npm with provenance, and listed in the official MCP Registry.

## Related Issue

No issue — this is a one-line docs change, and CONTRIBUTING sends third-party product integrations *out* of the tree rather than into it, which is what this is: OrcaReplay is a standalone tool, not a plugin under `plugins/`.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `README.md` — one entry under `## Community`, in the same 🔌 shape as the two entries above it.

## How to Test

Everything below was run against **Hermes Agent v0.21.0** and **orcareplay 0.2.3** from npm, on Windows, today. It needs no key: `opencode-free` is served anonymously.

1. Record a run.

   ```bash
   npm i -g orcareplay
   orca record hermes --tls-intercept --tls-hosts '+opencode.ai' -- \
     --provider opencode-free -m nemotron-3.5-lightning-free -z 'Reply with exactly the word: pong'
   ```

   Hermes answers `pong`, and orca writes a trace:

   ```
   info recorded run=run_5283cb8b4c54 events=15 blobs=2 exit=0
   ```

2. Read it.

   ```console
   $ orca show last
   run_5283cb8b4c54  hermes@0.2.3  15 events  exit 0

   SEQ  KIND   WHAT                             DETAIL
   3    NET    opencode.ai                      POST
   4    NET    opencode.ai                      status 0 · client left
   11   MODEL  nemotron-3.5-lightning-free      1 messages
   12   MODEL  nemotron-3.5-lightning-free      stop: end_turn · 12,114 in · 40 out
   ```

3. Replay it with the network off.

   ```console
   $ orca replay last
   info replaying exchanges=1 egress=blocked
   info replay.done reused=1/1 exit=0
   ```

   Hermes runs again and answers from the recording; nothing leaves the machine.

## Two things I would rather you heard from me than found later

**`status 0 · client left` at seq 3–8 is Hermes, not a bug in either of us.** Hermes fires a one-message background call and abandons it before the origin answers. orca keeps it as network traffic rather than promoting it to a replayable exchange, because an exchange with no response cannot be replayed — so a strict replay reports `unmatched=1` for it. Where that call lands relative to the real turns is not deterministic, and on a multi-turn recording it can stop a strict replay early; `--loose` carries it through. Written up in the adapter source.

**Forking a Hermes run onto a different model is not something I can claim.** It works for the harnesses orca redirects by base URL, but Hermes is captured by terminating TLS instead, and on my test the `--model` override was accepted and had no effect — the fork re-ran on the original model. So the entry says record and replay, and does not mention forking.

Also worth knowing if you ever compare notes on captured prompts: Hermes' system prompt is ~14,059 characters with the `<available_skills>` block, and comes out ~7,742 when `HERMES_HOME` is set but the skills directory is not found. `hermes skills list` showing `0 builtin` is the tell. I hit that myself with a shell that mangled a backslash in the path.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) — including §"Third-Party Product Integrations: Ship as a Standalone Plugin", which is why this is a link and not a directory under `plugins/`.
- [x] Docs-only; no code, no tests affected.
- [x] Affiliation disclosed.
