### PR TITLE
fix(kanban): classify gateway-restart worker deaths as supervisor_restart, not crashed

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -218,7 +218,8 @@ def notify_task_updated(
 # DispatchResult counters whose non-zero value means the tick did something.
 _TICK_ACTIVITY_FIELDS = (
     "spawned", "reclaimed", "promoted", "reconciled_orphans", "crashed", "stale",
-    "timed_out", "auto_blocked", "rate_limited", "auto_assigned_default",
+    "timed_out", "auto_blocked", "rate_limited", "supervisor_restarts",
+    "auto_assigned_default",
     "respawn_guarded", "skipped_per_profile_capped", "skipped_unassigned",
     "skipped_nonspawnable",
 )

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -742,15 +742,55 @@ class _DeadWorker:
     event_payload: dict
     protocol_violation: bool = False
     rate_limited: bool = False
+    supervisor_restart: bool = False
 
     @property
     def run_outcome(self) -> str:
         # A rate-limited requeue is recorded as ``rate_limited`` so board history
-        # doesn't show a phantom crash for a quota wall.
-        return "rate_limited" if self.rate_limited else "crashed"
+        # doesn't show a phantom crash for a quota wall; a supervisor-restart
+        # casualty as ``supervisor_restart`` so a gateway restart (OOM kill,
+        # operator restart, crash) doesn't masquerade as task crashes.
+        if self.rate_limited:
+            return "rate_limited"
+        if self.supervisor_restart:
+            return "supervisor_restart"
+        return "crashed"
 
 
-def _classify_dead_worker(pid: int, claimer: Optional[str]) -> _DeadWorker:
+def _supervisor_restart_boot_ts() -> Optional[float]:
+    """Create time of THIS dispatcher process, or ``None`` when unknowable.
+
+    Uses the same psutil helper as ``process_identity`` (portable across
+    Linux/macOS/Windows); ``None`` makes callers fail safe to legacy
+    crash classification.
+    """
+    try:
+        import psutil  # type: ignore
+
+        return psutil.Process().create_time()
+    except Exception:
+        return None
+
+
+def _supervisor_restart_collateral(claim_started_at: Optional[float]) -> bool:
+    """True when a dead pre-boot claim is provably supervisor-restart collateral.
+
+    A task claimed before this process was created cannot have been served
+    by a child of this process: the previous dispatcher/gateway life (and
+    its in-flight workers) died with a supervisor restart. Fails safe
+    (False → legacy crash accounting) whenever either timestamp is missing.
+    """
+    boot_ts = _supervisor_restart_boot_ts()
+    if claim_started_at is None or boot_ts is None:
+        return False
+    return claim_started_at < boot_ts
+
+
+def _classify_dead_worker(
+    pid: int,
+    claimer: Optional[str],
+    claim_started_at: Optional[float] = None,
+) -> _DeadWorker:
     """Map a dead worker's reaped exit status to its reclaim bookkeeping."""
     kind, code = _classify_worker_exit(pid)
     if kind == "clean_exit":
@@ -779,6 +819,28 @@ def _classify_dead_worker(pid: int, claimer: Optional[str]) -> _DeadWorker:
         error_text = f"pid {pid} exited with code {code}"
     elif kind == "signaled":
         error_text = f"pid {pid} killed by signal {code}"
+    elif kind == "unknown" and _supervisor_restart_collateral(claim_started_at):
+        # The claim predates this dispatcher process: the dead PID cannot
+        # have been our child. A previous gateway/dispatcher life (OOM kill,
+        # operator restart, crash) took its in-flight workers with it via
+        # supervisor cgroup cleanup, and this process never observed those
+        # exits — so the reap registry says ``unknown``. Supervisor-restart
+        # collateral, not a task failure: neutral release, no failure tick
+        # (same accounting as the rate-limited quota wall).
+        return _DeadWorker(
+            "supervisor_restart", code,
+            f"pid {pid} died with the previous gateway "
+            f"(supervisor restart collateral — not a task failure)",
+            "gateway_restart_collateral",
+            {
+                "pid": pid,
+                "claimer": claimer,
+                "exit_kind": "supervisor_restart",
+                "gateway_boot_ts": _supervisor_restart_boot_ts(),
+                "claim_started_at": claim_started_at,
+            },
+            supervisor_restart=True,
+        )
     else:
         error_text = f"pid {pid} not alive"
     event_payload = {"pid": pid, "claimer": claimer}
@@ -794,6 +856,9 @@ class _CrashSweep:
 
     crashed: list[str] = field(default_factory=list)
     rate_limited: list[str] = field(default_factory=list)
+    # Gateway-restart collateral: neutral releases (no failure counted, not
+    # crashes) — surfaced via ``detect_crashed_workers._last_supervisor_restart``.
+    supervisor_restarts: list[str] = field(default_factory=list)
     # ``(task_id, pid, claimer, protocol_violation, error_text)``: accounted
     # after the txn via ``_record_task_failure`` (needs its own write_txn).
     crash_details: list[tuple[str, int, str, bool, str]] = field(default_factory=list)
@@ -825,7 +890,7 @@ def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
                 continue
 
             pid = int(row["worker_pid"])
-            dead = _classify_dead_worker(pid, row["claim_lock"])
+            dead = _classify_dead_worker(pid, row["claim_lock"], claim_started_at=started_at)
             retry_status = _kb._retry_status_for_run(conn, row["id"])
             dead.event_payload["retry_status"] = retry_status
             cur = conn.execute(
@@ -854,18 +919,22 @@ def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
                 "outcome": dead.run_outcome,
                 "retry_status": retry_status,
             })
