### PR TITLE
feat(hosted-rooms): designated-owner routing as the no-match responder fallback

### DIFF
--- a/gateway/hosted_room_discussion.py
+++ b/gateway/hosted_room_discussion.py
@@ -521,13 +521,17 @@ def _build_prompt(
         "- Never reveal content from private conversations. Your reply is published verbatim."]
     fixed_bytes = len("\n".join([*opening, *rules]).encode("utf-8"))
     available = max(0, driver.MAX_PROMPT_BYTES - fixed_bytes - 1)
+    marker = "  [Earlier content omitted to fit this turn.]"
+    marker_bytes = len(marker.encode("utf-8")) + 1
     selected: list[str] = []
-    for event in reversed(delta):
+    for index, event in enumerate(reversed(delta)):
+        # Newest first; while older lines remain unplaced, keep room for the omission marker.
         line = f"  {_format_message(event, room)}"
-        if (line_bytes := len(line.encode("utf-8")) + 1) > available:
-            if not selected and available > 32:
-                selected.append(_truncate_utf8_text(line, max_bytes=available))
-            selected.append("  [Earlier content omitted to fit this turn.]")
+        reserve = marker_bytes if index < len(delta) - 1 else 0
+        if (line_bytes := len(line.encode("utf-8")) + 1) > available - reserve:
+            if not selected and available - marker_bytes > 32:
+                selected.append(_truncate_utf8_text(line, max_bytes=available - marker_bytes))
+            selected.append(marker)
             break
         selected.append(line)
         available -= line_bytes

