### PR TITLE
fix(cron): don't stamp the next occurrence on an off-tick manual run

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2491,7 +2491,8 @@ def _machine_id() -> str:
 
 
 def claim_job_for_fire(
-    job_id: str, *, claim_ttl_seconds: int = FIRE_CLAIM_TTL_SECONDS, force: bool = False, return_job: bool = False,
+    job_id: str, *, claim_ttl_seconds: int = FIRE_CLAIM_TTL_SECONDS, force: bool = False,
+    manual: bool = False, return_job: bool = False,
 ) -> Union[bool, Dict[str, Any]]:
     """Atomically claim a job for one external 'fire' (multi-machine at-most-once); True iff THIS
     caller won (``CronScheduler.fire_due``: exactly one of N replicas runs a job). Under the
@@ -2513,8 +2514,11 @@ def claim_job_for_fire(
             return False  # someone holds a fresh claim
         from cron.occurrences import completed_occurrence, scheduled_instant
 
-        manual = force or job.get("manual_run_at") == job.get("next_run_at")
-        instant = None if manual else scheduled_instant(job.get("next_run_at"))
+        # ``manual`` (an off-tick run-now) must NOT stamp an occurrence identity: outside a
+        # scheduler tick ``next_run_at`` is the NEXT occurrence, not the one being run, so
+        # stamping it would make completed_occurrence() skip that slot when it arrives.
+        manual_fire = force or manual or job.get("manual_run_at") == job.get("next_run_at")
+        instant = None if manual_fire else scheduled_instant(job.get("next_run_at"))
         if instant and completed_occurrence(job, instant):
             if job.get("schedule", {}).get("kind") in {"cron", "interval"}:
                 nxt = compute_next_run(job["schedule"], now.isoformat())

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -263,3 +263,49 @@ def test_same_thread_fire_fence_reentrancy_preserves_ownership(temp_home):
     assert result == {"outer": True, "inner": True}
     thread.join(timeout=2)
     assert thread.is_alive() is False
+
+
+def test_manual_claim_does_not_stamp_a_future_occurrence(temp_home):
+    """An off-tick run-now must not consume the NEXT scheduled slot.
+
+    Outside a scheduler tick ``next_run_at`` is the occurrence that has NOT happened
+    yet, so stamping it as a completed occurrence makes ``_job_is_due`` skip that slot
+    when it arrives — silently, with no error and no dispatch record. ``manual=True``
+    is the caller's declaration that this is an off-tick fire.
+    """
+    from cron.jobs import create_job, claim_job_for_fire, get_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="m")
+    pending = get_job(job["id"])["next_run_at"]
+
+    claimed = claim_job_for_fire(job["id"], manual=True, return_job=True)
+    assert isinstance(claimed, dict)
+    assert claimed["_scheduled_instant"] is None, (
+        f"manual fire stamped the future occurrence {pending}")
+
+
+def test_manual_claim_still_refuses_a_paused_job(temp_home):
+    """``manual=True`` suppresses only the occurrence stamp — unlike ``force=True`` it
+    must not resume a paused job, which the run-now tool relies on to refuse it."""
+    from cron.jobs import create_job, claim_job_for_fire, get_job, pause_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="mp")
+    pause_job(job["id"])
+
+    assert claim_job_for_fire(job["id"], manual=True) is False
+    assert get_job(job["id"]).get("paused_at") is not None
+
+
+def test_scheduler_tick_claim_still_stamps_its_occurrence(temp_home):
+    """The dedupe path stays intact for ordinary (non-manual) claims: a tick fire still
+    records the occurrence it ran, so a re-delivery cannot double-fire it."""
+    from cron.jobs import create_job, claim_job_for_fire, get_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="s")
+    pending = get_job(job["id"])["next_run_at"]
+
+    claimed = claim_job_for_fire(job["id"], return_job=True)
+    assert isinstance(claimed, dict)
+    assert claimed["_scheduled_instant"] is not None
+    from cron.occurrences import scheduled_instant
+    assert claimed["_scheduled_instant"] == scheduled_instant(pending)

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -79,7 +79,7 @@ class TestBackgroundDispatch:
             assert res["claimed"] is True
             assert res["dispatched"] is True
             assert res["delegation_id"]
-            m_claim.assert_called_once_with("job-bg-01", return_job=True)
+            m_claim.assert_called_once_with("job-bg-01", manual=True, return_job=True)
             # The job actually starts on the daemon executor.
             assert run_started.wait(timeout=5.0), "job never started in background"
         finally:
@@ -326,5 +326,5 @@ class TestCronjobRunToolIntegration:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-bg-13", return_job=True)
+        m_claim.assert_called_once_with("job-bg-13", manual=True, return_job=True)
         m_run.assert_called_once()

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -39,7 +39,7 @@ class TestCronjobRunExecutesImmediately:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-run-1", return_job=True)
+        m_claim.assert_called_once_with("job-run-1", manual=True, return_job=True)
         m_run.assert_called_once_with(claimed, adapters=None, loop=None, extra_prompt=None)
 
     def test_run_reconciles_external_provider_after_claimed_execution(self):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -184,7 +184,7 @@ def _claim_for_manual_run(job_id: str, log_label: str):
     ``(None, error_dict)`` in the ``_execute_job_now`` shape. A lost claim is labelled precisely —
     claim_job_for_fire also returns False for paused/disabled/missing jobs, not just in-flight ones."""
     try:
