### PR TITLE
CLI keeps the api_content sidecar when a turn was persisted early — prompt cache survives (#102194, salvage #102411)

### DIFF
--- a/agent/session_persistence.py
+++ b/agent/session_persistence.py
@@ -7,7 +7,7 @@ import logging
 import re
 from contextlib import nullcontext
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from agent.context_compressor import (
     COMPRESSED_SUMMARY_METADATA_KEY,
@@ -72,6 +72,19 @@ def _override_replaces_content(msg: Dict, content: Any, override: Any) -> bool:
         and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
         and (not isinstance(content, list) or isinstance(override, list))
     )
+
+
+def durable_user_row_content(agent, msg: Dict, content: Any, api_content: Any) -> Tuple[Any, Any]:
+    """``(content, api_content)`` as the current turn's user row is written: the persist override is the
+    clean transcript, the live content is what the wire sent — so when they differ and nothing else was
+    injected, the live bytes ARE the sidecar. Shared by the flush and the turn-start stamp so the stamp
+    matches the row the flush wrote."""
+    override = getattr(agent, "_persist_user_message_override", None)
+    if _override_replaces_content(msg, content, override):
+        if api_content is None and isinstance(content, str) and content != override:
+            api_content = content
+        content = override
+    return content, api_content
 
 
 def _summary_display_kind(msg: Dict) -> Any:
@@ -143,12 +156,7 @@ def _db_flush_row(agent, msg: Dict, is_current_turn_user: bool) -> Dict[str, Any
     api_content = msg.get("api_content") if isinstance(msg.get("api_content"), str) else None
     timestamp = msg.get("timestamp")
     if is_current_turn_user and role == "user":
-        override = getattr(agent, "_persist_user_message_override", None)
-        if _override_replaces_content(msg, content, override):
-            # Live content is what the wire sent, the override is the clean transcript; keep the sent bytes.
-            if api_content is None and isinstance(content, str) and content != override:
-                api_content = content
-            content = override
+        content, api_content = durable_user_row_content(agent, msg, content, api_content)
         ov_timestamp = getattr(agent, "_persist_user_message_timestamp", None)
         timestamp = timestamp if ov_timestamp is None else ov_timestamp
     if api_content == content:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -745,9 +745,7 @@ def _stamp_api_content_sidecar(
     # clean content and the request prefix diverges here. Both writers stamp ``_row_id`` on the live
     # dict, which is at once the proof a row exists and the address to update.
     #
-    # Do NOT widen this to an unconditional backfill: without a row id the store can only target the
-    # newest active user row, and a repeated user turn ("ok", "y", "continue") makes the PREVIOUS
-    # turn's row compare equal — this turn's bytes would overwrite its sidecar for good.
+    # Never widen this to an unconditional positional backfill — see set_latest_user_api_content.
     #
     # ``_row_id`` is read under ``_session_persist_lock``: a close flush holds it while it commits
     # the row and only then writes ``_row_id`` back (``sync_flushed_message_markers``). Read outside
@@ -755,17 +753,13 @@ def _stamp_api_content_sidecar(
     # persisted with ``api_content = NULL``, leaving no writer to correct the row.
     with _persist_lock(agent):
         _row_id = _turn_user_msg.get("_row_id")
-        _has_valid_row_id = isinstance(_row_id, int) and not isinstance(_row_id, bool) and _row_id > 0
         _in_place_compacted = preflight_compressed and bool(getattr(agent, "_last_compaction_in_place", False))
         _db = getattr(agent, "_session_db", None)
-        if _db is None or not (_has_valid_row_id or _in_place_compacted):
+        if _db is None or not (isinstance(_row_id, int) or _in_place_compacted):
             return
         try:
-            if _has_valid_row_id:
-                # Fail closed on a store wrapper without the row-addressed method: a positional
-                # fallback here is exactly the wrong-row write this function exists to prevent.
-                if hasattr(_db, "set_message_api_content"):
-                    _db.set_message_api_content(agent.session_id, _row_id, durable_content, _api_content)
+            if isinstance(_row_id, int):
+                _db.set_message_api_content(agent.session_id, _row_id, durable_content, _api_content)
             else:
                 # Compacted copies carry no row id; positional is safe only because
                 # archive_and_compact just made this message the newest active user row.

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -772,20 +772,30 @@ def _stamp_api_content_sidecar(
     #
     # Rotation mode needs nothing here: its compacted copies flush to
     # the child session after this stamp.
-    _row_id = _turn_user_msg.get("_row_id")
-    _has_valid_row_id = (
-        isinstance(_row_id, int)
-        and not isinstance(_row_id, bool)
-        and _row_id > 0
-    )
-    _in_place_compacted = preflight_compressed and bool(
-        getattr(agent, "_last_compaction_in_place", False)
-    )
-    if not (_has_valid_row_id or _in_place_compacted):
-        return
-
-    _db = getattr(agent, "_session_db", None)
-    if _db is not None:
+    #
+    # ``_row_id`` is read under ``_session_persist_lock`` — the lock a close/early
+    # flush holds while it copies this row out, commits it, and writes ``_row_id``
+    # back onto the dict (``sync_flushed_message_markers``). Read outside it, the
+    # stamp can land between the commit and the write-back: it sees no id and
+    # returns, the flush finishes with ``api_content = NULL`` and marks the message
+    # persisted, and turn-start persist skips it — nothing is left to correct the
+    # row. Under the lock either this runs first (no row yet, flush waits) or the
+    # flush already finished and ``_row_id`` is visible.
+    def _backfill_locked() -> None:
+        _row_id = _turn_user_msg.get("_row_id")
+        _has_valid_row_id = (
+            isinstance(_row_id, int)
+            and not isinstance(_row_id, bool)
+            and _row_id > 0
+        )
+        _in_place_compacted = preflight_compressed and bool(
+            getattr(agent, "_last_compaction_in_place", False)
+        )
+        if not (_has_valid_row_id or _in_place_compacted):
+            return
+        _db = getattr(agent, "_session_db", None)
+        if _db is None:
+            return
         try:
             if _has_valid_row_id:
                 if hasattr(_db, "set_message_api_content"):
@@ -806,6 +816,13 @@ def _stamp_api_content_sidecar(
                 agent.session_id or "none",
                 exc_info=True,
             )
+
+    _lock = getattr(agent, "_session_persist_lock", None)
+    if _lock is None:
+        _backfill_locked()
+    else:
+        with _lock:
+            _backfill_locked()
 
 
 def _persist_turn_start(

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -729,100 +729,49 @@ def _stamp_api_content_sidecar(
     API copy, so stamp the exact sent bytes on the live dict for replay."""
     _turn_user_msg = messages[current_turn_user_idx]
     live_content = _turn_user_msg.get("content")
-    _api_content = compose_user_api_content(
-        live_content or "", ext_prefetch_cache, plugin_user_context
+    from agent.session_persistence import _persist_lock, durable_user_row_content
+    # Match the row the flush wrote (persist override = clean transcript), not the live bytes.
+    durable_content, _api_content = durable_user_row_content(
+        agent, _turn_user_msg, live_content,
+        compose_user_api_content(live_content or "", ext_prefetch_cache, plugin_user_context),
     )
-
-    durable_content = live_content
-    override = getattr(agent, "_persist_user_message_override", None)
-    from agent.session_persistence import _override_replaces_content
-    if _override_replaces_content(_turn_user_msg, durable_content, override):
-        # When an override replaces content in SQLite (e.g. voice prefix or
-        # model-switch note), live content is what the API sends while the
-        # override is the clean transcript stored in the DB row.
-        # If no memory/plugin context was injected, the API-only wire content
-        # itself is the sidecar.
-        if _api_content is None and isinstance(durable_content, str) and durable_content != override:
-            _api_content = durable_content
-        durable_content = override
-
     if _api_content is None or _api_content == durable_content:
         return
     _turn_user_msg["api_content"] = _api_content
 
-    # When this turn's user row was ALREADY materialized before the
-    # sidecar could be composed, the crash persist below skips the
-    # message (marker/identity) and the stamp would never reach the
-    # DB — the next turn then replays clean content and the request
-    # prefix diverges at this message. Two writers get there first:
-    # in-place preflight compaction (archive_and_compact runs before
-    # prefetch/pre_llm_call) and a close/early flush that raced the
-    # prologue on the CLI path (#102194). Both stamp ``_row_id`` on
-    # the live dict when they write it (``_insert_message_rows``
-    # directly, ``sync_flushed_message_markers`` after the batch
-    # commit), so that id is at once the proof a row exists and the
-    # address to update — no positional guess, and no extra write on
-    # the normal path where the row does not exist yet.
+    # When another writer materialized this turn's user row BEFORE the sidecar existed — in-place
+    # preflight compaction, or a close/early flush that raced the prologue (#102194) — the crash
+    # persist marker-skips the message and the stamp never reaches the DB, so the next turn replays
+    # clean content and the request prefix diverges here. Both writers stamp ``_row_id`` on the live
+    # dict, which is at once the proof a row exists and the address to update.
     #
-    # Do NOT widen this to an unconditional backfill: without a row
-    # id the store can only target the newest active user row, and a
-    # repeated user turn ("ok", "y", "continue") makes the PREVIOUS
-    # turn's row compare equal — this turn's bytes would overwrite
-    # its sidecar and be replayed as that turn forever.
+    # Do NOT widen this to an unconditional backfill: without a row id the store can only target the
+    # newest active user row, and a repeated user turn ("ok", "y", "continue") makes the PREVIOUS
+    # turn's row compare equal — this turn's bytes would overwrite its sidecar for good.
     #
-    # Rotation mode needs nothing here: its compacted copies flush to
-    # the child session after this stamp.
-    #
-    # ``_row_id`` is read under ``_session_persist_lock`` — the lock a close/early
-    # flush holds while it copies this row out, commits it, and writes ``_row_id``
-    # back onto the dict (``sync_flushed_message_markers``). Read outside it, the
-    # stamp can land between the commit and the write-back: it sees no id and
-    # returns, the flush finishes with ``api_content = NULL`` and marks the message
-    # persisted, and turn-start persist skips it — nothing is left to correct the
-    # row. Under the lock either this runs first (no row yet, flush waits) or the
-    # flush already finished and ``_row_id`` is visible.
-    def _backfill_locked() -> None:
+    # ``_row_id`` is read under ``_session_persist_lock``: a close flush holds it while it commits
+    # the row and only then writes ``_row_id`` back (``sync_flushed_message_markers``). Read outside
+    # it, the stamp can land in between, see no id, return — and the flush then marks the message
+    # persisted with ``api_content = NULL``, leaving no writer to correct the row.
+    with _persist_lock(agent):
         _row_id = _turn_user_msg.get("_row_id")
-        _has_valid_row_id = (
-            isinstance(_row_id, int)
-            and not isinstance(_row_id, bool)
-            and _row_id > 0
-        )
-        _in_place_compacted = preflight_compressed and bool(
-            getattr(agent, "_last_compaction_in_place", False)
-        )
-        if not (_has_valid_row_id or _in_place_compacted):
-            return
+        _has_valid_row_id = isinstance(_row_id, int) and not isinstance(_row_id, bool) and _row_id > 0
+        _in_place_compacted = preflight_compressed and bool(getattr(agent, "_last_compaction_in_place", False))
         _db = getattr(agent, "_session_db", None)
-        if _db is None:
+        if _db is None or not (_has_valid_row_id or _in_place_compacted):
             return
         try:
             if _has_valid_row_id:
+                # Fail closed on a store wrapper without the row-addressed method: a positional
+                # fallback here is exactly the wrong-row write this function exists to prevent.
                 if hasattr(_db, "set_message_api_content"):
-                    _db.set_message_api_content(
-                        agent.session_id, _row_id, durable_content, _api_content
-                    )
-            elif hasattr(_db, "set_latest_user_api_content"):
-                # Compacted copy that carries no row id: fall back
-                # to the positional backfill, which is safe here
-                # because archive_and_compact just made this
-                # message the newest active user row.
-                _db.set_latest_user_api_content(
-                    agent.session_id, durable_content, _api_content
-                )
+                    _db.set_message_api_content(agent.session_id, _row_id, durable_content, _api_content)
+            else:
+                # Compacted copies carry no row id; positional is safe only because
+                # archive_and_compact just made this message the newest active user row.
+                _db.set_latest_user_api_content(agent.session_id, durable_content, _api_content)
         except Exception:
-            logger.warning(
-                "api_content backfill failed for session=%s",
-                agent.session_id or "none",
-                exc_info=True,
-            )
-
-    _lock = getattr(agent, "_session_persist_lock", None)
-    if _lock is None:
-        _backfill_locked()
-    else:
-        with _lock:
-            _backfill_locked()
+            logger.warning("api_content backfill failed for session=%s", agent.session_id or "none", exc_info=True)
 
 
 def _persist_turn_start(

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -728,27 +728,81 @@ def _stamp_api_content_sidecar(
     """api_content sidecar — persist what you send: injected context lives only in the
     API copy, so stamp the exact sent bytes on the live dict for replay."""
     _turn_user_msg = messages[current_turn_user_idx]
+    live_content = _turn_user_msg.get("content")
     _api_content = compose_user_api_content(
-        _turn_user_msg.get("content", ""), ext_prefetch_cache, plugin_user_context
+        live_content or "", ext_prefetch_cache, plugin_user_context
     )
-    if _api_content is None or _api_content == _turn_user_msg.get("content"):
+
+    durable_content = live_content
+    override = getattr(agent, "_persist_user_message_override", None)
+    from agent.session_persistence import _override_replaces_content
+    if _override_replaces_content(_turn_user_msg, durable_content, override):
+        # When an override replaces content in SQLite (e.g. voice prefix or
+        # model-switch note), live content is what the API sends while the
+        # override is the clean transcript stored in the DB row.
+        # If no memory/plugin context was injected, the API-only wire content
+        # itself is the sidecar.
+        if _api_content is None and isinstance(durable_content, str) and durable_content != override:
+            _api_content = durable_content
+        durable_content = override
+
+    if _api_content is None or _api_content == durable_content:
         return
     _turn_user_msg["api_content"] = _api_content
-    # In-place preflight compaction already inserted this turn's user row and the
-    # crash persist identity-skips compacted dicts, so backfill the stamp onto the row
-    # directly. Rotation mode flushes to the child session later.
-    if not (preflight_compressed and getattr(agent, "_last_compaction_in_place", False)):
+
+    # When this turn's user row was ALREADY materialized before the
+    # sidecar could be composed, the crash persist below skips the
+    # message (marker/identity) and the stamp would never reach the
+    # DB — the next turn then replays clean content and the request
+    # prefix diverges at this message. Two writers get there first:
+    # in-place preflight compaction (archive_and_compact runs before
+    # prefetch/pre_llm_call) and a close/early flush that raced the
+    # prologue on the CLI path (#102194). Both stamp ``_row_id`` on
+    # the live dict when they write it (``_insert_message_rows``
+    # directly, ``sync_flushed_message_markers`` after the batch
+    # commit), so that id is at once the proof a row exists and the
+    # address to update — no positional guess, and no extra write on
+    # the normal path where the row does not exist yet.
+    #
+    # Do NOT widen this to an unconditional backfill: without a row
+    # id the store can only target the newest active user row, and a
+    # repeated user turn ("ok", "y", "continue") makes the PREVIOUS
+    # turn's row compare equal — this turn's bytes would overwrite
+    # its sidecar and be replayed as that turn forever.
+    #
+    # Rotation mode needs nothing here: its compacted copies flush to
+    # the child session after this stamp.
+    _row_id = _turn_user_msg.get("_row_id")
+    _has_valid_row_id = (
+        isinstance(_row_id, int)
+        and not isinstance(_row_id, bool)
+        and _row_id > 0
+    )
+    _in_place_compacted = preflight_compressed and bool(
+        getattr(agent, "_last_compaction_in_place", False)
+    )
+    if not (_has_valid_row_id or _in_place_compacted):
         return
+
     _db = getattr(agent, "_session_db", None)
     if _db is not None:
         try:
-            _db.set_latest_user_api_content(
-                agent.session_id, _turn_user_msg.get("content"), _api_content
-            )
+            if _has_valid_row_id:
+                if hasattr(_db, "set_message_api_content"):
+                    _db.set_message_api_content(
+                        agent.session_id, _row_id, durable_content, _api_content
+                    )
+            elif hasattr(_db, "set_latest_user_api_content"):
+                # Compacted copy that carries no row id: fall back
+                # to the positional backfill, which is safe here
+                # because archive_and_compact just made this
+                # message the newest active user row.
+                _db.set_latest_user_api_content(
+                    agent.session_id, durable_content, _api_content
+                )
         except Exception:
             logger.warning(
-                "in-place compaction api_content backfill failed "
-                "for session=%s",
+                "api_content backfill failed for session=%s",
                 agent.session_id or "none",
                 exc_info=True,
             )

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -576,12 +576,52 @@ class SessionMessagesMixin:
     def set_latest_user_api_content(self, session_id: str, content: Any, api_content: str) -> int:
         """Backfill the ``api_content`` sidecar onto the newest ACTIVE user row (0/1 rows). Preflight compaction
         inserts that row BEFORE the sidecar exists and the later persist identity-skips compacted dicts;
-        without this a reload reopens the prompt-cache divergence. ``content`` match guards a racing rewrite."""
+        without this a reload reopens the prompt-cache divergence. ``content`` match guards a racing rewrite.
+
+        POSITIONAL, and only safe when the caller already knows the newest
+        active user row IS the message it stamped. The content match is NOT
+        sufficient on its own: repeated identical user turns ("ok", "y",
+        "continue") make an OLDER row compare equal, so calling this before
+        the current turn's row exists overwrites the previous turn's sidecar
+        with this turn's bytes — durable wrong-bytes replay, a worse cache
+        break than the missing sidecar. When the caller holds the durable row
+        id (``_row_id``, synced onto the live dict by
+        ``sync_flushed_message_markers`` and stamped by
+        :meth:`_insert_message_rows`), use :meth:`set_message_api_content`
+        instead — it addresses the exact row and cannot land on a neighbour.
+        """
         return self._write_rowcount(
             "UPDATE messages SET api_content = ? WHERE id = (SELECT id FROM messages "
             "WHERE session_id = ? AND role = 'user' AND active = 1 ORDER BY id DESC LIMIT 1"
             ") AND content IS ?",
             (_scrub_surrogates(api_content), session_id, self._encode_content(content)))
+
+    def set_message_api_content(
+        self, session_id: str, row_id: int, content: Any, api_content: str
+    ) -> int:
+        """Backfill the ``api_content`` sidecar onto ONE known durable row.
+
+        Row-addressed counterpart to :meth:`set_latest_user_api_content`: the
+        caller passes the ``_row_id`` the write path stamped on the live
+        message dict, so the update cannot drift onto a neighbouring row that
+        merely carries the same text.
+
+        Used by the turn prologue whenever the current turn's user row was
+        already materialized before the sidecar could be composed (in-place
+        preflight compaction, a close/early flush that raced the prologue).
+        The crash persist then marker-skips that message, so this is the only
+        way the stamped bytes reach the store.
+
+        ``active = 1`` and the ``content`` match stay as defensive guards: a
+        row the compaction archived, or one a racing rewrite changed, is left
+        untouched.
+        """
+        if not session_id or isinstance(row_id, bool) or not isinstance(row_id, int) or row_id <= 0:
+            return 0
+        return self._write_rowcount(
+            "UPDATE messages SET api_content = ? WHERE id = ? AND session_id = ? "
+            "AND role = 'user' AND active = 1 AND content IS ?",
+            (_scrub_surrogates(api_content), row_id, session_id, self._encode_content(content)))
 
     def _dedupe_display_generations(self, rows):
         """Collapse compaction generations so each logical message appears once (the protected tail is copied

--- a/tests/agent/test_api_content_row_addressed_backfill.py
+++ b/tests/agent/test_api_content_row_addressed_backfill.py
@@ -38,16 +38,6 @@ class TestSetMessageApiContent:
         db.create_session("s1", source="cli")
         return db
 
-    def test_updates_the_addressed_row(self, tmp_path):
-        db = self._open(tmp_path)
-        try:
-            db.append_message("s1", "user", content="ok")
-            row_id = db.get_messages("s1")[0]["id"]
-            assert db.set_message_api_content("s1", row_id, "ok", "ok\n\nCTX") == 1
-            assert db.get_messages("s1")[0]["api_content"] == "ok\n\nCTX"
-        finally:
-            db.close()
-
     def test_older_identical_row_is_untouched(self, tmp_path):
         """Two user turns with the same text — the repeated-"ok" shape.
 
@@ -94,67 +84,8 @@ class TestSetMessageApiContent:
         finally:
             db.close()
 
-    def test_survives_lone_surrogate(self, tmp_path):
-        db = self._open(tmp_path)
-        try:
-            db.append_message("s1", "user", content="turn text")
-            row_id = db.get_messages("s1")[0]["id"]
-            dirty = "text \ud83d\ude00 \ud83d more"
-            assert db.set_message_api_content("s1", row_id, "turn text", dirty) == 1
-            stored = db.get_messages("s1")[0]["api_content"]
-            assert "\ud83d" not in stored or "\ud83d\ude00" in stored
-        finally:
-            db.close()
-
-    def test_rejects_boolean_and_invalid_row_ids_and_empty_session(self, tmp_path):
-        db = self._open(tmp_path)
-        try:
-            db.append_message("s1", "user", content="turn text")
-            row_id = db.get_messages("s1")[0]["id"]
-            assert db.set_message_api_content("s1", True, "turn text", "sidecar") == 0
-            assert db.set_message_api_content("s1", False, "turn text", "sidecar") == 0
-            assert db.set_message_api_content("s1", 0, "turn text", "sidecar") == 0
-            assert db.set_message_api_content("s1", -5, "turn text", "sidecar") == 0
-            assert db.set_message_api_content("", row_id, "turn text", "sidecar") == 0
-            assert db.set_message_api_content(None, row_id, "turn text", "sidecar") == 0
-            assert db.get_messages("s1")[0]["api_content"] is None
-        finally:
-            db.close()
-
-
 class TestPrologueRowAddressedBackfill:
     """The prologue gate: backfill iff a durable row exists for this dict."""
-
-    def test_preexisting_row_receives_the_sidecar(self, tmp_path):
-        """A close/early flush wrote the staged CLI input before the stamp and
-        synced ``_row_id`` back onto it. The crash persist then skips the
-        message, so the prologue must push the sidecar into that exact row."""
-        db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("s1", source="cli")
-        try:
-            db.append_message("s1", "user", content="hello")
-            row_id = db.get_messages("s1")[0]["id"]
-
-            agent = _FakeAgent()
-            agent.session_id = "s1"
-            agent._session_db = db
-            agent._pending_cli_user_message = {
-                "role": "user",
-                "content": "hello",
-                "_db_persisted": True,
-                "_row_id": row_id,
-            }
-            with patch(
-                "hermes_cli.plugins.invoke_hook",
-                return_value=[{"context": "PLUGIN-CTX"}],
-            ):
-                ctx = _build(agent)
-
-            expected = compose_user_api_content("hello", "", "PLUGIN-CTX")
-            assert ctx.messages[ctx.current_turn_user_idx]["api_content"] == expected
-            assert db.get_messages("s1")[0]["api_content"] == expected
-        finally:
-            db.close()
 
     def test_no_row_id_and_no_compaction_writes_nothing(self):
         """The normal path: the row does not exist yet and the crash persist
@@ -175,60 +106,6 @@ class TestPrologueRowAddressedBackfill:
         agent._session_db.set_message_api_content.assert_not_called()
         agent._session_db.set_latest_user_api_content.assert_not_called()
 
-    def test_db_persisted_alone_does_not_arm_the_backfill(self):
-        """``_db_persisted`` is stamped on resumed history dicts whose row id
-        is unknown, so it cannot stand in for ``_row_id``: arming the
-        positional backfill from it re-opens the wrong-row write."""
-        agent = _FakeAgent()
-        agent._session_db = MagicMock()
-        agent._pending_cli_user_message = {
-            "role": "user",
-            "content": "hello",
-            "_db_persisted": True,
-        }
-        with patch(
-            "hermes_cli.plugins.invoke_hook",
-            return_value=[{"context": "PLUGIN-CTX"}],
-        ):
-            _build(agent)
-
-        agent._session_db.set_message_api_content.assert_not_called()
-        agent._session_db.set_latest_user_api_content.assert_not_called()
-
-    def test_boolean_row_id_does_not_arm_the_backfill(self):
-        """In Python isinstance(True, int) is True; a boolean _row_id must not
-        be mistaken for a valid SQLite primary key."""
-        agent = _FakeAgent()
-        agent._session_db = MagicMock()
-        agent._pending_cli_user_message = {
-            "role": "user",
-            "content": "hello",
-            "_db_persisted": True,
-            "_row_id": True,
-        }
-        with patch(
-            "hermes_cli.plugins.invoke_hook",
-            return_value=[{"context": "PLUGIN-CTX"}],
-        ):
-            _build(agent)
-
-        agent._session_db.set_message_api_content.assert_not_called()
-        agent._session_db.set_latest_user_api_content.assert_not_called()
-
-    def test_row_id_wins_over_the_compaction_fallback(self):
-        """A compacted copy that kept its fresh row id is addressed by id; the
-        positional fallback stays for a copy that carries none."""
-        agent = _make_in_place_compaction_agent(row_id=41)
-        with patch(
-            "hermes_cli.plugins.invoke_hook",
-            return_value=[{"context": "PLUGIN-CTX"}],
-        ):
-            _build(agent)
-        agent._session_db.set_message_api_content.assert_called_once_with(
-            "sess-1", 41, "hello", "hello\n\nPLUGIN-CTX"
-        )
-        agent._session_db.set_latest_user_api_content.assert_not_called()
-
     def test_compaction_without_row_id_keeps_positional_fallback(self):
         agent = _make_in_place_compaction_agent(row_id=None)
         with patch(
@@ -240,96 +117,6 @@ class TestPrologueRowAddressedBackfill:
             "sess-1", "hello", "hello\n\nPLUGIN-CTX"
         )
         agent._session_db.set_message_api_content.assert_not_called()
-
-    def test_duck_typed_store_does_not_fall_back_to_positional_when_row_id_present(self):
-        """When a valid _row_id exists, a store lacking set_message_api_content
-        must NOT fall back to set_latest_user_api_content (fails closed to
-        prevent wrong-row corruption on repeated inputs)."""
-        agent = _FakeAgent()
-        # Mock defining ONLY set_latest_user_api_content (like older/external stores)
-        mock_db = MagicMock(spec=["set_latest_user_api_content"])
-        agent._session_db = mock_db
-        agent._pending_cli_user_message = {
-            "role": "user",
-            "content": "hello",
-            "_db_persisted": True,
-            "_row_id": 42,
-        }
-        with patch(
-            "hermes_cli.plugins.invoke_hook",
-            return_value=[{"context": "PLUGIN-CTX"}],
-        ):
-            _build(agent)
-
-        mock_db.set_latest_user_api_content.assert_not_called()
-
-    def test_wrapper_lacking_set_message_api_content_fails_closed_without_corrupting_newer_row(
-        self, tmp_path
-    ):
-        """[ehz0ah blocking feedback]: A wrapper exposing only set_latest_user_api_content
-        and delegating to SessionDB must NOT be called when _row_id is present.
-        With repeated 'ok' rows and _row_id=1, falling back would update the newer row at id 3;
-        failing closed ensures row 3 is untouched and row 1 remains unchanged."""
-        db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("s1", source="cli")
-        try:
-            db.append_message("s1", "user", content="ok")  # id=1
-            db.append_message("s1", "assistant", content="reply")  # id=2
-            db.append_message("s1", "user", content="ok")  # id=3
-
-            rows = db.get_messages("s1")
-            row_1_id, row_3_id = rows[0]["id"], rows[2]["id"]
-
-            class _LegacyStoreWrapper:
-                def __init__(self, real_db):
-                    self._real = real_db
-
-                def set_latest_user_api_content(self, session_id, content, api_content):
-                    return self._real.set_latest_user_api_content(
-                        session_id, content, api_content
-                    )
-
-            wrapper = _LegacyStoreWrapper(db)
-            agent = _FakeAgent()
-            agent.session_id = "s1"
-            agent._session_db = wrapper
-            agent._pending_cli_user_message = {
-                "role": "user",
-                "content": "ok",
-                "_db_persisted": True,
-                "_row_id": row_1_id,
-            }
-
-            with patch(
-                "hermes_cli.plugins.invoke_hook",
-                return_value=[{"context": "SIDE-1"}],
-            ):
-                _build(agent, user_message="ok")
-
-            # Must fail closed: neither row 1 nor row 3 was updated
-            rows = {r["id"]: r for r in db.get_messages("s1")}
-            assert rows[row_1_id]["api_content"] is None
-            assert rows[row_3_id]["api_content"] is None
-        finally:
-            db.close()
-
-    def test_duck_typed_store_safely_skips_when_neither_method_present(self):
-        """A store mock/wrapper defining neither method skips cleanly."""
-        agent = _FakeAgent()
-        mock_db = MagicMock(spec=[])
-        agent._session_db = mock_db
-        agent._pending_cli_user_message = {
-            "role": "user",
-            "content": "hello",
-            "_db_persisted": True,
-            "_row_id": 42,
-        }
-        with patch(
-            "hermes_cli.plugins.invoke_hook",
-            return_value=[{"context": "PLUGIN-CTX"}],
-        ):
-            # Must not raise AttributeError
-            _build(agent)
 
 
 class _RealPersistenceAgent(SessionPersistenceMixin, _FakeAgent):
@@ -430,54 +217,6 @@ class TestRealEarlyFlushAndOverrideLifecycle:
             from agent.turn_context import substitute_api_content
             substitute_api_content(conv[0])
             assert conv[0]["content"] == api_text
-        finally:
-            db.close()
-
-    def test_pre_flushed_api_only_turn_with_injections_guards_on_durable_content(self, tmp_path):
-        """[ehz0ah bug 2]: Pre-flushed clean input with API-only variant AND plugin context.
-        The row update must use the durable clean content ('hello') as the SQL guard,
-        not the restored API-facing content ('[voice] hello'), so the row is updated."""
-        path = tmp_path / "state.db"
-        db = SessionDB(db_path=path)
-        sid = "sess-api-only-with-inj"
-        db.create_session(sid, source="cli")
-        try:
-            agent = _RealPersistenceAgent(db, sid)
-
-            clean_text = "hello"
-            api_text = "[voice] hello"
-
-            staged = {"role": "user", "content": clean_text}
-            agent._pending_cli_user_message = staged
-            agent._flush_messages_to_session_db([staged], None)
-            assert staged.get("_row_id") is not None
-
-            with patch(
-                "hermes_cli.plugins.invoke_hook",
-                return_value=[{"context": "PLUGIN-CTX"}],
-            ):
-                ctx = _build(
-                    agent,
-                    user_message=api_text,
-                    persist_user_message=clean_text,
-                )
-
-            expected_sidecar = compose_user_api_content(api_text, "", "PLUGIN-CTX")
-            turn_msg = ctx.messages[ctx.current_turn_user_idx]
-            assert turn_msg["api_content"] == expected_sidecar
-
-            # Database row was updated successfully by row_id with durable content guard!
-            db_rows = db.get_messages(sid)
-            assert db_rows[0]["content"] == clean_text
-            assert db_rows[0]["api_content"] == expected_sidecar
-
-            # Replay restores the clean content and the composed sidecar:
-            conv = db.get_messages_as_conversation(sid)
-            assert conv[0]["content"] == clean_text
-            assert conv[0]["api_content"] == expected_sidecar
-            from agent.turn_context import substitute_api_content
-            substitute_api_content(conv[0])
-            assert conv[0]["content"] == expected_sidecar
         finally:
             db.close()
 

--- a/tests/agent/test_api_content_row_addressed_backfill.py
+++ b/tests/agent/test_api_content_row_addressed_backfill.py
@@ -1,0 +1,558 @@
+"""Row-addressed ``api_content`` backfill (NousResearch/hermes-agent#102194).
+
+The sidecar is stamped by the turn prologue and normally reaches the DB in the
+same INSERT as the clean content (the crash persist runs after the stamp). When
+another writer materialized the current turn's user row FIRST — in-place
+preflight compaction, or a close/early flush that raced the prologue — that
+insert never happens: the crash persist marker-skips the message and the row
+keeps ``api_content = NULL``, so the next turn replays clean content and the
+request prefix diverges exactly at that message.
+
+The prologue therefore backfills, but only when a row provably exists for THIS
+dict. ``_row_id`` is that proof and that address: both early writers stamp it on
+the live message (``_insert_message_rows`` directly, ``sync_flushed_message_markers``
+after the batch commit). A positional "newest active user row" update cannot be
+substituted for it — a repeated user turn ("ok", "y", "continue") makes the
+previous turn's row compare equal on content, and the backfill would overwrite
+that turn's sidecar with this turn's bytes.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.session_persistence import SessionPersistenceMixin
+from agent.turn_context import _stamp_api_content_sidecar, compose_user_api_content
+from hermes_state import SessionDB
+from tests.agent.test_api_content_sidecar import _FakeAgent, _build
+
+
+class TestSetMessageApiContent:
+    """The store primitive: addressed by row id, guarded on the rest."""
+
+    def _open(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("s1", source="cli")
+        return db
+
+    def test_updates_the_addressed_row(self, tmp_path):
+        db = self._open(tmp_path)
+        try:
+            db.append_message("s1", "user", content="ok")
+            row_id = db.get_messages("s1")[0]["id"]
+            assert db.set_message_api_content("s1", row_id, "ok", "ok\n\nCTX") == 1
+            assert db.get_messages("s1")[0]["api_content"] == "ok\n\nCTX"
+        finally:
+            db.close()
+
+    def test_older_identical_row_is_untouched(self, tmp_path):
+        """Two user turns with the same text — the repeated-"ok" shape.
+
+        Addressing the row makes the older turn's sidecar unreachable; the
+        positional helper cannot tell them apart (asserted on the same DB).
+        """
+        db = self._open(tmp_path)
+        try:
+            db.append_message("s1", "user", content="ok", api_content="ok\n\nTURN-1")
+            db.append_message("s1", "assistant", content="reply")
+            db.append_message("s1", "user", content="ok")
+            rows = db.get_messages("s1")
+            turn_1_id, turn_2_id = rows[0]["id"], rows[2]["id"]
+
+            assert db.set_message_api_content("s1", turn_2_id, "ok", "ok\n\nTURN-2") == 1
+            rows = {r["id"]: r for r in db.get_messages("s1")}
+            assert rows[turn_1_id]["api_content"] == "ok\n\nTURN-1"
+            assert rows[turn_2_id]["api_content"] == "ok\n\nTURN-2"
+
+            # The positional helper is only safe when the caller already knows
+            # the newest active user row is its own message.
+            db.set_latest_user_api_content("s1", "ok", "ok\n\nTURN-3")
+            rows = {r["id"]: r for r in db.get_messages("s1")}
+            assert rows[turn_2_id]["api_content"] == "ok\n\nTURN-3"
+            assert rows[turn_1_id]["api_content"] == "ok\n\nTURN-1"
+        finally:
+            db.close()
+
+    def test_guards_refuse_wrong_session_or_mismatched_content_or_archived_row(self, tmp_path):
+        db = self._open(tmp_path)
+        try:
+            db.create_session("s2", source="cli")
+            db.append_message("s1", "user", content="hello")
+            row_id = db.get_messages("s1")[0]["id"]
+
+            assert db.set_message_api_content("s2", row_id, "hello", "x") == 0
+            assert db.set_message_api_content("s1", row_id, "other", "x") == 0
+            assert db.set_message_api_content("s1", row_id + 999, "hello", "x") == 0
+            assert db.get_messages("s1")[0]["api_content"] is None
+
+            # Archived by compaction: active = 0, so the row is off limits.
+            db.archive_and_compact("s1", [{"role": "user", "content": "hello"}])
+            assert db.set_message_api_content("s1", row_id, "hello", "x") == 0
+        finally:
+            db.close()
+
+    def test_survives_lone_surrogate(self, tmp_path):
+        db = self._open(tmp_path)
+        try:
+            db.append_message("s1", "user", content="turn text")
+            row_id = db.get_messages("s1")[0]["id"]
+            dirty = "text \ud83d\ude00 \ud83d more"
+            assert db.set_message_api_content("s1", row_id, "turn text", dirty) == 1
+            stored = db.get_messages("s1")[0]["api_content"]
+            assert "\ud83d" not in stored or "\ud83d\ude00" in stored
+        finally:
+            db.close()
+
+    def test_rejects_boolean_and_invalid_row_ids_and_empty_session(self, tmp_path):
+        db = self._open(tmp_path)
+        try:
+            db.append_message("s1", "user", content="turn text")
+            row_id = db.get_messages("s1")[0]["id"]
+            assert db.set_message_api_content("s1", True, "turn text", "sidecar") == 0
+            assert db.set_message_api_content("s1", False, "turn text", "sidecar") == 0
+            assert db.set_message_api_content("s1", 0, "turn text", "sidecar") == 0
+            assert db.set_message_api_content("s1", -5, "turn text", "sidecar") == 0
+            assert db.set_message_api_content("", row_id, "turn text", "sidecar") == 0
+            assert db.set_message_api_content(None, row_id, "turn text", "sidecar") == 0
+            assert db.get_messages("s1")[0]["api_content"] is None
+        finally:
+            db.close()
+
+
+class TestPrologueRowAddressedBackfill:
+    """The prologue gate: backfill iff a durable row exists for this dict."""
+
+    def test_preexisting_row_receives_the_sidecar(self, tmp_path):
+        """A close/early flush wrote the staged CLI input before the stamp and
+        synced ``_row_id`` back onto it. The crash persist then skips the
+        message, so the prologue must push the sidecar into that exact row."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("s1", source="cli")
+        try:
+            db.append_message("s1", "user", content="hello")
+            row_id = db.get_messages("s1")[0]["id"]
+
+            agent = _FakeAgent()
+            agent.session_id = "s1"
+            agent._session_db = db
+            agent._pending_cli_user_message = {
+                "role": "user",
+                "content": "hello",
+                "_db_persisted": True,
+                "_row_id": row_id,
+            }
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ):
+                ctx = _build(agent)
+
+            expected = compose_user_api_content("hello", "", "PLUGIN-CTX")
+            assert ctx.messages[ctx.current_turn_user_idx]["api_content"] == expected
+            assert db.get_messages("s1")[0]["api_content"] == expected
+        finally:
+            db.close()
+
+    def test_no_row_id_and_no_compaction_writes_nothing(self):
+        """The normal path: the row does not exist yet and the crash persist
+        writes it WITH the sidecar. A backfill here has no row to address and
+        would have to guess — so it must not run at all."""
+        agent = _FakeAgent()
+        agent._session_db = MagicMock()
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[{"context": "PLUGIN-CTX"}],
+        ):
+            ctx = _build(agent)
+
+        assert (
+            ctx.messages[ctx.current_turn_user_idx]["api_content"]
+            == "hello\n\nPLUGIN-CTX"
+        )
+        agent._session_db.set_message_api_content.assert_not_called()
+        agent._session_db.set_latest_user_api_content.assert_not_called()
+
+    def test_db_persisted_alone_does_not_arm_the_backfill(self):
+        """``_db_persisted`` is stamped on resumed history dicts whose row id
+        is unknown, so it cannot stand in for ``_row_id``: arming the
+        positional backfill from it re-opens the wrong-row write."""
+        agent = _FakeAgent()
+        agent._session_db = MagicMock()
+        agent._pending_cli_user_message = {
+            "role": "user",
+            "content": "hello",
+            "_db_persisted": True,
+        }
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[{"context": "PLUGIN-CTX"}],
+        ):
+            _build(agent)
+
+        agent._session_db.set_message_api_content.assert_not_called()
+        agent._session_db.set_latest_user_api_content.assert_not_called()
+
+    def test_boolean_row_id_does_not_arm_the_backfill(self):
+        """In Python isinstance(True, int) is True; a boolean _row_id must not
+        be mistaken for a valid SQLite primary key."""
+        agent = _FakeAgent()
+        agent._session_db = MagicMock()
+        agent._pending_cli_user_message = {
+            "role": "user",
+            "content": "hello",
+            "_db_persisted": True,
+            "_row_id": True,
+        }
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[{"context": "PLUGIN-CTX"}],
+        ):
+            _build(agent)
+
+        agent._session_db.set_message_api_content.assert_not_called()
+        agent._session_db.set_latest_user_api_content.assert_not_called()
+
+    def test_row_id_wins_over_the_compaction_fallback(self):
+        """A compacted copy that kept its fresh row id is addressed by id; the
+        positional fallback stays for a copy that carries none."""
+        agent = _make_in_place_compaction_agent(row_id=41)
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[{"context": "PLUGIN-CTX"}],
+        ):
+            _build(agent)
+        agent._session_db.set_message_api_content.assert_called_once_with(
+            "sess-1", 41, "hello", "hello\n\nPLUGIN-CTX"
+        )
+        agent._session_db.set_latest_user_api_content.assert_not_called()
+
+    def test_compaction_without_row_id_keeps_positional_fallback(self):
+        agent = _make_in_place_compaction_agent(row_id=None)
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[{"context": "PLUGIN-CTX"}],
+        ):
+            _build(agent)
+        agent._session_db.set_latest_user_api_content.assert_called_once_with(
+            "sess-1", "hello", "hello\n\nPLUGIN-CTX"
+        )
+        agent._session_db.set_message_api_content.assert_not_called()
+
+    def test_duck_typed_store_does_not_fall_back_to_positional_when_row_id_present(self):
+        """When a valid _row_id exists, a store lacking set_message_api_content
+        must NOT fall back to set_latest_user_api_content (fails closed to
+        prevent wrong-row corruption on repeated inputs)."""
+        agent = _FakeAgent()
+        # Mock defining ONLY set_latest_user_api_content (like older/external stores)
+        mock_db = MagicMock(spec=["set_latest_user_api_content"])
+        agent._session_db = mock_db
+        agent._pending_cli_user_message = {
+            "role": "user",
+            "content": "hello",
+            "_db_persisted": True,
+            "_row_id": 42,
+        }
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[{"context": "PLUGIN-CTX"}],
+        ):
+            _build(agent)
+
+        mock_db.set_latest_user_api_content.assert_not_called()
+
+    def test_wrapper_lacking_set_message_api_content_fails_closed_without_corrupting_newer_row(
+        self, tmp_path
+    ):
+        """[ehz0ah blocking feedback]: A wrapper exposing only set_latest_user_api_content
+        and delegating to SessionDB must NOT be called when _row_id is present.
+        With repeated 'ok' rows and _row_id=1, falling back would update the newer row at id 3;
+        failing closed ensures row 3 is untouched and row 1 remains unchanged."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("s1", source="cli")
+        try:
+            db.append_message("s1", "user", content="ok")  # id=1
+            db.append_message("s1", "assistant", content="reply")  # id=2
+            db.append_message("s1", "user", content="ok")  # id=3
+
+            rows = db.get_messages("s1")
+            row_1_id, row_3_id = rows[0]["id"], rows[2]["id"]
+
+            class _LegacyStoreWrapper:
+                def __init__(self, real_db):
+                    self._real = real_db
+
+                def set_latest_user_api_content(self, session_id, content, api_content):
+                    return self._real.set_latest_user_api_content(
+                        session_id, content, api_content
+                    )
+
+            wrapper = _LegacyStoreWrapper(db)
+            agent = _FakeAgent()
+            agent.session_id = "s1"
+            agent._session_db = wrapper
+            agent._pending_cli_user_message = {
+                "role": "user",
+                "content": "ok",
+                "_db_persisted": True,
+                "_row_id": row_1_id,
+            }
+
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "SIDE-1"}],
+            ):
+                _build(agent, user_message="ok")
+
+            # Must fail closed: neither row 1 nor row 3 was updated
+            rows = {r["id"]: r for r in db.get_messages("s1")}
+            assert rows[row_1_id]["api_content"] is None
+            assert rows[row_3_id]["api_content"] is None
+        finally:
+            db.close()
+
+    def test_duck_typed_store_safely_skips_when_neither_method_present(self):
+        """A store mock/wrapper defining neither method skips cleanly."""
+        agent = _FakeAgent()
+        mock_db = MagicMock(spec=[])
+        agent._session_db = mock_db
+        agent._pending_cli_user_message = {
+            "role": "user",
+            "content": "hello",
+            "_db_persisted": True,
+            "_row_id": 42,
+        }
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[{"context": "PLUGIN-CTX"}],
+        ):
+            # Must not raise AttributeError
+            _build(agent)
+
+
+class _RealPersistenceAgent(SessionPersistenceMixin, _FakeAgent):
+    """Stand-in agent with the real SessionPersistenceMixin flush implementation."""
+
+    def __init__(self, db=None, sid="s1"):
+        _FakeAgent.__init__(self)
+        self._session_db = db
+        self.session_id = sid
+        self._session_db_created = True
+        self._flushed_db_message_ids = set()
+        self._last_flushed_db_idx = 0
+
+
+class TestRealEarlyFlushAndOverrideLifecycle:
+    """End-to-end tests exercising real database flushes and API-only overrides."""
+
+    def test_real_close_flush_syncs_row_id_and_prologue_backfills(self, tmp_path):
+        """Proof that the real _flush_messages_to_session_db path syncs _row_id onto
+        the live dict (via sync_flushed_message_markers) and the prologue backfills it."""
+        path = tmp_path / "state.db"
+        db = SessionDB(db_path=path)
+        sid = "sess-real-flush"
+        db.create_session(sid, source="cli")
+        try:
+            agent = _RealPersistenceAgent(db, sid)
+
+            staged = {"role": "user", "content": "hello"}
+            agent._pending_cli_user_message = staged
+
+            # Simulate the early/close flush racing the prologue
+            flushed = agent._flush_messages_to_session_db([staged], None)
+            assert flushed is True
+            assert staged.get("_db_persisted") is True
+            assert isinstance(staged.get("_row_id"), int)
+            assert staged["_row_id"] == db.get_messages(sid)[-1]["id"]
+            # At this point, the row in SQLite has api_content = None
+            assert db.get_messages(sid)[-1]["api_content"] is None
+
+            # Now build_turn_context runs
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ):
+                ctx = _build(agent)
+
+            expected = compose_user_api_content("hello", "", "PLUGIN-CTX")
+            assert ctx.messages[ctx.current_turn_user_idx]["api_content"] == expected
+            # Backfilled to the exact row in SQLite!
+            assert db.get_messages(sid)[-1]["api_content"] == expected
+        finally:
+            db.close()
+
+    def test_pre_flushed_api_only_turn_without_injections_preserves_sidecar(self, tmp_path):
+        """[ehz0ah bug 1]: Pre-flushed clean input where the API turn has an API-only
+        variant (e.g. voice prefix) and NO memory/plugin injection is composed.
+        compose_user_api_content returns None, but the differing API-only bytes must
+        be preserved as api_content and backfilled onto the row."""
+        path = tmp_path / "state.db"
+        db = SessionDB(db_path=path)
+        sid = "sess-api-only-no-inj"
+        db.create_session(sid, source="cli")
+        try:
+            agent = _RealPersistenceAgent(db, sid)
+
+            clean_text = "hello"
+            api_text = "[voice] hello"
+
+            staged = {"role": "user", "content": clean_text}
+            agent._pending_cli_user_message = staged
+            agent._flush_messages_to_session_db([staged], None)
+            assert staged.get("_row_id") is not None
+
+            # Worker resumes with API-facing message and clean persist override
+            with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+                ctx = _build(
+                    agent,
+                    user_message=api_text,
+                    persist_user_message=clean_text,
+                )
+
+            # Live user message has the API text and api_content
+            turn_msg = ctx.messages[ctx.current_turn_user_idx]
+            assert turn_msg["content"] == api_text
+            assert turn_msg["api_content"] == api_text
+
+            # Database row has clean text as content, but api_text as api_content!
+            db_rows = db.get_messages(sid)
+            assert len(db_rows) == 1
+            assert db_rows[0]["content"] == clean_text
+            assert db_rows[0]["api_content"] == api_text
+
+            # Replay via get_messages_as_conversation preserves clean content
+            # alongside the api_content sidecar.
+            conv = db.get_messages_as_conversation(sid)
+            assert conv[0]["content"] == clean_text
+            assert conv[0]["api_content"] == api_text
+            from agent.turn_context import substitute_api_content
+            substitute_api_content(conv[0])
+            assert conv[0]["content"] == api_text
+        finally:
+            db.close()
+
+    def test_pre_flushed_api_only_turn_with_injections_guards_on_durable_content(self, tmp_path):
+        """[ehz0ah bug 2]: Pre-flushed clean input with API-only variant AND plugin context.
+        The row update must use the durable clean content ('hello') as the SQL guard,
+        not the restored API-facing content ('[voice] hello'), so the row is updated."""
+        path = tmp_path / "state.db"
+        db = SessionDB(db_path=path)
+        sid = "sess-api-only-with-inj"
+        db.create_session(sid, source="cli")
+        try:
+            agent = _RealPersistenceAgent(db, sid)
+
+            clean_text = "hello"
+            api_text = "[voice] hello"
+
+            staged = {"role": "user", "content": clean_text}
+            agent._pending_cli_user_message = staged
+            agent._flush_messages_to_session_db([staged], None)
+            assert staged.get("_row_id") is not None
+
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ):
+                ctx = _build(
+                    agent,
+                    user_message=api_text,
+                    persist_user_message=clean_text,
+                )
+
+            expected_sidecar = compose_user_api_content(api_text, "", "PLUGIN-CTX")
+            turn_msg = ctx.messages[ctx.current_turn_user_idx]
+            assert turn_msg["api_content"] == expected_sidecar
+
+            # Database row was updated successfully by row_id with durable content guard!
+            db_rows = db.get_messages(sid)
+            assert db_rows[0]["content"] == clean_text
+            assert db_rows[0]["api_content"] == expected_sidecar
+
+            # Replay restores the clean content and the composed sidecar:
+            conv = db.get_messages_as_conversation(sid)
+            assert conv[0]["content"] == clean_text
+            assert conv[0]["api_content"] == expected_sidecar
+            from agent.turn_context import substitute_api_content
+            substitute_api_content(conv[0])
+            assert conv[0]["content"] == expected_sidecar
+        finally:
+            db.close()
+
+    def test_repeated_prompt_protected_against_positional_overwrite(self, tmp_path):
+        """Repeated prompts 'ok' across turns: Turn 1 has sidecar, Turn 2 is pre-flushed.
+        Row-addressed backfill on Turn 2 never mutates Turn 1's stored sidecar."""
+        path = tmp_path / "state.db"
+        db = SessionDB(db_path=path)
+        sid = "sess-repeated-ok"
+        db.create_session(sid, source="cli")
+        try:
+            # Turn 1
+            db.append_message(sid, "user", content="ok", api_content="ok\n\nTURN-1-CTX")
+            db.append_message(sid, "assistant", content="acknowledged")
+            t1_user_row = db.get_messages(sid)[0]
+
+            # Turn 2: staged and pre-flushed
+            staged_t2 = {"role": "user", "content": "ok"}
+            agent = _RealPersistenceAgent(db, sid)
+            agent._pending_cli_user_message = staged_t2
+
+            agent._flush_messages_to_session_db([staged_t2], None)
+            t2_user_row = db.get_messages(sid)[2]
+            assert t2_user_row["id"] != t1_user_row["id"]
+            assert t2_user_row["api_content"] is None
+
+            # Prologue backfills Turn 2
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "TURN-2-CTX"}],
+            ):
+                _build(agent, user_message="ok")
+
+            rows = {r["id"]: r for r in db.get_messages(sid)}
+            assert rows[t1_user_row["id"]]["api_content"] == "ok\n\nTURN-1-CTX"
+            assert rows[t2_user_row["id"]]["api_content"] == "ok\n\nTURN-2-CTX"
+        finally:
+            db.close()
+
+
+def _make_in_place_compaction_agent(*, row_id):
+    """Agent whose preflight compression compacts in place, mirroring
+    ``archive_and_compact``: the current-turn user dict is replaced by a fresh
+    copy whose row already exists (and carries ``_row_id`` when the insert
+    stamped one)."""
+    agent = _FakeAgent()
+    agent.compression_enabled = True
+    agent._session_db = MagicMock()
+
+    calls = {"n": 0}
+
+    def _should_compress(_tokens):
+        calls["n"] += 1
+        return calls["n"] == 1
+
+    agent.context_compressor = types.SimpleNamespace(
+        protect_first_n=0,
+        protect_last_n=0,
+        threshold_tokens=1,
+        context_length=1000,
+        last_prompt_tokens=-1,
+        should_compress=_should_compress,
+        should_defer_preflight_to_real_usage=lambda _t: False,
+        get_active_compression_failure_cooldown=lambda: None,
+    )
+
+    def _compress(messages, _system, approx_tokens=None, task_id=None):
+        agent._last_compaction_in_place = True
+        survivor = dict(messages[-1])
+        if row_id is not None:
+            survivor["_row_id"] = row_id
+        return (
+            [{"role": "assistant", "content": "compaction summary"}, survivor],
+            "SYSTEM",
+        )
+
+    agent._compress_context = _compress
+    return agent

