### PR TITLE
fix(gateway): only count own-UID processes in the /proc scan (#105719)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -544,8 +544,14 @@ def _append_unique_pid(pids: list[int], pid: int | None, exclude_pids: set[int])
 
 
 def _iter_proc_cmdlines(exclude_pids: set[int]):
-    """Yield ``(pid, cmdline)`` from ``/proc`` (Docker without procps); raises if /proc is unusable."""
+    """Yield ``(pid, cmdline)`` from ``/proc`` (Docker without procps); raises if /proc is unusable.
+
+    Only processes owned by the current user: on a shared host every seat runs its own
+    gateway, and a sibling's ``HERMES_HOME`` rides the systemd unit environment where
+    argv inspection can never see it — so ownership is the only reliable identity.
+    """
     my_pid = os.getpid()
+    my_uid = os.getuid()
     for entry in os.listdir("/proc"):
         if not entry.isdigit():
             continue
@@ -553,6 +559,8 @@ def _iter_proc_cmdlines(exclude_pids: set[int]):
         if pid == my_pid or pid in exclude_pids:
             continue
         try:
+            if os.stat(f"/proc/{pid}").st_uid != my_uid:
+                continue
             with open(f"/proc/{pid}/cmdline", "rb") as _f:
                 cmdline = _f.read().decode("utf-8", errors="replace")
         except (OSError, PermissionError):

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -551,7 +551,7 @@ def _iter_proc_cmdlines(exclude_pids: set[int]):
     argv inspection can never see it — so ownership is the only reliable identity.
     """
     my_pid = os.getpid()
-    my_uid = os.getuid()
+    my_uid = os.getuid() if hasattr(os, "getuid") else None
     for entry in os.listdir("/proc"):
         if not entry.isdigit():
             continue
@@ -559,7 +559,7 @@ def _iter_proc_cmdlines(exclude_pids: set[int]):
         if pid == my_pid or pid in exclude_pids:
             continue
         try:
-            if os.stat(f"/proc/{pid}").st_uid != my_uid:
+            if my_uid is not None and os.stat(f"/proc/{pid}").st_uid != my_uid:
                 continue
             with open(f"/proc/{pid}/cmdline", "rb") as _f:
                 cmdline = _f.read().decode("utf-8", errors="replace")

--- a/tests/hermes_cli/test_gateway_proc_fallback.py
+++ b/tests/hermes_cli/test_gateway_proc_fallback.py
@@ -24,7 +24,16 @@ _OTHER_CMD = "python -m some_other_thing"
 
 def _fake_proc_dir(entries: dict):
     """Return side_effects that simulate /proc: isdir → True, listdir → pids,
-    open(cmdline) → null-delimited command bytes."""
+    open(cmdline) → null-delimited command bytes.
+
+    Every simulated process is owned by the current UID (the ownership filter in
+    ``_iter_proc_cmdlines`` lets these through); foreign-owner cases are covered by
+    ``TestProcOwnership`` below. Paths outside /proc fall through to the real os.stat
+    so unrelated callers (e.g. ``get_hermes_home().resolve()``) keep working.
+    """
+    my_uid = os.getuid()
+    real_stat = os.stat
+
     def _isdir(path):
         return str(path) == "/proc"
 
@@ -32,6 +41,14 @@ def _fake_proc_dir(entries: dict):
         if str(path) == "/proc":
             return [str(pid) for pid in entries] + ["self", "version"]
         raise FileNotFoundError(path)
+
+    def _stat(path, **kwargs):
+        path_str = str(path)
+        if path_str.startswith("/proc/"):
+            st = MagicMock()
+            st.st_uid = my_uid
+            return st
+        return real_stat(path, **kwargs)
 
     def _open(path, mode="r", **kwargs):
         path_str = str(path)
@@ -45,7 +62,7 @@ def _fake_proc_dir(entries: dict):
             return m
         raise FileNotFoundError(path)
 
-    return _isdir, _listdir, _open
+    return _isdir, _listdir, _stat, _open
 
 
 # ---------------------------------------------------------------------------
@@ -70,11 +87,12 @@ class TestProcFallback:
             12345: _GATEWAY_CMD,
             99999: _OTHER_CMD,
         }