-        claimed_job = claim_job_for_fire(job_id, return_job=True)
+        claimed_job = claim_job_for_fire(job_id, manual=True, return_job=True)
         if isinstance(claimed_job, dict):
             return claimed_job, None
         refreshed = get_job(job_id)


### PR DESCRIPTION
## What does this PR do?

An agent-invoked "run this cron job now" currently cancels that job's **next scheduled run**, silently.

`claim_job_for_fire()` derives the occurrence-dedupe identity from `next_run_at` *before* the same function advances it. On a scheduler tick, `next_run_at` **is** the occurrence being run — correct. On an off-tick manual run it is the **next** occurrence, so the execution gets stamped with the identity of a slot that has not happened yet. When that slot arrives, `_job_is_due()` finds a completed execution carrying it and skips the job.

The `manual` flag already exists to prevent exactly this, and both `_job_is_due()` and `claim_job_for_fire()` honour it. The agent-facing run-now path just never declares itself — `tools/cronjob_tools.py`, inside a function named `_claim_for_manual_run`:

```python
claimed_job = claim_job_for_fire(job_id, return_job=True)   # no force=, no manual=
```

This restores the design stated in #104790 — the column records *"the scheduled instant the execution was claimed for"*, and an off-tick manual run was claimed for no scheduled instant at all — rather than changing it.

### Why `manual=` and not `force=True`

`force` additionally calls `_activate_job_record()`, which resumes a paused or disabled job. The run-now tool must keep refusing those: its `is_job_runnable()` branch reports "Job is paused/disabled; resume it before running." Reusing `force` here would silently resume jobs the user had deliberately paused. The new flag suppresses only the occurrence stamp, and a test pins that distinction.

`next_run_at` re-anchoring further down `claim_job_for_fire()` is deliberately untouched — for a cron job, `compute_next_run(schedule, now)` at 17:40 returns 05:00 the following morning, so no slot is lost.

## Related Issue

