### PR TITLE
fix(config): warn when quoted container settings are ignored

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1216,6 +1216,43 @@ def _validate_web_backends(config: Dict[str, Any], issues: List[ConfigIssue]) ->
                    "Run 'hermes tools' and pick a different Web Search & Extract provider")
 
 
+def _validate_stringified_containers(
+    config: Dict[str, Any], issues: List[ConfigIssue], prefix: str = "",
+) -> None:
+    """Flag list/mapping settings stored as one quoted string.
+
+    Readers that require a container silently ignore these strings. Schema-declared strings remain
+    valid even when their contents use brackets or braces.
+    """
+    for key, value in config.items():
+        path = f"{prefix}.{key}" if prefix else str(key)
+        if isinstance(value, dict):
+            _validate_stringified_containers(value, issues, path)
+            continue
+        text = value.strip() if isinstance(value, str) else ""
+        if (
+            text[:1] not in ("[", "{")
+            or text[-1:] not in ("]", "}")
+            or isinstance(_default_value_for_key(path), str)
+        ):
+            continue
+        try:
+            parsed = yaml.safe_load(text)
+        except yaml.YAMLError:
+            continue
+        if not isinstance(parsed, (list, dict)):
+            continue
+        kind = "list" if isinstance(parsed, list) else "mapping"
+        _issue(
+            issues,
+            "warning",
+            f"{path} is a quoted string that looks like a {kind} — Hermes expects a real YAML "
+            f"{kind} here and ignores the string",
+            f"Re-run: hermes config set {path} '<value>' (stored as a real {kind}), or rewrite "
+            f"it in config.yaml using YAML {kind} syntax",
+        )
+
+
 def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:
     """Validate config.yaml structure and return detected issues (accepts a pre-loaded dict).
     Catches common YAML mistakes that otherwise surface as confusing runtime errors."""
@@ -1253,6 +1290,7 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                    f"Move '{key}' under the appropriate section")
 
     _validate_web_backends(config, issues)
+    _validate_stringified_containers(config, issues)
     return issues
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1216,41 +1216,83 @@ def _validate_web_backends(config: Dict[str, Any], issues: List[ConfigIssue]) ->
                    "Run 'hermes tools' and pick a different Web Search & Extract provider")
 
 
+_MISSING_CONTAINER_SCHEMA = object()
+_EXTRA_CONTAINER_SCHEMA = {
+    "custom_providers": [{"extra_body": {}, "extra_headers": {}}],
+    "model_catalog": {"excluded_providers": []},
+    "plugins": {"enabled": [], "disabled": []},
+    "providers": {"*": {"extra_body": {}, "extra_headers": {}}},
+}
+
+
+def _container_schema_child(schema: Any, key: Any) -> Any:
+    if isinstance(schema, dict):
+        return schema.get(key, schema.get("*", _MISSING_CONTAINER_SCHEMA))
+    if isinstance(schema, list) and schema:
+        return schema[0]
+    return _MISSING_CONTAINER_SCHEMA
+
+
 def _validate_stringified_containers(
-    config: Dict[str, Any], issues: List[ConfigIssue], prefix: str = "",
+    value: Any,
+    issues: List[ConfigIssue],
+    path: str = "",
+    default_schema: Any = DEFAULT_CONFIG,
+    extra_schema: Any = _EXTRA_CONTAINER_SCHEMA,
 ) -> None:
     """Flag list/mapping settings stored as one quoted string.
 
     Readers that require a container silently ignore these strings. Schema-declared strings remain
     valid even when their contents use brackets or braces.
     """
-    for key, value in config.items():
-        path = f"{prefix}.{key}" if prefix else str(key)
-        if isinstance(value, dict):
-            _validate_stringified_containers(value, issues, path)
-            continue
-        text = value.strip() if isinstance(value, str) else ""
-        if (
-            text[:1] not in ("[", "{")
-            or text[-1:] not in ("]", "}")
-            or isinstance(_default_value_for_key(path), str)
-        ):
-            continue
+    expected_type = next(
+        (kind for kind in (dict, list)
+         if isinstance(default_schema, kind) or isinstance(extra_schema, kind)),
+        None,
+    )
+    if expected_type is None:
+        return
+
+    if isinstance(value, str):
+        text = value.strip()
+        if text[:1] not in ("[", "{") or text[-1:] not in ("]", "}"):
+            return
         try:
             parsed = yaml.safe_load(text)
         except yaml.YAMLError:
