### PR TITLE
fix(hermes-bots): group-chat settings must read room-record members, not just bot-meta

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
@@ -45,14 +45,15 @@ import { $selectedBot } from './bot-state'
 import { createCanonicalChat } from './canonical-chat'
 import { $botMeta, botHandle, botRosterKey, filterBots, ROSTER_KEY, saveBotMeta } from './data'
 import { labeled, ResizableFrame } from './dialog-parts'
-import { GROUP_CHAT_MAX_MEMBERS, mintGroupRoomId, uniqueGroupChatName, updateGroupChat } from './group-chat'
+import { GROUP_CHAT_MAX_MEMBERS, mintGroupRoomId, $groupChats, uniqueGroupChatName, updateGroupChat } from './group-chat'
 import type { GroupChatRoom } from './group-chat'
 import { GroupImageControls } from './group-chat-parts'
 import {
   botGroups,
   durableGroupChatMembers,
+  groupChatNames,
+  groupMemberGroupNames,
   groupMembershipPatch,
-  knownGroups,
   liveGroupChatNames
 } from './group-membership'
 import { useBots } from './i18n'
@@ -1020,15 +1021,55 @@ interface GroupDialogProps {
   onClose: () => void
 }
 
+/** Evict one member from a room's durable `members` list. groupChatMemberBots
+ *  re-seats stored room members even when bot-meta no longer names the group,
+ *  so removing a bot from a group must also drop its stored descriptor or it
+ *  keeps appearing in the room. Matches identity the same way seating does
+ *  (roster key, plus legacy friendly-name fallback). */
+function evictFromGroupRoom(group: string, bot: RosterRow): void {
+  const key = botRosterKey(bot)
+  const nameKey = String(bot?.name || '')
+    .trim()
+    .toLowerCase()
+
+  void updateGroupChat(group, (room: GroupChatRoom) => {
+    const members = Array.isArray(room?.members) ? room.members : []
+
+    room.members = members.filter(descriptor => {
+      if (!descriptor) {
+        return true
+      }
+
+      if (botRosterKey(descriptor) === key) {
+        return false
+      }
+
+      return !(
+        nameKey &&
+        String(descriptor?.name || '')
+          .trim()
+          .toLowerCase() === nameKey
+      )
+    })
+
+    return room
+  })
+}
+
 /** Assign a bot to a group-chat membership without replacing its others.
  *  Existing groups are independent toggles; the input creates and joins a new
  *  one. Canonical groups + the legacy scalar projection ride ui_meta. */
 export function GroupDialog({ bot, onClose }: GroupDialogProps) {
   const b = useBots()
   const meta = useValue($botMeta)
+  const rooms = useValue($groupChats)
   const [name, setName] = useState('')
-  const current = botGroups(botRosterMeta(bot, meta))
-  const groups = knownGroups(meta)
+  // Membership is a UNION of bot-meta `groups` AND the room record's stored
+  // members (mirrors groupChatMemberBots). Reading meta alone leaves a member
+  // that rides the room record only — after a local-only ui_meta save, or a
+  // scoped remote member — invisible here, so it could never be removed.
+  const current = groupMemberGroupNames(bot, botRosterMeta(bot, meta), rooms)
+  const groups = groupChatNames(meta, rooms)
 
   const setMembership = (group: string, enabled: boolean) => {
     void saveBotMeta(bot, groupMembershipPatch(botRosterMeta(bot, meta), group, enabled))
@@ -1038,6 +1079,27 @@ export function GroupDialog({ bot, onClose }: GroupDialogProps) {
         ? `${displayName(bot, botRosterMeta(bot, meta))} added to “${group}”`
         : `${displayName(bot, botRosterMeta(bot, meta))} removed from “${group}”`
     })
+
+    // Removal must ALSO evict the member from the room's durable `members`
+    // list. groupChatMemberBots re-seats stored room members even when bot-meta
+    // no longer names the group, so without this the bot keeps appearing in the
+    // group chat after the box is unchecked. Adding needs no room write — the
+    // Create & join flow seats via durableGroupChatMembers.
+    if (!enabled) {
+      evictFromGroupRoom(group, bot)
+    }
+  }
+
+  const removeFromAll = () => {
+    void saveBotMeta(bot, {
+      groups: [],
+      group: null
+    })
+
+    // Clear the member from every room's durable member list too.
+    for (const group of current) {
+      evictFromGroupRoom(group, bot)
+    }
   }
 
   return (
@@ -1096,12 +1158,7 @@ export function GroupDialog({ bot, onClose }: GroupDialogProps) {
         {current.length ? (
           <Button
             className="justify-self-start"
-            onClick={() =>
-              void saveBotMeta(bot, {
-                groups: [],
-                group: null
-              })
-            }
+            onClick={removeFromAll}
             size="sm"
             variant="ghost"
           >

--- a/apps/desktop/src/plugins/hermes-bots/group-membership.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-membership.test.ts
@@ -370,3 +370,104 @@ describe('legacy display-name descriptors', () => {
     expect(modules.membership.groupChatMemberBots('room', [TAIYI], {})[0]).toBe(TAIYI)
   })
 })
+
+describe('groupMemberGroupNames (settings dialog view)', () => {
+  const SPARK = { connectionId: 'c1', name: 'spark', remoteSource: true, sourceScoped: true } as RosterRow
+
+  beforeEach(() => {
+    modules.chat.$groupChats.set({})
+  })
+
+  it('reports meta groups even with no room record', () => {
+    const names = modules.membership.groupMemberGroupNames(
+      { connectionId: 'local', name: 'researcher' },
+      { group: 'Research', groups: ['Research'] },
+      {}
+    )
+
+    expect(names).toEqual(['Research'])
+  })
+
+  it('reports a room-seated member whose meta dropped the group', () => {
+    // Reproduced bug: member is seated in the room only via the stored
+    // descriptor (meta no longer names the group) — the settings dialog must
+    // still list it so it can be removed.
+    modules.chat.$groupChats.set(
+      rooms({
+        Research: {
+          log: [],
+          members: [{ connectionId: 'c1', name: 'spark', remoteSource: true, sourceScoped: true }]
+        }
+      })
+    )
+
+    const names = modules.membership.groupMemberGroupNames(SPARK, { groups: [] }, modules.chat.$groupChats.get())
+
+    expect(names).toEqual(['Research'])
+  })
+
+  it('matches a legacy friendly-name descriptor to its room', () => {
+    modules.chat.$groupChats.set(
+      rooms({
+        Alphas: {
+          log: [],
+          members: [{ connectionId: 'local', name: '大司命' }]
+        }
+      })
+    )
+
+    const names = modules.membership.groupMemberGroupNames(
+      { connectionId: 'local', display_name: '大司命', name: 'taiyi' },
+      { groups: [] },
+      modules.chat.$groupChats.get()
+    )
+
+    expect(names).toEqual(['Alphas'])
+  })
+
+  it('ignores disbanded (tombstoned) rooms', () => {
+    modules.chat.$groupChats.set({
+      Old: { log: [], tombstone: true, members: [{ connectionId: 'c1', name: 'spark', remoteSource: true, sourceScoped: true }] }
+    })
+
+    expect(modules.membership.groupMemberGroupNames(SPARK, { groups: [] }, modules.chat.$groupChats.get())).toEqual([])
+  })
+
+  it('does not cross-match members across connections by bare name', () => {
+    modules.chat.$groupChats.set(
+      rooms({
+        Other: {
+          log: [],
+          members: [{ connectionId: 'alien', name: 'spark', remoteSource: true, sourceScoped: true }]
+        }
+      })
+    )
+
+    const names = modules.membership.groupMemberGroupNames(
+      { connectionId: 'c1', name: 'spark' },
+      { groups: [] },
+      modules.chat.$groupChats.get()
+    )
+
+    expect(names).toEqual([])
+  })
+
+  it('dedupes a group listed in both meta and the room record', () => {
+    modules.chat.$groupChats.set(
+      rooms({
+        Research: {
+          log: [],
+          members: [{ connectionId: 'c1', name: 'researcher' }]
+        }
+      })
+    )
+
+    const names = modules.membership.groupMemberGroupNames(
+      { connectionId: 'local', name: 'researcher' },
+      { groups: ['Research'] },
+      modules.chat.$groupChats.get()
+    )
+
+    expect(names).toEqual(['Research'])
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-membership.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-membership.ts
@@ -366,3 +366,50 @@ export function knownGroups(metaByName: Record<string, BotMeta>) {
     })
   )
 }
+
+/** Groups a single member ACTUALLY sits in, read from BOTH sources — bot-meta
+ *  `groups` AND the room record's stored `members` — mirroring how
+ *  `groupChatMemberBots` seats the room. The settings dialog must use this
+ *  union, or a member that rides the room record alone (e.g. after a local-only
+ *  ui_meta save, or a scoped remote member) stays invisible in the
+ *  Manage-groups dialog and can never be removed back out of the group. */
+export function groupMemberGroupNames(
+  member: RosterRow,
+  meta: BotMeta | null | undefined,
+  rooms: Record<string, GroupChat>
+): string[] {
+  const names = new Set(botGroups(meta))
+  const key = botRosterKey(member)
+  const nameKey = String(member?.name || '')
+    .trim()
+    .toLowerCase()
+
+  for (const [group, room] of Object.entries(rooms || {})) {
+    if (room?.tombstone) {
+      continue
+    }
+
+    const seated =
+      Array.isArray(room?.members) &&
+      room.members.some(descriptor => {
+        if (!descriptor) {
+          return false
+        }
+
+        if (botRosterKey(descriptor) === key) {
+          return true
+        }
+
+        // Legacy/friendly-name descriptors persist the display name under
+        // `name` — fall back to a case-insensitive name match so a room-seated
+        // member whose meta dropped the group still resolves to its room.
+        return nameKey && String(descriptor?.name || '').trim().toLowerCase() === nameKey
+      })
+
+    if (seated) {
+      names.add(group)
+    }
+  }
+
+  return [...names]
+}

--- a/apps/desktop/src/plugins/hermes-bots/group-membership.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-membership.ts
@@ -380,33 +380,58 @@ export function groupMemberGroupNames(
 ): string[] {
   const names = new Set(botGroups(meta))
   const key = botRosterKey(member)
-  const nameKey = String(member?.name || '')
-    .trim()
-    .toLowerCase()
+  const memberConnection = String(member?.connectionId || '')
+
+  // The member's own identity tokens: bare slug + every friendly/display name
+  // (same surface resolveLegacyMemberDescriptor matches against).
+  const memberTokens = new Set<string>()
+
+  for (const token of [member?.name, member?.handle, member?.display_name, ...botFriendlyNames(member)]) {
+    const trimmed = String(token || '')
+      .trim()
+      .toLowerCase()
+
+    if (trimmed) {
+      memberTokens.add(trimmed)
+    }
+  }
+
+  const seatsMember = (descriptor: GroupMember | RosterRow | null | undefined): boolean => {
+    if (!descriptor) {
+      return false
+    }
+
+    if (botRosterKey(descriptor) === key) {
+      return true
+    }
+
+    // Legacy/friendly-name descriptors: match by name, but STRICTLY within the
+    // member's connection scope — never capture a same-named row on a foreign
+    // connection (two `default`s on different machines must not merge). A
+    // descriptor WITHOUT a connectionId predates connection scoping, so only
+    // local (non-remote) members are legal matches.
+    const descriptorConnection = String(descriptor?.connectionId || '')
+    const sameConnection = descriptorConnection
+      ? descriptorConnection === memberConnection
+      : !member?.remoteSource
+
+    if (!sameConnection) {
+      return false
+    }
+
+    const descriptorName = String(descriptor?.name || '')
+      .trim()
+      .toLowerCase()
+
+    return Boolean(descriptorName && memberTokens.has(descriptorName))
+  }
 
   for (const [group, room] of Object.entries(rooms || {})) {
     if (room?.tombstone) {
       continue
     }
 
-    const seated =
-      Array.isArray(room?.members) &&
-      room.members.some(descriptor => {
-        if (!descriptor) {
-          return false
-        }
-
-        if (botRosterKey(descriptor) === key) {
-          return true
-        }
-
-        // Legacy/friendly-name descriptors persist the display name under
-        // `name` — fall back to a case-insensitive name match so a room-seated
-        // member whose meta dropped the group still resolves to its room.
-        return nameKey && String(descriptor?.name || '').trim().toLowerCase() === nameKey
-      })
-
-    if (seated) {
+    if (Array.isArray(room?.members) && room.members.some(seatsMember)) {
       names.add(group)
     }
   }


### PR DESCRIPTION
## Problem

In the desktop **Bot Mode** group-chat feature, a bot can be **visibly seated in a group chat but not appear in (or be removable via) the group's settings dialog** — the "Manage groups" dialog shows the bot as if it were not in the group, yet the group chat keeps listing it.

## Root cause

Group membership lives in **two places**:

* **Bot metadata** — the `groups` list (in each bot profile's `ui_meta['hermes-bots']`), read/written by `groupMembershipPatch()` / `botGroups()` / `knownGroups()`.
* **The room record** — `members[]` on the group-chat room (`durableGroupChatMembers()`), which is also what the room view seats from.

The **room view** merges **both** sources (`groupChatMemberBots()` = bot-meta + stored room members). But the **Manage-groups settings dialog** (`GroupDialog` in `create-dialog.tsx`) only read the **bot-meta** side via `knownGroups(meta)` / `botGroups(meta)`.

So any member whose membership lived *only* in the room record — e.g. after a local-only `ui_meta` save, or a source-scoped / remote member — stayed invisible in the settings dialog: it could neither be added nor removed, while the group chat kept rendering it.

## Fix

* **`group-membership.ts`** — add `groupMemberGroupNames()`, a union helper that lists a member's groups from **both** bot-meta and the room record's stored `members` (mirroring how `groupChatMemberBots` seats the room). The legacy friendly-name fallback is connection-scoped so two same-named rows on different connections never merge.
* **`create-dialog.tsx`** — `GroupDialog` now reads membership through the union, and toggling a member **off** (or "remove from all groups") also **evicts it from the room's durable `members` list** (`evictFromGroupRoom`) — without this, `groupChatMemberBots` would keep re-seating it.
* **`group-membership.test.ts`** — regression coverage: room-only members, friendly-name descriptors, tombstoned rooms, cross-connection isolation, and dedupe.

## Verification

`group-membership.test.ts`: **21/21 passing**.
