### PR TITLE
fix(gateway): redeliver failed obligations after in-place Telegram polling recovery

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1621,7 +1621,42 @@ class TelegramAdapter(BasePlatformAdapter):
             self._write_runtime_status_safe(
                 "connected", platform_state="connected", error_code=None, error_message=None,
             )
+            self._schedule_recovered_send_path_redelivery()
         self._send_path_degraded = False
+
+    def _schedule_recovered_send_path_redelivery(self) -> None:
+        """Replay this process's failed delivery obligations once polling recovers in place.
+
+        A final response rejected with ``send_path_degraded`` lands in the ledger as
+        ``state='failed'`` owned by the live gateway. The reconnect hook
+        (``_install_reconnected_adapter``) sweeps those rows, and ``_finalize_delivery_obligation``
+        compensates only when a replacement adapter took over — an in-place polling recovery is
+        neither, so the row would stay failed until restart even though the send path is
+        confirmed healthy seconds later. Reuse the runner's profile-scoped sweep: its atomic
+        claiming keeps a concurrent redelivery (flood timer, reconnect race) idempotent.
+        """
+        runner = getattr(self, "gateway_runner", None)
+        redeliver = getattr(runner, "_redeliver_failed_obligations_for_platform", None)
+        if not callable(redeliver):
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return  # no loop to schedule on (direct sync callers/tests); runtime paths always have one
+
+        async def _redeliver_recovered() -> None:
+            with contextlib.suppress(Exception):
+                result = redeliver(
+                    self.platform, profile=getattr(self, "_owner_profile", None)
+                )
+                if inspect.isawaitable(result):
+                    await result
+
+        task = asyncio.ensure_future(_redeliver_recovered())
+        tracked = getattr(self, "_background_tasks", None)
+        if tracked is not None:
+            tracked.add(task)
+            task.add_done_callback(tracked.discard)
 
     def _observe_polling_request_result(self, request, generation, result):
         """Record getUpdates progress from an observed do_request result (purely observational: PTB still

--- a/tests/gateway/test_telegram_send_path_health.py
+++ b/tests/gateway/test_telegram_send_path_health.py
@@ -5,6 +5,7 @@ can enter a wedged state where ``bot.send_message()`` returns a valid Message
 but nothing reaches the recipient.  ``_send_path_degraded`` short-circuits
 ``send()`` so cron's live-adapter branch falls through to standalone HTTP.
 """
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -182,4 +183,82 @@ def test_record_polling_progress_does_not_flip_when_not_running_or_fatal(running
         adapter._record_polling_progress(generation)
 
     write_status.assert_not_called()
+    assert adapter._send_path_degraded is False
+
+
+@pytest.mark.asyncio
+async def test_in_place_polling_recovery_sweeps_failed_obligations():
+    """An in-place polling recovery (no adapter replacement) must replay the
+    failed obligations the degraded send path stranded (#105804): the
+    reconnect hook never fires and the finalize compensation requires a
+    replacement adapter, so this sweep is the only redelivery trigger."""
+    adapter = _make_adapter()
+    generation, _event = adapter._begin_polling_generation()
+    adapter._running = True
+    redeliver = AsyncMock(return_value=0)
+    adapter.gateway_runner = MagicMock()
+    adapter.gateway_runner._redeliver_failed_obligations_for_platform = redeliver
+
+    with patch.object(adapter, "_write_runtime_status_safe"):
+        adapter._record_polling_progress(generation)
+    await asyncio.sleep(0)  # let the scheduled sweep task start
+
+    redeliver.assert_awaited_once_with(adapter.platform, profile=None)
+    assert adapter._send_path_degraded is False
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_in_place_polling_recovery_scopes_sweep_to_owner_profile():
+    """A secondary-profile adapter's sweep must claim only that profile's
+    rows, mirroring the reconnect hook's profile-scoped redelivery."""
+    adapter = _make_adapter()
+    generation, _event = adapter._begin_polling_generation()
+    adapter._running = True
+    adapter._owner_profile = "secondary"
+    redeliver = AsyncMock(return_value=0)
+    adapter.gateway_runner = MagicMock()
+    adapter.gateway_runner._redeliver_failed_obligations_for_platform = redeliver
+
+    with patch.object(adapter, "_write_runtime_status_safe"):
+        adapter._record_polling_progress(generation)
+    await asyncio.sleep(0)  # let the scheduled sweep task start
+
+    redeliver.assert_awaited_once_with(adapter.platform, profile="secondary")
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_healthy_progress_without_degraded_send_path_skips_sweep():
+    """Progress on an already-healthy send path must not spawn sweep tasks:
+    every getUpdates round-trip would otherwise schedule redundant ledger
+    queries."""
+    adapter = _make_adapter()
+    generation, _event = adapter._begin_polling_generation()
+    adapter._running = True
+    adapter._send_path_degraded = False
+    redeliver = AsyncMock(return_value=0)
+    adapter.gateway_runner = MagicMock()
+    adapter.gateway_runner._redeliver_failed_obligations_for_platform = redeliver
+
+    with patch.object(adapter, "_write_runtime_status_safe") as write_status:
+        adapter._record_polling_progress(generation)
+    await asyncio.sleep(0)
+
+    redeliver.assert_not_awaited()
+    write_status.assert_not_called()
+    await adapter.cancel_background_tasks()
+
+
+def test_polling_recovery_sweep_survives_missing_runner_or_loop():
+    """No gateway_runner wired (standalone adapter use): the sweep is a no-op,
+    not a crash. Same for sync callers with no running event loop."""
+    adapter = _make_adapter()
+    generation, _event = adapter._begin_polling_generation()
+    adapter._running = True
+
+    with patch.object(adapter, "_write_runtime_status_safe") as write_status:
+        adapter._record_polling_progress(generation)
+
+    write_status.assert_called_once()
     assert adapter._send_path_degraded is False


### PR DESCRIPTION
## Summary

With `gateway.delivery_ledger` enabled, a final response rejected with `send_path_degraded` during a Telegram polling outage is written to the ledger as `state='failed'` — and never redelivered when the same adapter's polling recovers seconds later, because:

- the reconnect-triggered replay (`_install_reconnected_adapter` → `_redeliver_failed_obligations_for_platform`) only fires on adapter **replacement**, not an in-place polling recovery;
- the compensation in `_finalize_delivery_obligation` (base.py) also requires a live **replacement** adapter (`live is not delivery_adapter`), false for in-place recovery;
- `_record_polling_progress` cleared `_send_path_degraded` and republished `connected` but never swept failed obligations.

**Fix:** when a confirmed getUpdates round-trip clears a previously-degraded send path, `_record_polling_progress` now schedules the runner's existing `_redeliver_failed_obligations_for_platform(platform, profile=<owner profile>)` — the same atomic-claim `sweep_failed_for_runtime` path the reconnect hook already uses. Redelivery stays idempotent (atomic claiming, attempts/staleness bounds), ownership-scoped to this process, and secondary-profile adapters get their own profile-scoped sweep.

Fixes #105804

## Testing

- `env -u HERMES_YOLO_MODE .venv/bin/python -m pytest tests/gateway/test_telegram_send_path_health.py -q` → **14 passed** (4 new regression tests: sweep fires on degraded→healthy transition, profile scoping, healthy-path skip, missing-runner/no-loop resilience)
- Neighbouring suites unaffected: `test_telegram_polling_health_confirmation.py` (4), `test_telegram_conflict.py` (10), `test_telegram_network_reconnect.py` (36), `test_telegram_polling_progress.py` (12), `test_telegram_start_polling_timeout.py` (3) — all green
- Mutation check: removing the sweep call makes the two redelivery tests fail (2 failed), restoring it makes them pass
- `ruff check` clean; `ruff format --diff` adds **0** new complaints vs clean main (verified by content-line diff against the stashed baseline)