### PR TITLE
fix(agent): harden bounded MCP investigation loops

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -544,6 +544,11 @@ _TURN_STATE: Dict[str, Any] = {
     "_budget_grace_call": False,
     "_run_budget_started_at": None,  # set by turn_context.prepare_turn when a budget is active
     "_run_budget_wrapup_injected": False,  # one-shot latch for the 80% wrap-up notice
+    "_force_toolless_final": False,  # request-local final synthesis after evidence/last iteration
+    "_final_synthesis_notice_injected": False,
+    "_final_synthesis_deadline": None,
+    "_capability_only_turn": False,
+    "_vague_recent_turn": False,
     # Activity tracking (API call / tool / stream chunk) for the gateway timeout handler and
     # "still working" notifications. Named provenances are stamped only by compression writers.
     "_last_activity_ts": lambda: time.time(),

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -28,6 +28,11 @@ from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import (FailoverReason, PROVIDER_STREAM_NON_JSON_ERROR_CODE)
 from agent.errors import EmptyStreamError
 from agent.chat_completion_stream_monitor import StreamingWaitMonitor
+from agent.run_budget import (
+    FINAL_SYNTHESIS_TIMEOUT,
+    PROVIDER_STALE_TIMEOUT,
+    ProviderWaitLifecycle,
+)
 from agent.fast_mode import effective_request_overrides
 from agent.turn_context import substitute_api_content
 from agent.gemini_native_adapter import is_native_gemini_base_url
@@ -2526,9 +2531,7 @@ class _StreamingCall(StreamingWaitMonitor):
         # Shared by the socket read timeout (``_stream_timeouts``) and the stale
         # detector (``_resolve_stale_timeout``); None until resolved.
         self._stream_stale_timeout = None
-        self._run_budget_expired = False
-        self._final_synthesis_expired = False
-        self._stale_killed = False
+        self._wait_lifecycle = ProviderWaitLifecycle(agent)
         self.stream_attempt_lock = threading.Lock()
         self.stream_attempt_state = {"current": 0, "cancelled": set(), "discarded_chunks": 0, "discarded_bytes": 0}
         self.managed_stream_holder = {"stream": None}
@@ -3089,11 +3092,8 @@ class _StreamingCall(StreamingWaitMonitor):
         if self._request_cancelled["value"]:
             logger.debug("Streaming worker caught %s after request cancellation — exiting without retry.", type(e).__name__)
             return False
-        if self._stale_killed and getattr(self.agent, "run_budget_seconds", None):
-            from agent.run_budget import ProviderStaleTimeout
-            self.result["error"] = ProviderStaleTimeout(
-                f"Provider produced no stream output for {int(self._stream_stale_timeout)}s"
-            )
+        if self._wait_lifecycle.is_aborted_for(PROVIDER_STALE_TIMEOUT):
+            self.result["error"] = self._wait_lifecycle.error()
             return False
         _is_timeout = isinstance(e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout))
         _is_conn_err = isinstance(e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError))
@@ -3201,7 +3201,9 @@ class _StreamingCall(StreamingWaitMonitor):
         self.agent._buffer_status(
             f"⚠️ No response from provider for {int(elapsed)}s (model: {self.api_kwargs.get('model', 'unknown')}, "
             f"context: ~{_est_ctx:,} tokens). Reconnecting...")
-        self._stale_killed = True
+        bounded_stale = self._wait_lifecycle.abort_on_provider_stale(
+            self._stream_stale_timeout
+        )
         with contextlib.suppress(Exception):
             self._cancel_current_stream_attempt("stale_stream_kill")
             self.clients.close_once("stale_stream_kill")
@@ -3210,39 +3212,26 @@ class _StreamingCall(StreamingWaitMonitor):
         self.last_chunk_time["t"] = time.time()
         self.agent._emit_wait_notice(f"⚠ no output from provider for {int(elapsed)}s — reconnecting...")
         self.agent._touch_activity(f"stale stream detected after {int(elapsed)}s, reconnecting")
-        if getattr(self.agent, "run_budget_seconds", None):
+        if bounded_stale:
             # A bounded interactive run must not spend another stale window in
             # the stream worker's internal retry loop. Publish the terminal
             # result from the monitor thread, then retire the worker's attempt.
-            from agent.run_budget import ProviderStaleTimeout
-            self.result["error"] = ProviderStaleTimeout(
-                f"Provider produced no stream output for {int(self._stream_stale_timeout)}s"
-            )
             self._request_cancelled["value"] = True
             if self.worker is not None:
                 self.worker.join(timeout=2.0)
             return True
         return False
 
-    def _abort_for_run_budget(self) -> None:
-        """Stop the current request once the turn's absolute wall-clock deadline wins."""
-        self._run_budget_expired = True
+    def _abort_for_wait_deadline(self, reason: str) -> None:
+        """Apply the bounded owner's winning deadline to this transport."""
+        self._wait_lifecycle.abort(reason)
         self._request_cancelled["value"] = True
-        self._cancel_current_stream_attempt("run_budget_exhausted")
+        self._cancel_current_stream_attempt(reason)
         with contextlib.suppress(Exception):
-            self.clients.close_once("run_budget_exhausted")
+            self.clients.close_once(reason)
         if self.worker is not None:
-            _join_worker_for_relay_teardown(self.worker, label="Streaming")
-
-    def _abort_for_final_synthesis_timeout(self) -> None:
-        """Stop a live-but-nonfinal stream at the absolute synthesis deadline."""
-        self._final_synthesis_expired = True
-        self._request_cancelled["value"] = True
-        self._cancel_current_stream_attempt("final_synthesis_timeout")
-        with contextlib.suppress(Exception):
-            self.clients.close_once("final_synthesis_timeout")
-        if self.worker is not None:
-            _join_worker_for_relay_teardown(self.worker, label="Final synthesis streaming")
+            label = "Final synthesis streaming" if reason == FINAL_SYNTHESIS_TIMEOUT else "Streaming"
+            _join_worker_for_relay_teardown(self.worker, label=label)
 
     def _abort_for_interrupt(self, stale_elapsed: float) -> None:
         """/stop seen by the monitor: mark cancelled, abort the request-local
@@ -3285,14 +3274,12 @@ class _StreamingCall(StreamingWaitMonitor):
                 if isinstance(_v, (int, float)):
                     _local_default = float(_v)
             timeout = env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", _local_default)
-            from agent.run_budget import cap_timeout_to_run_budget
-            self._stream_stale_timeout = cap_timeout_to_run_budget(self.agent, timeout)
+            self._stream_stale_timeout = self._wait_lifecycle.cap_provider_timeout(timeout)
             logger.debug("Local provider detected (%s) — stale stream timeout set to %.0fs",
                 self.agent.base_url, self._stream_stale_timeout)
             return
         timeout = base if configured is not None or env_configured else _cloud_stale_timeout(base, self.api_kwargs)
-        from agent.run_budget import cap_timeout_to_run_budget
-        self._stream_stale_timeout = cap_timeout_to_run_budget(self.agent, timeout)
+        self._stream_stale_timeout = self._wait_lifecycle.cap_provider_timeout(timeout)
 
     def _partial_stream_stub(self):
         """Tokens already reached the platform: a finish_reason="length" stub fires the
@@ -3357,14 +3344,9 @@ class _StreamingCall(StreamingWaitMonitor):
             self._monitor_loop()
         if self._monitor_interrupted["yes"]:
             raise InterruptedError("Agent interrupted during streaming API call")
-        if self._run_budget_expired:
-            from agent.run_budget import RunBudgetExceeded
-            raise RunBudgetExceeded("Conversation run budget expired while waiting for the provider")
-        if self._final_synthesis_expired:
-            from agent.run_budget import FinalSynthesisTimeout
-            raise FinalSynthesisTimeout(
-                "The provider did not finish the tool-free final response within its deadline"
-            )
+        lifecycle_error = self._wait_lifecycle.error()
+        if lifecycle_error is not None:
+            raise lifecycle_error
         if self.agent._interrupt_requested:  # worker returned early before the monitor saw the flag
             raise InterruptedError("Agent interrupted during streaming API call (post-worker)")
         if self.result["error"] is not None:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -615,7 +615,12 @@ def _cloud_stale_timeout(base: float, api_kwargs: dict) -> float:
 def _derive_stream_stale_timeout(agent, api_kwargs: dict) -> float:
     """Stale-stream patience for a provider that is never a local endpoint (Bedrock):
     the OpenAI/Anthropic stale detector's budget minus its local branch."""
-    return _cloud_stale_timeout(_configured_stale_base(agent), api_kwargs)
+    configured = get_provider_stale_timeout(agent.provider, agent.model)
+    timeout = configured if configured is not None else _cloud_stale_timeout(
+        _configured_stale_base(agent), api_kwargs
+    )
+    from agent.run_budget import cap_timeout_to_run_budget
+    return cap_timeout_to_run_budget(agent, timeout)
 
 
 def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
@@ -2521,6 +2526,9 @@ class _StreamingCall(StreamingWaitMonitor):
         # Shared by the socket read timeout (``_stream_timeouts``) and the stale
         # detector (``_resolve_stale_timeout``); None until resolved.
         self._stream_stale_timeout = None
+        self._run_budget_expired = False
+        self._final_synthesis_expired = False
+        self._stale_killed = False
         self.stream_attempt_lock = threading.Lock()
         self.stream_attempt_state = {"current": 0, "cancelled": set(), "discarded_chunks": 0, "discarded_bytes": 0}
         self.managed_stream_holder = {"stream": None}
@@ -3081,6 +3089,12 @@ class _StreamingCall(StreamingWaitMonitor):
         if self._request_cancelled["value"]:
             logger.debug("Streaming worker caught %s after request cancellation — exiting without retry.", type(e).__name__)
             return False
+        if self._stale_killed and getattr(self.agent, "run_budget_seconds", None):
+            from agent.run_budget import ProviderStaleTimeout
+            self.result["error"] = ProviderStaleTimeout(
+                f"Provider produced no stream output for {int(self._stream_stale_timeout)}s"
+            )
+            return False
         _is_timeout = isinstance(e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout))
         _is_conn_err = isinstance(e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError))
         _is_stream_parse_err = self.agent._is_provider_stream_parse_error(e)
@@ -3173,7 +3187,7 @@ class _StreamingCall(StreamingWaitMonitor):
         finally:
             self._call_done.set()
 
-    def _kill_stale_stream(self, elapsed: float) -> None:
+    def _kill_stale_stream(self, elapsed: float) -> bool:
         """SSE pings but no chunks: cancel the attempt and abort the request-local
         client so the retry loop opens a fresh one. The shared client is never
         closed from this (stranger) thread — earlier stale-killed workers may
@@ -3187,6 +3201,7 @@ class _StreamingCall(StreamingWaitMonitor):
         self.agent._buffer_status(
             f"⚠️ No response from provider for {int(elapsed)}s (model: {self.api_kwargs.get('model', 'unknown')}, "
             f"context: ~{_est_ctx:,} tokens). Reconnecting...")
+        self._stale_killed = True
         with contextlib.suppress(Exception):
             self._cancel_current_stream_attempt("stale_stream_kill")
             self.clients.close_once("stale_stream_kill")
@@ -3195,6 +3210,39 @@ class _StreamingCall(StreamingWaitMonitor):
         self.last_chunk_time["t"] = time.time()
         self.agent._emit_wait_notice(f"⚠ no output from provider for {int(elapsed)}s — reconnecting...")
         self.agent._touch_activity(f"stale stream detected after {int(elapsed)}s, reconnecting")
+        if getattr(self.agent, "run_budget_seconds", None):
+            # A bounded interactive run must not spend another stale window in
+            # the stream worker's internal retry loop. Publish the terminal
+            # result from the monitor thread, then retire the worker's attempt.
+            from agent.run_budget import ProviderStaleTimeout
+            self.result["error"] = ProviderStaleTimeout(
+                f"Provider produced no stream output for {int(self._stream_stale_timeout)}s"
+            )
+            self._request_cancelled["value"] = True
+            if self.worker is not None:
+                self.worker.join(timeout=2.0)
+            return True
+        return False
+
+    def _abort_for_run_budget(self) -> None:
+        """Stop the current request once the turn's absolute wall-clock deadline wins."""
+        self._run_budget_expired = True
+        self._request_cancelled["value"] = True
+        self._cancel_current_stream_attempt("run_budget_exhausted")
+        with contextlib.suppress(Exception):
+            self.clients.close_once("run_budget_exhausted")
+        if self.worker is not None:
+            _join_worker_for_relay_teardown(self.worker, label="Streaming")
+
+    def _abort_for_final_synthesis_timeout(self) -> None:
+        """Stop a live-but-nonfinal stream at the absolute synthesis deadline."""
+        self._final_synthesis_expired = True
+        self._request_cancelled["value"] = True
+        self._cancel_current_stream_attempt("final_synthesis_timeout")
+        with contextlib.suppress(Exception):
+            self.clients.close_once("final_synthesis_timeout")
+        if self.worker is not None:
+            _join_worker_for_relay_teardown(self.worker, label="Final synthesis streaming")
 
     def _abort_for_interrupt(self, stale_elapsed: float) -> None:
         """/stop seen by the monitor: mark cancelled, abort the request-local
@@ -3224,8 +3272,10 @@ class _StreamingCall(StreamingWaitMonitor):
         HERMES_LOCAL_STREAM_STALE_TIMEOUT — an infinite one stalled sessions on a
         crashed endpoint forever. Cloud values scale with context size and are
         floored for known reasoning models (else BrokenPipeError from the gateway)."""
-        base = _configured_stale_base(self.agent)
-        if base == 180.0 and self.agent.base_url and is_local_endpoint(self.agent.base_url):
+        configured = get_provider_stale_timeout(self.agent.provider, self.agent.model)
+        env_configured = os.getenv("HERMES_STREAM_STALE_TIMEOUT") is not None
+        base = configured if configured is not None else _configured_stale_base(self.agent)
+        if configured is None and not env_configured and base == 180.0 and self.agent.base_url and is_local_endpoint(self.agent.base_url):
             _local_default = 900.0
             with contextlib.suppress(Exception):
                 from hermes_cli.config import load_config_readonly
@@ -3234,11 +3284,15 @@ class _StreamingCall(StreamingWaitMonitor):
                 _v = _agent_cfg.get("local_stream_stale_timeout") if isinstance(_agent_cfg, dict) else None
                 if isinstance(_v, (int, float)):
                     _local_default = float(_v)
-            self._stream_stale_timeout = env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", _local_default)
+            timeout = env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", _local_default)
+            from agent.run_budget import cap_timeout_to_run_budget
+            self._stream_stale_timeout = cap_timeout_to_run_budget(self.agent, timeout)
             logger.debug("Local provider detected (%s) — stale stream timeout set to %.0fs",
                 self.agent.base_url, self._stream_stale_timeout)
             return
-        self._stream_stale_timeout = _cloud_stale_timeout(base, self.api_kwargs)
+        timeout = base if configured is not None or env_configured else _cloud_stale_timeout(base, self.api_kwargs)
+        from agent.run_budget import cap_timeout_to_run_budget
+        self._stream_stale_timeout = cap_timeout_to_run_budget(self.agent, timeout)
 
     def _partial_stream_stub(self):
         """Tokens already reached the platform: a finish_reason="length" stub fires the
@@ -3303,6 +3357,14 @@ class _StreamingCall(StreamingWaitMonitor):
             self._monitor_loop()
         if self._monitor_interrupted["yes"]:
             raise InterruptedError("Agent interrupted during streaming API call")
+        if self._run_budget_expired:
+            from agent.run_budget import RunBudgetExceeded
+            raise RunBudgetExceeded("Conversation run budget expired while waiting for the provider")
+        if self._final_synthesis_expired:
+            from agent.run_budget import FinalSynthesisTimeout
+            raise FinalSynthesisTimeout(
+                "The provider did not finish the tool-free final response within its deadline"
+            )
         if self.agent._interrupt_requested:  # worker returned early before the monitor saw the flag
             raise InterruptedError("Agent interrupted during streaming API call (post-worker)")
         if self.result["error"] is not None:

--- a/agent/chat_completion_nonstream.py
+++ b/agent/chat_completion_nonstream.py
@@ -218,6 +218,37 @@ class _NonStreamRequest:
         self._await_worker_after_kill(
             f"Non-streaming API call timed out after {int(elapsed)}s with no response (threshold: {int(wd.stale_timeout)}s)"
             + (f". {silent_hint}" if silent_hint else ""))
+        if getattr(agent, "run_budget_seconds", None):
+            from agent.run_budget import ProviderStaleTimeout
+            self.result["error"] = ProviderStaleTimeout(
+                f"Provider produced no response for {int(wd.stale_timeout)}s"
+            )
+
+    def _run_budget_kill(self) -> None:
+        """Abort this request at the turn's absolute wall-clock deadline."""
+        from agent.run_budget import RunBudgetExceeded
+
+        self.cancelled = True
+        self._abort_request("run_budget_exhausted")
+        self._await_worker_after_kill(
+            "Conversation run budget expired while waiting for the provider"
+        )
+        self.result["error"] = RunBudgetExceeded(
+            "Conversation run budget expired while waiting for the provider"
+        )
+
+    def _final_synthesis_kill(self) -> None:
+        """Abort a live provider call that outlived the tool-free final deadline."""
+        from agent.run_budget import FinalSynthesisTimeout
+
+        self.cancelled = True
+        self._abort_request("final_synthesis_timeout")
+        self._await_worker_after_kill(
+            "The provider did not finish the tool-free final response within its deadline"
+        )
+        self.result["error"] = FinalSynthesisTimeout(
+            "The provider did not finish the tool-free final response within its deadline"
+        )
 
     def _interrupt(self, elapsed: float) -> None:
         agent = self.agent
