### PR TITLE
Background-review fork advertises the parent's exact tools[] and keeps it through compaction (#103579, salvage #103581)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -864,7 +864,7 @@ def _inherit_parent_tool_surface(review_agent: Any, agent: Any) -> None:
     rebuild and do not clobber the inherited tools (#103579).
     """
     parent_tools = getattr(agent, "tools", None)
-    if not isinstance(parent_tools, (list, tuple)) or not parent_tools:
+    if not isinstance(parent_tools, (list, tuple)):
         return
     review_agent.tools = copy.deepcopy(list(parent_tools))
     review_agent.valid_tool_names = {

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -842,6 +842,29 @@ def _fork_init_kwargs(agent: Any, rt: Dict[str, Any], routed: bool, max_iteratio
     return kwargs
 
 
+def _inherit_parent_tool_surface(review_agent: Any, agent: Any) -> None:
+    """Copy the parent's advertised tools for a same-model cache-parity fork.
+
+    The parent's array is the last outbound payload: ``agent.tools`` is read
+    directly at request time and is not mutated between review turns because
+    ``_skip_mcp_refresh`` blocks the between-turn MCP refresh. Dispatch remains
+    restricted by the thread whitelist. Copying the whole surface covers every
+    dynamically injected tool (memory-provider, late MCP, and plugin-registered),
+    not just memory tools.
+    """
+    parent_tools = getattr(agent, "tools", None)
+    if not isinstance(parent_tools, (list, tuple)) or not parent_tools:
+        return
+    review_agent.tools = copy.deepcopy(list(parent_tools))
+    review_agent.valid_tool_names = {
+        entry["function"]["name"]
+        for entry in review_agent.tools
+        if isinstance(entry, dict)
+        and isinstance(entry.get("function"), dict)
+        and isinstance(entry["function"].get("name"), str)
+    }
+
+
 def build_cache_parity_fork(
     agent: Any, task_cfg: Optional[Dict[str, Any]] = None, *, max_iterations: int,
     write_origin: str = "background_review",
@@ -887,6 +910,7 @@ def build_cache_parity_fork(
     if not _routed:
         review_agent._cached_system_prompt = agent._cached_system_prompt
         review_agent.session_start = agent.session_start
+        _inherit_parent_tool_surface(review_agent, agent)
     _detach_fork_compression(review_agent)
     # Compaction bounds a single request; this bounds the WHOLE review (checked in
     # conversation_loop via _review_input_budget_exhausted).

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -842,6 +842,13 @@ def _fork_init_kwargs(agent: Any, rt: Dict[str, Any], routed: bool, max_iteratio
     return kwargs
 
 
+# Sentinel generation above any live registry generation. Mid-review compaction
+# boundaries re-run refresh_agent_mcp_tools(content_aware=True); freezing the
+# snapshot generation prevents compaction from rebuilding agent.tools and dropping
+# inherited provider tools (#103579).
+_FROZEN_TOOL_SNAPSHOT_GENERATION: int = 2_147_483_647
+
+
 def _inherit_parent_tool_surface(review_agent: Any, agent: Any) -> None:
     """Copy the parent's advertised tools for a same-model cache-parity fork.
 
@@ -851,6 +858,10 @@ def _inherit_parent_tool_surface(review_agent: Any, agent: Any) -> None:
     restricted by the thread whitelist. Copying the whole surface covers every
     dynamically injected tool (memory-provider, late MCP, and plugin-registered),
     not just memory tools.
+
+    Freezes ``_tool_snapshot_generation`` so mid-review compaction boundaries
+    (which invoke ``refresh_agent_mcp_tools(content_aware=True)``) refuse the
+    rebuild and do not clobber the inherited tools (#103579).
     """
     parent_tools = getattr(agent, "tools", None)
     if not isinstance(parent_tools, (list, tuple)) or not parent_tools:
@@ -863,6 +874,7 @@ def _inherit_parent_tool_surface(review_agent: Any, agent: Any) -> None:
         and isinstance(entry.get("function"), dict)
         and isinstance(entry["function"].get("name"), str)
     }
+    review_agent._tool_snapshot_generation = _FROZEN_TOOL_SNAPSHOT_GENERATION
 
 
 def build_cache_parity_fork(

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -842,39 +842,21 @@ def _fork_init_kwargs(agent: Any, rt: Dict[str, Any], routed: bool, max_iteratio
     return kwargs
 
 
-# Sentinel generation above any live registry generation. Mid-review compaction
-# boundaries re-run refresh_agent_mcp_tools(content_aware=True); freezing the
-# snapshot generation prevents compaction from rebuilding agent.tools and dropping
-# inherited provider tools (#103579).
-_FROZEN_TOOL_SNAPSHOT_GENERATION: int = 2_147_483_647
+# Above any live registry generation: _publish_tool_snapshot refuses an older-generation rebuild,
+# so the compaction-boundary refresh_agent_mcp_tools(content_aware=True) cannot rebuild the fork's
+# tools[] from the live registry and drop the inherited provider/plugin tools (#103579).
+_FROZEN_TOOL_SNAPSHOT_GENERATION = 2_147_483_647
 
 
 def _inherit_parent_tool_surface(review_agent: Any, agent: Any) -> None:
-    """Copy the parent's advertised tools for a same-model cache-parity fork.
-
-    The parent's array is the last outbound payload: ``agent.tools`` is read
-    directly at request time and is not mutated between review turns because
-    ``_skip_mcp_refresh`` blocks the between-turn MCP refresh. Dispatch remains
-    restricted by the thread whitelist. Copying the whole surface covers every
-    dynamically injected tool (memory-provider, late MCP, and plugin-registered),
-    not just memory tools.
-
-    Freezes ``_tool_snapshot_generation`` so mid-review compaction boundaries
-    (which invoke ``refresh_agent_mcp_tools(content_aware=True)``) refuse the
-    rebuild and do not clobber the inherited tools (#103579).
-    """
-    parent_tools = getattr(agent, "tools", None)
-    if not isinstance(parent_tools, (list, tuple)):
-        return
-    review_agent.tools = copy.deepcopy(list(parent_tools))
-    review_agent.valid_tool_names = {
-        entry["function"]["name"]
-        for entry in review_agent.tools
-        if isinstance(entry, dict)
-        and isinstance(entry.get("function"), dict)
-        and isinstance(entry["function"].get("name"), str)
-    }
+    """Same-model fork: advertise the parent's exact tools[] (its last outbound payload — an
+    empty list included) so the request prefix matches byte-for-byte, then freeze the snapshot
+    generation. Dispatch stays behind the review whitelist; advertising is not permission."""
+    # getattr: /btw and review callers build bare object.__new__ agents in tests without ``tools``.
+    review_agent.tools = copy.deepcopy(getattr(agent, "tools", None) or [])
+    review_agent.valid_tool_names = {tool["function"]["name"] for tool in review_agent.tools}
     review_agent._tool_snapshot_generation = _FROZEN_TOOL_SNAPSHOT_GENERATION
+
 
 
 def build_cache_parity_fork(

--- a/contributors/emails/agentai891@gmail.com
+++ b/contributors/emails/agentai891@gmail.com
@@ -1,0 +1,2 @@
+0xalydev
+# PR #103581 salvage

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -345,70 +345,6 @@ def test_routed_review_fork_does_not_inherit_reasoning_config():
         )
 
 
-def test_unrouted_review_fork_inherits_entire_tool_surface():
-    """Unrouted forks preserve all advertised tools and their name index (#103579)."""
-    import run_agent
-    from agent.background_review import build_cache_parity_fork
-
-    agent = _make_agent_stub(run_agent.AIAgent)
-    parent_tools = [
-        {"type": "function", "function": {"name": "base_tool"}},
-        {"type": "function", "function": {"name": "fact_store"}},
-        {"type": "function", "function": {"name": "fact_feedback"}},
-        {"type": "function", "function": {"name": "mcp_late_tool"}},
-        {"malformed": True},
-    ]
-    agent.tools = parent_tools
-
-    _Recorder = _make_recorder_class()
-
-    with patch.object(run_agent, "AIAgent", _Recorder):
-        fork, _rt, routed = build_cache_parity_fork(agent, max_iterations=5)
-        assert not routed
-        assert fork.tools == parent_tools
-        assert fork.tools is not parent_tools
-        assert fork.tools[0] is not parent_tools[0]
-        assert fork.valid_tool_names == {
-            "base_tool", "fact_store", "fact_feedback", "mcp_late_tool"
-        }
-        fork.tools.append({"type": "function", "function": {"name": "new"}})
-        assert len(fork.tools) != len(agent.tools)
-
-
-def test_routed_review_fork_does_not_inherit_tool_surface():
-    """Routed review fork does not inherit parent's tools[] across different models (#103579)."""
-    import run_agent
-    import agent.background_review as bg_review
-    from agent.background_review import build_cache_parity_fork
-
-    agent = _make_agent_stub(run_agent.AIAgent)
-    parent_tools = [
-        {"type": "function", "function": {"name": "parent_tool"}},
-    ]
-    agent.tools = parent_tools
-
-    _Recorder = _make_recorder_class()
-    routed_runtime = {
-        "provider": "openrouter",
-        "model": "aux-cheap-model",
-        "api_key": "test-key",
-        "base_url": None,
-        "api_mode": None,
-        "credential_pool": None,
-        "request_overrides": {},
-        "max_tokens": None,
-        "command": None,
-        "args": [],
-        "routed": True,
-    }
-
-    with patch.object(run_agent, "AIAgent", _Recorder), \
-         patch.object(bg_review, "_resolve_review_runtime", return_value=routed_runtime):
-        fork, _rt, routed = build_cache_parity_fork(agent, max_iterations=5)
-        assert routed
-        assert fork.tools is None
-
-
 def test_review_fork_inherited_tools_survive_compaction_refresh():
     """Inherited tools survive mid-review compaction refresh (#103579).
 
@@ -419,7 +355,7 @@ def test_review_fork_inherited_tools_survive_compaction_refresh():
     generation staleness check refuses the rebuild.
     """
     import run_agent
-    from agent.background_review import build_cache_parity_fork
+    from agent.background_review import _FROZEN_TOOL_SNAPSHOT_GENERATION, build_cache_parity_fork
     from tools.mcp_tool_agent import refresh_agent_mcp_tools
 
     agent = _make_agent_stub(run_agent.AIAgent)
@@ -437,10 +373,10 @@ def test_review_fork_inherited_tools_survive_compaction_refresh():
     with patch.object(run_agent, "AIAgent", _Recorder):
         fork, _rt, routed = build_cache_parity_fork(agent, max_iterations=5)
         assert not routed
-        assert fork._tool_snapshot_generation == 2_147_483_647
-        assert [t["function"]["name"] for t in fork.tools] == [
-            "terminal_command", "read_file", "memory", "fact_store", "fact_feedback"
-        ]
+        assert fork._tool_snapshot_generation == _FROZEN_TOOL_SNAPSHOT_GENERATION
+        assert fork.tools == parent_tools
+        # Deep copy: the fork's later in-place tool edits must not leak into the parent's array.
+        assert fork.tools is not parent_tools and fork.tools[0] is not parent_tools[0]
 
         # Simulate mid-review compaction boundary tool refresh
         added = refresh_agent_mcp_tools(fork, content_aware=True)
@@ -462,7 +398,7 @@ def test_unrouted_review_fork_inherits_empty_tool_surface():
     mid-review compaction do not break cache parity against the parent's empty surface.
     """
     import run_agent
-    from agent.background_review import build_cache_parity_fork
+    from agent.background_review import _FROZEN_TOOL_SNAPSHOT_GENERATION, build_cache_parity_fork
     from tools.mcp_tool_agent import refresh_agent_mcp_tools
 
     agent = _make_agent_stub(run_agent.AIAgent)
@@ -483,13 +419,10 @@ def test_unrouted_review_fork_inherits_empty_tool_surface():
         assert fork.tools == []
         assert fork.tools is not agent.tools
         assert fork.valid_tool_names == set()
-        assert fork._tool_snapshot_generation == 2_147_483_647
+        assert fork._tool_snapshot_generation == _FROZEN_TOOL_SNAPSHOT_GENERATION
 
         # Compaction refresh must refuse rebuild on frozen snapshot
         added = refresh_agent_mcp_tools(fork, content_aware=True)
         assert added == set()
         assert fork.tools == []
         assert fork.valid_tool_names == set()
-
-
-

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -355,7 +355,7 @@ def test_review_fork_inherited_tools_survive_compaction_refresh():
     generation staleness check refuses the rebuild.
     """
     import run_agent
-    from agent.background_review import _FROZEN_TOOL_SNAPSHOT_GENERATION, build_cache_parity_fork
+    from agent.background_review import build_cache_parity_fork
     from tools.mcp_tool_agent import refresh_agent_mcp_tools
 
     agent = _make_agent_stub(run_agent.AIAgent)
@@ -373,7 +373,6 @@ def test_review_fork_inherited_tools_survive_compaction_refresh():
     with patch.object(run_agent, "AIAgent", _Recorder):
         fork, _rt, routed = build_cache_parity_fork(agent, max_iterations=5)
         assert not routed
-        assert fork._tool_snapshot_generation == _FROZEN_TOOL_SNAPSHOT_GENERATION
         assert fork.tools == parent_tools
         # Deep copy: the fork's later in-place tool edits must not leak into the parent's array.
         assert fork.tools is not parent_tools and fork.tools[0] is not parent_tools[0]
@@ -398,7 +397,7 @@ def test_unrouted_review_fork_inherits_empty_tool_surface():
     mid-review compaction do not break cache parity against the parent's empty surface.
     """
     import run_agent
-    from agent.background_review import _FROZEN_TOOL_SNAPSHOT_GENERATION, build_cache_parity_fork
+    from agent.background_review import build_cache_parity_fork
     from tools.mcp_tool_agent import refresh_agent_mcp_tools
 
     agent = _make_agent_stub(run_agent.AIAgent)
@@ -419,7 +418,6 @@ def test_unrouted_review_fork_inherits_empty_tool_surface():
         assert fork.tools == []
         assert fork.tools is not agent.tools
         assert fork.valid_tool_names == set()
-        assert fork._tool_snapshot_generation == _FROZEN_TOOL_SNAPSHOT_GENERATION
 
         # Compaction refresh must refuse rebuild on frozen snapshot
         added = refresh_agent_mcp_tools(fork, content_aware=True)

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -103,6 +103,7 @@ def _make_recorder_class(captured=None, record_on_run=()):
             self.session_id = None
             self.tools = None
             self.valid_tool_names = set()
+            self._tool_snapshot_generation = 0
             self.ephemeral_system_prompt = kwargs.get("ephemeral_system_prompt")
 
         def run_conversation(self, *args, **kwargs):
@@ -406,4 +407,49 @@ def test_routed_review_fork_does_not_inherit_tool_surface():
         fork, _rt, routed = build_cache_parity_fork(agent, max_iterations=5)
         assert routed
         assert fork.tools is None
+
+
+def test_review_fork_inherited_tools_survive_compaction_refresh():
+    """Inherited tools survive mid-review compaction refresh (#103579).
+
+    Acceptance criterion 1 requires the fork to advertise the same tools[] as
+    the parent when targeting the same cache scope. Mid-review compaction
+    boundaries invoke refresh_agent_mcp_tools(content_aware=True), which re-reads
+    the live registry and drops memory provider tools unless the snapshot
+    generation staleness check refuses the rebuild.
+    """
+    import run_agent
+    from agent.background_review import build_cache_parity_fork
+    from tools.mcp_tool_agent import refresh_agent_mcp_tools
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    parent_tools = [
+        {"type": "function", "function": {"name": "terminal_command"}},
+        {"type": "function", "function": {"name": "read_file"}},
+        {"type": "function", "function": {"name": "memory"}},
+        {"type": "function", "function": {"name": "fact_store"}},
+        {"type": "function", "function": {"name": "fact_feedback"}},
+    ]
+    agent.tools = parent_tools
+
+    _Recorder = _make_recorder_class()
+
+    with patch.object(run_agent, "AIAgent", _Recorder):
+        fork, _rt, routed = build_cache_parity_fork(agent, max_iterations=5)
+        assert not routed
+        assert fork._tool_snapshot_generation == 2_147_483_647
+        assert [t["function"]["name"] for t in fork.tools] == [
+            "terminal_command", "read_file", "memory", "fact_store", "fact_feedback"
+        ]
+
+        # Simulate mid-review compaction boundary tool refresh
+        added = refresh_agent_mcp_tools(fork, content_aware=True)
+        assert added == set()
+        assert [t["function"]["name"] for t in fork.tools] == [
+            "terminal_command", "read_file", "memory", "fact_store", "fact_feedback"
+        ]
+        assert fork.valid_tool_names == {
+            "terminal_command", "read_file", "memory", "fact_store", "fact_feedback"
+        }
+
 

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -453,3 +453,43 @@ def test_review_fork_inherited_tools_survive_compaction_refresh():
         }
 
 
+def test_unrouted_review_fork_inherits_empty_tool_surface():
+    """Empty parent tools[] is a valid snapshot and must be copied and frozen (#103579).
+
+    If no tools pass availability when the parent is constructed (parent.tools = []),
+    the unrouted fork must inherit an empty list and freeze _tool_snapshot_generation.
+    This guarantees late MCP/plugin tools discovered during fork construction or
+    mid-review compaction do not break cache parity against the parent's empty surface.
+    """
+    import run_agent
+    from agent.background_review import build_cache_parity_fork
+    from tools.mcp_tool_agent import refresh_agent_mcp_tools
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    agent.tools = []
+
+    _BaseRecorder = _make_recorder_class()
+
+    class _RecorderWithLateTool(_BaseRecorder):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            # Simulate a late tool appearing in the constructor result before inheritance
+            self.tools = [{"type": "function", "function": {"name": "newly_available"}}]
+            self.valid_tool_names = {"newly_available"}
+
+    with patch.object(run_agent, "AIAgent", _RecorderWithLateTool):
+        fork, _rt, routed = build_cache_parity_fork(agent, max_iterations=5)
+        assert not routed
+        assert fork.tools == []
+        assert fork.tools is not agent.tools
+        assert fork.valid_tool_names == set()
+        assert fork._tool_snapshot_generation == 2_147_483_647
+
+        # Compaction refresh must refuse rebuild on frozen snapshot
+        added = refresh_agent_mcp_tools(fork, content_aware=True)
+        assert added == set()
+        assert fork.tools == []
+        assert fork.valid_tool_names == set()
+
+
+

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -101,6 +101,8 @@ def _make_recorder_class(captured=None, record_on_run=()):
             self.suppress_status_output = None
             self.session_start = None
             self.session_id = None
+            self.tools = None
+            self.valid_tool_names = set()
             self.ephemeral_system_prompt = kwargs.get("ephemeral_system_prompt")
 
         def run_conversation(self, *args, **kwargs):
@@ -340,3 +342,68 @@ def test_routed_review_fork_does_not_inherit_reasoning_config():
             f"Routed review fork was passed parent-only kwarg {_gated!r}; "
             "cache-parity inheritance must stay behind the not-routed gate."
         )
+
+
+def test_unrouted_review_fork_inherits_entire_tool_surface():
+    """Unrouted forks preserve all advertised tools and their name index (#103579)."""
+    import run_agent
+    from agent.background_review import build_cache_parity_fork
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    parent_tools = [
+        {"type": "function", "function": {"name": "base_tool"}},
+        {"type": "function", "function": {"name": "fact_store"}},
+        {"type": "function", "function": {"name": "fact_feedback"}},
+        {"type": "function", "function": {"name": "mcp_late_tool"}},
+        {"malformed": True},
+    ]
+    agent.tools = parent_tools
+
+    _Recorder = _make_recorder_class()
+
+    with patch.object(run_agent, "AIAgent", _Recorder):
+        fork, _rt, routed = build_cache_parity_fork(agent, max_iterations=5)
+        assert not routed
+        assert fork.tools == parent_tools
+        assert fork.tools is not parent_tools
+        assert fork.tools[0] is not parent_tools[0]
+        assert fork.valid_tool_names == {
+            "base_tool", "fact_store", "fact_feedback", "mcp_late_tool"
+        }
+        fork.tools.append({"type": "function", "function": {"name": "new"}})
+        assert len(fork.tools) != len(agent.tools)
+
+
+def test_routed_review_fork_does_not_inherit_tool_surface():
+    """Routed review fork does not inherit parent's tools[] across different models (#103579)."""
+    import run_agent
+    import agent.background_review as bg_review
+    from agent.background_review import build_cache_parity_fork
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    parent_tools = [
+        {"type": "function", "function": {"name": "parent_tool"}},
+    ]
+    agent.tools = parent_tools
+
+    _Recorder = _make_recorder_class()
+    routed_runtime = {
+        "provider": "openrouter",
+        "model": "aux-cheap-model",
+        "api_key": "test-key",
+        "base_url": None,
+        "api_mode": None,
+        "credential_pool": None,
+        "request_overrides": {},
+        "max_tokens": None,
+        "command": None,
+        "args": [],
+        "routed": True,
+    }
+
+    with patch.object(run_agent, "AIAgent", _Recorder), \
+         patch.object(bg_review, "_resolve_review_runtime", return_value=routed_runtime):
+        fork, _rt, routed = build_cache_parity_fork(agent, max_iterations=5)
+        assert routed
+        assert fork.tools is None
+


### PR DESCRIPTION
The background-review fork now advertises the parent's exact `tools[]` on the same-model path — including memory-provider, late-MCP and plugin tools, and an empty list — so its requests hit the parent's warm prefix cache instead of cold-reading ~66k tokens per review.

Salvage of #103581 by @0xalydev (three commits cherry-picked, authorship preserved), for #103579. #103937 by @jwilson411 applied the same copy but only when the parent had a live memory manager and did not survive compaction; credited as the sibling carrier.

## Root cause

`build_cache_parity_fork` builds the review fork with `skip_memory=True`, so `inject_memory_provider_tools` never runs on it and the fork's `tools[]` lacks the schemas the parent sent. Providers key the prefix cache on `tools[]`, which precedes the system prompt on the wire. A second gap: the compaction-boundary `refresh_agent_mcp_tools(content_aware=True)` rebuilt the fork's tools from the live registry mid-review and dropped them again.

## Changes

- `agent/background_review.py::_inherit_parent_tool_surface`: deep-copy `agent.tools` onto the unrouted fork, rebuild `valid_tool_names`, and set `_tool_snapshot_generation` to a sentinel above any registry generation so `_publish_tool_snapshot`'s staleness guard refuses the compaction rebuild. Routed forks (different model) untouched. Dispatch is unchanged: the review whitelist is derived from `get_tool_definitions`, not from `valid_tool_names`, so the fork still cannot execute `fact_store`; `/btw` shares the path with an empty whitelist.
- Commit 5 (ours): the helper collapsed to the two lines `agent_init` uses (the isinstance ladder guarded shapes that cannot exist), docstring cut to the WHY, tests trimmed to the two invariants (inherited tools survive the compaction refresh; empty parent surface is copied and frozen), sentinel literals replaced with the constant.

## Validation

| Check | Result |
|---|---|
| `test_background_review_cache_parity.py` + `test_background_review.py` + `test_background_review_tool_call_guard.py` + `test_side_question.py` | 41 passed |
| Real-import probe, parent with `fact_store`/`fact_feedback` | main: fork `tools=[]`, compaction refresh rebuilt 19 registry tools; branch: fork mirrors parent, refresh returns `set()` and the list is unchanged |
| Mutation: swap `agent/background_review.py` for main's copy | 2 red / 5 green in the parity file |
| ruff, windows-footguns, `git diff --check` | clean |

Closes #103579. Supersedes #103581, #103937 (credited above). Does not cover the main-thread cold-resume gap #105211 describes — that PR has its own open review findings.
