### PR TITLE
fix(cron): use errors=replace for no_agent script Popen on all platforms (#105582)

### DIFF
--- a/cron/scheduler_script.py
+++ b/cron/scheduler_script.py
@@ -339,15 +339,14 @@ def _run_job_script(
         from tools.environments.local import build_subprocess_env
         popen_kwargs: dict[str, Any] = {"start_new_session": True}
         if sys.platform == "win32":
-            popen_kwargs = {
+            popen_kwargs |= {
                 "creationflags": windows_hide_flags()
-                | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
-                # Lossy UTF-8 decode — locale-mismatched bytes from the STT command must not raise in the
-                # reader threads on non-UTF-8 Windows (#45099).
-                # Lossy UTF-8 decode — locale-mismatched bytes from the TTS command must not raise in the
-                # reader threads on non-UTF-8 Windows (#45099).
-                "encoding": "utf-8",
-                "errors": "replace"}
+                | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)}
+        # Lossy UTF-8 decode on all platforms — locale-mismatched bytes (STT/TTS commands,
+        # binary probes, SQLite WAL reads under concurrency) must not raise UnicodeDecodeError
+        # and kill the whole cron tick (#105582, #45099).
+        popen_kwargs["encoding"] = "utf-8"
+        popen_kwargs["errors"] = "replace"
         env = build_subprocess_env()
         env.update(env_overlay)
         # Subprocess cwd only (default: scripts-dir parent). NEVER os.chdir() the process.


### PR DESCRIPTION
## Fix: Use `errors='replace'` for no_agent script `Popen` on all platforms

### Problem
The Windows branch already set `encoding="utf-8", errors="replace"` in `popen_kwargs`, but the POSIX path used `text=True` with default `errors='strict'`. Any non-UTF-8 byte in the script's stdout raises `UnicodeDecodeError` and kills the whole cron tick, silently losing the alert output.

For a watchdog (no_agent) script, a silent failure is the worst-case outcome — the alert that should have been delivered is lost.

### Root Cause
```python
# Windows branch had:
popen_kwargs = {
    "creationflags": ...,
    "encoding": "utf-8",
    "errors": "replace"}
# POSIX path had:
popen_kwargs = {"start_new_session": True}
# Then both used:
proc = subprocess.Popen(argv, ..., text=True, **popen_kwargs)
```

`text=True` without explicit `errors=` defaults to `errors='strict'` on POSIX.

### Fix
Move `encoding="utf-8", errors="replace"` to the common `popen_kwargs` section so both platforms get lossy UTF-8 decode. Also changes the Windows branch from `popen_kwargs = {...}` (overwrite) to `popen_kwargs |= {...}` (merge) to preserve the common keys.

Fixes #105582