### PR TITLE
feat(wecom): instant acknowledgment on accepted inbound messages

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import random
 import re
 import time
 import uuid
@@ -62,6 +64,21 @@ HEARTBEAT_INTERVAL_SECONDS = 30.0
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 
 DEDUP_MAX_SIZE = 1000
+
+# Instant-acknowledgment phrases (upstream #16676): randomized so the client
+# shows fresh feedback rather than the same canned line. The ack is a
+# fire-and-forget APP_CMD_RESPONSE frame correlated to the inbound request id
+# — the only send mode WeCom AI Bots may use in group chats.
+WECOM_INSTANT_ACK_PHRASES = [
+    "收到，正在处理…",
+    "收到 ⏳ 这就开始",
+    "已收到，稍等片刻",
+    "收到，我去看看",
+    "好，收到，马上安排",
+    "来了来了，稍等",
+    "收到你的消息了",
+    "在的，这就处理",
+]
 
 
 def check_wecom_requirements() -> bool:
@@ -157,6 +174,15 @@ class WeComAdapter(WeComStreamMixin, WeComMediaMixin, ChatSendQueueMixin, BasePl
         self._stream_keepalive_interval_seconds = _extra_float("stream_keepalive_interval_seconds", STREAM_KEEPALIVE_INTERVAL_SECONDS)
         self._device_id = uuid.uuid4().hex
         self._last_chat_req_ids: Dict[str, str] = {}
+
+        # Instant ack (upstream #16676): reply immediately so users don't think
+        # the bot is dead while a slow query runs. Fire-and-forget; failures
+        # are logged, never fatal. Opt out with HERMES_WECOM_INSTANT_ACK=false.
+        self._instant_ack_enabled = (
+            str(os.getenv("HERMES_WECOM_INSTANT_ACK", "1")).strip().lower()
+            not in {"0", "false", "no", "off"}
+        )
+        self._ack_tasks: "set[asyncio.Task]" = set()
         # Turns keyed f"{chat_id}:{req_id|turn_id}"; expired chats clear on the next inbound req_id.
         self._stream_turns: Dict[str, StreamTurn] = {}
         self._stream_expired_chats, self._group_chat_ids = set(), set()  # groups can't receive proactive APP_CMD_SEND
@@ -474,7 +500,51 @@ class WeComAdapter(WeComStreamMixin, WeComMediaMixin, ChatSendQueueMixin, BasePl
         if (message_type == MessageType.TEXT and (self._text_batch_delay_seconds > 0 or has_pending_batch)) or (is_attachment_only and self._attachment_text_merge_delay_seconds > 0):
             self._enqueue_text_event(event)
         else:
-            await self.handle_message(event)
+            await self._dispatch_to_agent(event)
+
+    # ------------------------------------------------------------------
+    # Instant acknowledgment (upstream #16676)
+    # ------------------------------------------------------------------
+
+    async def _dispatch_to_agent(self, event: MessageEvent) -> None:
+        """Dispatch an accepted inbound event to the agent.
+
+        Fires a fire-and-forget instant acknowledgment first (non-blocking)
+        so the user gets immediate feedback on slow queries, then hands the
+        event to the normal handler. The ack is correlated to the inbound
+        request via APP_CMD_RESPONSE — the only send mode WeCom AI Bots may
+        use in group chats.
+        """
+        self._schedule_instant_ack(event)
+        await self.handle_message(event)
+
+    def _schedule_instant_ack(self, event: MessageEvent) -> None:
+        """Queue an ack unless disabled, a slash command, or un-correlatable."""
+        if not self._instant_ack_enabled:
+            return
+        text = (event.text or "").lstrip()
+        if text.startswith("/"):
+            return
+        req_id = self._payload_req_id(event.raw_message) if isinstance(event.raw_message, dict) else ""
+        if not req_id:
+            return
+        task = asyncio.create_task(self._send_instant_ack(req_id))
+        self._ack_tasks.add(task)
+        task.add_done_callback(self._ack_tasks.discard)
+
+    async def _send_instant_ack(self, reply_req_id: str) -> None:
+        """Send one short reply frame; never raise into the pipeline."""
+        phrase = random.choice(WECOM_INSTANT_ACK_PHRASES)
+        try:
+            await self._send_json(
+                {
+                    "cmd": APP_CMD_RESPONSE,
+                    "headers": {"req_id": reply_req_id},
+                    "body": self._markdown_body(phrase),
+                }
+            )
+        except Exception as exc:
+            logger.warning("[%s] Instant ack failed (ignored): %s", self.name, exc)
 
     def _admit_inbound(self, is_group: bool, chat_id: str, sender_id: str) -> bool:
         """Apply group_policy / dm_policy at intake; logs and returns False when dropped."""
@@ -521,7 +591,7 @@ class WeComAdapter(WeComStreamMixin, WeComMediaMixin, ChatSendQueueMixin, BasePl
             if not event:
                 return
             logger.info("[WeCom] Flushing batch %s (%d chars, %d media)", key, len(event.text or ""), len(event.media_urls or []))
-            await self.handle_message(event)
+            await self._dispatch_to_agent(event)
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -1554,3 +1554,228 @@ class TestFinalFrameAckTimeoutSemantics:
                 {"msgtype": "stream", "stream": {"id": "stream_x", "content": "x", "finish": True}},
                 is_final=True,
             )
+
+
+class TestWeComInstantAck:
+    """Instant acknowledgment on accepted inbound messages (#16676).
+
+    The ack must be: fire-and-forget (never block the read loop), correlated
+    to the inbound request via APP_CMD_RESPONSE (the only send mode WeCom AI
+    Bots may use in group chats), skipped for slash commands / blocked
+    senders, and must never break the pipeline when the send itself fails.
+    """
+
+    @staticmethod
+    def _text_payload(*, msgid, req_id, chat_id, chat_type, content):
+        return {
+            "cmd": "aibot_msg_callback",
+            "headers": {"req_id": req_id},
+            "body": {
+                "msgid": msgid,
+                "chatid": chat_id,
+                "chattype": chat_type,
+                "from": {"userid": chat_id},
+                "msgtype": "text",
+                "text": {"content": content},
+            },
+        }
+
+    @staticmethod
+    async def _drain_acks(adapter):
+        while adapter._ack_tasks:
+            await asyncio.gather(*list(adapter._ack_tasks))
+
+    @pytest.mark.asyncio
+    async def test_dm_text_ack_correlates_to_inbound_request(self):
+        from plugins.platforms.wecom.adapter import (
+            APP_CMD_RESPONSE,
+            WECOM_INSTANT_ACK_PHRASES,
+            WeComAdapter,
+        )
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"dm_policy": "open"})
+        )
+        adapter._text_batch_delay_seconds = 0
+        adapter.handle_message = AsyncMock()
+        adapter._extract_media = AsyncMock(return_value=([], []))
+        adapter._send_json = AsyncMock()
+
+        payload = self._text_payload(
+            msgid="msg-dm-1", req_id="req-dm-1",
+            chat_id="user-dm", chat_type="single", content="hello",
+        )
+
+        await adapter._on_message(payload)
+        adapter.handle_message.assert_awaited_once()
+        await self._drain_acks(adapter)
+
+        adapter._send_json.assert_awaited_once()
+        frame = adapter._send_json.await_args.args[0]
+        assert frame["cmd"] == APP_CMD_RESPONSE
+        assert frame["headers"]["req_id"] == "req-dm-1"
+        phrase = frame["body"]["markdown"]["content"]
+        assert phrase in WECOM_INSTANT_ACK_PHRASES
+
+    @pytest.mark.asyncio
+    async def test_group_ack_uses_reply_mode_not_proactive_send(self):
+        from plugins.platforms.wecom.adapter import (
+            APP_CMD_RESPONSE,
+            APP_CMD_SEND,
+            WeComAdapter,
+        )
+
+        adapter = WeComAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={"group_policy": "allowlist", "group_allow_from": ["group-1"]},
+            )
+        )
+        adapter._text_batch_delay_seconds = 0
+        adapter.handle_message = AsyncMock()
+        adapter._extract_media = AsyncMock(return_value=([], []))
+        adapter._send_json = AsyncMock()
+
+        payload = self._text_payload(
+            msgid="msg-g-1", req_id="req-g-1",
+            chat_id="group-1", chat_type="group", content="hi",
+        )
+
+        await adapter._on_message(payload)
+        adapter.handle_message.assert_awaited_once()
+        await self._drain_acks(adapter)
+
+        adapter._send_json.assert_awaited_once()
+        frame = adapter._send_json.await_args.args[0]
+        assert frame["cmd"] == APP_CMD_RESPONSE
+        assert frame["cmd"] != APP_CMD_SEND
+        assert frame["headers"]["req_id"] == "req-g-1"
+
+    @pytest.mark.asyncio
+    async def test_slash_command_skips_ack(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"dm_policy": "open"})
+        )
+        adapter._text_batch_delay_seconds = 0
+        adapter.handle_message = AsyncMock()
+        adapter._extract_media = AsyncMock(return_value=([], []))
+        adapter._send_json = AsyncMock()
+
+        payload = self._text_payload(
+            msgid="msg-cmd-1", req_id="req-cmd-1",
+            chat_id="user-cmd", chat_type="single", content="/new",
+        )
+
+        await adapter._on_message(payload)
+        adapter.handle_message.assert_awaited_once()
+        await self._drain_acks(adapter)
+        adapter._send_json.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_blocked_group_skips_ack_and_handler(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={"group_policy": "allowlist", "group_allow_from": ["group-ok"]},
+            )
+        )
+        adapter._text_batch_delay_seconds = 0
+        adapter.handle_message = AsyncMock()
+        adapter._extract_media = AsyncMock(return_value=([], []))
+        adapter._send_json = AsyncMock()
+
+        payload = self._text_payload(
+            msgid="msg-blocked-1", req_id="req-blocked-1",
+            chat_id="group-blocked", chat_type="group", content="hi",
+        )
+
+        await adapter._on_message(payload)
+        adapter.handle_message.assert_not_awaited()
+        await self._drain_acks(adapter)
+        adapter._send_json.assert_not_awaited()
+        assert "group-blocked" not in adapter._last_chat_req_ids
+
+    @pytest.mark.asyncio
+    async def test_ack_send_failure_never_breaks_pipeline(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"dm_policy": "open"})
+        )
+        adapter._text_batch_delay_seconds = 0
+        adapter.handle_message = AsyncMock()
+        adapter._extract_media = AsyncMock(return_value=([], []))
+        adapter._send_json = AsyncMock(side_effect=RuntimeError("ws closed"))
+
+        payload = self._text_payload(
+            msgid="msg-fail-1", req_id="req-fail-1",
+            chat_id="user-fail", chat_type="single", content="hello",
+        )
+
+        await adapter._on_message(payload)
+        adapter.handle_message.assert_awaited_once()
+        await self._drain_acks(adapter)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_batched_flush_acks_once_for_merged_text(self):
+        from gateway.platforms.event import MessageEvent, MessageType
+        from plugins.platforms.wecom.adapter import (
+            APP_CMD_RESPONSE,
+            WeComAdapter,
+        )
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"dm_policy": "open"})
+        )
+        adapter.handle_message = AsyncMock()
+        adapter._send_json = AsyncMock()
+        adapter._text_batch_delay_seconds = 0.05
+
+        payload = self._text_payload(
+            msgid="msg-batch-1", req_id="req-batch-1",
+            chat_id="user-batch", chat_type="single", content="part one",
+        )
+        key = "batch-session"
+        event = MessageEvent(
+            text="part one", message_type=MessageType.TEXT, raw_message=payload
+        )
+        adapter._pending_text_batches[key] = event
+        task = asyncio.create_task(adapter._flush_text_batch(key))
+        adapter._pending_text_batch_tasks[key] = task
+
+        await asyncio.sleep(0.12)
+        assert adapter.handle_message.await_count == 1
+        await self._drain_acks(adapter)
+
+        adapter._send_json.assert_awaited_once()
+        frame = adapter._send_json.await_args.args[0]
+        assert frame["cmd"] == APP_CMD_RESPONSE
+        assert frame["headers"]["req_id"] == "req-batch-1"
+
+    @pytest.mark.asyncio
+    async def test_env_toggle_disables_ack(self, monkeypatch):
+        monkeypatch.setenv("HERMES_WECOM_INSTANT_ACK", "false")
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"dm_policy": "open"})
+        )
+        assert adapter._instant_ack_enabled is False
+        adapter._text_batch_delay_seconds = 0
+        adapter.handle_message = AsyncMock()
+        adapter._extract_media = AsyncMock(return_value=([], []))
+        adapter._send_json = AsyncMock()
+
+        payload = self._text_payload(
+            msgid="msg-off-1", req_id="req-off-1",
+            chat_id="user-off", chat_type="single", content="hello",
+        )
+
+        await adapter._on_message(payload)
+        adapter.handle_message.assert_awaited_once()
+        await self._drain_acks(adapter)
+        adapter._send_json.assert_not_awaited()


