### PR TITLE
fix(bedrock): drop reasoning-only assistant turns from Converse messages

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -583,7 +583,14 @@ def convert_messages_to_converse(messages: List[Dict]) -> Tuple[Optional[List[Di
             append_turn("user", [{"toolResult": {
                 "toolUseId": msg.get("tool_call_id", ""), "content": [{"text": _safe_text(result_content)}]}}])
         elif role == "assistant":
-            append_turn("assistant", _assistant_blocks(msg, content) or [dict(_PLACEHOLDER_BLOCK)])
+            blocks = _assistant_blocks(msg, content)
+            # Sonnet 5 / Fable 5.1 reject a reasoningContent-only assistant message as
+            # prefill, killing the whole request even when a user turn follows (#105780).
+            # Such a turn carries no text and no toolUse, so dropping it cannot orphan a
+            # toolResult; same-role neighbours merge in append_turn, keeping alternation.
+            if blocks and all("reasoningContent" in block for block in blocks):
+                continue
+            append_turn("assistant", blocks or [dict(_PLACEHOLDER_BLOCK)])
         elif role == "user":
             append_turn("user", _convert_content_to_converse(content))
     if converse_msgs and converse_msgs[0]["role"] != "user":

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -255,6 +255,59 @@ class TestConvertMessagesToConverse:
         # Empty string should get a space placeholder
         assert msgs[0]["content"][0]["text"].strip() != "" or msgs[0]["content"][0]["text"] == " "
 
+    def test_reasoning_only_sidecar_turn_is_dropped(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+
+        messages = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": None,
+                "bedrock_content_blocks": [
+                    {"reasoningContent": {"redactedContentBase64": "cjE="}}
+                ],
+            },
+            {"role": "user", "content": "next"},
+        ]
+        _system, msgs = convert_messages_to_converse(messages)
+        # Sonnet 5 / Fable 5.1 reject the reasoning-only assistant message as prefill (#105780);
+        # the surrounding user turns merge into one.
+        assert [m["role"] for m in msgs] == ["user"]
+        assert all("reasoningContent" not in b for b in msgs[0]["content"])
+
+    def test_reasoning_details_only_turn_is_dropped(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+
+        messages = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning_details": [{"type": "redacted_thinking", "data": "cjE="}],
+            },
+            {"role": "user", "content": "next"},
+        ]
+        _system, msgs = convert_messages_to_converse(messages)
+        assert [m["role"] for m in msgs] == ["user"]
+        assert all("reasoningContent" not in b for b in msgs[0]["content"])
+
+    def test_leading_reasoning_only_turn_keeps_user_first_invariant(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "bedrock_content_blocks": [
+                    {"reasoningContent": {"redactedContentBase64": "cjE="}}
+                ],
+            },
+            {"role": "user", "content": "hello"},
+        ]
+        _system, msgs = convert_messages_to_converse(messages)
+        assert msgs and msgs[0]["role"] == "user"
+        assert msgs[-1]["role"] == "user"
+
 
 # ---------------------------------------------------------------------------
 # Response normalization: Converse → OpenAI


### PR DESCRIPTION
## Summary

Bedrock Converse rejects an assistant message whose content is a lone `reasoningContent` block as **assistant prefill** on newer models (`claude-sonnet-5`, `claude-fable-5-1`), killing the whole request with `ValidationException` even when a user turn follows. Older models (`claude-sonnet-4-6`) tolerate the shape, which is why this only surfaces now.

## Root cause

`convert_messages_to_converse()` (`agent/bedrock_adapter.py`) replayed `_assistant_blocks(msg, content)` verbatim. An assistant turn whose only payload is reasoning reaches Converse as:

```json
{"role": "assistant", "content": [{"reasoningContent": {"redactedContent": "..."}}]}
```

Two paths produce this shape:
- the authoritative `bedrock_content_blocks` sidecar captured at normalization time and replayed by `_replay_ordered_blocks()` — this shape survives `_is_thinking_only_assistant` because that sanitizer never inspects `bedrock_content_blocks`;
- `reasoning_details` redacted thinking with no text and no tool calls — reachable via the aux/summary Converse path (`BedrockAuxiliaryClient` → `call_converse`), which has no thinking-only sanitizer in front of it.

## Fix

In the `role == "assistant"` branch of `convert_messages_to_converse()`: drop a turn whose converted block list is non-empty and consists exclusively of `reasoningContent` blocks.

- Such a turn carries no text and no `toolUse`, so no tool pairing can dangle.
- Same-role neighbours already merge in `append_turn`, so user/assistant alternation stays valid; the existing first/last-user padding covers the edges.
- Turns with reasoning + text or reasoning + `toolUse` are untouched — interleaved replay and tool pairing stay byte-exact (covered by `test_bedrock_transport_replay.py`).

Fixes #105780.

## Testing

- `tests/agent/test_bedrock_adapter.py`: three regression tests — sidecar shape, `reasoning_details` shape, and a leading reasoning-only turn keeping the user-first invariant. Verified RED on the unfixed adapter (tests fail with the old pass-through behaviour) and GREEN with the fix.
- Full local run: `test_bedrock_adapter.py` + `test_bedrock_transport_replay.py` + `test_bedrock_empty_text_blocks.py` — 86 passed.
- `ruff check` clean; `ruff format --diff` delta on touched files equals the pre-existing baseline (no new formatter complaints on my lines).