### PR TITLE
fix(desktop): keep running subagents out of Done in status view

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -1,18 +1,31 @@
-import { cleanup, render } from '@testing-library/react'
+import { act, cleanup, render } from '@testing-library/react'
 import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $backgroundStatusBySession } from '@/store/composer-status'
+import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import { $subagentsBySession, type SubagentProgress } from '@/store/subagents'
 
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import type { VirtualSessionListProps } from './virtual-session-list'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  clearAllSessionStates()
+  $subagentsBySession.set({})
+  $backgroundStatusBySession.set({})
+})
+
+const statusDivider = { working: 'Working', done: 'Done' }
 
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
     t: {
       sidebar: {
+        statusDivider,
+        projects: { toggle: (label: string) => label },
         dateDivider: {
           earlierThisMonth: 'Earlier this month',
           lastMonth: 'Last month',
@@ -58,6 +71,66 @@ function generateSessions(count: number): SessionInfo[] {
 }
 
 const noop = () => {}
+
+it('keeps a parked parent Working until its last child and background task settle', () => {
+  const parent = makeSession('stored-parent')
+  publishSessionState('runtime-parent', { ...createClientSessionState(parent.id), busy: false })
+
+  const child = (id: string, status: SubagentProgress['status']): SubagentProgress => ({
+    id,
+    status,
+    parentId: null,
+    goal: 'test task',
+    taskCount: 2,
+    taskIndex: 0,
+    startedAt: 0,
+    updatedAt: 0,
+    filesRead: [],
+    filesWritten: [],
+    stream: []
+  })
+
+  const { container } = render(
+    <SidebarSessionsSection
+      activeSessionId={null}
+      emptyState={null}
+      grouping="status"
+      label="Sessions"
+      onArchiveSession={noop}
+      onDeleteSession={noop}
+      onResumeSession={noop}
+      onToggle={noop}
+      onTogglePin={noop}
+      onToggleUnread={noop}
+      open
+      pinned={false}
+      sessions={[parent]}
+    />
+  )
+
+  expect(container.textContent).toContain('Done')
+
+  for (const status of ['queued', 'running'] as const) {
+    act(() => $subagentsBySession.set({ 'runtime-parent': [child('a', status), child('b', 'running')] }))
+    expect(container.textContent).toContain('Working')
+    expect(container.textContent).not.toContain('Done')
+  }
+
+  act(() => $subagentsBySession.set({ 'runtime-parent': [child('a', 'completed'), child('b', 'running')] }))
+  expect(container.textContent).toContain('Working')
+
+  act(() =>
+    $backgroundStatusBySession.set({
+      'runtime-parent': [{ id: 'process', type: 'background', state: 'running', title: 'test process' }]
+    })
+  )
+  act(() => $subagentsBySession.set({ 'runtime-parent': [child('a', 'completed'), child('b', 'failed')] }))
+  expect(container.textContent).toContain('Working')
+
+  act(() => $backgroundStatusBySession.set({}))
+  expect(container.textContent).toContain('Done')
+  expect(container.textContent).not.toContain('Working')
+})
 
 describe('SidebarSessionsSection memoization & virtualizer stability', () => {
   it('memoizes flatRows and passes the exact same rows array reference across parent re-renders', () => {

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -27,7 +27,7 @@ import {
   toggleWorkspaceNodeCollapsed
 } from '@/store/layout'
 import { sessionPinId } from '@/store/session'
-import { $sessionDotStateById, hasLiveTurn } from '@/store/session-dot-state'
+import { $sessionDotStateById, sessionStatusBucket } from '@/store/session-dot-state'
 
 import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
 import { mergeVisibleReorder, orderRowsWithinGroups, reorderableRowIds } from './order'
@@ -396,7 +396,12 @@ export function SidebarSessionsSection({
         : grouping === 'status'
           ? groupEntriesByStatus(
               displayEntries,
-              entry => hasLiveTurn(dotStates[entry.session.id] ?? 'idle'),
+              entry => {
+                // ponytail: reuse the status filter's buckets; child work is not a live parent turn.
+                const bucket = sessionStatusBucket(dotStates[entry.session.id])
+
+                return bucket === 'working' || bucket === 'needs-input'
+              },
               statusDividerLabels
             )
           : toSessionRows(displayEntries)


### PR DESCRIPTION
## What does this PR do?

**A session must not appear under Done while its subagents or background terminal commands are still running.**

With **Sessions → Filters → Grouping → Status**, a parent that returns while delegated work continues is grouped under **Done**. The existing status store already knows about that work; the grouping consumer checks only whether the parent has a live turn. Users monitoring multiple sessions therefore receive a false completion signal.

Reuse `sessionStatusBucket`, already used by status filtering and ordering, at this one grouping call site. Background/delegated work stays **Working** until it settles. Sessions needing input remain Working. Normal idle/unread/draft sessions remain Done.

This does **not** make the parent appear to be thinking while its children work. No dot, spinner, execution, or delegation-lifecycle changes.

## Related Issue

No issue claimed as fixed. Related work inspected:
- #87915 addresses broader parent/delegation lifecycle and rehydration. This patch only corrects the grouping consumer using existing main-branch state.
- #103370 adds purple subagent/background indicators while preserving parent live-turn semantics. This grouping correction is complementary; it does not duplicate that visual treatment.

**Suggested triage: P2.** This is misleading activity/completion reporting with a workaround (inspect the session), not evidence of execution failure or data loss.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/sessions-section.tsx`: classify Working/Done using the existing activity bucket rather than parent-only `hasLiveTurn`.
- `apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx`: one real-store component lifecycle regression, including stored/runtime identity mapping, child activity, partial completion, failed/completed children, remaining terminal background work, and final settlement. Reset stores after tests.
- No dependencies, configuration, polling, strings, or backend changes.

## How to Test

1. Choose **Grouping → Status** in the Sessions sidebar.
2. Start delegated work and let the parent return while a child remains active.
3. Before: the session appears under Done. After: it remains under Working.
4. Finish the children while a background terminal command remains active: still Working.
5. Let all work settle: Done, unless another active/input signal remains.

### Verification

- Reproduced on unmodified upstream `d4d4ecfae0`: component regression expected Working, received `SessionsDonestored-parent`.
- After rebasing onto `8aa219ef60`: **39 focused tests pass**, renderer/Electron/E2E typecheck passes, changed-file lint passes, production build passes.
- Local-only Electron QA harness: **1 passed**, real backend and delegation path with held mock inference. Verified Working after the parent ends, then Done after all work settles. Harness is not part of the production diff.
- Packaged macOS build tested interactively with **real subagent execution and a real background terminal command**; Working grouping confirmed by the tester. The unchanged idle-looking row during background work is explicitly outside this fix and addressed separately by #103370.
- Earlier full-suite run on `d4d4ecfae0`: 9,488 passed, 6 skipped, 3 failed. The same three failures reproduced on the unchanged base (two voice-preference assertions and one POSIX managed SSH updater assertion). Full suite was not rerun after the final rebase.
- Independent read-only review found no actionable implementation/security regression. The component test does not independently isolate queued-only or needs-input cases; no claim of exhaustive state coverage.

## Checklist

- [x] Read contributing guidance and relevant AGENTS.md files.
- [x] Conventional commit; only the two related files changed.
- [x] Searched and inspected existing PRs; overlap explained above.
- [x] Added regression coverage and tested the actual Desktop workflow on macOS.
- [ ] `pytest tests/ -q`: not run; this is a renderer-only change.
- [x] Cross-platform impact considered: shared renderer logic only; Windows/Linux not exercised locally.
- [x] Documentation, config examples, architecture guidance, and tool schemas: N/A, no contract changes.
