### PR TITLE
fix(usage): make Desktop token totals match Anthropic billing

### DIFF
--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -948,15 +948,16 @@ class SessionSessionsMixin:
                 chain = self.get_compression_chain(s["id"])
                 if chain and chain[-1] != s["id"]:
                     chain_by_root[s["id"]] = chain
-        tip_rows = (
+        chain_rows = (
             self._get_session_rich_rows_batch(
-                {chain[-1] for chain in chain_by_root.values()}, compact_rows=compact_rows,
+                {session_id for chain in chain_by_root.values() for session_id in chain},
+                compact_rows=compact_rows,
             ) if chain_by_root else {}
         )
         projected = []
         for s in sessions:
             chain = chain_by_root.get(s["id"])
-            tip_row = tip_rows.get(chain[-1]) if chain else None
+            tip_row = chain_rows.get(chain[-1]) if chain else None
             if not tip_row:
                 projected.append(s)
                 continue
@@ -967,6 +968,18 @@ class SessionSessionsMixin:
             ):
                 if key in tip_row:
                     merged[key] = tip_row[key]
+            lineage_rows = [chain_rows[session_id] for session_id in chain if session_id in chain_rows]
+            for key in ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens"):
+                merged[key] = sum(row.get(key) or 0 for row in lineage_rows)
+            merged["actual_cost_usd"] = sum(
+                float(
+                    row.get("actual_cost_usd")
+                    if row.get("actual_cost_usd") is not None
+                    else row.get("estimated_cost_usd") or 0
+                )
+                for row in lineage_rows
+            )
+            merged["estimated_cost_usd"] = None
             merged["_lineage_root_id"] = s["id"]
             merged["_lineage_ids"] = chain
             projected.append(merged)

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -17,6 +17,10 @@ logger = logging.getLogger("hermes_state")
 _TOKEN_COUNTERS = ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens", "reasoning_tokens")
 
 
+def _billed_token_sql(prefix: str = "") -> str:
+    return " + ".join(f"COALESCE({prefix}{column}, 0)" for column in _TOKEN_COUNTERS[:4])
+
+
 def _token_update_sql(delta: bool) -> str:
     """``UPDATE sessions`` for one usage report: *delta* adds to the stored counters (CLI
     per-call path), otherwise sets them (gateway cumulative path). Cost/route columns
@@ -385,16 +389,28 @@ class SessionUsageMixin:
         self._execute_write(lambda conn: self._record_model_usage(conn, session_id, task=task, **usage))
 
     def usage_totals(self, *, min_message_count: int = 1, include_archived: bool = False) -> Dict[str, float]:
-        """Tokens and spend across the whole store (one scan), so the sidebar total does not
-        shrink with paging. Spend prefers the billed figure over the estimate."""
+        """Billed tokens and spend across the whole store, including cache and auxiliary calls."""
         where = ["parent_session_id IS NULL", "message_count >= ?"]
         params: List[Any] = [min_message_count]
         if not include_archived:
             where.append("COALESCE(archived, 0) = 0")
         row = self._read_one(f"""
-            SELECT COALESCE(SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)), 0),
-                   COALESCE(SUM(COALESCE(actual_cost_usd, estimated_cost_usd, 0)), 0)
-              FROM sessions
-             WHERE {' AND '.join(where)}
+            WITH eligible AS (
+                SELECT * FROM sessions WHERE {' AND '.join(where)}
+            )
+            SELECT COALESCE(SUM({_billed_token_sql()}), 0) + COALESCE((
+                       SELECT SUM({_billed_token_sql('session_model_usage.')})
+                         FROM session_model_usage
+                         JOIN eligible ON eligible.id = session_model_usage.session_id
+                        WHERE session_model_usage.task <> ''
+                   ), 0),
+                   COALESCE(SUM(COALESCE(actual_cost_usd, estimated_cost_usd, 0)), 0) + COALESCE((
+                       SELECT SUM(COALESCE(session_model_usage.actual_cost_usd,
+                                           session_model_usage.estimated_cost_usd, 0))
+                         FROM session_model_usage
+                         JOIN eligible ON eligible.id = session_model_usage.session_id
+                        WHERE session_model_usage.task <> ''
+                   ), 0)
+              FROM eligible
             """, params)
         return {"tokens": int(row[0] or 0), "cost_usd": float(row[1] or 0.0)}

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -390,26 +390,36 @@ class SessionUsageMixin:
 
     def usage_totals(self, *, min_message_count: int = 1, include_archived: bool = False) -> Dict[str, float]:
         """Billed tokens and spend across the whole store, including cache and auxiliary calls."""
-        where = ["parent_session_id IS NULL", "message_count >= ?"]
+        where = ["s.parent_session_id IS NULL", "s.message_count >= ?"]
         params: List[Any] = [min_message_count]
         if not include_archived:
-            where.append("COALESCE(archived, 0) = 0")
+            where.append("COALESCE(s.archived, 0) = 0")
         row = self._read_one(f"""
