### PR TITLE
fix(desktop): preserve ownership records on filesystem read errors

### DIFF
--- a/apps/desktop/electron/backend-ownership-file.test.ts
+++ b/apps/desktop/electron/backend-ownership-file.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test, vi } from 'vitest'
+
+import { createBackendOwnership, parseBackendOwnership } from './backend-ownership'
+import { readBackendOwnershipFile } from './backend-ownership-file'
+
+test.each(['EACCES', 'EIO', 'EBUSY'])(
+  'read failure %s preserves the roster across ownership operations',
+  async code => {
+    const original = { nonce: 'existing', pid: 42, profile: 'default', startMarker: 'start-42' }
+    const incoming = { ...original, nonce: 'incoming', pid: 43 }
+    const contents = JSON.stringify({ backends: [original] })
+    const error = Object.assign(new Error('roster read failed'), { code })
+
+    const read = vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      throw error
+    })
+
+    const write = vi.fn()
+    const quarantine = vi.fn()
+    const stop = vi.fn()
+    const probe = vi.fn(async () => true)
+
+    const ownership = createBackendOwnership({
+      store: { read: () => readBackendOwnershipFile('backend-ownership.json'), write, quarantine },
+      matchesIdentity: probe,
+      matchesParent: probe,
+      stop
+    })
+
+    try {
+      await assert.rejects(ownership.reapOrphans(), thrown => thrown === error)
+      assert.throws(
+        () => ownership.release(original),
+        thrown => thrown === error
+      )
+      await assert.rejects(ownership.claim(incoming), thrown => thrown === error)
+      assert.equal(write.mock.calls.length, 0)
+      assert.equal(quarantine.mock.calls.length, 0)
+      assert.equal(probe.mock.calls.length, 0)
+      assert.deepEqual(stop.mock.calls, [[incoming]]) // Only the failed new claim is cleaned up.
+
+      read.mockReturnValue(contents)
+      await ownership.reapOrphans()
+      assert.deepEqual(parseBackendOwnership(write.mock.calls[0][0]), [original])
+    } finally {
+      read.mockRestore()
+    }
+  }
+)
+
+test('native filesystem distinguishes a missing roster, a valid file, and a read error', async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-ownership-read-'))
+  const file = path.join(directory, 'backend-ownership.json')
+
+  try {
+    assert.equal(readBackendOwnershipFile(file), null)
+    const entry = { nonce: 'native', pid: 42, profile: 'default', startMarker: 'start-42' }
+
+    const roster = createBackendOwnership({
+      store: {
+        read: () => readBackendOwnershipFile(file),
+        write: contents => fs.writeFileSync(file, contents, 'utf8')
+      },
+      matchesIdentity: async () => true,
+      matchesParent: async () => true,
+      stop: () => {
+        throw new Error('A live parent must retain its backend')
+      }
+    })
+
+    await roster.claim(entry)
+    await roster.reapOrphans()
+    assert.deepEqual(parseBackendOwnership(fs.readFileSync(file, 'utf8')), [entry])
+    assert.equal(readBackendOwnershipFile(file), fs.readFileSync(file, 'utf8'))
+
+    // A directory at the configured file path produces a real read failure on Windows/Linux/macOS.
+    const write = vi.fn()
+    const stop = vi.fn()
+
+    const ownership = createBackendOwnership({
+      store: { read: () => readBackendOwnershipFile(directory), write },
+      matchesIdentity: async () => true,
+      matchesParent: async () => true,
+      stop
+    })
+
+    await assert.rejects(ownership.reapOrphans())
+    assert.equal(write.mock.calls.length, 0)
+    assert.equal(stop.mock.calls.length, 0)
+    assert.deepEqual(parseBackendOwnership(fs.readFileSync(file, 'utf8')), [entry])
+    roster.release(entry)
+    assert.deepEqual(parseBackendOwnership(fs.readFileSync(file, 'utf8')), [])
+  } finally {
+    fs.unlinkSync(file)
+    fs.rmdirSync(directory)
+  }
+})

--- a/apps/desktop/electron/backend-ownership-file.ts
+++ b/apps/desktop/electron/backend-ownership-file.ts
@@ -1,0 +1,14 @@
+import fs from 'node:fs'
+
+export function readBackendOwnershipFile(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null
+    }
+
+    // An unreadable roster is not empty: callers must not overwrite its records.
+    throw error
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -56,6 +56,7 @@ import {
   waitForHermesReady
 } from './backend-health'
 import { backendCommandMatches, createBackendOwnership, createBackendShutdownCoordinator } from './backend-ownership'
