### PR TITLE
fix(skills): posix-normalize model-facing skill paths on windows

### DIFF
--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -475,7 +475,7 @@ def _locate_skill(name: str, local_category_name: Optional[str], project_dirs: l
         # ambiguity WITHIN the project tier still refuses.
         candidates = [c for c in candidates if _under_any(c[1], project_dirs)] or candidates
     if len(candidates) > 1:
-        paths = [str(smd) for _, smd in candidates]
+        paths = [smd.as_posix() for _, smd in candidates]
         logger.warning("Skill name collision for '%s': %d candidates — %s", name, len(candidates), "; ".join(paths))
         return _fail(
             f"Ambiguous skill name '{name}': {len(candidates)} skills match across your local skills dir "
@@ -563,9 +563,10 @@ def skill_view(
             _parse_tags(hermes_meta.get(k) or frontmatter.get(k, "")) for k in ("tags", "related_skills"))
         linked_files = _skill_linked_files(skill_dir)
         try:
-            rel_path = str(skill_md.relative_to(active_skills_dir))
+            rel_path = skill_md.relative_to(active_skills_dir).as_posix()
         except ValueError:  # external skill — relative to its own parent dir
-            rel_path = str(skill_md.relative_to(skill_md.parent.parent)) if skill_md.parent.parent else skill_md.name
+            rel_path = (skill_md.relative_to(skill_md.parent.parent).as_posix()
+                        if skill_md.parent.parent else skill_md.name)
         skill_name = frontmatter.get("name", skill_md.stem if not skill_dir else skill_dir.name)
         readiness, readiness_extras = _skill_readiness(frontmatter, skill_name)
         rendered_content = content if not preprocess else _preprocess_skill(

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -371,7 +371,7 @@ def _skill_linked_files(skill_dir: Optional[Path]) -> dict:
     for sub, globs, recursive, files_only in _LINKED_FILE_SPECS if skill_dir else ():
         base = skill_dir / sub
         found = [
-            str(f.relative_to(skill_dir)) for g in globs if base.exists()
+            f.relative_to(skill_dir).as_posix() for g in globs if base.exists()
             for f in (base.rglob(g) if recursive else base.glob(g))
             if not files_only or f.is_file()]
         if found:

--- a/tools/skills_tool_plugin.py
+++ b/tools/skills_tool_plugin.py
@@ -58,7 +58,7 @@ def _available_skill_files(skill_dir: Path) -> Dict[str, List[str]]:
     for f in skill_dir.rglob("*"):
         if not f.is_file() or f.name == "SKILL.md":
             continue
-        rel = str(f.relative_to(skill_dir))
+        rel = f.relative_to(skill_dir).as_posix()
         top = rel.split("/", 1)[0] if "/" in rel else None
         if top in _SUPPORT_DIRS or f.suffix in _SKILL_FILE_EXTS:
             groups.setdefault(top if top in _SUPPORT_DIRS else "other", []).append(rel)

--- a/tools/skills_tool_plugin.py
+++ b/tools/skills_tool_plugin.py
@@ -165,7 +165,7 @@ def _plugin_skill_linked_files(skill_root: Path) -> Dict[str, List[str]] | None:
     linked: Dict[str, List[str]] = {}
     for category in _SUPPORT_DIRS:
         files = [
-            str(path.relative_to(skill_root)) for path in sorted((skill_root / category).rglob("*"))
+            path.relative_to(skill_root).as_posix() for path in sorted((skill_root / category).rglob("*"))
             if path.is_file() and validate_within_dir(path, skill_root) is None]
         if files:
             linked[category] = files


### PR DESCRIPTION
Fixes #105745

## Problem

On Windows, model-facing relative paths in skill tool results are built with `str(Path.relative_to(...))` and then split/grouped by `"/"`. `relative_to()` returns OS-native separators, so:

1. `_available_skill_files()` (`tools/skills_tool_plugin.py`) puts `referencespi.md` into the `"other"` group instead of `"references"` — `skill_view(name, file_path=<dir>)` surfaces an "available files" listing where the files are misgrouped (callers keying on `result["available_files"]["references"]` get a `KeyError`).
2. `_skill_linked_files()` (`tools/skills_tool.py`) and `_plugin_skill_linked_files()` (`tools/skills_tool_plugin.py`) leak backslashed paths into the model-facing `linked_files` dict of `skill_view` — a linked reference surfaces as `referencespi.md` while the `usage_hint` in the same result says to call `skill_view(file_path="references/api.md")`.
3. `skill_view` result `"path"` and collision `"matches"` carry backslashes (`sketch\SKILL.md`), while tests and consumers assume POSIX.
4. Five tests fail on Windows at `main` purely on these separator asserts (3 in `tests/tools/test_skills_tool.py`, 2 in `tests/test_plugin_skills.py`).

## Fix

Normalize to POSIX at the boundary where paths become strings in tool results:

- `tools/skills_tool_plugin.py:61` — `f.relative_to(skill_dir).as_posix()`
- `tools/skills_tool.py:566/568` — `rel_path = ...relative_to(...).as_posix()` (plus the external-skill fallback)
- `tools/skills_tool.py:478` — collision `matches = [smd.as_posix(), ...]`
- `tools/skills_tool.py:374` — `_skill_linked_files()`: `f.relative_to(skill_dir).as_posix()` (from review, thanks @gaoanze888)
- `tools/skills_tool_plugin.py:168` — `_plugin_skill_linked_files()`: `path.relative_to(skill_root).as_posix()` (from review, thanks @gaoanze888)

No behavioral change on POSIX systems (`as_posix()` is a no-op there — `PurePath.as_posix()` only swaps `\` for `/`).

## Verification (Windows 11, Python 3.14, clean shared clone of upstream main `d4d4ecfae0`)

Before fix (upstream main, no local patches):
```
FAILED tests/tools/test_skills_tool.py::TestSkillView::test_view_file_path_directory_returns_available_files
FAILED tests/tools/test_skills_tool.py::TestSkillViewCollisionDetection::test_nested_local_collides_with_top_level_external
FAILED tests/tools/test_skills_tool.py::TestSkillViewCollisionDetection::test_support_markdown_does_not_collide_with_real_skill
FAILED tests/test_plugin_skills.py::TestSkillViewQualifiedName::test_reads_supporting_file_with_containment
FAILED tests/test_plugin_skills.py::TestSkillViewQualifiedName::test_platform_gate_applies_before_supporting_file
```
(The last one is host-dependent: it expects `platforms: [windows]` to gate to unsupported, which only holds on a non-Windows runner. It fails identically with the fix stashed and is NOT addressed by this PR; the other 4 are separator asserts fixed by this PR + the review follow-up.)

After fix:
```
tests/tools/test_skills_tool.py + test_plugin_skills.py + test_skill_view_dedup.py + test_skill_view_path_check.py + test_skill_view_traversal.py
88 passed, 4 skipped, 1 failed (the pre-existing host-dependent test above)
```

Broader skills suite (`test_skill_manager_tool, test_skill_provenance, test_skills_list_modified_diff, test_skill_usage, test_skills_sync, test_skill_ledger`): 4 pre-existing Windows failures (symlink-privilege `WinError 1314` without a skip guard, skills_sync/ledger path handling) — verified identical on a stash of this fix applied away, i.e. NOT regressions from this PR; they are separate issues.

Minimal repro of the production bug (fixed by this change):
```python
from tools.skills_tool_plugin import _available_skill_files
_available_skill_files(d)  # {'other': ['referencespi.md']}  ->  {'references': ['references/api.md']}
from tools.skills_tool import _skill_linked_files
_skill_linked_files(d)  # {'references': ['referencespi.md']}  ->  {'references': ['references/api.md']}
```