### PR TITLE
feat(web): add persistent project Bot launcher

### DIFF
--- a/web/src/components/ProjectBotLauncher.test.tsx
+++ b/web/src/components/ProjectBotLauncher.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const profileScope = vi.hoisted(() => ({
+  profile: "",
+  currentProfile: "default",
+  profiles: ["default", "mapautogen", "microtwin", "scenarioautogen", "realtosim"],
+  setProfile: vi.fn(),
+}));
+
+vi.mock("@/contexts/useProfileScope", () => ({
+  useProfileScope: () => profileScope,
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(initialEntry = "/chat?resume=old-session&learn=keep-me") {
+  const { ProjectBotLauncher } = await import("./ProjectBotLauncher");
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <ProjectBotLauncher />
+      </MemoryRouter>,
+    );
+  });
+}
+
+beforeEach(() => {
+  profileScope.profile = "";
+  profileScope.currentProfile = "default";
+  profileScope.profiles = ["default", "mapautogen", "microtwin", "scenarioautogen", "realtosim"];
+  profileScope.setProfile.mockReset();
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+});
+
+describe("ProjectBotLauncher", () => {
+  it("marks Main CTO selected when the dashboard profile has no explicit scope", async () => {
+    await render("/chat");
+
+    const launch = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open Main CTO"]',
+    );
+    expect(launch?.getAttribute("aria-current")).toBe("true");
+  });
+
+  it("uses the dashboard process profile when there is no explicit scope", async () => {
+    profileScope.currentProfile = "realtosim";
+    await render("/chat");
+
+    const launch = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open Real-to-Sim PM"]',
+    );
+    expect(launch?.getAttribute("aria-current")).toBe("true");
+  });
+
+  it("opens the Map Autogen PM profile workspace without a stale resume id", async () => {
+    await render();
+
+    const launch = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open Map Autogen PM"]',
+    );
+    expect(launch).not.toBeNull();
+
+    await act(async () => launch!.click());
+
+    expect(profileScope.setProfile).toHaveBeenCalledWith("mapautogen", {
+      clearResume: true,
+    });
+  });
+
+  it("launches MicroTwin PM and marks the selected profile", async () => {
+    profileScope.profile = "microtwin";
+    await render("/chat?profile=microtwin");
+
+    const launch = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open MicroTwin PM"]',
+    );
+    expect(launch?.getAttribute("aria-current")).toBe("true");
+
+    await act(async () => launch!.click());
+    expect(profileScope.setProfile).toHaveBeenCalledWith("microtwin", {
+      clearResume: true,
+    });
+  });
+
+  it.each([
+    ["Main CTO", "default"],
+    ["Scenario Autocreation PM", "scenarioautogen"],
+    ["Real-to-Sim PM", "realtosim"],
+  ])("opens the %s workspace", async (name, profileId) => {
+    await render();
+
+    const launch = container.querySelector<HTMLButtonElement>(
+      `button[aria-label="Open ${name}"]`,
+    );
+    expect(launch).not.toBeNull();
+
+    await act(async () => launch!.click());
+    expect(profileScope.setProfile).toHaveBeenCalledWith(profileId, {
+      clearResume: true,
+    });
+  });
+
+  it("shows an unavailable pilot without launching a missing profile", async () => {
+    profileScope.profiles = ["default", "mapautogen"];
+    await render("/chat");
+
+    const launch = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open MicroTwin PM"]',
+    );
+    expect(launch?.disabled).toBe(true);
+    expect(container.textContent).toContain("Not configured");
+  });
+});