-            continue
+            return
         if not isinstance(parsed, (list, dict)):
-            continue
-        kind = "list" if isinstance(parsed, list) else "mapping"
+            return
+        kind = "list" if expected_type is list else "mapping"
         _issue(
             issues,
             "warning",
-            f"{path} is a quoted string that looks like a {kind} — Hermes expects a real YAML "
+            f"{path} is a quoted string that looks like a container — Hermes expects a real YAML "
             f"{kind} here and ignores the string",
             f"Re-run: hermes config set {path} '<value>' (stored as a real {kind}), or rewrite "
             f"it in config.yaml using YAML {kind} syntax",
         )
+        return
+
+    if isinstance(value, dict) and expected_type is dict:
+        for key, child in value.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            _validate_stringified_containers(
+                child,
+                issues,
+                child_path,
+                _container_schema_child(default_schema, key),
+                _container_schema_child(extra_schema, key),
+            )
+    elif isinstance(value, list) and expected_type is list:
+        for index, child in enumerate(value):
+            _validate_stringified_containers(
+                child,
+                issues,
+                f"{path}[{index}]",
+                _container_schema_child(default_schema, index),
+                _container_schema_child(extra_schema, index),
+            )
 
 
 def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1217,9 +1217,24 @@ def _validate_web_backends(config: Dict[str, Any], issues: List[ConfigIssue]) ->
 
 
 _MISSING_CONTAINER_SCHEMA = object()
+_MODEL_OVERRIDE_FIELDS_SCHEMA = {
+    "context_window": 0,
+    "max_output_tokens": 0,
+    "supports_tools": False,
+    "supports_vision": False,
+    "supports_reasoning": False,
+    "model_family": "",
+}
 _EXTRA_CONTAINER_SCHEMA = {
     "custom_providers": [{"extra_body": {}, "extra_headers": {}}],
     "model_catalog": {"excluded_providers": []},
+    "model_overrides": {
+        "_default": _MODEL_OVERRIDE_FIELDS_SCHEMA,
+        "*": {
+            "_default": _MODEL_OVERRIDE_FIELDS_SCHEMA,
+            "*": _MODEL_OVERRIDE_FIELDS_SCHEMA,
+        },
+    },
     "plugins": {"enabled": [], "disabled": []},
     "providers": {"*": {"extra_body": {}, "extra_headers": {}}},
 }
@@ -1239,12 +1254,15 @@ def _validate_stringified_containers(
     path: str = "",
     default_schema: Any = DEFAULT_CONFIG,
     extra_schema: Any = _EXTRA_CONTAINER_SCHEMA,
+    set_path: Optional[str] = None,
 ) -> None:
     """Flag list/mapping settings stored as one quoted string.
 
     Readers that require a container silently ignore these strings. Schema-declared strings remain
     valid even when their contents use brackets or braces.
     """
