### PR TITLE
fix(kanban): enforce host-cycle CPU admission limits

### DIFF
--- a/gateway/cpu_status.py
+++ b/gateway/cpu_status.py
@@ -1,0 +1,159 @@
+"""Host CPU pressure classification for the kanban dispatch admission guard.
+
+Mirrors :mod:`gateway.memory_status`'s ``classify_pressure`` pattern (t_4008d306
+/ Astra 2026-09-08 control-plane review P0): the dispatcher's memory guard
+already stops new worker spawns under critical *memory* pressure, but nothing
+equivalent existed for CPU. A saturated host (load average >> core count, or
+Linux PSI ``some`` CPU stall high) starves every board's workers the same way
+OOM does, so the same "critical -> spawn nothing, elevated -> at most one,
+unknown -> no restriction" contract applies here.
+
+Two independent signals are read, worst-of wins:
+
+- ``os.getloadavg()[0]`` (1-minute load) normalized by CPU count. Available on
+  every POSIX host, but blind to *why* the CPU is busy (a single pinned core
+  vs genuine host-wide contention) and smooths over short spikes.
+- Linux PSI ``/proc/pressure/cpu`` ``some avg60`` — the percentage of the last
+  60s some task was stalled waiting for CPU. This is the signal the 2026-09-08
+  probe used (avg300=76.64) and directly captures contention from cron jobs,
+  CI runs and local inference processes that never touch the kanban DB and so
+  are invisible to the dispatcher's own ``count_running_tasks*`` bookkeeping.
+  Unavailable in containers/non-Linux/cgroup v1-without-PSI hosts.
+
+Neither signal is authoritative alone: PSI is more precise but not always
+present; load average is universal but coarser. Reading both and taking the
+worse classification means a host with PSI available gets the sharper signal,
+and one without it still gets a coverage-limited but real admission decision
+rather than "unknown" whenever a single core is transiently pinned.
+
+Known coverage gap (honestly stated, not silently assumed complete): this
+module only classifies pressure *already on the host* — it does not itself
+enumerate or attribute load to cron, CI or inference processes. It cannot
+distinguish "the host is busy with legitimate reserved-capacity work" from
+"the host is busy with runaway dispatcher fan-out"; it only says "busy", which
+is exactly the level the memory guard operates at too.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+# Thresholds on normalized load (load1 / cpu_count). A value of 1.0 means
+# "as many runnable processes as cores" — the classic saturation line.
+_CRITICAL_NORMALIZED_LOAD = 2.0
+_ELEVATED_NORMALIZED_LOAD = 1.0
+
+# Thresholds on Linux PSI "some avg60" (percent of the last 60s with at least
+# one runnable task stalled on CPU). 300s-window figures from a point-in-time
+# probe (e.g. avg300=76.64) are worse-is-later signals of sustained pressure;
+# avg60 is used here for a tighter dispatch-tick reaction time.
+_CRITICAL_PSI_SOME_AVG60 = 60.0
+_ELEVATED_PSI_SOME_AVG60 = 20.0
+
+_PROC_PRESSURE_CPU_PATH = "/proc/pressure/cpu"
+
+_LEVEL_RANK = {"unknown": -1, "ok": 0, "elevated": 1, "critical": 2}
+
+
+def _nonneg_number(value: Any) -> Optional[float]:
+    """Return *value* as a float if it is a non-negative, non-bool number."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and value >= 0:
+        return float(value)
+    return None
+
+
+def _worse(a: str, b: str) -> str:
+    """The more severe of two pressure levels; ``unknown`` loses to any known level."""
+    ra, rb = _LEVEL_RANK.get(a, -1), _LEVEL_RANK.get(b, -1)
+    if ra < 0:
+        return b
+    if rb < 0:
+        return a
+    return a if ra >= rb else b
+
+
+def classify_load_pressure(load1: Any, cpu_count: Any) -> str:
+    """``ok``/``elevated``/``critical`` from 1-minute load average normalized
+    by CPU count; ``unknown`` when either input is missing/malformed."""
+    load = _nonneg_number(load1)
+    cores = _nonneg_number(cpu_count)
+    if load is None or cores is None or cores <= 0:
+        return "unknown"
+    normalized = load / cores
+    if normalized >= _CRITICAL_NORMALIZED_LOAD:
+        return "critical"
+    if normalized >= _ELEVATED_NORMALIZED_LOAD:
+        return "elevated"
+    return "ok"
+
+
+def classify_psi_pressure(psi_some_avg60: Any) -> str:
+    """``ok``/``elevated``/``critical`` from Linux PSI CPU ``some avg60``
+    (percent); ``unknown`` when the sample is missing/malformed."""
+    psi = _nonneg_number(psi_some_avg60)
+    if psi is None:
+        return "unknown"
+    if psi >= _CRITICAL_PSI_SOME_AVG60:
+        return "critical"
+    if psi >= _ELEVATED_PSI_SOME_AVG60:
+        return "elevated"
+    return "ok"
+
+
+def classify_cpu_pressure(
+    load1: Any = None,
+    cpu_count: Any = None,
+    psi_some_avg60: Any = None,
+) -> str:
+    """Worst-of load-average and PSI classification; ``unknown`` only when
+    BOTH signals are unavailable — "could not read either" must never read as
+    "fine", matching :func:`gateway.memory_status.classify_pressure`."""
+    return _worse(
+        classify_load_pressure(load1, cpu_count),
+        classify_psi_pressure(psi_some_avg60),
+    )
+
+
+def _read_psi_some_avg60(path: str = _PROC_PRESSURE_CPU_PATH) -> Optional[float]:
+    """Parse ``some avg60=<value>`` from ``/proc/pressure/cpu``; ``None`` when
+    the file is absent (non-Linux, containers without PSI, cgroup v1)."""
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                if not line.startswith("some "):
+                    continue
+                for field in line.split():
+                    if field.startswith("avg60="):
+                        return float(field.split("=", 1)[1])
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def sample_cpu() -> Dict[str, Any]:
+    """Best-effort host CPU snapshot: ``{}`` when nothing could be read.
+
+    Never raises — a missing ``/proc/pressure/cpu`` (non-Linux, containers) or
+    a ``getloadavg`` failure degrades to partial or empty results, letting
+    :func:`classify_cpu_pressure` fall back to ``unknown``/worse-of rather
+    than the caller crashing.
+    """
+    sample: Dict[str, Any] = {}
+    try:
+        load1, _load5, _load15 = os.getloadavg()
+        sample["load1"] = load1
+    except (OSError, AttributeError):
+        pass
+    try:
+        cpu_count = os.cpu_count()
+        if cpu_count:
+            sample["cpu_count"] = cpu_count
+    except Exception:
+        pass
+    psi = _read_psi_some_avg60()
+    if psi is not None:
+        sample["psi_some_avg60"] = psi
+    return sample

--- a/gateway/kanban_watchers_dispatcher.py
+++ b/gateway/kanban_watchers_dispatcher.py
@@ -170,11 +170,16 @@ class _KanbanDispatcher:
         self.disabled_corrupt_boards.pop(slug, None)
         return True
 
-    def tick_once_for_board(self, slug: str) -> Optional[object]:
+    def tick_once_for_board(self, slug: str, host_cycle: Optional[Any] = None) -> Optional[object]:
         """Run one dispatch_once for a specific board.
 
         The per-board DB is opened explicitly so boards never share a
-        connection or claim across each other.
+        connection or claim across each other. ``host_cycle`` (a
+        :class:`hermes_cli.kanban_db_dispatch.HostCyclePressure`), when
+        supplied, is the CPU-pressure decision + shared elevated-admission
+        budget for the WHOLE host cycle (see :meth:`tick_once`) — passed
+        straight through to ``dispatch_once`` so this board neither resamples
+        CPU nor gets its own independent elevated-spawn slot.
         """
         conn = None
         fingerprint = self.board_db_fingerprint(slug)
@@ -185,7 +190,7 @@ class _KanbanDispatcher:
             # No explicit init_db(): connect() runs the migration once per
             # process (see the matching note in the notifier collector).
             conn = _kbc().connect(board=slug)
-            return _kbd().dispatch_once(conn, board=slug, **kwargs)
+            return _kbd().dispatch_once(conn, board=slug, host_cycle=host_cycle, **kwargs)
         except Exception as exc:
             if self.is_corrupt_board_db_error(exc):
                 self.disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
@@ -206,8 +211,29 @@ class _KanbanDispatcher:
                     conn.close()
 
     def tick_once(self) -> list[tuple[str, Optional[object]]]:
