### PR TITLE
fix(auth): wait for Claude Code token rotation

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -106,6 +106,12 @@ CREDENTIAL_PERSIST_FAILED_REASON = "credential_persist_failed"
 # ``_seed_from_singletons`` would re-create them from the same stale tokens.
 DEAD_MANUAL_PRUNE_TTL_SECONDS = 24 * 60 * 60
 
+# Claude Code rotates its shared token pair out of process.  Anthropic can
+# reject the old pair before Claude Code's atomic file replacement is visible,
+# so a failed borrowed refresh needs a short bounded handoff window.
+_CLAUDE_CODE_ROTATION_WAIT_SECONDS = 2.0
+_CLAUDE_CODE_ROTATION_POLL_SECONDS = 0.25
+
 AUTH_TYPE_OAUTH = "oauth"
 AUTH_TYPE_API_KEY = "api_key"
 
@@ -1614,34 +1620,43 @@ class CredentialPool(CredentialPoolAdminMixin):
         """
         if self.provider == "anthropic":
             if entry.source == "claude_code":
-                synced = self._sync_anthropic_entry_from_credentials_file(entry)
-                if synced.refresh_token != entry.refresh_token:
-                    logger.debug("Retrying refresh with synced token from credentials file")
-                    try:
-                        from agent.anthropic_credentials import refresh_anthropic_oauth_pure
-                        refreshed = refresh_anthropic_oauth_pure(
-                            synced.refresh_token, use_json=synced.source.endswith("hermes_pkce"),
-                        )
-                        # Commit to the authoritative singleton BEFORE marking or
-                        # persisting the pool row, or a failed write leaves an
-                        # "ok" row that the next load_pool() re-seeds over.
-                        self._commit_anthropic_rotation(synced, refreshed)
-                        return self._adopt(
-                            synced,
-                            access_token=refreshed["access_token"],
-                            refresh_token=refreshed["refresh_token"],
-                            expires_at_ms=refreshed["expires_at_ms"],
-                            last_status=STATUS_OK,
-                            last_status_at=None,
-                            last_error_code=None,
-                        )
-                    except _RefreshDone as done:
-                        return done.result
-                    except Exception as retry_exc:
-                        logger.debug("Retry refresh also failed: %s", retry_exc)
-                elif not self._entry_needs_refresh(synced):
-                    logger.debug("Credentials file has valid token, using without refresh")
-                    return synced
+                deadline = time.monotonic() + _CLAUDE_CODE_ROTATION_WAIT_SECONDS
+                while True:
+                    synced = self._sync_anthropic_entry_from_credentials_file(entry)
+                    access_changed = synced.access_token != entry.access_token
+                    refresh_changed = synced.refresh_token != entry.refresh_token
+                    if access_changed and not self._entry_needs_refresh(synced):
+                        logger.debug("Adopting rotated token from Claude Code credentials file")
+                        return synced
+                    if refresh_changed:
+                        logger.debug("Retrying refresh with synced token from credentials file")
+                        try:
+                            from agent.anthropic_credentials import refresh_anthropic_oauth_pure
+                            refreshed = refresh_anthropic_oauth_pure(
+                                synced.refresh_token, use_json=synced.source.endswith("hermes_pkce"),
+                            )
+                            # Commit to the authoritative singleton BEFORE marking or
+                            # persisting the pool row, or a failed write leaves an
+                            # "ok" row that the next load_pool() re-seeds over.
+                            self._commit_anthropic_rotation(synced, refreshed)
+                            return self._adopt(
+                                synced,
+                                access_token=refreshed["access_token"],
+                                refresh_token=refreshed["refresh_token"],
+                                expires_at_ms=refreshed["expires_at_ms"],
+                                **_MARK_OK,
+                            )
+                        except _RefreshDone as done:
+                            return done.result
+                        except Exception as retry_exc:
+                            logger.debug("Retry refresh also failed: %s", retry_exc)
+                            break
+                    if access_changed:
+                        break
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    time.sleep(min(_CLAUDE_CODE_ROTATION_POLL_SECONDS, remaining))
             else:
                 # Backstop for pool-owned sources (hermes_pkce, manual:dashboard_pkce):
                 # the winner may have persisted between our pre-check and our POST.

--- a/tests/agent/test_credential_pool_anthropic_refresh_race.py
+++ b/tests/agent/test_credential_pool_anthropic_refresh_race.py
@@ -309,3 +309,115 @@ def test_concurrent_claude_code_refresh_recovers_via_credentials_file(monkeypatc
     # its own refresh, the loser via the credentials-file sync-and-retry.
     assert results["a"] is not None, "claude_code process A should recover"
     assert results["b"] is not None, "claude_code process B should recover"
+
+
+def test_claude_code_refresh_waits_for_external_rotation(monkeypatch):
+    """A rejected borrowed refresh waits for Claude Code's replacement pair.
+
+    Claude Code can revoke the shared access and refresh tokens before its
+    atomic credentials-file update becomes visible.  The old access token can
+    still have a future expiry, so expiry alone cannot prove that an unchanged
+    file read recovered the request that just received a 401.
+    """
+    stale = {
+        "accessToken": "stale-access",
+        "refreshToken": "stale-refresh",
+        "expiresAt": int(time.time() * 1000) + 3_600_000,
+    }
+    fresh = {
+        "accessToken": "fresh-access",
+        "refreshToken": "fresh-refresh",
+        "expiresAt": int(time.time() * 1000) + 3_600_000,
+    }
+    credential_reads = 0
+    refresh_calls: list[str] = []
+
+    def _read_credentials():
+        nonlocal credential_reads
+        credential_reads += 1
+        return stale if credential_reads <= 2 else fresh
+
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_claude_code_credentials",
+        _read_credentials,
+    )
+
+    def _rejected_refresh(refresh_token, *, use_json=False):
+        refresh_calls.append(refresh_token)
+        raise ValueError("invalid_grant: refresh token already used")
+
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.refresh_anthropic_oauth_pure",
+        _rejected_refresh,
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool._CLAUDE_CODE_ROTATION_WAIT_SECONDS", 0.01
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool._CLAUDE_CODE_ROTATION_POLL_SECONDS", 0.001
+    )
+
+    pool = CredentialPool(
+        "anthropic",
+        [
+            PooledCredential(
+                provider="anthropic",
+                id="pool-entry",
+                label="Claude Code",
+                auth_type=AUTH_TYPE_OAUTH,
+                priority=0,
+                source="claude_code",
+                access_token=stale["accessToken"],
+                refresh_token=stale["refreshToken"],
+                expires_at_ms=stale["expiresAt"],
+            )
+        ],
+    )
+
+    recovered = pool.try_refresh_matching(credential_id="pool-entry")
+
+    assert recovered is not None
+    assert recovered.access_token == "fresh-access"
+    assert recovered.refresh_token == "fresh-refresh"
+    assert refresh_calls == ["stale-refresh"]
+
+
+def test_claude_code_refresh_rejects_unchanged_revoked_token(monkeypatch):
+    """An unchanged file cannot recover the access token that just failed."""
+    stale = {
+        "accessToken": "stale-access",
+        "refreshToken": "stale-refresh",
+        "expiresAt": int(time.time() * 1000) + 3_600_000,
+    }
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_claude_code_credentials",
+        lambda: stale,
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.refresh_anthropic_oauth_pure",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            ValueError("invalid_grant: refresh token already used")
+        ),
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool._CLAUDE_CODE_ROTATION_WAIT_SECONDS", 0.01
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool._CLAUDE_CODE_ROTATION_POLL_SECONDS", 0.001
+    )
+
+    entry = PooledCredential(
+        provider="anthropic",
+        id="pool-entry",
+        label="Claude Code",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="claude_code",
+        access_token=stale["accessToken"],
+        refresh_token=stale["refreshToken"],
+        expires_at_ms=stale["expiresAt"],
+    )
+    pool = CredentialPool("anthropic", [entry])
+
+    assert pool.try_refresh_matching(credential_id=entry.id) is None
+    assert pool.entries()[0].last_status == STATUS_EXHAUSTED


### PR DESCRIPTION
## What does this PR do?

Keep a borrowed Claude Code credential available when the official CLI rotates its shared OAuth token pair just before Hermes handles a 401.

The refresh failure path previously reread the credential source once and treated an unchanged, future-dated access token as recovered. That token was the same token the provider had just rejected. Fast retries then exhausted the per-entry refresh budget and pinned the run to its fallback provider.

This adds a bounded two-second handoff window after the borrowed refresh fails. Hermes polls the authoritative Claude Code credential source and accepts a different valid access token when it appears. If the replacement pair is already expired, the existing refresh and durable commit path still runs. If the source never changes, recovery fails as before.

## Related Issue

Fixes #105797

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/credential_pool.py`
  - Wait briefly for an out-of-process Claude Code rotation after a rejected refresh.
  - Require a different, usable access token before treating the external file update as recovery.
  - Preserve the existing refresh and fail-closed commit path for changed but expired credentials.
- `tests/agent/test_credential_pool_anthropic_refresh_race.py`
  - Reproduce a delayed external token-file update deterministically.
  - Verify that an unchanged rejected token remains unrecoverable.

## How to Test

1. Run the focused Anthropic credential and pool tests:
   ```bash
   scripts/run_tests.sh \
     tests/agent/test_credential_pool.py \
     tests/agent/test_anthropic_keychain.py \
     tests/agent/test_credential_pool_anthropic_refresh_race.py \
     tests/agent/test_anthropic_oauth_stress.py \
     tests/agent/test_anthropic_borrowed_row_authority.py \
     tests/agent/test_anthropic_credential_persist_failure.py \
     tests/agent/test_anthropic_spent_rotation_verdict.py \
     tests/agent/test_credential_pool_oauth_writethrough.py -q
   ```
2. Confirm `110 passed, 1 skipped`. The skipped case is marked Windows-only and was not run on macOS.
3. Run `ruff check agent/credential_pool.py tests/agent/test_credential_pool_anthropic_refresh_race.py` and `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral polling and credential logic, with Windows CI coverage pending
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The new regression failed before the fix because recovery returned `stale-access` instead of `fresh-access`. It passes with the bounded handoff logic. No live credentials or provider calls are included.