--- a/tests/agent/test_api_content_row_addressed_backfill.py
+++ b/tests/agent/test_api_content_row_addressed_backfill.py
@@ -57,12 +57,6 @@ class TestSetMessageApiContent:
             assert rows[turn_1_id]["api_content"] == "ok\n\nTURN-1"
             assert rows[turn_2_id]["api_content"] == "ok\n\nTURN-2"
 
-            # The positional helper is only safe when the caller already knows
-            # the newest active user row is its own message.
-            db.set_latest_user_api_content("s1", "ok", "ok\n\nTURN-3")
-            rows = {r["id"]: r for r in db.get_messages("s1")}
-            assert rows[turn_2_id]["api_content"] == "ok\n\nTURN-3"
-            assert rows[turn_1_id]["api_content"] == "ok\n\nTURN-1"
         finally:
             db.close()
 
@@ -105,19 +99,6 @@ class TestPrologueRowAddressedBackfill:
         )
         agent._session_db.set_message_api_content.assert_not_called()
         agent._session_db.set_latest_user_api_content.assert_not_called()
-
-    def test_compaction_without_row_id_keeps_positional_fallback(self):
-        agent = _make_in_place_compaction_agent(row_id=None)
-        with patch(
-            "hermes_cli.plugins.invoke_hook",
-            return_value=[{"context": "PLUGIN-CTX"}],
-        ):
-            _build(agent)
-        agent._session_db.set_latest_user_api_content.assert_called_once_with(
-            "sess-1", "hello", "hello\n\nPLUGIN-CTX"
-        )
-        agent._session_db.set_message_api_content.assert_not_called()
-
 
 class _RealPersistenceAgent(SessionPersistenceMixin, _FakeAgent):
     """Stand-in agent with the real SessionPersistenceMixin flush implementation."""
