### PR TITLE
fix(security): block Windows Scheduled Task ops on the gateway task

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -58,6 +58,29 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # matching as "kill".
     r"|(?:\bp?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
     r"|(?:\bp?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
+    # Branch E: Windows Scheduled Task ops on a Hermes gateway task — the Windows analog of
+    # Branch B/C. `hermes_cli/gateway_windows.py` installs and supervises the gateway as a
+    # Scheduled Task named `Hermes_Gateway` / `Hermes_Gateway_<profile>` (`_TASK_NAME_DEFAULT`),
+    # so `schtasks /end /tn Hermes_Gateway_alice` and `Stop-ScheduledTask -TaskName
+    # Hermes_Gateway*` ARE the operation this pattern already blocks as `launchctl bootout
+    # ...ai.hermes.gateway` on macOS and `systemctl stop hermes-gateway` on Linux. Without this
+    # branch the identical intent is hard-blocked on macOS/Linux and silently allowed on Windows,
+    # leaving only the bypassable approval layer (tools/approval.py, skipped on force=True) —
+    # the same asymmetry #80260 closed for `bootout`/`remove`/`disable`.
+    # Both token orders are matched because the task name may precede or follow the op flag
+    # (`schtasks /tn Hermes_Gateway /end`), and the cmdlets accept the label from a pipeline
+    # (`Get-ScheduledTask -TaskName Hermes_Gateway* | Stop-ScheduledTask`).
+    # `/change` counts only with `/disable`, which is what makes a stop durable across boots —
+    # the schtasks analog of launchctl `disable`.
+    # `/run`, `/create` and `Get-ScheduledTask` are deliberately absent: starting is benign per
+    # Branch A and querying is read-only. The `hermes[_.\-]?gateway` anchor (underscore included
+    # for the Windows task-name spelling) keeps `schtasks /end /tn BackupJob` unblocked.
+    r"|(?:\bschtasks\b[^\n]*/(?:end|delete)\b[^\n]*\bhermes[_.\-]?gateway)"
+    r"|(?:\bschtasks\b[^\n]*\bhermes[_.\-]?gateway[^\n]*/(?:end|delete)\b)"
+    r"|(?:\bschtasks\b[^\n]*/change\b[^\n]*/disable\b[^\n]*\bhermes[_.\-]?gateway)"
+    r"|(?:\bschtasks\b[^\n]*\bhermes[_.\-]?gateway[^\n]*/change\b[^\n]*/disable\b)"
+    r"|(?:\b(?:stop|unregister|disable)-scheduledtask\b[^\n]*\bhermes[_.\-]?gateway)"
+    r"|(?:\bhermes[_.\-]?gateway[^\n]*\b(?:stop|unregister|disable)-scheduledtask\b)"
 )
 
 # Every branch uses `[^\n]*` between verb and label so matches cannot span unrelated lines. A POSIX

--- a/tests/cron/test_lifecycle_guard_windows_scheduled_task.py
+++ b/tests/cron/test_lifecycle_guard_windows_scheduled_task.py
@@ -1,0 +1,74 @@
+"""Windows Scheduled Task ops on the gateway task are gateway-lifecycle commands.
+
+``hermes_cli/gateway_windows.py`` installs and supervises the gateway as a
+Scheduled Task named ``Hermes_Gateway`` / ``Hermes_Gateway_<profile>``
+(``_TASK_NAME_DEFAULT``). Stopping or deleting that task is the same operation
+the guard already hard-blocks on the other two platforms:
+
+    macOS    launchctl bootout gui/501/ai.hermes.gateway   (Branch B)
+    Linux    systemctl stop hermes-gateway                 (Branch C)
+    Windows  schtasks /end /tn Hermes_Gateway_alice         (Branch E, here)
+
+Before Branch E the Windows forms returned False, so the identical intent was
+hard-blocked on macOS/Linux and silently allowed on Windows, leaving only the
+bypassable approval layer (``tools/approval.py``, skipped on ``force=True``) —
+the same asymmetry #80260 closed for ``bootout``/``remove``/``disable``.
+
+These are pure string-predicate tests: no Scheduled Task is created or touched,
+so they run identically on every host.
+"""
+
+import pytest
+
+from cron.lifecycle_guard import contains_gateway_lifecycle_command
+
+
+@pytest.mark.parametrize("command", [
+    # schtasks, op flag before the task name
+    "schtasks /end /tn Hermes_Gateway",
+    "schtasks /end /tn Hermes_Gateway_alice",
+    "schtasks /delete /tn Hermes_Gateway /f",
+    # ...and after it: flag order is not fixed on the command line
+    "schtasks /tn Hermes_Gateway_alice /end",
+    "schtasks /tn Hermes_Gateway /delete /f",
+    # `/change /disable` is what makes a stop durable across boots
+    "schtasks /change /disable /tn Hermes_Gateway",
+    "schtasks /tn Hermes_Gateway /change /disable",
+    # PowerShell cmdlets, label as an argument
+    "Stop-ScheduledTask -TaskName Hermes_Gateway_alice",
+    "Unregister-ScheduledTask -TaskName Hermes_Gateway -Confirm:$false",
+    "Disable-ScheduledTask -TaskName Hermes_Gateway",
+    # ...and label from a pipeline, where it precedes the cmdlet
+    "Get-ScheduledTask -TaskName Hermes_Gateway* | Stop-ScheduledTask",
+    # case-insensitive, and the hyphen/dot spellings of the label
+    "SCHTASKS /END /TN HERMES_GATEWAY",
+    "schtasks /end /tn hermes-gateway",
+    "schtasks /end /tn hermes.gateway",
+])
+def test_windows_scheduled_task_gateway_ops_are_blocked(command):
+    assert contains_gateway_lifecycle_command(command), f"should block: {command!r}"
+
+
+@pytest.mark.parametrize("command", [
+    # Unrelated tasks stay usable — the label anchor carries the whole decision.
+    "schtasks /end /tn BackupJob",
+    "schtasks /delete /tn NightlyIndex /f",
+    "Stop-ScheduledTask -TaskName SomeOtherTask",
+    # Read-only inspection is not a lifecycle op.
+    "schtasks /query /tn Hermes_Gateway",
+    "Get-ScheduledTask -TaskName Hermes_Gateway",
+    # Starting is benign, matching Branch A's exclusion of `hermes gateway start`.
+    "schtasks /run /tn Hermes_Gateway",
+    "schtasks /create /tn Hermes_Gateway /tr hermes.exe /sc onlogon",
+    # `/change` alone (e.g. re-pointing the run-as user) is not a stop.
+    "schtasks /change /tn Hermes_Gateway /ru SYSTEM",
+])
+def test_benign_and_unrelated_scheduled_task_commands_are_not_blocked(command):
+    assert not contains_gateway_lifecycle_command(command), f"should allow: {command!r}"
+
+
+def test_windows_branch_matches_the_other_platforms_for_the_same_intent():
+    """Stop-the-gateway must be blocked on all three platforms, not two."""
+    assert contains_gateway_lifecycle_command("launchctl bootout gui/501/ai.hermes.gateway")
+    assert contains_gateway_lifecycle_command("systemctl stop hermes-gateway")
+    assert contains_gateway_lifecycle_command("schtasks /end /tn Hermes_Gateway")


