### PR TITLE
fix(kanban): accept explicit successful workflow evidence

### DIFF
--- a/hermes_cli/kanban_pr_acceptance.py
+++ b/hermes_cli/kanban_pr_acceptance.py
@@ -12,6 +12,7 @@ from urllib.parse import quote
 
 _REPO = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 _PR = re.compile(r"https://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/pull/([1-9][0-9]*)")
+_WORKFLOW = re.compile(r"https://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/actions/runs/([1-9][0-9]*)")
 
 
 def validate_contract(value: str | None) -> str:
@@ -36,7 +37,7 @@ def _api(endpoint: str, *, query: str | None = None, paginate: bool = False):
     return value
 
 
-def collect_acceptance(contract: str, published_pr: str | None) -> dict:
+def collect_acceptance(contract: str, published_pr: str | None, metadata: dict | None = None) -> dict:
     receipt = {"ok": False, "classification": "missing", "head_sha": None,
                "pr_url": published_pr, "checks": [],
                "recovery": "Fix required failures, rerun infrastructure checks or wait, then retry completion. "
@@ -69,7 +70,13 @@ def collect_acceptance(contract: str, published_pr: str | None) -> dict:
                                     for r in rule["parameters"]["required_status_checks"])
         receipt["required"] = [{"context": c, "app_id": a} for c, a in sorted(required, key=str)]
         if not required:
-            receipt["detail"] = "No repository-required checks are configured; explicitly use a local-only contract for non-CI tasks."
+            _collect_workflow_evidence(repo, number, sha, metadata, receipt)
+            current = _api(f"repos/{repo}/pulls/{number}")
+            if current["head"]["sha"] != sha or current["base"]["ref"] != branch or (current["state"] == "closed" and not current.get("merged")):
+                receipt.update(classification="stale", detail="PR head/base changed while collecting evidence; retry.")
+                return receipt
+            receipt["classification"] = "success"
+            receipt["ok"] = True
             return receipt
         pages = _api(f"repos/{repo}/commits/{sha}/check-runs?per_page=100&filter=latest", paginate=True)
         runs = [run for page in pages for run in page["check_runs"]]
@@ -115,3 +122,45 @@ def _classify(check: dict, sha: str, outcome: str | None, is_run: bool) -> str:
     if is_run and check.get("status") != "completed":
         return "pending"
     return {"success": "success", "failure": "failure", "error": "infra", "pending": "pending"}.get(outcome, "infra")
+
+
+def _collect_workflow_evidence(repo: str, number: int, sha: str, metadata: dict | None, receipt: dict) -> None:
+    """Accept only explicitly declared, API-confirmed successful Actions runs."""
+    evidence = metadata.get("workflow_evidence") if isinstance(metadata, dict) else None
+    if not isinstance(evidence, list) or not evidence:
+        raise ValueError("explicit workflow evidence is required when no checks are configured")
+    seen = set()
+    for item in evidence:
+        if not isinstance(item, dict):
+            raise ValueError("malformed workflow evidence")
+        url = item.get("url")
+        match = _WORKFLOW.fullmatch(url or "")
+        if not match or match[1] != repo or match[2] in seen or item.get("head_sha") != sha:
+            raise ValueError("workflow evidence is not tied to the current PR head")
+        seen.add(match[2])
+        if item.get("status") != "completed" or item.get("conclusion") != "success":
+            raise ValueError("workflow evidence is not terminal-successful")
+        jobs = item.get("jobs")
+        if not isinstance(jobs, list) or not jobs:
+            raise ValueError("workflow job evidence is missing or incomplete")
+        run = _api(f"repos/{repo}/actions/runs/{match[2]}")
+        if (run.get("head_sha") != sha or run.get("status") != "completed" or
+                run.get("conclusion") != "success" or
+                not any(p.get("number") == number for p in run.get("pull_requests", []))):
+            raise ValueError("workflow run is stale, unsuccessful, or unrelated")
+        job_pages = _api(f"repos/{repo}/actions/runs/{match[2]}/jobs?per_page=100", paginate=True)
+        api_jobs = {job.get("id"): job for page in job_pages for job in page.get("jobs", [])}
+        if not api_jobs:
+            raise ValueError("workflow jobs are missing")
+        for job in jobs:
+            if not isinstance(job, dict) or job.get("id") not in api_jobs:
+                raise ValueError("declared workflow job is missing")
+            actual = api_jobs[job["id"]]
+            if (job.get("name") != actual.get("name") or job.get("status") != "completed" or
+                    job.get("conclusion") != "success" or actual.get("status") != "completed" or
+                    actual.get("conclusion") != "success"):
+                raise ValueError("workflow job is not terminal-successful")
+        receipt["checks"].append({"name": item.get("name") or f"workflow-{match[2]}",
+                                   "id": int(match[2]), "url": url, "head_sha": sha,
+                                   "classification": "success", "conclusion": "success",
+                                   "jobs": [job["id"] for job in jobs]})

--- a/hermes_cli/kanban_pr_acceptance_store.py
+++ b/hermes_cli/kanban_pr_acceptance_store.py
@@ -17,6 +17,8 @@ def prepare_acceptance(conn, task_id, expected_run_id, metadata):
     run_id, status, contract = snapshot
     if not contract or contract == "local-only":
         return None
