### PR TITLE
fix(gateway): preserve x-opencode-session on llm.oneshot commit-message generation (#105841)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2849,7 +2849,7 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
 
 
 _MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
-_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + ("requested_provider",)
+_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + ("requested_provider", "session_id", "cache_scope")
 
 
 def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -7012,6 +7012,10 @@ def call_llm(
     if latency_info is not None:
         latency_info["queue_wait_ms"] = _elapsed_ms(queue_started_at, request_started_at)
     prior_progress_hook = getattr(_aux_progress, "hook", None)
+    # When a caller supplies an explicit main_runtime with a session affinity
+    # (e.g. llm.oneshot inheriting the live session's runtime), publish it so
+    # the opencode-affinity header can be derived via _runtime_main_value.
+    _maybe_scoped = scoped_runtime_main(main_runtime) if isinstance(main_runtime, dict) and (main_runtime.get("session_id") or main_runtime.get("cache_scope")) else contextlib.nullcontext()
     try:
         with (
             aux_progress_hook(
@@ -7023,6 +7027,7 @@ def call_llm(
                 _stamp_latency_once, latency_info, "provider_dispatch_ms", request_started_at)),
             _aux_thread_local_hook(_aux_provider_response, functools.partial(
                 _stamp_latency_once, latency_info, "time_to_first_progress_ms", request_started_at)),
+            _maybe_scoped,
         ):
             response = _call_llm_impl(
                 task=task, provider=provider, model=model, base_url=base_url, api_key=api_key,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2734,7 +2734,7 @@ def _main_runtime_from_agent(agent) -> dict | None:
     if agent is None:
         return None
     runtime: dict = {}
-    for field in ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode"):
+    for field in ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode", "session_id"):
         value = getattr(agent, field, None)
         if isinstance(value, str) and value.strip():
             runtime[field] = value.strip()


### PR DESCRIPTION
Fixes #105841

OpenCode Go requires `x-opencode-session` on every request for backend affinity. Main turns sent the header via `opencode_affinity`, but `llm.oneshot` (commit-message generation) dropped the session id because `tui_gateway._main_runtime_from_agent` omitted `session_id` and `auxiliary_client._normalize_main_runtime` stripped it, so the stranded auxiliary call never published the affinity header and failed with `MissingSessionID` (400).

Changes:
- `tui_gateway/server.py`: include `session_id` in `_main_runtime_from_agent` so one-shots inherit the live session's affinity
- `agent/auxiliary_client.py`: preserve `session_id`/`cache_scope` in context fields and publish explicit `main_runtime` via `scoped_runtime_main` during `call_llm`, so title_generation and other one-shot calls ride the same warm backend

Tests: existing `test_opencode_session_affinity` still green, verified header now propagates via `call_llm(task=title_generation, main_runtime=...)` mock.