-            if dead.rate_limited or dead.protocol_violation:
+            if dead.rate_limited or dead.protocol_violation or dead.supervisor_restart:
                 # Stamp last_failure_error WITHOUT touching ``consecutive_failures``:
                 # a rate-limited requeue must show ``check_respawn_guard`` a quota
                 # blocker; a below-budget protocol violation never reaches
                 # ``_record_task_failure`` (which stamps this column), yet the
-                # board UI and retry worker need the corrective message.
+                # board UI and retry worker need the corrective message; a
+                # supervisor-restart casualty is not a task failure at all but
+                # the board/retry context should still say what happened.
                 conn.execute(
                     "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
                     (dead.error_text[:500], row["id"]),
                 )
             if dead.rate_limited:
                 sweep.rate_limited.append(row["id"])
+            elif dead.supervisor_restart:
+                sweep.supervisor_restarts.append(row["id"])
             else:
                 sweep.crashed.append(row["id"])
                 sweep.crash_details.append(
@@ -952,6 +1021,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # requeues did NOT count a failure and are NOT crashes.
     detect_crashed_workers._last_auto_blocked = auto_blocked  # type: ignore[attr-defined]
     detect_crashed_workers._last_rate_limited = sweep.rate_limited  # type: ignore[attr-defined]
+    # Gateway-restart collateral: neutral releases, neither crash nor quota wall.
+    detect_crashed_workers._last_supervisor_restart = sweep.supervisor_restarts  # type: ignore[attr-defined]
     # Fired only now, after the reclaim txn AND breaker accounting have
     # committed, so subscribers always observe fully durable board state.
     if sweep.exited_hook_payloads and _kb._kanban_observer_consumed("on_kanban_worker_exited"):

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -126,6 +126,11 @@ class DispatchResult:
     """Task ids whose workers bailed on a provider rate-limit / quota wall
     (EX_TEMPFAIL sentinel exit) and were released to ``ready`` WITHOUT counting
     a failure — a long quota window must never trip the circuit breaker."""
+    supervisor_restarts: list[str] = field(default_factory=list)
+    """Task ids reclaimed as gateway-restart collateral: dead pre-boot claim
+    (``unknown`` exit, claim predating this dispatcher process). Released to
+    ``ready`` WITHOUT counting a failure — the worker died with a previous
+    dispatcher/gateway life, not with this task."""
     skipped_locked: bool = False
     """True when another process held the board's dispatch lock: this tick did
     no DB writes; the lock holder is making progress on the same board."""
@@ -773,12 +778,19 @@ def _supervisor_restart_boot_ts() -> Optional[float]:
 
 
 def _supervisor_restart_collateral(claim_started_at: Optional[float]) -> bool:
-    """True when a dead pre-boot claim is provably supervisor-restart collateral.
+    """True when a dead pre-boot claim was spawned by a previous dispatcher life.
 
-    A task claimed before this process was created cannot have been served
-    by a child of this process: the previous dispatcher/gateway life (and
-    its in-flight workers) died with a supervisor restart. Fails safe
-    (False → legacy crash accounting) whenever either timestamp is missing.
+    Provable from durable state: a task claimed before this process was
+    created cannot have been served by a child of this process, so its exit
+    went unobserved by every live dispatcher. In the dominant deployment
+    (dispatcher runs inside the long-lived gateway, ``kanban.dispatch_in_gateway``),
+    ticks run every few seconds, so an exit stays unobserved only when the
+    worker died together with its owning dispatcher/gateway life — supervisor
+    restart collateral (OOM kill, operator restart, crash). Residual
+    ambiguity: a one-shot/standalone dispatcher that exits while its workers
+    keep running leaves the same signature (see discussion on this PR and
+    #83066/#103961). Fails safe (False → legacy crash accounting) whenever
+    either timestamp is missing.
     """
     boot_ts = _supervisor_restart_boot_ts()
     if claim_started_at is None or boot_ts is None:
@@ -1714,6 +1726,8 @@ def _run_reclaim_phase(
     # went back to ``ready`` and the respawn guard defers them until quota clears.
     result.auto_blocked.extend(getattr(detect_crashed_workers, "_last_auto_blocked", []))
     result.rate_limited.extend(getattr(detect_crashed_workers, "_last_rate_limited", []))
+    result.supervisor_restarts.extend(
+        getattr(detect_crashed_workers, "_last_supervisor_restart", []))
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = _kb.recompute_ready(conn, failure_limit=failure_limit)
 

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -710,7 +710,12 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     ).fetchall()
     for row in rows:
         outcome = row["outcome"] or ""
-        if outcome == "rate_limited":
+        if outcome in ("rate_limited", "supervisor_restart"):
+            # Neutral outcomes say nothing about the task: a quota wall, and a
+            # release that died with the previous gateway life. A neutral run
+            # neither consumes nor replenishes this budget — skipping it keeps
+            # the streak intact across an interleaved neutral release
+            # (violation, violation, supervisor_restart, violation -> 3).
             continue
         if outcome == "crashed" and (
             _kb._json_dict(row["metadata"]).get("protocol_violation")

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -149,7 +149,8 @@ VALID_HOOKS: Set[str] = {
     # worker_spawned (DISPATCHER, after PID persisted, inside the dispatch lock — stay fast):
     #   worker_pid, workspace_path (privacy: project layout/usernames).
     # worker_exited (tick-derived on dead-PID reclaim): worker_pid, exit_kind ("clean_exit" |
-    #   "rate_limited" | "nonzero_exit" | "signaled" | "unknown"), exit_code, outcome, retry_status.
+    #   "rate_limited" | "nonzero_exit" | "signaled" | "unknown" | "supervisor_restart"),
+    #   exit_code, outcome, retry_status.
     # worker_stale_claim (TTL-expired claim reclaimed; live-PID extensions do NOT fire):
     #   worker_pid, heartbeat_stale, retry_status.
     # task_updated (committed task-row write outside claim/complete/block, in whichever process

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1416,3 +1416,89 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         conn.close()
 
 
+
+
+# ---------------------------------------------------------------------------
+# Gateway-restart collateral: dead pre-boot claim is not a task crash
+# ---------------------------------------------------------------------------
+
+
+def test_supervisor_restart_preboot_claim_neutral_release(kanban_home, monkeypatch):
+    """Dead PID + unknown exit + claim predating dispatcher boot -> neutral.
+
+    Expected: outcome ``supervisor_restart``, event kind
+    ``gateway_restart_collateral``, no failure-counter tick, task back at
+    ``ready`` for respawn.
+    """
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="pre-boot collateral", assignee="worker")
+        kb.claim_task(conn, tid)
+        kbd._set_worker_pid(conn, tid, 234567)
+        monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+        boot_ts = time.time() + 3600.0  # "process booted" an hour from now
+        monkeypatch.setattr(kbd, "_supervisor_restart_boot_ts", lambda: boot_ts)
+
+        crashed = kbd.detect_crashed_workers(conn)
+
+        assert crashed == []  # not a crash — neutral release
+        assert kbd.detect_crashed_workers._last_supervisor_restart == [tid]
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+        run = kb.latest_run(conn, tid)
+        assert run.outcome == "supervisor_restart"
+        assert "supervisor restart collateral" in (run.error or "")
+        ev = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()
+        assert ev is not None and ev["kind"] == "gateway_restart_collateral"
+    finally:
+        conn.close()
+
+
+def test_supervisor_restart_postboot_claim_stays_crashed(kanban_home, monkeypatch):
+    """Claim AFTER dispatcher boot + unknown exit -> still a genuine crash.
+
+    The classification only fires when the claim provably predates the
+    dispatcher process: a newer claim with a dead unregistered PID keeps
+    legacy crash accounting.
+    """
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="post-boot unknown", assignee="worker")
+        kb.claim_task(conn, tid)
+        kbd._set_worker_pid(conn, tid, 456789)
+        monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+        boot_ts = time.time() - 3600.0  # booted an hour ago
+        monkeypatch.setattr(kbd, "_supervisor_restart_boot_ts", lambda: boot_ts)
+
+        crashed = kbd.detect_crashed_workers(conn)
+
+        assert crashed == [tid]
+        run = kb.latest_run(conn, tid)
+        assert run.outcome == "crashed"
+        assert kbd.detect_crashed_workers._last_supervisor_restart == []
+    finally:
+        conn.close()
+
+
+def test_supervisor_restart_boot_ts_unavailable_stays_crashed(kanban_home, monkeypatch):
+    """Boot ts unavailable -> fail safe: legacy crashed classification."""
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="no boot ts", assignee="worker")
+        kb.claim_task(conn, tid)
+        kbd._set_worker_pid(conn, tid, 567890)
+        monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+        monkeypatch.setattr(kbd, "_supervisor_restart_boot_ts", lambda: None)
+
+        crashed = kbd.detect_crashed_workers(conn)
+
+        assert crashed == [tid]
+        run = kb.latest_run(conn, tid)
+        assert run.outcome == "crashed"
+    finally:
+        conn.close()
+

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1502,3 +1502,64 @@ def test_supervisor_restart_boot_ts_unavailable_stays_crashed(kanban_home, monke
     finally:
         conn.close()
 
+
+
+# ---------------------------------------------------------------------------
+# P2 review follow-up: neutral supervisor_restart releases must preserve the
+# protocol-violation streak (neither consume nor replenish the budget).
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_violation_streak_survives_interleaved_supervisor_restart(kanban_home, monkeypatch):
+    """violation, violation, supervisor_restart, violation -> streak 3.
+
+    Regression for the review finding: ``_protocol_violation_streak`` skipped
+    only ``rate_limited`` among neutral outcomes, so a gateway-restart
+    collateral release interleaved between violations reset the trailing
+    streak to the runs after it — silently replenishing the violation budget
+    on every restart. A neutral release must be skipped exactly like a quota
+    wall: the streak crosses it.
+    """
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="streak across neutral", assignee="worker")
+
+        # Two violations: streak 2.
+        _drive_protocol_violation(conn, tid, 992001)
+        _drive_protocol_violation(conn, tid, 992002)
+        assert kbd._protocol_violation_streak(conn, tid) == 2
+
+        # Neutral release interleaved: a supervisor-restart collateral pass.
+        # Pre-boot claim + dead pid + no reaped exit -> supervisor_restart.
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        kbd._set_worker_pid(conn, tid, 992003)
+        monkeypatch.setattr(kb, "_pid_alive", lambda p: False)
+        monkeypatch.setattr(kbd, "_supervisor_restart_boot_ts", lambda: time.time() + 3600.0)
+        kbd.detect_crashed_workers(conn)
+        latest = kb.latest_run(conn, tid)
+        assert latest.outcome == "supervisor_restart", (
+            f"expected neutral supervisor_restart, got {latest.outcome}"
+        )
+
+        # Third violation after the neutral release: streak must be 3, not 1.
+        _drive_protocol_violation(conn, tid, 992004)
+        assert kbd._protocol_violation_streak(conn, tid) == 3
+    finally:
+        monkeypatch.undo()
+        conn.close()
+
+
+def test_protocol_violation_streak_completed_run_breaks(kanban_home):
+    """Control: a completed run between violations still breaks the streak."""
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="streak vs completed", assignee="worker")
+        _drive_protocol_violation(conn, tid, 993001)
+        kb._synthesize_ended_run(conn, tid, outcome="completed", summary="done")
+        _drive_protocol_violation(conn, tid, 993002)
+        # completed is a genuine success boundary: streak restarts at 1
+        assert kbd._protocol_violation_streak(conn, tid) == 1
+    finally:
+        conn.close()
+

--- a/tests/hermes_cli/test_supervisor_restart_tick_activity.py
+++ b/tests/hermes_cli/test_supervisor_restart_tick_activity.py
@@ -1,0 +1,35 @@
+import time
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+from tests.hermes_cli.test_kanban_core_functionality import kanban_home  # noqa: F401
+
+
+def test_dispatch_tick_supervisor_restart_is_activity_not_idle(kanban_home, monkeypatch):
+    """A supervisor-restart collateral release must surface in DispatchResult
+    and count as tick activity — a gateway restart releasing N pre-boot claims
+    must not read as an idle tick to on_kanban_dispatch_tick subscribers."""
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="pre-boot idle check", assignee="worker")
+        kb.claim_task(conn, tid)
+        kbd._set_worker_pid(conn, tid, 234568)
+        monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+        monkeypatch.setattr(
+            kbd, "_supervisor_restart_boot_ts", lambda: time.time() + 3600.0
+        )
+
+        result = kbd.dispatch_once(conn)
+
+        assert result.supervisor_restarts == [tid]
+        assert result.crashed == []
+        assert kbd.detect_crashed_workers._last_supervisor_restart == [tid]
+    finally:
+        conn.close()
+
+
+def test_tick_activity_fields_include_supervisor_restarts():
+    """The tick-activity whitelist must count supervisor-restart releases as
+    activity, else a restart-heavy tick reports outcome='idle' to subscribers."""
+    assert "supervisor_restarts" in kb._TICK_ACTIVITY_FIELDS


### PR DESCRIPTION
## Problem

When the gateway (or standalone `hermes kanban dispatch`) restarts — OOM kill, operator restart, crash — systemd's cgroup cleanup SIGKILLs the in-flight kanban workers with it. The replacement dispatcher process never observed those exits, so `_classify_worker_exit` returns `"unknown"` for their PIDs and `detect_crashed_workers` books them as `outcome=crashed` with a failure-counter tick.

Consequences: phantom crashes pollute board history, the circuit breaker ticks for non-task-failures (retry tokens burned on work that died through no fault of the task), and users learn to ignore the `pid N not alive` signal — the same signal class several open issues track on other platforms (#86579 Windows, #97296 macOS).

## Fix

A dead PID whose task was claimed **before this dispatcher process was created** provably was never this process's child: classify as supervisor-restart collateral.

- `outcome: supervisor_restart`, event kind `gateway_restart_collateral`, `exit_kind: supervisor_restart` in the run metadata + `on_kanban_worker_exited` payload
- released WITHOUT counting a failure — same neutral accounting as the existing rate-limited quota-wall path (`_record_task_failure` never runs)
- recovery semantics unchanged (release + respawn); only label and accounting change
- timestamps via `psutil.Process().create_time()` (same helper `process_identity` uses), portable across Linux/macOS/Windows; missing timestamps fail safe to legacy crash classification
- surfaced for introspection via `detect_crashed_workers._last_supervisor_restart`, mirroring `_last_rate_limited`

## Evidence

Live 38-day board audit: 16 of 17 chronic `pid not alive` runs matched gateway-restart events exactly (journal: `hermes-gateway.service: Killing process <pid> ... SIGKILL` at the same PID and second as the recorded crash row). One OOM restart produced a triple crash batch the same minute.

## Tests

3 new in `tests/hermes_cli/test_kanban_core_functionality.py`:
- neutral release: pre-boot claim + dead PID + unknown exit → outcome `supervisor_restart`, event emitted, `consecutive_failures == 0`, task back at `ready`
- post-boot claim + unknown exit → still `crashed` (invariant only fires when provable)
- boot-ts unavailable → fails safe to legacy `crashed`

RED-proven on the parent commit (3/3 fail without the fix); full file 27/27 green with it.
