### PR TITLE
fix(local-runtime): make tensor placement configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1169,6 +1169,20 @@ def _validate_fallback_model(fb: Any, issues: List[ConfigIssue]) -> None:
                         suffix=" — fallback will be disabled")
 
 
+def _validate_local_runtime(config: Dict[str, Any], issues: List[ConfigIssue]) -> None:
+    runtime = config.get("local_runtime")
+    if not isinstance(runtime, dict) or "tensor_placement" not in runtime:
+        return
+    placement = runtime.get("tensor_placement")
+    if not isinstance(placement, str) or placement not in {"host", "auto"}:
+        _issue(
+            issues,
+            "error",
+            f"local_runtime.tensor_placement must be 'host' or 'auto', got {placement!r}",
+            "Set local_runtime.tensor_placement to host (legacy spill rules) or auto (llama.cpp placement)",
+        )
+
+
 def _validate_web_backends(config: Dict[str, Any], issues: List[ConfigIssue]) -> None:
     """A stale web backend selection otherwise fails only at the first web_search/web_extract
     call with a generic "no registered provider" error; warn at startup instead."""
@@ -1206,6 +1220,7 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
 
     issues: List[ConfigIssue] = []
     _validate_voice(config, issues)
+    _validate_local_runtime(config, issues)
     cp = config.get("custom_providers")
     fb = config.get("fallback_model")
     for value, validator in ((cp, _validate_custom_providers), (fb, _validate_fallback_model)):
@@ -3715,6 +3730,17 @@ def _cmd_config_check(args):
         print()
         print(color(f"  {len(missing_config)} new config option(s) available", Colors.YELLOW))
         print("    Run 'hermes config migrate' to add them")
+
+    structure_issues = validate_config_structure()
+    if structure_issues:
+        print()
+        print(color("  Config structure issues:", Colors.BOLD))
+        for issue in structure_issues:
+            marker = "✗" if issue.severity == "error" else "⚠"
+            print(color(f"    {marker} {issue.message}",
+                        Colors.RED if issue.severity == "error" else Colors.YELLOW))
+            if issue.hint:
+                print(f"      → {issue.hint.splitlines()[0]}")
 
     print()
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3740,7 +3740,12 @@ def _cmd_config_check(args):
             print(color(f"    {marker} {issue.message}",
                         Colors.RED if issue.severity == "error" else Colors.YELLOW))
             if issue.hint:
-                print(f"      → {issue.hint.splitlines()[0]}")
+                # Print every hint line: multi-line hints are legal and truncating them
+                # silently hides the actionable half of the guidance.
+                hint_lines = issue.hint.splitlines()
+                print(f"      → {hint_lines[0]}")
+                for extra_line in hint_lines[1:]:
+                    print(f"        {extra_line}")
 
     print()
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2324,8 +2324,8 @@ DEFAULT_CONFIG = {
         # e.g. "us-central1" only if your models are region-pinned.
         "region": "global",
     },