--- a/web/src/components/ProjectBotLauncher.tsx
+++ b/web/src/components/ProjectBotLauncher.tsx
@@ -1,0 +1,120 @@
+import { Button } from "@nous-research/ui/ui/components/button";
+import { ArrowRight, Bot } from "lucide-react";
+import { useCallback } from "react";
+
+import { useProfileScope } from "@/contexts/useProfileScope";
+import { cn } from "@/lib/utils";
+
+interface PilotProjectBot {
+  id: string;
+  name: string;
+  project: string;
+  initials: string;
+}
+
+const PILOT_PROJECT_BOTS: readonly PilotProjectBot[] = [
+  {
+    id: "default",
+    name: "Main CTO",
+    project: "Chief of Staff",
+    initials: "CTO",
+  },
+  {
+    id: "mapautogen",
+    name: "Map Autogen PM",
+    project: "Map Autogen",
+    initials: "MA",
+  },
+  {
+    id: "microtwin",
+    name: "MicroTwin PM",
+    project: "MicroTwin",
+    initials: "MT",
+  },
+  {
+    id: "scenarioautogen",
+    name: "Scenario Autocreation PM",
+    project: "Scenario Autocreation",
+    initials: "SA",
+  },
+  {
+    id: "realtosim",
+    name: "Real-to-Sim PM",
+    project: "Real-to-Sim",
+    initials: "RS",
+  },
+];
+
+interface ProjectBotLauncherProps {
+  className?: string;
+  /** Close the mobile sheet after a Bot is selected. */
+  onPicked?: () => void;
+}
+
+/** Open a persistent dashboard workspace for the main CTO or a pilot project Bot. */
+export function ProjectBotLauncher({
+  className,
+  onPicked,
+}: ProjectBotLauncherProps) {
+  const { profile, currentProfile, profiles, setProfile } = useProfileScope();
+  const selectedProfile = profile || currentProfile || "default";
+
+  const launch = useCallback(
+    (profileId: string) => {
+      setProfile(profileId, { clearResume: true });
+      onPicked?.();
+    },
+    [onPicked, setProfile],
+  );
+
+  return (
+    <section
+      aria-label="Bot workspaces"
+      className={cn("flex min-w-0 flex-col gap-2 px-2", className)}
+    >
+      <div className="flex items-center gap-1.5 text-display text-xs tracking-wider text-text-tertiary">
+        <Bot className="h-3.5 w-3.5" aria-hidden />
+        <span>Bots</span>
+        <span className="ml-auto rounded-full bg-primary/10 px-1.5 py-0.5 text-[0.625rem] text-primary">
+          pilot
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-1.5">
+        {PILOT_PROJECT_BOTS.map((bot) => {
+          const available = profiles.includes(bot.id);
+          const selected = selectedProfile === bot.id;
+
+          return (
+            <Button
+              key={bot.id}
+              outlined={!selected}
+              size="sm"
+              disabled={!available}
+              aria-label={`Open ${bot.name}`}
+              aria-current={selected ? "true" : undefined}
+              onClick={() => launch(bot.id)}
+              className={cn(
+                "min-h-11 w-full min-w-0 justify-start gap-2 px-2 normal-case tracking-normal",
+                selected && "border-primary/60 bg-primary/10",
+              )}
+            >
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-current/20 bg-background font-mono-ui text-[0.6875rem] font-semibold">
+                {bot.initials}
+              </span>
+              <span className="flex min-w-0 flex-1 flex-col items-start leading-tight">
+                <span className="w-full truncate text-left text-sm font-medium">
+                  {bot.name}
+                </span>
+                <span className="w-full truncate text-left text-[0.6875rem] text-text-tertiary">
+                  {available ? bot.project : "Not configured"}
+                </span>
+              </span>
+              {available && <ArrowRight className="h-3.5 w-3.5 shrink-0" aria-hidden />}
+            </Button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/web/src/contexts/ProfileProvider.test.tsx
+++ b/web/src/contexts/ProfileProvider.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { act, useLayoutEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, useLocation, useNavigate } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { setManagementProfile } from "@/lib/api";
+import { ProfileProvider } from "./ProfileProvider";
+import { useProfileScope } from "./useProfileScope";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
+    getActiveProfile: vi.fn().mockResolvedValue({
+      current: "default",
+      active: "default",
+    }),
+  },
+  setManagementProfile: vi.fn(),
+}));
+
+interface CommittedScope {
+  url: string;
+  profile: string;
+  managementProfile: string | undefined;
+}
+
+function Harness({ commits }: { commits: CommittedScope[] }) {
+  const { profile, setProfile } = useProfileScope();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useLayoutEffect(() => {
+    const managementCalls = vi.mocked(setManagementProfile).mock.calls;
+    commits.push({
+      url: `${location.pathname}${location.search}`,
+      profile,
+      managementProfile: managementCalls[managementCalls.length - 1]?.[0],
+    });
+  }, [commits, location, profile]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setProfile("mapautogen", { clearResume: true })}
+      >
+        Open Map Autogen PM
+      </button>
+      <button type="button" onClick={() => navigate("/skills")}>
+        Open Skills
+      </button>
+      <output data-testid="location">{location.pathname}{location.search}</output>
+      <output data-testid="profile">{profile}</output>
+    </>
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+});
+
+describe("ProfileProvider", () => {
+  it("commits a clear-resume switch without stale profile scope", async () => {
+    const commits: CommittedScope[] = [];
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter
+          initialEntries={["/chat?profile=default&resume=old-session&learn=keep-me"]}
+        >
+          <ProfileProvider>
+            <Harness commits={commits} />
+          </ProfileProvider>
+        </MemoryRouter>,
+      );
+    });
+
+    const button = container.querySelector<HTMLButtonElement>("button");
+    await act(async () => button!.click());
+
+    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe(
+      "/chat?profile=mapautogen&learn=keep-me",
+    );
+    expect(container.querySelector('[data-testid="profile"]')?.textContent).toBe(
+      "mapautogen",
+    );
+    expect(commits).toContainEqual({
+      url: "/chat?profile=mapautogen&learn=keep-me",
+      profile: "mapautogen",
+      managementProfile: "mapautogen",
+    });
+    const skillsButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((candidate) => candidate.textContent?.includes("Skills"));
+    await act(async () => skillsButton!.click());
+
+    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe(
+      "/skills?profile=mapautogen",
+    );
+    expect(container.querySelector('[data-testid="profile"]')?.textContent).toBe(
+      "mapautogen",
+    );
+
+    for (const commit of commits) {
+      const urlProfile = new URLSearchParams(commit.url.split("?")[1]).get("profile");
+      if (urlProfile !== null) expect(commit.profile).toBe(urlProfile);
+      expect(commit.managementProfile).toBe(commit.profile);
+    }
+  });
+});

