### PR TITLE
fix(discord): isolate automation runs in persistent threads

### DIFF
--- a/cron/discord_threads.py
+++ b/cron/discord_threads.py
@@ -1,0 +1,152 @@
+"""Discord run notifications backed by the existing gateway session index."""
+
+import asyncio
+import hashlib
+
+from gateway.config import Platform
+from gateway.session import SessionSource, SessionStore
+from hermes_constants import get_hermes_home
+from hermes_time import now
+
+
+def _find_run_thread(store, run_id, parent_id):
+    for entry in store.list_sessions():
+        binding = entry.metadata.get("automation_run", {})
+        if binding.get("run_id") == run_id and binding.get("parent_chat_id") == parent_id:
+            return entry
+    return None
+
+
+def _bind_run_thread(store, job, thread_id, parent_id, content):
+    """Snapshot this run, never another run or the parent channel's history."""
+    source = SessionSource(
+        platform=Platform.DISCORD, chat_id=thread_id, thread_id=thread_id,
+        chat_type="thread", chat_name=job.get("name"),
+        user_id=(job.get("origin") or {}).get("user_id"),
+        automation_thread=True,
+    )
+    entry = store.get_or_create_session(source)
+    if not entry.metadata.get("automation_run"):
+        db = store._db
+        if db is None:
+            raise RuntimeError("Discord automation threads require the session database")
+        session_id = job.get("_cron_session_id")
+        messages = []
+        if session_id and db.get_session(session_id):
+            tip = db.get_compression_tip(session_id) or session_id
+            messages = db.get_messages_as_conversation(tip)
+        if not messages:
+            messages = [{"role": "user", "content": job.get("prompt") or job.get("name") or job["id"]}]
+        if not messages or messages[-1].get("content") != content:
+            messages.append({"role": "assistant", "content": content})
+        # The thread is not open yet, so this is initialization of a fresh
+        # conversation, never a rewrite of a user's ongoing conversation.
+        db.replace_messages(entry.session_id, messages)
+        store.set_session_metadata(entry.session_key, "automation_run", {
+            "automation_id": job["id"], "run_id": job["execution_id"],
+            "thread_id": thread_id, "parent_chat_id": parent_id,
+            "source_session_id": session_id,
+            "notification_hash": hashlib.sha256(content.encode()).hexdigest(),
+        })
+    return entry
+
+
+def _record_run_update(store, entry, content):
+    binding = entry.metadata["automation_run"]
+    digest = hashlib.sha256(content.encode()).hexdigest()
+    if digest != binding.get("notification_hash"):
+        session_id = store._db.get_compression_tip(entry.session_id) or entry.session_id
+        store._db.append_message(session_id, role="user", content=f"[Automation update]\n{content}")
+        store.set_session_metadata(entry.session_key, "automation_run", {
+            **binding, "notification_hash": digest,
+        })
+
+
+async def prepare_run_thread(job, config, pconfig, chat_id, content, adapter=None):
+    """Post a summary, persist its run context, then open its public thread.
+
+    Discord uses the starter message's ID as the thread ID, letting us save
+    the routing entry before replies can arrive. A retry reuses that entry.
+    DMs keep their existing delivery because Discord cannot thread them.
+    """
+    import aiohttp
+    from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+
+    store = getattr(adapter, "_session_store", None)
+    owns_store = store is None
+    if store is None:
+        store = await asyncio.to_thread(SessionStore, get_hermes_home() / "sessions", config)
+    if store._db is None:
+        raise RuntimeError("Discord automation threads require the session database")
+
+    try:
+        # The live client's HTTP implementation already handles Discord rate
+        # limits. Standalone cron uses the same configured Bot token and proxy.
+        client = getattr(adapter, "_client", None)
+        token = pconfig.token
+        if not client and not token:
+            from agent.secret_scope import get_secret
+            token = get_secret("DISCORD_BOT_TOKEN", "")
+        if not client and not token:
+            raise RuntimeError("DISCORD_BOT_TOKEN is not configured")
+        session_kwargs, request_kwargs = proxy_kwargs_for_aiohttp(
+            resolve_proxy_url(platform_env_var="DISCORD_PROXY")
+        )
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=30), **session_kwargs,
+        ) as http:
+            async def request(method, path, payload=None):
+                if client:
+                    from discord.http import Route
+                    return await client.http.request(Route(method, path), json=payload)
+                async with http.request(
+                    method, f"https://discord.com/api/v10{path}",
+                    headers={"Authorization": f"Bot {token}"},
+                    json=payload, **request_kwargs,
+                ) as response:
+                    if response.status not in (200, 201):
+                        raise RuntimeError(f"Discord thread API returned HTTP {response.status}")
+                    return await response.json()
+
+            channel = await request("GET", f"/channels/{chat_id}")
+            if channel["type"] in (1, 3):
+                return None
+            if channel["type"] in (10, 11, 12):
+                chat_id = str(channel["parent_id"])
+                channel = await request("GET", f"/channels/{chat_id}")
+            if channel["type"] not in (0, 5):
+                raise RuntimeError("Discord automation destination must be a text or announcement channel")
+            chat_id = str(chat_id)
+            entry = await asyncio.to_thread(_find_run_thread, store, job["execution_id"], chat_id)
+            name = " ".join(str(job.get("name") or job["id"]).split())[:75]
+            thread_name = f"{name} · {now().strftime('%b %d')}"
+            if entry is None:
+                summary = f"{name} — {job.get('_delivery_status', 'Completed')}\nDetails and follow-up in the thread."
+                nonce = hashlib.sha256(f"{job['execution_id']}:{chat_id}".encode()).hexdigest()[:24]
+                seed = await request("POST", f"/channels/{chat_id}/messages", {
+                    "content": summary, "allowed_mentions": {"parse": []},
+                    "nonce": nonce, "enforce_nonce": True,
+                })
+                entry = await asyncio.to_thread(
+                    _bind_run_thread, store, job, str(seed["id"]), chat_id, content,
+                )
+            binding = entry.metadata["automation_run"]
+            thread_id = binding["thread_id"]
+            if not binding.get("thread_created"):
+                # A crash after the REST call but before the metadata write is
+                # recoverable: GET the starter message to discover its thread.
+                seed = await request("GET", f"/channels/{chat_id}/messages/{thread_id}")
+                if not seed.get("thread"):
+                    await request("POST", f"/channels/{chat_id}/messages/{thread_id}/threads", {
+                        "name": thread_name, "auto_archive_duration": 1440,
+                    })
+                await asyncio.to_thread(store.set_session_metadata, entry.session_key, "automation_run", {
+                    **binding, "thread_created": True,
+                })
+            if adapter is not None:
+                await asyncio.to_thread(adapter._threads.mark, thread_id)
+            await asyncio.to_thread(_record_run_update, store, entry, content)
+            return thread_id
+    finally:
+        if owns_store:
+            await asyncio.to_thread(store._db.close)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3140,6 +3140,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     from tools.send_message_tool import _send_to_platform
     from gateway.config import load_gateway_config, Platform
 