-    # Managed llama.cpp runtime (docs: user-guide/local-models): official binaries, one supervised
-    # llama-server in router mode. No context/VRAM knobs by design.
+    # llama.cpp runtime: official binaries, one supervised llama-server in router mode.
+    # Context/VRAM policy remains automatic; tensor placement is an explicit opt-in policy knob.
     "local_runtime": {
         # Off = detection-only (Hermes still finds an external llama-server you run).
         "enabled": False,
@@ -2335,6 +2335,8 @@ DEFAULT_CONFIG = {
         # cuda|metal|vulkan|hip|cpu.
         "backend": "auto",
         "models_max": 4,  # Router process: how many models may be resident at once.
+        # host preserves the legacy spill policy; auto lets llama.cpp place tensors itself.
+        "tensor_placement": "host",
         "port": 0,  # Port for the managed server. 0 = pick a free port at spawn.
         # Extra ports detection probes for an external llama-server (besides 8080).
         "detect_ports": [],

--- a/hermes_cli/local_runtime/bootstrap.py
+++ b/hermes_cli/local_runtime/bootstrap.py
@@ -179,10 +179,10 @@ def ensure_local_runtime(config: dict, force: bool = False) -> "object | None":
     falls back to configured providers."""
     global _SUPERVISOR
     section = (config or {}).get("local_runtime") or {}
-    tensor_placement = validate_tensor_placement(
-        str(section.get("tensor_placement", "host")))
     if not force and not section.get("enabled"):
         return None
+    tensor_placement = validate_tensor_placement(
+        str(section.get("tensor_placement", "host")))
     if _SUPERVISOR is not None:
         return _SUPERVISOR
 

--- a/hermes_cli/local_runtime/bootstrap.py
+++ b/hermes_cli/local_runtime/bootstrap.py
@@ -16,6 +16,7 @@ import time
 from pathlib import Path
 
 from hermes_cli.local_runtime.binaries import runtimes_root
+from hermes_cli.local_runtime.context_policy import validate_tensor_placement
 from hermes_cli.local_runtime.gguf import SPLIT_PART_RE, model_id_from_stem
 
 logger = logging.getLogger(__name__)
@@ -140,8 +141,7 @@ def refresh_local_runtime() -> bool:
         logger.warning("local runtime refresh failed: %s", exc)
         return False
 
-
-def _generate_presets(mdir: Path, preset_path: Path) -> Path | None:
+def _generate_presets(mdir: Path, preset_path: Path, *, tensor_placement: str = "host") -> Path | None:
     """Write the launch-policy INI for every staged model; returns the path to hand the router.
 
     Priced against CAPACITY, not live free VRAM: this runs while the outgoing server instance may
@@ -156,7 +156,8 @@ def _generate_presets(mdir: Path, preset_path: Path) -> Path | None:
     from hermes_cli.local_runtime.presets import generate_presets
 
     try:
-        for entry in generate_presets(mdir, probe_budget(planning=True), preset_path):
+        for entry in generate_presets(mdir, probe_budget(planning=True), preset_path,
+                                       tensor_placement=tensor_placement):
             if entry.refusal:
                 logger.warning("model refused by physics check: %s", entry.refusal)
         return preset_path
@@ -178,6 +179,8 @@ def ensure_local_runtime(config: dict, force: bool = False) -> "object | None":
     falls back to configured providers."""
     global _SUPERVISOR
     section = (config or {}).get("local_runtime") or {}
+    tensor_placement = validate_tensor_placement(
+        str(section.get("tensor_placement", "host")))
     if not force and not section.get("enabled"):
         return None
     if _SUPERVISOR is not None:
@@ -232,7 +235,9 @@ def ensure_local_runtime(config: dict, force: bool = False) -> "object | None":
 
         mdir = models_dir()
         mdir.mkdir(parents=True, exist_ok=True)
-        preset_path = _generate_presets(mdir, runtimes_root() / "presets.ini")
+        preset_path = _generate_presets(
+            mdir, runtimes_root() / "presets.ini",
+            tensor_placement=tensor_placement)
 
         sup = LlamaServerSupervisor(install_dir, mdir, preset_path=preset_path,
                                     models_max=int(section.get("models_max", 4)),

--- a/hermes_cli/local_runtime/context_policy.py
+++ b/hermes_cli/local_runtime/context_policy.py
@@ -150,10 +150,22 @@ def growth_decision(profile: ModelProfile, budget: HardwareBudget, *,
                           reason=f"rung {current_window // 1024}K -> {next_rung // 1024}K")
 
 
-def spill_overrides(profile: ModelProfile) -> list[str]:
-    """-ot placement for spilled configs: expert/FFN weights to host so attention + KV stay
-    GPU-resident. MoE gets the expert pattern; hybrids push recurrent-layer FFNs (their
-    n_head_kv==0 layers carry no KV worth protecting)."""
+def validate_tensor_placement(tensor_placement: str) -> str:
+    """Validate the configured tensor-placement policy before runtime startup."""
+    if tensor_placement not in {"auto", "host"}:
+        raise ValueError(f"unsupported tensor placement: {tensor_placement!r}")
+    return tensor_placement
+
+
+def spill_overrides(profile: ModelProfile, *, tensor_placement: str = "host") -> list[str]:
+    """Return optional ``-ot`` rules for spilled discrete-GPU configurations.
+
+    ``host`` preserves the legacy policy; ``auto`` delegates tensor placement
+    to llama.cpp, which can be faster on some discrete GPUs.
+    """
+    validate_tensor_placement(tensor_placement)
+    if tensor_placement == "auto":
+        return []
     if profile.moe:
         return ["-ot", r"blk\.\d+\.ffn_.*_exps\.weight=CPU"]
     if profile.recurrent_layer_count:
@@ -163,10 +175,11 @@ def spill_overrides(profile: ModelProfile) -> list[str]:
 
 def launch_args(profile: ModelProfile, decision: WindowDecision, *, flash_attention: bool = True,
                 mtp_capable: bool = False, mtp_draft_depth: int = 3, uma: bool = False,
-                mtp_prefill: bool = False) -> list[str]:
+                mtp_prefill: bool = False, tensor_placement: str = "host") -> list[str]:
     """Per-model launch flags from a window decision. Explicit -c puts fit into
     spill-weights-and-hold-ctx; q8 KV cache wherever flash attention exists; -ot placement on
     spilled configs — DISCRETE cards only."""
+    validate_tensor_placement(tensor_placement)
     args = ["-c", str(decision.window)]
     if mtp_capable:
         args += ["--spec-type", "draft-mtp", "--spec-draft-n-max", str(mtp_draft_depth),
@@ -178,7 +191,7 @@ def launch_args(profile: ModelProfile, decision: WindowDecision, *, flash_attent
     if flash_attention:
         args += ["-ctk", "q8_0", "-ctv", "q8_0", "-fa", "on"]
     if decision.spilled and not uma:
-        args += spill_overrides(profile)
+        args += spill_overrides(profile, tensor_placement=tensor_placement)
     return args
 
 

--- a/hermes_cli/local_runtime/context_policy.py
+++ b/hermes_cli/local_runtime/context_policy.py
@@ -152,7 +152,7 @@ def growth_decision(profile: ModelProfile, budget: HardwareBudget, *,
 
 def validate_tensor_placement(tensor_placement: str) -> str:
     """Validate the configured tensor-placement policy before runtime startup."""
-    if tensor_placement not in {"auto", "host"}:
+    if not isinstance(tensor_placement, str) or tensor_placement not in {"auto", "host"}:
         raise ValueError(f"unsupported tensor placement: {tensor_placement!r}")
     return tensor_placement
 

--- a/hermes_cli/local_runtime/presets.py
+++ b/hermes_cli/local_runtime/presets.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from hermes_cli.local_runtime.context_policy import (
-    RUNTIME_OVERHEAD_BYTES, WindowDecision, initial_window, launch_args, ub_logits_bytes)
+    RUNTIME_OVERHEAD_BYTES, WindowDecision, initial_window, launch_args, ub_logits_bytes,
+    validate_tensor_placement)
 from hermes_cli.local_runtime.estimator import (
     HardwareBudget, ModelProfile, PhysicsRefusal, ctx_bytes, profile_from_gguf)
 from hermes_cli.local_runtime.gguf import model_id_from_stem, read_gguf_header
@@ -100,7 +101,7 @@ def _restore_grown_window(model_id: str, profile: ModelProfile, budget: Hardware
 
 
 def _preset_for(gguf: Path, budget: HardwareBudget,
-                mtp_capable: set[str]) -> PresetEntry | None:
+                mtp_capable: set[str], *, tensor_placement: str = "host") -> PresetEntry | None:
     """The launch decision for one staged model, or None when its header is unreadable."""
     from hermes_cli.local_runtime.catalog import entry_for_model
 
@@ -136,7 +137,8 @@ def _preset_for(gguf: Path, budget: HardwareBudget,
     # The launch flags MUST match the pricing above (same entry/is_mtp/posture).
     keys = _args_to_keys(launch_args(
         profile, decision, mtp_capable=is_mtp, uma=budget.uma, mtp_prefill=mtp_prefill,
-        mtp_draft_depth=entry.mtp_draft_depth if entry is not None else 3))
+        mtp_draft_depth=entry.mtp_draft_depth if entry is not None else 3,
+        tensor_placement=tensor_placement))
     if entry is not None and is_mtp:
         # Integrated-MTP targets sample on the backend, and so does the draft (pairing validated
         # against the vendor's published llama.cpp recipes).
@@ -165,15 +167,18 @@ def _preset_for(gguf: Path, budget: HardwareBudget,
 
 
 def generate_presets(models_dir: Path, budget: HardwareBudget, preset_path: Path,
-                     mtp_capable: set[str] | None = None) -> list[PresetEntry]:
+                     mtp_capable: set[str] | None = None,
+                     *, tensor_placement: str = "host") -> list[PresetEntry]:
     """Walk the staged models, run the launch decision per model, and write one INI. Refused
     models get no section (the picker surfaces the refusal from the returned entries)."""
+    validate_tensor_placement(tensor_placement)
     from hermes_cli.local_runtime.bootstrap import staged_in
 
     entries: list[PresetEntry] = []
     sections: list[str] = []
     for gguf in staged_in(models_dir, require_complete=False):
-        entry = _preset_for(gguf, budget, mtp_capable or set())
+        entry = _preset_for(gguf, budget, mtp_capable or set(),
+                            tensor_placement=tensor_placement)
         if entry is None:
             continue
         entries.append(entry)

--- a/tests/hermes_cli/test_boot_preset_staleness.py
+++ b/tests/hermes_cli/test_boot_preset_staleness.py
@@ -57,7 +57,14 @@ def test_invalid_tensor_placement_is_rejected_before_runtime_boot(monkeypatch):
 
     with pytest.raises(ValueError, match="unsupported tensor placement"):
         bootstrap.ensure_local_runtime(
-            {"local_runtime": {"enabled": False, "tensor_placement": "invalid"}})
+            {"local_runtime": {"enabled": True, "tensor_placement": "invalid"}})
+
+
+def test_disabled_runtime_ignores_tensor_placement_until_enabled(monkeypatch):
+    from hermes_cli.local_runtime import bootstrap
+
+    assert bootstrap.ensure_local_runtime(
+        {"local_runtime": {"enabled": False, "tensor_placement": "invalid"}}) is None
 
 
 def test_presets_stale_when_a_staged_model_has_no_section(hermes_home):

--- a/tests/hermes_cli/test_boot_preset_staleness.py
+++ b/tests/hermes_cli/test_boot_preset_staleness.py
@@ -32,6 +32,34 @@ def _write_presets(home, *model_ids):
     (pdir / "presets.ini").write_text(body, encoding="utf-8")
 
 
+def test_boot_passes_tensor_placement_to_preset_generation(tmp_path, monkeypatch):
+    import hermes_cli.local_runtime.bootstrap as boot
+    import hermes_cli.local_runtime.hardware as hardware
+    import hermes_cli.local_runtime.presets as presets
+
+    captured = {}
+    monkeypatch.setattr(hardware, "probe_budget", lambda planning=False: "budget")
+
+    def fake_generate(models_dir, budget, preset_path, **kwargs):
+        captured.update(models_dir=models_dir, budget=budget,
+                        preset_path=preset_path, kwargs=kwargs)
+        return []
+
+    monkeypatch.setattr(presets, "generate_presets", fake_generate)
+    preset_path = tmp_path / "presets.ini"
+
+    assert boot._generate_presets(tmp_path, preset_path, tensor_placement="auto") == preset_path
+    assert captured["kwargs"] == {"tensor_placement": "auto"}
+
+
+def test_invalid_tensor_placement_is_rejected_before_runtime_boot(monkeypatch):
+    from hermes_cli.local_runtime import bootstrap
+
+    with pytest.raises(ValueError, match="unsupported tensor placement"):
+        bootstrap.ensure_local_runtime(
+            {"local_runtime": {"enabled": False, "tensor_placement": "invalid"}})
+
+
 def test_presets_stale_when_a_staged_model_has_no_section(hermes_home):
     from hermes_cli.local_runtime.bootstrap import _presets_stale
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -15,6 +15,7 @@ from hermes_cli.config import (
     get_hermes_home,
     ensure_hermes_home,
     get_compatible_custom_providers,
+    validate_config_structure,
     _explicit_config_paths,
     _normalize_max_turns_config,
     is_provider_enabled,
@@ -32,6 +33,56 @@ from hermes_cli.config import (
     write_platform_config_field,
     _sanitize_env_lines,
 )
+
+
+class TestConfigCheck:
+    def test_reports_local_runtime_structure_issues(self, monkeypatch, capsys):
+        import hermes_cli.config as config_mod
+
+        monkeypatch.setattr(config_mod, "check_config_version", lambda **_: (41, 41))
+        monkeypatch.setattr(config_mod, "get_missing_config_fields", lambda: [])
+        monkeypatch.setattr(config_mod, "get_env_value", lambda _name: "")
+        monkeypatch.setattr(config_mod, "validate_config_structure", lambda: [
+            config_mod.ConfigIssue(
+                "error",
+                "local_runtime.tensor_placement must be 'host' or 'auto', got 'invalid'",
+                "Set local_runtime.tensor_placement to host or auto",
+            )
+        ])
+
+        config_mod._cmd_config_check(type("Args", (), {})())
+        output = capsys.readouterr().out
+        assert "Config structure issues" in output
+        assert "local_runtime.tensor_placement" in output
+
+
+    def test_invalid_tensor_placement_is_reported(self):
+        issues = validate_config_structure({
+            "local_runtime": {"tensor_placement": "invalid"},
+        })
+        assert any(
+            issue.severity == "error"
+            and "local_runtime.tensor_placement" in issue.message
+            for issue in issues
+        )
+
+    def test_valid_tensor_placement_is_accepted(self):
+        for placement in ("host", "auto"):
+            issues = validate_config_structure({
+                "local_runtime": {"tensor_placement": placement},
+            })
+            assert not any("local_runtime.tensor_placement" in issue.message for issue in issues)
+
+    def test_non_string_tensor_placement_is_reported(self):
+        for placement in ([], {}, 1):
+            issues = validate_config_structure({
+                "local_runtime": {"tensor_placement": placement},
+            })
+            assert any(
+                issue.severity == "error"
+                and "local_runtime.tensor_placement" in issue.message
+                for issue in issues
+            )
 
 
 class TestGetHermesHome:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -46,7 +46,8 @@ class TestConfigCheck:
             config_mod.ConfigIssue(
                 "error",
                 "local_runtime.tensor_placement must be 'host' or 'auto', got 'invalid'",
-                "Set local_runtime.tensor_placement to host or auto",
+                "Set local_runtime.tensor_placement to host or auto\n"
+                "Then restart the local runtime so the new placement takes effect",
             )
         ])
 
@@ -54,6 +55,8 @@ class TestConfigCheck:
         output = capsys.readouterr().out
         assert "Config structure issues" in output
         assert "local_runtime.tensor_placement" in output
+        # Multi-line hints must render in full — the second line carries the fix steps.
+        assert "Then restart the local runtime so the new placement takes effect" in output
 
 
     def test_invalid_tensor_placement_is_reported(self):

--- a/tests/hermes_cli/test_context_policy.py
+++ b/tests/hermes_cli/test_context_policy.py
@@ -308,12 +308,22 @@ def test_spill_overrides_are_configurable():
     assert spill_overrides(hybrid(), tensor_placement="auto") == []
     with pytest.raises(ValueError, match="unsupported tensor placement"):
         spill_overrides(moe(), tensor_placement="invalid")
+    for invalid in ([], {}, 1):
+        with pytest.raises(ValueError, match="unsupported tensor placement"):
+            spill_overrides(moe(), tensor_placement=invalid)
 
 
 def test_launch_args_auto_placement_omits_host_override():
     p = moe()
     spilled = WindowDecision(window=FLOOR, spill_bytes=4 * GIB, kv_on_gpu=True)
     args = launch_args(p, spilled, tensor_placement="auto")
+    assert "-ot" not in args
+
+
+def test_auto_placement_preserves_uma_no_host_override():
+    p = moe()
+    spilled = WindowDecision(window=FLOOR, spill_bytes=4 * GIB, kv_on_gpu=True)
+    args = launch_args(p, spilled, tensor_placement="auto", uma=True)
     assert "-ot" not in args
 
 

--- a/tests/hermes_cli/test_context_policy.py
+++ b/tests/hermes_cli/test_context_policy.py
@@ -300,10 +300,21 @@ def test_growth_refits_against_live_budget():
 # ── spill placement + launch args ────────────────────────────
 
 
-def test_spill_overrides_prefer_expert_and_recurrent_ffn():
-    assert "exps" in " ".join(spill_overrides(moe()))
-    assert "ffn" in " ".join(spill_overrides(hybrid()))
-    assert spill_overrides(dense()) == []
+def test_spill_overrides_are_configurable():
+    """Operators can keep legacy host pinning or delegate placement to llama.cpp."""
+    assert "exps" in " ".join(spill_overrides(moe()))  # default preserves compatibility
+    assert "exps" in " ".join(spill_overrides(moe(), tensor_placement="host"))
+    assert spill_overrides(moe(), tensor_placement="auto") == []
+    assert spill_overrides(hybrid(), tensor_placement="auto") == []
+    with pytest.raises(ValueError, match="unsupported tensor placement"):
+        spill_overrides(moe(), tensor_placement="invalid")
+
+
+def test_launch_args_auto_placement_omits_host_override():
+    p = moe()
+    spilled = WindowDecision(window=FLOOR, spill_bytes=4 * GIB, kv_on_gpu=True)
+    args = launch_args(p, spilled, tensor_placement="auto")
+    assert "-ot" not in args
 
 
 def test_launch_args_contract():

--- a/website/docs/user-guide/local-models.md
+++ b/website/docs/user-guide/local-models.md
@@ -113,6 +113,8 @@ local_runtime:
                      # The desktop "Use" button sets this automatically.
   backend: auto      # auto | cuda | metal | vulkan | hip | cpu
   tensor_placement: host  # host = legacy spill rules; auto = llama.cpp placement
+                      # For discrete GPUs, host keeps selected spill tensors on system RAM;
+                      # auto lets llama.cpp choose placement. UMA systems never force host pinning.
   tag: b10362        # pinned llama.cpp release; Hermes updates it with
                      # each release after re-validation
 ```

--- a/website/docs/user-guide/local-models.md
+++ b/website/docs/user-guide/local-models.md
@@ -112,6 +112,7 @@ local_runtime:
   enabled: false     # true = start the managed server with Hermes.
                      # The desktop "Use" button sets this automatically.
   backend: auto      # auto | cuda | metal | vulkan | hip | cpu
+  tensor_placement: host  # host = legacy spill rules; auto = llama.cpp placement
   tag: b10362        # pinned llama.cpp release; Hermes updates it with
                      # each release after re-validation
 ```


### PR DESCRIPTION
## Summary

- Restore the existing host tensor-pinning behavior as the default for spilled discrete-GPU configurations.
- Add `local_runtime.tensor_placement` with `host` and `auto` modes.
- Allow `auto` to delegate tensor placement to llama.cpp for hardware where forced host placement is slower.
- Thread the setting through runtime bootstrap, preset generation, and launch argument construction.
- Reject unsupported values before runtime startup instead of silently falling back to an unpoliced preset.

## Test plan

- `uv run --extra dev pytest tests/hermes_cli/test_context_policy.py tests/hermes_cli/test_local_runtime.py tests/hermes_cli/test_local_growth.py tests/hermes_cli/test_boot_preset_staleness.py -q`
- Result: 100 passed
- `ruff check` on changed Python files: passed
- `git diff --check`: passed
- `python -m compileall`: passed
