### PR TITLE
feat(desktop): add per-bot backend reconnect without app restart (#104074)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-reconnect.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-reconnect.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Per-bot reconnect (#104074): a local bot's context menu offers Reconnect
+ * that tears down its pooled backend without restarting the app.
+ *
+ * Remote/ghost rows have no local process to recycle, so the item is disabled.
+ * The handler calls window.hermesDesktop.recycleBackend(profile) and invalidates
+ * the roster query.
+ */
+import type * as HermesSdk from '@hermes/plugin-sdk'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BotRow } from './bot-row'
+import { translateBots } from './i18n-test-helper'
+import type { RosterRow } from './types'
+
+const { ensureAgent, ensureBotMetadata, notify, notifyError, openRosterBot, requestProfile, warmAgent, warmProfile } =
+  vi.hoisted(() => ({
+    ensureAgent: vi.fn(),
+    ensureBotMetadata: vi.fn(),
+    notify: vi.fn(),
+    notifyError: vi.fn(),
+    openRosterBot: vi.fn(),
+    requestProfile: vi.fn(),
+    warmAgent: vi.fn(),
+    warmProfile: vi.fn()
+  }))
+
+const queryInvalidate = vi.fn(async () => undefined)
+
+vi.mock('@hermes/plugin-sdk', async importOriginal => {
+  const sdk = await importOriginal<typeof HermesSdk>()
+  return {
+    ...sdk,
+    host: {
+      ...sdk.host,
+      ensureAgent,
+      notify,
+      notifyError,
+      requestProfile,
+      warmAgent,
+      warmProfile
+    },
+    queryClient: {
+      ...sdk.queryClient,
+      invalidateQueries: queryInvalidate
+    },
+    usePluginI18n: () => translateBots
+  }
+})
+
+vi.mock('./canonical-chat', () => ({
+  ensureBotMetadata,
+  notifyBotOpenFailure: vi.fn(),
+  openBotCanonicalChat: vi.fn(),
+  prepareBotSource: vi.fn(),
+  PROFILE_SESSION_LIST_LIMIT: 200
+}))
+
+vi.mock('./roster-actions', () => ({ openRosterBot }))
+
+const noop = () => undefined
+
+function renderRow(bot: RosterRow) {
+  render(<BotRow bot={bot} onDelete={noop} onEdit={noop} onGroup={noop} onNewSection={noop} />)
+  return screen.getByRole('button')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  ensureBotMetadata.mockResolvedValue({ pinned: false })
+  openRosterBot.mockResolvedValue(true)
+  requestProfile.mockResolvedValue({})
+  queryInvalidate.mockResolvedValue(undefined)
+  // Provide a fresh desktop bridge per test — individual tests override as needed.
+  ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = {
+    recycleBackend: vi.fn(async () => ({ ok: true }))
+  }
+})
+
+describe('per-bot reconnect menu (#104074)', () => {
+  it('shows Reconnect and calls recycleBackend with the bot profile for a local bot', async () => {
+    const recycleBackend = vi.fn(async () => ({ ok: true }))
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = { recycleBackend }
+
+    const bot = { name: 'alpha' } as RosterRow
+    fireEvent.contextMenu(renderRow(bot))
+    const item = await screen.findByText('Reconnect')
+    expect(item).toBeTruthy()
+    // Enabled for local bots.
+    expect(item.closest('[aria-disabled="true"]')).toBeNull()
+
+    fireEvent.click(item)
+
+    await waitFor(() => expect(recycleBackend).toHaveBeenCalledWith('alpha'))
+    expect(queryInvalidate).toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'success', message: expect.stringContaining('alpha') })
+    )
+  })
+
+  it('uses route targetProfile for alias routes', async () => {
+    const recycleBackend = vi.fn(async () => ({ ok: true }))
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = { recycleBackend }
+
+    const bot = {
+      name: 'moxie',
+      route: { connectionId: 'local', mode: 'local', profile: 'moxie', targetProfile: 'backend-moxie' }
+    } as unknown as RosterRow
+
+    fireEvent.contextMenu(renderRow(bot))
+    fireEvent.click(await screen.findByText('Reconnect'))
+    await waitFor(() => expect(recycleBackend).toHaveBeenCalledWith('backend-moxie'))
+  })
+
+  it('disables Reconnect for remote and ghost rows', async () => {
+    const remote = {
+      name: 'research',
+      connectionId: 'work',
+      remoteSource: true,
+      sourceScoped: true
+    } as RosterRow
+    fireEvent.contextMenu(renderRow(remote))
+    const remoteItem = await screen.findByText('Reconnect')
+    // Disabled items render with aria-disabled or data-disabled — either signals non-interactive.
+    const disabled =
+      remoteItem.getAttribute('aria-disabled') === 'true' ||
+      remoteItem.hasAttribute('data-disabled') ||
+      remoteItem.getAttribute('data-disabled') === 'true'
+    expect(disabled).toBe(true)
+  })
+
+  it('disables Reconnect for ghost rows', async () => {
+    const ghost = { name: 'beta', ghost: true } as RosterRow
+    fireEvent.contextMenu(renderRow(ghost))
+    const item = await screen.findByText('Reconnect')
+    const disabled =
+      item.getAttribute('aria-disabled') === 'true' ||
+      item.hasAttribute('data-disabled') ||
+      item.getAttribute('data-disabled') === 'true'
+    expect(disabled).toBe(true)
+  })
+
+  it('shows error when recycleBackend is unavailable', async () => {
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = {}
+    const bot = { name: 'alpha' } as RosterRow
+    fireEvent.contextMenu(renderRow(bot))
+    fireEvent.click(await screen.findByText('Reconnect'))
+    await waitFor(() => expect(notifyError).toHaveBeenCalled())
+  })
+
+  it('surfaces recycleBackend failures', async () => {
+    const recycleBackend = vi.fn(async () => {
+      throw new Error('pool busy')
+    })
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = { recycleBackend }
+    const bot = { name: 'alpha' } as RosterRow
+    fireEvent.contextMenu(renderRow(bot))
+    fireEvent.click(await screen.findByText('Reconnect'))
+    await waitFor(() => expect(notifyError).toHaveBeenCalledWith(expect.any(Error), 'Reconnect failed'))
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
@@ -28,6 +28,7 @@ import {
   useI18n,
   useValue
 } from '@hermes/plugin-sdk'
+import { useState } from 'react'
 
 import { avatarColor, botAppearance, BotFace } from './avatar'
 import { isBackfilledFacePng } from './avatar-image'
@@ -221,6 +222,38 @@ export function BotRow({ bot, onDelete, onEdit, onGroup, onNewSection, showHandl
   const sections = useValue($botSections)
   const dragging = useValue($draggingBot) === rosterKey
   const currentSectionId = botSectionId(bot, allMeta)
+  const [reconnecting, setReconnecting] = useState(false)
+
+  // Per-bot reconnect (#104074): tears down the pooled local backend for this
+  // bot's profile and lets the next dial re-spawn it — no full app restart.
+  // Remote/ghost rows have no local process to recycle, so the item is disabled.
+  const canReconnect = !bot.ghost && !bot.remoteSource
+  const reconnectProfile =
+    (bot.route?.targetProfile || bot.route?.profile || bot.targetProfile || bot.name || '').trim() || 'default'
+
+  const handleReconnect = async () => {
+    if (reconnecting || !canReconnect) return
+    const desktop = (window as unknown as { hermesDesktop?: { recycleBackend?: (p: string) => Promise<unknown> } })
+      ?.hermesDesktop
+    if (typeof desktop?.recycleBackend !== 'function') {
+      host.notifyError?.(new Error('Reconnect unavailable — update Desktop'), b.bot.reconnectFailed)
+      return
+    }
+    setReconnecting(true)
+    try {
+      await desktop.recycleBackend(reconnectProfile)
+      // Roster is cached by React Query — invalidate so the next poll shows live.
+      await queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
+      host.notify?.({
+        kind: 'success',
+        message: b.bot.reconnected(displayName(bot, meta) || reconnectProfile)
+      })
+    } catch (error) {
+      host.notifyError?.(error, b.bot.reconnectFailed)
+    } finally {
+      setReconnecting(false)
+    }
+  }
 
   const row = (
     <RowButton
@@ -311,6 +344,13 @@ export function BotRow({ bot, onDelete, onEdit, onGroup, onNewSection, showHandl
       <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem onSelect={() => void openRosterBot(bot)}>{b.bot.openBotChat}</ContextMenuItem>
+        <ContextMenuItem
+          disabled={!canReconnect || reconnecting}
+          onSelect={() => void handleReconnect()}
+        >
+          <Codicon className="mr-1.5" name="refresh" />
+          {reconnecting ? b.bot.reconnecting : b.bot.reconnect}
+        </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem
           onSelect={() => {

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -122,6 +122,10 @@ type BotsMessages = {
     chatEmpty: string
     /** First line of a brand-new bot's forever-chat — see `kickoffText`. */
     kickoff: string
+    reconnect: string
+    reconnecting: string
+    reconnected: (name: string) => string
+    reconnectFailed: string
   }
   /** Avatar picker: shapes, blobs, pets, uploads, generation. */
   avatar: {
@@ -348,7 +352,11 @@ const en: BotsMessages = {
     openAnotherChatUnsupported: 'Update Hermes Desktop to open another Bot chat.',
     remoteConnectionsUnsupported: 'Update Hermes Desktop to chat with bots on other connections.',
     chatEmpty: 'Say something to get started.',
-    kickoff: 'Hey, tell me about yourself!'
+    kickoff: 'Hey, tell me about yourself!',
+    reconnect: 'Reconnect',
+    reconnecting: 'Reconnecting…',
+    reconnected: name => `Reconnected ${name}`,
+    reconnectFailed: 'Reconnect failed'
   },
   avatar: {
     classicShapes: 'Classic shapes',
@@ -565,7 +573,11 @@ const ja: BotsMessages = {
     openAnotherChatUnsupported: '別のボットチャットを開くには Hermes Desktop を更新してください。',
     remoteConnectionsUnsupported: '他の接続上のボットとチャットするには Hermes Desktop を更新してください。',
     chatEmpty: '何か書いて始めましょう。',
-    kickoff: 'こんにちは、自己紹介をしてください！'
+    kickoff: 'こんにちは、自己紹介をしてください！',
+    reconnect: '再接続',
+    reconnecting: '再接続中…',
+    reconnected: name => `${name} を再接続しました`,
+    reconnectFailed: '再接続に失敗しました'
   },
   avatar: {
     classicShapes: 'クラシックシェイプ',
@@ -778,7 +790,11 @@ const zh: BotsMessages = {
     openAnotherChatUnsupported: '请更新 Hermes Desktop 以打开另一个机器人聊天。',
     remoteConnectionsUnsupported: '请更新 Hermes Desktop 以与其他连接上的机器人聊天。',
     chatEmpty: '说点什么开始吧。',
-    kickoff: '你好，介绍一下你自己吧！'
+    kickoff: '你好，介绍一下你自己吧！',
+    reconnect: '重连',
+    reconnecting: '重连中…',
+    reconnected: name => `已重连 ${name}`,
+    reconnectFailed: '重连失败'
   },
   avatar: {
     classicShapes: '经典形状',
@@ -991,7 +1007,11 @@ const zhHant: BotsMessages = {
     openAnotherChatUnsupported: '請更新 Hermes Desktop 以開啟另一個機器人聊天。',
     remoteConnectionsUnsupported: '請更新 Hermes Desktop 以與其他連線上的機器人聊天。',
     chatEmpty: '說點什麼開始吧。',
-    kickoff: '你好，介紹一下你自己吧！'
+    kickoff: '你好，介紹一下你自己吧！',
+    reconnect: '重新連線',
+    reconnecting: '重新連線中…',
+    reconnected: name => `已重新連線 ${name}`,
+    reconnectFailed: '重新連線失敗'
   },
   avatar: {
     classicShapes: '經典形狀',


### PR DESCRIPTION
## What does this PR do?

Adds a **per-bot Reconnect** action to Bot Mode that recovers a wedged local backend without restarting the whole Desktop app.

- `BotRow` context menu now shows **Reconnect** (Codicon `refresh`). For local bots it calls the existing `window.hermesDesktop.recycleBackend(profile)` IPC (same `backend-recycle.ts` path used by Settings → Models for code-skew #97046) which tears down the pooled `hermes serve` child for that profile and lets the next dial re-spawn it. Invalidation of `ROSTER_KEY` refreshes the roster.
- Remote/ghost rows render the item **disabled** (no local process to recycle). Alias routes resolve via `route.targetProfile` → `route.profile` → `bot.targetProfile` → `bot.name`.
- Adds i18n keys `bot.reconnect / reconnecting / reconnected / reconnectFailed` in `en`/`ja`/`zh`/`zh-hant` plus typed `BotsMessages` entries.
- Global gateway reconnect for the active route already landed in **#105001** (WS `open` → visible, scoped to active route only). This PR covers the *remaining* per-bot pooled-process gap noted as `held` in #104904 — not the pool-starvation root cause itself.

No new `HERMES_*` env vars, no new IPC, no durable writes — ephemeral React state + React Query invalidation only.

## Related Issue

Refs #104074 — active-gateway WS slice landed in #105001; this covers the per-bot pooled-process gap. The historical Windows pool-starvation latch itself remains `held` per #104904.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix
- [ ] 🔒 Security fix

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/bot-row.tsx` — add `useState(reconnecting)`, `canReconnect` guard, `reconnectProfile` resolution, `handleReconnect` (recycleBackend + `queryClient.invalidateQueries(ROSTER_KEY)` + success/error toasts), and `ContextMenuItem` with `Codicon refresh` (disabled for `ghost`/`remoteSource`).
- `apps/desktop/src/plugins/hermes-bots/i18n.ts` — add `bot.reconnect` family to type and to `en`/`ja`/`zh`/`zh-hant` bundles.
- `apps/desktop/src/plugins/hermes-bots/bot-reconnect.test.tsx` — 6 tests: local happy path (called with `alpha`, invalidates, success notify), alias `targetProfile` (`backend-moxie`), remote disabled, ghost disabled, missing bridge error, thrown failure surfacing.

## How to Test

1. Start Desktop with 2+ local bot profiles (pool slot starvation repro: tight `HERMES_DESKTOP_POOL_MAX` or 6+ bots as in issue).
2. Wedge one bot's backend (or kill its pooled `hermes serve` child) — DMs/group for that bot time out while CLI `hermes -p <bot> chat -q` still answers and other bots stay healthy.
3. In Bots pane, right-click the wedged bot → **Reconnect**. Verify toast `Reconnected <bot>` and `recycleBackend` log `[pool-limits]` / backend restart in `desktop.log`. 1:1 DM and group chat for that bot recovers; other bots' model backends stay warm (no cold reload).
4. Verify disabled: remote `remoteSource` and `ghost` rows show Reconnect disabled; local alias bots call with `targetProfile`.
5. Run: `npm run test:ui -- src/plugins/hermes-bots/bot-reconnect.test.tsx` (or full `apps/desktop` vitest project) — 6 tests pass; existing `bot-row.test.tsx` still green. Pre-publish adversarial gate (2 voices) APROBAR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(desktop): ... (#104074)`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #105001 (MERGED, WS slice) + sweep via `search/issues?q=104074+type:pr` + `issues/104074/timeline` cross-references
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — 3 files, 226 insertions
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (desktop-only); added JS tests above + `git diff --check` clean
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — `bot-reconnect.test.tsx` (6 cases)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.1 (v2026.9.7), upstream ee84ccd8

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — i18n covers UI; `website/docs/user-guide/desktop.md` reconnect section already added by #105001 (global WS) — per-bot is discoverable via context menu
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — no new config
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — same `recycleBackend` path already handles Windows local backends (issue's `llama-swap` context)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Context menu `Reconnect` appears directly under `Open Bot Chat` (disabled for remote/ghost). Success toast: `Reconnected <name>` (localized).
