### PR TITLE
fix(cron): fail closed when terminal metadata is dropped

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -92,6 +92,12 @@ _fire_fence_lock_state = threading.local()
 # _jobs_lock(), so blocking forever on a wedged sibling process would freeze the ticker and every
 # job. 30s is far above any legitimate critical section yet under one status-alarm threshold.
 _JOBS_LOCK_TIMEOUT_SECONDS = 30.0
+
+# Durable operator-visible accounting for terminal metadata writes that cannot
+# find their job record. The profile extension collector consumes this sidecar.
+_last_mark_not_found_count = 0
+_last_mark_not_found_at: Optional[str] = None
+_last_mark_not_found_job: Optional[str] = None
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
@@ -2270,11 +2276,35 @@ def mark_job_run(
     def locked():
         found = _with_job(job_id, apply, missing=_MISSING)
         if found is _MISSING:
-            logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
+            global _last_mark_not_found_count, _last_mark_not_found_at, _last_mark_not_found_job
+            now = _hermes_now().isoformat()
+            _last_mark_not_found_count += 1
+            _last_mark_not_found_at = now
+            _last_mark_not_found_job = job_id
+            stats_path = _current_cron_store().cron_dir / "mark_job_run_drops.json"
+            try:
+                previous = json.loads(stats_path.read_text(encoding="utf-8"))
+                count = max(int(previous.get("count", 0)), _last_mark_not_found_count)
+            except (FileNotFoundError, OSError, ValueError, TypeError, AttributeError):
+                count = _last_mark_not_found_count
+            try:
+                atomic_write_text(stats_path, json.dumps({
+                    "count": count, "last_at": now, "last_job_id": job_id,
+                }, sort_keys=True))
+            except OSError:
+                logger.exception("mark_job_run: failed to persist drop counter")
+            logger.error(
+                "mark_job_run: job_id %s not found; terminal metadata was not persisted "
+                "(drop_count=%d, counter=%s)", job_id, count, stats_path)
             return False
         return found
 
     return _under_fire_fence(job_id, locked)
+
+
+def get_mark_not_found_stats() -> tuple[int, Optional[str], Optional[str]]:
+    """Return process-local drop count, timestamp, and last missing job id."""
+    return _last_mark_not_found_count, _last_mark_not_found_at, _last_mark_not_found_job
 
 
 def _write_oneshot_diagnostic(job: Dict[str, Any], text: str, what: str) -> bool:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2818,10 +2818,10 @@ def _finish_completed_run(d: _RunDelivery, fire_owner: Optional[str], execution_
     if d.blocked_config:
         mark_kwargs["status"] = "blocked_config"
     marked = mark_job_run(job["id"], d.success, d.error, **mark_kwargs)
-    if fire_owner is not None and not marked:
-        finish_execution(
-            execution_id, success=False,
-            error="Fire claim ownership lost before terminal completion.")
+    if not marked:
+        error = "Cron terminal metadata write failed: mark_job_run did not persist jobs.json"
+        finish_execution(execution_id, success=False, error=error)
+        logger.error("Job %s terminal metadata was not persisted; failing closed", job["id"])
         return True
     delivery_outcome = _classify_delivery_outcome(
         delivery_error=d.delivery_error,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2819,9 +2819,20 @@ def _finish_completed_run(d: _RunDelivery, fire_owner: Optional[str], execution_
         mark_kwargs["status"] = "blocked_config"
     marked = mark_job_run(job["id"], d.success, d.error, **mark_kwargs)
     if not marked:
-        error = "Cron terminal metadata write failed: mark_job_run did not persist jobs.json"
-        finish_execution(execution_id, success=False, error=error)
-        logger.error("Job %s terminal metadata was not persisted; failing closed", job["id"])
+        # Preserve the fire-claim CAS contract: a fenced completion that no
+        # longer owns its claim must be recorded as ownership loss, not as a
+        # generic metadata failure.  Unfenced runs use the C2 fail-closed
+        # metadata error so a ledger success can never outlive jobs.json.
+        if fire_owner is not None:
+            finish_execution(
+                execution_id,
+                success=False,
+                error="Fire claim ownership lost before terminal completion.",
+            )
+        else:
+            error = "Cron terminal metadata write failed: mark_job_run did not persist jobs.json"
+            finish_execution(execution_id, success=False, error=error)
+            logger.error("Job %s terminal metadata was not persisted; failing closed", job["id"])
         return True
     delivery_outcome = _classify_delivery_outcome(
         delivery_error=d.delivery_error,

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -353,7 +353,7 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
     monkeypatch.setattr(scheduler, "run_job", fake_run_job)
     monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
     monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: True)
 
     assert scheduler.run_one_job({"id": "job-3", "execution_id": "exec-3"}) is True
     assert run_execution_ids == ["exec-3"]

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1,5 +1,6 @@
 """Tests for cron/jobs.py — schedule parsing, job CRUD, and due-job detection."""
 
+import json
 import threading
 import pytest
 from datetime import datetime, timedelta, timezone
@@ -18,6 +19,7 @@ from cron.jobs import (
     resume_job,
     remove_job,
     mark_job_run,
+    get_mark_not_found_stats,
     advance_next_run,
     claim_dispatch,
     claim_job_for_fire,
@@ -616,6 +618,13 @@ class TestResolveJobRef:
 
 
 class TestMarkJobRun:
+    def test_missing_job_persists_probe_visible_drop_counter(self, tmp_cron_dir):
+        assert mark_job_run("missing-job", success=True) is False
+        stats = json.loads((tmp_cron_dir / "cron" / "mark_job_run_drops.json").read_text())
+        assert stats["count"] >= 1
+        assert stats["last_job_id"] == "missing-job"
+        assert get_mark_not_found_stats()[2] == "missing-job"
+
     def test_increments_completed(self, tmp_cron_dir):
         job = create_job(prompt="Test", schedule="every 1h")
         mark_job_run(job["id"], success=True)


### PR DESCRIPTION
C2 follow-up: make terminal jobs.json persistence failures visible and fail closed. mark_job_run writes a profile-scoped mark_job_run_drops.json sidecar when the job record is absent; scheduler records the execution as failed whenever terminal metadata persistence returns false. Adds focused regression coverage. No schedule, gateway, runtime, or credential changes. The required 24h post-landing runtime window remains an operator gate and is intentionally not claimed in this draft.