### PR TITLE
fix(auxiliary): authenticate pinned custom-provider aux routes with the matching entry credential

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4318,6 +4318,31 @@ def _named_custom_api_key(custom_entry: Dict[str, Any], provider: str, custom_ba
     return custom_key or "no-key-required"
 
 
+def _named_custom_key_for_base(custom_base: str) -> str:
+    """Named custom provider credential matching ``custom_base`` ("" when no entry matches).
+
+    A pinned aux route whose provider name degrades to ``custom`` (non-built-in name paired
+    with an explicit base_url) must still authenticate with that provider's configured
+    credential chain; falling straight through to the OPENAI_API_KEY / same-host-main ladder
+    sends a placeholder (or the main provider's key when the hosts happen to match) and the
+    pinned endpoint 401s. (#105721)
+    """
+    with contextlib.suppress(Exception):
+        from hermes_cli.runtime_provider import _get_named_custom_provider, find_custom_provider_identity
+        stripped = str(custom_base or "").rstrip("/")
+        # Entry URLs and aux pins may disagree on a trailing /v1; try both spellings.
+        for base in (stripped, stripped[: -3] if stripped.lower().endswith("/v1") else None):
+            if not base:
+                continue
+            identity = find_custom_provider_identity(base)
+            name = identity.split(":", 1)[1].strip() if identity and ":" in identity else (identity or "").strip()
+            entry = _get_named_custom_provider(name) if name else None
+            if entry is not None:
+                key = _named_custom_api_key(entry, name, base)
+                return "" if key == "no-key-required" else key
+    return ""
+
+
 def _build_bedrock_client(provider: str, model: Optional[str], *, raw_codex: bool) -> Tuple[Optional[Any], Optional[str]]:
     """AWS Bedrock: Claude → Anthropic Bedrock SDK (prompt caching, thinking); OpenAI models
     (GPT-5.5/5.6) → Bedrock Mantle's OpenAI Responses endpoint; everything else → Converse API."""
@@ -4546,6 +4571,7 @@ def _resolve_custom_branch(req: _ResolveRequest) -> _ResolveResult:
             wrap_base = (req.explicit_base_url or "").strip().rstrip("/")
         custom_key = (
             (req.explicit_api_key or "").strip()
+            or _named_custom_key_for_base(custom_base)
             or _scoped_key_env("OPENAI_API_KEY")
             or _read_main_api_key_if_same_host(custom_base)
             or "no-key-required"  # local servers don't need auth

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -1,6 +1,7 @@
 """Tests for named custom provider and 'main' alias resolution in auxiliary_client."""
 
 import json
+import os
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -441,3 +442,97 @@ class TestResolveProviderClientMainRuntimeCustom:
         assert model == "explicit-model"
         assert "explicit.example.com" in str(client.base_url)
         assert client.api_key == "sk-explicit"
+
+
+class TestPinnedVisionNamedCustomCredentials:
+    """A pinned auxiliary.vision route must authenticate with the named provider's credential.
+
+    The vision resolution path re-resolves the task config with an explicit provider +
+    base_url, which degrades a named custom provider to bare ``custom``; the custom branch
+    must then still use that provider's configured credential chain instead of falling
+    straight through to the OPENAI_API_KEY / same-host-main / placeholder ladder (#105721).
+    """
+
+    def test_pinned_provider_base_url_uses_entry_credential(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("HERMES_TEST_BEANS_KEY", "sentinel-beans-key")
+        _write_config(tmp_path, {
+            "model": {
+                "default": "main-flash",
+                "provider": "zai",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+            },
+            "auxiliary": {
+                "vision": {
+                    "provider": "beans",
+                    "model": "vision-model",
+                    "base_url": "http://beans.local/v1",
+                },
+            },
+            "custom_providers": [
+                {"name": "beans", "base_url": "http://beans.local/v1", "key_env": "HERMES_TEST_BEANS_KEY"},
+            ],
+        })
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        provider, client, model = resolve_vision_provider_client(
+            provider="beans", model="vision-model", base_url="http://beans.local/v1", api_key=None,
+        )
+
+        expected = os.environ["HERMES_TEST_BEANS_KEY"]
+        assert client is not None
+        assert "beans.local" in str(client.base_url)
+        assert client.api_key == expected
+
+    def test_pinned_provider_entry_url_without_v1_suffix(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("HERMES_TEST_BEANS_KEY", "sentinel-beans-key")
+        _write_config(tmp_path, {
+            "auxiliary": {
+                "vision": {
+                    "provider": "beans",
+                    "model": "vision-model",
+                    "base_url": "http://beans.local/v1",
+                },
+            },
+            "custom_providers": [
+                {"name": "beans", "base_url": "http://beans.local", "key_env": "HERMES_TEST_BEANS_KEY"},
+            ],
+        })
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        provider, client, model = resolve_vision_provider_client(
+            provider="beans", model="vision-model", base_url="http://beans.local/v1", api_key=None,
+        )
+
+        expected = os.environ["HERMES_TEST_BEANS_KEY"]
+        assert client is not None
+        assert "beans.local" in str(client.base_url)
+        assert client.api_key == expected
+
+    def test_no_matching_entry_keeps_placeholder_fallback(self, tmp_path, monkeypatch):
+        """No custom_providers entry for the pinned endpoint: the existing fallback ladder
+        (and its placeholder) stays unchanged — the fix only adds a resolution source."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        _write_config(tmp_path, {
+            "model": {
+                "default": "main-flash",
+                "provider": "zai",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+            },
+            "auxiliary": {
+                "vision": {
+                    "provider": "beans",
+                    "model": "vision-model",
+                    "base_url": "http://beans.local/v1",
+                },
+            },
+        })
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        provider, client, model = resolve_vision_provider_client(
+            provider="beans", model="vision-model", base_url="http://beans.local/v1", api_key=None,
+        )
+
+        assert client is not None
+        assert client.api_key == "no-key-required"


### PR DESCRIPTION
## What does this PR do?

When `auxiliary.vision` is pinned to a named custom provider with a `base_url` (and no inline `api_key`), the vision resolution path re-resolves the task config with an explicit provider + base_url. That second pass degrades a non-built-in provider name to bare `custom` (`_preserve_provider_with_base_url` only keeps first-class providers), so the request lands in the custom-branch credential ladder which never consults the named provider's configured credential chain (api_key / key_env / key_cmd / credential pool).

With no `OPENAI_API_KEY` in the environment and the main model on a different provider, the pinned endpoint authenticated with the `no-key-required` placeholder — and when the main model happened to sit on a provider whose host matched, it silently used the main provider's key. Either way the pinned provider 401'd, and success tracked whichever provider the main model was on (100% correlation across sessions and mid-session model switches in #105721).

This PR resolves the named custom provider entry by the explicit base_url (tolerating a trailing `/v1` spelling difference) before the OPENAI_API_KEY / same-host-main / placeholder fallbacks, so a pinned route always authenticates with that provider's own credential chain.

## Related Issue

Fixes #105721

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: added `_named_custom_key_for_base()`, which maps an explicit custom base_url back to its named custom provider entry (`find_custom_provider_identity`, both `/v1` spellings) and resolves the entry credential via the existing `_named_custom_api_key` chain; returns "" (no behavior change) when nothing matches or resolution fails.
- `agent/auxiliary_client.py`: inserted that lookup into `_resolve_custom_branch`'s credential ladder, between the explicit api_key and the `OPENAI_API_KEY` fallback.
- `tests/agent/test_auxiliary_named_custom_providers.py`: three regression tests — pinned vision route uses the entry credential (key_env form), the `/v1`-suffix spelling variant still matches, and an endpoint with no matching entry keeps the existing placeholder fallback.

## How to Test

1. Configure a main model on provider B (e.g. `zai`) and pin `auxiliary.vision` to a named custom provider A (`provider` + `base_url`, no aux-level `api_key`), with A's credential configured under `custom_providers` (inline `api_key`, `key_env`, or the credential pool).
2. Before this PR: `vision_analyze` sends the placeholder credential (or the main provider's key) to A and A rejects it with 401; success only when the main model is on A.
3. After this PR: `vision_analyze` authenticates with A's configured credential regardless of the main provider. Observed result: `resolve_vision_provider_client(provider=<A>, base_url=<A url>, api_key=None)` now returns a client whose `api_key` is A's entry credential (was `no-key-required`).
4. `pytest tests/agent/test_auxiliary_named_custom_providers.py -q` — 22 passed (plus the three new tests), `ruff check` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A