### PR TITLE
fix(cron): gate the lifecycle walk's recursion on POSIX-shell sources

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -107,7 +107,7 @@ _LAUNCHCTL_LIFECYCLE_VERBS_RE = re.compile(
 )
 _HERMES_GATEWAY_LABEL_RE = re.compile(r"(?i)\bhermes[.\-]?gateway\b")
 
-_SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})
+_SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh", "ash"})
 _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "+O", "-o", "+o"})
 _SHELL_COMMAND_FLAGS = {"-c", "--command"}
 _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
@@ -789,6 +789,23 @@ def _is_posix_shell_source(text: str) -> bool:
     return _SHEBANG_POSIX_SHELL_RE.match(text) is not None
 
 
+def _is_locally_executable(path: Path) -> bool:
+    """True when *path* exists locally and carries any execute bit.
+
+    An executable, shebang-less file reached in command position still ends up parsed by a POSIX
+    shell: execve(2) fails with ENOEXEC and the calling shell falls back to interpreting the file
+    as shell source line by line, so the recursive walk must keep following it. A file without an
+    execute bit cannot be reached that way — bare execution fails with EACCES — and a remote-only
+    file's mode is not observable from here, so in both cases the observable evidence keeps the
+    (cheaper, still literal-scanned) direct-scan path.
+    """
+    try:
+        return os.access(str(path), os.X_OK)
+    except (OSError, ValueError):
+        # ValueError: embedded NUL from a decoded binary tokenized as a path — never crash the guard.
+        return False
+
+
 # --- referenced-script reading ----------------------------------------------------------------
 
 def _has_binary_magic(data: bytes) -> bool:
@@ -961,11 +978,17 @@ def _contains_unsafe_gateway_action(
             # budget and fail closed on benign CLIs (#105758). The literal-command regex still
             # scans the text — only the recursive reference walk is gated, mirroring the entry
             # point's .py exemption (#77131, #78398).
-            if not budget.charge_text(script_text):
+            if _is_locally_executable(resolved):
+                # An execute bit with no shell shebang is still shell-reachable — the POSIX
+                # ENOEXEC fallback interprets the file as shell source line by line — so a
+                # second-hop lifecycle command hidden in such a file stays inside the walk.
+                pass
+            elif not budget.charge_text(script_text):
                 return _budget_exhausted("text", depth)
-            if _direct_lifecycle_scan(script_text):
+            elif not _direct_lifecycle_scan(script_text):
+                continue
+            else:
                 return True
-            continue
         # Relative references inside a script resolve against that script's directory, not the cwd.
         if recurse(script_text, _resolve_script_directory(str(resolved)) or cwd):
             return True

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -692,8 +692,13 @@ def _iter_option_values(segment: list[str], start: int, option: str) -> Iterator
             yield token[len(prefix):]
 
 
-def _references_at(segment: list[str], index: int, cwd: Optional[str]) -> Iterator[Path]:
-    """Yield the scripts the token at *index* executes, if any."""
+def _references_at(
+    segment: list[str], index: int, cwd: Optional[str]
+) -> Iterator[tuple[Path, bool]]:
+    """Yield ``(script, forced_shell)`` for the scripts the token at *index* executes, if any.
+
+    *forced_shell* is True when a POSIX shell provably parses the file — it was handed to
+    ``bash``/``sh``/… or ``source``/``.`` — and False for a bare path executed on its own shebang."""
     if index >= len(segment):
         return
     executable = segment[index]
@@ -701,7 +706,8 @@ def _references_at(segment: list[str], index: int, cwd: Optional[str]) -> Iterat
 
     if executable_name in {".", "source"}:
         if len(segment) > index + 1:
-            yield from _resolved_or_nothing(segment[index + 1], cwd)
+            for path in _resolved_or_nothing(segment[index + 1], cwd):
+                yield path, True
         return
 
     if executable_name in _SHELL_EXECUTABLES:
@@ -722,19 +728,24 @@ def _references_at(segment: list[str], index: int, cwd: Optional[str]) -> Iterat
                 continue
             break
         if arg_index < len(arguments) and arguments[arg_index] not in _SHELL_COMMAND_FLAGS:
-            yield from _resolved_or_nothing(arguments[arg_index], cwd)
+            for path in _resolved_or_nothing(arguments[arg_index], cwd):
+                yield path, True
         return
 
     # A bare "/" is pathlib's division operator in Python sources, not an executable; resolving it
     # hits the filesystem root and fails the regular-file check, hard-blocking innocent .py scripts.
     if executable.strip("/") and ("/" in executable or executable.endswith((".sh", ".bash", ".zsh"))):
-        yield from _resolved_or_nothing(executable, cwd)
+        for path in _resolved_or_nothing(executable, cwd):
+            yield path, False
 
 
-def _iter_referenced_shell_scripts(command: str, *, cwd: Optional[str] = None) -> Iterator[Path]:
-    """Yield scripts executed directly or through a POSIX shell. Each segment is read at the
-    original token AND at the peeled wrapper target — additive on purpose: peeling must never REMOVE
-    a reference (a local ``./timeout`` is a script, not the coreutils wrapper)."""
+def _iter_referenced_shell_scripts(
+    command: str, *, cwd: Optional[str] = None
+) -> Iterator[tuple[Path, bool]]:
+    """Yield ``(script, forced_shell)`` for scripts executed directly or through a POSIX shell.
+    Each segment is read at the original token AND at the peeled wrapper target — additive on
+    purpose: peeling must never REMOVE a reference (a local ``./timeout`` is a script, not the
+    coreutils wrapper)."""
     for segment in _iter_command_segments(command):
         index = _command_token_index(segment)
         if index is None:
@@ -763,6 +774,19 @@ def _iter_shell_command_payloads(command: str) -> Iterator[str]:
             if argument in _SHELL_COMMAND_FLAGS:
                 yield arguments[arg_index + 1]
                 break
+
+
+_SHEBANG_POSIX_SHELL_RE = re.compile(r"\A#![^\n]*\b(?:%s)\b" % "|".join(sorted(_SHELL_EXECUTABLES)))
+
+
+def _is_posix_shell_source(text: str) -> bool:
+    """True when *text* opens with a POSIX-shell shebang (``#!/bin/sh``, ``#!/usr/bin/env bash``, …).
+
+    The recursive reference walk only chases edges that exist when a POSIX shell parses the file;
+    feeding another interpreter's source (a minified Node bundle's regex literals, pathlib's ``/``
+    division) to ``shlex`` yields path-shaped garbage, not script references (#77131, #105758).
+    """
+    return _SHEBANG_POSIX_SHELL_RE.match(text) is not None
 
 
 # --- referenced-script reading ----------------------------------------------------------------
@@ -903,7 +927,7 @@ def _contains_unsafe_gateway_action(
         if recurse(payload, cwd):
             return True
 
-    for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
+    for script_path, forced_shell in _iter_referenced_shell_scripts(command, cwd=cwd):
         # Do not touch a FileProvider path even to discover whether the file is hydrated.
         if _on_cloud_path(script_path):
             return True
@@ -929,6 +953,18 @@ def _contains_unsafe_gateway_action(
             if unsafe:
                 return True
         if not script_text:
+            continue
+        if not forced_shell and not _is_posix_shell_source(script_text):
+            # A bare path executes on its own shebang, so a non-POSIX-shell interpreter's source
+            # never reaches a shell as *source*: recursing would only shell-tokenize its literals
+            # (a minified Node bundle's regexes) into garbage paths that burn the remote-read
+            # budget and fail closed on benign CLIs (#105758). The literal-command regex still
+            # scans the text — only the recursive reference walk is gated, mirroring the entry
+            # point's .py exemption (#77131, #78398).
+            if not budget.charge_text(script_text):
+                return _budget_exhausted("text", depth)
+            if _direct_lifecycle_scan(script_text):
+                return True
             continue
         # Relative references inside a script resolve against that script's directory, not the cwd.
         if recurse(script_text, _resolve_script_directory(str(resolved)) or cwd):

--- a/tests/cron/test_lifecycle_guard_budget.py
+++ b/tests/cron/test_lifecycle_guard_budget.py
@@ -239,3 +239,68 @@ def test_default_budget_admits_a_wide_benign_wrapper_graph(tmp_path):
     evil.write_text("hermes gateway restart\n", encoding="utf-8")
     hub.write_text(hub.read_text() + f"bash {evil}\n", encoding="utf-8")
     assert guard(f"bash {hub}") is True
+
+
+# --- non-shell sources do not burn the remote-read budget (#105758) ---------
+
+
+def _minified_node_bundle(shebang: str | None) -> str:
+    """A minified Node CLI bundle's slash-containing tokens (regex literals, strings), one per
+    line so each sits in command position and is yielded as a candidate script path."""
+    tokens = "\n".join(f"/n+{i}/g" for i in range(80))
+    prefix = "" if shebang is None else shebang + "\n"
+    return f"{prefix}{tokens}\nmodule.exports=1\n"
+
+
+def test_non_shell_bundle_does_not_exhaust_remote_read_budget(tmp_path):
+    """A Node CLI bundle referenced as the executable: shell-tokenizing its regex literals
+    used to yield 64+ garbage paths, exhaust the remote-read budget, and fail closed (#105758)."""
+    bundle = tmp_path / "ob"
+    bundle.write_text(_minified_node_bundle("#!/usr/bin/env node"), encoding="utf-8")
+    reads: list[str] = []
+
+    def remote(path: str):
+        reads.append(path)
+        return None
+
+    assert guard(f"{bundle} --version", read_remote_script=remote) is False
+    assert reads == []
+
+
+def test_non_shell_bundle_without_shebang_is_still_allowed(tmp_path):
+    """Shebang-less bundles (executed via the kernel's sh fallback only when shell-shaped)
+    are the same false-positive class; literal commands are still direct-scanned below."""
+    bundle = tmp_path / "tool"
+    bundle.write_text(_minified_node_bundle(None), encoding="utf-8")
+    reads: list[str] = []
+
+    def remote(path: str):
+        reads.append(path)
+        return None
+
+    assert guard(f"{bundle} --version", read_remote_script=remote) is False
+    assert reads == []
+
+
+def test_literal_lifecycle_command_in_non_shell_source_still_blocked(tmp_path):
+    """Gating only the recursive walk must not gate the regex: a literal lifecycle command
+    in ANY referenced text — shell or not — stays blocked."""
+    script = tmp_path / "note.txt"
+    script.write_text("echo 'run this later:'\nhermes gateway restart\n", encoding="utf-8")
+
+    assert guard(f"bash {script}") is True
+
+
+def test_shell_invocations_still_recurse_into_references(tmp_path):
+    """Forced-shell references (``bash <script>`` on a shebang-less script) and bare paths whose
+    own shebang is a POSIX shell keep the full recursive walk: a sourced second-level script
+    holding the lifecycle command is still found."""
+    inner = tmp_path / "inner.sh"
+    inner.write_text("echo prep\nhermes gateway restart\n", encoding="utf-8")
+    forced = tmp_path / "forced.sh"
+    forced.write_text("source ./inner.sh\n", encoding="utf-8")
+    shebanged = tmp_path / "shebanged.sh"
+    shebanged.write_text("#!/bin/sh\nsource ./inner.sh\n", encoding="utf-8")
+
+    assert guard(f"bash {forced}") is True
+    assert guard(f"{shebanged}") is True

--- a/tests/cron/test_lifecycle_guard_budget.py
+++ b/tests/cron/test_lifecycle_guard_budget.py
@@ -268,10 +268,12 @@ def test_non_shell_bundle_does_not_exhaust_remote_read_budget(tmp_path):
 
 
 def test_non_shell_bundle_without_shebang_is_still_allowed(tmp_path):
-    """Shebang-less bundles (executed via the kernel's sh fallback only when shell-shaped)
-    are the same false-positive class; literal commands are still direct-scanned below."""
+    """A shebang-less bundle with NO execute bit cannot be reached as shell source (bare execution
+    fails with EACCES, so no ENOEXEC fallback ever parses it) — same false-positive class as the
+    shebanged bundle; literal commands are still direct-scanned below."""
     bundle = tmp_path / "tool"
     bundle.write_text(_minified_node_bundle(None), encoding="utf-8")
+    bundle.chmod(0o644)
     reads: list[str] = []
 
     def remote(path: str):
@@ -280,6 +282,44 @@ def test_non_shell_bundle_without_shebang_is_still_allowed(tmp_path):
 
     assert guard(f"{bundle} --version", read_remote_script=remote) is False
     assert reads == []
+
+
+def test_executable_shebangless_reference_keeps_full_walk(tmp_path):
+    """An execute bit with no shell shebang is shell-reachable: execve fails with ENOEXEC and the
+    calling POSIX shell interprets the file as shell source line by line, so the recursive walk
+    must keep following it — a second-hop lifecycle command must not hide behind the shape."""
+    inner = tmp_path / "inner.sh"
+    inner.write_text("echo prep\nhermes gateway restart\n", encoding="utf-8")
+    carrier = tmp_path / "carrier"
+    carrier.write_text(f"exec {inner}\n", encoding="utf-8")
+    reads: list[str] = []
+
+    def remote(path: str):
+        reads.append(path)
+        return None
+
+    carrier.chmod(0o755)
+    assert guard(f"{carrier}", read_remote_script=remote) is True
+    assert reads == []
+
+    # Same file without the execute bit is unreachable as shell source: only the literal scan of
+    # the carrier text runs (it references inner.sh but carries no lifecycle command itself).
+    carrier.chmod(0o644)
+    assert guard(f"{carrier}", read_remote_script=remote) is False
+
+
+def test_busybox_ash_is_a_posix_shell_source(tmp_path):
+    """`ash` joins the shell executables: a ``#!/bin/ash`` shebang keeps the recursive walk on a
+    bare reference, and an explicit ``ash <script>`` invocation stays forced-shell (BusyBox)."""
+    inner = tmp_path / "inner.sh"
+    inner.write_text("echo prep\nhermes gateway restart\n", encoding="utf-8")
+    ashed = tmp_path / "ashed"
+    ashed.write_text("#!/bin/ash\nexec ./inner.sh\n", encoding="utf-8")
+    bare = tmp_path / "bare"
+    bare.write_text("exec ./inner.sh\n", encoding="utf-8")
+
+    assert guard(f"{ashed}", cwd=str(tmp_path)) is True
+    assert guard(f"ash {bare}", cwd=str(tmp_path)) is True
 
 
 def test_literal_lifecycle_command_in_non_shell_source_still_blocked(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Fixes a lifecycle-guard false positive introduced by the Sep 3 scan-budget commits: benign commands that execute a Node.js CLI bundle (e.g. `obsidian-headless`' `ob`) were blocked with "command or referenced script cannot restart, stop, or uninstall the gateway". The walk shell-tokenized the minified bundle, treated its ~152 regex-literal/string tokens as candidate script paths, exhausted the 64-read remote budget on them, and failed closed.

The reference walk now distinguishes how a referenced script is reached:

- A reference **forced through a POSIX shell** (`bash <script>`, `sh <script>`, `source`/`.`) keeps the full recursive walk — a shell provably parses that file, whatever its own shebang says.
- A **bare path executed on its own shebang** only recurses when its first line is a POSIX-shell shebang (`#!/bin/sh`, `#!/usr/bin/env bash`, …). Any other interpreter's source (Node, Python, Ruby bundles) never reaches a shell as *source*, so tokenizing it only produces path-shaped garbage.

Non-shell sources are still scanned by the literal-command regex (fail-closed on oversized/unreadable inputs is untouched) — only the recursive reference walk is gated. This mirrors the entry point's existing `.py` exemption (#77131, #78398).

## Related Issue

Fixes #105758

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/lifecycle_guard.py`: `_references_at`/`_iter_referenced_shell_scripts` now yield `(script, forced_shell)` so the walk knows whether a POSIX shell provably parses the file; added `_is_posix_shell_source` (shebang sniff aligned with `_SHELL_EXECUTABLES`).
- `cron/lifecycle_guard.py`: the walk recurses into forced-shell references as before; bare-path references without a POSIX-shell shebang get a budgeted direct regex scan only.
- `tests/cron/test_lifecycle_guard_budget.py`: regression tests — a minified Node bundle (with and without shebang) no longer burns the remote-read budget; a literal lifecycle command in non-shell text is still blocked; shell-invoked and shell-shebang sources still recurse into second-level scripts.

## How to Test

1. `pytest tests/cron/test_lifecycle_guard_budget.py -q` — should pass 20/20 (16 existing + 4 new).
2. Before/after proof with the issue's repro shape (a local bundle whose lines are regex-literal tokens, executed via its own shebang with a `read_remote_script` callback):
   - before this PR: `blocked: True` with `lifecycle guard scan budget exhausted (remote reads at depth 1); failing closed`
   - after this PR: `blocked: False`, and the remote-read callback is never called.
3. `pytest tests/cron/ tests/hermes_cli/test_gateway_restart_loop.py tests/tools/test_approval.py -q` — observed result: all pass except `test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`, which fails identically on a clean `upstream/main` checkout (pre-existing, unrelated).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A