### PR TITLE
fix(documents): reference the bundled pdf skill in runtime guidance

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2462,7 +2462,7 @@ def _build_document_context_note(
         f"[The user sent a document: '{display_name}'. It is saved at: {agent_path}. "
         f"Its text is not inlined here (it's a binary format such as PDF or DOCX). "
         f"To read it, extract the document's text yourself — for example with the "
-        f"terminal tool or the ocr-and-documents skill — before answering, instead "
+        f"terminal tool (or the pdf skill for PDF/OCR) — before answering, instead "
         f"of asking the user to paste the contents.]")
 
 

--- a/tests/tools/test_document_skill_references.py
+++ b/tests/tools/test_document_skill_references.py
@@ -1,0 +1,73 @@
+"""Generated document guidance must name an available bundled skill (#105689).
+
+No model or messaging service is called. Only the PDF page-text reader is
+controlled, using the same mixed text/scan fixture shape as test_read_extract.
+The prompt builders and skill loader use their production implementations.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def bundled_pdf_home(tmp_path, monkeypatch):
+    source = Path(__file__).resolve().parents[2] / "skills"
+    # Scan the entire unmodified bundled catalog through the supported config
+    # surface, so absence is not manufactured by a PDF-only fixture.
+    (tmp_path / "skills").mkdir()
+    (tmp_path / "config.yaml").write_text(
+        json.dumps({"skills": {"external_dirs": [str(source)]}}), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    assert load_skill("pdf").get("success") is True
+    assert load_skill("pdf", "references/ocr-extraction.md").get("success") is True
+    return tmp_path
+
+
+def load_skill(name, file_path=None):
+    from tools import skills_tool  # noqa: F401 -- registers the real tool
+    from tools.registry import registry
+
+    args = {"name": name}
+    if file_path is not None:
+        args["file_path"] = file_path
+    return json.loads(registry.dispatch("skill_view", args))
+
+
+def assert_referenced_skill_resolves(note):
+    match = re.search(r"(?:or the |use the )([a-z][a-z0-9-]*) skill", note)
+    assert match is not None, f"No named skill in generated note: {note}"
+    name = match.group(1)
+    loaded = load_skill(name)
+    assert loaded.get("success") is True, (
+        f"Runtime note points to an unavailable skill: {name!r}; {loaded.get('error')}"
+    )
+
+
+def test_gateway_attachment_note_names_a_loadable_skill(bundled_pdf_home):
+    from gateway.platforms.event import MessageEvent, MessageType
+    from gateway.run import GatewayRunner
+
+    event = MessageEvent(
+        text="Summarize this attachment.",
+        message_type=MessageType.DOCUMENT,
+        source=None,
+        media_urls=[str(bundled_pdf_home / "contract.pdf")],
+        media_types=["application/pdf"],
+    )
+    note = GatewayRunner._prepend_inbound_document_notes(event, event.text)
+    assert_referenced_skill_resolves(note)
+
+
+def test_pdf_coverage_note_names_a_loadable_skill(bundled_pdf_home, monkeypatch):
+    from tools import read_extract
+
+    pages = ["A readable introductory page with sufficient text."] + [""] * 3
+    monkeypatch.setattr(read_extract, "_pdf_page_texts", lambda _path: pages)
+    note = read_extract._pdf_coverage_note(str(bundled_pdf_home / "mixed-scan.pdf"))
+    assert "3 of 4 pages" in note
+    assert_referenced_skill_resolves(note)

--- a/tests/tools/test_read_extract.py
+++ b/tests/tools/test_read_extract.py
@@ -743,7 +743,7 @@ class TestPdfCoverageNote(unittest.TestCase):
         self.assertIn("pages 4-9", note)        # contiguous empty gap
         self.assertIn("(6 pages)", note)        # gap size stated
         self.assertIn("vision_analyze", note)   # recovery path is named
-        self.assertIn("ocr-and-documents", note)
+        self.assertIn("pdf skill", note)
         self.assertIn("do NOT OCR or render everything", note)
 
     def test_gap_labels_carry_preceding_section_text(self):

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -304,7 +304,7 @@ def _pdf_coverage_note(path: str, display_path: Optional[str] = None) -> str:
         "everything. For the gaps that matter, render just that range with "
         f"`pdftoppm -jpeg -r 150 -f <first> -l <last> '{shown}' /tmp/page` "
         "and inspect each image with the vision_analyze tool, or use the "
-        "ocr-and-documents skill (marker-pdf) for bulk OCR of large "
+        "pdf skill (marker-pdf) for bulk OCR of large "
         "ranges.]\n")
 
 


### PR DESCRIPTION
## What does this PR do?

Document attachment notes and PDF extraction-coverage warnings refer to the removed `ocr-and-documents` skill. Following either note produces `Skill 'ocr-and-documents' not found.`, although the bundled `pdf` skill already contains the OCR capability.

Point both runtime notes at `pdf`. The generic document note limits that suggestion to PDF/OCR and retains the terminal option for other document formats.

## Related Issue

Fixes #105689

Related work: #98903 updates separate skill documentation; #96738 changes the document note's tool preference. This PR preserves the current tool priority and only corrects the unavailable skill references.

## Type of Change

- [x] Bug fix

## Changes Made

- Correct the skill reference in the gateway attachment note and PDF coverage warning.
- Update the existing coverage-warning expectation.
- Add two regression checks that generate the notes and resolve their named skill through the real tool registry against the bundled catalog in an isolated `HERMES_HOME`.

## How to Test

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/gateway/test_document_context_note.py \
  tests/tools/test_read_extract.py \
  tests/tools/test_document_skill_references.py \
  tests/tools/test_read_file_schema_gating.py \
  -j 2
```

**72 passed, 0 failed, 3 skipped** on macOS arm64 / Python 3.11.15. The skips require the optional `firecrawl-anydoc` converter. Before the fix, both skill-resolution checks failed with the missing-skill error; loading `pdf` and `references/ocr-extraction.md` succeeded as a control.

The PDF page-text input is controlled to exercise the coverage warning. This validates generated guidance and skill resolution, without claiming live OCR or model validation. The full repository suite was not run.

Ruff, Python compilation, and `git diff --check` passed. The Windows-footgun scan passed for both production files and the new regression file. The existing `test_read_extract.py` reports two missing-encoding warnings on unchanged lines 458/473; the same warnings reproduce on the unmodified base.

## Checklist

- [x] Read the contribution guide and searched related issues/PRs.
- [x] Conventional Commit; changes are limited to this issue.
- [x] Added regression coverage and ran the targeted tests above.
- [x] Tested on macOS; considered cross-platform paths and skill availability.
- [x] No configuration, dependency, or architecture changes.