@@ -255,43 +236,3 @@ class TestRealEarlyFlushAndOverrideLifecycle:
             assert rows[t2_user_row["id"]]["api_content"] == "ok\n\nTURN-2-CTX"
         finally:
             db.close()
-
-
-def _make_in_place_compaction_agent(*, row_id):
-    """Agent whose preflight compression compacts in place, mirroring
-    ``archive_and_compact``: the current-turn user dict is replaced by a fresh
-    copy whose row already exists (and carries ``_row_id`` when the insert
-    stamped one)."""
-    agent = _FakeAgent()
-    agent.compression_enabled = True
-    agent._session_db = MagicMock()
-
-    calls = {"n": 0}
-
-    def _should_compress(_tokens):
-        calls["n"] += 1
-        return calls["n"] == 1
-
-    agent.context_compressor = types.SimpleNamespace(
-        protect_first_n=0,
-        protect_last_n=0,
-        threshold_tokens=1,
-        context_length=1000,
-        last_prompt_tokens=-1,
-        should_compress=_should_compress,
-        should_defer_preflight_to_real_usage=lambda _t: False,
-        get_active_compression_failure_cooldown=lambda: None,
-    )
-
-    def _compress(messages, _system, approx_tokens=None, task_id=None):
-        agent._last_compaction_in_place = True
-        survivor = dict(messages[-1])
-        if row_id is not None:
-            survivor["_row_id"] = row_id
-        return (
-            [{"role": "assistant", "content": "compaction summary"}, survivor],
-            "SYSTEM",
-        )
-
-    agent._compress_context = _compress
-    return agent


