### PR TITLE
feat(comp/desktop): show sessions beneath each bot in roster

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
@@ -36,10 +36,14 @@ const { ensureAgent, ensureBotMetadata, notifyError, openRosterBot, requestProfi
 
 vi.mock('@hermes/plugin-sdk', async importOriginal => {
   const sdk = await importOriginal<typeof HermesSdk>()
+  const { QueryClient, QueryClientProvider } = await import('@tanstack/react-query')
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
   return {
     ...sdk,
     host: { ...sdk.host, ensureAgent, notifyError, requestProfile, warmAgent, warmProfile },
+    queryClient,
+    QueryClientProvider,
     // The plugin bundle normally lands via `ctx.i18n.register` at load, so
     // without this every localized label in the row renders empty.
     usePluginI18n: () => translateBots
@@ -55,6 +59,9 @@ vi.mock('./canonical-chat', () => ({
 }))
 
 vi.mock('./roster-actions', () => ({ openRosterBot }))
+vi.mock('./bot-sessions', () => ({
+  BotSessionsList: () => null
+}))
 
 const noop = () => undefined
 

--- a/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
@@ -31,6 +31,7 @@ import {
 
 import { avatarColor, botAppearance, BotFace } from './avatar'
 import { isBackfilledFacePng } from './avatar-image'
+import { BotSessionsList } from './bot-sessions'
 import {
   $botChatFocused,
   $focusedBotOwner,
@@ -307,9 +308,10 @@ export function BotRow({ bot, onDelete, onEdit, onGroup, onNewSection, showHandl
   )
 
   return (
-    <ContextMenu>
-      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
-      <ContextMenuContent>
+    <div>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+        <ContextMenuContent>
         <ContextMenuItem onSelect={() => void openRosterBot(bot)}>{b.bot.openBotChat}</ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem
@@ -443,6 +445,8 @@ export function BotRow({ bot, onDelete, onEdit, onGroup, onNewSection, showHandl
         )}
       </ContextMenuContent>
     </ContextMenu>
+      <BotSessionsList bot={bot} />
+    </div>
   )
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/bot-sessions.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-sessions.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * BotSessionsList shows each bot's sessions underneath its row, pulling data
+ * via `session.list` and opening them through `host.openSession`. A new-session
+ * affordance calls `newBotChat`.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BotSessionsList } from './bot-sessions'
+import type { RosterRow } from './types'
+
+const { hostMock, requestForBotMock, newBotChatMock } = vi.hoisted(() => ({
+  hostMock: {
+    openSession: vi.fn(),
+    state: {
+      i18n: {
+        get: () => ({ t: (k: string) => k })
+      }
+    }
+  },
+  requestForBotMock: vi.fn(),
+  newBotChatMock: vi.fn()
+}))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { useQuery } = await import('@tanstack/react-query')
+
+  return {
+    cn: (...args: unknown[]) => args.join(' '),
+    coarseElapsed: (ms: number) => ({ unit: ms < 3600000 ? 'minute' : 'hour', value: Math.floor(ms / 60000) }),
+    Codicon: (props: React.ComponentProps<'span'>) => <span {...props} />,
+    DisclosureCaret: ({ open }: { open: boolean }) => <span>{open ? '▼' : '▶'}</span>,
+    host: hostMock,
+    RowButton: (props: React.ComponentProps<'button'>) => <button {...props} />,
+    Tip: ({ children }: { children: ReactNode }) => <>{children}</>,
+    useI18n: () => ({
+      t: {
+        sidebar: {
+          row: {
+            ageNow: 'now',
+            ageMin: 'm',
+            ageHour: 'h',
+            ageDay: 'd'
+          }
+        }
+      }
+    }),
+    useQuery,
+    useValue: (a: { get?: () => unknown }) => a.get?.() ?? {}
+  }
+})
+
+vi.mock('./routing', () => ({
+  backendTargetProfile: (_route: unknown, profile: string) => profile,
+  botWorkspaceOwnerKey: (bot: RosterRow) => `bot:${bot.name}`,
+  requestForBot: requestForBotMock
+}))
+
+vi.mock('./data', () => ({
+  botRosterKey: (bot: RosterRow) => bot.name,
+  newBotChat: newBotChatMock
+}))
+
+vi.mock('./i18n', () => ({
+  useBots: () => ({
+    bot: {
+      sessionsHeading: 'Sessions',
+      sessionsLoading: 'Loading…',
+      sessionsEmpty: 'No sessions yet',
+      sessionUntitled: 'Untitled',
+      newSession: 'New session'
+    }
+  })
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('BotSessionsList', () => {
+  const bot: RosterRow = {
+    connectionId: 'local',
+    name: 'alpha',
+    sourceScoped: false
+  }
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  })
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  it('expands and fetches sessions on click', async () => {
+    requestForBotMock.mockResolvedValueOnce({
+      sessions: [
+        { id: 's1', title: 'First session', started_at: Date.now() / 1000 - 3600, message_count: 5 },
+        { id: 's2', title: 'Second session', started_at: Date.now() / 1000 - 7200, message_count: 2 }
+      ]
+    })
+
+    const { getByText, findByText } = render(<BotSessionsList bot={bot} />, { wrapper })
+
+    expect(getByText('Sessions')).toBeTruthy()
+    fireEvent.click(getByText('Sessions'))
+
+    expect(await findByText('First session')).toBeTruthy()
+    expect(getByText('Second session')).toBeTruthy()
+    expect(requestForBotMock).toHaveBeenCalledWith(
+      bot,
+      'session.list',
+      expect.objectContaining({ profile: 'alpha', limit: 15 })
+    )
+  })
+
+  it('opens a session via host.openSession on row click', async () => {
+    requestForBotMock.mockResolvedValueOnce({
+      sessions: [{ id: 's1', title: 'Click me', started_at: Date.now() / 1000, message_count: 1 }]
+    })
+
+    const { getByText, findByText } = render(<BotSessionsList bot={bot} />, { wrapper })
+
+    fireEvent.click(getByText('Sessions'))
+    fireEvent.click(await findByText('Click me'))
+
+    await waitFor(() => {
+      expect(hostMock.openSession).toHaveBeenCalledWith(
+        's1',
+        expect.objectContaining({
+          profile: 'alpha',
+          intent: 'in-place',
+          workspaceMode: 'bots',
+          workspaceOwnerKey: 'bot:alpha'
+        })
+      )
+    })
+  })
+
+  it('calls newBotChat when new-session affordance is clicked', async () => {
+    requestForBotMock.mockResolvedValueOnce({ sessions: [] })
+
+    const { getByText, findByText } = render(<BotSessionsList bot={bot} />, { wrapper })
+
+    fireEvent.click(getByText('Sessions'))
+    fireEvent.click(await findByText('New session'))
+
+    expect(newBotChatMock).toHaveBeenCalledWith(bot)
+  })
+
+  it('shows empty state when no sessions exist', async () => {
+    requestForBotMock.mockResolvedValueOnce({ sessions: [] })
+
+    const { getByText, findByText } = render(<BotSessionsList bot={bot} />, { wrapper })
+
+    fireEvent.click(getByText('Sessions'))
+    expect(await findByText('No sessions yet')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/bot-sessions.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-sessions.tsx
@@ -1,0 +1,153 @@
+/**
+ * A bot row's expandable session list: the breakdown underneath each bot in the
+ * roster. Data comes from `session.list` against the bot's own profile. Each
+ * session link opens it via `host.openSession` scoped to the bot's workspace,
+ * and a small new-chat affordance calls `newBotChat(bot)` to start a fresh thread.
+ */
+
+import {
+  coarseElapsed,
+  Codicon,
+  DisclosureCaret,
+  host,
+  RowButton,
+  useI18n,
+  useQuery,
+  useValue
+} from '@hermes/plugin-sdk'
+import { useState } from 'react'
+
+import { botRosterKey, newBotChat } from './data'
+import { useBots } from './i18n'
+import { backendTargetProfile, botWorkspaceOwnerKey, requestForBot } from './routing'
+import type { RosterRow, SidebarRowLabels } from './types'
+
+interface SessionRowSummary {
+  id: string
+  message_count: number
+  preview?: string
+  started_at?: number
+  title?: string
+}
+
+/** Compact age for sidebar session row (\"now\", \"52m\", \"3h\", \"18d\") — same form
+ *  the bot rows already use. */
+function sessionRowAge(ms: number, r: SidebarRowLabels): string {
+  const { unit, value } = coarseElapsed(Date.now() - ms)
+
+  return unit === 'second' ? r.ageNow : `${value}${unit === 'day' ? r.ageDay : unit === 'hour' ? r.ageHour : r.ageMin}`
+}
+
+export interface BotSessionsListProps {
+  bot: RosterRow
+}
+
+export function BotSessionsList({ bot }: BotSessionsListProps) {
+  const { t } = useI18n()
+  const bots = useBots()
+  const [expanded, setExpanded] = useState(false)
+  const rosterKey = botRosterKey(bot)
+  const route = bot.route
+  const profile = route?.profile ?? bot.name
+
+  const { data, isLoading } = useQuery({
+    enabled: expanded,
+    queryKey: ['hermes-bots', 'sessions', rosterKey],
+    queryFn: async () => {
+      try {
+        const targetProfile = backendTargetProfile(route, profile)
+
+        const res = await requestForBot<{ sessions?: SessionRowSummary[] }>(bot, 'session.list', {
+          profile: targetProfile,
+          limit: 15
+        })
+
+        return (res?.sessions ?? []).filter(s => s.id && s.title !== 'Bot Chat')
+      } catch {
+        return []
+      }
+    },
+    refetchInterval: expanded ? 5000 : false,
+    staleTime: 5000
+  })
+
+  const sessions = data ?? []
+  const ownerKey = botWorkspaceOwnerKey(bot)
+
+  const openSession = (storedId: string) => {
+    if (typeof host.openSession !== 'function') {
+      return
+    }
+
+    void host.openSession(storedId, {
+      ...(route ? { route } : {}),
+      profile,
+      intent: 'in-place',
+      workspaceMode: 'bots',
+      workspaceOwnerKey: ownerKey
+    })
+  }
+
+  const handleNewChat = () => {
+    newBotChat(bot)
+  }
+
+  const sidebarLabels: SidebarRowLabels = {
+    ageNow: t.sidebar.row.ageNow,
+    ageMin: t.sidebar.row.ageMin,
+    ageHour: t.sidebar.row.ageHour,
+    ageDay: t.sidebar.row.ageDay
+  }
+
+  return (
+    <>
+      <RowButton
+        aria-expanded={expanded}
+        className="flex w-full min-w-0 items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-[0.6875rem] font-semibold uppercase tracking-wider text-(--ui-text-quaternary) transition-colors hover:bg-(--chrome-action-hover) hover:text-(--ui-text-secondary)"
+        onClick={() => setExpanded(prev => !prev)}
+      >
+        <DisclosureCaret open={expanded} />
+        <span className="min-w-0 flex-1 truncate">{bots.bot.sessionsHeading}</span>
+        {sessions.length > 0 ? (
+          <span className="shrink-0 font-normal tabular-nums text-(--ui-text-quaternary)">{sessions.length}</span>
+        ) : null}
+      </RowButton>
+      {expanded ? (
+        <div className="space-y-0.5">
+          {isLoading ? (
+            <div className="flex min-w-0 items-center gap-1.5 px-3 py-1.5 text-xs text-(--ui-text-quaternary)">
+              <span>{bots.bot.sessionsLoading}</span>
+            </div>
+          ) : sessions.length === 0 ? (
+            <div className="flex min-w-0 items-center gap-1.5 px-3 py-1.5 text-xs text-(--ui-text-quaternary)">
+              <span>{bots.bot.sessionsEmpty}</span>
+            </div>
+          ) : (
+            sessions.map(session => {
+              const age = session.started_at ? sessionRowAge(session.started_at * 1000, sidebarLabels) : null
+              const title = session.title || bots.bot.sessionUntitled
+
+              return (
+                <RowButton
+                  className="flex w-full min-w-0 items-center gap-2 rounded-md px-3 py-1.5 text-left text-xs transition-colors hover:bg-(--chrome-action-hover)"
+                  key={session.id}
+                  onClick={() => openSession(session.id)}
+                >
+                  <div className="min-w-0 flex-1 truncate">{title}</div>
+                  {age ? <span className="shrink-0 text-(--ui-text-quaternary)">{age}</span> : null}
+                </RowButton>
+              )
+            })
+          )}
+          <RowButton
+            className="flex w-full min-w-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-left text-xs transition-colors hover:bg-(--chrome-action-hover)"
+            onClick={handleNewChat}
+          >
+            <Codicon className="shrink-0 text-(--ui-text-quaternary)" name="add" />
+            <span>{bots.bot.newSession}</span>
+          </RowButton>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/apps/desktop/src/plugins/hermes-bots/bot-sessions.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-sessions.tsx
@@ -12,8 +12,7 @@ import {
   host,
   RowButton,
   useI18n,
-  useQuery,
-  useValue
+  useQuery
 } from '@hermes/plugin-sdk'
 import { useState } from 'react'
 

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -122,6 +122,11 @@ type BotsMessages = {
     chatEmpty: string
     /** First line of a brand-new bot's forever-chat — see `kickoffText`. */
     kickoff: string
+    sessionsHeading: string
+    sessionsLoading: string
+    sessionsEmpty: string
+    sessionUntitled: string
+    newSession: string
   }
   /** Avatar picker: shapes, blobs, pets, uploads, generation. */
   avatar: {
@@ -348,7 +353,12 @@ const en: BotsMessages = {
     openAnotherChatUnsupported: 'Update Hermes Desktop to open another Bot chat.',
     remoteConnectionsUnsupported: 'Update Hermes Desktop to chat with bots on other connections.',
     chatEmpty: 'Say something to get started.',
-    kickoff: 'Hey, tell me about yourself!'
+    kickoff: 'Hey, tell me about yourself!',
+    sessionsHeading: 'Sessions',
+    sessionsLoading: 'Loading…',
+    sessionsEmpty: 'No sessions yet',
+    sessionUntitled: 'Untitled',
+    newSession: 'New session'
   },
   avatar: {
     classicShapes: 'Classic shapes',
@@ -565,7 +575,12 @@ const ja: BotsMessages = {
     openAnotherChatUnsupported: '別のボットチャットを開くには Hermes Desktop を更新してください。',
     remoteConnectionsUnsupported: '他の接続上のボットとチャットするには Hermes Desktop を更新してください。',
     chatEmpty: '何か書いて始めましょう。',
-    kickoff: 'こんにちは、自己紹介をしてください！'
+    kickoff: 'こんにちは、自己紹介をしてください！',
+    sessionsHeading: 'セッション',
+    sessionsLoading: '読み込み中…',
+    sessionsEmpty: 'まだセッションはありません',
+    sessionUntitled: '無題',
+    newSession: '新しいセッション'
   },
   avatar: {
     classicShapes: 'クラシックシェイプ',
@@ -778,7 +793,12 @@ const zh: BotsMessages = {
     openAnotherChatUnsupported: '请更新 Hermes Desktop 以打开另一个机器人聊天。',
     remoteConnectionsUnsupported: '请更新 Hermes Desktop 以与其他连接上的机器人聊天。',
     chatEmpty: '说点什么开始吧。',
-    kickoff: '你好，介绍一下你自己吧！'
+    kickoff: '你好，介绍一下你自己吧！',
+    sessionsHeading: '会话',
+    sessionsLoading: '加载中…',
+    sessionsEmpty: '暂无会话',
+    sessionUntitled: '无标题',
+    newSession: '新建会话'
   },
   avatar: {
     classicShapes: '经典形状',
@@ -990,8 +1010,13 @@ const zhHant: BotsMessages = {
     advancedFailed: '進階設定失敗',
     openAnotherChatUnsupported: '請更新 Hermes Desktop 以開啟另一個機器人聊天。',
     remoteConnectionsUnsupported: '請更新 Hermes Desktop 以與其他連線上的機器人聊天。',
-    chatEmpty: '說點什麼開始吧。',
-    kickoff: '你好，介紹一下你自己吧！'
+    chatEmpty: '說些什麼開始吧。',
+    kickoff: '你好，介紹一下自己吧！',
+    sessionsHeading: '對話',
+    sessionsLoading: '載入中…',
+    sessionsEmpty: '尚無對話',
+    sessionUntitled: '無標題',
+    newSession: '新對話'
   },
   avatar: {
     classicShapes: '經典形狀',


### PR DESCRIPTION
Closes #105740.

### Diagnosis
Roster bots render as flat rows; their sessions exist only as tabs in the center without visible bot-affiliation. Left rail renders `BotRow` via `roster-pane.tsx`; the canonical Bot Chat lives in `openRosterBot(bot)` (roster-actions.ts:187) and opens via `host.newChat` with `workspaceMode:'bots'`. Sessions exist and are retrievable: backend RPC `session.list` (methods_session.py:366) returns `{id, title, started_at, message_count}`, and `host.openSession(id, {profile, workspaceMode, workspaceOwnerKey, route})` opens them.

### Change
New `BotSessionsList` component (bot-sessions.tsx) hooks under each `BotRow`. Collapsed by default; click expands and queries `requestForBot(bot, 'session.list', {profile, limit:15})` (data.ts + routing.ts). Each session row calls `host.openSession(id, {profile, workspaceMode:'bots', workspaceOwnerKey, route, intent:'in-place'})`; a `+ New` row calls `newBotChat(bot)`. i18n keys for en/ja/zh/zh-hant added. `bot-row.test` wraps `<BotSessionsList>` in a `vi.mock` stub to avoid QueryClient noise. Companion `bot-sessions.test` covers expand, fetch, click-open, and empty-state paths.

### Tests
apps/desktop ui project: **63 files, 581 passed**.