+    if set_path is None:
+        set_path = path
     expected_type = next(
         (kind for kind in (dict, list)
          if isinstance(default_schema, kind) or isinstance(extra_schema, kind)),
@@ -1269,7 +1287,7 @@ def _validate_stringified_containers(
             "warning",
             f"{path} is a quoted string that looks like a container — Hermes expects a real YAML "
             f"{kind} here and ignores the string",
-            f"Re-run: hermes config set {path} '<value>' (stored as a real {kind}), or rewrite "
+            f"Re-run: hermes config set {set_path} '<value>' (stored as a real {kind}), or rewrite "
             f"it in config.yaml using YAML {kind} syntax",
         )
         return
@@ -1283,6 +1301,7 @@ def _validate_stringified_containers(
                 child_path,
                 _container_schema_child(default_schema, key),
                 _container_schema_child(extra_schema, key),
+                f"{set_path}.{key}" if set_path else str(key),
             )
     elif isinstance(value, list) and expected_type is list:
         for index, child in enumerate(value):
@@ -1292,6 +1311,7 @@ def _validate_stringified_containers(
                 f"{path}[{index}]",
                 _container_schema_child(default_schema, index),
                 _container_schema_child(extra_schema, index),
+                f"{set_path}.{index}" if set_path else str(index),
             )
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1227,6 +1227,7 @@ _MODEL_OVERRIDE_FIELDS_SCHEMA = {
 }
 _EXTRA_CONTAINER_SCHEMA = {
     "custom_providers": [{"extra_body": {}, "extra_headers": {}}],
+    "mcp_servers": {},
     "model_catalog": {"excluded_providers": []},
     "model_overrides": {
         "_default": _MODEL_OVERRIDE_FIELDS_SCHEMA,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1236,7 +1236,7 @@ _MODEL_OVERRIDE_FIELDS_SCHEMA = {
 }
 _EXTRA_CONTAINER_SCHEMA = {
     **{key: {} for key in _PLATFORM_CONFIG_ROOT_KEYS},
-    "custom_providers": [{"extra_body": {}, "extra_headers": {}}],
+    "custom_providers": [{"models": [], "extra_body": {}, "extra_headers": {}}],
     "mcp_servers": {
         "*": {
             "args": [],

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1068,6 +1068,15 @@ def check_config_version(*, raise_on_parse_error: bool = False) -> Tuple[int, in
 
 # ---- Config structure validation ----
 
+
+# Platform roots are open mappings even when an unused platform is omitted from DEFAULT_CONFIG.
+# Config-key validation and container-shape validation must share this list.
+_PLATFORM_CONFIG_ROOT_KEYS = frozenset({
+    "discord", "telegram", "slack", "whatsapp", "signal", "mattermost",
+    "matrix", "feishu", "wecom", "weixin", "bluebubbles", "qqbot", "yuanbao",
+    "email", "sms", "dingtalk",
+})
+
 # DEFAULT_CONFIG is the single source of truth for documented roots; the set is derived so new
 # defaults are accepted automatically. These optional/legacy roots are valid on disk but
 # intentionally absent from DEFAULT_CONFIG (omitted when unused / alternate schema forms).
@@ -1226,8 +1235,21 @@ _MODEL_OVERRIDE_FIELDS_SCHEMA = {
     "model_family": "",
 }
 _EXTRA_CONTAINER_SCHEMA = {
+    **{key: {} for key in _PLATFORM_CONFIG_ROOT_KEYS},
     "custom_providers": [{"extra_body": {}, "extra_headers": {}}],
-    "mcp_servers": {},
+    "mcp_servers": {
+        "*": {
+            "args": [],
+            "client_cert": [],
+            "env": {},
+            "headers": {},
+            "identity_header": {},
+            "tools": {"include": [], "exclude": []},
+            "sampling": {"allowed_models": []},
+            "elicitation": {},
+            "lifecycle": {},
+        },
+    },
     "model_catalog": {"excluded_providers": []},
     "model_overrides": {
         "_default": _MODEL_OVERRIDE_FIELDS_SCHEMA,
@@ -3296,14 +3318,11 @@ _OPEN_DICT_TOP_LEVEL_KEYS = frozenset({
 # Top-level keys whose sub-keys are partially schema-defined (e.g. a PlatformConfig dataclass) but
 # where users may add fields DEFAULT_CONFIG doesn't enumerate: validate the FIRST segment only.
 _SCHEMA_DEFINED_DICT_KEYS = frozenset({
-    # Platform configs — PlatformConfig dataclass + dynamic extras
-    "discord", "telegram", "slack", "whatsapp", "signal", "mattermost",
-    "matrix", "feishu", "wecom", "weixin", "bluebubbles", "qqbot", "yuanbao",
-    "email", "sms", "dingtalk",
     # MCP server template / dynamic auth dicts
     "sessions", "checkpoints",
     # Plugin enable/disable lists + index_url override; absent from DEFAULT_CONFIG.
-    "plugins"})
+    "plugins",
+}) | _PLATFORM_CONFIG_ROOT_KEYS
 
 # Top-level keys that can be ANY user-supplied name.
 _DYNAMIC_TOP_LEVEL_KEYS = frozenset({

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -5,6 +5,7 @@ from hermes_cli.config import (
     DEFAULT_CONFIG,
     _EXTRA_KNOWN_ROOT_KEYS,
     _KNOWN_ROOT_KEYS,
+    _set_nested,
     validate_config_structure,
     ConfigIssue,
 )
@@ -153,30 +154,65 @@ class TestStringifiedContainers:
     def test_container_typed_values_stored_as_strings_are_reported(self):
         cases = (
             ({"model_catalog": {"excluded_providers": '["openai-api", "copilot"]'}},
-             "model_catalog.excluded_providers", "list"),
+             "model_catalog.excluded_providers", "model_catalog.excluded_providers", "list"),
             ({"plugins": {"enabled": "['state', 'status']"}},
-             "plugins.enabled", "list"),
+             "plugins.enabled", "plugins.enabled", "list"),
             ({"model_overrides": '{"custom": {"model": {"supports_tools": false}}}'},
-             "model_overrides", "mapping"),
+             "model_overrides", "model_overrides", "mapping"),
             ({"custom_providers": [{
                 "name": "local",
                 "base_url": "http://localhost:8000/v1",
                 "extra_body": "{temperature: 0}",
-             }]}, "custom_providers[0].extra_body", "mapping"),
+             }]}, "custom_providers[0].extra_body", "custom_providers.0.extra_body", "mapping"),
             ({"custom_providers": [{
                 "name": "local",
                 "base_url": "http://localhost:8000/v1",
                 "extra_headers": "{X-Service-Token: secret}",
-             }]}, "custom_providers[0].extra_headers", "mapping"),
+             }]}, "custom_providers[0].extra_headers", "custom_providers.0.extra_headers", "mapping"),
         )
 
