### PR TITLE
fix(desktop): stop transcript text bleeding through task cards (salvage #69069)

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $threadScrolledUp, resetThreadScroll } from '@/store/thread-scroll'
+
+import { ComposerStatusStack } from './index'
+
+class TestResizeObserver {
+  disconnect() {}
+  observe() {}
+  unobserve() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+describe('ComposerStatusStack scroll treatment', () => {
+  beforeEach(() => {
+    $threadScrolledUp.set(true)
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetThreadScroll()
+  })
+
+  it('dims only the status content while keeping the dock card opaque', () => {
+    const view = render(
+      <MemoryRouter>
+        <I18nProvider configClient={null} initialLocale="en">
+          <ComposerStatusStack queue={<div>Queued task</div>} sessionId={null} />
+        </I18nProvider>
+      </MemoryRouter>
+    )
+
+    const card = view.container.querySelector<HTMLElement>('[class*="bg-(--composer-fill)"]')
+    const dimmedContent = screen.getByText('Queued task').closest<HTMLElement>('.opacity-30')
+
+    expect(card).not.toBeNull()
+    expect(card?.classList.contains('opacity-30')).toBe(false)
+    expect(dimmedContent).not.toBeNull()
+    expect(dimmedContent).not.toBe(card)
+    expect(card?.contains(dimmedContent)).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/index.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -301,14 +301,19 @@ export function ComposerStatusStack({ onSubmit, queue, sessionId }: ComposerStat
             composerDockCard('top'),
             // Inset (mx-2) so the stack reads slightly narrower than the composer
             // surface below it — the original look.
-            'mx-2 overflow-hidden rounded-b-none border-b border-b-transparent pt-0.5',
-            'transition-opacity duration-200 ease-out',
-            scrolledUp ? 'opacity-30 group-hover/composer:opacity-100' : 'opacity-100'
+            'mx-2 overflow-hidden rounded-b-none border-b border-b-transparent pt-0.5'
           )}
         >
-          {sections.map(section => (
-            <div key={section.key}>{section.node}</div>
-          ))}
+          <div
+            className={cn(
+              'transition-opacity duration-200 ease-out',
+              scrolledUp ? 'opacity-30 group-hover/composer:opacity-100' : 'opacity-100'
+            )}
+          >
+            {sections.map(section => (
+              <div key={section.key}>{section.node}</div>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/contributors/emails/153183032+lesterlxt@users.noreply.github.com
+++ b/contributors/emails/153183032+lesterlxt@users.noreply.github.com
@@ -1,0 +1,2 @@
+lesterlxt
+# PR #69069 salvage


### PR DESCRIPTION
Desktop subagent/task cards no longer let transcript text show through when scrolling up.

## Changes
- Preserve the status card's shared fill and blur at full opacity; apply the existing scroll dimming and hover recovery only to an inner content wrapper.
- Retain the current in-flow dock, height cap, non-shrinking card, and session-scoped status groups.
- Salvage @lesterlxt's fix from #69069 with original commit authorship; adapt its regression test to the current `react-router` import and add contributor attribution.

Root cause: `opacity-30` was applied to the element painting `--composer-fill`, compositing its background and task text at 30% opacity over the transcript.

## Validation
**Live repro:** Current `origin/main` (`866332bfb52`) reproduced transcript/task text collision in native Linux Electron with the production `ComposerStatusStack`, stores and stylesheet. The same scroll/hover interactions with this fix remove the bleed-through.

| Check | Before | After |
| --- | --- | --- |
| Scroll up with four expanded subagents | Card opacity `0.3`; transcript visibly collides with tasks | Card opacity `1`; inner content `0.3`; transcript occluded |
| Hover status card | Whole card returns to `1` | Content returns to `1`; surface remains `1` |
| At transcript bottom | Card `1` | Card `1` |
| Narrow/short viewport, 540×360 | Card `0.3` | Card `1` |
| Regression test | Fails on main at opacity boundary | Passes |
| Desktop UI suite | — | 747 files / 7,342 tests passed |
| Desktop typecheck and lint | — | Passed |
| Windows footgun / compatibility-pointer checks / diff whitespace | — | Passed |

Fidelity: an isolated native Electron window rendering the actual production component and CSS with synthetic task state, driven through real wheel, expand, hover, resize and input interactions. This is renderer-level live QA, not a full-shell/backend or real-model delegation run. Screenshots were visually inspected before and after. No credentials or inference were used. The test preserves scroll dimming rather than removing it.

Related: #69069, #69027. No merge or automatic issue closure is requested by this PR.

## Infographic
![Desktop task cards remain opaque while their content dims](https://v3b.fal.media/files/b/0aa9960e/C57BGJOF8DlB_XmcsF_Le_j8prv0Vl.png)
