### PR TITLE
fix(cron): reject broken script jobs before they can be scheduled

### DIFF
--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -84,11 +84,13 @@ def test_cronjob_tool_create_no_agent_without_script_errors(hermes_env):
     assert "no_agent=True requires a script" in result.get("error", "")
 
 
-def test_cronjob_tool_create_rejects_invalid_no_agent_scripts_in_active_profile(hermes_env):
+def test_cronjob_tool_create_rejects_invalid_no_agent_scripts_in_active_profile(
+    hermes_env, monkeypatch,
+):
     from cron.jobs import load_jobs
     from tools.cronjob_tools import cronjob
 
-    missing = hermes_env / "scripts" / "missing.sh"
+    monkeypatch.setattr(pathlib.Path, "home", lambda: hermes_env.parent)
     missing_result = json.loads(cronjob(
         action="create",
         schedule="every 5m",
@@ -105,9 +107,11 @@ def test_cronjob_tool_create_rejects_invalid_no_agent_scripts_in_active_profile(
     ))
 
     assert missing_result.get("success") is False
-    assert f"Script file not found: {missing}" in missing_result.get("error", "")
+    assert "Script file not found: ~/.hermes/scripts/missing.sh" in missing_result.get("error", "")
     assert absolute_result.get("success") is False
-    assert str(hermes_env / "scripts") in absolute_result.get("error", "")
+    assert "~/.hermes/scripts" in absolute_result.get("error", "")
+    assert str(hermes_env) not in missing_result.get("error", "")
+    assert str(hermes_env) not in absolute_result.get("error", "")
     assert load_jobs() == []
 
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -84,6 +84,56 @@ def test_cronjob_tool_create_no_agent_without_script_errors(hermes_env):
     assert "no_agent=True requires a script" in result.get("error", "")
 
 
+def test_cronjob_tool_create_rejects_invalid_no_agent_scripts_in_active_profile(hermes_env):
+    from cron.jobs import load_jobs
+    from tools.cronjob_tools import cronjob
+
+    missing = hermes_env / "scripts" / "missing.sh"
+    missing_result = json.loads(cronjob(
+        action="create",
+        schedule="every 5m",
+        script="missing.sh",
+        no_agent=True,
+        deliver="local",
+    ))
+    absolute_result = json.loads(cronjob(
+        action="create",
+        schedule="every 5m",
+        script=str(hermes_env.parent / "outside.sh"),
+        no_agent=True,
+        deliver="local",
+    ))
+
+    assert missing_result.get("success") is False
+    assert f"Script file not found: {missing}" in missing_result.get("error", "")
+    assert absolute_result.get("success") is False
+    assert str(hermes_env / "scripts") in absolute_result.get("error", "")
+    assert load_jobs() == []
+
+
+def test_cronjob_tool_update_rejects_missing_no_agent_script_without_mutation(hermes_env):
+    from cron.jobs import get_job
+    from tools.cronjob_tools import cronjob
+
+    (hermes_env / "scripts" / "present.sh").write_text("echo ok\n")
+    created = json.loads(cronjob(
+        action="create",
+        schedule="every 5m",
+        script="present.sh",
+        no_agent=True,
+        deliver="local",
+    ))
+
+    result = json.loads(cronjob(
+        action="update",
+        job_id=created["job_id"],
+        script="missing.sh",
+    ))
+
+    assert result.get("success") is False
+    assert get_job(created["job_id"])["script"] == "present.sh"
+
+
 # ---------------------------------------------------------------------------
 # scheduler.run_job: short-circuit behavior
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -451,6 +451,7 @@ class TestCronjobToolScript:
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
 
+        (cron_env / "scripts" / "some_script.py").write_text("print('ok')\n")
         create_result = json.loads(cronjob(
             action="create",
             schedule="every 1h",
@@ -471,6 +472,7 @@ class TestCronjobToolScript:
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
 
+        (cron_env / "scripts" / "data_collector.py").write_text("print('ok')\n")
         cronjob(
             action="create",
             schedule="every 1h",

--- a/tools/cronjob_job_args.py
+++ b/tools/cronjob_job_args.py
@@ -295,14 +295,15 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     if not script or not script.strip():
         return None
 
-    from hermes_constants import get_hermes_home
+    from hermes_constants import display_hermes_home, get_hermes_home
     raw = script.strip()
     scripts_dir = get_hermes_home() / "scripts"
+    scripts_display = f"{display_hermes_home()}/scripts"
     if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
         return (
-            f"Script path must be relative to {scripts_dir}. "
+            f"Script path must be relative to {scripts_display}. "
             f"Got absolute or home-relative path: {raw!r}. "
-            f"Place scripts in {scripts_dir} and use just the filename.")
+            f"Place scripts in {scripts_display} and use just the filename.")
 
     from tools.path_security import validate_within_dir
     scripts_dir.mkdir(parents=True, exist_ok=True)
@@ -310,9 +311,10 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     if validate_within_dir(resolved_script, scripts_dir):
         return f"Script path escapes the scripts directory via traversal: {raw!r}"
     if not resolved_script.is_file():
+        relative_script = resolved_script.relative_to(scripts_dir.resolve()).as_posix()
         return (
-            f"Script file not found: {resolved_script}. "
-            f"Create it in {scripts_dir} first.")
+            f"Script file not found: {scripts_display}/{relative_script}. "
+            f"Create it in {scripts_display} first.")
     return None
 
 

--- a/tools/cronjob_job_args.py
+++ b/tools/cronjob_job_args.py
@@ -290,23 +290,29 @@ def _validate_cron_base_url(
 
 def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     """Scripts must be relative paths within HERMES_HOME/scripts/ (absolute / ~ / drive-letter
-    rejected — prompt-injection guard). Error string if blocked, else None; empty = clear."""
+    rejected — prompt-injection guard) and name an existing file. Error string if blocked, else
+    None; empty = clear."""
     if not script or not script.strip():
         return None
 
     from hermes_constants import get_hermes_home
     raw = script.strip()
+    scripts_dir = get_hermes_home() / "scripts"
     if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
         return (
-            f"Script path must be relative to ~/.hermes/scripts/. "
+            f"Script path must be relative to {scripts_dir}. "
             f"Got absolute or home-relative path: {raw!r}. "
-            f"Place scripts in ~/.hermes/scripts/ and use just the filename.")
+            f"Place scripts in {scripts_dir} and use just the filename.")
 
     from tools.path_security import validate_within_dir
-    scripts_dir = get_hermes_home() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
-    if validate_within_dir(scripts_dir / raw, scripts_dir):
+    resolved_script = (scripts_dir / raw).resolve()
+    if validate_within_dir(resolved_script, scripts_dir):
         return f"Script path escapes the scripts directory via traversal: {raw!r}"
+    if not resolved_script.is_file():
+        return (
+            f"Script file not found: {resolved_script}. "
+            f"Create it in {scripts_dir} first.")
     return None
 
 


### PR DESCRIPTION
## What does this PR do?

Rejects cron jobs whose configured script does not exist before the job is persisted. This prevents no-agent and other script-backed jobs from registering successfully only to fail on every fire, and reports the actual active profile's scripts directory instead of the global default path.

### Symptom

A `no_agent` cron job with a mistyped or misplaced `script` registers successfully, then fails when it fires with `Script not found`. Validation guidance also points named-profile users at the wrong global scripts directory.

### Impact

Affected recurring jobs fail on every fire. A once-only job can consume its only scheduled occurrence before the configuration error is discovered.

### Bug Cause

**Trigger:** `tools/cronjob_job_args.py:291` / `_validate_cron_script_path` accepts an in-bound relative path without checking that it names a regular file.

**Causal chain:**
1. A create or update request supplies a missing script path.
2. API-boundary validation checks only path shape and containment, so the job is persisted.
3. The scheduler discovers the missing file only at fire time and the job fails instead of running.

**Why it is wrong:** A deterministic local configuration error is deferred until execution, after registration has already succeeded. The validation message also hardcodes `~/.hermes/scripts/` even though runtime resolution is based on the active profile's `HERMES_HOME`.

**Working sibling / contrast:** Existing traversal validation rejects paths that resolve outside the scripts directory; runtime execution also reports missing files, but too late to protect registration.

**Ruled out:** Schedule parsing and scheduler dispatch are not involved. The same invalid path is accepted before any fire is created, directly at the cron tool validation boundary.

### Fix

Resolve the candidate beneath the active profile's scripts directory, preserve the traversal check, and require the resolved target to be a regular file before create or update can persist it. Validation guidance now names that same profile-aware directory. Regression coverage verifies failed creates leave no job behind and failed updates preserve the existing script.

## Related Issue

Closes #105760

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/cronjob_job_args.py` - reject missing/non-file script targets and use profile-aware path guidance.
- `tests/cron/test_cron_no_agent.py` - cover create/update rejection and persistence invariants.
- `tests/cron/test_cron_script.py` - create declared scripts in existing success-path fixtures.

## How to Test

1. Create a no-agent cron job that names a missing script and verify registration fails with the active profile scripts directory.
2. Update an existing no-agent job to a missing script and verify the stored job remains unchanged.
3. Run:

```bash
scripts/run_tests.sh tests/cron/test_cron_no_agent.py tests/cron/test_cron_script.py
```

Local result: 51 passed, 2 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; user-facing behavior is covered by the existing tool schema and validation output
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide - uses `pathlib.Path` and the existing cross-platform containment helper
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; the schema already states scripts resolve beneath the active Hermes scripts directory
