### PR TITLE
fix(agent): clear auth_token when authenticating via api_key (#105774)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -352,6 +352,8 @@ def _new_sdk_client(sdk, kwargs: Dict[str, Any], headers: Dict[str, str]):
     client = sdk.Anthropic(**kwargs)
     if "auth_token" in kwargs and "api_key" not in kwargs:
         client.api_key = None
+    elif "api_key" in kwargs and "auth_token" not in kwargs:
+        client.auth_token = None
     return client
 
 


### PR DESCRIPTION
## Fix: Clear `auth_token` when authenticating via `api_key`

### Problem
When `build_anthropic_client` uses `style == "api_key"` (third-party Anthropic-compatible endpoints), only `api_key` is set in kwargs. The Anthropic Python SDK then fills `auth_token` from the `ANTHROPIC_AUTH_TOKEN` environment variable, causing:

1. **Credential leak**: Any `ANTHROPIC_AUTH_TOKEN` in the user's environment is transmitted as `Authorization: Bearer ***` to third-party endpoints on every request
2. **Functional failure**: Endpoints that validate `Authorization` first reject the request with 401

### Fix
The existing guard in `_new_sdk_client` already handles the reverse case (bearer auth leaking `api_key` from env by setting `client.api_key = None`). Add the symmetric guard: clear `auth_token` when only `api_key` is set.

```python
# Existing (line 353-354)
if "auth_token" in kwargs and "api_key" not in kwargs:
    client.api_key = None
# Added
elif "api_key" in kwargs and "auth_token" not in kwargs:
    client.auth_token = None
```

### Verification
Confirmed by header fingerprinting: without this fix, `Authorization: Bearer $ANTHROPIC_AUTH_TOKEN` is sent alongside `x-api-key: <provider_key>` to custom providers.

Fixes #105774