### PR TITLE
fix(config): preserve explicit null settings when stripping defaults

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1716,6 +1716,8 @@ def _strip_default_values(
     when equal to the default. Dicts whose every child is stripped are removed entirely so
     default-only subtrees never bloat ``config.yaml``."""
     preserve_keys = {("_config_version",)} | set(preserve_keys or ())
+    # None is a valid authored value, not a signal to remove the node.
+    dropped = object()
 
     def _strip(value: Any, default: Any, path: Tuple[str, ...]) -> Any:
         if path in preserve_keys:
@@ -1723,10 +1725,11 @@ def _strip_default_values(
         if isinstance(value, dict) and value:
             default_dict = default if isinstance(default, dict) else {}
             stripped = {k: _strip(v, default_dict.get(k), path + (k,)) for k, v in value.items()}
-            return {k: v for k, v in stripped.items() if v is not None} or None
-        return None if value == default else copy.deepcopy(value)
+            return {k: v for k, v in stripped.items() if v is not dropped} or dropped
+        return dropped if value == default else copy.deepcopy(value)
 
-    return _strip(config, defaults, ()) or {}
+    stripped = _strip(config, defaults, ())
+    return {} if stripped is dropped else stripped
 
 
 def split_model_config_default(raw_default: Any) -> tuple[str, str]:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1719,6 +1719,70 @@ class TestConfigNormalizationDoesNotOverwriteUserValues:
 
 
 
+class TestExplicitNullConfigPreservation:
+    def test_first_save_keeps_null_instead_of_a_non_null_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setitem(DEFAULT_CONFIG, "x_first_save", {"optional": "default"})
+        config_path = tmp_path / "config.yaml"
+        assert not config_path.exists()
+
+        save_config({"x_first_save": {"optional": None}})
+
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert raw["x_first_save"] == {"optional": None}
+        assert load_config()["x_first_save"]["optional"] is None
+
+    @pytest.mark.parametrize("operation", ["save", "partial_save", "migrate"])
+    def test_authored_nulls_survive_config_writes(self, tmp_path, monkeypatch, operation):
+        from hermes_cli.resource_limits import configured_nofile_soft_limit
+        from agent.agent_runtime_helpers import prompt_caching_disabled_from_config
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = tmp_path / "config.yaml"
+        seed = {
+            "_config_version": DEFAULT_CONFIG["_config_version"] - (operation == "migrate"),
+            "runtime": {"nofile_soft_limit": None},
+            "prompt_caching": {"cache_ttl": None},
+            "x_null_preservation": {"nested": {"optional": None}, "keep": "value"},
+        }
+        config_path.write_text(yaml.safe_dump(seed), encoding="utf-8")
+
+        if operation == "migrate":
+            migrate_config(interactive=False, quiet=True)
+        elif operation == "partial_save":
+            save_config({"display": {"skin": "mono"}}, merge_existing=True)
+        else:
+            config = load_config()
+            config["display"]["skin"] = "mono"
+            save_config(config)
+
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert raw["runtime"]["nofile_soft_limit"] is None
+        assert raw["prompt_caching"]["cache_ttl"] is None
+        assert raw["x_null_preservation"] == seed["x_null_preservation"]
+        assert "terminal" not in raw
+        assert configured_nofile_soft_limit() is None
+        assert prompt_caching_disabled_from_config() is True
+        if operation == "migrate":
+            assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+        else:
+            assert raw["display"]["skin"] == "mono"
+
+    @pytest.mark.parametrize("value", [None, False, 0, "", [], [None], {"optional": None}])
+    def test_authored_default_values_survive_stripping(self, value):
+        from hermes_cli.config import _strip_default_values
+
+        config = {"authored": value, "default_only": {"optional": None, "enabled": True}}
+        result = _strip_default_values(config, defaults=config, preserve_keys={("authored",)})
+        assert result == {"authored": value}
+
+    def test_only_default_nulls_produce_an_empty_mapping(self):
+        from hermes_cli.config import _strip_default_values
+
+        defaults = {"optional": None, "nested": {"optional": None}}
+        assert _strip_default_values(defaults, defaults=defaults) == {}
+
+
 class TestCodexAppServerAutoConfig:
     """codex_app_server_auto ships a default and survives migration untouched."""
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2517,6 +2517,33 @@ class TestConfigRoundTrip:
 
 
 
+    @pytest.mark.parametrize("partial", [True, False], ids=["partial", "full"])
+    def test_unrelated_settings_save_preserves_explicit_nulls(self, partial):
+        from hermes_cli.config import get_config_path, load_config, read_raw_config
+
+        seed = {
+            "_config_version": DEFAULT_CONFIG["_config_version"],
+            "runtime": {"nofile_soft_limit": None},
+            "prompt_caching": {"cache_ttl": None},
+            "x_null_preservation": {"optional": None, "keep": "value"},
+        }
+        get_config_path().write_text(yaml.safe_dump(seed), encoding="utf-8")
+        payload = {} if partial else self.client.get("/api/config").json()
+        payload.setdefault("display", {})["skin"] = "mono"
+
+        response = self.client.put("/api/config", json={"config": payload})
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+        raw = read_raw_config()
+        assert raw["runtime"]["nofile_soft_limit"] is None
+        assert raw["prompt_caching"]["cache_ttl"] is None
+        assert raw["x_null_preservation"] == seed["x_null_preservation"]
+        assert raw["display"]["skin"] == "mono"
+        reloaded = load_config()
+        assert reloaded["runtime"]["nofile_soft_limit"] is None
+        assert reloaded["prompt_caching"]["cache_ttl"] is None
+
     def test_round_trip_preserves_schema_invisible_nested_keys(self):
         """Nested keys that aren't in CONFIG_SCHEMA must also survive a
         round-trip. Deep-merge is required — a shallow merge would drop


### PR DESCRIPTION
## What does this PR do?

Fixes configuration saves and migrations silently dropping user-set `null` values during default stripping. `_strip_default_values()` uses `None` both as a valid value and as its deletion marker, so the parent dictionary discards nulls even when their paths were explicitly preserved. Use a dedicated sentinel for discarded nodes without changing default-value comparison or explicit-path preservation rules.

For example:

```yaml
runtime:
  nofile_soft_limit: null
prompt_caching:
  cache_ttl: null
```

Before this fix, saving an unrelated skin change removes both keys. The next load restores the default nofile target and cache TTL, undoing the user's opt-outs. The same loss occurs during migration.

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/config.py`: use a distinct stripped-node sentinel in `_strip_default_values()`.
- `tests/hermes_cli/test_config.py`: cover first saves of null overrides against non-null defaults, full and partial saves, migration, consumer behavior after reload, and sparse-config controls.
- `tests/hermes_cli/test_web_server.py`: cover partial and full settings PUT requests that change an unrelated field.

## How to Test

With the example above in a temporary `HERMES_HOME`:

```python
from hermes_cli.config import load_config, save_config

config = load_config()
config["display"]["skin"] = "mono"
save_config(config)
```

Both null keys should remain in `config.yaml`. Unknown nested settings already present in the raw configuration, including null-valued fields, survive saves and migrations. Default-only sections remain omitted.

```bash
bash scripts/run_tests.sh -j 2 --file-retries 0 \
  tests/hermes_cli/test_config.py tests/hermes_cli/test_web_server.py -q
```

Added 14 test cases. Seven fail on unmodified main (`b3399c1396`), demonstrating the bug; the other seven protect existing behavior. All 14 pass with this fix. Both modified test files pass in full: **322 passed, 5 skipped**.

Validated on macOS with Python 3.11 using the repository's per-file runner, isolated homes, and no retries. A broader 61-file selection also passes. The full repository test suite and native Linux/Windows suites were not run.

<details>
<summary>Broader validation and static checks</summary>

The selection covers config writers, loaders, migrations, settings endpoints, CLI/Gateway/TUI callers, and the resource-limit and prompt-cache consumers.

| Revision | Passed | Failed | Skipped |
| --- | ---: | ---: | ---: |
| Unmodified main (`b3399c1396`) | 1,252 | 0 | 7 |
| With this fix and 14 added cases | 1,266 | 0 | 7 |

**Environment:** Python 3.11.15 with dev/test dependencies and `hindsight-client==0.6.1`, used for both revisions. Activate the environment and run from a checkout without a local `.venv` or `venv`, which the runner would prefer over `HERMES_PYTHON`.

```bash
TEST_PYTHON="$(python -c 'import sys; print(sys.executable)')"
TEST_ROOT="$(mktemp -d)"
TEST_ROOT="$(cd "$TEST_ROOT" && pwd -P)"
mkdir -p "$TEST_ROOT/home" "$TEST_ROOT/tmp"

env -i \
  HOME="$TEST_ROOT/home" \
  TEMP="$TEST_ROOT/tmp" \
  TMP="$TEST_ROOT/tmp" \
  PATH="$(dirname "$TEST_PYTHON"):$PATH" \
  HERMES_PYTHON="$TEST_PYTHON" \
  nice -n 10 bash scripts/run_tests.sh -j 2 --file-retries 0 --file-timeout 90 \
  tests/agent/test_cache_disabled_on_stubs.py \
  tests/agent/test_prompt_cache_ttl_propagation.py \
  tests/agent/test_prompt_caching.py \
  tests/cli/test_cli_pet_pane.py \
  tests/cli/test_cli_save_config_value.py \
  tests/cron/test_file_permissions.py \
  tests/gateway/test_config.py \
  tests/gateway/test_display_config.py \
  tests/gateway/test_model_command_profile_config.py \
  tests/gateway/test_slash_config_writes_routed_profile.py \
  tests/hermes_cli/test_agent_import.py \
  tests/hermes_cli/test_aux_config.py \
  tests/hermes_cli/test_clear_stale_base_url.py \
  tests/hermes_cli/test_config.py \
  tests/hermes_cli/test_config_dotted_key_names.py \
  tests/hermes_cli/test_config_env_expansion.py \
  tests/hermes_cli/test_config_env_ref_parity.py \
  tests/hermes_cli/test_config_env_refs.py \
  tests/hermes_cli/test_config_guard_surfaces.py \
  tests/hermes_cli/test_config_loader_e2e.py \
  tests/hermes_cli/test_config_set_coercion.py \
  tests/hermes_cli/test_config_set_list_values.py \
  tests/hermes_cli/test_config_set_platforms_redirect.py \
  tests/hermes_cli/test_config_validation.py \
  tests/hermes_cli/test_dashboard_admin_endpoints.py \
  tests/hermes_cli/test_fallback_cmd.py \
  tests/hermes_cli/test_local_quickstart.py \
  tests/hermes_cli/test_managed_scope_cli_config.py \
  tests/hermes_cli/test_managed_scope_config.py \
  tests/hermes_cli/test_mcp_catalog.py \
  tests/hermes_cli/test_mcp_security.py \
  tests/hermes_cli/test_moa_config.py \
  tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py \
  tests/hermes_cli/test_noninteractive_config_guard.py \
  tests/hermes_cli/test_personality_single_owner.py \
  tests/hermes_cli/test_picker_key_cmd_discovery.py \
  tests/hermes_cli/test_plugin_auxiliary_tasks.py \
  tests/hermes_cli/test_plugin_config_state_bridge.py \
  tests/hermes_cli/test_profiles.py \
  tests/hermes_cli/test_read_raw_config_readonly.py \
  tests/hermes_cli/test_relay_plugin_cutover.py \
  tests/hermes_cli/test_set_config_value.py \
  tests/hermes_cli/test_setup.py \
  tests/hermes_cli/test_setup_model_provider.py \
  tests/hermes_cli/test_setup_noninteractive.py \
  tests/hermes_cli/test_sibling_config_migration.py \
  tests/hermes_cli/test_terminal_menu_fallbacks.py \
  tests/hermes_cli/test_update_config_migration_on_current.py \
  tests/hermes_cli/test_web_server.py \
  tests/hermes_cli/test_web_server_config_offloop.py \
  tests/honcho_plugin/test_recall_sync.py \
  tests/plugins/memory/test_hindsight_provider.py \
  tests/plugins/memory/test_supermemory_provider.py \
  tests/test_honcho_client_config.py \
  tests/test_iron_proxy.py \
  tests/test_iron_proxy_cli.py \
  tests/test_resource_limits.py \
  tests/tools/test_write_approval.py \
  tests/tui_gateway/test_compression_config_hot_reload.py \
  tests/tui_gateway/test_config_profile_scope.py \
  tests/tui_gateway/test_config_set_display_toggles.py \
  -q --tb=short
```

The physical temp path avoids macOS's `/tmp` symlink: Hermes preserves permissions across links, while this test expects a plain directory.

**Skipped:** six Windows-only cases; one WAL-sidecar test because Hermes uses SQLite DELETE mode in this environment.

**Static checks:** full-repository Ruff, `check-windows-footguns.py --all`, `check_compat_pointers.py`, and `git diff --check` pass. The three changed files retain 89 existing type diagnostics on each revision, with none added or removed. Comparison uses relative path, rule, message, and occurrence count, ignoring line-number shifts.

</details>

## Checklist

- [x] Read the contributing guide; kept the diff limited to this bug.
- [x] Added bug-reproducing tests and existing-behavior controls.
- [x] Verified save/migration preservation and sparse-config behavior on macOS.
- [x] Ran lint and relevant tests; documented platform limits.

