### PR TITLE
fix(tools): strip leading UTF-8 BOM before in-process lint so BOM-marked files are not reported as broken

### DIFF
--- a/contributors/emails/kyr76789@gmail.com
+++ b/contributors/emails/kyr76789@gmail.com
@@ -1,0 +1,2 @@
+hyeonsang010716
+# fix(tools): BOM-marked files no longer reported as broken by write_file lint — contributor attribution

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -155,6 +155,27 @@ class TestCheckLintInproc:
         result = ops._check_lint("/tmp/a.json", content='{"a": 1}')
         assert result.success is True
 
+    @pytest.mark.parametrize("path,content", [
+        ("/tmp/bom.json", '{"a": 1}'),
+        ("/tmp/bom.toml", 'k = "v"\n'),
+        ("/tmp/bom.py", "x = 1\n"),
+        ("/tmp/bom.yaml", "a: 1\n"),
+    ])
+    def test_inproc_ignores_leading_bom(self, ops, path, content):
+        """A leading UTF-8 BOM is an encoding marker, not a syntax error. write_file
+        re-prepends the on-disk BOM before linting, so json.loads/tomllib/ast.parse
+        would otherwise flag every BOM-marked file as broken."""
+        result = ops._check_lint(path, content="\ufeff" + content)
+        assert result.success is True, result.output
+        assert result.output == ""
+
+    def test_inproc_mid_content_bom_is_still_data(self, ops):
+        """Only a LEADING BOM is stripped; U+FEFF elsewhere stays and lints as-is."""
+        result = ops._check_lint("/tmp/mid.json", content='{"a": "\ufeff"}')
+        assert result.success is True
+        result = ops._check_lint("/tmp/mid2.json", content='{"a": \ufeff1}')
+        assert result.success is False
+
 
     def test_toml_inproc_error(self, ops):
         result = ops._check_lint("/tmp/b.toml", content='[section\nk = "v"')
@@ -189,6 +210,15 @@ class TestCheckLintDelta:
         # File is still broken — don't lie and claim success — but flag it as pre-existing
         assert r.success is False
         assert "pre-existing" in (r.message or "").lower()
+
+    def test_bom_marked_file_is_not_reported_as_broken(self, ops):
+        """Regression: a BOM-marked JSON edit used to fail both the post and pre lint
+        with "Unexpected UTF-8 BOM", which the delta filter then reported as
+        "pre-existing lint errors — the file is still broken" on a valid file."""
+        r = ops._check_lint_delta("/tmp/bom.json", pre_content='\ufeff{"a": 1}',
+                                  post_content='\ufeff{"a": 2}')
+        assert r.success is True, (r.output, r.message)
+        assert not r.skipped
 
 
 # =========================================================================

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -381,6 +381,19 @@ class TestBomHandling:
         target.write_bytes(self.BOM.encode("utf-8") + b"x = 1\n")
         assert ops._file_has_bom(str(target), pre_content="x = 1\n") is True
 
