### PR TITLE
feat(context): inject per-session project context files from projects.db

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1437,6 +1437,102 @@ def _truncate_content(
     return content[:head_chars] + marker + content[-tail_chars:]
 
 
+CONTEXT_INCLUDE_MAX_DEPTH = 10
+
+
+def _expand_context_includes(
+    content: str,
+    base_dir: Path,
+    *,
+    confine: bool = False,
+    _depth: int = 0,
+    _visited: Optional[set] = None,
+) -> str:
+    """Expand ``@path`` include directives in a context file.
+
+    A line whose only non-whitespace content is ``@<path>`` is replaced by the
+    contents of ``<path>``, resolved relative to ``base_dir`` (the directory of
+    the file the directive appears in). Includes nest: an included file's own
+    ``@`` directives are expanded relative to that file's directory. This lets a
+    single ``SOUL.md`` compose separate, independently-edited files (a global
+    identity, an agent role, a project overlay) that stay live on disk - editing
+    an included file changes the next prompt build with no reinstall.
+
+    Robustness is deliberate: only a whole-line ``@path`` (no space after the
+    ``@``) is a directive, so an email address or an inline ``@handle`` is never
+    mistaken for one. Every file is expanded at most once across the whole
+    tree - a repeated include, a diamond, or a cycle collapses to a single copy
+    and later encounters leave a visible ``[include skipped ...]`` marker rather
+    than duplicating content or looping. Missing, unreadable, over-deep, and
+    (when ``confine``) out-of-tree targets each leave their own visible marker
+    instead of raising. The single shared visited set also bounds total work:
+    each file is read once, so a fan-out cannot amplify into N**depth copies.
+
+    ``confine`` controls the trust boundary. Operator-owned files (``SOUL.md``)
+    leave it False so an include may reach across the filesystem (e.g. a vault
+    checked out elsewhere) - that author can already put anything in the prompt.
+    Files discovered from the working directory (``.hermes.md``, ``AGENTS.md``,
+    ``CLAUDE.md``) may come from an untrusted cloned repo, so they set it True:
+    absolute paths and ``..``/symlink escapes out of ``base_dir`` are refused,
+    which stops a hostile checked-in context file from reading host secrets
+    (``@/etc/passwd``, ``@~/.ssh/id_rsa``) into the model's context.
+    """
+    if "@" not in content:
+        return content
+    if _visited is None:
+        _visited = set()
+    if _depth >= CONTEXT_INCLUDE_MAX_DEPTH:
+        return content
+
+    out_lines: List[str] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("@"):
+            out_lines.append(line)
+            continue
+        # A directive is a bare @path on its own line: no space after the @ and
+        # no whitespace inside. Prose that merely starts with @, or "@ foo", is
+        # left untouched.
+        rel = stripped[1:]
+        if not rel or any(c.isspace() for c in rel):
+            out_lines.append(line)
+            continue
+        target = (base_dir / rel).resolve()
+        if confine:
+            try:
+                target.relative_to(base_dir.resolve())
+            except ValueError:
+                out_lines.append(f"[include outside base dir: {rel}]")
+                continue
+        key = str(target)
+        if key in _visited:
+            # Already expanded somewhere in the tree (repeat, diamond, or cycle):
+            # emit once, skip the rest - this is what bounds total work.
+            out_lines.append(f"[include skipped (already included): {rel}]")
+            continue
+        if not target.is_file():
+            out_lines.append(f"[include not found: {rel}]")
+            continue
+        try:
+            included = target.read_text(encoding="utf-8").strip()
+        except Exception as e:
+            logger.debug("Could not read include %s: %s", target, e)
+            out_lines.append(f"[include unreadable: {rel}]")
+            continue
+        _visited.add(key)
+        expanded = _expand_context_includes(
+            included,
+            target.parent,
+            confine=confine,
+            _depth=_depth + 1,
+            _visited=_visited,
+        )
+        if _depth + 1 >= CONTEXT_INCLUDE_MAX_DEPTH and "@" in expanded:
+            expanded += f"\n[include depth limit reached at: {rel}]"
+        out_lines.append(expanded)
+    return "\n".join(out_lines)
+
+
 def load_soul_md(context_length: Optional[int] = None, home_override: "Path | None" = None) -> Optional[str]:
     """SOUL.md from HERMES_HOME (identity slot #1), or None.
 
@@ -1465,6 +1561,7 @@ def load_soul_md(context_length: Optional[int] = None, home_override: "Path | No
             content = strip_legacy_protocol(content).strip()
         if not content:
             return None
+        content = _expand_context_includes(content, soul_path.parent)
         return _truncate_content(_scan_context_content(content, "SOUL.md"), "SOUL.md", context_length=context_length,
                                  read_path=str(soul_path))
     except Exception as e:
@@ -1493,8 +1590,9 @@ def _load_hermes_md(cwd_path: Path, context_length: Optional[int] = None) -> str
     """.hermes.md / HERMES.md — nearest match walking up to the git root."""
     hermes_md_path = _find_hermes_md(cwd_path)
     content = _read_context_file(hermes_md_path) if hermes_md_path else ""
-    if not content:
+    if not content or hermes_md_path is None:
         return ""
+    content = _expand_context_includes(content, hermes_md_path.parent, confine=True)
     label = str(hermes_md_path.relative_to(cwd_path)) if hermes_md_path.is_relative_to(cwd_path) else hermes_md_path.name
     return _context_section(_strip_yaml_frontmatter(content), label, ".hermes.md", hermes_md_path, context_length)
 
@@ -1534,6 +1632,7 @@ def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str
                 continue
             if content not in seen_content:  # else: identical copy along the chain
                 seen_content.add(content)
+                content = _expand_context_includes(content, directory, confine=True)
                 label = name if directory == cwd_resolved else os.path.relpath(candidate, cwd_resolved)
                 sections.append(_context_section(content, label, label, candidate, context_length))
             break  # first name match wins per directory
@@ -1549,6 +1648,7 @@ def _load_claude_md(cwd_path: Path, context_length: Optional[int] = None) -> str
     for name in ("CLAUDE.md", "claude.md"):
         content = _read_context_file(cwd_path / name)
         if content:
+            content = _expand_context_includes(content, cwd_path, confine=True)
             return _context_section(content, name, "CLAUDE.md", cwd_path / name, context_length)
     return ""
 

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -92,3 +92,23 @@ def resolve_context_cwd() -> Path | None:
     launch dir). An existing configured path is honored verbatim — including the Hermes source tree, a
     legitimate workspace when developing Hermes; fallback-directory policy lives in the caller."""
     return _resolve_configured_cwd(override_is_final=True)
+
+
+def resolve_logical_cwd() -> str:
+    """The session's configured cwd as a raw string, WITHOUT host is_dir validation.
+
+    resolve_context_cwd/resolve_agent_cwd host-validate the path (it must be a real local dir),
+    which is correct for reading LOCAL context files but wrong for keying a lookup that lives off-host:
+    a non-local (ssh/docker) backend's cwd is a path inside the target environment and never exists on
+    this host, so host-validation would drop it. This returns the session override (else TERMINAL_CWD)
+    verbatim so callers can match it against config keyed on the working_dir (e.g. a project's
+    primary_path). Empty string when nothing is configured. Mirrors the non-local exemption in
+    tui_gateway.session_workdir._completion_cwd.
+
+    Off-host paths MUST be absolute (no '~' or relative): the lookup normalizes via
+    projects_db._normalize_path, which expands/abspaths against THIS host, so a relative or
+    '~'-prefixed off-host working_dir would mis-key and silently miss.
+    """
+    override = _SESSION_CWD.get()
+    override = "" if override is _UNSET else str(override).strip()
+    return override or scope_terminal_cwd().strip()

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -25,7 +25,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, drain_truncation_warnings,
 )
 from agent import prompt_builder as _pb
