### PR TITLE
fix(agent): log the truncated tool-call give-up path to agent.log

### DIFF
--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -281,6 +281,14 @@ def _retry_truncated_tool_call(st: _Trunc, api_kwargs: Any) -> TruncationVerdict
         agent._ephemeral_max_output_tokens = min(_tc_boost, max(32768, _tc_requested_cap or 0))
         return st.done("continue")  # don't append the broken response
     agent._flush_status_buffer()
+    # ERROR level (not just the _vprint below, which is stdout-only and suppressed by
+    # suppress_status_output) so a give-up after 4 silent retries is visible in agent.log
+    # and errors.log instead of leaving a gap between the last tool result and nothing (#105771).
+    logger.error(
+        "%sTruncated tool call: giving up after %d retries (stub_stall=%s, max_tokens=%s) session=%s",
+        agent.log_prefix, st.truncated_tool_call_retries, st.is_stub,
+        getattr(agent, "_ephemeral_max_output_tokens", None), agent.session_id or "none",
+    )
     if st.is_stub:
         agent._vprint(
             f"{agent.log_prefix}⚠️  Stream kept dropping mid tool-call after 4 retries — the action was not executed.",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4452,6 +4452,41 @@ class TestRunConversation:
         assert "truncated due to output length limit" in result["error"]
         mock_handle_function_call.assert_not_called()
 
+    def test_truncated_tool_call_give_up_logs_error_to_agent_log(self, agent, caplog):
+        """The give-up path after 4 silent retries must land an ERROR record on the
+        "agent.conversation_loop" logger (what feeds agent.log/errors.log), not just an
+        _vprint the CLI can suppress — otherwise a dead session shows only a gap between
+        the last tool result and nothing (#105771)."""
+        self._setup_agent(agent)
+        agent.session_id = "session-105771"
+        bad_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"partial',
+            call_id="c1",
+        )
+        resp = _mock_response(content="", finish_reason="length", tool_calls=[bad_tc])
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch("model_tools.handle_function_call"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            caplog.at_level(logging.ERROR, logger="agent.conversation_loop"),
+        ):
+            result = agent.run_conversation("write the report")
+
+        assert result["completed"] is False
+        give_up_records = [
+            r for r in caplog.records
+            if r.name == "agent.conversation_loop" and r.levelno == logging.ERROR
+            and "Truncated tool call" in r.getMessage()
+        ]
+        assert len(give_up_records) == 1
+        message = give_up_records[0].getMessage()
+        assert "giving up after 4 retries" in message
+        assert "session-105771" in message
+
     def test_truncated_tool_call_retries_once_before_refusing(self, agent):
         """When tool call args are truncated, the agent retries the API call
         (up to 3 times). If a retry succeeds (valid JSON args), tool execution


### PR DESCRIPTION
After 4 silent retries on a truncated tool-call response, the give-up branch in _retry_truncated_tool_call() (agent/turn_truncation.py) only called agent._vprint(force=True), which prints to stdout only (and is fully silenced by suppress_status_output). It never touched the "agent.conversation_loop" logger, so nothing about the give-up reached agent.log or errors.log. A dead session shows the last tool result, then a multi-minute gap while all 4 retries burn their generations, then nothing — no error line and no "Turn ended" — indistinguishable from an idle agent when read from the log alone.

The sibling content-filter-refusal give-up path a few functions over already establishes the fix pattern: log an ERROR record right before ending the turn (turn_truncation.py's existing
`logger.warning("...Model declined to respond...")` call, and the identical "ERROR level ... so outer-loop failures land in agent.log AND errors.log" precedent in agent/turn_loop_errors.py). Applied the same pattern here: a logger.error() call carrying the retry count, whether it was a stub-stall vs a real truncation, the last ephemeral max_tokens used, and the session id, right before the existing vprint lines.

Scoped narrowly to the log-blind give-up path only. The issue's other reported problem (the max_tokens boost never actually growing past the requested cap on retries) already has two contested open PRs (#72802, #73600) reworking that exact clamp logic, and the repo's own AI triage explicitly called out the log-blind path as "the new part of this report" — distinct from that ongoing consolidation.

Added a regression test (test_truncated_tool_call_give_up_logs_error_to_agent_log in tests/run_agent/test_run_agent.py) that drives a real give-up through agent.run_conversation() with a permanently-truncated tool call response and asserts, via caplog, exactly one ERROR record on the "agent.conversation_loop" logger naming the retry count and session id. RED-verified against unmodified main (test fails, no such record exists); GREEN with the fix. Full tests/run_agent/test_run_agent.py suite: 284 passed, 1 pre-existing unrelated failure (missing optional `anthropic` package in this sandbox, reproduced identically on unmodified main). ruff check is clean on both touched files.

This resolves only the log-blind give-up path (the issue's second reported problem, which the repo's own AI triage flagged as new and distinct from #72770's contested boost-cap clamp fixes). The boost never actually growing past the requested cap (the issue's first problem) is intentionally left to whichever of #72802/#73600 lands, so this does not close #105771 outright.

Addresses #105771


Claude-Session: https://claude.ai/code/session_01LUtGTop5iGKi5vfWnKnwET

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