-        """Run one dispatch_once per board. Returns (slug, result) pairs."""
-        return [(slug, self.tick_once_for_board(slug)) for slug in self._board_slugs()]
+        """Run one dispatch_once per board. Returns (slug, result) pairs.
+
+        Host CPU pressure is sampled and classified ONCE here, for the whole
+        host cycle, and handed to every board via a shared
+        ``HostCyclePressure`` (t_4008d306 rework): the prior per-board
+        sampling let each board see its own "elevated" reading and admit its
+        own new worker, so N boards could spawn N workers in one cycle
+        instead of the intended host-wide cap of 1. One sample + one shared
+        remaining-slot counter, mutated in place as boards dispatch
+        sequentially below, keeps the SUM of new spawns across all boards in
+        this cycle at <= 1 under elevated pressure (0 under critical — every
+        board still returns ``may_spawn=False`` on its own critical reading).
+        Every board still runs its own reclaim/promotion bookkeeping
+        regardless of the shared budget.
+        """
+        kbd = _kbd()
+        sample = kbd._system_cpu_sample()
+        cpu_pressure = kbd._cpu_pressure_level(sample)
+        host_cycle = kbd.HostCyclePressure(cpu_pressure=cpu_pressure)
+        return [
+            (slug, self.tick_once_for_board(slug, host_cycle=host_cycle))
+            for slug in self._board_slugs()
+        ]
 
     def ready_nonempty(self) -> bool:
         """Is there a ready+assigned+unclaimed task on ANY board the dispatcher would spawn for?

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1555,15 +1555,22 @@ def dispatch_once(
 
 def _call_spawn_fn(spawn_fn, task: Task, workspace: str, board: Optional[str]) -> Optional[int]:
     """Back-compat: older spawn_fn signatures (and test stubs) accept only
-    ``(task, workspace)``; pass ``board`` only when the callable supports it."""
+    ``(task, workspace)``; pass ``board`` only when the callable supports it.
+
+    Signature inspection is the only thing guarded by the ``except`` below --
+    ``spawn_fn`` itself is invoked exactly once, outside the handler, so a
+    ``TypeError``/``ValueError`` raised by the callback's own body propagates
+    once instead of being mistaken for a signature-inspection failure and
+    retried without ``board``.
+    """
     import inspect
     try:
-        sig = inspect.signature(spawn_fn)
-        if "board" in sig.parameters:
-            return spawn_fn(task, workspace, board=board)
-        return spawn_fn(task, workspace)
+        passes_board = "board" in inspect.signature(spawn_fn).parameters
     except (TypeError, ValueError):
