### PR TITLE
feat(memory): add gateway-aware OpenViking recall

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -31,6 +31,14 @@ Then configure Hermes:
 hermes memory setup    # select "openviking"
 ```
 
+Setup asks how the Hermes instance is used:
+
+- **Personal Agent** keeps the current Hermes session settings. Automatic
+  recall uses user-level memory and the current gateway peer only.
+- **Shared Agent** shares each group or thread session between its participants.
+  Automatic recall can use user-level memory and all peer memories. Setup shows
+  a privacy warning and requires confirmation before it changes session settings.
+
 The setup can link to an existing `~/.openviking/ovcli.conf`, copy its current
 connection values into Hermes, or create a minimal `ovcli.conf` when one does
 not exist.
@@ -73,6 +81,7 @@ profile's `.env`:
 | `OPENVIKING_ACCOUNT` | `default` | Tenant account for local/trusted mode |
 | `OPENVIKING_USER` | `default` | Tenant user for local/trusted mode |
 | `OPENVIKING_AGENT` | (none) | Optional peer ID for separate assistant context |
+| `OPENVIKING_RECALL_SCOPE` | `shared` | Automatic recall scope: `shared` or `peer` |
 
 When `OPENVIKING_API_KEY` is set, Hermes lets OpenViking derive account/user
 identity from the key. In local or trusted deployments without an API key,
@@ -80,6 +89,54 @@ Hermes sends `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` as identity headers.
 Hermes also sends `User-Agent: openviking-memory-hermes/<version>` on
 OpenViking requests. This standard harness identifier contains the Hermes
 version, but no per-user identifier, and does not add a separate request.
+
+### Gateway users and recall scope
+
+For gateway turns, Hermes assigns each human sender an OpenViking peer ID. The
+ID uses the platform and the stable alternate user ID when available. Otherwise,
+it uses the platform user ID. Examples are `telegram.182736` and
+`feishu.on_abc123`. Unsafe or long source IDs get a readable prefix and a short
+hash. This keeps IDs valid and prevents collisions.
+
+The peer ID is added to user messages during capture. It does not replace the
+OpenViking tenant user or the optional assistant peer. Gateway surfaces that do
+not provide both a platform and a sender ID keep the existing user-level capture
+behavior.
+
+Configure automatic recall in `config.yaml`:
+
+```yaml
+memory:
+  openviking:
+    recall_scope: shared  # shared or peer
+```
+
+The scopes have these effects:
+
+| Scope | Automatic recall |
+|-------|------------------|
+| `shared` | User-level memory and all peer memories |
+| `peer` | User-level memory and the current human peer only |
+
+If `peer` recall has no valid gateway sender, Hermes searches user-level memory
+only. It does not fall back to all peer memories. The scope applies to automatic
+recall. Explicit OpenViking tools keep their configured assistant identity and
+their existing scope arguments.
+
+The Shared Agent setup profile writes this complete preset:
+
+```yaml
+group_sessions_per_user: false
+thread_sessions_per_user: false
+memory:
+  openviking:
+    recall_scope: shared
+```
+
+Different groups still use different Hermes sessions. Committed OpenViking
+memories are available from other chats according to `recall_scope`. The
+Personal Agent profile sets `recall_scope: peer` and does not change the current
+Hermes session settings.
 
 ### Optional peer identity
 
@@ -104,10 +161,11 @@ Hermes session.
 
 Upgrades do not move or delete existing memories. Installations that relied
 on the old implicit `hermes` peer now use user memory for new writes. Without
-a peer ID, default OpenViking search covers user memory and existing peer
+a peer ID, shared OpenViking search covers user memory and existing peer
 memories under the same OpenViking user. Old peer memories stay at their
 existing paths and remain searchable. Ranking and result limits determine
-which memories are returned. Keep a peer ID if you need the narrower view.
+which memories are returned. Use `recall_scope: peer` for narrower automatic
+recall.
 
 Set `agent: hermes` to restore peer-scoped writes. Memories written at user
 scope before this change stay there and remain searchable. This setting

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1161,11 +1161,17 @@ class _TurnUpload:
         if self.batch_messages and self.next_index == len(self.batch_messages):
             return
         # Plain-text fallback: one user + one assistant message.
+        user_message: Dict[str, Any] = {
+            "role": "user",
+            "parts": [{"type": "text", "text": self.user_content[:4000]}],
+        }
+        if self.provider._user_id:
+            user_message["peer_id"] = self.provider._user_id
         assistant_message: Dict[str, Any] = {"role": "assistant", "parts": [{"type": "text", "text": _message_text(self.assistant_content)[:4000]}]}
         if self.provider._agent:
             assistant_message["peer_id"] = self.provider._agent
         client.post(f"/api/v1/sessions/{self.sid}/messages/batch",
-                    {"messages": [{"role": "user", "parts": [{"type": "text", "text": self.user_content[:4000]}]}, assistant_message]})
+                    {"messages": [user_message, assistant_message]})
 
     def run(self) -> None:
         try:
@@ -1208,6 +1214,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def __init__(self):
         self._client: Optional[_VikingClient] = None
         self._endpoint = self._api_key = self._account = self._user = self._agent = ""
+        # The gateway sender is a peer inside the configured OpenViking user.
+        # It is not the OpenViking tenant identity stored in ``self._user``.
+        self._user_id = ""
         self._session_id, self._turn_count, self._hermes_home = "", 0, ""
         # (conn snapshot, user): keyed on the snapshot so every client built from it
         # shares the resolved user and a /reload invalidates it.
@@ -1406,6 +1415,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._env_refresh_enabled = True
         self._session_id = session_id
         self._turn_count = 0
+        self._user_id = str(kwargs.get("user_id") or "").strip()
         self._hermes_home = str(kwargs.get("hermes_home") or "").strip() or str(_hermes_home_path())
         self._acquire_run_lock()
         self._profile_prefetched_sessions.clear()
@@ -1961,7 +1971,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
         return [message for message in messages[start_idx : end_idx + 1] if isinstance(message, dict)]
 
     @staticmethod
-    def _messages_to_openviking_batch(messages: List[Dict[str, Any]], *, assistant_peer_id: str = "") -> List[Dict[str, Any]]:
+    def _messages_to_openviking_batch(
+        messages: List[Dict[str, Any]],
+        *,
+        assistant_peer_id: str = "",
+        user_peer_id: str = "",
+    ) -> List[Dict[str, Any]]:
         """Convert Hermes canonical messages into OpenViking batch payloads.
 
         Recall-tool calls/results are dropped (re-ingesting recalled memory would
@@ -1969,13 +1984,15 @@ class OpenVikingMemoryProvider(MemoryProvider):
         whose result is in the slice is emitted only via its result part.
         """
         assistant_peer_id = str(assistant_peer_id or "").strip()
+        user_peer_id = str(user_peer_id or "").strip()
         dict_messages = [m for m in messages if isinstance(m, dict)]
         tool_calls_by_id, completed_tool_ids, skipped_tool_ids = _index_tool_calls(dict_messages)
         payload_messages: List[Dict[str, Any]] = []
         pending_tool_parts: List[Dict[str, Any]] = []
 
         def emit(role: str, parts: List[Dict[str, Any]]) -> None:
-            peer = {"peer_id": assistant_peer_id} if role == "assistant" and assistant_peer_id else {}
+            peer_id = assistant_peer_id if role == "assistant" else user_peer_id if role == "user" else ""
+            peer = {"peer_id": peer_id} if peer_id else {}
             payload_messages.append({"role": role, "parts": parts, **peer})
 
         def flush_tool_parts() -> None:
@@ -2029,7 +2046,11 @@ class OpenVikingMemoryProvider(MemoryProvider):
             if message.get("role") == "user":
                 message["content"] = user_content  # first user message carries the skill-stripped text
                 break
-        batch_messages = self._messages_to_openviking_batch(turn_messages, assistant_peer_id=self._agent)
+        batch_messages = self._messages_to_openviking_batch(
+            turn_messages,
+            assistant_peer_id=self._agent,
+            user_peer_id=self._user_id,
+        )
         if env_var_enabled(_SYNC_TRACE_ENV):
             logger.info(
                 "OpenViking sync_turn trace: session_arg=%r cached_session=%r messages_param_supported=true messages_present=%s "

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1618,7 +1618,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
     @classmethod
     def _post_prefetch_search(cls, client: _VikingClient, query: str, session_id: str, *, limit: int,
-                              context_type: str | List[str], target_uri: Optional[str] = None,
+                              context_type: str | List[str], target_uri: Optional[str | List[str]] = None,
                               deadline: float, request_timeout: float) -> dict:
         """Session-aware search first, falling back to search/find (budget errors propagate)."""
         base_payload = {
@@ -1656,10 +1656,19 @@ class OpenVikingMemoryProvider(MemoryProvider):
             deadline = time.monotonic() + cfg["timeout_seconds"]
             target_uri = None
             # Without an actor peer, OpenViking's default user-root search also
-            # includes all peers. Restrict the no-sender case to user memory.
+            # includes all peers. Use exact roots to exclude peer directories.
             if cfg["scope"] == "peer" and not self._user_id:
                 user = self._user_space(client, timeout=self._remaining_recall_timeout(deadline, cfg["request_timeout_seconds"]))
-                target_uri = f"viking://user/{user}/memories"
+                user_memory_uri = f"viking://user/{user}/memories"
+                target_uri = (
+                    [
+                        user_memory_uri,
+                        f"viking://user/{user}/resources",
+                        "viking://resources",
+                    ]
+                    if cfg["resources"]
+                    else user_memory_uri
+                )
             result = self._unwrap_result(self._post_prefetch_search(
                 client, query_text, session_id, limit=max(cfg["limit"] * 4, 20),
                 context_type=["memory", "resource"] if cfg["resources"] else "memory",

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import atexit
 import errno
+import hashlib
 import json
 import logging
 import math
@@ -70,6 +71,10 @@ _READ_BATCH_FULL_LIMIT = 2500
 _LEVEL_ENDPOINTS = {"abstract": "/api/v1/content/abstract", "overview": "/api/v1/content/overview", "full": "/api/v1/content/read"}
 _LEVEL_MAX_CHARS = {"abstract": 1200, "overview": 4000}
 _RECALL_SUMMARY_KEYS = ("abstract", "overview", "text", "content")
+_RECALL_SCOPES = ("shared", "peer")
+_DEFAULT_RECALL_SCOPE = "shared"
+_GATEWAY_PEER_ID_MAX_LENGTH = 128
+_GATEWAY_PEER_ID_HASH_LENGTH = 12
 
 
 def _cfg_field(key: str, description: str, **extra) -> dict:
@@ -86,6 +91,12 @@ _CONFIG_SCHEMA = [
     _cfg_field("account", "Advanced local identity override (leave blank for user API keys)"),
     _cfg_field("user", "Advanced local user override (leave blank for user API keys)"),
     _cfg_field("agent", "Optional peer ID for separate assistant context. Uses user memory when no peer is configured.", default=_DEFAULT_AGENT),
+    _cfg_field(
+        "recall_scope",
+        "Automatic recall scope. 'shared' searches all memory in the OpenViking user; 'peer' searches user memory and the current gateway peer only.",
+        default=_DEFAULT_RECALL_SCOPE,
+        choices=list(_RECALL_SCOPES),
+    ),
     _cfg_field("recall_limit", "Maximum memories injected by automatic recall", type="integer", minimum=1, maximum=100, default=6),
     _cfg_field("recall_score_threshold", "Minimum relevance score for automatic recall", type="number", minimum=0.0, maximum=1.0, step=0.01, default=0.15),
     _cfg_field("recall_max_injected_chars", "Maximum total characters injected by recall", type="integer", minimum=100, maximum=50000, default=4000),
@@ -188,6 +199,26 @@ def _derive_openviking_user_text(content: Any) -> str:
     """Strip Hermes slash-skill scaffolding before sending content to OpenViking
     (MemoryManager already does this for the fan-out; kept for direct hook callers)."""
     return extract_user_instruction_from_skill_message(content) or ""
+
+
+def _gateway_peer_id(*, platform: Any, user_id: Any = "", user_id_alt: Any = "") -> str:
+    """Return a safe, platform-scoped OpenViking peer ID for a gateway sender."""
+    platform_text = str(platform or "").strip().lower()
+    sender_text = str(user_id_alt or user_id or "").strip()
+    if not platform_text or not sender_text:
+        return ""
+
+    raw = f"{platform_text}.{sender_text}"
+    if len(raw) <= _GATEWAY_PEER_ID_MAX_LENGTH and re.fullmatch(r"[a-zA-Z0-9_.@-]+", raw) and raw not in {".", ".."} and raw.count("@") <= 1:
+        return raw
+
+    # Keep a readable prefix for Studio while the digest prevents two unsafe
+    # source IDs from collapsing to the same sanitized value.
+    safe = re.sub(r"[^a-zA-Z0-9_.@-]+", "-", raw)
+    safe = re.sub(r"@+", "-", safe).strip(".-") or "gateway-peer"
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:_GATEWAY_PEER_ID_HASH_LENGTH]
+    prefix_limit = _GATEWAY_PEER_ID_MAX_LENGTH - len(digest) - 1
+    return f"{safe[:prefix_limit].rstrip('.-') or 'gateway-peer'}-{digest}"
 
 
 def _preview(value: Any, limit: int = 160) -> str:
@@ -1415,7 +1446,11 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._env_refresh_enabled = True
         self._session_id = session_id
         self._turn_count = 0
-        self._user_id = str(kwargs.get("user_id") or "").strip()
+        self._user_id = _gateway_peer_id(
+            platform=kwargs.get("platform"),
+            user_id=kwargs.get("user_id"),
+            user_id_alt=kwargs.get("user_id_alt"),
+        )
         self._hermes_home = str(kwargs.get("hermes_home") or "").strip() or str(_hermes_home_path())
         self._acquire_run_lock()
         self._profile_prefetched_sessions.clear()
@@ -1520,6 +1555,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
         endpoint, api_key, account, user, agent = self._conn_snapshot or self._settings_tuple()
         return _VikingClient(endpoint, api_key, account=account, user=user, agent=agent)
 
+    def _new_recall_client(self, recall_scope: str) -> _VikingClient:
+        """Build a request client without changing capture or tool identity."""
+        endpoint, api_key, account, user, _agent = self._conn_snapshot or self._settings_tuple()
+        actor_peer = self._user_id if recall_scope == "peer" else ""
+        return _VikingClient(endpoint, api_key, account=account, user=user, agent=actor_peer)
+
     # -- prompt / prefetch ---------------------------------------------------
 
     def system_prompt_block(self) -> str:
@@ -1577,9 +1618,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
     @classmethod
     def _post_prefetch_search(cls, client: _VikingClient, query: str, session_id: str, *, limit: int,
-                              context_type: str | List[str], deadline: float, request_timeout: float) -> dict:
+                              context_type: str | List[str], target_uri: Optional[str] = None,
+                              deadline: float, request_timeout: float) -> dict:
         """Session-aware search first, falling back to search/find (budget errors propagate)."""
-        base_payload = {"query": query, "limit": limit, "score_threshold": 0, "context_type": context_type}
+        base_payload = {
+            "query": query, "limit": limit, "score_threshold": 0, "context_type": context_type,
+            **({"target_uri": target_uri} if target_uri else {}),
+        }
         if session_id:
             try:
                 return client.post("/api/v1/search/search", {**base_payload, "session_id": session_id},
@@ -1594,12 +1639,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
         query_text = (query or "").strip()
         if len(query_text) < _RECALL_QUERY_MIN_CHARS:
             return ""
+        cfg = self._recall_config()
         try:
             if client is None:
-                if self._env_refresh_enabled:
-                    client = self._ensure_client()
-                elif self._client is not None:
-                    client = self._new_client()  # legacy/hand-wired path: no env baseline yet
+                if self._env_refresh_enabled and not self._ensure_client():
+                    return ""
+                if self._client is not None:
+                    client = self._new_recall_client(cfg["scope"])
         except Exception as e:
             logger.debug("OpenViking prefetch client build failed: %s", e)
             return ""
@@ -1607,11 +1653,17 @@ class OpenVikingMemoryProvider(MemoryProvider):
             return ""
 
         try:
-            cfg = self._recall_config()
             deadline = time.monotonic() + cfg["timeout_seconds"]
+            target_uri = None
+            # Without an actor peer, OpenViking's default user-root search also
+            # includes all peers. Restrict the no-sender case to user memory.
+            if cfg["scope"] == "peer" and not self._user_id:
+                user = self._user_space(client, timeout=self._remaining_recall_timeout(deadline, cfg["request_timeout_seconds"]))
+                target_uri = f"viking://user/{user}/memories"
             result = self._unwrap_result(self._post_prefetch_search(
                 client, query_text, session_id, limit=max(cfg["limit"] * 4, 20),
                 context_type=["memory", "resource"] if cfg["resources"] else "memory",
+                target_uri=target_uri,
                 deadline=deadline, request_timeout=cfg["request_timeout_seconds"],
             ))
             if not isinstance(result, dict):
@@ -1670,7 +1722,22 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
     def _recall_config(self) -> Dict[str, Any]:
         cfg = _load_hermes_openviking_config()
-        return {key.removeprefix("recall_"): self._setting(key, cfg) for key in _RECALL_SETTING_KEYS}
+        env_scope = os.environ.get("OPENVIKING_RECALL_SCOPE")
+        raw_scope = env_scope or cfg.get("recall_scope") or _DEFAULT_RECALL_SCOPE
+        scope = str(raw_scope).strip().lower()
+        if scope not in _RECALL_SCOPES:
+            source = "OPENVIKING_RECALL_SCOPE" if env_scope else "memory.openviking.recall_scope"
+            warning_key = (source, repr(raw_scope))
+            with _INVALID_SETTING_WARNINGS_LOCK:
+                first = warning_key not in _INVALID_SETTING_WARNINGS
+                _INVALID_SETTING_WARNINGS.add(warning_key)
+            if first:
+                logger.warning("Invalid %s value %r; using %r.", source, raw_scope, _DEFAULT_RECALL_SCOPE)
+            scope = _DEFAULT_RECALL_SCOPE
+        return {
+            "scope": scope,
+            **{key.removeprefix("recall_"): self._setting(key, cfg) for key in _RECALL_SETTING_KEYS},
+        }
 
     def _profile_token_budget(self) -> int:
         return self._setting("profile_token_budget", _load_hermes_openviking_config())

--- a/plugins/memory/openviking/_setup.py
+++ b/plugins/memory/openviking/_setup.py
@@ -15,6 +15,8 @@ from typing import Optional
 
 _SETUP_CANCELLED = object()
 _CANCEL_OPTION = ("Cancel setup", "no changes saved")
+_PERSONAL_PROFILE = "personal"
+_SHARED_PROFILE = "shared"
 
 
 def _ov():
@@ -24,6 +26,55 @@ def _ov():
 
 def _say(message: str) -> None:
     print(f"  {message}", flush=True)
+
+
+def _select_usage_profile(select, cancelled) -> str | object:
+    """Select the memory/session policy before connection setup."""
+    while True:
+        choice = select(
+            "  OpenViking usage profile",
+            [
+                ("Personal Agent", "recall user memory and the current gateway peer; keep existing session settings"),
+                ("Shared Agent", "share group and thread context; recall memory from all peers"),
+            ],
+            default=0,
+            cancel_returns=cancelled,
+        )
+        if choice == cancelled:
+            return _SETUP_CANCELLED
+        if choice == 0:
+            return _PERSONAL_PROFILE
+        if choice != 1:
+            continue
+
+        _say("Shared Agent will share short-term group and thread context between participants.")
+        _say("Automatic recall can use user-level memory and all peer memories in this OpenViking user.")
+        confirm = select(
+            "  Confirm Shared Agent",
+            [
+                ("Apply Shared Agent", "set shared group/thread sessions and shared recall"),
+                ("Go back", "choose a different usage profile"),
+                _CANCEL_OPTION,
+            ],
+            default=1,
+            cancel_returns=cancelled,
+        )
+        if confirm == 0:
+            return _SHARED_PROFILE
+        if confirm != 1:
+            return _SETUP_CANCELLED
+
+
+def _apply_usage_profile(config: dict, provider_config: dict, profile: str) -> None:
+    """Apply the selected policy without changing unrelated provider settings."""
+    if profile == _PERSONAL_PROFILE:
+        provider_config["recall_scope"] = "peer"
+        return
+    if profile != _SHARED_PROFILE:
+        raise ValueError(f"Unknown OpenViking usage profile: {profile}")
+    config["group_sessions_per_user"] = False
+    config["thread_sessions_per_user"] = False
+    provider_config["recall_scope"] = "shared"
 
 
 def _retry_or_cancel_manual_setup(select, title: str, message: str, cancelled):
@@ -375,6 +426,13 @@ def run_setup(hermes_home: str, config: dict) -> None:
     common = dict(select=_curses_select, cancelled=_CANCELLED, config=config, provider_config=provider_config, env_path=env_path)
 
     print("\n  OpenViking memory setup\n")
+    usage_profile = _select_usage_profile(_curses_select, _CANCELLED)
+    if usage_profile is _SETUP_CANCELLED:
+        _print_cancelled_setup()
+        return
+    if not isinstance(usage_profile, str):  # defensive: custom selectors can return any sentinel
+        _print_cancelled_setup()
+        return
 
     profiles = _ov()._discover_ovcli_profiles()
     if profiles:
@@ -395,4 +453,5 @@ def run_setup(hermes_home: str, config: dict) -> None:
     if result is _SETUP_CANCELLED:
         _print_cancelled_setup()
     elif result:
+        _apply_usage_profile(config, provider_config, usage_profile)
         save_config(config)

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -108,6 +108,7 @@ def make_prefetch_provider(monkeypatch, responses, **env):
     FakeRecallClient.responses = responses
     for key in (
         "OPENVIKING_RECALL_LIMIT",
+        "OPENVIKING_RECALL_SCOPE",
         "OPENVIKING_RECALL_SCORE_THRESHOLD",
         "OPENVIKING_RECALL_MAX_INJECTED_CHARS",
         "OPENVIKING_RECALL_TIMEOUT_SECONDS",
@@ -277,6 +278,7 @@ class TestOpenVikingConfigSchema:
         env_vars = {entry.get("env_var") for entry in schema}
 
         assert "OPENVIKING_RECALL_LIMIT" in env_vars
+        assert "OPENVIKING_RECALL_SCOPE" in env_vars
         assert "OPENVIKING_RECALL_SCORE_THRESHOLD" in env_vars
         assert "OPENVIKING_RECALL_MAX_INJECTED_CHARS" in env_vars
         assert "OPENVIKING_RECALL_TIMEOUT_SECONDS" in env_vars
@@ -289,7 +291,9 @@ class TestOpenVikingConfigSchema:
         assert fields["recall_limit"]["maximum"] == 100
         assert fields["recall_score_threshold"]["type"] == "number"
         assert fields["recall_prefer_abstract"]["type"] == "boolean"
+        assert fields["recall_scope"]["choices"] == ["shared", "peer"]
         assert provider._recall_config() == {
+            "scope": "shared",
             "limit": 6,
             "score_threshold": 0.15,
             "max_injected_chars": 4000,
@@ -313,6 +317,7 @@ memory:
   provider: openviking
   openviking:
     recall_limit: 12
+    recall_scope: peer
     recall_score_threshold: 0.42
     recall_max_injected_chars: 8000
     profile_token_budget: 7000
@@ -334,6 +339,7 @@ memory:
         cfg = provider._recall_config()
 
         assert cfg["limit"] == 12
+        assert cfg["scope"] == "peer"
         assert cfg["score_threshold"] == 0.42
         assert cfg["max_injected_chars"] == 8000
         assert cfg["timeout_seconds"] == 2.0
@@ -355,6 +361,7 @@ memory:
   provider: openviking
   openviking:
     recall_limit: 12
+    recall_scope: peer
     recall_resources: true
 """,
             encoding="utf-8",
@@ -362,12 +369,14 @@ memory:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         # Override config.yaml via env
         monkeypatch.setenv("OPENVIKING_RECALL_LIMIT", "6")
+        monkeypatch.setenv("OPENVIKING_RECALL_SCOPE", "shared")
         monkeypatch.setenv("OPENVIKING_RECALL_RESOURCES", "false")
 
         provider = OpenVikingMemoryProvider()
         cfg = provider._recall_config()
 
         assert cfg["limit"] == 6, "env var should override config.yaml"
+        assert cfg["scope"] == "shared"
         assert cfg["resources"] is False, "env var false should override config.yaml true"
 
     def test_recall_config_partial_config_yaml(self, monkeypatch, tmp_path):
@@ -432,6 +441,7 @@ memory:
             "_load_hermes_openviking_config",
             lambda: {
                 "recall_limit": "many",
+                "recall_scope": "everyone-nearby",
                 "recall_score_threshold": True,
                 "recall_prefer_abstract": "sometimes",
                 "profile_token_budget": "7.5",
@@ -442,6 +452,7 @@ memory:
         cfg = provider._recall_config()
 
         assert cfg["limit"] == 6
+        assert cfg["scope"] == "shared"
         assert cfg["score_threshold"] == 0.15
         assert cfg["prefer_abstract"] is False
         assert provider._profile_token_budget() == 6000
@@ -639,7 +650,7 @@ class TestOpenVikingRead:
 class TestOpenVikingAutoRecallPrefetch:
     @pytest.mark.parametrize("peer", ["", "hermes"])
     def test_prefetch_e2e_sends_limit_and_reads_l2_content(self, monkeypatch, peer):
-        records = {"searches": [], "reads": [], "listings": [], "headers": []}
+        records = {"searches": [], "reads": [], "listings": [], "headers": [], "search_headers": []}
 
         class Handler(BaseHTTPRequestHandler):
             def _send_json(self, payload):
@@ -707,6 +718,7 @@ class TestOpenVikingAutoRecallPrefetch:
                 payload = json.loads(self.rfile.read(length).decode("utf-8") or "{}")
                 records["headers"].append(dict(self.headers))
                 if self.path == "/api/v1/search/search":
+                    records["search_headers"].append(dict(self.headers))
                     records["searches"].append(payload)
                     if payload.get("context_type") == "memory":
                         self._send_json({
@@ -785,7 +797,9 @@ class TestOpenVikingAutoRecallPrefetch:
             {key.lower(): value for key, value in headers.items()}
             for headers in records["headers"]
         ]
-        assert all(headers.get("x-openviking-actor-peer", "") == peer for headers in normalized_headers)
+        assert any(headers.get("x-openviking-actor-peer", "") == peer for headers in normalized_headers)
+        search_headers = {key.lower(): value for key, value in records["search_headers"][0].items()}
+        assert "x-openviking-actor-peer" not in search_headers
         assert all(
             headers.get("user-agent") == f"openviking-memory-hermes/{_HERMES_VERSION}"
             for headers in normalized_headers

--- a/tests/plugins/memory/test_openviking_optional_peer.py
+++ b/tests/plugins/memory/test_openviking_optional_peer.py
@@ -16,7 +16,7 @@ import plugins.memory.openviking as ov
 def isolated_config(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
-    for key in (*ov._OPENVIKING_ENV_KEYS, "OPENVIKING_CLI_CONFIG_FILE"):
+    for key in (*ov._OPENVIKING_ENV_KEYS, "OPENVIKING_CLI_CONFIG_FILE", "OPENVIKING_RECALL_SCOPE"):
         # Track absent keys too, so setup's direct environment writes are undone.
         monkeypatch.setenv(key, "")
         monkeypatch.delenv(key, raising=False)
@@ -147,6 +147,7 @@ def test_new_setup_does_not_ask_for_or_save_peer(
 
     def select(title, options, **kwargs):
         choices = {
+            "  OpenViking usage profile": 0,
             "  OpenViking connection": 0 if credential == "service" else 1,
             "  OpenViking credential": {"dev": 2, "user": 0, "root": 1}.get(
                 credential, 0
@@ -183,6 +184,61 @@ def test_new_setup_does_not_ask_for_or_save_peer(
         )
         assert "actor_peer_id" not in saved
         assert "agent_id" not in saved
+    assert saved_config["recall_scope"] == "peer"
+    assert "group_sessions_per_user" not in config
+    assert "thread_sessions_per_user" not in config
+
+
+def test_personal_usage_profile_preserves_session_policy():
+    config = {
+        "group_sessions_per_user": True,
+        "thread_sessions_per_user": False,
+        "memory": {"openviking": {"recall_limit": 9}},
+    }
+    provider_config = config["memory"]["openviking"]
+
+    ov._setup._apply_usage_profile(config, provider_config, "personal")
+
+    assert provider_config["recall_scope"] == "peer"
+    assert config["group_sessions_per_user"] is True
+    assert config["thread_sessions_per_user"] is False
+    assert provider_config["recall_limit"] == 9
+
+
+def test_shared_usage_profile_applies_full_preset():
+    config = {
+        "group_sessions_per_user": True,
+        "thread_sessions_per_user": True,
+        "memory": {"openviking": {"recall_limit": 9}},
+    }
+    provider_config = config["memory"]["openviking"]
+
+    ov._setup._apply_usage_profile(config, provider_config, "shared")
+
+    assert provider_config["recall_scope"] == "shared"
+    assert config["group_sessions_per_user"] is False
+    assert config["thread_sessions_per_user"] is False
+    assert provider_config["recall_limit"] == 9
+
+
+def test_shared_usage_profile_requires_explicit_confirmation(capsys):
+    selections = iter([1, 0])
+    menus = []
+
+    def select(title, options, **kwargs):
+        menus.append((title, options, kwargs))
+        return next(selections)
+
+    result = ov._setup._select_usage_profile(select, -1)
+
+    assert result == "shared"
+    assert [title for title, _, _ in menus] == [
+        "  OpenViking usage profile",
+        "  Confirm Shared Agent",
+    ]
+    output = capsys.readouterr().out
+    assert "share short-term group and thread context" in output
+    assert "all peer memories" in output
 
 
 @pytest.mark.parametrize("peer", ["", "work-assistant"])

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1905,3 +1905,66 @@ class TestOpenVikingEnvWriter:
         assert env.read_text(encoding="utf-8").splitlines() == [
             "A=1", "OPENAI_API_KEY=new", "B=2",
         ]
+
+
+def test_initialize_threads_gateway_user_identity(monkeypatch):
+    """The gateway threads user_id into initialize() so memory providers can
+    scope per-user data (#98498). OpenViking used to drop it, attributing
+    every unnamed preference to the single configured tenant user."""
+    _clear_openviking_env(monkeypatch)
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "https://viking.example")
+
+    class FakeVikingClient:
+        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+            pass
+
+        def health(self):
+            return False
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
+
+    provider = OpenVikingMemoryProvider()
+    provider.initialize("session-1", platform="cli", user_id="alice")
+
+    assert provider._user_id == "alice"
+    # The configured tenant stays the shared data space, untouched.
+    assert provider._user != "alice"
+
+    # Without a gateway identity nothing changes (single-user instances).
+    provider2 = OpenVikingMemoryProvider()
+    provider2.initialize("session-2", platform="cli")
+    assert provider2._user_id == ""
+
+
+@pytest.mark.parametrize("user_peer_id", ["alice", ""])
+def test_turn_payloads_use_runtime_user_identity_on_every_write_path(user_peer_id):
+    messages = [
+        {"role": "user", "content": "remember I like tea"},
+        {"role": "assistant", "content": "noted"},
+    ]
+
+    batch = OpenVikingMemoryProvider._messages_to_openviking_batch(
+        messages, assistant_peer_id="hermes", user_peer_id=user_peer_id
+    )
+    provider = _make_provider_with_session("sid", turn_count=0)
+    provider._user_id = user_peer_id
+    provider._agent = "hermes"
+    posted = []
+
+    class Client:
+        def post(self, path, payload):
+            posted.append((path, payload))
+
+    openviking_module._TurnUpload(
+        provider, "sid", [], "remember I like tea", "noted"
+    ).post(Client())
+
+    expected_peer = {"peer_id": user_peer_id} if user_peer_id else {}
+    assert batch[0] == {
+        "role": "user",
+        "parts": [{"type": "text", "text": "remember I like tea"}],
+        **expected_peer,
+    }
+    assert batch[1]["peer_id"] == "hermes"
+    assert posted[0][1]["messages"][0] == batch[0]
+    assert posted[0][1]["messages"][1]["peer_id"] == "hermes"

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1,8 +1,10 @@
 import json
 import os
+import re
 import socket
 import threading
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -35,6 +37,7 @@ def _clear_openviking_env(monkeypatch):
         "OPENVIKING_ACCOUNT",
         "OPENVIKING_USER",
         "OPENVIKING_AGENT",
+        "OPENVIKING_RECALL_SCOPE",
         "OPENVIKING_CLI_CONFIG_FILE",
         "OPENVIKING_PROFILE_TOKEN_BUDGET",
     ):
@@ -293,7 +296,7 @@ def test_post_setup_existing_profile_picker_validates_and_links_saved_profile(
         validate_values,
         raising=False,
     )
-    choices = iter([0, 0])
+    choices = iter([0, 0, 0])
     monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: next(choices))
     config = {"memory": {}}
 
@@ -311,6 +314,7 @@ def test_post_setup_existing_profile_picker_validates_and_links_saved_profile(
     assert config["memory"]["openviking"] == {
         "use_ovcli_config": True,
         "ovcli_config_path": str(saved_path),
+        "recall_scope": "peer",
     }
     env_text = env_path.read_text(encoding="utf-8")
     assert "OPENVIKING_" not in env_text
@@ -1907,7 +1911,7 @@ class TestOpenVikingEnvWriter:
         ]
 
 
-def test_initialize_threads_gateway_user_identity(monkeypatch):
+def test_initialize_derives_platform_scoped_gateway_peer_identity(monkeypatch):
     """The gateway threads user_id into initialize() so memory providers can
     scope per-user data (#98498). OpenViking used to drop it, attributing
     every unnamed preference to the single configured tenant user."""
@@ -1924,9 +1928,14 @@ def test_initialize_threads_gateway_user_identity(monkeypatch):
     monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
 
     provider = OpenVikingMemoryProvider()
-    provider.initialize("session-1", platform="cli", user_id="alice")
+    provider.initialize(
+        "session-1",
+        platform="feishu",
+        user_id="ou_application_scoped",
+        user_id_alt="on_stable_union_id",
+    )
 
-    assert provider._user_id == "alice"
+    assert provider._user_id == "feishu.on_stable_union_id"
     # The configured tenant stays the shared data space, untouched.
     assert provider._user != "alice"
 
@@ -1934,6 +1943,106 @@ def test_initialize_threads_gateway_user_identity(monkeypatch):
     provider2 = OpenVikingMemoryProvider()
     provider2.initialize("session-2", platform="cli")
     assert provider2._user_id == ""
+
+
+@pytest.mark.parametrize(
+    ("platform", "user_id", "user_id_alt", "expected"),
+    [
+        ("telegram", "182736", "", "telegram.182736"),
+        ("feishu", "ou_app", "on_stable", "feishu.on_stable"),
+        ("", "182736", "", ""),
+        ("telegram", "", "", ""),
+    ],
+)
+def test_gateway_peer_id_uses_platform_and_prefers_stable_alt_id(
+    platform, user_id, user_id_alt, expected
+):
+    assert (
+        openviking_module._gateway_peer_id(
+            platform=platform, user_id=user_id, user_id_alt=user_id_alt
+        )
+        == expected
+    )
+
+
+def test_gateway_peer_id_sanitizes_unsafe_values_without_collisions():
+    first = openviking_module._gateway_peer_id(
+        platform="google/chat", user_id="users/alice@example.com"
+    )
+    second = openviking_module._gateway_peer_id(
+        platform="google/chat", user_id="users:alice@example.com"
+    )
+    long_id = openviking_module._gateway_peer_id(
+        platform="telegram", user_id="x" * 500
+    )
+
+    assert first != second
+    assert all(re.fullmatch(r"[a-zA-Z0-9_.@-]+", value) for value in (first, second, long_id))
+    assert all(len(value) <= openviking_module._GATEWAY_PEER_ID_MAX_LENGTH for value in (first, second, long_id))
+
+
+@pytest.mark.parametrize(
+    ("scope", "user_peer_id", "expected_actor", "expected_target"),
+    [
+        ("shared", "telegram.42", "", None),
+        ("peer", "telegram.42", "telegram.42", None),
+        ("peer", "", "", "viking://user/alice/memories"),
+    ],
+)
+def test_automatic_recall_applies_configured_peer_scope(
+    monkeypatch, scope, user_peer_id, expected_actor, expected_target
+):
+    clients = []
+    requests = []
+
+    class Client:
+        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+            self._user = user
+            self._agent = agent
+            clients.append(self)
+
+        def post(self, path, payload=None, **kwargs):
+            requests.append((path, dict(payload or {})))
+            return {"result": {"memories": [], "resources": []}}
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", Client)
+    provider = _make_prefetch_provider()
+    provider._conn_snapshot = (
+        "https://openviking.example",
+        "key",
+        "account",
+        "alice",
+        "configured-assistant",
+    )
+    provider._user_id = user_peer_id
+    monkeypatch.setattr(provider, "_recall_config", lambda: {
+        "scope": scope,
+        "limit": 6,
+        "score_threshold": 0.15,
+        "max_injected_chars": 4000,
+        "timeout_seconds": 4.0,
+        "request_timeout_seconds": 3.0,
+        "full_read_limit": 2,
+        "prefer_abstract": False,
+        "resources": False,
+    })
+    monkeypatch.setattr(provider, "_user_space", lambda *args, **kwargs: "alice")
+
+    provider._search_prefetch_context("remember project context")
+
+    assert clients[-1]._agent == expected_actor
+    assert requests == [
+        (
+            "/api/v1/search/find",
+            {
+                "query": "remember project context",
+                "limit": 24,
+                "score_threshold": 0,
+                "context_type": "memory",
+                **({"target_uri": expected_target} if expected_target else {}),
+            },
+        )
+    ]
 
 
 @pytest.mark.parametrize("user_peer_id", ["alice", ""])
@@ -1957,7 +2066,7 @@ def test_turn_payloads_use_runtime_user_identity_on_every_write_path(user_peer_i
 
     openviking_module._TurnUpload(
         provider, "sid", [], "remember I like tea", "noted"
-    ).post(Client())
+    ).post(cast(_VikingClient, Client()))
 
     expected_peer = {"peer_id": user_peer_id} if user_peer_id else {}
     assert batch[0] == {

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -2045,6 +2045,67 @@ def test_automatic_recall_applies_configured_peer_scope(
     ]
 
 
+def test_no_sender_peer_recall_includes_enabled_resource_roots_on_fallback(
+    monkeypatch,
+):
+    requests = []
+
+    class Client:
+        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+            self._user = user
+            self._agent = agent
+
+        def post(self, path, payload=None, **kwargs):
+            requests.append((path, dict(payload or {})))
+            if path == "/api/v1/search/search":
+                raise RuntimeError("session search unavailable")
+            return {"result": {"memories": [], "resources": []}}
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", Client)
+    provider = _make_prefetch_provider()
+    provider._conn_snapshot = (
+        "https://openviking.example",
+        "key",
+        "account",
+        "alice",
+        "configured-assistant",
+    )
+    provider._user_id = ""
+    monkeypatch.setattr(provider, "_recall_config", lambda: {
+        "scope": "peer",
+        "limit": 6,
+        "score_threshold": 0.15,
+        "max_injected_chars": 4000,
+        "timeout_seconds": 4.0,
+        "request_timeout_seconds": 3.0,
+        "full_read_limit": 2,
+        "prefer_abstract": False,
+        "resources": True,
+    })
+    monkeypatch.setattr(provider, "_user_space", lambda *args, **kwargs: "alice")
+
+    provider._search_prefetch_context(
+        "remember project context", session_id="session-1"
+    )
+
+    target_uri = [
+        "viking://user/alice/memories",
+        "viking://user/alice/resources",
+        "viking://resources",
+    ]
+    base_payload = {
+        "query": "remember project context",
+        "limit": 24,
+        "score_threshold": 0,
+        "context_type": ["memory", "resource"],
+        "target_uri": target_uri,
+    }
+    assert requests == [
+        ("/api/v1/search/search", {**base_payload, "session_id": "session-1"}),
+        ("/api/v1/search/find", base_payload),
+    ]
+
+
 @pytest.mark.parametrize("user_peer_id", ["alice", ""])
 def test_turn_payloads_use_runtime_user_identity_on_every_write_path(user_peer_id):
     messages = [


### PR DESCRIPTION
## What does this PR do?

This PR makes OpenViking capture gateway senders as platform-scoped peers and adds explicit automatic-recall policies for personal and shared Hermes instances.

The configured OpenViking user remains the shared tenant. Each sender gets a stable peer ID from `platform + (user_id_alt or user_id)`. Different groups keep their existing separate Hermes sessions.

Automatic recall now supports:

- `shared`: user-level memory and all peer memories.
- `peer`: user-level memory and the current sender peer only. Without a valid sender, recall is limited to user-level memory.

The setup wizard adds two profiles:

- **Personal Agent**: sets `recall_scope: peer` and preserves current session settings.
- **Shared Agent**: sets `group_sessions_per_user: false`, `thread_sessions_per_user: false`, and `recall_scope: shared` after a privacy confirmation.

This includes and adapts the fix from #98506. Its source commit remains authored by @liuhao1024.

## Related Issue

Fixes #98498

Supersedes #98506.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/memory/openviking/__init__.py`
  - Derive safe, readable, platform-scoped peer IDs for gateway senders.
  - Attach the sender peer to user messages on structured and fallback capture paths.
  - Add `shared` and `peer` automatic-recall scopes without changing capture or explicit-tool identity.
