### PR TITLE
Fix desktop app locale formatting, tree-hash gitignore, and Windows update verify cwd

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -578,7 +578,7 @@ export function renderRpcResult(response: unknown, name: string): string {
     const total = Number(r.total ?? 0)
 
     const lines: string[] = [
-      `Usage: ${calls.toLocaleString()} calls · ${input.toLocaleString()} in / ${output.toLocaleString()} out · ${total.toLocaleString()} total`
+      `Usage: ${calls.toLocaleString('en-US')} calls · ${input.toLocaleString('en-US')} in / ${output.toLocaleString('en-US')} out · ${total.toLocaleString('en-US')} total`
     ]
 
     if (Array.isArray(r.credits_lines)) {

--- a/apps/desktop/src/app/settings/billing/billing-amounts.ts
+++ b/apps/desktop/src/app/settings/billing/billing-amounts.ts
@@ -114,7 +114,7 @@ export function formatMoney(value?: null | number | string): string {
     return EMPTY_BILLING_VALUE
   }
 
-  return new Intl.NumberFormat(undefined, {
+  return new Intl.NumberFormat('en-US', {
     currency: 'USD',
     maximumFractionDigits: amount % 1 === 0 ? 0 : 2,
     minimumFractionDigits: amount % 1 === 0 ? 0 : 2,

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
@@ -76,7 +76,7 @@ export function clampForDisplay(value: string, max = MAX_TOOL_RENDER_CHARS): str
 
   const omitted = value.length - max
 
-  return `${value.slice(0, max)}\n\n… ${omitted.toLocaleString()} more characters truncated — use Copy for the full output.`
+  return `${value.slice(0, max)}\n\n… ${omitted.toLocaleString('en-US')} more characters truncated — use Copy for the full output.`
 }
 
 export function prettyJson(value: unknown): string {

--- a/apps/desktop/src/store/voice-prefs.test.ts
+++ b/apps/desktop/src/store/voice-prefs.test.ts
@@ -15,7 +15,7 @@ it('keeps the desktop toggle local across config refreshes', async () => {
       localStorage.clear()
       vi.resetModules()
       const prefs = await import('./voice-prefs')
-      const write = vi.spyOn(localStorage, 'setItem')
+      const write = vi.spyOn(Storage.prototype, 'setItem')
 
       if (fails) {
         write.mockImplementation(() => {
@@ -44,7 +44,7 @@ it('migrates the legacy preference once, not on every refresh', async () => {
       localStorage.clear()
       vi.resetModules()
       const prefs = await import('./voice-prefs')
-      const write = vi.spyOn(localStorage, 'setItem')
+      const write = vi.spyOn(Storage.prototype, 'setItem')
 
       if (fails) {
         write.mockImplementation(() => {

--- a/hermes_cli/main_web_build.py
+++ b/hermes_cli/main_web_build.py
@@ -114,7 +114,10 @@ def _hash_source_tree(project_root: Path, tree_dir: Path) -> str:
     spec = PathSpec.from_lines("gitignore", lines)
 
     def _ignored(path: Path) -> bool:
-        return spec.match_file(str(path.relative_to(project_root)))
+        rel = str(path.relative_to(project_root))
+        # pathspec treats trailing-/ patterns as directory-only; a bare path
+        # without the slash does not match them, so test both forms.
+        return spec.match_file(rel) or spec.match_file(rel + "/")
 
     for name in ("package.json", "package-lock.json"):
         p = project_root / name

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1422,6 +1422,24 @@ try {
     Show-ProgressWindow
     Write-HandoffLog "hand-off start: root=$InstallRoot branch=$Branch desktopPid=$DesktopPid pid=$PID"
 
+    # Run FROM the install root, mirroring posix.sh (`cd "$INSTALL_ROOT"`):
+    # `hermes update`, the desktop-build child, and the verification child
+    # all resolve the project tree from the current working directory
+    # (verify_windows_desktop_update(Path.cwd()), project_root probing).
+    # Without this the wrapper's own cwd (wherever the Desktop spawned it)
+    # propagates to every CreateProcess child via inherited-current-directory,
+    # so verification reads the WRONG tree and reports the desktop executable
+    # missing after a perfectly good build.
+    if (Test-Path -LiteralPath $InstallRoot -PathType Container) {
+        Set-Location -LiteralPath $InstallRoot -ErrorAction Stop
+        Write-HandoffLog "working directory set to $InstallRoot"
+    } else {
+        $finalCode = 3
+        $finalMsg = "Update aborted: install root $InstallRoot is missing. Repair the installation before retrying."
+        Write-HandoffLog $finalMsg
+        exit $finalCode
+    }
+
     # -- 0. Claim the update marker with OUR pid ---------------------------
     try {
         $epoch = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()


### PR DESCRIPTION
## Summary

Three independent fixes:

1. **Desktop app number formatting (locale)** — force `en-US` in `toLocaleString` / `Intl.NumberFormat` across `use-prompt-actions/utils.ts`, `billing-amounts.ts`, and `fallback-model/format.ts` so usage/billing/counts render consistently (`.` decimal, `,` grouping) regardless of the host OS locale.
2. **Desktop UI test fix** — `voice-prefs.test.ts`: spy on `Storage.prototype.setItem` (jsdom's `Storage` methods live on the prototype; `vi.spyOn` on the instance silently no-ops, which made the quota-exceeded test non-deterministic).
3. **Windows Desktop update verify** — `scripts/desktop-update/windows.ps1`: `Set-Location` to the install root before running update/rebuild/verify. The verification child runs `verify_windows_desktop_update(Path.cwd())` and resolves the project tree from the CWD; the wrapper previously never changed the CWD, so verification read the wrong tree and failed with "The updated Desktop executable is missing" after a perfectly good build. Mirrors what `posix.sh` does (`cd "$INSTALL_ROOT"`).
4. **Tree-hash gitignore** — `hermes_cli/main_web_build.py`: match trailing-slash gitignore patterns as file paths too, so directory-only patterns (e.g. `dist/`) correctly ignore files beneath them.

## Verification

- `verify_windows_desktop_update(Path.cwd())` with cwd = install root returns exit 0; with the wrong cwd it reproduces the exact `RuntimeError` seen in the update log. `windows.ps1 -InstallRoot <root> -SelfTestMarker` runs to exit 0 with "working directory set to <root>".
- Desktop UI tests pass (the 5 previously-failing files, 141 tests).

Closes the reported desktop update failure where the update completed but verification reported the desktop executable missing.