### PR TITLE
fix(desktop): preserve omitted error turns in timeline order

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -577,6 +577,31 @@ describe('preserveLocalAssistantErrors', () => {
     expect(merged[2]?.error).toBe('OpenRouter 403')
   })
 
+  it('reinserts an omitted older error turn at its original timeline position', () => {
+    const nextMessages: ChatMessage[] = [
+      { id: 'stored-first-user', parts: [{ text: 'first', type: 'text' }], role: 'user' },
+      { id: 'stored-first-assistant', parts: [{ text: 'first answer', type: 'text' }], role: 'assistant' },
+      { id: 'stored-third-user', parts: [{ text: 'third', type: 'text' }], role: 'user' },
+      { id: 'stored-third-assistant', parts: [{ text: 'third answer', type: 'text' }], role: 'assistant' }
+    ]
+
+    const currentMessages: ChatMessage[] = [
+      ...nextMessages.slice(0, 2),
+      { id: 'user-failed', parts: [{ text: 'second', type: 'text' }], role: 'user' },
+      { error: 'provider failed', id: 'assistant-failed', parts: [], role: 'assistant' },
+      ...nextMessages.slice(2)
+    ]
+
+    expect(preserveLocalAssistantErrors(nextMessages, currentMessages).map(message => message.id)).toEqual([
+      'stored-first-user',
+      'stored-first-assistant',
+      'user-failed',
+      'assistant-failed',
+      'stored-third-user',
+      'stored-third-assistant'
+    ])
+  })
+
   it('does not keep orphan local user turns when there is no inline assistant error', () => {
     const nextMessages: ChatMessage[] = [
       {

--- a/apps/desktop/src/lib/chat-messages/reconciliation.ts
+++ b/apps/desktop/src/lib/chat-messages/reconciliation.ts
@@ -183,11 +183,55 @@ export function preserveLocalAssistantErrors(
     return mergedNextMessages
   }
 
-  const preserved = currentMessages
-    .filter(message => preserveIds.has(message.id))
-    .map(message => ({ ...message, pending: false }))
+  // Keep omitted error turns in their original timeline position. Hydration can
+  // omit a failed turn while retaining newer messages; appending the preserved
+  // pair to the end makes an older reply appear after newer user turns.
+  const nextIndexById = new Map(mergedNextMessages.map((message, index) => [message.id, index]))
+  const insertionAfter = new Map<number, ChatMessage[]>()
 
-  return [...mergedNextMessages, ...preserved]
+  for (let index = 0; index < currentMessages.length; ) {
+    if (!preserveIds.has(currentMessages[index].id)) {
+      index += 1
+
+      continue
+    }
+
+    const runStart = index
+    const run: ChatMessage[] = []
+
+    while (index < currentMessages.length && preserveIds.has(currentMessages[index].id)) {
+      run.push({ ...currentMessages[index], pending: false })
+      index += 1
+    }
+
+    let anchor = -1
+
+    for (let probe = runStart - 1; probe >= 0; probe -= 1) {
+      const candidateIndex = nextIndexById.get(currentMessages[probe].id)
+
+      if (candidateIndex !== undefined) {
+        anchor = candidateIndex
+
+        break
+      }
+    }
+
+    if (anchor === -1) {anchor = mergedNextMessages.length}
+    const groups = insertionAfter.get(anchor) ?? []
+    insertionAfter.set(anchor, [...groups, ...run])
+  }
+
+  const ordered: ChatMessage[] = []
+  ordered.push(...(insertionAfter.get(-1) ?? []))
+
+  for (let index = 0; index < mergedNextMessages.length; index += 1) {
+    ordered.push(mergedNextMessages[index])
+    ordered.push(...(insertionAfter.get(index) ?? []))
+  }
+
+  ordered.push(...(insertionAfter.get(mergedNextMessages.length) ?? []))
+
+  return ordered
 }
 
 export function branchGroupForUser(userMessage: ChatMessage): string {


### PR DESCRIPTION
## Summary

Fixes a renderer reconciliation path that could display an older assistant response after newer user messages.

`preserveLocalAssistantErrors` previously appended locally preserved error turns to the end of the hydrated transcript. When hydration omitted an older failed turn but retained newer messages, this corrupted visible chronological order. The fix reinserts each omitted contiguous run after the nearest preceding hydrated message ID, while retaining end-appending behavior when no anchor exists.

## Regression coverage

- Added a test for an omitted older error turn between completed turns.
- Focused Desktop suite: 76/76 passing.
- Desktop typecheck: passing.
- Desktop lint: 0 errors (pre-existing warnings only).
- Production Desktop build: passing, including Electron bundling and native dependency staging.

Fixes the ordering symptoms reported in #86890.