### PR TITLE
fix(cron): only recurse into shell scripts during lifecycle guard walk

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -110,6 +110,10 @@ _HERMES_GATEWAY_LABEL_RE = re.compile(r"(?i)\bhermes[.\-]?gateway\b")
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})
 _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "+O", "-o", "+o"})
 _SHELL_COMMAND_FLAGS = {"-c", "--command"}
+# Recursion shell-tokenizes referenced scripts. Only POSIX-shell source is meaningful to
+# tokenize; feeding Node/Python/Ruby/etc. bundles to shlex generates bogus path tokens that
+# exhaust the scan budget and fail closed on innocent commands. See #78398.
+_SHELL_SHEBANG_RE = re.compile(r"^#!.*\b(?:sh|bash|dash|ksh|zsh)\b", re.IGNORECASE)
 _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
 _MAX_REFERENCED_SCRIPT_DEPTH = 8
 _CONTROL_CHARS = frozenset(";&|()")
@@ -777,6 +781,23 @@ def _has_binary_magic(data: bytes) -> bool:
     return data.startswith(_BINARY_MAGICS)
 
 
+def _is_shell_script(text: str, path: Path) -> bool:
+    """Return True when the file should be shell-tokenized by the recursive walk.
+
+    A non-shell shebang (e.g. ``#!/usr/bin/env node``) is the strongest signal to skip.
+    Without a shebang, conventional shell extensions are trusted; suffixless files are also
+    recursed into so that bare launchers still get scanned. Other extensions (``.py``,
+    ``.js``, ``.rb``, etc.) are skipped because shlexing them produces bogus path tokens.
+    """
+    if not text:
+        return False
+    first_line = text.lstrip("\ufeff").splitlines()[0]
+    if first_line.startswith("#!"):
+        return bool(_SHELL_SHEBANG_RE.match(first_line))
+    suffix = path.suffix.lower()
+    return suffix in ("", ".sh", ".bash", ".zsh", ".ksh")
+
+
 def _read_referenced_script(
     path: Path, *, max_bytes: Optional[int] = None
 ) -> tuple[Optional[str], bool]:
@@ -929,6 +950,11 @@ def _contains_unsafe_gateway_action(
             if unsafe:
                 return True
         if not script_text:
+            continue
+        # The walk shell-tokenizes the file text. Only POSIX-shell source is meaningful to
+        # recurse into; non-shell interpreters generate bogus path tokens from regex literals
+        # and strings and can exhaust the scan budget on a benign command.
+        if not _is_shell_script(script_text, resolved):
             continue
         # Relative references inside a script resolve against that script's directory, not the cwd.
         if recurse(script_text, _resolve_script_directory(str(resolved)) or cwd):

--- a/tests/cron/test_lifecycle_guard_budget.py
+++ b/tests/cron/test_lifecycle_guard_budget.py
@@ -239,3 +239,61 @@ def test_default_budget_admits_a_wide_benign_wrapper_graph(tmp_path):
     evil.write_text("hermes gateway restart\n", encoding="utf-8")
     hub.write_text(hub.read_text() + f"bash {evil}\n", encoding="utf-8")
     assert guard(f"bash {hub}") is True
+
+
+def test_non_shell_shebang_skips_recursive_scan(tmp_path):
+    """A Node/Python/Ruby/etc. bundle must not be shell-tokenized: shlex turns
+    regex literals and strings into bogus path tokens that exhaust the
+    remote-read budget and fail closed on an innocent command."""
+    bundle = tmp_path / "ob"
+    # Minified-JS shape: many slash-containing tokens, non-shell shebang.
+    bundle.write_text(
+        "#!/usr/bin/env node\n"
+        "const r1 = /foo/bar/g;\n"
+        "const r2 = /^[a-z/]+$/g;\n"
+        "const r3 = /usr/bin/env node;\n",
+        encoding="utf-8",
+    )
+    bundle.chmod(0o755)
+
+    reads: list[str] = []
+
+    def remote(path: str):
+        reads.append(path)
+        return None
+
+    assert guard(str(bundle), cwd=str(tmp_path), read_remote_script=remote) is False
+    # No remote reads attempted for bogus tokens inside the bundle.
+    assert reads == []
+
+
+def test_shell_shebang_still_recurses(tmp_path):
+    """A script with a POSIX shell shebang is still recursed into."""
+    inner = tmp_path / "inner.sh"
+    outer = tmp_path / "outer.sh"
+    inner.write_text("#!/bin/bash\nhermes gateway restart\n", encoding="utf-8")
+    outer.write_text(f"#!/bin/bash\n{inner}\n", encoding="utf-8")
+    inner.chmod(0o755)
+    outer.chmod(0o755)
+
+    assert guard(str(outer), cwd=str(tmp_path)) is True
+
+
+def test_no_shebang_shell_extension_still_recurses(tmp_path):
+    """Backward compat: .sh files without a shebang are still treated as shell."""
+    inner = tmp_path / "inner.sh"
+    outer = tmp_path / "outer.sh"
+    inner.write_text("hermes gateway restart\n", encoding="utf-8")
+    outer.write_text(f"{inner}\n", encoding="utf-8")
+    inner.chmod(0o755)
+    outer.chmod(0o755)
+
+    assert guard(str(outer), cwd=str(tmp_path)) is True
+
+
+def test_unknown_extension_without_shebang_is_skipped(tmp_path):
+    """A .py/.js/etc. file without a shebang is not shell-tokenized."""
+    script = tmp_path / "helper.py"
+    script.write_text("# hermes gateway restart\n", encoding="utf-8")
+
+    assert guard(f"python {script}", cwd=str(tmp_path)) is False


### PR DESCRIPTION
## Summary
The terminal lifecycle guard falsely blocks benign commands that invoke Node.js CLI bundles (e.g. `obsidian-headless`' `ob` CLI) with:

> Blocked: command or referenced script cannot restart, stop, or uninstall the gateway from inside the gateway process.

The block is caused by the **64 remote-read cap** introduced in the Sep 3 scan-budget commits (`d99eed7d83`, `e4c1e56d5d`) interacting with the recursive referenced-script walk.

## Regression range
- Works on: **2026-08-28** (before budget cap)
- Broken on: **2026-09-08** (`main` at `d4d4ecfae0c135b7bb52ff4f782ffef17bbc90c7`)
- Introducing commits: `d99eed7d83` "perf(cron): bound the lifecycle guard's whole-walk scan work" and `e4c1e56d5d` "perf(cron): 1 MiB walk budget".

## Reproduction

```python
# /home/gilad/.npm-global/bin/ob is obsidian-headless v0.0.13, a 216 KB minified Node bundle
from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script

contains_gateway_lifecycle_command_or_referenced_script(
    "/home/gilad/.npm-global/bin/ob --version",
    cwd="/home/gilad/.npm-global/bin",
    read_remote_script=lambda p: None,  # terminal guard supplies a real callback
)
# Returns True (blocked) because the remote-read budget exhausts.
```

With `read_remote_script=None` the function returns `False`, confirming the block depends on the remote-read path.

## Root cause

1. The command's executable is `/home/gilad/.npm-global/bin/ob`.
2. `_iter_referenced_shell_scripts` yields this path as a "referenced script".
3. The guard reads the file successfully (it is text, not binary).
4. It then **shell-tokenizes the entire minified JavaScript bundle** to look for nested scripts.
5. The bundle contains **152 slash-containing tokens** from regex literals and strings, e.g. `/^[x00-x19s,[]{}]/`, `/n+/g`, `/usr/bin/env`.
6. Each bogus token is treated as a candidate script path; when `read_remote_script` is provided, the guard tries to read it remotely.
7. After **64 remote reads** the budget is exhausted and the guard **fails closed**, blocking the command.

Before `d99eed7d83` there was no `_MAX_LIFECYCLE_SCAN_REMOTE_READS` cap, so the walk could finish and return `False`.

## Why this is a bug class, not a one-off

The recursive walk is only meaningful for **POSIX shell source**. Feeding non-shell interpreters (Node, Python, Ruby, etc.) to `shlex` produces path-shaped garbage and burns the scan budget without improving security. Any sufficiently large interpreted-executable bundle with regex literals or URL strings will trigger this.

## Suggested fix

Only recurse into referenced scripts whose first line indicates a POSIX shell shebang (`#!/bin/sh`, `#!/usr/bin/env bash`, etc.). This preserves the budget's DoS intent while avoiding false positives on non-shell bundles.

## Environment

- Host: Debian 13 VPS
- Hermes: `main` at `d4d4ecfae0c135b7bb52ff4f782ffef17bbc90c7`
- Obsidian CLI: `obsidian-headless` v0.0.13
- File: `cron/lifecycle_guard.py`, `_contains_unsafe_gateway_action` (recursive walk)

## Related commits/PRs

- `d99eed7d83` perf(cron): bound the lifecycle guard's whole-walk scan work (#78398)
- `e1a791b9f6` refactor(cron): fold review findings into the lifecycle scan budget
- `e4c1e56d5d` perf(cron): 1 MiB walk budget
- `2fe6fd9b6c` refactor(terminal): lifted script reader (provided the callback that now exhausts the cap)