+    if not isinstance(contract, str):
+        return False
     if status not in {"running", "ready", "blocked", "review"} or (expected_run_id is not None and run_id != expected_run_id):
         return False
     published_pr = metadata.get("published_pr") if isinstance(metadata, dict) else None
@@ -29,7 +31,7 @@ def prepare_acceptance(conn, task_id, expected_run_id, metadata):
             conn.execute("UPDATE tasks SET completion_contract=? WHERE id=?", (published_pr, task_id))
         snapshot = (run_id, status, published_pr)
         contract = published_pr
-    return snapshot, collect_acceptance(contract, published_pr)
+    return snapshot, collect_acceptance(contract, published_pr, metadata)
 
 
 def record_acceptance(conn, task_id, acceptance):

--- a/tests/hermes_cli/test_kanban_pr_acceptance.py
+++ b/tests/hermes_cli/test_kanban_pr_acceptance.py
@@ -22,7 +22,7 @@ def github(tmp_path, monkeypatch):
             if self.path == "/graphql":
                 value = {"data": {"repository": {"pullRequest": {
                     "headRefOid": sha, "baseRefName": "main", "state": "OPEN",
-                    "baseRef": {"branchProtectionRule": {"requiredStatusChecks": [
+                    "baseRef": {"branchProtectionRule": {"requiredStatusChecks": [] if state.get("no_required") else [
                         {"context": "required", "app": {"databaseId": 1}}]}}}}}}
             elif "/rules/branches/" in self.path:
                 value = [[]]
@@ -129,3 +129,35 @@ def test_acceptance_receipts_and_terminal_write_share_run_ownership(github):
             assert kb.get_task(conn, tid).status != "done"
             assert conn.execute("SELECT count(*) FROM task_events WHERE task_id=? AND kind='pr_acceptance'", (tid,)).fetchone()[0] == 0
             github.pop("race")
+
+
+@pytest.mark.linux_only
+def test_pr_completion_accepts_explicit_successful_workflow_without_required_checks(github, monkeypatch):
+    from hermes_cli import kanban_pr_acceptance as acceptance
+
+    sha = "a" * 40
+    workflow = {"url": "https://github.com/acme/repo/actions/runs/42", "head_sha": sha,
+                "status": "completed", "conclusion": "success",
+                "jobs": [{"id": 7, "name": "test", "status": "completed", "conclusion": "success"}]}
+    original = acceptance._api
+    def api(endpoint, **kwargs):
+        if endpoint.endswith("/actions/runs/42"):
+            return {"head_sha": sha, "status": "completed", "conclusion": "success",
+                    "pull_requests": [{"number": 7}]}
+        if endpoint.endswith("/actions/runs/42/jobs?per_page=100"):
+            return [{"total_count": 1, "jobs": [workflow["jobs"][0]]}]
+        return original(endpoint, **kwargs)
+    monkeypatch.setattr(acceptance, "_api", api)
+    github["no_required"] = True
+    with connect() as conn:
+        for evidence in (
+            [workflow],
+            [{**workflow, "head_sha": "b" * 40}],
+            [{**workflow, "conclusion": "skipped"}],
+            [{**workflow, "jobs": [{**workflow["jobs"][0], "conclusion": "cancelled"}]}],
+            [],
+        ):
+            tid = kb.create_task(conn, title="workflow", completion_contract="acme/repo")
+            ok = kb.complete_task(conn, tid, metadata={"published_pr": "https://github.com/acme/repo/pull/7",
+                "workflow_evidence": evidence})
+            assert ok is (evidence == [workflow])

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -63,7 +63,9 @@ re-reads the PR head/base. Optional failed/skipped telemetry does not veto accep
 required checks. Missing, pending, failed, cancelled, timed-out, stale, skipped or
 neutral **required** evidence cannot complete the card. Neither can zero-run
 acceptance, unreadable policy or GitHub API failures. A repository without required
-checks needs a local-only contract. `gh` must be authenticated with read access to
+checks requires explicit `metadata.workflow_evidence`: each declared Actions run
+must identify the exact PR head, URL, terminal-successful run, and terminal-successful
+jobs confirmed by GitHub. `gh` must be authenticated with read access to
 the repository's checks and rules; no remote writes are performed by this gate.
 
 Rejection retains the active card and workspace. Durable `pr_acceptance` events


### PR DESCRIPTION
## Summary
- accept explicitly declared GitHub Actions evidence when no required branch-protection checks exist
- verify exact PR head, workflow run, and declared job success through GitHub APIs
- retain required-check acceptance behavior and add regression coverage

## Verification
- `python -m py_compile hermes_cli/kanban_pr_acceptance.py hermes_cli/kanban_pr_acceptance_store.py tests/hermes_cli/test_kanban_pr_acceptance.py`
- `git diff --check`
- Local tests were not run per task instruction; repository CI is authoritative.

Rollback: revert commit ddecea1aafe9904ad21b18d7803fb1c84c8b2f9f.
Runtime behavior was not claimed or exercised locally.
