### PR TITLE
fix(whatsapp): route notification replies to originating sessions

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -247,11 +247,31 @@ agent:main:{platform}:{chat_type}[:{chat_id}][:{thread_id}][:{participant_id}]
 - `participant_id` = `user_id_alt` or `user_id` (in that priority).
 - WhatsApp identifiers are canonicalized to handle JID/LID alias flips.
 
-### Special Case: WhatApp
+### Special Case: WhatsApp
 
 WhatsApp phone numbers go through `canonical_whatsapp_identifier()` which strips the
 `@s.whatsapp.net` suffix and normalizes to E.164 format. This prevents session fragmentation
 when the bridge returns different alias forms of the same phone number.
+
+### WhatsApp Notification Reply Ownership
+
+When a live Desktop or TUI session sends a WhatsApp notification through `hermes send`, Hermes
+stores every transport-confirmed outbound message ID with the originating session in a
+profile-local `notification-replies.db`. An authenticated native WhatsApp reply that quotes one
+of those messages is delivered to that existing owner session instead of becoming a turn in the
+ordinary WhatsApp chat session.
+
+The quote is an address, not authorization. Approval, clarification, and tool-safety checks still
+run in the owner session. Unquoted approval-like text is not assigned by proximity: while a live
+notification route exists, Hermes asks the sender to quote the specific notification. Ordinary
+unquoted chat continues in the normal WhatsApp session.
+
+Routes expire after seven days. Phone and LID forms are matched through the established WhatsApp
+identity mapping; Hermes does not guess that unknown identifiers are equivalent. Unknown or stale
+quotes do not acquire approval authority. Distinct native reply IDs may create distinct follow-up
+turns, while transport replay of the same reply ID is deduplicated. Delivery is currently supported
+for Desktop and TUI owner sessions; unsupported or closed owners retain a durable queued reply for
+an explicit supported resume rather than creating a new agent in the messaging gateway.
 
 ---
 

--- a/gateway/notification_replies.py
+++ b/gateway/notification_replies.py
@@ -1,0 +1,164 @@
+"""Profile-local notification correlation, separate from chat transcripts.
+
+A transport quote is an address, never authority to approve a tool. Only the
+normal authenticated ingress may deposit a reply for an existing owner.
+"""
+from uuid import uuid4
+from contextlib import closing, contextmanager
+from pathlib import Path
+import sqlite3
+import re
+import time
+
+from hermes_constants import get_hermes_home
+from gateway.session_context import get_session_env
+from gateway.whatsapp_identity import to_whatsapp_jid
+
+
+@contextmanager
+def connect(home):
+    db = sqlite3.connect(Path(home) / 'notification-replies.db', timeout=10)
+    try:
+        db.row_factory = sqlite3.Row
+        db.execute('''CREATE TABLE IF NOT EXISTS notification_routes (
+            message_id TEXT PRIMARY KEY, session_id TEXT NOT NULL,
+            chat_id TEXT NOT NULL, source TEXT NOT NULL, created REAL NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending', reply_id TEXT, reply_text TEXT)''')
+        db.execute('CREATE UNIQUE INDEX IF NOT EXISTS notification_reply_once '
+                   'ON notification_routes(chat_id, reply_id) WHERE reply_id IS NOT NULL')
+        with db:
+            yield db
+    finally:
+        db.close()
+
+
+def capture_origin(platform):
+    if platform != 'whatsapp':
+        return None
+    session_id = get_session_env('HERMES_SESSION_ID')
+    home = get_hermes_home()
+    if not session_id or not (home / 'state.db').exists():
+        return None
+    with closing(sqlite3.connect(f'file:{home / "state.db"}?mode=ro', uri=True)) as db:
+        row = db.execute('SELECT source FROM sessions WHERE id=?', (session_id,)).fetchone()
+    if not row or row[0] == 'whatsapp':
+        return None
+    return dict(home=home, session_id=session_id, source=row[0])
+
+
+def prepare_send(origin, chat_id, message, media_files, max_length):
+    if not origin:
+        return
+    # Until the sender returns every partial-success ID, never commission an
+    # approval notification whose first chunk/attachment cannot be correlated.
+    if media_files or not message.strip() or len(message) > min(max_length or 4000, 4000):
+        raise ValueError('Cross-session WhatsApp notifications currently require one text-only message (at most 4000 characters). Send attachments in the originating session.')
+    origin['intent_id'] = 'sending:' + uuid4().hex
+    with connect(origin['home']) as db:
+        db.execute('INSERT INTO notification_routes(message_id, session_id, chat_id, source, created, status) '
+                   "VALUES (?, ?, ?, ?, ?, 'sending')",
+                   (origin['intent_id'], origin['session_id'], to_whatsapp_jid(chat_id), origin['source'], time.time()))
+
+
+def record_sent(origin, chat_id, result):
+    if not origin:
+        return
+    message_id = result.get('message_id') if result.get('success') else None
+    try:
+        with connect(origin['home']) as db:
+            db.execute('UPDATE notification_routes SET message_id=?, status=? WHERE message_id=?',
+                       (message_id or origin['intent_id'], 'pending' if message_id else 'uncertain', origin['intent_id']))
+    except sqlite3.Error:
+        # Delivery already happened. Returning a send failure invites a duplicate
+        # send; keep the pre-send intent and report routing failure separately.
+        message_id = None
+    if not message_id:
+        result['routing_warning'] = 'Notification delivery/correlation is uncertain. Do not resend automatically; reply in the originating session.'
+    else:
+        result['reply_routing'] = {'session_id': origin['session_id'], 'status': 'pending'}
+
+
+_REPLY_TTL = 7 * 24 * 60 * 60
+_OWNER_SURFACES = frozenset({'desktop', 'tui'})
+_APPROVAL = re.compile(r'^/?(?:yes|no|y|n|ok(?:ay)?|approve(?:d)?|deny|confirm|continue|proceed|go ahead|do it|sure|sounds good)\b', re.I)
+
+
+def origin_exists(home, session_id, source):
+    if not (Path(home) / 'state.db').exists():
+        return False
+    db = sqlite3.connect(f'file:{Path(home) / "state.db"}?mode=ro', uri=True)
+    try:
+        row = db.execute('SELECT source FROM sessions WHERE id=?', (session_id,)).fetchone()
+        return bool(row and row[0] == source)
+    finally:
+        db.close()
+
+
+def _uncertain_quote(db, event):
+    return bool(event.reply_to_message_id and event.reply_to_is_own_message and db.execute(
+        "SELECT 1 FROM notification_routes WHERE chat_id=? AND status IN ('sending', 'uncertain') LIMIT 1",
+        (to_whatsapp_jid(event.source.chat_id),)).fetchone())
+
+
+def is_reply_candidate(event):
+    """Read-only adapter bypass hint; authorization still happens in the runner."""
+    if event.source.platform.value != 'whatsapp' or event.internal:
+        return False
+    home = get_hermes_home()
+    if not (home / 'notification-replies.db').exists():
+        return False
+    try:
+        with connect(home) as db:
+            if event.reply_to_message_id:
+                return db.execute('SELECT 1 FROM notification_routes WHERE message_id=?',
+                                  (event.reply_to_message_id,)).fetchone() is not None or _uncertain_quote(db, event)
+            return bool(_APPROVAL.match(event.text.strip()) and db.execute(
+                "SELECT 1 FROM notification_routes WHERE chat_id=? AND status IN ('pending', 'sending', 'uncertain') LIMIT 1",
+                (to_whatsapp_jid(event.source.chat_id),)).fetchone())
+    except sqlite3.Error:
+        return True  # a broken routing store must not steer the current workstream
+
+
+def accept_reply(event):
+    """Called AFTER gateway authentication, BEFORE current-chat controls. None = ordinary chat."""
+    if event.source.platform.value != 'whatsapp' or event.internal:
+        return None
+    home = get_hermes_home()
+    if not (home / 'notification-replies.db').exists():
+        return None
+    try:
+        return _accept_stored_reply(home, event)
+    except (sqlite3.Error, OSError):
+        return 'Notification routing is unavailable. Nothing was started; please reply in the originating session.'
+
+
+def _accept_stored_reply(home, event):
+    with connect(home) as db:
+        db.execute('BEGIN IMMEDIATE')
+        row = db.execute('SELECT * FROM notification_routes WHERE message_id=?',
+                         (event.reply_to_message_id,)).fetchone()
+        if row is None:
+            if _uncertain_quote(db, event):
+                return 'Cannot correlate this quote while notification delivery is uncertain. Please reply in the originating session.'
+            pending = db.execute("SELECT 1 FROM notification_routes WHERE chat_id=? AND status IN ('pending', 'sending', 'uncertain') LIMIT 1",
+                                 (to_whatsapp_jid(event.source.chat_id),)).fetchone()
+            if pending and not event.reply_to_message_id and _APPROVAL.match(event.text.strip()):
+                return 'Please quote the specific notification you are answering, or reply in its originating session. No approval was applied.'
+            return None
+        source = event.source
+        if (source.chat_type != 'dm' or to_whatsapp_jid(source.chat_id) != row['chat_id']
+                or to_whatsapp_jid(source.user_id or '') != row['chat_id']):
+            return 'This notification reply cannot be verified for this sender and chat. Reply in the originating session.'
+        if row['source'] not in _OWNER_SURFACES:
+            return 'Please reply in the originating session; this surface does not support remote continuation yet.'
+        if not origin_exists(home, row['session_id'], row['source']):
+            return 'The originating session is unavailable. Nothing was started; check that workstream manually.'
+        if time.time() - row['created'] > _REPLY_TTL:
+            return 'This notification has expired. Please confirm in the originating session.'
+        if not event.message_id or not event.text.strip() or event.media_urls:
+            return 'Please send a text-only reply to this notification; no action was taken.'
+        if row['status'] != 'pending':
+            return 'This notification already has a reply; it will not be run again. Check the originating session.'
+        db.execute("UPDATE notification_routes SET status='queued', reply_id=?, reply_text=? "
+                   "WHERE message_id=? AND status='pending'", (event.message_id, event.text, row['message_id']))
+    return 'Reply queued for the originating session. Open or resume that session if it is not running; no task was started in WhatsApp.'

--- a/gateway/notification_replies.py
+++ b/gateway/notification_replies.py
@@ -1,31 +1,56 @@
-"""Profile-local notification correlation, separate from chat transcripts.
+"""Durable WhatsApp notification-address and owner-mailbox routing.
 
