### PR TITLE
fix(agent): keep x-opencode-session on stateless one-shots

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6058,9 +6058,16 @@ def _build_call_kwargs(
         ):
             kwargs["_reasoning_config"] = dict(reasoning_config)
     # OpenCode relay session affinity — same key as the main turn so compression/title/vision
-    # calls stay on the conversation's warm backend.
+    # calls stay on the conversation's warm backend. Stateless one-shots (commit messages
+    # fired from the review panel between turns) carry no conversation identity at all, but
+    # the relay requires the header for routing too (Console Go 400 MissingSessionID) — fall
+    # back to a stable per-task key so those calls land on one warm backend instead of being
+    # rejected (#105841).
     from agent.opencode_affinity import merge_opencode_session_headers
-    return merge_opencode_session_headers(kwargs, provider, base_url, _runtime_main_value("session_id") or None)
+    session_key = _runtime_main_value("session_id") or None
+    if not session_key:
+        session_key = f"oneshot:{task}" if task else "oneshot"
+    return merge_opencode_session_headers(kwargs, provider, base_url, session_key)
 
 
 def _validate_llm_response(

--- a/tests/agent/test_opencode_session_affinity.py
+++ b/tests/agent/test_opencode_session_affinity.py
@@ -60,3 +60,25 @@ def test_auxiliary_calls_share_the_main_turn_session_key():
         assert "x-opencode-session" not in (other.get("extra_headers") or {})
     finally:
         aux._RUNTIME_MAIN_CONTEXT.reset(token)
+
+
+def test_stateless_oneshot_still_sends_the_session_header():
+    """Review-panel one-shots run between turns: no live session, no ambient
+    conversation. The relay still requires the header for routing (Console Go
+    400 MissingSessionID), so derive a stable per-task key instead of sending
+    nothing (#105841)."""
+    kwargs = aux._build_call_kwargs(
+        "opencode-go", "glm-5", _MSGS, base_url="https://opencode.ai/zen/go/v1", task="commit_message",
+    )
+    assert kwargs["extra_headers"]["x-opencode-session"] == "oneshot:commit_message"
+
+    taskless = aux._build_call_kwargs(
+        "opencode-go", "glm-5", _MSGS, base_url="https://opencode.ai/zen/go/v1",
+    )
+    assert taskless["extra_headers"]["x-opencode-session"] == "oneshot"
+
+    plain = aux._build_call_kwargs(
+        "openrouter", "anthropic/claude-sonnet-4.6", _MSGS, base_url="https://openrouter.ai/api/v1",
+        task="commit_message",
+    )
+    assert "x-opencode-session" not in (plain.get("extra_headers") or {})


### PR DESCRIPTION
Fixes #105841.

The header's value was derived exclusively from conversation identity — ambient conversation context, then affinity scope, then the live session's id. That covers every call made from inside a turn, which is why the chat path came right once the affinity work landed. But one-shots fired *between* turns have none of the three: the review panel's commit-message button goes through `llm.oneshot`, which only finds a `main_runtime` when a session is live, and when you're sitting in the review panel none is. So `opencode_session_headers` resolved an empty key, returned `{}`, and the request shipped without the header — which Console Go now rejects with 400 MissingSessionID, since it needs the header for routing, not just cache warmth.

The fix adds a last-resort key in `_build_call_kwargs`: when there's no conversation identity at all, use `oneshot:<task>` (or plain `oneshot` for taskless calls). It's stable, so same-task one-shots still share one warm backend — commit messages stick together, titles stick together — and it satisfies the routing requirement. Nothing changes for non-OpenCode targets, and a caller-pinned header still wins over the derived one.

Tested in `tests/agent/test_opencode_session_affinity.py`: stateless call with `task="commit_message"` sends `oneshot:commit_message`, a taskless stateless call still sends a header, and openrouter targets remain untouched. The aux/affinity/oneshot test surface has an identical failure set before and after this change (4 pre-existing failures unrelated to headers).

One thing I noticed while tracing: the desktop's commit-message call doesn't pass `task`, so the gateway default (`title_generation`) becomes the scope key. Routing-wise that's fine — the key only needs to be opaque and stable — but if you'd rather commit messages get their own scope, the desktop client could pass `task: 'commit_message'` and this fix already handles the rest.