--- a/web/src/contexts/ProfileProvider.tsx
+++ b/web/src/contexts/ProfileProvider.tsx
@@ -45,14 +45,16 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     () => searchParams.get("profile") ?? "",
   );
 
-  // Mirror into the api module synchronously on every render where it
-  // changed, so fetches fired by child effects in the same commit see it.
-  setManagementProfile(profile);
-
   // A profile param arriving via in-app navigation (e.g. the Profiles
   // page's "Manage skills & tools" linking to /skills?profile=X) must win
   // over current state — it's an explicit scope request.
   const urlProfile = searchParams.get("profile");
+  const effectiveProfile = urlProfile ?? profile;
+
+  // Mirror into the api module synchronously on every render where it
+  // changed, so fetches fired by child effects in the same commit see it.
+  setManagementProfile(effectiveProfile);
+
   useEffect(() => {
     if (urlProfile !== null && urlProfile !== profile) {
       setManagementProfile(urlProfile);
@@ -64,19 +66,16 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
   // Re-assert ?profile= after navigations that dropped it (bare nav links).
   // Runs on every pathname/profile change; no-ops when already in sync.
   useEffect(() => {
-    const inUrl = searchParams.get("profile") ?? "";
-    if ((profile || "") === inUrl) return;
+    if (urlProfile !== null || !profile) return;
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
-        if (profile) next.set("profile", profile);
-        else next.delete("profile");
+        next.set("profile", profile);
         return next;
       },
       { replace: true },
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pathname, profile]);
+  }, [pathname, profile, setSearchParams, urlProfile]);
 
   useEffect(() => {
     let cancelled = false;
@@ -110,25 +109,26 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const setProfile = useCallback(
-    (name: string) => {
-      setManagementProfile(name);
-      setProfileState(name);
+    (name: string, options?: { clearResume?: boolean }) => {
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);
           if (name) next.set("profile", name);
           else next.delete("profile");
+          if (options?.clearResume) next.delete("resume");
           return next;
         },
         { replace: true },
       );
+      setManagementProfile(name);
+      setProfileState(name);
     },
     [setSearchParams],
   );
 
   const value = useMemo(
-    () => ({ profile, currentProfile, profiles, setProfile }),
-    [profile, currentProfile, profiles, setProfile],
+    () => ({ profile: effectiveProfile, currentProfile, profiles, setProfile }),
+    [effectiveProfile, currentProfile, profiles, setProfile],
   );
 
   return (

--- a/web/src/contexts/profile-context.ts
+++ b/web/src/contexts/profile-context.ts
@@ -8,7 +8,7 @@ export interface ProfileContextValue {
   currentProfile: string;
   /** Known profile names (includes "default"). */
   profiles: string[];
-  setProfile: (name: string) => void;
+  setProfile: (name: string, options?: { clearResume?: boolean }) => void;
 }
 
 export const ProfileContext = createContext<ProfileContextValue>({

--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -94,6 +94,9 @@ vi.mock("@/components/ChatSidebar", () => ({
 vi.mock("@/components/ChatSessionList", () => ({
   ChatSessionList: () => null,
 }));
+vi.mock("@/components/ProjectBotLauncher", () => ({
+  ProjectBotLauncher: () => <section data-testid="project-bot-launcher" />,
+}));
 vi.mock("@/components/Backdrop", () => ({ Backdrop: () => null }));
 vi.mock("@/plugins", () => ({
   PluginSlot: () => null,
@@ -332,6 +335,14 @@ describe("ChatPage side panel collapse", () => {
       </MemoryRouter>,
     );
   }
+
+  it("includes the project Bot launcher in the desktop chat rail", async () => {
+    await renderChat();
+
+    expect(
+      container.querySelector('[data-testid="project-bot-launcher"]'),
+    ).not.toBeNull();
+  });
 
   it("collapses the desktop side panel and persists the choice", async () => {
     localStorage.clear();

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -32,6 +32,7 @@ import { useSearchParams } from "react-router";
 
 import { ChatSidebar } from "@/components/ChatSidebar";
 import { ChatSessionList } from "@/components/ChatSessionList";
+import { ProjectBotLauncher } from "@/components/ProjectBotLauncher";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
@@ -1794,6 +1795,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               "border-t border-current/10",
             )}
           >
+            <ProjectBotLauncher
+              className="border-b border-current/10 py-2"
+              onPicked={closeMobilePanel}
+            />
             <div className="border-b border-current/10 px-1 py-2">
               <ChatSidebar
                 channel={channel}
@@ -1965,6 +1970,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
                 <X />
               </Button>
             </div>
+            <ProjectBotLauncher className="shrink-0 border-b border-current/10 pb-3" />
             {/* Model picker — keeps the rail thin. */}
             <div className="shrink-0">
               <ChatSidebar


### PR DESCRIPTION
## Summary
- add a dashboard Bot switcher for Main CTO, Map Autogen, MicroTwin, Scenario Autocreation, and Real-to-Sim
- atomically switch profile scope while clearing stale resume IDs and preserving unrelated URL parameters
- make chat PTY identity follow the selected profile and add regression coverage

## Verification
- authenticated dashboard smoke test confirmed by Dib
- 305/305 web tests pass
- web typecheck passes
- web lint passes with 0 errors (27 pre-existing warnings)
- production web build passes
- independent security/logic review passes