### PR TITLE
fix: correct two stale in-code comments left out of the docs batch (#105788)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1775,7 +1775,8 @@ DEFAULT_CONFIG = {
         # (sys.executable): max isolation, project deps/relative paths won't work. Env scrubbing
         # (*_API_KEY, *_TOKEN, *_SECRET, ...) and the tool whitelist apply in both modes.
         "mode": "project",
-        # Session kernels are always on locally (`kernel_mode` is ignored; remote backends run
+        # Session kernels are always on locally (`kernel_mode` is ignored) and remotely
+        # (tools/code_kernel_remote.py; a backend that cannot spawn a kernel fails open to
         # per-call). One kernel per (session owner, mode, interpreter, cwd, tool-set) keeps state
         # across calls and turns; subagents get their own. Kernels die with the session, after
         # kernel_idle_timeout idle seconds, or by LRU eviction past max_session_kernels. A

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -118,7 +118,7 @@ TIPS = [
     "provider_routing controls OpenRouter provider sorting, whitelisting, and blacklisting.",
     # --- Tools & Capabilities ---
     "execute_code runs Python scripts that call Hermes tools programmatically — results stay out of context.",
-    "delegate_task spawns up to 3 concurrent sub-agents by default (delegation.max_concurrent_children) with isolated contexts for parallel work.",
+    "delegate_task spawns up to 10 concurrent sub-agents by default (delegation.max_concurrent_children) with isolated contexts for parallel work.",
     "web_extract works on PDF URLs — pass any PDF link and it converts to markdown.",
     "search_files is ripgrep-backed and faster than grep — use it instead of terminal grep.",
     "patch uses 9 fuzzy matching strategies so minor whitespace differences won't break edits.",


### PR DESCRIPTION
Two stale in-code references the docs batch (#105788) flagged as out of scope for a docs-only PR, now fixed:

- `hermes_cli/tips.py` told users `delegate_task` "spawns up to 3 concurrent sub-agents"; the default is 10 (`config_defaults.py:1256`, migration notes in `config_migrations.py:613`).
- `hermes_cli/config_defaults.py` comment claimed "remote backends run per-call" — contradicted by `tools/code_kernel_remote.py` (remote session kernels since #96991, per-call only as fail-open).

Comment-only: one tips list entry, one config comment rewritten to the actual kernel lifecycle. No behaviour change.

| Validation | Result |
|---|---|
| `tests/hermes_cli/test_tips.py` | 6 passed |
| ruff / check-windows-footguns / check_compat_pointers | clean |

Refs #105788 (closing comment credits this follow-up).