-        for config, path, kind in cases:
+        for config, display_path, set_path, kind in cases:
             issues = self._quoted_string_issues(config)
             assert len(issues) == 1
             assert issues[0].severity == "warning"
-            assert path in issues[0].message
+            assert display_path in issues[0].message
             assert kind in issues[0].message
-            assert f"hermes config set {path}" in issues[0].hint
+            assert f"hermes config set {set_path}" in issues[0].hint
+
+    def test_indexed_repair_hint_targets_the_list_member(self):
+        config = {"custom_providers": [{"extra_body": "{temperature: 0}"}]}
+        issue = self._quoted_string_issues(config)[0]
+        set_path = issue.hint.split("hermes config set ", 1)[1].split(" ", 1)[0]
+
+        _set_nested(config, set_path, {"temperature": 0})
+
+        assert config["custom_providers"][0]["extra_body"] == {"temperature": 0}
+        assert "custom_providers[0]" not in config
+
+    def test_dynamic_model_override_containers_are_reported(self):
+        cases = (
+            ({"model_overrides": {"openai": '{gpt-5: {supports_tools: false}}'}},
+             "model_overrides.openai"),
+            ({"model_overrides": {"openai": {"gpt-5": "{supports_tools: false}"}}},
+             "model_overrides.openai.gpt-5"),
+            ({"model_overrides": {"_default": "{supports_tools: false}"}},
+             "model_overrides._default"),
+        )
+
+        for config, path in cases:
+            issues = self._quoted_string_issues(config)
+            assert len(issues) == 1
+            assert path in issues[0].message
+
+    def test_bracket_like_model_family_string_is_not_reported(self):
+        config = {
+            "model_overrides": {
+                "openai": {"gpt-5": {"model_family": "[reasoning]"}},
+                "_default": {"model_family": "{unknown}"},
+            },
+        }
+
+        assert self._quoted_string_issues(config) == []
 
     def test_legitimate_strings_and_real_containers_are_not_reported(self):
         config = {

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -158,6 +158,16 @@ class TestStringifiedContainers:
              "plugins.enabled", "list"),
             ({"model_overrides": '{"custom": {"model": {"supports_tools": false}}}'},
              "model_overrides", "mapping"),
+            ({"custom_providers": [{
+                "name": "local",
+                "base_url": "http://localhost:8000/v1",
+                "extra_body": "{temperature: 0}",
+             }]}, "custom_providers[0].extra_body", "mapping"),
+            ({"custom_providers": [{
+                "name": "local",
+                "base_url": "http://localhost:8000/v1",
+                "extra_headers": "{X-Service-Token: secret}",
+             }]}, "custom_providers[0].extra_headers", "mapping"),
         )
 
         for config, path, kind in cases:
@@ -172,8 +182,9 @@ class TestStringifiedContainers:
         config = {
             "approvals": {"mode": "[off]"},
             "model_catalog": {"excluded_providers": ["openai-api"]},
-            "plugins": {"enabled": ["state"]},
+            "plugins": {"enabled": ["state", "[literal-plugin-name]"]},
             "custom_note": "[INST] not a list",
+            "MY_APP_SETTING": '["foo"]',
         }
 
         assert self._quoted_string_issues(config) == []

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -141,3 +141,40 @@ class TestUnknownTopLevelKeys:
         assert any("base_url" in i.message for i in misplaced)
         assert any("api_key" in i.message for i in misplaced)
 
+
+class TestStringifiedContainers:
+    @staticmethod
+    def _quoted_string_issues(config):
+        return [
+            issue for issue in validate_config_structure(config)
+            if "quoted string" in issue.message
+        ]
+
+    def test_container_typed_values_stored_as_strings_are_reported(self):
+        cases = (
+            ({"model_catalog": {"excluded_providers": '["openai-api", "copilot"]'}},
+             "model_catalog.excluded_providers", "list"),
+            ({"plugins": {"enabled": "['state', 'status']"}},
+             "plugins.enabled", "list"),
+            ({"model_overrides": '{"custom": {"model": {"supports_tools": false}}}'},
+             "model_overrides", "mapping"),
+        )
+
+        for config, path, kind in cases:
+            issues = self._quoted_string_issues(config)
+            assert len(issues) == 1
+            assert issues[0].severity == "warning"
+            assert path in issues[0].message
+            assert kind in issues[0].message
+            assert f"hermes config set {path}" in issues[0].hint
+
+    def test_legitimate_strings_and_real_containers_are_not_reported(self):
+        config = {
+            "approvals": {"mode": "[off]"},
+            "model_catalog": {"excluded_providers": ["openai-api"]},
+            "plugins": {"enabled": ["state"]},
+            "custom_note": "[INST] not a list",
+        }
+
+        assert self._quoted_string_issues(config) == []
+

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -174,6 +174,11 @@ class TestStringifiedContainers:
             ({"custom_providers": [{
                 "name": "local",
                 "base_url": "http://localhost:8000/v1",
+                "models": '["qwen"]',
+             }]}, "custom_providers[0].models", "custom_providers.0.models", "list"),
+            ({"custom_providers": [{
+                "name": "local",
+                "base_url": "http://localhost:8000/v1",
                 "extra_body": "{temperature: 0}",
              }]}, "custom_providers[0].extra_body", "custom_providers.0.extra_body", "mapping"),
             ({"custom_providers": [{

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -155,6 +155,16 @@ class TestStringifiedContainers:
         cases = (
             ({"mcp_servers": "{demo: {command: python, args: [server.py]}}"},
              "mcp_servers", "mcp_servers", "mapping"),
+            ({"signal": "{enabled: true, require_mention: false}"},
+             "signal", "signal", "mapping"),
+            ({"mcp_servers": {"demo": {"args": "[server.py]"}}},
+             "mcp_servers.demo.args", "mcp_servers.demo.args", "list"),
+            ({"mcp_servers": {"demo": {"env": "{TOKEN: abc}"}}},
+             "mcp_servers.demo.env", "mcp_servers.demo.env", "mapping"),
+            ({"mcp_servers": {"demo": {"headers": "{Authorization: Bearer token}"}}},
+             "mcp_servers.demo.headers", "mcp_servers.demo.headers", "mapping"),
+            ({"mcp_servers": {"demo": {"identity_header": "{name: X-User, value: alice}"}}},
+             "mcp_servers.demo.identity_header", "mcp_servers.demo.identity_header", "mapping"),
             ({"model_catalog": {"excluded_providers": '["openai-api", "copilot"]'}},
              "model_catalog.excluded_providers", "model_catalog.excluded_providers", "list"),
             ({"plugins": {"enabled": "['state', 'status']"}},
@@ -219,7 +229,14 @@ class TestStringifiedContainers:
     def test_legitimate_strings_and_real_containers_are_not_reported(self):
         config = {
             "approvals": {"mode": "[off]"},
-            "mcp_servers": {"demo": {"command": "python", "args": ["server.py"]}},
+            "mcp_servers": {"demo": {
+                "command": "python",
+                "args": ["server.py"],
+                "env": {"TOKEN": "abc"},
+                "headers": {"Authorization": "Bearer token"},
+                "identity_header": {"name": "X-User", "value": "alice"},
+            }},
+            "signal": {"enabled": True, "require_mention": False},
             "model_catalog": {"excluded_providers": ["openai-api"]},
             "plugins": {"enabled": ["state", "[literal-plugin-name]"]},
             "custom_note": "[INST] not a list",

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -153,6 +153,8 @@ class TestStringifiedContainers:
 
     def test_container_typed_values_stored_as_strings_are_reported(self):
         cases = (
+            ({"mcp_servers": "{demo: {command: python, args: [server.py]}}"},
+             "mcp_servers", "mcp_servers", "mapping"),
             ({"model_catalog": {"excluded_providers": '["openai-api", "copilot"]'}},
              "model_catalog.excluded_providers", "model_catalog.excluded_providers", "list"),
             ({"plugins": {"enabled": "['state', 'status']"}},
@@ -217,6 +219,7 @@ class TestStringifiedContainers:
     def test_legitimate_strings_and_real_containers_are_not_reported(self):
         config = {
             "approvals": {"mode": "[off]"},
+            "mcp_servers": {"demo": {"command": "python", "args": ["server.py"]}},
             "model_catalog": {"excluded_providers": ["openai-api"]},
             "plugins": {"enabled": ["state", "[literal-plugin-name]"]},
             "custom_note": "[INST] not a list",


### PR DESCRIPTION
## What does this PR do?

Hermes now warns when a list or mapping setting was stored as one quoted string, instead of silently ignoring the setting and falling back to defaults. The shared config-structure validator reports the dotted key and a repair command while preserving schema-declared string values.

### Symptom

Quoted container values such as `model_catalog.excluded_providers: '["openai-api"]'` and `plugins.enabled: "['state']"` load without a config warning, but their readers reject the resulting string.

### Impact

Affected settings look saved but do not take effect. Users can unknowingly retain providers they intended to exclude or fail to enable selected plugins.

### Bug Cause

**Trigger:** `hermes_cli/config.py:1256` / `validate_config_structure`

**Causal chain:**
1. A stale or hand-edited `config.yaml` stores list or mapping syntax inside a quoted YAML scalar.
2. YAML loading returns a string, and the shared structure validator does not inspect nested scalar types.
3. Readers guarded by `isinstance(value, list)` reject the string and silently use an empty or missing default.

**Why it is wrong:** The configuration remains valid YAML, so parse checks pass even though the runtime cannot consume the stored type.

**Working sibling / contrast:** `hermes config set` already parses structured literals and exempts keys whose default is a string; this change applies the same schema-aware distinction to validation.

**Ruled out:** Per-reader normalization would leave other container settings vulnerable to the same silent fallback and would change read semantics rather than diagnose malformed stored data.

### Fix

Recursively inspect mapping leaves during structure validation. When a string has bracketed list or mapping syntax, parses to a container, and is not a schema-declared string, emit a warning that names the key and explains how to rewrite it. Regression tests cover JSON arrays, Python-style list representations, mappings, real containers, ordinary strings, and declared string keys.

## Related Issue

Closes #105706

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` - detect quoted list and mapping values in the shared structure validator.
- `tests/hermes_cli/test_config_validation.py` - cover malformed container strings and legitimate controls.

## How to Test

1. Store `model_catalog.excluded_providers` or `plugins.enabled` as a quoted list in `config.yaml` and run `hermes doctor`.
2. Confirm the Config Structure section names the malformed key and suggests `hermes config set`.
3. Run the focused regression suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_config_validation.py
```

Result: 13 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; the warning and repair hint are self-contained
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config key changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - platform-independent parsing only
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A; automated regression coverage exercises the validator behavior.
