### PR TITLE
fix(cron): require shell shape for content-derived script references (#105758)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -683,12 +683,17 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
 # --- referenced-script discovery --------------------------------------------------------------
 
 def _looks_like_shell_script(path: Path) -> bool:
-    """True when *path* is plausibly a shell script: a shell suffix, or any ``#!`` shebang line.
+    """True when *path* is plausibly a shell script: a shell suffix, a leading ``#!`` shebang line,
+    or the executable bit set on a regular file.
 
     Gates only the bare-path branch of ``_references_at`` when the token it is judging came from a
     referenced script's own content rather than a command that will actually run — see
     ``content_derived`` there. A non-shell interpreter (Node, Python, ...) never starts a real
-    script with ``#!``-less garbage, so this stays cheap: two bytes, no shlex.
+    script with ``#!``-less garbage, so shape checks stay cheap: two bytes, no shlex. The executable
+    bit is also required (not just suffix/shebang) because a POSIX shell's ENOEXEC fallback runs any
+    executable, shebang-less, non-.sh-suffixed file handed to it via ``./name`` — the same shape
+    that ``test_nul_padded_script_without_shebang_is_scanned`` already covers one level up, at the
+    directly-invoked (non content-derived) branch.
     """
     if path.suffix in _SHELL_SCRIPT_SUFFIXES:
         return True
@@ -701,6 +706,8 @@ def _looks_like_shell_script(path: Path) -> bool:
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             return False
+        if metadata.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+            return True
         return os.read(descriptor, 2) == b"#!"
     except OSError:
         return False

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -108,6 +108,7 @@ _LAUNCHCTL_LIFECYCLE_VERBS_RE = re.compile(
 _HERMES_GATEWAY_LABEL_RE = re.compile(r"(?i)\bhermes[.\-]?gateway\b")
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})
+_SHELL_SCRIPT_SUFFIXES = (".sh", ".bash", ".zsh")
 _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "+O", "-o", "+o"})
 _SHELL_COMMAND_FLAGS = {"-c", "--command"}
 _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
@@ -681,6 +682,32 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
 
 # --- referenced-script discovery --------------------------------------------------------------
 
+def _looks_like_shell_script(path: Path) -> bool:
+    """True when *path* is plausibly a shell script: a shell suffix, or any ``#!`` shebang line.
+
+    Gates only the bare-path branch of ``_references_at`` when the token it is judging came from a
+    referenced script's own content rather than a command that will actually run — see
+    ``content_derived`` there. A non-shell interpreter (Node, Python, ...) never starts a real
+    script with ``#!``-less garbage, so this stays cheap: two bytes, no shlex.
+    """
+    if path.suffix in _SHELL_SCRIPT_SUFFIXES:
+        return True
+    flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except (OSError, ValueError):
+        return False
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            return False
+        return os.read(descriptor, 2) == b"#!"
+    except OSError:
+        return False
+    finally:
+        os.close(descriptor)
+
+
 def _iter_option_values(segment: list[str], start: int, option: str) -> Iterator[str]:
     """Yield values given to *option*, in both ``--opt v`` and ``--opt=v`` form."""
     prefix = option + "="
@@ -692,8 +719,20 @@ def _iter_option_values(segment: list[str], start: int, option: str) -> Iterator
             yield token[len(prefix):]
 
 
-def _references_at(segment: list[str], index: int, cwd: Optional[str]) -> Iterator[Path]:
-    """Yield the scripts the token at *index* executes, if any."""
+def _references_at(
+    segment: list[str], index: int, cwd: Optional[str], content_derived: bool = False
+) -> Iterator[Path]:
+    """Yield the scripts the token at *index* executes, if any.
+
+    ``content_derived`` marks that *segment* was tokenized out of a referenced script's own text
+    rather than a command a shell will actually run. In that mode the bare-path branch below — the
+    only branch that *guesses* a token is a script from its shape — requires the candidate to look
+    like a shell script (see ``_looks_like_shell_script``): a non-shell interpreted bundle (Node,
+    Python, ...) can contain hundreds of slash-containing tokens from regex literals and strings
+    that resolve to real files (``/usr/bin/env``) without being scripts at all, and chasing them
+    exhausts the remote-read budget on an innocent CLI invocation (#105758). The ``.``/``source`` and
+    shell-argument branches name an interpreter explicitly and stay unconditional.
+    """
     if index >= len(segment):
         return
     executable = segment[index]
@@ -727,11 +766,15 @@ def _references_at(segment: list[str], index: int, cwd: Optional[str]) -> Iterat
 
     # A bare "/" is pathlib's division operator in Python sources, not an executable; resolving it
     # hits the filesystem root and fails the regular-file check, hard-blocking innocent .py scripts.
-    if executable.strip("/") and ("/" in executable or executable.endswith((".sh", ".bash", ".zsh"))):
-        yield from _resolved_or_nothing(executable, cwd)
+    if executable.strip("/") and ("/" in executable or executable.endswith(_SHELL_SCRIPT_SUFFIXES)):
+        for resolved in _resolved_or_nothing(executable, cwd):
+            if not content_derived or _looks_like_shell_script(resolved):
+                yield resolved
 
 
-def _iter_referenced_shell_scripts(command: str, *, cwd: Optional[str] = None) -> Iterator[Path]:
+def _iter_referenced_shell_scripts(
+    command: str, *, cwd: Optional[str] = None, content_derived: bool = False
+) -> Iterator[Path]:
     """Yield scripts executed directly or through a POSIX shell. Each segment is read at the
     original token AND at the peeled wrapper target — additive on purpose: peeling must never REMOVE
     a reference (a local ``./timeout`` is a script, not the coreutils wrapper)."""
@@ -739,10 +782,10 @@ def _iter_referenced_shell_scripts(command: str, *, cwd: Optional[str] = None) -
         index = _command_token_index(segment)
         if index is None:
             continue
-        yield from _references_at(segment, index, cwd)
+        yield from _references_at(segment, index, cwd, content_derived)
         peeled = _peel_transparent_prefixes(segment, index)
         if peeled != index:
-            yield from _references_at(segment, peeled, cwd)
+            yield from _references_at(segment, peeled, cwd, content_derived)
 
 
 def _iter_shell_command_payloads(command: str) -> Iterator[str]:
@@ -884,6 +927,7 @@ def _read_script_for_scanning(script_path: str) -> str:
 def _contains_unsafe_gateway_action(
     command: str, *, cwd: Optional[str], depth: int, visited: set[Path], budget: _LifecycleScanBudget,
     read_remote_script: Optional[_ReadRemoteScriptFn] = None,
+    content_derived: bool = False,
 ) -> bool:
     # Charge BEFORE _direct_lifecycle_scan: every scan in it tokenizes with shlex.
     if not budget.charge_text(command):
@@ -893,17 +937,17 @@ def _contains_unsafe_gateway_action(
     if depth >= _MAX_REFERENCED_SCRIPT_DEPTH:
         return True
 
-    def recurse(text: str, cwd: Optional[str]) -> bool:
+    def recurse(text: str, cwd: Optional[str], *, content_derived: bool) -> bool:
         return _contains_unsafe_gateway_action(
             text, cwd=cwd, depth=depth + 1, visited=visited, budget=budget,
-            read_remote_script=read_remote_script,
+            read_remote_script=read_remote_script, content_derived=content_derived,
         )
 
     for payload in _iter_shell_command_payloads(command):
-        if recurse(payload, cwd):
+        if recurse(payload, cwd, content_derived=content_derived):
             return True
 
-    for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
+    for script_path in _iter_referenced_shell_scripts(command, cwd=cwd, content_derived=content_derived):
         # Do not touch a FileProvider path even to discover whether the file is hydrated.
         if _on_cloud_path(script_path):
             return True
@@ -931,7 +975,7 @@ def _contains_unsafe_gateway_action(
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's directory, not the cwd.
-        if recurse(script_text, _resolve_script_directory(str(resolved)) or cwd):
+        if recurse(script_text, _resolve_script_directory(str(resolved)) or cwd, content_derived=True):
             return True
     return False
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1881,6 +1881,41 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         assert any("head -c" in c for c in calls)
 
 
+class TestNonShellBundleDoesNotBurnRemoteReadBudget:
+    """#105758: a Node/Python CLI bundle's regex-literal and URL tokens must not be chased as
+    referenced scripts. Before the fix, each bogus slash-containing token pulled from the bundle's
+    own content was treated as a candidate script path and charged a remote read; a bundle with
+    more distinct bogus tokens than the 64-read cap exhausted the budget and the guard failed
+    closed, blocking a benign direct invocation of the CLI."""
+
+    def test_content_derived_bare_paths_do_not_exhaust_remote_read_budget(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        bundle = tmp_path / "ob"
+        # Mimics a minified Node bundle: a shebang for a non-shell interpreter followed by many
+        # standalone slash-containing tokens (regex literals in real bundles), each shaped like an
+        # absolute path but resolving to nothing on disk.
+        lines = [f"/bogus/regex_literal_{i}/tail" for i in range(100)]
+        bundle.write_text("#!/usr/bin/env node\n" + "\n".join(lines) + "\n", encoding="utf-8")
+
+        remote_reads = []
+
+        def read_remote_script(path):
+            remote_reads.append(path)
+            return None
+
+        blocked = contains_gateway_lifecycle_command_or_referenced_script(
+            f"{bundle} --version",
+            cwd=str(tmp_path),
+            read_remote_script=read_remote_script,
+        )
+
+        assert blocked is False
+        assert remote_reads == []
+
+
 class TestCronCreateLifecycleBlockExtra:
     """Additional cron create lifecycle guard coverage."""
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1915,6 +1915,36 @@ class TestNonShellBundleDoesNotBurnRemoteReadBudget:
         assert blocked is False
         assert remote_reads == []
 
+    def test_executable_no_shebang_second_hop_is_still_scanned(self, tmp_path):
+        """The content_derived gate must not key on shebang/suffix alone.
+
+        A real second-hop wrapper script is often invoked as ``./name`` with the executable bit
+        set and no shebang and no ``.sh``-family suffix — bash's ENOEXEC fallback still runs it as
+        a shell script. Gating solely on shebang/suffix (as ``_looks_like_shell_script`` did before
+        this test) reintroduces, one level down, exactly the bypass
+        ``test_nul_padded_script_without_shebang_is_scanned`` guards against at the top level: an
+        attacker who controls both files defeats the guard by simply omitting a shebang and an
+        .sh-family suffix on the referenced script.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        wrapper = tmp_path / "wrapper.sh"
+        wrapper.write_text("#!/bin/sh\n./payload\n")
+        wrapper.chmod(0o755)
+
+        payload = tmp_path / "payload"
+        payload.write_text("hermes gateway restart\n")
+        payload.chmod(0o755)
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash {wrapper}", cwd=str(tmp_path)
+            )
+            is True
+        )
+
 
 class TestCronCreateLifecycleBlockExtra:
     """Additional cron create lifecycle guard coverage."""


