### PR TITLE
fix(opencode): synthesize session header for stateless one-shot calls

### DIFF
--- a/agent/opencode_affinity.py
+++ b/agent/opencode_affinity.py
@@ -72,6 +72,16 @@ def opencode_session_headers(
         )
     except Exception:
         key = str(session_id or "")
+    if not key:
+        # Stateless one-shot calls (commit-message generation via ``hermes -z``, standalone
+        # cron jobs) run outside any conversation turn, so affinity scope and the ambient
+        # conversation contextvar are both unavailable. OpenCode requires the header to
+        # route and 400s with ``MissingSessionID`` when it is absent; there is no prompt
+        # cache to keep warm across a single stateless request, so synthesize a per-call
+        # opaque key. See #105841.
+        from uuid import uuid4
+
+        key = uuid4().hex
     return {OPENCODE_SESSION_HEADER: key} if key else {}
 
 

--- a/tests/agent/test_opencode_affinity_stateless.py
+++ b/tests/agent/test_opencode_affinity_stateless.py
@@ -1,0 +1,212 @@
+"""Tests for the OpenCode session-affinity header, including the stateless
+fallback that synthesizes an opaque key when no conversation context is
+available (commit-message generation via ``hermes -z``, standalone cron jobs).
+
+Bug #105841: one-shot/stateless calls run outside any conversation turn, so
+``get_affinity_scope()`` / ``get_conversation_context()`` are both ``None`` and
+``opencode_session_headers`` returned ``{}`` — OpenCode then 400s with
+``MissingSessionID``. The fix synthesizes a per-call opaque key so the header is
+always present for OpenCode targets.
+"""
+from __future__ import annotations
+
+import re
+
+# Standalone-runner shim (pytest unavailable in some sandboxes). Assertions are
+# pytest-compatible so this file also runs under ``pytest tests/agent/``.
+_PASSED = 0
+_FAILED = 0
+
+
+class _Monkey:
+    def __init__(self) -> None:
+        self._undo: list = []
+
+    def setattr(self, target, attr, value):
+        prev = getattr(target, attr)
+        self._undo.append((target, attr, prev))
+        setattr(target, attr, value)
+
+    def undo(self) -> None:
+        for target, attr, prev in reversed(self._undo):
+            setattr(target, attr, prev)
+        self._undo.clear()
+
+
+def _import_affinity():
+    import agent.opencode_affinity as aff
+    return aff
+
+
+def _import_portal_tags():
+    import agent.portal_tags as pt
+    return pt
+
+
+_UUID_HEX_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+# ---- Tests -----------------------------------------------------------------
+
+
+def test_stateless_opencode_target_gets_synthesized_header():
+    """No affinity scope, no conversation context, no explicit session_id
+    (the one-shot / commit-gen state) -> header MUST still be present with an
+    opaque per-call key (previously returned {} -> MissingSessionID 400)."""
+    mp = _Monkey()
+    try:
+        aff = _import_affinity()
+        pt = _import_portal_tags()
+        mp.setattr(aff, "is_opencode_target", lambda provider, base_url: True)
+        mp.setattr(pt, "get_affinity_scope", lambda: None)
+        mp.setattr(pt, "get_conversation_context", lambda: None)
+
+        headers = aff.opencode_session_headers("opencode-go", "https://opencode.ai/v1")
+        assert aff.OPENCODE_SESSION_HEADER in headers, "header missing for stateless opencode target"
+        key = headers[aff.OPENCODE_SESSION_HEADER]
+        assert isinstance(key, str) and key, "synthesized key must be a non-empty string"
+        assert _UUID_HEX_RE.match(key), f"synthesized key must be a uuid4 hex, got {key!r}"
+    finally:
+        mp.undo()
+
+
+def test_stateless_synthesized_keys_differ_per_call():
+    """Each stateless call gets its own opaque key (no unintended session
+    sharing between independent one-shot requests)."""
+    mp = _Monkey()
+    try:
+        aff = _import_affinity()
+        pt = _import_portal_tags()
+        mp.setattr(aff, "is_opencode_target", lambda provider, base_url: True)
+        mp.setattr(pt, "get_affinity_scope", lambda: None)
+        mp.setattr(pt, "get_conversation_context", lambda: None)
+
+        k1 = aff.opencode_session_headers("opencode-go", "https://opencode.ai/v1")[
+            aff.OPENCODE_SESSION_HEADER]
+        k2 = aff.opencode_session_headers("opencode-go", "https://opencode.ai/v1")[
+            aff.OPENCODE_SESSION_HEADER]
+        assert k1 != k2, "per-call synthesized keys must differ"
+    finally:
+        mp.undo()
+
+
+def test_conversation_context_wins_over_synthesis():
+    """When a conversation context IS available, it is used (synthesis is only a
+    fallback for the stateless case) -- preserves conversation prompt-cache
+    warmth."""
+    mp = _Monkey()
+    try:
+        aff = _import_affinity()
+        pt = _import_portal_tags()
+        mp.setattr(aff, "is_opencode_target", lambda provider, base_url: True)
+        mp.setattr(pt, "get_affinity_scope", lambda: None)
+        mp.setattr(pt, "get_conversation_context", lambda: "conv-session-123")
+
+        headers = aff.opencode_session_headers("opencode-go", "https://opencode.ai/v1")
+        assert headers[aff.OPENCODE_SESSION_HEADER] == "conv-session-123", \
+            "conversation context must win over synthesis"
+    finally:
+        mp.undo()
+
+
+def test_explicit_session_id_wins_when_no_context():
+    """Explicit session_id argument is used when no ambient context exists
+    (preserves the documented fallback order)."""
+    mp = _Monkey()
+    try:
+        aff = _import_affinity()
+        pt = _import_portal_tags()
+        mp.setattr(aff, "is_opencode_target", lambda provider, base_url: True)
+        mp.setattr(pt, "get_affinity_scope", lambda: None)
+        mp.setattr(pt, "get_conversation_context", lambda: None)
+
+        headers = aff.opencode_session_headers(
+            "opencode-go", "https://opencode.ai/v1", session_id="explicit-sess-456")
+        assert headers[aff.OPENCODE_SESSION_HEADER] == "explicit-sess-456", \
+            "explicit session_id must win over synthesis"
+    finally:
+        mp.undo()
+
+
+def test_non_opencode_target_returns_empty():
+    """Non-OpenCode targets never get the header (synthesis only applies to
+    OpenCode targets)."""
+    mp = _Monkey()
+    try:
+        aff = _import_affinity()
+        mp.setattr(aff, "is_opencode_target", lambda provider, base_url: False)
+
+        headers = aff.opencode_session_headers("openai", "https://api.openai.com/v1")
+        assert headers == {}, "non-opencode target must return {}"
+    finally:
+        mp.undo()
+
+
+def test_merge_synthesizes_header_into_kwargs():
+    """merge_opencode_session_headers injects the synthesized header into the
+    call kwargs for stateless opencode targets (the fix path for commit-gen)."""
+    mp = _Monkey()
+    try:
+        aff = _import_affinity()
+        pt = _import_portal_tags()
+        mp.setattr(aff, "is_opencode_target", lambda provider, base_url: True)
+        mp.setattr(pt, "get_affinity_scope", lambda: None)
+        mp.setattr(pt, "get_conversation_context", lambda: None)
+
+        kwargs = {"extra_headers": {"x-request-id": "abc"}}
+        result = aff.merge_opencode_session_headers(
+            kwargs, provider="opencode-go", base_url="https://opencode.ai/v1")
+        merged = result.get("extra_headers", {})
+        assert aff.OPENCODE_SESSION_HEADER in merged, \
+            "merge must inject synthesized header for stateless opencode target"
+        assert merged.get("x-request-id") == "abc", "caller headers must be preserved"
+        key = merged[aff.OPENCODE_SESSION_HEADER]
+        assert _UUID_HEX_RE.match(key), f"synthesized key must be uuid4 hex, got {key!r}"
+    finally:
+        mp.undo()
+
+
+def test_merge_preserves_caller_header_over_synthesis():
+    """When the caller already set x-opencode-session, that value wins
+    (setdefault semantics) -- synthesis never overrides an explicit value."""
+    mp = _Monkey()
+    try:
+        aff = _import_affinity()
+        pt = _import_portal_tags()
+        mp.setattr(aff, "is_opencode_target", lambda provider, base_url: True)
+        mp.setattr(pt, "get_affinity_scope", lambda: None)
+        mp.setattr(pt, "get_conversation_context", lambda: None)
+
+        caller_key = "caller-provided-session"
+        kwargs = {"extra_headers": {aff.OPENCODE_SESSION_HEADER: caller_key}}
+        result = aff.merge_opencode_session_headers(
+            kwargs, provider="opencode-go", base_url="https://opencode.ai/v1")
+        merged = result.get("extra_headers", {})
+        assert merged[aff.OPENCODE_SESSION_HEADER] == caller_key, \
+            "caller's explicit header must win over synthesis (setdefault)"
+    finally:
+        mp.undo()
+
+
+# ---- Standalone runner -----------------------------------------------------
+
+
+def _run():
+    import inspect
+    tests = [(name, fn) for name, fn in sorted(globals().items())
+             if name.startswith("test_") and inspect.isfunction(fn)]
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print("PASS", name)
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            print("FAIL", name, "->", type(exc).__name__, str(exc)[:200])
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return failed
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(1 if _run() else 0)