- `plugins/memory/openviking/_setup.py`
  - Add Personal Agent and Shared Agent setup profiles.
  - Require confirmation before applying shared session settings.
- `plugins/memory/openviking/README.md`
  - Document peer derivation, recall behavior, configuration, and session boundaries.
- OpenViking plugin tests
  - Cover peer derivation, capture, fallback behavior, recall scopes, headers, validation, and both setup profiles.

## How to Test

1. `uv run --no-sync python -m pytest tests/plugins/memory/test_openviking_provider.py tests/plugins/memory/test_openviking_optional_peer.py tests/openviking_plugin/test_openviking.py -q`
   - Result: `164 passed`.
2. `uv run --no-sync python -m pytest tests/plugins/memory tests/openviking_plugin -q`
   - Branch result: `461 passed, 2 failed, 2 skipped`.
   - Exact `upstream/main` result: `447 passed, 2 failed, 2 skipped`.
   - The same two existing Mem0 backend-routing tests fail on both heads.
3. `uv run --no-sync ruff check` on all changed Python files.
   - Result: passed.
4. `uv run --no-sync ty check plugins/memory/openviking/__init__.py plugins/memory/openviking/_setup.py`
   - Result: 29 existing diagnostics on both this branch and exact `upstream/main`; no new diagnostic.
5. Local simulated OpenViking flow:
   - Capture used peer `telegram.100200300` and preserved the assistant peer.
   - Shared recall sent no actor-peer restriction.
   - Peer recall used `telegram.100200300`.
   - Peer recall without a sender targeted user-level memory only.

Real gateway end-to-end testing is still pending.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and identified #98506 as the source change
- [x] My PR contains only OpenViking plugin, test, and documentation changes for this feature
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on macOS 26.6 arm64

### Documentation & Housekeeping

- [x] I have updated the OpenViking plugin documentation
- [x] `cli-config.yaml.example`: N/A; this plugin exposes configuration through its schema and setup flow
- [x] `CONTRIBUTING.md` and `AGENTS.md`: N/A; no repository workflow changed
- [x] I have considered cross-platform impact; CI must provide Windows verification
- [x] Tool descriptions/schemas: N/A; no explicit tool behavior changed
