### PR TITLE
feat(desktop): allow plugins to render system activity indicators

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/instance.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/instance.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/components/ui/button'
 import { KbdCombo } from '@/components/ui/kbd'
 import { Loader } from '@/components/ui/loader'
 import { useI18n } from '@/i18n'
+// starting the terminal is system work, independent of Agent turns.
+import { SystemActivitySlot } from '@/lib/system-activity'
 import { cn } from '@/lib/utils'
 
 import { reportTerminalShell } from './terminals'
@@ -59,11 +61,19 @@ export function TerminalInstance({
     >
       {status === 'starting' && (
         <div className="pointer-events-none absolute inset-0 z-10 grid place-items-center">
-          <Loader
-            className="size-8 text-(--ui-text-tertiary)"
-            pathSteps={180}
-            strokeScale={0.68}
-            type="spiral-search"
+          <SystemActivitySlot
+            activity="processing"
+            fallback={
+              <Loader
+                className="size-8 text-(--ui-text-tertiary)"
+                pathSteps={180}
+                strokeScale={0.68}
+                type="spiral-search"
+              />
+            }
+            label={t.common.loading}
+            paused={!active}
+            placement="region"
           />
         </div>
       )}

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -3,6 +3,8 @@ import { atom } from 'nanostores'
 import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import { isElementInHiddenPane, PANE_HIDDEN_ATTR } from '@/components/pane-shell/pane-visibility'
+// retained terminal activity follows the persistent surface's visibility.
+import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { markRightPanePerf } from '@/debug/right-pane-events'
 import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
@@ -288,7 +290,9 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
   // conhost on Windows. After that `mounted` latches: shells persist while hidden.
   return (
     <div aria-hidden={!visible} data-persistent-terminal="" style={style}>
-      {mounted && <TerminalWorkspace onAddSelectionToChat={onAddSelectionToChat} />}
+      <PaneVisibleContext value={visible}>
+        {mounted && <TerminalWorkspace onAddSelectionToChat={onAddSelectionToChat} />}
+      </PaneVisibleContext>
     </div>
   )
 }

--- a/apps/desktop/src/app/session-import/index.tsx
+++ b/apps/desktop/src/app/session-import/index.tsx
@@ -10,6 +10,8 @@ import { Loader } from '@/components/ui/loader'
 import { SearchField } from '@/components/ui/search-field'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { useI18n } from '@/i18n'
+// imported history is read through the system activity area.
+import { SystemActivitySlot } from '@/lib/system-activity'
 import { cn } from '@/lib/utils'
 import { setSessionOwnerHint } from '@/store/session'
 import type { SessionOwnerRoute } from '@/store/session-request-router'
@@ -179,7 +181,16 @@ export function SessionImportView({ owner, onClose, onOpenSession }: SessionImpo
               )}
             </div>
             <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-5">
