### PR TITLE
fix(cli): resolve Bedrock wire from the session model at CLI startup

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -184,7 +184,10 @@ class CLIAgentSetupMixin:
         try:
             runtime = resolve_runtime_provider(
                 requested=self.requested_provider, explicit_api_key=self._explicit_api_key,
-                explicit_base_url=self._explicit_base_url)
+                explicit_base_url=self._explicit_base_url,
+                # Bedrock picks its wire per model (Claude -> anthropic_messages, else Converse);
+                # without target_model the resolver decides from model.default, not the session model.
+                target_model=self.model or None)
         except Exception as exc:
             _primary_exc = exc
         if _primary_exc is not None:

--- a/tests/hermes_cli/test_cli_bedrock_session_model_wire.py
+++ b/tests/hermes_cli/test_cli_bedrock_session_model_wire.py
@@ -1,0 +1,99 @@
+"""CLI startup must resolve Bedrock's wire for the SESSION model, not the config default.
+
+Regression for #50292.  ``hermes chat -m <non-Claude Bedrock id> --provider bedrock`` on a
+profile whose ``model.default`` is a Claude id started on the AnthropicBedrock wire
+(``anthropic_messages``); Bedrock rejected the Anthropic-format tool schema with
+``HTTP 400 ... Invalid 'tools': missing field 'type'`` and the fallback chain replaced the
+requested model.
+
+The resolver half already honours ``target_model`` (``current_model = target_model or
+default``); the defect is the startup caller, ``_ensure_runtime_credentials``, which never
+passed it.  These tests drive that caller with the real ``resolve_runtime_provider`` and a
+Claude default in config, and assert on the ``api_mode`` the CLI ends up with -- the one
+thing that decides which wire the first request uses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+CLAUDE_DEFAULT = "us.anthropic.claude-opus-5"
+
+
+class _RuntimeCLI(CLIAgentSetupMixin):
+    """The minimal HermesCLI shell ``_ensure_runtime_credentials`` reads and writes."""
+
+    def __init__(self, *, model: str, provider: str):
+        self.model = model
+        self.requested_provider = provider
+        self.provider = provider
+        self.api_key = None
+        self.base_url = None
+        self.api_mode = "chat_completions"
+        self.acp_command = None
+        self.acp_args = []
+        self.agent = None
+        self._fallback_model = []
+        self._explicit_api_key = None
+        self._explicit_base_url = None
+        self._credential_pool = None
+        self._provider_source = None
+        self._active_agent_route_signature = None
+
+    def _normalize_model_for_provider(self, _provider: str) -> bool:
+        return False
+
+
+@pytest.fixture
+def bedrock_claude_default(monkeypatch):
+    """A profile whose default is Claude on Bedrock, with credentials the resolver accepts.
+
+    ``requested_provider="bedrock"`` is an *explicit* selection, so the resolver trusts
+    boto3's credential chain instead of probing for keys; the env vars below only keep
+    boto3 itself from wandering into IMDS/SSO lookups inside the test.  ``HERMES_HOME``
+    is already a per-test tempdir (autouse ``_hermetic_environment``), so the config
+    written here is the only one the mtime-cached loader can see.
+    """
+    from hermes_constants import get_hermes_home
+
+    (get_hermes_home() / "config.yaml").write_text(
+        f"model:\n  default: {CLAUDE_DEFAULT}\n  provider: bedrock\nbedrock:\n  region: us-west-2\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIATESTNOTREAL0000000")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test-secret-not-real")
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
+
+def _startup(model: str) -> _RuntimeCLI:
+    cli = _RuntimeCLI(model=model, provider="bedrock")
+    assert cli._ensure_runtime_credentials() is True
+    return cli
+
+
+def test_non_claude_session_model_uses_converse_despite_claude_default(bedrock_claude_default):
+    """The invariant: ``-m`` names a Converse-only model, the profile default is Claude."""
+    cli = _startup("zai.glm-4.7-flash")
+    assert cli.api_mode == "bedrock_converse"
+    assert cli.provider == "bedrock"
+    # The model the session runs is the one that was asked for, not the default.
+    assert cli.model == "zai.glm-4.7-flash"
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "global.anthropic.claude-sonnet-5",
+        "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+    ],
+)
+def test_claude_session_model_keeps_anthropic_wire(bedrock_claude_default, model):
+    """Control: passing ``target_model`` must not regress Claude ids -- on any inference-profile
+    prefix ``is_anthropic_bedrock_model`` normalises -- to Converse."""
+    cli = _startup(model)
+    assert cli.api_mode == "anthropic_messages", model
+    assert cli.provider == "bedrock"


### PR DESCRIPTION
## What does this PR do?

`hermes chat -m <non-Claude Bedrock id> --provider bedrock` on a profile whose `model.default` is a Claude id started on the AnthropicBedrock wire (`api_mode=anthropic_messages`). Bedrock rejected the Anthropic-format tool schema:

```
HTTP 400 {"error":{"code":"validation_error","message":"Failed to deserialize the JSON body into the target type: ?[0]: Invalid 'tools': missing field `type` ..."}}
```

The fallback chain then replaced the requested model with the first configured fallback and the turn completed there, so the only traces were the "Model fallback: ... unavailable" notice and the `Fallback activated: <requested> -> <fallback>` line in `agent.log`. The model the user asked for never ran.

**Mechanism.** The resolver side is already correct on `main`: `_resolve_bedrock_runtime` (`hermes_cli/runtime_provider_backends.py:210`) computes `current_model = str(target_model or model_cfg.get("default") or "")` and routes Claude ids to `anthropic_messages` via `is_anthropic_bedrock_model(current_model)` (`:218`), everything else to `bedrock_converse`; `resolve_runtime_provider` threads `target_model` to that rung (`hermes_cli/runtime_provider.py:860-861`). The startup caller, `CLIAgentSetupMixin._ensure_runtime_credentials` (`hermes_cli/cli_agent_setup_mixin.py:185-187`), was the one model-dependent caller that did not pass `target_model`, so the wire was decided from `config.yaml`'s default on every startup. `model_switch`, `oneshot`, `moa_loop`, `agent_runtime_helpers`, `model_metadata`, `auxiliary_client`, `background_review` and `curator` all already pass it.

**Fix.** Pass `target_model=self.model or None` at that call site. Nothing in the resolver changes: the regional-prefix normalisation (`us.`/`global.`/`eu.`) keeps Claude ids on the Anthropic wire, and the Mantle (`codex_responses`) branch is unaffected.

**Relationship to existing PRs.** This is the same one-kwarg hunk as #96457 (no tests there), and it is the "primary CLI call-site change" the sweeper review on #50300 said current `main` still needs, with the "focused CLI regression coverage" that review asked for. If the author of #96457 prefers to add the tests there, I am happy to close this one in its favour.

**Deliberately not changed.** `_resolve_fallback_runtime` (`hermes_cli/cli_agent_setup_mixin.py:284-290`) builds `_fb_kwargs` without `target_model` and has the same shape (the #50300 review also flagged it). Left for a follow-up with its own regression test rather than folded in untested; glad to add it here if maintainers would rather have both in one PR. `_runtime_credentials_ready` (`:312-314`) is a keyless probe that only inspects `api_key`/`base_url` and does not need the model.

## Related Issue

Fixes #50292
Refs #96457, #50300

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/cli_agent_setup_mixin.py`: `_ensure_runtime_credentials` passes `target_model=self.model or None` to `resolve_runtime_provider` (one kwarg plus a two-line comment).
- `tests/hermes_cli/test_cli_bedrock_session_model_wire.py` (new): drives the real `_ensure_runtime_credentials` and the real `resolve_runtime_provider` against a Claude-default Bedrock config written to the per-test `HERMES_HOME`, and asserts on the `api_mode` the CLI ends up with. One invariant plus one parametrized control:
  - `test_non_claude_session_model_uses_converse_despite_claude_default` -- the invariant. RED on unaltered `main` (`AssertionError: assert 'anthropic_messages' == 'bedrock_converse'`), GREEN with the fix.
  - `test_claude_session_model_keeps_anthropic_wire[...]` -- control over three Claude ids (`us.`, `global.`, `eu.` prefixes): passing `target_model` must not push Claude to Converse. Passes before and after; it is there to pin the other half of the routing while the invariant moves.

## How to Test

1. `config.yaml` with `model.default: us.anthropic.claude-<any>` and `model.provider: bedrock`, AWS credentials available.
2. `hermes chat -m <non-Claude Bedrock id> --provider bedrock -q "run a shell command that echoes ok"` (any prompt that triggers a tool call). On `main`: the 400 above in `~/.hermes/logs/agent.log` followed by a "Model fallback" notice and the answer coming from the fallback model. With this PR: the request goes out on `bedrock_converse`, the tool runs, no fallback.
3. `scripts/run_tests.sh tests/hermes_cli/test_cli_bedrock_session_model_wire.py` -> 4 passed. Revert the one-line hunk in `hermes_cli/cli_agent_setup_mixin.py` and re-run -> 1 failed (the invariant), 3 passed (the control).
4. Neighbours, all green via `scripts/run_tests.sh -j 1 <file>`: `tests/hermes_cli/test_cli_custom_provider_vision.py` (2), `test_copilot_runtime_api_mode.py` (14), `test_bedrock_model_picker.py` (9), `test_runtime_provider_resolution.py` (65), `test_mcp_discovery_timing.py` (12), `test_base_url_host_identity.py` (13), `tests/cli/test_single_query_clarify.py` (5), `tests/cli/test_subagent_notification_display.py` (1), `tests/cli/test_cli_active_agent_ref_wiring.py` (2), `tests/run_agent/test_callable_api_key.py` (12).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate -- it overlaps #96457 and #50300 on purpose; see above.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (unit tests); the live reproduction and fix were observed on Linux with a real Bedrock account.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