+    def test_write_file_bom_json_lint_is_clean(self, ops, tmp_path: Path):
+        # write_file re-prepends the on-disk BOM and then lints that content.
+        # json.loads rejects a leading BOM, so a valid BOM-marked file used to
+        # come back with lint status "error" ("file is still broken") on every
+        # write, and the LSP tier (gated on a clean lint) was skipped.
+        target = tmp_path / "settings.json"
+        target.write_bytes(self.BOM.encode("utf-8") + b'{"a": 1}\n')
+        res = ops.write_file(str(target), '{"a": 2}\n')
+        assert res.error is None, res.error
+        assert target.read_bytes() == self.BOM.encode("utf-8") + b'{"a": 2}\n'
+        assert res.lint is not None
+        assert res.lint["status"] == "ok", res.lint
+
 
 class TestProtectedInstructionFiles:
     """Writes to agent-instruction files ALWAYS require approval.

--- a/tools/file_operations_lint.py
+++ b/tools/file_operations_lint.py
@@ -10,7 +10,7 @@ import os
 import tomllib
 from typing import Callable, Dict, Optional
 
-from tools.file_operations_common import LintResult
+from tools.file_operations_common import LintResult, _strip_bom
 
 # Shell linters by extension (external toolchain). ``.tsx`` is deliberately absent:
 # it hits the "No linter" skip and LSP covers it when enabled.
@@ -138,6 +138,11 @@ class LintMixin:
                 if read_result.exit_code != 0:
                     return LintResult(skipped=True, message=f"Failed to read {path} for lint")
                 content = read_result.stdout
+            # A leading UTF-8 BOM is an encoding marker, not syntax: json.loads,
+            # tomllib and ast.parse all reject it, so linting BOM-bearing content
+            # (write_file re-prepends the on-disk BOM; ``cat`` returns it) would
+            # flag every BOM-marked file as broken.
+            content, _ = _strip_bom(content)
             ok, err = inproc(content)
             if err == "__SKIP__":
                 return LintResult(skipped=True, message=f"No linter available for {ext} (missing dependency)")


### PR DESCRIPTION
## What does this PR do?

`write_file` preserves a UTF-8 BOM that was on disk by re-prepending it to the new content before writing ("prepend only when absent" in `tools/file_operations.py`). It then lints that same BOM-bearing content through `_check_lint_delta`. `json.loads`, `tomllib.loads` and `ast.parse` all reject a leading U+FEFF, so on every write to a valid BOM-marked file:

- the post-write lint fails with `JSONDecodeError: Unexpected UTF-8 BOM (decode using utf-8-sig)`,
- the pre-write lint (content read back via `cat`, BOM included) fails with the same error,
- the delta filter sees "no new errors" and returns `success=False` with
  `"Pre-existing lint errors — this edit didn't introduce new ones but the file is still broken."`

The tool result carries `lint.status: "error"` for a file that is perfectly valid, and the LSP diagnostics tier is skipped because it is gated on a clean syntax lint. BOM-marked `.json` / `.toml` / `.py` files are common on Windows (Notepad, Windows PowerShell 5.1 `Set-Content -Encoding UTF8`), so the model is told a valid file is broken on every edit of such a file.

`_fail_closed_syntax_error` already lints the raw, BOM-less content for exactly this reason (its docstring: "post-shim linting would false-positive on a BOM-marked file"); the post-write lint was never given the same treatment.

**Fix:** strip only a *leading* BOM at the linter boundary in `LintMixin._check_lint`, reusing the existing `_strip_bom` helper. This covers both the caller-supplied `content=` path and the `cat` re-read path. A U+FEFF anywhere else is still data and still lints as-is (covered by a test).

## Related Issue

No existing issue or PR found (searched open and closed PRs/issues for "BOM lint", "utf-8-sig write_file", "Unexpected UTF-8 BOM").

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations_lint.py`: `_check_lint` strips a leading UTF-8 BOM before handing content to an in-process linter.
- `tests/tools/test_file_operations_edge_cases.py`: `_check_lint` accepts BOM-prefixed JSON/TOML/Python/YAML; a mid-content U+FEFF is still treated as data; `_check_lint_delta` no longer reports a BOM-marked edit as "still broken".
- `tests/tools/test_file_write_safety.py`: end-to-end `write_file` against a real `LocalEnvironment` — a BOM-marked JSON file round-trips with the BOM preserved and `lint.status == "ok"`.
- `contributors/emails/kyr76789@gmail.com`: contributor attribution mapping (via `scripts/add_contributor.py`).

## How to Test

1. Reproduce on `main` from the repo venv:
   ```python
   from tools.file_operations import ShellFileOperations
   ops = ShellFileOperations.__new__(ShellFileOperations); ops._command_cache = {}
   print(ops._check_lint_delta("x.json", pre_content="\ufeff{\"a\": 1}", post_content="\ufeff{\"a\": 2}").to_dict())
   # {'status': 'error', 'output': 'JSONDecodeError: Unexpected UTF-8 BOM (decode using utf-8-sig) (line 1, column 1)',
   #  'message': "Pre-existing lint errors — this edit didn't introduce new ones but the file is still broken."}
   ```
2. Run the tests:
   ```bash
   pytest tests/tools/test_file_operations_edge_cases.py tests/tools/test_file_write_safety.py -q
   ```
   The four new tests fail on `main` (`Unexpected UTF-8 BOM` / `invalid non-printable character U+FEFF`) and pass with this change.
3. Manually: create a JSON file with a BOM (`printf '\xef\xbb\xbf{"a": 1}\n' > x.json`, or save from Notepad with "UTF-8 with BOM"), edit it with the `write_file` tool from Hermes, and check the result's `lint` field is `{"status": "ok", ...}` and the BOM is still on disk.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected tests (`tests/tools/test_file_operations_edge_cases.py`, `tests/tools/test_file_write_safety.py`); the only failures on my machine are pre-existing Windows-environment failures in `test_file_write_safety.py` (POSIX sensitive-path checks, `st_mode` assertion, symlink privilege) that fail identically on `main`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11 (repo `.venv`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no user-facing behavior beyond the false error going away)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string handling; the bug is most visible on Windows where BOM-marked files are common