@@ -257,6 +288,16 @@ class _NonStreamRequest:
             now = h.time.time()
             elapsed = now - self.call_start
             self._emit_wait_notice(elapsed, heartbeat=poll_count % 100 == 0)
+            from agent.run_budget import remaining_run_budget_seconds
+            remaining = remaining_run_budget_seconds(agent, now=now)
+            if remaining is not None and remaining <= 0:
+                self._run_budget_kill()
+                break
+            from agent.run_budget import remaining_final_synthesis_seconds
+            final_remaining = remaining_final_synthesis_seconds(agent, now=now)
+            if final_remaining is not None and final_remaining <= 0:
+                self._final_synthesis_kill()
+                break
             last_event_ts, last_progress_ts, retry_started_ts = self._codex_watchdog_snapshot()
             retry_ttfb_elapsed = now - retry_started_ts if retry_started_ts is not None else None
             if wd.ttfb_enabled and retry_ttfb_elapsed is not None and retry_ttfb_elapsed > wd.ttfb_timeout:

--- a/agent/chat_completion_nonstream.py
+++ b/agent/chat_completion_nonstream.py
@@ -11,10 +11,13 @@ class _NonStreamRequest:
     """
 
     def __init__(self, agent, api_kwargs: dict):
+        from agent.run_budget import ProviderWaitLifecycle
+
         self.agent = agent
         self.api_kwargs = api_kwargs
         self.result = {"response": None, "error": None}
         self.clients = h._RequestClientRegistry(agent)
+        self.wait_lifecycle = ProviderWaitLifecycle(agent)
         # Request-local cancel flag: agent._interrupt_requested is cleared at turn
         # boundaries but this daemon worker can outlive the turn, so it must know THIS
         # request was force-closed and not surface the transport error as a bug (#6600).
@@ -218,37 +221,17 @@ class _NonStreamRequest:
         self._await_worker_after_kill(
             f"Non-streaming API call timed out after {int(elapsed)}s with no response (threshold: {int(wd.stale_timeout)}s)"
             + (f". {silent_hint}" if silent_hint else ""))
-        if getattr(agent, "run_budget_seconds", None):
-            from agent.run_budget import ProviderStaleTimeout
-            self.result["error"] = ProviderStaleTimeout(
-                f"Provider produced no response for {int(wd.stale_timeout)}s"
-            )
+        if self.wait_lifecycle.abort_on_provider_stale(wd.stale_timeout):
+            self.result["error"] = self.wait_lifecycle.error()
 
-    def _run_budget_kill(self) -> None:
-        """Abort this request at the turn's absolute wall-clock deadline."""
-        from agent.run_budget import RunBudgetExceeded
-
+    def _wait_deadline_kill(self, reason: str) -> None:
+        """Apply the bounded owner's winning deadline to this transport."""
+        self.wait_lifecycle.abort(reason)
         self.cancelled = True
-        self._abort_request("run_budget_exhausted")
-        self._await_worker_after_kill(
-            "Conversation run budget expired while waiting for the provider"
-        )
-        self.result["error"] = RunBudgetExceeded(
-            "Conversation run budget expired while waiting for the provider"
-        )
-
-    def _final_synthesis_kill(self) -> None:
-        """Abort a live provider call that outlived the tool-free final deadline."""
-        from agent.run_budget import FinalSynthesisTimeout
-
-        self.cancelled = True
-        self._abort_request("final_synthesis_timeout")
-        self._await_worker_after_kill(
-            "The provider did not finish the tool-free final response within its deadline"
-        )
-        self.result["error"] = FinalSynthesisTimeout(
-            "The provider did not finish the tool-free final response within its deadline"
-        )
+        self._abort_request(reason)
+        error = self.wait_lifecycle.error()
+        self._await_worker_after_kill(str(error))
+        self.result["error"] = error
 
     def _interrupt(self, elapsed: float) -> None:
         agent = self.agent
@@ -288,15 +271,9 @@ class _NonStreamRequest:
             now = h.time.time()
             elapsed = now - self.call_start
             self._emit_wait_notice(elapsed, heartbeat=poll_count % 100 == 0)
-            from agent.run_budget import remaining_run_budget_seconds
-            remaining = remaining_run_budget_seconds(agent, now=now)
-            if remaining is not None and remaining <= 0:
-                self._run_budget_kill()
-                break
-            from agent.run_budget import remaining_final_synthesis_seconds
-            final_remaining = remaining_final_synthesis_seconds(agent, now=now)
-            if final_remaining is not None and final_remaining <= 0:
-                self._final_synthesis_kill()
+            deadline_reason = self.wait_lifecycle.expired_deadline(now=now)
+            if deadline_reason is not None:
+                self._wait_deadline_kill(deadline_reason)
                 break
             last_event_ts, last_progress_ts, retry_started_ts = self._codex_watchdog_snapshot()
             retry_ttfb_elapsed = now - retry_started_ts if retry_started_ts is not None else None

--- a/agent/chat_completion_stream_monitor.py
+++ b/agent/chat_completion_stream_monitor.py
@@ -71,15 +71,9 @@ class StreamingWaitMonitor:
                 self._mon.last_heartbeat = _hb_now
                 self._heartbeat(int(_hb_now - self.last_chunk_time["t"]))
             _stale_elapsed = time.time() - self.last_chunk_time["t"]
-            from agent.run_budget import remaining_run_budget_seconds
-            _run_remaining = remaining_run_budget_seconds(self.agent)
-            if _run_remaining is not None and _run_remaining <= 0:
-                self._abort_for_run_budget()
-                return
-            from agent.run_budget import remaining_final_synthesis_seconds
-            _final_remaining = remaining_final_synthesis_seconds(self.agent)
-            if _final_remaining is not None and _final_remaining <= 0:
-                self._abort_for_final_synthesis_timeout()
+            deadline_reason = self._wait_lifecycle.expired_deadline(now=_hb_now)
+            if deadline_reason is not None:
+                self._abort_for_wait_deadline(deadline_reason)
                 return
             if _stale_elapsed > self._stream_stale_timeout:
                 self._mon.wait_notice_started_ts = None  # Reconnect status has its own owner.

--- a/agent/chat_completion_stream_monitor.py
+++ b/agent/chat_completion_stream_monitor.py
@@ -71,10 +71,20 @@ class StreamingWaitMonitor:
                 self._mon.last_heartbeat = _hb_now
                 self._heartbeat(int(_hb_now - self.last_chunk_time["t"]))
             _stale_elapsed = time.time() - self.last_chunk_time["t"]
+            from agent.run_budget import remaining_run_budget_seconds
+            _run_remaining = remaining_run_budget_seconds(self.agent)
+            if _run_remaining is not None and _run_remaining <= 0:
+                self._abort_for_run_budget()
+                return
+            from agent.run_budget import remaining_final_synthesis_seconds
+            _final_remaining = remaining_final_synthesis_seconds(self.agent)
+            if _final_remaining is not None and _final_remaining <= 0:
+                self._abort_for_final_synthesis_timeout()
+                return
             if _stale_elapsed > self._stream_stale_timeout:
                 self._mon.wait_notice_started_ts = None  # Reconnect status has its own owner.
-                self._kill_stale_stream(_stale_elapsed)
+                if self._kill_stale_stream(_stale_elapsed):
+                    return
             if self.agent._interrupt_requested:
                 self._abort_for_interrupt(_stale_elapsed)
                 return
