### PR TITLE
feat(mcp): add Aave to the MCP catalog (remote streamable HTTP, no auth)

### DIFF
--- a/optional-mcps/aave/manifest.yaml
+++ b/optional-mcps/aave/manifest.yaml
@@ -4,7 +4,7 @@ manifest_version: 1
 
 name: aave
 description: 'Aave V3 and V4: lending markets, positions, rewards, governance, and unsigned transaction building.'
-source: https://mcp.aave.com/llms.txt
+source: https://aave.com/docs/mcp
 
 # Official protocol-hosted remote MCP (URL-only - Hermes never spawns a local
 # process for this entry). No authentication required (verified live

--- a/optional-mcps/aave/manifest.yaml
+++ b/optional-mcps/aave/manifest.yaml
@@ -1,0 +1,48 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: aave
+description: 'Aave V3 and V4: lending markets, positions, rewards, governance, and unsigned transaction building.'
+source: https://mcp.aave.com/llms.txt
+
+# Official protocol-hosted remote MCP (URL-only - Hermes never spawns a local
+# process for this entry). No authentication required (verified live
+# 2026-09-08: initialize succeeds anonymously, protocolVersion 2025-06-18,
+# streamable HTTP; a GET asking for text/event-stream returns 405 by design,
+# so this entry must not be configured as transport.type sse).
+
+transport:
+  type: http
+  url: https://mcp.aave.com
+
+auth:
+  type: none
+
+# No exclusions. 40 tools, 38 read-only; no meta-tool gateway, no generic
+# HTTP/SQL executor, no telemetry, feedback or upsell tools. The two writes
+# relay a signature the user already produced in their own wallet.
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - aave
+    - lending apy
+    - borrow rate
+  hosts:
+    - aave.com
+    - app.aave.com
+
+post_install: |
+  No account or credentials needed - tools are available as soon as the
+  session restarts.
+
+  Non-custodial: the server holds no keys and submits nothing. Reads return
+  market and position data; every prepare_* tool returns an unsigned
+  transaction or EIP-712 typed data for the user's own wallet to sign.
+
+  CAUTION: two tools relay something the user already signed -
+  submit_signed_order (a CoW swap order, whose signature covers price,
+  amounts, recipient and deadline, so the relay cannot alter them) and
+  cancel_order (the user's own order). Hermes's normal tool-approval flow
+  applies.


### PR DESCRIPTION
## What does this PR do?

Adds Aave to the Nous-approved MCP catalog, so `hermes mcp install aave` connects Hermes to the
official Aave MCP server. The catalog has no DeFi or onchain-lending entry today; Aave is the
largest lending protocol, and the server is run by Aave itself rather than a third party wrapping
a public API.

One file, `optional-mcps/aave/manifest.yaml`. Official protocol-hosted remote MCP, URL only, so
Hermes never spawns a local process for it.

## Related Issue

No issue. Catalog addition.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/aave/manifest.yaml` — `transport.type: http`, `url: https://mcp.aave.com`,
  `auth.type: none`, suggestion keywords/hosts, and a `post_install` note covering the two
  signature-relay tools.

## How to Test

Verified live against the endpoint on 2026-09-08:

1. `initialize` succeeds anonymously, `protocolVersion: 2025-06-18`, `serverInfo.name: aave-mcp`.
2. `tools/list` returns 40 tools, 38 carrying `readOnlyHint: true`, every one with a title.
3. Transport is streamable HTTP. A GET asking for `text/event-stream` returns 405 by design, which
   is why this entry is `type: http` and must not be configured as `sse`.
4. The manifest parses with this repo's own loader:
   `hermes_cli/mcp_catalog.py::_parse_manifest` returns
   `aave | http https://mcp.aave.com | auth none`.

Manifest-only change, so no Python code paths are touched and no tests were added.

## Notes on the tool surface

Nothing is excluded by default, and the debloat standard from #94513 is the reason:

- No meta-tool gateway, no generic HTTP or SQL executor, no dynamic tool mounting.
- No telemetry, feedback, upsell or duplicate-search tools.
- 38 of 40 tools are reads (markets, reserves, APY history, positions, rewards, Savings GHO, swap
  quotes, governance). Every `prepare_*` tool is a read too: it returns an unsigned transaction or
  EIP-712 typed data for the user's own wallet to sign.
- The two writes relay a signature the user already produced: `submit_signed_order` (a CoW swap
  order, whose signature covers price, amounts, recipient and deadline, so the relay cannot alter
  them) and `cancel_order` (the user's own order). The server holds no keys and cannot move funds
  on its own. `post_install` carries a CAUTION line for them, in the shape of the `robinhood` entry.

## Screenshots / Logs

```
$ curl -s -X POST https://mcp.aave.com -H 'content-type: application/json' \
  -H 'accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"hermes-check","version":"1"}}}'
{"result":{"protocolVersion":"2025-06-18", ... "serverInfo":{"name":"aave-mcp","version":"1.0.0","title":"Aave"}}}

$ ... tools/list
40 tools, writes: ['submit_signed_order', 'cancel_order']
```
