### PR TITLE
fix(active_sessions): tolerate wall-clock steps in _pid_liveness create_time check

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -300,6 +300,20 @@ def _write_entries(path: Path, entries: list[dict[str, Any]]) -> None:
             pass
 
 
+# psutil's Process.create_time() is a wall-clock timestamp (epoch seconds derived
+# from /proc/<pid> on Linux, boot+wall on macOS/Windows), so it shifts when the
+# wall clock steps — NTP correction, laptop sleep/wake, DST (#105714). A 1 ms
+# tolerance (the prior value) false-pruned a live session after any such step,
+# silently dropping its lease from the registry on the next read/write.
+# 2.0 s tolerates a clock step while still catching a recycled PID: a reused
+# PID's create_time differs by the process's whole age (seconds to days),
+# never ~1 s. #62505 / #66518 fixed the same defect in mcp_stdio_watchdog /
+# slash_worker by dropping create_time for the POSIX parent relationship, which
+# does not apply here — active sessions are arbitrary CLI/TUI processes, not
+# children of a known parent.
+_PID_START_TOLERANCE_S = 2.0
+
+
 def _process_start_time(pid: int) -> Optional[float]:
     # Pair pid with create_time when psutil can read it, so a recycled pid does not
     # keep a stale lease alive indefinitely.
