### PR TITLE
fix(telegram): caption a lone final MEDIA photo

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1809,6 +1809,9 @@ class BasePlatformAdapter(ABC):
     # answer, and an acknowledgement would silently abandon the task (#57056). Read generically via
     # ``getattr(adapter, "interactive_resume", True)`` — no per-platform branching at the call site.
     interactive_resume: bool = True
+    # UTF-16 caption budget for merging the final prose INTO a lone image attachment (one photo
+    # message instead of text + photo). 0 disables the merge; see ``_final_caption_media_path``.
+    final_caption_media_limit: int = 0
     # Back-reference to the running ``GatewayRunner`` (set by gateway/run.py); ``build_source``
     # resolves the inbound profile via ``runner._profile_name_for_source``.
     gateway_runner = None  # type: ignore[assignment]
@@ -3801,16 +3804,69 @@ class BasePlatformAdapter(ABC):
             await self._finalize_delivery_obligation(obligation_id, result, event, delivery_adapter)
         return result, delivery_adapter
 
+    async def send_final_captioned_image(
+        self, chat_id: str, image_path: str, caption: str, reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        """Deliver the final prose and its lone image as ONE message. Default: a photo with a plain
+        caption; adapters with rich captions override (Telegram renders MarkdownV2)."""
+        return await self.send_image_file(
+            chat_id=chat_id, image_path=image_path, caption=caption, reply_to=reply_to,
+            metadata=metadata)
+
+    def _final_caption_media_path(self, extracted: "_ExtractedResponse") -> Optional[str]:
+        """The lone image MEDIA attachment that may carry the final prose as its caption, so the
+        turn lands as ONE photo message instead of text + photo. ``None`` — keep the standalone
+        text-then-attachment path — for every other shape: no/over-long caption, more than one
+        attachment of any kind, voice, a non-image extension, or ``[[as_document]]``."""
+        limit = getattr(self, "final_caption_media_limit", 0)
+        text = extracted.text_content
+        if not limit or not text or extracted.force_document_attachments:
+            return None
+        if extracted.images or extracted.local_files or len(extracted.media_files) != 1:
+            return None
+        path, is_voice = extracted.media_files[0]
+        if is_voice or Path(path).suffix.lower() not in _IMAGE_EXTS:
+            return None
+        return path if utf16_len(text) <= limit else None
+
     async def _send_final_text(
         self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any],
-        is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable) -> None:
-        """Normal-lane final: the ledger bracket plus the message-id owner's ephemeral delete."""
-        result, delivery_adapter = await self.send_final_ledgered(
-            event, session_key, text_content, metadata,
-            reply_to=_reply_anchor_for_event(event), is_ephemeral_response=is_ephemeral_response)
+        is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable,
+        caption_media_path: Optional[str] = None) -> bool:
+        """Normal-lane final: the ledger bracket plus the message-id owner's ephemeral delete.
+
+        With ``caption_media_path`` the text rides as that image's caption (one photo message);
+        returns True only when THAT send succeeded — a refusal falls back to the plain text send
+        and leaves the image to the normal attachment lane."""
+        combined = False
+        if not caption_media_path:
+            result, delivery_adapter = await self.send_final_ledgered(
+                event, session_key, text_content, metadata,
+                reply_to=_reply_anchor_for_event(event), is_ephemeral_response=is_ephemeral_response)
+        else:
+            delivery_adapter = self._final_delivery_adapter(event.source)
+            logger.info("[%s] Sending response (%d chars) to %s", delivery_adapter.name,
+                        len(text_content), event.source.chat_id)
+            _obligation_id = await self._record_delivery_obligation(
+                event, session_key, text_content, delivery_adapter, is_ephemeral_response)
+            _reply_to = _reply_anchor_for_event(event)
+            result = await delivery_adapter.send_final_captioned_image(
+                chat_id=event.source.chat_id, image_path=caption_media_path,
+                caption=text_content, reply_to=_reply_to, metadata=metadata)
+            combined = bool(getattr(result, "success", False))
+            if not combined:
+                logger.warning("[%s] Captioned photo send failed (%s); falling back to text + "
+                               "standalone attachment", delivery_adapter.name,
+                               getattr(result, "error", None))
+                result = await delivery_adapter._send_with_retry(
+                    chat_id=event.source.chat_id, content=text_content,
+                    reply_to=_reply_to, metadata=metadata)
+            if _obligation_id is not None:
+                await self._finalize_delivery_obligation(_obligation_id, result, event, delivery_adapter)
         record_delivery(result)
         if ephemeral_ttl and ephemeral_ttl > 0 and result.success and result.message_id:
             delivery_adapter._schedule_ephemeral_delete(event.source.chat_id, result.message_id, ephemeral_ttl)
