### PR TITLE
fix(gateway): report launchd supervision truthfully through stderr-timestamp wrapper

### DIFF
--- a/contributors/emails/anfeng@anfengdeMacBook-Air.local
+++ b/contributors/emails/anfeng@anfengdeMacBook-Air.local
@@ -1,0 +1,2 @@
+anfeng-crystal
+# PR #105811 salvage (gateway: report launchd supervision truthfully through stderr-timestamp wrapper)

--- a/gateway/control_socket.py
+++ b/gateway/control_socket.py
@@ -19,6 +19,7 @@ import socket
 import sys
 import tempfile
 import time
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -76,22 +77,72 @@ def resolve_client_socket_path(home: Path) -> Optional[Path]:
     return None
 
 
+_LAUNCHD_ANCESTRY_MAX_HOPS = 4
+
+
+def _ancestor_xpc_service_labels(max_hops: int = _LAUNCHD_ANCESTRY_MAX_HOPS) -> list[str]:
+    """Non-empty ``XPC_SERVICE_NAME`` labels found in this process's ancestry, nearest first.
+
+    launchd stamps ``XPC_SERVICE_NAME=<job label>`` only on its direct child. Generated macOS
+    plists wrap the gateway in the ``hermes_cli.stderr_timestamp`` logger, so the gateway
+    grandchild sees ``XPC_SERVICE_NAME=0`` (the wrapper's own docstring documents the same) and
+    ``_detect_supervisor`` below used to degrade to the generic ``--external-supervisor`` claim.
+    Best-effort psutil walk, bounded; every failure just returns fewer labels.
+    """
+    labels: list[str] = []
+    try:
+        import psutil
+
+        proc = psutil.Process()
+        for _ in range(max_hops):
+            parent = proc.parent()
+            if parent is None or parent.pid <= 1:
+                break
+            with contextlib.suppress(Exception):
+                label = str(parent.environ().get("XPC_SERVICE_NAME", "")).strip()
+                if label and label != "0":
+                    labels.append(label)
+            proc = parent
+    except Exception:
+        pass
+    return labels
+
+
 def _detect_supervisor() -> str:
     """Supervisor kind for THIS process from its own launch env (not inferred outside-in).
+
+    Thin env-reading wrapper; the decision core is :func:`_supervisor_from_launch_context`
+    (platform as data) so the wrapped-launchd contract is testable on every host.
 
     Unlike the outside-in `_detect_supervisor_for_pid` scan, this answers from the process's own launch
     context — which is exactly the provenance the 92091 design wants declared rather than inferred. See
     #92091.
     """
-    env = os.environ
+    return _supervisor_from_launch_context(
+        os.environ, sys.argv,
+        is_darwin=sys.platform == "darwin",
+        ancestor_xpc_labels=_ancestor_xpc_service_labels() if sys.platform == "darwin" else (),
+    )
+
+
+def _supervisor_from_launch_context(
+    env: Mapping[str, str], argv: Sequence[str], *, is_darwin: bool,
+    ancestor_xpc_labels: Sequence[str] = (),
+) -> str:
+    """Decision core of :func:`_detect_supervisor`; pure, platform passed as data."""
     if env.get("INVOCATION_ID"):
         return "systemd"
-    if sys.platform == "darwin" and (env.get("XPC_SERVICE_NAME", "").startswith("ai.hermes")
-                                     or env.get("LAUNCHD_SOCKET")):
-        return "launchd"
+    if is_darwin:
+        if env.get("XPC_SERVICE_NAME", "").startswith("ai.hermes") or env.get("LAUNCHD_SOCKET"):
+            return "launchd"
+        # Generated launchd plists wrap the gateway in the stderr-timestamp logger; launchd stamps
+        # XPC_SERVICE_NAME only on the wrapper, so the gateway itself sees "0". Resolve the wrapped
+        # case through the wrapper's own env instead of degrading to the generic external claim.
+        if any(label.startswith("ai.hermes") for label in ancestor_xpc_labels):
+            return "launchd"
     if env.get("HERMES_DESKTOP_MANAGED"):
         return "desktop"
-    return "external" if "--external-supervisor" in sys.argv else "manual"
+    return "external" if "--external-supervisor" in argv else "manual"
 
 
 def build_identify_payload() -> dict[str, Any]:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -203,8 +203,28 @@ def _get_service_pids(all_profiles: bool = False) -> set:
                                 pass
             except (FileNotFoundError, subprocess.TimeoutExpired):
                 pass
