### PR TITLE
fix(update): retry repo-scoped 429 fetches and fall back to guarded ZIP update

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -91,7 +91,7 @@ from hermes_cli.update_cmd_git import (  # noqa: F401
     _ORPHAN_RESCUE_REF_MAX_AGE_DAYS, _add_upstream_remote, _assess_parked_branch_switch,
     _branch_head_label, _branch_head_suffix, _classify_fetch_failure, _count_commits_between,
     _discard_lockfile_churn, _ensure_non_trampoline_git, _get_origin_url, _git_is_trampoline,
-    _has_upstream_remote, _is_fork, _locate_real_git, _mark_skip_upstream_prompt,
+    _has_upstream_remote, _is_fork, _is_rate_limited, _locate_real_git, _mark_skip_upstream_prompt,
     _normalize_managed_eol, _portable_git_candidates, _print_fetch_failure,
     _print_parked_branch_kept_notice, _print_parked_branch_skip_warning,
     _prune_orphan_rescue_refs, _should_skip_upstream_prompt, _sync_fork_with_upstream,
@@ -1246,6 +1246,51 @@ def _apply_pulled_update(
         node_failures=node_failures, update_complete=update_complete)
 
 
+def _fetch_with_throttle_recovery(
+    git_cmd, branch: str, *, attempts: int = 4, base_delay: float = 5.0
+):
+    """Scoped fetch with the installer's repo-scoped 429 resilience (#105857, parity with #99480).
+
+    A repo-scoped 429 throttles git's pack negotiation — the fetch dies mid-transfer with
+    "RPC failed; HTTP 429 / expected 'packfile'" — while small requests still succeed, and it
+    can outlast the "try again in 5 minutes" cadence, so retry with bounded backoff before
+    giving up. Non-rate-limit failures return immediately: retrying a DNS error or an auth
+    failure cannot help. Returns the last CompletedProcess."""
+    fetch_result = _git_run(git_cmd, ["fetch", "origin", branch], network=True)
+    if fetch_result.returncode == 0 or not _is_rate_limited(fetch_result.stderr):
+        return fetch_result
+    for attempt in range(2, attempts + 1):
+        _time.sleep((attempt - 1) * base_delay)
+        print(
+            f"→ Still rate-limited — retrying fetch (attempt {attempt}/{attempts})..."
+        )
+        fetch_result = _git_run(git_cmd, ["fetch", "origin", branch], network=True)
+        if fetch_result.returncode == 0 or not _is_rate_limited(fetch_result.stderr):
+            break
+    return fetch_result
+
+
+def _fallback_to_zip_after_throttled_fetch(
+    args,
+    *,
+    had_desktop_app_before_update: bool,
+    gateway_mode: bool,
+    _windows_gateway_resume,
+):
+    """Persistent repo-scoped 429: git's pack protocol stays throttled, but the codeload archive
+    download does not, so a healthy install need not stay behind upstream (#105857). Same guarded
+    path as the Windows ZIP mode — ``_update_via_zip`` refuses to overlay a dirty/untracked
+    checkout (#87304), so the fallback fails closed on local work."""
+    print("→ Git fetch stays rate-limited — falling back to the guarded ZIP update...")
+    try:
+        desktop_build_ok = _update_via_zip(
+            args, had_desktop_app_before_update=had_desktop_app_before_update)
+    finally:
+        _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+    if gateway_mode:
+        _write_gateway_update_exit_code(desktop_build_ok)
+
+
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always restore stdio even on
     ``sys.exit``. Self-lock deferral deliberately does NOT run here (pre-fetch it stranded users
@@ -1319,9 +1364,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
         _m()._warn_orphaned_update_autostashes(git_cmd, _m().PROJECT_ROOT)
 
         print("→ Fetching updates...")
-        fetch_result = _git_run(git_cmd, ["fetch", "origin", branch], network=True)
+        fetch_result = _fetch_with_throttle_recovery(git_cmd, branch)
         if fetch_result.returncode != 0:
             _print_fetch_failure(fetch_result.stderr)
+            if _is_rate_limited(fetch_result.stderr):
+                _fallback_to_zip_after_throttled_fetch(
+                    args,
+                    had_desktop_app_before_update=had_desktop_app_before_update,
+                    gateway_mode=gateway_mode,
+                    _windows_gateway_resume=_windows_gateway_resume)
+                return
             sys.exit(1)
 
         current_branch = _current_branch_name(git_cmd, check=True)

--- a/hermes_cli/update_cmd_git.py
+++ b/hermes_cli/update_cmd_git.py
@@ -340,6 +340,14 @@ _FETCH_FAILURE_RULES = (
 )
 
 
+def _is_rate_limited(stderr: str) -> bool:
+    """True when the fetch stderr carries the repo-scoped HTTP 429 / rate-limit signature.
+
+    Mirrors the first rule in ``_FETCH_FAILURE_RULES`` so retry/fallback decisions key on
+    exactly the stderr the classifier will report to the user (#105857)."""
+    return _has_http_code(stderr or "", "429") or "rate limit" in (stderr or "").lower()
+
+
 def _classify_fetch_failure(stderr: str) -> str:
     """Map git-fetch stderr to a one-line diagnosis (caller also prints the raw first line)."""
     return next((message for matches, message in _FETCH_FAILURE_RULES if matches(stderr)), "✗ Failed to fetch updates from origin.")

--- a/tests/hermes_cli/test_update_fetch_throttle_recovery.py
+++ b/tests/hermes_cli/test_update_fetch_throttle_recovery.py
@@ -1,0 +1,193 @@
+"""Repo-scoped HTTP 429 recovery for `hermes update` (#105857).
+
+GitHub's repo-scoped 429 throttles git's pack negotiation — the fetch dies
+mid-transfer with "RPC failed; HTTP 429 / expected 'packfile'" — while small
+requests (ls-remote) still succeed, and the throttle can outlast the "try
+again in 5 minutes" cadence the message suggests. #90696 classified the error
+but the updater still exited after one attempt, leaving a healthy install
+permanently behind upstream. The fetch now retries with the installer's
+bounded backoff (#99480 parity) and, when the throttle persists, falls back
+to the guarded ZIP path instead of exiting.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+RATE_LIMIT_STDERR = (
+    "error: RPC failed; HTTP 429 curl 22 The requested URL returned error: 429\n"
+    "fatal: expected flush after ref listing"
+)
+DNS_STDERR = (
+    "fatal: unable to access 'https://github.com/NousResearch/hermes-agent.git/':"
+    " Could not resolve host: github.com"
+)
+
+
+def _fetch_result(returncode=0, stderr=""):
+    return SimpleNamespace(returncode=returncode, stderr=stderr, stdout="")
+
+
+class TestIsRateLimited:
+    def test_rpc_429_signature(self):
+        assert update_cmd._is_rate_limited(RATE_LIMIT_STDERR) is True
+
+    def test_rate_limit_phrase_without_code(self):
+        assert update_cmd._is_rate_limited("fatal: GitHub rate limit exceeded") is True
+
+    def test_dns_failure_is_not_rate_limit(self):
+        assert update_cmd._is_rate_limited(DNS_STDERR) is False
+
+    def test_empty_and_none_are_safe(self):
+        assert update_cmd._is_rate_limited("") is False
+        assert update_cmd._is_rate_limited(None) is False
+
+
+class TestFetchWithThrottleRecovery:
+    def _run(self, results):
+        calls = []
+
+        def fake_git_run(git_cmd, args, **kwargs):
+            calls.append(list(args))
+            return results[len(calls) - 1]
+
+        with (
+            patch.object(update_cmd, "_git_run", side_effect=fake_git_run),
+            patch.object(update_cmd._time, "sleep") as sleeps,
+        ):
+            result = update_cmd._fetch_with_throttle_recovery(["git"], "main")
+        return result, calls, sleeps
+
+    def test_success_first_try_does_not_retry(self):
+        result, calls, sleeps = self._run([_fetch_result(0)])
+        assert result.returncode == 0
+        assert calls == [["fetch", "origin", "main"]]
+        sleeps.assert_not_called()
+
+    def test_429_then_success_retries_with_backoff(self):
+        result, calls, sleeps = self._run([
+            _fetch_result(1, RATE_LIMIT_STDERR),
+            _fetch_result(1, RATE_LIMIT_STDERR),
+            _fetch_result(0),
+        ])
+        assert result.returncode == 0
+        assert len(calls) == 3
+        # Backoff matches the installer (#99480): 5s before attempt 2, 10s before attempt 3.
+        assert [c.args[0] for c in sleeps.call_args_list] == [5.0, 10.0]
+
+    def test_persistent_429_exhausts_attempts_and_keeps_last_result(self):
+        result, calls, sleeps = self._run([_fetch_result(1, RATE_LIMIT_STDERR)] * 4)
+        assert result.returncode == 1
+        assert result.stderr == RATE_LIMIT_STDERR
+        assert len(calls) == 4
+        assert [c.args[0] for c in sleeps.call_args_list] == [5.0, 10.0, 15.0]
+
+    def test_non_rate_failure_returns_without_retry(self):
+        result, calls, sleeps = self._run([_fetch_result(1, DNS_STDERR)])
+        assert result.returncode == 1
+        assert calls == [["fetch", "origin", "main"]]
+        sleeps.assert_not_called()
+
+    def test_429_flipping_to_other_error_stops_retrying(self):
+        result, calls, sleeps = self._run([
+            _fetch_result(1, RATE_LIMIT_STDERR),
+            _fetch_result(1, DNS_STDERR),
+        ])
+        assert result.returncode == 1
+        assert result.stderr == DNS_STDERR
+        assert len(calls) == 2
+        assert [c.args[0] for c in sleeps.call_args_list] == [5.0]
+
+
+class TestZipFallbackAfterThrottledFetch:
+    def _run_fallback(self, *, gateway_mode, zip_return=True, zip_side_effect=None):
+        resumes, exit_codes = [], []
+        with (
+            patch.object(
+                update_cmd,
+                "_update_via_zip",
+                return_value=zip_return,
+                side_effect=zip_side_effect,
+            ) as zip_call,
+            patch.object(
+                update_cmd._m(),
+                "_resume_windows_gateways_after_update",
+                side_effect=lambda token: resumes.append(token),
+            ),
+            patch.object(
+                update_cmd,
+                "_write_gateway_update_exit_code",
+                side_effect=lambda ok: exit_codes.append(ok),
+            ),
+        ):
+            update_cmd._fallback_to_zip_after_throttled_fetch(
+                "args-sentinel",
+                had_desktop_app_before_update=False,
+                gateway_mode=gateway_mode,
+                _windows_gateway_resume="resume-token",
+            )
+        return zip_call, resumes, exit_codes
+
+    def test_gateway_mode_calls_zip_resumes_gateways_writes_exit_code(self):
+        zip_call, resumes, exit_codes = self._run_fallback(gateway_mode=True)
+        zip_call.assert_called_once_with(
+            "args-sentinel", had_desktop_app_before_update=False
+        )
+        assert resumes == ["resume-token"]
+        assert exit_codes == [True]
+
+    def test_interactive_mode_skips_gateway_exit_code(self):
+        _, resumes, exit_codes = self._run_fallback(gateway_mode=False)
+        assert resumes == ["resume-token"]
+        assert exit_codes == []
+
+    def test_paused_gateways_resume_even_when_zip_refuses(self, capsys):
+        # _update_via_zip exits (dirty checkout / non-main branch) — the paused
+        # Windows gateways must still be resumed (finally contract).
+        def _refuse(_args, **_kwargs):
+            raise SystemExit(1)
+
+        resumes = []
+        with (
+            patch.object(update_cmd, "_update_via_zip", side_effect=_refuse),
+            patch.object(
+                update_cmd._m(),
+                "_resume_windows_gateways_after_update",
+                side_effect=lambda token: resumes.append(token),
+            ),
+            pytest.raises(SystemExit),
+        ):
+            update_cmd._fallback_to_zip_after_throttled_fetch(
+                "args",
+                had_desktop_app_before_update=False,
+                gateway_mode=True,
+                _windows_gateway_resume="token",
+            )
+        assert resumes == ["token"]
+        assert "falling back to the guarded ZIP update" in capsys.readouterr().out
+
+
+class TestCmdUpdateWiring:
+    def test_fetch_failure_branch_routes_429_to_zip_and_exits_otherwise(self):
+        import inspect
+
+        src = inspect.getsource(update_cmd._cmd_update_impl)
+        fetch_idx = src.index("→ Fetching updates...")
+        assert "_fetch_with_throttle_recovery(" in src[fetch_idx:]
+        tail = src[src.index("_print_fetch_failure", fetch_idx) :]
+        assert "_fallback_to_zip_after_throttled_fetch(" in tail
+        assert "sys.exit(1)" in tail
+
+    def test_fallback_only_fires_for_rate_limit(self):
+        import inspect
+
+        src = inspect.getsource(update_cmd._cmd_update_impl)
+        tail = src[
+            src.index("_print_fetch_failure", src.index("→ Fetching updates...")) :
+        ]
+        guarded = tail[: tail.index("sys.exit(1)")]
+        assert "_is_rate_limited(" in guarded


### PR DESCRIPTION
## What does this PR do?

`hermes update` exited after a single `git fetch` attempt. A persistent repo-scoped HTTP 429 throttles git's pack negotiation (the fetch dies mid-transfer with `RPC failed; HTTP 429 / expected 'packfile'`) while small requests such as `git ls-remote` still succeed, so "try again in 5 minutes" can loop forever and a healthy install stays permanently behind upstream (#105857). #90696 classified the error accurately but did not make updates recover.

This brings the resilience the fresh installer gained in #99480 to the existing-install update path:

1. The scoped fetch retries repo-scoped 429s with the installer's bounded backoff (4 attempts, 5s/10s/15s).
2. When the throttle persists, the updater falls back to the guarded ZIP update instead of exiting — the ZIP archive comes from codeload, which does not go through git's pack protocol.
3. Non-rate-limit failures (DNS, auth, outages) keep exiting immediately after the existing classified message — retrying those cannot help, so behavior there is unchanged.

## Related Issue

Fixes #105857

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd_git.py`: add `_is_rate_limited(stderr)`, mirroring the first rule of `_FETCH_FAILURE_RULES` so retry/fallback decisions key on exactly the stderr the classifier reports to the user.
- `hermes_cli/update_cmd.py`: add `_fetch_with_throttle_recovery()` — scoped fetch + bounded-backoff retry for rate-limit failures only; returns the last result so the caller still prints the accurate 429 diagnosis.
- `hermes_cli/update_cmd.py`: add `_fallback_to_zip_after_throttled_fetch()` — same guarded path as the Windows ZIP mode; `_update_via_zip` already refuses to overlay a dirty/untracked checkout (#87304), resumes paused Windows gateways in a `finally`, and writes the gateway exit code when running under gateway mode.
- `hermes_cli/update_cmd.py`: wire both helpers into `_cmd_update_impl`'s fetch failure branch; non-rate-limit failures keep `sys.exit(1)`.
- `tests/hermes_cli/test_update_fetch_throttle_recovery.py`: 14 regression tests covering the classifier predicate, retry/backoff/stop conditions, ZIP fallback contracts (gateway exit code, gateway resume even when the ZIP path refuses), and the `_cmd_update_impl` wiring.

## How to Test

1. `pytest tests/hermes_cli/test_update_fetch_throttle_recovery.py -q` — Observed result: 14 passed.
2. `pytest tests/hermes_cli/test_update_fetch_failure_classifier.py tests/hermes_cli/test_update_self_lock.py tests/hermes_cli/test_update_upstream_prompt_noninteractive.py tests/hermes_cli/test_update_zip_fallback_guards.py tests/hermes_cli/test_cmd_update.py -q` — Observed result: 124 passed (existing update-path suites unchanged).
3. `ruff check` on the three touched files — Observed result: all checks passed; the new code sections are also clean under `ruff format --check` (the pre-existing whole-file format drift in `update_cmd.py` import blocks is untouched).
4. Simulate the throttle without touching the network: with `_git_run` patched to return returncode 1 and the 429 stderr from #105857, the updater should print the retry lines with backoff, keep the accurate 429 diagnosis, and only then announce the guarded ZIP fallback; with a DNS-error stderr it should print the diagnosis and exit 1 with no retries.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the 429 path itself is covered by unit tests since the throttle cannot be reproduced locally

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/hermes_cli/test_update_fetch_throttle_recovery.py -q
..............                                                           [100%]
14 passed in 0.26s
```