-

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -400,10 +400,19 @@ OPENAI_MODEL_EXECUTION_GUIDANCE = (
     "# Execution discipline\n"
     "<tool_persistence>\n"
     "- Use tools whenever they improve correctness, completeness, or grounding.\n"
+    "- Before the first call, honor bounds and defaults in the active skill and tool schema; request a small/default "
+    "result set rather than the maximum unless the task requires more.\n"
     "- Do not stop early when another tool call would materially improve the result.\n"
     "- If a tool returns empty, partial, or suspiciously narrow results, retry with a broader or different query or "
     "strategy before concluding.\n"
-    "- Keep calling tools until: (1) the task is complete, AND (2) you have verified the result.\n"
+    "- A successful read result is evidence. Never repeat the same read with identical arguments as 'verification' "
+    "unless its result explicitly says it is retryable; otherwise change the scope for a concrete evidence gap.\n"
+    "- Honor structured result contracts: when a composite says it is assembled and no component follow-up is "
+    "needed, use its included evidence instead of re-reading those components.\n"
+    "- For a capability-only question that explicitly forbids operations, use only capability/schema introspection; "
+    "do not perform domain investigation reads.\n"
+    "- Keep calling tools until the task is complete and materially unverified gaps are closed; once evidence is "
+    "sufficient, stop calling tools and produce the answer.\n"
     "</tool_persistence>\n\n"
     "<mandatory_tool_use>\n"
     "NEVER answer these from memory or mental computation — ALWAYS use a tool:\n"
@@ -469,9 +478,24 @@ def execution_guidance_text(valid_tool_names=None) -> str:
     Without web tools (e.g. Blank Slate) the ``web_search`` mentions would dangle, so they are dropped/adjusted.
     """
     text = OPENAI_MODEL_EXECUTION_GUIDANCE
-    if valid_tool_names is not None and "web_search" not in valid_tool_names:
+    if valid_tool_names is None:
+        return text
+    names = set(valid_tool_names)
+    if "web_search" not in names:
         text = text.replace("- Current facts (weather, news, versions) → use web_search\n", "")
         text = text.replace("(search_files, web_search, read_file, etc.)", "(search_files, read_file, etc.)")
+    if not names.intersection({"terminal", "execute_code"}):
+        for line in (
+            "- Arithmetic, math, calculations → use terminal or execute_code\n",
+            "- Hashes, encodings, checksums → use terminal (e.g. sha256sum, base64)\n",
+            "- Current time, date, timezone → use terminal (e.g. date)\n",
+            "- System state: OS, CPU, memory, disk, ports, processes → use terminal\n",
+            "- Git history, branches, diffs → use terminal\n",
+        ):
+            text = text.replace(line, "")
+    if not names.intersection({"read_file", "search_files", "terminal"}):
+        text = text.replace("- File contents, sizes, line counts → use read_file, search_files, or terminal\n", "")
+        text = text.replace("(search_files, read_file, etc.)", "(an available connected lookup tool)")
     return text
 
 

--- a/agent/run_budget.py
+++ b/agent/run_budget.py
@@ -1,0 +1,71 @@
+"""Wall-clock run-budget helpers shared by loop and provider wait paths."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+
+class RunBudgetExceeded(TimeoutError):
+    """A provider request outlived the conversation turn's wall-clock budget."""
+
+
+class ProviderStaleTimeout(TimeoutError):
+    """A bounded run stopped after one provider no-progress window."""
+
+
+class FinalSynthesisTimeout(TimeoutError):
+    """A tool-free final response exceeded its absolute synthesis deadline."""
+
+
+def remaining_run_budget_seconds(agent: Any, *, now: float | None = None) -> float | None:
+    """Remaining seconds, or ``None`` when this turn has no active wall-clock budget."""
+    budget = getattr(agent, "run_budget_seconds", None)
+    started = getattr(agent, "_run_budget_started_at", None)
+    if not isinstance(budget, (int, float)) or isinstance(budget, bool) or budget <= 0 or not started:
+        return None
+    return float(budget) - ((time.time() if now is None else now) - float(started))
+
+
+def cap_timeout_to_run_budget(agent: Any, timeout: float) -> float:
+    """Never let one provider wait extend beyond an active run budget."""
+    remaining = remaining_run_budget_seconds(agent)
+    if remaining is None:
+        return timeout
+    return max(0.05, min(float(timeout), remaining))
+
+
+def arm_final_synthesis_deadline(agent: Any, *, now: float | None = None) -> float | None:
+    """Arm the tool-free final deadline once, ideally when its last tool result lands.
+
+    Provider stale timeouts are progress-aware: reasoning chunks legitimately refresh
+    them. A final synthesis needs a different guarantee because an endlessly reasoning
+    model can otherwise keep the stream alive without producing a visible answer. The
+    explicit provider stale setting is reused as the absolute final-turn budget, with
+    the conversation run budget remaining the outer cap.
+    """
+    existing = getattr(agent, "_final_synthesis_deadline", None)
+    if isinstance(existing, (int, float)):
+        return float(existing)
+    try:
+        timeout, _implicit = agent._resolved_api_call_stale_timeout_base()
+        timeout = float(timeout)
+    except Exception:
+        return None
+    if timeout <= 0:
+        return None
+    current = time.time() if now is None else float(now)
+    remaining = remaining_run_budget_seconds(agent, now=current)
+    if remaining is not None:
+        timeout = min(timeout, max(0.05, remaining))
+    deadline = current + timeout
+    agent._final_synthesis_deadline = deadline
+    return deadline
+
+
+def remaining_final_synthesis_seconds(agent: Any, *, now: float | None = None) -> float | None:
+    """Seconds left for an armed forced-final turn, or ``None`` when unarmed."""
+    deadline = getattr(agent, "_final_synthesis_deadline", None)
+    if not isinstance(deadline, (int, float)):
+        return None
+    return float(deadline) - (time.time() if now is None else float(now))

--- a/agent/run_budget.py
+++ b/agent/run_budget.py
@@ -1,8 +1,10 @@
-"""Wall-clock run-budget helpers shared by loop and provider wait paths."""
+"""Bounded owner for run, provider-wait, and final-synthesis lifecycle."""
 
 from __future__ import annotations
 
 import time
+import threading
+from dataclasses import dataclass, field
 from typing import Any
 
 
@@ -16,6 +18,19 @@ class ProviderStaleTimeout(TimeoutError):
 
 class FinalSynthesisTimeout(TimeoutError):
     """A tool-free final response exceeded its absolute synthesis deadline."""
+
+
+RUN_BUDGET_EXHAUSTED = "run_budget_exhausted"
+PROVIDER_STALE_TIMEOUT = "provider_stale_timeout"
+FINAL_SYNTHESIS_TIMEOUT = "final_synthesis_timeout"
+
+_ABORT_MESSAGES = {
+    RUN_BUDGET_EXHAUSTED: "Conversation run budget expired while waiting for the provider",
+    PROVIDER_STALE_TIMEOUT: "Provider produced no response within the configured stale timeout",
+    FINAL_SYNTHESIS_TIMEOUT: (
+        "The provider did not finish the tool-free final response within its deadline"
+    ),
+}
 
 
 def remaining_run_budget_seconds(agent: Any, *, now: float | None = None) -> float | None:
@@ -69,3 +84,85 @@ def remaining_final_synthesis_seconds(agent: Any, *, now: float | None = None) -
     if not isinstance(deadline, (int, float)):
         return None
     return float(deadline) - (time.time() if now is None else float(now))
+
+
+def enter_final_synthesis(agent: Any, *, now: float | None = None) -> float | None:
+    """Move one turn into request-local tool-free synthesis and arm its deadline."""
+    agent._force_toolless_final = True
+    return arm_final_synthesis_deadline(agent, now=now)
+
+
+def reset_final_synthesis(agent: Any) -> None:
+    """Reset final-synthesis lifecycle state at the start of a user turn."""
+    agent._force_toolless_final = False
+    agent._final_synthesis_notice_injected = False
+    agent._final_synthesis_deadline = None
+
+
+@dataclass
+class ProviderWaitLifecycle:
+    """Request-local deadline and abort state shared by provider wait drivers.
+
+    Transport owners still close their own sockets and join their own workers;
+    this object decides which bounded condition won and supplies the terminal
+    exception.  The lock makes the monitor/worker hand-off one-shot.
+    """
+
+    agent: Any
+    _abort_reason: str | None = None
+    _stale_timeout: float | None = None
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def cap_provider_timeout(self, timeout: float) -> float:
+        return cap_timeout_to_run_budget(self.agent, timeout)
+
+    def expired_deadline(self, *, now: float | None = None) -> str | None:
+        """Return the winning absolute deadline, without mutating abort state."""
+        run_remaining = remaining_run_budget_seconds(self.agent, now=now)
+        if run_remaining is not None and run_remaining <= 0:
+            return RUN_BUDGET_EXHAUSTED
+        final_remaining = remaining_final_synthesis_seconds(self.agent, now=now)
+        if final_remaining is not None and final_remaining <= 0:
+            return FINAL_SYNTHESIS_TIMEOUT
+        return None
+
+    def abort(self, reason: str, *, stale_timeout: float | None = None) -> bool:
+        """Record the first bounded abort reason; return whether this call won."""
+        if reason not in _ABORT_MESSAGES:
+            raise ValueError(f"unknown provider-wait abort reason: {reason}")
+        with self._lock:
+            if self._abort_reason is not None:
+                return False
+            self._abort_reason = reason
+            self._stale_timeout = stale_timeout
+            return True
+
+    def abort_on_provider_stale(self, stale_timeout: float) -> bool:
+        """Bounded turns stop after one stale window instead of reconnecting."""
+        if remaining_run_budget_seconds(self.agent) is None:
+            return False
+        return self.abort(PROVIDER_STALE_TIMEOUT, stale_timeout=stale_timeout)
+
+    def is_aborted_for(self, reason: str) -> bool:
+        with self._lock:
+            return self._abort_reason == reason
+
+    @property
+    def abort_reason(self) -> str | None:
+        with self._lock:
+            return self._abort_reason
+
+    def error(self) -> TimeoutError | None:
+        """Build the typed terminal error for the recorded lifecycle outcome."""
+        with self._lock:
+            reason, stale_timeout = self._abort_reason, self._stale_timeout
+        if reason is None:
+            return None
+        message = _ABORT_MESSAGES[reason]
+        if reason == PROVIDER_STALE_TIMEOUT and stale_timeout is not None:
+            message = f"Provider produced no response for {int(stale_timeout)}s"
+        if reason == RUN_BUDGET_EXHAUSTED:
+            return RunBudgetExceeded(message)
+        if reason == PROVIDER_STALE_TIMEOUT:
+            return ProviderStaleTimeout(message)
+        return FinalSynthesisTimeout(message)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -425,10 +425,23 @@ class _ParsedCall:
 
 def _parse_tool_call(agent, tool_call, *, flatten_probe: bool = False) -> _ParsedCall:
     name = _canonical_tool_name(tool_call.function.name)
+    emitted_name = name
     args, parse_error = _parse_tool_arguments(tool_call.function.arguments)
     scope_block = None
     if parse_error is None:
         name, args, scope_block = _unwrap_tool_search_call(agent, name, args, flatten_probe=flatten_probe)
+    if parse_error is None and scope_block is None:
+        normalize = getattr(agent._tool_guardrails, "normalize_args", None)
+        normalized_args = normalize(name, args) if callable(normalize) else args
+        if normalized_args != args:
+            args = dict(normalized_args)
+            # Keep a directly emitted call's transcript aligned with what is
+            # actually dispatched. A tool_search bridge call retains its outer
+            # wire shape; its resolved args are tracked in _ManagedToolResult.
+            if emitted_name == name:
+                tool_call.function.arguments = json.dumps(
+                    args, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+                )
     return _ParsedCall(tool_call, name, args, [], parse_error, scope_block)
 
 
@@ -607,6 +620,9 @@ def _blocked_tool_result(agent, ref: _ToolCallRef, *, block_message: Optional[st
         result, error_type, error_message = json.dumps({"error": block_message}, ensure_ascii=False), block_error_type, block_message
     else:
         result = agent._guardrail_block_result(guardrail_decision)
+        if getattr(guardrail_decision, "action", None) == "reuse":
+            ref.emit_post(agent, result, status="reused")
+            return result
         error_type = "guardrail_block"
         error_message = getattr(guardrail_decision, "message", None) or "Tool blocked by guardrail policy"
     ref.emit_post(agent, result, status="blocked", error_type=error_type, error_message=error_message)

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
+from datetime import datetime, timedelta
 from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Mapping
 
@@ -55,7 +57,12 @@ PROGRESS_RESET_TOOL_NAMES = frozenset({
     "cronjob_manage", "todo", "todo_list", "memory", "skill_manage",
 })
 
-_BOOL_FIELDS = ("warnings_enabled", "hard_stop_enabled", "non_interactive_hard_stop_enabled")
+_BOOL_FIELDS = (
+    "warnings_enabled",
+    "hard_stop_enabled",
+    "non_interactive_hard_stop_enabled",
+    "finalize_on_complete_composite",
+)
 # Threshold field -> (nested section, nested key). The flat legacy key is the field name itself.
 _THRESHOLD_SOURCES: dict[str, tuple[str, str]] = {
     "exact_failure_warn_after": ("warn_after", "exact_failure"),
@@ -111,6 +118,10 @@ class ToolCallGuardrailConfig:
     warnings_enabled: bool = True
     hard_stop_enabled: bool = False
     non_interactive_hard_stop_enabled: bool = True
+    # Single-scope investigations benefit from an immediate tool-free synthesis
+    # after a complete composite.  Longer orchestrations can disable only that
+    # transition while retaining component coverage and exact-result reuse.
+    finalize_on_complete_composite: bool = True
     exact_failure_warn_after: int = 2
     exact_failure_block_after: int = 5
     same_tool_failure_warn_after: int = 3
@@ -170,7 +181,7 @@ class ToolCallSignature:
 class ToolGuardrailDecision:
     """Decision returned by the tool-call guardrail controller."""
 
-    action: str = "allow"  # allow | warn | block | halt
+    action: str = "allow"  # allow | warn | finalize | restrict | reuse | block | halt
     code: str = "allow"
     message: str = ""
     tool_name: str = ""
@@ -300,8 +311,48 @@ class ToolCallGuardrailController:
         self._identical_streak_first_call_id: str = ""
         # tool_call_id -> spillover path, so a stub referencing a persisted-output preview can't dangle.
         self._persisted_result_paths: dict[str, str] = {}
+        # MCP servers can explicitly declare that an unchanged successful result
+        # is reusable. Composite results can also declare which component reads
+        # they already assembled. Both caches are per turn and store only hashed
+        # call signatures or in-memory native identifiers.
+        self._reusable_mcp_calls: set[ToolCallSignature] = set()
+        self._mcp_composite_coverage: list[_CompositeCoverage] = []
+        self._capability_only = False
+        self._vague_recent = False
         self._turn_web_search_count = 0
         self._turn_subagent_count = 0
+
+    def set_capability_only(self, enabled: bool) -> None:
+        """Restrict this turn to MCP capability/schema reads when explicitly requested."""
+        self._capability_only = bool(enabled)
+
+    def set_vague_recent(self, enabled: bool) -> None:
+        """Enable conservative MCP bounds for an unqualified recent-time request."""
+        self._vague_recent = bool(enabled)
+
+    def normalize_args(self, tool_name: str, args: Mapping[str, Any] | None) -> Mapping[str, Any]:
+        """Bound vague-recent MCP reads before dispatch; explicit user ranges are excluded."""
+        original = _coerce_args(args)
+        server, _component = _mcp_tool_parts(tool_name)
+        if not self._vague_recent or server is None:
+            return original
+        normalized = dict(original)
+        count = normalized.get("count")
+        if ((isinstance(count, (int, float)) and not isinstance(count, bool) and count > 10)
+                or (isinstance(count, str) and count.strip().isdigit() and int(count) > 10)):
+            normalized["count"] = 10
+        start, end = normalized.get("start"), normalized.get("end")
+        parsed_start, parsed_end = _parse_timestamp(start), _parse_timestamp(end)
+        try:
+            oversized_window = (
+                parsed_start is not None and parsed_end is not None
+                and parsed_end - parsed_start > timedelta(hours=24)
+            )
+        except TypeError:  # mixed naive/aware timestamps: leave untouched for schema validation
+            oversized_window = False
+        if oversized_window:
+            normalized["start"] = _format_timestamp_like(parsed_end - timedelta(hours=24), start)
+        return normalized
 
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
@@ -323,6 +374,38 @@ class ToolCallGuardrailController:
         args = _coerce_args(args)
         signature = ToolCallSignature.from_call(tool_name, args)
         allow = ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+
+        restricted_name = _underlying_tool_name(tool_name, args)
+        restricted_server, restricted_component = _mcp_tool_parts(restricted_name)
+        if (self._capability_only and restricted_server is not None
+                and restricted_component not in {"get_capabilities", "get_agent_guide"}):
+            return self._decide(
+                "restrict", "capability_only_scope", tool_name, 1, signature,
+                message=(
+                    f"Skipped {restricted_name}: this turn explicitly requested capability "
+                    "introspection without domain investigation. Synthesize the answer from "
+                    "get_capabilities and, if already present, get_agent_guide."
+                ),
+            )
+
+        if signature in self._reusable_mcp_calls:
+            return self._decide(
+                "reuse", "reusable_result_already_available", tool_name, 1, signature,
+                message=(
+                    f"Skipped {tool_name}: an identical successful MCP result is already "
+                    "available earlier in this turn. Use that result and finish the answer."
+                ),
+            )
+        covered = self._covered_by_composite(tool_name, args)
+        if covered:
+            return self._decide(
+                "reuse", "covered_by_composite_result", tool_name, 1, signature,
+                message=(
+                    f"Skipped {tool_name}: the same native entity and scope are already "
+                    "covered by an assembled MCP result that requires no component follow-up. "
+                    "Use the existing composite evidence and finish the answer."
+                ),
+            )
 
         # Loop caps apply regardless of hard_stop_enabled (which only governs the detector).
         cap_block = self._check_loop_cap(tool_name, args, signature)
@@ -378,6 +461,11 @@ class ToolCallGuardrailController:
                 )
             return ToolGuardrailDecision(tool_name=tool_name, count=exact_count, signature=signature)
 
+        assembled_complete = self._record_mcp_result_contract(tool_name, args, result, signature)
+        _server, component = _mcp_tool_parts(_underlying_tool_name(tool_name, args))
+        capability_complete = self._capability_only and component in {
+            "get_capabilities", "get_agent_guide",
+        }
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
         # A successful mutation is progress for every failing signature still counted
@@ -387,6 +475,20 @@ class ToolCallGuardrailController:
             self._same_tool_failure_counts.clear()
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)
+            if (
+                assembled_complete and self.config.finalize_on_complete_composite
+            ) or capability_complete:
+                return self._decide(
+                    "finalize",
+                    "capability_evidence_collected" if capability_complete else "composite_evidence_assembled",
+                    tool_name, 1, signature,
+                    message=(
+                        "The requested capability evidence is available. Synthesize the capability-only answer now."
+                        if capability_complete else
+                        "The MCP result is assembled and explicitly requires no component follow-up. "
+                        "Synthesize the answer now from its included evidence."
+                    ),
+                )
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
         result_hash = _result_hash(result)
@@ -399,6 +501,68 @@ class ToolCallGuardrailController:
 
     def _is_idempotent(self, tool_name: str) -> bool:
         return tool_name not in self.config.mutating_tools and tool_name in self.config.idempotent_tools
+
+    def _record_mcp_result_contract(
+        self, tool_name: str, args: Mapping[str, Any], result: str | None,
+        signature: ToolCallSignature,
+    ) -> bool:
+        """Remember only explicit structured MCP reuse/completeness contracts."""
+        server, _ = _mcp_tool_parts(tool_name)
+        structured = _mcp_structured_content(result)
+        if server is None or structured is None:
+            return False
+        mappings = list(_iter_mappings(structured))
+        if any(mapping.get("reuseResult") is True for mapping in mappings):
+            self._reusable_mcp_calls.add(signature)
+        for mapping in mappings:
+            state = mapping.get("resultState")
+            assembled = mapping.get("assembled") is True or (
+                isinstance(state, str) and state.strip().lower() == "assembled"
+            )
+            includes = mapping.get("includes")
+            if not assembled or mapping.get("componentFollowupNeeded") is not False or not isinstance(includes, Mapping):
+                continue
+            components = frozenset(
+                _normalize_component_name(str(name))
+                for name, included in includes.items()
+                if included is True and _normalize_component_name(str(name))
+            )
+            if not components:
+                continue
+            # Associate component coverage only with IDs on the exact contract
+            # object (plus the composite call's IDs). Recursing through every
+            # evidence row would falsely treat a secondary device as the primary
+            # entity whose detail the composite says it included.
+            native_ids = frozenset({
+                *_native_id_values(mapping, recursive=False),
+                *_native_id_values(args, recursive=False),
+            })
+            scope_values = frozenset(_scope_values(args))
+            self._mcp_composite_coverage.append(
+                _CompositeCoverage(server, components, native_ids, scope_values)
+            )
+            return True
+        return False
+
+    def _covered_by_composite(self, tool_name: str, args: Mapping[str, Any]) -> bool:
+        server, component = _mcp_tool_parts(tool_name)
+        if server is None or component is None:
+            return False
+        normalized = _normalize_component_name(component)
+        call_ids = set(_native_id_values(args))
+        if not call_ids:
+            return False
+        call_scope = set(_scope_values(args))
+        for coverage in self._mcp_composite_coverage:
+            if coverage.server != server or normalized not in coverage.components:
+                continue
+            if not call_ids.intersection(coverage.native_ids):
+                continue
+            # An explicitly changed time bound is a changed scope and remains allowed.
+            if call_scope and not call_scope.issubset(coverage.scope_values):
+                continue
+            return True
+        return False
 
     def observe_call(
         self, tool_name: str, args: Mapping[str, Any] | None, result: str | None,
@@ -480,6 +644,13 @@ class ToolCallGuardrailController:
 
 def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:
     """Build a synthetic role=tool content string for a blocked tool call."""
+    if decision.action in {"reuse", "restrict"}:
+        return json.dumps({
+            "result": decision.message,
+            "reused": decision.action == "reuse",
+            "blockedByTurnPolicy": decision.action == "restrict",
+            "guardrail": decision.to_metadata(),
+        }, ensure_ascii=False)
     return json.dumps({"error": decision.message, "guardrail": decision.to_metadata()}, ensure_ascii=False)
 
 
@@ -522,6 +693,170 @@ def _coerce_args(args: Mapping[str, Any] | None) -> Mapping[str, Any]:
 def _result_hash(result: str | None) -> str:
     parsed = safe_json_loads(result or "")
     return _sha256(_canonical_json(parsed) if parsed is not None else (result or ""))
+
+
+@dataclass(frozen=True)
+class _CompositeCoverage:
+    server: str
+    components: frozenset[str]
+    native_ids: frozenset[str]
+    scope_values: frozenset[str]
+
+
+def _mcp_tool_parts(tool_name: str) -> tuple[str | None, str | None]:
+    """Return the generated MCP server/tool components without guessing names."""
+    if not isinstance(tool_name, str) or not tool_name.startswith("mcp_"):
+        return None, None
+    server, separator, component = tool_name[4:].partition("__")
+    return (server, component) if separator and server and component else (None, None)
+
+
+def _underlying_tool_name(tool_name: str, args: Mapping[str, Any]) -> str:
+    """Return a bridge target when present, otherwise the directly emitted tool name."""
+    if tool_name == "tool_call":
+        target = args.get("name")
+        if isinstance(target, str) and target.strip():
+            return target.strip()
+    return tool_name
+
+
+def is_capability_only_request(value: Any) -> bool:
+    """Detect an explicit capability ask that also forbids operational investigation.
+
+    This intentionally requires both halves. A general question about what a system can
+    do is not restricted unless the user also says not to investigate findings.
+    """
+    text = _request_text(value)
+    if not text:
+        return False
+    normalized = " ".join(text.casefold().split())
+    capability_markers = (
+        "capability", "capabilities", "capability-only", "available tools",
+        "investigation capabilities", "untersuchungsmöglich", "welche untersuch",
+    )
+    no_investigation_markers = (
+        "do not investigate", "without investigating", "no investigation",
+        "keine untersuchung", "keine findings", "keine investigation",
+        "führe keine untersuchung", "fuehre keine untersuchung",
+    )
+    return any(marker in normalized for marker in capability_markers) and any(
+        marker in normalized for marker in no_investigation_markers
+    )
+
+
+def is_vague_recent_request(value: Any) -> bool:
+    """True for a recent-time ask only when the user supplied no concrete bound."""
+    text = _request_text(value)
+    if not text:
+        return False
+    normalized = " ".join(text.casefold().split())
+    recent_markers = (
+        "recent", "lately", "latest activity", "in letzter zeit", "kürzlich", "kuerzlich", "aktuell",
+    )
+    if not any(marker in normalized for marker in recent_markers):
+        return False
+    explicit_bound = re.search(
+        r"\b\d{4}-\d{2}-\d{2}\b|\b\d+(?:[.,]\d+)?\s*(?:h|hours?|stunden?|d|days?|tage?n?)\b|"
+        r"\bcount\s*[=:]?\s*\d+\b",
+        normalized,
+    )
+    return explicit_bound is None
+
+
+def _request_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return " ".join(
+            str(part.get("text") or "") for part in value if isinstance(part, Mapping)
+        )
+    return ""
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _format_timestamp_like(value: datetime, original: Any) -> str:
+    rendered = value.isoformat()
+    if isinstance(original, str) and original.strip().endswith("Z"):
+        rendered = rendered.replace("+00:00", "Z")
+    return rendered
+
+
+def _mcp_structured_content(result: str | None) -> Any | None:
+    parsed = safe_json_loads(result or "")
+    if not isinstance(parsed, Mapping):
+        return None
+    structured = parsed.get("structuredContent")
+    if isinstance(structured, (Mapping, list)):
+        return structured
+    # MCP results with no usable text put structuredContent directly in `result`.
+    nested = parsed.get("result")
+    return nested if isinstance(nested, (Mapping, list)) else None
+
+
+def _iter_mappings(value: Any):
+    if isinstance(value, Mapping):
+        yield value
+        for child in value.values():
+            yield from _iter_mappings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _iter_mappings(child)
+
+
+def _normalize_component_name(value: str) -> str:
+    normalized = "".join(ch for ch in value.lower() if ch.isalnum())
+    for prefix in ("get", "read", "fetch", "list"):
+        if normalized.startswith(prefix) and len(normalized) > len(prefix):
+            return normalized[len(prefix):]
+    return normalized
+
+
+def _native_id_values(value: Any, *, recursive: bool = True):
+    """Yield scalar values whose field name denotes an exact native identifier."""
+    if not isinstance(value, Mapping):
+        return
+    for key, child in value.items():
+        raw_key = str(key)
+        lowered = raw_key.casefold()
+        normalized = "".join(ch for ch in lowered if ch.isalnum())
+        is_id_key = (
+            normalized in {"id", "pbid", "did", "pid", "uuid"}
+            or lowered.endswith(("_id", "-id"))
+            or (len(raw_key) > 2 and raw_key.endswith(("Id", "ID")))
+        )
+        if is_id_key and isinstance(child, (str, int)) and not isinstance(child, bool):
+            yield str(child)
+        if recursive and isinstance(child, Mapping):
+            yield from _native_id_values(child, recursive=True)
+        elif recursive and isinstance(child, list):
+            for item in child:
+                if isinstance(item, Mapping):
+                    yield from _native_id_values(item, recursive=True)
+
+
+def _scope_values(args: Mapping[str, Any]):
+    """Return time-bound argument values used to distinguish a changed read scope."""
+    exact_names = {
+        "start", "end", "from", "to", "since", "until",
+        "starttime", "endtime", "fromtime", "totime",
+        "starttimestamp", "endtimestamp",
+    }
+    for key, value in args.items():
+        normalized = "".join(ch for ch in str(key).lower() if ch.isalnum())
+        is_bound = normalized in exact_names or normalized.endswith(
+            ("starttime", "endtime", "starttimestamp", "endtimestamp", "since", "until")
+        )
+        if is_bound:
+            if isinstance(value, (str, int, float)) and not isinstance(value, bool):
+                yield str(value)
 
 
 _BOOL_WORDS = {w: True for w in ("1", "true", "yes", "on", "enabled")} | {w: False for w in ("0", "false", "no", "off", "disabled")}

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -203,6 +203,28 @@ class ToolGuardrailDecision:
         return data
 
 
+@dataclass(frozen=True)
+class RecentRequestProvenance:
+    """Origin of recent-request bounds carried from user text to dispatch.
+
+    Tool arguments alone cannot distinguish a number copied from the request
+    from one invented by the model.  Preserve that authority boundary before
+    the model call and consult it when normalizing emitted MCP arguments.
+    """
+
+    is_recent: bool = False
+    quantity_source: str = "model_or_default"
+    range_source: str = "model_or_default"
+
+    @property
+    def is_vague(self) -> bool:
+        return (
+            self.is_recent
+            and self.quantity_source != "user"
+            and self.range_source != "user"
+        )
+
+
 def _canonical_json(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
 
@@ -318,7 +340,7 @@ class ToolCallGuardrailController:
         self._reusable_mcp_calls: set[ToolCallSignature] = set()
         self._mcp_composite_coverage: list[_CompositeCoverage] = []
         self._capability_only = False
-        self._vague_recent = False
+        self._recent_request = RecentRequestProvenance()
         self._turn_web_search_count = 0
         self._turn_subagent_count = 0
 
@@ -327,19 +349,28 @@ class ToolCallGuardrailController:
         self._capability_only = bool(enabled)
 
     def set_vague_recent(self, enabled: bool) -> None:
-        """Enable conservative MCP bounds for an unqualified recent-time request."""
-        self._vague_recent = bool(enabled)
+        """Compatibility shim for callers without request-bound provenance."""
+        self._recent_request = RecentRequestProvenance(is_recent=bool(enabled))
+
+    def set_recent_request_provenance(self, provenance: RecentRequestProvenance) -> None:
+        """Carry user/default ownership of recent-request bounds into dispatch."""
+        self._recent_request = (
+            provenance if isinstance(provenance, RecentRequestProvenance)
+            else RecentRequestProvenance()
+        )
 
     def normalize_args(self, tool_name: str, args: Mapping[str, Any] | None) -> Mapping[str, Any]:
         """Bound vague-recent MCP reads before dispatch; explicit user ranges are excluded."""
         original = _coerce_args(args)
         server, _component = _mcp_tool_parts(tool_name)
-        if not self._vague_recent or server is None:
+        provenance = self._recent_request
+        if not provenance.is_recent or server is None:
             return original
         normalized = dict(original)
         count = normalized.get("count")
-        if ((isinstance(count, (int, float)) and not isinstance(count, bool) and count > 10)
-                or (isinstance(count, str) and count.strip().isdigit() and int(count) > 10)):
+        if (provenance.quantity_source != "user" and (
+                (isinstance(count, (int, float)) and not isinstance(count, bool) and count > 10)
+                or (isinstance(count, str) and count.strip().isdigit() and int(count) > 10))):
             normalized["count"] = 10
         start, end = normalized.get("start"), normalized.get("end")
         parsed_start, parsed_end = _parse_timestamp(start), _parse_timestamp(end)
@@ -350,7 +381,7 @@ class ToolCallGuardrailController:
             )
         except TypeError:  # mixed naive/aware timestamps: leave untouched for schema validation
             oversized_window = False
-        if oversized_window:
+        if oversized_window and provenance.range_source != "user":
             normalized["start"] = _format_timestamp_like(parsed_end - timedelta(hours=24), start)
         return normalized
 
@@ -533,13 +564,13 @@ class ToolCallGuardrailController:
             # object (plus the composite call's IDs). Recursing through every
             # evidence row would falsely treat a secondary device as the primary
             # entity whose detail the composite says it included.
-            native_ids = frozenset({
-                *_native_id_values(mapping, recursive=False),
-                *_native_id_values(args, recursive=False),
+            native_identities = frozenset({
+                *_native_identities(mapping, recursive=False),
+                *_native_identities(args, recursive=False),
             })
             scope_values = frozenset(_scope_values(args))
             self._mcp_composite_coverage.append(
-                _CompositeCoverage(server, components, native_ids, scope_values)
+                _CompositeCoverage(server, components, native_identities, scope_values)
             )
             return True
         return False
@@ -549,14 +580,14 @@ class ToolCallGuardrailController:
         if server is None or component is None:
             return False
         normalized = _normalize_component_name(component)
-        call_ids = set(_native_id_values(args))
-        if not call_ids:
+        call_identities = set(_native_identities(args))
+        if not call_identities:
             return False
         call_scope = set(_scope_values(args))
         for coverage in self._mcp_composite_coverage:
             if coverage.server != server or normalized not in coverage.components:
                 continue
-            if not call_ids.intersection(coverage.native_ids):
+            if not call_identities.intersection(coverage.native_identities):
                 continue
             # An explicitly changed time bound is a changed scope and remains allowed.
             if call_scope and not call_scope.issubset(coverage.scope_values):
@@ -699,7 +730,7 @@ def _result_hash(result: str | None) -> str:
 class _CompositeCoverage:
     server: str
     components: frozenset[str]
-    native_ids: frozenset[str]
+    native_identities: frozenset[tuple[str, str]]
     scope_values: frozenset[str]
 
 
@@ -746,21 +777,42 @@ def is_capability_only_request(value: Any) -> bool:
 
 def is_vague_recent_request(value: Any) -> bool:
     """True for a recent-time ask only when the user supplied no concrete bound."""
+    return recent_request_provenance(value).is_vague
+
+
+def recent_request_provenance(value: Any) -> RecentRequestProvenance:
+    """Classify recent bounds while retaining whether the user supplied them."""
     text = _request_text(value)
     if not text:
-        return False
+        return RecentRequestProvenance()
     normalized = " ".join(text.casefold().split())
     recent_markers = (
-        "recent", "lately", "latest activity", "in letzter zeit", "kürzlich", "kuerzlich", "aktuell",
+        "recent", "lately", "latest", "newest", "in letzter zeit", "kürzlich",
+        "kuerzlich", "aktuell", "neuest", "letzten",
     )
     if not any(marker in normalized for marker in recent_markers):
-        return False
-    explicit_bound = re.search(
-        r"\b\d{4}-\d{2}-\d{2}\b|\b\d+(?:[.,]\d+)?\s*(?:h|hours?|stunden?|d|days?|tage?n?)\b|"
-        r"\bcount\s*[=:]?\s*\d+\b",
+        return RecentRequestProvenance()
+    explicit_quantity = re.search(
+        r"\bcount\s*[=:]?\s*\d+\b|"
+        r"\b(?:show|list|display|return|get|fetch)\s+(?:me\s+)?(?:the\s+)?\d+\b|"
+        r"\bgive\s+me\s+(?:the\s+)?\d+\b|"
+        r"\b(?:top|latest|newest|recent|most\s+recent)\s+\d+\b|"
+        r"\b\d+\s+(?:most\s+recent|recent|latest|newest|neuest\w*|aktuell\w*|letzte\w*)\b|"
+        r"\b\d+\s+(?:findings?|items?|results?|events?|records?|alerts?|devices?)\b",
         normalized,
     )
-    return explicit_bound is None
+    explicit_range = re.search(
+        r"\b\d{4}-\d{2}-\d{2}\b|"
+        r"\b\d+(?:[.,]\d+)?\s*(?:h|hours?|stunden?|d|days?|tage?n?|weeks?|wochen?|months?|monate?n?)\b|"
+        r"\b(?:today|yesterday|heute|gestern)\b|"
+        r"\b(?:since|until|from|between|seit|bis|zwischen)\b",
+        normalized,
+    )
+    return RecentRequestProvenance(
+        is_recent=True,
+        quantity_source="user" if explicit_quantity else "model_or_default",
+        range_source="user" if explicit_range else "model_or_default",
+    )
 
 
 def _request_text(value: Any) -> str:
@@ -819,8 +871,8 @@ def _normalize_component_name(value: str) -> str:
     return normalized
 
 
-def _native_id_values(value: Any, *, recursive: bool = True):
-    """Yield scalar values whose field name denotes an exact native identifier."""
+def _native_identities(value: Any, *, recursive: bool = True):
+    """Yield normalized ``(field namespace, value)`` native identities."""
     if not isinstance(value, Mapping):
         return
     for key, child in value.items():
@@ -833,13 +885,13 @@ def _native_id_values(value: Any, *, recursive: bool = True):
             or (len(raw_key) > 2 and raw_key.endswith(("Id", "ID")))
         )
         if is_id_key and isinstance(child, (str, int)) and not isinstance(child, bool):
-            yield str(child)
+            yield normalized, str(child)
         if recursive and isinstance(child, Mapping):
-            yield from _native_id_values(child, recursive=True)
+            yield from _native_identities(child, recursive=True)
         elif recursive and isinstance(child, list):
             for item in child:
                 if isinstance(item, Mapping):
-                    yield from _native_id_values(item, recursive=True)
+                    yield from _native_identities(item, recursive=True)
 
 
 def _scope_values(args: Mapping[str, Any]):

--- a/agent/turn_api_error.py
+++ b/agent/turn_api_error.py
@@ -77,6 +77,32 @@ def handle_api_error(
     if agent.thinking_callback:
         agent.thinking_callback("")
 
+    from agent.run_budget import FinalSynthesisTimeout, ProviderStaleTimeout, RunBudgetExceeded
+    if isinstance(api_error, (FinalSynthesisTimeout, ProviderStaleTimeout, RunBudgetExceeded)):
+        reason = (
+            "final_synthesis_timeout" if isinstance(api_error, FinalSynthesisTimeout)
+            else "provider_stale_timeout" if isinstance(api_error, ProviderStaleTimeout)
+            else "run_budget_exhausted"
+        )
+        final = (
+            "The provider did not finish the tool-free final response within the configured deadline; "
+            "the request was stopped without issuing more tool calls."
+            if reason == "final_synthesis_timeout"
+            else "The provider produced no response within the configured stale timeout; "
+            "the request was stopped without retrying the same silent path."
+            if reason == "provider_stale_timeout"
+            else "The conversation run budget expired while waiting for the provider; the request was stopped."
+        )
+        from agent.message_metadata import append_message
+        append_message(messages, {"role": "assistant", "content": final})
+        agent._persist_session(messages, conversation_history)
+        return _verdict("return", {
+            "final_response": final, "messages": messages, "api_calls": api_call_count,
+            "completed": False, "failed": True, "error": final,
+            "turn_exit_reason": reason, "failure_reason": reason,
+            "failure_retryable": False,
+        })
+
     _recovered, active_system_prompt = recover_before_classification(
         agent, api_error, messages=messages, api_messages=api_messages, api_kwargs=api_kwargs,
         active_system_prompt=active_system_prompt,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -444,8 +444,6 @@ _PER_TURN_RESET_STATE: Tuple[Tuple[str, Any], ...] = (
     ("_tool_guardrail_halt_decision", None), ("_vision_supported", True),
     ("_iteration_budget_warning_injected", False),
     ("_run_budget_wrapup_injected", False), ("_verification_stop_nudges", 0),
-    ("_force_toolless_final", False), ("_final_synthesis_notice_injected", False),
-    ("_final_synthesis_deadline", None),
     ("_capability_only_turn", False),
     ("_vague_recent_turn", False),
     ("_pre_verify_nudges", 0),
@@ -456,6 +454,8 @@ def _reset_per_turn_agent_state(agent: Any) -> None:
     """Reset retry counters, guardrails, iteration and run budgets at turn start."""
     for name, value in _PER_TURN_RESET_STATE:
         setattr(agent, name, value)
+    from agent.run_budget import reset_final_synthesis
+    reset_final_synthesis(agent)
     agent._turn_failed_file_mutations = {}
     agent._turn_file_mutation_paths = set()
     agent._tool_guardrails.reset_for_turn()
@@ -855,15 +855,22 @@ def build_turn_context(
 
     # Preserve the original user message (no nudge injection).
     original_user_message = persist_user_message if persist_user_message is not None else user_message
-    from agent.tool_guardrails import is_capability_only_request, is_vague_recent_request
+    from agent.tool_guardrails import is_capability_only_request, recent_request_provenance
     agent._capability_only_turn = is_capability_only_request(original_user_message)
-    agent._vague_recent_turn = is_vague_recent_request(original_user_message)
+    recent_provenance = recent_request_provenance(original_user_message)
+    agent._vague_recent_turn = recent_provenance.is_vague
     set_capability_only = getattr(agent._tool_guardrails, "set_capability_only", None)
     if callable(set_capability_only):
         set_capability_only(agent._capability_only_turn)
-    set_vague_recent = getattr(agent._tool_guardrails, "set_vague_recent", None)
-    if callable(set_vague_recent):
-        set_vague_recent(agent._vague_recent_turn)
+    set_recent_provenance = getattr(
+        agent._tool_guardrails, "set_recent_request_provenance", None,
+    )
+    if callable(set_recent_provenance):
+        set_recent_provenance(recent_provenance)
+    else:
+        set_vague_recent = getattr(agent._tool_guardrails, "set_vague_recent", None)
+        if callable(set_vague_recent):
+            set_vague_recent(agent._vague_recent_turn)
     should_review_memory = _tick_memory_nudge(agent)
     _emit_reaction(agent, original_user_message)
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -444,6 +444,10 @@ _PER_TURN_RESET_STATE: Tuple[Tuple[str, Any], ...] = (
     ("_tool_guardrail_halt_decision", None), ("_vision_supported", True),
     ("_iteration_budget_warning_injected", False),
     ("_run_budget_wrapup_injected", False), ("_verification_stop_nudges", 0),
+    ("_force_toolless_final", False), ("_final_synthesis_notice_injected", False),
+    ("_final_synthesis_deadline", None),
+    ("_capability_only_turn", False),
+    ("_vague_recent_turn", False),
     ("_pre_verify_nudges", 0),
 )
 
@@ -851,6 +855,15 @@ def build_turn_context(
 
     # Preserve the original user message (no nudge injection).
     original_user_message = persist_user_message if persist_user_message is not None else user_message
+    from agent.tool_guardrails import is_capability_only_request, is_vague_recent_request
+    agent._capability_only_turn = is_capability_only_request(original_user_message)
+    agent._vague_recent_turn = is_vague_recent_request(original_user_message)
+    set_capability_only = getattr(agent._tool_guardrails, "set_capability_only", None)
+    if callable(set_capability_only):
+        set_capability_only(agent._capability_only_turn)
+    set_vague_recent = getattr(agent._tool_guardrails, "set_vague_recent", None)
+    if callable(set_vague_recent):
+        set_vague_recent(agent._vague_recent_turn)
     should_review_memory = _tick_memory_nudge(agent)
     _emit_reaction(agent, original_user_message)
 

--- a/agent/turn_explainers.py
+++ b/agent/turn_explainers.py
@@ -45,6 +45,14 @@ _EXIT_REASON_EXPLANATIONS: Dict[str, str] = {
         "the per-turn iteration/cost budget was exhausted before a "
         "final answer. Send `continue` to keep going."
     ),
+    "run_budget_exhausted": (
+        "the configured wall-clock run budget expired before a final answer. "
+        "The in-flight provider request was stopped."
+    ),
+    "final_synthesis_timeout": (
+        "the provider kept the final synthesis request alive but did not finish an answer "
+        "within its configured deadline. The request was stopped without running more tools."
+    ),
     "ollama_runtime_context_too_small": (
         "the local model's context window was too small to finish. "
         "Increase the context size or use a larger model."

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -415,9 +415,8 @@ def begin_iteration(
     # tool call on the last round consumes the budget and the loop exits before
     # the model ever sees its result or can produce an answer.
     if agent.iteration_budget.remaining == 0:
-        agent._force_toolless_final = True
-        from agent.run_budget import arm_final_synthesis_deadline
-        arm_final_synthesis_deadline(agent)
+        from agent.run_budget import enter_final_synthesis
+        enter_final_synthesis(agent)
     return _verdict("fallthrough")
 
 

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -27,6 +27,49 @@ ITERATION_BUDGET_WARNING_TEMPLATE = (
     "solely because of this warning."
 )
 
+FINAL_SYNTHESIS_NOTICE = (
+    "[SYSTEM NOTICE — final synthesis] Tool access is closed for this request. "
+    "Answer the user now from the evidence already collected; do not request another tool call."
+)
+
+
+def _maybe_inject_final_synthesis_notice(agent: Any, messages: Any) -> bool:
+    """Append the one-shot synthesis directive to the current tool-result tail."""
+    if (not getattr(agent, "_force_toolless_final", False)
+            or getattr(agent, "_final_synthesis_notice_injected", False)):
+        return False
+    from agent.context_compressor import _DB_PERSISTED_MARKER
+    if (not messages or messages[-1].get("role") != "tool"
+            or messages[-1].get(_DB_PERSISTED_MARKER)):
+        return False
+    content = messages[-1].get("content", "")
+    if isinstance(content, str):
+        messages[-1]["content"] = content + f"\n\n{FINAL_SYNTHESIS_NOTICE}"
+    elif isinstance(content, list) or content is None:
+        messages[-1]["content"] = [*(content or []), {"type": "text", "text": FINAL_SYNTHESIS_NOTICE}]
+    else:
+        return False
+    agent._final_synthesis_notice_injected = True
+    return True
+
+
+def _prepare_forced_final_request(agent: Any) -> None:
+    """Make a forced synthesis cheap and bounded without changing session defaults."""
+    if not getattr(agent, "_force_toolless_final", False):
+        return
+    from agent.run_budget import arm_final_synthesis_deadline
+
+    arm_final_synthesis_deadline(agent)
+    # Deep reasoning already happened while choosing and gathering evidence. A
+    # request-local reasoning-off hint and modest output cap keep the final answer
+    # from consuming the entire run budget. Providers that reject reasoning-off
+    # already have a compatibility retry path; no persistent setting is changed.
+    agent._ephemeral_reasoning_off = True
+    configured = getattr(agent, "max_tokens", None)
+    agent._ephemeral_max_output_tokens = min(configured, 2048) if (
+        isinstance(configured, int) and configured > 0
+    ) else 2048
+
 
 def _maybe_inject_iteration_budget_warning(agent: Any, messages: Any) -> bool:
     """Append the opt-in one-shot warning to the newest tool result."""
@@ -135,6 +178,9 @@ def prepare_iteration(agent: Any,*, messages: Any, api_call_count: Any) -> Itera
     # same cache-safe channel as /steer (newest tool result); off with no budget.
     if getattr(agent, "run_budget_seconds", None):
         _maybe_inject_run_budget_wrapup(agent, messages)
+
+    _prepare_forced_final_request(agent)
+    _maybe_inject_final_synthesis_notice(agent, messages)
 
     # Use the same cache-safe channel as /steer; never add a synthetic user/system row.
     _maybe_inject_iteration_budget_warning(agent, messages)
@@ -344,6 +390,12 @@ def begin_iteration(
             )
         return _verdict("break")
 
+    from agent.run_budget import remaining_run_budget_seconds
+    _run_remaining = remaining_run_budget_seconds(agent)
+    if _run_remaining is not None and _run_remaining <= 0:
+        _turn_exit_reason = "run_budget_exhausted"
+        return _verdict("break")
+
     api_call_count += 1
     agent._api_call_count = api_call_count
     agent._touch_activity(f"starting API call #{api_call_count}")
@@ -359,6 +411,13 @@ def begin_iteration(
         if not agent.quiet_mode:
             agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")
         return _verdict("break")
+    # Reserve the final allowed model round for synthesis. Without this, a
+    # tool call on the last round consumes the budget and the loop exits before
+    # the model ever sees its result or can produce an answer.
+    if agent.iteration_budget.remaining == 0:
+        agent._force_toolless_final = True
+        from agent.run_budget import arm_final_synthesis_deadline
+        arm_final_synthesis_deadline(agent)
     return _verdict("fallthrough")
 
 

--- a/agent/turn_request_assembly.py
+++ b/agent/turn_request_assembly.py
@@ -21,6 +21,11 @@ from agent.turn_context import build_api_messages
 logger = logging.getLogger("agent.conversation_loop")
 
 
+def _select_tools_for_api(agent: Any) -> Any:
+    """Return a request-local empty registry for a forced synthesis round."""
+    return [] if getattr(agent, "_force_toolless_final", False) else agent.tools
+
+
 @dataclass
 class AssembledRequest:
     """Always ``action == "fallthrough"``; the fields are the iteration locals the assembly
@@ -188,7 +193,7 @@ def assemble_api_request(
     # Build the request-local cache sections LAST, after every transcript mutation;
     # the canonical tool registry stays undecorated. Marked ``content`` becomes text
     # blocks the whitespace pass skips, so the same row's bytes vary across turns.
-    tools_for_api = agent.tools
+    tools_for_api = _select_tools_for_api(agent)
     if agent._use_prompt_caching and agent.provider != "moa":
         from agent.prompt_caching import envelope_tool_part_cache_markers_supported
 

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -252,7 +252,7 @@ def _build_chat_parser(subparsers) -> argparse.ArgumentParser:
     add("--run-budget", type=float, default=None, metavar="SECONDS", dest="run_budget", help=(
         "Optional wall-clock budget in seconds for each conversation run. "
         "At 80%% elapsed the agent gets a one-time wrap-up notice, and "
-        "implicit provider stale timeouts are capped to the remaining "
+        "all provider waits are capped to the remaining "
         "budget so one hung call can't consume the run. Unset = off. "
         "Also configurable as agent.run_budget_seconds in config.yaml. "
         "Intended for one-shot/eval invocations with a hard ceiling."))

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -54,7 +54,7 @@ DEFAULT_CONFIG = {
         # null = off; set a ratio strictly between 0 and 1 (for example, 0.75).
         "budget_warning_ratio": None,
         # Wall-clock budget (seconds) per run. null = off. When set: one-time wrap-up notice at 80%
-        # elapsed; implicit provider stale timeouts capped to remaining budget. CLI equivalent:
+        # elapsed; every provider wait is capped to the remaining budget. CLI equivalent:
         # `hermes chat --run-budget N`.
         "run_budget_seconds": None,
         # Gateway inactivity timeout (seconds). Only fires when the agent is completely idle — not
@@ -505,6 +505,10 @@ DEFAULT_CONFIG = {
     "tool_loop_guardrails": {
         "warnings_enabled": True,
         "hard_stop_enabled": False,
+        # Complete MCP composites normally move directly to a tool-free answer.
+        # Disable for long multi-finding orchestrations; composite component
+        # coverage and exact-result reuse remain enforced.
+        "finalize_on_complete_composite": True,
         # Unattended gateway/cron platforms hard-stop by default (nobody can /stop a model that
         # ignores warnings); interactive cli/tui/desktop/acp stay warning-only.
         "non_interactive_hard_stop_enabled": True,
@@ -1794,13 +1798,13 @@ DEFAULT_CONFIG = {
             # Tiered: tier 0 (no deferrable tools) = everything eager; tier 1 = bridge + a
             # name+description manifest when it fits the budget (degrades to names-only); tier 2
             # (over budget even names-only, e.g. ~3,300-tool APIs) = bare bridge + a
-            # one-line-per-server summary (name + tool count). "auto"|"on" = activate when at least
-            # one deferrable tool exists ("auto" is an alias of "on" today, reserved for a future
-            # budget-gated mode; keep it the default so explicit "on"/"off" pins are unaffected).
+            # one-line-per-server summary (name + tool count). "on" activates whenever a
+            # deferrable tool exists; "auto" keeps small catalogs eager and activates when their
+            # schemas exceed threshold_pct of the active context window.
             # "off" = pass-through, no bridge.
             "enabled": "auto",
-            # Listing budget as % of the model's context length; effective budget = min(this % of
-            # context, listing_max_tokens). Range 0..100.
+            # Auto-activation threshold and listing budget as % of the model's context length;
+            # effective listing budget = min(this % of context, listing_max_tokens). Range 0..100.
             "threshold_pct": 5,
             # Hits per query when the model omits `limit`. Range 1..max_search_limit.
             "search_default_limit": 5,

--- a/model_tools.py
+++ b/model_tools.py
@@ -461,9 +461,9 @@ def _compute_tool_definitions(enabled_toolsets: Optional[List[str]] = None, disa
     except Exception as e:  # pragma: no cover — defensive
         logger.warning("Schema sanitization skipped: %s", e)
 
-    # Tool Search (progressive disclosure): replace MCP/plugin tools with the
-    # tool_search/describe/call bridge when the deferrable surface exceeds the
-    # configured share of the context window. Core tools are never deferred.
+    # Tool Search (progressive disclosure): in auto mode replace MCP/plugin tools
+    # with the tool_search/describe/call bridge when the deferrable surface exceeds
+    # the configured share of the context window. Core tools are never deferred.
     # Must be the LAST step (after sanitization); idempotent if called twice.
     try:
         from tools.tool_search import assemble_tool_defs, load_config as _load_ts_config

--- a/run_agent.py
+++ b/run_agent.py
@@ -1236,9 +1236,8 @@ class AIAgent(
         if decision.action in {"warn", "halt"}:
             function_result = append_toolguard_guidance(function_result, decision)
         elif decision.action == "finalize":
-            self._force_toolless_final = True
-            from agent.run_budget import arm_final_synthesis_deadline
-            arm_final_synthesis_deadline(self)
+            from agent.run_budget import enter_final_synthesis
+            enter_final_synthesis(self)
             function_result = (function_result or "") + (
                 "\n\n[Hermes final-synthesis guard: " + decision.message + "]"
             )
@@ -1260,10 +1259,9 @@ class AIAgent(
 
     def _guardrail_block_result(self, decision: ToolGuardrailDecision) -> str:
         self._set_tool_guardrail_halt(decision)
-        if decision.action in {"reuse", "restrict"}:
-            self._force_toolless_final = True
-            from agent.run_budget import arm_final_synthesis_deadline
-            arm_final_synthesis_deadline(self)
+        if decision.action == "reuse":
+            from agent.run_budget import enter_final_synthesis
+            enter_final_synthesis(self)
         return toolguard_synthetic_result(decision)
 
     def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -563,19 +563,16 @@ class AIAgent(
 
         from agent.chat_completion_helpers import estimate_request_context_tokens
         est_tokens = estimate_request_context_tokens(api_payload)
-        timeout = max(stale_base, 240.0) if est_tokens > 100_000 else max(stale_base, 150.0) if est_tokens > 50_000 else stale_base
-        # Run-budget cap: an implicit stale timeout is capped at half the remaining budget (>= 60s) so one
-        # hung call cannot eat the run. Never raises the timeout; explicit user config still wins.
-        run_budget = getattr(self, "run_budget_seconds", None)
-        started = getattr(self, "_run_budget_started_at", None)
-        if run_budget and started and not self._stale_timeout_is_explicit():
-            remaining = float(run_budget) - (time.time() - started)
-            timeout = min(timeout, max(60.0, remaining * 0.5))
-        return timeout
+        timeout = stale_base if self._stale_timeout_is_explicit() else (
+            max(stale_base, 240.0) if est_tokens > 100_000
+            else max(stale_base, 150.0) if est_tokens > 50_000
+            else stale_base
+        )
+        from agent.run_budget import cap_timeout_to_run_budget
+        return cap_timeout_to_run_budget(self, timeout)
 
     def _stale_timeout_is_explicit(self) -> bool:
-        """True when the user explicitly configured the stale timeout (config or env var); implicit values
-        (reasoning floors, the 90s default) yield to the run-budget cap, explicit ones never do."""
+        """True when the user explicitly configured the stale timeout (config or env var)."""
         return (get_provider_stale_timeout(self.provider, self.model) is not None
                 or os.getenv("HERMES_API_CALL_STALE_TIMEOUT") is not None)
 
@@ -1238,6 +1235,13 @@ class AIAgent(
             function_result = result_stub
         if decision.action in {"warn", "halt"}:
             function_result = append_toolguard_guidance(function_result, decision)
+        elif decision.action == "finalize":
+            self._force_toolless_final = True
+            from agent.run_budget import arm_final_synthesis_deadline
+            arm_final_synthesis_deadline(self)
+            function_result = (function_result or "") + (
+                "\n\n[Hermes final-synthesis guard: " + decision.message + "]"
+            )
         if decision.should_halt:
             self._set_tool_guardrail_halt(decision)
         else:
@@ -1256,6 +1260,10 @@ class AIAgent(
 
     def _guardrail_block_result(self, decision: ToolGuardrailDecision) -> str:
         self._set_tool_guardrail_halt(decision)
+        if decision.action in {"reuse", "restrict"}:
+            self._force_toolless_final = True
+            from agent.run_budget import arm_final_synthesis_deadline
+            arm_final_synthesis_deadline(self)
         return toolguard_synthetic_result(decision)
 
     def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -29,6 +29,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
+    execution_guidance_text,
     PARALLEL_TOOL_CALL_GUIDANCE,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     MEMORY_GUIDANCE,
@@ -1120,6 +1121,19 @@ class TestOpenAIModelExecutionGuidance:
     def test_guidance_gates_completion_on_verification(self):
         text = OPENAI_MODEL_EXECUTION_GUIDANCE.lower()
         assert "plausible subset" in text
+
+    def test_guidance_distinguishes_evidence_reuse_from_verification(self):
+        text = OPENAI_MODEL_EXECUTION_GUIDANCE.lower()
+        assert "identical arguments" in text
+        assert "component follow-up" in text
+        assert "capability-only" in text
+        assert "once evidence is sufficient" in text
+
+    def test_scoped_guidance_never_names_absent_shell_or_file_tools(self):
+        text = execution_guidance_text({"mcp_example__get_capabilities"}).lower()
+        assert "use terminal" not in text
+        assert "read_file" not in text
+        assert "search_files" not in text
 
 
 class TestExecutionGuidanceModels:

--- a/tests/agent/test_run_budget.py
+++ b/tests/agent/test_run_budget.py
@@ -4,11 +4,11 @@ Covers:
 
 1. Stale-timeout deadline scaling in
    ``run_agent.py:AIAgent._compute_non_stream_stale_timeout``:
-   - an active run budget CAPS an implicit stale timeout (default 90s and
-     reasoning floors like deepseek's 600s) at ``max(60, remaining * 0.5)``;
+   - an active run budget CAPS every provider wait at the remaining wall-clock
+     budget, including explicit operator timeouts;
    - the cap never RAISES the timeout above what it would otherwise be;
-   - explicit user configuration (provider ``stale_timeout_seconds`` or the
-     ``HERMES_API_CALL_STALE_TIMEOUT`` env var) always wins untouched;
+   - explicit user configuration wins over model/context floors but not over
+     the absolute run deadline;
    - no budget => completely unchanged behavior.
 
 2. One-time-ness of the 80% wrap-up notice injection in
@@ -120,10 +120,7 @@ def test_no_budget_stale_timeout_unchanged(monkeypatch, tmp_path):
 
 
 def test_active_budget_caps_implicit_reasoning_floor(monkeypatch, tmp_path):
-    """deepseek-v4-pro's 600s implicit floor yields to a tighter deadline cap.
-
-    900s budget, 800s elapsed -> remaining 100s -> cap = max(60, 50) = 60s.
-    """
+    """deepseek-v4-pro's 600s implicit floor yields to the remaining deadline."""
     import run_agent
     monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
     agent = _make_agent(
@@ -136,11 +133,12 @@ def test_active_budget_caps_implicit_reasoning_floor(monkeypatch, tmp_path):
     assert base == 600.0 and implicit is False
 
     agent._run_budget_started_at = time.time() - 800
-    assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 60.0
+    timeout = agent._compute_non_stream_stale_timeout({"input": "hi"})
+    assert 95.0 <= timeout <= 100.0
 
 
-def test_active_budget_cap_half_remaining(monkeypatch, tmp_path):
-    """Cap is remaining * 0.5 when that exceeds the 60s floor."""
+def test_active_budget_caps_at_remaining_time(monkeypatch, tmp_path):
+    """A long implicit timeout is capped at the absolute remaining time."""
     import run_agent
     monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
     agent = _make_agent(
@@ -148,9 +146,9 @@ def test_active_budget_cap_half_remaining(monkeypatch, tmp_path):
         model="deepseek/deepseek-v4-pro",
         run_budget_seconds=900,
     )
-    agent._run_budget_started_at = time.time() - 100  # remaining ~800 -> cap ~400
+    agent._run_budget_started_at = time.time() - 400  # remaining ~500 < 600s floor
     timeout = agent._compute_non_stream_stale_timeout({"input": "hi"})
-    assert 395.0 <= timeout <= 400.0
+    assert 495.0 <= timeout <= 500.0
 
 
 def test_active_budget_never_raises_timeout(monkeypatch, tmp_path):
@@ -165,23 +163,42 @@ def test_active_budget_never_raises_timeout(monkeypatch, tmp_path):
     assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 90.0
 
 
-def test_explicit_provider_config_wins_over_budget_cap(monkeypatch, tmp_path):
-    """Explicit stale_timeout_seconds is never capped by the run budget."""
+def test_explicit_provider_config_yields_to_absolute_budget(monkeypatch, tmp_path):
+    """Explicit stale timeout wins over floors, but not the run deadline."""
     import run_agent
     monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: 1800.0)
     agent = _make_agent(tmp_path, monkeypatch, run_budget_seconds=900)
     agent._run_budget_started_at = time.time() - 800
-    assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 1800.0
+    timeout = agent._compute_non_stream_stale_timeout({"input": "hi"})
+    assert 95.0 <= timeout <= 100.0
 
 
-def test_explicit_env_var_wins_over_budget_cap(monkeypatch, tmp_path):
-    """HERMES_API_CALL_STALE_TIMEOUT is explicit config — never capped."""
+def test_explicit_env_var_yields_to_absolute_budget(monkeypatch, tmp_path):
+    """The explicit env value is still capped by the absolute run deadline."""
     import run_agent
     monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
     agent = _make_agent(tmp_path, monkeypatch, run_budget_seconds=900)
     monkeypatch.setenv("HERMES_API_CALL_STALE_TIMEOUT", "1200")
     agent._run_budget_started_at = time.time() - 800
-    assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 1200.0
+    timeout = agent._compute_non_stream_stale_timeout({"input": "hi"})
+    assert 95.0 <= timeout <= 100.0
+
+
+def test_explicit_stream_stale_timeout_wins_over_qwen_reasoning_floor(monkeypatch, tmp_path):
+    """A configured 120s watchdog must stay 120s for a Qwen3 model."""
+    import agent.chat_completion_helpers as helpers
+    monkeypatch.setattr(helpers, "get_provider_stale_timeout", lambda *a, **k: 120.0)
+    agent = _make_agent(
+        tmp_path, monkeypatch,
+        model="qwen/qwen3.8-27b",
+        provider="nvidia-spark",
+        base_url="http://127.0.0.1:8000/v1",
+        run_budget_seconds=300,
+    )
+    agent._run_budget_started_at = time.time()
+    call = helpers._StreamingCall(agent, {"model": agent.model, "messages": []}, None)
+    call._resolve_stale_timeout()
+    assert 119.0 <= call._stream_stale_timeout <= 120.0
 
 
 def test_budget_without_started_clock_is_inert(monkeypatch, tmp_path):
@@ -322,3 +339,76 @@ def test_turn_clock_stamped_only_with_budget(monkeypatch, tmp_path):
 
     assert agent_with._run_budget_started_at is not None
     assert agent_with._run_budget_wrapup_injected is False
+
+
+def test_forced_final_synthesis_uses_request_local_empty_tool_registry():
+    from agent.turn_request_assembly import _select_tools_for_api
+
+    class Agent:
+        tools = [{"type": "function", "function": {"name": "read_something"}}]
+        _force_toolless_final = False
+
+    agent = Agent()
+    assert _select_tools_for_api(agent) is agent.tools
+    agent._force_toolless_final = True
+    assert _select_tools_for_api(agent) == []
+    assert agent.tools  # canonical registry is not mutated
+
+
+def test_final_synthesis_notice_is_one_shot_on_tool_tail():
+    from agent.turn_iteration_prep import (
+        FINAL_SYNTHESIS_NOTICE,
+        _maybe_inject_final_synthesis_notice,
+    )
+
+    agent = _StubAgent()
+    agent._force_toolless_final = True
+    agent._final_synthesis_notice_injected = False
+    messages = _tool_messages()
+    assert _maybe_inject_final_synthesis_notice(agent, messages) is True
+    assert FINAL_SYNTHESIS_NOTICE in messages[-1]["content"]
+    assert _maybe_inject_final_synthesis_notice(agent, messages) is False
+    assert messages[-1]["content"].count(FINAL_SYNTHESIS_NOTICE) == 1
+
+
+def test_final_synthesis_deadline_uses_explicit_stale_timeout_and_is_one_shot():
+    from agent.run_budget import (
+        arm_final_synthesis_deadline,
+        remaining_final_synthesis_seconds,
+    )
+
+    class Agent:
+        run_budget_seconds = 300
+        _run_budget_started_at = 900.0
+        _final_synthesis_deadline = None
+
+        @staticmethod
+        def _resolved_api_call_stale_timeout_base():
+            return 120.0, False
+
+    agent = Agent()
+    deadline = arm_final_synthesis_deadline(agent, now=1000.0)
+    assert deadline == 1120.0
+    assert remaining_final_synthesis_seconds(agent, now=1001.0) == 119.0
+    assert arm_final_synthesis_deadline(agent, now=1050.0) == 1120.0
+
+
+def test_forced_final_request_disables_reasoning_and_caps_output():
+    from agent.turn_iteration_prep import _prepare_forced_final_request
+
+    class Agent:
+        _force_toolless_final = True
+        _final_synthesis_deadline = None
+        run_budget_seconds = 300
+        _run_budget_started_at = time.time()
+        max_tokens = None
+
+        @staticmethod
+        def _resolved_api_call_stale_timeout_base():
+            return 120.0, False
+
+    agent = Agent()
+    _prepare_forced_final_request(agent)
+    assert agent._ephemeral_reasoning_off is True
+    assert agent._ephemeral_max_output_tokens == 2048
+    assert 0 < agent._final_synthesis_deadline - time.time() <= 120.0

--- a/tests/agent/test_run_budget.py
+++ b/tests/agent/test_run_budget.py
@@ -412,3 +412,52 @@ def test_forced_final_request_disables_reasoning_and_caps_output():
     assert agent._ephemeral_reasoning_off is True
     assert agent._ephemeral_max_output_tokens == 2048
     assert 0 < agent._final_synthesis_deadline - time.time() <= 120.0
+
+
+def test_provider_wait_lifecycle_owns_deadline_precedence_and_typed_abort():
+    from agent.run_budget import (
+        FINAL_SYNTHESIS_TIMEOUT,
+        RUN_BUDGET_EXHAUSTED,
+        FinalSynthesisTimeout,
+        ProviderWaitLifecycle,
+        RunBudgetExceeded,
+    )
+
+    class Agent:
+        run_budget_seconds = 300
+        _run_budget_started_at = 900.0
+        _final_synthesis_deadline = 1100.0
+
+    lifecycle = ProviderWaitLifecycle(Agent())
+    assert lifecycle.expired_deadline(now=1050.0) is None
+    assert lifecycle.expired_deadline(now=1150.0) == FINAL_SYNTHESIS_TIMEOUT
+    assert lifecycle.expired_deadline(now=1250.0) == RUN_BUDGET_EXHAUSTED
+
+    assert lifecycle.abort(FINAL_SYNTHESIS_TIMEOUT) is True
+    assert lifecycle.abort(RUN_BUDGET_EXHAUSTED) is False
+    assert isinstance(lifecycle.error(), FinalSynthesisTimeout)
+
+    run_lifecycle = ProviderWaitLifecycle(Agent())
+    assert run_lifecycle.abort(RUN_BUDGET_EXHAUSTED) is True
+    assert isinstance(run_lifecycle.error(), RunBudgetExceeded)
+
+
+def test_provider_wait_lifecycle_stale_is_terminal_only_for_bounded_turns():
+    from agent.run_budget import ProviderStaleTimeout, ProviderWaitLifecycle
+
+    bounded = type("Agent", (), {
+        "run_budget_seconds": 30,
+        "_run_budget_started_at": time.time(),
+        "_final_synthesis_deadline": None,
+    })()
+    lifecycle = ProviderWaitLifecycle(bounded)
+    assert lifecycle.abort_on_provider_stale(4.9) is True
+    assert isinstance(lifecycle.error(), ProviderStaleTimeout)
+    assert "4s" in str(lifecycle.error())
+
+    unbounded = type("Agent", (), {
+        "run_budget_seconds": None,
+        "_run_budget_started_at": None,
+        "_final_synthesis_deadline": None,
+    })()
+    assert ProviderWaitLifecycle(unbounded).abort_on_provider_stale(4.9) is False

--- a/tests/agent/test_stall_guards.py
+++ b/tests/agent/test_stall_guards.py
@@ -12,17 +12,173 @@ Two guards, both notice/re-prompt-only:
    short reply that ENDS on an announced next action, feeding the existing
    bounded intent-ack continuation path (no new recovery machinery).
 
-These assert behavior contracts, not message snapshots.
+MCP tools can additionally opt successful results into per-turn reuse and
+declare assembled component coverage. These assert behavior contracts, not
+message snapshots.
 """
+
+import json
 
 from agent.agent_runtime_helpers import trailing_continue_intent
 from agent.tool_guardrails import (
     IDENTICAL_RESULT_STUB_MIN_CHARS,
     STALL_GUARD_IDENTICAL_CALL_THRESHOLD,
     STALL_GUARD_REPEATABLE_TOOLS,
+    ToolCallGuardrailConfig,
     ToolCallGuardrailController,
+    toolguard_synthetic_result,
     is_stall_guard_repeatable,
 )
+
+
+def test_explicit_mcp_reuse_contract_skips_identical_successful_call():
+    c = ToolCallGuardrailController()
+    tool = "mcp_example__read_finding"
+    args = {"finding_id": "native-7", "count": 10}
+    result = '{"result":"summary","structuredContent":{"reuseResult":true,"findingId":"native-7"}}'
+
+    c.after_call(tool, args, result, failed=False)
+    repeated = c.before_call(tool, args)
+    assert repeated.action == "reuse"
+    assert repeated.allows_execution is False
+    assert json.loads(toolguard_synthetic_result(repeated))["reused"] is True
+    assert c.before_call(tool, {**args, "count": 9}).allows_execution is True
+
+
+def test_assembled_mcp_result_blocks_only_covered_native_scope():
+    c = ToolCallGuardrailController()
+    composite = "mcp_example__investigate_finding"
+    args = {"finding_id": "native-7", "start": "s1", "end": "e1"}
+    result = json.dumps({
+        "result": "summary",
+        "structuredContent": {
+            "resultState": "assembled",
+            "componentFollowupNeeded": False,
+            "includes": {"findingDetail": True, "networkEvidence": True},
+            "findingId": "native-7",
+            "deviceId": "device-2",
+        },
+    })
+    decision = c.after_call(composite, args, result, failed=False)
+    assert decision.action == "finalize"
+
+    assert c.before_call(
+        "mcp_example__get_finding_detail", {"finding_id": "native-7"}
+    ).code == "covered_by_composite_result"
+    assert c.before_call(
+        "mcp_example__get_network_evidence", {"device_id": "device-2", "start": "s1", "end": "e1"}
+    ).action == "reuse"
+    assert c.before_call(
+        "mcp_example__get_network_evidence", {"device_id": "device-2", "start": "s2", "end": "e2"}
+    ).allows_execution is True
+    assert c.before_call(
+        "mcp_example__get_network_evidence", {"device_id": "guessed-id"}
+    ).allows_execution is True
+
+
+def test_composite_coverage_does_not_promote_nested_secondary_ids():
+    c = ToolCallGuardrailController()
+    c.after_call(
+        "mcp_example__investigate_finding",
+        {"finding_id": "native-7", "start": "s1", "end": "e1"},
+        json.dumps({
+            "structuredContent": {
+                "resultState": "assembled",
+                "componentFollowupNeeded": False,
+                "includes": {"deviceDetail": True},
+                "findingId": "native-7",
+                "deviceId": "primary-device",
+                "networkEvidence": [{"deviceId": "secondary-device"}],
+            },
+        }),
+        failed=False,
+    )
+
+    assert c.before_call(
+        "mcp_example__get_device_detail", {"device_id": "primary-device"}
+    ).action == "reuse"
+    assert c.before_call(
+        "mcp_example__get_device_detail", {"device_id": "secondary-device"}
+    ).allows_execution is True
+
+
+def test_assembled_mcp_result_arms_toolless_final_synthesis():
+    agent = _fake_agent()
+    result = json.dumps({
+        "result": "summary",
+        "structuredContent": {
+            "resultState": "assembled",
+            "componentFollowupNeeded": False,
+            "includes": {"findingDetail": True},
+            "findingId": "native-7",
+        },
+    })
+
+    output = agent._append(
+        "mcp_example__investigate_finding", {"finding_id": "native-7"}, result
+    )
+
+    assert agent._force_toolless_final is True
+    assert "final-synthesis guard" in output
+
+
+def test_long_orchestration_can_retain_composite_coverage_without_finalizing():
+    config = ToolCallGuardrailConfig.from_mapping({
+        "finalize_on_complete_composite": False,
+    })
+    assert config.finalize_on_complete_composite is False
+    c = ToolCallGuardrailController(config)
+    result = json.dumps({
+        "structuredContent": {
+            "resultState": "assembled",
+            "componentFollowupNeeded": False,
+            "includes": {"findingDetail": True},
+            "findingId": "native-7",
+        },
+    })
+
+    decision = c.after_call(
+        "mcp_example__investigate_finding", {"finding_id": "native-7"}, result,
+        failed=False,
+    )
+
+    assert decision.allows_execution is True
+    assert c.before_call(
+        "mcp_example__get_finding_detail", {"finding_id": "native-7"}
+    ).action == "reuse"
+
+
+def test_capability_only_intent_requires_capability_and_no_investigation():
+    from agent.tool_guardrails import is_capability_only_request
+
+    assert is_capability_only_request(
+        "Erkläre die Untersuchungsmöglichkeiten; führe keine Untersuchung von Findings durch."
+    ) is True
+    assert is_capability_only_request("Welche Untersuchungsmöglichkeiten gibt es?") is False
+    assert is_capability_only_request("Do not investigate this finding yet.") is False
+
+
+def test_vague_recent_mcp_args_are_bounded_but_explicit_ranges_are_not():
+    from agent.tool_guardrails import is_vague_recent_request
+
+    assert is_vague_recent_request("Untersuche ungewöhnliche Aktivität in letzter Zeit") is True
+    assert is_vague_recent_request("Investigate recent activity from the last 48 hours") is False
+
+    c = ToolCallGuardrailController()
+    c.set_vague_recent(True)
+    bounded = c.normalize_args(
+        "mcp_example__list_findings",
+        {"count": 25, "start": "2026-09-06T15:00:00Z", "end": "2026-09-08T15:00:00Z"},
+    )
+    assert bounded == {
+        "count": 10,
+        "start": "2026-09-07T15:00:00Z",
+        "end": "2026-09-08T15:00:00Z",
+    }
+
+    c.set_vague_recent(False)
+    explicit = {"count": 25, "start": "2026-09-06T15:00:00Z", "end": "2026-09-08T15:00:00Z"}
+    assert c.normalize_args("mcp_example__list_findings", explicit) is explicit
 
 
 def _observe_n(controller, n, tool="web_search", args=None, result="same result"):

--- a/tests/agent/test_stall_guards.py
+++ b/tests/agent/test_stall_guards.py
@@ -102,6 +102,34 @@ def test_composite_coverage_does_not_promote_nested_secondary_ids():
     ).allows_execution is True
 
 
+def test_composite_coverage_preserves_typed_id_namespaces_and_aliases():
+    c = ToolCallGuardrailController()
+    c.after_call(
+        "mcp_example__investigate_finding",
+        {"finding_id": "7"},
+        json.dumps({
+            "structuredContent": {
+                "resultState": "assembled",
+                "componentFollowupNeeded": False,
+                "includes": {"device-detail": True, "finding_detail": True},
+                "findingId": "7",
+                "deviceID": "2",
+            },
+        }),
+        failed=False,
+    )
+
+    assert c.before_call(
+        "mcp_example__get_device_detail", {"device_id": "7"}
+    ).allows_execution is True
+    assert c.before_call(
+        "mcp_example__get_device_detail", {"device-id": "2"}
+    ).action == "reuse"
+    assert c.before_call(
+        "mcp_example__get_finding_detail", {"finding-id": "7"}
+    ).action == "reuse"
+
+
 def test_assembled_mcp_result_arms_toolless_final_synthesis():
     agent = _fake_agent()
     result = json.dumps({
@@ -159,10 +187,13 @@ def test_capability_only_intent_requires_capability_and_no_investigation():
 
 
 def test_vague_recent_mcp_args_are_bounded_but_explicit_ranges_are_not():
-    from agent.tool_guardrails import is_vague_recent_request
+    from agent.tool_guardrails import is_vague_recent_request, recent_request_provenance
 
     assert is_vague_recent_request("Untersuche ungewöhnliche Aktivität in letzter Zeit") is True
     assert is_vague_recent_request("Investigate recent activity from the last 48 hours") is False
+    explicit_count = recent_request_provenance("show the 50 most recent findings")
+    assert explicit_count.quantity_source == "user"
+    assert explicit_count.range_source == "model_or_default"
 
     c = ToolCallGuardrailController()
     c.set_vague_recent(True)

--- a/tests/run_agent/test_stream_stale_circuit_breaker.py
+++ b/tests/run_agent/test_stream_stale_circuit_breaker.py
@@ -81,7 +81,7 @@ class TestStreamStaleCircuitBreaker:
             fired.append(True)
             call._call_done.set()
 
-        monkeypatch.setattr(call, "_abort_for_final_synthesis_timeout", abort)
+        monkeypatch.setattr(call, "_abort_for_wait_deadline", lambda _reason: abort())
         call._monitor_loop()
         assert fired == [True]
 

--- a/tests/run_agent/test_stream_stale_circuit_breaker.py
+++ b/tests/run_agent/test_stream_stale_circuit_breaker.py
@@ -15,6 +15,7 @@ The harness mirrors tests/run_agent/test_28161_anthropic_stream_pool_cleanup.py.
 """
 
 import threading
+import time
 
 import httpx
 import pytest
@@ -61,6 +62,29 @@ def _good_stream_cm():
 
 
 class TestStreamStaleCircuitBreaker:
+    def test_forced_final_deadline_is_absolute_despite_live_chunks(self, monkeypatch):
+        """Reasoning chunks may refresh stale liveness, but not the final deadline."""
+        import agent.chat_completion_helpers as helpers
+
+        agent = _make_anthropic_agent(run_budget_seconds=5)
+        agent._run_budget_started_at = time.time()
+        agent._force_toolless_final = True
+        agent._final_synthesis_deadline = time.time() + 0.05
+        call = helpers._StreamingCall(agent, {}, None)
+        call._stream_stale_timeout = 60.0
+        call._call_done = threading.Event()
+        call._monitor_interrupted = {"yes": False}
+        call.worker = None
+        fired = []
+
+        def abort():
+            fired.append(True)
+            call._call_done.set()
+
+        monkeypatch.setattr(call, "_abort_for_final_synthesis_timeout", abort)
+        call._monitor_loop()
+        assert fired == [True]
+
     def test_interrupted_pre_response_wait_advances_streak(self, monkeypatch):
         """Qualified pre-response interrupts advance the breaker, while early
         and mid-stream user cancellations remain neutral."""
@@ -152,3 +176,35 @@ class TestStreamStaleCircuitBreaker:
 
         # At least one stale kill happened; the streak must have advanced.
         assert agent._consecutive_stale_streams >= 1
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_budgeted_stale_stream_is_terminal_without_internal_retry(self, monkeypatch):
+        """A bounded run spends one stale window, not retries times that window."""
+        from agent.run_budget import ProviderStaleTimeout
+
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.1")
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+        agent = _make_anthropic_agent(run_budget_seconds=5)
+        agent._run_budget_started_at = time.time()
+        unblock = threading.Event()
+
+        def _blocking_gen():
+            unblock.wait(timeout=2.0)
+            raise httpx.ConnectError("connection dropped after close()")
+            yield
+
+        def _stream_side_effect(*args, **kwargs):
+            cm = MagicMock()
+            stream = MagicMock()
+            stream.__iter__ = MagicMock(return_value=_blocking_gen())
+            cm.__enter__ = MagicMock(return_value=stream)
+            cm.__exit__ = MagicMock(return_value=False)
+            return cm
+
+        agent._anthropic_client.messages.stream.side_effect = _stream_side_effect
+        agent._abort_request_anthropic_client = lambda *a, **k: unblock.set()
+
+        with pytest.raises(ProviderStaleTimeout):
+            agent._interruptible_streaming_api_call({})
+
+        assert agent._anthropic_client.messages.stream.call_count == 1

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -94,6 +94,11 @@ def _hard_stop_config(**overrides) -> dict:
     return cfg
 
 
+def _direct_mcp_config() -> dict:
+    """Keep direct-call E2E cases independent of process-global registry size."""
+    return {"tools": {"tool_search": {"enabled": "off"}}}
+
+
 def test_gateway_platform_uses_hard_stop_default_without_cli_opt_in():
     agent = _make_agent("web_search", platform="telegram")
     args = {"query": "same"}
@@ -132,7 +137,7 @@ def test_mcp_reuse_contract_prevents_second_runtime_dispatch():
     assert agent._force_toolless_final is True
 
 
-def test_capability_only_policy_blocks_investigation_before_dispatch():
+def test_capability_only_policy_blocks_investigation_without_forcing_final():
     tool = "mcp_example__list_findings"
     agent = _make_agent(tool)
     agent._tool_guardrails.set_capability_only(True)
@@ -147,7 +152,57 @@ def test_capability_only_policy_blocks_investigation_before_dispatch():
 
     dispatch.assert_not_called()
     assert '"blockedByTurnPolicy": true' in messages[0]["content"]
-    assert agent._force_toolless_final is True
+    assert agent._force_toolless_final is False
+
+
+def test_capability_only_recovery_dispatches_read_then_uses_toolless_synthesis():
+    investigation = "mcp_example__list_findings"
+    capability = "mcp_example__get_capabilities"
+    guide = "mcp_example__get_agent_guide"
+    agent = _make_agent(
+        investigation, capability, guide, config=_direct_mcp_config(),
+    )
+    agent._disable_streaming = True
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(investigation, '{"count":10}', "c-denied")],
+        ),
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(capability, "{}", "c-capability")],
+        ),
+        _mock_response(content="Capability summary", finish_reason="stop"),
+    ]
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=_direct_mcp_config()),
+        patch("hermes_cli.config.load_config_readonly", return_value=_direct_mcp_config()),
+        patch(
+            "model_tools.get_tool_definitions",
+            return_value=_make_tool_defs(investigation, capability, guide),
+        ),
+        patch("model_tools.handle_function_call", return_value='{"available":true}') as dispatch,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(
+            "Explain the investigation capabilities without investigating findings."
+        )
+
+    assert dispatch.call_count == 1
+    assert dispatch.call_args.args[:2] == (capability, {})
+    request_tools = [
+        call.kwargs.get("tools", [])
+        for call in agent.client.chat.completions.create.call_args_list
+    ]
+    assert request_tools[0]
+    assert request_tools[1]  # restrict did not hide the still-authorized capability tools
+    assert request_tools[2] == []
+    assert result["final_response"] == "Capability summary"
 
 
 def test_capability_only_policy_allows_capability_read_then_forces_synthesis():
@@ -200,6 +255,83 @@ def test_vague_recent_bounds_are_applied_before_mcp_dispatch():
     assert sent["start"] == "2026-09-07T15:00:00Z"
     assert sent["end"] == "2026-09-08T15:00:00Z"
     assert json.loads(msg.tool_calls[0].function.arguments) == sent
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "show the 50 most recent findings",
+        "list the latest 50 findings",
+        "return 50 recent findings",
+    ],
+)
+def test_explicit_recent_quantity_survives_request_to_dispatch(request_text):
+    tool = "mcp_example__list_findings"
+    agent = _make_agent(tool, config=_direct_mcp_config())
+    agent._disable_streaming = True
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(tool, '{"count":50}', "c-explicit-count")],
+        ),
+        _mock_response(content="done", finish_reason="stop"),
+    ]
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=_direct_mcp_config()),
+        patch("hermes_cli.config.load_config_readonly", return_value=_direct_mcp_config()),
+        patch("model_tools.get_tool_definitions", return_value=_make_tool_defs(tool)),
+        patch("model_tools.handle_function_call", return_value='{"items":[]}') as dispatch,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(request_text, task_id="task-1")
+
+    assert dispatch.call_args.args[1]["count"] == 50
+    assert result["final_response"] == "done"
+
+
+@pytest.mark.parametrize(
+    ("request_text", "expected_start"),
+    [
+        ("show recent findings", "2026-09-07T15:00:00Z"),
+        ("show recent findings from the last 48 hours", "2026-09-06T15:00:00Z"),
+    ],
+)
+def test_recent_default_bounds_respect_explicit_range_provenance(request_text, expected_start):
+    tool = "mcp_example__list_findings"
+    agent = _make_agent(tool, config=_direct_mcp_config())
+    agent._disable_streaming = True
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(tool, json.dumps({
+                "count": 50,
+                "start": "2026-09-06T15:00:00Z",
+                "end": "2026-09-08T15:00:00Z",
+            }), "c-recent-provenance")],
+        ),
+        _mock_response(content="done", finish_reason="stop"),
+    ]
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=_direct_mcp_config()),
+        patch("hermes_cli.config.load_config_readonly", return_value=_direct_mcp_config()),
+        patch("model_tools.get_tool_definitions", return_value=_make_tool_defs(tool)),
+        patch("model_tools.handle_function_call", return_value='{"items":[]}') as dispatch,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        agent.run_conversation(request_text, task_id="task-1")
+
+    sent = dispatch.call_args.args[1]
+    assert sent["count"] == 10  # quantity remained model/default-derived
+    assert sent["start"] == expected_start
+    assert sent["end"] == "2026-09-08T15:00:00Z"
 
 
 @pytest.mark.parametrize("platform", ["desktop", "acp"])

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -105,6 +105,103 @@ def test_gateway_platform_uses_hard_stop_default_without_cli_opt_in():
     assert decision.code == "repeated_exact_failure_block"
 
 
