### PR TITLE
fix(browser): re-probe Chromium on repeated autoinstall attempts

### DIFF
--- a/tests/tools/test_browser_chromium_autoinstall.py
+++ b/tests/tools/test_browser_chromium_autoinstall.py
@@ -92,6 +92,40 @@ class TestInstall:
         assert bt_install._maybe_autoinstall_chromium() is False
 
 
+class TestStaleCacheOnFailure:
+    def test_manual_install_after_failed_autoinstall_is_detected(self, monkeypatch):
+        """#105746: a failed autoinstall must not freeze the negative cache forever.
+
+        Mirrors the real call order in ``_browser_command_preflight``: ``_chromium_installed()``
+        runs first (caching the negative result), then ``_maybe_autoinstall_chromium()``. Once the
+        autoinstall attempt has failed, the next preflight round must re-probe disk rather than keep
+        reporting the pre-install absence, so a manual ``npx playwright install`` becomes visible
+        without a process restart.
+        """
+        monkeypatch.delenv("AGENT_BROWSER_EXECUTABLE_PATH", raising=False)
+        monkeypatch.setattr(shutil, "which", lambda name: None)
+        chromium_present = {"value": False}
+        monkeypatch.setattr(bt_install, "_chromium_search_roots", lambda: ["/fake/ms-playwright"])
+        monkeypatch.setattr("os.path.isdir", lambda p: p == "/fake/ms-playwright")
+        monkeypatch.setattr(bt_install, "_has_chromium_build", lambda root: chromium_present["value"])
+
+        # Preflight's first check: Chromium absent, negative result cached.
+        assert bt_install._chromium_installed() is False
+
+        # Autoinstall attempt fails (e.g. offline, no npx).
+        monkeypatch.setattr(bt_install, "_running_in_docker", lambda: False)
+        monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(bt_install, "_find_agent_browser", lambda: (_ for _ in ()).throw(FileNotFoundError()))
+        assert bt_install._maybe_autoinstall_chromium() is False
+
+        # User installs Chromium manually; the on-disk probe now finds it.
+        chromium_present["value"] = True
+
+        # Without invalidating the cache on the failure path, this would still return False.
+        assert bt_install._maybe_autoinstall_chromium() is True
+        assert bt_install._chromium_installed() is True
+
+
 class TestOneShot:
     def test_second_call_does_not_reinstall(self, monkeypatch):
         monkeypatch.setattr("tools.browser_tool_install._running_in_docker", lambda: False)

--- a/tools/browser_tool_install.py
+++ b/tools/browser_tool_install.py
@@ -250,6 +250,7 @@ def _maybe_autoinstall_chromium() -> bool:
     """
     _bt = _origin()
     if _bt._chromium_autoinstall_attempted:
+        _bt._cached_chromium_installed = None  # re-probe: the user may have installed it manually since the last attempt
         return _chromium_installed()
     _bt._chromium_autoinstall_attempted = True
     if _running_in_docker():


### PR DESCRIPTION
Fixes #105746

## Problem

`_chromium_installed()` caches its result in `_bt._cached_chromium_installed`. `_maybe_autoinstall_chromium()` only clears that cache on its **success** path (after a successful install). Every early-return failure branch — Docker (`_running_in_docker()`), `security.allow_lazy_installs` disabled, `agent-browser` CLI not found, non-zero install exit — returns `False` without touching the cache.

Once autoinstall has been attempted once per process, all later calls route through:

```python
if _bt._chromium_autoinstall_attempted:
    return _chromium_installed()
```

which just re-reads the same frozen `False`. So if the first autoinstall attempt fails and the user then installs Chromium manually (exactly as the error message instructs, e.g. `npx playwright install --with-deps chromium`), Hermes keeps reporting "Chromium browser is missing" for the rest of the process lifetime — only a restart clears it. Docker deployments are hit hardest, since the docker branch returns before any install attempt at all.

## Fix

Invalidate `_cached_chromium_installed` right before that "already attempted" branch re-checks, so every call after the first re-probes disk instead of trusting a stale negative result:

```python
if _bt._chromium_autoinstall_attempted:
    _bt._cached_chromium_installed = None  # re-probe: the user may have installed it manually since the last attempt
    return _chromium_installed()
```

This is the minimal fix suggested in the issue and covers all failure paths in one place, since every one of them sets `_chromium_autoinstall_attempted = True` before returning — so the very next call, regardless of which branch failed, goes through this re-probe.

## Test

Added `TestStaleCacheOnFailure::test_manual_install_after_failed_autoinstall_is_detected` to `tests/tools/test_browser_chromium_autoinstall.py`, mirroring the real call order in `_browser_command_preflight()` (`_chromium_installed()` first, then `_maybe_autoinstall_chromium()`): probes disk as Chromium-absent, fails one autoinstall attempt (`FileNotFoundError` from `_find_agent_browser`), flips the disk probe to Chromium-present (simulating a manual install), and asserts a subsequent `_maybe_autoinstall_chromium()` call now returns `True`.

Confirmed the test fails without the fix:

```
$ git checkout HEAD~1 -- tools/browser_tool_install.py
$ scripts/run_tests.sh tests/tools/test_browser_chromium_autoinstall.py -v
...
FAILED tests/tools/test_browser_chromium_autoinstall.py::TestStaleCacheOnFailure::test_manual_install_after_failed_autoinstall_is_detected
assert False is True
========================= 1 failed, 6 passed in 1.42s ==========================
$ git checkout HEAD -- tools/browser_tool_install.py
```

And passes with the fix applied:

```
$ scripts/run_tests.sh tests/tools/test_browser_chromium_autoinstall.py -v
...
tests/tools/test_browser_chromium_autoinstall.py::TestStaleCacheOnFailure::test_manual_install_after_failed_autoinstall_is_detected PASSED [ 85%]
...
=== Summary: 1 files, 7 tests passed, 0 failed (100% complete) in 1.9s (8 workers) ===
```

Also ran the surrounding browser test files to check for regressions — all green:

```
$ scripts/run_tests.sh tests/tools/test_browser_chromium_check.py tests/tools/test_browser_hardening.py tests/gateway/test_browser_control_api.py -v
=== Summary: 3 files, 46 tests passed, 0 failed ===
```

`ruff check` on both changed files: all checks passed.

## AI assistance disclosure

This PR was prepared by an AI coding agent (Claude), including the diagnosis, fix, and test. It was reviewed against the issue's own repro and suggested fix before being pushed.
