### PR TITLE
fix(cron): validate script existence and fix profile-aware path in error messages

### DIFF
--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -451,6 +451,7 @@ class TestCronjobToolScript:
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
 
+        (cron_env / "scripts" / "some_script.py").write_text("print('hi')\n")
         create_result = json.loads(cronjob(
             action="create",
             schedule="every 1h",
@@ -471,6 +472,7 @@ class TestCronjobToolScript:
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
 
+        (cron_env / "scripts" / "data_collector.py").write_text("print('hi')\n")
         cronjob(
             action="create",
             schedule="every 1h",

--- a/tests/tools/test_cronjob_job_args.py
+++ b/tests/tools/test_cronjob_job_args.py
@@ -1,0 +1,36 @@
+"""Tests for tools/cronjob_job_args.py::_validate_cron_script_path (issue #105761).
+
+Regression coverage: the validator used to accept a script path that pointed
+at a file that doesn't exist, only failing later at every cron fire with a
+generic "Script not found" error from cron/scheduler_script.py. It also
+hardcoded "~/.hermes/scripts/" in its messages even though resolution goes
+through get_hermes_home(), which is per-profile.
+"""
+
+from hermes_constants import get_hermes_home
+from tools.cronjob_job_args import _validate_cron_script_path
+
+
+class TestValidateCronScriptPath:
+    def test_missing_script_file_is_rejected_at_creation_time(self):
+        error = _validate_cron_script_path("does_not_exist.sh")
+        assert error is not None
+        assert "not found" in error.lower()
+
+    def test_existing_script_file_passes(self):
+        scripts_dir = get_hermes_home() / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        (scripts_dir / "real.sh").write_text("#!/bin/sh\necho hi\n")
+        assert _validate_cron_script_path("real.sh") is None
+
+    def test_missing_file_error_names_the_resolved_scripts_dir(self):
+        # The resolved dir must appear literally so the message stays correct
+        # under profiles, where get_hermes_home() is not the global ~/.hermes.
+        scripts_dir = get_hermes_home() / "scripts"
+        error = _validate_cron_script_path("missing.py")
+        assert str(scripts_dir) in error
+
+    def test_absolute_path_error_names_the_resolved_scripts_dir_not_global_literal(self):
+        scripts_dir = get_hermes_home() / "scripts"
+        error = _validate_cron_script_path("/etc/passwd")
+        assert str(scripts_dir) in error

--- a/tools/cronjob_job_args.py
+++ b/tools/cronjob_job_args.py
@@ -296,17 +296,22 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
 
     from hermes_constants import get_hermes_home
     raw = script.strip()
+    scripts_dir = get_hermes_home() / "scripts"
     if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
         return (
-            f"Script path must be relative to ~/.hermes/scripts/. "
+            f"Script path must be relative to {scripts_dir}/. "
             f"Got absolute or home-relative path: {raw!r}. "
-            f"Place scripts in ~/.hermes/scripts/ and use just the filename.")
+            f"Place scripts in {scripts_dir}/ and use just the filename.")
 
     from tools.path_security import validate_within_dir
-    scripts_dir = get_hermes_home() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
-    if validate_within_dir(scripts_dir / raw, scripts_dir):
+    resolved_script = scripts_dir / raw
+    if validate_within_dir(resolved_script, scripts_dir):
         return f"Script path escapes the scripts directory via traversal: {raw!r}"
+    if not resolved_script.is_file():
+        return (
+            f"Script file not found: {resolved_script}. "
+            f"Create it in {scripts_dir}/ first.")
     return None
 
 


### PR DESCRIPTION
Fixes #105761.

## Problem

`_validate_cron_script_path` in `tools/cronjob_job_args.py` (used by the
`cronjob` tool for both `script=` and `monitor_script=` on `no_agent`/monitor
cron jobs) only checked that the path was relative and contained within
`HERMES_HOME/scripts/`. It never checked the file actually existed, so a
job whose script was placed in the wrong directory registered successfully
and then failed on every trigger with a generic `"Script not found: ..."`
from `cron/scheduler_script.py:290`. For once-only jobs, the failed run
drops the job from `jobs.json`, so the missed event can't recover.

The absolute/home-relative-path error message also hardcoded the literal
`"~/.hermes/scripts/"`, even though resolution actually goes through
`get_hermes_home()`, which is per-profile (`<profile>/scripts/` under a
non-default profile). The message actively misled users running profiles
into placing scripts in the wrong directory.

## Fix

In `_validate_cron_script_path`:
1. Build both error messages from the resolved `scripts_dir` instead of a
   hardcoded `~/.hermes/scripts/` literal.
2. After the traversal/containment check, verify the resolved script
   `is_file()` and return a `"Script file not found: <resolved path>.
   Create it in <scripts_dir>/ first."` error if not — surfacing the
   mistake at job creation/update time instead of at every scheduled fire.

## Testing

Added `tests/tools/test_cronjob_job_args.py` covering `_validate_cron_script_path`:
- a nonexistent script is rejected at validation time
- an existing script passes
- the "not found" and absolute-path error messages both name the actual
  resolved `scripts_dir` (not a hardcoded global path)

Also updated two pre-existing tests in `tests/cron/test_cron_script.py`
(`test_clear_script`, `test_list_shows_script`) that created jobs
referencing a script file that never existed on disk — this is exactly the
gap being closed, so those tests now create the referenced script file
before calling `cronjob(action="create", ...)`.

Confirmed the new tests fail without the fix:
```
$ git checkout HEAD~1 -- tools/cronjob_job_args.py
$ python -m pytest tests/tools/test_cronjob_job_args.py -v
...
FAILED tests/tools/test_cronjob_job_args.py::TestValidateCronScriptPath::test_missing_script_file_is_rejected_at_creation_time - assert None is not None
FAILED tests/tools/test_cronjob_job_args.py::TestValidateCronScriptPath::test_missing_file_error_names_the_resolved_scripts_dir - TypeError: argument of type 'NoneType' is not iterable
FAILED tests/tools/test_cronjob_job_args.py::TestValidateCronScriptPath::test_absolute_path_error_names_the_resolved_scripts_dir_not_global_literal - assert '/tmp/.../hermes_test/scripts' in "Script path must be relative to ~/.hermes/scripts/. ..."
3 failed, 1 passed in 1.00s
$ git checkout HEAD -- tools/cronjob_job_args.py
```

And pass with the fix, along with the full existing suite for the touched
files:
```
$ python -m pytest tests/tools/test_cronjob_job_args.py tests/tools/test_cronjob_tools.py \
    tests/tools/test_cronjob_run_background.py tests/tools/test_cronjob_run_delivery_notice.py \
    tests/tools/test_cronjob_run_immediate.py tests/cron/ -v
...
2 failed, 1328 passed, 19 skipped   # (the 2 pre-existing tests noted above, fixed as described)
```
After updating those two tests to create their referenced script file:
```
$ python -m pytest tests/cron/test_cron_script.py -v
32 passed, 1 skipped
```

Also ran `ruff check` on the touched files — no issues.

## AI assistance disclosure

This PR was written by an autonomous coding agent (Claude) based on the
repro and suggested fix described in #105761.