+        return combined
 
     async def _notify_turn_error(self, event: MessageEvent, e: BaseException) -> Optional[dict]:
         """Tell the user a turn failed rather than leaving radio silence (last resort:
@@ -3995,9 +4051,12 @@ class BasePlatformAdapter(ABC):
                     with contextlib.suppress(OSError):
                         os.remove(_tts_requested_path)
                 if text_content and not _tts_caption_delivered:
-                    await self._send_final_text(
+                    _combined = await self._send_final_text(
                         event, session_key, text_content, _final_thread_metadata,
-                        is_ephemeral_response, _ephemeral_ttl, _record_delivery)
+                        is_ephemeral_response, _ephemeral_ttl, _record_delivery,
+                        caption_media_path=self._final_caption_media_path(extracted))
+                    if _combined:
+                        extracted = dataclasses.replace(extracted, media_files=[])
                 await self._deliver_attachments(
                     event, extracted, _final_thread_metadata,
                     anything_sent=delivery_attempted or _tts_caption_delivered,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -373,6 +373,7 @@ class TelegramAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = 4096
     supports_code_blocks = True  # MarkdownV2 renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+    final_caption_media_limit = 1024  # sendPhoto caption cap, in UTF-16 units
     RICH_MESSAGE_MAX_CHARS = 32768  # Bot API 10.1 rich cap; above it use legacy chunking
     _SPLIT_THRESHOLD = 4000  # chunk near this length ⇒ a client-side split continuation is almost certain
     MEDIA_GROUP_WAIT_SECONDS = 0.8
@@ -4734,6 +4735,37 @@ class TelegramAdapter(BasePlatformAdapter):
         return await self._send_local_file(
             "Image", image_path, chat_id, reply_to, metadata, "photo",
             lambda f: {"photo": f, "caption": self._caption_1024(caption)}, _photo_failed)
+
+    async def send_final_captioned_image(
+        self, chat_id: str, image_path: str, caption: str, reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        """Final prose + its lone image as one photo message, caption rendered as MarkdownV2 (same
+        reason as the #32029 voice-caption ladder: an unformatted agent reply shows literal
+        asterisks). Overflow, a formatting failure or a rejected entity list falls back to the
+        plain-caption photo path."""
+        formatted = None
+        if self._bot and caption:
+            try:
+                _rendered = self.format_message(caption)
+                formatted = _rendered if utf16_len(_rendered) <= 1024 else None
+            except Exception:
+                logger.debug("[%s] photo caption MarkdownV2 formatting failed; sending plain caption",
+                             self.name, exc_info=True)
+        if not formatted or not os.path.exists(image_path):
+            return await super().send_final_captioned_image(
+                chat_id, image_path, caption, reply_to, metadata=metadata)
+        try:
+            with open(image_path, "rb") as f:
+                msg = await self._send_media(
+                    self._bot.send_photo, chat_id, reply_to, metadata, "photo",
+                    reset_media=lambda: f.seek(0), photo=f, caption=formatted,
+                    parse_mode=ParseMode.MARKDOWN_V2)
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] captioned photo MarkdownV2 send failed, retrying plain: %s",
+                           self.name, _redact_telegram_error_text(e))
+            return await super().send_final_captioned_image(
+                chat_id, image_path, caption, reply_to, metadata=metadata)
 
     async def _send_local_file(
         self, label: str, path: str, chat_id, reply_to, metadata, media_key: str, build_kwargs, on_error,

--- a/tests/gateway/test_telegram_final_photo_caption.py
+++ b/tests/gateway/test_telegram_final_photo_caption.py
@@ -1,0 +1,323 @@
+"""Live Telegram final delivery: prose + ONE image ``MEDIA:`` tag is one photo message.
+
+The non-streaming final path (``BasePlatformAdapter._process_message_background``) used to
+always split such a turn into two Telegram messages — a text message followed by a standalone
+photo. Telegram captions hold 1024 UTF-16 units, so the common "here's your chart" reply fits
+in a single captioned photo.
+
+Pinned here against a real ``TelegramAdapter`` driven by a fake Bot API object (no network):
+
+* prose + exactly one image MEDIA tag, caption within budget -> ONE ``sendPhoto`` with the
+  prose as caption, carrying the reply/thread anchors the text message would have carried;
+* caption over 1024 UTF-16 units (astral chars cost two) -> standalone behaviour is preserved:
+  a text message plus a separate photo;
+* every other shape (two attachments, a non-image MEDIA tag, an image URL, ``[[as_document]]``,
+  a voice tag) keeps the standalone split;
+* a refused captioned photo falls back to text + standalone attachment — the prose is never lost.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.event import MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+class _FakeBot:
+    """Records Bot API calls instead of talking to Telegram."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+        self.photo_error: Exception | None = None
+        self._next_id = 100
+
+    def _record(self, name, kwargs):
+        self.calls.append((name, dict(kwargs)))
+        self._next_id += 1
+        return SimpleNamespace(message_id=self._next_id)
+
+    async def send_photo(self, **kwargs):
+        if self.photo_error is not None:
+            raise self.photo_error
+        return self._record("send_photo", kwargs)
+
+    async def send_message(self, **kwargs):
+        return self._record("send_message", kwargs)
+
+    async def send_media_group(self, **kwargs):
+        return [self._record("send_media_group", kwargs)]
+
+    async def send_document(self, **kwargs):
+        return self._record("send_document", kwargs)
+
+    async def send_video(self, **kwargs):
+        return self._record("send_video", kwargs)
+
+    async def send_voice(self, **kwargs):
+        return self._record("send_voice", kwargs)
+
+    async def send_chat_action(self, **kwargs):
+        return None
+
+    def names(self):
+        return [name for name, _ in self.calls]
+
+    def kwargs_for(self, name):
+        return [kw for n, kw in self.calls if n == name]
+
+
+async def _hold_typing(_chat_id, interval=2.0, metadata=None, stop_event=None):
+    if stop_event is not None:
+        await stop_event.wait()
+    else:
+        await asyncio.Event().wait()
+
+
+@pytest.fixture()
+def bot(monkeypatch):
+    """A connected TelegramAdapter whose transport is a fake bot, ledger disabled."""
+    monkeypatch.setattr("gateway.delivery_ledger.ledger_enabled", lambda: False)
+    return _FakeBot()
+
+
+@pytest.fixture()
+def adapter(bot):
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    a._bot = bot
+    a._keep_typing = _hold_typing
+    # Bot API 10.1 rich sends are a separate transport; pin the legacy sendMessage path.
+    a._should_attempt_rich = lambda *_a, **_kw: False
+    return a
+
+
+def _event(text="make me a chart"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="4242", chat_type="dm"),
+        message_id="7",
+    )
+
+
+def _media_file(tmp_path, monkeypatch, name, payload=b"\x89PNG\r\n"):
+    root = tmp_path / "media-cache"
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    monkeypatch.setattr("gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS", (root,))
+    return path.resolve()
+
+
+async def _run(adapter, response):
+    async def handler(_event):
+        return response
+
+    adapter.set_message_handler(handler)
+    event = _event()
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+
+# ---------------------------------------------------------------------------
+# The merge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prose_plus_one_image_is_a_single_captioned_photo(adapter, bot, tmp_path, monkeypatch):
+    png = _media_file(tmp_path, monkeypatch, "chart.png")
+    await _run(adapter, f"Here is your **chart**.\nMEDIA:{png}")
+
+    assert bot.names() == ["send_photo"], (
+        f"expected one captioned photo, got {bot.names()}")
+    caption = bot.kwargs_for("send_photo")[0]["caption"]
+    assert "chart" in caption and "Here is your" in caption
+    # MarkdownV2 rendering, same reason as the #32029 voice-caption ladder.
+    assert caption.startswith("Here is your *chart*")
+
+
+@pytest.mark.asyncio
+async def test_captioned_photo_keeps_the_reply_anchor(adapter, bot, tmp_path, monkeypatch):
+    """The merged message carries the anchor the text message would have carried."""
+    png = _media_file(tmp_path, monkeypatch, "chart.png")
+
+    async def handler(_event):
+        return f"Done.\nMEDIA:{png}"
+
+    adapter.set_message_handler(handler)
+    event = MessageEvent(
+        text="chart please",
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="-1001", chat_type="group"),
+        message_id="9",
+    )
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert bot.names() == ["send_photo"]
+    assert bot.kwargs_for("send_photo")[0]["reply_to_message_id"] == 9
+
+
+@pytest.mark.asyncio
+async def test_captioned_photo_keeps_forum_topic_routing(adapter, bot, tmp_path, monkeypatch):
+    """Forum topics route by topic id and deliberately carry no reply anchor
+    (``_reply_anchor_for_event``) — the merged message must not change that."""
+    png = _media_file(tmp_path, monkeypatch, "chart.png")
+
+    async def handler(_event):
+        return f"Done.\nMEDIA:{png}"
+
+    adapter.set_message_handler(handler)
+    event = MessageEvent(
+        text="in a topic",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM, chat_id="-1001", chat_type="group", thread_id="55"),
+        message_id="9",
+    )
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert bot.names() == ["send_photo"]
+    sent = bot.kwargs_for("send_photo")[0]
+    assert sent["message_thread_id"] == 55
+    assert sent["reply_to_message_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Shapes that MUST keep the standalone split
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_caption_over_1024_utf16_units_stays_split(adapter, bot, tmp_path, monkeypatch):
+    """Astral chars cost two UTF-16 units — 513 emoji overflow a 1024-unit caption."""
+    png = _media_file(tmp_path, monkeypatch, "chart.png")
+    prose = "😀" * 513
+    await _run(adapter, f"{prose}\nMEDIA:{png}")
+
+    names = bot.names()
+    assert "send_message" in names, f"long prose must keep its own text message: {names}"
+    assert "send_photo" in names or "send_media_group" in names, (
+        f"the photo must still be delivered standalone: {names}")
+
+
+@pytest.mark.asyncio
+async def test_caption_at_the_1024_utf16_boundary_still_merges(adapter, bot, tmp_path, monkeypatch):
+    png = _media_file(tmp_path, monkeypatch, "chart.png")
+    await _run(adapter, f"{'a' * 1024}\nMEDIA:{png}")
+
+    assert bot.names() == ["send_photo"], f"1024 units must still merge: {bot.names()}"
+
+
+@pytest.mark.asyncio
+async def test_two_media_tags_stay_split(adapter, bot, tmp_path, monkeypatch):
+    first = _media_file(tmp_path, monkeypatch, "one.png")
+    second = first.parent / "two.png"
+    second.write_bytes(b"\x89PNG\r\n")
+    await _run(adapter, f"Two charts.\nMEDIA:{first}\nMEDIA:{second}")
+
+    assert "send_message" in bot.names(), f"albums are out of scope: {bot.names()}"
+
+
+@pytest.mark.asyncio
+async def test_non_image_media_tag_stays_split(adapter, bot, tmp_path, monkeypatch):
+    pdf = _media_file(tmp_path, monkeypatch, "report.pdf")
+    await _run(adapter, f"The report.\nMEDIA:{pdf}")
+
+    assert bot.names() == ["send_message", "send_document"], bot.names()
+
+
+@pytest.mark.asyncio
+async def test_as_document_marker_stays_split(adapter, bot, tmp_path, monkeypatch):
+    png = _media_file(tmp_path, monkeypatch, "chart.png")
+    await _run(adapter, f"Full quality.[[as_document]]\nMEDIA:{png}")
+
+    assert "send_message" in bot.names() and "send_photo" not in bot.names(), bot.names()
+
+
+@pytest.mark.asyncio
+async def test_image_url_alongside_media_tag_stays_split(adapter, bot, tmp_path, monkeypatch):
+    png = _media_file(tmp_path, monkeypatch, "chart.png")
+    await _run(adapter, f"Both.\n![pic](https://example.com/pic.png)\nMEDIA:{png}")
+
+    assert "send_message" in bot.names(), bot.names()
+
+
+@pytest.mark.asyncio
+async def test_text_only_response_is_unchanged(adapter, bot):
+    await _run(adapter, "Just words.")
+
+    assert bot.names() == ["send_message"], bot.names()
+
+
+@pytest.mark.asyncio
+async def test_media_only_response_is_unchanged(adapter, bot, tmp_path, monkeypatch):
+    png = _media_file(tmp_path, monkeypatch, "chart.png")
+    await _run(adapter, f"MEDIA:{png}")
+
+    assert "send_message" not in bot.names(), bot.names()
+
+
+# ---------------------------------------------------------------------------
+# Failure fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_captioned_send_falls_back_to_text_plus_attachment(
+        adapter, bot, tmp_path, monkeypatch):
+    """An unsuccessful merged send must not swallow the prose: the text goes out on its own
+    and the image returns to the standalone attachment lane."""
+    png = _media_file(tmp_path, monkeypatch, "chart.png")
+
+    async def _refuse(*_a, **_kw):
+        return SendResult(success=False, error="boom")
+
+    monkeypatch.setattr(adapter, "send_final_captioned_image", _refuse)
+    await _run(adapter, f"Here it is.\nMEDIA:{png}")
+
+    names = bot.names()
+    assert "send_message" in names, f"prose lost after a refused merge: {names}"
+    assert "send_photo" in names or "send_media_group" in names, (
+        f"image lost after a refused merge: {names}")
+
+
+@pytest.mark.asyncio
+async def test_photo_refusal_keeps_the_prose_on_the_document_fallback(
+        adapter, bot, tmp_path, monkeypatch):
+    """Telegram refusing sendPhoto (bad dimensions) drops to sendDocument — which still
+    carries the prose as its caption, so the turn stays one message."""
+    png = _media_file(tmp_path, monkeypatch, "chart.png")
+    bot.photo_error = RuntimeError("Photo_invalid_dimensions")
+    await _run(adapter, f"Here it is.\nMEDIA:{png}")
+
+    assert bot.names() == ["send_document"], bot.names()
+    assert bot.kwargs_for("send_document")[0]["caption"] == "Here it is."
+
+
+@pytest.mark.asyncio
+async def test_non_telegram_adapter_never_merges(tmp_path, monkeypatch):
+    """The merge is opt-in per adapter (``final_caption_media_limit``)."""
+    from tests.gateway.test_73771_media_resend_dedup import _DummyAdapter  # noqa: PLC0415
+
+    png = _media_file(tmp_path, monkeypatch, "chart.png")
+    adapter = _DummyAdapter()
+    adapter._keep_typing = _hold_typing
+
+    async def handler(_event):
+        return f"Here.\nMEDIA:{png}"
+
+    adapter.set_message_handler(handler)
+    event = MessageEvent(
+        text="chart",
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.DISCORD, chat_id="1", chat_type="dm"),
+        message_id="1",
+    )
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert [entry["content"] for entry in adapter.sent] == ["Here."]
+    assert adapter.images_sent and str(png) in adapter.images_sent[0]


### PR DESCRIPTION
## Summary
- Deliver a final response with prose and one local image `MEDIA:` tag as one Telegram photo caption when it fits Telegram's 1024 UTF-16-unit caption limit.
- Preserve the existing standalone delivery path for long prose, multiple or non-image attachments, and document delivery.
- Retain reply and forum-topic metadata; fall back to separate text and attachment when the combined send is refused.

## Tests
- `python -m pytest tests/gateway/test_telegram_final_delivery.py tests/gateway/test_telegram_caption_merge.py tests/gateway/test_telegram_reply_mode.py tests/gateway/test_telegram_final_photo_caption.py -q`
- Result: `48 passed`

## Risk and rollback
- Scope is opt-in for Telegram only and one validated local image attachment. The fallback leaves the established text-plus-attachment path intact. Revert this commit to roll back.
