### PR TITLE
fix(desktop): keep IPC channel names out of file preview errors

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { MarkdownPreview } from './preview-file'
+import { friendlyPreviewError, MarkdownPreview } from './preview-file'
 
 // Behavior tests for the .md file preview renderer: input markdown goes
 // through normalizeFilePreviewMath -> Streamdown (+ KaTeX math plugin) and must
@@ -49,5 +49,40 @@ describe('MarkdownPreview', () => {
     expect(anchor?.getAttribute('href')).toBe('https://example.com/docs')
     expect(anchor?.getAttribute('target')).toBe('_blank')
     expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+})
+
+// Guards #105750: a deleted/moved file surfaced Electron's "Error invoking
+// remote method 'hermes:readFileDataUrl'" wrapper verbatim in the pane.
+describe('friendlyPreviewError', () => {
+  const fileGoneBody = 'This file may have been moved, renamed, or deleted.'
+
+  it('turns the wrapped IPC missing-file failure into friendly copy', () => {
+    const message = friendlyPreviewError(
+      new Error("Error invoking remote method 'hermes:readFileDataUrl': Error: File preview failed: file does not exist."),
+      fileGoneBody
+    )
+
+    expect(message).toBe(fileGoneBody)
+  })
+
+  it('recognizes raw ENOENT from a file deleted between stat and read', () => {
+    expect(friendlyPreviewError(new Error("ENOENT: no such file or directory, open '/tmp/gone.png'"), fileGoneBody)).toBe(
+      fileGoneBody
+    )
+  })
+
+  it('strips the invoke wrapper but keeps readable causes', () => {
+    const message = friendlyPreviewError(
+      new Error("Error invoking remote method 'hermes:readFileDataUrl': Error: File preview failed: file is too large (20971520 bytes; limit 16777216 bytes)."),
+      fileGoneBody
+    )
+
+    expect(message).toBe('File preview failed: file is too large (20971520 bytes; limit 16777216 bytes).')
+  })
+
+  it('passes plain errors and non-Error values through', () => {
+    expect(friendlyPreviewError(new Error('Timed out'), fileGoneBody)).toBe('Timed out')
+    expect(friendlyPreviewError('boom', fileGoneBody)).toBe('boom')
   })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -265,6 +265,19 @@ function dataUrlToBlob(dataUrl: string) {
   return new Blob([bytes], { type: 'application/pdf' })
 }
 
+// Electron wraps every rejected invoke in "Error invoking remote method
+// 'hermes:...': Error: ...", which used to leak internal IPC channel names
+// into the pane next to the real cause (#105750). Strip that wrapper and turn
+// missing-file failures into friendly copy; other causes (too large,
+// unreadable, …) keep their already-readable message.
+export function friendlyPreviewError(error: unknown, fileGoneBody: string): string {
+  const message = (error instanceof Error ? error.message : String(error))
+    .replace(/^Error invoking remote method '[^']+':\s*/, '')
+    .replace(/^Error:\s*/, '')
+
+  return /file does not exist|no such file or directory/i.test(message) ? fileGoneBody : message
+}
+
 async function readTextPreview(filePath: string) {
   try {
     return await readDesktopFileText(filePath)
@@ -777,7 +790,7 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
       } catch (error) {
         if (active) {
           setState({
-            error: error instanceof Error ? error.message : String(error),
+            error: friendlyPreviewError(error, t.preview.fileGoneBody),
             loading: false
           })
         }
@@ -799,6 +812,7 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
     isText,
     reloadKey,
     selfReload,
+    t.preview.fileGoneBody,
     target.dataUrl,
     target.language
   ])

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3317,6 +3317,7 @@ export const en: Translations = {
     closePane: 'Close preview pane',
     loading: 'Loading preview',
     unavailable: 'Preview unavailable',
+    fileGoneBody: 'This file may have been moved, renamed, or deleted.',
     opening: 'Opening...',
     hide: 'Hide',
     openPreview: 'Open preview',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2860,6 +2860,7 @@ export interface Translations {
     closePane: string
     loading: string
     unavailable: string
+    fileGoneBody: string
     opening: string
     hide: string
     openPreview: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3465,6 +3465,7 @@ export const zh: Translations = {
     closePane: '关闭预览面板',
     loading: '正在加载预览',
     unavailable: '预览不可用',
+    fileGoneBody: '该文件可能已被移动、重命名或删除。',
     opening: '正在打开...',
     hide: '隐藏',
     openPreview: '打开预览',


### PR DESCRIPTION
## What does this PR do?

When a previewed file no longer exists (deleted, moved, or renamed), the preview pane dumped Electron's raw invoke wrapper into the empty state:

```
Preview unavailable
Error invoking remote method 'hermes:readFileDataUrl': Error: File preview failed: file does not exist.
```

That message exposes internal IPC channel names to end users. This PR normalizes file-preview load failures through a new `friendlyPreviewError` helper that (1) strips Electron's `Error invoking remote method 'hermes:...':` wrapper (and the nested `Error:` prefix) and (2) recognizes the hardened read path's missing-file message — plus raw `ENOENT` from a file deleted between stat and read — and renders a friendly "This file may have been moved, renamed, or deleted." body instead. Other causes such as "file is too large" or "file is not readable" keep their already-readable message, just without the wrapper.

This follows the same pattern as the existing `friendlyRemoteAttachError` in `use-prompt-actions/utils.ts`, which already translates internal attach errors for the failure toast. The normalization sits in the single `load()` catch of `PreviewFile`, so image, PDF, and text previews are all covered.

## Related Issue

Fixes #105750

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/right-rail/preview-file.tsx`: added exported `friendlyPreviewError(error, fileGoneBody)`; the `load()` catch now stores its result in `state.error` (and `t.preview.fileGoneBody` joined the effect's dependency array).
- `apps/desktop/src/i18n/en.ts` + `types.ts`: new `preview.fileGoneBody` string ("This file may have been moved, renamed, or deleted.").
- `apps/desktop/src/i18n/zh.ts`: zh is a fully-translated locale, so the new key gets a Chinese string ("该文件可能已被移动、重命名或删除。"); other locales fall back to English via `defineLocale`.
- `apps/desktop/src/app/chat/right-rail/preview-file.test.tsx`: 4 regression tests for `friendlyPreviewError`.

## How to Test

1. `cd apps/desktop && npx vitest run src/app/chat/right-rail/preview-file.test.tsx`
2. Observed result: 8 passed (4 pre-existing `MarkdownPreview` tests + 4 new `friendlyPreviewError` tests, including the exact wrapped ENOENT message from the issue).
3. Also ran `npx vitest run src/i18n src/app/chat/right-rail/preview-pane.test.tsx` (45 passed before the types/zh additions, 36 re-passed after), `npx eslint` on all touched files (clean), and `npx tsc -p . --noEmit` (clean).
4. Manual equivalent: preview a file in the desktop app, delete it on disk, and reload the preview — the pane should show "Preview unavailable / This file may have been moved, renamed, or deleted." with no `hermes:` channel name.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suite (`vitest run` in `apps/desktop` — this is a TypeScript/renderer change, so the Python `pytest` suite doesn't cover it) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64); the touched code path is platform-independent renderer logic (issue was reported on Windows — the fix normalizes the error string identically on all platforms)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no documented behavior change; the user-facing string is new)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure string normalization in renderer code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ npx vitest run src/app/chat/right-rail/preview-file.test.tsx
 ✓ |ui| src/app/chat/right-rail/preview-file.test.tsx (8 tests) 91ms
 Test Files  1 passed (1)
      Tests  8 passed (8)
```
