### PR TITLE
Surface switch (desktop↔TUI) no longer rebuilds the system prompt and re-prefills the request (#104414, salvage #104494)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -677,6 +677,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             except Exception:
                 pass
             agent._cached_system_prompt = agent._build_system_prompt(system_message)
+            _stage_surface_switch_note(agent, agent._cached_system_prompt, conversation_history)
             # Persist so the NEXT turn restores the new bytes verbatim (cache break is
             # once per capability change). on_session_start not re-fired: continuation.
             _persist_system_prompt(
@@ -787,11 +788,15 @@ _SURFACE_SWITCH_NOTE_PREFIX = "[System: This conversation is now being answered 
 def _stored_prompt_platform(prompt: str) -> str:
     """The ``Platform:`` value the stored prompt was built with ("" when absent).
 
-    Last match wins, like the volatile-tier reads in ``_stored_prompt_matches_runtime``: the
-    trailer sits at the very end, so embedded project context cannot shadow it.
+    Parses only the authoritative identity portion before `# Hermes runtime environment`
+    so embedder prose (e.g. HERMES_ENVIRONMENT_HINT decoys) cannot shadow it.
     """
+    identity, runtime_marker, _ = prompt.rpartition(f"\n\n{RUNTIME_ENVIRONMENT_HEADING}\n\n")
+    runtime_marker = runtime_marker if prompt.endswith(RUNTIME_ENVIRONMENT_END) else ""
+    lines = (identity if runtime_marker else prompt).splitlines()
+
     prefix = "Platform:"
-    matches = [line[len(prefix):].strip() for line in prompt.splitlines() if line.startswith(prefix)]
+    matches = [line[len(prefix):].strip() for line in lines if line.startswith(prefix)]
     return matches[-1] if matches else ""
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -739,6 +739,12 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # First turn of a new session (or recovering from a broken stored prompt).
     agent._cached_system_prompt = agent._build_system_prompt(system_message)
 
+    # The rebuilt prompt describes the CURRENT surface, but a surface note left in the
+    # transcript by an earlier switch does not — retire it here too, or a rebuild for an
+    # unrelated reason (a model switch) would leave the newest interface statement in the
+    # request naming a surface the conversation has left (#104414).
+    _stage_surface_switch_note(agent, agent._cached_system_prompt, conversation_history)
+
     # Plugin hook: on_session_start — fired once for a brand-new session, not on continuation.
     try:
         from hermes_cli.lifecycle import invoke_hook as _invoke_hook
@@ -805,47 +811,55 @@ def _transcript_row_texts(msg):
                 yield part["text"]
 
 
-def _surface_already_announced(conversation_history, platform: str) -> bool:
-    """True when the NEWEST surface note in the transcript already names ``platform``.
+def _last_announced_surface(conversation_history) -> str:
+    """The surface named by the NEWEST surface note in the transcript ("" when there is none).
 
-    The note is stamped into the ``api_content`` sidecar, so every later turn replays it; the
-    gateway builds a fresh AIAgent per turn and would otherwise stack one copy per turn until
-    the next compaction.  Only the newest note is consulted — an older one names the surface
-    the conversation has since left.
+    The note is stamped into the ``api_content`` sidecar and persisted, so it is the last thing
+    the model was TOLD it is running on — and it outranks the stored prompt's own ``Platform:``
+    trailer once a switch has been announced.  Only the newest note counts: an older one names
+    a surface the conversation has since left.  Reading it back is also what stops a fresh
+    AIAgent per turn (the gateway shape) from stacking one copy of the note per turn.
     """
     for msg in reversed(conversation_history or []):
         for text in _transcript_row_texts(msg):
             if _SURFACE_SWITCH_NOTE_PREFIX in text:
-                return text.rsplit(_SURFACE_SWITCH_NOTE_PREFIX, 1)[1].startswith(f"{platform} (")
-    return False
+                return text.rsplit(_SURFACE_SWITCH_NOTE_PREFIX, 1)[1].split(".", 1)[0].strip()
+    return ""
 
 
-def _stage_surface_switch_note(agent, stored_prompt: str, conversation_history) -> bool:
-    """Stage the correction note when the reused prompt describes a different surface.
+def _stage_surface_switch_note(agent, prompt: str, conversation_history) -> bool:
+    """Stage a correction when the request would otherwise misdescribe the current surface.
 
-    Returns whether the note was staged — the caller pairs that with re-persisting the tool
-    names, because this is the turn the surface's toolset actually changes under it.  The note
-    is one-shot per turn (consumed by ``agent.turn_context.consume_surface_switch_note``) and
-    is skipped when the transcript already carries one for this surface.
+    Compares the runtime surface against what the model was last told — the newest surface note
+    if one exists, else ``prompt``'s own ``Platform:`` trailer.  Consulting the note matters in
+    both directions: switching BACK to the surface the prompt was built for (desktop -> tui ->
+    desktop) leaves the trailer agreeing with the runtime while a stale note still tells the
+    model otherwise, and a rebuild for an unrelated reason (a model switch) refreshes the prompt
+    but not that note.
+
+    The full surface guidance is attached only when the prompt itself is out of date; when the
+    prompt already describes the current surface the note just retires the stale one.  Returns
+    whether it staged — the caller pairs that with re-persisting the tool names, because this is
+    the turn the surface's toolset changes under it.
     """
     current = str(getattr(agent, "platform", "") or "").strip()
-    stored = _stored_prompt_platform(stored_prompt)
-    if not current or not stored or stored == current:
-        return False
-    if _surface_already_announced(conversation_history, current):
+    described = _stored_prompt_platform(prompt)
+    told = _last_announced_surface(conversation_history) or described
+    if not current or not told or told == current:
         return False
     from agent.system_prompt import platform_surface_hint
+    hint = platform_surface_hint(agent) if described != current else ""
+    where = "the guidance below" if hint else "the interface section in the system prompt above"
     note = (
-        f"{_SURFACE_SWITCH_NOTE_PREFIX}{current} (the system prompt above was written for "
-        f"{stored}). Its interface section no longer applies — use the guidance below for "
-        "formatting, file delivery and any interface-specific capability.]"
+        f"{_SURFACE_SWITCH_NOTE_PREFIX}{current}. Any earlier interface guidance in this "
+        f"conversation is superseded — follow {where} for formatting, file delivery and any "
+        "interface-specific capability.]"
     )
-    hint = platform_surface_hint(agent)
     agent._surface_switch_note = f"{note}\n{hint}" if hint else note
     logger.info(
         "Session %s switched surface %s -> %s; keeping the stored system prompt and delivering "
         "the new surface guidance as a turn note (prefix cache preserved).",
-        agent.session_id, stored, current,
+        agent.session_id, told, current,
     )
     return True
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -690,16 +690,21 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         agent._cached_system_prompt = stored_prompt
         # The reused bytes may describe the surface this conversation STARTED on; correct that
         # at the tail of the request instead of rebuilding the prompt in front of it (#104414).
-        surface_changed = _stage_surface_switch_note(agent, stored_prompt, conversation_history)
+        announced_switch = _stage_surface_switch_note(agent, stored_prompt, conversation_history)
         # Same contract for tools[]: pin the array to the order this session already
         # sent (tools freeze) instead of re-probing every check_fn on a fresh AIAgent.
-        # NOT across a surface switch: the saved names are the PREVIOUS surface's toolset
-        # (``coding_context: focus`` gives desktop a desktop_ui toolset the TUI has no use for)
-        # and the tool registry is process-global, so the merge would re-advertise tools this
-        # surface cannot run. The fresh, toolset-correct array wins there.
+        # NOT on the turn that announces a surface switch: the saved names are the PREVIOUS
+        # surface's toolset (``coding_context: focus`` gives desktop a desktop_ui toolset the
+        # TUI has no use for) and the tool registry is process-global, so the merge would
+        # re-advertise tools this surface cannot run.  The fresh, toolset-correct array wins,
+        # and is persisted so the very next turn pins THAT one — the freeze is skipped once,
+        # not disabled for the rest of the session.
         try:
             saved_tools = session_row.get("tool_names") if session_row else None
-            if saved_tools and not surface_changed:
+            if announced_switch:
+                from tools.mcp_tool_agent import persist_agent_tool_names
+                persist_agent_tool_names(agent)
+            elif saved_tools:
                 from tools.mcp_tool_agent import restore_agent_tool_prefix
                 restore_agent_tool_prefix(agent, json.loads(saved_tools))
         except Exception:
@@ -818,17 +823,17 @@ def _surface_already_announced(conversation_history, platform: str) -> bool:
 def _stage_surface_switch_note(agent, stored_prompt: str, conversation_history) -> bool:
     """Stage the correction note when the reused prompt describes a different surface.
 
-    Returns whether the surface actually drifted — the caller also uses it to decide whether
-    the saved tool prefix may be pinned.  The note itself is one-shot per turn (consumed by
-    ``agent.turn_context.consume_surface_switch_note``) and is skipped when the transcript
-    already carries one for this surface, but that does not make the drift go away.
+    Returns whether the note was staged — the caller pairs that with re-persisting the tool
+    names, because this is the turn the surface's toolset actually changes under it.  The note
+    is one-shot per turn (consumed by ``agent.turn_context.consume_surface_switch_note``) and
+    is skipped when the transcript already carries one for this surface.
     """
     current = str(getattr(agent, "platform", "") or "").strip()
     stored = _stored_prompt_platform(stored_prompt)
     if not current or not stored or stored == current:
         return False
     if _surface_already_announced(conversation_history, current):
-        return True
+        return False
     from agent.system_prompt import platform_surface_hint
     note = (
         f"{_SURFACE_SWITCH_NOTE_PREFIX}{current} (the system prompt above was written for "

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -693,20 +693,21 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         announced_switch = _stage_surface_switch_note(agent, stored_prompt, conversation_history)
         # Same contract for tools[]: pin the array to the order this session already
         # sent (tools freeze) instead of re-probing every check_fn on a fresh AIAgent.
-        # NOT on the turn that announces a surface switch: the saved names are the PREVIOUS
-        # surface's toolset (``coding_context: focus`` gives desktop a desktop_ui toolset the
-        # TUI has no use for) and the tool registry is process-global, so the merge would
-        # re-advertise tools this surface cannot run.  The fresh, toolset-correct array wins,
-        # and is persisted so the very next turn pins THAT one — the freeze is skipped once,
-        # not disabled for the rest of the session.
+        # The pin holds ON the announcing turn too.  tools[] is serialized AHEAD of the system
+        # prompt this branch just preserved, so dropping the previous surface's toolset would
+        # change the request at token 0 and re-prefill everything behind it — the exact cost
+        # #104414 is about, paid on the exact turn we are here to make cheap.  The merge still
+        # ADDS what the new surface brought (a tui -> desktop switch pays a break no freeze can
+        # avoid), and what it carries FORWARD is named in the note instead, so a tool that can
+        # only answer ``tool_error("desktop only")`` here does not read as a live capability.
         try:
             saved_tools = session_row.get("tool_names") if session_row else None
-            if announced_switch:
-                from tools.mcp_tool_agent import persist_agent_tool_names
-                persist_agent_tool_names(agent)
-            elif saved_tools:
+            if saved_tools:
                 from tools.mcp_tool_agent import restore_agent_tool_prefix
+                built_for_this_surface = _agent_tool_names(agent)
                 restore_agent_tool_prefix(agent, json.loads(saved_tools))
+                if announced_switch:
+                    _note_inert_pinned_tools(agent, built_for_this_surface)
         except Exception:
             logger.debug("tool prefix restore skipped", exc_info=True)
         # Prompt-section callbacks are new-session-only; recover their frozen bytes
@@ -825,6 +826,40 @@ def _last_announced_surface(conversation_history) -> str:
             if _SURFACE_SWITCH_NOTE_PREFIX in text:
                 return text.rsplit(_SURFACE_SWITCH_NOTE_PREFIX, 1)[1].split(".", 1)[0].strip()
     return ""
+
+
+def _agent_tool_names(agent) -> list:
+    """The names in ``agent.tools``, in wire order ([] when the attribute is unreadable)."""
+    names = []
+    try:
+        for entry in getattr(agent, "tools", None) or []:
+            name = (entry.get("function") or {}).get("name", "") if isinstance(entry, dict) else ""
+            if name:
+                names.append(name)
+    except Exception:
+        return []
+    return names
+
+
+def _note_inert_pinned_tools(agent, built_for_this_surface: list) -> None:
+    """Name the pinned tools THIS surface did not build, at the end of the switch note.
+
+    The freeze keeps a previous surface's tools on the wire deliberately — removing them is the
+    one thing that would still re-prefill the request behind the preserved prompt — so the model
+    has to be TOLD they are inert here, or it plans around a ``focus_pane`` that a terminal turn
+    can only answer with ``tool_error("desktop only")``.  Rides the note, so it is one-shot and
+    lands behind the cached prefix like the rest of the correction.
+    """
+    surface_names = set(built_for_this_surface)
+    inert = [name for name in _agent_tool_names(agent) if name not in surface_names]
+    note = getattr(agent, "_surface_switch_note", "") or ""
+    if not inert or not note:
+        return
+    agent._surface_switch_note = note + (
+        "\n[System: These tools stay listed for this conversation (dropping them would discard "
+        "the cached request prefix) but were not loaded for this interface — expect a call to "
+        f"one of them to fail: {', '.join(inert)}.]"
+    )
 
 
 def _stage_surface_switch_note(agent, prompt: str, conversation_history) -> bool:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -688,11 +688,18 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         # Continuing session — reuse the exact system prompt from the
         # previous turn so the Anthropic cache prefix matches.
         agent._cached_system_prompt = stored_prompt
+        # The reused bytes may describe the surface this conversation STARTED on; correct that
+        # at the tail of the request instead of rebuilding the prompt in front of it (#104414).
+        surface_changed = _stage_surface_switch_note(agent, stored_prompt, conversation_history)
         # Same contract for tools[]: pin the array to the order this session already
         # sent (tools freeze) instead of re-probing every check_fn on a fresh AIAgent.
+        # NOT across a surface switch: the saved names are the PREVIOUS surface's toolset
+        # (``coding_context: focus`` gives desktop a desktop_ui toolset the TUI has no use for)
+        # and the tool registry is process-global, so the merge would re-advertise tools this
+        # surface cannot run. The fresh, toolset-correct array wins there.
         try:
             saved_tools = session_row.get("tool_names") if session_row else None
-            if saved_tools:
+            if saved_tools and not surface_changed:
                 from tools.mcp_tool_agent import restore_agent_tool_prefix
                 restore_agent_tool_prefix(agent, json.loads(saved_tools))
         except Exception:
@@ -753,6 +760,91 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     )
 
 
+# A surface switch (desktop <-> TUI, a session resumed under a different host) changes only
+# which interface renders the reply, but the surface guidance and the ``Platform:`` trailer are
+# embedded in the persisted prompt.  Rebuilding for it produced a system prompt that diverged
+# from the cached one within its first blocks, so the ENTIRE request behind it re-prefilled —
+# a 220K-token session came back at a 1% cache hit (#104414).  The stored bytes are therefore
+# kept and the CURRENT surface's guidance is delivered on the per-turn user-message channel
+# instead: that lands after the cached prefix, is stamped into the byte-stable ``api_content``
+# sidecar so later turns replay it unchanged, and the prompt itself converges at the next
+# rebuild boundary (compaction).
+_SURFACE_SWITCH_NOTE_PREFIX = "[System: This conversation is now being answered on a different interface: "
+
+
+def _stored_prompt_platform(prompt: str) -> str:
+    """The ``Platform:`` value the stored prompt was built with ("" when absent).
+
+    Last match wins, like the volatile-tier reads in ``_stored_prompt_matches_runtime``: the
+    trailer sits at the very end, so embedded project context cannot shadow it.
+    """
+    prefix = "Platform:"
+    matches = [line[len(prefix):].strip() for line in prompt.splitlines() if line.startswith(prefix)]
+    return matches[-1] if matches else ""
+
+
+def _transcript_row_texts(msg):
+    """Every string the model actually saw for one transcript row: the wire sidecar first,
+    then the stored content (plain string, or the text parts of a multimodal list)."""
+    if not isinstance(msg, dict):
+        return
+    sidecar = msg.get("api_content")
+    if isinstance(sidecar, str):
+        yield sidecar
+    content = msg.get("content")
+    if isinstance(content, str):
+        yield content
+    elif isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                yield part["text"]
+
+
+def _surface_already_announced(conversation_history, platform: str) -> bool:
+    """True when the NEWEST surface note in the transcript already names ``platform``.
+
+    The note is stamped into the ``api_content`` sidecar, so every later turn replays it; the
+    gateway builds a fresh AIAgent per turn and would otherwise stack one copy per turn until
+    the next compaction.  Only the newest note is consulted — an older one names the surface
+    the conversation has since left.
+    """
+    for msg in reversed(conversation_history or []):
+        for text in _transcript_row_texts(msg):
+            if _SURFACE_SWITCH_NOTE_PREFIX in text:
+                return text.rsplit(_SURFACE_SWITCH_NOTE_PREFIX, 1)[1].startswith(f"{platform} (")
+    return False
+
+
+def _stage_surface_switch_note(agent, stored_prompt: str, conversation_history) -> bool:
+    """Stage the correction note when the reused prompt describes a different surface.
+
+    Returns whether the surface actually drifted — the caller also uses it to decide whether
+    the saved tool prefix may be pinned.  The note itself is one-shot per turn (consumed by
+    ``agent.turn_context.consume_surface_switch_note``) and is skipped when the transcript
+    already carries one for this surface, but that does not make the drift go away.
+    """
+    current = str(getattr(agent, "platform", "") or "").strip()
+    stored = _stored_prompt_platform(stored_prompt)
+    if not current or not stored or stored == current:
+        return False
+    if _surface_already_announced(conversation_history, current):
+        return True
+    from agent.system_prompt import platform_surface_hint
+    note = (
+        f"{_SURFACE_SWITCH_NOTE_PREFIX}{current} (the system prompt above was written for "
+        f"{stored}). Its interface section no longer applies — use the guidance below for "
+        "formatting, file delivery and any interface-specific capability.]"
+    )
+    hint = platform_surface_hint(agent)
+    agent._surface_switch_note = f"{note}\n{hint}" if hint else note
+    logger.info(
+        "Session %s switched surface %s -> %s; keeping the stored system prompt and delivering "
+        "the new surface guidance as a turn note (prefix cache preserved).",
+        agent.session_id, stored, current,
+    )
+    return True
+
+
 def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     """Return False when the persisted runtime-identity lines are stale."""
 
@@ -780,8 +872,9 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
                         return candidate[len(prefix):].strip()
         return ""
 
-    # Model/provider identity, then cwd drift, then runtime-surface drift (reusing a
-    # desktop-built prompt on a terminal session would inject the wrong runtime hints).
+    # Model/provider identity, then cwd drift.  A cwd change is a real content change (context
+    # files, the workspace snapshot and the coding posture are all resolved from it), so it
+    # still rebuilds; the runtime surface does not — see the note above.
     for label, attr in (("Model", "model"), ("Provider", "provider")):
         stored = line_value(label)
         current = str(getattr(agent, attr, "") or "").strip()
@@ -792,9 +885,10 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     stored_cwd = host_info_value("Current working directory")
     if stored_cwd and stored_cwd != str(resolve_agent_cwd()):
         return False
-    stored_platform = line_value("Platform")
-    current_platform = str(getattr(agent, "platform", "") or "").strip()
-    return not (stored_platform and current_platform and stored_platform != current_platform)
+    # Platform is deliberately NOT an identity field: a surface switch does not invalidate the
+    # stored bytes, it only makes their interface section out of date, and that is corrected by
+    # _stage_surface_switch_note without touching the cached prefix (#104414).
+    return True
 
 
 # Named so _is_synthetic_compression_user_turn can recognize a crash-persisted nudge by

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -29,6 +29,7 @@ from agent.prompt_caching import (
     strip_anthropic_tool_cache_control,
 )
 from agent.runtime_cwd import resolve_agent_cwd
+from agent.surface_switch import identity_line_value, note_inert_pinned_tools, stage_surface_switch_note
 from agent.turn_context import PreflightCompressionTimedOut, build_turn_context
 from agent.turn_retry_state import TurnRetryState
 # Phase helpers of the turn loop, bound at import so a source-tree swap cannot load a
@@ -677,7 +678,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             except Exception:
                 pass
             agent._cached_system_prompt = agent._build_system_prompt(system_message)
-            _stage_surface_switch_note(agent, agent._cached_system_prompt, conversation_history)
+            stage_surface_switch_note(agent, agent._cached_system_prompt, conversation_history)
             # Persist so the NEXT turn restores the new bytes verbatim (cache break is
             # once per capability change). on_session_start not re-fired: continuation.
             _persist_system_prompt(
@@ -691,7 +692,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         agent._cached_system_prompt = stored_prompt
         # The reused bytes may describe the surface this conversation STARTED on; correct that
         # at the tail of the request instead of rebuilding the prompt in front of it (#104414).
-        announced_switch = _stage_surface_switch_note(agent, stored_prompt, conversation_history)
+        announced_switch = stage_surface_switch_note(agent, stored_prompt, conversation_history)
         # Same contract for tools[]: pin the array to the order this session already
         # sent (tools freeze) instead of re-probing every check_fn on a fresh AIAgent.
         # The pin holds ON the announcing turn too.  tools[] is serialized AHEAD of the system
@@ -704,11 +705,11 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         try:
             saved_tools = session_row.get("tool_names") if session_row else None
             if saved_tools:
-                from tools.mcp_tool_agent import restore_agent_tool_prefix
-                built_for_this_surface = _agent_tool_names(agent)
+                from tools.mcp_tool_agent import _def_name, restore_agent_tool_prefix
+                built_for_this_surface = [_def_name(t) for t in agent.tools or []]
                 restore_agent_tool_prefix(agent, json.loads(saved_tools))
                 if announced_switch:
-                    _note_inert_pinned_tools(agent, built_for_this_surface)
+                    note_inert_pinned_tools(agent, built_for_this_surface)
         except Exception:
             logger.debug("tool prefix restore skipped", exc_info=True)
         # Prompt-section callbacks are new-session-only; recover their frozen bytes
@@ -745,7 +746,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # transcript by an earlier switch does not — retire it here too, or a rebuild for an
     # unrelated reason (a model switch) would leave the newest interface statement in the
     # request naming a surface the conversation has left (#104414).
-    _stage_surface_switch_note(agent, agent._cached_system_prompt, conversation_history)
+    stage_surface_switch_note(agent, agent._cached_system_prompt, conversation_history)
 
     # Plugin hook: on_session_start — fired once for a brand-new session, not on continuation.
     try:
@@ -773,157 +774,17 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     )
 
 
-# A surface switch (desktop <-> TUI, a session resumed under a different host) changes only
-# which interface renders the reply, but the surface guidance and the ``Platform:`` trailer are
-# embedded in the persisted prompt.  Rebuilding for it produced a system prompt that diverged
-# from the cached one within its first blocks, so the ENTIRE request behind it re-prefilled —
-# a 220K-token session came back at a 1% cache hit (#104414).  The stored bytes are therefore
-# kept and the CURRENT surface's guidance is delivered on the per-turn user-message channel
-# instead: that lands after the cached prefix, is stamped into the byte-stable ``api_content``
-# sidecar so later turns replay it unchanged, and the prompt itself converges at the next
-# rebuild boundary (compaction).
-_SURFACE_SWITCH_NOTE_PREFIX = "[System: This conversation is now being answered on a different interface: "
-
-
-def _stored_prompt_platform(prompt: str) -> str:
-    """The ``Platform:`` value the stored prompt was built with ("" when absent).
-
-    Parses only the authoritative identity portion before `# Hermes runtime environment`
-    so embedder prose (e.g. HERMES_ENVIRONMENT_HINT decoys) cannot shadow it.
-    """
-    identity, runtime_marker, _ = prompt.rpartition(f"\n\n{RUNTIME_ENVIRONMENT_HEADING}\n\n")
-    runtime_marker = runtime_marker if prompt.endswith(RUNTIME_ENVIRONMENT_END) else ""
-    lines = (identity if runtime_marker else prompt).splitlines()
-
-    prefix = "Platform:"
-    matches = [line[len(prefix):].strip() for line in lines if line.startswith(prefix)]
-    return matches[-1] if matches else ""
-
-
-def _transcript_row_texts(msg):
-    """Every string the model actually saw for one transcript row: the wire sidecar first,
-    then the stored content (plain string, or the text parts of a multimodal list)."""
-    if not isinstance(msg, dict):
-        return
-    sidecar = msg.get("api_content")
-    if isinstance(sidecar, str):
-        yield sidecar
-    content = msg.get("content")
-    if isinstance(content, str):
-        yield content
-    elif isinstance(content, list):
-        for part in content:
-            if isinstance(part, dict) and isinstance(part.get("text"), str):
-                yield part["text"]
-
-
-def _last_announced_surface(conversation_history) -> str:
-    """The surface named by the NEWEST surface note in the transcript ("" when there is none).
-
-    The note is stamped into the ``api_content`` sidecar and persisted, so it is the last thing
-    the model was TOLD it is running on — and it outranks the stored prompt's own ``Platform:``
-    trailer once a switch has been announced.  Only the newest note counts: an older one names
-    a surface the conversation has since left.  Reading it back is also what stops a fresh
-    AIAgent per turn (the gateway shape) from stacking one copy of the note per turn.
-    """
-    for msg in reversed(conversation_history or []):
-        for text in _transcript_row_texts(msg):
-            if _SURFACE_SWITCH_NOTE_PREFIX in text:
-                return text.rsplit(_SURFACE_SWITCH_NOTE_PREFIX, 1)[1].split(".", 1)[0].strip()
-    return ""
-
-
-def _agent_tool_names(agent) -> list:
-    """The names in ``agent.tools``, in wire order ([] when the attribute is unreadable)."""
-    names = []
-    try:
-        for entry in getattr(agent, "tools", None) or []:
-            name = (entry.get("function") or {}).get("name", "") if isinstance(entry, dict) else ""
-            if name:
-                names.append(name)
-    except Exception:
-        return []
-    return names
-
-
-def _note_inert_pinned_tools(agent, built_for_this_surface: list) -> None:
-    """Name the pinned tools THIS surface did not build, at the end of the switch note.
-
-    The freeze keeps a previous surface's tools on the wire deliberately — removing them is the
-    one thing that would still re-prefill the request behind the preserved prompt — so the model
-    has to be TOLD they are inert here, or it plans around a ``focus_pane`` that a terminal turn
-    can only answer with ``tool_error("desktop only")``.  Rides the note, so it is one-shot and
-    lands behind the cached prefix like the rest of the correction.
-    """
-    surface_names = set(built_for_this_surface)
-    inert = [name for name in _agent_tool_names(agent) if name not in surface_names]
-    note = getattr(agent, "_surface_switch_note", "") or ""
-    if not inert or not note:
-        return
-    agent._surface_switch_note = note + (
-        "\n[System: These tools stay listed for this conversation (dropping them would discard "
-        "the cached request prefix) but were not loaded for this interface — expect a call to "
-        f"one of them to fail: {', '.join(inert)}.]"
-    )
-
-
-def _stage_surface_switch_note(agent, prompt: str, conversation_history) -> bool:
-    """Stage a correction when the request would otherwise misdescribe the current surface.
-
-    Compares the runtime surface against what the model was last told — the newest surface note
-    if one exists, else ``prompt``'s own ``Platform:`` trailer.  Consulting the note matters in
-    both directions: switching BACK to the surface the prompt was built for (desktop -> tui ->
-    desktop) leaves the trailer agreeing with the runtime while a stale note still tells the
-    model otherwise, and a rebuild for an unrelated reason (a model switch) refreshes the prompt
-    but not that note.
-
-    The full surface guidance is attached only when the prompt itself is out of date; when the
-    prompt already describes the current surface the note just retires the stale one.  Returns
-    whether it staged — the caller pairs that with re-persisting the tool names, because this is
-    the turn the surface's toolset changes under it.
-    """
-    current = str(getattr(agent, "platform", "") or "").strip()
-    described = _stored_prompt_platform(prompt)
-    told = _last_announced_surface(conversation_history) or described
-    if not current or not told or told == current:
-        return False
-    from agent.system_prompt import platform_surface_hint
-    hint = platform_surface_hint(agent) if described != current else ""
-    where = "the guidance below" if hint else "the interface section in the system prompt above"
-    note = (
-        f"{_SURFACE_SWITCH_NOTE_PREFIX}{current}. Any earlier interface guidance in this "
-        f"conversation is superseded — follow {where} for formatting, file delivery and any "
-        "interface-specific capability.]"
-    )
-    agent._surface_switch_note = f"{note}\n{hint}" if hint else note
-    logger.info(
-        "Session %s switched surface %s -> %s; keeping the stored system prompt and delivering "
-        "the new surface guidance as a turn note (prefix cache preserved).",
-        agent.session_id, told, current,
-    )
-    return True
-
-
 def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     """Return False when the persisted runtime-identity lines are stale."""
 
     identity, runtime_marker, runtime = prompt.rpartition(f"\n\n{RUNTIME_ENVIRONMENT_HEADING}\n\n")
     # Legacy prose may quote the heading, but only the new renderer ends in this boundary.
     runtime_marker = runtime_marker if prompt.endswith(RUNTIME_ENVIRONMENT_END) else ""
-    # The final runtime block can contain embedder prose, not authoritative identity.
-    lines = (identity if runtime_marker else prompt).splitlines()
-
-    def line_value(label: str) -> str:
-        """Last matching line wins — safe ONLY for volatile-tier fields at the END of the
-        prompt (embedded project context could shadow earlier fields; see ``host_info_value``)."""
-        prefix = f"{label}:"
-        matches = [line[len(prefix):].strip() for line in lines if line.startswith(prefix)]
-        return matches[-1] if matches else ""
 
     def host_info_value(label: str) -> str:
         """New prompts delimit runtime hints; legacy prompts put them before context."""
         prefix = f"{label}:"
-        host_lines = runtime.split("\n\n", 1)[0].splitlines() if runtime_marker else lines
+        host_lines = (runtime.split("\n\n", 1)[0] if runtime_marker else prompt).splitlines()
         for idx, line in enumerate(host_lines):
             if line.startswith("User home directory:"):
                 for candidate in host_lines[idx + 1: idx + 4]:
@@ -933,9 +794,9 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
 
     # Model/provider identity, then cwd drift.  A cwd change is a real content change (context
     # files, the workspace snapshot and the coding posture are all resolved from it), so it
-    # still rebuilds; the runtime surface does not — see the note above.
+    # still rebuilds; the runtime surface does not (agent/surface_switch.py).
     for label, attr in (("Model", "model"), ("Provider", "provider")):
-        stored = line_value(label)
+        stored = identity_line_value(prompt, label)
         current = str(getattr(agent, attr, "") or "").strip()
         if stored and current and stored != current:
             return False
@@ -946,7 +807,7 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
         return False
     # Platform is deliberately NOT an identity field: a surface switch does not invalidate the
     # stored bytes, it only makes their interface section out of date, and that is corrected by
-    # _stage_surface_switch_note without touching the cached prefix (#104414).
+    # agent.surface_switch.stage_surface_switch_note without touching the cached prefix (#104414).
     return True
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -29,7 +29,9 @@ from agent.prompt_caching import (
     strip_anthropic_tool_cache_control,
 )
 from agent.runtime_cwd import resolve_agent_cwd
-from agent.surface_switch import identity_line_value, note_inert_pinned_tools, stage_surface_switch_note
+from agent.surface_switch import (
+    identity_line_value, note_inert_pinned_tools, split_runtime_boundary, stage_surface_switch_note,
+)
 from agent.turn_context import PreflightCompressionTimedOut, build_turn_context
 from agent.turn_retry_state import TurnRetryState
 # Phase helpers of the turn loop, bound at import so a source-tree swap cannot load a
@@ -705,8 +707,9 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         try:
             saved_tools = session_row.get("tool_names") if session_row else None
             if saved_tools:
-                from tools.mcp_tool_agent import _def_name, restore_agent_tool_prefix
-                built_for_this_surface = [_def_name(t) for t in agent.tools or []]
+                from tools.mcp_tool_agent import agent_tool_names, restore_agent_tool_prefix
+                # Captured BEFORE the pin merges the previous surface's tools back in.
+                built_for_this_surface = agent_tool_names(agent) if announced_switch else []
                 restore_agent_tool_prefix(agent, json.loads(saved_tools))
                 if announced_switch:
                     note_inert_pinned_tools(agent, built_for_this_surface)
@@ -777,9 +780,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
 def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     """Return False when the persisted runtime-identity lines are stale."""
 
-    identity, runtime_marker, runtime = prompt.rpartition(f"\n\n{RUNTIME_ENVIRONMENT_HEADING}\n\n")
-    # Legacy prose may quote the heading, but only the new renderer ends in this boundary.
-    runtime_marker = runtime_marker if prompt.endswith(RUNTIME_ENVIRONMENT_END) else ""
+    _identity, runtime_marker, runtime = split_runtime_boundary(prompt)
 
     def host_info_value(label: str) -> str:
         """New prompts delimit runtime hints; legacy prompts put them before context."""

--- a/agent/surface_switch.py
+++ b/agent/surface_switch.py
@@ -1,0 +1,138 @@
+"""Surface switch without a prompt rebuild (#104414).
+
+A surface switch (desktop <-> TUI, a session resumed under a different host) changes only which
+interface renders the reply, but the surface guidance and the ``Platform:`` trailer are embedded
+in the persisted system prompt.  Rebuilding for it diverged the prompt within its first blocks,
+so the ENTIRE request behind it re-prefilled — a 220K-token session came back at a 1% cache hit.
+The stored bytes are therefore kept and the CURRENT surface's guidance is delivered on the
+per-turn user-message channel instead: that lands after the cached prefix and is stamped into
+the byte-stable ``api_content`` sidecar so later turns replay it unchanged.  The prompt itself
+converges at the next rebuild boundary (compaction).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterator, List
+
+from agent.prompt_builder import RUNTIME_ENVIRONMENT_END, RUNTIME_ENVIRONMENT_HEADING
+
+logger = logging.getLogger("run_agent")
+
+_SURFACE_SWITCH_NOTE_PREFIX = "[System: This conversation is now being answered on a different interface: "
+# Closes the surface name in the note; platform names are free-form for plugin platforms, so the
+# terminator (not ".") delimits the parse.
+_SURFACE_NAME_END = " — any earlier interface guidance"
+# Only the newest note matters, and the note is re-stamped on the switch turn, so a bounded tail
+# scan is enough; without a bound every turn of a never-switched session walks the whole transcript.
+_NOTE_SCAN_TAIL = 200
+
+
+def identity_line_value(prompt: str, label: str) -> str:
+    """Last ``Label: value`` line in the authoritative identity portion of a persisted prompt.
+
+    Legacy prose may quote the runtime heading, but only the new renderer ENDS in the boundary;
+    the final runtime block is embedder prose, never identity, so it is excluded when present.
+    Last match wins — safe only for volatile-tier trailer fields at the end of the prompt."""
+    identity, runtime_marker, _ = prompt.rpartition(f"\n\n{RUNTIME_ENVIRONMENT_HEADING}\n\n")
+    runtime_marker = runtime_marker if prompt.endswith(RUNTIME_ENVIRONMENT_END) else ""
+    prefix = f"{label}:"
+    matches = [
+        line[len(prefix):].strip()
+        for line in (identity if runtime_marker else prompt).splitlines()
+        if line.startswith(prefix)
+    ]
+    return matches[-1] if matches else ""
+
+
+def _transcript_row_texts(msg: Any) -> Iterator[str]:
+    """Every string the model actually saw for one transcript row: the wire sidecar first, then
+    the stored content (plain string, or the text parts of a multimodal list — where the note
+    lands as a durable text part because a list cannot take the string sidecar)."""
+    if not isinstance(msg, dict):
+        return
+    sidecar = msg.get("api_content")
+    if isinstance(sidecar, str):
+        yield sidecar
+    content = msg.get("content")
+    if isinstance(content, str):
+        yield content
+    elif isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                yield part["text"]
+
+
+def _last_announced_surface(conversation_history: Any) -> str:
+    """The surface named by the NEWEST switch note in the transcript ("" when none).
+
+    Once a switch has been announced, that note — not the stored prompt's ``Platform:`` trailer —
+    is the last thing the model was told it runs on.  Reading it back is also what keeps a fresh
+    AIAgent per turn (the gateway shape) from stacking one copy of the note per turn."""
+    for msg in reversed((conversation_history or [])[-_NOTE_SCAN_TAIL:]):
+        for text in _transcript_row_texts(msg):
+            if _SURFACE_SWITCH_NOTE_PREFIX in text:
+                tail = text.rsplit(_SURFACE_SWITCH_NOTE_PREFIX, 1)[1]
+                return tail.split(_SURFACE_NAME_END, 1)[0].strip()
+    return ""
+
+
+def _agent_tool_names(agent: Any) -> List[str]:
+    from tools.mcp_tool_agent import _def_name
+    return [name for name in map(_def_name, getattr(agent, "tools", None) or []) if name]
+
+
+def note_inert_pinned_tools(agent: Any, built_for_this_surface: List[str]) -> None:
+    """Name, at the end of the staged note, the pinned tools THIS surface did not build.
+
+    The freeze keeps a previous surface's tools on the wire deliberately — removing them is the one
+    thing that would still re-prefill the request behind the preserved prompt — so the model has
+    to be TOLD they are inert here, or it plans around a ``focus_pane`` a terminal turn can only
+    answer with ``tool_error("desktop only")``."""
+    surface_names = set(built_for_this_surface)
+    inert = [name for name in _agent_tool_names(agent) if name not in surface_names]
+    note = getattr(agent, "_surface_switch_note", "") or ""
+    if not inert or not note:
+        return
+    agent._surface_switch_note = note + (
+        "\n[System: These tools stay listed for this conversation (dropping them would discard "
+        "the cached request prefix) but were not loaded for this interface — expect a call to "
+        f"one of them to fail: {', '.join(inert)}.]"
+    )
+
+
+def stage_surface_switch_note(agent: Any, prompt: str, conversation_history: Any) -> bool:
+    """Stage a one-shot correction when the request would otherwise misdescribe the surface.
+
+    Compares the runtime surface against what the model was last told — the newest switch note
+    if one exists, else ``prompt``'s own ``Platform:`` trailer.  Consulting the note matters in
+    both directions: switching BACK to the prompt's surface (desktop -> tui -> desktop) leaves the
+    trailer agreeing with the runtime while a stale note still says otherwise, and a rebuild for
+    an unrelated reason (a model switch) refreshes the prompt but not that note.  The full surface
+    guidance is attached only when the prompt itself is out of date; otherwise the note just
+    retires the stale one.  Returns whether it staged.
+
+    MoA and codex_app_server turns never stamp the ``api_content`` sidecar, so the note could not
+    be read back and would be re-sent every turn; those modes keep the stored prompt and skip the
+    note entirely."""
+    if getattr(agent, "provider", None) == "moa" or getattr(agent, "api_mode", None) == "codex_app_server":
+        return False
+    current = str(getattr(agent, "platform", "") or "").strip()
+    described = identity_line_value(prompt, "Platform")
+    told = _last_announced_surface(conversation_history) or described
+    if not current or not told or told == current:
+        return False
+    from agent.system_prompt import platform_surface_hint
+    hint = platform_surface_hint(agent) if described != current else ""
+    where = "the guidance below" if hint else "the interface section in the system prompt above"
+    note = (
+        f"{_SURFACE_SWITCH_NOTE_PREFIX}{current}{_SURFACE_NAME_END} in this conversation is "
+        f"superseded — follow {where} for formatting, file delivery and any interface-specific "
+        "capability.]"
+    )
+    agent._surface_switch_note = f"{note}\n{hint}" if hint else note
+    logger.info(
+        "Session %s switched surface %s -> %s; keeping the stored system prompt and delivering "
+        "the new surface guidance as a turn note (prefix cache preserved).",
+        agent.session_id, told, current,
+    )
+    return True

--- a/agent/surface_switch.py
+++ b/agent/surface_switch.py
@@ -12,8 +12,9 @@ converges at the next rebuild boundary (compaction).
 from __future__ import annotations
 
 import logging
-from typing import Any, Iterator, List
+from typing import Any, List
 
+from agent.message_content import flatten_message_text
 from agent.prompt_builder import RUNTIME_ENVIRONMENT_END, RUNTIME_ENVIRONMENT_HEADING
 
 logger = logging.getLogger("run_agent")
@@ -27,39 +28,21 @@ _SURFACE_NAME_END = " — any earlier interface guidance"
 _NOTE_SCAN_TAIL = 200
 
 
+def split_runtime_boundary(prompt: str) -> tuple:
+    """``(identity, runtime_marker, runtime)`` of a persisted prompt.  Legacy prose may quote
+    the runtime heading, but only the new renderer ENDS in the boundary; when the marker is
+    empty the whole prompt is identity."""
+    identity, runtime_marker, runtime = prompt.rpartition(f"\n\n{RUNTIME_ENVIRONMENT_HEADING}\n\n")
+    return (identity, runtime_marker, runtime) if prompt.endswith(RUNTIME_ENVIRONMENT_END) else (prompt, "", "")
+
+
 def identity_line_value(prompt: str, label: str) -> str:
-    """Last ``Label: value`` line in the authoritative identity portion of a persisted prompt.
-
-    Legacy prose may quote the runtime heading, but only the new renderer ENDS in the boundary;
-    the final runtime block is embedder prose, never identity, so it is excluded when present.
-    Last match wins — safe only for volatile-tier trailer fields at the end of the prompt."""
-    identity, runtime_marker, _ = prompt.rpartition(f"\n\n{RUNTIME_ENVIRONMENT_HEADING}\n\n")
-    runtime_marker = runtime_marker if prompt.endswith(RUNTIME_ENVIRONMENT_END) else ""
+    """Last ``Label: value`` line in the identity portion (the final runtime block is embedder
+    prose, never identity).  Last match wins — safe only for the volatile-tier trailer fields."""
     prefix = f"{label}:"
-    matches = [
-        line[len(prefix):].strip()
-        for line in (identity if runtime_marker else prompt).splitlines()
-        if line.startswith(prefix)
-    ]
+    matches = [line[len(prefix):].strip() for line in split_runtime_boundary(prompt)[0].splitlines()
+               if line.startswith(prefix)]
     return matches[-1] if matches else ""
-
-
-def _transcript_row_texts(msg: Any) -> Iterator[str]:
-    """Every string the model actually saw for one transcript row: the wire sidecar first, then
-    the stored content (plain string, or the text parts of a multimodal list — where the note
-    lands as a durable text part because a list cannot take the string sidecar)."""
-    if not isinstance(msg, dict):
-        return
-    sidecar = msg.get("api_content")
-    if isinstance(sidecar, str):
-        yield sidecar
-    content = msg.get("content")
-    if isinstance(content, str):
-        yield content
-    elif isinstance(content, list):
-        for part in content:
-            if isinstance(part, dict) and isinstance(part.get("text"), str):
-                yield part["text"]
 
 
 def _last_announced_surface(conversation_history: Any) -> str:
@@ -69,16 +52,16 @@ def _last_announced_surface(conversation_history: Any) -> str:
     is the last thing the model was told it runs on.  Reading it back is also what keeps a fresh
     AIAgent per turn (the gateway shape) from stacking one copy of the note per turn."""
     for msg in reversed((conversation_history or [])[-_NOTE_SCAN_TAIL:]):
-        for text in _transcript_row_texts(msg):
-            if _SURFACE_SWITCH_NOTE_PREFIX in text:
-                tail = text.rsplit(_SURFACE_SWITCH_NOTE_PREFIX, 1)[1]
-                return tail.split(_SURFACE_NAME_END, 1)[0].strip()
+        # The note only ever lands on a user row: in its api_content sidecar, or as a text part
+        # when the content is a multimodal list (which cannot take the string sidecar).
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        sidecar = msg.get("api_content")
+        text = (sidecar if isinstance(sidecar, str) else "") + "\n" + flatten_message_text(msg.get("content"))
+        if _SURFACE_SWITCH_NOTE_PREFIX in text:
+            tail = text.rsplit(_SURFACE_SWITCH_NOTE_PREFIX, 1)[1]
+            return tail.split(_SURFACE_NAME_END, 1)[0].strip()
     return ""
-
-
-def _agent_tool_names(agent: Any) -> List[str]:
-    from tools.mcp_tool_agent import _def_name
-    return [name for name in map(_def_name, getattr(agent, "tools", None) or []) if name]
 
 
 def note_inert_pinned_tools(agent: Any, built_for_this_surface: List[str]) -> None:
@@ -88,8 +71,9 @@ def note_inert_pinned_tools(agent: Any, built_for_this_surface: List[str]) -> No
     thing that would still re-prefill the request behind the preserved prompt — so the model has
     to be TOLD they are inert here, or it plans around a ``focus_pane`` a terminal turn can only
     answer with ``tool_error("desktop only")``."""
+    from tools.mcp_tool_agent import agent_tool_names
     surface_names = set(built_for_this_surface)
-    inert = [name for name in _agent_tool_names(agent) if name not in surface_names]
+    inert = [name for name in agent_tool_names(agent) if name not in surface_names]
     note = getattr(agent, "_surface_switch_note", "") or ""
     if not inert or not note:
         return
@@ -117,12 +101,14 @@ def stage_surface_switch_note(agent: Any, prompt: str, conversation_history: Any
     if getattr(agent, "provider", None) == "moa" or getattr(agent, "api_mode", None) == "codex_app_server":
         return False
     current = str(getattr(agent, "platform", "") or "").strip()
+    if not current:
+        return False
     described = identity_line_value(prompt, "Platform")
     told = _last_announced_surface(conversation_history) or described
-    if not current or not told or told == current:
+    if not told or told == current:
         return False
-    from agent.system_prompt import platform_surface_hint
-    hint = platform_surface_hint(agent) if described != current else ""
+    from agent.system_prompt import platform_hint
+    hint = platform_hint(agent) if described != current else ""
     where = "the guidance below" if hint else "the interface section in the system prompt above"
     note = (
         f"{_SURFACE_SWITCH_NOTE_PREFIX}{current}{_SURFACE_NAME_END} in this conversation is "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -457,6 +457,16 @@ def _timestamp_line(agent: Any) -> str:
     return timestamp_line + "".join(f"\n{label}: {value}" for label, value in trailer if value)
 
 
+def platform_surface_hint(agent: Any) -> str:
+    """The rendering-surface guidance for ``agent.platform`` ("" when the surface has none).
+
+    Public because a session that changed surface mid-conversation keeps its stored prompt
+    (rebuilding it re-prefills the whole request) and delivers the CURRENT surface's guidance
+    through the per-turn user-message channel instead — see ``_SURFACE_SWITCH_NOTE_PREFIX``
+    in ``agent.conversation_loop`` (#104414)."""
+    return _platform_hint(agent) or ""
+
+
 def _memory_parts(agent: Any) -> List[str]:
     """Built-in memory/USER.md blocks plus the external provider block (gated on
     the same check ``inject_memory_provider_tools`` uses, so we never advertise
@@ -736,7 +746,7 @@ def format_tools_for_system_message(agent: Any) -> str:
 
 
 __all__ = ["build_system_prompt_parts", "build_system_prompt", "invalidate_system_prompt",
-           "restore_plugin_prompt_sections", "format_tools_for_system_message"]
+           "platform_surface_hint", "restore_plugin_prompt_sections", "format_tools_for_system_message"]
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -381,7 +381,7 @@ def _active_profile_line(agent: Any) -> str:
     )
 
 
-def _platform_hint(agent: Any) -> str:
+def platform_hint(agent: Any) -> str:
     """Built-in/plugin platform hint + Telegram rich-messages opt-in + config
     override + desktop TUI clarifier."""
     platform_key = (agent.platform or "").lower().strip()
@@ -455,16 +455,6 @@ def _timestamp_line(agent: Any) -> str:
     trailer = (("Session ID", agent.session_id if agent.pass_session_id else None), ("Model", agent.model),
                ("Provider", agent.provider), ("Platform", agent.platform))
     return timestamp_line + "".join(f"\n{label}: {value}" for label, value in trailer if value)
-
-
-def platform_surface_hint(agent: Any) -> str:
-    """The rendering-surface guidance for ``agent.platform`` ("" when the surface has none).
-
-    Public because a session that changed surface mid-conversation keeps its stored prompt
-    (rebuilding it re-prefills the whole request) and delivers the CURRENT surface's guidance
-    through the per-turn user-message channel instead — see ``_SURFACE_SWITCH_NOTE_PREFIX``
-    in ``agent.conversation_loop`` (#104414)."""
-    return _platform_hint(agent) or ""
 
 
 def _memory_parts(agent: Any) -> List[str]:
@@ -589,7 +579,7 @@ def _post_workspace_parts(agent: Any) -> List[str]:
             pass  # Probe failure must never block prompt build.
     if getattr(agent, "_bot_mode_protocol", True):
         parts.extend(_bot_mode_parts(agent))
-    parts += [_active_profile_line(agent), _platform_hint(agent)]
+    parts += [_active_profile_line(agent), platform_hint(agent)]
     return parts
 
 
@@ -746,7 +736,7 @@ def format_tools_for_system_message(agent: Any) -> str:
 
 
 __all__ = ["build_system_prompt_parts", "build_system_prompt", "invalidate_system_prompt",
-           "platform_surface_hint", "restore_plugin_prompt_sections", "format_tools_for_system_message"]
+           "platform_hint", "restore_plugin_prompt_sections", "format_tools_for_system_message"]
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -114,22 +114,25 @@ def extract_api_content_sidecar(msg: Mapping[str, Any]) -> Optional[str]:
     return v if isinstance(v, str) else None
 
 
-def consume_gateway_turn_context_notes(agent: Any) -> str:
-    """Pop the gateway's per-turn must-deliver notes off the agent (one-shot, so the
-    system prompt stays byte-stable and a cached agent never replays a stale note)."""
-    notes = getattr(agent, "_gateway_turn_context_notes", "") or ""
-    if hasattr(agent, "_gateway_turn_context_notes"):
+def _pop_turn_note(agent: Any, attr: str) -> str:
+    """One-shot per-turn note: read and clear, so the system prompt stays byte-stable and a
+    cached agent never replays a stale note."""
+    note = getattr(agent, attr, "") or ""
+    if hasattr(agent, attr):
         with suppress(Exception):
-            agent._gateway_turn_context_notes = ""
-    return notes if isinstance(notes, str) else ""
+            setattr(agent, attr, "")
+    return note if isinstance(note, str) else ""
+
+
+def consume_gateway_turn_context_notes(agent: Any) -> str:
+    """Pop the gateway's per-turn must-deliver notes."""
+    return _pop_turn_note(agent, "_gateway_turn_context_notes")
 
 
 def consume_surface_switch_note(agent: Any) -> str:
-    """Pop the one-shot surface-switch note staged by the system-prompt restore (#104414); it rides
-    the same user-message channel as the gateway's must-deliver notes, behind the cached prefix."""
-    note = getattr(agent, "_surface_switch_note", "") or ""
-    agent._surface_switch_note = ""
-    return note if isinstance(note, str) else ""
+    """Pop the surface-switch note staged by the system-prompt restore (#104414); rides the same
+    user-message channel as the gateway notes, behind the cached prefix."""
+    return _pop_turn_note(agent, "_surface_switch_note")
 
 
 def append_notes_to_multimodal_content(content: Any, notes: str) -> bool:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -124,6 +124,20 @@ def consume_gateway_turn_context_notes(agent: Any) -> str:
     return notes if isinstance(notes, str) else ""
 
 
+def consume_surface_switch_note(agent: Any) -> str:
+    """Pop the one-shot surface-change note staged by the system-prompt restore.
+
+    Rides the same user-message channel as the gateway's must-deliver notes: a session that
+    moved between surfaces keeps its stored system prompt (rebuilding it re-prefills the whole
+    request) and gets the new surface's guidance here, behind the cached prefix (#104414).
+    """
+    note = getattr(agent, "_surface_switch_note", "") or ""
+    if hasattr(agent, "_surface_switch_note"):
+        with suppress(Exception):
+            agent._surface_switch_note = ""
+    return note if isinstance(note, str) else ""
+
+
 def append_notes_to_multimodal_content(content: Any, notes: str) -> bool:
     """Append must-deliver notes as a durable text part on a multimodal (list) user
     message (the sidecar path returns ``None`` for non-string content)."""
@@ -663,11 +677,15 @@ def _collect_pre_llm_call_context(
 def _merge_gateway_notes(
     agent: Any, messages: List[Any], current_turn_user_idx: int, plugin_user_context: str
 ) -> str:
-    """Gateway must-deliver notes ride the user-message injection channel (one-shot,
-    gateway-staged) so the ephemeral system prompt stays byte-stable. Multimodal (list)
-    content can't take the string sidecar — append a durable text part instead."""
-    _gateway_notes = consume_gateway_turn_context_notes(agent)
-    if not _gateway_notes:
+    """Must-deliver per-turn notes ride the user-message injection channel (one-shot) so the
+    ephemeral system prompt stays byte-stable: the gateway's staged notes, then the
+    surface-switch correction. Multimodal (list) content can't take the string sidecar —
+    append a durable text part instead."""
+    _turn_notes = "\n\n".join(
+        part for part in (consume_gateway_turn_context_notes(agent),
+                          consume_surface_switch_note(agent)) if part
+    )
+    if not _turn_notes:
         return plugin_user_context
     _gw_turn_content = (
         messages[current_turn_user_idx].get("content")
@@ -676,10 +694,10 @@ def _merge_gateway_notes(
         else None
     )
     if isinstance(_gw_turn_content, list):
-        append_notes_to_multimodal_content(_gw_turn_content, _gateway_notes)
+        append_notes_to_multimodal_content(_gw_turn_content, _turn_notes)
         return plugin_user_context
     return (
-        plugin_user_context + "\n\n" + _gateway_notes if plugin_user_context else _gateway_notes
+        plugin_user_context + "\n\n" + _turn_notes if plugin_user_context else _turn_notes
     )
 
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -125,16 +125,10 @@ def consume_gateway_turn_context_notes(agent: Any) -> str:
 
 
 def consume_surface_switch_note(agent: Any) -> str:
-    """Pop the one-shot surface-change note staged by the system-prompt restore.
-
-    Rides the same user-message channel as the gateway's must-deliver notes: a session that
-    moved between surfaces keeps its stored system prompt (rebuilding it re-prefills the whole
-    request) and gets the new surface's guidance here, behind the cached prefix (#104414).
-    """
+    """Pop the one-shot surface-switch note staged by the system-prompt restore (#104414); it rides
+    the same user-message channel as the gateway's must-deliver notes, behind the cached prefix."""
     note = getattr(agent, "_surface_switch_note", "") or ""
-    if hasattr(agent, "_surface_switch_note"):
-        with suppress(Exception):
-            agent._surface_switch_note = ""
+    agent._surface_switch_note = ""
     return note if isinstance(note, str) else ""
 
 

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -70,7 +70,11 @@ class TestSurfaceSwitch:
             {"role": "assistant", "content": "hello"},
         ]
 
-    def _restore(self, *, stored: str, current: str, history=None, tool_names=None):
+    @staticmethod
+    def _tool(name: str) -> dict:
+        return {"type": "function", "function": {"name": name, "parameters": {}}}
+
+    def _restore(self, *, stored: str, current: str, history=None, tool_names=None, tools=None):
         db = MagicMock()
         row = {"system_prompt": self._stored(stored)}
         if tool_names is not None:
@@ -78,6 +82,8 @@ class TestSurfaceSwitch:
         db.get_session.return_value = row
         agent = _make_agent(session_db=db)
         agent.platform = current
+        if tools is not None:
+            agent.tools = tools
         agent._platform_hint_overrides = None
         agent._surface_switch_note = ""
         agent._gateway_turn_context_notes = ""
@@ -144,12 +150,11 @@ class TestSurfaceSwitch:
         agent._build_system_prompt.assert_called_once()
         assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")
 
-    def test_tool_prefix_is_replaced_on_the_turn_that_announces_a_switch(self):
-        """The saved names are the PREVIOUS surface's toolset.
+    def test_tool_prefix_stays_pinned_on_the_turn_that_announces_a_switch(self):
+        """tools[] is serialized ahead of the prompt this branch went out of its way to keep.
 
-        The tool registry is process-global, so ``_merge_preserving_prefix`` would keep a
-        saved-but-not-loaded tool (e.g. the desktop_ui toolset a `coding_context: focus`
-        desktop session gets) and re-advertise it on a TUI session that cannot run it.
+        Rebuilding the array for the new surface would move token 0 and re-prefill the whole
+        request — the cost #104414 is about — on the very turn the fix exists to make cheap.
         """
         from unittest.mock import patch
 
@@ -158,12 +163,40 @@ class TestSurfaceSwitch:
             patch("tools.mcp_tool_agent.persist_agent_tool_names") as persist,
         ):
             self._restore(stored="desktop", current="tui", tool_names='["desktop_ui_tool"]')
-        pin.assert_not_called()
-        persist.assert_called_once()
+        pin.assert_called_once()
+        persist.assert_not_called()
+
+    def test_the_note_names_the_tools_the_pin_carried_forward(self):
+        """A pinned tool this surface did not build is inert here — say so.
+
+        Keeping it on the wire is what preserves the prefix, so the model has to learn from the
+        note that calling it only returns ``tool_error("desktop only")``.
+        """
+        from unittest.mock import patch
+
+        def _carry_desktop_tool(agent, saved_names):
+            agent.tools = [self._tool("read_file"), self._tool("focus_pane")]
+            return True
+
+        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix", _carry_desktop_tool):
+            agent = self._restore(stored="desktop", current="tui", tool_names='["focus_pane"]',
+                                  tools=[self._tool("read_file")])
+        assert "focus_pane" in agent._surface_switch_note
+        assert "were not loaded for this interface" in agent._surface_switch_note
+        # Only the carried-over name: a tool this surface built is not inert.
+        assert "read_file" not in agent._surface_switch_note.split("were not loaded for this interface")[1]
+
+    def test_the_note_says_nothing_about_tools_when_the_pin_carries_none(self):
+        from unittest.mock import patch
+
+        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix", lambda agent, names: False):
+            agent = self._restore(stored="desktop", current="tui", tool_names='["read_file"]',
+                                  tools=[self._tool("read_file")])
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui.")
+        assert "were not loaded for this interface" not in agent._surface_switch_note
 
     def test_tool_prefix_is_pinned_again_on_the_next_turn(self):
-        # The freeze is skipped once, not disabled for the rest of the session: the announcing
-        # turn persisted this surface's tools, so the next turn pins those.
+        # The pin is never skipped, on the announcing turn or after it.
         from unittest.mock import patch
 
         with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -111,6 +111,28 @@ class TestSurfaceSwitch:
     def test_unknown_surface_stages_nothing(self):
         assert self._restore(stored="", current="tui")._surface_switch_note == ""
 
+    def test_stored_prompt_platform_ignores_runtime_hint_decoys(self):
+        from agent.prompt_builder import RUNTIME_ENVIRONMENT_END, RUNTIME_ENVIRONMENT_HEADING
+        from agent.conversation_loop import _stored_prompt_platform
+
+        decoy = "Host: Example\nPlatform: tui\n"
+        stored = (
+            "SYSTEM PROMPT BODY\n\nConversation started: Monday, January 05, 2026\n"
+            "Model: test-model\nProvider: openrouter\nPlatform: desktop\n\n"
+            f"{RUNTIME_ENVIRONMENT_HEADING}\n\n{decoy}\n\n{RUNTIME_ENVIRONMENT_END}"
+        )
+        assert _stored_prompt_platform(stored) == "desktop"
+
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        agent.platform = "tui"
+        agent._platform_hint_overrides = None
+        agent._surface_switch_note = ""
+        agent._gateway_turn_context_notes = ""
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui.")
+
     def test_not_restaged_once_the_transcript_carries_it(self):
         # The note is stamped into the byte-stable api_content sidecar, and the gateway
         # builds a fresh AIAgent per turn — without the dedup every turn would add a copy.
@@ -146,6 +168,24 @@ class TestSurfaceSwitch:
         agent._surface_switch_note = ""
 
         _restore_or_build_system_prompt(agent, None, self._announced("tui"))
+
+        agent._build_system_prompt.assert_called_once()
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")
+
+    def test_bot_chat_epoch_rebuild_also_retires_a_stale_note(self):
+        # A Bot Chat capability epoch refresh refreshes the prompt but not the
+        # note already sitting in the transcript.
+        from unittest.mock import patch
+
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": self._stored("desktop")}
+        agent = _make_agent(session_db=db, prebuilt_prompt=self._stored("desktop"))
+        agent.platform = "desktop"
+        agent._platform_hint_overrides = None
+        agent._surface_switch_note = ""
+
+        with patch("agent.conversation_loop._bot_chat_prompt_stale", return_value=True):
+            _restore_or_build_system_prompt(agent, None, self._announced("tui"))
 
         agent._build_system_prompt.assert_called_once()
         assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -61,6 +61,15 @@ class TestSurfaceSwitch:
             f"Platform: {platform}"
         )
 
+    @staticmethod
+    def _announced(platform: str) -> list:
+        """A transcript whose newest surface note says the model is on ``platform``."""
+        return [
+            {"role": "user", "content": "hi",
+             "api_content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}{platform}. superseded]"},
+            {"role": "assistant", "content": "hello"},
+        ]
+
     def _restore(self, *, stored: str, current: str, history=None, tool_names=None):
         db = MagicMock()
         row = {"system_prompt": self._stored(stored)}
@@ -85,7 +94,7 @@ class TestSurfaceSwitch:
     def test_switch_stages_the_new_surface_guidance(self):
         agent = self._restore(stored="desktop", current="tui")
         note = agent._surface_switch_note
-        assert note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui (")
+        assert note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui.")
         # The correction carries the CURRENT surface's hint, so the model is not left
         # following the desktop guidance still sitting in the reused prompt.
         assert "terminal UI (TUI)" in note
@@ -99,22 +108,41 @@ class TestSurfaceSwitch:
     def test_not_restaged_once_the_transcript_carries_it(self):
         # The note is stamped into the byte-stable api_content sidecar, and the gateway
         # builds a fresh AIAgent per turn — without the dedup every turn would add a copy.
-        history = [
-            {"role": "user", "content": "hi",
-             "api_content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}tui (...)]"},
-            {"role": "assistant", "content": "hello"},
-        ]
-        agent = self._restore(stored="desktop", current="tui", history=history)
+        agent = self._restore(stored="desktop", current="tui", history=self._announced("tui"))
         assert agent._surface_switch_note == ""
 
     def test_a_further_switch_is_announced_again(self):
         # Only the NEWEST note counts: it names the surface the conversation has left.
-        history = [
-            {"role": "user", "content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}tui (...)]"},
-            {"role": "assistant", "content": "hello"},
-        ]
-        agent = self._restore(stored="desktop", current="cli", history=history)
-        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}cli (")
+        agent = self._restore(stored="desktop", current="cli", history=self._announced("tui"))
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}cli.")
+
+    def test_returning_to_the_prompts_own_surface_is_announced(self):
+        """desktop -> tui -> desktop.
+
+        The trailer now agrees with the runtime, so comparing against the prompt alone would
+        stage nothing and leave the model acting on the stale "you are on tui" note.
+        """
+        agent = self._restore(stored="desktop", current="desktop", history=self._announced("tui"))
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")
+        # The prompt already describes this surface, so the note retires the stale one and
+        # points at the prompt instead of duplicating the whole hint.
+        assert "the interface section in the system prompt above" in agent._surface_switch_note
+
+    def test_rebuild_also_retires_a_stale_note(self):
+        # A rebuild for an unrelated reason (a model switch) refreshes the prompt but not the
+        # note already sitting in the transcript.
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": self._stored("desktop")}
+        agent = _make_agent(session_db=db, prebuilt_prompt=self._stored("desktop"))
+        agent.model = "other-model"
+        agent.platform = "desktop"
+        agent._platform_hint_overrides = None
+        agent._surface_switch_note = ""
+
+        _restore_or_build_system_prompt(agent, None, self._announced("tui"))
+
+        agent._build_system_prompt.assert_called_once()
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")
 
     def test_tool_prefix_is_replaced_on_the_turn_that_announces_a_switch(self):
         """The saved names are the PREVIOUS surface's toolset.
@@ -138,12 +166,8 @@ class TestSurfaceSwitch:
         # turn persisted this surface's tools, so the next turn pins those.
         from unittest.mock import patch
 
-        history = [
-            {"role": "user", "content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}tui (...)]"},
-            {"role": "assistant", "content": "hello"},
-        ]
         with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:
-            self._restore(stored="desktop", current="tui", history=history,
+            self._restore(stored="desktop", current="tui", history=self._announced("tui"),
                           tool_names='["read_file"]')
         pin.assert_called_once()
 

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -116,7 +116,7 @@ class TestSurfaceSwitch:
         agent = self._restore(stored="desktop", current="cli", history=history)
         assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}cli (")
 
-    def test_tool_prefix_is_not_pinned_across_a_switch(self):
+    def test_tool_prefix_is_replaced_on_the_turn_that_announces_a_switch(self):
         """The saved names are the PREVIOUS surface's toolset.
 
         The tool registry is process-global, so ``_merge_preserving_prefix`` would keep a
@@ -125,9 +125,27 @@ class TestSurfaceSwitch:
         """
         from unittest.mock import patch
 
-        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:
+        with (
+            patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin,
+            patch("tools.mcp_tool_agent.persist_agent_tool_names") as persist,
+        ):
             self._restore(stored="desktop", current="tui", tool_names='["desktop_ui_tool"]')
         pin.assert_not_called()
+        persist.assert_called_once()
+
+    def test_tool_prefix_is_pinned_again_on_the_next_turn(self):
+        # The freeze is skipped once, not disabled for the rest of the session: the announcing
+        # turn persisted this surface's tools, so the next turn pins those.
+        from unittest.mock import patch
+
+        history = [
+            {"role": "user", "content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}tui (...)]"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:
+            self._restore(stored="desktop", current="tui", history=history,
+                          tool_names='["read_file"]')
+        pin.assert_called_once()
 
     def test_tool_prefix_is_still_pinned_on_the_same_surface(self):
         from unittest.mock import patch

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -20,7 +20,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from agent.conversation_loop import _SURFACE_SWITCH_NOTE_PREFIX, _restore_or_build_system_prompt
+from agent.conversation_loop import _restore_or_build_system_prompt
+from agent.surface_switch import _SURFACE_NAME_END, _SURFACE_SWITCH_NOTE_PREFIX, identity_line_value
 
 
 def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
@@ -66,7 +67,7 @@ class TestSurfaceSwitch:
         """A transcript whose newest surface note says the model is on ``platform``."""
         return [
             {"role": "user", "content": "hi",
-             "api_content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}{platform}. superseded]"},
+             "api_content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}{platform}{_SURFACE_NAME_END} superseded]"},
             {"role": "assistant", "content": "hello"},
         ]
 
@@ -100,7 +101,7 @@ class TestSurfaceSwitch:
     def test_switch_stages_the_new_surface_guidance(self):
         agent = self._restore(stored="desktop", current="tui")
         note = agent._surface_switch_note
-        assert note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui.")
+        assert note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui{_SURFACE_NAME_END}")
         # The correction carries the CURRENT surface's hint, so the model is not left
         # following the desktop guidance still sitting in the reused prompt.
         assert "terminal UI (TUI)" in note
@@ -108,12 +109,8 @@ class TestSurfaceSwitch:
     def test_same_surface_stages_nothing(self):
         assert self._restore(stored="cli", current="cli")._surface_switch_note == ""
 
-    def test_unknown_surface_stages_nothing(self):
-        assert self._restore(stored="", current="tui")._surface_switch_note == ""
-
     def test_stored_prompt_platform_ignores_runtime_hint_decoys(self):
         from agent.prompt_builder import RUNTIME_ENVIRONMENT_END, RUNTIME_ENVIRONMENT_HEADING
-        from agent.conversation_loop import _stored_prompt_platform
 
         decoy = "Host: Example\nPlatform: tui\n"
         stored = (
@@ -121,7 +118,7 @@ class TestSurfaceSwitch:
             "Model: test-model\nProvider: openrouter\nPlatform: desktop\n\n"
             f"{RUNTIME_ENVIRONMENT_HEADING}\n\n{decoy}\n\n{RUNTIME_ENVIRONMENT_END}"
         )
-        assert _stored_prompt_platform(stored) == "desktop"
+        assert identity_line_value(stored, "Platform") == "desktop"
 
         db = MagicMock()
         db.get_session.return_value = {"system_prompt": stored}
@@ -131,18 +128,13 @@ class TestSurfaceSwitch:
         agent._surface_switch_note = ""
         agent._gateway_turn_context_notes = ""
         _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
-        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui.")
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui{_SURFACE_NAME_END}")
 
     def test_not_restaged_once_the_transcript_carries_it(self):
         # The note is stamped into the byte-stable api_content sidecar, and the gateway
         # builds a fresh AIAgent per turn — without the dedup every turn would add a copy.
         agent = self._restore(stored="desktop", current="tui", history=self._announced("tui"))
         assert agent._surface_switch_note == ""
-
-    def test_a_further_switch_is_announced_again(self):
-        # Only the NEWEST note counts: it names the surface the conversation has left.
-        agent = self._restore(stored="desktop", current="cli", history=self._announced("tui"))
-        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}cli.")
 
     def test_returning_to_the_prompts_own_surface_is_announced(self):
         """desktop -> tui -> desktop.
@@ -151,7 +143,7 @@ class TestSurfaceSwitch:
         stage nothing and leave the model acting on the stale "you are on tui" note.
         """
         agent = self._restore(stored="desktop", current="desktop", history=self._announced("tui"))
-        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop{_SURFACE_NAME_END}")
         # The prompt already describes this surface, so the note retires the stale one and
         # points at the prompt instead of duplicating the whole hint.
         assert "the interface section in the system prompt above" in agent._surface_switch_note
@@ -170,25 +162,7 @@ class TestSurfaceSwitch:
         _restore_or_build_system_prompt(agent, None, self._announced("tui"))
 
         agent._build_system_prompt.assert_called_once()
-        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")
-
-    def test_bot_chat_epoch_rebuild_also_retires_a_stale_note(self):
-        # A Bot Chat capability epoch refresh refreshes the prompt but not the
-        # note already sitting in the transcript.
-        from unittest.mock import patch
-
-        db = MagicMock()
-        db.get_session.return_value = {"system_prompt": self._stored("desktop")}
-        agent = _make_agent(session_db=db, prebuilt_prompt=self._stored("desktop"))
-        agent.platform = "desktop"
-        agent._platform_hint_overrides = None
-        agent._surface_switch_note = ""
-
-        with patch("agent.conversation_loop._bot_chat_prompt_stale", return_value=True):
-            _restore_or_build_system_prompt(agent, None, self._announced("tui"))
-
-        agent._build_system_prompt.assert_called_once()
-        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop{_SURFACE_NAME_END}")
 
     def test_tool_prefix_stays_pinned_on_the_turn_that_announces_a_switch(self):
         """tools[] is serialized ahead of the prompt this branch went out of its way to keep.
@@ -225,31 +199,6 @@ class TestSurfaceSwitch:
         assert "were not loaded for this interface" in agent._surface_switch_note
         # Only the carried-over name: a tool this surface built is not inert.
         assert "read_file" not in agent._surface_switch_note.split("were not loaded for this interface")[1]
-
-    def test_the_note_says_nothing_about_tools_when_the_pin_carries_none(self):
-        from unittest.mock import patch
-
-        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix", lambda agent, names: False):
-            agent = self._restore(stored="desktop", current="tui", tool_names='["read_file"]',
-                                  tools=[self._tool("read_file")])
-        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui.")
-        assert "were not loaded for this interface" not in agent._surface_switch_note
-
-    def test_tool_prefix_is_pinned_again_on_the_next_turn(self):
-        # The pin is never skipped, on the announcing turn or after it.
-        from unittest.mock import patch
-
-        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:
-            self._restore(stored="desktop", current="tui", history=self._announced("tui"),
-                          tool_names='["read_file"]')
-        pin.assert_called_once()
-
-    def test_tool_prefix_is_still_pinned_on_the_same_surface(self):
-        from unittest.mock import patch
-
-        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:
-            self._restore(stored="cli", current="cli", tool_names='["read_file"]')
-        pin.assert_called_once()
 
     def test_note_rides_the_user_message_channel_once(self):
         from agent.turn_context import _merge_gateway_notes, consume_surface_switch_note

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from agent.conversation_loop import _restore_or_build_system_prompt
+from agent.conversation_loop import _SURFACE_SWITCH_NOTE_PREFIX, _restore_or_build_system_prompt
 
 
 def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
@@ -38,6 +38,111 @@ def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
     agent._use_prompt_caching = False
     agent._build_system_prompt = MagicMock(return_value=prebuilt_prompt)
     return agent
+
+
+# ---------------------------------------------------------------------------
+# Surface switch (#104414)
+# ---------------------------------------------------------------------------
+
+
+class TestSurfaceSwitch:
+    """A desktop <-> TUI switch must not rebuild the system prompt.
+
+    The rebuild it used to trigger changed the first blocks of a 200K+ token request, so
+    the whole conversation re-prefilled at a ~1% cache hit. The stored bytes are now reused
+    and the new surface's guidance is delivered as a per-turn note behind the cached prefix.
+    """
+
+    @staticmethod
+    def _stored(platform: str) -> str:
+        return (
+            "SYSTEM PROMPT BODY\n\nConversation started: Monday, January 05, 2026\n"
+            "Model: test-model\nProvider: openrouter\n"
+            f"Platform: {platform}"
+        )
+
+    def _restore(self, *, stored: str, current: str, history=None, tool_names=None):
+        db = MagicMock()
+        row = {"system_prompt": self._stored(stored)}
+        if tool_names is not None:
+            row["tool_names"] = tool_names
+        db.get_session.return_value = row
+        agent = _make_agent(session_db=db)
+        agent.platform = current
+        agent._platform_hint_overrides = None
+        agent._surface_switch_note = ""
+        agent._gateway_turn_context_notes = ""
+        _restore_or_build_system_prompt(
+            agent, None, history if history is not None else [{"role": "user", "content": "hi"}]
+        )
+        return agent
+
+    def test_switch_reuses_the_stored_prompt(self):
+        agent = self._restore(stored="desktop", current="tui")
+        assert agent._cached_system_prompt == self._stored("desktop")
+        agent._build_system_prompt.assert_not_called()
+
+    def test_switch_stages_the_new_surface_guidance(self):
+        agent = self._restore(stored="desktop", current="tui")
+        note = agent._surface_switch_note
+        assert note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui (")
+        # The correction carries the CURRENT surface's hint, so the model is not left
+        # following the desktop guidance still sitting in the reused prompt.
+        assert "terminal UI (TUI)" in note
+
+    def test_same_surface_stages_nothing(self):
+        assert self._restore(stored="cli", current="cli")._surface_switch_note == ""
+
+    def test_unknown_surface_stages_nothing(self):
+        assert self._restore(stored="", current="tui")._surface_switch_note == ""
+
+    def test_not_restaged_once_the_transcript_carries_it(self):
+        # The note is stamped into the byte-stable api_content sidecar, and the gateway
+        # builds a fresh AIAgent per turn — without the dedup every turn would add a copy.
+        history = [
+            {"role": "user", "content": "hi",
+             "api_content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}tui (...)]"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        agent = self._restore(stored="desktop", current="tui", history=history)
+        assert agent._surface_switch_note == ""
+
+    def test_a_further_switch_is_announced_again(self):
+        # Only the NEWEST note counts: it names the surface the conversation has left.
+        history = [
+            {"role": "user", "content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}tui (...)]"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        agent = self._restore(stored="desktop", current="cli", history=history)
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}cli (")
+
+    def test_tool_prefix_is_not_pinned_across_a_switch(self):
+        """The saved names are the PREVIOUS surface's toolset.
+
+        The tool registry is process-global, so ``_merge_preserving_prefix`` would keep a
+        saved-but-not-loaded tool (e.g. the desktop_ui toolset a `coding_context: focus`
+        desktop session gets) and re-advertise it on a TUI session that cannot run it.
+        """
+        from unittest.mock import patch
+
+        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:
+            self._restore(stored="desktop", current="tui", tool_names='["desktop_ui_tool"]')
+        pin.assert_not_called()
+
+    def test_tool_prefix_is_still_pinned_on_the_same_surface(self):
+        from unittest.mock import patch
+
+        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:
+            self._restore(stored="cli", current="cli", tool_names='["read_file"]')
+        pin.assert_called_once()
+
+    def test_note_rides_the_user_message_channel_once(self):
+        from agent.turn_context import _merge_gateway_notes, consume_surface_switch_note
+
+        agent = self._restore(stored="desktop", current="tui")
+        staged = agent._surface_switch_note
+        assert _merge_gateway_notes(agent, [{"role": "user", "content": "hi"}], 0, "") == staged
+        assert consume_surface_switch_note(agent) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool_agent.py
+++ b/tools/mcp_tool_agent.py
@@ -24,6 +24,11 @@ def _agent_tool_defs(agent) -> list:
     return list(getattr(agent, "tools", None) or [])
 
 
+def agent_tool_names(agent) -> list:
+    """Names of ``agent.tools`` in wire order (unnamed entries skipped)."""
+    return [name for name in map(_def_name, _agent_tool_defs(agent)) if name]
+
+
 def _resolve_refresh_toolsets(agent, enabled_override, disabled_override):
     """Explicit reloads pass freshly-resolved toolsets (so a server just ENABLED in config is
     picked up) and the agent's selection is updated to match; automatic paths pass nothing

--- a/website/docs/developer-guide/prompt-assembly.md
+++ b/website/docs/developer-guide/prompt-assembly.md
@@ -49,8 +49,10 @@ Consequence for stored prompts: `_stored_prompt_matches_runtime()` (`agent/conve
 the first host-info paragraph after the rendered `# Hermes runtime environment` boundary, with a
 closing marker at the absolute end distinguishing this layout from legacy prose quoting the heading.
 The runtime boundary follows all project, operator, memory and plugin text, so examples in those
-blocks do not masquerade as the runtime cwd. Model/provider/platform are read before the runtime
-boundary, excluding embedder descriptions. Legacy prompts retain their original
+blocks do not masquerade as the runtime cwd. Model/provider are read before the runtime boundary,
+excluding embedder descriptions. `Platform:` is deliberately not an identity field: a surface switch
+(desktop ↔ TUI) keeps the stored bytes and delivers the current surface's guidance as a one-shot note on
+the per-turn user-message channel (`agent/surface_switch.py`), so the cached prefix survives (#104414). Legacy prompts retain their original
 host-before-context anchor, so prompts persisted before the reorder still validate.
 
 When `skip_context_files` is set (e.g., subagent delegation), SOUL.md is not loaded and the hardcoded `DEFAULT_AGENT_IDENTITY` is used instead.


### PR DESCRIPTION
Answering a live session from a different surface (desktop → TUI, or a session resumed as the dashboard's PTY TUI child after a restart) no longer rebuilds the system prompt and re-prefills the whole request; the stored bytes are reused and the new surface's guidance rides the per-turn user-message channel behind the cached prefix.

Salvage of #104494 by @JoaoMarcos44 (five commits cherry-picked, authorship preserved; @StanleyStetson's tools-pin review and @ehz0ah's two gap reports are credited in those commits), for #104414. #104484 by @jwilson411 dropped both Platform and cwd from the identity check with no correction — cwd drift genuinely changes prompt bytes (context files, workspace snapshot), so that half is not taken.

## Root cause

`_stored_prompt_matches_runtime` treated the `Platform:` trailer as runtime identity. The surface is advisory metadata about the renderer, but it was baked into the one artifact that determines the cache prefix; correcting one paragraph cost a full re-prefill (reported: 240K cached → 1.5K).

## Changes

- `Platform` is no longer an identity field; Model/Provider/cwd still rebuild.
- `agent/surface_switch.py` (new sibling): `stage_surface_switch_note` compares the runtime surface against the newest switch note in the transcript (read back from `api_content`, which is what stops a fresh AIAgent per turn from stacking notes) or the prompt's own trailer, and stages a one-shot note plus the current surface's hint. `note_inert_pinned_tools` names the tools the pinned `tools[]` carries that this surface did not build. `identity_line_value` is the single parser for the identity trailer, shared with `_stored_prompt_matches_runtime`.
- `agent/turn_context.py`: `consume_surface_switch_note` joins the gateway notes in `_merge_gateway_notes`.
- The saved `tool_names` prefix stays pinned on the announcing turn (`tools[]` precedes the prompt on the wire; dropping the previous surface's toolset would re-prefill anyway).
- Commit 6 (ours): the six helpers moved out of the `conversation_loop` facade into the sibling; MoA and `codex_app_server` turns skip the note (they never stamp the sidecar, so it would be re-sent every turn); the announced surface is delimited by a fixed terminator instead of `split(".")` (a plugin platform with a dot in its name would have re-staged forever); transcript scan bounded to the last 200 rows; `_def_name` reused; 17 tests trimmed to 10; `website/docs/developer-guide/prompt-assembly.md` updated.

## Validation

| Check | Result |
|---|---|
| `test_system_prompt_restore.py`, `test_compression_persistence.py`, `test_turn_context.py`, `test_system_prompt.py`, `test_api_content_sidecar.py`, `test_side_question.py` | 150 passed |
| Real-import probe desktop→tui | main: stored prompt rejected (rebuild); branch: reused, note staged once, not re-staged on turn 2, tui→desktop stages a retire-only note, fresh session no-op, `platform=None` no-op |
| Mutation: restore Platform as identity | 5 red / 21 green |
| MoA / codex_app_server / dotted platform probes on the final stack | no note / no note / parsed `my.plat`, no re-stage |
| ruff, windows-footguns, compat pointers, `git diff --check` | clean |

Closes #104414. Supersedes #104494, #104484 (credited above).
