### PR TITLE
perf: unconditional import of all 43 bundled plugins causes 15-30s startup delay on Windows

### DIFF
--- a/agent/provider_registry.py
+++ b/agent/provider_registry.py
@@ -24,6 +24,43 @@ def lower_key(name: str) -> str:
     return name.strip().lower()
 
 
+class DeferredLoaders:
+    """One-shot loaders a registry runs on its first real read (:meth:`materialize`).
+
+    A bundled backend plugin registers its import here instead of importing at startup, so a
+    process that never uses the capability never pays for the module import. Cancellation is the
+    caller's job (the loader itself checks a flag after taking the discovery lock); a cancelled
+    loader is simply a no-op that is dropped on the next materialize.
+    """
+
+    def __init__(self, logger: logging.Logger, label: str) -> None:
+        self._logger = logger
+        self._label = label
+        self._loaders: List[Callable[[], None]] = []
+        self._lock = threading.Lock()
+
+    def register(self, loader: Callable[[], None]) -> None:
+        """Queue *loader* for the next :meth:`materialize`."""
+        with self._lock:
+            self._loaders.append(loader)
+
+    def materialize(self) -> None:
+        """Run every pending loader once, in registration order. A raising loader is logged, never
+        propagated — one broken plugin must not break the read (or the other plugins)."""
+        with self._lock:
+            loaders, self._loaders = self._loaders, []
+        for loader in loaders:
+            try:
+                loader()
+            except Exception as exc:  # noqa: BLE001
+                self._logger.warning("Deferred %s load failed: %s", self._label, exc, exc_info=True)
+
+    def clear(self) -> None:
+        """Drop pending loaders without running them. **Test-only.**"""
+        with self._lock:
+            self._loaders.clear()
+
+
 class ProviderRegistry(Generic[P]):
     """Global + per-scope provider map with plugin snapshot/restore support.
 
@@ -52,6 +89,8 @@ class ProviderRegistry(Generic[P]):
         self._lock = threading.Lock()
         # "TTS provider" but "Registered browser provider": acronyms keep their case.
         self._log_label = label if label.isupper() else label[0].lower() + label[1:]
+        # Bundled backends queue their import here; the first real read materializes them.
+        self._deferred = DeferredLoaders(logger, self._log_label)
 
     def _target(self, scope: Optional[str], *, create: bool) -> Dict[str, P]:
         if scope is None:
@@ -96,8 +135,14 @@ class ProviderRegistry(Generic[P]):
                 f"Registered {self._log_label} provider '%s' (%s)", key, type(provider).__name__,
             )
 
+    def register_deferred(self, loader: Callable[[], None]) -> None:
+        """Queue a bundled backend's import for this registry's first real read (see
+        :class:`DeferredLoaders`). Callers wire cancellation themselves."""
+        self._deferred.register(loader)
+
     def merged(self, scope: Optional[str] = None) -> Dict[str, P]:
         """Global map overlaid with the active profile's scoped map (a copy)."""
+        self._deferred.materialize()
         with self._lock:
             merged = dict(self._providers)
             merged.update(self._scoped_providers.get(scope or hermes_home_key(), {}))
@@ -111,6 +156,7 @@ class ProviderRegistry(Generic[P]):
         """Return the provider registered under *name* (scoped first), or None."""
         if not isinstance(name, str):
             return None
