### PR TITLE
fix(desktop): keep subagent rows visible when timeline is paused (#105631)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/delegate.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/delegate.tsx
@@ -85,9 +85,12 @@ function DelegateRowView({ row }: { row: DelegateRow }) {
   // Only a child that reported its own session id has somewhere to go.
   const open = sessionId ? () => void openSessionInNewWindow(sessionId, { watch: true }) : undefined
 
+  // Mark the goal row, never this wrapper. Opacity on a parent of the ticker
+  // opens a stacking context that lets the transformed reel paint old activity
+  // lines through the one-line window.
   return (
-    <div className="grid min-w-0 max-w-full gap-0.5" data-conversation-scaffold="">
-      <div className="flex min-w-0 max-w-full items-center gap-1.5">
+    <div className="grid min-w-0 max-w-full gap-0.5">
+      <div className="flex min-w-0 max-w-full items-center gap-1.5" data-conversation-scaffold="">
         <span className={SCAFFOLD_GLYPH_CLASS}>{statusGlyph(row.status, statusLabel)}</span>
         <button
           className={cn(

--- a/apps/desktop/src/lib/use-enter-animation.test.tsx
+++ b/apps/desktop/src/lib/use-enter-animation.test.tsx
@@ -47,7 +47,7 @@ describe('useEnterAnimation', () => {
     const played = mountAnimated(true, 'plays-once')
 
     expect(played).toBeDefined()
-    expect(played?.keyframes[0]).toMatchObject({ opacity: 0 })
+    expect(played?.keyframes[0]).toMatchObject({ transform: 'translateY(0.375rem)' })
   })
 
   it('stays out of the way when disabled', () => {
@@ -64,19 +64,21 @@ describe('useEnterAnimation', () => {
   })
 
   /**
-   * The animation fills forwards, so any value in its last keyframe is held in
-   * the animation origin of the cascade for the life of the element — above
-   * the stylesheet. Naming an end opacity therefore doesn't just finish the
-   * fade, it permanently overrules whatever opacity CSS wants the element to
-   * rest at, and transcript scaffolding rests dimmed. Rows that animated in
-   * during the turn stayed bright while their rehydrated neighbours faded, and
-   * no hover could lift the bright ones because the sheet had lost the
-   * argument. Opacity has to be left to CSS at the end.
+   * Opacity on any keyframe, with fill that holds while the document timeline
+   * is paused (alt-tab, HUD hide, an unfocused window), pins the node at that
+   * value. Opening at 0 left subagent rows and thinking blocks invisible.
+   * Closing at 1 left scaffolding too bright for hover to lift. CSS already
+   * rests those surfaces at 0.67. The slide is transform-only, and fill is
+   * backwards so the offset applies on the first frame then the effect
+   * releases instead of holding a compositor layer for the life of the node.
    */
-  it('leaves the resting opacity to the stylesheet', () => {
+  it('never animates opacity, and does not hold a filled transform', () => {
     const played = mountAnimated(true, 'resting-opacity')
 
-    expect(played?.options.fill).toBe('both')
-    expect(played?.keyframes.at(-1)).not.toHaveProperty('opacity')
+    expect(played?.options.fill).toBe('backwards')
+
+    for (const frame of played?.keyframes ?? []) {
+      expect(frame).not.toHaveProperty('opacity')
+    }
   })
 })

--- a/apps/desktop/src/lib/use-enter-animation.ts
+++ b/apps/desktop/src/lib/use-enter-animation.ts
@@ -79,23 +79,20 @@ export function useEnterAnimation(enabled: boolean, animationKey?: string): (el:
       return
     }
 
-    el.animate(
-      [
-        { opacity: 0, transform: 'translateY(0.375rem)' },
-        // No `opacity` on the way out, deliberately. A filled animation holds
-        // its final value in the animation origin of the cascade, which
-        // outranks the stylesheet for as long as the element lives — naming 1
-        // here permanently pinned full opacity onto everything the sheet dims.
-        // Transcript scaffolding is dimmed that way, so a tool row or thinking
-        // header kept whichever opacity it happened to mount with: full if it
-        // animated in during the turn, faded if it was rehydrated or remounted
-        // past its one-shot key. Adjacent identical rows disagreed, and hover
-        // couldn't lift the pinned ones. Left neutral, opacity rises to
-        // whatever CSS says it should be and answers hover afterwards.
-        { transform: 'translateY(0)' }
-      ],
-      { duration: 180, easing: 'cubic-bezier(0.16, 1, 0.3, 1)', fill: 'both' }
-    )
+    // Transform only. Opacity in any keyframe outranks the stylesheet while
+    // the effect applies. fill: 'both' plus opacity: 0 on the opening frame
+    // pinned subagent rows and thinking blocks invisible whenever Chromium
+    // paused the document timeline (alt-tab, HUD hide, an unfocused window).
+    // Naming 1 on the way out pinned scaffolding bright so hover could not
+    // lift it. CSS already rests those surfaces at 0.67. fill is backwards
+    // so the offset applies on the first frame, then the effect releases
+    // instead of holding transform: translateY(0) as a compositor layer that
+    // can stop overflow from clipping a descendant ticker reel.
+    el.animate([{ transform: 'translateY(0.375rem)' }, { transform: 'translateY(0)' }], {
+      duration: 180,
+      easing: 'cubic-bezier(0.16, 1, 0.3, 1)',
+      fill: 'backwards'
+    })
 
     if (key) {
       // In React StrictMode the first mount can be immediately torn down.

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2224,6 +2224,10 @@ button[data-slot='aui_msg-reactions'] svg {
 .tool-ticker {
   height: var(--conversation-line-height);
   overflow: hidden;
+  /* clip beats hidden when an ancestor opacity stacking context would
+     otherwise let the transformed reel paint old rows through the window. */
+  overflow: clip;
+  isolation: isolate;
 }
 
 .tool-ticker__reel {


### PR DESCRIPTION
Fixes #105631

Live delegate rows and thinking blocks disappeared after 12-48h AFK in Hermes Desktop. `useEnterAnimation` opened at `opacity: 0` with `fill: both`. Chromium pauses the document timeline on alt-tab, HUD hide, or unfocused window, so nodes stuck at the opening frame and appeared invisible. Main agent also froze.

* `apps/desktop/src/lib/use-enter-animation.ts`: transform-only keyframes, `fill: backwards` so effect releases instead of holding compositor layer.
* `apps/desktop/src/components/assistant-ui/tool/delegate.tsx`: move `data-conversation-scaffold` from wrapper to goal row so ticker reel does not paint through its one-line window.
* `apps/desktop/src/styles.css`: `.tool-ticker` uses `overflow: clip` + `isolation: isolate`.
* `apps/desktop/src/lib/use-enter-animation.test.tsx`: update expectations (no opacity, fill backwards).

Same root cause as #105579 / PR #105580. Tested: syntax check ok; desktop vitest unavailable in this runner due to missing rolldown dep, verified keyframe expectations match patched test.