### PR TITLE
fix(errors): classify 503 auth_unavailable as auth, not overloaded

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -259,6 +259,13 @@ _AUTH_PATTERNS = (
     "forbidden", "invalid token", "token expired", "token revoked", "access denied",
 )
 
+# A credential pool with no live credential (xAI: "auth_unavailable: no auth available
+# (providers=xai, model=...)") arrives as HTTP 503. It reads like server overload but is a
+# credential problem — the identical request cannot succeed on this credential no matter how
+# many times it is retried, so it must rotate/fall back like a real auth failure instead of
+# burning the full retry budget as a false "overloaded" (#105717).
+_AUTH_UNAVAILABLE_PATTERNS = ("auth_unavailable", "no auth available")
+
 # Empty-response advisories (OpenRouter / nano-gpt). Checked before overflow
 # because the text often mentions "max_tokens" (caused compression spirals).
 _EMPTY_PROVIDER_RESPONSE_PATTERNS = (
@@ -725,6 +732,14 @@ def _classify_400(c: _Ctx) -> Verdict:
     return _V_FORMAT_ERROR
 
 
+def _status_503(c: _Ctx) -> Verdict:
+    # Credential-pool exhaustion (xAI "auth_unavailable: no auth available") before the
+    # generic overload/overflow checks: retrying the same credential can never succeed.
+    if any(p in c.msg for p in _AUTH_UNAVAILABLE_PATTERNS):
+        return _V_AUTH_ROTATE
+    return _first_match(c.msg, _OVERFLOW_AS_5XX_RULES) or _V_OVERLOADED
+
+
 # 401 not retryable on its own: rotation/refresh run before the retryability
 # check, then the client-error abort path (fallback first) is correct. 408 is
 # retry-safe (RFC 9110 §15.5.9; proxies emit it when generation outruns the
@@ -733,7 +748,7 @@ _STATUS_HANDLERS: Dict[int, Callable[[_Ctx], Verdict]] = {
     400: _classify_400, 401: lambda c: _V_AUTH_ROTATE, 402: lambda c: _classify_402(c.msg, dict),
     403: _status_403, 404: _status_404, 408: lambda c: _V_TIMEOUT, 413: lambda c: _V_PAYLOAD_TOO_LARGE,
     429: _status_429, 500: _status_5xx, 502: _status_5xx,
-    503: lambda c: _first_match(c.msg, _OVERFLOW_AS_5XX_RULES) or _V_OVERLOADED,
+    503: _status_503,
     529: lambda c: _first_match(c.msg, _OVERFLOW_AS_5XX_RULES) or _V_OVERLOADED,
 }
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -464,6 +464,22 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.overloaded
 
+    def test_503_auth_unavailable_rotates_instead_of_overloaded(self):
+        """xAI's credential pool reports 'auth_unavailable: no auth available' as HTTP 503.
+        Classifying it as generic overload lets the retry loop burn the full retry budget
+        retrying the exact same uncredentialed call; it must instead rotate/fall back like a
+        real auth failure so a delegate leaf fails fast instead of exhausting its iteration
+        budget without ever executing its task. (#105717)"""
+        e = MockAPIError(
+            "API call failed after 10 retries: HTTP 503: auth_unavailable: no auth available "
+            "(providers=xai, model=grok-4.6)",
+            status_code=503,
+        )
+        result = classify_api_error(e, provider="xai", model="grok-4.6")
+        assert result.reason == FailoverReason.auth
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
 
     def test_408_request_timeout_is_retryable_timeout(self):
         """HTTP 408 Request Timeout is a transient timing failure the server


### PR DESCRIPTION
## What does this PR do?

Fixes error classification so a `503` reporting credential-pool exhaustion (e.g. xAI's
`auth_unavailable: no auth available (providers=xai, model=grok-4.6)`) is treated as an
auth failure (rotate credential / fall back, fail fast) instead of a generic `overloaded`
verdict (retry the identical request with backoff).

`agent/error_classifier.py`'s `_STATUS_HANDLERS[503]` only checked the context-overflow /
empty-response patterns before falling back to `overloaded`, which is `retryable=True` with
no rotation or fallback. For a request that has no live credential at all, retrying the
identical call cannot ever succeed — the retry loop instead burned its full `max_retries`
budget on the same dead credential before giving up, exactly as reported: a `delegate_task`
child spent all 10 retries and returned `completed/truncated` without ever executing its
assigned work.

## Related Issue

Fixes #105717

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: added `_AUTH_UNAVAILABLE_PATTERNS` (`"auth_unavailable"`,
  `"no auth available"`) and a `_status_503()` handler that checks them first and returns
  the same `auth` verdict (`retryable=False`, `should_rotate_credential=True`,
  `should_fallback=True`) that a 401 already gets, before falling through to the existing
  overflow/overloaded checks.
- `tests/agent/test_error_classifier.py`: added
  `test_503_auth_unavailable_rotates_instead_of_overloaded`, reproducing the exact error
  string from the issue.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_error_classifier.py -k test_503_auth_unavailable_rotates_instead_of_overloaded`
2. Confirmed the new test fails on the pre-fix code (`git checkout HEAD~1 -- agent/error_classifier.py`) with:
   ```
   AssertionError: assert <FailoverReason.overloaded: 'overloaded'> == <FailoverReason.auth: 'auth'>
   ```
3. With the fix restored, the full file passes: `135 tests passed, 0 failed`.
4. Full `tests/agent/` run: same 9 pre-existing failures (missing sandbox credentials —
   `test_vision_routing_31179.py`, `test_nous_portal_anthropic_wire.py`, etc.) reproduce
   identically on unmodified `main`; no new failures introduced.
5. `ruff check agent/error_classifier.py tests/agent/test_error_classifier.py` — all checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (via `scripts/run_tests.sh`, scoped to `tests/agent/`; pre-existing unrelated failures confirmed present on unmodified `main`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (CI sandbox)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A, inline comment only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (N/A, pure error-message classification, no platform dependency)

---

*Drafted with AI assistance (Claude); classification, fix, and test verification reviewed before submission.*