### PR DESCRIPTION
Fixes #105758.

## Root cause

`cron/lifecycle_guard.py`'s referenced-script walk recurses into any file a
command touches, looking for hidden `hermes gateway restart`-shaped commands.
For a bare executable reference (no `bash`/`source` in front of it), the
walk's only signal that a token inside that file's *content* is itself
another script is shape: does it contain a `/`, or end in `.sh`/`.bash`/
`.zsh`? A minified Node/Python CLI bundle is full of tokens that satisfy that
shape by accident — regex literals (`/^[\x00-\x19\s,[\]{}]/`), URL-ish
strings, `/usr/bin/env` — without being scripts at all.

Each such bogus candidate still costs a local read attempt, and when that
misses, a remote read via the terminal guard's `read_remote_script` callback
(a real backend round trip). The walk's remote-read budget is a flat 64
(`_MAX_LIFECYCLE_SCAN_REMOTE_READS`, added in `d99eed7d83`/`e4c1e56d5d`).
Obsidian-headless's `ob` CLI alone produces 152 such tokens, so the budget
exhausts partway through and the guard **fails closed**, blocking a plain
`ob --version` invocation.

## Fix

Thread a `content_derived` flag through the referenced-script discovery path
(`_references_at` → `_iter_referenced_shell_scripts` → the recursive walk in
`_contains_unsafe_gateway_action`). It is `False` for the command the agent
actually typed and `True` once the walk is inside a referenced script's own
text. Only the *bare-path guess* branch of `_references_at` — the one
inferring "this token is a script" purely from its shape — consults it: when
`content_derived` is `True`, the candidate must additionally look like a
shell script (`_looks_like_shell_script`) before it is chased any further.