-        _isdir, _listdir, _open = _fake_proc_dir(entries)
+        _isdir, _listdir, _stat, _open = _fake_proc_dir(entries)
 
         with (
             patch("os.path.isdir", side_effect=_isdir),
             patch("os.listdir", side_effect=_listdir),
+            patch("os.stat", side_effect=_stat),
             patch("builtins.open", side_effect=_open),
             patch("hermes_cli.gateway._get_ancestor_pids", return_value=set()),
             patch("subprocess.run") as mock_ps,
@@ -97,12 +115,18 @@ class TestProcFallback:
                 return ["12345", "self"]
             raise FileNotFoundError
 
+        def _stat(path):
+            st = MagicMock()
+            st.st_uid = os.getuid()
+            return st
+
         def _open(path, mode="r", **kwargs):
             raise PermissionError("no access")
 
         with (
             patch("os.path.isdir", side_effect=_isdir),
             patch("os.listdir", side_effect=_listdir),
+            patch("os.stat", side_effect=_stat),
             patch("builtins.open", side_effect=_open),
             patch("hermes_cli.gateway._get_ancestor_pids", return_value=set()),
             patch("subprocess.run") as mock_ps,
@@ -112,6 +136,111 @@ class TestProcFallback:
         # PermissionError swallowed — empty result, no crash
         assert 12345 not in pids
         mock_ps.assert_not_called()  # /proc dir existed, so ps not called
+
+
+@pytest.mark.linux_only
+class TestProcOwnership:
+    """The /proc arm must only count processes owned by the current user (#105719).
+
+    On a multi-user host each seat runs its own gateway with ``HERMES_HOME`` passed
+    through the systemd unit environment — invisible in argv — so the profile matcher
+    cannot tell seats apart by command line. Ownership of ``/proc/<pid>`` is the
+    only signal a sibling seat cannot fake.
+    """
+
+    def test_foreign_uid_gateway_not_counted(self):
+        """A gateway process owned by another user is never this seat's gateway."""
+        my_pid = os.getpid()
+        my_uid = os.getuid()
+        entries = {
+            my_pid: "python -m hermes_cli.main",
+            12345: _GATEWAY_CMD,  # another user's seat
+            67890: _GATEWAY_CMD,  # this user's own gateway
+        }
+
+        def _isdir(path):
+            return str(path) == "/proc"
+
+        def _listdir(path):
+            if str(path) == "/proc":
+                return [str(pid) for pid in entries] + ["self", "version"]
+            raise FileNotFoundError(path)
+
+        def _stat(path, **kwargs):
+            path_str = str(path)
+            if path_str.startswith("/proc/"):
+                pid = int(path_str.split("/proc/")[1])
+                st = MagicMock()
+                st.st_uid = my_uid if pid == 67890 else my_uid + 1000
+                return st
+            return real_stat(path, **kwargs)
+
+        real_stat = os.stat
+
+        def _open(path, mode="r", **kwargs):
+            path_str = str(path)
+            if "/cmdline" in path_str:
+                pid = int(path_str.split("/proc/")[1].split("/")[0])
+                raw = entries.get(pid, "").encode("utf-8").replace(b" ", b"\x00")
+                m = MagicMock()
+                m.read.return_value = raw
+                m.__enter__ = lambda s: s
+                m.__exit__ = MagicMock(return_value=False)
+                return m
+            raise FileNotFoundError(path)
+
+        with (
+            patch("os.path.isdir", side_effect=_isdir),
+            patch("os.listdir", side_effect=_listdir),
+            patch("os.stat", side_effect=_stat),
+            patch("builtins.open", side_effect=_open),
+            patch("hermes_cli.gateway._get_ancestor_pids", return_value=set()),
+            patch("subprocess.run") as mock_ps,
+        ):
+            pids = gateway_mod._scan_gateway_pids(set(), all_profiles=True)
+
+        assert 67890 in pids
+        assert 12345 not in pids
+        mock_ps.assert_not_called()
+
+    def test_proc_stat_failure_skips_pid(self):
+        """An un-stat-able /proc entry is skipped, never crashes the scan."""
+        my_pid = os.getpid()
+        real_stat = os.stat
+
+        def _isdir(path):
+            return str(path) == "/proc"
+
+        def _listdir(path):
+            if str(path) == "/proc":
+                return [str(my_pid), "12345", "self"]
+            raise FileNotFoundError(path)
+
+        def _stat(path, **kwargs):
+            path_str = str(path)
+            if path_str.startswith("/proc/"):
+                raise FileNotFoundError(path)
+            return real_stat(path, **kwargs)
+
+        def _open(path, mode="r", **kwargs):
+            m = MagicMock()
+            m.read.return_value = _GATEWAY_CMD.encode("utf-8").replace(b" ", b"\x00")
+            m.__enter__ = lambda s: s
+            m.__exit__ = MagicMock(return_value=False)
+            return m
+
+        with (
+            patch("os.path.isdir", side_effect=_isdir),
+            patch("os.listdir", side_effect=_listdir),
+            patch("os.stat", side_effect=_stat),
+            patch("builtins.open", side_effect=_open),
+            patch("hermes_cli.gateway._get_ancestor_pids", return_value=set()),
+            patch("subprocess.run") as mock_ps,
+        ):
+            pids = gateway_mod._scan_gateway_pids(set(), all_profiles=True)
+
+        assert pids == []
+        mock_ps.assert_not_called()
 
 
 class TestPsFallbackBsdCompat:

--- a/tests/hermes_cli/test_gateway_proc_fallback.py
+++ b/tests/hermes_cli/test_gateway_proc_fallback.py
@@ -115,7 +115,7 @@ class TestProcFallback:
                 return ["12345", "self"]
             raise FileNotFoundError
 
-        def _stat(path):
+        def _stat(path, **kwargs):
             st = MagicMock()
             st.st_uid = os.getuid()
             return st


### PR DESCRIPTION
## What

`_iter_proc_cmdlines` — the `/proc` arm of `_scan_gateway_pids` — read `/proc/*/cmdline` with no owner check. On a multi-user host every seat runs its own gateway, and a sibling seat's `HERMES_HOME` rides the systemd unit environment where the argv-based profile matcher can never see it, so every `hermes_cli.main gateway run` on the box matched. A fresh seat with no gateway unit at all reported `Gateway Service: ✓ running` with other users' PIDs, and `_builtin_gateway_liveness` (`hermes_cli/cron.py`) gates its "gateway is not running — jobs won't fire automatically" warning on the same scan, so the false positive also silenced that warning.

## Fix

Filter the `/proc` scan to processes whose `/proc/<pid>` directory is owned by the current UID — fail-closed: a sibling seat's gateway is never ours, even when the kernel happens to permit reading its cmdline. The existing `PermissionError` skip stays as the second line of defense; a PID that vanishes between `listdir` and `stat` is skipped exactly as before.

## Tests

`TestProcOwnership` in `tests/hermes_cli/test_gateway_proc_fallback.py` (linux_only, like the rest of the /proc suite):

- a gateway process owned by another UID is ignored while this user's own gateway is still detected;
- an un-stat-able `/proc` entry is skipped without crashing the scan.

The pre-existing `_fake_proc_dir` helper now fakes `os.stat` for `/proc/<pid>` (same-UID) and falls through to the real `os.stat` elsewhere so unrelated callers (`get_hermes_home().resolve()`) keep working under the patch.

Fixes #105719