### PR TITLE
feat(gateway): add per-chat tool progress overrides

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1698,6 +1698,19 @@ display:
   # Toggle at runtime with /verbose in the CLI
   tool_progress: all
 
+  # Gateway chats can override tool progress without changing the rest of the
+  # platform. A <chat_id>:<thread_id> entry wins over its chat-wide entry.
+  # Quote IDs so YAML preserves them as strings. Escape dots in thread IDs
+  # when writing through `hermes config set` (for example `1712\.345`).
+  # platforms:
+  #   telegram:
+  #     tool_progress: all
+  #     chats:
+  #       "-1001234567890":
+  #         tool_progress: off
+  #       "-1001234567890:65":
+  #         tool_progress: verbose
+
   # Per-platform defaults can be quieter than the global setting. Telegram
   # tunes for mobile: tool_progress and busy_ack_detail default off (no
   # per-tool breadcrumb stream, no "iteration 21/60" debug detail in busy

--- a/contributors/emails/jarvis_ubuntu@icloud.com
+++ b/contributors/emails/jarvis_ubuntu@icloud.com
@@ -1,0 +1,1 @@
+Jarvis-Arthur

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -1,7 +1,8 @@
 """Per-platform display/verbosity resolver (``resolve_display_setting``).
 
-Resolution order, first non-None wins: ``display.platforms.<platform>.<key>`` →
-``display.<key>`` → ``_PLATFORM_DEFAULTS[platform][key]`` → ``_GLOBAL_DEFAULTS[key]``.
+Resolution order, first non-None wins: an exact chat/topic override →
+``display.platforms.<platform>.<key>`` → ``display.<key>`` →
+``_PLATFORM_DEFAULTS[platform][key]`` → ``_GLOBAL_DEFAULTS[key]``.
 Exception: ``display.streaming`` is CLI-only; gateway streaming follows the top-level
 ``streaming`` config unless a per-platform override sets it. Legacy
 ``display.tool_progress_overrides`` is still read as a ``tool_progress`` fallback.
@@ -76,16 +77,56 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
 
 # Canonical set of per-platform overrideable keys (for validation).
 OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
+CHAT_OVERRIDEABLE_KEYS = frozenset({"tool_progress"})
 
 
-def resolve_display_setting(user_config: dict, platform_key: str, setting: str, fallback: Any = None) -> Any:
-    """Resolve a display setting with per-platform override support (see module docstring for order).
+def _chat_setting_value(
+    platform_config: Any, setting: str, *, chat_id: Any = None, thread_id: Any = None,
+) -> tuple[bool, Any]:
+    """Return the most-specific configured chat value without conflating null with an override."""
+    if setting not in CHAT_OVERRIDEABLE_KEYS or chat_id is None or not isinstance(platform_config, dict):
+        return False, None
+    chats = platform_config.get("chats")
+    if not isinstance(chats, dict):
+        return False, None
+    chat_key = str(chat_id)
+    candidates = ([f"{chat_key}:{thread_id}"] if thread_id not in (None, "") else []) + [chat_key]
+    for candidate in candidates:
+        entry = chats.get(candidate)
+        if isinstance(entry, dict) and entry.get(setting) is not None:
+            return True, entry[setting]
+    return False, None
+
+
+def has_chat_display_override(
+    user_config: dict, platform_key: str, setting: str, *, chat_id: Any = None, thread_id: Any = None,
+) -> bool:
+    """Return whether the exact chat/topic explicitly configures a supported setting."""
+    display_cfg = user_config.get("display") or {}
+    platform_config = (display_cfg.get("platforms") or {}).get(platform_key)
+    configured, _ = _chat_setting_value(
+        platform_config, setting, chat_id=chat_id, thread_id=thread_id,
+    )
+    return configured
+
+
+def resolve_display_setting(
+    user_config: dict, platform_key: str, setting: str, fallback: Any = None, *,
+    chat_id: Any = None, thread_id: Any = None,
+) -> Any:
+    """Resolve a display setting with per-platform and supported per-chat overrides.
 
     ``platform_key`` is the platform config key (``"telegram"``; see ``_platform_config_key`` in
-    gateway/run.py). Returns *fallback* when nothing is configured.
+    gateway/run.py). ``chat_id`` and ``thread_id`` enable the optional ``chats`` lookup for settings
+    listed in :data:`CHAT_OVERRIDEABLE_KEYS`. Returns *fallback* when nothing is configured.
     """
     display_cfg = user_config.get("display") or {}
     plat_overrides = (display_cfg.get("platforms") or {}).get(platform_key)