Explicit shell invocations (`bash x`, `. x`, `source x`) are untouched by
this gate — those name the interpreter directly, so the walk keeps scanning
them unconditionally regardless of the target's own shebang, and a real
wrapper-script graph is still fully covered (see
`test_nul_padded_script_without_shebang_is_scanned`, still passing).

### Follow-up: executable-bit check (post-review)

An independent review caught that the first version of `_looks_like_shell_script`
keyed only on a `.sh`/`.bash`/`.zsh` suffix or a leading `#!` shebang. That
misses the common real-world shape of a second-hop wrapper script: invoked as
`./name`, executable, no shebang, no `.sh`-family suffix. A POSIX shell's
ENOEXEC fallback runs that file exactly like a shell script, so gating on
shebang/suffix alone let an attacker who controls both the wrapper and the
second-hop file defeat the guard by simply omitting them on the second hop —
the same class of bypass `test_nul_padded_script_without_shebang_is_scanned`
already guards against one level up (direct `bash script` invocation), just
reintroduced one level down in the new content-derived branch.

Fixed by also treating a content-derived candidate as chase-worthy when it is
a regular file with any of the executable bits set
(`stat.S_IXUSR|S_IXGRP|S_IXOTH`), in addition to the suffix/shebang checks.
This still filters the reported bug (a bundle's internal regex-literal/URL
tokens resolve to nonexistent paths, so the `os.open` in
`_looks_like_shell_script` fails and the check returns `False` regardless of
this change) while closing the bypass.