-        return spawn_fn(task, workspace)
+        passes_board = False
+    if passes_board:
+        return spawn_fn(task, workspace, board=board)
+    return spawn_fn(task, workspace)
 
 
 def _dispatch_lane_task(
@@ -1749,8 +1756,9 @@ def _tick_spawn_budget(
     max_in_progress: Optional[int],
     board: Optional[str],
     host_cycle: Optional[HostCyclePressure] = None,
-) -> tuple[bool, Optional[int]]:
-    """``(may_spawn, spawn_budget)`` for this tick; ``budget None`` = uncapped.
+) -> tuple[bool, Optional[int], Optional[HostCyclePressure]]:
+    """``(may_spawn, spawn_budget, effective_host_cycle)``; ``budget None`` =
+    uncapped.
 
     ``max_spawn`` is a live per-board concurrency cap (running + this tick's
     spawns), not a per-tick budget — a per-tick reading would grow concurrency
@@ -1763,6 +1771,13 @@ def _tick_spawn_budget(
     cycle plus the cycle's shared remaining elevated-admission slots — this call
     must not resample CPU itself (that would double-sample and let each board
     see a different reading) and must not widen the shared budget back to 1.
+
+    ``effective_host_cycle`` is ``host_cycle`` unchanged when the caller supplied
+    one. When the caller omitted it (direct/manual call) and this tick classifies
+    as elevated, a fresh single-call :class:`HostCyclePressure` is created here so
+    the caller's ready and review loops share one mutable elevated-admission
+    reservation for this call, exactly like the gateway's cross-board one --
+    otherwise ``None`` (no elevated reservation needed this tick).
     """
     # Count already-running tasks so max_spawn enforces concurrency, not a
     # per-tick budget: "running" tasks stay running until the worker calls
@@ -1775,13 +1790,13 @@ def _tick_spawn_budget(
     # Both ready and review loops consume from the same budget.
     if max_spawn is not None:
         if running_count >= max_spawn:
-            return False, None
+            return False, None, host_cycle
         spawn_budget = max_spawn - running_count
 
     if max_in_progress is not None:
         total_running = running_count + count_running_tasks_other_boards(board)
         if total_running >= max_in_progress:
-            return False, None
+            return False, None, host_cycle
         remaining = max_in_progress - total_running
         if spawn_budget is None or spawn_budget > remaining:
             spawn_budget = remaining
@@ -1797,7 +1812,7 @@ def _tick_spawn_budget(
             "kanban dispatch: system memory pressure is critical; "
             "spawning no new workers this tick (deferred, not dropped)"
         )
-        return False, None
+        return False, None, host_cycle
 
     # Host-wide CPU-pressure guard (t_4008d306): same defer-not-drop contract as
     # the memory guard above, applied to load average / PSI instead of
@@ -1813,8 +1828,9 @@ def _tick_spawn_budget(
             "kanban dispatch: host CPU pressure is critical; "
             "spawning no new workers this tick (deferred, not dropped)"
         )
-        return False, None
+        return False, None, host_cycle
 
+    effective_host_cycle = host_cycle
     if mem_pressure == "elevated":
         result.memory_pressure = mem_pressure
     if cpu_pressure == "elevated":
@@ -1826,6 +1842,13 @@ def _tick_spawn_budget(
             # cycle's slot already spent (an earlier board in this same cycle
             # consumed it) gets 0, never a fresh 1.
             elevated_cap = max(host_cycle.remaining_elevated_spawns, 0)
+        elif cpu_pressure == "elevated":
+            # Direct/manual call (no shared host_cycle): create this call's own
+            # single-use elevated reservation so the ready and review loops
+            # below share and permanently deplete the same slot, instead of
+            # each independently counting successful spawns only.
+            effective_host_cycle = HostCyclePressure(cpu_pressure="elevated")
+            elevated_cap = effective_host_cycle.remaining_elevated_spawns
         else:
             elevated_cap = 1
         if spawn_budget is None or spawn_budget > elevated_cap:
@@ -1834,7 +1857,7 @@ def _tick_spawn_budget(
                 "limiting to at most %d new worker(s) this tick", mem_pressure, cpu_pressure, elevated_cap,
             )
             spawn_budget = elevated_cap
-    return True, spawn_budget
+    return True, spawn_budget, effective_host_cycle
 
 
 def _lane_rows(conn: sqlite3.Connection, status: str) -> list[sqlite3.Row]:
@@ -1908,7 +1931,7 @@ def _dispatch_once_locked(
         conn, result, stale_timeout_seconds=stale_timeout_seconds,
         failure_limit=failure_limit, reconcile_orphans=reconcile_orphans,
     )
-    may_spawn, spawn_budget = _tick_spawn_budget(
+    may_spawn, spawn_budget, host_cycle = _tick_spawn_budget(
         conn, result, max_spawn=max_spawn, max_in_progress=max_in_progress, board=board,
         host_cycle=host_cycle,
     )

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -133,6 +133,12 @@ class DispatchResult:
     """Memory pressure that restricted this tick: ``"critical"`` (no new
     workers), ``"elevated"`` (at most one), ``None`` (no restriction).
     Reclaim/promotion bookkeeping still ran; deferred tasks stay queued."""
+    cpu_pressure: Optional[str] = None
+    """Host CPU pressure (load-average / PSI, see :mod:`gateway.cpu_status`)
+    that restricted this tick: ``"critical"`` (no new workers), ``"elevated"``
+    (at most one), ``None`` (no restriction). Same host-global, defer-not-drop
+    contract as ``memory_pressure`` — a single reading of the whole machine,
+    not a per-board budget, so cron/CI/local-inference load registers too."""
 
 
 # Bounded registry of recently-reaped worker exits, filled by the reap loop in
@@ -1415,6 +1421,43 @@ def _memory_pressure_level(sample: Optional[Mapping[str, Any]] = None) -> str:
         return "unknown"
 
 
+def _system_cpu_sample() -> dict:
+    """Best-effort host CPU snapshot (load average + PSI), ``{}`` when unknown.
+
+    Local import + module-level indirection mirrors :func:`_system_memory_sample`:
+    keeps this module importable without ``gateway`` and gives tests a seam
+    (monkeypatch ``kbd._system_cpu_sample``) so results don't depend on the CI
+    runner's live load average.
+    """
+    try:
+        from gateway.cpu_status import sample_cpu
+        return sample_cpu() or {}
+    except Exception:
+        return {}
+
+
+def _cpu_pressure_level(sample: Optional[Mapping[str, Any]] = None) -> str:
+    """Classify host CPU pressure: ok/elevated/critical/unknown.
+
+    Reuses :func:`gateway.cpu_status.classify_cpu_pressure` (worst-of
+    normalized load average and Linux PSI ``some avg60``). ``unknown`` (non-
+    Linux, read failure, containers without PSI) imposes no restriction —
+    same fail-open-on-unreadable convention as :func:`_memory_pressure_level`,
+    never brick dispatch where neither signal is available.
+    """
+    if sample is None:
+        sample = _system_cpu_sample()
+    if not sample:
+        return "unknown"
+    try:
+        from gateway.cpu_status import classify_cpu_pressure
+        return classify_cpu_pressure(
+            sample.get("load1"), sample.get("cpu_count"), sample.get("psi_some_avg60"),
+        )
+    except Exception:
+        return "unknown"
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -1689,20 +1732,39 @@ def _tick_spawn_budget(
     # critical -> spawn nothing this tick; elevated -> at most one new worker.
     # Reclaim/promotion already ran, so bookkeeping stays live; deferred tasks
     # wait for a later tick. "unknown" imposes no restriction.
-    pressure = _memory_pressure_level()
-    if pressure == "critical":
-        result.memory_pressure = pressure
+    mem_pressure = _memory_pressure_level()
+    if mem_pressure == "critical":
+        result.memory_pressure = mem_pressure
         _kb._log.warning(
             "kanban dispatch: system memory pressure is critical; "
             "spawning no new workers this tick (deferred, not dropped)"
         )
         return False, None
-    if pressure == "elevated":
-        result.memory_pressure = pressure
+
+    # Host-wide CPU-pressure guard (t_4008d306): same host-global, defer-not-drop
+    # contract as the memory guard above, applied to load average / PSI instead
+    # of MemAvailable. This reads the WHOLE host's CPU state — same signal for
+    # every board's tick — so it is one host-global admission decision, not a
+    # per-board budget; cron/CI/local-inference load registers here even though
+    # those processes are invisible to ``count_running_tasks*``.
+    cpu_pressure = _cpu_pressure_level()
+    if cpu_pressure == "critical":
+        result.cpu_pressure = cpu_pressure
+        _kb._log.warning(
+            "kanban dispatch: host CPU pressure is critical; "
+            "spawning no new workers this tick (deferred, not dropped)"
+        )
+        return False, None
+
+    if mem_pressure == "elevated":
+        result.memory_pressure = mem_pressure
+    if cpu_pressure == "elevated":
+        result.cpu_pressure = cpu_pressure
+    if mem_pressure == "elevated" or cpu_pressure == "elevated":
         if spawn_budget is None or spawn_budget > 1:
             _kb._log.warning(
-                "kanban dispatch: system memory pressure is elevated; "
-                "limiting to at most 1 new worker this tick"
+                "kanban dispatch: system pressure is elevated (memory=%s, cpu=%s); "
+                "limiting to at most 1 new worker this tick", mem_pressure, cpu_pressure,
             )
             spawn_budget = 1
     return True, spawn_budget

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1580,10 +1580,20 @@ def _dispatch_lane_task(
     spawn_fn,
     per_profile_cap: Optional[int],
     per_profile_running: dict[str, int],
+    host_cycle: Optional["HostCyclePressure"] = None,
 ) -> bool:
     """Guard, claim, resolve the workspace and spawn one ready/review row.
     Returns True when a spawn slot was consumed (real or ``dry_run``); every
     skip is recorded on ``result``.
+
+    ``host_cycle``, when supplied and currently reading ``"elevated"``, has its
+    shared ``remaining_elevated_spawns`` slot reserved (decremented) immediately
+    before ``spawn_fn`` is invoked below -- the point the spawn attempt is
+    authorized, before any post-launch operation (PID persistence, the spawned
+    hook) can fail. The reservation is never refunded on an exception from
+    ``spawn_fn``/PID persistence, because a child process may already exist by
+    then; a task that never reaches this point (guard-blocked, claim lost,
+    workspace resolution failed) never touches the shared slot.
     """
     task_id = row["id"]
     # Non-profile assignees (control-plane lanes that pull via ``claim_task``)
@@ -1652,6 +1662,11 @@ def _dispatch_lane_task(
         # worker's system prompt via KANBAN_GUIDANCE.
         claimed.skills = list(dict.fromkeys([*(claimed.skills or []), "sdlc-review"]))
     try:
+        if host_cycle is not None and host_cycle.cpu_pressure == "elevated":
+            # Reserve now, before the spawn attempt: a child may already exist
+            # even if spawn_fn raises or the PID fails to persist below, so once
+            # reserved this slot is never refunded on those paths.
+            host_cycle.remaining_elevated_spawns = max(host_cycle.remaining_elevated_spawns - 1, 0)
         pid = _call_spawn_fn(spawn_fn if spawn_fn is not None else _default_spawn, claimed, str(workspace), board)
         if pid:
             _set_worker_pid(conn, claimed.id, int(pid))
@@ -1883,9 +1898,11 @@ def _dispatch_once_locked(
     the PID so later ticks catch crashes before the TTL. Cap semantics:
     :func:`_tick_spawn_budget`. ``host_cycle`` carries the shared host-cycle
     CPU-pressure decision (see :class:`HostCyclePressure`); its remaining
-    elevated-admission slot is decremented in place by however many workers
-    THIS board actually spawns, so the next board in the same cycle sees the
-    reduced budget."""
+    elevated-admission slot is reserved (decremented) by :func:`_dispatch_lane_task`
+    at the moment each individual spawn attempt is authorized -- before
+    ``spawn_fn`` runs, never refunded afterward -- so the next board (or the
+    next row in this same board's own loops) sees the reduced budget even when
+    the attempt's outcome is an ambiguous or post-launch failure."""
     result = DispatchResult()
     _run_reclaim_phase(
         conn, result, stale_timeout_seconds=stale_timeout_seconds,
@@ -1931,11 +1948,17 @@ def _dispatch_once_locked(
         dry_run=dry_run, ttl_seconds=ttl_seconds, board=board,
         failure_limit=failure_limit, spawn_fn=spawn_fn,
         per_profile_cap=per_profile_cap, per_profile_running=per_profile_running,
+        host_cycle=host_cycle,
     )
     default_assignee = _resolve_default_assignee(default_assignee)
     spawned = 0
     for row in ready_rows:
         if ready_budget is not None and spawned >= ready_budget:
+            break
+        if host_cycle is not None and host_cycle.cpu_pressure == "elevated" and host_cycle.remaining_elevated_spawns <= 0:
+            # The cycle's shared slot was already spent by an earlier attempt
+            # (this board or an earlier one) -- including one whose outcome
+            # was an ambiguous/post-launch failure, which never refunds it.
             break
         row_assignee = row["assignee"]
         if not row_assignee:
@@ -1958,16 +1981,13 @@ def _dispatch_once_locked(
     for row in review_rows:
         if spawn_budget is not None and spawned >= spawn_budget:
             break
+        if host_cycle is not None and host_cycle.cpu_pressure == "elevated" and host_cycle.remaining_elevated_spawns <= 0:
+            break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
         if _dispatch_lane_task(conn, row, row["assignee"], result, lane="review", **lane_kwargs):
             spawned += 1
-    if host_cycle is not None and result.cpu_pressure == "elevated" and spawned:
-        # Consume this board's spawns from the cycle-shared elevated budget so
-        # the next board dispatched in this same host cycle sees the reduced
-        # remainder rather than a freshly-reset 1.
-        host_cycle.remaining_elevated_spawns = max(host_cycle.remaining_elevated_spawns - spawned, 0)
     return result
 
 

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -136,9 +136,34 @@ class DispatchResult:
     cpu_pressure: Optional[str] = None
     """Host CPU pressure (load-average / PSI, see :mod:`gateway.cpu_status`)
     that restricted this tick: ``"critical"`` (no new workers), ``"elevated"``
-    (at most one), ``None`` (no restriction). Same host-global, defer-not-drop
-    contract as ``memory_pressure`` — a single reading of the whole machine,
-    not a per-board budget, so cron/CI/local-inference load registers too."""
+    (at most one), ``None`` (no restriction). Same defer-not-drop contract as
+    ``memory_pressure``. When driven by :meth:`gateway.kanban_watchers_dispatcher
+    ._KanbanDispatcher.tick_once` (the production gateway path), CPU is sampled
+    ONCE per host cycle and the elevated-admission slot is shared across every
+    board via ``host_cycle`` — the sum of new spawns across ALL boards in one
+    host cycle is capped at 1, not 1-per-board. A direct/manual ``dispatch_once``
+    call with no ``host_cycle`` still samples CPU for itself and applies the
+    same cap to that single call, unchanged from prior behavior."""
+
+
+@dataclass
+class HostCyclePressure:
+    """One host-wide CPU-pressure decision, shared across every board's
+    ``dispatch_once`` call within a single gateway host cycle
+    (:meth:`gateway.kanban_watchers_dispatcher._KanbanDispatcher.tick_once`).
+
+    ``cpu_pressure`` is sampled/classified exactly once per host cycle and
+    handed to every board so they all see the same reading — no per-board
+    resampling, no churn between boards in the same cycle.
+    ``remaining_elevated_spawns`` starts at 1 (the whole cycle's elevated-
+    admission budget) and is decremented in place as boards spawn under
+    elevated pressure, so the SUM of new spawns across all boards in this
+    cycle stays <= 1. Boards are dispatched sequentially within one
+    ``tick_once`` call, so no locking is needed around the mutation.
+    """
+
+    cpu_pressure: str
+    remaining_elevated_spawns: int = 1
 
 
 # Bounded registry of recently-reaped worker exits, filled by the reap loop in
@@ -1472,6 +1497,7 @@ def dispatch_once(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    host_cycle: Optional[HostCyclePressure] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
 
@@ -1480,6 +1506,15 @@ def dispatch_once(
     frames. The loser returns an empty ``DispatchResult`` with
     ``skipped_locked=True`` and writes nothing; the lock is keyed on the
     resolved DB path so unrelated boards tick in parallel.
+
+    ``host_cycle`` (optional): a :class:`HostCyclePressure` sampled once by the
+    caller (see :meth:`gateway.kanban_watchers_dispatcher._KanbanDispatcher
+    .tick_once`) and shared across every board dispatched in the same host
+    cycle, so a host-wide elevated-CPU-pressure reading admits at most one new
+    worker in total across all boards, not one per board. Omit it for a
+    direct/manual single-board call — CPU is then sampled fresh for just this
+    call, with its own independent cap of at most one new worker, unchanged
+    from prior behavior.
     """
     def _locked_tick() -> DispatchResult:
         return _dispatch_once_locked(
@@ -1495,6 +1530,7 @@ def dispatch_once(
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
             reconcile_orphans=reconcile_orphans,
+            host_cycle=host_cycle,
         )
 
     try:
@@ -1697,6 +1733,7 @@ def _tick_spawn_budget(
     max_spawn: Optional[int],
     max_in_progress: Optional[int],
     board: Optional[str],
+    host_cycle: Optional[HostCyclePressure] = None,
 ) -> tuple[bool, Optional[int]]:
     """``(may_spawn, spawn_budget)`` for this tick; ``budget None`` = uncapped.
 
@@ -1705,6 +1742,12 @@ def _tick_spawn_budget(
     by N every tick. ``max_in_progress`` is a HOST-level cap: running workers on
     every other board count against the same budget, else N boards multiply the
     cap by N — exactly the fan-out the memory-derived default exists to prevent.
+
+    ``host_cycle``, when supplied by :meth:`_KanbanDispatcher.tick_once`, carries
+    a CPU-pressure reading already sampled/classified once for the whole host
+    cycle plus the cycle's shared remaining elevated-admission slots — this call
+    must not resample CPU itself (that would double-sample and let each board
+    see a different reading) and must not widen the shared budget back to 1.
     """
     # Count already-running tasks so max_spawn enforces concurrency, not a
     # per-tick budget: "running" tasks stay running until the worker calls
@@ -1741,13 +1784,14 @@ def _tick_spawn_budget(
         )
         return False, None
 
-    # Host-wide CPU-pressure guard (t_4008d306): same host-global, defer-not-drop
-    # contract as the memory guard above, applied to load average / PSI instead
-    # of MemAvailable. This reads the WHOLE host's CPU state — same signal for
-    # every board's tick — so it is one host-global admission decision, not a
-    # per-board budget; cron/CI/local-inference load registers here even though
-    # those processes are invisible to ``count_running_tasks*``.
-    cpu_pressure = _cpu_pressure_level()
+    # Host-wide CPU-pressure guard (t_4008d306): same defer-not-drop contract as
+    # the memory guard above, applied to load average / PSI instead of
+    # MemAvailable. When ``host_cycle`` is supplied (the production gateway
+    # path, see :meth:`_KanbanDispatcher.tick_once`), CPU was already
+    # sampled/classified ONCE for the whole host cycle — reuse that reading
+    # instead of resampling per board. A direct/manual call with no
+    # ``host_cycle`` samples for itself, exactly as before.
+    cpu_pressure = host_cycle.cpu_pressure if host_cycle is not None else _cpu_pressure_level()
     if cpu_pressure == "critical":
         result.cpu_pressure = cpu_pressure
         _kb._log.warning(
@@ -1761,12 +1805,20 @@ def _tick_spawn_budget(
     if cpu_pressure == "elevated":
         result.cpu_pressure = cpu_pressure
     if mem_pressure == "elevated" or cpu_pressure == "elevated":
-        if spawn_budget is None or spawn_budget > 1:
+        if host_cycle is not None and cpu_pressure == "elevated":
+            # Host-cycle-shared budget: the SUM of spawns across every board in
+            # this cycle must stay <= 1, not 1 per board. A board that finds the
+            # cycle's slot already spent (an earlier board in this same cycle
+            # consumed it) gets 0, never a fresh 1.
+            elevated_cap = max(host_cycle.remaining_elevated_spawns, 0)
+        else:
+            elevated_cap = 1
+        if spawn_budget is None or spawn_budget > elevated_cap:
             _kb._log.warning(
                 "kanban dispatch: system pressure is elevated (memory=%s, cpu=%s); "
-                "limiting to at most 1 new worker this tick", mem_pressure, cpu_pressure,
+                "limiting to at most %d new worker(s) this tick", mem_pressure, cpu_pressure, elevated_cap,
             )
-            spawn_budget = 1
+            spawn_budget = elevated_cap
     return True, spawn_budget
 
 
@@ -1823,12 +1875,17 @@ def _dispatch_once_locked(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    host_cycle: Optional[HostCyclePressure] = None,
 ) -> DispatchResult:
     """One dispatcher tick: reclaim stale/crashed running tasks, promote
     todo -> ready, then atomically claim each spawnable ready/review row and
     call ``spawn_fn(task, workspace_path, board) -> Optional[int]``, recording
     the PID so later ticks catch crashes before the TTL. Cap semantics:
-    :func:`_tick_spawn_budget`."""
+    :func:`_tick_spawn_budget`. ``host_cycle`` carries the shared host-cycle
+    CPU-pressure decision (see :class:`HostCyclePressure`); its remaining
+    elevated-admission slot is decremented in place by however many workers
+    THIS board actually spawns, so the next board in the same cycle sees the
+    reduced budget."""
     result = DispatchResult()
     _run_reclaim_phase(
         conn, result, stale_timeout_seconds=stale_timeout_seconds,
@@ -1836,6 +1893,7 @@ def _dispatch_once_locked(
     )
     may_spawn, spawn_budget = _tick_spawn_budget(
         conn, result, max_spawn=max_spawn, max_in_progress=max_in_progress, board=board,
+        host_cycle=host_cycle,
     )
     if not may_spawn:
         return result
@@ -1905,6 +1963,11 @@ def _dispatch_once_locked(
             continue
         if _dispatch_lane_task(conn, row, row["assignee"], result, lane="review", **lane_kwargs):
             spawned += 1
+    if host_cycle is not None and result.cpu_pressure == "elevated" and spawned:
+        # Consume this board's spawns from the cycle-shared elevated budget so
+        # the next board dispatched in this same host cycle sees the reduced
+        # remainder rather than a freshly-reset 1.
+        host_cycle.remaining_elevated_spawns = max(host_cycle.remaining_elevated_spawns - spawned, 0)
     return result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -584,6 +584,7 @@ testpaths = ["tests"]
 markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
+    "real_cpu_guard: opt out of the autouse stub that neutralizes the kanban dispatcher's host-CPU pressure guard",
     "real_agent_prewarm: opt out of the autouse stub that disables the tui_gateway deferred agent pre-warm timer",
     "requires_wal: needs the runtime to actually enable SQLite WAL mode (skipped where Hermes falls back to journal_mode=DELETE)",
     "no_isolate: opt out of per-file subprocess isolation (tests share mutable module-level state)",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -609,14 +609,24 @@ def _neutralize_kanban_cpu_guard(request, monkeypatch):
     i.e. the pre-guard behaviour every existing test was written against.
     Tests that exercise the guard itself opt out with
     ``@pytest.mark.real_cpu_guard`` or patch the seam directly.
+
+    Patches the reload-stable origin ``gateway.cpu_status.sample_cpu`` rather
+    than ``hermes_cli.kanban_db_dispatch._system_cpu_sample``: several tests
+    (e.g. ``test_kanban_per_profile_cap.py``) purge every ``hermes_cli*``
+    module from ``sys.modules`` and reimport a fresh ``kanban_db_dispatch``
+    module object mid-test, which has no memory of a patch applied to the
+    OLD module object and would otherwise read the real, possibly-critical
+    host CPU state. ``gateway.cpu_status`` is never purged by that pattern,
+    and ``_system_cpu_sample`` re-imports ``sample_cpu`` from it on every
+    call, so patching it here survives any number of ``hermes_cli`` reloads.
     """
     if request.node.get_closest_marker("real_cpu_guard"):
         return
     try:
-        from hermes_cli import kanban_db_dispatch as _kbd_mod
+        from gateway import cpu_status as _cpu_status_mod
     except Exception:
         return
-    monkeypatch.setattr(_kbd_mod, "_system_cpu_sample", lambda: {}, raising=False)
+    monkeypatch.setattr(_cpu_status_mod, "sample_cpu", lambda: {}, raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -597,6 +597,29 @@ def _neutralize_kanban_memory_guard(request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _neutralize_kanban_cpu_guard(request, monkeypatch):
+    """Pin the kanban dispatcher's host-CPU guard to "no data" for every test.
+
+    Mirrors ``_neutralize_kanban_memory_guard`` above for the CPU-pressure
+    guard (t_4008d306): the dispatcher now also consults live load average /
+    PSI before spawning. Left un-patched, dispatch tests would pass or fail
+    based on how loaded the host running the suite happens to be — exactly
+    the flakiness the memory-guard neutralizer already exists to prevent.
+    Defaulting the sample to ``{}`` makes the pressure level ``"unknown"``,
+    i.e. the pre-guard behaviour every existing test was written against.
+    Tests that exercise the guard itself opt out with
+    ``@pytest.mark.real_cpu_guard`` or patch the seam directly.
+    """
+    if request.node.get_closest_marker("real_cpu_guard"):
+        return
+    try:
+        from hermes_cli import kanban_db_dispatch as _kbd_mod
+    except Exception:
+        return
+    monkeypatch.setattr(_kbd_mod, "_system_cpu_sample", lambda: {}, raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _neutralize_webbrowser(monkeypatch):
     """Record browser-open attempts instead of opening real browser windows."""
     import webbrowser as _webbrowser

--- a/tests/gateway/test_cpu_status.py
+++ b/tests/gateway/test_cpu_status.py
@@ -1,0 +1,53 @@
+"""Unit tests for :mod:`gateway.cpu_status` (t_4008d306 host-CPU admission)."""
+
+from __future__ import annotations
+
+from gateway import cpu_status as cs
+
+
+def test_classify_load_pressure_tiers():
+    assert cs.classify_load_pressure(1.0, 8) == "ok"
+    assert cs.classify_load_pressure(8.0, 8) == "elevated"
+    assert cs.classify_load_pressure(16.0, 8) == "critical"
+
+
+def test_classify_load_pressure_unknown_on_bad_input():
+    assert cs.classify_load_pressure(None, 8) == "unknown"
+    assert cs.classify_load_pressure(1.0, None) == "unknown"
+    assert cs.classify_load_pressure(1.0, 0) == "unknown"
+    assert cs.classify_load_pressure(True, 8) == "unknown"  # bool rejected
+
+
+def test_classify_psi_pressure_tiers():
+    assert cs.classify_psi_pressure(2.0) == "ok"
+    assert cs.classify_psi_pressure(25.0) == "elevated"
+    assert cs.classify_psi_pressure(76.64) == "critical"
+    assert cs.classify_psi_pressure(None) == "unknown"
+
+
+def test_classify_cpu_pressure_worst_of_both():
+    # Load says ok, PSI says critical -> critical.
+    assert cs.classify_cpu_pressure(1.0, 8, 90.0) == "critical"
+    # Load says critical, PSI unavailable -> critical (single known signal wins).
+    assert cs.classify_cpu_pressure(51.47, 8, None) == "critical"
+    # Both unavailable -> unknown, never silently "ok".
+    assert cs.classify_cpu_pressure(None, None, None) == "unknown"
+
+
+def test_sample_cpu_never_raises(monkeypatch):
+    monkeypatch.setattr(cs.os, "getloadavg", lambda: (_ for _ in ()).throw(OSError()))
+    monkeypatch.setattr(cs, "_read_psi_some_avg60", lambda: None)
+    assert cs.sample_cpu() == {"cpu_count": cs.os.cpu_count()} or cs.sample_cpu() == {}
+
+
+def test_read_psi_some_avg60_parses_real_format(tmp_path):
+    psi_file = tmp_path / "cpu"
+    psi_file.write_text(
+        "some avg10=12.34 avg60=76.64 avg300=50.00 total=1234567\n"
+        "full avg10=0.00 avg60=0.00 avg300=0.00 total=0\n"
+    )
+    assert cs._read_psi_some_avg60(str(psi_file)) == 76.64
+
+
+def test_read_psi_some_avg60_missing_file_returns_none(tmp_path):
+    assert cs._read_psi_some_avg60(str(tmp_path / "does-not-exist")) is None

--- a/tests/gateway/test_kanban_dispatcher_host_cpu_budget.py
+++ b/tests/gateway/test_kanban_dispatcher_host_cpu_budget.py
@@ -175,6 +175,62 @@ def test_tick_once_elevated_cpu_pressure_with_pid_persistence_fault_still_launch
                 assert row is not None and row.status == "ready", (slug, task_id, row and row.status)
 
 
+def test_tick_once_board_aware_callback_typeerror_invokes_exactly_once(
+    kanban_home, dispatcher, monkeypatch,
+):
+    """Regression for the t_75790124 review finding: a board-aware
+    ``_default_spawn`` replacement that raises ``TypeError`` from its own body
+    (not a signature mismatch) must be invoked exactly once across the whole
+    host cycle -- ``_call_spawn_fn`` must not mistake the callback's own
+    ``TypeError`` for an ``inspect.signature`` failure and retry it a second
+    time without ``board``."""
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: _cpu_sample("elevated"))
+    calls = []
+
+    def board_aware_spawn(task, workspace, *, board=None):
+        calls.append((board, task.id))
+        raise TypeError("callback's own bug, not a signature mismatch")
+
+    monkeypatch.setattr(kbd, "_default_spawn", board_aware_spawn)
+
+    results = dispatcher.tick_once()
+
+    assert len(calls) <= 1, calls
+    assert _total_spawned(results) == 0
+
+
+def test_tick_once_elevated_pre_spawn_rejection_leaves_shared_slot_for_later_board(
+    kanban_home, dispatcher, monkeypatch,
+):
+    """A row rejected before any spawn attempt (nonspawnable profile) on the
+    FIRST board must not spend the host-cycle-shared elevated reservation --
+    a later board's eligible row must still get the one shared spawn."""
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: _cpu_sample("elevated"))
+    from hermes_cli import profiles
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name != "not-a-profile")
+
+    with kbc.connect(board=BOARDS[0]) as conn:
+        conn.execute(
+            "UPDATE tasks SET assignee = ? WHERE id = ?",
+            ("not-a-profile", kanban_home[BOARDS[0]]["ready"]),
+        )
+
+    spawned = []
+
+    def fake_default_spawn(task, workspace, *, board=None):
+        spawned.append((board, task.id))
+        return 4242
+
+    monkeypatch.setattr(kbd, "_default_spawn", fake_default_spawn)
+
+    results = dispatcher.tick_once()
+    results_by_slug = dict(results)
+
+    assert kanban_home[BOARDS[0]]["ready"] in results_by_slug[BOARDS[0]].skipped_nonspawnable
+    assert len(spawned) == 1, spawned
+    assert _total_spawned(results) == 1
+
+
 def test_tick_once_critical_cpu_pressure_spawns_nothing_but_still_reclaims_and_promotes(
     kanban_home, dispatcher, monkeypatch,
 ):

--- a/tests/gateway/test_kanban_dispatcher_host_cpu_budget.py
+++ b/tests/gateway/test_kanban_dispatcher_host_cpu_budget.py
@@ -1,0 +1,153 @@
+"""Host-cycle-shared CPU admission budget for ``_KanbanDispatcher.tick_once``
+(t_4008d306 rework).
+
+The rejected candidate (68c83f0) sampled/classified CPU pressure separately
+inside each board's own ``dispatch_once`` call. The production gateway calls
+``dispatch_once`` once per board every tick
+(``_KanbanDispatcher.tick_once`` -> ``tick_once_for_board``), so a per-board
+reading let every board independently admit its own "at most one" elevated
+worker: three boards -> three spawns in one host cycle, not the intended
+host-wide cap of one.
+
+This module proves the fix directly against a REAL ``_KanbanDispatcher`` over
+three real boards/DBs (no mocking of ``tick_once`` or ``dispatch_once``
+internals beyond the CPU sample and the process-spawning seam):
+
+1. Elevated pressure: the SUM of new spawns across all boards in ONE
+   ``tick_once()`` call is <= 1.
+2. Critical pressure: the SUM of new spawns is exactly 0, while every board's
+   reclaim/promotion bookkeeping still runs and affected tasks stay ready
+   (deferred, not dropped).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+from gateway.kanban_watchers_dispatcher import _DispatcherSettings, _KanbanDispatcher
+
+BOARDS = ("alpha-board", "beta-board", "gamma-board")
+
+
+def _cpu_sample(level: str) -> dict:
+    if level == "critical":
+        return {"load1": 40.0, "cpu_count": 8, "psi_some_avg60": 76.64}
+    if level == "elevated":
+        return {"load1": 9.0, "cpu_count": 8, "psi_some_avg60": 25.0}
+    return {"load1": 1.0, "cpu_count": 8, "psi_some_avg60": 2.0}
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with three real boards, each holding a ready
+    task, a stale (unheartbeated, never-pid-set) running task, and a
+    done-parent/todo-child pair to exercise reclaim + promotion."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    board_state = {}
+    for slug in BOARDS:
+        kb.create_board(slug)
+        with kbc.connect(board=slug) as conn:
+            ready_id = kb.create_task(conn, title="ready", assignee="alice")
+            stale_id = kb.create_task(conn, title="stale-running", assignee="alice")
+            kb.claim_task(conn, stale_id, ttl_seconds=1)
+            # ``ttl_seconds`` is clamped to a minimum of 1s by
+            # ``_resolve_claim_ttl_seconds``; force the claim into the past
+            # directly so ``release_stale_claims`` treats it as expired
+            # without relying on real wall-clock sleeps in this test.
+            conn.execute(
+                "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+                (int(time.time()) - 10_000, stale_id),
+            )
+            parent_id = kb.create_task(conn, title="parent", assignee="alice")
+            child_id = kb.create_task(conn, title="child", assignee="alice", parents=[parent_id])
+            conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (parent_id,))
+        board_state[slug] = {"ready": ready_id, "stale": stale_id, "child": child_id}
+    return board_state
+
+
+@pytest.fixture
+def all_assignees_spawnable(monkeypatch):
+    """Pretend every assignee maps to a real Hermes profile (mirrors
+    ``tests/hermes_cli/conftest.py``'s fixture, which isn't visible to
+    ``tests/gateway/`` — pytest conftest fixtures don't cross sibling dirs)."""
+    from hermes_cli import profiles
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+
+
+@pytest.fixture
+def dispatcher(all_assignees_spawnable):
+    settings = _DispatcherSettings(
+        interval=60.0,
+        max_spawn=None,
+        max_in_progress=None,
+        failure_limit=5,
+        stale_timeout_seconds=0,
+        reconcile_orphans=True,
+        default_assignee=None,
+        max_in_progress_per_profile=None,
+    )
+    return _KanbanDispatcher(kb, settings)
+
+
+def _total_spawned(results) -> int:
+    return sum(len(result.spawned) for _slug, result in results if result is not None)
+
+
+def test_tick_once_elevated_cpu_pressure_spawns_at_most_one_across_all_boards(
+    kanban_home, dispatcher, monkeypatch,
+):
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: _cpu_sample("elevated"))
+    spawned = []
+
+    def fake_default_spawn(task, workspace, *, board=None):
+        spawned.append((board, task.id))
+        return 4242
+
+    monkeypatch.setattr(kbd, "_default_spawn", fake_default_spawn)
+
+    results = dispatcher.tick_once()
+
+    assert _total_spawned(results) <= 1
+    assert len(spawned) <= 1
+    # Every board's own reading agreed (one host-cycle sample), so a slot
+    # was spent by at most the FIRST board that had spawnable work.
+    for _slug, result in results:
+        if result is not None:
+            assert result.cpu_pressure in ("elevated", None)
+
+
+def test_tick_once_critical_cpu_pressure_spawns_nothing_but_still_reclaims_and_promotes(
+    kanban_home, dispatcher, monkeypatch,
+):
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: _cpu_sample("critical"))
+
+    def must_not_spawn(task, workspace, *, board=None):
+        raise AssertionError(f"spawn_fn must not be called under critical CPU pressure (board={board})")
+
+    monkeypatch.setattr(kbd, "_default_spawn", must_not_spawn)
+
+    results = dispatcher.tick_once()
+    results_by_slug = dict(results)
+
+    assert _total_spawned(results) == 0
+    for slug in BOARDS:
+        result = results_by_slug[slug]
+        assert result is not None
+        assert result.cpu_pressure == "critical"
+        assert result.spawned == []
+        assert result.reclaimed >= 1
+        assert result.promoted >= 1
+        with kbc.connect(board=slug) as conn:
+            for task_id in (kanban_home[slug]["ready"], kanban_home[slug]["stale"], kanban_home[slug]["child"]):
+                row = kb.get_task(conn, task_id)
+                assert row is not None and row.status == "ready", (slug, task_id, row and row.status)

--- a/tests/gateway/test_kanban_dispatcher_host_cpu_budget.py
+++ b/tests/gateway/test_kanban_dispatcher_host_cpu_budget.py
@@ -126,6 +126,55 @@ def test_tick_once_elevated_cpu_pressure_spawns_at_most_one_across_all_boards(
             assert result.cpu_pressure in ("elevated", None)
 
 
+def test_tick_once_elevated_cpu_pressure_with_pid_persistence_fault_still_launches_at_most_one(
+    kanban_home, dispatcher, monkeypatch,
+):
+    """Regression for the t_194e18d6 review finding: the shared elevated slot
+    must be reserved BEFORE ``spawn_fn`` is invoked, not after PID persistence
+    succeeds. Inject ``_set_worker_pid`` raising ``OSError`` after ``spawn_fn``
+    returns a real PID (4242) -- a real ambiguous/post-launch failure, since
+    the child process was already created. The actual spawn CALLBACK count
+    (not ``DispatchResult.spawned``, which undercounts this exact failure) must
+    stay <= 1 across the whole cycle, and later boards must still reclaim and
+    promote their stale/blocked work."""
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: _cpu_sample("elevated"))
+    launch_calls = []
+
+    def fake_default_spawn(task, workspace, *, board=None):
+        launch_calls.append((board, task.id))
+        return 4242
+
+    monkeypatch.setattr(kbd, "_default_spawn", fake_default_spawn)
+
+    def failing_set_worker_pid(conn, task_id, pid):
+        raise OSError("simulated PID persistence fault")
+
+    monkeypatch.setattr(kbd, "_set_worker_pid", failing_set_worker_pid)
+
+    results = dispatcher.tick_once()
+    results_by_slug = dict(results)
+
+    # The bug: DispatchResult.spawned undercounts here, since the failing
+    # board's attempt raises inside the try/except and is recorded as a
+    # failure, not a spawn. The invariant under test is on the real callback
+    # invocation count, which is what actually matters for host load.
+    assert len(launch_calls) <= 1, launch_calls
+    assert _total_spawned(results) <= len(launch_calls)
+
+    # Later boards (after the one that consumed the shared slot, whether its
+    # attempt "succeeded" from DispatchResult's point of view or not) must
+    # still run reclaim/promotion and keep their affected tasks retained.
+    for slug in BOARDS:
+        result = results_by_slug[slug]
+        assert result is not None
+        assert result.reclaimed >= 1
+        assert result.promoted >= 1
+        with kbc.connect(board=slug) as conn:
+            for task_id in (kanban_home[slug]["stale"], kanban_home[slug]["child"]):
+                row = kb.get_task(conn, task_id)
+                assert row is not None and row.status == "ready", (slug, task_id, row and row.status)
+
+
 def test_tick_once_critical_cpu_pressure_spawns_nothing_but_still_reclaims_and_promotes(
     kanban_home, dispatcher, monkeypatch,
 ):

--- a/tests/hermes_cli/test_kanban_cpu_guard.py
+++ b/tests/hermes_cli/test_kanban_cpu_guard.py
@@ -26,6 +26,7 @@ Covers:
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -248,3 +249,62 @@ def test_dispatch_combines_worse_of_memory_and_cpu_pressure(
     assert spawns == []
     assert res.memory_pressure is None
     assert res.cpu_pressure == "critical"
+
+
+# ---------------------------------------------------------------------------
+# Test neutralizer reload-stability (t_4008d306 rework, review finding #2)
+# ---------------------------------------------------------------------------
+
+
+def test_default_neutralizer_returns_empty_sample_without_marker():
+    """Sanity baseline: absent ``@pytest.mark.real_cpu_guard``, the autouse
+    fixture in ``tests/conftest.py`` keeps the CPU guard neutral for every
+    test, regardless of the host's actual load."""
+    assert kbd._system_cpu_sample() == {}
+    assert kbd._cpu_pressure_level() == "unknown"
+
+
+def test_neutralizer_survives_hermes_cli_module_purge_and_reimport():
+    """The autouse neutralizer must patch a RELOAD-STABLE origin, not a
+    ``hermes_cli.kanban_db_dispatch`` module attribute directly.
+
+    ``tests/hermes_cli/test_kanban_per_profile_cap.py`` (and similar tests)
+    purge every ``hermes_cli``/``hermes_state``/``hermes_constants`` module
+    from ``sys.modules`` and reimport fresh module objects mid-test. A patch
+    applied only to the OLD ``kanban_db_dispatch`` module object is invisible
+    to that fresh module, which would then read the REAL (possibly critical)
+    host CPU state instead of the neutral default — exactly the failure the
+    independent review reproduced. ``tests/conftest.py`` patches
+    ``gateway.cpu_status.sample_cpu`` instead, which survives because
+    ``gateway.*`` modules are never purged by that pattern and
+    ``_system_cpu_sample`` re-imports ``sample_cpu`` from it on every call.
+    """
+    purge_prefixes = ("hermes_cli", "hermes_state")
+    removed = {}
+    for mod_name in list(sys.modules):
+        if mod_name.startswith(purge_prefixes) or mod_name == "hermes_constants":
+            removed[mod_name] = sys.modules.pop(mod_name)
+    try:
+        from hermes_cli import kanban_db_dispatch as fresh_kbd
+
+        assert fresh_kbd is not kbd, "expected a genuinely fresh module object after the purge"
+        assert fresh_kbd._system_cpu_sample() == {}
+        assert fresh_kbd._cpu_pressure_level() == "unknown"
+    finally:
+        # Restore the original module objects so later tests in this process
+        # keep using the identities they already hold references to.
+        for mod_name in list(sys.modules):
+            if mod_name.startswith(purge_prefixes) or mod_name == "hermes_constants":
+                del sys.modules[mod_name]
+        sys.modules.update(removed)
+
+
+@pytest.mark.real_cpu_guard
+def test_real_cpu_guard_marker_exposes_real_sampling_without_dispatch():
+    """Opting out with ``@pytest.mark.real_cpu_guard`` must expose the REAL
+    ``gateway.cpu_status.sample_cpu`` seam (not the neutralized ``{}``),
+    while this test performs no dispatch at all — proving the opt-out only
+    widens what CAN be sampled, never forces an actual worker spawn."""
+    sample = kbd._system_cpu_sample()
+    assert sample, "real_cpu_guard should expose the real, non-neutralized CPU sample"
+    assert "load1" in sample or "psi_some_avg60" in sample

--- a/tests/hermes_cli/test_kanban_cpu_guard.py
+++ b/tests/hermes_cli/test_kanban_cpu_guard.py
@@ -1,0 +1,250 @@
+"""Host-global CPU-pressure kanban dispatch guard (t_4008d306).
+
+The 2026-09-08 Astra control-plane review found no host-wide CPU admission:
+the dispatcher already refuses to spawn new workers under critical *memory*
+pressure (``test_kanban_memory_guard.py``), but a saturated host (high load
+average / PSI) had no equivalent stop. At 13:16 BST the host reported load
+averages 51.47/50.01/47.34 with CPU PSI some avg300=76.64 — exactly the
+"every representative board dispatch should defer, not spawn, not drop"
+condition this guard exists for.
+
+Covers:
+
+1. :func:`hermes_cli.kanban_db_dispatch._cpu_pressure_level` — classification
+   via :mod:`gateway.cpu_status` (worst-of load average / PSI).
+2. The live CPU-pressure guard inside ``dispatch_once`` — critical pressure
+   spawns nothing (``spawned == []``) across representative boards; elevated
+   pressure spawns at most one; unknown imposes no restriction (fail-open,
+   matching the memory guard's documented convention).
+3. One HOST-GLOBAL decision: the guard reads the whole machine once per tick,
+   not a per-board budget — asserted here by running it against several
+   distinct boards/DBs and confirming the same pressure reading gates all of
+   them identically in the same tick.
+4. Defer, never drop: tasks skipped under critical CPU pressure stay in their
+   dispatchable status and spawn once pressure clears.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_dispatch as kbd
+from hermes_cli import kanban_db_connect as kbc
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+# ---------------------------------------------------------------------------
+# _cpu_pressure_level
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_pressure_level_unknown_on_empty_sample(monkeypatch):
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: {})
+    assert kbd._cpu_pressure_level() == "unknown"
+
+
+def test_cpu_pressure_level_classifies_via_load_average():
+    ok = {"load1": 1.0, "cpu_count": 8}
+    elevated = {"load1": 9.0, "cpu_count": 8}
+    critical = {"load1": 51.47, "cpu_count": 8}
+    assert kbd._cpu_pressure_level(ok) == "ok"
+    assert kbd._cpu_pressure_level(elevated) == "elevated"
+    assert kbd._cpu_pressure_level(critical) == "critical"
+
+
+def test_cpu_pressure_level_classifies_via_psi_when_load_unavailable():
+    # Mirrors the 2026-09-08 probe: CPU PSI some avg300=76.64 without a usable
+    # load-average/cpu_count pairing (e.g. cgroup-limited container).
+    assert kbd._cpu_pressure_level({"psi_some_avg60": 76.64}) == "critical"
+    assert kbd._cpu_pressure_level({"psi_some_avg60": 5.0}) == "ok"
+
+
+def test_cpu_pressure_level_worst_of_both_signals():
+    # Load looks fine but PSI says critical (or vice versa) -> critical wins.
+    sample = {"load1": 1.0, "cpu_count": 8, "psi_some_avg60": 90.0}
+    assert kbd._cpu_pressure_level(sample) == "critical"
+
+
+# ---------------------------------------------------------------------------
+# dispatch_once under CPU pressure — RED/GREEN invariant coverage
+# ---------------------------------------------------------------------------
+
+
+def _load_probe_sample(level: str) -> dict:
+    """Representative host reading at each tier, using the actual probed
+    2026-09-08 figures for "critical" (load avg 51.47 on an 8-core box)."""
+    if level == "critical":
+        return {"load1": 51.47, "cpu_count": 8, "psi_some_avg60": 76.64}
+    if level == "elevated":
+        return {"load1": 9.0, "cpu_count": 8, "psi_some_avg60": 25.0}
+    return {"load1": 1.0, "cpu_count": 8, "psi_some_avg60": 2.0}
+
+
+# Representative boards a real host dispatches across, per the P0 acceptance
+# criterion: "every representative board dispatch defers safely".
+REPRESENTATIVE_BOARDS = ("jarvis-os", "sycode-trading", "upero")
+
+
+@pytest.mark.parametrize("board", REPRESENTATIVE_BOARDS)
+def test_RED_dispatch_spawns_nothing_under_critical_cpu_pressure(
+    kanban_home, all_assignees_spawnable, monkeypatch, board,
+):
+    """RED: this is the exact regression the card exists to close — before the
+    guard existed, critical CPU pressure did not stop a spawn. GREEN below
+    proves the guard closes it for every representative board."""
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: _load_probe_sample("critical"))
+    spawns = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append(task.id)
+        return 42
+
+    with kbc.connect(board=board) as conn:
+        for title in ("a", "b", "c"):
+            kb.create_task(conn, title=title, assignee="alice")
+        res = kbd.dispatch_once(conn, spawn_fn=fake_spawn, board=board)
+
+    # The required invariant: critical CPU pressure returns spawned=[], never
+    # drops the queued work, and records why.
+    assert spawns == []
+    assert res.spawned == []
+    assert res.cpu_pressure == "critical"
+
+
+def test_GREEN_dispatch_critical_cpu_pressure_defers_not_drops(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """Tasks skipped under CPU pressure stay dispatchable and spawn once the
+    host's load clears — deferred, never dropped."""
+    sample = {"value": _load_probe_sample("critical")}
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: sample["value"])
+    spawns = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append(task.id)
+        return 42
+
+    with kbc.connect() as conn:
+        task = kb.create_task(conn, title="a", assignee="alice")
+        res = kbd.dispatch_once(conn, spawn_fn=fake_spawn)
+        assert spawns == []
+        assert res.spawned == []
+        row = kb.get_task(conn, task)
+        assert row is not None and row.status == "ready"
+
+        sample["value"] = _load_probe_sample("ok")
+        res = kbd.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert spawns == [task]
+    assert res.cpu_pressure is None
+
+
+def test_dispatch_elevated_cpu_pressure_spawns_at_most_one(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: _load_probe_sample("elevated"))
+    spawns = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append(task.id)
+        return 42
+
+    with kbc.connect() as conn:
+        for title in ("a", "b", "c"):
+            kb.create_task(conn, title=title, assignee="alice")
+        res = kbd.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert len(spawns) == 1
+    assert res.cpu_pressure == "elevated"
+
+
+def test_dispatch_elevated_cpu_pressure_does_not_widen_tighter_budget(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """A caller cap already at 0 remaining must not be widened to 1."""
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: _load_probe_sample("elevated"))
+    spawns = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append(task.id)
+        return 42
+
+    with kbc.connect() as conn:
+        running = kb.create_task(conn, title="running", assignee="alice")
+        kb.claim_task(conn, running)
+        kb.create_task(conn, title="ready", assignee="bob")
+        res = kbd.dispatch_once(conn, spawn_fn=fake_spawn, max_in_progress=1)
+
+    assert spawns == []
+    assert res.spawned == []
+
+
+def test_dispatch_unknown_cpu_pressure_imposes_no_restriction(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: {})
+    spawns = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append(task.id)
+        return 42
+
+    with kbc.connect() as conn:
+        for title in ("a", "b", "c"):
+            kb.create_task(conn, title=title, assignee="alice")
+        res = kbd.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert len(spawns) == 3
+    assert res.cpu_pressure is None
+
+
+def test_dispatch_critical_cpu_pressure_still_runs_reclaim_bookkeeping(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """The guard must only stop NEW spawns — reclaim/promotion still run."""
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: _load_probe_sample("critical"))
+    with kbc.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="alice")
+        child = kb.create_task(conn, title="child", assignee="alice", parents=[parent])
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (parent,))
+        res = kbd.dispatch_once(conn, spawn_fn=lambda *a, **k: 42)
+        row = kb.get_task(conn, child)
+
+    assert res.cpu_pressure == "critical"
+    assert row is not None
+    assert row.status == "ready"
+
+
+def test_dispatch_combines_worse_of_memory_and_cpu_pressure(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """Critical CPU pressure stops spawning even when memory reads fine, and
+    vice versa — the two guards are independent, worst-of-both gates."""
+    monkeypatch.setattr(kbd, "_system_memory_sample", lambda: {"mem_available_kib": 10**7, "mem_total_kib": 10**8})
+    monkeypatch.setattr(kbd, "_system_cpu_sample", lambda: _load_probe_sample("critical"))
+    spawns = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append(task.id)
+        return 42
+
+    with kbc.connect() as conn:
+        kb.create_task(conn, title="a", assignee="alice")
+        res = kbd.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert spawns == []
+    assert res.memory_pressure is None
+    assert res.cpu_pressure == "critical"

--- a/tests/hermes_cli/test_kanban_direct_elevated_admission.py
+++ b/tests/hermes_cli/test_kanban_direct_elevated_admission.py
@@ -1,0 +1,225 @@
+"""Direct/standalone elevated-CPU admission (t_4008d306 rework 3).
+
+The t_75790124 independent review found that ``dispatch_once(host_cycle=None)``
+-- the direct/manual call path used by ``hermes kanban dispatch`` and the
+standalone daemon (no shared :class:`~hermes_cli.kanban_db_dispatch.
+HostCyclePressure`) -- classified elevated CPU pressure and set
+``spawn_budget = 1``, but only accounted for it via ``DispatchResult.spawned``.
+An ambiguous callback exception, or a PID-persistence failure after a real
+launch, left ``spawned`` at 0 and let the very next ready/review row attempt
+another launch, contradicting the documented at-most-one-worker cap.
+
+It also found ``_call_spawn_fn`` wrapped both ``inspect.signature`` AND the
+actual ``spawn_fn`` invocation in one ``except (TypeError, ValueError)``, so a
+board-aware callback that itself raised ``TypeError`` was silently retried a
+second time without ``board``.
+
+This module proves the fix directly against ``dispatch_once`` with no
+``host_cycle`` argument (the exact call shape of the rejected paths), by
+counting real callback invocations rather than trusting ``DispatchResult``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_dispatch as kbd
+from hermes_cli import kanban_db_connect as kbc
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _elevated_sample() -> dict:
+    return {"load1": 9.0, "cpu_count": 8, "psi_some_avg60": 25.0}
+
+
+def _mark_review(conn, task_id: str) -> None:
+    conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (task_id,))
+
+
+# ---------------------------------------------------------------------------
+# Ambiguous callback exception: at most one real invocation, ready and review
+# ---------------------------------------------------------------------------
+
+
+def test_RED_direct_elevated_ready_ambiguous_exception_invokes_at_most_once(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    monkeypatch.setattr(kbd, "_system_cpu_sample", _elevated_sample)
+    calls = []
+
+    def flaky_spawn(task, workspace, board=None):
+        calls.append(task.id)
+        raise RuntimeError("ambiguous: may have already forked before raising")
+
+    with kbc.connect() as conn:
+        for title in ("a", "b", "c"):
+            kb.create_task(conn, title=title, assignee="alice")
+        res = kbd.dispatch_once(conn, spawn_fn=flaky_spawn)
+
+    assert len(calls) <= 1, calls
+    assert res.spawned == []
+    assert res.cpu_pressure == "elevated"
+
+
+def test_RED_direct_elevated_review_ambiguous_exception_invokes_at_most_once(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    monkeypatch.setattr(kbd, "_system_cpu_sample", _elevated_sample)
+    calls = []
+
+    def flaky_spawn(task, workspace, board=None):
+        calls.append(task.id)
+        raise RuntimeError("ambiguous: may have already forked before raising")
+
+    with kbc.connect() as conn:
+        ids = [kb.create_task(conn, title=t, assignee="alice") for t in ("a", "b", "c")]
+        for tid in ids:
+            _mark_review(conn, tid)
+        res = kbd.dispatch_once(conn, spawn_fn=flaky_spawn)
+
+    assert len(calls) <= 1, calls
+    assert res.spawned == []
+    assert res.cpu_pressure == "elevated"
+
+
+# ---------------------------------------------------------------------------
+# PID 4242 then _set_worker_pid OSError: at most one real invocation
+# ---------------------------------------------------------------------------
+
+
+def test_RED_direct_elevated_ready_pid_persistence_failure_invokes_at_most_once(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    monkeypatch.setattr(kbd, "_system_cpu_sample", _elevated_sample)
+    calls = []
+
+    def launching_spawn(task, workspace, board=None):
+        calls.append(task.id)
+        return 4242
+
+    def failing_set_worker_pid(conn, task_id, pid):
+        raise OSError("simulated PID persistence fault")
+
+    monkeypatch.setattr(kbd, "_set_worker_pid", failing_set_worker_pid)
+
+    with kbc.connect() as conn:
+        for title in ("a", "b", "c"):
+            kb.create_task(conn, title=title, assignee="alice")
+        res = kbd.dispatch_once(conn, spawn_fn=launching_spawn)
+
+    assert len(calls) <= 1, calls
+    assert res.spawned == []
+    assert res.cpu_pressure == "elevated"
+
+
+def test_RED_direct_elevated_review_pid_persistence_failure_invokes_at_most_once(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    monkeypatch.setattr(kbd, "_system_cpu_sample", _elevated_sample)
+    calls = []
+
+    def launching_spawn(task, workspace, board=None):
+        calls.append(task.id)
+        return 4242
+
+    def failing_set_worker_pid(conn, task_id, pid):
+        raise OSError("simulated PID persistence fault")
+
+    monkeypatch.setattr(kbd, "_set_worker_pid", failing_set_worker_pid)
+
+    with kbc.connect() as conn:
+        ids = [kb.create_task(conn, title=t, assignee="alice") for t in ("a", "b", "c")]
+        for tid in ids:
+            _mark_review(conn, tid)
+        res = kbd.dispatch_once(conn, spawn_fn=launching_spawn)
+
+    assert len(calls) <= 1, calls
+    assert res.spawned == []
+    assert res.cpu_pressure == "elevated"
+
+
+# ---------------------------------------------------------------------------
+# Board-aware callback raising TypeError must invoke exactly once
+# ---------------------------------------------------------------------------
+
+
+def test_RED_direct_board_aware_callback_typeerror_invokes_exactly_once(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """The callback accepts ``board`` (so ``inspect.signature`` succeeds) and
+    raises ``TypeError`` from its OWN body. The old ``_call_spawn_fn`` caught
+    that ``TypeError`` in the same handler guarding ``inspect.signature`` and
+    retried the callback a second time without ``board`` -- this must not
+    happen: the callback's own ``TypeError`` propagates once."""
+    calls = []
+
+    def board_aware_spawn(task, workspace, board=None):
+        calls.append((board, task.id))
+        raise TypeError("callback's own bug, not a signature mismatch")
+
+    with kbc.connect() as conn:
+        kb.create_task(conn, title="a", assignee="alice")
+        res = kbd.dispatch_once(conn, spawn_fn=board_aware_spawn)
+
+    assert len(calls) == 1, calls
+    assert res.spawned == []
+
+
+def test_RED_direct_board_aware_callback_typeerror_review_lane_invokes_exactly_once(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    calls = []
+
+    def board_aware_spawn(task, workspace, board=None):
+        calls.append((board, task.id))
+        raise TypeError("callback's own bug, not a signature mismatch")
+
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="a", assignee="alice")
+        _mark_review(conn, tid)
+        res = kbd.dispatch_once(conn, spawn_fn=board_aware_spawn)
+
+    assert len(calls) == 1, calls
+    assert res.spawned == []
+
+
+# ---------------------------------------------------------------------------
+# Pre-spawn non-attempt must not consume the per-call elevated slot
+# ---------------------------------------------------------------------------
+
+
+def test_direct_elevated_pre_spawn_rejection_leaves_slot_available_for_later_task(
+    kanban_home, monkeypatch,
+):
+    """A row rejected before any spawn attempt (unknown/nonspawnable profile)
+    must not spend the per-call elevated reservation -- a later eligible row
+    in the SAME call must still get its one spawn."""
+    monkeypatch.setattr(kbd, "_system_cpu_sample", _elevated_sample)
+    from hermes_cli import profiles
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "alice")
+    spawns = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append(task.id)
+        return 4242
+
+    with kbc.connect() as conn:
+        rejected = kb.create_task(conn, title="rejected", assignee="not-a-profile")
+        eligible = kb.create_task(conn, title="eligible", assignee="alice")
+        res = kbd.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert rejected in res.skipped_nonspawnable
+    assert spawns == [eligible]
+    assert len(res.spawned) == 1 and res.spawned[0][0] == eligible


### PR DESCRIPTION
## Summary

- add host-wide CPU pressure sampling at the gateway dispatch-cycle boundary
- share one elevated-pressure admission slot across every board in that cycle
- stop all new worker attempts at critical pressure while preserving reclaim/promotion bookkeeping
- make CPU-guard tests reload-stable
- reserve admission before ambiguous spawn/PID-persistence failures
- apply the same one-attempt safety to direct/standalone dispatch
- prevent callback-raised `TypeError` from invoking a spawn callback twice

## Safety contract

- normal/unknown pressure keeps existing dispatch semantics
- elevated CPU permits at most one actual spawn callback per host cycle or direct dispatch call
- critical CPU permits zero spawn callbacks
- ambiguous/post-launch failures never refund an admission slot
- definite pre-spawn non-attempts do not consume the slot
- reclaim, promotion and defer bookkeeping continue under pressure

## Verification

Exact independently approved head: `3896934f9ae506fa3523cdc33883d6ddf593153f`

Independent review:
- 24 invocation-count and mechanism assertions passed
- 180 serial pytest executions passed, 1 expected Windows-only skip
- focused CPU/memory/gateway, per-profile and 15-file regression sets passed
- Ruff, compileall, `git diff --check`, and `setup.py build_py` inclusion passed
- exact head and clean tree verified before and after review

Review evidence on the DGX:
`/home/frank/.hermes/kanban/boards/jarvis-os/workspaces/t_1e98dcdf/REVIEW.md`

## Activation warning

This draft PR proves durable publication only. It does not authorize merge or activation. The live Jarvis gateway remains unchanged. Activation is separately gated on an approved exact source revision, zero active workers, rollback capture, gateway-safe A3 restart preflight, and post-restart critical/elevated admission probes.

## Base state

The reviewed branch is intentionally unchanged from the approved artifact and is currently 154 commits behind upstream `main`. If current-main reconciliation changes the head, the reconciled head requires fresh independent review before activation.
