### PR TITLE
fix(local-runtime): detect discrete AMD VRAM

### DIFF
--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -8,11 +8,13 @@ stripped PATH — gateway and service sessions don't inherit the interactive env
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from contextlib import suppress
 import logging
 import os
 import re
 import shutil
+import struct
 import subprocess
 import sys
 import time
@@ -44,6 +46,15 @@ _POOL_RAM_FRACTION = 0.75
 
 # cuDeviceGetAttribute enum: device is integrated with host memory.
 _CU_DEVICE_ATTRIBUTE_INTEGRATED = 18
+
+# Linux amdgpu DRM ABI. AMDGPU_INFO_DEV_INFO's ids_flags bit 0 is
+# AMDGPU_IDS_FLAGS_FUSION, the kernel's APU classification.
+_DRM_AMDGPU_INFO = 0x05
+_AMDGPU_INFO_DEV_INFO = 0x16
+_AMDGPU_IDS_FLAGS_FUSION = 0x1
+_AMDGPU_DEVICE_ID_OFFSET = 0
+_AMDGPU_IDS_FLAGS_OFFSET = 136
+_AMDGPU_INFO_BUFFER_SIZE = 256
 
 # One probe per process once a device answers (silicon doesn't change); a miss retries after this
 # long so a runtime installed mid-session gets picked up by the engine fallback.
@@ -157,6 +168,88 @@ def _nvidia_vram() -> tuple[int, int] | None:
         total_mib, free_mib = (int(x) for x in out.stdout.strip().splitlines()[0].split(","))
         return total_mib << 20, free_mib << 20
     return None
