### PR TITLE
feat(slack): make the native task card title configurable

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1328,6 +1328,8 @@ platform_toolsets:
 #       # Render live tool calls as Slack-native plan/task cards. This explicit
 #       # opt-in works even though Slack text tool_progress defaults to off.
 #       native_task_cards: false
+#       # Title of the plan/task card and its text fallback. Default: "Hermes is working".
+#       task_card_title: "Hermes is working"
 #       # Slack user IDs whose Web-API posts (user token, e.g. your own
 #       # dashboard/mobile front-end) count as human instead of being dropped
 #       # as app traffic. Narrower than allow_bots: all. Users only — never apps.

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -313,10 +313,18 @@ class TurnRunner:
         def visible_tasks(self) -> List[Dict[str, str]]:
             return [self.tasks[task_id] for task_id in self.task_order[-8:]]
 
+        def card_title(self) -> str:
+            getter = getattr(self.adapter, "native_task_card_title", None)
+            try:
+                title = str(getter() or "").strip() if callable(getter) else ""
+            except Exception:
+                title = ""
+            return title or "Hermes is working"
+
         def fallback_text(self) -> str:
             labels = {"in_progress": "running", "complete": "complete", "error": "error"}
             lines = [f"- {t['title']} - {labels.get(t['status'], t['status'])}" for t in self.visible_tasks()]
-            return "Hermes is working\n" + "\n".join(lines)
+            return self.card_title() + "\n" + "\n".join(lines)
 
         def _upsert(self, call_id: str, title: str) -> Dict[str, str]:
             if call_id not in self.tasks:
@@ -382,7 +390,7 @@ class TurnRunner:
             return
         if not st.native_failed:
             result = await st.adapter.send_native_task_card_progress(
-                chat_id=ctx.source.chat_id, tasks=st.visible_tasks(), title="Hermes is working",
+                chat_id=ctx.source.chat_id, tasks=st.visible_tasks(), title=st.card_title(),
                 reply_to=ctx._progress_reply_to, metadata=ctx._progress_metadata, fallback_text=st.fallback_text(),
             )
             if getattr(result, "success", False):

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1884,6 +1884,13 @@ class SlackAdapter(BasePlatformAdapter):
                 return self._truthy_config(value)
         return False
 
+    def native_task_card_title(self) -> str:
+        """Title of the live plan/task card; ``platforms.slack.extra.task_card_title``."""
+        extra = self.config.extra if isinstance(self.config.extra, dict) else {}
+        title = extra.get("task_card_title", extra.get("taskCardTitle"))
+        title = str(title).strip() if title is not None else ""
+        return title[:256] or "Hermes is working"
+
     def _native_task_card_key(
         self, chat_id: str, reply_to: Optional[str], metadata: Optional[Dict[str, Any]]
     ) -> Optional[Tuple[str, str, str]]:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -5041,6 +5041,21 @@ class TestNativeTaskCardProgress:
             PlatformConfig(enabled=True, token="xoxb-fake-token")
         ).native_task_cards_enabled() is False
 
+    def test_task_card_title_is_configurable(self):
+        config = PlatformConfig(
+            enabled=True,
+            token="xoxb-fake-token",
+            extra={"native_task_cards": True, "task_card_title": "  Talos is working  "},
+        )
+
+        assert SlackAdapter(config).native_task_card_title() == "Talos is working"
+        assert SlackAdapter(
+            PlatformConfig(enabled=True, token="xoxb-fake-token", extra={"task_card_title": ""})
+        ).native_task_card_title() == "Hermes is working"
+        assert SlackAdapter(
+            PlatformConfig(enabled=True, token="xoxb-fake-token")
+        ).native_task_card_title() == "Hermes is working"
+
     @pytest.mark.asyncio
     async def test_native_updates_are_serialized_and_workspace_scoped(self, adapter):
         team_client = AsyncMock()

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -435,6 +435,10 @@ platforms:
       # fallback current for the rest of the turn.
       native_task_cards: false
 
+      # Title shown on the plan/task card and its text fallback.
+      # Default: "Hermes is working".
+      task_card_title: "Hermes is working"
+
       # Suggested prompts pinned at the top of Agent view's Messages tab.
       # Either a list of {title, message} rows, or a titled object:
       # {title: "Start here", prompts: [{title: "Plan", message: "..."}]}
@@ -469,6 +473,7 @@ platforms:
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
 | `platforms.slack.extra.native_task_cards` | `false` | When `true`, renders live tool calls as Slack-native plan/task cards. This is an explicit progress opt-in independent of Slack's default `tool_progress: off`; native API failures fall back to one continuously edited text update. |
+| `platforms.slack.extra.task_card_title` | `"Hermes is working"` | Title of the native plan/task card and of its text fallback, for deployments where the bot goes by another name. |
 | `platforms.slack.extra.suggested_prompts` | `[]` | Up to four `{title, message}` prompts for Agent/Assistant DM entry points; accepts either a list or `{title, prompts}`. |
 | `platforms.slack.extra.assistant_thread_titles` | `true` | When `true`, names Agent/Assistant DM threads from the first user message. |
 | `platforms.slack.extra.allow_bots` | `"none"` | Controls messages from other Slack bots: `"none"` ignores them, `"mentions"` accepts a bot message only when **that message itself** @mentions Hermes, and `"all"` accepts all of them. Use `"mentions"` for the safest bot-to-bot collaboration mode. See [Accepting messages from other bots](#accepting-messages-from-other-bots-allow_bots). |


### PR DESCRIPTION
## What does this PR do?

The Slack native plan/task card (`platforms.slack.extra.native_task_cards`) and its editable text fallback are always titled "Hermes is working". Deployments where the bot goes by another display name show the wrong name on every turn. This adds `platforms.slack.extra.task_card_title`, defaulting to "Hermes is working", read by the Slack adapter and used by the turn runner for both the card and the fallback text.

Smaller alternative to #93742, which derives the title from the profile `display_name` and extends the relay contract. This one is a plain config key with no profile or relay changes. Happy to close it if #93742 lands first.

## Related Issue

Related to #93742.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/slack/adapter.py`: `native_task_card_title()` reads `extra.task_card_title` (or `taskCardTitle`), trims, caps at 256 chars, falls back to "Hermes is working".
- `gateway/run_turn_runner.py`: `card_title()` on the native progress state asks the adapter for the title; used for `send_native_task_card_progress` and for the fallback text header.
- `tests/gateway/test_slack.py`: `test_task_card_title_is_configurable`.
- `website/docs/user-guide/messaging/slack.md`, `cli-config.yaml.example`: document the key.

## How to Test

1. Set `platforms.slack.extra.native_task_cards: true` and `platforms.slack.extra.task_card_title: "Talos is working"`.
2. Ask the bot for something that runs a few tools in a Slack thread.
3. The card and, when Slack rejects the stream, the fallback message are titled "Talos is working". Without the key the title stays "Hermes is working".
4. `pytest tests/gateway/test_slack.py -k NativeTaskCard tests/gateway/test_run_progress_topics.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (see #93742 above)
- [x] My PR contains only changes related to this feature
- [x] I've run the Slack and progress test files (34 passed); full suite not run locally
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, gateway on Slack Socket Mode

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example`
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact: N/A, string config only
- [x] Tool descriptions/schemas: N/A