-A transport quote is an address, never authority to approve a tool. Only the
-normal authenticated ingress may deposit a reply for an existing owner.
+A transport quote is an address, never authority to approve a tool. Only normal
+authenticated ingress may deposit a reply for an existing session owner.
 """
-from uuid import uuid4
+from __future__ import annotations
+
 from contextlib import closing, contextmanager
 from pathlib import Path
-import sqlite3
 import re
+import sqlite3
 import time
+from uuid import uuid4
 
-from hermes_constants import get_hermes_home
 from gateway.session_context import get_session_env
-from gateway.whatsapp_identity import to_whatsapp_jid
+from gateway.whatsapp_identity import canonical_whatsapp_identifier
+from hermes_constants import get_hermes_home
+
+
+_REPLY_TTL = 7 * 24 * 60 * 60
+_OWNER_SURFACES = frozenset({"desktop", "tui"})
+_APPROVAL = re.compile(
+    r"^/?(?:yes|no|y|n|ok(?:ay)?|approve(?:d)?|deny|confirm|continue|proceed|go ahead|do it|sure|sounds good)\b",
+    re.I,
+)
 
 
 @contextmanager
 def connect(home):
-    db = sqlite3.connect(Path(home) / 'notification-replies.db', timeout=10)
+    db = sqlite3.connect(Path(home) / "notification-replies.db", timeout=10)
     try:
         db.row_factory = sqlite3.Row
-        db.execute('''CREATE TABLE IF NOT EXISTS notification_routes (
+        db.execute(
+            """CREATE TABLE IF NOT EXISTS notification_routes (
             message_id TEXT PRIMARY KEY, session_id TEXT NOT NULL,
             chat_id TEXT NOT NULL, source TEXT NOT NULL, created REAL NOT NULL,
-            status TEXT NOT NULL DEFAULT 'pending', reply_id TEXT, reply_text TEXT)''')
-        db.execute('CREATE UNIQUE INDEX IF NOT EXISTS notification_reply_once '
-                   'ON notification_routes(chat_id, reply_id) WHERE reply_id IS NOT NULL')
+            status TEXT NOT NULL DEFAULT 'pending', reply_id TEXT, reply_text TEXT)"""
+        )
+        db.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS notification_reply_once "
+            "ON notification_routes(chat_id, reply_id) WHERE reply_id IS NOT NULL"
+        )
+        db.execute(
+            """CREATE TABLE IF NOT EXISTS notification_reply_queue (
+            reply_id TEXT PRIMARY KEY, message_id TEXT NOT NULL,
+            session_id TEXT NOT NULL, source TEXT NOT NULL,
+            reply_text TEXT NOT NULL, created REAL NOT NULL,
+            status TEXT NOT NULL DEFAULT 'queued')"""
+        )
+        db.execute(
+            "CREATE INDEX IF NOT EXISTS notification_reply_owner_queue "
+            "ON notification_reply_queue(session_id, status, created)"
+        )
         with db:
             yield db
     finally:
@@ -33,132 +58,301 @@ def connect(home):
 
 
 def capture_origin(platform):
-    if platform != 'whatsapp':
+    if platform != "whatsapp":
         return None
-    session_id = get_session_env('HERMES_SESSION_ID')
+    session_id = get_session_env("HERMES_SESSION_ID")
     home = get_hermes_home()
-    if not session_id or not (home / 'state.db').exists():
+    if not session_id or not (home / "state.db").exists():
         return None
     with closing(sqlite3.connect(f'file:{home / "state.db"}?mode=ro', uri=True)) as db:
-        row = db.execute('SELECT source FROM sessions WHERE id=?', (session_id,)).fetchone()
-    if not row or row[0] == 'whatsapp':
+        row = db.execute("SELECT source FROM sessions WHERE id=?", (session_id,)).fetchone()
+    if not row or row[0] == "whatsapp":
         return None
-    return dict(home=home, session_id=session_id, source=row[0])
+    return {"home": home, "session_id": session_id, "source": row[0]}
 
 
 def prepare_send(origin, chat_id, message, media_files, max_length):
+    """Persist intent before transport dispatch without restricting its native payload."""
     if not origin:
         return
-    # Until the sender returns every partial-success ID, never commission an
-    # approval notification whose first chunk/attachment cannot be correlated.
-    if media_files or not message.strip() or len(message) > min(max_length or 4000, 4000):
-        raise ValueError('Cross-session WhatsApp notifications currently require one text-only message (at most 4000 characters). Send attachments in the originating session.')
-    origin['intent_id'] = 'sending:' + uuid4().hex
-    with connect(origin['home']) as db:
-        db.execute('INSERT INTO notification_routes(message_id, session_id, chat_id, source, created, status) '
-                   "VALUES (?, ?, ?, ?, ?, 'sending')",
-                   (origin['intent_id'], origin['session_id'], to_whatsapp_jid(chat_id), origin['source'], time.time()))
+    origin["intent_id"] = "sending:" + uuid4().hex
+    with connect(origin["home"]) as db:
+        db.execute(
+            "INSERT INTO notification_routes(message_id, session_id, chat_id, source, created, status) "
+            "VALUES (?, ?, ?, ?, ?, 'sending')",
+            (
+                origin["intent_id"],
+                origin["session_id"],
+                canonical_whatsapp_identifier(chat_id),
+                origin["source"],
+                time.time(),
+            ),
+        )
+
+
+def _result_message_ids(result) -> list[str]:
+    values = result.get("message_ids") or result.get("partial_message_ids") or []
+    if not values and isinstance(result.get("raw_response"), dict):
+        values = result["raw_response"].get("message_ids") or []
+    if isinstance(values, str):
+        values = [values]
+    ids = [str(value) for value in values if value]
+    last = result.get("message_id")
+    if last:
+        ids.append(str(last))
+    return list(dict.fromkeys(ids))
 
 
 def record_sent(origin, chat_id, result):
+    """Replace the pre-send intent with every transport-confirmed outbound ID."""
     if not origin:
         return
-    message_id = result.get('message_id') if result.get('success') else None
+    message_ids = _result_message_ids(result)
     try:
-        with connect(origin['home']) as db:
-            db.execute('UPDATE notification_routes SET message_id=?, status=? WHERE message_id=?',
-                       (message_id or origin['intent_id'], 'pending' if message_id else 'uncertain', origin['intent_id']))
+        with connect(origin["home"]) as db:
+            row = db.execute(
+                "SELECT session_id, chat_id, source, created FROM notification_routes WHERE message_id=?",
+                (origin["intent_id"],),
+            ).fetchone()
+            if row is None:
+                raise sqlite3.IntegrityError("send intent disappeared")
+            if not message_ids:
+                db.execute(
+                    "UPDATE notification_routes SET status='uncertain' WHERE message_id=?",
+                    (origin["intent_id"],),
+                )
+            else:
+                db.execute("DELETE FROM notification_routes WHERE message_id=?", (origin["intent_id"],))
+                db.executemany(
+                    "INSERT INTO notification_routes(message_id, session_id, chat_id, source, created, status) "
+                    "VALUES (?, ?, ?, ?, ?, 'pending')",
+                    [(message_id, row["session_id"], row["chat_id"], row["source"], row["created"])
+                     for message_id in message_ids],
+                )
     except sqlite3.Error:
         # Delivery already happened. Returning a send failure invites a duplicate
-        # send; keep the pre-send intent and report routing failure separately.
-        message_id = None
-    if not message_id:
-        result['routing_warning'] = 'Notification delivery/correlation is uncertain. Do not resend automatically; reply in the originating session.'
-    else:
-        result['reply_routing'] = {'session_id': origin['session_id'], 'status': 'pending'}
+        # send, so report uncertain correlation separately.
+        message_ids = []
+        try:
+            with connect(origin["home"]) as db:
+                db.execute(
+                    "UPDATE notification_routes SET status='uncertain' WHERE message_id=?",
+                    (origin["intent_id"],),
+                )
+        except sqlite3.Error:
+            pass
+    if not message_ids:
+        result["routing_warning"] = (
+            "Notification delivery/correlation is uncertain. Do not resend automatically; "
+            "reply in the originating session."
+        )
+        return
+    result["message_ids"] = message_ids
+    result["reply_routing"] = {
+        "session_id": origin["session_id"],
+        "status": "partial" if result.get("error") else "pending",
+        "message_ids": message_ids,
+    }
+    if result.get("error"):
+        result["routing_warning"] = (
+            "Some notification parts were delivered and are reply-addressable. Do not resend automatically."
+        )
 
 
-_REPLY_TTL = 7 * 24 * 60 * 60
-_OWNER_SURFACES = frozenset({'desktop', 'tui'})
-_APPROVAL = re.compile(r'^/?(?:yes|no|y|n|ok(?:ay)?|approve(?:d)?|deny|confirm|continue|proceed|go ahead|do it|sure|sounds good)\b', re.I)
+def resolve_origin_session(home, session_id, source):
+    """Return the native compression tip, or the existing explicit-closed owner.
 
+    Explicitly closed owners remain addressable so normal ``session.resume`` can
+    recreate them; missing rows and source changes fail closed.
+    """
+    if not (Path(home) / "state.db").exists():
+        return None
+    from hermes_state import SessionDB
 
-def origin_exists(home, session_id, source):
-    if not (Path(home) / 'state.db').exists():
-        return False
-    db = sqlite3.connect(f'file:{Path(home) / "state.db"}?mode=ro', uri=True)
+    db = SessionDB(db_path=Path(home) / "state.db")
     try:
-        row = db.execute('SELECT source FROM sessions WHERE id=?', (session_id,)).fetchone()
-        return bool(row and row[0] == source)
+        row = db.get_session(session_id)
+        if not row or row.get("source") != source:
+            return None
+        tip_id = db.get_compression_tip(session_id) or session_id
+        tip = db.get_session(tip_id)
+        return tip_id if tip and tip.get("source") == source else None
     finally:
         db.close()
 
 
+def owner_session_lineage(home, session_id, source) -> tuple[str, ...]:
+    """Return compression ancestors addressable by one currently live owner."""
+    if not (Path(home) / "state.db").exists():
+        return ()
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=Path(home) / "state.db")
+    try:
+        current = db.get_session(session_id)
+        if not current or current.get("source") != source:
+            return ()
+        lineage = db.get_compression_lineage(session_id) or [session_id]
+        return tuple(
+            candidate_id for candidate_id in lineage
+            if (candidate := db.get_session(candidate_id)) and candidate.get("source") == source
+        )
+    finally:
+        db.close()
+
+
+def _live_cutoff() -> float:
+    return time.time() - _REPLY_TTL
+
+
 def _uncertain_quote(db, event):
-    return bool(event.reply_to_message_id and event.reply_to_is_own_message and db.execute(
-        "SELECT 1 FROM notification_routes WHERE chat_id=? AND status IN ('sending', 'uncertain') LIMIT 1",
-        (to_whatsapp_jid(event.source.chat_id),)).fetchone())
+    return bool(
+        event.reply_to_message_id
+        and event.reply_to_is_own_message
+        and db.execute(
+            "SELECT 1 FROM notification_routes WHERE chat_id=? AND created>=? "
+            "AND status IN ('sending', 'uncertain') LIMIT 1",
+            (canonical_whatsapp_identifier(event.source.chat_id), _live_cutoff()),
+        ).fetchone()
+    )
+
+
+def _routing_shaped(event) -> bool:
+    return bool(
+        (event.reply_to_message_id and event.reply_to_is_own_message)
+        or _APPROVAL.match(event.text.strip())
+    )
 
 
 def is_reply_candidate(event):
     """Read-only adapter bypass hint; authorization still happens in the runner."""
-    if event.source.platform.value != 'whatsapp' or event.internal:
+    if event.source.platform.value != "whatsapp" or event.internal:
         return False
     home = get_hermes_home()
-    if not (home / 'notification-replies.db').exists():
+    if not (home / "notification-replies.db").exists():
         return False
     try:
         with connect(home) as db:
             if event.reply_to_message_id:
-                return db.execute('SELECT 1 FROM notification_routes WHERE message_id=?',
-                                  (event.reply_to_message_id,)).fetchone() is not None or _uncertain_quote(db, event)
-            return bool(_APPROVAL.match(event.text.strip()) and db.execute(
-                "SELECT 1 FROM notification_routes WHERE chat_id=? AND status IN ('pending', 'sending', 'uncertain') LIMIT 1",
-                (to_whatsapp_jid(event.source.chat_id),)).fetchone())
+                return bool(
+                    db.execute(
+                        "SELECT 1 FROM notification_routes WHERE message_id=?",
+                        (event.reply_to_message_id,),
+                    ).fetchone()
+                    or _uncertain_quote(db, event)
+                    or (event.reply_to_is_own_message and _APPROVAL.match(event.text.strip()))
+                )
+            return bool(
+                _APPROVAL.match(event.text.strip())
+                and db.execute(
+                    "SELECT 1 FROM notification_routes WHERE chat_id=? AND created>=? "
+                    "AND status IN ('pending', 'queued', 'dispatching', 'dispatched', 'sending', 'uncertain') LIMIT 1",
+                    (canonical_whatsapp_identifier(event.source.chat_id), _live_cutoff()),
+                ).fetchone()
+            )
     except sqlite3.Error:
-        return True  # a broken routing store must not steer the current workstream
+        # Do not block unrelated conversation merely because this optional store broke.
+        return _routing_shaped(event)
 
 
 def accept_reply(event):
     """Called AFTER gateway authentication, BEFORE current-chat controls. None = ordinary chat."""
-    if event.source.platform.value != 'whatsapp' or event.internal:
+    if event.source.platform.value != "whatsapp" or event.internal:
         return None
     home = get_hermes_home()
-    if not (home / 'notification-replies.db').exists():
+    if not (home / "notification-replies.db").exists():
         return None
     try:
         return _accept_stored_reply(home, event)
     except (sqlite3.Error, OSError):
-        return 'Notification routing is unavailable. Nothing was started; please reply in the originating session.'
+        if _routing_shaped(event):
+            return (
+                "Notification routing is unavailable. Nothing was started; "
+                "please reply in the originating session."
+            )
+        return None
 
 
 def _accept_stored_reply(home, event):
     with connect(home) as db:
-        db.execute('BEGIN IMMEDIATE')
-        row = db.execute('SELECT * FROM notification_routes WHERE message_id=?',
-                         (event.reply_to_message_id,)).fetchone()
+        db.execute("BEGIN IMMEDIATE")
+        row = db.execute(
+            "SELECT * FROM notification_routes WHERE message_id=?",
+            (event.reply_to_message_id,),
+        ).fetchone()
         if row is None:
             if _uncertain_quote(db, event):
-                return 'Cannot correlate this quote while notification delivery is uncertain. Please reply in the originating session.'
-            pending = db.execute("SELECT 1 FROM notification_routes WHERE chat_id=? AND status IN ('pending', 'sending', 'uncertain') LIMIT 1",
-                                 (to_whatsapp_jid(event.source.chat_id),)).fetchone()
+                return (
+                    "Cannot correlate this quote while notification delivery is uncertain. "
+                    "Please reply in the originating session."
+                )
+            pending = db.execute(
+                "SELECT 1 FROM notification_routes WHERE chat_id=? AND created>=? "
+                "AND status IN ('pending', 'queued', 'dispatching', 'dispatched', 'sending', 'uncertain') LIMIT 1",
+                (canonical_whatsapp_identifier(event.source.chat_id), _live_cutoff()),
+            ).fetchone()
             if pending and not event.reply_to_message_id and _APPROVAL.match(event.text.strip()):
-                return 'Please quote the specific notification you are answering, or reply in its originating session. No approval was applied.'
+                return (
+                    "Please quote the specific notification you are answering, or reply in its "
+                    "originating session. No approval was applied."
+                )
+            if (
+                event.reply_to_message_id
+                and event.reply_to_is_own_message
+                and _APPROVAL.match(event.text.strip())
+            ):
+                return (
+                    "Cannot correlate this historical quote. No approval was applied; "
+                    "confirm in the originating session."
+                )
             return None
         source = event.source
-        if (source.chat_type != 'dm' or to_whatsapp_jid(source.chat_id) != row['chat_id']
-                or to_whatsapp_jid(source.user_id or '') != row['chat_id']):
-            return 'This notification reply cannot be verified for this sender and chat. Reply in the originating session.'
-        if row['source'] not in _OWNER_SURFACES:
-            return 'Please reply in the originating session; this surface does not support remote continuation yet.'
-        if not origin_exists(home, row['session_id'], row['source']):
-            return 'The originating session is unavailable. Nothing was started; check that workstream manually.'
-        if time.time() - row['created'] > _REPLY_TTL:
-            return 'This notification has expired. Please confirm in the originating session.'
+        route_identity = canonical_whatsapp_identifier(row["chat_id"])
+        if (
+            source.chat_type != "dm"
+            or canonical_whatsapp_identifier(source.chat_id) != route_identity
+            or canonical_whatsapp_identifier(source.user_id or "") != route_identity
+        ):
+            return (
+                "This notification reply cannot be verified for this sender and chat. "
+                "Reply in the originating session."
+            )
+        if row["source"] not in _OWNER_SURFACES:
+            return (
+                "Please reply in the originating session; this surface does not support "
+                "remote continuation yet."
+            )
+        owner_session_id = resolve_origin_session(home, row["session_id"], row["source"])
+        if not owner_session_id:
+            return (
+                "The originating session is unavailable. Nothing was started; "
+                "check that workstream manually."
+            )
+        if row["created"] < _live_cutoff():
+            return "This notification has expired. Please confirm in the originating session."
         if not event.message_id or not event.text.strip() or event.media_urls:
-            return 'Please send a text-only reply to this notification; no action was taken.'
-        if row['status'] != 'pending':
-            return 'This notification already has a reply; it will not be run again. Check the originating session.'
-        db.execute("UPDATE notification_routes SET status='queued', reply_id=?, reply_text=? "
-                   "WHERE message_id=? AND status='pending'", (event.message_id, event.text, row['message_id']))
-    return 'Reply queued for the originating session. Open or resume that session if it is not running; no task was started in WhatsApp.'
+            return "Please send a text-only reply to this notification; no action was taken."
+        if row["status"] in {"sending", "uncertain", "expired"}:
+            return (
+                "This notification cannot currently accept a routed reply. "
+                "Please confirm in the originating session."
+            )
+        try:
+            db.execute(
+                "INSERT INTO notification_reply_queue(reply_id, message_id, session_id, source, reply_text, created) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (event.message_id, row["message_id"], owner_session_id, row["source"], event.text, time.time()),
+            )
+        except sqlite3.IntegrityError:
+            return (
+                "This reply was already received; it will not be run again. "
+                "Check the originating session."
+            )
+        db.execute(
+            "UPDATE notification_routes SET status='queued', reply_id=?, reply_text=? WHERE message_id=?",
+            (event.message_id, event.text, row["message_id"]),
+        )
+    return (
+        "Reply queued for the originating session. Open or resume that session if it is not running; "
+        "no task was started in WhatsApp."
+    )

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1197,6 +1197,11 @@ class GatewayInboundMixin:
         if _paused_notice is not None:
             return _paused_notice
 
+        from gateway.notification_replies import accept_reply
+        _notification_reply = accept_reply(event)
+        if _notification_reply is not None:
+            return _notification_reply
+
         _quick_key = self._session_key_for_source(source)
         _reply = await self._hm_pending_reply_intercepts(event, source, _quick_key)
         if _reply is not None:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -856,6 +856,7 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
         import aiohttp
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+    message_ids: list[str] = []
     try:
         bridge_port = (getattr(pconfig, "extra", {}) or {}).get("bridge_port", 3000)
         normalized_chat_id = to_whatsapp_jid(chat_id)
@@ -875,27 +876,36 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
             if (message or "").strip() and not media_caption:
                 last_message_id, err = await _post("send", {"chatId": normalized_chat_id, "message": message}, 30, "bridge")
                 if err:
-                    return err
+                    return {**err, "message_ids": message_ids}
+                if last_message_id:
+                    message_ids.append(str(last_message_id))
             # 2) Each media file as a native attachment (mediaType picks the WhatsApp kind).
             for media_path, is_voice in media:
                 if not os.path.exists(media_path):
                     # In caption mode the words would vanish with the missing file — deliver the caption as a plain message.
                     if media_caption:
                         try:
-                            await _post("send", {"chatId": normalized_chat_id, "message": media_caption}, 30)
+                            fallback_id, _ = await _post(
+                                "send", {"chatId": normalized_chat_id, "message": media_caption}, 30
+                            )
+                            if fallback_id:
+                                message_ids.append(str(fallback_id))
                         except Exception:
                             logger.warning("WhatsApp caption-fallback send failed for missing media")
-                    return {"error": f"WhatsApp media file not found: {media_path}"}
+                    return {"error": f"WhatsApp media file not found: {media_path}", "message_ids": message_ids}
                 media_type = _bridge_media_type(media_path, is_voice, force_document)
                 payload: Dict[str, Any] = {"chatId": normalized_chat_id, "filePath": media_path, "mediaType": media_type}
                 payload.update({k: v for k, v in (("fileName", os.path.basename(media_path) if media_type == "document" else None), ("caption", media_caption)) if v})
                 mid, err = await _post("send-media", payload, 120, "media")
                 if err:
-                    return err
+                    return {**err, "message_ids": message_ids}
                 last_message_id = mid or last_message_id
-        return {"success": True, "platform": "whatsapp", "chat_id": normalized_chat_id, "message_id": last_message_id}
+                if mid:
+                    message_ids.append(str(mid))
+        return {"success": True, "platform": "whatsapp", "chat_id": normalized_chat_id,
+                "message_id": last_message_id, "message_ids": message_ids}
     except Exception as e:
-        return {"error": f"WhatsApp send failed: {e}"}
+        return {"error": f"WhatsApp send failed: {e}", "message_ids": message_ids}
 
 
 def interactive_setup() -> None:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -680,6 +680,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             print(f"[{self.name}] {bridge_exit}")
         return bool(bridge_exit)
 
+    async def handle_message(self, event: MessageEvent) -> None:
+        from gateway.notification_replies import is_reply_candidate
+        if self._message_handler and is_reply_candidate(event):
+            await self._dispatch_inline_reply(event)
+            return
+        await super().handle_message(event)
+
     async def _poll_messages(self) -> None:
         while self._running:
             if not self._http_session or await self._report_bridge_exit():
@@ -692,7 +699,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                             if event:
                                 # Fire-and-forget: a slow bridge /read must not delay dispatch.
                                 asyncio.create_task(self._send_read_receipt(msg_data))
-                                if event.message_type == MessageType.TEXT:
+                                from gateway.notification_replies import is_reply_candidate
+                                if event.message_type == MessageType.TEXT and not is_reply_candidate(event):
                                     self._enqueue_text_event(event)
                                 else:
                                     await self.handle_message(event)

--- a/tests/gateway/test_notification_reply_routing.py
+++ b/tests/gateway/test_notification_reply_routing.py
@@ -16,7 +16,7 @@ from hermes_state import SessionDB
 
 
 CHAT = '15551234567@s.whatsapp.net'
-ORIGIN = '20260907_171053_a1fb73'
+ORIGIN = '20260101_120000_a1b2c3'
 
 
 def send_notification(home, monkeypatch, *, wire_result=None, message='Publication needs approval',
@@ -264,7 +264,7 @@ def event(text='Go ahead', quote='notice-1', sender=CHAT, chat=CHAT):
         message_id='reply-1', reply_to_message_id=quote, reply_to_is_own_message=bool(quote))
 
 
-def install_lid_alias(home, lid='243993266942172', phone='15551234567'):
+def install_lid_alias(home, lid='999991234567890', phone='15551234567'):
     mapping_dir = home / 'whatsapp' / 'session'
     mapping_dir.mkdir(parents=True, exist_ok=True)
     (mapping_dir / f'lid-mapping-{lid}.json').write_text(json.dumps(phone), encoding='utf-8')
@@ -275,7 +275,7 @@ def test_phone_target_accepts_authenticated_lid_alias(tmp_path, monkeypatch):
     monkeypatch.setenv('HERMES_HOME', str(tmp_path))
     install_lid_alias(tmp_path)
     path = send_notification(tmp_path, monkeypatch)
-    lid = '243993266942172@lid'
+    lid = '999991234567890@lid'
     incoming = event(sender=lid, chat=lid)
     runner = inbound_runner(monkeypatch)
     monkeypatch.setenv('WHATSAPP_ALLOWED_USERS', '15551234567')

--- a/tests/gateway/test_notification_reply_routing.py
+++ b/tests/gateway/test_notification_reply_routing.py
@@ -474,3 +474,89 @@ def test_desktop_owner_poller_continues_existing_surface_once(tmp_path, monkeypa
     assert original['source'] == 'desktop'
     with sqlite3.connect(tmp_path / 'notification-replies.db') as db:
         assert db.execute('SELECT status FROM notification_routes').fetchone()[0] == 'dispatched'
+
+
+def test_owner_mailbox_uses_real_prompt_admission_and_persists_visible_turn(tmp_path, monkeypatch):
+    """Only the model call is substituted; owner admission, turn runner, events,
+    session history, and SQLite persistence use their production implementations.
+    """
+    import threading
+    from types import SimpleNamespace
+    from tui_gateway import server
+    from tui_gateway.session_notification_replies import poll_replies
+
+    class InlineThread:
+        def __init__(self, target=None, daemon=None, args=(), kwargs=None):
+            self.target, self.args, self.kwargs = target, args, kwargs or {}
+
+        def start(self):
+            if self.target:
+                self.target(*self.args, **self.kwargs)
+
+        def is_alive(self):
+            return False
+
+        def join(self, timeout=None):
+            return None
+
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    monkeypatch.delenv('HERMES_PROFILE', raising=False)
+    monkeypatch.setattr(server.threading, 'Thread', InlineThread)
+    monkeypatch.setattr(server, '_wire_callbacks', lambda sid: None)
+    monkeypatch.setattr(server, '_sync_agent_model_with_config', lambda sid, session: None)
+    monkeypatch.setattr(server, '_sync_agent_compression_with_config', lambda sid, session: None)
+    monkeypatch.setattr(server, '_sync_bot_capabilities', lambda sid, session: None)
+    monkeypatch.setattr(server, '_session_cwd', lambda session: str(tmp_path))
+    monkeypatch.setattr(server, '_register_session_cwd', lambda session: None)
+    monkeypatch.setattr(server, '_tts_stream_begin', lambda: None)
+    monkeypatch.setattr(server, '_sync_session_key_after_compress', lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, '_get_usage', lambda agent: {})
+    emitted = []
+    monkeypatch.setattr(server, '_emit', lambda kind, sid, payload=None: emitted.append((kind, sid, payload)))
+
+    send_notification(tmp_path, monkeypatch)
+    asyncio.run(inbound_runner(monkeypatch)._handle_message(event()))
+    state = SessionDB(db_path=tmp_path / 'state.db')
+
+    def deterministic_model_boundary(message, **kwargs):
+        state.append_message(ORIGIN, 'user', kwargs['persist_user_message'])
+        state.append_message(ORIGIN, 'assistant', 'Deterministic owner acknowledgement')
+        return {'final_response': 'Deterministic owner acknowledgement', 'messages': [
+            *kwargs['conversation_history'],
+            {'role': 'user', 'content': kwargs['persist_user_message']},
+            {'role': 'assistant', 'content': 'Deterministic owner acknowledgement'},
+        ]}
+
+    agent = SimpleNamespace(
+        session_id=ORIGIN, model='test/model', provider='test',
+        run_conversation=deterministic_model_boundary, clear_interrupt=lambda: None,
+    )
+    owner = {
+        'session_key': ORIGIN, 'source': 'desktop',
+        'history_lock': threading.Lock(), 'running': False, 'agent': agent,
+        'history': [{'role': 'assistant', 'content': 'Original work'}],
+        'history_version': 0, 'attached_images': [], 'image_counter': 0,
+        'cols': 80, 'slash_worker': None, 'show_reasoning': False,
+        'tool_progress_mode': 'all', 'inflight_turn': None,
+    }
+    server._sessions['real-owner-tab'] = owner
+    try:
+        poll_replies('real-owner-tab', owner, tmp_path, server._run_prompt_submit)
+    finally:
+        server._sessions.pop('real-owner-tab', None)
+        server._release_active_session_slot(owner)
+        state.close()
+
+    assert [message['content'] for message in owner['history'][-2:]] == [
+        'Go ahead', 'Deterministic owner acknowledgement']
+    persisted = SessionDB(db_path=tmp_path / 'state.db')
+    try:
+        assert [(message['role'], message['content']) for message in persisted.get_messages(ORIGIN)[-2:]] == [
+            ('user', 'Go ahead'), ('assistant', 'Deterministic owner acknowledgement')]
+    finally:
+        persisted.close()
+    assert any(kind == 'message.start' and sid == 'real-owner-tab' for kind, sid, _ in emitted)
+    assert any(kind == 'message.complete' and payload['text'] == 'Deterministic owner acknowledgement'
+               for kind, _, payload in emitted)
+    with sqlite3.connect(tmp_path / 'notification-replies.db') as db:
+        assert db.execute('SELECT status FROM notification_reply_queue').fetchone()[0] == 'dispatched'

--- a/tests/gateway/test_notification_reply_routing.py
+++ b/tests/gateway/test_notification_reply_routing.py
@@ -3,6 +3,7 @@ import argparse
 import asyncio
 import json
 import sqlite3
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -18,7 +19,8 @@ CHAT = '15551234567@s.whatsapp.net'
 ORIGIN = '20260907_171053_a1fb73'
 
 
-def send_notification(home, monkeypatch, *, wire_result=None, message='Publication needs approval', expected_exit=0):
+def send_notification(home, monkeypatch, *, wire_result=None, message='Publication needs approval',
+                      expected_exit=0, patch_route=False, wire_exception=None):
     from tools import send_message_tool as send
     from hermes_cli.send_cmd import cmd_send
     from gateway.session_context import set_session_vars
@@ -28,13 +30,19 @@ def send_notification(home, monkeypatch, *, wire_result=None, message='Publicati
     set_session_vars(session_id=ORIGIN, source='desktop', profile='default')
     monkeypatch.setattr('gateway.config.load_gateway_config', lambda: GatewayConfig(
         platforms={Platform.WHATSAPP: PlatformConfig(enabled=True)}))
-    wire = AsyncMock(return_value=wire_result if wire_result is not None else {'success': True, 'message_id': 'notice-1'})
-    monkeypatch.setitem(send._TEXT_SENDERS, 'whatsapp', wire)
+    wire = AsyncMock(
+        return_value=wire_result if wire_result is not None else {'success': True, 'message_id': 'notice-1'},
+        side_effect=wire_exception,
+    )
+    if patch_route:
+        monkeypatch.setattr(send, '_send_to_platform', wire)
+    else:
+        monkeypatch.setitem(send._TEXT_SENDERS, 'whatsapp', wire)
     with pytest.raises(SystemExit) as exit_info:
         cmd_send(argparse.Namespace(to='whatsapp:' + CHAT, message=message,
                                    json=True, file=None, subject=None, quiet=False))
     assert exit_info.value.code == expected_exit
-    if wire_result is not None or expected_exit == 0:
+    if patch_route or wire_result is not None or expected_exit == 0:
         wire.assert_awaited_once()
     else:
         wire.assert_not_awaited()
@@ -48,7 +56,7 @@ def test_cli_notification_retains_origin_across_connections(tmp_path, monkeypatc
     with sqlite3.connect(path) as db:
         row = db.execute('SELECT session_id, chat_id FROM notification_routes WHERE message_id=?',
                          ('notice-1',)).fetchone()
-    assert row == (ORIGIN, CHAT)
+    assert row == (ORIGIN, '15551234567')
 
 
 def test_terminal_subprocess_send_captures_origin_without_contextvars(tmp_path, monkeypatch):
@@ -111,6 +119,64 @@ def test_same_native_reply_id_cannot_authorize_two_notifications(tmp_path, monke
         assert db.execute("SELECT count(*) FROM notification_routes WHERE status='queued'").fetchone()[0] == 1
 
 
+def test_distinct_followups_to_one_notification_are_each_queued(tmp_path, monkeypatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    path = send_notification(tmp_path, monkeypatch)
+    runner = inbound_runner(monkeypatch)
+
+    first = asyncio.run(runner._handle_message(event(text='First answer')))
+    followup = event(text='Additional detail')
+    followup.message_id = 'reply-2'
+    second = asyncio.run(runner._handle_message(followup))
+
+    assert 'queued' in first.lower()
+    assert 'queued' in second.lower()
+    with sqlite3.connect(path) as db:
+        assert db.execute('SELECT reply_id, reply_text FROM notification_reply_queue ORDER BY created').fetchall() == [
+            ('reply-1', 'First answer'), ('reply-2', 'Additional detail')]
+
+
+@pytest.mark.parametrize('rotate_before_reply', [True, False])
+def test_compression_rotated_owner_receives_reply_at_live_tip(tmp_path, monkeypatch, rotate_before_reply):
+    import threading
+    from tui_gateway.session_notification_replies import poll_replies
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    path = send_notification(tmp_path, monkeypatch)
+    runner = inbound_runner(monkeypatch)
+    db = SessionDB(db_path=tmp_path / 'state.db')
+    if not rotate_before_reply:
+        asyncio.run(runner._handle_message(event()))
+    db.end_session(ORIGIN, 'compression')
+    db.create_session('compressed-tip', source='desktop', parent_session_id=ORIGIN)
+    db.close()
+    if rotate_before_reply:
+        asyncio.run(runner._handle_message(event()))
+    session = {'session_key': 'compressed-tip', 'source': 'desktop', 'agent': object(),
+               'history_lock': threading.Lock(), 'running': False}
+    calls = []
+
+    poll_replies('tip-tab', session, tmp_path,
+                 lambda rid, sid, owner, text, **kwargs: calls.append((sid, owner, text)) or True)
+
+    assert calls == [('tip-tab', session, 'Go ahead')]
+    with sqlite3.connect(path) as route_db:
+        assert route_db.execute('SELECT status FROM notification_reply_queue').fetchone()[0] == 'dispatched'
+
+
+def test_explicitly_closed_owner_keeps_reply_queued_for_manual_resume(tmp_path, monkeypatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    path = send_notification(tmp_path, monkeypatch)
+    db = SessionDB(db_path=tmp_path / 'state.db')
+    db.end_session(ORIGIN, 'user_exit')
+    db.close()
+
+    result = asyncio.run(inbound_runner(monkeypatch)._handle_message(event()))
+
+    assert 'open or resume' in result.lower()
+    with sqlite3.connect(path) as route_db:
+        assert route_db.execute('SELECT session_id, status FROM notification_reply_queue').fetchone() == (ORIGIN, 'queued')
+
+
 def test_corrupt_routing_store_fails_closed(tmp_path, monkeypatch):
     monkeypatch.setenv('HERMES_HOME', str(tmp_path))
     path = send_notification(tmp_path, monkeypatch)
@@ -120,11 +186,64 @@ def test_corrupt_routing_store_fails_closed(tmp_path, monkeypatch):
     assert 'unavailable' in result.lower()
     runner._hm_pending_reply_intercepts.assert_not_awaited()
 
+    ordinary = event(text='How is the weather?', quote=None)
+    result = asyncio.run(runner._handle_message(ordinary))
+    assert result == 'ordinary chat'
+    runner._hm_pending_reply_intercepts.assert_awaited_once()
+
 
 @pytest.mark.parametrize('message', ['X' * 8000, 'MEDIA:/tmp/test-notification.png'])
-def test_unsupported_notification_payload_fails_before_send(tmp_path, monkeypatch, message):
+def test_notification_payload_is_not_rejected_by_reply_routing(tmp_path, monkeypatch, message):
     monkeypatch.setenv('HERMES_HOME', str(tmp_path))
-    send_notification(tmp_path, monkeypatch, message=message, expected_exit=1)
+    media = tmp_path / 'test-notification.png'
+    media.write_bytes(b'image')
+    message = message.replace('/tmp/test-notification.png', str(media))
+    path = send_notification(tmp_path, monkeypatch, message=message, patch_route=True,
+                             wire_result={'success': True, 'message_id': 'notice-last',
+                                          'message_ids': ['notice-first', 'notice-last']})
+    with sqlite3.connect(path) as db:
+        rows = db.execute("SELECT message_id, status FROM notification_routes "
+                          "WHERE message_id NOT LIKE 'sending:%' ORDER BY message_id").fetchall()
+    assert rows == [('notice-first', 'pending'), ('notice-last', 'pending')]
+
+
+def test_partial_multipart_failure_correlates_delivered_ids_without_resend(tmp_path, monkeypatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    pdf = tmp_path / 'report.pdf'
+    pdf.write_bytes(b'%PDF-1.4')
+    path = send_notification(
+        tmp_path, monkeypatch, message=f'Report attached\nMEDIA:{pdf}', expected_exit=1, patch_route=True,
+        wire_result={'error': 'second attachment failed', 'message_ids': ['text-id', 'pdf-id']})
+    with sqlite3.connect(path) as db:
+        rows = db.execute("SELECT message_id, status FROM notification_routes "
+                          "WHERE message_id NOT LIKE 'sending:%' ORDER BY message_id").fetchall()
+    assert rows == [('pdf-id', 'pending'), ('text-id', 'pending')]
+
+
+def test_dispatch_exception_leaves_durable_uncertain_intent(tmp_path, monkeypatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    path = send_notification(tmp_path, monkeypatch, expected_exit=1, patch_route=True,
+                             wire_exception=RuntimeError('connection dropped after write'))
+    with sqlite3.connect(path) as db:
+        assert db.execute('SELECT status FROM notification_routes').fetchone()[0] == 'uncertain'
+
+
+def test_chunk_sender_retains_ids_before_partial_failure():
+    from tools.send_message_tool import _send_chunks
+    results = iter([
+        {'success': True, 'message_id': 'chunk-1'},
+        {'error': 'chunk 2 failed', 'message_ids': ['chunk-2-partial']},
+    ])
+
+    result = asyncio.run(_send_chunks(
+        ['one', 'two'], lambda *_: _async_next(results), collect_message_ids=True))
+
+    assert result['error'] == 'chunk 2 failed'
+    assert result['message_ids'] == ['chunk-1', 'chunk-2-partial']
+
+
+async def _async_next(iterator):
+    return next(iterator)
 
 
 def inbound_runner(monkeypatch):
@@ -143,6 +262,58 @@ def event(text='Go ahead', quote='notice-1', sender=CHAT, chat=CHAT):
     return MessageEvent(text=text, message_type=MessageType.TEXT,
         source=SessionSource(platform=Platform.WHATSAPP, user_id=sender, chat_id=chat, chat_type='dm'),
         message_id='reply-1', reply_to_message_id=quote, reply_to_is_own_message=bool(quote))
+
+
+def install_lid_alias(home, lid='243993266942172', phone='15551234567'):
+    mapping_dir = home / 'whatsapp' / 'session'
+    mapping_dir.mkdir(parents=True, exist_ok=True)
+    (mapping_dir / f'lid-mapping-{lid}.json').write_text(json.dumps(phone), encoding='utf-8')
+    (mapping_dir / f'lid-mapping-{phone}_reverse.json').write_text(json.dumps(lid), encoding='utf-8')
+
+
+def test_phone_target_accepts_authenticated_lid_alias(tmp_path, monkeypatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    install_lid_alias(tmp_path)
+    path = send_notification(tmp_path, monkeypatch)
+    lid = '243993266942172@lid'
+    incoming = event(sender=lid, chat=lid)
+    runner = inbound_runner(monkeypatch)
+    monkeypatch.setenv('WHATSAPP_ALLOWED_USERS', '15551234567')
+
+    result = asyncio.run(runner._handle_message(incoming))
+
+    assert 'queued' in result.lower()
+    with sqlite3.connect(path) as db:
+        assert db.execute('SELECT reply_id FROM notification_routes WHERE message_id=?',
+                          ('notice-1',)).fetchone()[0] == 'reply-1'
+
+
+def test_expired_routes_do_not_intercept_unquoted_approval(tmp_path, monkeypatch):
+    from gateway.notification_replies import is_reply_candidate
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    path = send_notification(tmp_path, monkeypatch)
+    with sqlite3.connect(path) as db:
+        db.execute('UPDATE notification_routes SET created=?', (time.time() - 8 * 24 * 60 * 60,))
+    incoming = event(quote=None)
+    runner = inbound_runner(monkeypatch)
+
+    assert is_reply_candidate(incoming) is False
+    result = asyncio.run(runner._handle_message(incoming))
+
+    assert result == 'ordinary chat'
+    runner._hm_pending_reply_intercepts.assert_awaited_once()
+
+
+def test_unknown_historical_approval_quote_is_not_current_chat_authority(tmp_path, monkeypatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    send_notification(tmp_path, monkeypatch)
+    runner = inbound_runner(monkeypatch)
+
+    result = asyncio.run(runner._handle_message(event(quote='historical-message')))
+
+    assert 'cannot correlate' in result.lower()
+    assert 'approval' in result.lower()
+    runner._hm_pending_reply_intercepts.assert_not_awaited()
 
 
 @pytest.mark.parametrize('case, expected', [
@@ -267,6 +438,8 @@ def test_owner_mailbox_fences_stale_foreign_and_replayed_work(tmp_path, monkeypa
         assert status == 'dispatching'
     if case == 'refused':
         assert status == 'queued' and session['running'] is False
+    if case in ('deleted', 'expired'):
+        assert status == 'expired'
 
 
 def test_desktop_owner_poller_continues_existing_surface_once(tmp_path, monkeypatch):

--- a/tests/gateway/test_notification_reply_routing.py
+++ b/tests/gateway/test_notification_reply_routing.py
@@ -1,0 +1,303 @@
+"""Notification correlation through the real CLI sender and authenticated ingress."""
+import argparse
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from hermes_state import SessionDB
+
+
+CHAT = '15551234567@s.whatsapp.net'
+ORIGIN = '20260907_171053_a1fb73'
+
+
+def send_notification(home, monkeypatch, *, wire_result=None, message='Publication needs approval', expected_exit=0):
+    from tools import send_message_tool as send
+    from hermes_cli.send_cmd import cmd_send
+    from gateway.session_context import set_session_vars
+    db = SessionDB(db_path=home / 'state.db')
+    db.create_session(ORIGIN, source='desktop')
+    db.close()
+    set_session_vars(session_id=ORIGIN, source='desktop', profile='default')
+    monkeypatch.setattr('gateway.config.load_gateway_config', lambda: GatewayConfig(
+        platforms={Platform.WHATSAPP: PlatformConfig(enabled=True)}))
+    wire = AsyncMock(return_value=wire_result if wire_result is not None else {'success': True, 'message_id': 'notice-1'})
+    monkeypatch.setitem(send._TEXT_SENDERS, 'whatsapp', wire)
+    with pytest.raises(SystemExit) as exit_info:
+        cmd_send(argparse.Namespace(to='whatsapp:' + CHAT, message=message,
+                                   json=True, file=None, subject=None, quiet=False))
+    assert exit_info.value.code == expected_exit
+    if wire_result is not None or expected_exit == 0:
+        wire.assert_awaited_once()
+    else:
+        wire.assert_not_awaited()
+    return home / 'notification-replies.db'
+
+
+def test_cli_notification_retains_origin_across_connections(tmp_path, monkeypatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    path = send_notification(tmp_path, monkeypatch)
+    assert path.exists(), 'CLI send lost the originating desktop session and outbound message ID'
+    with sqlite3.connect(path) as db:
+        row = db.execute('SELECT session_id, chat_id FROM notification_routes WHERE message_id=?',
+                         ('notice-1',)).fetchone()
+    assert row == (ORIGIN, CHAT)
+
+
+def test_terminal_subprocess_send_captures_origin_without_contextvars(tmp_path, monkeypatch):
+    import subprocess
+    import sys
+    from tools.environments.local import _make_run_env
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    send_notification(tmp_path, monkeypatch)
+    env = _make_run_env({})
+    assert env['HERMES_SESSION_ID'] == ORIGIN
+    env['HOME'] = str(tmp_path)
+    program = '''
+import argparse
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+import gateway.config
+from tools import send_message_tool as send
+from hermes_cli.send_cmd import cmd_send
+gateway.config.load_gateway_config = lambda: GatewayConfig(platforms={Platform.WHATSAPP: PlatformConfig(enabled=True)})
+async def wire(*args):
+    return {'success': True, 'message_id': 'child-notice'}
+send._TEXT_SENDERS['whatsapp'] = wire
+cmd_send(argparse.Namespace(to='whatsapp:15551234567@s.whatsapp.net', message='Child approval notification', json=True))
+'''
+    result = subprocess.run([sys.executable, '-c', program], env=env, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload['reply_routing']['session_id'] == ORIGIN
+    with sqlite3.connect(tmp_path / 'notification-replies.db') as db:
+        assert db.execute('SELECT session_id FROM notification_routes WHERE message_id=?',
+                          ('child-notice',)).fetchone()[0] == ORIGIN
+
+
+@pytest.mark.parametrize('wire_result, expected_exit', [
+    ({'error': 'Bridge timeout'}, 1), ({'success': True, 'message_id': None}, 0),
+])
+def test_uncertain_send_never_creates_an_executable_route(tmp_path, monkeypatch, wire_result, expected_exit):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    path = send_notification(tmp_path, monkeypatch, wire_result=wire_result, expected_exit=expected_exit)
+    assert path.exists(), 'Send intent must be durable before touching the transport'
+    with sqlite3.connect(path) as db:
+        assert db.execute('SELECT status FROM notification_routes').fetchone()[0] == 'uncertain'
+    runner = inbound_runner(monkeypatch)
+    result = asyncio.run(runner._handle_message(event(quote=None)))
+    assert 'quote' in result.lower()
+    runner._hm_pending_reply_intercepts.assert_not_awaited()
+    result = asyncio.run(runner._handle_message(event(quote='unreturned-message-id')))
+    assert 'correlate' in result.lower()
+    runner._hm_pending_reply_intercepts.assert_not_awaited()
+
+
+def test_same_native_reply_id_cannot_authorize_two_notifications(tmp_path, monkeypatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    path = send_notification(tmp_path, monkeypatch)
+    send_notification(tmp_path, monkeypatch, wire_result={'success': True, 'message_id': 'notice-2'})
+    runner = inbound_runner(monkeypatch)
+    asyncio.run(runner._handle_message(event()))
+    result = asyncio.run(runner._handle_message(event(quote='notice-2')))
+    assert 'queued' not in result.lower()
+    with sqlite3.connect(path) as db:
+        assert db.execute("SELECT count(*) FROM notification_routes WHERE status='queued'").fetchone()[0] == 1
+
+
+def test_corrupt_routing_store_fails_closed(tmp_path, monkeypatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    path = send_notification(tmp_path, monkeypatch)
+    path.write_bytes(b'broken database')
+    runner = inbound_runner(monkeypatch)
+    result = asyncio.run(runner._handle_message(event()))
+    assert 'unavailable' in result.lower()
+    runner._hm_pending_reply_intercepts.assert_not_awaited()
+
+
+@pytest.mark.parametrize('message', ['X' * 8000, 'MEDIA:/tmp/test-notification.png'])
+def test_unsupported_notification_payload_fails_before_send(tmp_path, monkeypatch, message):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    send_notification(tmp_path, monkeypatch, message=message, expected_exit=1)
+
+
+def inbound_runner(monkeypatch):
+    from gateway.run import GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner.adapters = {}
+    runner.session_store = None
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    runner._hm_pending_reply_intercepts = AsyncMock(return_value='ordinary chat')
+    monkeypatch.setenv('WHATSAPP_ALLOWED_USERS', CHAT)
+    return runner
+
+
+def event(text='Go ahead', quote='notice-1', sender=CHAT, chat=CHAT):
+    return MessageEvent(text=text, message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.WHATSAPP, user_id=sender, chat_id=chat, chat_type='dm'),
+        message_id='reply-1', reply_to_message_id=quote, reply_to_is_own_message=bool(quote))
+
+
+@pytest.mark.parametrize('case, expected', [
+    ('normal', 'queued'), ('unquoted', 'quote'), ('ordinary', 'ordinary chat'),
+    ('replay', 'already'), ('deleted', 'unavailable'), ('stale', 'expired'),
+    ('unsupported', 'originating session'), ('wrong-chat', 'cannot be verified'),
+    ('unauthorized', None), ('attachment', 'text-only'), ('empty', 'text-only'),
+])
+def test_authenticated_reply_never_reaches_current_chat_controls(tmp_path, monkeypatch, case, expected):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    path = send_notification(tmp_path, monkeypatch)
+    runner = inbound_runner(monkeypatch)
+    incoming = event()
+    if case == 'unquoted':
+        incoming.reply_to_message_id = None
+    if case == 'ordinary':
+        incoming = event(text='What is the weather?', quote=None)
+    if case == 'wrong-chat':
+        incoming.source.chat_id = '15550000000@s.whatsapp.net'
+    if case == 'unauthorized':
+        incoming.source.user_id = '15550000000@s.whatsapp.net'
+    if case == 'attachment':
+        incoming.media_urls = ['/tmp/not-read.png']
+    if case == 'empty':
+        incoming.text = ''
+    if case == 'deleted':
+        with sqlite3.connect(tmp_path / 'state.db') as db:
+            db.execute('DELETE FROM sessions WHERE id=?', (ORIGIN,))
+    if case in ('stale', 'unsupported'):
+        with sqlite3.connect(path) as db:
+            if case == 'stale':
+                db.execute('UPDATE notification_routes SET created=0')
+            else:
+                db.execute("UPDATE notification_routes SET source='telegram'")
+    if case == 'replay':
+        asyncio.run(runner._handle_message(incoming))
+    result = asyncio.run(runner._handle_message(incoming))
+    if expected is None:
+        assert result is None
+    else:
+        assert expected in result.lower(), result
+    if case == 'ordinary':
+        runner._hm_pending_reply_intercepts.assert_awaited_once()
+    else:
+        runner._hm_pending_reply_intercepts.assert_not_awaited()
+    with sqlite3.connect(path) as db:
+        row = db.execute('SELECT status, reply_text FROM notification_routes WHERE message_id=?',
+                         ('notice-1',)).fetchone()
+    if case in ('normal', 'replay'):
+        assert row == ('queued', 'Go ahead')
+    else:
+        assert row[1] is None
+
+
+@pytest.mark.parametrize('quoted', [True, False])
+def test_notification_reply_bypasses_busy_adapter_without_touching_its_task(tmp_path, monkeypatch, quoted):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    send_notification(tmp_path, monkeypatch)
+    runner = inbound_runner(monkeypatch)
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={'dm_policy': 'allowlist'}))
+    adapter._message_handler = runner._handle_message
+    incoming = asyncio.run(adapter._build_message_event({
+        'chatId': CHAT, 'senderId': CHAT, 'messageId': 'reply-1', 'body': 'Go ahead',
+        'isGroup': False, 'hasQuotedMessage': quoted,
+        'quotedMessageId': 'notice-1' if quoted else None, 'quotedText': 'Publication needs approval',
+    }))
+    assert incoming is not None
+    assert incoming.reply_to_message_id == ('notice-1' if quoted else None)
+    key = adapter._event_session_key(incoming)
+    guard = object()
+    adapter._active_sessions[key] = guard
+    adapter._heal_stale_session_lock = lambda *a: None
+    adapter._handle_message_while_active = AsyncMock()
+    adapter._send_with_retry = AsyncMock()
+    asyncio.run(adapter.handle_message(incoming))
+    adapter._send_with_retry.assert_awaited_once()
+    adapter._handle_message_while_active.assert_not_awaited()
+    assert adapter._active_sessions[key] is guard
+
+
+@pytest.mark.parametrize('case', ['busy', 'deleted', 'expired', 'other-session', 'other-profile', 'wrong-surface', 'refused', 'uncertain', 'replay'])
+def test_owner_mailbox_fences_stale_foreign_and_replayed_work(tmp_path, monkeypatch, case):
+    import threading
+    from tui_gateway.session_notification_replies import poll_replies
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    path = send_notification(tmp_path, monkeypatch)
+    asyncio.run(inbound_runner(monkeypatch)._handle_message(event()))
+    session = {'session_key': ORIGIN, 'source': 'desktop', 'agent': object(),
+               'history_lock': threading.Lock(), 'running': case == 'busy'}
+    home = tmp_path
+    if case == 'other-session':
+        session['session_key'] = 'unrelated'
+    if case == 'other-profile':
+        home = tmp_path / 'other-profile'; home.mkdir()
+    if case == 'wrong-surface':
+        session['source'] = 'whatsapp'
+    if case == 'deleted':
+        with sqlite3.connect(tmp_path / 'state.db') as db:
+            db.execute('DELETE FROM sessions WHERE id=?', (ORIGIN,))
+    if case == 'expired':
+        with sqlite3.connect(path) as db:
+            db.execute('UPDATE notification_routes SET created=0')
+    calls = []
+    def submit(*args, **kwargs):
+        calls.append(args)
+        if case == 'uncertain':
+            raise RuntimeError('dispatch outcome unknown')
+        return case != 'refused'
+    if case == 'uncertain':
+        with pytest.raises(RuntimeError):
+            poll_replies('tab', session, home, submit)
+    else:
+        poll_replies('tab', session, home, submit)
+    if case in ('replay', 'uncertain'):
+        session['running'] = False
+        poll_replies('tab', session, home, submit)
+    assert len(calls) == (1 if case in ('replay', 'refused', 'uncertain') else 0)
+    with sqlite3.connect(path) as db:
+        status = db.execute('SELECT status FROM notification_routes').fetchone()[0]
+    if case == 'uncertain':
+        assert status == 'dispatching'
+    if case == 'refused':
+        assert status == 'queued' and session['running'] is False
+
+
+def test_desktop_owner_poller_continues_existing_surface_once(tmp_path, monkeypatch):
+    import threading
+    from tui_gateway import server
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    monkeypatch.setattr(server, '_hermes_home', tmp_path)
+    send_notification(tmp_path, monkeypatch)
+    runner = inbound_runner(monkeypatch)
+    asyncio.run(runner._handle_message(event()))
+    original = {'session_key': ORIGIN, 'source': 'desktop', 'profile_home': str(tmp_path),
+                'history_lock': threading.Lock(), 'running': False, 'agent': object(),
+                'history': [{'role': 'assistant', 'content': 'Original work'}]}
+    delivered = threading.Event()
+    calls = []
+    def submit(rid, sid, session, text, **kwargs):
+        calls.append((sid, session, text))
+        delivered.set()
+        return True
+    monkeypatch.setattr(server, '_run_prompt_submit', submit)
+    monkeypatch.setattr(server, '_notif_poll_kanban', lambda *a: None)
+    stop = threading.Event()
+    thread = threading.Thread(target=server._notification_poller_loop,
+                              args=(stop, 'original-tab', original), daemon=True)
+    thread.start()
+    try:
+        assert delivered.wait(8), 'Owning desktop poller never received the queued WhatsApp reply'
+    finally:
+        stop.set()
+        thread.join(5)
+    assert calls == [('original-tab', original, 'Go ahead')]
+    assert original['source'] == 'desktop'
+    with sqlite3.connect(tmp_path / 'notification-replies.db') as db:
+        assert db.execute('SELECT status FROM notification_routes').fetchone()[0] == 'dispatched'

--- a/tests/tools/test_whatsapp_send_message_media.py
+++ b/tests/tools/test_whatsapp_send_message_media.py
@@ -122,6 +122,7 @@ def test_text_plus_mixed_media_routes_native_types():
                 )
             )
         assert res["success"] is True
+        assert res["message_ids"] == ["t1", "m1", "m2", "m3"]
         # text first, then three media uploads in order
         assert calls[0][0].endswith("/send")
         assert calls[0][1]["message"] == "hello"
@@ -155,3 +156,23 @@ def test_missing_captioned_file_falls_back_to_text():
     assert len(calls) == 1
     assert calls[0][0].endswith("/send")
     assert calls[0][1]["message"] == "floor plan"
+    assert res["message_ids"] == ["t1"]
+
+
+def test_partial_media_failure_returns_every_confirmed_id():
+    first = _tmpfile(".pdf")
+    second = _tmpfile(".pdf")
+    try:
+        session_ctx, _ = _session_with([
+            _resp(200, {"messageId": "text-id"}),
+            _resp(200, {"messageId": "first-pdf-id"}),
+            _resp(500, text_data="upload failed"),
+        ])
+        with patch("aiohttp.ClientSession", return_value=session_ctx):
+            res = asyncio.run(_standalone_send(
+                _pconfig(), "12345", "report", media_files=[(first, False), (second, False)]))
+        assert "error" in res
+        assert res["message_ids"] == ["text-id", "first-pdf-id"]
+    finally:
+        os.unlink(first)
+        os.unlink(second)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -253,6 +253,7 @@ def _handle_send(args):
         return tool_error(_relay_denial)
 
     from gateway.notification_replies import capture_origin, prepare_send, record_sent
+    origin = None
     try:
         origin = capture_origin(platform_name)
         prepare_send(origin, chat_id, cleaned_message, media_files, _platform_max_length(platform))
@@ -273,6 +274,8 @@ def _handle_send(args):
             result["error"] = _sanitize_error_text(result["error"])
         return json.dumps(result)
     except Exception as e:
+        if origin:
+            record_sent(origin, chat_id, {"error": str(e)})
         return json.dumps(_error(f"Send failed: {e}"))
 
 
@@ -499,17 +502,27 @@ async def _send_via_adapter(platform, pconfig, chat_id, chunk, *, thread_id=None
                       f"expected a dict with 'success' or 'error' keys, got {type(result).__name__}")}
 
 
-async def _send_chunks(chunks, send_one):
-    """``send_one(chunk, is_last)`` in order; stop at the first error dict, else last result."""
+async def _send_chunks(chunks, send_one, *, collect_message_ids=False):
+    """Send in order; WhatsApp may retain all IDs before partial failure."""
     result = None
+    message_ids = []
     # --- Matrix: route ALL sends through the native adapter so text is encrypted in E2EE rooms too (issue:
     # text-only sends arrived with a red padlock because they took the raw-HTTP standalone path). The
     # adapter reuses the live gateway's E2EE session when available (#46310) and falls back to an
     # encryption-aware ephemeral adapter for standalone/cron. ---
     for i, chunk in enumerate(chunks):
         result = await send_one(chunk, i == len(chunks) - 1)
+        if collect_message_ids and isinstance(result, dict):
+            ids = result.get("message_ids") or []
+            if isinstance(ids, str):
+                ids = [ids]
+            message_ids.extend(str(message_id) for message_id in ids if message_id)
+            if result.get("message_id"):
+                message_ids.append(str(result["message_id"]))
         if isinstance(result, dict) and result.get("error"):
             break
+    if collect_message_ids and isinstance(result, dict) and message_ids:
+        result["message_ids"] = list(dict.fromkeys(message_ids))
     return result
 
 
@@ -554,8 +567,13 @@ async def _send_plugin_standalone(platform_name, pconfig, chat_id, message, chun
         if caption is not None:
             return await sender(pconfig, chat_id, "", thread_id=thread_id, media_files=media_files,
                                 caption=caption, **extra)
-    return await _send_chunks(chunks, lambda chunk, is_last: sender(
-        pconfig, chat_id, chunk, thread_id=thread_id, media_files=media_files if is_last else empty_media, **extra))
+    return await _send_chunks(
+        chunks,
+        lambda chunk, is_last: sender(
+            pconfig, chat_id, chunk, thread_id=thread_id,
+            media_files=media_files if is_last else empty_media, **extra),
+        collect_message_ids=platform_name == "whatsapp",
+    )
 
 
 def _via_adapter_route(p, pc, cid, chunk, media, tid, fd):
@@ -641,7 +659,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         # Plugin platform: live gateway adapter if available, else standalone_sender_fn.
         send_one = lambda chunk, is_last: _via_adapter_route(  # noqa: E731
             platform, pconfig, chat_id, chunk, media_files if is_last else [], thread_id, force_document)
-    last_result = await _send_chunks(chunks, send_one)
+    last_result = await _send_chunks(chunks, send_one, collect_message_ids=platform_name == "whatsapp")
     if (warning and isinstance(last_result, dict) and last_result.get("success")
             and not last_result.get("media_delivered")):
         last_result["warnings"] = [*last_result.get("warnings", []), warning]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -252,17 +252,22 @@ def _handle_send(args):
     if _relay_denial:
         return tool_error(_relay_denial)
 
+    from gateway.notification_replies import capture_origin, prepare_send, record_sent
     try:
+        origin = capture_origin(platform_name)
+        prepare_send(origin, chat_id, cleaned_message, media_files, _platform_max_length(platform))
         from model_tools import _run_async
         # Only custom plugin handlers receive the complete typed request.
         handler_args = {"args": args} if entry is not None and entry.send_message_handler is not None else {}
         result = _run_async(_send_to_platform(platform, pconfig, chat_id, cleaned_message, thread_id=thread_id,
                                               media_files=media_files, force_document=force_document_attachments,
                                               **handler_args))
+        if isinstance(result, dict):
+            record_sent(origin, chat_id, result)
         if isinstance(result, dict) and result.get("success"):
             if used_home_channel:
                 result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
-            if mirror_text and _mirror_sent_message(platform_name, chat_id, mirror_text, thread_id):
+            if not origin and mirror_text and _mirror_sent_message(platform_name, chat_id, mirror_text, thread_id):
                 result["mirrored"] = True
         if isinstance(result, dict) and "error" in result:
             result["error"] = _sanitize_error_text(result["error"])

--- a/tui_gateway/session_notification_replies.py
+++ b/tui_gateway/session_notification_replies.py
@@ -1,0 +1,45 @@
+"""Drain addressed human replies only in the already-existing desktop owner.
+
+The messaging gateway must never reconstruct a GUI agent with messaging tools.
+This runs on the same idle poller as heartbeat/kanban, through normal turn admission.
+"""
+import time
+from gateway.notification_replies import connect, origin_exists, _REPLY_TTL, _OWNER_SURFACES
+
+
+def poll_replies(sid, session, home, submit):
+    if not (home / 'notification-replies.db').exists():
+        return
+    with session['history_lock']:
+        if (session.get('running') or session.get('_finalized') or session.get('_closing')
+                or not session.get('agent')):
+            return
+        with connect(home) as db:
+            db.execute('BEGIN IMMEDIATE')
+            row = db.execute("SELECT * FROM notification_routes WHERE session_id=? AND status='queued' "
+                             "ORDER BY created LIMIT 1", (session.get('session_key'),)).fetchone()
+            if row is None:
+                return
+            if session.get('source') != row['source'] or row['source'] not in _OWNER_SURFACES:
+                return
+            if (not origin_exists(home, row['session_id'], row['source'])
+                    or time.time() - row['created'] > _REPLY_TTL):
+                db.execute("UPDATE notification_routes SET status='expired' WHERE message_id=?", (row['message_id'],))
+                return
+            db.execute("UPDATE notification_routes SET status='dispatching' WHERE message_id=?",
+                       (row['message_id'],))
+        session['running'] = True
+    # An exception/crash after claim is uncertain, NOT a retryable approval. Keep
+    # dispatching durable so another process/poller cannot run it a second time.
+    try:
+        started = submit('notification:' + row['message_id'], sid, session, row['reply_text'], image_paths=[])
+    except BaseException:
+        with session['history_lock']:
+            session['running'] = False
+        raise
+    with connect(home) as db:
+        db.execute('UPDATE notification_routes SET status=? WHERE message_id=?',
+                   ('dispatched' if started else 'queued', row['message_id']))
+    if not started:
+        with session['history_lock']:
+            session['running'] = False

--- a/tui_gateway/session_notification_replies.py
+++ b/tui_gateway/session_notification_replies.py
@@ -4,42 +4,100 @@ The messaging gateway must never reconstruct a GUI agent with messaging tools.
 This runs on the same idle poller as heartbeat/kanban, through normal turn admission.
 """
 import time
-from gateway.notification_replies import connect, origin_exists, _REPLY_TTL, _OWNER_SURFACES
+
+from gateway.notification_replies import (
+    _OWNER_SURFACES,
+    _REPLY_TTL,
+    connect,
+    owner_session_lineage,
+)
 
 
 def poll_replies(sid, session, home, submit):
-    if not (home / 'notification-replies.db').exists():
+    if not (home / "notification-replies.db").exists():
         return
-    with session['history_lock']:
-        if (session.get('running') or session.get('_finalized') or session.get('_closing')
-                or not session.get('agent')):
+    with session["history_lock"]:
+        if (
+            session.get("running")
+            or session.get("_finalized")
+            or session.get("_closing")
+            or not session.get("agent")
+        ):
             return
+        session_key = session.get("session_key")
+        source = session.get("source")
+        owner_ids = owner_session_lineage(home, session_key, source)
         with connect(home) as db:
-            db.execute('BEGIN IMMEDIATE')
-            row = db.execute("SELECT * FROM notification_routes WHERE session_id=? AND status='queued' "
-                             "ORDER BY created LIMIT 1", (session.get('session_key'),)).fetchone()
+            db.execute("BEGIN IMMEDIATE")
+            cutoff = time.time() - _REPLY_TTL
+            db.execute(
+                "UPDATE notification_reply_queue SET status='expired' WHERE status='queued' "
+                "AND message_id IN (SELECT message_id FROM notification_routes WHERE created<?)",
+                (cutoff,),
+            )
+            db.execute(
+                "UPDATE notification_routes SET status='expired' WHERE created<? AND message_id IN "
+                "(SELECT message_id FROM notification_reply_queue WHERE status='expired')",
+                (cutoff,),
+            )
+            if not owner_ids:
+                db.execute(
+                    "UPDATE notification_reply_queue SET status='expired' "
+                    "WHERE status='queued' AND session_id=?",
+                    (session_key,),
+                )
+                db.execute(
+                    "UPDATE notification_routes SET status='expired' WHERE message_id IN "
+                    "(SELECT message_id FROM notification_reply_queue "
+                    "WHERE status='expired' AND session_id=?)",
+                    (session_key,),
+                )
+                return
+            placeholders = ",".join("?" for _ in owner_ids)
+            row = db.execute(
+                "SELECT q.*, r.created AS notification_created FROM notification_reply_queue q "
+                "JOIN notification_routes r ON r.message_id=q.message_id "
+                f"WHERE q.status='queued' AND q.session_id IN ({placeholders}) "
+                "ORDER BY q.created LIMIT 1",
+                owner_ids,
+            ).fetchone()
             if row is None:
                 return
-            if session.get('source') != row['source'] or row['source'] not in _OWNER_SURFACES:
+            if source != row["source"] or row["source"] not in _OWNER_SURFACES:
                 return
-            if (not origin_exists(home, row['session_id'], row['source'])
-                    or time.time() - row['created'] > _REPLY_TTL):
-                db.execute("UPDATE notification_routes SET status='expired' WHERE message_id=?", (row['message_id'],))
-                return
-            db.execute("UPDATE notification_routes SET status='dispatching' WHERE message_id=?",
-                       (row['message_id'],))
-        session['running'] = True
+            db.execute(
+                "UPDATE notification_reply_queue SET status='dispatching' WHERE reply_id=?",
+                (row["reply_id"],),
+            )
+            db.execute(
+                "UPDATE notification_routes SET status='dispatching' WHERE message_id=?",
+                (row["message_id"],),
+            )
+        session["running"] = True
     # An exception/crash after claim is uncertain, NOT a retryable approval. Keep
     # dispatching durable so another process/poller cannot run it a second time.
     try:
-        started = submit('notification:' + row['message_id'], sid, session, row['reply_text'], image_paths=[])
+        started = submit(
+            "notification:" + row["message_id"],
+            sid,
+            session,
+            row["reply_text"],
+            image_paths=[],
+        )
     except BaseException:
-        with session['history_lock']:
-            session['running'] = False
+        with session["history_lock"]:
+            session["running"] = False
         raise
     with connect(home) as db:
-        db.execute('UPDATE notification_routes SET status=? WHERE message_id=?',
-                   ('dispatched' if started else 'queued', row['message_id']))
+        status = "dispatched" if started else "queued"
+        db.execute(
+            "UPDATE notification_reply_queue SET status=? WHERE reply_id=?",
+            (status, row["reply_id"]),
+        )
+        db.execute(
+            "UPDATE notification_routes SET status=? WHERE message_id=?",
+            (status, row["message_id"]),
+        )
     if not started:
-        with session['history_lock']:
-            session['running'] = False
+        with session["history_lock"]:
+            session["running"] = False

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -574,6 +574,11 @@ def _notification_poller_loop(stop_event: threading.Event, sid: str, session: di
         if now - last_kanban_poll >= _KANBAN_POLL_SECONDS:
             last_kanban_poll = now
             _notif_poll_kanban(sid, session)
+            try:
+                from tui_gateway.session_notification_replies import poll_replies
+                poll_replies(sid, session, _session_home(session), _run_prompt_submit)
+            except Exception as reply_exc:
+                _notif_log_failure("notification reply poll failed", reply_exc)
         try:
             evt = queue.get(timeout=0.5)
         except Exception:


### PR DESCRIPTION
## Bug Description

When a Desktop or TUI session sent a WhatsApp notification, a native quoted reply was handled by the ordinary WhatsApp chat instead of the originating workstream.

## Root Cause

The outbound mirror retained only text. It did not durably associate transport message IDs with the sender session. Inbound routing therefore had no authenticated address for returning quoted replies to that owner.

## Fix

- Record pre-send intent and every transport-confirmed WhatsApp message ID in a profile-local SQLite store.
- Intercept authenticated native replies before local WhatsApp controls and queue them for the existing Desktop/TUI owner.
- Canonicalize phone/JID/LID identity through the established alias mapping.
- Keep unquoted chat in WhatsApp; approval-like text requires a specific quote while a live route exists.
- Preserve text, media, multipart, partial-failure, expiry, replay-deduplication, compression-lineage, and restart behavior.
- Document the ownership and authorization contract.

## How to Verify

1. From two Desktop/TUI sessions, send WhatsApp notifications A and B.
2. Native-quote each notification and verify its reply appears only in its originating session.
3. Send an unquoted approval phrase and verify Hermes requests a specific quote without creating an owner turn.
4. Send ordinary unquoted chat and verify it stays in the WhatsApp session.
5. Repeat with a PDF notification and verify correlation to the returned media message ID.

## Test Plan

- [x] 32-file retries-disabled routing/regression package: 409 passed, 3 Windows-only skips.
- [x] Current-main targeted routing, media, and relay-authorization package: 126 passed.
- [x] Ruff, compileall, diff-check, and added-line security/privacy scan passed.
- [x] Harmless live canary verified text isolation, approval clarification, ordinary chat, and PDF correlation.
- [ ] Whole repository: 46,085 passed and 404 skipped; 89 failures were confined to 37 unrelated files under the reused partial-extras venv (primarily missing `acp` and `hindsight_client_api`). No changed test failed; CI should rerun with all extras.

## Risk Assessment

Medium. The change touches authenticated WhatsApp ingress, outbound delivery, SQLite persistence, and Desktop/TUI admission. It is fail-closed on uncertain correlation and routing-store errors, does not treat a quote as authorization, and leaves ordinary unquoted chat unchanged.

## Current Scope

Owner delivery is intentionally limited to Desktop and TUI sessions. Closed owners retain queued replies for explicit resume. Mailbox deduplication prevents replay admission but does not claim exactly-once external tool effects.