+
+
+def _amd_info_integrated(response: bytes, expected_device_id: int) -> bool | None:
+    device_id = struct.unpack_from("=I", response, _AMDGPU_DEVICE_ID_OFFSET)[0]
+    if device_id != expected_device_id:
+        return None
+    ids_flags = struct.unpack_from("=Q", response, _AMDGPU_IDS_FLAGS_OFFSET)[0]
+    return bool(ids_flags & _AMDGPU_IDS_FLAGS_FUSION)
+
+
+def _amd_device_integrated(device: Path) -> bool | None:
+    """Read amdgpu's FUSION flag for one sysfs device."""
+    if sys.platform != "linux":
+        return None
+
+    import ctypes
+
+    class AmdgpuInfoRequest(ctypes.Structure):
+        _fields_ = [
+            ("return_pointer", ctypes.c_uint64),
+            ("return_size", ctypes.c_uint32),
+            ("query", ctypes.c_uint32),
+            ("params", ctypes.c_uint32 * 4),
+        ]
+
+    try:
+        libdrm = ctypes.CDLL("libdrm.so.2")
+        command_write = libdrm.drmCommandWrite
+        command_write.argtypes = [ctypes.c_int, ctypes.c_ulong, ctypes.c_void_p, ctypes.c_ulong]
+        command_write.restype = ctypes.c_int
+        expected_device_id = int((device / "device").read_text(encoding="utf-8").strip(), 16)
+        render = next((device / "drm").glob("renderD*"))
+        descriptor = os.open(f"/dev/dri/{render.name}", os.O_RDWR | os.O_CLOEXEC)
+    except (AttributeError, OSError, StopIteration, ValueError):
+        return None
+
+    try:
+        response = ctypes.create_string_buffer(_AMDGPU_INFO_BUFFER_SIZE)
+        request = AmdgpuInfoRequest(
+            ctypes.addressof(response),
+            _AMDGPU_INFO_BUFFER_SIZE,
+            _AMDGPU_INFO_DEV_INFO,
+            (ctypes.c_uint32 * 4)(),
+        )
+        # libdrm builds DRM_IOW with the host architecture's ioctl layout.
+        if command_write(
+            descriptor,
+            _DRM_AMDGPU_INFO,
+            ctypes.byref(request),
+            ctypes.sizeof(request),
+        ) != 0:
+            return None
+    except (OSError, ValueError):
+        return None
+    finally:
+        os.close(descriptor)
+
+    return _amd_info_integrated(response.raw, expected_device_id)
+
+
+def _amd_vram_from_devices(devices: Iterable[Path]) -> tuple[int, int] | None:
+    best: tuple[int, int] | None = None
+    for device in devices:
+        try:
+            if (device / "vendor").read_text(encoding="utf-8").strip().lower() != "0x1002":
+                continue
+            if _amd_device_integrated(device) is not False:
+                continue
+            total = int((device / "mem_info_vram_total").read_text(encoding="utf-8"))
+            used = int((device / "mem_info_vram_used").read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if total > 0 and (best is None or total > best[0]):
+            best = total, max(0, total - used)
+    return best
+
+
+def _amd_vram() -> tuple[int, int] | None:
+    """Return the largest driver-confirmed discrete AMD VRAM pool on Linux."""
+    if sys.platform != "linux":
+        return None
+    return _amd_vram_from_devices(Path("/sys/class/drm").glob("card*/device"))
 
 
 def _cuda_driver_pool() -> "tuple[int, bool | None] | None":
@@ -290,8 +383,11 @@ def probe_budget(*, planning: bool = False) -> HardwareBudget:
         return _uma_budget(base, unified)
 
     if vram is None:
-        # No NVIDIA device visible: Metal/Vulkan/CPU paths budget from RAM as UMA (Apple
-        # Silicon) — conservative for discrete AMD until a vendor probe lands.
+        vram = _amd_vram()
+
+    if vram is None:
+        # No discrete GPU visible: Metal/Vulkan/CPU paths budget from RAM as UMA. AMD APUs
+        # and unreadable AMD driver state deliberately stay on this conservative fallback.
         return _uma_budget(ram_total if planning else ram_avail, ram_total)
 
     total, free = vram

--- a/tests/hermes_cli/test_amd_discrete_budget.py
+++ b/tests/hermes_cli/test_amd_discrete_budget.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import ctypes
+import os
+from pathlib import Path
+import struct
+
+import pytest
+
+import hermes_cli.local_runtime.hardware as hw
+
+GIB = 1 << 30
+
+
+def test_discrete_amd_uses_vram_budget_instead_of_host_ram(monkeypatch):
+    vram_total = 25_753_026_560
+    vram_used = 1_494_384_640
+    ram_total = 67_004_100_608
+
+    monkeypatch.setattr(hw, "_nvidia_vram", lambda: None)
+    monkeypatch.setattr(hw, "_unified_pool_bytes", lambda *_: None)
+    monkeypatch.setattr(
+        hw,
+        "_amd_vram",
+        lambda: (vram_total, vram_total - vram_used),
+        raising=False,
+    )
+    monkeypatch.setattr(hw, "_ram_bytes", lambda: (ram_total, 48 * GIB))
+
+    budget = hw.probe_budget(planning=True)
+
+    margin = max(hw._MARGIN_FLOOR, int(vram_total * hw._MARGIN_FRACTION))
+    assert budget.uma is False
+    assert budget.total_device_bytes == vram_total
+    assert budget.usable_vram_bytes == vram_total - margin
+    assert budget.ram_available_bytes == ram_total
+
+
+@pytest.mark.linux_only
+def test_amd_probe_uses_driver_classification_and_discrete_vram(tmp_path, monkeypatch):
+    devices = []
+    responses = {}
+    for card, render, device_id, flags, total, used in (
+        ("card0", "renderD128", 0x15BF, 1, 96 * GIB, GIB),
+        ("card1", "renderD129", 0x744C, 0, 24 * GIB, 2 * GIB),
+    ):
+        device = tmp_path / card / "device"
+        (device / "drm").mkdir(parents=True)
+        (device / "drm" / render).touch()
+        (device / "vendor").write_text("0x1002\n", encoding="utf-8")
+        (device / "device").write_text(f"0x{device_id:x}\n", encoding="utf-8")
+        (device / "mem_info_vram_total").write_text(str(total), encoding="utf-8")
+        (device / "mem_info_vram_used").write_text(str(used), encoding="utf-8")
+        devices.append(device)
+        responses[render] = (device_id, flags)
+
+    descriptors = {}
+    closed = []
+
+    def fake_open(path, flags):
+        render = Path(path).name
+        assert flags == os.O_RDWR | os.O_CLOEXEC
+        descriptor = len(descriptors) + 100
+        descriptors[descriptor] = render
+        return descriptor
+
+    class FakeCommandWrite:
+        argtypes = None
+        restype = None
+
+        def __call__(self, descriptor, command, request_pointer, request_size):
+            assert command == hw._DRM_AMDGPU_INFO
+            assert request_size == 32
+            request = request_pointer._obj
+            assert request.query == hw._AMDGPU_INFO_DEV_INFO
+            device_id, flags = responses[descriptors[descriptor]]
+            response = bytearray(hw._AMDGPU_INFO_BUFFER_SIZE)
+            struct.pack_into("=I", response, hw._AMDGPU_DEVICE_ID_OFFSET, device_id)
+            struct.pack_into("=Q", response, hw._AMDGPU_IDS_FLAGS_OFFSET, flags)
+            ctypes.memmove(request.return_pointer, bytes(response), len(response))
+            return 0
+
+    class FakeLibdrm:
+        drmCommandWrite = FakeCommandWrite()
+
+    monkeypatch.setattr(hw.os, "open", fake_open)
+    monkeypatch.setattr(hw.os, "close", closed.append)
+    monkeypatch.setattr(ctypes, "CDLL", lambda name: FakeLibdrm())
+
+    assert hw._amd_vram_from_devices(devices) == (24 * GIB, 22 * GIB)
+    assert closed == [100, 101]


### PR DESCRIPTION
## What does this PR do?

Discrete AMD GPUs on Linux no longer inherit host RAM as their GPU capacity when no NVIDIA device is present. Hermes now asks the amdgpu driver whether each AMD device is integrated, then budgets a confirmed discrete device from its sysfs VRAM totals.

The classification uses the kernel's `AMDGPU_IDS_FLAGS_FUSION` flag through `libdrm`. Unknown driver state and integrated AMD devices keep the existing conservative RAM fallback. This avoids guessing from VRAM-to-RAM ratios, which overlap between discrete cards and large APU carves.

On the reported RX 7900 XTX system, the old path returned `uma=True` with 67,004,100,608 bytes of host RAM as device capacity. The fixed path returns a discrete budget from the reported 25,753,026,560-byte VRAM pool and retains host RAM as spill capacity.

## Related Issue

Fixes #105710

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/local_runtime/hardware.py` queries the amdgpu FUSION flag through `drmCommandWrite`, reads discrete VRAM totals from sysfs, and reuses the existing discrete budget calculation.
- `tests/hermes_cli/test_amd_discrete_budget.py` covers the reported budget shape and a mixed APU plus discrete GPU probe.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_amd_discrete_budget.py tests/hermes_cli/test_unified_pool_quirk.py tests/hermes_cli/test_local_recommendation.py tests/hermes_cli/test_budget_source.py -v --tb=short`.
2. Confirm the related suite reports 41 passed. On macOS, two Linux-only cases are skipped and run in the Linux CI lane.
3. On a Linux host with a discrete AMD GPU and no NVIDIA device, call `probe_budget(planning=True)` and confirm `uma=False` with `total_device_bytes` equal to `mem_info_vram_total`.

The focused budget regression fails on the unfixed parent because it returns `uma=True` and budgets system RAM. Ruff, bytecode compilation, and `git diff --check` also pass. Native AMD hardware validation is still pending.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS arm64, focused and related unit tests only

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, internal hardware classification only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the AMD probe returns before loading Linux-only libraries on other platforms
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable.
