### PR TITLE
fix(gateway): guard display: null in _wire_turn_agent_callbacks (#105674)

### DIFF
--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1176,7 +1176,7 @@ class TurnRunner:
                 if pdc is not None:
                     pdc[ctx.session_key] = bg_release
         # display.memory_notifications: off | on (generic "💾 Memory updated", default) | verbose.
-        mem_notif = ctx.user_config.get("display", {}).get("memory_notifications")
+        mem_notif = (ctx.user_config.get("display") or {}).get("memory_notifications")
         if isinstance(mem_notif, bool):
             mem_notif = "on" if mem_notif else "off"
         agent.memory_notifications = str(mem_notif).lower() if mem_notif else "on"


### PR DESCRIPTION
## Fix: Guard `display: null` in `_wire_turn_agent_callbacks`

### Problem
When a profile's `config.yaml` contains `display: null`, every non-oneshot gateway turn crashes with:
```
AttributeError: 'NoneType' object has no attribute 'get'
```
at `gateway/run_turn_runner.py`, line 1179.

`.get("display", {})` returns `None` (not the `{}` default) when the key exists but is null, so the chained `.get("memory_notifications")` raises.

### Fix
```python
# Before
mem_notif = ctx.user_config.get("display", {}).get("memory_notifications")
# After
mem_notif = (ctx.user_config.get("display") or {}).get("memory_notifications")
```

This matches the `or {}` guard already used in:
- `gateway/runtime_footer.py` line 50
- `gateway/display_config.py` line 87

### Impact
Profiles shipping `display: null` (e.g. rsh, milka, milka-staff) fail on **every** non-oneshot turn. Oneshot (`-z`) turns bypass `_wire_turn_agent_callbacks`, which masks the regression during smoke tests.

Fixes #105674