+    configured, value = _chat_setting_value(
+        plat_overrides, setting, chat_id=chat_id, thread_id=thread_id,
+    )
+    if configured:
+        return _normalise(setting, value)
     if isinstance(plat_overrides, dict) and plat_overrides.get(setting) is not None:
         return _normalise(setting, plat_overrides[setting])
     if setting == "tool_progress":  # legacy display.tool_progress_overrides.<platform>

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2580,7 +2580,7 @@ class GatewayTurnMixin:
             _gateway_platform_value, _has_platform_display_override, _load_gateway_config,
             _platform_config_key,
         )
-        from gateway.display_config import resolve_display_setting
+        from gateway.display_config import has_chat_display_override, resolve_display_setting
         from gateway.status_phrases import choose_status_phrase, resolve_status_phrase_catalog
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
@@ -2602,13 +2602,19 @@ class GatewayTurnMixin:
                 getattr(_agent_display, _setter)(_cast(_val))
 
         # Tool progress mode; HERMES_TOOL_PROGRESS_MODE wins only when the config never set it.
-        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
+        _resolved_tp = resolve_display_setting(
+            user_config, platform_key, "tool_progress",
+            chat_id=source.chat_id, thread_id=source.thread_id,
+        )
         _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
         _platform_cfg = (_display_cfg.get("platforms") or {}).get(platform_key) or {}
         _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
         _tool_progress_configured = "tool_progress" in _display_cfg or any(
             isinstance(cfg, dict) and key in cfg
             for cfg, key in ((_platform_cfg, "tool_progress"), (_legacy_tp_overrides, platform_key))
+        ) or has_chat_display_override(
+            user_config, platform_key, "tool_progress",
+            chat_id=source.chat_id, thread_id=source.thread_id,
         )
         progress_mode = _env_tp if _env_tp and not _tool_progress_configured else (_resolved_tp or _env_tp or "all")
         # "accumulate" (edit one bubble) or "separate" (one msg per tool)

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -50,6 +50,33 @@ class TestResolveDisplaySetting:
         assert resolve_display_setting(config, "slack", "tool_progress") == "off"
         assert resolve_display_setting(config, "telegram", "tool_progress") == "all"
 
+    def test_chat_and_thread_progress_overrides_are_more_specific_than_platform(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "all",
+                        "chats": {
+                            "-100123": {"tool_progress": False},
+                            "-100123:65": {"tool_progress": "verbose"},
+                        },
+                    }
+                }
+            }
+        }
+
+        assert resolve_display_setting(
+            config, "telegram", "tool_progress", chat_id=-100123,
+        ) == "off"
+        assert resolve_display_setting(
+            config, "telegram", "tool_progress", chat_id="-100123", thread_id=65,
+        ) == "verbose"
+        assert resolve_display_setting(
+            config, "telegram", "tool_progress", chat_id="-100999",
+        ) == "all"
+
 
 # ---------------------------------------------------------------------------
 # Backward compatibility: tool_progress_overrides

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -50,7 +50,10 @@ class TestResolveDisplaySetting:
         assert resolve_display_setting(config, "slack", "tool_progress") == "off"
         assert resolve_display_setting(config, "telegram", "tool_progress") == "all"
 
-    def test_chat_and_thread_progress_overrides_are_more_specific_than_platform(self):
+    def test_chat_and_thread_progress_overrides_are_more_specific_than_platform(
+        self, tmp_path, monkeypatch,
+    ):
+        from hermes_cli.config import load_config, set_config_value
         from gateway.display_config import resolve_display_setting
 
         config = {
@@ -76,6 +79,21 @@ class TestResolveDisplaySetting:
         assert resolve_display_setting(
             config, "telegram", "tool_progress", chat_id="-100999",
         ) == "all"
+
+        # The documented CLI escape must persist a dotted thread ID as one key.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        set_config_value(
+            "display.platforms.slack.chats.C123:1712345678\\.123456.tool_progress",
+            "verbose",
+        )
+        persisted = load_config()
+        assert resolve_display_setting(
+            persisted,
+            "slack",
+            "tool_progress",
+            chat_id="C123",
+            thread_id="1712345678.123456",
+        ) == "verbose"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -481,6 +481,36 @@ def _make_runner(adapter):
     return runner
 
 
