### PR TITLE
fix(skills): emit POSIX-separated paths from skill_view fields

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -399,6 +399,57 @@ class TestSkillView:
         # The caller gets the same helpful listing as a truly missing file.
         assert "references/api.md" in result["available_files"]["references"]
 
+    def test_view_path_fields_are_posix_separated(self, tmp_path):
+        """Every model-facing relative path in a skill_view result must be
+        "/"-separated (#105745).
+
+        The fields are built from ``Path.relative_to()``, whose ``str()`` is
+        "\\"-separated on Windows — which misroutes linked files into the
+        "other" available-files group and puts OS-native separators into
+        ``path``/``linked_files``. Asserted unconditionally so the POSIX shape
+        is locked on every host.
+        """
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "my-skill")
+            refs_dir = skill_dir / "references"
+            refs_dir.mkdir()
+            (refs_dir / "api.md").write_text("# API Docs\nEndpoint info.")
+
+            result = json.loads(skill_view("my-skill"))
+            listing = json.loads(skill_view("my-skill", file_path="references"))
+
+        assert result["path"] == "my-skill/SKILL.md"
+        assert result["linked_files"]["references"] == ["references/api.md"]
+        assert listing["available_files"]["references"] == ["references/api.md"]
+
+    # ``windows_only`` rather than ``skipif(os.name != "nt")``: the Windows CI
+    # job selects ``-m windows_only``, so a bare skipif would leave this
+    # skipped on Linux AND unselected there — dead on every host. On Windows
+    # these asserts catch a ``str(relative_to())`` regression for real.
+    @pytest.mark.windows_only
+    def test_view_path_fields_are_posix_separated_on_windows(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "my-skill")
+            refs_dir = skill_dir / "references"
+            refs_dir.mkdir()
+            (refs_dir / "api.md").write_text("# API Docs\nEndpoint info.")
+
+            result = json.loads(skill_view("my-skill"))
+            listing = json.loads(skill_view("my-skill", file_path="references"))
+
+        assert result["path"] == "my-skill/SKILL.md"
+        assert result["linked_files"]["references"] == ["references/api.md"]
+        assert listing["available_files"]["references"] == ["references/api.md"]
+        # references/api.md must land in its support-dir group, not "other".
+        assert "other" not in listing["available_files"]
+        # No OS-native separator leaks into any model-facing field.
+        assert "\\" not in result["path"]
+        assert all(
+            "\\" not in f for files in result["linked_files"].values() for f in files)
+        assert all(
+            "\\" not in f
+            for group in listing["available_files"].values() for f in group)
+
     def test_disabled_skill_blocked_enabled_allowed(self, tmp_path):
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
@@ -911,6 +962,33 @@ class TestSkillViewCollisionDetection:
         assert any("external" in p for p in result["matches"])
         assert "hint" in result
 