+def test_mcp_reuse_contract_prevents_second_runtime_dispatch():
+    tool = "mcp_example__read_finding"
+    args = {"finding_id": "native-7"}
+    agent = _make_agent(tool)
+    agent._tool_guardrails.after_call(
+        tool,
+        args,
+        json.dumps({
+            "result": "grounded summary",
+            "structuredContent": {"reuseResult": True, "findingId": "native-7"},
+        }),
+        failed=False,
+    )
+    msg = SimpleNamespace(
+        content="",
+        tool_calls=[_mock_tool_call(tool, json.dumps(args), "c-reuse")],
+    )
+    messages = []
+
+    with patch("model_tools.handle_function_call") as dispatch:
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    dispatch.assert_not_called()
+    assert '"reused": true' in messages[0]["content"]
+    assert agent._force_toolless_final is True
+
+
+def test_capability_only_policy_blocks_investigation_before_dispatch():
+    tool = "mcp_example__list_findings"
+    agent = _make_agent(tool)
+    agent._tool_guardrails.set_capability_only(True)
+    msg = SimpleNamespace(
+        content="",
+        tool_calls=[_mock_tool_call(tool, '{"count": 10}', "c-cap-scope")],
+    )
+    messages = []
+
+    with patch("model_tools.handle_function_call") as dispatch:
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    dispatch.assert_not_called()
+    assert '"blockedByTurnPolicy": true' in messages[0]["content"]
+    assert agent._force_toolless_final is True
+
+
+def test_capability_only_policy_allows_capability_read_then_forces_synthesis():
+    tool = "mcp_example__get_capabilities"
+    agent = _make_agent(tool)
+    agent._tool_guardrails.set_capability_only(True)
+    msg = SimpleNamespace(
+        content="",
+        tool_calls=[_mock_tool_call(tool, "{}", "c-cap-read")],
+    )
+    messages = []
+
+    with patch("model_tools.handle_function_call", return_value='{"available": true}') as dispatch:
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    dispatch.assert_called_once()
+    assert agent._force_toolless_final is True
+
+
+def test_capability_only_policy_unwraps_tool_search_bridge_target():
+    from agent.tool_guardrails import ToolCallGuardrailController
+
+    controller = ToolCallGuardrailController()
+    controller.set_capability_only(True)
+    decision = controller.before_call(
+        "tool_call",
+        {"name": "mcp_example__investigate_finding", "arguments": {"finding_id": "native-1"}},
+    )
+    assert decision.action == "restrict"
+
+
+def test_vague_recent_bounds_are_applied_before_mcp_dispatch():
+    tool = "mcp_example__list_findings"
+    agent = _make_agent(tool)
+    agent._tool_guardrails.set_vague_recent(True)
+    msg = SimpleNamespace(
+        content="",
+        tool_calls=[_mock_tool_call(tool, json.dumps({
+            "count": 25,
+            "start": "2026-09-06T15:00:00Z",
+            "end": "2026-09-08T15:00:00Z",
+        }), "c-recent-bounds")],
+    )
+
+    with patch("model_tools.handle_function_call", return_value='{"items": []}') as dispatch:
+        agent._execute_tool_calls_sequential(msg, [], "task-1")
+
+    sent = dispatch.call_args.args[1]
+    assert sent["count"] == 10
+    assert sent["start"] == "2026-09-07T15:00:00Z"
+    assert sent["end"] == "2026-09-08T15:00:00Z"
+    assert json.loads(msg.tool_calls[0].function.arguments) == sent
+
+
 @pytest.mark.parametrize("platform", ["desktop", "acp"])
 def test_interactive_platforms_keep_warning_only_default(platform):
     agent = _make_agent("web_search", platform=platform)

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -234,6 +234,15 @@ class TestThresholdGate:
         cfg = ToolSearchConfig.from_raw({"enabled": "off"})
         assert not should_activate(cfg, deferrable_tokens=1_000_000, context_length=200_000)
 