-from agent.runtime_cwd import resolve_context_cwd
+from agent.runtime_cwd import resolve_context_cwd, resolve_logical_cwd
 from hermes_constants import get_default_hermes_root, get_hermes_home
 from utils import is_truthy_value
 
@@ -591,9 +591,57 @@ def _context_files_part(agent: Any, ctx_len: Optional[int], soul_loaded: bool) -
     if agent.skip_context_files:
         return []
     launch_artifact = getattr(agent, "_context_cwd_is_launch_artifact", False)
-    return [_pb.build_context_files_prompt(
+    parts = [_pb.build_context_files_prompt(
         cwd=None if launch_artifact else resolve_context_cwd(), skip_soul=soul_loaded, context_length=ctx_len,
         allow_install_tree_fallback=agent.platform in ("cli", "tui"), home_override=_agent_home(agent))]
+    parts.extend(_project_context_parts(ctx_len))
+    return parts
+
+
+def _project_context_parts(ctx_len: Optional[int]) -> List[str]:
+    """Per-session, per-project context file for the CWD tier.
+
+    Resolves THIS session's project from its raw session cwd against the profile's projects.db and
+    reads the single rendered context file recorded in the ``context_path:<project_id>`` meta key.
+    That file is provisioned by the vault (one ``@``-include per context source, general -> specific)
+    and expanded here the same way SOUL.md is - so the customer-wide and project-specific AGENTS.md
+    compose into one section. Vault provisioning owns what path is stored and what it includes (no
+    vault-layout knowledge here). Any failure (no db, no project, no meta, unreadable file) degrades
+    to no project context; the whole thing is best-effort so prompt-cache stability is preserved.
+    Callers MUST append the result to the cwd-dependent context tier only, never the stable prefix.
+
+    Scope: keyed on the CONFIGURED logical cwd (session override / TERMINAL_CWD), with no os.getcwd()
+    fallback - a plain local CLI launched inside a registered project folder gets no project context.
+    Intended: project context follows a provisioned working_dir (the vault's remote ssh agents), not
+    an ambient launch dir.
+    """
+    try:
+        cwd = resolve_logical_cwd()  # raw, NOT host-validated: an ssh/docker project working_dir lives off-host
+        if not cwd:
+            return []
+        from hermes_cli import projects_db
+        # Read-only best-effort: do NOT let a prompt build CREATE projects.db (connect() would
+        # mkdir+schema it). Skip the sqlite open+scan entirely for the common project-less profile.
+        if not projects_db.projects_db_path().exists():
+            return []
+        with projects_db.connect_closing(projects_db.projects_db_path()) as conn:
+            project = projects_db.project_for_path(conn, str(cwd))
+            if project is None:
+                return []
+            raw = projects_db._get_meta(conn, "context_path:" + project.id)
+        if not raw:
+            return []
+        path = Path(raw)
+        content = _pb._read_context_file(path)
+        if not content:
+            return []
+        # confine=False: the rendered file @-includes absolute vault paths that live outside its own
+        # dir (same trust posture as SOUL.md - the provisioner authored what it includes).
+        content = _pb._expand_context_includes(content, path.parent, confine=False)
+        return [_pb._context_section(content, "project context", raw, path, ctx_len)]
+    except Exception as exc:
+        logger.debug("project context skipped: %s", exc)
+        return []  # any failure -> no project context (mirror the except-pass posture)
 
 
 def _join_tier(parts: List[Optional[str]]) -> str:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -12,6 +12,8 @@ import pytest
 
 from agent.prompt_builder import (
     _scan_context_content,
+    _expand_context_includes,
+    load_soul_md,
     _truncate_content,
     _parse_skill_file,
     _skill_should_show,
@@ -1213,3 +1215,131 @@ class TestContextFileReadTimeout:
 
         with pytest.raises(FileNotFoundError):
             _read_text_with_timeout(tmp_path / "missing.md", timeout=1.0)
+
+
+class TestExpandContextIncludes:
+    """`@path` include directives in context files (SOUL.md, AGENTS.md, ...)."""
+
+    def test_no_directive_returns_content_unchanged(self, tmp_path):
+        content = "# Identity\n\nPlain content, no includes.\n"
+        assert _expand_context_includes(content, tmp_path) == content
+
+    def test_includes_a_sibling_file(self, tmp_path):
+        (tmp_path / "role.md").write_text("You are the assistant.", encoding="utf-8")
+        content = "# Identity\n\n@role.md\n"
+        out = _expand_context_includes(content, tmp_path)
+        assert "You are the assistant." in out
+        assert "@role.md" not in out
+
+    def test_directive_must_be_alone_on_the_line(self, tmp_path):
+        # An email-like token or inline @ is NOT an include directive.
+        (tmp_path / "role.md").write_text("SHOULD NOT APPEAR", encoding="utf-8")
+        content = "Contact me at foo@role.md for details.\n"
+        out = _expand_context_includes(content, tmp_path)
+        assert "Contact me at foo@role.md for details." in out
+        assert "SHOULD NOT APPEAR" not in out
+
+    def test_leading_whitespace_allowed(self, tmp_path):
+        (tmp_path / "role.md").write_text("INCLUDED", encoding="utf-8")
+        out = _expand_context_includes("   @role.md\n", tmp_path)
+        assert "INCLUDED" in out
+
+    def test_nested_includes_resolve_relative_to_each_file(self, tmp_path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (tmp_path / "a.md").write_text("A\n@sub/b.md\n", encoding="utf-8")
+        (sub / "b.md").write_text("B\n@c.md\n", encoding="utf-8")
+        (sub / "c.md").write_text("C", encoding="utf-8")
+        out = _expand_context_includes("@a.md\n", tmp_path)
+        assert "A" in out and "B" in out and "C" in out
+        assert "@" not in out
+
+    def test_missing_target_leaves_a_marker_not_crash(self, tmp_path):
+        out = _expand_context_includes("@nope.md\n", tmp_path)
+        assert "nope.md" in out  # a visible marker names the missing file
+        # the whole load must not raise and must not silently vanish
+        assert out.strip() != ""
+
+    def test_cycle_is_broken(self, tmp_path):
+        (tmp_path / "a.md").write_text("A\n@b.md\n", encoding="utf-8")
+        (tmp_path / "b.md").write_text("B\n@a.md\n", encoding="utf-8")
+        out = _expand_context_includes("@a.md\n", tmp_path)
+        # both bodies appear once; the back-reference is stopped, not infinite
+        assert "A" in out and "B" in out
+
+    def test_depth_is_bounded(self, tmp_path):
+        # A long chain must terminate rather than recurse without bound.
+        for i in range(30):
+            (tmp_path / f"f{i}.md").write_text(f"L{i}\n@f{i + 1}.md\n", encoding="utf-8")
+        (tmp_path / "f30.md").write_text("END", encoding="utf-8")
+        out = _expand_context_includes("@f0.md\n", tmp_path)
+        assert "L0" in out  # starts expanding
+        # terminates and leaves a visible marker rather than a dangling directive
+        assert "depth limit reached" in out
+        assert "END" not in out  # never reached the bottom of the over-deep chain
+
+    def test_diamond_includes_each_file_once(self, tmp_path):
+        # root -> a, b; both -> shared. shared must appear once, not twice.
+        (tmp_path / "a.md").write_text("A\n@shared.md\n", encoding="utf-8")
+        (tmp_path / "b.md").write_text("B\n@shared.md\n", encoding="utf-8")
+        (tmp_path / "shared.md").write_text("SHARED_BODY", encoding="utf-8")
+        out = _expand_context_includes("@a.md\n@b.md\n", tmp_path)
+        assert out.count("SHARED_BODY") == 1
+        assert "already included" in out  # the second reference is marked
+
+    def test_unreadable_target_leaves_a_marker(self, tmp_path):
+        # A directory (not a file) is not a valid include target.
+        (tmp_path / "adir").mkdir()
+        out = _expand_context_includes("@adir\n", tmp_path)
+        assert "adir" in out
+        assert out.strip() != ""
+
+
+class TestExpandContextIncludesConfinement:
+    """confine=True refuses escapes; confine=False (SOUL) allows cross-tree."""
+
+    def test_confined_rejects_absolute_path(self, tmp_path):
+        outside = tmp_path / "secret.md"
+        outside.write_text("TOP SECRET", encoding="utf-8")
+        base = tmp_path / "repo"
+        base.mkdir()
+        out = _expand_context_includes(f"@{outside}\n", base, confine=True)
+        assert "TOP SECRET" not in out
+        assert "outside base dir" in out
+
+    def test_confined_rejects_parent_traversal(self, tmp_path):
+        (tmp_path / "secret.md").write_text("TOP SECRET", encoding="utf-8")
+        base = tmp_path / "repo"
+        base.mkdir()
+        out = _expand_context_includes("@../secret.md\n", base, confine=True)
+        assert "TOP SECRET" not in out
+        assert "outside base dir" in out
+
+    def test_confined_allows_in_tree_include(self, tmp_path):
+        base = tmp_path / "repo"
+        base.mkdir()
+        (base / "role.md").write_text("IN TREE", encoding="utf-8")
+        out = _expand_context_includes("@role.md\n", base, confine=True)
+        assert "IN TREE" in out
+
+    def test_unconfined_allows_absolute_path(self, tmp_path):
+        # SOUL.md (confine=False) may compose files anywhere - e.g. a vault.
+        outside = tmp_path / "vault" / "global.md"
+        outside.parent.mkdir()
+        outside.write_text("VAULT GLOBAL", encoding="utf-8")
+        base = tmp_path / "home"
+        base.mkdir()
+        out = _expand_context_includes(f"@{outside}\n", base, confine=False)
+        assert "VAULT GLOBAL" in out
+
+
+class TestSoulMdIncludes:
+    """load_soul_md expands @ includes relative to HERMES_HOME."""
+
+    def test_soul_expands_includes(self, tmp_path, monkeypatch):
+        (tmp_path / "SOUL.md").write_text("# Soul\n\n@global.md\n", encoding="utf-8")
+        (tmp_path / "global.md").write_text("GLOBAL RULES", encoding="utf-8")
+        out = load_soul_md(home_override=tmp_path)
+        assert out is not None
+        assert "GLOBAL RULES" in out
+        assert "@global.md" not in out

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -811,3 +811,141 @@ class TestConversationStartedTwoLine:
         assert "Conversation started:" not in vol
         assert "as of the last context rebuild" not in vol
 
+
+# ── Per-session, per-project context injection ───────────────────────────────
+# The session's project is resolved from its raw cwd against the profile's
+# projects.db; the single rendered file in `context_path:<id>` (a set of
+# @-includes, expanded like SOUL.md) is appended to the CWD context tier only —
+# never the byte-stable prefix.
+
+
+def _seed_projects_db(home, cwd, context_files):
+    """A projects.db under *home* with a project owning *cwd* and a
+    `context_path:<id>` meta key pointing at a rendered file that @-includes each
+    of *context_files* (abs paths) — the vault's provisioning shape."""
+    import os as _os
+
+    from hermes_cli import projects_db
+
+    _os.environ["HERMES_HOME"] = str(home)
+    home = Path(home)
+    home.mkdir(parents=True, exist_ok=True)
+    rendered = home / "projects_ctx.md"
+    rendered.write_text("\n".join(f"@{p}" for p in context_files))
+    with projects_db.connect_closing(projects_db.projects_db_path()) as conn:
+        pid = projects_db.create_project(conn, name="proj", primary_path=str(cwd))
+        from hermes_cli.sqlite_util import write_txn
+
+        with write_txn(conn):
+            projects_db._upsert_meta_locked(conn, "context_path:" + pid, str(rendered))
+    return pid
+
+
+class TestProjectContextInjection:
+    def _build_context(self, agent, cwd):
+        # Drive the REAL cwd resolution via _SESSION_CWD (as a live session does); do NOT mock
+        # resolve_context_cwd/resolve_logical_cwd - that would hide whether a non-local (remote,
+        # non-existent-on-host) cwd actually resolves to a project. Only the non-project context
+        # base is stubbed.
+        import agent.runtime_cwd as _rc
+        tok = _rc._SESSION_CWD.set(str(cwd))
+        try:
+            with (
+                patch("agent.prompt_builder.load_soul_md", return_value=""),
+                patch("agent.prompt_builder.build_environment_hints", return_value=""),
+                patch("agent.prompt_builder.build_context_files_prompt", return_value="BASE_CONTEXT"),
+            ):
+                return build_system_prompt_parts(agent)
+        finally:
+            _rc._SESSION_CWD.reset(tok)
+
+    def test_injects_meta_listed_files_for_matching_cwd(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        # A REMOTE-style working_dir that does NOT exist on this host (the ssh case): host-validated
+        # resolution would drop it, so this proves the project lookup keys on the raw logical cwd.
+        cwd = "/home/felix/projects/xsd-parser"
+        shared = tmp_path / "shared_context.md"
+        shared.write_text("SHARED PROJECT CONTEXT")
+        overlay = tmp_path / "overlay_context.md"
+        overlay.write_text("AGENT OVERLAY CONTEXT")
+        _seed_projects_db(tmp_path / "home", cwd, [shared, overlay])
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+
+        parts = self._build_context(_make_agent(), cwd)
+
+        assert "SHARED PROJECT CONTEXT" in parts["context"]
+        assert "AGENT OVERLAY CONTEXT" in parts["context"]
+        # Routed through _context_section → carries the "## project context" header.
+        assert "## project context" in parts["context"]
+        # Cwd tier only — never the byte-stable prefix.
+        assert "SHARED PROJECT CONTEXT" not in parts["stable"]
+        assert "AGENT OVERLAY CONTEXT" not in parts["stable"]
+
+    def test_oversized_project_context_is_capped(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        cwd = tmp_path / "workspace"
+        cwd.mkdir()
+        big = tmp_path / "big_context.md"
+        big.write_text("X" * 500_000)  # far above any CONTEXT_FILE_MAX_CHARS ceiling
+        _seed_projects_db(tmp_path / "home", cwd, [big])
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+
+        parts = self._build_context(_make_agent(), cwd)
+
+        assert "## project context" in parts["context"]
+        assert "[...truncated" in parts["context"]  # budget cap applied
+        assert len(parts["context"]) < 500_000
+
+    def test_no_project_match_injects_nothing_and_does_not_raise(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        cwd = tmp_path / "workspace"
+        cwd.mkdir()
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        shared = tmp_path / "shared_context.md"
+        shared.write_text("SHARED PROJECT CONTEXT")
+        # Project owns `other`, not `cwd`.
+        _seed_projects_db(tmp_path / "home", other, [shared])
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+
+        parts = self._build_context(_make_agent(), cwd)
+
+        assert "SHARED PROJECT CONTEXT" not in parts["context"]
+        assert parts["context"].count("BASE_CONTEXT") == 1
+
+    def test_no_db_injects_nothing_and_does_not_raise(self, monkeypatch, tmp_path):
+        # HERMES_HOME points at a dir with no projects.db yet.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "empty_home"))
+        (tmp_path / "empty_home").mkdir()
+        cwd = tmp_path / "workspace"
+        cwd.mkdir()
+
+        parts = self._build_context(_make_agent(), cwd)
+
+        assert "BASE_CONTEXT" in parts["context"]
+
+    def test_never_mutates_the_stable_prefix(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        cwd = tmp_path / "workspace"
+        cwd.mkdir()
+        shared = tmp_path / "shared_context.md"
+        shared.write_text("SHARED PROJECT CONTEXT")
+        pid = _seed_projects_db(tmp_path / "home", cwd, [shared])
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+
+        stable_with_project = self._build_context(_make_agent(), cwd)["stable"]
+
+        # Same HERMES_HOME (so the env-derived prefix is byte-identical), but now
+        # drop the project's context meta: the stable prefix must be unchanged and
+        # never carry project context.
+        from hermes_cli import projects_db
+        from hermes_cli.sqlite_util import write_txn
+
+        with projects_db.connect_closing(projects_db.projects_db_path()) as conn:
+            with write_txn(conn):
+                conn.execute("DELETE FROM project_meta WHERE key = ?", ("context_path:" + pid,))
+        stable_without_project = self._build_context(_make_agent(), cwd)["stable"]
+
+        assert stable_with_project == stable_without_project
+        assert "SHARED PROJECT CONTEXT" not in stable_with_project
+

--- a/website/docs/user-guide/features/context-files.md
+++ b/website/docs/user-guide/features/context-files.md
@@ -162,6 +162,30 @@ The following project context files have been loaded and should be followed:
 
 Notice that SOUL content is inserted directly, without extra wrapper text.
 
+## Composing files with `@` includes
+
+Any context file (`SOUL.md`, `.hermes.md`, `AGENTS.md`, `CLAUDE.md`) can pull in another file with an `@` include directive. A line whose only content is `@<path>` is replaced by the contents of that file, resolved relative to the directory of the file the directive appears in:
+
+```markdown
+# SOUL.md
+
+@identity/global.md
+@identity/role.md
+```
+
+This keeps a single identity or instruction file composed of smaller, independently-edited pieces that stay live on disk - editing an included file changes the next prompt build with no reinstall or copy step. It is the natural way to share one global identity across agents while layering a per-agent role or a per-project overlay on top.
+
+Includes nest: an included file's own `@` directives are expanded relative to *that* file's location, so a directory of building blocks can reference its siblings.
+
+Rules and safeguards:
+
+- **Whole-line only.** A directive must be a bare `@path` alone on its line (leading whitespace is allowed, but no space after the `@`). An email address or an inline `@handle` in prose is never treated as an include.
+- **Relative paths.** The path resolves against the including file's directory. Use forward slashes; subdirectories like `@sub/role.md` work.
+- **Each file is included once.** A file referenced more than once across the whole tree (a repeat, a diamond, or a cycle) is expanded on first encounter; later references collapse to an `[include skipped (already included): <path>]` marker. This also bounds the work: no include chain can amplify into an exponential blow-up, because every file is read at most once.
+- **Missing files are visible, not fatal.** A directive pointing at a file that does not exist is replaced by an `[include not found: <path>]` marker (or `[include unreadable: ...]` / `[include depth limit reached at: ...]` for the other failure modes) rather than raising or silently vanishing.
+- **Trust boundary depends on the file.** `SOUL.md` lives in the Hermes home and is operator-owned, so its includes may point anywhere on the filesystem (for example a vault checked out under a different path). The working-directory files (`.hermes.md`, `AGENTS.md`, `CLAUDE.md`) may come from an untrusted cloned repo, so their includes are **confined**: absolute paths and `..`/symlink targets that escape the file's own directory are refused with an `[include outside base dir: <path>]` marker. This prevents a hostile checked-in context file from reading host secrets into the prompt.
+- **Same scanning as the top-level file.** Included content is run through the same prompt-injection scan and size cap after expansion, so an include cannot smuggle content past those checks.
+
 ## Security: Prompt Injection Protection
 
 All context files are scanned for potential prompt injection before being included. The scanner checks for:


### PR DESCRIPTION
**Draft — depends on #98614** (`feature/context-file-includes`).

This branch is stacked on `feature/context-file-includes`. Because a cross-fork PR must target a branch that exists in this repo, GitHub shows this PR against `main` and therefore includes #98614's two commits in the diff. **Only the final commit is new here:**

- `feat(context): inject per-session project context files from projects.db` — `810a58eb0`

The other two commits (`feat(agent): expand @ includes in context files`, `docs(agent): document @ include directives`) belong to #98614 — review them there. Kept as a draft until #98614 lands; once it merges into `main`, rebasing this branch drops the duplicated commits and the diff collapses to the single new commit. No re-open needed.

## What does this PR do?

Injects a **per-session, per-project context file** into the CWD context tier, resolved from the session's project rather than its launch directory.

When a session runs with a configured working directory (a session cwd override, or `TERMINAL_CWD`), this looks that path up in the profile's `projects.db`, and if it maps to a registered project, reads the single rendered context file recorded in that project's `context_path:<project_id>` meta key and expands it exactly like `SOUL.md` (`@`-includes, general → specific). That rendered file is provisioned externally (the vault records one `@`-include per context source), so a customer-wide `AGENTS.md` and a project-specific one compose into one `## project context` section without this code knowing any vault layout.

Why it builds on the `@`-include work (#98614): the injected file is a thin list of `@`-includes that must expand the same way `SOUL.md` does, with the same non-confined trust posture (the provisioner authored what it includes). This PR reuses `_expand_context_includes(..., confine=False)` from that branch rather than re-implementing include expansion.

Two deliberate design choices, both to keep prompt caching intact and behavior predictable:

- **Keyed on the configured *logical* cwd, not a host-validated path.** `resolve_context_cwd()` host-validates (the dir must exist locally), which is right for reading local context files but wrong for keying a lookup whose working_dir lives off-host: a non-local (ssh/docker) backend's project cwd never exists on the gateway host. The new `resolve_logical_cwd()` returns the raw session override / `TERMINAL_CWD` verbatim so the lookup keys on the same string the project was registered under. Off-host paths must be absolute (the lookup normalizes against this host).
- **No `os.getcwd()` fallback.** A plain local CLI launched *inside* a registered project folder gets no project context; project context only follows a provisioned working_dir. This keeps the stable prompt prefix byte-identical for ordinary launches.

Everything is best-effort and appended to the **cwd-dependent** tier only, never the byte-stable prefix: no db, no project match, no meta key, or an unreadable file all degrade silently to no project context. It also never *creates* `projects.db` from a prompt build — the sqlite open is skipped entirely when the file doesn't exist, so the common project-less profile pays nothing.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

Depends on #98614.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. Only 810a58eb0 is new in this PR. -->

- `agent/runtime_cwd.py`: add `resolve_logical_cwd()` — the session's configured cwd as a raw string, **without** host `is_dir` validation (session override → `TERMINAL_CWD` → empty). Mirrors the non-local exemption in `tui_gateway.session_workdir._completion_cwd`; documents that off-host working_dirs must be absolute (the lookup normalizes against this host).
- `agent/system_prompt.py`: `_context_files_part` now appends `_project_context_parts(ctx_len)`. New `_project_context_parts` resolves the session's project from the logical cwd against `projects.db` (read-only, no db creation), reads the `context_path:<project_id>` meta file, expands it with `_pb._expand_context_includes(..., confine=False)`, and returns one `_context_section(..., "project context", ...)`. Any failure → no project context (except-pass posture).
- `tests/agent/test_system_prompt.py`: `TestProjectContextInjection` — matching-cwd injection (incl. a remote-style cwd that does not exist on the host), oversize-cap, no-project-match no-op, no-db no-op, and a guard that the byte-stable prefix is never mutated.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. In a profile's `projects.db`, register a project whose `primary_path` is a working directory (a remote ssh path works — it need not exist on the host), and set its `context_path:<project_id>` meta to a rendered file that `@`-includes one or more context sources.
2. Start a session with that working_dir as its cwd (session cwd override or `TERMINAL_CWD`).
3. The system prompt's cwd context tier gains a `## project context` section composed from those includes. A session in a non-registered dir, or a plain local launch, gets nothing added.
4. Automated: `pytest tests/agent/test_system_prompt.py -q -k ProjectContextInjection`.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits) <!-- Draft: carries #98614's 2 commits until it lands; see the note at the top. Only 810a58eb0 is new. -->
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- behavior documented in docstrings; project-context provisioning is vault-owned, out of tree -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A <!-- no new config keys -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- logical cwd is compared raw; local reads still go through the existing path helpers -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the feature in action. -->
