### PR TITLE
fix(llamacpp): honor configured detection ports

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -454,8 +454,9 @@ def _llamacpp_pdef() -> Optional[ProviderDef]:
     one) resolves — reachability is the credential. Without this rung model-switch rejected the very
     provider the Local Models 'Use' flow writes to config."""
     try:
+        from hermes_cli.config import load_config_readonly
         from hermes_cli.local_runtime.endpoint import resolve_llamacpp_endpoint
-        endpoint = resolve_llamacpp_endpoint(wait_for_boot_s=0)
+        endpoint = resolve_llamacpp_endpoint(load_config_readonly(), wait_for_boot_s=0)
     except Exception:
         endpoint = None
     if not endpoint:

--- a/tests/hermes_cli/test_local_runtime.py
+++ b/tests/hermes_cli/test_local_runtime.py
@@ -382,6 +382,31 @@ def test_llamacpp_endpoint_stale_state_falls_through(tmp_path, monkeypatch):
     assert DEFAULT_PROBE_PORTS  # (import kept honest)
 
 
+def test_llamacpp_provider_detects_configured_non_default_port(
+        tmp_path, monkeypatch, stub_server):
+    """The provider resolver must forward local_runtime.detect_ports to external detection."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    port, handler = stub_server
+    handler.props = {"build_info": "b-test", "model_path": "model.gguf"}
+    (hermes_home / "config.yaml").write_text(
+        f"local_runtime:\n  detect_ports:\n    - {port}\n",
+        encoding="utf-8",
+    )
+
+    # Keep the test independent of services that may be running on the
+    # production default port on a developer machine.
+    monkeypatch.setattr("hermes_cli.local_runtime.detect.DEFAULT_PROBE_PORTS", ())
+
+    from hermes_cli.providers import resolve_provider_full
+
+    provider = resolve_provider_full("llamacpp")
+    assert provider is not None
+    assert provider.source == "local-runtime"
+    assert provider.base_url == f"http://127.0.0.1:{port}/v1"
+
+
 def test_llamacpp_dead_server_raises_friendly_error(tmp_path, monkeypatch):
     """A llamacpp send with no server must say WHY in user terms, not fall
     through to the generic custom path (which lands on a cloud provider


### PR DESCRIPTION
## What does this PR do?

When provider: llamacpp is resolved, pass Hermes’ loaded configuration into endpoint discovery. This makes local_runtime.detect_ports work on the real provider-resolution path instead of only when callers invoke the endpoint helper directly. Managed-server state still wins, and the default port behavior is unchanged.

## Related Issue

Fixes #105834

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Load the cached read-only config in the llama.cpp provider resolver.
- Forward it to resolve_llamacpp_endpoint.
- Add an end-to-end regression using a real stub llama-server on a configured non-default port.

## How to Test

1. Start llama-server on a non-default port.
2. Add that port under local_runtime.detect_ports in config.yaml.
3. Resolve the llamacpp provider and verify its base URL uses that server.

## Verification

- scripts/run_tests.sh tests/hermes_cli/test_local_runtime.py — 54 passed
- scripts/run_tests.sh tests/hermes_cli/test_provider_catalog.py tests/hermes_cli/test_runtime_provider_resolution.py — 69 passed
- Ruff check and git diff --check passed

## Checklist

- [x] I read the contributing and repository guidance.
- [x] The commit follows Conventional Commits.
- [x] I searched open issues and PRs for overlap.
- [x] The PR contains only the focused fix and regression.
- [x] I added and ran tests for the change.
- [x] Tested on macOS.
- [x] Documentation/config examples are N/A: no config key or public interface was added.
- [x] Cross-platform behavior was considered; detection continues to use the existing loopback and port-probe implementation.