### PR TITLE
fix(dashboard): hoist compaction imports out of /messages handler

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -13,6 +13,8 @@ import sqlite3
 import time
 from typing import Callable, List, Optional
 
+from agent.compaction_display import project_compaction_message_for_display
+from agent.context_compressor import is_compaction_summary_message
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
@@ -502,9 +504,6 @@ async def get_session_latest_descendant(session_id: str, profile: Optional[str] 
 
 def _project_for_display(messages: list) -> list:
     """Replace compaction summaries with their display-only projection."""
-    from agent.compaction_display import project_compaction_message_for_display
-    from agent.context_compressor import is_compaction_summary_message
-
     projected_messages = []
     for message in messages:
         if not is_compaction_summary_message(message):


### PR DESCRIPTION
## Problem

`_project_for_display()` in `hermes_cli/web_routers/sessions.py` imported `agent.compaction_display` and `agent.context_compressor` inside the function. The first `GET /api/sessions/{id}/messages` after a dashboard (re)start therefore paid the cold import chain inline in the request path.

Measured on a self-hosted VPS dashboard (Ubuntu 24.04, Python 3.11):

| | before | after |
|---|---|---|
| first request after start | 2.6–3.8 s | 0.22–0.5 s |
| warm requests | 15–20 ms | 15–20 ms (unchanged) |

## Change

Hoist both imports to module level; no behavior change. The cost moves into process startup (one-time, ~0.5 s module import on this box) instead of the first user-facing request.

## Testing

- Module import verified (no cycles).
- Running in production on a self-hosted dashboard since Aug 31, web-server suite green there (175/175).
- Full suite left to CI on this branch.