### PR TITLE
fix(agent): OpenCode aux callers with no conversation scope still send a session header

### DIFF
--- a/agent/opencode_affinity.py
+++ b/agent/opencode_affinity.py
@@ -17,9 +17,35 @@ so the header cannot drift per code path.
 
 from __future__ import annotations
 
+import hashlib
+import os
+import threading
+import time
 from typing import Any, Optional
 
 OPENCODE_SESSION_HEADER = "x-opencode-session"
+
+_PROCESS_FALLBACK_KEY: Optional[str] = None
+_PROCESS_FALLBACK_LOCK = threading.Lock()
+
+
+def _process_affinity_key() -> str:
+    """Stable process-lifetime affinity key for OpenCode callers with NO conversation scope.
+
+    Post-turn auxiliary callers (goal judge, /loop, kanban loops) run on executor threads
+    where the turn-scoped affinity contextvars are not set. OpenCode's relay rejects headerless
+    requests with ``MissingSessionID`` (HTTP 400), so an empty scope must still send a header —
+    the process itself is the scope then. Cached once per process so repeated aux calls stay
+    pinned to one warm upstream; unique per process so concurrent Hermes instances don't share
+    a routing bucket.
+    """
+    global _PROCESS_FALLBACK_KEY
+    if _PROCESS_FALLBACK_KEY is None:
+        with _PROCESS_FALLBACK_LOCK:
+            if _PROCESS_FALLBACK_KEY is None:
+                seed = f"{os.getpid()}-{time.time_ns()}"
+                _PROCESS_FALLBACK_KEY = "aux-" + hashlib.sha256(seed.encode()).hexdigest()[:24]
+    return _PROCESS_FALLBACK_KEY
 
 
 def is_opencode_target(provider: Optional[str], base_url: Optional[str]) -> bool:
@@ -72,7 +98,10 @@ def opencode_session_headers(
         )
     except Exception:
         key = str(session_id or "")
-    return {OPENCODE_SESSION_HEADER: key} if key else {}
+    # Post-turn aux callers (goal judge, /loop, kanban) have no conversation scope at all.
+    # An empty header means OpenCode rejects the request with MissingSessionID — send a
+    # stable process-lifetime key instead so the process is its own affinity scope.
+    return {OPENCODE_SESSION_HEADER: key or _process_affinity_key()}
 
 
 def merge_opencode_session_headers(

--- a/tests/agent/test_opencode_session_affinity.py
+++ b/tests/agent/test_opencode_session_affinity.py
@@ -60,3 +60,22 @@ def test_auxiliary_calls_share_the_main_turn_session_key():
         assert "x-opencode-session" not in (other.get("extra_headers") or {})
     finally:
         aux._RUNTIME_MAIN_CONTEXT.reset(token)
+
+
+def test_no_conversation_scope_still_sends_stable_process_key():
+    """Post-turn aux callers (goal judge, /loop, kanban) run on executor threads with no
+    affinity contextvars. An empty header makes OpenCode's relay reject the request with
+    MissingSessionID (HTTP 400), so a scope-less OpenCode target must still send a header —
+    a stable process-lifetime key."""
+    from agent.opencode_affinity import _process_affinity_key, opencode_session_headers
+
+    first = opencode_session_headers("opencode-go", "https://opencode.ai/go/v1/", None)
+    second = opencode_session_headers("opencode-go", "https://opencode.ai/go/v1/", None)
+    assert first["x-opencode-session"] == second["x-opencode-session"]
+    assert first["x-opencode-session"].startswith("aux-")
+
+    # The key is stable for the life of the process and unique per process seed.
+    assert _process_affinity_key() == first["x-opencode-session"]
+
+    # Non-OpenCode targets are still left untouched.
+    assert opencode_session_headers("openrouter", "https://openrouter.ai/api/v1", None) == {}


### PR DESCRIPTION
## What does this PR do?

When the `/goal` judge's fallback walk lands on an OpenCode provider, every judge call dies with `HTTP 400 MissingSessionID`. Post-turn auxiliary callers (goal judge, `/loop`, kanban loops) run on executor threads where the turn-scoped affinity contextvars are not set and `_runtime_main_value('session_id')` is empty, so `agent/opencode_affinity.py::opencode_session_headers()` returned `{}` for OpenCode targets — and OpenCode's relay rejects headerless requests. The fix: when no conversational scope resolves, send a stable process-lifetime key (`aux-<sha24>`) so the process is its own affinity scope. Conversation-scoped calls are unchanged.

## Related Issue

Fixes #105802

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/opencode_affinity.py:32` — new `_process_affinity_key()`: process-lifetime affinity key (`aux-` + sha256[:24] of pid+time), cached once under a lock, so scope-less OpenCode aux calls stay pinned to one warm upstream and concurrent Hermes processes never share a routing bucket.
- `agent/opencode_affinity.py:104` — `opencode_session_headers()` now returns the header unconditionally for OpenCode targets (`key or _process_affinity_key()`) instead of dropping it when empty.
- `tests/agent/test_opencode_session_affinity.py:64` — new `test_no_conversation_scope_still_sends_stable_process_key`: pins the header-must-be-present invariant (stable key, `aux-` prefix, non-OpenCode targets untouched).

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_opencode_session_affinity.py` — 7/7 pass.
2. Red-on-base proof: `git stash push -- agent/opencode_affinity.py` then rerun — exactly the new test fails (1 failed, 6 passed); restore and all pass.
3. Manual repro of the issue: in a bare thread, `opencode_session_headers('opencode-go', 'https://opencode.ai/go/v1/', None)` returned `{}` before this change, `{"x-opencode-session": "aux-..."}` after.
4. Live wire check: a real `call_llm(task='goal_judge', ...)` fallback request to opencode-go with the stamped header completes without `MissingSessionID` (previously 400 on every attempt).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_opencode_session_affinity.py -q` and all tests pass (7/7)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (Python 3.11)

### Documentation and Housekeeping

- [x] My changes generate no new warnings
- [x] I have updated the docstrings where the header semantics are documented

## Merge Confidence

**HIGH** — one-module change, conversation-scoped behavior byte-identical (explicit ids and contextvar keys win as before), scope-less OpenCode calls previously 400'd deterministically so the new path can only replace a failure with a working pinned route. 7/7 targeted tests green, new test proven red on base.