Fixes #105690

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py` — add keyword-only `manual: bool = False` to `claim_job_for_fire()`; fold it into the existing flag as `manual_fire` (renamed from `manual` to avoid shadowing the new parameter inside the `apply` closure, which would otherwise raise `UnboundLocalError`). Comment records why an off-tick fire must not stamp an occurrence.
- `tools/cronjob_tools.py` — `_claim_for_manual_run()` passes `manual=True`.
- `tests/tools/test_cronjob_run_background.py`, `tests/tools/test_cronjob_run_immediate.py` — three `assert_called_once_with` assertions pinned the old call signature; they now pin `manual=True`, so dropping the flag again fails loudly instead of silently reintroducing the skip.
- `tests/cron/test_claim_job_for_fire.py` — three regression tests:
  - `test_manual_claim_does_not_stamp_a_future_occurrence` — the bug itself
  - `test_manual_claim_still_refuses_a_paused_job` — pins `manual` ≠ `force`
  - `test_scheduler_tick_claim_still_stamps_its_occurrence` — pins that ordinary tick dedupe is unchanged

## How to Test

Reproduce on base:

```python
from cron.jobs import create_job, claim_job_for_fire, get_job
job = create_job(prompt="x", schedule="every 5m", name="m")
pending = get_job(job["id"])["next_run_at"]
claimed = claim_job_for_fire(job["id"], return_job=True)
assert claimed["_scheduled_instant"] is None   # fails on base: equals `pending`
```

Then:

1. `pytest tests/cron/ -q` → 1236 passed, 1 skipped
2. Revert `cron/jobs.py` only and re-run the three new tests → 2 fail, 1 passes (the tick test passes on base, as it should — it pins existing behaviour)
3. Restore and re-run → all pass

I also verified on the real call path rather than only through tests: claiming a live recurring job with `manual=True` yields `_scheduled_instant: None` and leaves `next_run_at` correctly at the upcoming slot.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not achievable in my environment; see below**
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS, Linux 6.8.0, Python 3.11.15

**On the full-suite checkbox — what I ran instead, and why.**

`pytest tests/ -q` cannot complete on my machine, for two reasons that both reproduce on an unmodified checkout:

1. `pytest-asyncio` is not installed, so every `async def` test errors with *"async def functions are not natively supported"*, and `tests/gateway/relay/test_relay_going_idle.py` + `tests/gateway/relay/test_ws_transport.py` fail to **collect**, which aborts the whole run.
2. With those two `--ignore`d, the run then hangs at ~20% — blocked in `do_wait` on a test-spawned subprocess that never exits, 0% CPU indefinitely.

Rather than tick a box I could not verify, I ran a controlled comparison. I took every test file that imports or exercises the changed modules — `grep -rlE "cron\.jobs|cron import jobs|cronjob_tools|claim_job_for_fire|_scheduled_instant|completed_occurrence" tests/`, **92 files** — and ran that set against this branch and against a clean checkout of the same base commit (`6e2b8e070d`), same interpreter, same environment:

| | passed | failed | skipped |
|---|---|---|---|
| base `6e2b8e070d` | 1737 | 53 | 1 |
| this branch | 1740 | 53 | 1 |

The two failure sets are **byte-identical** (`comm` in both directions returns empty). All 53 are the `pytest-asyncio` gap above, confined to `test_web_server_cron_profiles.py` (23), `test_api_server_jobs.py` (20) and `test_cron_interrupt_notification.py` (10). The +3 passes are the new regression tests.

Worth flagging: my first pass at this comparison showed **56** failures on the branch. The three extra were the `assert_called_once_with` signature assertions listed above — real, caught only because the base comparison was run rather than assumed. They are fixed in this commit. If you would rather they were a separate commit, say so and I will split it.

`pytest tests/cron/ -q` on this branch: **1236 passed, 1 skipped**.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments in the changed functions) — no user-facing docs affected
- [x] `cli-config.yaml.example` — N/A, no config keys added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact considered — pure Python control flow, no platform-specific behaviour
- [x] Tool descriptions/schemas — N/A, the cronjob tool's schema and description are unchanged

## Logs

Reproduction on my install — three manual runs, each stamping a future slot that was then skipped:

| When | source | `scheduled_instant` stamped | Effect |
|---|---|---|---|
| Sep 7 16:58 | `direct` | `2026-09-08T05:20:00Z` | killed the 05:20 run |
| Sep 7 17:40 | `direct` | `2026-09-08T05:00:00Z` | killed the 05:00 run |
| Sep 8 05:14 | `direct` | `2026-09-09T05:00:00Z` | would have killed the next day's |

Corroborating signals: `last_dispatch` on both jobs still read the previous day (a dispatch always stamps it, so the scheduler never reached dispatch), `next_run_at` had advanced by two intervals rather than one, and the ticker was healthy throughout — other jobs ran every two minutes across the same window.