+    # ``windows_only`` (see TestSkillView for the marker rationale): on Windows
+    # ``str(Path)`` is "\\"-separated, which breaks the 'category/skill-name'
+    # subpath these refusal paths exist to surface (#105745).
+    @pytest.mark.windows_only
+    def test_collision_matches_are_posix_separated_on_windows(self, tmp_path):
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+
+        _make_skill(
+            local_dir,
+            "explore-codebase",
+            category="foundations/runtime",
+            body="LOCAL VERSION",
+        )
+        _make_skill(external_dir, "explore-codebase", body="EXTERNAL VERSION")
+
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            raw = skill_view("explore-codebase")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert len(result["matches"]) == 2
+        assert any("foundations/runtime" in p for p in result["matches"])
+        assert all("\\" not in p for p in result["matches"])
 
     def test_support_markdown_does_not_collide_with_real_skill(self, tmp_path):
         """Supporting reference docs named <skill>.md are not skills.
@@ -969,3 +1047,33 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is False
         assert "Ambiguous" in result["error"]
         assert len(result["matches"]) == 2
+
+
+class TestPluginSkillLinkedFilesPosixSeparators:
+    """``_plugin_skill_linked_files`` feeds the model-facing ``linked_files``
+    field of plugin skill_view results, so entries must be "/"-separated
+    (#105745) — the usage hint shows 'references/api.md' as the file_path form.
+    """
+
+    def test_entries_are_posix_separated(self, tmp_path):
+        from tools.skills_tool_plugin import _plugin_skill_linked_files
+
+        refs = tmp_path / "references"
+        refs.mkdir()
+        (refs / "api.md").write_text("# API")
+
+        assert _plugin_skill_linked_files(tmp_path) == {
+            "references": ["references/api.md"]}
+
+    # ``windows_only`` (see TestSkillView for the marker rationale): on Windows
+    # ``str(relative_to())`` is "\\"-separated in this field (#105745).
+    @pytest.mark.windows_only
+    def test_entries_are_posix_separated_on_windows(self, tmp_path):
+        from tools.skills_tool_plugin import _plugin_skill_linked_files
+
+        refs = tmp_path / "references"
+        refs.mkdir()
+        (refs / "api.md").write_text("# API")
+
+        assert _plugin_skill_linked_files(tmp_path) == {
+            "references": ["references/api.md"]}

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -371,7 +371,9 @@ def _skill_linked_files(skill_dir: Optional[Path]) -> dict:
     for sub, globs, recursive, files_only in _LINKED_FILE_SPECS if skill_dir else ():
         base = skill_dir / sub
         found = [
-            str(f.relative_to(skill_dir)) for g in globs if base.exists()
+            # as_posix(): linked_files feed the model's file_path calls (usage_hint
+            # shows 'references/api.md'); str(relative_to()) is "\"-separated on Windows.
+            f.relative_to(skill_dir).as_posix() for g in globs if base.exists()
             for f in (base.rglob(g) if recursive else base.glob(g))
             if not files_only or f.is_file()]
         if found:
@@ -475,7 +477,9 @@ def _locate_skill(name: str, local_category_name: Optional[str], project_dirs: l
         # ambiguity WITHIN the project tier still refuses.
         candidates = [c for c in candidates if _under_any(c[1], project_dirs)] or candidates
     if len(candidates) > 1:
-        paths = [str(smd) for _, smd in candidates]
+        # as_posix(): matches is model-facing and its categorized subpaths are
+        # matched as 'category/skill-name' strings; str(Path) is "\"-separated on Windows.
+        paths = [smd.as_posix() for _, smd in candidates]
         logger.warning("Skill name collision for '%s': %d candidates — %s", name, len(candidates), "; ".join(paths))
         return _fail(
             f"Ambiguous skill name '{name}': {len(candidates)} skills match across your local skills dir "
@@ -563,9 +567,11 @@ def skill_view(
             _parse_tags(hermes_meta.get(k) or frontmatter.get(k, "")) for k in ("tags", "related_skills"))
         linked_files = _skill_linked_files(skill_dir)
         try:
-            rel_path = str(skill_md.relative_to(active_skills_dir))
+            # as_posix(): path is model-facing and asserted/tested as
+            # 'category/skill/SKILL.md'; str(relative_to()) is "\"-separated on Windows.
+            rel_path = skill_md.relative_to(active_skills_dir).as_posix()
         except ValueError:  # external skill — relative to its own parent dir
-            rel_path = str(skill_md.relative_to(skill_md.parent.parent)) if skill_md.parent.parent else skill_md.name
+            rel_path = skill_md.relative_to(skill_md.parent.parent).as_posix() if skill_md.parent.parent else skill_md.name
         skill_name = frontmatter.get("name", skill_md.stem if not skill_dir else skill_dir.name)
         readiness, readiness_extras = _skill_readiness(frontmatter, skill_name)
         rendered_content = content if not preprocess else _preprocess_skill(

--- a/tools/skills_tool_plugin.py
+++ b/tools/skills_tool_plugin.py
@@ -58,7 +58,9 @@ def _available_skill_files(skill_dir: Path) -> Dict[str, List[str]]:
     for f in skill_dir.rglob("*"):
         if not f.is_file() or f.name == "SKILL.md":
             continue
-        rel = str(f.relative_to(skill_dir))
+        # as_posix(): the split("/", 1) grouping and the model-facing listing
+        # both key on "/" — str(relative_to()) carries "\" on Windows.
+        rel = f.relative_to(skill_dir).as_posix()
         top = rel.split("/", 1)[0] if "/" in rel else None
         if top in _SUPPORT_DIRS or f.suffix in _SKILL_FILE_EXTS:
             groups.setdefault(top if top in _SUPPORT_DIRS else "other", []).append(rel)
@@ -165,7 +167,7 @@ def _plugin_skill_linked_files(skill_root: Path) -> Dict[str, List[str]] | None:
     linked: Dict[str, List[str]] = {}
     for category in _SUPPORT_DIRS:
         files = [
-            str(path.relative_to(skill_root)) for path in sorted((skill_root / category).rglob("*"))
+            path.relative_to(skill_root).as_posix() for path in sorted((skill_root / category).rglob("*"))
             if path.is_file() and validate_within_dir(path, skill_root) is None]
         if files:
             linked[category] = files


### PR DESCRIPTION
## What does this PR do?

On Windows, the model-facing relative paths in `skill_view` results were built with `str(Path.relative_to(...))`, which is `\`-separated. This caused two user-visible breakages (#105745):

1. `_available_skill_files()` groups linked files by `rel.split("/", 1)[0]` — on Windows the top-dir check never matches, so `references/api.md` lands in the `"other"` group instead of `"references"`, and callers keying on support-dir groups get a `KeyError`.
2. `result["path"]`, `linked_files` entries, and the collision-refusal `matches` list carry OS-native backslashes, while the usage hint, the model, and the tests all expect the `'category/skill/SKILL.md'` POSIX form.

The fix normalizes at the boundary where paths become strings, via `Path.relative_to(...).as_posix()` / `Path.as_posix()` — no behavior change on POSIX hosts.

## Related Issue

Fixes #105745

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_tool_plugin.py` — `_available_skill_files()`: `rel` is now `as_posix()`, so the `split("/", 1)` grouping and the served listing are correct on every host.
- `tools/skills_tool_plugin.py` — `_plugin_skill_linked_files()`: entries are now POSIX-separated.
- `tools/skills_tool.py` — `_skill_linked_files()`: entries are now POSIX-separated.
- `tools/skills_tool.py` — `skill_view()` `result["path"]`: both the `active_skills_dir` form and the external-skill fallback use `as_posix()`.
- `tools/skills_tool.py` — collision refusal `matches`: `smd.as_posix()` so the surfaced `category/skill-name` subpaths stay matchable.
- `tests/tools/test_skills_tool.py` — unconditional POSIX-shape locks plus `windows_only`-marked twins that run on the real Windows CI lane (`tests-os.yml` selects `-m windows_only`), where the pre-fix `str()` form actually fails.

## How to Test

1. `pytest tests/tools/test_skills_tool.py -q` — should pass (44 passed, 3 skipped on macOS; the skipped ones are the `windows_only` twins).
2. `pytest tests/tools/test_skills_tool.py -m windows_only -q` on Windows (or the Windows lane of `tests-os.yml`) — the marked tests fail at HEAD with backslash-separated `path`/`linked_files`/`available_files["other"]` misgrouping and pass with this change.
3. Observed result on macOS (this change): `69 passed, 4 skipped` across the skill_view family (`test_skills_tool.py`, `test_skill_view_dedup.py`, `test_skill_view_traversal.py`, `test_skill_view_path_check.py`, `test_skills_tool_profile_scope.py`, `test_skills_tool_discovery_cache.py`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this is a Windows-path bug fix; `windows_only` tests added for the real Windows CI lane
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A