### PR TITLE
fix(bedrock): drop reasoning-only assistant turns Bedrock rejects as prefill (#105780)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -583,7 +583,16 @@ def convert_messages_to_converse(messages: List[Dict]) -> Tuple[Optional[List[Di
             append_turn("user", [{"toolResult": {
                 "toolUseId": msg.get("tool_call_id", ""), "content": [{"text": _safe_text(result_content)}]}}])
         elif role == "assistant":
-            append_turn("assistant", _assistant_blocks(msg, content) or [dict(_PLACEHOLDER_BLOCK)])
+            blocks = _assistant_blocks(msg, content)
+            if blocks and all("reasoningContent" in b for b in blocks):
+                # Bedrock Sonnet 5 / Fable 5.1 reject an assistant turn whose only
+                # payload is reasoningContent (no text/toolUse) as illegal prefill
+                # (#105780). Drop the turn: Bedrock does not need its own prior
+                # reasoning replayed (it stays in the trajectory's reasoning_details
+                # sidecar), and the following user turn (or the tail pad below)
+                # remains the last message Bedrock sees.
+                continue
+            append_turn("assistant", blocks or [dict(_PLACEHOLDER_BLOCK)])
         elif role == "user":
             append_turn("user", _convert_content_to_converse(content))
     if converse_msgs and converse_msgs[0]["role"] != "user":

--- a/tests/agent/test_bedrock_reasoning_only_assistant.py
+++ b/tests/agent/test_bedrock_reasoning_only_assistant.py
@@ -1,0 +1,131 @@
+"""Regression tests for Bedrock Converse reasoning-only assistant turn rejection.
+
+Bedrock's Converse API raises on Sonnet 5 / Fable 5.1::
+
+    ValidationException: This model does not support assistant message prefill.
+    The conversation must end with a user message.
+
+when an assistant turn in the conversation history contains ONLY ``reasoningContent``
+blocks (redacted thinking, no text, no toolUse) — e.g. a reasoning-only turn produced
+by claude-sonnet-5 or claude-fable-5-1 with extended thinking. Older models
+(claude-sonnet-4-6) tolerate it. Ref: issue #105780.
+
+``convert_messages_to_converse`` drops such turns: Bedrock does not need its own prior
+reasoning replayed (it stays in the trajectory's ``reasoning_details`` sidecar), and the
+following user turn (or the tail pad) remains the last message Bedrock sees. Populated
+turns (reasoning + text, reasoning + toolUse) are kept.
+"""
+from agent.bedrock_adapter import convert_messages_to_converse
+
+# "decryptedreasoning" base64 — _decode_redacted accepts strict base64 and returns bytes.
+_REASONING_B64 = "ZGVjcnlwdGVkcmVhc29uaW5n"
+
+
+def _reasoning_only_assistant():
+    """An assistant turn whose only payload is redacted reasoning (no text/toolUse)."""
+    return {
+        "role": "assistant",
+        "content": None,
+        "reasoning_details": [{"type": "redacted_thinking", "data": _REASONING_B64}],
+    }
+
+
+def test_reasoning_only_assistant_turn_is_dropped():
+    messages = [
+        {"role": "user", "content": "what is 2+2?"},
+        _reasoning_only_assistant(),
+        {"role": "user", "content": "and 3+3?"},
+    ]
+    _system, msgs = convert_messages_to_converse(messages)
+    # No assistant turn survives — the two user turns merge into one (same-role merge).
+    assert [m["role"] for m in msgs] == ["user"]
+    # No reasoningContent block reaches Bedrock.
+    assert all("reasoningContent" not in b for m in msgs for b in m["content"])
+
+
+def test_reasoning_only_assistant_at_tail_pads_user_last():
+    messages = [
+        {"role": "user", "content": "q"},
+        _reasoning_only_assistant(),
+    ]
+    _system, msgs = convert_messages_to_converse(messages)
+    # The reasoning-only assistant is dropped, so the tail pad adds a user turn.
+    assert msgs[-1]["role"] == "user"
+    assert all("reasoningContent" not in b for m in msgs for b in m["content"])
+
+
+def test_reasoning_only_assistant_at_head_pads_user_first():
+    messages = [
+        _reasoning_only_assistant(),
+        {"role": "user", "content": "q"},
+    ]
+    _system, msgs = convert_messages_to_converse(messages)
+    assert msgs[0]["role"] == "user"
+    assert msgs[-1]["role"] == "user"
+    assert all("reasoningContent" not in b for m in msgs for b in m["content"])
+
+
+def test_reasoning_plus_text_assistant_turn_is_kept():
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_details": [{"type": "redacted_thinking", "data": _REASONING_B64}],
+        },
+        {"role": "user", "content": "next"},
+    ]
+    _system, msgs = convert_messages_to_converse(messages)
+    # The assistant turn has text, so it survives — alternation user/assistant/user.
+    assert [m["role"] for m in msgs] == ["user", "assistant", "user"]
+    assistant_blocks = msgs[1]["content"]
+    assert any("text" in b for b in assistant_blocks)
+    assert any("reasoningContent" in b for b in assistant_blocks)
+
+
+def test_reasoning_plus_tooluse_assistant_turn_is_kept():
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": None,
+            "reasoning_details": [{"type": "redacted_thinking", "data": _REASONING_B64}],
+            "tool_calls": [{"id": "call_1", "function": {"name": "calc", "arguments": '{"x":1}'}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "2"},
+        {"role": "user", "content": "next"},
+    ]
+    _system, msgs = convert_messages_to_converse(messages)
+    # The assistant turn has a toolUse, so it survives (reasoning + toolUse).
+    assert "assistant" in [m["role"] for m in msgs]
+    assistant = next(m for m in msgs if m["role"] == "assistant")
+    assert any("toolUse" in b for b in assistant["content"])
+    assert any("reasoningContent" in b for b in assistant["content"])
+
+
+def test_bedrock_content_blocks_sidecar_reasoning_only_is_dropped():
+    """The ordered bedrock_content_blocks sidecar path also drops reasoning-only turns."""
+    messages = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": None,
+            "bedrock_content_blocks": [{"reasoningContent": {"text": "internal reasoning"}}],
+        },
+        {"role": "user", "content": "next"},
+    ]
+    _system, msgs = convert_messages_to_converse(messages)
+    assert [m["role"] for m in msgs] == ["user"]
+    assert all("reasoningContent" not in b for m in msgs for b in m["content"])
+
+
+def test_text_only_assistant_turn_is_kept():
+    """Sanity: a normal text-only assistant turn is unaffected by the reasoning-only guard."""
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "answer"},
+        {"role": "user", "content": "next"},
+    ]
+    _system, msgs = convert_messages_to_converse(messages)
+    assert [m["role"] for m in msgs] == ["user", "assistant", "user"]
+    assert msgs[1]["content"] == [{"text": "answer"}]