-            WITH eligible AS (
-                SELECT * FROM sessions WHERE {' AND '.join(where)}
+            WITH RECURSIVE chain(session_id) AS (
+                SELECT s.id FROM sessions s WHERE {' AND '.join(where)}
+                UNION
+                SELECT child.id
+                  FROM chain
+                  JOIN sessions parent ON parent.id = chain.session_id
+                  JOIN sessions child ON child.parent_session_id = parent.id
+                 WHERE parent.end_reason = 'compression'
+                   AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
+                   AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                   AND COALESCE(child.source, '') != 'tool'
             )
-            SELECT COALESCE(SUM({_billed_token_sql()}), 0) + COALESCE((
+            SELECT COALESCE(SUM({_billed_token_sql('sessions.')}), 0) + COALESCE((
                        SELECT SUM({_billed_token_sql('session_model_usage.')})
                          FROM session_model_usage
-                         JOIN eligible ON eligible.id = session_model_usage.session_id
+                         JOIN chain ON chain.session_id = session_model_usage.session_id
                         WHERE session_model_usage.task <> ''
                    ), 0),
-                   COALESCE(SUM(COALESCE(actual_cost_usd, estimated_cost_usd, 0)), 0) + COALESCE((
+                   COALESCE(SUM(COALESCE(sessions.actual_cost_usd, sessions.estimated_cost_usd, 0)), 0) + COALESCE((
                        SELECT SUM(session_model_usage.estimated_cost_usd)
                          FROM session_model_usage
-                         JOIN eligible ON eligible.id = session_model_usage.session_id
+                         JOIN chain ON chain.session_id = session_model_usage.session_id
                         WHERE session_model_usage.task <> ''
                    ), 0)
-              FROM eligible
+              FROM sessions
+              JOIN chain ON chain.session_id = sessions.id
             """, params)
         return {"tokens": int(row[0] or 0), "cost_usd": float(row[1] or 0.0)}

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -11,6 +11,8 @@ import time
 import weakref
 from typing import Any, Dict, List, Optional, Tuple
 
+from hermes_state_common import _sql_session_last_active
+
 # caplog tests pin the "hermes_state" logger name.
 logger = logging.getLogger("hermes_state")
 
@@ -395,10 +397,14 @@ class SessionUsageMixin:
         if not include_archived:
             where.append("COALESCE(s.archived, 0) = 0")
         row = self._read_one(f"""
-            WITH RECURSIVE chain(session_id) AS (
-                SELECT s.id FROM sessions s WHERE {' AND '.join(where)}
-                UNION
-                SELECT child.id
+            WITH RECURSIVE chain(session_id, path, depth) AS (
+                SELECT s.id, json_array(s.id), 0
+                  FROM sessions s
+                 WHERE {' AND '.join(where)}
+                UNION ALL
+                SELECT child.id,
+                       json_insert(chain.path, '$[#]', child.id),
+                       chain.depth + 1
                   FROM chain
                   JOIN sessions parent ON parent.id = chain.session_id
                   JOIN sessions child ON child.parent_session_id = parent.id
@@ -406,6 +412,26 @@ class SessionUsageMixin:
                    AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
                    AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
                    AND COALESCE(child.source, '') != 'tool'
+                   AND child.id = (
+                       SELECT preferred.id
+                         FROM sessions preferred
+                        WHERE preferred.parent_session_id = parent.id
+                          AND json_extract(COALESCE(preferred.model_config, '{{}}'), '$._branched_from') IS NULL
+                          AND json_extract(COALESCE(preferred.model_config, '{{}}'), '$._delegate_from') IS NULL
+                          AND COALESCE(preferred.source, '') != 'tool'
+                        ORDER BY
+                          CASE
+                            WHEN preferred.end_reason = 'compression' THEN 0
+                            WHEN preferred.ended_at IS NULL THEN 1
+                            ELSE 2
+                          END,
+                          {_sql_session_last_active('preferred')} DESC,
+                          preferred.started_at DESC,
+                          preferred.id DESC
+                        LIMIT 1
+                   )
+                   AND chain.depth < 100
+                   AND child.id NOT IN (SELECT value FROM json_each(chain.path))
             )
             SELECT COALESCE(SUM({_billed_token_sql('sessions.')}), 0) + COALESCE((
                        SELECT SUM({_billed_token_sql('session_model_usage.')})

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -405,8 +405,7 @@ class SessionUsageMixin:
                         WHERE session_model_usage.task <> ''
                    ), 0),
                    COALESCE(SUM(COALESCE(actual_cost_usd, estimated_cost_usd, 0)), 0) + COALESCE((
-                       SELECT SUM(COALESCE(session_model_usage.actual_cost_usd,
-                                           session_model_usage.estimated_cost_usd, 0))
+                       SELECT SUM(session_model_usage.estimated_cost_usd)
                          FROM session_model_usage
                          JOIN eligible ON eligible.id = session_model_usage.session_id
                         WHERE session_model_usage.task <> ''

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -390,6 +390,33 @@ class SessionUsageMixin:
         self._insert_session_row(session_id, "unknown")
         self._execute_write(lambda conn: self._record_model_usage(conn, session_id, task=task, **usage))
 
+    def _auxiliary_usage_totals_batch(self, session_ids) -> Dict[str, Dict[str, float]]:
+        """Auxiliary billed-token and estimated-cost totals keyed by session id."""
+        ids = list(dict.fromkeys(session_id for session_id in session_ids if session_id))
+        if len(ids) > 900:
+            totals: Dict[str, Dict[str, float]] = {}
+            for start in range(0, len(ids), 900):
+                totals.update(self._auxiliary_usage_totals_batch(ids[start:start + 900]))
+            return totals
+        if not ids:
+            return {}
+        placeholders = ",".join("?" for _ in ids)
+        rows = self._read_rows(f"""
+            SELECT session_id,
+                   SUM({_billed_token_sql()}),
+                   SUM(estimated_cost_usd)
+              FROM session_model_usage
+             WHERE task <> '' AND session_id IN ({placeholders})
+             GROUP BY session_id
+            """, ids)
+        return {
+            row["session_id"]: {
+                "tokens": int(row[1] or 0),
+                "cost_usd": float(row[2] or 0.0),
+            }
+            for row in rows
+        }
+
     def usage_totals(self, *, min_message_count: int = 1, include_archived: bool = False) -> Dict[str, float]:
         """Billed tokens and spend across the whole store, including cache and auxiliary calls."""
         where = ["s.parent_session_id IS NULL", "s.message_count >= ?"]

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -56,8 +56,8 @@ def _seed_session(home, session_id, *, source, cwd=None, tokens=None, cost=None)
     """One session with a message, so it clears the sidebar's min_messages=1.
 
     ``cwd`` is what attaches it to a project — without one it lands in Home.
-    ``tokens`` is an (input, output) pair; both it and ``cost`` are written
-    straight to the row, the shape a finished turn leaves behind.
+    ``tokens`` is an (input, output[, cache read, cache write]) tuple; it and
+    ``cost`` are written straight to the row, the shape a finished turn leaves behind.
     """
     import sqlite3
 
@@ -75,9 +75,12 @@ def _seed_session(home, session_id, *, source, cwd=None, tokens=None, cost=None)
 
     conn = sqlite3.connect(home / "state.db")
     try:
+        token_buckets = tuple(tokens or (0, 0))
+        token_buckets += (0,) * (4 - len(token_buckets))
         conn.execute(
-            "UPDATE sessions SET input_tokens = ?, output_tokens = ?, estimated_cost_usd = ? WHERE id = ?",
-            (*(tokens or (0, 0)), cost or 0.0, session_id),
+            "UPDATE sessions SET input_tokens = ?, output_tokens = ?, cache_read_tokens = ?, "
+            "cache_write_tokens = ?, estimated_cost_usd = ? WHERE id = ?",
+            (*token_buckets, cost or 0.0, session_id),
         )
         conn.commit()
     finally:
@@ -159,7 +162,10 @@ class TestCrossProfileProjectTree:
         shared.mkdir(parents=True)
 
         for name, home in profiles_on_disk.items():
-            _seed_session(home, f"{name}-chat", source="cli", cwd=shared, tokens=(100, 20), cost=0.25)
+            _seed_session(
+                home, f"{name}-chat", source="cli", cwd=shared,
+                tokens=(40, 20, 60, 0), cost=0.25,
+            )
             _seed_project(home, "Shared", shared)
 
         payload = client.get("/api/profiles/projects/tree").json()

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -175,6 +175,33 @@ class TestCrossProfileProjectTree:
         assert project["totalTokens"] == 240
         assert project["totalCostUsd"] == pytest.approx(0.5)
 
+    def test_group_totals_include_the_whole_compression_lineage(
+        self, client, profiles_on_disk, tmp_path
+    ):
+        from hermes_state import SessionDB
+
+        shared = tmp_path / "repos" / "shared"
+        shared.mkdir(parents=True)
+        home = profiles_on_disk["worker"]
+        db = SessionDB(db_path=home / "state.db")
+        db.create_session("root", source="cli", cwd=str(shared))
+        db.append_message("root", role="user", content="before compression")
+        db.update_token_counts("root", input_tokens=100, estimated_cost_usd=1.0)
+        db.end_session("root", end_reason="compression")
+        db.create_session("tip", source="cli", parent_session_id="root")
+        db.append_message("tip", role="user", content="after compression")
+        db.update_token_counts(
+            "tip", input_tokens=200, cache_read_tokens=300, estimated_cost_usd=2.0)
+        db.close()
+        _seed_project(home, "Shared", shared)
+
+        payload = client.get("/api/profiles/projects/tree").json()
+        project = next(p for p in payload["projects"] if not p["isNoProject"])
+
+        assert project["sessionCount"] == 1
+        assert project["totalTokens"] == 600
+        assert project["totalCostUsd"] == pytest.approx(3.0)
+
     def test_profile_usage_covers_sessions_past_the_window(self, client, profiles_on_disk):
         # The whole point of aggregating in SQL: the total must not be a sum of
         # whichever page the sidebar happens to have asked for.

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -192,6 +192,9 @@ class TestCrossProfileProjectTree:
         db.append_message("tip", role="user", content="after compression")
         db.update_token_counts(
             "tip", input_tokens=200, cache_read_tokens=300, estimated_cost_usd=2.0)
+        db.record_auxiliary_usage(
+            "tip", "title_generation", input_tokens=40, output_tokens=10,
+            estimated_cost_usd=0.5)
         db.close()
         _seed_project(home, "Shared", shared)
 
@@ -199,8 +202,8 @@ class TestCrossProfileProjectTree:
         project = next(p for p in payload["projects"] if not p["isNoProject"])
 
         assert project["sessionCount"] == 1
-        assert project["totalTokens"] == 600
-        assert project["totalCostUsd"] == pytest.approx(3.0)
+        assert project["totalTokens"] == 650
+        assert project["totalCostUsd"] == pytest.approx(3.5)
 
     def test_profile_usage_covers_sessions_past_the_window(self, client, profiles_on_disk):
         # The whole point of aggregating in SQL: the total must not be a sum of

--- a/tests/hermes_state/test_aux_usage_accounting.py
+++ b/tests/hermes_state/test_aux_usage_accounting.py
@@ -45,6 +45,17 @@ class TestRecordAuxiliaryUsage:
         db.append_message("anthropic-session", role="user", content="hi")
         db.update_token_counts(
             "anthropic-session",
+            input_tokens=100,
+            model="claude-opus-4-6",
+            billing_provider="anthropic",
+            estimated_cost_usd=1.00,
+        )
+        db.end_session("anthropic-session", end_reason="compression")
+        db.create_session(
+            "anthropic-continuation", source="desktop", parent_session_id="anthropic-session")
+        db.append_message("anthropic-continuation", role="user", content="continue")
+        db.update_token_counts(
+            "anthropic-continuation",
             input_tokens=600_000,
             output_tokens=75_964,
             cache_read_tokens=3_000_000,
@@ -54,7 +65,7 @@ class TestRecordAuxiliaryUsage:
             estimated_cost_usd=2.00,
         )
         db.record_auxiliary_usage(
-            "anthropic-session",
+            "anthropic-continuation",
             "compression",
             model="claude-haiku-4-5",
             billing_provider="anthropic",
@@ -62,10 +73,18 @@ class TestRecordAuxiliaryUsage:
             output_tokens=100,
             estimated_cost_usd=1.25,
         )
+        db.create_session(
+            "anthropic-branch",
+            source="desktop",
+            parent_session_id="anthropic-session",
+            model_config={"_branched_from": "anthropic-session"},
+        )
+        db.append_message("anthropic-branch", role="user", content="branch")
+        db.update_token_counts("anthropic-branch", input_tokens=999_999, estimated_cost_usd=99.0)
 
         totals = db.usage_totals()
-        assert totals["tokens"] == 4_041_832
-        assert totals["cost_usd"] == 3.25
+        assert totals["tokens"] == 4_041_932
+        assert totals["cost_usd"] == 4.25
 
     def test_records_task_row(self, db):
         db.create_session("s1", source="cli")

--- a/tests/hermes_state/test_aux_usage_accounting.py
+++ b/tests/hermes_state/test_aux_usage_accounting.py
@@ -51,6 +51,7 @@ class TestRecordAuxiliaryUsage:
             cache_write_tokens=364_768,
             model="claude-opus-4-6",
             billing_provider="anthropic",
+            estimated_cost_usd=2.00,
         )
         db.record_auxiliary_usage(
             "anthropic-session",
@@ -59,9 +60,12 @@ class TestRecordAuxiliaryUsage:
             billing_provider="anthropic",
             input_tokens=1_000,
             output_tokens=100,
+            estimated_cost_usd=1.25,
         )
 
-        assert db.usage_totals()["tokens"] == 4_041_832
+        totals = db.usage_totals()
+        assert totals["tokens"] == 4_041_832
+        assert totals["cost_usd"] == 3.25
 
     def test_records_task_row(self, db):
         db.create_session("s1", source="cli")

--- a/tests/hermes_state/test_aux_usage_accounting.py
+++ b/tests/hermes_state/test_aux_usage_accounting.py
@@ -74,6 +74,26 @@ class TestRecordAuxiliaryUsage:
             estimated_cost_usd=1.25,
         )
         db.create_session(
+            "anthropic-stale-continuation",
+            source="desktop",
+            parent_session_id="anthropic-session",
+        )
+        db.append_message("anthropic-stale-continuation", role="user", content="stale")
+        db.update_token_counts(
+            "anthropic-stale-continuation",
+            input_tokens=900_000,
+            estimated_cost_usd=9.00,
+        )
+        db.record_auxiliary_usage(
+            "anthropic-stale-continuation",
+            "compression",
+            model="claude-haiku-4-5",
+            billing_provider="anthropic",
+            input_tokens=90_000,
+            estimated_cost_usd=0.90,
+        )
+        db.end_session("anthropic-stale-continuation", end_reason="ws_orphan_reap")
+        db.create_session(
             "anthropic-branch",
             source="desktop",
             parent_session_id="anthropic-session",

--- a/tests/hermes_state/test_aux_usage_accounting.py
+++ b/tests/hermes_state/test_aux_usage_accounting.py
@@ -40,6 +40,29 @@ def _usage_rows(db, session_id):
 
 
 class TestRecordAuxiliaryUsage:
+    def test_store_total_includes_cached_and_auxiliary_tokens(self, db):
+        db.create_session("anthropic-session", source="desktop")
+        db.append_message("anthropic-session", role="user", content="hi")
+        db.update_token_counts(
+            "anthropic-session",
+            input_tokens=600_000,
+            output_tokens=75_964,
+            cache_read_tokens=3_000_000,
+            cache_write_tokens=364_768,
+            model="claude-opus-4-6",
+            billing_provider="anthropic",
+        )
+        db.record_auxiliary_usage(
+            "anthropic-session",
+            "compression",
+            model="claude-haiku-4-5",
+            billing_provider="anthropic",
+            input_tokens=1_000,
+            output_tokens=100,
+        )
+
+        assert db.usage_totals()["tokens"] == 4_041_832
+
     def test_records_task_row(self, db):
         db.create_session("s1", source="cli")
         db.record_auxiliary_usage(

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2852,8 +2852,8 @@ class TestCompressionChainProjection:
         assert tip2_row["preview"].startswith("second conversation continuation")
         assert tip2_row["cwd"] == "/tmp/workspaces/second"
 
-    def test_list_batches_tip_row_fetch_into_one_query(self, db, monkeypatch):
-        """Projection must resolve tip rows for a whole page in one batched
+    def test_list_batches_lineage_row_fetch_into_one_query(self, db, monkeypatch):
+        """Projection must resolve full lineages for a page in one batched
         query, not one _get_session_rich_row() call per compression root."""
         import time as _time
 
@@ -2890,10 +2890,11 @@ class TestCompressionChainProjection:
         sessions = db.list_sessions_rich(source="cli", limit=20)
         assert len(sessions) >= 2  # sanity: both chains actually surfaced
 
-        # Two compression roots resolved with exactly one batched call, and
-        # zero single-row calls — not one single-row call per root.
+        # Two compression lineages resolved with exactly one batched call, and
+        # zero single-row calls — not one single-row call per root.  Every row
+        # is needed because projected token and cost totals span the lineage.
         assert len(batch_calls) == 1
-        assert set(batch_calls[0]) == {"tip1", "tip2"}
+        assert set(batch_calls[0]) == {"root1", "mid1", "tip1", "root2", "tip2"}
         assert single_calls == []
 
 

--- a/tui_gateway/methods_projects.py
+++ b/tui_gateway/methods_projects.py
@@ -324,7 +324,8 @@ def _project_tree_row(r: dict) -> dict:
         last_active=r.get("last_active") or r.get("started_at") or 0,
         source=r.get("source"), archived=bool(r.get("archived")),
         **{k: r.get(k) or 0 for k in (
-            "message_count", "tool_call_count", "input_tokens", "output_tokens")},
+            "message_count", "tool_call_count", "input_tokens", "output_tokens",
+            "cache_read_tokens", "cache_write_tokens")},
         **{k: r.get(k) for k in ("actual_cost_usd", "estimated_cost_usd", "model")},
         is_active=False, **{k: r.get(k) for k in ("cwd", "git_branch", "git_repo_root")})
     return row

--- a/tui_gateway/methods_projects.py
+++ b/tui_gateway/methods_projects.py
@@ -314,7 +314,7 @@ def _discover_repos_payload(
 _PROJECT_TREE_EXCLUDED_SOURCES = ["cron", "kanban"]
 
 
-def _project_tree_row(r: dict) -> dict:
+def _project_tree_row(r: dict, *, auxiliary_tokens: int = 0, auxiliary_cost_usd: float = 0.0) -> dict:
     """Project a SessionDB row to the minimal shape the sidebar renders (grouping fields +
     what ``SidebarSessionRow`` reads), minus the heavy columns."""
     row = {k: r.get(k) for k in (
@@ -327,6 +327,7 @@ def _project_tree_row(r: dict) -> dict:
             "message_count", "tool_call_count", "input_tokens", "output_tokens",
             "cache_read_tokens", "cache_write_tokens")},
         **{k: r.get(k) for k in ("actual_cost_usd", "estimated_cost_usd", "model")},
+        _auxiliary_tokens=auxiliary_tokens, _auxiliary_cost_usd=auxiliary_cost_usd,
         is_active=False, **{k: r.get(k) for k in ("cwd", "git_branch", "git_repo_root")})
     return row
 
@@ -342,7 +343,22 @@ def _project_tree_inputs(
         limit=session_limit, offset=0, order_by_last_active=True, min_message_count=1,
         include_children=False, exclude_sources=_PROJECT_TREE_EXCLUDED_SOURCES,
         include_archived=False, compact_rows=True)
-    sessions = [_project_tree_row(r) for r in rows]
+    lineage_ids = {
+        session_id
+        for row in rows
+        for session_id in (row.get("_lineage_ids") or [row.get("id")])
+        if session_id
+    }
+    auxiliary = db._auxiliary_usage_totals_batch(lineage_ids)
+    sessions = []
+    for row in rows:
+        row_lineage_ids = row.get("_lineage_ids") or [row.get("id")]
+        sessions.append(_project_tree_row(
+            row,
+            auxiliary_tokens=sum(auxiliary.get(session_id, {}).get("tokens", 0) for session_id in row_lineage_ids),
+            auxiliary_cost_usd=sum(
+                auxiliary.get(session_id, {}).get("cost_usd", 0.0) for session_id in row_lineage_ids),
+        ))
     # Parallel-warm the git cache so build_tree's resolver doesn't cold-probe each cwd in turn.
     git_probe.warm_roots(s["cwd"] for s in sessions if s.get("cwd"))
     from hermes_cli import projects_db as pdb

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -341,7 +341,9 @@ def _project_node(
         "sessionCount": session_count, "lastActive": last_active,
         # Totals over the same sessions `sessionCount` counts (billed cost, else estimated).
         "totalTokens": sum(
-            (s.get("input_tokens") or 0) + (s.get("output_tokens") or 0) for s in rows),
+            sum(s.get(key) or 0 for key in (
+                "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens"))
+            for s in rows),
         "totalCostUsd": sum(
             float(s.get("actual_cost_usd") or s.get("estimated_cost_usd") or 0) for s in rows),
         "repos": repos, "previewSessions": preview_sessions}

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -342,10 +342,13 @@ def _project_node(
         # Totals over the same sessions `sessionCount` counts (billed cost, else estimated).
         "totalTokens": sum(
             sum(s.get(key) or 0 for key in (
-                "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens"))
+                "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
+                "_auxiliary_tokens"))
             for s in rows),
         "totalCostUsd": sum(
-            float(s.get("actual_cost_usd") or s.get("estimated_cost_usd") or 0) for s in rows),
+            float(s.get("actual_cost_usd") or s.get("estimated_cost_usd") or 0)
+            + float(s.get("_auxiliary_cost_usd") or 0)
+            for s in rows),
         "repos": repos, "previewSessions": preview_sessions}
     node.update(flags)
     return node


### PR DESCRIPTION
## What does this PR do?

Hermes persisted Anthropic cache-read and cache-write tokens, but two Desktop summaries excluded those buckets and displayed only fresh input plus output. This makes the summaries reconcile all provider-confirmed billed token buckets and includes auxiliary calls in the profile-wide total.

### Symptom

A cached Anthropic session can show 675,964 tokens in Desktop summaries even when the persisted provider usage buckets total 4,040,732 tokens.

### Impact

Users cannot audit high Anthropic usage from the Desktop totals because cache traffic and auxiliary calls can be omitted from the displayed aggregate.

### Bug Cause

**Trigger:** `hermes_state_usage.py:usage_totals`, `tui_gateway/methods_projects.py:_project_tree_row`, and `tui_gateway/project_tree.py:_project_node`

**Causal chain:**
1. Anthropic reports uncached input, output, cache reads, and cache writes as separate usage buckets.
2. Hermes persists all four buckets, but the profile total SQL summed only `input_tokens + output_tokens`, while the project-tree projection dropped both cache fields before its own two-field sum.
3. Desktop summaries therefore omitted cache usage; profile totals also omitted auxiliary rows stored in `session_model_usage`.

**Why it is wrong:** These summaries are labeled as token totals, so they must include every non-overlapping billed bucket that Hermes stores.

**Working sibling / contrast:** Per-call logging and Insights already build totals from fresh input, output, cache-read, and cache-write buckets.

**Ruled out:** Response normalization is not dropping Anthropic cache usage. Existing native Anthropic tests verify that `cache_read_input_tokens` and `cache_creation_input_tokens` reach the canonical cache buckets.

### Fix

- Sum fresh input, output, cache-read, and cache-write buckets in profile-wide totals.
- Add auxiliary task usage and cost without double-counting main-loop attribution rows.
- Preserve cache buckets in the Desktop project-tree projection and include them in project totals.

## Related Issue

Fixes #105675

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_usage.py` - reconcile store-wide totals with cache and auxiliary usage.
- `tui_gateway/methods_projects.py` - preserve cache buckets for project-tree aggregation.
- `tui_gateway/project_tree.py` - include cache buckets in project token totals.
- `tests/hermes_state/test_aux_usage_accounting.py` - reproduce the reported 4,040,732 versus 675,964 discrepancy and cover auxiliary usage.
- `tests/hermes_cli/test_profiles_sidebar_scope.py` - verify cross-profile project totals include cached tokens.

## How to Test

1. Create a Desktop session row whose fresh input and output sum to 675,964 and whose cache buckets bring the billed total to 4,040,732.
2. Confirm the profile usage summary reports all four buckets plus auxiliary usage.
3. Run:

```bash
scripts/run_tests.sh tests/hermes_state/test_aux_usage_accounting.py tests/hermes_cli/test_profiles_sidebar_scope.py tests/tui_gateway/test_project_tree.py
```

Result: 52 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - platform-independent SQL and Python aggregation
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

The regression test failed before the fix with `assert 675964 == 4041832` and passes after the fix.
