### PR TITLE
fix(agent): isolate periodic scheduler callbacks from blocking siblings (#102574)

### DIFF
--- a/agent/periodic_scheduler.py
+++ b/agent/periodic_scheduler.py
@@ -3,15 +3,24 @@
 Replaces the per-child ``while not stop.wait(interval): body()`` daemon
 threads (delegate heartbeat, durable turn-lease refresher, turn-liveness
 watchdog).  With ~130 in-process subagents those added 2-3 sleeping OS
-threads per child; this module runs every periodic body on ONE daemon
-thread ordered by a heap of due times.
+threads per child.  This module keeps ONE daemon thread that only orders due
+times; every due body runs on its own short-lived daemon worker.  A blocked
+callback therefore cannot delay unrelated lease/liveness timers, while
+steady-state thread use stays near zero (workers exist only while a body is
+actually running, never one per scheduled handle).
 
 Semantics match the loop they replace: the first call happens ``interval``
 seconds after :func:`schedule`, and each following call ``interval`` seconds
 after the previous body *returned* (drift-free wrt. body duration was never
 a property of the old loops either).  A body that returns ``False`` stops
 itself; a body that raises is logged at debug and rescheduled — one bad
-callback must never kill the shared thread.
+callback must never kill the shared thread.  A handle never overlaps itself:
+it is re-queued only once its in-flight run has returned.  A worker-start
+failure never retires the handle: it is re-queued and logged at warning.
+
+Prior art: per-handle-worker isolation follows #102458 (jfreshpicks);
+bounded-pool alternatives #102615/#102657/#104488 were rejected for
+preserving a shared starvation domain; originates from #102030.
 """
 
 from __future__ import annotations
@@ -26,18 +35,20 @@ from typing import Callable, Optional
 logger = logging.getLogger(__name__)
 
 _THREAD_NAME = "hermes-periodic-scheduler"
+_CALLBACK_THREAD_PREFIX = "hermes-periodic-callback"
 
 
 class ScheduledHandle:
     """Cancel token for one scheduled periodic callback."""
 
-    __slots__ = ("_fn", "_interval", "_cancelled", "_scheduler")
+    __slots__ = ("_fn", "_interval", "_cancelled", "_scheduler", "_runner")
 
     def __init__(self, scheduler: "PeriodicScheduler", fn: Callable[[], object], interval: float):
         self._scheduler = scheduler
         self._fn = fn
         self._interval = interval
         self._cancelled = False
+        self._runner: Optional[threading.Thread] = None
 
     @property
     def cancelled(self) -> bool:
@@ -56,7 +67,6 @@ class PeriodicScheduler:
         self._heap: list = []  # (due, seq, handle)
         self._seq = itertools.count()
         self._thread: Optional[threading.Thread] = None
-        self._running: Optional[ScheduledHandle] = None
 
     def schedule(self, fn: Callable[[], object], interval: float) -> ScheduledHandle:
         handle = ScheduledHandle(self, fn, float(interval))
@@ -72,8 +82,54 @@ class PeriodicScheduler:
         with self._cond:
             handle._cancelled = True
             self._cond.notify()
-            if wait and self._running is handle and threading.current_thread() is not self._thread:
-                self._cond.wait_for(lambda: self._running is not handle, timeout=wait)
+            runner = handle._runner
+        if wait and runner is not None and threading.current_thread() is not runner:
+            runner.join(wait)
+
+    def _dispatch(self, handle: ScheduledHandle) -> None:
+        """Start ``handle``'s body on its own worker.  Called with ``_cond`` held
+        so ``cancel`` can never observe a half-set runner."""
+        runner = threading.Thread(
+            target=self._run_callback,
+            args=(handle,),
+            name=f"{_CALLBACK_THREAD_PREFIX}-{id(handle):x}",
+            daemon=True,
+        )
+        handle._runner = runner
+        try:
+            runner.start()
+        except Exception:
+            handle._runner = None
+            logger.warning(
+                "failed to start periodic callback worker %r; retrying in %s s",
+                handle._fn,
+                handle._interval,
+                exc_info=True,
+            )
+            if not handle._cancelled:
+                heapq.heappush(
+                    self._heap,
+                    (time.monotonic() + handle._interval, next(self._seq), handle),
+                )
+                self._cond.notify_all()
+
+    def _run_callback(self, handle: ScheduledHandle) -> None:
+        stop = False
+        try:
+            stop = handle._fn() is False
+        except Exception:
+            logger.debug("periodic callback %r raised", handle._fn, exc_info=True)
+        finally:
+            with self._cond:
+                handle._runner = None
+                if stop:
+                    handle._cancelled = True
+                elif not handle._cancelled:
+                    heapq.heappush(
+                        self._heap,
+                        (time.monotonic() + handle._interval, next(self._seq), handle),
+                    )
+                self._cond.notify_all()
 
     def _run(self) -> None:
         while True:
@@ -91,28 +147,13 @@ class PeriodicScheduler:
                         self._cond.wait(delay)
                         continue
                     heapq.heappop(self._heap)
-                    self._running = handle
+                    self._dispatch(handle)
                     break
-            stop = False
-            try:
-                stop = handle._fn() is False
-            except Exception:
-                logger.debug("periodic callback %r raised", handle._fn, exc_info=True)
-            with self._cond:
-                self._running = None
-                if stop:
-                    handle._cancelled = True
-                elif not handle._cancelled:
-                    heapq.heappush(
-                        self._heap,
-                        (time.monotonic() + handle._interval, next(self._seq), handle),
-                    )
-                self._cond.notify_all()
 
 
 _DEFAULT = PeriodicScheduler()
 
 
 def schedule(fn: Callable[[], object], interval: float) -> ScheduledHandle:
-    """Run ``fn()`` every ``interval`` seconds on the shared scheduler thread."""
+    """Run ``fn()`` every ``interval`` seconds via the shared scheduler."""
     return _DEFAULT.schedule(fn, interval)

--- a/agent/turn_facade_lease.py
+++ b/agent/turn_facade_lease.py
@@ -4,7 +4,8 @@ One process at a time may load -> run -> flush a session shared through state.db
 resume, gateway, background delivery). ``admit_durable_turn_lease`` acquires the row lease (or
 returns the early result the façade must hand back); ``DurableTurnLease`` owns the periodic
 refresher, the turn-liveness watchdog wiring, and the lease-loss / stall interrupt plumbing. Both
-timers run on the shared scheduler thread (``agent/periodic_scheduler.py``), not per-turn threads.
+timers run via the shared scheduler (``agent/periodic_scheduler.py``; timer thread orders,
+bodies run on per-handle workers), not per-turn threads.
 """
 import logging
 import os
@@ -172,7 +173,7 @@ class DurableTurnLease:
                 _set_interrupt(False, agent._execution_thread_id)
 
     def refresh_tick(self):
-        """One periodic renewal (every ``refresh_interval`` on the shared scheduler); a miss or
+        """One periodic renewal (every ``refresh_interval`` via the shared scheduler); a miss or
         error interrupts the turn. Returning False stops the timer.
 
         The holder-qualified UPDATE fences a late refresher from a successor lease. The façade's

--- a/agent/turn_liveness.py
+++ b/agent/turn_liveness.py
@@ -86,8 +86,8 @@ def resolve_turn_liveness_settings(
 
 
 class TurnLivenessWatchdog:
-    """Sampled-idle watchdog bound to one conversation turn (polls on the
-    shared periodic scheduler thread).
+    """Sampled-idle watchdog bound to one conversation turn (via the shared
+    periodic scheduler; timer thread orders, body runs on its own worker).
 
     ``activity_lock`` must be the SAME lock ``AIAgent._touch_activity`` stamps
     the activity clock with; run_agent owns the lease state and callbacks.
@@ -110,7 +110,7 @@ class TurnLivenessWatchdog:
         self._deactivate_turn = deactivate_turn
 
     def schedule(self):
-        """Start polling on the shared periodic scheduler thread; returns the cancel handle.
+        """Start polling via the shared periodic scheduler; returns the cancel handle.
         Scheduled at turn entry, after the turn-active flag and activity clock are stamped."""
         from agent.periodic_scheduler import schedule
 

--- a/tests/agent/test_periodic_scheduler.py
+++ b/tests/agent/test_periodic_scheduler.py
@@ -1,4 +1,4 @@
-"""agent/periodic_scheduler: one shared thread runs every periodic timer."""
+"""agent/periodic_scheduler: one timer thread dispatches isolated callbacks."""
 
 import threading
 import time
@@ -24,7 +24,7 @@ def test_two_intervals_fire_proportionally_and_cancel_stops_one():
 
     assert _wait_until(lambda: len(slow) >= 3)
     assert len(fast) > len(slow)  # 5x interval ratio -> clearly more fast ticks
-    # Both ran on this scheduler's single thread, not on new threads.
+    # Scheduling another timer creates no persistent per-handle thread.
     before = threading.active_count()
     sched.schedule(lambda: None, 0.01).cancel()
     assert threading.active_count() == before
@@ -89,4 +89,91 @@ def test_module_level_schedule_uses_shared_default():
     handles = [schedule(lambda: None, 0.01) for _ in range(20)]
     assert threading.active_count() == before
     for handle in handles:
+        handle.cancel()
+
+
+def test_blocked_callback_does_not_stall_due_sibling(monkeypatch):
+    scheduler = PeriodicScheduler()
+    monkeypatch.setattr(periodic_scheduler, "_DEFAULT", scheduler)
+    blocker_entered = threading.Event()
+    release_blocker = threading.Event()
+    sibling_ran = threading.Event()
+
+    def blocker():
+        blocker_entered.set()
+        release_blocker.wait(2.0)
+        return False
+
+    def sibling():
+        sibling_ran.set()
+        return False
+
+    blocker_handle = schedule(blocker, 0.01)
+    assert blocker_entered.wait(1.0)
+    sibling_handle = schedule(sibling, 0.01)
+    try:
+        assert sibling_ran.wait(0.30), (
+            "a blocked periodic callback stalled an unrelated due callback"
+        )
+    finally:
+        release_blocker.set()
+        blocker_handle.cancel(wait=1.0)
+        sibling_handle.cancel(wait=1.0)
+
+
+def test_slow_callback_never_overlaps_itself():
+    sched = PeriodicScheduler()
+    lock = threading.Lock()
+    two_runs = threading.Event()
+    running = 0
+    peak_running = 0
+    completed = 0
+
+    def slow():
+        nonlocal running, peak_running, completed
+        with lock:
+            running += 1
+            peak_running = max(peak_running, running)
+        time.sleep(0.05)
+        with lock:
+            running -= 1
+            completed += 1
+            if completed >= 2:
+                two_runs.set()
+
+    handle = sched.schedule(slow, 0.01)
+    try:
+        assert two_runs.wait(2.0)
+        assert peak_running == 1, "a handle ran concurrently with itself"
+    finally:
+        handle.cancel(wait=2.0)
+
+
+def test_worker_start_failure_keeps_timer(monkeypatch):
+    sched = PeriodicScheduler()
+    fired: list = []
+    real_thread = threading.Thread
+    attempts = {"n": 0}
+
+    def flaky(*args, **kwargs):
+        name = kwargs.get("name", "")
+        if name.startswith(periodic_scheduler._CALLBACK_THREAD_PREFIX) and attempts["n"] == 0:
+            attempts["n"] += 1
+
+            class Boom:
+                def start(self):
+                    raise RuntimeError("no threads")
+
+            return Boom()
+        attempts["n"] += 1
+        return real_thread(*args, **kwargs)
+
+    monkeypatch.setattr(periodic_scheduler.threading, "Thread", flaky)
+    handle = sched.schedule(lambda: fired.append(1), 0.01)
+    try:
+        assert _wait_until(lambda: bool(fired), timeout=3.0), (
+            "worker-start failure silently retired the timer"
+        )
+        assert not handle.cancelled
+    finally:
         handle.cancel()

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -203,7 +203,7 @@ def _dump_subagent_timeout_diagnostic(
 # ── Per-run helpers ──────────────────────────────────────────────────────────
 
 class _Heartbeat:
-    """One child's parent-activity heartbeat on the shared periodic scheduler thread
+    """One child's parent-activity heartbeat via the shared periodic scheduler
     (``agent.periodic_scheduler``) — not one daemon thread per child. NOT started at construction:
     the caller calls ``start()`` inside its ``try`` so a failed schedule (OS thread exhaustion on
     first use) leaves ``handle`` None and ``stop()`` is a no-op."""


### PR DESCRIPTION
## What Problem This Solves

`PeriodicScheduler` ran every periodic body inline on its single daemon thread (`agent/periodic_scheduler.py::_run` calling `handle._fn()`), so one blocked callback — a slow SQLite/lease-refresh call, a wedged filesystem or network-adjacent heartbeat — stalled *every* other due timer in the process. Since the shared scheduler now hosts safety-critical work (durable turn-lease refresh, turn-liveness watchdog, delegated-child heartbeat), that coupling made a single blocked callback a process-wide liveness failure domain: leases expired while their refresher was starved, and the liveness watchdog never fired.

This change keeps the one daemon scheduler thread as the heap/timing owner, but dispatches each due body onto its own short-lived daemon worker (`hermes-periodic-callback-*`). A blocked callback can no longer delay an unrelated due sibling. Existing semantics are preserved:

- A handle never overlaps itself: it is re-queued only after its in-flight run returns.
- `cancel(wait=)` still blocks for that handle's in-flight run (now a worker `join`), never for unrelated callbacks, and cancel-from-within-a-callback cannot deadlock.
- A `False` return still stops the callback; a raised exception is still logged at debug and rescheduled.
- No per-handle thread is created at schedule time, so steady-state thread use stays near zero and worker growth is bounded by the number of handles that currently have an in-flight run.

## Evidence

Reproduced and verified locally on `866332bfb52c46e543143b2620a9aeee8bce9c77` (Python 3.11.15, Windows 11):

- Red on baseline: the regression from the issue, `tests/agent/test_periodic_scheduler.py::test_blocked_callback_does_not_stall_due_sibling`, fails on unmodified `origin/main` with `AssertionError: a blocked periodic callback stalled an unrelated due callback` (the sibling misses its 300 ms deadline).
- Green after the fix: the same test passes, and `test_slow_callback_never_overlaps_itself` confirms a slow callback never overlaps itself.
- Sabotage-verify: reverting only `agent/periodic_scheduler.py` (keeping the new tests) turns the regression red again; restoring the fix turns it green.
- Reliability: `tests/agent/test_periodic_scheduler.py` passed 20/20 consecutive runs; the regression test passed 15/15 consecutive runs.
- Consumer suites: `tests/agent/test_periodic_scheduler.py tests/agent/test_turn_facade_lease.py tests/agent/test_turn_liveness.py tests/run_agent/test_turn_liveness_watchdog.py tests/tools/test_heartbeat_stale_thresholds.py` → 35 passed.

Known pre-existing, unrelated flake: `tests/run_agent/test_tool_activity_heartbeat.py::test_heartbeat_touches_periodically_and_stops` (a wall-clock `time.sleep(0.12)` vs a 0.05 s cadence) fails intermittently on unmodified `origin/main` as well (observed 1/5 on baseline, 2/5 with the fix). It does not use `periodic_scheduler`; `agent/tool_executor.py::_run_tool_activity_heartbeat` owns its own thread.

Closes #102574
