### PR TITLE
fix(update): degrade past repo-scoped HTTP 429 with bounded retry (#105857)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -156,13 +156,20 @@ def _git_run(git_cmd, args, cwd=None, *, check=False, network=False):
         **(_no_prompt_git_kwargs() if network else {}))
 
 
-# Bring the fresh-install clone resilience (#89624, install.sh) to the existing-install update path
-# (#105857). GitHub throttles packfile generation for this large repo with a repo-scoped HTTP 429
-# that a one-shot ``ls-remote`` slips past but a full ``fetch origin main`` dies on — so a single
-# failed attempt strands a healthy checkout behind upstream. Retry with bounded backoff, then degrade
-# to a blobless fetch (``--filter=blob:none``): commits+trees transfer as many small packs that get
-# past the throttle, and the blobs are then materialized by the checkout/pull below as a separate
-# request that the same throttle-aware handling can wrap.
+# Degrade past a *transient* repo-scoped HTTP 429 on the existing-install update path (#105857).
+# GitHub throttles packfile generation for this large repo with a repo-scoped HTTP 429 that a
+# one-shot ``ls-remote`` slips past but a full ``fetch origin main`` dies on — so a single failed
+# attempt strands a healthy checkout behind upstream across indefinite manual retries. Retry with
+# bounded linear backoff so a transient/secondary throttle self-clears; only a 429 retries, so
+# unrelated errors (no network, auth, DNS) still fail fast. Shared by the apply and ``--check`` paths.
+#
+# NB: a ``--filter=blob:none`` degradation was considered (mirroring the fresh-install clone,
+# #89624) but is deliberately NOT done here: a filtered fetch into an ordinary full checkout
+# *persistently* rewrites it into a partial clone (it sets ``remote.origin.promisor=true`` /
+# ``partialclonefilter=blob:none``), so every later git op may demand-fetch omitted blobs over the
+# network. Realizing those blobs through the subsequent ``merge --ff-only`` on a still-throttled
+# remote is unproven and the config mutation must be transaction-owned/restored. That belongs in a
+# separate change with a real ordinary-clone regression, not folded into this retry fix.
 _FETCH_MAX_ATTEMPTS = 4
 
 
@@ -171,26 +178,25 @@ def _fetch_is_rate_limited(stderr: str) -> bool:
     return _has_http_code(stderr or "", "429") or "rate limit" in (stderr or "").lower()
 
 
