### PR TITLE
fix: make /review recognizable in live subagent viewers

### DIFF
--- a/agent/review_engine.py
+++ b/agent/review_engine.py
@@ -97,8 +97,15 @@ def collect_parent_loaded_skills(parent_agent, messages: List[Dict[str, Any]], l
 
 
 def build_review_task(snapshot: List[Dict[str, str]], user_prompt: str = "", loaded_skills: Optional[List[str]] = None) -> tuple:
-    """Compose the reviewer subagent's (goal, context) pair."""
+    """Compose a viewer-friendly goal and the complete reviewer briefing."""
+    focus = " ".join(user_prompt.split())
+    goal = f"Review: {focus}" if focus else "Review recent work"
+    if len(goal) > 80:
+        goal = goal[:79].rstrip() + "…"
+    # The goal is also the live worker label; keep the full instructions in context.
     lines = [
+        _REVIEW_GOAL,
+        "",
         "You were spawned by the /review command. The following is an excerpt of the most recent conversation "
         "between the user and their primary agent. It is your starting evidence — the work to "
         "review is referenced in it.",
@@ -126,7 +133,7 @@ def build_review_task(snapshot: List[Dict[str, str]], user_prompt: str = "", loa
         "the primary agent and its user. Be direct and specific; do not "
         "soften findings.",
     ]
-    return _REVIEW_GOAL, "\n".join(lines)
+    return goal, "\n".join(lines)
 
 
 def _load_review_credentials_cfg() -> Optional[Dict[str, Any]]:
@@ -176,15 +183,11 @@ def start_review(parent_agent, messages: List[Dict[str, Any]], user_prompt: str 
 
 def format_dispatch_note(result: Dict[str, Any], user_prompt: str = "") -> str:
     """Human-facing one-liner for a successful dispatch. Shared by surfaces."""
+    if result.get("status") == "dispatched":
+        return "Review started. Results will return here."
     model = str(result.get("review_model") or "").strip()
     model_note = f" on {model}" if model else ""
     focus_note = f" (focus: {user_prompt.strip()})" if user_prompt.strip() else ""
-    if result.get("status") == "dispatched":
-        return (
-            f"⚖ Review subagent dispatched{model_note}{focus_note} — it is "
-            f"investigating the last {DEFAULT_CONTEXT_MESSAGES} messages in "
-            f"the background and its full review will re-enter this conversation when it finishes."
-        )
     # Synchronous fallback (channels that cannot route async completions).
     return (
         f"⚖ Review completed synchronously{model_note}{focus_note} — "

--- a/tests/agent/test_review_engine.py
+++ b/tests/agent/test_review_engine.py
@@ -97,15 +97,21 @@ def test_build_review_task_includes_excerpt_and_prompt():
         {"role": "user", "text": "review my PR"},
         {"role": "assistant", "text": "PR #99 opened"},
     ]
-    goal, context = build_review_task(snap, "focus on security")
-    assert "reviewer" in goal.lower()
+    prompt = "focus on security\n" + "keep these instructions intact " * 20
+    goal, context = build_review_task(snap, prompt)
+    assert goal.startswith("Review: focus on security ")
+    assert len(goal) <= 80 and "\n" not in goal
+    assert goal.endswith("…")
+    assert re_mod._REVIEW_GOAL in context
     assert "[USER]" in context and "[PRIMARY AGENT]" in context
     assert "PR #99 opened" in context
-    assert "focus on security" in context
+    assert prompt.strip() in context
 
 
 def test_build_review_task_without_prompt_has_no_instruction_block():
     goal, context = build_review_task([{"role": "user", "text": "hi"}])
+    assert goal == "Review recent work"
+    assert re_mod._REVIEW_GOAL in context
     assert "Additional review instructions" not in context
 
 
@@ -243,7 +249,8 @@ def test_start_review_dispatches_background_and_completes(monkeypatch):
     # The reviewer briefing carries the conversation excerpt + user prompt.
     assert "PR #77 opened" in built["context"]
     assert "check the tests" in built["context"]
-    assert "reviewer" in built["goal"].lower()
+    assert built["goal"].startswith("Review: ")
+    assert re_mod._REVIEW_GOAL in built["context"]
 
     # The completion re-enters via the shared queue like any subagent.
     deadline = time.monotonic() + 5.0
@@ -504,12 +511,13 @@ def test_review_registered_in_every_aux_surface():
 # ---------------------------------------------------------------------------
 
 def test_format_dispatch_note_dispatched():
+    prompt = "security\n" * 100
     note = format_dispatch_note(
-        {"status": "dispatched", "review_model": "opus"}, "security"
+        {"status": "dispatched", "review_model": "opus"}, prompt
     )
-    assert "dispatched on opus" in note
-    assert "focus: security" in note
-    assert "re-enter" in note
+    assert "Review started" in note and "return here" in note
+    assert "security" not in note and "\n" not in note
+    assert len(note) < 80
 
 
 def test_format_dispatch_note_sync_fallback():

--- a/tests/gateway/test_review_command.py
+++ b/tests/gateway/test_review_command.py
@@ -103,7 +103,7 @@ async def test_review_command_dispatches_background_subagent(monkeypatch):
     runner = _make_runner(agent)
     out = await runner._handle_review_command(_Event("check tests"))
 
-    assert "dispatched" in out
+    assert out == re_mod.format_dispatch_note({"status": "dispatched"})
     assert "PR #5 opened" in built["context"]
     assert "check tests" in built["context"]
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -262,6 +262,8 @@ What happens:
 
 The canonical flow: your main agent opens a PR, you type `/review`, and a second pair of eyes investigates it while you keep working; the review lands back in the chat addressed to the agent that created the PR.
 
+Dispatch prints only “Review started. Results will return here.” The live subagent viewer identifies the worker as **Review: your focus** (or **Review recent work** for bare `/review`), with a shortened single-line label; the reviewer still receives your full instructions. In the classic CLI, the dock above the composer shows elapsed time and latest activity; **F6** opens the roster with its model, transcript, steering, and stop controls. The same review label appears in the TUI and Desktop subagent viewers.
+
 ### Review model
 
 By default the reviewer runs on your main model. To pin a dedicated review model, set `auxiliary.review` in `config.yaml`:


### PR DESCRIPTION
/review is recognizable in the existing live subagent viewers without a multi-line dispatch announcement.

## Changes
- Use `Review: <focus>` or `Review recent work` as the shared worker goal, bounded to a single-line label.
- Keep the complete reviewer instructions and user focus in the child context; preserve the existing snapshot, loaded skills, credentials, tools, and async completion path.
- Replace the repeated dispatch paragraph with `Review started. Results will return here.` Synchronous fallback output remains unchanged.
- Document the existing CLI dock and F6 controls.

The viewer was displaying the reviewer’s generic instruction paragraph as its task label, while the dispatch acknowledgement repeated the user's focus in full.

## Validation
**Live repro:** current-main classic CLI PTY showed the review dock already working, but with the long generic task label and wrapped dispatch paragraph. The identical fixed replay shows the short acknowledgement and `Review: check the plan for missing tests`; F6 roster/transcript, exact composer draft/cursor preservation, 100×30 and 80×20 layouts, worker retirement, and receiver-side completion delivery pass.

| Check | Result |
| --- | --- |
| Review-engine tests | 26 passed; two changed behavior checks first failed on base |
| Actual CLI UI probe | Real slash dispatch, delegate_task, registry, terminal tool, and parent completion; deterministic loopback inference, not vendor inference |
| Real-model reviewer smoke | One Gemini Flash reviewer via OpenRouter, two API calls, real read_file, planted subtraction defect found, labeled live registry entry observed, clean retirement |
| Provider billing readback | Generation receipts total $0.003691; not a local estimate |
| Ruff, Windows-footgun scan, compat pointers, diff whitespace | Passed |
| Gateway review regression | Initial CI found one gateway assertion still expecting the old acknowledgement. It now compares with the shared formatter; all 30 gateway/review-engine tests pass, including completion routing. |
| Full agent/run_agent directories | 8,710 passed, 30 skipped, 0 failed across 723 files; final review-engine rerun also passed (26 tests) |

Private ANSI-replay screenshots and probe receipts remain local; no trajectories are published. TUI/Desktop use the same shared goal, but were not separately driven natively in this scoped change. No viewer lifecycle, ownership, model tool schema, or parent prompt-cache changes. This does not establish why an older long-running CLI session lacked the dock.

Related: #105593.

## Infographic
![Clearer review progress](https://v3b.fal.media/files/b/0aa9976d/ohxq1dkOyB0WxStZoE_DS_HideJ0yh.png)
