### PR TITLE
feat(api): allow clearing session model override

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -69,6 +69,7 @@ _STATIC_FEATURE_FLAGS = {
     "run_approval_response": True, "tool_progress_events": True, "approval_events": True,
     "session_resources": True, "model_options": True, "session_chat": True,
     "session_chat_streaming": True, "session_fork": True, "session_model_lock": True,
+    "session_model_clear": True,
     "admin_config_rw": False, "jobs_admin": False, "memory_write_api": False,
     "skills_api": True, "audio_api": False, "realtime_voice": False,
     "session_continuity_header": "X-Hermes-Session-Id",
@@ -3220,7 +3221,11 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
 
     @_require_auth
     async def _handle_session_model_lock(self, request: "web.Request") -> "web.Response":
-        """POST /api/sessions/{session_id}/model — backend-ack a Browser model lock."""
+        """POST /api/sessions/{session_id}/model — set or clear a session model lock.
+
+        A missing ``model`` remains invalid; JSON null explicitly clears the
+        session-scoped lock and returns to normal routing.
+        """
         session_id = request.match_info["session_id"]
         _, err = await self._get_existing_session_or_404(session_id)
         if err:
@@ -3228,6 +3233,23 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
+        if "model" not in body:
+            return _error_response(
+                "model is required; use null to clear the session model lock",
+                400, code="missing_model")
+        if body["model"] is None:
+            db = await self._ensure_session_db_async()
+            if db is None:
+                return self._session_db_unavailable()
+            await asyncio.to_thread(db.clear_session_model, session_id)
+            return web.json_response({
+                "object": "hermes.session.model_lock", "session_id": session_id,
+                "runtime": {"provider": "", "model": "", "route_source": "global",
+                             "requested": {"provider": "", "model": ""},
+                             "model_lock": "cleared"}})
+        if not isinstance(body["model"], str) or not body["model"].strip():
+            return _error_response(
+                "model must be a non-empty string or null", 400, code="invalid_model")
         runtime_request = self._session_runtime_request_from_body(body)
         runtime_request["require_model_lock"] = True
         lock_error = self._runtime_lock_error(runtime_request)

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -651,6 +651,25 @@ class SessionSessionsMixin:
             lambda merged: (model, merged, session_id),
         )
 
