### PR TITLE
fix(#105825): background review fork inherits primary, not fallback runtime

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -203,14 +203,18 @@ def load_background_review_settings() -> tuple[bool, Dict[str, Any]]:
 
 def _resolve_review_runtime(agent: Any, task_cfg: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Resolve provider/model/credentials for the review fork. Default (auto / unset / same as
-    parent): the parent's live runtime with ``routed=False`` (codex_app_server -> codex_responses
-    downgrade applied). When ``auxiliary.background_review.{provider,model}`` names a different
-    concrete model, resolve that runtime and set ``routed=True``."""
-    parent_runtime = agent._current_main_runtime()
-    parent_api_mode = parent_runtime.get("api_mode") or None
+    parent): the parent's PRIMARY runtime (from ``_primary_runtime`` snapshot) with ``routed=False``
+    (codex_app_server -> codex_responses downgrade applied). This ensures the review fork runs on
+    the primary model, even when the parent turn has failed over to a fallback provider. When
+    ``auxiliary.background_review.{provider,model}`` names a different concrete model, resolve that
+    runtime and set ``routed=True``."""
+    primary_runtime = getattr(agent, "_primary_runtime", None) or agent._current_main_runtime()
+    parent_api_mode = primary_runtime.get("api_mode") or None
     parent = {
-        "provider": agent.provider, "model": agent.model,
-        "api_key": parent_runtime.get("api_key") or None, "base_url": parent_runtime.get("base_url") or None,
+        "provider": primary_runtime.get("provider") or agent.provider,
+        "model": primary_runtime.get("model") or agent.model,
+        "api_key": primary_runtime.get("api_key") or None,
+        "base_url": primary_runtime.get("base_url") or None,
         "api_mode": "codex_responses" if parent_api_mode == "codex_app_server" else parent_api_mode,
         "credential_pool": getattr(agent, "_credential_pool", None),
         "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),


### PR DESCRIPTION
Fixes #105825

**Bug:** after failover `primary → fallback`, the background-review turn inherited the fallback model from the parent's LIVE runtime at turn-end, burning fallback costs for every review.

**Root cause:** `agent/background_review.py:209` called `agent._current_main_runtime()` (live fallback) and `agent.provider/model` (also fallback).

**Fix:** replaced live-runtime source with `agent._primary_runtime or agent._current_main_runtime()` fallback; parent model/provider dict keys now read from the snapshot (`primary_runtime.get("provider"/"model")`). The snapshot is written ONLY by init and `switch_model()` (agent_runtime_helpers.py:2162); failover never writes it — so bg-review now always runs on the primary model.

**Tests:** all existing bg-review + primary-restore tests pass (54 specs).

**Example:** session `20260908_153404_61db26` (issue evidence): primary `deepseek-v4-pro` failed over to `qwen/qwen3.7-max (polza)` mid-turn; user turn ended on qwen at 15:43:24; **before fix** bg-review ran on `qwen/qwen3.7-max provider=polza` (line from log); **after fix** it runs on `deepseek-v4-pro` from snapshot.