### PR DESCRIPTION
## What does this PR do?

Drops assistant turns whose **only** payload is `reasoningContent` (redacted thinking, no text, no `toolUse`) before they are sent to the AWS Bedrock Converse API. Such turns make **claude-sonnet-5 / claude-fable-5-1** raise `ValidationException` ("This model does not support assistant message prefill. The conversation must end with a user message."). Older models (claude-sonnet-4-6) tolerate them.

## Related Issue

Fixes #105780

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

`agent/bedrock_adapter.py` — `convert_messages_to_converse()`, assistant branch:

Before, every assistant turn was appended unconditionally:

```python
elif role == "assistant":
    append_turn("assistant", _assistant_blocks(msg, content) or [dict(_PLACEHOLDER_BLOCK)])
```

After, a reasoning-only turn is skipped so it never reaches Bedrock:

```python
elif role == "assistant":
    blocks = _assistant_blocks(msg, content)
    if blocks and all("reasoningContent" in b for b in blocks):
        # Bedrock Sonnet 5 / Fable 5.1 reject an assistant turn whose only
        # payload is reasoningContent (no text/toolUse) as illegal prefill
        # (#105780). Drop the turn: Bedrock does not need its own prior
        # reasoning replayed (it stays in the trajectory's reasoning_details
        # sidecar), and the following user turn (or the tail pad below)
        # remains the last message Bedrock sees.
        continue
    append_turn("assistant", blocks or [dict(_PLACEHOLDER_BLOCK)])
```

Why this is safe:

- **No reasoning is lost.** The redacted/encrypted reasoning stays in the trajectory's `reasoning_details` sidecar (and the `bedrock_content_blocks` ordered sidecar). It is simply not *replayed* to Bedrock, which never needs its own prior reasoning — Bedrock generated it.
- **Alternation is preserved.** Dropping the reasoning-only assistant turn lets the surrounding user turns merge (same-role merge already exists), and the existing head/tail pad still guarantees a user turn is first and last — exactly what Converse requires.
- **Populated turns are untouched.** The guard uses `all("reasoningContent" in b for b in blocks)`, so a turn with `reasoningContent` + `text`, or `reasoningContent` + `toolUse`, is **kept** (a `text`/`toolUse` block makes the `all(...)` false). Only *pure* reasoning-only turns are dropped.
- **Both reconstruction paths covered.** `_assistant_blocks` produces reasoning-only blocks from either `reasoning_details` (`redactedContent` bytes) or the `bedrock_content_blocks` sidecar; the guard matches both.

## How to Test

```
.venv/bin/python -m pytest tests/agent/test_bedrock_reasoning_only_assistant.py -q
```

New regression tests (`tests/agent/test_bedrock_reasoning_only_assistant.py`, 7 cases):

1. `test_reasoning_only_assistant_turn_is_dropped` — reasoning-only turn between two user turns is dropped; the users merge; no `reasoningContent` reaches Bedrock.
2. `test_reasoning_only_assistant_at_tail_pads_user_last` — reasoning-only as the last turn is dropped and the tail pad restores a user-last conversation.
3. `test_reasoning_only_assistant_at_head_pads_user_first` — reasoning-only as the first turn is dropped and the head pad restores a user-first conversation.
4. `test_reasoning_plus_text_assistant_turn_is_kept` — reasoning + text survives; alternation `user/assistant/user` intact; both blocks present.
5. `test_reasoning_plus_tooluse_assistant_turn_is_kept` — reasoning + `toolUse` survives; both blocks present.
6. `test_bedrock_content_blocks_sidecar_reasoning_only_is_dropped` — the ordered `bedrock_content_blocks` sidecar path also drops reasoning-only turns.
7. `test_text_only_assistant_turn_is_kept` — sanity: a normal text-only assistant turn is unaffected by the new guard.

All 7 pass. The existing `test_bedrock_empty_text_blocks.py` (#9486 placeholder) and `test_bedrock_adapter.py` suites are unchanged and green.

## Checklist

### Code
- [x] My code follows the style guidelines (ruff clean on both files)
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective and that populated turns are preserved
- [x] New and existing unit tests pass locally (7/7 new; existing bedrock suites green)

### Documentation & Housekeeping
- [x] The change is documented in the inline comment with the issue reference (#105780)
- [x] No user-facing CLI/config change — no docs update needed