+    def clear_session_model(self, session_id: str) -> None:
+        """Clear the persisted session model and confirmed runtime lock atomically.
+
+        Only fields written by the session model-lock path are removed. Lineage
+        and unrelated model configuration survive, while the prompt snapshot is
+        invalidated so a rebuilt turn cannot retain stale model/provider text.
+        """
+        if not session_id:
+            return
+        self.flush_token_counts()
+        self._write_model_config_patch(
+            session_id, {key: None for key in (
+                "browser_model_lock", "model", "provider", "base_url", "api_mode",
+                "gateway_runtime", "route_source", "model_options",
+            )},
+            "UPDATE sessions SET model = NULL, model_config = ?, "
+            "system_prompt = NULL, system_prompt_hash = NULL WHERE id = ?",
+        )
+
     def _write_model_config_patch(
         self, session_id: str, patch: Dict[str, Any],
         sql: str = "UPDATE sessions SET model_config = ? WHERE id = ?",

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -66,6 +66,7 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["session_chat"] is True
     assert features["session_chat_streaming"] is True
     assert features["session_fork"] is True
+    assert features["session_model_clear"] is True
     assert features["run_steer"] is True
     assert features["admin_config_rw"] is False
     assert features["memory_write_api"] is False
@@ -461,6 +462,121 @@ async def test_session_chat_stream_treats_pre_existing_poisoned_row_as_no_model(
 
 def _register_session_model_route(app, adapter):
     app.router.add_post("/api/sessions/{session_id}/model", adapter._handle_session_model_lock)
+
+
+@pytest.mark.asyncio
+async def test_session_model_null_clear_is_scoped_and_invalidates_prompt_snapshot(adapter, session_db):
+    session_id = session_db.create_session(
+        "clear-model", "api_server", model="old/model",
+        model_config={
+            "browser_model_lock": {"provider": "old", "model": "old/model", "confirmed": True},
+            "provider": "old", "base_url": "https://old.example/v1",
+            "_branched_from": "parent", "unrelated": "keep",
+        },
+        system_prompt="Model: old/model\nProvider: old",
+    )
+    other_id = session_db.create_session("other-model", "api_server", model="keep/model")
+    app = _create_session_app(adapter)
+    _register_session_model_route(app, adapter)
+    async with TestClient(TestServer(app)) as cli:
+        missing = await cli.post(f"/api/sessions/{session_id}/model", json={})
+        assert missing.status == 400
+        assert (await missing.json())["error"]["code"] == "missing_model"
+        for value in ("", "  ", False, [], {}):
+            invalid = await cli.post(f"/api/sessions/{session_id}/model", json={"model": value})
+            assert invalid.status == 400
+            assert (await invalid.json())["error"]["code"] == "invalid_model"
+        cleared = await cli.post(f"/api/sessions/{session_id}/model", json={"model": None})
+        assert cleared.status == 200
+        assert (await cleared.json())["runtime"]["model_lock"] == "cleared"
+        # Idempotent clears are still successful and remain session-scoped.
+        assert (await cli.post(f"/api/sessions/{session_id}/model", json={"model": None})).status == 200
+
+    row = session_db.get_session(session_id)
+    assert row["model"] is None
+    assert row["system_prompt"] is None
+    assert row["system_prompt_hash"] is None
+    assert session_db.get_session(other_id)["model"] == "keep/model"
+    config = row["model_config"]
+    if isinstance(config, str):
+        import json
+        config = json.loads(config)
+    assert config == {"_branched_from": "parent", "unrelated": "keep"}
+
+
+@pytest.mark.asyncio
+async def test_session_model_clear_preserves_non_lock_config_and_history_after_reopen(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    sid = db.create_session(
+        "reopen-clear", "api_server", model="old/model",
+        model_config={"browser_model_lock": {"model": "old/model"}, "model_options": {"stale": True},
+                      "lineage": "parent", "unrelated": {"keep": True}},
+        system_prompt="stale model footer",
+    )
+    db.append_message(sid, "user", "history survives")
+    db.clear_session_model(sid)
+    assert db.get_messages_as_conversation(sid)[0]["content"] == "history survives"
+    db.close()
+    reopened = SessionDB(tmp_path / "state.db")
+    try:
+        row = reopened.get_session(sid)
+        assert row["model"] is None
+        config = row["model_config"]
+        if isinstance(config, str):
+            import json
+            config = json.loads(config)
+        assert config == {"lineage": "parent", "unrelated": {"keep": True}}
+    finally:
+        reopened.close()
+
+
+@pytest.mark.asyncio
+async def test_session_model_clear_routes_global_then_allows_new_lock(adapter, session_db, monkeypatch):
+    """The real lock/chat handlers must stop reusing A after clear, then accept Y."""
+    _patch_api_server_runtime(monkeypatch)
+    session_id = session_db.create_session("route-clear-chat", "api_server")
+    calls = []
+
+    async def fake_run(**kwargs):
+        calls.append(kwargs)
+        return {"final_response": "ok", "session_id": session_id}, {"total_tokens": 1}
+
+    app = _create_session_app(adapter)
+    _register_session_model_route(app, adapter)
+    with patch.object(adapter, "_resolve_route", return_value=None), patch.object(
+        adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            pinned_a = await cli.post(f"/api/sessions/{session_id}/model", json={
+                "provider": "nous", "model": "A", "require_model_lock": True})
+            assert pinned_a.status == 200, await pinned_a.text()
+            first = await cli.post(f"/api/sessions/{session_id}/chat", json={"message": "first"})
+            assert first.status == 200, await first.text()
+
+            cleared = await cli.post(f"/api/sessions/{session_id}/model", json={"model": None})
+            assert cleared.status == 200
+            after_clear = await cli.get(f"/api/sessions/{session_id}")
+            assert after_clear.status == 200
+            assert (await after_clear.json())["session"]["model"] is None
+            second = await cli.post(f"/api/sessions/{session_id}/chat", json={"message": "second"})
+            assert second.status == 200, await second.text()
+
+            pinned_y = await cli.post(f"/api/sessions/{session_id}/model", json={
+                "provider": "nous", "model": "Y", "require_model_lock": True})
+            assert pinned_y.status == 200, await pinned_y.text()
+            third = await cli.post(f"/api/sessions/{session_id}/chat", json={"message": "third"})
+            assert third.status == 200, await third.text()
+
+    assert calls[0]["confirmed_runtime_lock"] is True
+    assert calls[0]["route_source"] == "session_model_lock"
+    assert calls[0]["route"] == {"provider": "nous", "model": "A"}
+    assert calls[1]["confirmed_runtime_lock"] is False
+    assert calls[1]["route_source"] == "global"
+    assert calls[1]["session_model"] is None
+    assert calls[1]["route"] is None
+    assert calls[2]["confirmed_runtime_lock"] is True
+    assert calls[2]["route_source"] == "session_model_lock"
+    assert calls[2]["route"] == {"provider": "nous", "model": "Y"}
+    assert session_db.get_session(session_id)["model"] == "Y"
 
 
 def _patch_api_server_runtime(monkeypatch):

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -553,6 +553,7 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
 | `POST` | `/api/sessions/{id}/chat` | Run one synchronous agent turn |
 | `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |
+| `POST` | `/api/sessions/{id}/model` | Set a session model lock, or clear it with `{"model": null}` |
 
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
 


### PR DESCRIPTION
## What does this PR do?

Adds a session-scoped API operation to clear a persisted model override and return subsequent routing to the global/default model. Scope: only the session model-lock/override API, its persistence cleanup, regression tests, and endpoint documentation.

## Related Issue

Related to #102658.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`: advertise `session_model_clear` and accept `{"model": null}` to clear the session override.
- `hermes_state_sessions.py`: atomically clear persisted lock fields and invalidate the stale prompt snapshot while preserving unrelated configuration and lineage.
- `tests/gateway/test_session_api.py`: cover missing/invalid input, scoped and idempotent clearing, persistence, history, and global routing after clear.
- `website/docs/user-guide/features/api-server.md`: document the clear form of the model endpoint.

Behavior receipts:

- Baseline null-clear attempt: **RED**, HTTP `400`, error code `missing_model`.
- Candidate null-clear attempt: **GREEN**, HTTP `200`, runtime `model_lock: "cleared"`, with subsequent routing reported as `route_source: "global"`.

## How to Test

1. `/opt/hermes/deploy-validation/venv/bin/pytest -q tests/gateway/test_session_api.py` → **23 passed**.
2. `/opt/hermes/deploy-validation/venv/bin/pytest -q tests/gateway/test_session_api.py tests/test_hermes_state.py tests/gateway/test_multiplex_api_server_routing.py` → **286 passed, 2 failed**. The two failures are pre-existing state/FTS failures.
3. Frozen-base comparison using the same selected command → **283 passed, 2 failed**, with the same two failure nodes:
   - `tests/test_hermes_state.py::TestConnectionLifecycle::test_failed_read_only_open_does_not_leak_tracked_connection`
   - `tests/test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries`
4. `/opt/hermes/deploy-validation/venv/bin/pytest -q` → **14 collection errors**. The frozen base produced the same 14 error nodes, so the full-suite collection result is base-equivalent.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the full suite has 14 collection errors, all reproduced on the frozen base
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux — Python 3.11.16; focused regression coverage also passed on Python 3.12.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `website/docs/user-guide/features/api-server.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — platform-independent HTTP/SQLite session-state logic; Windows footgun check passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Static receipt: `git diff --check upstream/main...HEAD` passed with no output.

No production or fork-only code changes are included.