+def test_turn_display_resolves_tool_progress_for_the_exact_chat(monkeypatch):
+    adapter = ProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    runner._resolve_turn_toolsets = lambda *_args: (set(), set())
+    config = {
+        "display": {
+            "platforms": {
+                "telegram": {
+                    "chats": {"-100123": {"tool_progress": "off"}},
+                }
+            }
+        }
+    }
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: config)
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "verbose")
+
+    quiet = runner._run_agent_display_settings(SessionSource(
+        platform=Platform.TELEGRAM, chat_id="-100123", chat_type="group",
+    ))
+    default = runner._run_agent_display_settings(SessionSource(
+        platform=Platform.TELEGRAM, chat_id="6819688407", chat_type="dm",
+    ))
+
+    assert quiet.progress_mode == "off"
+    assert quiet.tool_progress_enabled is False
+    assert default.progress_mode == "verbose"
+    assert default.tool_progress_enabled is True
+
+
 @pytest.mark.asyncio
 async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch, tmp_path):
     """Slack DM progress should keep event ts fallback threading."""

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2164,6 +2164,29 @@ From the CLI, use the canonical path — `hermes config set display.platforms.te
 
 Platforms without an override fall back to the global `tool_progress` value. Valid platform keys: `telegram`, `discord`, `slack`, `signal`, `whatsapp`, `matrix`, `mattermost`, `email`, `sms`, `homeassistant`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`. The legacy `display.tool_progress_overrides` key still loads for backward compatibility but is deprecated and migrated into `display.platforms` on first load.
 
+To change tool progress for one gateway chat without affecting the rest of its platform, add a `chats` entry keyed by the platform's chat ID. A topic/thread-specific `<chat_id>:<thread_id>` entry takes precedence over the chat-wide entry:
+
+```yaml
+display:
+  platforms:
+    telegram:
+      tool_progress: all
+      chats:
+        "-1001234567890":
+          tool_progress: off
+        "-1001234567890:65":
+          tool_progress: verbose
+```
+
+The full precedence is topic/thread → chat → platform → global → built-in default. `/verbose` continues to change the platform-wide value; it does not edit a chat override.
+
+Use the canonical config path when scripting this. If a thread ID contains a dot, escape it so the dotted-key parser keeps it inside the map key:
+
+```bash
+hermes config set 'display.platforms.telegram.chats.-1001234567890.tool_progress' off
+hermes config set 'display.platforms.slack.chats.C123:1712345678\.123456.tool_progress' off
+```
+
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.


### PR DESCRIPTION
## What does this PR do?

Adds exact chat/topic overrides for gateway tool-progress visibility:

```yaml
display:
  platforms:
    telegram:
      tool_progress: all
      chats:
        "-1001234567890":
          tool_progress: off
```

Resolution follows topic/thread → chat → platform → legacy platform override → global → built-in default. `/verbose` remains platform-wide.

This is a current-main salvage of #31488. The first commit retains @Jarvis-Arthur's authorship for the original resolver and precedence design; the following commits adapt it to the current split gateway runtime and add documentation and regression coverage. The scope is intentionally limited to `tool_progress`, which is resolved per turn without introducing process-global display-state races.

## Related Issue

Related: #31488

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Resolve `display.platforms.<platform>.chats.<chat_id>[:<thread_id>].tool_progress` before broader display defaults.
- Pass the current chat/topic identity into turn-local tool-progress resolution, including environment-fallback handling.
- Document YAML and CLI configuration, including escaped dotted thread IDs.
- Cover precedence, YAML normalization, runtime propagation, and real config persistence.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py`.
2. Configure one chat with `tool_progress: off` while leaving its platform set to `all`.
3. Confirm that chat suppresses tool progress and an unconfigured chat retains the platform setting.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool schema change)

## Screenshots / Logs

- Changed gateway test files: 53 passed, 0 failed.
- Gateway suite: 7,918 passed; six unrelated host/environment failures reproduced unchanged on the frozen upstream base.
- Docusaurus production build completed successfully.
- Independent exact-head review found no publication blockers.