+        # Generated plists wrap the gateway in the stderr-timestamp logger, so launchd's service
+        # PID is the WRAPPER while the gateway runs as its child. Without the descendants, the
+        # update's manual-gateway sweep classifies the freshly respawned gateway as a manual
+        # process and kills it right after the launchd restart (it comes back via KeepAlive, at
+        # the cost of a needless extra restart cycle). Over-inclusion is safe: these PIDs are
+        # only ever protected from the kill sweep, never targeted.
+        pids |= _descendant_pids(pids)
 
     return pids
+
+
+def _descendant_pids(pids: set) -> set:
+    """All descendant PIDs of ``pids`` (best effort, psutil; failures yield fewer)."""
+    descendants: set = set()
+    for pid in pids:
+        try:
+            import psutil
+
+            descendants.update(child.pid for child in psutil.Process(pid).children(recursive=True))
+        except Exception:
+            continue
+    return descendants
 
 
 def _get_parent_pid(pid: int) -> int | None:

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -648,6 +648,13 @@ def _surviving_gateway_pids_after_failed_restart():
 _MANUAL_GATEWAY_SKIP_REASON = (
     "manual gateway has no supervisor relaunch authority; left running for explicit operator restart"
 )
+# A gateway declaring supervisor "external" launched with ``--external-supervisor``: some
+# supervisor outside Hermes owns its relaunch. The recovery pass must not restart it out from
+# under that supervisor; survivors are caught by the post-restart verification probe.
+_EXTERNAL_GATEWAY_SKIP_REASON = (
+    "external supervisor owns this gateway's relaunch; left for that supervisor (KeepAlive or"
+    " process manager) to revive"
+)
 _DESKTOP_SERVE_SKIP_REASON = (
     "desktop app owns and respawns this serve backend;"
     " the recovery pass must not restart it out from under its supervisor"
@@ -689,7 +696,7 @@ def _gateway_recovery_partition(plan, *, skip_profiles: set[str] | None = None) 
                 if supervisor in _FRESH_RESTART_SUPERVISORS:
                     candidates.setdefault(profile, str(supervisor))
                     continue
-                reason = _MANUAL_GATEWAY_SKIP_REASON
+                reason = _EXTERNAL_GATEWAY_SKIP_REASON if supervisor == "external" else _MANUAL_GATEWAY_SKIP_REASON
             elif kind in ("serve", "dashboard"):
                 reason = _DESKTOP_SERVE_SKIP_REASON if supervisor == "desktop" else _SERVE_SKIP_REASON
             else:

--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -71,6 +71,11 @@ def _detect_supervisor_for_pid(pid: int, service_pids: set, windows_service_pids
 _RESTART_MECHANISMS = {
     "systemd": "systemd", "launchd": "launchd", "desktop": "desktop",
     "windows-service": "windows-service", "manual-serve": "respawn-argv",
+    # A gateway launched with ``--external-supervisor`` declares only "some supervisor outside
+    # Hermes owns my restart" — the update's manual-gateway phase hands it back to that supervisor
+    # (externally_supervised_profiles), so the mechanism id must NOT fall through to "manual",
+    # which claims no supervisor relaunch authority at all.
+    "external": "external-supervisor",
 }
 
 _MECHANISM_DESCRIPTIONS = {
@@ -79,6 +84,7 @@ _MECHANISM_DESCRIPTIONS = {
     "desktop": "Desktop app respawns its serve backend",
     "windows-service": "sc.exe stop before venv mutation, sc.exe start after update",
     "respawn-argv": "stop before code swap, relaunch with recorded launch args",
+    "external-supervisor": "external supervisor (launchd wrapper / process manager) relaunches it",
 }
 
 _SERVE_KINDS = ("serve", "dashboard")

--- a/tests/gateway/test_control_socket.py
+++ b/tests/gateway/test_control_socket.py
@@ -403,3 +403,59 @@ def test_runtime_inventory_prefers_socket_supervisor(tmp_path: Path, monkeypatch
     # supervisor comes from the gateway's own declaration, not a PID scan
     assert gws[0].supervisor == "systemd"
     assert gws[0].code_sha == "SHA555"
+
+
+# ---------------------------------------------------------------------------
+# Supervisor declaration — wrapped launchd gateways
+# ---------------------------------------------------------------------------
+
+def test_launch_context_supervisor_wrapped_launchd_resolves_launchd():
+    """A gateway wrapped in the stderr-timestamp logger still declares launchd.
+
+    Generated macOS plists launch the logger wrapper, not the gateway: launchd stamps
+    ``XPC_SERVICE_NAME=<label>`` only on its direct child, so the gateway grandchild sees
+    ``"0"`` and used to degrade to the generic ``--external-supervisor`` claim.
+    """
+    from gateway.control_socket import _supervisor_from_launch_context
+
+    assert (
+        _supervisor_from_launch_context(
+            {"XPC_SERVICE_NAME": "0"},
+            ["hermes", "gateway", "run", "--external-supervisor"],
+            is_darwin=True,
+            ancestor_xpc_labels=["ai.hermes.gateway"],
+        )
+        == "launchd"
+    )
+
+
+def test_launch_context_supervisor_direct_evidence_and_foreign_ancestry():
+    from gateway.control_socket import _supervisor_from_launch_context
+
+    # Direct positive env evidence outranks ancestry (unchanged precedence).
+    assert (
+        _supervisor_from_launch_context(
+            {"INVOCATION_ID": "abc"},
+            [],
+            is_darwin=True,
+            ancestor_xpc_labels=["ai.hermes.gateway"],
+        )
+        == "systemd"
+    )
+    # Ancestry only resolves Hermes-managed labels; a foreign wrapper stays "external".
+    assert (
+        _supervisor_from_launch_context(
+            {},
+            ["hermes", "gateway", "run", "--external-supervisor"],
+            is_darwin=True,
+            ancestor_xpc_labels=["com.example.other"],
+        )
+        == "external"
+    )
+    # Off-darwin the ancestry path never fires.
+    assert (
+        _supervisor_from_launch_context(
+            {}, [], is_darwin=False, ancestor_xpc_labels=["ai.hermes.gateway"]
+        )
+        == "manual"
+    )

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1277,3 +1277,81 @@ def test_find_profile_gateway_processes_strict_propagates_profile_listing_failur
 
     with pytest.raises(RuntimeError, match="profile listing failed"):
         gateway.find_profile_gateway_processes(strict=True)
+
+
+# ---------------------------------------------------------------------------
+# launchd-wrapped gateways: service PID is the stderr-timestamp wrapper, the
+# gateway itself is its child — the sweep must protect BOTH.
+# ---------------------------------------------------------------------------
+
+_WRAPPER_TREE_SCRIPT = (
+    "import subprocess, sys, time\n"
+    "p = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(25)'])\n"
+    "print(p.pid, flush=True)\n"
+    "time.sleep(25)\n"
+)
+
+
+def _spawn_wrapper_with_child():
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _WRAPPER_TREE_SCRIPT],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    child_pid = int(proc.stdout.readline().strip())
+    return proc, child_pid
+
+
+def _terminate_tree(proc):
+    import psutil
+
+    try:
+        for child in psutil.Process(proc.pid).children(recursive=True):
+            child.terminate()
+    except psutil.Error:
+        pass
+    proc.terminate()
+    proc.wait(timeout=10)
+
+
+def test_descendant_pids_walks_real_process_tree():
+    """_descendant_pids reaches grandchildren via psutil (best effort)."""
+    import time
+
+    proc, child_pid = _spawn_wrapper_with_child()
+    try:
+        deadline = time.time() + 10
+        while time.time() < deadline and child_pid not in gateway._descendant_pids({proc.pid}):
+            time.sleep(0.1)
+        assert child_pid in gateway._descendant_pids({proc.pid})
+    finally:
+        _terminate_tree(proc)
+
+
+def test_get_service_pids_protects_wrapped_gateway_descendant(monkeypatch):
+    """launchd's service PID is the wrapper; the wrapped gateway grandchild must be included.
+
+    Without descendant expansion, the update's manual-gateway sweep classifies the freshly
+    respawned gateway as a manual process and kills it right after the launchd restart.
+    """
+    import time
+
+    wrapper, gateway_pid = _spawn_wrapper_with_child()
+    try:
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway, "launchd_gateway_labels_for_install", lambda: [])
+        monkeypatch.setattr(
+            gateway,
+            "_locate_launchd_gateway_service",
+            lambda label: ("gui/501", wrapper.pid),
+        )
+        pids = gateway._get_service_pids(all_profiles=True)
+        assert wrapper.pid in pids
+        deadline = time.time() + 10
+        while time.time() < deadline and gateway_pid not in pids:
+            time.sleep(0.2)
+            pids = gateway._get_service_pids(all_profiles=True)
+        assert gateway_pid in pids
+    finally:
+        _terminate_tree(wrapper)

--- a/tests/hermes_cli/test_restart_plan_reconciliation.py
+++ b/tests/hermes_cli/test_restart_plan_reconciliation.py
@@ -329,3 +329,44 @@ def test_mixed_fleet_only_the_missed_one_escalates(capsys):
     assert "ghost" in missed_block
     assert "[default]" not in missed_block
     assert "[work]" not in missed_block
+
+
+def test_external_supervisor_maps_to_external_supervisor_mechanism():
+    """A gateway declaring supervisor "external" is supervised — never "manual".
+
+    The plan/receipt mechanism for an ``--external-supervisor`` gateway must name the
+    external supervisor that owns its relaunch; the old ``.get(supervisor, "manual")``
+    fallback claimed no supervisor relaunch authority existed at all.
+    """
+    assert _restart_mechanism("external", "default") == "external-supervisor"
+    # display derives FROM the id — no silent fallback to the manual recovery hint
+    assert "external supervisor" in describe_restart_mechanism("external-supervisor", "default")
+    # the runtime record built from a declared "external" supervisor carries the honest id
+    assert _rt("default", 1, supervisor="external").restart_via == "external-supervisor"
+
+
+def test_every_mechanism_id_has_a_description():
+    """Policy-table contract: each id _RESTART_MECHANISMS can emit has display prose."""
+    from hermes_cli.update_inventory import _MECHANISM_DESCRIPTIONS, _RESTART_MECHANISMS
+
+    assert set(_RESTART_MECHANISMS.values()) <= set(_MECHANISM_DESCRIPTIONS)
+
+
+def test_external_gateway_partition_gets_external_skip_reason():
+    """Abort recovery explains an external-supervisor gateway by its own contract."""
+    from types import SimpleNamespace
+
+    from hermes_cli.update_cmd_fleet import _EXTERNAL_GATEWAY_SKIP_REASON, _gateway_recovery_partition
+
+    plan = SimpleNamespace(
+        runtimes=[
+            SimpleNamespace(
+                kind="gateway", profile="default", pid=1,
+                supervisor="external", restart_via="external-supervisor",
+            ),
+        ]
+    )
+    candidates, skipped = _gateway_recovery_partition(plan)
+    assert candidates == {}
+    assert len(skipped) == 1
+    assert skipped[0]["reason"] == _EXTERNAL_GATEWAY_SKIP_REASON


### PR DESCRIPTION
## Problem

Generated macOS launchd plists launch the `hermes_cli.stderr_timestamp` logger **wrapper**, not the gateway. launchd stamps `XPC_SERVICE_NAME=<label>` only on its **direct child** (the wrapper), so the gateway **grandchild** sees `XPC_SERVICE_NAME=0` and declares the generic `"external"` supervisor (the `--external-supervisor` fallback).

The inventory mechanism table (`_RESTART_MECHANISMS`) had no `"external"` key, so the update plan fell through to **`"manual"`** — claiming *no supervisor relaunch authority exists* when launchd actually owns the restart. Observed consequences on every update on a wrapped-launchd install:

- update plans/receipts recorded a false `restart_via="manual"` for launchd-managed gateways, steering the recovery pass and reporting down the wrong path;
- the manual-gateway kill sweep could classify a freshly respawned (wrapped) gateway as a manual process and kill it right after the launchd restart (it comes back via `KeepAlive`, at the cost of an extra restart cycle and confusing abort logs).

## Fix

- **`gateway/control_socket.py`** — `_detect_supervisor()` now resolves the wrapped case by walking the process ancestry for launchd's `XPC_SERVICE_NAME` label (`ai.hermes.*`). Decision core extracted into a pure `_supervisor_from_launch_context(env, argv, *, is_darwin, ancestor_xpc_labels)` so the contract is unit-testable on any host without faking the OS.
- **`hermes_cli/update_inventory.py`** — `_RESTART_MECHANISMS` maps `"external"` → new id `"external-supervisor"` (never falls through to `"manual"`), with matching `_MECHANISM_DESCRIPTIONS` prose.
- **`hermes_cli/gateway.py`** — `_get_service_pids()` unions **descendants** of launchd service PIDs, so the wrapped gateway grandchild is protected from the manual-gateway sweep.
- **`hermes_cli/update_cmd_fleet.py`** — abort-recovery partitioning gives `external` gateways their own skip reason (external supervisor owns the relaunch) instead of the manual one.

## Verification

- New tests: wrapped-launchd declaration (`tests/gateway/test_control_socket.py`), mechanism-table contract + external skip reason (`tests/hermes_cli/test_restart_plan_reconciliation.py`), descendant expansion over a real process tree (`tests/hermes_cli/test_gateway.py`).
- Affected suites green: 116 passed, 3 skipped across `test_control_socket`, `test_restart_plan_reconciliation`, `test_update_inventory`, `test_gateway`, `test_ensure_gateway_service`, `test_update_launchd_unloaded_gateway`, `test_gateway_external_supervisor`.
- Live on a wrapped-launchd install: `hermes update -y` and `hermes gateway restart` both exit 0; receipt no longer records `manual` for the launchd-managed gateway.

## Repro of the mislabel

```python
# live: wrapper has XPC_SERVICE_NAME=ai.hermes.gateway, gateway grandchild sees "0"
>>> from hermes_cli.update_inventory import _restart_mechanism
>>> _restart_mechanism("external", "default")  # before: "manual"  after: "external-supervisor"
```