### PR TITLE
feat(gateway): expose authenticated hosted A2A and API routes

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1005,6 +1005,10 @@ group_sessions_per_user: true
 #       enabled: true
 #       extra:
 #         key: "your-api-server-secret"
+#         # On a hosted deployment whose HTTPS hostname serves the dashboard,
+#         # opt in to https://<dashboard-host>/hermes-api/*.
+#         # Authentication still uses API_SERVER_KEY at the API listener.
+#         public_route: true
 #         model_routes:
 #           # Xiaozhi clients send model="minimax-m2" → routed to MiniMax via OpenRouter
 #           minimax-m2:

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -38,6 +38,9 @@ _GATE_PUBLIC_PREFIXES: tuple[str, ...] = (
     "/auth/login", "/auth/callback", "/auth/native/authorize", "/auth/native/token",
     "/auth/native/refresh", "/auth/password-login", "/auth/logout", "/login",
     "/api/auth/providers", "/api/mcp/oauth/callback/",
+    # Machine-to-machine proxy routes delegate authentication to the loopback
+    # A2A/API listener. They must never enter the browser OAuth redirect flow.
+    "/a2a/", "/hermes-api/",
     "/assets/", "/favicon.ico", "/ds-assets/", "/fonts/", "/fonts-terminal/")
 
 

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -42,13 +42,14 @@ _GATE_PUBLIC_PREFIXES: tuple[str, ...] = (
     # A2A/API listener. They must never enter the browser OAuth redirect flow.
     "/a2a/", "/hermes-api/",
     "/assets/", "/favicon.ico", "/ds-assets/", "/fonts/", "/fonts-terminal/")