@@ -342,7 +356,7 @@ def _pid_liveness(pid: Any, process_start_time: Any = None, *, lenient: bool = F
     current_start = _process_start_time(pid_int)
     if current_start is None:
         return True if lenient else None
-    return abs(current_start - expected_start) < 0.001
+    return abs(current_start - expected_start) < _PID_START_TOLERANCE_S
 
 
 def _prune_dead(entries: list[dict[str, Any]], *, strict: bool = False) -> list[dict[str, Any]]:

--- a/tests/hermes_cli/test_active_sessions_pid_liveness_clock_step.py
+++ b/tests/hermes_cli/test_active_sessions_pid_liveness_clock_step.py
@@ -1,0 +1,81 @@
+"""Regression: _pid_liveness must tolerate a wall-clock step (NTP/sleep/DST).
+
+Before #105714 the create_time comparison used a 1 ms tolerance, so a ~1 s wall
+clock step (NTP correction, laptop sleep/wake, the DST shift on 2026-10-25)
+made psutil report a create_time ~1 s away from the value recorded when the
+lease was taken. A live process was silently deemed dead and its lease pruned
+from the active session registry on the next read/write — nothing errored, the
+state file just stopped describing reality.
+
+The fix widens the tolerance to ``_PID_START_TOLERANCE_S`` (2.0 s): a clock
+step under ~2 s no longer false-prunes, while a recycled PID is still caught
+(a reused PID's create_time differs by the process's whole age — seconds to
+days, never ~1 s).
+"""
+from unittest.mock import patch
+
+from hermes_cli import active_sessions as a
+import gateway.status as gs
+
+
+PID = 4242
+RECORDED = 1_757_000_000.0
+
+
+def test_no_clock_step_live_process_stays_alive():
+    """Baseline: recorded start matches current start -> live."""
+    with patch.object(gs, "_pid_exists", return_value=True), \
+         patch.object(a, "_process_start_time", return_value=RECORDED):
+        assert a._pid_liveness(PID, RECORDED) is True
+
+
+def test_clock_step_does_not_false_prune_live_session():
+    """The same live process after a 1 s wall-clock step must still be alive.
+
+    This is the #105714 regression: a 1 ms tolerance returned False here; the
+    2 s tolerance returns True.
+    """
+    with patch.object(gs, "_pid_exists", return_value=True), \
+         patch.object(a, "_process_start_time", return_value=RECORDED + 1.0):
+        assert a._pid_liveness(PID, RECORDED) is True
+
+
+def test_recycled_pid_is_still_caught():
+    """A PID reused by a fresh process (create_time an hour away) is still pruned.
+
+    2 s still catches recycling: a reused PID's create_time differs by the whole
+    process age (seconds-days), never ~1 s.
+    """
+    with patch.object(gs, "_pid_exists", return_value=True), \
+         patch.object(a, "_process_start_time", return_value=RECORDED + 3600.0):
+        assert a._pid_liveness(PID, RECORDED) is False
+
+
+def test_prune_dead_keeps_clock_stepped_lease():
+    """End-to-end: a clock-stepped live session survives _prune_dead."""
+    entry = {
+        "pid": PID,
+        "process_start_time": RECORDED,
+        "lease_id": "x",
+        "session_id": "s",
+        "surface": "cli",
+    }
+    with patch.object(gs, "_pid_exists", return_value=True), \
+         patch.object(a, "_process_start_time", return_value=RECORDED + 1.0):
+        survivors = a._prune_dead([entry])
+    assert len(survivors) == 1
+    assert survivors[0]["session_id"] == "s"
+
+
+def test_prune_dead_drops_a_genuinely_dead_session():
+    """Regression guard: a process whose PID no longer exists is still pruned."""
+    entry = {
+        "pid": PID,
+        "process_start_time": RECORDED,
+        "lease_id": "x",
+        "session_id": "s",
+        "surface": "cli",
+    }
+    with patch.object(gs, "_pid_exists", return_value=False):
+        survivors = a._prune_dead([entry])
+    assert survivors == []


### PR DESCRIPTION
Fixes #105714. The third site named in #62505 / #66518: `_pid_liveness` in `hermes_cli/active_sessions.py` still compared `create_time` with a 1 ms tolerance, so a ~1 s wall-clock step (NTP correction, laptop sleep/wake, the DST shift on 2026-10-25) made psutil report a `create_time` ~1 s away from the value recorded when the lease was taken. A live process was silently deemed dead and `_prune_dead` dropped its lease from the active session registry on the next read/write — nothing errored, the state file just stopped describing reality.

## Fix
Widen the tolerance to `_PID_START_TOLERANCE_S = 2.0` s:
- A clock step under ~2 s no longer false-prunes a live session.
- A recycled PID is still caught — a reused PID's `create_time` differs by the process's whole age (seconds to days), never ~1 s.

## Why widen rather than drop `create_time` entirely
#62505 / #66518 fixed the same defect in `mcp_stdio_watchdog` / `slash_worker` by dropping `create_time` for the POSIX parent relationship (`getppid()`). That does not apply here — active sessions are arbitrary CLI/TUI processes, not children of a known parent, so the start-time check is the only thing that detects PID recycling. Dropping it entirely would let a recycled PID keep a stale lease alive until the lease's own TTL. Widening preserves recycle detection for the realistic case (recycle differs by ≫ 2 s) while tolerating clock steps.

`Process.create_time(monotonic=True)` is not available on psutil 7.2.2 (signature is `(self)`) — verified by the reporter — so a tolerance band is the practical option today.

## Tests
Added `tests/hermes_cli/test_active_sessions_pid_liveness_clock_step.py` (5 tests, all pass standalone):
- baseline: recorded start == current start → live
- **regression**: 1 s clock step → still live (was `False` before the fix)
- recycled PID (create_time 1 h away) → still pruned
- `_prune_dead` keeps a clock-stepped live lease
- `_prune_dead` still drops a genuinely dead (PID no longer exists) session

---
*AI-assisted: I read `_pid_liveness` / `_prune_dead` on `main`, applied the reporter's proposed option 1 (widen), and verified the 5 regression tests standalone (pytest isn't available in my sandbox, so I ran them via a minimal stub; they use only `unittest.mock.patch` + plain asserts, so they run unmodified under real pytest in CI). Happy to adjust the band or switch to a drop-and-rely-on-`updated_at` design if a maintainer prefers that direction.*