+    # Direct delivery callers also need a stable identity for this invocation.
+    job = dict(job)
+    job.setdefault("execution_id", uuid.uuid4().hex)
+
     # Optionally wrap the content with a header/footer so the user knows this
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
     # in config.yaml for clean output.
@@ -3473,8 +3477,40 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # the row first (F5).
         thread_seeded = False
         opened_thread_id: Optional[str] = None
+        discord_run_thread = False
+        if platform == Platform.DISCORD and not (transport and transport.is_relay):
+            from cron.discord_threads import prepare_run_thread
+
+            coro = prepare_run_thread(
+                job, config, pconfig, str(thread_id or chat_id), mirror_text,
+                runtime_adapter if live_adapter_ready else None,
+            )
+            try:
+                if live_adapter_ready:
+                    from agent.async_utils import safe_schedule_threadsafe
+                    future = safe_schedule_threadsafe(coro, loop)
+                    if future is None:
+                        raise RuntimeError("Discord gateway loop is unavailable")
+                    try:
+                        run_thread_id = future.result(timeout=60)
+                    except concurrent.futures.TimeoutError:
+                        future.cancel()
+                        raise
+                else:
+                    run_thread_id = asyncio.run(coro)
+                if run_thread_id:
+                    thread_id = run_thread_id
+                    discord_run_thread = thread_seeded = True
+                    in_channel_surface = False
+                    mirror_this_target = False
+            except Exception as exc:
+                coro.close()
+                delivery_errors.append(f"Discord automation thread preparation failed: {exc}")
+                # Never dump this run into the shared channel after a failure.
+                continue
         if (
             mirror_this_target
+            and not discord_run_thread
             and not in_channel_surface
             and runtime_adapter is not None
             and loop is not None
@@ -5820,7 +5856,8 @@ def run_job(
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return True, "", SILENT_MARKER, None
-    _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    _cron_session_id = f"cron_{job_id}_{job.get('execution_id') or uuid.uuid4().hex}"
+    job["_cron_session_id"] = _cron_session_id
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
@@ -7263,6 +7300,8 @@ def _run_one_job_body(
     execution_id = job.get("execution_id")
     if not execution_id:
         execution_id = create_execution(job["id"], source="direct")["id"]
+    # Run-local metadata must not leak back into the persisted job definition.
+    job = dict(job, execution_id=execution_id)
     delivery_attempted = False
     delivery_error = None
     # Durable failure-incident bookkeeping for this run (see cron.incidents):
@@ -7514,6 +7553,7 @@ def _run_one_job_body(
                         if not owns_delivery:
                             raise _FireClaimLostDuringSideEffect
                         delivery_attempted = True
+                        job["_delivery_status"] = "Completed" if success else "Needs attention"
                         delivery_error = _deliver_result(
                             job,
                             deliver_content,
@@ -7672,6 +7712,7 @@ def _run_one_job_body(
             else:
                 try:
                     delivery_attempted = True
+                    job["_delivery_status"] = "Needs attention"
                     delivery_error = _deliver_result(
                         job,
                         # Composed exactly like the normal failure delivery above.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -219,6 +219,10 @@ class SessionSource:
     # forge it across the wire or have it restored from persistence.
     delivered_via_upstream_relay: bool = False
 
+    # Local-only routing signal, resolved from the persisted automation binding.
+    # Never accept it from the wire: one automation thread is one conversation.
+    automation_thread: bool = False
+
     def __post_init__(self) -> None:
         # D-Q2.5 dual-field reconciliation: `scope_id` is canonical, `guild_id`
         # is the deprecated alias. Mirror whichever was provided onto the other
@@ -1063,7 +1067,7 @@ def is_shared_multi_user_session(
     if source.chat_type == "dm":
         return False
     if source.thread_id:
-        return not thread_sessions_per_user
+        return source.automation_thread or not thread_sessions_per_user
     return not group_sessions_per_user
 
 
@@ -1202,7 +1206,7 @@ def build_session_key(
     # conversation).  Per-user isolation only applies when explicitly enabled
     # via thread_sessions_per_user, or when there is no thread (regular group).
     isolate_user = group_sessions_per_user
-    if effective_thread_id and not thread_sessions_per_user:
+    if effective_thread_id and (source.automation_thread or not thread_sessions_per_user):
         isolate_user = False
 
     if isolate_user and participant_id:
@@ -2115,6 +2119,16 @@ class SessionStore:
             had_activity = bool(row.get("message_count") or 0) or (
                 last_activity is not None
             )
+        metadata = {}
+        # Agent shutdown/compression rebuilds SessionEntry from the session
+        # row. Keep the run binding stored in the routing index, including
+        # its no-expiry policy, when recovering that same conversation.
+        if source.platform == Platform.DISCORD and source.thread_id and self._db:
+            saved = self._db.load_gateway_routing_entries(scope=self._routing_scope()).get(session_key)
+            if saved:
+                previous = SessionEntry.from_dict(json.loads(saved))
+                if self._compression_tip_for_session_id(previous.session_id) == str(row["id"]):
+                    metadata = previous.metadata
         return SessionEntry(
             session_key=session_key,
             session_id=str(row["id"]),
@@ -2125,6 +2139,7 @@ class SessionStore:
             platform=source.platform,
             chat_type=source.chat_type,
             reset_had_activity=bool(had_activity),
+            metadata=metadata,
         )
 
     def _find_gateway_session_row(
@@ -2411,6 +2426,8 @@ class SessionStore:
         Used by the background expiry watcher to proactively flush memories.
         Sessions with active background processes are never considered expired.
         """
+        if entry.metadata.get("automation_run"):
+            return False
         if self._has_active_processes_safe(entry.session_key, context="expiry"):
             logger.debug(
                 "Session %s not expired — active background processes",
@@ -2467,6 +2484,8 @@ class SessionStore:
         resolving the policy are treated as "not finalizable" (safe: the idle
         sweep falls back to reaping the agent rather than pinning it).
         """
+        if entry.metadata.get("automation_run"):
+            return False
         try:
             policy = self.config.get_reset_policy(
                 platform=entry.platform,
@@ -2511,6 +2530,8 @@ class SessionStore:
         
         Sessions with active background processes are never reset.
         """
+        if entry.metadata.get("automation_run"):
+            return None
         session_key = self._generate_session_key(source)
         if self._has_active_processes_safe(session_key, context="reset"):
             logger.debug(
@@ -3071,6 +3092,25 @@ class SessionStore:
             if entry is None:
                 return default
             return entry.metadata.get(key, default)
+
+    def get_automation_thread(self, thread_id: str) -> Optional[SessionEntry]:
+        """Resolve a Discord run through the existing durable routing index."""
+        source = SessionSource(
+            platform=Platform.DISCORD, chat_id=str(thread_id),
+            thread_id=str(thread_id), chat_type="thread", automation_thread=True,
+        )
+        entry = self.lookup_by_session_key(self._generate_session_key(source))
+        if entry is None and self._db:
+            # A standalone cron process can publish a route after this
+            # gateway loaded its in-memory index.
+            key = self._generate_session_key(source)
+            saved = self._db.load_gateway_routing_entries(scope=self._routing_scope()).get(key)
+            if saved:
+                candidate = SessionEntry.from_dict(json.loads(saved))
+                if candidate.metadata.get("automation_run"):
+                    with self._lock:
+                        entry = self._entries.setdefault(key, candidate)
+        return entry if entry and entry.metadata.get("automation_run") else None
 
     def set_session_metadata(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2691,8 +2691,10 @@ class DiscordAdapter(BasePlatformAdapter):
             free_channels = self._discord_free_response_channels()
             in_bot_thread = (
                 isinstance(message.channel, discord.Thread)
-                and str(message.channel.id) in self._threads
-                and not self._discord_thread_require_mention()
+                and (await self._is_automation_thread(str(message.channel.id)) or (
+                    str(message.channel.id) in self._threads
+                    and not self._discord_thread_require_mention()
+                ))
             )
             if (
                 self._discord_require_mention()
@@ -8094,6 +8096,14 @@ class DiscordAdapter(BasePlatformAdapter):
                     raise Exception(f"HTTP {resp.status}")
                 return await resp.read()
 
+    async def _is_automation_thread(self, thread_id: Optional[str]) -> bool:
+        store = getattr(self, "_session_store", None)
+        if not thread_id or store is None:
+            return False
+        from gateway.session import SessionEntry
+        entry = await asyncio.to_thread(store.get_automation_thread, thread_id)
+        return isinstance(entry, SessionEntry)
+
     async def _handle_message(
         self,
         message: DiscordMessage,
@@ -8120,6 +8130,8 @@ class DiscordAdapter(BasePlatformAdapter):
         if is_thread:
             thread_id = str(message.channel.id)
             parent_channel_id = self._get_parent_channel_id(message.channel)
+
+        automation_thread = await self._is_automation_thread(thread_id)
 
         is_voice_linked_channel = False
 
@@ -8184,9 +8196,11 @@ class DiscordAdapter(BasePlatformAdapter):
             # are gated the same as channels.  Useful when multiple bots share
             # a thread.
             in_bot_thread = (
-                is_thread
-                and thread_id in self._threads
-                and not self._discord_thread_require_mention()
+                automation_thread or (
+                    is_thread
+                    and thread_id in self._threads
+                    and not self._discord_thread_require_mention()
+                )
             )
 
             if require_mention and not is_free_channel and not in_bot_thread:
@@ -8320,6 +8334,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 or self._derive_auto_thread_name(message.content or "")
             ) if auto_threaded_channel is not None else None,
         )
+
+        source.automation_thread = automation_thread
 
         # Build media URLs -- download image attachments to local cache so the
         # vision tool can access them reliably (Discord CDN URLs can expire).

--- a/tests/cron/test_discord_run_threads.py
+++ b/tests/cron/test_discord_run_threads.py
@@ -1,0 +1,200 @@
+"""Run delivery and inbound routing with real SQLite; only Discord is faked."""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cron.discord_threads import prepare_run_thread
+from cron.scheduler import _deliver_result
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.session import SessionSource, SessionStore, build_session_key
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+@pytest.fixture
+def setup(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    pconfig = PlatformConfig(enabled=True, token="test-token")
+    config = GatewayConfig(platforms={Platform.DISCORD: pconfig})
+    store = SessionStore(tmp_path / "sessions", config)
+    adapter = DiscordAdapter(pconfig)
+    adapter._session_store = store
+    calls, seeds, opened = [], {}, set()
+
+    async def request(route, *, json=None):
+        path = route.path
+        calls.append((route.method, path, json))
+        if path == "/channels/100":
+            return {"id": "100", "type": 0}
+        if path == "/channels/100/messages":
+            seed_id = str(200 + len(seeds))
+            seeds[seed_id] = json
+            return {"id": seed_id}
+        seed_id = path.split("/")[4]
+        if path.endswith("/threads"):
+            # The mapping and full context must already be durable when
+            # Discord makes the thread visible to participants.
+            fresh = SessionStore(tmp_path / "sessions", config)
+            entry = fresh.get_automation_thread(seed_id)
+            assert entry and fresh.load_transcript(entry.session_id)
+            opened.add(seed_id)
+            return {"id": seed_id}
+        return {"id": seed_id, **({"thread": {"id": seed_id}} if seed_id in opened else {})}
+
+    adapter._client = SimpleNamespace(http=SimpleNamespace(request=request), user=SimpleNamespace(id=999))
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="900"))
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
+    monkeypatch.setattr("cron.scheduler.load_config", lambda: {})
+    return config, pconfig, store, adapter, calls
+
+
+@pytest.mark.asyncio
+async def test_scheduler_delivers_each_run_to_its_own_durable_context(setup, tmp_path):
+    config, _, store, adapter, calls = setup
+    for run_id, name, detail in [("run-a", "YouTube Research", "Third topic: whales"), ("run-b", "GitHub Task", "Fix parser")]:
+        store._db.create_session(run_id, source="cron")
+        store._db.replace_messages(run_id, [
+            {"role": "user", "content": f"Research {name}"},
+            {"role": "assistant", "content": detail},
+        ])
+        error = await asyncio.to_thread(_deliver_result, {
+            "id": name, "name": name, "execution_id": run_id,
+            "_cron_session_id": run_id, "deliver": "discord:100",
+        }, detail, {Platform.DISCORD: adapter}, asyncio.get_running_loop())
+        assert error is None
+    assert len([call for call in calls if call[1] == "/channels/100/messages"]) == 2
+    destinations = [call.kwargs["metadata"]["thread_id"] for call in adapter.send.await_args_list]
+    assert destinations == ["200", "201"]
+    # Simulate a restart and an idle interval long enough to trigger normal
+    # session resets. The thread route must retain its conversation anyway.
+    restarted = SessionStore(tmp_path / "sessions", config)
+    entries = [restarted.get_automation_thread(t) for t in destinations]
+    assert entries[0].session_id != entries[1].session_id
+    for thread_id, entry in zip(destinations, entries):
+        entry.updated_at = datetime.now(timezone.utc) - timedelta(days=30)
+        source = SessionSource(platform=Platform.DISCORD, chat_id=thread_id,
+            thread_id=thread_id, chat_type="thread", user_id="42", automation_thread=True)
+        assert restarted.get_or_create_session(source).session_id == entry.session_id
+        assert not restarted._is_session_expired(entry)
+        assert not restarted.is_session_finalizable(entry)
+    assert "whales" in str(restarted.load_transcript(entries[0].session_id))
+    assert "Fix parser" not in str(restarted.load_transcript(entries[0].session_id))
+    assert entries[0].metadata["automation_run"]["run_id"] == "run-a"
+    # Normal agent teardown also ends a DB session. Recovery must retain
+    # the run binding instead of rebuilding an unlabelled expiring entry.
+    for entry in entries:
+        restarted._db.end_session(entry.session_id, "agent_close")
+    again = SessionStore(tmp_path / "sessions", config)
+    assert again.get_automation_thread("200").session_id == entries[0].session_id
+    assert again.get_automation_thread("201").session_id == entries[1].session_id
+    again._db.end_session(entries[0].session_id, "compression")
+    again._db.create_session("compressed", source="discord", parent_session_id=entries[0].session_id)
+    compressed = SessionStore(tmp_path / "sessions", config)
+    assert compressed.get_automation_thread("200").session_id == "compressed"
+    assert compressed.get_automation_thread("200").metadata["automation_run"]["run_id"] == "run-a"
+
+
+@pytest.mark.asyncio
+async def test_retry_reuses_thread_and_failure_never_sends_details_to_parent(setup):
+    config, pconfig, store, adapter, calls = setup
+    job = {"id": "job", "execution_id": "run", "name": "Research", "prompt": "Research whales"}
+    first = await prepare_run_thread(job, config, pconfig, "100", "Whales", adapter)
+    assert await prepare_run_thread(job, config, pconfig, "100", "Whales", adapter) == first
+    assert len([call for call in calls if call[1] == "/channels/100/messages"]) == 1
+    assert len(store.list_sessions()) == 1
+    assert await prepare_run_thread(job, config, pconfig, "100", "More whale research", adapter) == first
+    assert "More whale research" in str(store.load_transcript(store.get_automation_thread(first).session_id))
+    adapter._client.http.request = AsyncMock(side_effect=RuntimeError("Missing thread permission"))
+    error = await asyncio.to_thread(_deliver_result, dict(job, execution_id="failed-run", deliver="discord:100"),
+        "Private details", {Platform.DISCORD: adapter}, asyncio.get_running_loop())
+    assert "Missing thread permission" in error
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reply_without_mention_resolves_run_after_restart(setup, tmp_path, monkeypatch):
+    config, pconfig, _, adapter, _ = setup
+    config.thread_sessions_per_user = True
+    thread_id = await prepare_run_thread(
+        {"id": "youtube", "execution_id": "run", "name": "YouTube", "prompt": "Find topics"},
+        config, pconfig, "100", "Third topic: whales", adapter,
+    )
+    restarted = DiscordAdapter(pconfig)
+    restarted._session_store = SessionStore(tmp_path / "sessions", config)
+    restarted._client = SimpleNamespace(user=SimpleNamespace(id=999))
+    restarted._threads.clear()  # also exercises tracker eviction / missing cache
+    restarted._text_batch_delay_seconds = 0
+    restarted.handle_message = AsyncMock()
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+
+    class Thread:
+        id = int(thread_id)
+        name = "YouTube"
+        parent_id = 100
+        parent = SimpleNamespace(id=100, name="automation", topic=None)
+        guild = SimpleNamespace(id=1, name="Home")
+        def history(self, **kwargs):
+            async def empty():
+                for item in []:
+                    yield item
+            return empty()
+
+    monkeypatch.setattr("plugins.platforms.discord.adapter.discord.Thread", Thread)
+    message = SimpleNamespace(id=555, channel=Thread(), content="第三个选题继续研究",
+        author=SimpleNamespace(id=42, display_name="User", name="User", bot=False),
+        attachments=[], mentions=[], reference=None, created_at=datetime.now(timezone.utc), guild=Thread.guild)
+    assert await restarted._handle_message(message)
+    event = restarted.handle_message.await_args.args[0]
+    entry = restarted._session_store.get_automation_thread(thread_id)
+    assert event.source.chat_id == event.source.thread_id == thread_id
+    assert build_session_key(event.source, thread_sessions_per_user=True) == entry.session_key
+    assert restarted._session_store.get_or_create_session(event.source).session_id == entry.session_id
+    assert "whales" in str(restarted._session_store.load_transcript(entry.session_id))
+
+
+@pytest.mark.asyncio
+async def test_standalone_uses_existing_token_and_publishes_resumable_route(setup, monkeypatch):
+    config, pconfig, store, adapter, _ = setup
+    store.list_sessions()  # live gateway has already loaded its routing cache
+    handle = adapter._client.http.request
+
+    class Response:
+        status = 200
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *args):
+            pass
+        async def json(self):
+            return self.data
+
+    class HTTP:
+        def __init__(self, **kwargs):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *args):
+            pass
+        def request(self, method, url, *, headers, json, **kwargs):
+            assert headers["Authorization"] == "Bot test-token"
+            response = Response()
+            async def enter():
+                response.data = await handle(SimpleNamespace(method=method, path=url.split("/v10")[1]), json=json)
+                return response
+            class Pending(Response):
+                async def __aenter__(self):
+                    return await enter()
+            return Pending()
+
+    monkeypatch.setattr("aiohttp.ClientSession", HTTP)
+    thread_id = await prepare_run_thread(
+        {"id": "script", "execution_id": "script-run", "prompt": "Run report"},
+        config, pconfig, "100", "Script report", None,
+    )
+    entry = store.get_automation_thread(thread_id)
+    assert entry.metadata["automation_run"]["run_id"] == "script-run"
+    assert "Script report" in str(store.load_transcript(entry.session_id))

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -498,6 +498,7 @@ class TestDeliverResultWrapping:
 
         with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
              patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("cron.discord_threads.prepare_run_thread", new=AsyncMock(return_value="run-thread")), \
              patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
             _deliver_result(
                 job,
@@ -516,6 +517,8 @@ class TestDeliverResultWrapping:
         adapter.send_voice.assert_called_once()
         voice_call = adapter.send_voice.call_args
         assert voice_call[1]["audio_path"] == str(media_path)
+        assert adapter.send.call_args.kwargs["metadata"]["thread_id"] == "run-thread"
+        assert voice_call.kwargs["metadata"]["thread_id"] == "run-thread"
 
 
 class TestDeliverResultErrorReturns:

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -782,6 +782,28 @@ Notes:
 - When `voice_fx.enabled` is `false`, voice playback uses the original one-shot path and nothing changes.
 
 
+## Automation run threads
+
+Cron notifications sent by the native Discord Bot to a text or announcement
+channel now create one public thread per run. The channel receives a short
+completion or attention summary; details, attachments, and follow-up replies
+stay in the thread. Existing thread destinations create the new run's thread
+under their parent channel. The existing Bot token and delivery channel are reused.
+
+The gateway's existing `state.db` routing index stores the thread's session ID
+and `automation_run` metadata (job ID, execution ID, source session ID). Each
+thread starts with a snapshot of that run's conversation, or its prompt and
+output for script-only jobs. Replies resume this context after a restart,
+without requiring an @mention. Automatic daily/idle resets do not clear these
+run conversations; explicit `/new` still starts a fresh conversation.
+
+This does not require `cron.mirror_delivery` or `attach_to_session`. Creating
+the thread requires the Bot's Create Public Threads permission; replying
+requires Send Messages in Threads. Preparation failures are reported as delivery
+errors, without spilling the detailed output into the parent channel. DMs
+and relay transports retain their existing behavior. For automation delivery,
+use a text or announcement channel rather than a forum parent.
+
 ## Forum Channels
 
 Discord forum channels (type 15) don't accept direct messages — every post in a forum must be a thread. Hermes auto-detects forum channels and creates a new thread post whenever it needs to send there, so text replies, TTS, images, voice messages, and file attachments all work without special handling from the agent.
@@ -927,5 +949,4 @@ Leave `everyone` and `roles` at `false` unless you know exactly why you need the
 :::
 
 For more information on securing your Hermes Agent deployment, see the [Security Guide](../security.md).
-
 


### PR DESCRIPTION
## What does this PR do?

Native Discord cron delivery posts one summary in the configured server channel and opens a thread for each execution. Follow-up messages continue that run's conversation instead of the parent channel or another run. The existing Bot token, SessionStore, SQLite gateway routing index, and delivery pipeline are reused.

This draft is based on an existing installation at `a0a63a1bc21115ba8da7fed6fdb695522dd37c96`; it is deployed and validated against that baseline. It may need adaptation to the newer upstream scheduler/session decomposition before upstream merge.

## Related Issue

Related: #105160 (parent-channel discoverability for thread-delivered cron output).

## Type of Change

- [x] Bug fix

## Changes Made

- `cron/discord_threads.py`: create a starter message, persist the execution binding and run transcript before opening its thread, reuse the thread on delivery retries, and append subsequent run updates.
- `cron/scheduler.py`: retain a unique execution/session identity and send native Discord text and attachments to the prepared thread. Thread-creation failures are reported rather than posting details to the parent channel.
- `gateway/session.py`: reuse durable routing metadata to recover the conversation after restart, normal agent close, and context compression; automation threads share their run context without automatic idle resets.
- `plugins/platforms/discord/adapter.py`: resolve mapped thread replies without requiring a mention, including startup backfill, while retaining existing user/channel authorization.
- Four focused regressions, one existing media-delivery fixture update, and Discord documentation.

DMs and relay delivery keep their existing behavior. Native automation destinations support text and announcement channels; forum destinations report a delivery error. No new database, config keys, Bot, dependencies, or event bus.

## How to Test

1. Run `scripts/run_tests.sh tests/cron/test_discord_run_threads.py tests/cron/test_scheduler.py tests/gateway/test_session.py tests/cron/test_cron_thread_seed_dm_keying.py tests/cron/test_mirror_origin_fallback.py tests/gateway/test_discord_allowed_channels.py tests/gateway/test_discord_free_response.py tests/gateway/test_discord_missed_message_backfill.py tests/gateway/test_discord_thread_persistence.py tests/cron/test_scheduler_cron_session_isolation.py tests/cron/test_scheduler_completion_verification.py`.
2. Run two cron executions delivered to a Discord text channel. Verify separate summary messages and threads; text and media belong in each run's thread.
3. Reply in one thread without a mention, restart the gateway, and reply again. Verify the run transcript is retained and the other run's conversation remains separate.

Validation: 242 focused/regression tests passed through the canonical runner, Ruff passed for changed Python files, Python compilation passed, and `git diff --check` passed. macOS runtime restarted successfully at this commit and the existing Discord Bot reconnected. Live Discord verification also passed: two synthetic cron runs produced separate parent summaries and threads; unmentioned user replies returned different expected answers from the two run transcripts. After a graceful gateway restart, a follow-up in the first thread returned the same expected answer and retained the exact conversation ID. Automated regressions additionally cover compression and retry behavior using real SQLite/session routing with mocked Discord transport.

## Checklist

- [x] Read the contributing guide and searched related PRs/issues.
- [x] Conventional commit; only related changes.
- [x] Added regression coverage and updated relevant documentation.
- [x] Tested on macOS with Python 3.11.
- [ ] Full repository test suite (targeted suite run instead).
- [ ] Forward-port against current upstream main before requesting review.
