### PR TITLE
fix(model_normalize): only normalize dots-to-hyphens for Claude models on anthropic provider

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -229,7 +229,15 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
     if provider in _DOT_TO_HYPHEN_PROVIDERS:
         bare = _strip_matching_provider_prefix(name, provider)
-        return bare if "/" in bare else _dots_to_hyphens(bare)
+        if "/" in bare:
+            return bare
+        # Only normalize dots to hyphens for Claude-family model IDs.
+        # Non-Claude models (e.g. qwen3.5-plus, minimax-m2.5-free) use dots
+        # as canonical version separators and must be preserved when routed
+        # through an Anthropic-compatible provider.
+        if bare.lower().startswith("claude"):
+            return _dots_to_hyphens(bare)
+        return bare
 
     # Copilot's own normalizer knows the alias table (vendor stripping, dash-to-dot repair for Claude)
     # and live-catalog lookups; without it dash-notation Claude ids hit HTTP 400 model_not_supported.


### PR DESCRIPTION
## Problem

When using an `anthropic`-compatible provider with a non-Claude model whose canonical ID contains a dotted version number — for example, `qwen3.5-plus` — Hermes normalizes dots to hyphens before sending the request. The provider accepts the original dotted ID, but Hermes sends `qwen3-5-plus`, resulting in:

```
HTTP 400: Invalid model name
```

This is especially confusing because the model is valid and configured correctly; the identifier is corrupted **only during provider normalization**.

## Root Cause

In `hermes_cli/model_normalize.py`, the `_DOT_TO_HYPHEN_PROVIDERS` set contains `"anthropic"`, and the normalization function applies dot-to-hyphen to **every** model on the Anthropic provider unconditionally:

```python
if provider in _DOT_TO_HYPHEN_PROVIDERS:
    bare = _strip_matching_provider_prefix(name, provider)
    return bare if "/" in bare else _dots_to_hyphens(bare)
```

This is correct for Claude models (`claude-opus-4.6` → `claude-opus-4-6`) but incorrect for non-Claude models whose IDs contain meaningful dots (e.g. `qwen3.5-plus`, `minimax-m2.5-free`, `mimo-v2.5-pro`).

## Fix

Gate the dot-to-hyphen conversion on Claude-shaped model IDs only. Non-Claude models preserve their canonical spelling:

```python
if provider in _DOT_TO_HYPHEN_PROVIDERS:
    bare = _strip_matching_provider_prefix(name, provider)
    if "/" in bare:
        return bare
    # Only normalize dots to hyphens for Claude-family model IDs.
    if bare.lower().startswith("claude"):
        return _dots_to_hyphens(bare)
    return bare
```

## Related Issues

- Closes #22196
- Related: #22246, #40261 (alternative approaches to the same root cause)
- The parallel fix in `agent/anthropic_adapter.py` (commit 7141cda9) already narrows the adapter-side normalization to Claude models — this brings `model_normalize.py` in line.

## Testing

- Existing tests for Claude models continue to normalize dots→hyphens as expected
- Non-Claude models preserve their canonical dotted IDs
- No regressions expected — the change only relaxes normalization that was overly broad