-def _fetch_updates_resilient(git_cmd, branch, *, sleep=_time.sleep):
-    """``git fetch origin <branch>`` that degrades past a repo-scoped HTTP 429 (#105857).
+def _fetch_with_rate_limit_retry(git_cmd, fetch_args, *, sleep=_time.sleep):
+    """``git fetch <fetch_args>`` that degrades past a transient repo-scoped HTTP 429 (#105857).
 
-    Returns the final ``CompletedProcess`` (caller inspects ``returncode``). A non-rate-limit
-    failure is returned immediately so unrelated errors (no network, auth) still fail fast; only a
-    429 triggers the retry/backoff and blobless fallback. If the blobless attempt does not get
-    further, the original 429 result is preserved so ``_print_fetch_failure`` keeps its accurate
-    diagnosis."""
-    result = _git_run(git_cmd, ["fetch", "origin", branch], network=True)
+    ``fetch_args`` is the argv after ``fetch`` (e.g. ``["origin", branch]`` on the apply path, or
+    ``["--depth", "1", "upstream", branch]`` on ``--check``), so both the apply and check paths
+    share one retry policy. Returns the final ``CompletedProcess`` (caller inspects ``returncode``).
+    A non-rate-limit failure is returned immediately so unrelated errors still fail fast; only a 429
+    triggers the bounded 5/10/15s backoff. When every attempt is throttled the last 429 result is
+    returned so ``_print_fetch_failure`` keeps its accurate diagnosis."""
+    result = _git_run(git_cmd, ["fetch", *fetch_args], network=True)
     if result.returncode == 0 or not _fetch_is_rate_limited(result.stderr):
         return result
     for attempt in range(2, _FETCH_MAX_ATTEMPTS + 1):
         sleep((attempt - 1) * 5)
         print(f"  Rate-limited (HTTP 429) — retrying fetch (attempt {attempt}/{_FETCH_MAX_ATTEMPTS})...")
-        result = _git_run(git_cmd, ["fetch", "origin", branch], network=True)
+        result = _git_run(git_cmd, ["fetch", *fetch_args], network=True)
         if result.returncode == 0 or not _fetch_is_rate_limited(result.stderr):
             return result
-    print("  Still rate-limited — retrying with a blobless fetch (--filter=blob:none)...")
-    blobless = _git_run(git_cmd, ["fetch", "--filter=blob:none", "origin", branch], network=True)
-    return blobless if blobless.returncode == 0 else result
+    return result
 
 
 def _capture_head_sha(git_cmd, cwd) -> str | None:
@@ -539,12 +545,12 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     fetch_result = None
     if branch == "main" and _git_run(git_cmd, ["remote", "get-url", "upstream"]).returncode == 0:
         print("→ Fetching from upstream...")
-        fetch_result = _git_run(git_cmd, ["fetch"] + depth_args + ["upstream", branch], network=True)
+        fetch_result = _fetch_with_rate_limit_retry(git_cmd, depth_args + ["upstream", branch])
     if fetch_result is not None and fetch_result.returncode == 0:
         compare_branch = f"upstream/{branch}"
     else:
         print("→ Fetching from origin...")
-        fetch_result = _git_run(git_cmd, ["fetch"] + depth_args + ["origin", branch], network=True)
+        fetch_result = _fetch_with_rate_limit_retry(git_cmd, depth_args + ["origin", branch])
         compare_branch = f"origin/{branch}"
 
     if fetch_result.returncode != 0:
@@ -1356,7 +1362,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         _m()._warn_orphaned_update_autostashes(git_cmd, _m().PROJECT_ROOT)
 
         print("→ Fetching updates...")
-        fetch_result = _fetch_updates_resilient(git_cmd, branch)
+        fetch_result = _fetch_with_rate_limit_retry(git_cmd, ["origin", branch])
         if fetch_result.returncode != 0:
             _print_fetch_failure(fetch_result.stderr)
             sys.exit(1)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -91,7 +91,7 @@ from hermes_cli.update_cmd_git import (  # noqa: F401
     _ORPHAN_RESCUE_REF_MAX_AGE_DAYS, _add_upstream_remote, _assess_parked_branch_switch,
     _branch_head_label, _branch_head_suffix, _classify_fetch_failure, _count_commits_between,
     _discard_lockfile_churn, _ensure_non_trampoline_git, _get_origin_url, _git_is_trampoline,
-    _has_upstream_remote, _is_fork, _locate_real_git, _mark_skip_upstream_prompt,
+    _has_http_code, _has_upstream_remote, _is_fork, _locate_real_git, _mark_skip_upstream_prompt,
     _normalize_managed_eol, _portable_git_candidates, _print_fetch_failure,
     _print_parked_branch_kept_notice, _print_parked_branch_skip_warning,
     _prune_orphan_rescue_refs, _should_skip_upstream_prompt, _sync_fork_with_upstream,
@@ -154,6 +154,43 @@ def _git_run(git_cmd, args, cwd=None, *, check=False, network=False):
         git_cmd + args, cwd=_m().PROJECT_ROOT if cwd is None else cwd, capture_output=True,
         text=True, encoding="utf-8", errors="replace", check=check,
         **(_no_prompt_git_kwargs() if network else {}))
+
+
+# Bring the fresh-install clone resilience (#89624, install.sh) to the existing-install update path
+# (#105857). GitHub throttles packfile generation for this large repo with a repo-scoped HTTP 429
+# that a one-shot ``ls-remote`` slips past but a full ``fetch origin main`` dies on — so a single
+# failed attempt strands a healthy checkout behind upstream. Retry with bounded backoff, then degrade
+# to a blobless fetch (``--filter=blob:none``): commits+trees transfer as many small packs that get
+# past the throttle, and the blobs are then materialized by the checkout/pull below as a separate
+# request that the same throttle-aware handling can wrap.
+_FETCH_MAX_ATTEMPTS = 4
+
+
+def _fetch_is_rate_limited(stderr: str) -> bool:
+    """True when a failed git fetch's stderr is the repo-scoped HTTP 429 packfile throttle."""
+    return _has_http_code(stderr or "", "429") or "rate limit" in (stderr or "").lower()
+
+
+def _fetch_updates_resilient(git_cmd, branch, *, sleep=_time.sleep):
+    """``git fetch origin <branch>`` that degrades past a repo-scoped HTTP 429 (#105857).
+
+    Returns the final ``CompletedProcess`` (caller inspects ``returncode``). A non-rate-limit
+    failure is returned immediately so unrelated errors (no network, auth) still fail fast; only a
+    429 triggers the retry/backoff and blobless fallback. If the blobless attempt does not get
+    further, the original 429 result is preserved so ``_print_fetch_failure`` keeps its accurate
+    diagnosis."""
+    result = _git_run(git_cmd, ["fetch", "origin", branch], network=True)
+    if result.returncode == 0 or not _fetch_is_rate_limited(result.stderr):
+        return result
+    for attempt in range(2, _FETCH_MAX_ATTEMPTS + 1):
+        sleep((attempt - 1) * 5)
+        print(f"  Rate-limited (HTTP 429) — retrying fetch (attempt {attempt}/{_FETCH_MAX_ATTEMPTS})...")
+        result = _git_run(git_cmd, ["fetch", "origin", branch], network=True)
+        if result.returncode == 0 or not _fetch_is_rate_limited(result.stderr):
+            return result
+    print("  Still rate-limited — retrying with a blobless fetch (--filter=blob:none)...")
+    blobless = _git_run(git_cmd, ["fetch", "--filter=blob:none", "origin", branch], network=True)
+    return blobless if blobless.returncode == 0 else result
 
 
 def _capture_head_sha(git_cmd, cwd) -> str | None:
@@ -1319,7 +1356,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         _m()._warn_orphaned_update_autostashes(git_cmd, _m().PROJECT_ROOT)
 
         print("→ Fetching updates...")
-        fetch_result = _git_run(git_cmd, ["fetch", "origin", branch], network=True)
+        fetch_result = _fetch_updates_resilient(git_cmd, branch)
         if fetch_result.returncode != 0:
             _print_fetch_failure(fetch_result.stderr)
             sys.exit(1)

--- a/tests/hermes_cli/test_update_fetch_rate_limit_retry.py
+++ b/tests/hermes_cli/test_update_fetch_rate_limit_retry.py
@@ -1,0 +1,101 @@
+"""`hermes update`'s fetch degrades past a repo-scoped HTTP 429 instead of exiting
+after one attempt (#105857).
+
+GitHub throttles packfile generation for this large repo with a repo-scoped HTTP 429
+that a one-shot ``ls-remote`` slips past but a full ``fetch origin main`` dies on. The
+updater used to print the (accurate) 429 diagnosis and ``sys.exit(1)`` immediately,
+stranding a healthy checkout behind upstream across indefinite manual retries. It must
+now mirror the fresh-install clone resilience (#89624, install.sh): retry with bounded
+backoff, then degrade to a blobless (``--filter=blob:none``) fetch whose small packs get
+past the throttle. A non-rate-limit failure must still fail fast.
+"""
+
+import subprocess
+
+from hermes_cli import update_cmd
+
+
+def _result(returncode, stderr=""):
+    return subprocess.CompletedProcess(args=["git"], returncode=returncode, stdout="", stderr=stderr)
+
+
+RATE_LIMIT = (
+    "error: RPC failed; HTTP 429 curl 22 The requested URL returned error: 429\n"
+    "fatal: expected flush after ref listing"
+)
+DNS_FAILURE = (
+    "fatal: unable to access 'https://github.com/x.git/': Could not resolve host: github.com"
+)
+
+
+class _GitStub:
+    """Records each ``_git_run`` call and returns queued results in order."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls = []
+
+    def __call__(self, git_cmd, args, cwd=None, *, check=False, network=False):
+        self.calls.append(list(args))
+        return self._results.pop(0)
+
+
+def _run(monkeypatch, results):
+    stub = _GitStub(results)
+    slept = []
+    monkeypatch.setattr(update_cmd, "_git_run", stub)
+    out = update_cmd._fetch_updates_resilient(["git"], "main", sleep=slept.append)
+    return out, stub, slept
+
+
+class TestFetchUpdatesResilient:
+    def test_first_attempt_success_no_retry(self, monkeypatch):
+        out, stub, slept = _run(monkeypatch, [_result(0)])
+        assert out.returncode == 0
+        assert len(stub.calls) == 1
+        assert slept == []  # never slept
+
+    def test_non_rate_limit_failure_fails_fast(self, monkeypatch):
+        out, stub, slept = _run(monkeypatch, [_result(128, DNS_FAILURE)])
+        assert out.returncode == 128
+        assert len(stub.calls) == 1  # no retry on a non-429 error
+        assert slept == []
+
+    def test_recovers_on_a_retry_before_blobless(self, monkeypatch):
+        out, stub, slept = _run(
+            monkeypatch, [_result(1, RATE_LIMIT), _result(1, RATE_LIMIT), _result(0)])
+        assert out.returncode == 0
+        assert len(stub.calls) == 3
+        # Backoff applied before each retry; blobless not reached.
+        assert slept == [5, 10]
+        assert all("--filter=blob:none" not in c for c in stub.calls)
+
+    def test_degrades_to_blobless_after_exhausting_retries(self, monkeypatch):
+        # 4 rate-limited plain fetches, then a successful blobless fetch.
+        out, stub, slept = _run(
+            monkeypatch,
+            [_result(1, RATE_LIMIT)] * 4 + [_result(0)])
+        assert out.returncode == 0
+        assert len(stub.calls) == 5
+        assert slept == [5, 10, 15]  # backoff before attempts 2, 3, 4
+        assert stub.calls[-1] == ["fetch", "--filter=blob:none", "origin", "main"]
+
+    def test_preserves_original_429_when_blobless_also_fails(self, monkeypatch):
+        # Every attempt throttled — caller must still get a 429 result so the accurate
+        # rate-limit diagnosis (not the blobless failure) is what gets printed.
+        blobless_fail = _result(1, "fatal: some other blobless failure")
+        out, stub, slept = _run(
+            monkeypatch, [_result(1, RATE_LIMIT)] * 4 + [blobless_fail])
+        assert out.returncode == 1
+        assert update_cmd._fetch_is_rate_limited(out.stderr)
+        assert out.stderr == RATE_LIMIT  # original 429, not the blobless stderr
+
+
+class TestFetchIsRateLimited:
+    def test_detects_http_429_and_rate_limit_phrase(self):
+        assert update_cmd._fetch_is_rate_limited(RATE_LIMIT)
+        assert update_cmd._fetch_is_rate_limited("fatal: GitHub rate limit exceeded")
+
+    def test_non_rate_limit_is_false(self):
+        assert not update_cmd._fetch_is_rate_limited(DNS_FAILURE)
+        assert not update_cmd._fetch_is_rate_limited("")

--- a/tests/hermes_cli/test_update_fetch_rate_limit_retry.py
+++ b/tests/hermes_cli/test_update_fetch_rate_limit_retry.py
@@ -1,13 +1,14 @@
-"""`hermes update`'s fetch degrades past a repo-scoped HTTP 429 instead of exiting
-after one attempt (#105857).
+"""`hermes update`'s fetch degrades past a *transient* repo-scoped HTTP 429 instead of
+exiting after one attempt (#105857).
 
 GitHub throttles packfile generation for this large repo with a repo-scoped HTTP 429
 that a one-shot ``ls-remote`` slips past but a full ``fetch origin main`` dies on. The
 updater used to print the (accurate) 429 diagnosis and ``sys.exit(1)`` immediately,
 stranding a healthy checkout behind upstream across indefinite manual retries. It must
-now mirror the fresh-install clone resilience (#89624, install.sh): retry with bounded
-backoff, then degrade to a blobless (``--filter=blob:none``) fetch whose small packs get
-past the throttle. A non-rate-limit failure must still fail fast.
+now retry with bounded linear backoff so a transient/secondary throttle self-clears. A
+non-rate-limit failure must still fail fast. The retry policy is shared by the apply
+path (``fetch origin main``) and the ``--check`` path (``fetch [--depth 1]
+upstream|origin main``) via ``fetch_args`` passthrough.
 """
 
 import subprocess
@@ -40,15 +41,16 @@ class _GitStub:
         return self._results.pop(0)
 
 
-def _run(monkeypatch, results):
+def _run(monkeypatch, results, fetch_args=None):
     stub = _GitStub(results)
     slept = []
     monkeypatch.setattr(update_cmd, "_git_run", stub)
-    out = update_cmd._fetch_updates_resilient(["git"], "main", sleep=slept.append)
+    out = update_cmd._fetch_with_rate_limit_retry(
+        ["git"], fetch_args if fetch_args is not None else ["origin", "main"], sleep=slept.append)
     return out, stub, slept
 
 
-class TestFetchUpdatesResilient:
+class TestFetchWithRateLimitRetry:
     def test_first_attempt_success_no_retry(self, monkeypatch):
         out, stub, slept = _run(monkeypatch, [_result(0)])
         assert out.returncode == 0
@@ -61,34 +63,34 @@ class TestFetchUpdatesResilient:
         assert len(stub.calls) == 1  # no retry on a non-429 error
         assert slept == []
 
-    def test_recovers_on_a_retry_before_blobless(self, monkeypatch):
+    def test_recovers_on_a_retry(self, monkeypatch):
         out, stub, slept = _run(
             monkeypatch, [_result(1, RATE_LIMIT), _result(1, RATE_LIMIT), _result(0)])
         assert out.returncode == 0
         assert len(stub.calls) == 3
-        # Backoff applied before each retry; blobless not reached.
-        assert slept == [5, 10]
-        assert all("--filter=blob:none" not in c for c in stub.calls)
+        assert slept == [5, 10]  # backoff applied before each retry
 
-    def test_degrades_to_blobless_after_exhausting_retries(self, monkeypatch):
-        # 4 rate-limited plain fetches, then a successful blobless fetch.
-        out, stub, slept = _run(
-            monkeypatch,
-            [_result(1, RATE_LIMIT)] * 4 + [_result(0)])
-        assert out.returncode == 0
-        assert len(stub.calls) == 5
-        assert slept == [5, 10, 15]  # backoff before attempts 2, 3, 4
-        assert stub.calls[-1] == ["fetch", "--filter=blob:none", "origin", "main"]
-
-    def test_preserves_original_429_when_blobless_also_fails(self, monkeypatch):
-        # Every attempt throttled — caller must still get a 429 result so the accurate
-        # rate-limit diagnosis (not the blobless failure) is what gets printed.
-        blobless_fail = _result(1, "fatal: some other blobless failure")
-        out, stub, slept = _run(
-            monkeypatch, [_result(1, RATE_LIMIT)] * 4 + [blobless_fail])
+    def test_exhausts_retries_and_returns_last_429(self, monkeypatch):
+        # Every one of the 4 attempts is throttled; the final 429 result is returned so
+        # _print_fetch_failure keeps the accurate rate-limit diagnosis.
+        out, stub, slept = _run(monkeypatch, [_result(1, RATE_LIMIT)] * 4)
         assert out.returncode == 1
         assert update_cmd._fetch_is_rate_limited(out.stderr)
-        assert out.stderr == RATE_LIMIT  # original 429, not the blobless stderr
+        assert len(stub.calls) == 4
+        assert slept == [5, 10, 15]  # backoff before attempts 2, 3, 4
+
+    def test_passes_fetch_args_through_verbatim(self, monkeypatch):
+        # The --check path shares this policy via arg passthrough (upstream + --depth).
+        out, stub, _ = _run(
+            monkeypatch, [_result(0)], fetch_args=["--depth", "1", "upstream", "main"])
+        assert out.returncode == 0
+        assert stub.calls[0] == ["fetch", "--depth", "1", "upstream", "main"]
+
+    def test_never_degrades_to_a_blobless_filter(self, monkeypatch):
+        # A --filter=blob:none fetch would persistently rewrite an ordinary checkout into a
+        # partial clone; the retry path must never issue one.
+        _, stub, _ = _run(monkeypatch, [_result(1, RATE_LIMIT)] * 4)
+        assert all("--filter=blob:none" not in c for c in stub.calls)
 
 
 class TestFetchIsRateLimited:


### PR DESCRIPTION
## What

`hermes update` (and `hermes update --check`) died on the first repo-scoped **HTTP 429** GitHub returns when it throttles packfile generation for this large repo. A one-shot `ls-remote` slips past the throttle but a full `fetch origin main` hits it, so a single failed attempt printed the (accurate) 429 diagnosis and `sys.exit(1)`, stranding a healthy checkout behind upstream across indefinite manual retries.

## Fix

`_fetch_with_rate_limit_retry(git_cmd, fetch_args)` wraps the fetch with a bounded **5/10/15s linear backoff** so a transient/secondary throttle self-clears. It takes the argv after `fetch`, so both call sites share one retry policy:

- **apply** path — `fetch origin main`
- **`--check`** path — `fetch [--depth 1] upstream|origin main` (previously still `sys.exit(1)`d on the first 429)

Only a 429 retries; unrelated failures (no network, auth, DNS) still fail fast, and the last 429 result is returned so `_print_fetch_failure` keeps its accurate diagnosis.

## Scope note (why no blobless fallback)

An earlier revision degraded to a `--filter=blob:none` fetch (mirroring the fresh-install clone, #89624). That was **dropped** after review: a filtered fetch into an *ordinary full checkout* **persistently** rewrites it into a partial clone — it sets `remote.origin.promisor=true` / `partialclonefilter=blob:none` (verified empirically), so every later git op may demand-fetch omitted blobs over the network. Realizing those blobs through the subsequent `merge --ff-only` on a still-throttled remote is unproven, and the config mutation must be transaction-owned/restored. That belongs in a **separate** change carrying a real ordinary-clone regression, not folded into this retry fix.

## Tests

`tests/hermes_cli/test_update_fetch_rate_limit_retry.py`: first-attempt success (no sleep), non-429 fails fast, recovers mid-retry, exhausts retries and returns the last 429, `fetch_args` passthrough (`--depth 1 upstream main`), and never issues a `--filter=blob:none`.

Fixes #105857