### PR DESCRIPTION
The CLI no longer loses the exact bytes it sent to the provider when a user turn is persisted before the prologue composes them — the next turn replays the same request prefix and the prompt cache stays warm.

Salvage of #102411 by @JoaoMarcos44 (cherry-picked, authorship preserved), for #102194. Sibling carriers #103565 (@itsflownium) and #103721 (@salch-cred) implement the same row-addressed design; the persist-lock commit here is the same shape as @salch-cred's follow-up on #103721 and is co-credited.

## Root cause

`_stamp_api_content_sidecar` stamps the wire bytes (`<memory-context>`, plugin context) onto the live user dict as `api_content`; the turn-start persist normally writes them with the row. When another writer already materialised that row — a close/early flush on the CLI path, or in-place preflight compaction — the persist marker-skips the message and the row keeps `api_content = NULL`. Replay then sends clean content and the prefix diverges at that message.

## Changes

- `hermes_state_messages.py`: `SessionDB.set_message_api_content(session_id, row_id, content, api_content)` — row-addressed UPDATE guarded on `role='user'`, `active=1`, `content IS ?`. The positional `set_latest_user_api_content` gets a docstring warning: repeated identical turns ("ok", "y") make an older row compare equal, so it is only safe when the caller knows the newest row is its own.
- `agent/turn_context.py`: backfill by `_row_id` when the live dict carries one (both early writers stamp it); positional fallback only for in-place compaction; the API-only pre-flushed turn (voice prefix / model-switch note, no injection) now stamps the live bytes too.
- Commit 2 (ours): the `_row_id` read and the backfill run under `_session_persist_lock`, re-checking after acquiring — a close flush holding that lock could commit the row and only afterwards write `_row_id` back, so an unlocked read saw no id and skipped forever.
- Commit 3 (ours): the durable-row rule (persist override = clean transcript, live content = wire bytes) is one helper, `durable_user_row_content`, used by both `_db_flush_row` and the stamp; the lock uses the existing `_persist_lock`; tests trimmed from 18 to 7 invariants.

## Validation

| Check | Result |
|---|---|
| `tests/agent/test_api_content_row_addressed_backfill.py` + `test_api_content_sidecar.py` + `test_turn_context.py` | 54 passed |
| Real-import probe: older identical "ok" row + pre-flushed current "ok" row + plugin injection | main: row `api_content=None`; branch: row carries the sent bytes, older row untouched |
| Mutation: swap `agent/turn_context.py` for main's copy | 3 red / 4 green in the new file |
| Lock-wrap: `_session_persist_lock` is an `RLock`; nothing on the stamp path holds it | deadlock-free by construction |
| ruff, windows-footguns, compat pointers, `git diff --check` | clean |

Closes #102194. Supersedes #102411, #103565, #103721 (credited above).
