### PR TITLE
fix(plugins): route execution middleware through lazy discovery (#105827)

### DIFF
--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -159,10 +159,10 @@ class _DownstreamExecutionError(Exception):
 
 
 def _run_execution_chain(kind: str, terminal_call: Callable[[Any], Any], **kwargs: Any) -> Any:
-    from hermes_cli.plugins import get_plugin_manager
+    from hermes_cli.plugins import _delivery_manager
 
     payload_key = "request" if "request" in kwargs else "args"
-    callbacks = list(get_plugin_manager()._middleware.get(kind, []))
+    callbacks = list(_delivery_manager()._middleware.get(kind, []))
     if not callbacks:
         return terminal_call(kwargs[payload_key])
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -31,6 +31,7 @@ from hermes_cli.middleware import (
     VALID_MIDDLEWARE,
     apply_llm_request_middleware,
     apply_tool_request_middleware,
+    run_llm_execution_middleware,
     run_tool_execution_middleware,
 )
 
@@ -928,6 +929,48 @@ class TestDeliveryParity:
         monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: stub)
 
         assert plugins_mod.invoke_hook("anything") == ["stubbed"]
+
+    def test_execution_chain_lazily_discovers(self, monkeypatch):
+        """Execution middleware must fire on cold surfaces too (#105827).
+
+        ``run_tool_execution_middleware`` / ``run_llm_execution_middleware`` deliver via
+        ``_run_execution_chain``, which used to read ``get_plugin_manager()._middleware``
+        directly — no lazy discovery — so a registered fail-closed policy gate was silently
+        skipped (fail-open) on surfaces that never ran discovery at startup (query mode
+        ``chat -q``, cron delivery, dashboard, TUI slash workers). The chain must route
+        through ``_delivery_manager()`` like every other delivery entry point (#64178).
+        """
+        fired = []
+        terminal_calls = []
+
+        def _tool_gate(**kw):
+            fired.append(kw.get("tool_name"))
+            return {"denied": True}  # fail-closed: returns without calling next_call
+
+        def _llm_gate(**kw):
+            fired.append("llm")
+            return {"denied": True}
+
+        def _register(m):
+            m._middleware.setdefault("tool_execution", []).append(_tool_gate)
+            m._middleware.setdefault("llm_execution", []).append(_llm_gate)
+
+        mgr = self._fresh_manager(monkeypatch, _register)
+
+        def _terminal(payload):
+            terminal_calls.append(payload)
+            return "terminal-ran"
+
+        tool_result = run_tool_execution_middleware("terminal", {"path": "x"}, _terminal)
+        assert mgr._discovered is True, "execution chain must lazily discover on cold surfaces"
+        assert fired == ["terminal"]
+        assert tool_result == {"denied": True}
+        assert terminal_calls == [], "a fail-closed gate must not be bypassed by terminal execution"
+
+        llm_result = run_llm_execution_middleware({"messages": []}, _terminal)
+        assert fired == ["terminal", "llm"]
+        assert llm_result == {"denied": True}
+        assert terminal_calls == []
 
 
 class TestForceReloadSymmetry:


### PR DESCRIPTION
## What does this PR do?

`_run_execution_chain` (the function `run_tool_execution_middleware` / `run_llm_execution_middleware` actually deliver through) read `get_plugin_manager()._middleware` directly, with no lazy discovery. Every other delivery entry point (`invoke_hook`, `invoke_middleware`, `has_middleware`, `has_hook`) routes through `_delivery_manager()`, which runs `discover_and_load()` when discovery never happened — that lazy-discovery pass landed with the #64178 parity work but missed this function.

As a result, `tool_execution` / `llm_execution` middleware registered by user plugins silently failed to fire on surfaces that never run plugin discovery at startup: query mode (`chat -q` / `-z`), cron delivery, dashboard, and TUI slash workers (none of them import `model_tools`, whose import side-effect is the discovery trigger on the interactive CLI path). A plugin's fail-closed policy gate (e.g. "deny when the policy backend is unreachable") was therefore silently fail-open outside interactive sessions — a security-relevant silent failure, not a cosmetic one.

The fix routes the chain through `_delivery_manager()` exactly like the sibling entry points, so middleware delivery no longer depends on which surface imported the module.

## Related Issue

Fixes #105827

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/middleware.py` — `_run_execution_chain` now resolves callbacks via `_delivery_manager()._middleware` instead of the raw `get_plugin_manager()._middleware`, closing the lazy-discovery gap left by #64178 (2-line change, no behavior difference on already-discovered surfaces).
- `tests/hermes_cli/test_plugins.py` — new regression test `TestDeliveryParity::test_execution_chain_lazily_discovers`: a registered fail-closed gate must fire (and must NOT be bypassed by terminal execution) on a cold, never-discovered manager, for both `tool_execution` and `llm_execution` chains.

## How to Test

1. `python -m pytest tests/hermes_cli/test_plugins.py::TestDeliveryParity -q`
   - Observed result: `5 passed` (4 pre-existing parity tests + the new one). Before the fix the new test fails at `assert mgr._discovered is True` — the chain skipped discovery, the gate never fired, and the terminal call ran, which is exactly the fail-open behavior reported in the issue.
2. `python -m pytest tests/hermes_cli/test_plugins.py tests/run_agent/test_run_agent.py tests/run_agent/test_run_agent_codex_responses.py -q`
   - Observed result: `423 passed, 1 failed`; the single failure (`TestAnthropicInterruptHandler::test_interruptible_anthropic_interrupt_never_closes_shared_client`, an `anthropic_adapter` ImportError) reproduces identically on a clean checkout with this change stashed, i.e. it is a pre-existing local-environment failure unrelated to this PR.
3. `ruff check hermes_cli/middleware.py tests/hermes_cli/test_plugins.py` — Observed result: all checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the related test surfaces and verified the change itself is green — targeted `tests/hermes_cli/test_plugins.py::TestDeliveryParity`: 5 passed; broader `tests/hermes_cli/test_plugins.py` + `tests/run_agent/` run: 423 passed, 1 failed where the single failure is a pre-existing local-environment failure unrelated to this change (reproduced identically on a clean checkout with this change stashed — see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (arm64, darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