-              {sessions.isPending && <Loader className="mx-auto my-12" label={copy.scanning} />}
+              {sessions.isPending && (
+                <div className="my-12 grid place-items-center">
+                  <SystemActivitySlot
+                    activity="loading"
+                    fallback={<Loader className="mx-auto" label={copy.scanning} />}
+                    label={copy.scanning}
+                    placement="region"
+                  />
+                </div>
+              )}
               {sessions.isError && (
                 <ErrorState className="p-5" description={copy.scanHelp} title={copy.scanError}>
                   <Button onClick={() => void sessions.refetch()} variant="secondary">
@@ -270,7 +281,16 @@ export function SessionImportView({ owner, onClose, onOpenSession }: SessionImpo
                   </p>
                 </div>
                 <div aria-live="polite" className="min-h-0 flex-1 overflow-y-auto px-8 pb-8" key={current.id}>
-                  {preview.isPending && <Loader className="mx-auto my-12" label={copy.previewLoading} />}
+                  {preview.isPending && (
+                    <div className="my-12 grid place-items-center">
+                      <SystemActivitySlot
+                        activity="loading"
+                        fallback={<Loader className="mx-auto" label={copy.previewLoading} />}
+                        label={copy.previewLoading}
+                        placement="region"
+                      />
+                    </div>
+                  )}
                   {preview.isError && (
                     <ErrorState description={copy.previewHelp} title={copy.previewError}>
                       <Button onClick={() => void preview.refetch()} variant="secondary">

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -1319,7 +1319,8 @@ function ServerConfig({
       )}
       {!saved && <p className="mt-3 text-[0.68rem] text-muted-foreground/60">{m.unsavedConnect}</p>}
 
-      {status === 'probing' && <PageLoader className="min-h-24" label={t.skills.loading} />}
+      {/* browser consent is a person wait; only the active probe animates. */}
+      {status === 'probing' && !authing && <PageLoader activity="connecting" className="min-h-24" label={t.common.connecting} />}
 
       {/* No inline error dump — the status dot/line says "Error"/"Needs
           authentication", and the actual failure lands in the logs pane below

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -18,6 +18,8 @@ import type { DesktopUpdateBlocker, DesktopUpdateCommit, DesktopUpdateStage, Des
 import { useI18n } from '@/i18n'
 import { buildCommitChangelog, type CommitGroup } from '@/lib/commit-changelog'
 import { AlertCircle, Check, Copy, Terminal } from '@/lib/icons'
+// customize update activity while the updater owns progress and recovery.
+import { SystemActivitySlot } from '@/lib/system-activity'
 import { resolveUpdateCopy, type UpdateTarget } from '@/lib/update-copy'
 import { cn } from '@/lib/utils'
 import {
@@ -176,7 +178,14 @@ function IdleView({
   if (!status && checking) {
     return (
       <CenteredStatus
-        icon={<Loader className="size-12" label={u.checking} type="lemniscate-bloom" />}
+        icon={
+          <SystemActivitySlot
+            activity="loading"
+            fallback={<Loader className="size-12" label={u.checking} type="lemniscate-bloom" />}
+            label={u.checking}
+            placement="region"
+          />
+        }
         title={u.checking}
       />
     )
@@ -398,7 +407,12 @@ function ApplyingView({ apply, isBackend }: { apply: UpdateApplyState; isBackend
   return (
     <div className="grid gap-5 px-6 pb-6 pt-7">
       <div className="flex flex-col items-center gap-3 text-center">
-        <Loader className="size-16" label={label} type="lemniscate-bloom" />
+        <SystemActivitySlot
+          activity="processing"
+          fallback={<Loader className="size-16" label={label} type="lemniscate-bloom" />}
+          hasProgress
+          placement="region"
+        />
 
         <DialogTitle className="text-center text-xl">{label}</DialogTitle>
         <DialogDescription className="text-center text-sm">{body}</DialogDescription>

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -13,6 +13,8 @@ import { Loader } from '@/components/ui/loader'
 import { StatusPulse } from '@/components/ui/status-pulse'
 import { getLocalModelsStatus } from '@/hermes'
 import { useI18n } from '@/i18n'
+// Stored-session hydration is system activity; running turns keep their own mark.
+import { SystemActivitySlot } from '@/lib/system-activity'
 import { cn } from '@/lib/utils'
 import { $backgroundResume } from '@/store/background-delegation'
 import { sessionCompacting } from '@/store/compaction'
@@ -228,13 +230,19 @@ export const CenteredThreadSpinner: FC = () => {
       className="pointer-events-none absolute inset-0 z-1 grid place-items-center"
       role="status"
     >
-      <Loader
-        aria-hidden="true"
-        className="size-12 text-midground/70"
-        pathSteps={220}
-        role="presentation"
-        strokeScale={0.72}
-        type="rose-curve"
+      <SystemActivitySlot
+        activity="loading"
+        fallback={
+          <Loader
+            aria-hidden="true"
+            className="size-12 text-midground/70"
+            pathSteps={220}
+            role="presentation"
+            strokeScale={0.72}
+            type="rose-curve"
+          />
+        }
+        placement="region"
       />
     </div>
   )

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -9,6 +9,8 @@ import type { DesktopConnectionConfig } from '@/global'
 import { useI18n } from '@/i18n'
 import { openExternalLink } from '@/lib/external-link'
 import { ChevronLeft, ExternalLink, FileText, Loader2, LogIn, RefreshCw, SlidersHorizontal, Wrench } from '@/lib/icons'
+// the recovery settings load is a system wait.
+import { SystemActivitySlot } from '@/lib/system-activity'
 import { $desktopBoot } from '@/store/boot'
 import { notify, notifyError } from '@/store/notifications'
 import { $desktopOnboarding } from '@/store/onboarding'
@@ -360,7 +362,18 @@ export function BootFailureOverlay() {
             {copy.back}
           </button>
           <div className="min-h-0 flex-1 pt-4">
-            <Suspense fallback={<Loader className="mx-auto my-16 size-6 text-(--ui-text-tertiary)" />}>
+            <Suspense
+              fallback={
+                <div className="my-16 grid place-items-center">
+                  <SystemActivitySlot
+                    activity="loading"
+                    fallback={<Loader className="mx-auto size-6 text-(--ui-text-tertiary)" />}
+                    label={t.common.loading}
+                    placement="region"
+                  />
+                </div>
+              }
+            >
               <GatewaySettings embedded />
             </Suspense>
           </div>

--- a/apps/desktop/src/components/gateway-connecting-overlay.tsx
+++ b/apps/desktop/src/components/gateway-connecting-overlay.tsx
@@ -3,6 +3,9 @@ import { useEffect, useRef, useState } from 'react'
 
 import { DecodeText } from '@/components/ui/decode-text'
 import { prefersReducedMotion } from '@/hooks/use-media-query'
+import { useI18n } from '@/i18n'
+// replace only the cold-boot mark, preserving connection and exit gates.
+import { SystemActivitySlot } from '@/lib/system-activity'
 import { cn } from '@/lib/utils'
 import { $desktopBoot } from '@/store/boot'
 import { $gatewaySwitching } from '@/store/gateway-switch'
@@ -37,6 +40,7 @@ function forcedPreview(): boolean {
 }
 
 export function GatewayConnectingOverlay() {
+  const { t } = useI18n()
   const gatewayState = useStore($gatewayState)
   const boot = useStore($desktopBoot)
   const gatewaySwitching = useStore($gatewaySwitching)
@@ -146,15 +150,23 @@ export function GatewayConnectingOverlay() {
       // in styles.css.
       data-glass-opaque=""
     >
-      <DecodeText
-        active={phase === 'live' && (previewing || connecting)}
-        className={cn(
-          'pl-[0.4em] text-(--theme-primary) transition duration-300 ease-out',
-          leaving ? 'translate-y-2 opacity-0 saturate-0' : 'translate-y-0 opacity-100 saturate-100'
-        )}
-        cursor
-        prefix={4}
-        text={TEXT}
+      <SystemActivitySlot
+        activity="connecting"
+        fallback={
+          <DecodeText
+            active={phase === 'live' && (previewing || connecting)}
+            className={cn(
+              'pl-[0.4em] text-(--theme-primary) transition duration-300 ease-out',
+              leaving ? 'translate-y-2 opacity-0 saturate-0' : 'translate-y-0 opacity-100 saturate-100'
+            )}
+            cursor
+            prefix={4}
+            text={TEXT}
+          />
+        }
+        label={t.common.connecting}
+        paused={leaving}
+        placement="threshold"
       />
     </div>
   )

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -14,6 +14,8 @@ import { useI18n } from '@/i18n'
 import { Search } from '@/lib/icons'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
+// model inventory loading is system activity.
+import { SystemActivitySlot } from '@/lib/system-activity'
 import { foldIncludes, normalize } from '@/lib/text'
 import {
   $visibleModels,
@@ -100,7 +102,14 @@ export function ModelVisibilityDialog({
         <div className="max-h-[55vh] overflow-y-auto pb-1">
           {providers.length === 0 ? (
             <div className="px-3 py-5 text-center text-xs text-muted-foreground">
-              {modelOptions.isPending ? <GlyphSpinner className="mx-auto text-sm" /> : copy.noAuthenticatedProviders}
+              {modelOptions.isPending ? (
+                <SystemActivitySlot
+                  activity="loading"
+                  fallback={<GlyphSpinner className="mx-auto text-sm" />}
+                  label={t.common.loading}
+                  placement="inline"
+                />
+              ) : copy.noAuthenticatedProviders}
             </div>
           ) : (
             providers.map(provider => {

--- a/apps/desktop/src/components/page-loader.tsx
+++ b/apps/desktop/src/components/page-loader.tsx
@@ -1,14 +1,18 @@
 import type { ComponentProps } from 'react'
 
 import { Loader } from '@/components/ui/loader'
+// classify the region wait without replacing Hermes's loader primitive.
+import { type SystemActivityProps, SystemActivitySlot } from '@/lib/system-activity'
 import { cn } from '@/lib/utils'
 
 interface PageLoaderProps extends Omit<ComponentProps<'div'>, 'children'> {
   label?: string
+  activity?: SystemActivityProps['activity']
 }
 
 export function PageLoader({
   'aria-label': ariaLabel,
+  activity = 'loading',
   className,
   label = 'Loading',
   role = 'status',
@@ -21,13 +25,19 @@ export function PageLoader({
       className={cn('grid h-full place-items-center', className)}
       role={role}
     >
-      <Loader
-        aria-hidden="true"
-        className="size-10 text-primary/70"
-        pathSteps={220}
-        role="presentation"
-        strokeScale={0.72}
-        type="rose-curve"
+      <SystemActivitySlot
+        activity={activity}
+        fallback={
+          <Loader
+            aria-hidden="true"
+            className="size-10 text-primary/70"
+            pathSteps={220}
+            role="presentation"
+            strokeScale={0.72}
+            type="rose-curve"
+          />
+        }
+        placement="region"
       />
     </div>
   )

--- a/apps/desktop/src/lib/system-activity.test.tsx
+++ b/apps/desktop/src/lib/system-activity.test.tsx
@@ -1,0 +1,162 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { memo, useEffect, useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { PageLoader } from '@/components/page-loader'
+import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
+import { createPluginContext } from '@/contrib/plugin'
+
+import {
+  SYSTEM_ACTIVITY_AREA,
+  type SystemActivityContribution,
+  type SystemActivityProps,
+  SystemActivitySlot
+} from './system-activity'
+
+const disposers: Array<() => void> = []
+const ctx = createPluginContext('activity-test', dispose => disposers.push(dispose))
+
+afterEach(() => {
+  cleanup()
+  disposers.splice(0).forEach(dispose => dispose())
+  vi.restoreAllMocks()
+})
+
+it('keeps the region status host-owned while a scoped renderer mounts, changes kind and disposes', () => {
+  const stopped = vi.fn()
+
+  function CustomActivity({ activity, placement }: SystemActivityProps) {
+    const [identity] = useState('same mount')
+    useEffect(() => stopped, [])
+
+    return (
+      <span data-testid="custom">
+        {activity}:{placement}:{identity}
+      </span>
+    )
+  }
+
+  const renderer: SystemActivityContribution = { render: CustomActivity }
+  const view = render(<PageLoader label="Loading saved files" />)
+  expect(screen.getByRole('status', { name: 'Loading saved files' }).querySelector('svg')).not.toBeNull()
+
+  let remove = () => {}
+  act(() => {
+    remove = ctx.register({ area: SYSTEM_ACTIVITY_AREA, id: 'mark', data: renderer })
+  })
+  expect(screen.getByTestId('custom').textContent).toBe('loading:region:same mount')
+  expect(screen.getAllByRole('status')).toHaveLength(1)
+  expect(view.container.querySelector('svg')).toBeNull()
+
+  view.rerender(<PageLoader activity="connecting" label="Connecting the server" />)
+  expect(screen.getByTestId('custom').textContent).toBe('connecting:region:same mount')
+  expect(stopped).not.toHaveBeenCalled()
+
+  act(remove)
+  expect(stopped).toHaveBeenCalledOnce()
+  expect(screen.getByRole('status', { name: 'Connecting the server' }).querySelector('svg')).not.toBeNull()
+})
+
+it('renders a memoized plugin component through the same status host', () => {
+  const MemoizedActivity = memo(function Activity({ activity }: SystemActivityProps) {
+    return <span>Memoized {activity}</span>
+  })
+
+  ctx.register({
+    area: SYSTEM_ACTIVITY_AREA,
+    id: 'memoized',
+    data: { render: MemoizedActivity } satisfies SystemActivityContribution
+  })
+
+  render(<PageLoader label="Loading saved files" />)
+  expect(screen.getByRole('status', { name: 'Loading saved files' }).textContent).toBe('Memoized loading')
+  expect(screen.getAllByRole('status')).toHaveLength(1)
+})
+
+it('honors intentional omission beside progress but restores native feedback after renderer failure', () => {
+  const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+  const view = render(
+    <SystemActivitySlot activity="processing" fallback={<span>Native mark</span>} hasProgress placement="region" />
+  )
+
+  let remove = () => {}
+  act(() => {
+    remove = ctx.register({
+      area: SYSTEM_ACTIVITY_AREA,
+      id: 'mark',
+      data: {
+        render: ({ hasProgress }) => (hasProgress ? null : <span>Custom mark</span>)
+      } satisfies SystemActivityContribution
+    })
+  })
+  expect(view.container.textContent).toBe('')
+  act(remove)
+  expect(screen.getByText('Native mark')).toBeTruthy()
+
+  act(() => {
+    ctx.register({
+      area: SYSTEM_ACTIVITY_AREA,
+      id: 'broken',
+      data: {
+        render: () => {
+          throw new Error('Broken custom renderer')
+        }
+      } satisfies SystemActivityContribution
+    })
+  })
+  expect(screen.getByText('Native mark')).toBeTruthy()
+  expect(error).toHaveBeenCalled()
+
+  act(() => {
+    ctx.register({
+      area: SYSTEM_ACTIVITY_AREA,
+      id: 'broken',
+      data: { render: () => <span>Recovered custom mark</span> } satisfies SystemActivityContribution
+    })
+  })
+  expect(screen.getByText('Recovered custom mark')).toBeTruthy()
+  expect(screen.queryByText('Native mark')).toBeNull()
+})
+
+it('passes Hermes pane and window visibility into the renderer without changing operation state', () => {
+  vi.spyOn(window.document, 'hasFocus').mockReturnValue(true)
+  const stopped = vi.fn()
+
+  function ObservableActivity({ activity, paused }: SystemActivityProps) {
+    useEffect(() => stopped, [])
+
+    return (
+      <span>
+        {activity}:{paused ? 'still' : 'moving'}
+      </span>
+    )
+  }
+
+  ctx.register({
+    area: SYSTEM_ACTIVITY_AREA,
+    id: 'mark',
+    data: {
+      render: ObservableActivity
+    } satisfies SystemActivityContribution
+  })
+
+  const host = (visible: boolean) => (
+    <PaneVisibleContext value={visible}>
+      <SystemActivitySlot activity="loading" fallback={null} placement="inline" />
+    </PaneVisibleContext>
+  )
+
+  const view = render(host(true))
+  expect(screen.getByText('loading:moving')).toBeTruthy()
+  view.rerender(host(false))
+  expect(screen.getByText('loading:still')).toBeTruthy()
+  view.rerender(host(true))
+  act(() => window.dispatchEvent(new Event('blur')))
+  expect(screen.getByText('loading:still')).toBeTruthy()
+  act(() => window.dispatchEvent(new Event('focus')))
+  expect(screen.getByText('loading:moving')).toBeTruthy()
+  expect(stopped).not.toHaveBeenCalled()
+  view.unmount()
+  expect(stopped).toHaveBeenCalledOnce()
+})

--- a/apps/desktop/src/lib/system-activity.tsx
+++ b/apps/desktop/src/lib/system-activity.tsx
@@ -1,0 +1,82 @@
+import { type ComponentType, createElement, type ReactNode, useEffect, useState } from 'react'
+
+import { ErrorBoundary } from '@/components/error-boundary'
+import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
+import { useContributions } from '@/contrib'
+import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
+
+export const SYSTEM_ACTIVITY_AREA = 'ui.systemActivity'
+
+/** An operation owned by the app, never an Agent turn or a wait for a person. */
+export interface SystemActivityProps {
+  activity: 'loading' | 'connecting' | 'processing'
+  placement: 'inline' | 'region' | 'threshold'
+  /** Freeze the mark while its pane/window is hidden or its operation is leaving. */
+  paused: boolean
+  /** Host-owned status text, available to render visibly at an application threshold. */
+  label?: string
+  /** The host already renders progress for this same operation. */
+  hasProgress?: boolean
+}
+
+export interface SystemActivityContribution {
+  /** Decorative component; the host owns accessibility. Null deliberately omits the mark. */
+  render: ComponentType<SystemActivityProps>
+}
+
+interface SystemActivitySlotProps extends Omit<SystemActivityProps, 'paused'> {
+  fallback: ReactNode
+  /** Omit when the surrounding status already supplies the accessible name. */
+  label?: string
+  paused?: boolean
+}
+
+/** Only the mark is replaceable; operation state, text and recovery stay with its caller. */
+export function SystemActivitySlot({ fallback, label, ...props }: SystemActivitySlotProps) {
+  const contributions = useContributions(SYSTEM_ACTIVITY_AREA)
+
+  const owner = contributions.find(
+    contribution => (contribution.data as SystemActivityContribution | undefined)?.render != null
+  )
+
+  const [boundary, setBoundary] = useState({ owner, revision: 0 })
+
+  // A replacement registration must recover even if the previous renderer failed.
+  if (boundary.owner !== owner) {
+    setBoundary({ owner, revision: boundary.revision + 1 })
+  }
+
+  if (!owner) {
+    return fallback
+  }
+
+  return (
+    <ErrorBoundary fallback={() => fallback} key={boundary.revision} label={`contrib:${owner.id}`}>
+      {label ? (
+        <span aria-label={label} className="inline-flex" role="status">
+          <ContributedActivity label={label} render={(owner.data as SystemActivityContribution).render} {...props} />
+        </span>
+      ) : (
+        <ContributedActivity render={(owner.data as SystemActivityContribution).render} {...props} />
+      )}
+    </ErrorBoundary>
+  )
+}
+
+function ContributedActivity({
+  render,
+  paused = false,
+  ...props
+}: Omit<SystemActivitySlotProps, 'fallback'> & SystemActivityContribution) {
+  const paneVisible = usePaneVisible()
+  const [windowPaused, setWindowPaused] = useState(() => document.hidden || !document.hasFocus())
+
+  useEffect(() => {
+    const controller = createRendererLoopPauseController(() => setWindowPaused(controller.isPaused()))
+    setWindowPaused(controller.isPaused())
+
+    return controller.dispose
+  }, [])
+
+  return createElement(render, { ...props, paused: paused || !paneVisible || windowPaused })
+}

--- a/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
@@ -7,6 +7,8 @@
  * the name pattern that gates the draft.
  */
 
+// only this operation's mark is contributed; native fallback stays intact.
+import { SystemActivitySlot } from '@hermes/plugin-sdk'
 import {
   Badge,
   Button,
@@ -807,7 +809,12 @@ export function CreateAgentDialog({ open, onClose, roster }: CreateAgentDialogPr
                   </div>
                 ) : !createdForCaps ? (
                   <div className="flex justify-center py-4">
-                    <GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />
+                    <SystemActivitySlot
+                      activity="processing"
+                      fallback={<GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />}
+                      label={t.common.loading}
+                      placement="inline"
+                    />
                   </div>
                 ) : SkillsView ? (
                   <ResizableFrame height={440} minHeight={280}>
@@ -836,7 +843,12 @@ export function CreateAgentDialog({ open, onClose, roster }: CreateAgentDialogPr
                 </div>
               ) : !caps ? (
                 <div className="flex justify-center py-4">
-                  <GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />
+                  <SystemActivitySlot
+                    activity="loading"
+                    fallback={<GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />}
+                    label={t.common.loading}
+                    placement="inline"
+                  />
                 </div>
               ) : advTab === 'skills' ? (
                 noSkills ? (

--- a/apps/desktop/src/plugins/hermes-bots/cron.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/cron.tsx
@@ -4,6 +4,8 @@
  * detail dialogs, and the pane the right tile renders.
  */
 
+// only this operation's mark is contributed; native fallback stays intact.
+import { SystemActivitySlot } from '@hermes/plugin-sdk'
 import {
   atom,
   Button,
@@ -1272,7 +1274,12 @@ export function RoutinesPane() {
       ) : null}
       {isLoading && !view.all.length ? (
         <div className="flex flex-1 items-center justify-center">
-          <GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />
+          <SystemActivitySlot
+            activity="loading"
+            fallback={<GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />}
+            label={t.common.loading}
+            placement="region"
+          />
         </div>
       ) : error && !view.all.length ? (
         <PanelEmpty

--- a/apps/desktop/src/plugins/hermes-bots/model-picker.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/model-picker.test.tsx
@@ -18,6 +18,7 @@
  * dispatch at all for a row whose connection is gone.
  */
 
+import type * as HermesSdk from '@hermes/plugin-sdk'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
@@ -34,10 +35,13 @@ const { hostMock } = vi.hoisted(() => ({
   }
 }))
 
-vi.mock('@hermes/plugin-sdk', async () => {
+// keep the activity slot and localization real alongside the existing host doubles.
+vi.mock('@hermes/plugin-sdk', async importOriginal => {
+  const sdk = await importOriginal<typeof HermesSdk>()
   const { useQuery } = await import('@tanstack/react-query')
 
   return {
+    ...sdk,
     Button: (props: React.ComponentProps<'button'>) => <button {...props} />,
     GlyphSpinner: () => <span data-testid="spinner" />,
     host: hostMock,

--- a/apps/desktop/src/plugins/hermes-bots/model-picker.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/model-picker.tsx
@@ -6,6 +6,8 @@
  * Shared by the advanced profile editor and the create dialog.
  */
 
+// only this operation's mark is contributed; native fallback stays intact.
+import { SystemActivitySlot, useI18n } from '@hermes/plugin-sdk'
 import {
   Button,
   GlyphSpinner,
@@ -117,6 +119,7 @@ interface ModelPickerProps {
 }
 
 export function ModelPicker({ bot = null, value, onChange, placeholderModel = 'gateway default' }: ModelPickerProps) {
+  const { t } = useI18n()
   const { data, isLoading, error } = useModelOptions(bot)
 
   // Hooks are ALWAYS declared up front, before any conditional return.
@@ -130,7 +133,12 @@ export function ModelPicker({ bot = null, value, onChange, placeholderModel = 'g
   if (isLoading) {
     return (
       <div className="flex justify-center py-2">
-        <GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />
+        <SystemActivitySlot
+          activity="loading"
+          fallback={<GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />}
+          label={t.common.loading}
+          placement="inline"
+        />
       </div>
     )
   }

--- a/apps/desktop/src/plugins/hermes-bots/pet.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/pet.test.tsx
@@ -12,6 +12,7 @@
  * failure must be evicted; a success must not be refetched.
  */
 
+import type * as HermesSdk from '@hermes/plugin-sdk'
 import { render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -27,7 +28,9 @@ const { hostMock, UnboundedCache, useQueryMock } = vi.hoisted(() => ({
   useQueryMock: vi.fn()
 }))
 
-vi.mock('@hermes/plugin-sdk', () => ({
+// retain the real activity slot and localization; only the existing host/cache doubles vary.
+vi.mock('@hermes/plugin-sdk', async importOriginal => ({
+  ...(await importOriginal<typeof HermesSdk>()),
   Button: (props: React.ComponentProps<'button'>) => <button {...props} />,
   cn: (...parts: unknown[]) => parts.filter(Boolean).join(' '),
   GlyphSpinner: () => <span />,

--- a/apps/desktop/src/plugins/hermes-bots/pet.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/pet.tsx
@@ -3,6 +3,8 @@
  * frame as the bot's profile picture.
  */
 
+// only this operation's mark is contributed; native fallback stays intact.
+import { SystemActivitySlot, useI18n } from '@hermes/plugin-sdk'
 import { Button, cn, GlyphSpinner, host, Input, LruCache, RowButton, useQuery } from '@hermes/plugin-sdk'
 import { useEffect, useState } from 'react'
 
@@ -140,6 +142,7 @@ interface PetTabProps {
 }
 
 export function PetTab({ image, onImage }: PetTabProps) {
+  const { t } = useI18n()
   const b = useBots()
   // Selection is dialog-local: committed by the dialog's Save like any
   // uploaded/generated image (a direct meta write here gets clobbered by
@@ -161,7 +164,12 @@ export function PetTab({ image, onImage }: PetTabProps) {
   if (isLoading) {
     return (
       <div className="flex justify-center py-4">
-        <GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />
+        <SystemActivitySlot
+          activity="loading"
+          fallback={<GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />}
+          label={t.common.loading}
+          placement="inline"
+        />
       </div>
     )
   }

--- a/apps/desktop/src/plugins/hermes-bots/profile-config.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/profile-config.tsx
@@ -8,6 +8,8 @@
  * detection.
  */
 
+// only this operation's mark is contributed; native fallback stays intact.
+import { SystemActivitySlot, useI18n } from '@hermes/plugin-sdk'
 import * as sdk from '@hermes/plugin-sdk'
 import {
   Checkbox,
@@ -128,6 +130,7 @@ interface AdvancedProfileConfigProps {
 }
 
 export function AdvancedProfileConfig({ bot, state, setState }: AdvancedProfileConfigProps) {
+  const { t } = useI18n()
   const b = useBots()
   const [loaded, setLoaded] = useState(false)
   const [unsupported, setUnsupported] = useState(false)
@@ -193,7 +196,12 @@ export function AdvancedProfileConfig({ bot, state, setState }: AdvancedProfileC
   if (!state.loaded) {
     return (
       <div className="flex justify-center py-4">
-        <GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />
+        <SystemActivitySlot
+          activity="loading"
+          fallback={<GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />}
+          label={t.common.loading}
+          placement="inline"
+        />
       </div>
     )
   }

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -7,6 +7,8 @@
  * the dialogs; nothing in Bot Mode imports it except the plugin entry point.
  */
 
+// only this operation's mark is contributed; native fallback stays intact.
+import { SystemActivitySlot } from '@hermes/plugin-sdk'
 import {
   atom,
   Button,
@@ -889,7 +891,12 @@ export function BotsPane() {
       ) : null}
       {(isLoading || initialRosterLoading) && !roster.length ? (
         <div className="flex flex-1 items-center justify-center">
-          <GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />
+          <SystemActivitySlot
+            activity="loading"
+            fallback={<GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />}
+            label={t.common.loading}
+            placement="region"
+          />
         </div>
       ) : error && !roster.length ? (
         <div className="grid gap-2 px-3 py-4 text-xs text-(--ui-text-tertiary)">

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -8,6 +8,8 @@
  * actions, and the detail drawer. Dispatch nudges ride every write (see api.ts).
  */
 
+// only this operation's mark is contributed; native fallback stays intact.
+import { SystemActivitySlot, useI18n } from '@hermes/plugin-sdk'
 import {
   Button,
   cn,
@@ -1080,6 +1082,7 @@ function SelectionBar({
 // ── page ─────────────────────────────────────────────────────────────────────
 
 export function KanbanBoardPage() {
+  const { t } = useI18n()
   const k = useKanban()
   const qc = useQueryClient()
   const slug = useValue($boardSlug)
@@ -1373,7 +1376,12 @@ export function KanbanBoardPage() {
         </div>
       ) : !filtered ? (
         <div className="grid flex-1 place-items-center">
-          <Loader type="lemniscate-bloom" />
+          <SystemActivitySlot
+            activity="loading"
+            fallback={<Loader type="lemniscate-bloom" />}
+            label={t.common.loading}
+            placement="region"
+          />
         </div>
       ) : total === 0 ? (
         <div className="grid flex-1 place-items-center px-4 text-center">

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -5,6 +5,8 @@
  * comments (+composer), activity, run history, and the worker log tail.
  */
 
+// only this operation's mark is contributed; native fallback stays intact.
+import { SystemActivitySlot, useI18n } from '@hermes/plugin-sdk'
 import {
   Badge,
   Button,
@@ -548,6 +550,7 @@ export function TaskDrawer({
   onClose: () => void
   onOpen: (id: string) => void
 }) {
+  const { t } = useI18n()
   const k = useKanban()
   const qc = useQueryClient()
   const slug = useValue($boardSlug)
@@ -752,7 +755,12 @@ export function TaskDrawer({
           <ErrorState title={errorMessage} />
         ) : !detail || !task ? (
           <div className="grid h-32 place-items-center">
-            <Loader type="lemniscate-bloom" />
+            <SystemActivitySlot
+              activity="loading"
+              fallback={<Loader type="lemniscate-bloom" />}
+              label={t.common.loading}
+              placement="region"
+            />
           </div>
         ) : (
           <div className="flex flex-col gap-4 text-sm">

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1702,6 +1702,13 @@ export const TITLEBAR_AREAS = { center: 'titleBar.center', left: 'titleBar.left'
  *  setup.runtime_check, reconciled) — pass `host.request`. Don't hand-roll
  *  readiness from raw RPC shapes. */
 export { evaluateRuntimeReadiness, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
+// system-operation rendering through the existing contribution registry.
+export {
+  SYSTEM_ACTIVITY_AREA,
+  type SystemActivityContribution,
+  type SystemActivityProps,
+  SystemActivitySlot
+} from '@/lib/system-activity'
 /** Canonical time formatting — every surface pulls from here so timestamps read
  *  the same app-wide. For a row's AGE, bucket with `coarseElapsed` and render
  *  the compact suffixes (`t.sidebar.row.ageMin` → "52m"), which is what the

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -211,6 +211,7 @@ Import the area constants from the SDK; each area has its own `data` payload.
 | ⌘K palette | `PALETTE_AREA` | `data: PaletteContribution` |
 | Keybind | `KEYBINDS_AREA` | `data: KeybindContribution` |
 | Theme | `THEMES_AREA` | `data` as a `DesktopTheme` |
+| System activity | `SYSTEM_ACTIVITY_AREA` (`'ui.systemActivity'`) | `data` as a `SystemActivityContribution` |
 | Composer | `COMPOSER_AREAS.*` | render slots, or middleware / attachment providers |
 
 ### Panes
@@ -380,6 +381,43 @@ Both doors persist per profile, so a plugin-driven switch sticks exactly like a
 manual pick. To tint the *active* theme rather than replace it, use
 `setAccentOverride(hex)` and clear it in `ctx.onDispose` — the bundled `accent`
 plugin is the worked example.
+
+### System activity
+
+Themes are declarative colors and typography. To customize the mark for an
+app-owned operation, register a renderer in the existing contribution registry:
+
+```tsx
+import { SYSTEM_ACTIVITY_AREA, type SystemActivityContribution } from '@hermes/plugin-sdk'
+
+ctx.register({
+  id: 'activity',
+  area: SYSTEM_ACTIVITY_AREA,
+  data: { render: MyActivityMark } satisfies SystemActivityContribution
+})
+```
+
+The renderer receives `activity` (`loading`, `connecting`, or `processing`),
+`placement` (`inline`, `region`, or `threshold`), and `paused`. Honor `paused`:
+the host combines the operation's exit state with Hermes pane and window
+visibility. Also respect reduced motion and release animation resources on
+unmount. The rendered mark is decorative. `SystemActivitySlot` owns the live
+status name through its `label` prop; omit it when the surrounding status
+already supplies that name. The renderer also receives this label so a full
+application threshold can keep the operation visible beside its mark.
+
+`hasProgress` means the host already renders progress for this operation.
+Returning `null` deliberately omits the additional mark. Missing registration
+or a rendering error restores the caller's native fallback. The first enabled
+renderer in registry order owns the slot; registrations are disposed with the
+plugin. The host retains operation state, progress, copy and recovery controls.
+
+This area covers system waits, including loading saved conversations and
+catalogs. Agent turns, waiting for a person's approval, settled statuses,
+compact icon slots, and existing skeletons keep their own presentation.
+`PageLoader` defaults to `loading`; its `activity` prop identifies an active
+connection probe. Other callers opt in through `SystemActivitySlot` with their
+existing native mark as `fallback`.
 
 ### Composer extensions
 


### PR DESCRIPTION
## What does this PR do?

Allow desktop plugins to customize loading, connecting and processing indicators through the existing contribution registry. Theme tokens can style native marks but cannot supply a renderer. This extension lets plugins provide those visuals while Hermes retains operation state and native fallbacks.

`ui.systemActivity` replaces only the visual mark. Hermes continues to own operation state, status labels, measured progress and recovery. With no enabled renderer, or if it throws, the original indicator remains. Agent turn activity is outside this area.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Add `SystemActivitySlot`, typed renderer props and SDK exports using the existing registry, error boundary and pane/window pause controller. Support component state, memoized renderers, intentional omission, disposal and same-id replacement after failure.
- Adopt the slot in page and saved-session loading, catalog/inventory reads, terminal startup, connection, update and session-import surfaces. Existing compact action spinners and Agent turn indicators retain their behavior.
- Document the SDK contract and registration example. No product-specific artwork, dependency or theme is included.
- Add behavioral lifecycle tests; preserve existing model-picker and pet test assertions with partial SDK mocks.

## How to Test

From the repository root:

1. `npm ci`
2. `npm run test:ui -w apps/desktop -- src/lib/system-activity.test.tsx src/plugins/hermes-bots/model-picker.test.tsx src/plugins/hermes-bots/pet.test.tsx`
3. `npm run typecheck -w apps/desktop`, `npm run lint -w apps/desktop`, `npm run build -w apps/desktop`
4. Register the example from `website/docs/developer-guide/desktop-plugin-sdk.md`, open a loading surface, then disable the plugin. Confirm its mark appears while enabled and Hermes's native indicator returns when disabled. The renderer must treat `paused` as a freeze signal and leave accessible naming to the host.

## Checklist

- [x] Read the Contributing Guide and root/desktop/source AGENTS.md (at upstream base c8aa5608c2).
- [x] Conventional Commit messages; searched existing issues and PRs; only this feature is included.
- [x] Added behavioral tests. Focused upstream desktop run: 3 files, 13 tests passed on macOS arm64.
- [x] Upstream desktop typecheck, lint and production build completed. Lint reports existing warnings; no errors.
- [ ] Full Python suite — not run for this renderer-only contribution; no Python files changed.
- [x] Browser component smoke at 1220 × 800 and 800 × 600: real `PageLoader`, inline and threshold slots; native fallback, custom renderer, pause, throwing renderer, replacement and removal. Captures inspected. This is an isolated Chromium fixture, not an Electron/gateway startup test.
- [x] Updated desktop SDK documentation. Config keys, tool schemas and bundled skills: N/A.
- [x] Considered cross-platform behavior: uses existing renderer visibility handling, with no new platform branches or native dependencies. Windows/Linux runtime checks were not run locally.

## Screenshots / Logs

Verified upstream head: `26712376620cd92f7ac92ede14694913f780b78a`, based on `c8aa5608c24e3636e77c267650c0f1f52e44adb0`.

```text
Focused UI: 3 files passed; 13 tests passed
Desktop typecheck: passed
Desktop lint: no errors; changed system-activity module/tests pass with --max-warnings=0
Desktop production build: passed (renderer, Electron bundles, native dependency staging)
Browser component smoke: native → custom → paused → failure fallback → replacement → removal passed
```

No native gateway, packaging, Python-suite or Windows/Linux runtime result is claimed.
