### PR TITLE
fix: resolve systemd scope probe executable from PATH

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1885,6 +1885,27 @@ class TestSystemdCgroupIsolation:
     ENTIRE gateway cgroup, taking down the messaging control plane.
     """
 
+    def test_scope_probe_resolves_true_from_path(self, monkeypatch):
+        """The probe must work on NixOS, where /bin/true does not exist."""
+        import tools.process_registry as process_registry
+
+        monkeypatch.setattr(process_registry, "_IS_LINUX", True)
+        process_registry._SYSTEMD_SCOPE_AVAILABLE = None
+        process_registry._SYSTEMD_SCOPE_PROBED_AT = 0.0
+
+        binaries = {
+            "systemd-run": "/nix/systemd-run",
+            "true": "/nix/true",
+        }
+        monkeypatch.setattr("shutil.which", binaries.get)
+        completed = MagicMock(return_value=MagicMock(returncode=0, stderr=b""))
+        monkeypatch.setattr(process_registry.subprocess, "run", completed)
+
+        assert process_registry._systemd_run_user_scope_available() is True
+        argv = completed.call_args.args[0]
+        assert argv[-1] == "/nix/true"
+        assert "/bin/true" not in argv
+
     @pytest.fixture()
     def _gateway_identity(self, monkeypatch):
         """Opt-in: mark this test as running AS the live gateway process."""

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -150,7 +150,7 @@ def _systemd_run_user_scope_available() -> bool:
     """True if ``systemd-run --user --scope`` can create a cgroup.
     ``shutil.which`` alone is insufficient: system services and containers may lack
     the user D-Bus bus even with the binary on PATH (every spawn would fail with
-    ``Failed to connect to user bus``), so a cheap ``/bin/true`` probe is run and cached."""
+    ``Failed to connect to user bus``), so a cheap PATH-resolved ``true`` probe is run and cached."""
     global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
     verdict = _systemd_scope_cached()
     if verdict is not None:
@@ -170,8 +170,9 @@ def _systemd_run_user_scope_available() -> bool:
                 if binary:
                     # Unique unit avoids collisions; the timeout bounds D-Bus.
                     probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+                    probe_true = shutil.which("true") or "/bin/true"
                     result = subprocess.run(
-                        _systemd_scope_argv(binary, probe_unit, "/bin/true"), capture_output=True, timeout=3,
+                        _systemd_scope_argv(binary, probe_unit, probe_true), capture_output=True, timeout=3,
                     )
                     available = result.returncode == 0
                     if not available:


### PR DESCRIPTION
## Summary

- Resolve the `true` executable through `PATH` for the restart-safe systemd scope probe.
- Preserve `/bin/true` as a fallback for conventional Linux systems.
- Add a regression test covering NixOS-style executable paths.

On NixOS, `/bin/true` may not exist while `true` is available at `/run/current-system/sw/bin/true`. The existing hard-coded probe incorrectly marked `systemd-run --user --scope` unavailable, causing supervised cron workers to fail before execution.

## Test plan

- `python -m pytest -q tests/tools/test_process_registry.py -k scope_probe_resolves_true_from_path`
- `python -m pytest -q tests/tools/test_process_registry.py`

Both were run inside Microsandbox. Result: 104 passed, 4 skipped for the full test file.