+_MACHINE_ROUTE_ROOTS = frozenset({"/a2a", "/hermes-api"})
 
 
 def _path_is_public(path: str) -> bool:
     """:data:`PUBLIC_API_PATHS` (shared with the legacy middleware) matched exactly so
-    ``/api/status`` never exposes ``/api/status/extension``; :data:`_GATE_PUBLIC_PREFIXES`
-    prefix-matched."""
-    return path in PUBLIC_API_PATHS or any(
+    ``/api/status`` never exposes ``/api/status/extension``; machine route roots matched
+    exactly; :data:`_GATE_PUBLIC_PREFIXES` prefix-matched."""
+    return path in PUBLIC_API_PATHS or path in _MACHINE_ROUTE_ROOTS or any(
         path == p or path.startswith(p) for p in _GATE_PUBLIC_PREFIXES)
 
 

--- a/hermes_cli/web_routers/service_proxy.py
+++ b/hermes_cli/web_routers/service_proxy.py
@@ -60,6 +60,8 @@ def _merge_platform_block(config: dict, name: str) -> dict:
         merged.update(block)
         if isinstance(block.get("extra"), dict):
             merged_extra.update(block["extra"])
+    if name == "api_server" and "port" in merged and "port" not in merged_extra:
+        merged_extra["port"] = merged.pop("port")
     if merged_extra:
         merged["extra"] = merged_extra
     return merged

--- a/hermes_cli/web_routers/service_proxy.py
+++ b/hermes_cli/web_routers/service_proxy.py
@@ -78,10 +78,7 @@ def _service_route(name: str) -> _ServiceRoute | None:
     extra = block.get("extra") if isinstance(block.get("extra"), dict) else {}
     if block.get("enabled") is not True or extra.get("public_route") is not True:
         return None
-    if name == "a2a" and not (
-        os.environ.get("A2A_BEARER_TOKEN", "").strip()
-        or os.environ.get("A2A_PEER_TOKENS", "").strip()
-    ):
+    if name == "a2a" and not os.environ.get("A2A_PEER_TOKENS", "").strip():
         return None
     raw_port = os.environ.get(port_env, "").strip() or extra.get("port", default_port)
     try:
@@ -121,6 +118,25 @@ async def _stream_upstream(
         await client.aclose()
 
 
+async def _bounded_a2a_body(request: Request) -> bytes | None:
+    """Read no more than the A2A limit plus one overflow sentinel byte."""
+    declared_length = request.headers.get("content-length")
+    if declared_length is not None:
+        try:
+            if int(declared_length) > _A2A_MAX_BODY_BYTES:
+                return None
+        except ValueError:
+            pass
+
+    body = bytearray()
+    async for chunk in request.stream():
+        remaining = _A2A_MAX_BODY_BYTES + 1 - len(body)
+        body.extend(chunk[:remaining])
+        if len(body) > _A2A_MAX_BODY_BYTES or len(chunk) > remaining:
+            return None
+    return bytes(body)
+
+
 async def _proxy(request: Request, service: str, path: str) -> StreamingResponse | JSONResponse:
     route = _service_route(service)
     if route is None:
@@ -129,21 +145,21 @@ async def _proxy(request: Request, service: str, path: str) -> StreamingResponse
     suffix = f"/{path}" if path else "/"
     query = request.url.query
     upstream_url = f"http://127.0.0.1:{route.port}{suffix}" + (f"?{query}" if query else "")
+    if service == "a2a":
+        body = await _bounded_a2a_body(request)
+        if body is None:
+            return JSONResponse({"error": "request body too large"}, status_code=413)
+        content: bytes | AsyncIterator[bytes] = body
+    elif request.method in {"GET", "HEAD", "OPTIONS"}:
+        content = b""
+    else:
+        content = request.stream()
+
     client = httpx.AsyncClient(
         trust_env=False,
         timeout=httpx.Timeout(connect=5.0, read=None, write=30.0, pool=5.0),
     )
     try:
-        if service == "a2a":
-            body = await request.body()
-            if len(body) > _A2A_MAX_BODY_BYTES:
-                await client.aclose()
-                return JSONResponse({"error": "request body too large"}, status_code=413)
-            content: bytes | AsyncIterator[bytes] = body
-        elif request.method in {"GET", "HEAD", "OPTIONS"}:
-            content = b""
-        else:
-            content = request.stream()
         upstream_request = client.build_request(
             request.method,
             upstream_url,

--- a/hermes_cli/web_routers/service_proxy.py
+++ b/hermes_cli/web_routers/service_proxy.py
@@ -30,7 +30,7 @@ _HOP_BY_HOP_HEADERS = frozenset({
     "te", "trailer", "transfer-encoding", "upgrade",
 })
 _PRIVATE_REQUEST_HEADERS = frozenset({
-    "cookie", "host", "content-length", "x-hermes-dashboard-token",
+    "cookie", "host", "content-length", "x-hermes-session-token",
     "forwarded", "x-forwarded-for", "x-forwarded-host", "x-forwarded-prefix",
     "x-forwarded-proto",
 })

--- a/hermes_cli/web_routers/service_proxy.py
+++ b/hermes_cli/web_routers/service_proxy.py
@@ -1,0 +1,176 @@
+"""Opt-in public dashboard routes for the gateway's A2A and API listeners.
+
+Hosted deployments terminate TLS at the dashboard hostname while the gateway's
+protocol listeners remain on loopback.  These routes bridge that boundary without
+sharing dashboard cookies: each upstream listener keeps ownership of its bearer
+authentication.
+"""
+from __future__ import annotations
+
+import os
+import urllib.parse
+from dataclasses import dataclass
+from typing import AsyncIterator
+
+import httpx
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from hermes_cli.config import load_config
+from hermes_cli.dashboard_auth.prefix import prefix_from_request, resolve_public_url
+
+router = APIRouter()
+
+_A2A_PREFIX = "/a2a"
+_API_PREFIX = "/hermes-api"
+_A2A_MAX_BODY_BYTES = 1024 * 1024
+_ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
+_HOP_BY_HOP_HEADERS = frozenset({
+    "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+    "te", "trailer", "transfer-encoding", "upgrade",
+})
+_PRIVATE_REQUEST_HEADERS = frozenset({
+    "cookie", "host", "content-length", "x-hermes-dashboard-token",
+    "forwarded", "x-forwarded-for", "x-forwarded-host", "x-forwarded-prefix",
+    "x-forwarded-proto",
+})
+_PRIVATE_RESPONSE_HEADERS = _HOP_BY_HOP_HEADERS | frozenset({"content-length", "set-cookie"})
+
+
+@dataclass(frozen=True)
+class _ServiceRoute:
+    name: str
+    prefix: str
+    port: int
+
+
+def _merge_platform_block(config: dict, name: str) -> dict:
+    """Mirror gateway platform-block precedence for the two fields used here."""
+    gateway = config.get("gateway") if isinstance(config.get("gateway"), dict) else {}
+    merged: dict = {}
+    merged_extra: dict = {}
+    sources = (
+        (gateway.get("platforms") or {}).get(name) if isinstance(gateway.get("platforms"), dict) else None,
+        (config.get("platforms") or {}).get(name) if isinstance(config.get("platforms"), dict) else None,
+        gateway.get(name),
+    )
+    for block in sources:
+        if not isinstance(block, dict):
+            continue
+        merged.update(block)
+        if isinstance(block.get("extra"), dict):
+            merged_extra.update(block["extra"])
+    if merged_extra:
+        merged["extra"] = merged_extra
+    return merged
+
+
+def _service_route(name: str) -> _ServiceRoute | None:
+    specs = {
+        "a2a": (_A2A_PREFIX, "A2A_PORT", 9900),
+        "api_server": (_API_PREFIX, "API_SERVER_PORT", 8642),
+    }
+    prefix, port_env, default_port = specs[name]
+    config = load_config() or {}
+    block = _merge_platform_block(config, name)
+    extra = block.get("extra") if isinstance(block.get("extra"), dict) else {}
+    if block.get("enabled") is not True or extra.get("public_route") is not True:
+        return None
+    if name == "a2a" and not (
+        os.environ.get("A2A_BEARER_TOKEN", "").strip()
+        or os.environ.get("A2A_PEER_TOKENS", "").strip()
+    ):
+        return None
+    raw_port = os.environ.get(port_env, "").strip() or extra.get("port", default_port)
+    try:
+        port = int(raw_port)
+    except (TypeError, ValueError):
+        return None
+    if not 1 <= port <= 65535:
+        return None
+    return _ServiceRoute(name=name, prefix=prefix, port=port)
+
+
+def _forwarded_headers(request: Request, route: _ServiceRoute) -> dict[str, str]:
+    headers = {
+        key: value for key, value in request.headers.items()
+        if key.lower() not in _HOP_BY_HOP_HEADERS | _PRIVATE_REQUEST_HEADERS
+    }
+    public_url = resolve_public_url()
+    parsed = urllib.parse.urlparse(public_url) if public_url else None
+    public_host = parsed.netloc if parsed and parsed.netloc else request.headers.get("host", "")
+    public_scheme = parsed.scheme if parsed and parsed.scheme else request.url.scheme
+    base_prefix = parsed.path.rstrip("/") if parsed and parsed.path else prefix_from_request(request)
+    headers["host"] = f"127.0.0.1:{route.port}"
+    headers["x-forwarded-host"] = public_host
+    headers["x-forwarded-proto"] = public_scheme
+    headers["x-forwarded-prefix"] = f"{base_prefix}{route.prefix}"
+    return headers
+
+
+async def _stream_upstream(
+    response: httpx.Response, client: httpx.AsyncClient
+) -> AsyncIterator[bytes]:
+    try:
+        async for chunk in response.aiter_raw():
+            yield chunk
+    finally:
+        await response.aclose()
+        await client.aclose()
+
+
+async def _proxy(request: Request, service: str, path: str) -> StreamingResponse | JSONResponse:
+    route = _service_route(service)
+    if route is None:
+        return JSONResponse({"error": "service route is not enabled"}, status_code=404)
+
+    suffix = f"/{path}" if path else "/"
+    query = request.url.query
+    upstream_url = f"http://127.0.0.1:{route.port}{suffix}" + (f"?{query}" if query else "")
+    client = httpx.AsyncClient(
+        trust_env=False,
+        timeout=httpx.Timeout(connect=5.0, read=None, write=30.0, pool=5.0),
+    )
+    try:
+        if service == "a2a":
+            body = await request.body()
+            if len(body) > _A2A_MAX_BODY_BYTES:
+                await client.aclose()
+                return JSONResponse({"error": "request body too large"}, status_code=413)
+            content: bytes | AsyncIterator[bytes] = body
+        elif request.method in {"GET", "HEAD", "OPTIONS"}:
+            content = b""
+        else:
+            content = request.stream()
+        upstream_request = client.build_request(
+            request.method,
+            upstream_url,
+            headers=_forwarded_headers(request, route),
+            content=content,
+        )
+        upstream = await client.send(upstream_request, stream=True)
+    except (httpx.HTTPError, OSError):
+        await client.aclose()
+        return JSONResponse({"error": f"{service} listener is unavailable"}, status_code=503)
+
+    response_headers = {
+        key: value for key, value in upstream.headers.items()
+        if key.lower() not in _PRIVATE_RESPONSE_HEADERS
+    }
+    return StreamingResponse(
+        _stream_upstream(upstream, client),
+        status_code=upstream.status_code,
+        headers=response_headers,
+    )
+
+
+@router.api_route(_A2A_PREFIX, methods=_ALLOWED_METHODS)
+@router.api_route(f"{_A2A_PREFIX}/{{path:path}}", methods=_ALLOWED_METHODS)
+async def proxy_a2a(request: Request, path: str = ""):
+    return await _proxy(request, "a2a", path)
+
+
+@router.api_route(_API_PREFIX, methods=_ALLOWED_METHODS)
+@router.api_route(f"{_API_PREFIX}/{{path:path}}", methods=_ALLOWED_METHODS)
+async def proxy_api_server(request: Request, path: str = ""):
+    return await _proxy(request, "api_server", path)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -933,6 +933,7 @@ from hermes_cli.web_routers import (  # noqa: E402
     tools as _tools_routes,
     analytics as _analytics_routes,
     chat_ws as _chat_ws_routes,
+    service_proxy as _service_proxy_routes,
     dashboard_ui as _dashboard_ui_routes,
 )
 
@@ -963,6 +964,7 @@ app.include_router(_skills_routes.router)
 app.include_router(_tools_routes.router)
 app.include_router(_analytics_routes.router)
 app.include_router(_chat_ws_routes.router)
+app.include_router(_service_proxy_routes.router)
 app.include_router(_dashboard_ui_routes.router)
 
 # Plugin API routes and the dashboard auth routes (/login, /auth/*, /api/auth/*)

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -169,7 +169,7 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
         return self.client_address[0] if self.client_address else ""
 
     def _request_public_url(self) -> str:
-        """A2A_PUBLIC_URL > X-Forwarded-Host / Host (scheme from X-Forwarded-Proto) > "" (bind host).
+        """A2A_PUBLIC_URL > forwarded authority/prefix > Host > "" (bind host).
 
         Empty means "caller has no info, fall back to bind host". See #41711.
         """
@@ -178,7 +178,11 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
             return explicit
         host = (self.headers.get("X-Forwarded-Host", "") or self.headers.get("Host", "")).split(",")[0].strip()
         scheme = (self.headers.get("X-Forwarded-Proto", "") or "http").split(",")[0].strip()
-        return f"{scheme}://{host}/" if host else ""
+        prefix = (self.headers.get("X-Forwarded-Prefix", "") or "").split(",")[0].strip()
+        if (not prefix.startswith("/") or ".." in prefix or "//" in prefix
+                or any(char in prefix for char in "\\?#<>\"' \r\n\t")):
+            prefix = ""
+        return f"{scheme}://{host}{prefix.rstrip('/')}/" if host else ""
 
     def do_GET(self):  # noqa: N802
         adapter = self.adapter

--- a/tests/hermes_cli/test_dashboard_service_routes.py
+++ b/tests/hermes_cli/test_dashboard_service_routes.py
@@ -166,6 +166,29 @@ def test_api_route_strips_dashboard_credentials_and_keeps_api_key(
     assert payload["session_token"] is None
 
 
+def test_api_route_uses_gateway_api_server_port(
+    public_dashboard, echo_server, monkeypatch
+):
+    monkeypatch.setattr(service_proxy, "load_config", lambda: {
+        "gateway": {
+            "api_server": {
+                "enabled": True,
+                "port": echo_server,
+                "extra": {"public_route": True},
+            }
+        }
+    })
+    monkeypatch.delenv("API_SERVER_PORT", raising=False)
+
+    response = public_dashboard.get(
+        "/hermes-api/health",
+        headers={"Authorization": "Bearer api-key"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["path"] == "/health"
+
+
 def test_a2a_public_url_includes_forwarded_prefix(monkeypatch):
     monkeypatch.delenv("A2A_PUBLIC_URL", raising=False)
     handler = object.__new__(A2ARequestHandler)

--- a/tests/hermes_cli/test_dashboard_service_routes.py
+++ b/tests/hermes_cli/test_dashboard_service_routes.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli.web_routers import service_proxy
+from plugins.platforms.a2a.adapter import A2ARequestHandler
+
+
+class _EchoHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):  # noqa: A002
+        return None
+
+    def _reply(self, body: bytes = b"") -> None:
+        payload = json.dumps({
+            "path": self.path,
+            "authorization": self.headers.get("Authorization"),
+            "cookie": self.headers.get("Cookie"),
+            "dashboard_token": self.headers.get("X-Hermes-Dashboard-Token"),
+            "forwarded_host": self.headers.get("X-Forwarded-Host"),
+            "forwarded_proto": self.headers.get("X-Forwarded-Proto"),
+            "forwarded_prefix": self.headers.get("X-Forwarded-Prefix"),
+            "body": body.decode("utf-8"),
+        }).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Set-Cookie", "upstream=must-not-escape")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self):  # noqa: N802
+        self._reply()
+
+    def do_POST(self):  # noqa: N802
+        self._reply(self.rfile.read(int(self.headers.get("Content-Length", "0"))))
+
+
+@pytest.fixture
+def echo_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+@pytest.fixture
+def public_dashboard():
+    previous = {
+        key: getattr(web_server.app.state, key, None)
+        for key in ("bound_host", "bound_port", "auth_required", "trusted_public_hosts")
+    }
+    web_server.app.state.bound_host = "agent.example.com"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    web_server.app.state.trusted_public_hosts = frozenset({"agent.example.com"})
+    try:
+        yield TestClient(web_server.app, base_url="https://agent.example.com")
+    finally:
+        for key, value in previous.items():
+            setattr(web_server.app.state, key, value)
+
+
+def _route_config(name: str, port: int) -> dict:
+    return {
+        "gateway": {"platforms": {
+            name: {"enabled": True, "extra": {"public_route": True, "port": port}},
+        }}
+    }
+
+
+def test_disabled_service_route_returns_json_instead_of_oauth_redirect(
+    public_dashboard, monkeypatch
+):
+    monkeypatch.setattr(service_proxy, "load_config", lambda: {})
+
+    response = public_dashboard.get("/a2a/.well-known/agent-card.json", follow_redirects=False)
+
+    assert response.status_code == 404
+    assert response.json() == {"error": "service route is not enabled"}
+
+
+def test_service_route_prefix_does_not_open_similar_dashboard_path(
+    public_dashboard, monkeypatch
+):
+    monkeypatch.setattr(service_proxy, "load_config", lambda: {})
+
+    response = public_dashboard.get("/a2attack", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["location"]
+
+
+def test_a2a_public_route_requires_its_own_service_credential(
+    public_dashboard, echo_server, monkeypatch
+):
+    monkeypatch.setattr(service_proxy, "load_config", lambda: _route_config("a2a", echo_server))
+    monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
+    monkeypatch.delenv("A2A_PEER_TOKENS", raising=False)
+
+    response = public_dashboard.get("/a2a/.well-known/agent-card.json")
+
+    assert response.status_code == 404
+    assert response.json() == {"error": "service route is not enabled"}
+
+
+def test_a2a_route_preserves_service_auth_and_advertised_prefix(
+    public_dashboard, echo_server, monkeypatch
+):
+    monkeypatch.setattr(service_proxy, "load_config", lambda: _route_config("a2a", echo_server))
+    monkeypatch.setenv("A2A_PEER_TOKENS", "nova:test-token")
+    monkeypatch.delenv("A2A_PORT", raising=False)
+
+    response = public_dashboard.post(
+        "/a2a/?mode=send",
+        headers={"Authorization": "Bearer test-token"},
+        json={"jsonrpc": "2.0"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["path"] == "/?mode=send"
+    assert payload["authorization"] == "Bearer test-token"
+    assert payload["forwarded_host"] == "agent.example.com"
+    assert payload["forwarded_proto"] == "https"
+    assert payload["forwarded_prefix"] == "/a2a"
+    assert json.loads(payload["body"]) == {"jsonrpc": "2.0"}
+    assert "set-cookie" not in response.headers
+
+
+def test_api_route_strips_dashboard_credentials_and_keeps_api_key(
+    public_dashboard, echo_server, monkeypatch
+):
+    monkeypatch.setattr(
+        service_proxy, "load_config", lambda: _route_config("api_server", echo_server))
+    monkeypatch.delenv("API_SERVER_PORT", raising=False)
+
+    response = public_dashboard.get(
+        "/hermes-api/api/sessions?limit=1",
+        headers={
+            "Authorization": "Bearer api-key",
+            "Cookie": "hermes_session_at=private",
+            "X-Hermes-Dashboard-Token": "private",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["path"] == "/api/sessions?limit=1"
+    assert payload["authorization"] == "Bearer api-key"
+    assert payload["cookie"] is None
+    assert payload["dashboard_token"] is None
+
+
+def test_a2a_public_url_includes_forwarded_prefix(monkeypatch):
+    monkeypatch.delenv("A2A_PUBLIC_URL", raising=False)
+    handler = object.__new__(A2ARequestHandler)
+    handler.headers = {
+        "X-Forwarded-Host": "agent.example.com",
+        "X-Forwarded-Proto": "https",
+        "X-Forwarded-Prefix": "/a2a",
+    }
+
+    assert handler._request_public_url() == "https://agent.example.com/a2a/"

--- a/tests/hermes_cli/test_dashboard_service_routes.py
+++ b/tests/hermes_cli/test_dashboard_service_routes.py
@@ -79,23 +79,27 @@ def _route_config(name: str, port: int) -> dict:
     }
 
 
+@pytest.mark.parametrize(
+    "path", ["/a2a", "/a2a/.well-known/agent-card.json", "/hermes-api"]
+)
 def test_disabled_service_route_returns_json_instead_of_oauth_redirect(
-    public_dashboard, monkeypatch
+    public_dashboard, monkeypatch, path
 ):
     monkeypatch.setattr(service_proxy, "load_config", lambda: {})
 
-    response = public_dashboard.get("/a2a/.well-known/agent-card.json", follow_redirects=False)
+    response = public_dashboard.get(path, follow_redirects=False)
 
     assert response.status_code == 404
     assert response.json() == {"error": "service route is not enabled"}
 
 
+@pytest.mark.parametrize("path", ["/a2attack", "/hermes-apix"])
 def test_service_route_prefix_does_not_open_similar_dashboard_path(
-    public_dashboard, monkeypatch
+    public_dashboard, monkeypatch, path
 ):
     monkeypatch.setattr(service_proxy, "load_config", lambda: {})
 
-    response = public_dashboard.get("/a2attack", follow_redirects=False)
+    response = public_dashboard.get(path, follow_redirects=False)
 
     assert response.status_code == 302
     assert "/login" in response.headers["location"]

--- a/tests/hermes_cli/test_dashboard_service_routes.py
+++ b/tests/hermes_cli/test_dashboard_service_routes.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 from fastapi.testclient import TestClient
+from starlette.requests import Request
 
 from hermes_cli import web_server
 from hermes_cli.web_routers import service_proxy
 from plugins.platforms.a2a.adapter import A2ARequestHandler
+from plugins.platforms.a2a.security import A2ASecurityContext
 
 
 class _EchoHandler(BaseHTTPRequestHandler):
@@ -48,6 +51,42 @@ def echo_server():
     thread.start()
     try:
         yield server.server_port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+@pytest.fixture
+def a2a_identity_server():
+    identities: list[str] = []
+
+    class _RecordingRateLimiter:
+        def allow(self, identity: str) -> bool:
+            identities.append(identity)
+            return False
+
+    class _Adapter:
+        _security_context = A2ASecurityContext(
+            bearer_token="",
+            peer_tokens=(("nova-token", "nova"), ("cairn-token", "cairn")),
+            trusted_peers=frozenset(),
+            allow_all_users=False,
+            requested_host="127.0.0.1",
+            push_secret="",
+        )
+        _rate_limiter = _RecordingRateLimiter()
+
+        @staticmethod
+        def _route_for_request(path, params):
+            return {}
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), A2ARequestHandler)
+    server.adapter = _Adapter()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_port, identities
     finally:
         server.shutdown()
         server.server_close()
@@ -118,6 +157,19 @@ def test_a2a_public_route_requires_its_own_service_credential(
     assert response.json() == {"error": "service route is not enabled"}
 
 
+def test_a2a_public_route_rejects_shared_bearer_without_peer_tokens(
+    public_dashboard, echo_server, monkeypatch
+):
+    monkeypatch.setattr(service_proxy, "load_config", lambda: _route_config("a2a", echo_server))
+    monkeypatch.setenv("A2A_BEARER_TOKEN", "shared-token")
+    monkeypatch.delenv("A2A_PEER_TOKENS", raising=False)
+
+    response = public_dashboard.get("/a2a/.well-known/agent-card.json")
+
+    assert response.status_code == 404
+    assert response.json() == {"error": "service route is not enabled"}
+
+
 def test_a2a_route_preserves_service_auth_and_advertised_prefix(
     public_dashboard, echo_server, monkeypatch
 ):
@@ -140,6 +192,92 @@ def test_a2a_route_preserves_service_auth_and_advertised_prefix(
     assert payload["forwarded_prefix"] == "/a2a"
     assert json.loads(payload["body"]) == {"jsonrpc": "2.0"}
     assert "set-cookie" not in response.headers
+
+
+def test_a2a_proxy_rejects_declared_oversize_without_reading_unauthenticated_body(monkeypatch):
+    receive_calls = 0
+
+    async def receive():
+        nonlocal receive_calls
+        receive_calls += 1
+        raise AssertionError("oversized declared body must not be read")
+
+    request = Request({
+        "type": "http",
+        "method": "POST",
+        "path": "/a2a/",
+        "query_string": b"",
+        "headers": [(b"content-length", str(service_proxy._A2A_MAX_BODY_BYTES + 1).encode())],
+        "scheme": "https",
+        "server": ("agent.example.com", 443),
+        "client": ("203.0.113.10", 1234),
+    }, receive)
+    monkeypatch.setattr(
+        service_proxy,
+        "_service_route",
+        lambda service: service_proxy._ServiceRoute(service, "/a2a", 9900),
+    )
+
+    response = asyncio.run(service_proxy._proxy(request, "a2a", ""))
+
+    assert response.status_code == 413
+    assert receive_calls == 0
+
+
+def test_a2a_proxy_stops_chunked_invalid_auth_body_at_overflow_sentinel(monkeypatch):
+    limit = service_proxy._A2A_MAX_BODY_BYTES
+    events = iter([
+        {"type": "http.request", "body": b"x" * limit, "more_body": True},
+        {"type": "http.request", "body": b"y", "more_body": True},
+        {"type": "http.request", "body": b"must-not-be-read", "more_body": False},
+    ])
+    receive_calls = 0
+
+    async def receive():
+        nonlocal receive_calls
+        receive_calls += 1
+        return next(events)
+
+    request = Request({
+        "type": "http",
+        "method": "POST",
+        "path": "/a2a/",
+        "query_string": b"",
+        "headers": [
+            (b"authorization", b"Bearer invalid"),
+            (b"transfer-encoding", b"chunked"),
+        ],
+        "scheme": "https",
+        "server": ("agent.example.com", 443),
+        "client": ("203.0.113.11", 1234),
+    }, receive)
+    monkeypatch.setattr(
+        service_proxy,
+        "_service_route",
+        lambda service: service_proxy._ServiceRoute(service, "/a2a", 9900),
+    )
+
+    response = asyncio.run(service_proxy._proxy(request, "a2a", ""))
+
+    assert response.status_code == 413
+    assert receive_calls == 2
+
+
+def test_a2a_public_route_preserves_two_peer_identities(
+    public_dashboard, a2a_identity_server, monkeypatch
+):
+    port, identities = a2a_identity_server
+    monkeypatch.setattr(service_proxy, "load_config", lambda: _route_config("a2a", port))
+    monkeypatch.setenv("A2A_PEER_TOKENS", "nova:nova-token,cairn:cairn-token")
+    monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
+    request = {"jsonrpc": "2.0", "id": "identity", "method": "SendMessage", "params": {}}
+
+    nova = public_dashboard.post("/a2a/", headers={"Authorization": "Bearer nova-token"}, json=request)
+    cairn = public_dashboard.post("/a2a/", headers={"Authorization": "Bearer cairn-token"}, json=request)
+
+    assert nova.status_code == 429
+    assert cairn.status_code == 429
+    assert identities == ["nova", "cairn"]
 
 
 def test_api_route_strips_dashboard_credentials_and_keeps_api_key(

--- a/tests/hermes_cli/test_dashboard_service_routes.py
+++ b/tests/hermes_cli/test_dashboard_service_routes.py
@@ -21,7 +21,7 @@ class _EchoHandler(BaseHTTPRequestHandler):
             "path": self.path,
             "authorization": self.headers.get("Authorization"),
             "cookie": self.headers.get("Cookie"),
-            "dashboard_token": self.headers.get("X-Hermes-Dashboard-Token"),
+            "session_token": self.headers.get("X-Hermes-Session-Token"),
             "forwarded_host": self.headers.get("X-Forwarded-Host"),
             "forwarded_proto": self.headers.get("X-Forwarded-Proto"),
             "forwarded_prefix": self.headers.get("X-Forwarded-Prefix"),
@@ -150,7 +150,7 @@ def test_api_route_strips_dashboard_credentials_and_keeps_api_key(
         headers={
             "Authorization": "Bearer api-key",
             "Cookie": "hermes_session_at=private",
-            "X-Hermes-Dashboard-Token": "private",
+            "X-Hermes-Session-Token": "private",
         },
     )
 
@@ -159,7 +159,7 @@ def test_api_route_strips_dashboard_credentials_and_keeps_api_key(
     assert payload["path"] == "/api/sessions?limit=1"
     assert payload["authorization"] == "Bearer api-key"
     assert payload["cookie"] is None
-    assert payload["dashboard_token"] is None
+    assert payload["session_token"] is None
 
 
 def test_a2a_public_url_includes_forwarded_prefix(monkeypatch):

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -171,6 +171,11 @@ Once a peer is registered, the messaging protocol taught to every Bot Chat (`age
 
 Requirements: the peer machine runs the `api_server` gateway platform with a strong `API_SERVER_KEY`; reachability is your network's business (LAN, Tailscale, VPN). The key is a credential and lives in `~/.hermes/.env` as `HERMES_PEER_<NAME>_KEY`; peer names/URLs live in `config.yaml` under `bot_peers`.
 
+On a hosted instance that exposes only its dashboard hostname, set
+`gateway.platforms.api_server.extra.public_route: true` and register
+`https://<dashboard-host>/hermes-api` as the peer URL. The hosted route forwards the API bearer
+credential to the loopback listener without exposing or depending on the browser's OAuth cookie.
+
 :::note One-way reachability (NAT)
 Cross-gateway links are direct gateway-to-gateway connections — Desktop is a
 viewer, not a relay. A gateway behind home NAT can dial out to a public peer

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -700,8 +700,8 @@ hermes peer add nova --url https://nova.example/hermes-api --key <NOVA_API_SERVE
 ```
 
 The bridge bypasses browser OAuth because machine callers cannot complete an interactive login,
-but it does not bypass API authentication: the `Authorization: Bearer ***` header is
-passed to the loopback API listener, which remains the security boundary. Dashboard cookies and
+but it does not bypass API authentication: the bearer-token `Authorization` header is passed to
+the loopback API listener, which remains the security boundary. Dashboard cookies and
 the private dashboard session token are stripped. Enable the same route and register the opposite
 URL on both instances for bidirectional `hermes peer dm` delivery.
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -700,7 +700,7 @@ hermes peer add nova --url https://nova.example/hermes-api --key <NOVA_API_SERVE
 ```
 
 The bridge bypasses browser OAuth because machine callers cannot complete an interactive login,
-but it does not bypass API authentication: the `Authorization: Bearer <API_SERVER_KEY>` header is
+but it does not bypass API authentication: the `Authorization: Bearer ***` header is
 passed to the loopback API listener, which remains the security boundary. Dashboard cookies and
 the private dashboard session token are stripped. Enable the same route and register the opposite
 URL on both instances for bidirectional `hermes peer dm` delivery.

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -676,6 +676,35 @@ gateway:
 
 `port`, `key`, `host`, `cors_origins`, and `model_name` are automatically bridged into the platform's `extra` settings, so they behave exactly like their `API_SERVER_*` environment-variable counterparts. Environment variables take precedence over `config.yaml` values. The block is also accepted under `gateway.platforms.api_server:` or a top-level `platforms.api_server:` section.
 
+### Hosted dashboard route
+
+Hosted instances whose public hostname normally serves only the OAuth-gated dashboard can expose
+the API server through an opt-in loopback bridge:
+
+```yaml
+gateway:
+  platforms:
+    api_server:
+      enabled: true
+      extra:
+        port: 8642
+        public_route: true
+```
+
+Keep the strong `API_SERVER_KEY` in `.env`. The externally reachable API base becomes
+`https://<dashboard-host>/hermes-api`; for example, `GET /hermes-api/v1/models` and
+`POST /hermes-api/api/sessions/<id>/chat`. Set that base directly when registering a peer:
+
+```bash
+hermes peer add nova --url https://nova.example/hermes-api --key <NOVA_API_SERVER_KEY>
+```
+
+The bridge bypasses browser OAuth because machine callers cannot complete an interactive login,
+but it does not bypass API authentication: the `Authorization: Bearer <API_SERVER_KEY>` header is
+passed to the loopback API listener, which remains the security boundary. Dashboard cookies and
+the private dashboard session token are stripped. Enable the same route and register the opposite
+URL on both instances for bidirectional `hermes peer dm` delivery.
+
 ### Concurrent-run cap
 
 The API server limits how many agent runs may execute at once across the OpenAI-compatible and Runs endpoints. The cap is read from `gateway.api_server.max_concurrent_runs` (default **10**; `0` disables the limit, negative values clamp to 0). When the cap is reached, new run-starting requests are rejected with **HTTP 429** `Too many concurrent runs (max N)` — clients should back off and retry.

--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -106,7 +106,9 @@ Secure by default; every widening step is explicit:
 | `A2A_PUSH_SECRET` | bearer token | HMAC secret for push-notification signing |
 | `A2A_ADVERTISED_TOOLSETS` | all registered | Restrict which skills appear on the Agent Card |
 
-Behind a reverse proxy or Kubernetes Service, set `A2A_PUBLIC_URL` (or rely on `X-Forwarded-Host`/`X-Forwarded-Proto`) so the Agent Card advertises a URL peers can actually call back.
+Behind a reverse proxy or Kubernetes Service, set `A2A_PUBLIC_URL` to the complete externally
+routable A2A URL (including any path prefix), or leave it unset and rely on forwarded host,
+scheme, and prefix headers so the Agent Card advertises a URL peers can actually call back.
 
 ## Hosted dashboard route
 
@@ -133,8 +135,10 @@ https://<dashboard-host>/a2a/                         # SendMessage POST
 The Agent Card GET remains public, as required by A2A discovery. Every task POST is authenticated
 by the A2A listener's bearer token; the browser dashboard OAuth session is neither required nor
 forwarded. The bridge targets only `127.0.0.1` and is disabled unless both `public_route: true`
-and an A2A token are configured, so `A2A_HOST` may remain at its safe loopback default. Forwarded
-host, scheme, and path-prefix metadata make the card advertise the `/a2a/` HTTPS URL automatically.
+and an A2A token are configured, so `A2A_HOST` may remain at its safe loopback default. Leave
+`A2A_PUBLIC_URL` unset to have forwarded host, scheme, and path-prefix metadata make the card
+advertise the `/a2a/` HTTPS URL automatically. An explicit `A2A_PUBLIC_URL` takes precedence and
+must include the mounted route, for example `https://<dashboard-host>/a2a`.
 
 For bidirectional delivery, enable the route on both instances and add each `/a2a` URL plus that
 instance's peer token to the other instance's `a2a_agents` map.
@@ -155,7 +159,7 @@ curl -X POST http://your-host:9900/ \
 
 ## Troubleshooting
 
-- **Peers can't reach the card URL** — the card was advertising your bind address; set `A2A_PUBLIC_URL` to the externally routable URL.
+- **Peers can't reach the card URL** — set `A2A_PUBLIC_URL` to the complete externally routable URL. For a hosted dashboard route it must include `/a2a`; alternatively, leave it unset so forwarded host, scheme, and prefix headers determine the advertised URL.
 - **`401 Unauthorized`** — token mismatch; check `A2A_PEER_TOKENS`/`A2A_BEARER_TOKEN` on the server and the peer's `auth:` block.
 - **Server won't bind non-localhost** — by design: set a bearer token first, then `A2A_HOST=0.0.0.0`.
 - **Replies time out on long tasks** — raise `A2A_REPLY_TIMEOUT`, or have the caller register a push-notification config and poll `GetTask`.

--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -108,6 +108,37 @@ Secure by default; every widening step is explicit:
 
 Behind a reverse proxy or Kubernetes Service, set `A2A_PUBLIC_URL` (or rely on `X-Forwarded-Host`/`X-Forwarded-Proto`) so the Agent Card advertises a URL peers can actually call back.
 
+## Hosted dashboard route
+
+When a hosted deployment exposes only the authenticated dashboard hostname, opt the A2A
+platform into the dashboard's loopback bridge:
+
+```yaml
+gateway:
+  platforms:
+    a2a:
+      enabled: true
+      extra:
+        port: 9900
+        public_route: true
+```
+
+Configure `A2A_PEER_TOKENS` (preferred) or `A2A_BEARER_TOKEN` as usual. The public endpoint is:
+
+```text
+https://<dashboard-host>/a2a/.well-known/agent-card.json
+https://<dashboard-host>/a2a/                         # SendMessage POST
+```
+
+The Agent Card GET remains public, as required by A2A discovery. Every task POST is authenticated
+by the A2A listener's bearer token; the browser dashboard OAuth session is neither required nor
+forwarded. The bridge targets only `127.0.0.1` and is disabled unless both `public_route: true`
+and an A2A token are configured, so `A2A_HOST` may remain at its safe loopback default. Forwarded
+host, scheme, and path-prefix metadata make the card advertise the `/a2a/` HTTPS URL automatically.
+
+For bidirectional delivery, enable the route on both instances and add each `/a2a` URL plus that
+instance's peer token to the other instance's `a2a_agents` map.
+
 ## Quick test
 
 ```bash

--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -125,7 +125,7 @@ gateway:
         public_route: true
 ```
 
-Configure `A2A_PEER_TOKENS` (preferred) or `A2A_BEARER_TOKEN` as usual. The public endpoint is:
+Configure `A2A_PEER_TOKENS` with a distinct credential for each caller. The public endpoint is:
 
 ```text
 https://<dashboard-host>/a2a/.well-known/agent-card.json
@@ -133,9 +133,9 @@ https://<dashboard-host>/a2a/                         # SendMessage POST
 ```
 
 The Agent Card GET remains public, as required by A2A discovery. Every task POST is authenticated
-by the A2A listener's bearer token; the browser dashboard OAuth session is neither required nor
-forwarded. The bridge targets only `127.0.0.1` and is disabled unless both `public_route: true`
-and an A2A token are configured, so `A2A_HOST` may remain at its safe loopback default. Leave
+by the A2A listener's per-peer bearer token; the browser dashboard OAuth session is neither required
+nor forwarded. The bridge targets only `127.0.0.1` and is disabled unless both `public_route: true`
+and `A2A_PEER_TOKENS` are configured, so `A2A_HOST` may remain at its safe loopback default. Leave
 `A2A_PUBLIC_URL` unset to have forwarded host, scheme, and path-prefix metadata make the card
 advertise the `/a2a/` HTTPS URL automatically. An explicit `A2A_PUBLIC_URL` takes precedence and
 must include the mounted route, for example `https://<dashboard-host>/a2a`.


### PR DESCRIPTION
## What does this PR do?

Adds opt-in authenticated HTTPS routes for hosted Hermes instances whose public hostname currently serves only the OAuth-gated dashboard. A2A peers can discover and call `https://<host>/a2a/`, while `hermes peer` and other API clients can use `https://<host>/hermes-api` without requiring an interactive browser login.

### Motivation

Hosted Hermes instances can run A2A on loopback port 9900 and the API server on loopback port 8642, but another isolated instance cannot reach those listeners through the public dashboard hostname. The dashboard OAuth redirect is also not usable for machine-to-machine calls.

### Behavior

- `gateway.platforms.a2a.extra.public_route: true` exposes `/a2a/*` only when A2A is enabled and an A2A bearer or peer token is configured.
- `gateway.platforms.api_server.extra.public_route: true` exposes `/hermes-api/*` only when the API server platform is enabled.
- Browser OAuth is bypassed only for these protocol prefixes. The downstream A2A or API listener still verifies its own bearer credential.
- Dashboard cookies and the private dashboard session token are never forwarded.
- The proxy target is fixed to `127.0.0.1` and the configured service port.
- Forwarded host, scheme, and path-prefix metadata make Agent Cards advertise the public `/a2a/` URL.

### Implementation

A bounded FastAPI proxy streams API requests and responses to the loopback gateway listeners, while A2A requests retain the listener's 1 MiB request limit and content-length semantics. The dashboard auth gate treats only the exact `/a2a/` and `/hermes-api/` prefixes as machine routes, and A2A Agent Card URL construction now honors a validated forwarded prefix.

## Related Issue

Closes #105764

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Tests

## Changes Made

- `hermes_cli/web_routers/service_proxy.py` - add opt-in loopback proxy routes with header isolation and streaming.
- `hermes_cli/dashboard_auth/middleware.py` - keep machine routes out of browser OAuth redirects.
- `plugins/platforms/a2a/adapter.py` - include a validated proxy prefix in advertised Agent Card URLs.
- `tests/hermes_cli/test_dashboard_service_routes.py` - cover routing, auth-header preservation, credential stripping, opt-in guards, and prefix isolation.
- `website/docs/user-guide/` and `cli-config.yaml.example` - document URL patterns, authentication, configuration, and bidirectional setup.

## How to Test

1. Enable either gateway platform with `extra.public_route: true` and configure its service bearer credential.
2. Fetch `https://<dashboard-host>/a2a/.well-known/agent-card.json` or call `https://<dashboard-host>/hermes-api/v1/models` with the matching bearer credential.
3. Run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_dashboard_service_routes.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the repository test entry on the targeted tests and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] `CONTRIBUTING.md` and `AGENTS.md` are not affected
- [x] I've considered cross-platform impact; the implementation uses portable FastAPI/httpx APIs and loopback TCP
- [x] Tool descriptions and schemas are not affected

## Screenshots / Logs

Not applicable. This is a machine-to-machine HTTP surface with automated integration coverage.