+        self._deferred.materialize()
         key = self.normalize(name)
         with self._lock:
             return (
@@ -154,13 +200,15 @@ class ProviderRegistry(Generic[P]):
             self._scoped_providers.clear()
             self._scoped_generations.clear()
             self._generation += 1
+        self._deferred.clear()
 
     def export(self, namespace: Dict[str, Any]) -> None:
         """Bind the historical module-level API (+ ``_providers``/``_scoped_providers``/
         ``_lock`` test hooks) into a ``*_registry`` module namespace."""
         namespace.update(
             _providers=self._providers, _scoped_providers=self._scoped_providers, _lock=self._lock,
-            register_provider=self.register, list_providers=self.list_providers,
+            register_provider=self.register, register_deferred=self.register_deferred,
+            list_providers=self.list_providers,
             get_provider=self.get_provider, snapshot_registration=self.snapshot_registration,
             restore_registration=self.restore_registration,
             registry_generation=self.registry_generation, _reset_for_tests=self.reset_for_tests,

--- a/hermes_cli/dashboard_auth/registry.py
+++ b/hermes_cli/dashboard_auth/registry.py
@@ -1,12 +1,14 @@
 """Module-level registry for DashboardAuthProvider instances. Plugins call ``register_provider``
-via the plugin context hook at startup; the auth gate iterates ``list_providers()`` and uses
-``get_provider`` to dispatch on the session's ``provider`` field."""
+via the plugin context hook; bundled providers are deferred (see ``register_deferred``) so their
+module only imports when the auth gate first reads this registry. The gate iterates
+``list_providers()`` and uses ``get_provider`` to dispatch on the session's ``provider`` field."""
 from __future__ import annotations
 
 import logging
 import threading
-from typing import List, Optional
+from typing import Callable, List, Optional
 
+from agent.provider_registry import DeferredLoaders
 from hermes_constants import hermes_home_key
 from hermes_cli.dashboard_auth.base import DashboardAuthProvider, assert_protocol_compliance
 
@@ -14,6 +16,13 @@ _log = logging.getLogger(__name__)
 _lock = threading.Lock()
 _providers: dict[str, DashboardAuthProvider] = {}
 _scoped_providers: dict[str, dict[str, DashboardAuthProvider]] = {}
+# Bundled dashboard-auth plugins queue their import here; the first gate read runs them.
+_deferred = DeferredLoaders(_log, "dashboard auth")
+
+
+def register_deferred(loader: Callable[[], None]) -> None:
+    """Queue a bundled provider plugin's import for the first read of this registry."""
+    _deferred.register(loader)
 
 
 def _merged(scope: Optional[str] = None) -> dict[str, DashboardAuthProvider]:
@@ -47,6 +56,7 @@ def register_provider(provider: DashboardAuthProvider, *, scope: Optional[str] =
 
 def get_provider(name: str, *, scope: Optional[str] = None) -> Optional[DashboardAuthProvider]:
     """Return the registered provider for ``name``, or None if unknown."""
+    _deferred.materialize()
     with _lock:
         return _merged(scope).get(name)
 
@@ -76,6 +86,7 @@ def restore_registration(
 
 def list_providers(*, scope: Optional[str] = None) -> List[DashboardAuthProvider]:
     """All registered providers, in registration order."""
+    _deferred.materialize()
     with _lock:
         return list(_merged(scope).values())
 
@@ -120,6 +131,7 @@ def unregister_global_provider(name: str, provider: DashboardAuthProvider) -> bo
 
 def clear_providers() -> None:
     """Test-only: drop all registrations."""
+    _deferred.clear()
     with _lock:
         _providers.clear()
         _scoped_providers.clear()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1336,7 +1336,12 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
         if verdict.action == "load_now":
             self._load_plugin(manifest)
         elif verdict.action == "defer":
-            self._register_deferred_platform(manifest)
+            # Bundled backends defer onto their provider registry; bundled platforms onto the
+            # platform registry. Everything else only reaches "defer" through one of those kinds.
+            if manifest.kind == "platform":
+                self._register_deferred_platform(manifest)
+            else:
+                self._register_deferred_backend(manifest)
         else:
             self._plugins[manifest_key(manifest)] = LoadedPlugin(
                 manifest=manifest, enabled=verdict.enabled, error=verdict.error)

--- a/hermes_cli/plugins_discovery.py
+++ b/hermes_cli/plugins_discovery.py
@@ -174,7 +174,7 @@ def gate_manifest(
     manifest: PluginManifest, disabled: Set[str], enabled: Optional[Set[str]]
 ) -> ManifestGate:
     """Decide how one winning manifest is handled. Gate order matters: legacy relay refusal, explicit disable,
-    category-owned kinds (exclusive / model-provider), bundled auto-loads (backend now, platform deferred),
+    category-owned kinds (exclusive / model-provider), bundled lazy-loads (backend and platform deferred),
     then ``plugins.enabled`` opt-in (path-derived key or legacy bare name)."""
     lookup_key = manifest_key(manifest)
     names = {lookup_key, manifest.name}
@@ -203,12 +203,10 @@ def gate_manifest(
         return _placeholder(
             None, logging.DEBUG, "Skipping '%s' (model-provider, handled by providers/ discovery)", enabled=True)
     if manifest.source == "bundled":
-        # Bundled backends auto-load; selection among them is ``<category>.provider`` config.
-        if manifest.kind == "backend":
-            return ManifestGate("load_now")
-        # Bundled platforms register LAZILY: eagerly importing ~20 heavy SDKs added seconds to every `hermes`
-        # invocation. A deferred loader keeps every platform available on first use.
-        if manifest.kind == "platform":
+        # Bundled backends and platforms register LAZILY: eagerly importing their SDKs added seconds to
+        # every `hermes` invocation on Windows. Selection among backends is ``<category>.provider``
+        # config; a deferred loader keeps each one available the moment its registry is first read.
+        if manifest.kind in ("backend", "platform"):
             return ManifestGate("defer")
     if enabled is None or not names & enabled:
         return _placeholder(

--- a/hermes_cli/plugins_loader.py
+++ b/hermes_cli/plugins_loader.py
@@ -36,6 +36,17 @@ _NS_PARENT = "hermes_plugins"
 _MODULE_NAMESPACE_LOCK = threading.RLock()
 _BARE_MODULE_SCOPE: Dict[str, str] = {}  # bare module name -> owning scope_key
 
+# Bundled backend category -> module exposing the registry it feeds. Deferring a category means
+# "import the plugin the first time something reads that registry"; a category missing here has no
+# registry to hang the trigger on, so it keeps loading eagerly.
+_BACKEND_REGISTRY_MODULES = {
+    "web": "agent.web_search_registry",
+    "browser": "agent.browser_registry",
+    "image_gen": "agent.image_gen_registry",
+    "video_gen": "agent.video_gen_registry",
+    "dashboard_auth": "hermes_cli.dashboard_auth.registry",
+}
+
 
 def _evict_modules(module_name: str) -> None:
     """Drop ``module_name`` and every ``module_name.*`` submodule from ``sys.modules``."""
@@ -215,6 +226,47 @@ class PluginLoaderMixin:
                 "" if complete else " The remainder will be missing from CLI/TUI sessions.",
                 exc_info=_PLUGINS_DEBUG,
             )
+
+    def _register_deferred_backend(self, manifest: PluginManifest) -> None:
+        """Register a lazy loader for a bundled backend: the provider module imports only when the
+        registry it feeds is first read (a web search, an image generation, the dashboard auth gate),
+        instead of on every CLI startup; a placeholder ``LoadedPlugin`` keeps it visible in
+        ``hermes plugins list`` until then.
+
+        Backends with no registry to trigger on (tool-only plugins such as ``spotify``) stay eager —
+        they are few and cheap.
+        """
+        from hermes_cli.plugins import LoadedPlugin
+        lookup_key = manifest_key(manifest)
+        category = lookup_key.split("/", 1)[0]
+        module_name = _BACKEND_REGISTRY_MODULES.get(category)
+        if module_name is None:
+            self._load_plugin(manifest)
+            return
+        self._plugins[lookup_key] = LoadedPlugin(manifest=manifest, enabled=True, deferred=True)
+        cancelled = threading.Event()
+        try:
+            registry = importlib.import_module(module_name)
+
+            def _loader(_manifest: PluginManifest = manifest) -> None:
+                # Lock before checking cancellation: if an unload won the race the plugin must stay
+                # gone; if loading won, unload waits and disposes whatever this registers.
+                with self._discovery_lock, _plugin_home_scope(self.home_path):
+                    if cancelled.is_set():
+                        return
+                    self._load_plugin_scoped(_manifest)
+
+            registry.register_deferred(_loader)
+            # Ledger entry so unload / force re-discovery cancels the pending loader instead of
+            # letting a disabled plugin import later on the first registry read.
+            self._track_registration(manifest, "deferred_backend", lookup_key, cancelled.set)
+            logger.debug("Registered deferred backend loader: %s (%s)", lookup_key, module_name)
+        except Exception:
+            # Fall back to eager loading so the backend is never silently lost.
+            logger.debug(
+                "Deferred backend registration failed for '%s'; eager-loading", lookup_key, exc_info=True)
+            self._plugins.pop(lookup_key, None)
+            self._load_plugin(manifest)
 
     def _warn_python_dependencies(self, manifest: PluginManifest) -> None:
         """Warn about missing declared pip dependencies with an install hint — NEVER auto-install.

--- a/tests/hermes_cli/test_deferred_backend_providers.py
+++ b/tests/hermes_cli/test_deferred_backend_providers.py
@@ -1,0 +1,220 @@
+"""Bundled backends must not import at startup (issue #52284).
+
+Discovery used to ``import`` every bundled ``kind: backend`` plugin unconditionally, dragging each
+provider SDK into every ``hermes`` invocation — 15-30s of startup on Windows. A bundled backend now
+registers a one-shot loader on the registry it feeds (web search, image/video generation, browser,
+dashboard auth); the module imports the first time that registry is actually read, and a placeholder
+``LoadedPlugin(deferred=True)`` keeps it visible to discovery, enable/disable and ``hermes plugins
+list`` until then.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _write_backend_plugin(root: Path, name: str, *, register_body: str = "    pass\n"):
+    """A synthetic bundled ``web/`` backend whose import is observable via ``_backend_probe``."""
+    from hermes_cli.plugins import PluginManifest
+
+    plugin_dir = root / "web" / name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.dump({"name": name, "kind": "backend", "version": "1.0.0"}), encoding="utf-8"
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "import _backend_probe\n"
+        "_backend_probe.imports += 1\n"
+        "\n"
+        "\n"
+        "def register(ctx):\n" + register_body,
+        encoding="utf-8",
+    )
+    return PluginManifest(
+        name=name, kind="backend", source="bundled", path=str(plugin_dir), key=f"web/{name}"
+    )
+
+
+@pytest.fixture
+def probe(monkeypatch):
+    mod = types.ModuleType("_backend_probe")
+    mod.imports = 0
+    monkeypatch.setitem(sys.modules, "_backend_probe", mod)
+    return mod
+
+
+@pytest.fixture
+def clean_state():
+    """Undo whatever a synthetic plugin left in the process-wide registries/modules."""
+    from agent import web_search_registry
+
+    before_modules = set(sys.modules)
+    yield
+    web_search_registry._reset_for_tests()
+    for name in set(sys.modules) - before_modules:
+        if name.startswith(("hermes_plugins.", "plugins.web.probe")):
+            sys.modules.pop(name, None)
+
+
+def _bundled_backend_keys(mgr, category: str):
+    return sorted(
+        key
+        for key, plugin in mgr._plugins.items()
+        if plugin.manifest.source == "bundled"
+        and plugin.manifest.kind == "backend"
+        and key.startswith(f"{category}/")
+    )
+
+
+# ── the reported symptom: no SDK import at discovery ───────────────────────
+
+
+class TestDiscoveryDoesNotImportBackends:
+    def test_bundled_backends_are_deferred_placeholders(self):
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        for category in ("web", "image_gen", "video_gen", "browser", "dashboard_auth"):
+            keys = _bundled_backend_keys(mgr, category)
+            assert keys, f"no bundled {category} backends discovered"
+            for key in keys:
+                plugin = mgr._plugins[key]
+                assert plugin.deferred is True, f"{key} imported at discovery"
+                assert plugin.module is None, f"{key} imported its module at discovery"
+
+    def test_tool_only_backend_without_a_registry_stays_eager(self):
+        """``spotify`` feeds no registry, so there is nothing to defer onto."""
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        spotify = mgr._plugins.get("spotify")
+        assert spotify is not None
+        assert spotify.deferred is False
+
+
+# ── semantics preserved: the first registry read loads the backend ──────────
+
+
+class TestRegistryReadMaterializesBackends:
+    def test_web_registry_read_registers_bundled_providers(self):
+        from agent import web_search_registry
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        tavily = mgr._plugins["web/tavily"]
+        assert tavily.deferred is True
+
+        names = {provider.name for provider in web_search_registry.list_providers()}
+
+        assert {"tavily", "ddgs"} <= names
+        assert mgr._plugins["web/tavily"].deferred is False
+        assert mgr._plugins["web/tavily"].module is not None
+
+    def test_active_provider_resolution_triggers_the_deferred_import(self):
+        """``get_active_search_provider`` reads through ``merged()``, not just ``list_providers()``."""
+        from agent import web_search_registry
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert mgr._plugins["web/ddgs"].deferred is True
+        web_search_registry.get_active_search_provider()
+
+        assert mgr._plugins["web/ddgs"].deferred is False
+
+    def test_dashboard_auth_registry_read_materializes_providers(self):
+        """The dashboard's fail-closed gate reads this registry — it must still see plugins."""
+        from hermes_cli.dashboard_auth import registry as auth_registry
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert mgr._plugins["dashboard_auth/basic"].deferred is True
+
+        auth_registry.list_providers()
+
+        assert mgr._plugins["dashboard_auth/basic"].deferred is False
+        assert mgr._plugins["dashboard_auth/basic"].module is not None
+
+
+# ── enable/disable + error isolation ───────────────────────────────────────
+
+
+class TestDeferredBackendLifecycle:
+    def test_unload_cancels_a_pending_loader(self, tmp_path, probe, clean_state):
+        from agent import web_search_registry
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        mgr._register_deferred_backend(_write_backend_plugin(tmp_path, "probeweb"))
+
+        assert mgr._plugins["web/probeweb"].deferred is True
+        assert probe.imports == 0
+
+        mgr.unload()
+        web_search_registry.list_providers()
+
+        assert probe.imports == 0, "a disabled/unloaded backend was imported on a registry read"
+
+    def test_disabled_backend_never_imports(self, tmp_path, probe, clean_state):
+        from agent import web_search_registry
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        manifest = _write_backend_plugin(tmp_path, "probeweb")
+        mgr._register_deferred_backend(manifest)
+
+        # A disabled backend is dropped from the ledger, exactly like an unloaded one.
+        owned = [r for r in mgr._registration_order if r.plugin_key == "web/probeweb"]
+        mgr._dispose_registrations(owned)
+        mgr._forget_registrations(owned)
+
+        web_search_registry.list_providers()
+
+        assert probe.imports == 0
+
+    def test_failing_deferred_load_is_isolated(self, tmp_path, probe, clean_state):
+        """One broken bundled backend must not break the registry read for every other one."""
+        from agent import web_search_registry
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+        mgr._register_deferred_backend(
+            _write_backend_plugin(
+                tmp_path, "probeweb", register_body="    raise RuntimeError('boom')\n"
+            )
+        )
+
+        names = {provider.name for provider in web_search_registry.list_providers()}
+
+        assert {"tavily", "ddgs"} <= names
+        assert "boom" in (mgr._plugins["web/probeweb"].error or "")
+
+    def test_deferred_load_runs_once(self, tmp_path, probe, clean_state):
+        from agent import web_search_registry
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        mgr._register_deferred_backend(_write_backend_plugin(tmp_path, "probeweb"))
+
+        web_search_registry.list_providers()
+        web_search_registry.list_providers()
+
+        assert probe.imports == 1


### PR DESCRIPTION
## What Problem This Solves

`PluginManager.discover_and_load()` imported every bundled `kind: backend` plugin eagerly at startup.
Each import drags in that provider's SDK (`tavily`, `ddgs`, `fal`, `openai`, `firecrawl`, `httpx`,
`google-genai`, OAuth/JWT stacks, …), so a plain `hermes` invocation paid for 29 backend plugins
whether or not it ever searched the web, generated an image, or served the dashboard. On Windows this
is the 15–30s startup delay reported in #52284 (import cost is 2–4x higher there than on Linux).

Bundled `kind: platform` plugins already solve exactly this with a deferred loader keyed on
`platform_registry`; backends had no equivalent. This PR gives them one.

## What Changed

Bundled backends now register a one-shot loader on the registry they feed and import on that
registry's **first real read**:

| category | registry | trigger |
|---|---|---|
| `web` | `agent.web_search_registry` | first `list_providers()` / `get_active_search_provider()` |
| `browser` | `agent.browser_registry` | first read |
| `image_gen` | `agent.image_gen_registry` | first read |
| `video_gen` | `agent.video_gen_registry` | first read |
| `dashboard_auth` | `hermes_cli.dashboard_auth.registry` | first `list_providers()` / `get_provider()` (the dashboard's fail-closed gate) |

- `agent/provider_registry.py`: `ProviderRegistry.register_deferred(loader)` + a `DeferredLoaders`
  queue that `merged()` (every read path funnels through it) drains exactly once.
- `hermes_cli/plugins_discovery.py`: bundled `backend` manifests gate to `defer` like `platform`.
- `hermes_cli/plugins_loader.py`: `_register_deferred_backend()` records a
  `LoadedPlugin(deferred=True)` placeholder, registers the loader on the target registry, and puts a
  cancellation handle in the ownership ledger. The loader re-checks cancellation **after** taking the
  discovery lock, so an unload/disable that wins the race cannot be resurrected by an in-flight
  materialize. A backend with no registry to hang off (e.g. tool-only `spotify`) stays eager.
- `hermes_cli/dashboard_auth/registry.py`: same materialize-on-read seam.

Semantics preserved: discovery still finds all 59 bundled plugins (`hermes plugins list` shows
deferred backends from the placeholder), enable/disable and unload cancel pending loaders, provider
resolution is unchanged (same providers, same order, just later), and a backend whose import or
`register()` raises is isolated to that plugin — the registry read still returns every other provider.

## Evidence

Windows 11, Python 3.11.15, fresh process per sample, `D:/code/wt-52284` at `origin/main`
(before = `git stash` of this diff, after = applied). 5 CLI samples, 3 discovery samples.

| metric | before | after |
|---|---|---|
| `discover_and_load()` (median) | 427.1 ms | **235.1 ms** (−45%) |
| plugin modules imported at discovery | 35 | **7** (−80%) |
| bundled plugins deferred | 22 | **50** (+28 backends) |
| bundled plugins with module loaded at discovery | 32 | **4** |
| plugins discovered | 59 | 59 |
| web providers after first read | 10 | 10 (unchanged) |
| modules imported after a web read | 35 | 17 |
| `hermes <unknown-cmd>` (argparse runs discovery) | 0.916 s | **0.735 s** (−181 ms) |
| `hermes --help` (discovery skipped, control) | 0.514 s | 0.533 s |

The first registry read costs 13.9 ms (the web group's import), paid only by invocations that actually
use a provider.

## Tests

`tests/hermes_cli/test_deferred_backend_providers.py` — 9 tests: discovery leaves backends
unimported, the first read of each registry registers the bundled providers, unload/disable cancel a
pending loader, a failing deferred load is isolated, and a loader runs exactly once. Red on
`origin/main` (7 failed), green with the fix; sabotage-verified by reverting the gate and the
cancellation check (7 failures).

Related suites: `tests/hermes_cli/test_plugins.py`, `test_plugins_hub_perf_guard.py`,
`test_startup_plugin_gating.py`, `test_deferred_platform_client_tools.py`,
`test_dashboard_auth_plugin_hook.py`, `test_dashboard_basic_auth_plugin_enable.py`,
`test_plugin_manifest_v2.py`, `test_plugin_capabilities.py`, `test_plugin_ownership_ledger.py`,
`test_safe_mode.py`, `test_plugins_tts_registration.py`, `test_plugins_transcription_registration.py`,
`tests/agent/test_image_gen_registry.py`, `tests/gateway/test_platform_plugin_handlers.py`
→ 231 passed, 3 failed; the 3 (`test_plugin_ownership_ledger.py`, platform-registry scope tests) fail
identically on unmodified `origin/main`.

Closes #52284
