### PR TITLE
fix(desktop): route /skills approval verbs to the gateway instead of the sidebar

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -261,7 +261,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
         const { render: renderSlashOutput, sessionId, storedSessionId } = resolved
 
-        if (!isDesktopSlashCommand(name)) {
+        if (!isDesktopSlashCommand(name, arg)) {
           renderSlashOutput(desktopSlashUnavailableMessage(name) || `/${name} is not available in the desktop app.`)
 
           return
@@ -1190,7 +1190,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         }
 
         const ctx: SlashActionCtx = { arg, command, name, recordInput, sessionHint }
-        const surface = resolveDesktopCommand(`/${name}`)?.surface
+        const surface = resolveDesktopCommand(`/${name}`, arg)?.surface
 
         switch (surface?.kind) {
           case 'unavailable': {

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -171,6 +171,23 @@ describe('desktop slash command curation', () => {
     expect(isDesktopSlashCommand('/pets')).toBe(false)
   })
 
+  it('lets /skills approval verbs through to the gateway but keeps the hub sidebar-only', () => {
+    // Bare /skills (and its hub subcommands) still point at the sidebar — the
+    // desktop has no search/install UI to run them against.
+    expect(resolveDesktopCommand('/skills')?.surface).toEqual({ kind: 'unavailable', reason: 'settings' })
+    expect(isDesktopSlashCommand('skills')).toBe(false)
+    expect(resolveDesktopCommand('/skills', 'search foo')?.surface).toEqual({ kind: 'unavailable', reason: 'settings' })
+    expect(isDesktopSlashCommand('skills', 'search foo')).toBe(false)
+
+    // pending/approve/reject/diff/approval are the only way to unstick a
+    // staged skill write with skills.write_approval on — the gateway already
+    // handles them (_handle_skills_command), so they must reach it.
+    for (const arg of ['pending', 'approve abc123', 'reject abc123', 'diff abc123', 'approval on']) {
+      expect(resolveDesktopCommand('/skills', arg)?.surface).toEqual({ kind: 'exec' })
+      expect(isDesktopSlashCommand('skills', arg)).toBe(true)
+    }
+  })
+
   it('routes /wake through the desktop wake action instead of the slash worker', () => {
     expect(resolveDesktopCommand('/wake')?.surface).toEqual({ kind: 'action', action: 'wake' })
     expect(desktopSlashCommandArgumentMode('/wake')).toBe('options')

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -468,9 +468,29 @@ export function canonicalDesktopSlashCommand(command: string): string {
   return ALIAS_TO_CANONICAL.get(normalized) || catalogCanonical(normalized) || normalized
 }
 
+// `/skills` is gated to the sidebar for its hub verbs (search, install, …),
+// but pending/approve/reject/diff/approval are the only way to unblock a
+// staged skill write with `skills.write_approval: true` — the sidebar has no
+// approval UI. The gateway (`_handle_skills_command`) already accepts exactly
+// these verbs and rejects the rest, so letting them through here just stops
+// the desktop shell from swallowing a request the backend already handles.
+const SKILLS_APPROVAL_SUBCOMMANDS = new Set(['pending', 'approve', 'reject', 'diff', 'approval'])
+
+function isSkillsApprovalSubcommand(arg: string | undefined): boolean {
+  const sub = arg?.trim().split(/\s+/, 1)[0]?.toLowerCase()
+
+  return Boolean(sub && SKILLS_APPROVAL_SUBCOMMANDS.has(sub))
+}
+
 /** Resolve a command (or alias) to its desktop spec, or null for unknown/extension commands. */
-export function resolveDesktopCommand(command: string): DesktopCommandSpec | null {
-  return SPEC_BY_NAME.get(canonicalDesktopSlashCommand(command)) ?? specFromCatalog(command)
+export function resolveDesktopCommand(command: string, arg?: string): DesktopCommandSpec | null {
+  const spec = SPEC_BY_NAME.get(canonicalDesktopSlashCommand(command)) ?? specFromCatalog(command)
+
+  if (spec?.name === '/skills' && spec.surface.kind === 'unavailable' && isSkillsApprovalSubcommand(arg)) {
+    return { ...spec, surface: exec() }
+  }
+
+  return spec
 }
 
 function isKnownHermesSlashCommand(command: string): boolean {
@@ -518,8 +538,8 @@ export function slashCompletionGroup(command: string, kind?: string | null): 'Co
 }
 
 /** Gates execution: true unless the command is a known no-desktop-surface command. */
-export function isDesktopSlashCommand(command: string): boolean {
-  const spec = resolveDesktopCommand(command)
+export function isDesktopSlashCommand(command: string, arg?: string): boolean {
+  const spec = resolveDesktopCommand(command, arg)
 
   if (spec) {
     return spec.surface.kind !== 'unavailable'


### PR DESCRIPTION
## What does this PR do?

Fixes `/skills` so the desktop app can reach the write-approval verbs
(`pending`, `approve`, `reject`, `diff`, `approval`) instead of swallowing
them with a generic "managed from the desktop sidebar" message.

## Related Issue

Fixes #105759

## Root cause

`hermes_cli/commands.py` declares the whole `/skills` command as
`desktop="settings"`, even though its subcommand list mixes two groups:
hub verbs that only make sense from the sidebar (`search`, `browse`,
`inspect`, `install`, `audit`) and write-approval verbs that have a working
backend handler but no sidebar UI (`pending`, `approve`, `reject`, `diff`,
`approval`).

On the desktop side, `apps/desktop/src/lib/desktop-slash-commands.ts` looked
up the desktop surface for `/skills` by command name only, ignoring the
typed subcommand, so every `/skills ...` invocation — including
`/skills approve <id>` — hit the same `unavailable: 'settings'` surface and
never reached `slash.exec` / `command.dispatch`. The gateway handler
(`gateway/slash_commands.py::_handle_skills_command`) already implements
exactly this split correctly; it was just unreachable from the desktop
client.

With `skills.write_approval: true`, this meant staged skill writes queued by
`skill_manage` had no way to be approved or rejected from the desktop app.

## Changes Made

- `apps/desktop/src/lib/desktop-slash-commands.ts`: `resolveDesktopCommand`
  and `isDesktopSlashCommand` now take an optional `arg`. For `/skills`
  specifically, if the first word of `arg` is one of `pending`, `approve`,
  `reject`, `diff`, `approval`, the surface resolves to `exec` (reaching the
  gateway) instead of `unavailable`. Bare `/skills` and its hub verbs
  (`search`, `install`, ...) are unaffected and still point at the sidebar.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts`: pass the
  parsed `arg` through at the two call sites that gate on desktop command
  availability (the main dispatcher switch and `runExec`'s guard).
- `apps/desktop/src/lib/desktop-slash-commands.test.ts`: added a test
  asserting bare `/skills` and hub verbs stay `unavailable`, while the five
  approval verbs resolve to `exec` and pass `isDesktopSlashCommand`.

No backend changes — `_handle_skills_command` already accepts exactly these
verbs and rejects the rest (`gateway_config_gate="skills.write_approval"` in
`hermes_cli/commands.py` already overrides `cli_only` for the gateway).

## How to Test

1. `hermes config set skills.write_approval true`
2. In the desktop app, have the agent stage a skill write (any
   create/patch via `skill_manage`) — it returns `staged: true` and a file
   appears under `~/.hermes/pending/skills/`.
3. Send `/skills pending` or `/skills approve <id>` in the desktop composer.

**Before:** `/skills is managed from the desktop sidebar.` — nothing
reaches the gateway, the pending write is untouched.
**After:** the request reaches `_handle_skills_command` and returns the
pending list / `Approved 1 skills write(s).` as it does from `hermes chat`.

`/skills search foo` (a hub verb) still returns the sidebar message,
unchanged.

### Automated test proving the fix

Added `desktop-slash-commands.test.ts` case
`'lets /skills approval verbs through to the gateway but keeps the hub
sidebar-only'`.

Confirmed it fails without the fix (`git checkout HEAD~1 -- <files>`, run,
restore):

```
❯ src/lib/desktop-slash-commands.test.ts:186:62
AssertionError: expected { kind: 'unavailable', …(1) } to deeply equal { kind: 'exec' }
- Expected
+ Received
  {
-   "kind": "exec",
+   "kind": "unavailable",
+   "reason": "settings",
  }
 Test Files  1 failed (1)
      Tests  1 failed | 32 passed (33)
```

And passes with the fix applied:

```
 Test Files  1 passed (1)
      Tests  33 passed (33)
```

Full suite after the fix (`npx vitest run --project electron`):

```
 Test Files  151 passed | 2 skipped (153)
      Tests  2139 passed | 6 skipped (2145)
```

`npx tsc -p . --noEmit` (renderer typecheck) and
`npx eslint src/lib/desktop-slash-commands.ts src/lib/desktop-slash-commands.test.ts src/app/session/hooks/use-prompt-actions/slash.ts`
both pass with no output.

## What platforms tested on

Linux (sandboxed CI-style container) — frontend-only change (TypeScript/Vitest),
no OS-specific code touched.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(desktop):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added tests for my change (required for bug fixes)
- [x] I've considered cross-platform impact — N/A, this is a routing table
      change in the shared Electron/React frontend

## AI-assistance disclosure

This change was prepared with AI assistance (an autonomous coding agent),
with the diff reviewed and verified (test run before/after the fix, lint,
typecheck, and full suite) before opening this PR.