+import { readBackendOwnershipFile } from './backend-ownership-file'
 import {
   canImportHermesCli,
   execProbeSync,
@@ -3682,13 +3683,7 @@ const backendOwnership = createBackendOwnership({
   matchesParent: backendParentMatches,
   stop: stopOwnedBackend,
   store: {
-    read: () => {
-      try {
-        return fs.readFileSync(DESKTOP_BACKEND_OWNERSHIP_PATH, 'utf8')
-      } catch {
-        return null
-      }
-    },
+    read: () => readBackendOwnershipFile(DESKTOP_BACKEND_OWNERSHIP_PATH),
     write: writeBackendOwnership,
     // A corrupt ownership file is moved aside instead of being rewritten
     // away by the reap sweep — its records are the only pointer to any


### PR DESCRIPTION
## What does this PR do?

Desktop currently converts every filesystem error reading `backend-ownership.json` into `null`. The ownership manager interprets that as a missing/empty roster: a reap can replace the existing records with an empty list, and a new claim can replace them with just the new backend. A transient read failure must not authorize either replacement.

Return `null` only for `ENOENT`; propagate other errors to the existing claim, release and startup error handlers. The claim path still cleans up its newly spawned backend when persistence fails. Extract the actual filesystem reader from Electron main so the production read path can be exercised without starting the app.

Reproduced against upstream main `866332bfb52c46e543143b2620a9aeee8bce9c77` on native Windows, including a real filesystem read failure.

## Related Issue

No matching filesystem-read-error issue/PR found. Searched open and closed issues and PRs for `backend-ownership`, `ownership read failure`, `ownership EACCES`, `ownership EIO`, and `ownership readFileSync`.

Related but distinct: #90497 protects malformed JSON after a successful read (the record-loss portion of #89298). This fixes errors before parsing; the existing malformed-JSON quarantine behavior is unchanged. Reviewed #94020 and #94923 as well; neither changes this reader.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/backend-ownership-file.ts`: distinguish a missing file from a failed read, preserving the original error.
- `apps/desktop/electron/main.ts`: wire the filesystem reader into the existing ownership store.
- `apps/desktop/electron/backend-ownership-file.test.ts`: two invariant tests, one parametrized across three read errors. Exercise reap, release, claim cleanup and recovery through the actual ownership manager; exercise missing/valid files and a directory-at-file-path read failure using the native filesystem.

## How to Test

1. Install the root workspace dependencies with `npm ci --ignore-scripts --no-audit --no-fund` (these tests do not launch Electron or native addons).
2. From `apps/desktop`, run `node ../../node_modules/vitest/vitest.mjs run --project electron electron/backend-ownership-file.test.ts electron/backend-ownership.test.ts electron/backend-claim.test.ts`.
3. Run `node ../../node_modules/typescript/bin/tsc -p tsconfig.electron.json --noEmit`.

RED: extracting the original reader without changing its catch-all behavior made all four new cases fail with `Missing expected rejection`. GREEN: 37 tests passed across the three files after restricting the empty-file fallback to `ENOENT`.

The EACCES/EIO/EBUSY cases inject errors into `fs.readFileSync`; they do not claim live ACL-denial or sharing-violation reproduction. The separate native filesystem test creates a temporary roster, claims/reaps/releases it, and checks a real read failure when the configured file path is a directory. No existing backend processes are stopped by these tests.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix (no unrelated commits).
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; no Python changes, focused Electron tests above were run.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: native Windows, Node 26.7.0, Vitest 4.1.10.

### Documentation & Housekeeping

- [x] I've updated relevant documentation or N/A — internal reader contract documented inline; no user interface changes.
- [x] I've updated `cli-config.yaml.example` or N/A — no configuration changes.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` or N/A — no architectural/workflow contract changes.
- [x] I've considered cross-platform impact — uses Node's filesystem error codes; no OS spoofing, new process probes or permissions changes. Linux/macOS execution not performed locally.
- [x] I've updated tool descriptions/schemas or N/A — no tool changes.

## Screenshots / Logs

```text
RED:   Test Files 1 failed; Tests 4 failed
GREEN: Test Files 3 passed; Tests 37 passed
tsc -p tsconfig.electron.json --noEmit: exit 0
ESLint for both new files with --max-warnings 0: exit 0
Prettier --check for both new files: exit 0
git diff --cached --check: exit 0
```

No full repository suite, packaged Desktop E2E, live ACL-denial tests, or Linux/macOS run is claimed. The existing Vite `__dirname` config-loader advisory remains; it did not fail the tests.
