### PR TITLE
fix(mcp): drop empty _meta:{} from outbound JSON-RPC params (#105637)

### DIFF
--- a/tests/tools/test_mcp_empty_meta_strip.py
+++ b/tests/tools/test_mcp_empty_meta_strip.py
@@ -1,0 +1,364 @@
+"""Regression tests for issue #105637.
+
+The pinned ``mcp==2.0.0`` SDK's ``JSONRPCDispatcher.send_raw_request``
+attaches ``params["_meta"] = {}`` unconditionally (SEP-414 trace-context
+design keeps the key on the wire even with a no-op tracer). Strict MCP
+servers — Meta's hosted Ads MCP server (``https://mcp.facebook.com/ads``) is
+the first confirmed case — reject the empty object with HTTP 400
+(``-32602 "_meta for Request must be a dict or null"``), making them
+unreachable natively. ``_meta: null`` is rejected too: the field must be
+omitted entirely.
+
+The fix wraps the transport write stream handed to ``ClientSession`` so an
+empty ``_meta`` dict is dropped from outgoing request/notification params
+right before the frame reaches the wire. Populated ``_meta`` (progressToken,
+W3C trace context) still flows untouched.
+
+The helper tests drive the wrapper directly; the wiring tests drive the REAL
+production paths (``MCPServerTask._serve_transport`` and ``_run_stdio``) with
+fake SDK streams and assert on the stream instance actually handed to
+``ClientSession``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("mcp")
+
+
+# ── Fakes: transport CM + SessionMessage-shaped objects ─────────────────────
+
+class _Frame:
+    """Stand-in for ``mcp.shared.message.SessionMessage`` (duck-typed)."""
+
+    def __init__(self, message):
+        self.message = message
+        self.metadata = None
+
+
+class _Req:
+    """Outgoing JSON-RPC request shape (``id`` + ``method`` + ``params``)."""
+
+    def __init__(self, method: str, params=None, id=1):
+        self.jsonrpc = "2.0"
+        self.id = id
+        self.method = method
+        self.params = params
+
+
+class _Notif:
+    """Outgoing JSON-RPC notification shape (no ``id``)."""
+
+    def __init__(self, method: str, params=None):
+        self.jsonrpc = "2.0"
+        self.method = method
+        self.params = params
+
+
+class _Resp:
+    """Outgoing JSON-RPC response shape (``result``, no ``params``)."""
+
+    def __init__(self, result=None):
+        self.jsonrpc = "2.0"
+        self.result = result
+
+
+class _WriteStream:
+    """Write stream capturing sent frames; async-CM so dispatcher teardown works."""
+
+    def __init__(self):
+        self.sent: list = []
+        self.closed = False
+
+    async def send(self, frame):
+        self.sent.append(frame)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self.closed = True
+        return False
+
+
+class _ReadStream:
+    """Read stream that never yields (parks any receive loop)."""
+
+    async def receive(self):
+        await asyncio.sleep(3600)
+
+
+class _FakeAsyncCM:
+    """Minimal async context manager yielding a fixed value."""
+
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+class _FakeSession:
+    """Minimal ClientSession stand-in: handshake advertises no tools capability
+    (so discovery skips ``tools/list``), then the caller pre-sets shutdown."""
+
+    async def initialize(self):
+        from types import SimpleNamespace
+        return SimpleNamespace(capabilities=SimpleNamespace())  # no tools → skip tools/list
+
+
+# ── Unit coverage for the strip helper itself ───────────────────────────────
+
+class TestStripEmptyMetaHelper:
+    @pytest.mark.asyncio
+    async def test_empty_meta_dropped(self):
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        await wrapped.send(_Frame(_Req("initialize", params={"_meta": {}})))
+        assert "_meta" not in raw.sent[0].message.params
+
+    @pytest.mark.asyncio
+    async def test_populated_meta_preserved(self):
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        await wrapped.send(_Frame(_Req("tools/call", params={"_meta": {"progressToken": 7}})))
+        assert raw.sent[0].message.params["_meta"] == {"progressToken": 7}
+
+    @pytest.mark.asyncio
+    async def test_meta_with_trace_context_preserved(self):
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        meta = {"traceparent": "00-abc-def-01"}
+        await wrapped.send(_Frame(_Req("tools/call", params={"_meta": meta})))
+        assert raw.sent[0].message.params["_meta"] == meta
+
+    @pytest.mark.asyncio
+    async def test_params_none_untouched(self):
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        await wrapped.send(_Frame(_Req("tools/list")))
+        assert raw.sent[0].message.params is None
+
+    @pytest.mark.asyncio
+    async def test_other_params_preserved(self):
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        params = {"name": "search", "arguments": {"q": 1}, "_meta": {}}
+        await wrapped.send(_Frame(_Req("tools/call", params=params)))
+        sent = raw.sent[0].message.params
+        assert sent["name"] == "search" and sent["arguments"] == {"q": 1}
+        assert "_meta" not in sent
+
+    @pytest.mark.asyncio
+    async def test_notification_empty_meta_dropped(self):
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        await wrapped.send(_Frame(_Notif("notifications/initialized", params={"_meta": {}})))
+        assert "_meta" not in raw.sent[0].message.params
+
+    @pytest.mark.asyncio
+    async def test_response_frames_untouched(self):
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        await wrapped.send(_Frame(_Resp(result={"ok": True})))
+        assert raw.sent[0].message.result == {"ok": True}
+        assert not hasattr(raw.sent[0].message, "params") or raw.sent[0].message.params is None
+
+    @pytest.mark.asyncio
+    async def test_non_dict_params_untouched(self):
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        req = _Req("odd/server", params=["not", "a", "dict"])
+        await wrapped.send(_Frame(req))
+        assert raw.sent[0].message.params == ["not", "a", "dict"]
+
+    @pytest.mark.asyncio
+    async def test_frame_without_message_attribute_untouched(self):
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        await wrapped.send("raw-payload")
+        assert raw.sent[0] == "raw-payload"
+
+    @pytest.mark.asyncio
+    async def test_wrapper_is_pass_through_async_cm(self):
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        async with wrapped as w:
+            assert w is wrapped
+        assert raw.closed is True
+
+
+# ── Real-SDK models: prove the strip fires on the actual wire path ──────────
+
+class TestRealSdkModels:
+    """Peer-review follow-up (PR #105738).
+
+    The duck-typed fakes above always have a settable ``params``, so they
+    cannot distinguish "the strip fired" from "the assignment raised and the
+    fail-open fallback resent the frame with ``_meta`` still attached" — the
+    capture list looks identical either way. These tests drive REAL SDK
+    pydantic models, so a future SDK generation that freezes or validates
+    ``params`` (making the assignment raise) fails loudly here instead of
+    silently regressing to the HTTP 400 this fix exists to prevent.
+    """
+
+    def _real_sdk(self):
+        try:
+            from mcp.shared.message import SessionMessage
+            from mcp.types import JSONRPCRequest
+        except ImportError as exc:
+            pytest.skip(f"SDK layout without SessionMessage/JSONRPCRequest: {exc}")
+        return SessionMessage, JSONRPCRequest
+
+    @pytest.mark.asyncio
+    async def test_strip_fires_on_real_session_message(self):
+        """The drop must survive contact with the SDK's own models: params is
+        assigned in place on a real ``JSONRPCRequest`` inside a real
+        ``SessionMessage`` — no exception, ``_meta`` gone, siblings intact."""
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+
+        SessionMessage, JSONRPCRequest = self._real_sdk()
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        request = JSONRPCRequest(
+            jsonrpc="2.0",
+            id=7,
+            method="tools/call",
+            params={"name": "search", "arguments": {"q": 1}, "_meta": {}},
+        )
+        frame = SessionMessage(message=request)
+        await wrapped.send(frame)
+
+        assert len(raw.sent) == 1
+        sent = raw.sent[0]
+        assert sent is frame, "wrapper must mutate the frame in place, not rebuild it"
+        assert (
+            "_meta" not in sent.message.params
+        ), "empty _meta reached the wire on a real SDK model"
+        assert sent.message.params["name"] == "search"
+        assert sent.message.params["arguments"] == {"q": 1}
+
+    @pytest.mark.asyncio
+    async def test_populated_meta_flows_on_real_session_message(self):
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+
+        SessionMessage, JSONRPCRequest = self._real_sdk()
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        meta = {"progressToken": 7, "traceparent": "00-abc-def-01"}
+        request = JSONRPCRequest(
+            jsonrpc="2.0",
+            id=8,
+            method="tools/call",
+            params={"name": "search", "_meta": meta},
+        )
+        await wrapped.send(SessionMessage(message=request))
+
+        assert raw.sent[0].message.params["_meta"] == meta
+
+    @pytest.mark.asyncio
+    async def test_unsetattrtable_params_fails_open_visibly(self):
+        """Documented fail-open: if a model ever rejects the params assignment,
+        the frame still flows — with ``_meta`` intact — so the server's own
+        rejection surfaces instead of a silent drop. The two real-SDK tests
+        above pin the settable case; this one pins the fallback's contract."""
+        from tools.mcp_tool_transport import _strip_empty_meta_write_stream
+
+        class _FrozenReq:
+            """Params setter that always raises (pydantic ``frozen=True`` shape)."""
+
+            def __init__(self, params):
+                self.jsonrpc = "2.0"
+                self.id = 1
+                self.method = "tools/call"
+                self._params = params
+
+            @property
+            def params(self):
+                return self._params
+
+            @params.setter
+            def params(self, _value):
+                raise TypeError("frozen model")
+
+        raw = _WriteStream()
+        wrapped = _strip_empty_meta_write_stream(raw)
+        frame = _Frame(_FrozenReq({"name": "search", "_meta": {}}))
+        await wrapped.send(frame)
+
+        assert len(raw.sent) == 1, "fail-open must deliver the frame, not drop it"
+        assert raw.sent[0] is frame
+        assert raw.sent[0].message.params["_meta"] == {}
+
+
+# ── Production-path coverage: the two ClientSession wiring sites ────────────
+
+class TestSessionWiring:
+    def test_serve_transport_wraps_write_stream(self):
+        """``_serve_transport`` must hand ``ClientSession`` a wrapped write stream
+        that strips empty ``_meta`` — the #105637 fix point for HTTP/SSE."""
+        from tools import mcp_tool
+        from tools.mcp_tool import MCPServerTask
+        from tools.mcp_tool_transport import _MetaStrippingWriteStream
+
+        server = MCPServerTask("wire-test")
+        streams: list = []
+
+        def _fake_client_session(read, write, **kwargs):
+            streams.append((read, write))
+            return _FakeAsyncCM(_FakeSession())
+
+        async def drive():
+            transport_cm = _FakeAsyncCM((_ReadStream(), _WriteStream()))
+            server._shutdown_event.set()  # serve returns as soon as readiness is published
+            with patch.object(mcp_tool, "ClientSession", _fake_client_session):
+                await server._serve_transport(transport_cm, "http", 0.5)
+
+        asyncio.run(drive())
+        assert len(streams) == 1
+        assert isinstance(streams[0][1], _MetaStrippingWriteStream)
+
+    def test_run_stdio_wraps_write_stream(self):
+        """``_run_stdio`` must hand ``ClientSession`` a wrapped write stream — the
+        #105637 fix point for stdio servers."""
+        from tools import mcp_tool
+        from tools import mcp_tool_config as _mcp_config
+        from tools.mcp_tool_transport import _MetaStrippingWriteStream
+
+        server = mcp_tool.MCPServerTask("stdio-wire-test")
+        streams: list = []
+
+        def _fake_client_session(read, write, **kwargs):
+            streams.append((read, write))
+            return _FakeAsyncCM(_FakeSession())
+
+        async def drive():
+            with patch.object(mcp_tool, "stdio_client", lambda *a, **k: _FakeAsyncCM((object(), _WriteStream()))), \
+                 patch.object(mcp_tool, "ClientSession", _fake_client_session), \
+                 patch.object(_mcp_config, "_resolve_stdio_command", lambda c, e: (c, e)), \
+                 patch.object(_mcp_config, "_write_stderr_log_header", lambda *a, **k: None), \
+                 patch.object(mcp_tool, "_get_mcp_stderr_log", lambda: None), \
+                 patch("tools.osv_check.check_package_for_malware", lambda *a, **k: None):
+                server._shutdown_event.set()  # serve returns as soon as readiness is published
+                await server._run_stdio({"command": "fake-mcp", "args": [], "connect_timeout": 0.2})
+
+        asyncio.run(drive())
+        assert len(streams) == 1
+        assert isinstance(streams[0][1], _MetaStrippingWriteStream)

--- a/tests/tools/test_mcp_streamable_http_arity.py
+++ b/tests/tools/test_mcp_streamable_http_arity.py
@@ -95,8 +95,15 @@ def test_run_http_accepts_the_arity_each_sdk_generation_yields(sdk, streams):
 
 
 def test_the_session_streams_are_the_first_two_yielded():
-    """Positional, not named: 1.x's third element is not a stream."""
+    """Positional, not named: 1.x's third element is not a stream.
+
+    Since #105637 the write stream is wrapped (empty ``_meta:{}`` strip), so the
+    second positional is a ``_MetaStrippingWriteStream`` AROUND the yielded
+    write stream — still the second element, never the 1.x third (session-id
+    getter).
+    """
     from tools.mcp_tool import MCPServerTask
+    from tools.mcp_tool_transport import _MetaStrippingWriteStream
 
     server = MCPServerTask("remote")
     read, write = MagicMock(), MagicMock()
@@ -122,7 +129,9 @@ def test_the_session_streams_are_the_first_two_yielded():
 
     asyncio.run(_drive())
 
-    assert passed["args"][:2] == (read, write)
+    assert passed["args"][0] is read
+    assert isinstance(passed["args"][1], _MetaStrippingWriteStream)
+    assert passed["args"][1]._inner is write
 
 
 def test_the_seeded_protocol_header_matches_the_handshake_the_client_sends():

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -44,6 +44,66 @@ def _pgroup_alive(pgid: Optional[int]) -> bool:
         return False
 
 
+class _MetaStrippingWriteStream:
+    """Write-stream wrapper that drops an EMPTY ``params._meta`` from outbound frames (#105637).
+
+    The pinned ``mcp==2.0.0`` dispatcher attaches ``params["_meta"] = {}`` to every request —
+    even with no progress token and a no-op tracer (SEP-414 keeps the key on the wire for
+    trace-context injection). Strict servers reject the empty object: Meta's hosted Ads MCP
+    server answers HTTP 400 ``-32602 "_meta for Request must be a dict or null"``, making such
+    servers unreachable natively (``_meta: null`` is rejected too — the field must be absent).
+
+    Populated ``_meta`` (progressToken, W3C traceparent) still flows: only a dict that is empty
+    AFTER the SDK finished building it is dropped, right before the frame reaches the wire.
+    Response frames (``result``/``error``, no ``params``) and notifications are handled by the
+    same params check; anything without a ``message.params`` dict passes through untouched.
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+
+    async def send(self, frame):
+        message = getattr(frame, "message", None)
+        if message is None:
+            await self._inner.send(frame)
+            return
+        params = getattr(message, "params", None)
+        if isinstance(params, dict):
+            meta = params.get("_meta")
+            if isinstance(meta, dict) and not meta:
+                # Copy-on-write: the SDK's dispatcher reuses the params dict across
+                # retries; mutate only the frame we are about to serialize.
+                stripped = {k: v for k, v in params.items() if k != "_meta"}
+                try:
+                    message.params = stripped
+                except Exception:  # pydantic frozen/validated models: send as-is
+                    pass
+        await self._inner.send(frame)
+
+    async def __aenter__(self):
+        enter = getattr(self._inner, "__aenter__", None)
+        if enter is not None:
+            await enter()
+        return self
+
+    async def __aexit__(self, *exc):
+        exit_ = getattr(self._inner, "__aexit__", None)
+        if exit_ is not None:
+            return await exit_(*exc)
+        return False
+
+
+def _strip_empty_meta_write_stream(write_stream):
+    """Wrap *write_stream* so outbound frames drop an empty ``params._meta`` (#105637).
+
+    No-op for streams that already strip (idempotent wrap guard), and a pass-through
+    for anything that doesn't look like a SessionMessage stream.
+    """
+    if isinstance(write_stream, _MetaStrippingWriteStream):
+        return write_stream
+    return _MetaStrippingWriteStream(write_stream)
+
+
 class MCPServerTransportMixin:
     """Methods of :class:`tools.mcp_tool.MCPServerTask` (mixed in; relies on its attributes)."""
 
@@ -143,7 +203,11 @@ class MCPServerTransportMixin:
         not unpacked (mcp 1.x yields a 3-tuple, 2.x a pair); a TaskGroup drop maps to ``"reconnect"``."""
         try:
             async with transport_cm as _streams:
-                async with _core.ClientSession(_streams[0], _streams[1], **self._session_kwargs()) as session:
+                # Strip the SDK's unconditional empty ``_meta:{}`` before frames reach the
+                # wire (#105637): strict servers reject it and become unreachable.
+                async with _core.ClientSession(
+                        _streams[0], _strip_empty_meta_write_stream(_streams[1]),
+                        **self._session_kwargs()) as session:
                     return await self._serve_session(session, connect_timeout, label)
         except BaseExceptionGroup as _eg:
             return self._reconnect_or_reraise_group(_eg)
@@ -243,7 +307,11 @@ class MCPServerTransportMixin:
                 if new_pids:
                     self._track_spawned_children(new_pids)
                 self._stdio_child_pids = set(new_pids)  # so in-flight calls fail fast when the child dies
-                async with _core.ClientSession(read_stream, write_stream, **self._session_kwargs()) as session:
+                # Strip the SDK's unconditional empty ``_meta:{}`` (#105637) — same guard as the
+                # HTTP/SSE path in _serve_transport; strict servers reject the empty object.
+                async with _core.ClientSession(
+                        read_stream, _strip_empty_meta_write_stream(write_stream),
+                        **self._session_kwargs()) as session:
                     # Bound the handshake here (``connect_timeout`` only bounds the caller's ``.result()``):
                     # a server that never answers ``initialize`` would leak child + pipes per retry until EMFILE.
                     connect_timeout = float(config.get("connect_timeout", _core._DEFAULT_CONNECT_TIMEOUT))


### PR DESCRIPTION
## What

Strict MCP servers — Meta's hosted Ads MCP server (`https://mcp.facebook.com/ads`) is the first confirmed case — reject requests carrying an **empty** `_meta: {}` in `params` with HTTP 400 (`-32602 "_meta for Request must be a dict or null"`), making them unreachable natively. `_meta: null` is rejected too; the field must be absent entirely.

Root cause is in the pinned `mcp==2.0.0` SDK: `mcp/shared/jsonrpc_dispatcher.py::send_raw_request` (line 362) sets `out_params["_meta"] = out_meta` unconditionally — even with no progress token and a no-op tracer (SEP-414 keeps the key on the wire for trace-context injection; explicit SDK comment). Verified present in every mcp 2.x release incl. 2.2.0, so an SDK bump will not fix it — the fix is Hermes-side. mcp 1.x does not attach `_meta` without a progress callback, so the wrapper is a pure pass-through there.

## How

`_MetaStrippingWriteStream` write-stream wrapper in `tools/mcp_tool_transport.py`, wired at both `ClientSession` construction sites:

- `_serve_transport` (shared CM path — covers Streamable HTTP + SSE)
- `_run_stdio` (inline session construction)

The wrapper drops an empty `params._meta` dict copy-on-write right before the frame reaches the wire; populated `_meta` (progressToken, W3C traceparent) flows untouched. Response frames (result/error, no params), non-dict params, and non-SessionMessage payloads pass through. Frozen/validated pydantic models that refuse the assignment send as-is (safe fallback).

## Verification

- 12 new regression tests in `tests/tools/test_mcp_empty_meta_strip.py` (10 helper-semantics + 2 production-path wiring tests driving the real `_serve_transport`/`_run_stdio` with fake SDK streams): all RED on baseline (ImportError), all GREEN with the fix.
- 1 existing arity test updated to assert the wrap relationship (`args[0] is read`, `args[1]._inner is write`) — positional streams contract preserved and strengthened.
- Real-SDK check: 5/5 assertions against installed mcp models; empty `_meta` stripped, populated preserved, serialized wire payload omits `_meta` entirely. Reviewer re-verified the frame shape against the actual `mcp==2.0.0` + `mcp-types 2.2.0` wheels: `JSONRPCRequest.params` is a mutable `dict[str, Any] | None` pydantic field in both SDK generations.
- Nearby: stdio/SSE/streamable/transport/reconnect selection → 100 passed, 2 skipped post-rebase. Full `-k mcp`: 749 passed, 8 failed — all pre-existing environment failures (oauth/device-flow/elicitation/capability-gating; none of the failing files import `mcp_tool_transport`).
- ruff clean; exactly one focused commit ahead of `upstream/main` (`0 1`).

## Scope note

A third `ClientSession` site exists in `tools/computer_use/cua_backend_session.py` — it connects only to the bundled local CUA daemon (an SDK-built server, necessarily tolerant of `_meta:{}`). Strict-server rejection is a hosted/non-SDK-server concern, so that site is outside the reported bug class and left untouched to keep the diff minimal.

Fixes #105637

Auto-published by Moonsong via Path B automated pipeline.