### PR DESCRIPTION
## Problem

Stateless one-shot calls — commit-message generation via `hermes -z`, standalone cron jobs — run outside any conversation turn, so `get_affinity_scope()` and the ambient `get_conversation_context()` contextvar are both unavailable. With no explicit `session_id` argument either, `opencode_session_headers` resolves to an empty key and returns `{}`:

```python
key = _cache_scope_from_session_id(
    get_affinity_scope() or get_conversation_context() or session_id
)  # all None -> ""
return {OPENCODE_SESSION_HEADER: key} if key else {}  # -> {} (no header)
```

OpenCode then rejects the request:

```
Error code: 400 - {'type': 'error', 'error': {'type': 'MissingSessionID',
'message': 'Request is missing x-opencode-session and cannot be routed efficiently.'}}
```

This is the gap behind #105841. The chat path was fixed (it has a conversation context), but the one-shot / commit-generation path still hits the 400 because it runs with no ambient context.

## Fix

`opencode_session_headers` is the single chokepoint for every OpenCode request — the module docstring states it covers `Every OpenCode request — main turn on any transport, auxiliary calls (compression, titles, vision, MoA) — goes through opencode_session_headers so the header cannot drift per code path.` Synthesizing a per-call opaque key there, **only when the key resolves empty**, closes the gap for all stateless code paths at once:

```python
if not key:
    # Stateless one-shot calls (commit-message generation via ``hermes -z``,
    # standalone cron jobs) run outside any conversation turn, so affinity scope
    # and the ambient conversation contextvar are both unavailable. OpenCode
    # requires the header to route and 400s with ``MissingSessionID`` when it is
    # absent; there is no prompt cache to keep warm across a single stateless
    # request, so synthesize a per-call opaque key. See #105841.
    from uuid import uuid4
    key = uuid4().hex
```

### Why synthesize (not set the contextvar)?

The alternative — setting `_conversation_id` in `hermes_cli/oneshot.py:_run_agent` — is more invasive (requires threading the lifecycle of the contextvar through the one-shot path) and only fixes that one path. The chokepoint fix is general: it covers any stateless caller (one-shot CLI, standalone cron, web one-shots) without each one having to remember to set context. It also aligns with the module's stated design (`the header cannot drift per code path`).

### Behavior preservation

- **Conversation calls**: `get_conversation_context()` returns a real session_id, so `key` is non-empty → synthesis **not triggered** → existing sticky-routing / prompt-cache warmth across the turns of one conversation is preserved.
- **Cron calls**: `_cache_scope_from_session_id` extracts the `cron_<job>` logical scope (matching `_CRON_SESSION_ID_RE`) → non-empty → synthesis **not triggered** → cron-fires-of-one-job-share-a-scope behavior preserved.
- **Explicit `session_id` arg**: used as fallback before synthesis → synthesis **not triggered**.
- **Non-OpenCode targets**: return `{}` early (before synthesis) → untouched.
- **Caller-set header**: `merge_opencode_session_headers` uses `setdefault` → a caller-pinned `x-opencode-session` wins over synthesis.

Synthesis fires **only** in the genuinely stateless case (no affinity scope, no conversation context, no explicit session_id) — exactly the case that previously sent no header and 400'd.

## Tests

`tests/agent/test_opencode_affinity_stateless.py` (7 tests, all pass):

1. `test_stateless_opencode_target_gets_synthesized_header` — the core fix: no context → header present with a uuid4-hex key (previously `{}`).
2. `test_stateless_synthesized_keys_differ_per_call` — per-call keys differ (no unintended session sharing).
3. `test_conversation_context_wins_over_synthesis` — real context is used, synthesis skipped.
4. `test_explicit_session_id_wins_when_no_context` — explicit arg used, synthesis skipped.
5. `test_non_opencode_target_returns_empty` — non-OpenCode targets untouched.
6. `test_merge_synthesizes_header_into_kwargs` — `merge_opencode_session_headers` injects the synthesized header + preserves caller headers.
7. `test_merge_preserves_caller_header_over_synthesis` — `setdefault`: caller's `x-opencode-session` wins over synthesis.

Closes #105841.