### PR TITLE
fix(tui-gateway): preserve profile runtime scope for side agents

### DIFF
--- a/tests/tui_gateway/test_ephemeral_profile_override.py
+++ b/tests/tui_gateway/test_ephemeral_profile_override.py
@@ -1,4 +1,4 @@
-"""Regression tests: profile HERMES_HOME override in ephemeral agent threads (#50233).
+"""Regression tests: profile runtime scope in ephemeral agent threads (#50233).
 
 Why: normal prompt turns bind ``session['profile_home']`` via
 ``set_hermes_home_override`` before ``run_conversation`` so the turn runs against
@@ -14,10 +14,18 @@ a non-default profile would run against the wrong home. This module locks in:
      background server the restart just started — maintainer problem #1).
   3. Both paths RESTORE the override after the turn (reset token from set), exactly
      like the normal prompt turn, and skip the bind entirely when no profile is set.
+  4. Both paths bind the FULL profile runtime scope (HERMES_HOME + secret scope +
+     terminal scope), not HOME alone: HOME without the secret scope resolves the
+     side agent's credentials from the launch profile's ambient environment, and
+     HOME without the terminal scope resolves its execution backend/policy from
+     there too.
 
 How to test: run this module with pytest; each test drives the real RPC handler
 from ``tui_gateway.server._methods`` with ``threading.Thread`` patched to run the
 target inline, then asserts on the recorded override set/reset calls and the agent.
+The scope tests (4) capture real ``get_hermes_home()`` / ``get_secret()`` /
+``terminal_env()`` values inside the ephemeral turn: no scope machinery is mocked
+away, so they fail against the old HOME-only implementation.
 """
 
 from unittest.mock import MagicMock, patch
@@ -156,3 +164,131 @@ class TestPreviewRestartProfileOverride:
         override_calls["set"].assert_not_called()
         override_calls["reset"].assert_not_called()
         override_calls["agent"].close.assert_not_called()
+
+
+class TestSideAgentProfileRuntimeScope:
+    """The ephemeral turn binds the FULL profile runtime scope (HOME + secret +
+    terminal), not HOME alone.
+
+    Setup: a tmp target profile P (``.env`` holds ``SIDECAR_PROBE_KEY=profile-val``,
+    ``config.yaml`` pins ``terminal.backend: docker``) while the ambient process
+    environment holds the launch profile's values (``SIDECAR_PROBE_KEY=launch-val``,
+    ``TERMINAL_ENV=local``). The real ``prompt.background`` handler runs inline and
+    the mocked agent captures real ``get_hermes_home()`` / ``get_secret()`` /
+    ``terminal_env()`` values inside the turn. No scope machinery is mocked away:
+    against the old HOME-only implementation the secret assertions observe the
+    launch value with no scope installed, and the terminal assertions observe the
+    ambient launch backend.
+    """
+
+    @pytest.fixture
+    def profile_home(self, tmp_path):
+        home = tmp_path / "profiles" / "work"
+        home.mkdir(parents=True)
+        (home / ".env").write_text("SIDECAR_PROBE_KEY=profile-val\n")
+        (home / "config.yaml").write_text("terminal:\n  backend: docker\n")
+        return home
+
+    @pytest.fixture
+    def launch_env(self, monkeypatch):
+        monkeypatch.setenv("SIDECAR_PROBE_KEY", "launch-val")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    @pytest.fixture
+    def scoped_run(self, profile_home):
+        """Run ``prompt.background`` inline; capture the real scope state observed
+        inside the ephemeral turn. Returns (session, captured)."""
+        from agent.secret_scope import current_secret_scope, get_secret
+        from hermes_constants import get_hermes_home
+        from tools.terminal_scope import get_terminal_scope, terminal_env
+
+        captured = {}
+        agent_instance = MagicMock()
+
+        def _capture(**kwargs):
+            captured["home"] = str(get_hermes_home())
+            captured["scope"] = current_secret_scope()
+            captured["secret"] = get_secret("SIDECAR_PROBE_KEY")
+            captured["term_scope"] = get_terminal_scope()
+            captured["terminal_env"] = terminal_env("TERMINAL_ENV", "local")
+            return {"final_response": "done"}
+
+        agent_instance.run_conversation.side_effect = _capture
+        session = {
+            "agent": MagicMock(), "session_key": "sess_k",
+            "profile_home": str(profile_home),
+        }
+        with patch("tui_gateway.server.threading.Thread", _InlineThread), \
+            patch("tui_gateway.server._background_agent_kwargs", return_value={}), \
+            patch("tui_gateway.server._set_session_context", return_value=None), \
+            patch("tui_gateway.server._clear_session_context"), \
+            patch("tui_gateway.server._session_cwd", return_value="/tmp"), \
+            patch("tui_gateway.server._emit"), \
+            patch("run_agent.AIAgent", return_value=agent_instance):
+            with patch("tui_gateway.server._sess", return_value=(session, None)):
+                handler = srv._methods["prompt.background"]
+                resp = handler(
+                    "rid1", {"text": "hi", "session_id": "ui1"})
+        assert resp.get("result", {}).get("task_id", "").startswith("bg_")
+        return session, captured
+
+    def test_side_agent_binds_home(self, launch_env, scoped_run):
+        """HOME resolves to the target profile inside the ephemeral turn."""
+        _session, captured = scoped_run
+        assert captured["home"] == _session["profile_home"]
+
+    def test_side_agent_binds_secret_scope(self, launch_env, scoped_run):
+        """Credentials resolve from the target profile, not ambient launch env."""
+        from agent.secret_scope import get_secret
+
+        _session, captured = scoped_run
+        assert captured["scope"] is not None
+        assert captured["scope"].get("SIDECAR_PROBE_KEY") == "profile-val"
+        assert captured["secret"] == "profile-val"
+        # ... and the scope is released afterwards (no leak into this context).
+        assert get_secret("SIDECAR_PROBE_KEY") == "launch-val"
+
+    def test_side_agent_binds_terminal_scope(self, launch_env, scoped_run):
+        """Terminal authority resolves from the target profile's config."""
+        from tools.terminal_scope import get_terminal_scope, terminal_env
+
+        _session, captured = scoped_run
+        assert captured["term_scope"] is not None
+        assert captured["terminal_env"] == "docker"
+        # ... and the scope is released afterwards (ambient restored).
+        assert get_terminal_scope() is None
+        assert terminal_env("TERMINAL_ENV", "local") == "local"
+
+    def test_side_agent_profiless_unchanged(self, launch_env):
+        """Without profile_home the turn runs fully ambient, as before."""
+        from agent.secret_scope import current_secret_scope, get_secret
+        from hermes_constants import get_hermes_home
+        from tools.terminal_scope import get_terminal_scope
+
+        ambient_home = str(get_hermes_home())
+        captured = {}
+        agent_instance = MagicMock()
+
+        def _capture(**kwargs):
+            captured["home"] = str(get_hermes_home())
+            captured["scope"] = current_secret_scope()
+            captured["secret"] = get_secret("SIDECAR_PROBE_KEY")
+            captured["term_scope"] = get_terminal_scope()
+            return {"final_response": "done"}
+
+        agent_instance.run_conversation.side_effect = _capture
+        session = {"agent": MagicMock(), "session_key": "sess_k", "profile_home": None}
+        with patch("tui_gateway.server.threading.Thread", _InlineThread), \
+            patch("tui_gateway.server._background_agent_kwargs", return_value={}), \
+            patch("tui_gateway.server._set_session_context", return_value=None), \
+            patch("tui_gateway.server._clear_session_context"), \
+            patch("tui_gateway.server._session_cwd", return_value="/tmp"), \
+            patch("tui_gateway.server._emit"), \
+            patch("run_agent.AIAgent", return_value=agent_instance):
+            with patch("tui_gateway.server._sess", return_value=(session, None)):
+                srv._methods["prompt.background"](
+                    "rid1", {"text": "hi", "session_id": "ui1"})
+        assert captured["home"] == ambient_home
+        assert captured["scope"] is None
+        assert captured["secret"] == "launch-val"
+        assert captured["term_scope"] is None

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -913,24 +913,19 @@ def _spawn_side_agent(
 
     def run():
         session_tokens = _set_session_context(task_id, cwd=(cwd or _session_cwd(session)))
-        # Bug #50233: ephemeral agent threads don't inherit the session's HERMES_HOME override (the
-        # ContextVar set on the session-create thread doesn't propagate here), so a background turn under a
-        # non-default profile would run against the wrong home. Re-bind the override for the duration of
-        # this turn, exactly as the normal prompt turn does, and restore it afterward.
-        # Bug #50233: ephemeral preview-restart agent threads don't inherit the session's HERMES_HOME
-        # override (the ContextVar set on the session-create thread doesn't propagate here). Re-bind it for
-        # the duration of the turn, mirroring the normal prompt turn, then restore it. NOTE: we deliberately
-        # do NOT close this agent through task-wide process cleanup — the whole point of preview.restart is
-        # to leave a background server running under this task_id, and AIAgent.close() would kill every
-        # process for the task_id and tear down the very server the restart just started.
-        profile_home = session.get("profile_home")
-        home_token = set_hermes_home_override(profile_home) if profile_home else None
+        # Bug #50233 (+ secret/terminal scope pairing): ephemeral agent threads don't inherit the
+        # session's profile scopes (the ContextVars set on the session-create thread don't propagate
+        # here), so a background turn under a non-default profile would run against the wrong home —
+        # and, worse, resolve credentials and terminal policy from the launch profile. Bind the full
+        # profile runtime scope (HERMES_HOME + secret + terminal) for the duration of this turn,
+        # exactly as the normal prompt turn does. No-op when the session has no profile_home.
+        # NOTE: we deliberately do NOT close this agent through task-wide process cleanup — the whole
+        # point of preview.restart is to leave a background server running under this task_id, and
+        # AIAgent.close() would kill every process for the task_id and tear down the very server the
+        # restart just started.
         try:
-            try:
+            with _session_profile_runtime_scope(session):
                 text = body()
-            finally:
-                if home_token is not None:
-                    reset_hermes_home_override(home_token)
             _emit(event, parent, {"task_id": task_id, **extra, "text": text})
         except Exception as e:
             _emit(event, parent, {"task_id": task_id, **extra, "text": f"error: {e}"})


### PR DESCRIPTION
## Summary

Completes profile runtime-scope propagation for ephemeral TUI Gateway side-agent threads.

PR #86389 fixed `HERMES_HOME` propagation for `prompt.background` and `preview.restart`, but the new worker thread still did not inherit the session's secret and terminal `ContextVar` scopes. This could leave an ephemeral execution with a mixed profile context:

* `HERMES_HOME` → routed profile
* secret scope → launch profile
* terminal scope → launch profile

This change binds the existing `_session_profile_runtime_scope(session)` around the ephemeral side-agent execution so all three profile-scoped authorities remain aligned for the lifetime of the thread.

## Root cause

`prompt.background`, `prompt.btw`, and `preview.restart` execute the side agent in a fresh `threading.Thread`.

`ContextVar` state from the session's execution context is not automatically propagated to that thread. The existing code explicitly rebound `HERMES_HOME`, but did not bind the corresponding secret and terminal scopes.

As a result, credential and terminal resolution could fall back to the ambient launch profile.

## Fix

Replace the HOME-only override with the existing `_session_profile_runtime_scope(session)` abstraction:

```python
with _session_profile_runtime_scope(session):
    text = body()
```

This preserves:

* profile `HERMES_HOME`
* profile secret scope
* profile terminal scope

and restores the previous context when the ephemeral execution exits, including error paths.

## Regression coverage

Added regression tests that exercise the real `prompt.background` RPC path with the worker thread inlined.

The tests verify:

* `HERMES_HOME` resolves to the target profile
* secrets resolve from the target profile
* terminal scope resolves to the target profile
* all scopes are restored after execution
* profile-less sessions retain their existing behavior

The tests use real scope resolution rather than mocking the scope machinery, and reproduce the failure against the pre-fix implementation.

## Validation

* `tests/tui_gateway/test_ephemeral_profile_override.py`: 10/10 passed
* Related TUI Gateway tests: 20/20 passed
* `ruff check`: passed
* `git diff --check`: passed

Related precedent: #86389 fixed the corresponding `HERMES_HOME` propagation issue for these ephemeral threads. This PR addresses the remaining secret/terminal runtime-scope propagation at the same execution boundary.