--- a/gateway/hosted_room_discussion.py
+++ b/gateway/hosted_room_discussion.py
@@ -559,7 +559,10 @@ def _build_prompt(
     marker_bytes = len(marker.encode("utf-8")) + 1
     selected: list[str] = []
     for index, event in enumerate(reversed(delta)):
-        # Newest first; while older lines remain unplaced, keep room for the omission marker.
+        # Newest first. Every line but the oldest is placed only if the omission marker still fits after it,
+        # so whenever a later line is dropped the marker has its bytes. The oldest line may take the full
+        # remainder: nothing older can be omitted after it, and if it is the one dropped it is still earlier
+        # than everything shown, so the marker text stays accurate.
         line = f"  {_format_message(event, room)}"
         reserve = marker_bytes if index < len(delta) - 1 else 0
         if (line_bytes := len(line.encode("utf-8")) + 1) > available - reserve:
@@ -655,7 +658,10 @@ def plan_next_task(
     thread_messages, discussion_messages, member_messages = _thread_messages(validated, discussion)
     if len(member_messages) >= MAX_DISCUSSION_MESSAGES:
         return decide("bounded", "max_messages")
-    terminals = {  # (round, member) -> latest terminal kind for this Discussion
+    # (round, member) -> latest terminal kind for this Discussion. ``validated`` is in strict ``seq`` order
+    # (_validate_event rejects anything else), so the last write per key is the highest-seq terminal, not
+    # whichever the caller happened to list last.
+    terminals = {
         (int(event.payload["round_index"]), str(event.payload["member_id"])): event.kind for event in validated
         if event.kind in _TERMINAL_EVENT_KINDS and event.payload.get("discussion_event_id") == discussion.event_id}
     watermarks = _effective_watermarks(validated, initial_watermarks)

--- a/gateway/hosted_room_discussion.py
+++ b/gateway/hosted_room_discussion.py
@@ -56,6 +56,8 @@ _TERMINAL_FIELDS = {  # kind -> exact payload fields (coordinates + seen_through
         ("turn.cancelled", ("reason",)), ("turn.deferred", ("execution_generation", "reason")))}
 _TERMINAL_OPTIONAL_FIELDS = {"turn.failed": frozenset({"reason_code"})}
 _TERMINAL_EVENT_KINDS = frozenset(_TERMINAL_FIELDS)
+_OWNER_FALLBACK_TERMINALS = frozenset({"turn.deferred", "turn.failed"})
+_OWNER_UNAVAILABLE_NOTICE = "[Owner @{handle} was unavailable for this message; it is routed to you.]"
 # Gateway-authored control events: kind -> (exact payload fields, identifier fields).
 _GATEWAY_EVENT_FIELDS = {
     "room.activity": (
@@ -82,6 +84,7 @@ class DiscussionMember:
     handle: str
     display_name: str = ""
     target: Mapping[str, Any] | None = None
+    owner: bool = False
 
 
 @dataclass(frozen=True)
@@ -92,6 +95,11 @@ class DiscussionRoom:
     members: tuple[DiscussionMember, ...]
     gateway_id: str
     authority_epoch: int
+
+    @property
+    def owner(self) -> DiscussionMember | None:
+        """The room-configured default responder for an unmentioned user message, if any."""
+        return next((member for member in self.members if member.owner), None)
 
 
 @dataclass(frozen=True)
@@ -227,7 +235,7 @@ def _validate_member(raw: Any, index: int, known_profiles: set[str]) -> Discussi
             f"member {index} contains cross-gateway fields: {', '.join(sorted(remote_fields))}")
     member = _exact_fields(
         raw, label=f"member {index}", required=frozenset({"member_id", "profile", "handle"}),
-        optional=frozenset({"display_name", "target"}))
+        optional=frozenset({"display_name", "owner", "target"}))
     member_id, profile, handle = (
         _identifier(member[field], label=f"member {index} {label}")
         for field, label in (("member_id", "id"), ("profile", "profile"), ("handle", "handle")))
@@ -236,7 +244,9 @@ def _validate_member(raw: Any, index: int, known_profiles: set[str]) -> Discussi
         raise DiscussionValidationError(f"member {index} display_name must be a string")
     if len(display_name := display_name.strip()) > hosted_rooms.MAX_ACTOR_LABEL_CHARS:
         raise DiscussionValidationError(f"member {index} display_name is too long")
-    return DiscussionMember(member_id, profile, handle, display_name, target)
+    if not isinstance(owner := member.get("owner", False), bool):
+        raise DiscussionValidationError(f"member {index} owner must be a boolean")
+    return DiscussionMember(member_id, profile, handle, display_name, target, owner)
 
 
 def validate_roster(value: Any, *, local_profiles: Iterable[str]) -> tuple[DiscussionMember, ...]:
@@ -262,6 +272,8 @@ def validate_roster(value: Any, *, local_profiles: Iterable[str]) -> tuple[Discu
                 raise DiscussionValidationError(message)
             seen.add(key)
         members.append(member)
+    if sum(member.owner for member in members) > 1:
+        raise DiscussionValidationError("at most one member can be the room owner")
     return tuple(members)
 
 
@@ -305,6 +317,25 @@ def resolve_mentions(
     if everyone or (default_all and not mentioned):
         return tuple(members)
     return tuple(member for member in members if member.handle.casefold() in mentioned)
+
+
+def _round_zero_responders(
+    text: str, room: DiscussionRoom, terminals: Mapping[tuple[int, str], str]
+) -> tuple[tuple[DiscussionMember, ...], DiscussionMember | None]:
+    """Responders to the user's message, and the owner they stand in for when routing fell back.
+
+    Precedence: mentions or @everyone, else the configured owner, else everyone. An owner whose round-0 turn
+    ended deferred or failed keeps the leading slot (already terminal, so it is skipped) and the rest of the
+    roster follows in order, so an unmentioned human message never goes unanswered because its default
+    responder was unavailable. A pass is an answer and triggers no fallback; a mentioned owner is never one.
+    """
+    if mentioned := resolve_mentions((text,), room.members, default_all=False):
+        return mentioned, None
+    if (owner := room.owner) is None:
+        return tuple(room.members), None
+    if terminals.get((0, owner.member_id)) in _OWNER_FALLBACK_TERMINALS:
+        return (owner, *(member for member in room.members if member.member_id != owner.member_id)), owner
+    return (owner,), None
 
 
 def _unaddressed_member_mentions(
@@ -480,6 +511,9 @@ def _derive_member_watermarks(events: Sequence[_ValidatedEvent]) -> dict[tuple[s
 
 
 def _member_digest(member: DiscussionMember) -> str:
+    # Ownership is frozen with the roster at creation, so it stays out of the digest: it selects who speaks,
+    # not who the member is. Any future roster mutation must preserve or version the routing configuration
+    # used by admitted tasks; hashing one member's own flag would not cover another member's changed routing.
     target = compact_json(member.target or {"kind": "local", "profile": member.profile}, ensure_ascii=False)
     return hashlib.sha256(f"{member.member_id}\0{member.profile}\0{member.handle}\0{target}".encode()).hexdigest()[:24]
 
@@ -506,12 +540,12 @@ def _truncate_utf8_text(value: Any, *, max_bytes: int, suffix: str = "") -> str:
 
 def _build_prompt(
     *, room: DiscussionRoom, member: DiscussionMember, messages: Sequence[_ValidatedEvent], watermark: int,
-    seen_through_seq: int) -> str:
+    seen_through_seq: int, notice: str | None = None) -> str:
     delta = [event for event in messages if watermark < event.seq <= seen_through_seq][- MAX_DISCUSSION_DELTA_LINES:]
     peers = ", ".join(f"@{candidate.handle}" for candidate in room.members if candidate.member_id != member.member_id)
     opening = [
         f'[Discussion: "{room.name}"] You are @{member.handle}, one participant '
-        f"with {peers or 'no other members'} and the user.", "",
+        f"with {peers or 'no other members'} and the user.", *([notice] if notice else []), "",
         "New messages in this thread since your last turn (oldest first):"]
     rules = [
         "", "Rules for this Discussion:",
@@ -621,20 +655,21 @@ def plan_next_task(
     thread_messages, discussion_messages, member_messages = _thread_messages(validated, discussion)
     if len(member_messages) >= MAX_DISCUSSION_MESSAGES:
         return decide("bounded", "max_messages")
-    terminals = {
-        (int(event.payload["round_index"]), str(event.payload["member_id"])) for event in validated
+    terminals = {  # (round, member) -> latest terminal kind for this Discussion
+        (int(event.payload["round_index"]), str(event.payload["member_id"])): event.kind for event in validated
         if event.kind in _TERMINAL_EVENT_KINDS and event.payload.get("discussion_event_id") == discussion.event_id}
     watermarks = _effective_watermarks(validated, initial_watermarks)
     seen_through_seq = max(event.seq for event in thread_messages)
     for round_index in range(MAX_DISCUSSION_ROUNDS):
-        # The user's message selects the first round, with no mention meaning
-        # everyone. Later rounds are opt-in: only a peer explicitly cited by a
-        # Bot and not heard from afterward gets another turn. Every member's
-        # watermark remains intact, so a peer cited later still receives the
-        # complete bounded transcript delta without consuming turns meanwhile.
-        responders = (
-            resolve_mentions((str(discussion.payload["text"]),), room.members) if round_index == 0
-            else _unaddressed_member_mentions(discussion_messages, room))
+        # The user's message selects the first round: mentions or @everyone,
+        # else the room's configured owner, else everyone. Later rounds are
+        # opt-in: only a peer explicitly cited by a Bot and not heard from
+        # afterward gets another turn. Every member's watermark remains intact,
+        # so a peer cited later still receives the complete bounded transcript
+        # delta without consuming turns meanwhile.
+        responders, unavailable_owner = (
+            _round_zero_responders(str(discussion.payload["text"]), room, terminals) if round_index == 0
+            else (_unaddressed_member_mentions(discussion_messages, room), None))
         for member_index, member in enumerate(_rotate(responders, round_index)):
             if (round_index, member.member_id) in terminals:
                 continue
@@ -643,7 +678,8 @@ def plan_next_task(
                 continue
             prompt = _build_prompt(
                 room=room, member=member, messages=thread_messages, watermark=watermark,
-                seen_through_seq=seen_through_seq)
+                seen_through_seq=seen_through_seq, notice=_OWNER_UNAVAILABLE_NOTICE.format(
+                    handle=unavailable_owner.handle) if unavailable_owner else None)
             return decide("task", "member_turn", task=_make_task_plan(
                 room=room, discussion_event=discussion, member=member, member_index=member_index,
                 round_index=round_index, seen_through_seq=seen_through_seq, prompt=prompt))

--- a/tests/gateway/hosted_room_responder_precedence.json
+++ b/tests/gateway/hosted_room_responder_precedence.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Language-neutral responder-precedence contract for group rooms: explicit mentions and @everyone win, then the configured owner when nothing matches, then the whole room for rooms without an owner. Roster order is research, build, review; `owner` names the handle flagged on the roster or null. `expected` is the ordered round-0 responder list when every member passes. The hosted planner (gateway/hosted_room_discussion.py) is the reference implementation; the Desktop client's group-rounds.ts may adopt these cases once its relevance tier lands.",
+  "cases": [
+    {"name": "explicit_mention_beats_owner", "text": "@research inspect this", "owner": "build", "expected": ["research"]},
+    {"name": "explicit_mention_of_owner", "text": "@build inspect this", "owner": "build", "expected": ["build"]},
+    {"name": "two_mentions_keep_roster_order", "text": "@review then @research", "owner": "build", "expected": ["research", "review"]},
+    {"name": "everyone_beats_owner", "text": "@everyone inspect this", "owner": "build", "expected": ["research", "build", "review"]},
+    {"name": "all_beats_owner", "text": "@all inspect this", "owner": "build", "expected": ["research", "build", "review"]},
+    {"name": "broadcast_mixed_with_direct_mention_is_everyone", "text": "@research @ALL inspect this", "owner": "build", "expected": ["research", "build", "review"]},
+    {"name": "mentions_are_case_insensitive", "text": "@REVIEW inspect this", "owner": "build", "expected": ["review"]},
+    {"name": "no_match_with_owner", "text": "inspect this", "owner": "build", "expected": ["build"]},
+    {"name": "unknown_handle_is_no_match_with_owner", "text": "@unknown inspect this", "owner": "build", "expected": ["build"]},
+    {"name": "no_match_without_owner_is_whole_room", "text": "inspect this", "owner": null, "expected": ["research", "build", "review"]},
+    {"name": "unknown_handle_without_owner_is_whole_room", "text": "@unknown inspect this", "owner": null, "expected": ["research", "build", "review"]}
+  ]
+}

--- a/tests/gateway/test_hosted_room_discussion.py
+++ b/tests/gateway/test_hosted_room_discussion.py
@@ -588,6 +588,23 @@ def test_oversized_member_reply_is_truncated_and_next_turn_stays_serviceable(
     assert "Earlier content omitted" in followup.payload["prompt"]
 
 
+def test_omission_marker_stands_in_for_a_dropped_oldest_line(room_db: tuple[Path, dict]):
+    """Two maximal user messages: the newest is placed with the marker's bytes reserved, so when the oldest
+    cannot take the remainder the marker leads the delta, the newest survives whole, and the prompt fits."""
+    db, room = room_db
+    _append_user(db, event_id="user-old", text="o" * discussion.MAX_USER_TEXT_BYTES)
+    _append_user(db, event_id="user-new", text="n" * discussion.MAX_USER_TEXT_BYTES)
+
+    prompt = _next_task(room, db).payload["prompt"]
+    lines = prompt.split("\n")
+
+    assert len(prompt.encode("utf-8")) <= driver.MAX_PROMPT_BYTES
+    assert "oooo" not in prompt
+    marker_at = lines.index("  [Earlier content omitted to fit this turn.]")
+    assert lines[marker_at + 1] == f"  User (user): {'n' * discussion.MAX_USER_TEXT_BYTES}"
+    assert lines[marker_at + 2] == ""  # nothing else in the delta; the rules follow
+
+
 def test_three_round_bound(room_db: tuple[Path, dict]):
     db, room = room_db
     room["members"] = MEMBERS[:2]

--- a/tests/gateway/test_hosted_room_discussion.py
+++ b/tests/gateway/test_hosted_room_discussion.py
@@ -747,3 +747,15 @@ def test_malformed_log_and_task_reconstruction_fail_closed(
             malformed,
             local_profiles=LOCAL_PROFILES,
         )
+
+
+def test_prompt_stays_serviceable_at_every_delta_boundary(tmp_path: Path):
+    """Any valid transcript yields a prompt within the driver limit, omission marker included."""
+    for index, middle in enumerate(range(64_900, 64_980, 2)):
+        db = tmp_path / f"state-{index}.db"
+        room = hosted_rooms.create_room(
+            db, room_id=ROOM_ID, name="Release", members=MEMBERS, authority_gateway_id=GATEWAY_ID, now=1)
+        for seq, size in enumerate((1_000, middle, discussion.MAX_USER_TEXT_BYTES)):
+            _append_user(db, event_id=f"user-{seq}", text="x" * size)
+        prompt = _next_task(room, db).payload["prompt"]
+        assert len(prompt.encode("utf-8")) <= driver.MAX_PROMPT_BYTES, middle

--- a/tests/gateway/test_hosted_room_discussion.py
+++ b/tests/gateway/test_hosted_room_discussion.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 
@@ -749,13 +750,238 @@ def test_malformed_log_and_task_reconstruction_fail_closed(
         )
 
 
-def test_prompt_stays_serviceable_at_every_delta_boundary(tmp_path: Path):
-    """Any valid transcript yields a prompt within the driver limit, omission marker included."""
-    for index, middle in enumerate(range(64_900, 64_980, 2)):
+# -- designated-owner routing: the no-match fallback tier ---------------------
+OWNER_PROFILE = "build"
+OWNED_MEMBERS = [{**member, "owner": True} if member["profile"] == OWNER_PROFILE else member for member in MEMBERS]
+PRECEDENCE_CASES = json.loads(
+    (Path(__file__).with_name("hosted_room_responder_precedence.json")).read_text("utf-8"))["cases"]
+
+
+def _create_room(db: Path, members: list[dict]) -> dict:
+    return hosted_rooms.create_room(
+        db,
+        room_id=ROOM_ID,
+        name="Release",
+        members=members,
+        authority_gateway_id=GATEWAY_ID,
+        now=1,
+    )
+
+
+def _owned_members(owner: str | None) -> list[dict]:
+    return [{**member, "owner": True} if member["profile"] == owner else member for member in MEMBERS]
+
+
+def _round_zero_profiles(room: dict, db: Path) -> list[str]:
+    """Drain one Discussion with every member passing; return the responders in turn order."""
+    profiles: list[str] = []
+    while True:
+        decision = discussion.plan_next_task(room, _events(db), local_profiles=LOCAL_PROFILES)
+        if decision.status != "task":
+            assert decision.status == "settled", decision
+            return profiles
+        assert decision.task is not None
+        assert decision.task.round_index == 0
+        profiles.append(decision.task.member.profile)
+        _settle_next(room, db, text="(pass)")
+
+
+def _fail_or_defer(room: dict, db: Path, task: discussion.DiscussionTaskPlan, status: str) -> None:
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status=status,
+        result={"reason": "member_unavailable"} if status == "deferred" else {"error": "owner crashed"},
+        execution_generation=1 if status == "deferred" else None,
+        local_profiles=LOCAL_PROFILES,
+    )
+    _append_publication(db, publication)
+
+
+@pytest.mark.parametrize("case", PRECEDENCE_CASES, ids=[case["name"] for case in PRECEDENCE_CASES])
+def test_responder_precedence_matches_the_shared_contract(tmp_path: Path, case: dict):
+    db = tmp_path / "state.db"
+    room = _create_room(db, _owned_members(case["owner"]))
+    _append_user(db, event_id="user-1", text=case["text"])
+
+    assert _round_zero_profiles(room, db) == case["expected"]
+
+
+def test_owner_flag_is_validated_onto_the_roster():
+    members = discussion.validate_roster(OWNED_MEMBERS, local_profiles=LOCAL_PROFILES)
+    assert [member.owner for member in members] == [False, True, False]
+    room = discussion.validate_room(
+        {"room_id": ROOM_ID, "name": "Release", "members": OWNED_MEMBERS,
+         "authority_gateway_id": GATEWAY_ID, "authority_epoch": 1},
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert room.owner is not None and room.owner.profile == OWNER_PROFILE
+    assert discussion.validate_room(
+        {"room_id": ROOM_ID, "name": "Release", "members": MEMBERS,
+         "authority_gateway_id": GATEWAY_ID, "authority_epoch": 1},
+        local_profiles=LOCAL_PROFILES,
+    ).owner is None
+
+
+@pytest.mark.parametrize(
+    ("members", "match"),
+    [
+        ([{**MEMBERS[0], "owner": True}, {**MEMBERS[1], "owner": True}], "at most one"),
+        ([{**MEMBERS[0], "owner": "yes"}, MEMBERS[1]], "owner must be a boolean"),
+    ],
+)
+def test_owner_flag_is_exclusive_and_boolean(members: list[dict], match: str):
+    with pytest.raises(discussion.DiscussionValidationError, match=match):
+        discussion.validate_roster(members, local_profiles=LOCAL_PROFILES)
+
+
+@pytest.mark.parametrize("owner", [OWNER_PROFILE, None])
+@pytest.mark.parametrize("text", ["hello", "@ everyone hi"])
+def test_unmentioned_human_message_never_has_zero_responders(tmp_path: Path, owner: str | None, text: str):
+    db = tmp_path / "state.db"
+    room = _create_room(db, _owned_members(owner))
+    _append_user(db, event_id="user-1", text=text)
+
+    decision = discussion.plan_next_task(room, _events(db), local_profiles=LOCAL_PROFILES)
+    assert decision.status == "task", decision
+
+
+@pytest.mark.parametrize("status", ["deferred", "failed"])
+def test_unavailable_owner_falls_back_to_the_rest_of_the_room_visibly(tmp_path: Path, status: str):
+    db = tmp_path / "state.db"
+    room = _create_room(db, OWNED_MEMBERS)
+    _append_user(db, event_id="user-1", text="Ship it?")
+
+    owner_task = _next_task(room, db)
+    assert owner_task.member.profile == OWNER_PROFILE
+    assert owner_task.member_index == 0
+    assert "unavailable" not in owner_task.payload["prompt"]
+    _fail_or_defer(room, db, owner_task, status)
+
+    fallback: list[discussion.DiscussionTaskPlan] = []
+    for expected_profile, expected_index in (("research", 1), ("review", 2)):
+        task = _next_task(room, db)
+        assert (task.member.profile, task.round_index, task.member_index) == (expected_profile, 0, expected_index)
+        assert f"[Owner @{OWNER_PROFILE} was unavailable for this message; it is routed to you.]" in task.payload["prompt"]
+        fallback.append(_settle_next(room, db, text="(pass)"))
+
+    decision = discussion.plan_next_task(room, _events(db), local_profiles=LOCAL_PROFILES)
+    assert (decision.status, decision.reason) == ("settled", "silent_round")
+    kinds = [event["kind"] for event in _events(db)]
+    assert kinds.count(f"turn.{status}") == 1  # the owner's fallback trigger stays visible in the log
+    assert [event["payload"]["member_id"] for event in _events(db) if event["kind"] == "turn.settled"] == [
+        "member-research", "member-review"]
+
+
+def test_owner_pass_settles_the_round_as_silence(tmp_path: Path):
+    db = tmp_path / "state.db"
+    room = _create_room(db, OWNED_MEMBERS)
+    _append_user(db, event_id="user-1", text="Anything to add?")
+
+    owner_task = _settle_next(room, db, text="(pass)")
+    assert owner_task.member.profile == OWNER_PROFILE
+
+    decision = discussion.plan_next_task(room, _events(db), local_profiles=LOCAL_PROFILES)
+    assert (decision.status, decision.reason) == ("settled", "silent_round")
+
+
+def test_owner_reply_hands_off_to_cited_peers_as_before(tmp_path: Path):
+    db = tmp_path / "state.db"
+    room = _create_room(db, OWNED_MEMBERS)
+    _append_user(db, event_id="user-1", text="Ship it?")
+
+    owner_task = _settle_next(room, db, text="@review please sign off.")
+    assert owner_task.member.profile == OWNER_PROFILE
+
+    second = _next_task(room, db)
+    assert (second.member.profile, second.round_index) == ("review", 1)
+
+
+def test_owner_fallback_task_is_deterministic_and_reconstructs_after_restart(tmp_path: Path):
+    db = tmp_path / "state.db"
+    room = _create_room(db, OWNED_MEMBERS)
+    _append_user(db, event_id="user-1", text="Ship it?")
+    _fail_or_defer(room, db, _next_task(room, db), "deferred")
+
+    first = _next_task(room, db)
+    assert (first.member.profile, first.member_index) == ("research", 1)
+    assert first == _next_task(room, db)
+    assert set(first.payload) == {"target_member_id", "target_profile", "prompt", "source_event_seq"}
+
+    driver.admit_task(db, first.identity, payload=first.payload, clock=time.time)
+    reconstructed = discussion.reconstruct_task_plan(
+        room, _events(db), driver.get_task(db, first.identity), local_profiles=LOCAL_PROFILES)
+    assert reconstructed == first
+    # A restart re-plans from the same durable log and must land on the same task.
+    assert discussion.plan_next_task(room, _events(db), local_profiles=LOCAL_PROFILES).task == first
+
+
+@pytest.mark.parametrize("text", [f"@{OWNER_PROFILE} and @review, thoughts?", "@everyone thoughts?"])
+def test_explicitly_mentioned_owner_going_offline_triggers_no_owner_fallback(tmp_path: Path, text: str):
+    """Mentions win outright: a mentioned owner that defers is silence, not a routing fallback."""
+    db = tmp_path / "state.db"
+    room = _create_room(db, OWNED_MEMBERS)
+    _append_user(db, event_id="user-1", text=text)
+
+    tasks: list[discussion.DiscussionTaskPlan] = []
+    while (decision := discussion.plan_next_task(room, _events(db), local_profiles=LOCAL_PROFILES)).status == "task":
+        assert decision.task is not None
+        tasks.append(decision.task)
+        if decision.task.member.profile == OWNER_PROFILE:
+            _fail_or_defer(room, db, decision.task, "deferred")
+        else:
+            _settle_next(room, db, text="(pass)")
+
+    assert [task.member.profile for task in tasks] == (
+        [OWNER_PROFILE, "review"] if text.startswith(f"@{OWNER_PROFILE}") else ["research", OWNER_PROFILE, "review"])
+    assert not any("unavailable" in task.payload["prompt"] for task in tasks)
+
+
+@pytest.mark.parametrize("owner", [OWNER_PROFILE, None])
+def test_prompt_stays_serviceable_at_every_delta_boundary(tmp_path: Path, owner: str | None):
+    """Any valid transcript yields a prompt within the driver limit, with or without the owner notice."""
+    for index, middle in enumerate(range(64_860, 64_980, 2)):
         db = tmp_path / f"state-{index}.db"
-        room = hosted_rooms.create_room(
-            db, room_id=ROOM_ID, name="Release", members=MEMBERS, authority_gateway_id=GATEWAY_ID, now=1)
+        room = _create_room(db, _owned_members(owner))
         for seq, size in enumerate((1_000, middle, discussion.MAX_USER_TEXT_BYTES)):
             _append_user(db, event_id=f"user-{seq}", text="x" * size)
+        if owner:
+            _fail_or_defer(room, db, _next_task(room, db), "deferred")
         prompt = _next_task(room, db).payload["prompt"]
         assert len(prompt.encode("utf-8")) <= driver.MAX_PROMPT_BYTES, middle
+
+
+def test_owner_retry_that_defers_again_keeps_the_fallback_going(tmp_path: Path):
+    db = tmp_path / "state.db"
+    room = _create_room(db, OWNED_MEMBERS)
+    _append_user(db, event_id="user-1", text="Ship it?")
+    owner_task = _next_task(room, db)
+    _fail_or_defer(room, db, owner_task, "deferred")
+    assert _settle_next(room, db, text="(pass)").member.profile == "research"
+
+    retried = discussion.plan_publication(
+        room, _events(db), owner_task, status="deferred", result={"reason": "member_unavailable"},
+        execution_generation=2, local_profiles=LOCAL_PROFILES)
+    _append_publication(db, retried)
+
+    task = _next_task(room, db)
+    assert (task.member.profile, task.round_index, task.member_index) == ("review", 0, 2)
+
+
+def test_owner_retry_that_answers_ends_the_fallback_without_a_second_owner_turn(tmp_path: Path):
+    db = tmp_path / "state.db"
+    room = _create_room(db, OWNED_MEMBERS)
+    _append_user(db, event_id="user-1", text="Ship it?")
+    owner_task = _next_task(room, db)
+    _fail_or_defer(room, db, owner_task, "deferred")
+    assert _settle_next(room, db, text="(pass)").member.profile == "research"
+
+    recovered = discussion.plan_publication(
+        room, _events(db), owner_task, status="settled", result={"text": "(pass)"}, local_profiles=LOCAL_PROFILES)
+    _append_publication(db, recovered)
+
+    decision = discussion.plan_next_task(room, _events(db), local_profiles=LOCAL_PROFILES)
+    assert (decision.status, decision.reason) == ("settled", "silent_round")
+    owner_turns = [e for e in _events(db) if e["kind"].startswith("turn.") and e["payload"]["member_id"] == "member-build"]
+    assert [e["kind"] for e in owner_turns] == ["turn.deferred", "turn.settled"]

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -2089,3 +2089,23 @@ def test_local_profiles_skips_delete_tombstones_and_dot_dirs(tmp_path: Path):
     service = HostedRoomService(_server(), db_path=tmp_path / "shared-state.db")
 
     assert service.local_profiles() == ("default", "ops")
+
+
+def test_create_room_persists_the_designated_owner_flag(tmp_path: Path):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.local_profiles = lambda: ("default", "ops")
+    room = service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops", "owner": True},
+        ],
+    )
+
+    assert [member.get("owner") for member in room["members"]] == [None, True]
+    stored = hosted_rooms.list_rooms(db)[0]
+    assert [member.get("owner") for member in stored["members"]] == [None, True]
+    validated = discussion.validate_room(stored, local_profiles=service.local_profiles())
+    assert validated.owner is not None and validated.owner.member_id == "ops"

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -443,7 +443,8 @@ class HostedRoomService:
                 {
                     "member_id": member.member_id, "profile": member.profile,
                     "handle": member.handle, "target": dict(member.target or {}),
-                    **({"display_name": member.display_name} if member.display_name else {})}
+                    **({"display_name": member.display_name} if member.display_name else {}),
+                    **({"owner": True} if member.owner else {})}
                 for member in normalized],
             authority_gateway_id=hosted_rooms.local_authority_gateway_id())
         self.runtime.wakeup()


### PR DESCRIPTION
Implements the no-match fallback tier of group-room responder selection, as agreed with
@andredezzy on #98610 (that PR owns the client-side relevance filter; this one takes the
fallback and stays out of `group-rounds.ts`), under the five-point contract accepted on #95163.

## What changes

Round 0 of a hosted-room Discussion (`plan_next_task` in `gateway/hosted_room_discussion.py`)
now resolves responders in three tiers:

1. Explicit `@handle` mentions, or `@everyone` / `@all`. Always wins.
2. Otherwise the room's configured owner, alone.
3. Otherwise (no owner configured) the whole roster. Byte-for-byte today's behavior.

The owner is an optional boolean `owner` field on exactly one roster member, set through
`groups.create`. It is room configuration, not a registry of room names, and carries no
deployment-specific defaults. Validation: must be a boolean, at most one per roster.
`HostedRoomService.create_room` persists the flag.

**Unavailable owner.** If the owner's round-0 turn ended `turn.deferred` or `turn.failed`, the
responder list becomes owner first (already terminal, so skipped) followed by the rest of the
roster in order. Each fallback member's prompt carries one line:
`[Owner @<handle> was unavailable for this message; it is routed to you.]`
The fallback is derived purely from the durable log: no connectivity probing, no retry loop,
bounded by the existing 3-round / 10-message caps. A pass by the owner is an answer and settles
the round as silence, as any full-pass round does today. A mentioned owner never triggers the
fallback (tier 1 wins outright). A second deferral keeps the fallback going; a later owner
answer ends it without a second owner turn. Rounds 1 and 2 (bot-citation driven) are unchanged.

## Contract check

| Point | Where |
|---|---|
| 1. Mentions and `@everyone` always win | `_round_zero_responders`, tier 1; fixture cases incl. `@research @ALL` |
| 2. Unmentioned human message never gets zero responders | tiers 2 and 3 plus the fallback list; `test_unmentioned_human_message_never_has_zero_responders` |
| 3. Default responder is generic/configured | `owner` flag on the roster row; no names or profiles in code |
| 4. Offline/deferred owner falls back visibly, no loops | typed terminal events trigger it; notice line; existing caps; retry-transition tests |
| 5. Every `groups.*` client sees the same decision | selection is server-side only; Desktop is untouched |

## Determinism and the member digest

`plan_next_task` stays pure. `reconstruct_task_plan` is unchanged: it rebuilds a task from its
turn-id coordinates and compares, which is independent of why a member was selected, and a
fallback task at `member_index >= 1` round-trips through admit, restart, and reconstruction
(`test_owner_fallback_task_is_deterministic_and_reconstructs_after_restart`).

Ownership is frozen with the roster at creation, so `_member_digest` deliberately remains
unchanged. Future roster mutation must preserve or version the routing configuration used by
admitted tasks; hashing a member's own flag would not cover another member's changed routing.
No `room.members_changed` emitter exists today, so an owner change is a new room.

## Shared contract for the client

`tests/gateway/hosted_room_responder_precedence.json` is a language-neutral table of
precedence cases driving one parametrized test here. It is the hand-off for `group-rounds.ts`:
once #98610's relevance tier lands and the client has a real "no match" state, it can adopt the
same cases without this PR touching that file. That is what makes "one policy, both clients"
credible without a turf conflict.

## Prerequisite commit

The first commit fixes a pre-existing budget bug in `_build_prompt`: transcript lines were
admitted up to the full remaining budget and the `[Earlier content omitted ...]` marker was then
appended unaccounted, so a valid transcript within ~46 bytes of the driver limit raised instead
of planning the turn. Reproducible on `main` with no owner involved; the fallback notice moves
the boundary onto previously serviceable inputs, so routing must not land without it. Happy to
split it into its own PR if preferred; merge order is fix first either way.

## Out of scope

- `apps/desktop/src/plugins/hermes-bots/group-rounds.ts` and the relevance filter (#98610).
- Desktop wiring of the hosted `groups.*` API (#97846, @dokterdok) and host-offline recovery
  (#97681). This PR changes only server-side selection; Desktop reaches it once #97846 merges.
- `gateway/hosted_room_execution_policy.py` is a capability contract, not the selection seam.
- Roster mutation / `room.members_changed`.

## Tests

Red-first for every tier and contract point, in the existing `test_hosted_room_discussion.py`
idiom, plus `test_create_room_persists_the_designated_owner_flag` in the service suite.

```
scripts/run_tests.sh tests/tui_gateway/ tests/gateway/test_hosted_room_discussion.py \
  tests/gateway/test_hosted_room_execution_policy.py tests/gateway/test_hosted_room_gateway_lifecycle.py \
  tests/hermes_cli/test_web_server_boot_handshake.py
=== Summary: 126 files, 1171 tests passed, 0 failed, 8 skipped ===   (rebased on c8aa5608c2)
ruff check .  -> All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
