### PR TITLE
fix: clarify kanban operator review changes

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -982,6 +982,8 @@ def _cmd_request_changes(args: argparse.Namespace) -> int:
     with kbc.connect_closing() as conn:
         ok, detail = kb.request_changes(conn, tid, reason=reason, expected_run_id=_worker_run_id_for(tid))
         if not ok:
+            if detail == "task is not in an active review run":
+                detail += "; operator/manual review changes use reopen-review"
             return _err(f"cannot request changes for {tid}: {detail or 'invalid review state'}")
         print(f"Requested changes for {tid}" + (f"; routed to {detail}" if detail else ""))
     return 0
@@ -1264,7 +1266,7 @@ Common subcommands:
   `comment <id> <msg>`  Append a comment
   `attach <id> <path>`  Attach a local file; `attachments <id>` to list
   `complete <id>…`      Mark task(s) done
-  `request-review <id>` Enter first-class review; `request-changes <id> <reason>` returns an active review to its implementer
+  `request-review <id>` Enter first-class review; `request-changes <id> <reason>` returns an active reviewer run; `reopen-review <id>` handles operator changes
   `block <id> [reason]` Mark blocked; `schedule <id> [reason]` parks time-delay work; `unblock <id>` to revive
   `assign <id> <profile>`  Reassign
   `boards list`         Show all boards

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -319,7 +319,7 @@ _SPECS = [
                   "task to review even without owning its run (clears the worker's claim)."),
     ], help="Move a task to 'review' (implementation done, awaiting review) — NOT a block"),
     _cmd("request-changes", [_TASK_ID, _arg("reason", nargs="+", help="Concrete changes required before re-review")],
-         help="Reviewer verdict: return the active review run to its implementer"),
+         help="Reviewer verdict: return the active review run to its implementer; operators use reopen-review"),
     _cmd("reopen-review", [
         _TASK_IDS,
         _reason("Optional reason/note — recorded as a comment before reopening. Quote multi-word reasons."),

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -254,6 +254,32 @@ def test_worker_guidance_distinguishes_same_card_and_downstream_review() -> None
     assert "escalate" in skill_text.lower()
 
 
+def test_cli_request_changes_without_active_review_points_operator_to_reopen_review(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="manual review", assignee="builder")
+        assert kb.request_review(conn, task_id, summary="ready for operator")
+
+    output = kc.run_slash(f"request-changes {task_id} 'needs more tests'")
+
+    assert "cannot request changes" in output
+    assert "reopen-review" in output
+    with kbc.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "review"
+        assert task.assignee == "builder"
+
+
 def test_cli_reopen_review_is_transition_first_and_redacts_reason(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- keep `request-changes` scoped to active reviewer-owned runs
- point operator/manual review changes to `reopen-review` in CLI error/help text
- add regression coverage for the non-mutating refusal path

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_review_surfaces.py tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py tests/agent/test_kanban_stop.py -q --tb=short` => 18 passed, 1 skipped
- live temp-HOME CLI smoke: request-review -> request-changes refusal with reopen-review guidance -> reopen-review -> ready
- independent delegate review passed with no security concerns or logic errors

## Local evidence
- /home/hl-metabase/.hermes/upstream_audit/current-20260908/source_change_receipt.json
- /home/hl-metabase/.hermes/cache/delegation/live/deleg_e9c5da13/task-0.log