### PR DESCRIPTION
## What

The gateway-lifecycle guard has no Windows branch. It hard-blocks stopping the gateway on macOS and Linux, but the equivalent Windows commands pass straight through.

Measured on `866332bfb5`:

```
launchctl bootout gui/501/ai.hermes.gateway        -> True   (Branch B)
systemctl stop hermes-gateway                      -> True   (Branch C)
hermes gateway restart                             -> True   (Branch A)

schtasks /end /tn Hermes_Gateway_alice             -> False
schtasks /delete /tn Hermes_Gateway /f             -> False
Stop-ScheduledTask -TaskName Hermes_Gateway_alice  -> False
Unregister-ScheduledTask -TaskName Hermes_Gateway  -> False
```

Branch D covers only POSIX `pkill`/`kill`, so Windows had nothing.

## Why it matters

`hermes_cli/gateway_windows.py` installs and supervises the gateway **as a Scheduled Task** named `Hermes_Gateway` / `Hermes_Gateway_<profile>` (`_TASK_NAME_DEFAULT`, `_task_name()`). So `schtasks /end /tn Hermes_Gateway_alice` isn't an approximation of stopping the gateway — it *is* stopping the gateway, exactly as `launchctl bootout ...ai.hermes.gateway` is on macOS.

That leaves only the bypassable approval layer (`tools/approval.py`, skipped on `force=True`) covering Windows, while the hard block — documented as "force=True cannot help here" — covers the other two platforms. Same asymmetry #80260 closed for `bootout`/`remove`/`disable`, one platform over.

## Scope of the match

Branch E anchors on the task label, so unrelated tasks are untouched. Both token orders are matched because the task name may precede or follow the op flag, and the cmdlets accept the label from a pipeline.

Deliberately **not** matched:

| form | why |
|---|---|
| `schtasks /run`, `/create` | starting is benign — mirrors Branch A excluding `hermes gateway start` |
| `schtasks /query`, `Get-ScheduledTask` | read-only |
| `schtasks /change` without `/disable` | re-pointing run-as user isn't a stop |
| `schtasks /end /tn BackupJob` | label anchor carries the decision |

`/change` counts only together with `/disable`, which is what makes a stop durable across boots — the schtasks analog of launchctl `disable`.

## Tests

New `tests/cron/test_lifecycle_guard_windows_scheduled_task.py`: **23 passing** — 14 positives (both flag orders, `/change /disable`, three cmdlets, pipeline shape, hyphen/dot label spellings) and 8 negatives from the table above, plus one test asserting the same intent is blocked on all three platforms rather than two.

Pure string-predicate tests: no Scheduled Task is created or touched, so they behave identically on Linux CI.

**Teeth verified by mutation** — reverting the Branch E hunk turns 15 of the 23 red, and the 8 that stay green are exactly the negatives.

**No regressions.** `tests/hermes_cli/test_gateway_restart_loop.py`, `tests/tools/test_approval.py`, `tests/cron/test_lifecycle_guard_budget.py`: the sorted set of failing test ids is **identical** to pristine `upstream/main` (66 either way — all pre-existing on my Windows box). Compared by test-id set, not count, since collection ordering makes counts unreliable.

## Not overlapping

#98244 also concerns Windows gateway restart but is a different mechanism — an unsupervised direct-spawn gateway restarting itself via `terminal_tool.py`/`code_execution_tool.py`. It doesn't touch `cron/lifecycle_guard.py`. This PR is the guard's missing platform branch and is complementary.

Found while verifying an AI-review note on my #94379, which flagged scheduled-task kill forms as the missing Branch-B analog on Windows.
