### PR TITLE
fix(gateway): print the duplicate-instance refusal to stderr

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4811,11 +4811,16 @@ async def _start_gateway_replace_existing_instance(existing_pid: int, replace: b
             "Another gateway instance is already running (PID %d, HERMES_HOME=%s). "
             "Use 'hermes gateway restart' to replace it, or 'hermes gateway stop' first.",
             existing_pid, hermes_home)
+        # stderr, not stdout: a service-manager-supervised gateway (launchd KeepAlive, systemd
+        # Restart=) drops stdout unless StandardOutPath is wired, while stderr is the stream the
+        # supervisor wrappers collect — a stdout-only refusal reads as a silent exit-1 crash-loop
+        # (#105781).
         print(
             f"\n❌ Gateway already running (PID {existing_pid}).\n"
             f"   Use 'hermes gateway restart' to replace it,\n"
             f"   or 'hermes gateway stop' to kill it first.\n"
-            f"   Or use 'hermes gateway run --replace' to auto-replace.\n")
+            f"   Or use 'hermes gateway run --replace' to auto-replace.\n",
+            file=sys.stderr)
         return False
 
     # Never signal a process not provably ours (a poisoned PID record → cross-profile restart loop).

--- a/tests/gateway/test_gateway_process_exit.py
+++ b/tests/gateway/test_gateway_process_exit.py
@@ -89,3 +89,17 @@ def test_exit_backstop_releases_pid_file_and_runtime_lock(monkeypatch):
     assert exc_info.value.code == 78
     remove_pid.assert_called_once_with()
     release_lock.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_instance_refusal_reaches_stderr(capsys):
+    """The duplicate-instance refusal must go to stderr: a service-manager-supervised gateway
+    (launchd KeepAlive, systemd Restart=) drops stdout unless StandardOutPath is wired, while
+    stderr is the stream supervisor wrappers collect and timestamp. A stdout-only refusal is a
+    silent exit-1 that the supervisor interprets as transient and retries forever (#105781)."""
+    refused = await gateway_run._start_gateway_replace_existing_instance(4242, replace=False)
+    captured = capsys.readouterr()
+
+    assert refused is False
+    assert "Gateway already running (PID 4242)" in captured.err
+    assert captured.out == ""


### PR DESCRIPTION
## What does this PR do?

A service-manager-supervised gateway (`hermes gateway run --external-supervisor` under launchd KeepAlive / systemd `Restart=`) that finds another gateway holding the runtime exits with code 1 within milliseconds — and until now the refusal was effectively invisible: launchd reads it as a transient failure and retries forever, with nothing in the logs an operator would look at (#105781).

Why it was silent: `--external-supervisor` marks the process as supervisor-launched, which intentionally short-circuits both CLI-level conflict guards (`_guard_supervised_gateway_conflict`, `_guard_existing_gateway_process_conflict` — they must never wedge the service into a refusal loop). The authoritative check then happens inside `start_gateway` → `_start_gateway_replace_existing_instance(replace=False)`, which prints the boxed refusal to **stdout**. A supervised process's stdout is dropped unless the unit wires `StandardOutPath`, while stderr is exactly the stream supervisors collect (launchd's stderr wrapper timestamps it into `gateway.error.log`; systemd puts it in the journal). The `logger.error` companion line only reaches `logs/errors.log`, not the gateway logs an operator tails during a crash-loop.

Fix: print the refusal to **stderr** so the reason always lands where the supervisor's log pipeline can capture it. Interactive shells lose nothing — stderr is on the same terminal.

## Related Issue

Fixes #105781

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — `_start_gateway_replace_existing_instance`: the duplicate-instance refusal box now prints to `sys.stderr` instead of stdout, with a comment recording the supervisor-visibility constraint.
- `tests/gateway/test_gateway_process_exit.py` — new regression test asserting the refusal text lands on stderr and stdout stays empty.

## How to Test

1. Start a gateway (e.g. the installed launchd agent) and note its PID.
2. Reproduce the supervisor view by discarding stdout the way launchd does:
   `python -m hermes_cli.main gateway run --external-supervisor > /dev/null`
3. Observed result before: exits 1 with no visible reason anywhere an operator looks (`gateway.log` / `gateway.error.log`).
4. Observed result after: exits 1 and stderr (→ `gateway.error.log` via the supervisor's stderr wrapper, or the journal under systemd) shows:
   ```
   ❌ Gateway already running (PID <pid>).
      Use 'hermes gateway restart' to replace it, ...
   ```
   Verified live on macOS with the launchd-supervised agent holding the runtime.
5. `pytest tests/gateway/test_gateway_process_exit.py -q` → 4 passed (includes the new regression).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — `tests/gateway/` on this branch: 7880 passed; the 20 failures reproduce identically on clean `main@8aa219ef60` (environment/baseline, unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin, arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Live reproduction on macOS (launchd agent `ai.hermes.gateway` holding the runtime, stdout discarded to mimic the supervisor):

```
$ python -m hermes_cli.main gateway run --external-supervisor > /dev/null
$ echo $?
1
$ # stderr:
❌ Gateway already running (PID 54745).
   Use 'hermes gateway restart' to replace it,
   or 'hermes gateway stop' to kill it first.
   Or use 'hermes gateway run --replace' to auto-replace.
```