+    def test_auto_keeps_small_catalog_eager_but_on_forces_bridge(self):
+        from tools.tool_search import ToolSearchConfig, should_activate
+
+        auto = ToolSearchConfig.from_raw({"enabled": "auto", "threshold_pct": 5})
+        assert not should_activate(auto, deferrable_tokens=9_000, context_length=200_000)
+        assert should_activate(auto, deferrable_tokens=11_000, context_length=200_000)
+        forced = ToolSearchConfig.from_raw({"enabled": "on", "threshold_pct": 5})
+        assert should_activate(forced, deferrable_tokens=1, context_length=200_000)
+
 
     def test_token_estimate_proportional_to_schema_size(self):
         from tools.tool_search import estimate_tokens_from_schemas
@@ -633,7 +642,7 @@ class TestCatalogListing:
             defs.append(_td(name, "Perform a deliberately verbose connected service action."))
 
         cfg = ToolSearchConfig.from_raw(None)
-        result = assemble_tool_defs(defs, context_length=1_000_000, config=cfg)
+        result = assemble_tool_defs(defs, context_length=200_000, config=cfg)
         search = next(
             td for td in result.tool_defs
             if td["function"]["name"] == "tool_search"

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -2,7 +2,8 @@
 event-triggered core tools are replaced in the model-visible array by three bridge tools —
 tool_search / tool_describe / tool_call. Invariants: core tools (``toolsets._HERMES_CORE_TOOLS``)
 and session-gated GUI toolsets never defer unless named in ``defer``; ANY deferrable tool
-activates the bridge (the listing scales with budget, not activation); the catalog is
+activates the bridge when their schemas exceed the configured context share (or when
+explicitly enabled); the catalog is
 stateless — rebuilt from the live tool-defs every assembly (a session-keyed one drifts and
 silently drops tools); bridge calls route through ``model_tools.handle_function_call``."""
 
@@ -30,9 +31,8 @@ _MAX_QUERIES_PER_CALL = _MAX_DESCRIBE_NAMES_PER_CALL = 10  # bound the work one 
 @dataclass(frozen=True)
 class ToolSearchConfig:
     """Resolved, validated tool-search configuration for a single assembly."""
-    enabled: str  # "auto" | "on" | "off" — "auto" is an alias of "on" today
-    # Listing budget as % of context; does NOT gate activation, only bounds how much
-    # the embedded manifest may consume before it degrades (full -> names -> bare).
+    enabled: str  # "auto" | "on" | "off"
+    # Auto-activation threshold and listing budget as % of context.
     threshold_pct: float  # 0..100
     search_default_limit: int
     max_search_limit: int
@@ -181,10 +181,15 @@ def estimate_tokens_from_schemas(tool_defs: Iterable[Dict[str, Any]]) -> int:
 
 def should_activate(config: ToolSearchConfig, deferrable_tokens: int,
                     context_length: Optional[int]) -> bool:
-    """``"off"`` never activates; ``"on"``/``"auto"`` activate whenever any deferrable tool
-    exists ("auto" is reserved for a future budget-gated mode — do not distinguish them
-    without that design). ``context_length`` is kept for caller compatibility."""
-    return config.enabled != "off" and deferrable_tokens > 0
+    """Resolve off/on directly; auto defers only when schemas exceed its context share."""
+    if config.enabled == "off" or deferrable_tokens <= 0:
+        return False
+    if config.enabled == "on":
+        return True
+    if not context_length or context_length <= 0:
+        return True  # unknown capacity: preserve the conservative bridge behavior
+    threshold = int(context_length * (config.threshold_pct / 100.0))
+    return deferrable_tokens > threshold
 
 
 def listing_token_budget(config: ToolSearchConfig, context_length: Optional[int]) -> int:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1161,7 +1161,9 @@ hermes chat --run-budget 850 -q "..."
 When a budget is set, two things happen:
 
 1. **Wrap-up notice at 80%.** When 80% of the budget has elapsed, Hermes injects a **one-time** notice (delivered cache-safely, appended to the newest tool result like `/steer` messages) telling the model to stop new discovery/verification work and produce the final deliverable from the state it already has. It fires at most once per run and mirrors the existing iteration-budget wrap-up mechanism — there are no repeated pressure warnings.
-2. **Deadline-scaled stale timeouts.** Implicit non-streaming stale timeouts (the 90s default and the reasoning-model floors, e.g. 600s for DeepSeek reasoning models) are capped at `max(60, remaining_budget × 0.5)` so a single silently-hung provider call can never consume the rest of the run. The cap only ever *tightens* the timeout — it never raises it — and an explicitly configured `stale_timeout_seconds` (provider/model config or `HERMES_API_CALL_STALE_TIMEOUT`) always wins untouched.
+2. **A real provider deadline.** Streaming and non-streaming provider waits are capped at the exact remaining wall-clock budget, so a single silently-hung request cannot outlive the run. An explicitly configured `stale_timeout_seconds` still wins over reasoning-model and large-context floors, but the absolute run deadline always wins over it. In a budgeted run, hitting the configured stale timeout is terminal for that turn instead of silently opening another identical internal stream retry.
+
+A finite iteration cap also reserves its final permitted model request for synthesis: Hermes sends that request without tools so a last-round tool result cannot consume the budget without giving the model a chance to answer.
 
 The budget is per `run_conversation` turn (it resets on each user message) and the feature is completely dormant when unset — no clock reads, no injection, no timeout changes.
 
@@ -1855,6 +1857,7 @@ The platform-aware default can be disabled for an unattended deployment, or hard
 tool_loop_guardrails:
   warnings_enabled: true       # inject warnings into tool results (default: true)
   hard_stop_enabled: false     # also BLOCK the call past the hard-stop threshold (default: false)
+  finalize_on_complete_composite: true  # tool-free answer after a complete MCP composite
   non_interactive_hard_stop_enabled: true  # default hard stops for gateway/cron
   warn_after:
     exact_failure: 2           # identical failing call repeated N times
@@ -1870,6 +1873,8 @@ tool_loop_guardrails:
 ```
 
 `hard_stop_enabled` explicitly enables hard stops on every platform. When it remains `false`, `non_interactive_hard_stop_enabled` still enables them for unattended gateway/cron-style platforms while preserving warning-only behavior for CLI, TUI, Desktop, ACP, subagents, and `api_server` runs (supervised task loops with a live parent or client). Set `non_interactive_hard_stop_enabled: false` to opt an unattended deployment out. See also [Docker / unattended deployments](docker.md).
+
+`finalize_on_complete_composite` normally moves directly to a tool-free synthesis turn when an MCP result declares itself assembled with no component follow-up needed. Set it to `false` for long multi-finding orchestrations that must continue to other independent findings or sources. The result's component-coverage and exact-reuse contracts remain active, so disabling the transition does not permit redundant component reads.
 
 Hard stops are designed to catch **replays** — the same call, unchanged, with nothing happening in between — not legitimate iteration:
 

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -10,8 +10,9 @@ session, their JSON schemas can consume a substantial fraction of the
 context window on every turn — even when only a few of them are relevant
 to what the user actually asked for.
 
-**Tool Search** is Hermes' opt-in progressive-disclosure layer for that
-problem. When activated, MCP and plugin tools are replaced in the
+**Tool Search** is Hermes' progressive-disclosure layer for that problem.
+In the default `auto` mode it activates only when eligible schemas exceed
+the configured share of the context window. When activated, MCP and plugin tools are replaced in the
 model-visible tools array by three bridge tools, and the model loads each
 specific tool's schema on demand.
 
@@ -72,13 +73,14 @@ see the underlying tool, not the bridge.
 
 ## When does it activate?
 
-Tool Search uses **tiered disclosure**: the presence of *any* deferrable
-(MCP/plugin) tool activates the bridge; what scales with catalog size is
-how much of the catalog stays visible, not whether schemas defer.
+Tool Search uses **tiered disclosure**. In `auto` mode, a deferrable
+(MCP/plugin) catalog stays eager while its schemas fit within
+`threshold_pct` of the active context; larger catalogs activate the bridge.
+Explicit `on` always activates when a deferrable tool exists.
 
 | Tier | Condition | What the model sees |
 | --- | --- | --- |
-| **0** | No MCP/plugin tools | Every tool eager, no bridge. Pass-through. |
+| **0** | No MCP/plugin tools, or schemas fit the `auto` threshold | Every tool eager, no bridge. Pass-through. |
 | **1** | Deferred catalog's listing fits the budget | Bridge + a skills-style manifest of every deferred tool (name + short description, degrading to names-only when over budget). Degradation is **per server**: when one oversized server (Cloudflare) is attached alongside small ones (Linear), the small servers keep their per-tool listings and only the oversized server collapses to a summary line. |
 | **2** | Per-tool listing exceeds the budget even names-only for every server (e.g. Cloudflare's flat API surface alone: ~3,300 tools whose names are ~32K tokens) | Bare bridge + a one-line-per-server summary (server name + tool count), so the model knows which domains are reachable; individual tools are discoverable only through `tool_search`. |
 
@@ -102,8 +104,8 @@ tools:
 
 | Key | Default | Meaning |
 | --- | --- | --- |
-| `enabled` | `auto` | `auto`/`on` activate whenever at least one deferrable tool exists; `off` disables entirely (everything stays eager). `auto` is currently an alias of `on` — it is reserved for a future mode that inlines schemas when they fit the context and defers only when they don't. Pin `on` or `off` if you want today's behavior guaranteed across upgrades. |
-| `threshold_pct` | `5` | Listing budget as a percentage of the active model's context length. Range 0–100. |
+| `enabled` | `auto` | `auto` keeps eligible schemas eager while they fit the threshold; `on` always activates when at least one deferrable tool exists; `off` disables the bridge entirely. |
+| `threshold_pct` | `5` | Auto-activation threshold and listing budget as a percentage of the active model's context length. Range 0–100. |
 | `search_default_limit` | `5` | Hits returned per query when the model calls `tool_search` without a `limit`. |
 | `max_search_limit` | `25` | Hard upper bound the model can request via `limit` (per query). Range 1–50. |
 | `listing` | `auto` | Embed a skills-style manifest of every deferred tool (name + first sentence of its description, ≤60 chars, grouped by MCP server) in the `tool_search` bridge description. `auto` includes it when it fits the budget (falling back to names-only, then to the tier-2 server summary); `on`/`off` force either way. |
@@ -140,8 +142,8 @@ round trip usually disappears — the model goes straight to
 `tool_describe`. Live benchmarking showed the listing mode matching
 eager loading's task success while costing less than the bare bridge.
 
-If you want the old always-eager behavior for a small toolset, set
-`enabled: off`.
+If you want always-eager behavior regardless of catalog size, set
+`enabled: off`; use `enabled: on` to force the bridge even for a small toolset.
 
 ## Trade-offs that don't go away
 


### PR DESCRIPTION
## Dependency

**Depends on #105116 for MCP `structuredContent` preservation.** This PR does not modify `tools/mcp_tool_handlers.py` or its renderer tests. #105116 remains the owner of MCP result rendering and breaker correctness; this PR owns generic agent, lifecycle, and tool-loop hardening. Direct changed-file overlap remains zero.

## Summary

- Based on current `upstream/main` (`b2aa855b626ff8688eb34b95c60ee8b6a4af3679`); current head is `f5b205659bd3a86e980b41837edb0a698aabf0a1`.
- Make `tool_search: auto` keep small MCP/plugin catalogs eager and defer only when schemas cross the configured context threshold.
- Enforce bounded streaming/non-streaming provider waits, total run budgets, and an absolute tool-free final-synthesis deadline.
- Add generic exact-result reuse and server-declared assembled-composite coverage without domain-specific risk scoring.
- Restrict explicit capability-only turns to capability/schema reads without making a denied investigation call terminal.
- Bound only model/default-derived recent MCP quantities and ranges; preserve explicit user quantities and time ranges.
- Reserve the final model round for synthesis and remove terminal/file/web guidance when those tools are unavailable.

## Review fixes

- `restrict` now blocks only the disallowed MCP call. `get_capabilities` and `get_agent_guide` remain available; a successful allowed capability read then enters tool-free synthesis.
- Recent-bound provenance is carried from request text as user-specified vs model/default-derived. Natural explicit counts such as `50 most recent`, `latest 50`, and `50 recent` are never clamped to 10; genuinely unqualified recent reads retain the 10/24h policy, and explicit ranges remain unchanged.
- Composite coverage stores normalized typed `(id_field, value)` identities, so `findingId="7"` cannot cover `device_id="7"`; ID-field aliases normalize consistently.
- `agent/run_budget.py` is now the bounded owner for run/final deadlines, provider wait capping, one-shot abort outcomes, typed timeout errors, and final-synthesis enter/reset state. Streaming and non-streaming drivers consume that lifecycle API and retain only transport-specific socket/thread cleanup.

## Validation

Standalone #105850 head:

- 547 tests passed across 20 relevant Agent, provider-wait, Tool Search, and tool-loop files.
- Ruff on every changed Python file: passed.
- Diff checks: passed.
- AMD64 Docker build plus production-image import/build-SHA smoke: passed.

Temporary `current main + #105116@621f7b21ff + #105850@f5b205659b` composition:

- 1,233 tests passed across 82 MCP/Agent/tool-loop files (710 + 523 isolated partitions).
- Includes all 62 `tests/tools/test_mcp*.py` files and the real in-memory MCP SDK acceptance path.
- Ruff and diff-check: passed.
- AMD64 Docker build plus combined renderer/lifecycle import smoke: passed.

Adjacent #94180 (`1f0d6adcc0`) composition:

- Clean merge, including the shared `model_tools.py`; its deny-all discovery rule composes with this PR's auto-defer behavior.
- 303 tests passed and 6 expected skips across explicit-empty/default policy, disabled toolsets, live-agent authority, GUI surfaces, registry behavior, and Tool Search auto/on/off. Registry-mutating groups were run in isolated pytest processes to avoid synthetic test-tool leakage.

## Hosted CI note

Exact-head runs `34259705149` (CI), `34259704275` (Docker), and `34259704373` (Nix) all ended `action_required` with zero jobs. This is a GitHub/maintainer approval startup blocker; this PR does not modify workflow files, and no code change was made to speculate around it.

No MCP server code, production deployment, credential, or production container was changed.