Added `test_executable_no_shebang_second_hop_is_still_scanned` reproducing
the exact bypass (a `wrapper.sh` that runs `./payload`, where `payload` is
chmod +x with no shebang and no recognized suffix and contains
`hermes gateway restart`). Confirmed it fails without the executable-bit
check (`git stash` the source fix only, run, then restore):

```
blocked (without executable-bit check): False
```

And passes with the fix:

```
blocked (with executable-bit check): True
```

## Test

Added `TestNonShellBundleDoesNotBurnRemoteReadBudget` in
`tests/hermes_cli/test_gateway_restart_loop.py`, reproducing the issue with a
synthetic bundle (a `#!/usr/bin/env node` shebang followed by 100 standalone
bogus slash-shaped tokens, mimicking the regex-literal noise in a real
minified bundle) and a counting `read_remote_script` stub, plus the
executable-bit bypass test described above.

Confirmed the original bug's fix still holds (`git checkout HEAD~2 --
cron/lifecycle_guard.py`, run, then restore):

```
lifecycle guard scan budget exhausted (remote reads at depth 1); failing closed
blocked (pre-fix): True
remote_reads (pre-fix): 64
```

And passes with the fix:

```
blocked: False
remote_reads: 0
```

Full test run after both commits:

```
$ python3 -m pytest tests/hermes_cli/test_gateway_restart_loop.py tests/cron/test_lifecycle_guard_budget.py tests/hermes_cli/test_lifecycle.py -q
318 passed
```

`ruff check cron/lifecycle_guard.py tests/hermes_cli/test_gateway_restart_loop.py` — all checks passed.

## Disclosure

This PR was prepared with AI assistance (Claude Code), including the root
cause analysis, the fix, and the regression tests (including the follow-up
executable-bit fix after independent review). All test output above was run
and verified locally, not fabricated.
