### PR TITLE
docs(sessions): fix tip box that still says auto-prune ships disabled

### DIFF
--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -951,5 +951,5 @@ hermes sessions prune --older-than 30 --yes
 ```
 
 :::tip
-The database grows slowly (typical: 10-15 MB for hundreds of sessions) and session history powers `session_search` recall across past conversations, so auto-prune ships disabled. Enable it if you're running a heavy gateway/cron workload where `state.db` is meaningfully affecting performance (observed failure mode: 384 MB state.db with ~1000 sessions slowing down FTS5 inserts and `/resume` listing). Use `hermes sessions prune` for one-off cleanup without turning on the automatic sweep.
+Auto-prune is **on by default**: ended sessions that have been inactive for `sessions.retention_days` (default 90) are removed at startup, and active sessions are never touched (see [Automatic Cleanup](#automatic-cleanup) above). Session history powers `session_search` recall across past conversations, so if you want to keep every ended session forever, set `sessions.auto_prune: false` in `config.yaml`, or raise `retention_days`. With auto-prune off, `hermes sessions prune` remains available for one-off cleanup (observed failure mode without any pruning: a 384 MB `state.db` with ~1000 sessions slowing down FTS5 inserts and `/resume` listing).
 :::


### PR DESCRIPTION
## What
- `user-guide/sessions.md`: the tip box under the prune commands is rewritten to the shipped default (auto-prune on, 90-day retention of ended sessions, how to turn it off), keeping the observed 384 MB failure mode as the reason to prune.

## Why
The *Automatic Cleanup* section on the same page says auto-prune is on by default since #54189, and the yaml comment says "default is true", while the tip further down still said "auto-prune ships disabled. Enable it if...". One page, two answers. Source: `"auto_prune": True` in `hermes_cli/config_defaults.py`. Verified against `main` @ ee84ccd8 (2026-09-08); source read from the same SHA.