### PR TITLE
docs(code-execution): document the session kernel, reset, and stdout spillover

### DIFF
--- a/website/docs/user-guide/features/code-execution.md
+++ b/website/docs/user-guide/features/code-execution.md
@@ -160,7 +160,7 @@ Switching mode changes where scripts run and which interpreter runs them, not wh
 | Resource | Limit | Notes |
 |----------|-------|-------|
 | **Timeout** | 5 minutes (300s) | Script is killed with SIGTERM, then SIGKILL after 5s grace |
-| **Stdout** | 50 KB | Output truncated with `[output truncated at 50KB]` notice |
+| **Stdout** | 50 KB | Shown head-and-tail inline; the full output is saved to `~/.hermes/cache/exec/` and the path is included in the result |
 | **Stderr** | 10 KB | Included in output on non-zero exit for debugging |
 | **Tool calls** | 50 per execution | Error returned when limit reached |
 
@@ -173,6 +173,29 @@ code_execution:
   timeout: 300       # Max seconds per script (default: 300)
   max_tool_calls: 50 # Max tool calls per execution (default: 50)
 ```
+
+## State Between Calls (the session kernel)
+
+On the local terminal backend, `execute_code` does not start a fresh interpreter for every call. Each session owns a persistent Python kernel, so variables, imports, and loaded data from one call are available in the next. The agent can load a dataset once and query it across several turns instead of re-reading it every time. Subagents get their own kernel; kernels are never shared across sessions.
+
+What ends a kernel:
+
+- **Timeout or interrupt.** A cell that hits the timeout (or is interrupted) kills the kernel process and its state is lost on purpose; the result says so and the next call starts a fresh kernel.
+- **`reset=true`.** The agent can pass `reset: true` to discard the kernel's state and start clean. This is also the way to pick up environment changes: a kernel's environment is frozen when it spawns, so a newly allowlisted passthrough variable is invisible until the kernel is reset.
+- **Idle timeout and eviction.** Kernels die with the session, after `code_execution.kernel_idle_timeout` idle seconds (default 1800), or when more than `code_execution.max_session_kernels` (default 4) are alive and the oldest is evicted.
+
+The security envelope is the same as a one-shot script: environment scrubbing, the tool whitelist, and the per-call tool budget all apply to every cell, and tool-call authority (approvals, session, allow-list) is rebound on each cell.
+
+```yaml
+# ~/.hermes/config.yaml
+code_execution:
+  kernel_idle_timeout: 1800   # seconds a kernel may sit idle before it is reaped
+  max_session_kernels: 4      # kernels kept alive at once; oldest is evicted past this
+```
+
+**Remote backends** (Docker, SSH, Modal) run a remote session kernel with the same contract. If the kernel cannot be spawned on the backend, Hermes falls back to running each call as a standalone script and says so in the result.
+
+**Large output.** Stdout over 50 KB is shown head-and-tail inline, and the full text is saved under `~/.hermes/cache/exec/` with the path included in the result, so the agent can page through it with `read_file` instead of re-running the script.
 
 ## How Tool Calls Work Inside Scripts
 


### PR DESCRIPTION
## What
- `user-guide/features/code-execution.md`: new **State Between Calls (the session kernel)** section: state persists across `execute_code` calls in a per-session kernel, what ends a kernel (timeout/interrupt, `reset=true`, idle timeout, eviction), env frozen at spawn, same security envelope per cell, remote-backend kernel with fail-open per-call fallback, and the >50 KB stdout spill to `~/.hermes/cache/exec/` with the path in the result. The Resource Limits stdout row now describes the spill instead of a plain truncation notice.

## Why
The page describes project vs strict mode, the minimal environment and the RPC channel, but none of the session-kernel behaviour shipped in v2026.8.31 (#94647, #96787, #96991, #97043). Sources: `tools/code_kernel.py` docstring, `tools/code_kernel_remote.py` docstring, `tools/code_execution_tool.py:80-96` (spill), `hermes_cli/config_defaults.py` (`kernel_idle_timeout: 1800`, `max_session_kernels: 4`). One crumb for the team, not touched here: the comment at `hermes_cli/config_defaults.py:1778` still says "remote backends run per-call", which `tools/code_kernel_remote.py` contradicts. Verified against `main` @ ee84ccd8 (2026-09-08); source read from the same SHA.