### PR DESCRIPTION
## Summary

WeCom AI Bot (WebSocket mode) delivers no intermediate feedback while
the agent is processing a message. Long-running queries — large session
context re-prefilled every turn, or tool-heavy turns that run minutes —
look exactly like a dead bot. This PR sends an immediate, short
acknowledgment the moment an accepted inbound message is dispatched to
the agent, so users know the request landed and is being worked on.

## Motivation

Observed in production (WeCom DM, heavy agent usage):
- Simple questions (<=2 tool calls) median ~22s, dominated by
  re-prefilling a ~140k-token session context every turn.
- Tool-heavy turns routinely take minutes; the longest took 2h05m
  (84 tool calls).
- WeCom subscription (errcode 846609) expires when a turn outlives the
  session window, and users re-send during the dead window.

Users cannot tell "working" from "dead" without any feedback — this is
the cheapest possible fix (see also #16676).

## Changes

- plugins/platforms/wecom/adapter.py
  - Wrap both inbound dispatch sites in _dispatch_to_agent(), which
    schedules the acknowledgment first, then calls handle_message().
  - _send_instant_ack() sends an APP_CMD_RESPONSE markdown frame with
    headers.req_id correlated to the inbound request (reply-mode — the
    only send mode WeCom AI Bots may use in group chats; APP_CMD_SEND
    would be rejected there).
  - Fire-and-forget: async task tracked in _ack_tasks, exceptions logged
    as warnings only, never raised into the pipeline.
  - Phrase pool of 8 short Chinese acknowledgments, chosen randomly per
    message to avoid sounding canned.
  - No ack for slash commands or messages lacking a req_id.
  - Text-batched (client-side split) messages ack exactly once, at
    dispatch time.
  - Opt-out env HERMES_WECOM_INSTANT_ACK=false (default enabled).
- tests/gateway/test_wecom.py — TestWeComInstantAck (7 tests):
  DM frame uses cmd=APP_CMD_RESPONSE with req_id correlation and phrase
  from the pool; group chat uses reply-mode (not APP_CMD_SEND); slash
  commands get no ack; policy-rejected messages never reach the handler;
  ack failure does not break the pipeline; batched long text acks once;
  env flag can disable.

## Test plan

- pytest tests/gateway/test_wecom.py::TestWeComInstantAck -v → 7/7 pass
- Full tests/gateway/test_wecom.py: 31 passed, 1 pre-existing failure
  (TestMediaUpload::test_download_remote_bytes_blocks_connect_time_rebind
  — environmental httpx issue, reproduced on clean HEAD via stash).

## Notes for reviewers

- Follows the review guidance on #16676: implemented in the adapter,
  reply-mode for groups, with tests.
- No pending futures are used for the ack, so it cannot collide with the
  normal reply's req_id future bookkeeping.

Refs #16676
