### PR TITLE
fix(cron): keep a delivered run's success through a transient post-delivery claim blip (#105861)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2803,6 +2803,23 @@ def _finish_interrupted_run(job: dict, execution_id: str, delivery_error: Option
         error="Interrupted by gateway shutdown before terminal completion.")
 
 
+def _delivery_phase_interrupted(d: _RunDelivery) -> bool:
+    """Whether the save/compose/deliver phase ended in an ownership-lost interruption that must
+    overwrite the run outcome with ``_OWNERSHIP_LOST_INTERRUPTED`` (#105861).
+
+    True ONLY when the claim was lost *during* the side effect — ``_save_compose_deliver`` raised
+    ``_FireClaimLostDuringSideEffect`` (``side_effect_ownership_lost``), so delivery did not
+    complete under a held claim. A claim that merely reads as lost *after* a completed delivery is
+    deliberately NOT an interruption here: the heartbeat's sampled ``fence.lost()`` flips
+    permanently on a single transient missed tick (disk latency, a concurrent jobs.json rewrite, a
+    brief spawn spike), and honoring it post-delivery overwrote an already-delivered success with
+    ``_OWNERSHIP_LOST_INTERRUPTED`` — poisoning job history and firing false watchdog alerts while
+    the message had in fact been sent. The authoritative post-delivery ownership check is the
+    owner-fenced ``mark_job_run`` in ``_finish_completed_run``: it records a genuine loss atomically
+    at mark time, and records the real success when the claim is (still) held."""
+    return d.side_effect_ownership_lost
+
+
 def _finish_completed_run(d: _RunDelivery, fire_owner: Optional[str], execution_id: str) -> bool:
     """mark_job_run (owner-fenced) + execution ledger row for a run that reached delivery."""
     job = d.job
@@ -2997,7 +3014,10 @@ def _run_one_job_body(
             # Every path must tear down deferred agent(s) so they never leak subprocesses/clients.
             _teardown_deferred()
 
-        if d.side_effect_ownership_lost or _fire_claim_ownership_lost():
+        # Only a claim lost *during* delivery interrupts the run; a claim that reads as lost after a
+        # completed delivery is left to _finish_completed_run's owner-fenced mark_job_run, so a
+        # transient heartbeat blip no longer overwrites a delivered success with an error (#105861).
+        if _delivery_phase_interrupted(d):
             _record_fire_ownership_lost(job["id"], fire_owner, execution_id)
             return True
 

--- a/tests/gateway/test_cron_delivered_success_survives_claim_blip.py
+++ b/tests/gateway/test_cron_delivered_success_survives_claim_blip.py
@@ -1,0 +1,59 @@
+"""A delivered cron run's success must survive a transient post-delivery fire-claim blip (#105861).
+
+Agent-mode cron jobs hold a durable fire claim that a heartbeat re-validates every 60s. The run
+wrapper (``_run_one_job_body``) used to short-circuit to ``_record_fire_ownership_lost`` whenever
+``d.side_effect_ownership_lost or _fire_claim_ownership_lost()`` was truthy *after* the
+save/compose/deliver phase. ``fence.lost()`` (``_fire_claim_ownership_lost``) is a sampled flag that
+flips permanently on a single transient missed heartbeat tick, so a completed, already-delivered run
+got its ``last_status`` overwritten with ``Interrupted by shutdown before terminal completion.`` —
+poisoning job history and firing false watchdog alerts even though the message was sent.
+
+The post-delivery interruption decision is now ``_delivery_phase_interrupted(d)``, which is True only
+when the claim was lost *during* the side effect (delivery did not complete). A completed delivery is
+left to ``_finish_completed_run``'s owner-fenced ``mark_job_run``, the authoritative ownership check.
+"""
+
+import inspect
+
+from cron import scheduler
+from cron.scheduler import _delivery_phase_interrupted
+
+
+def _delivery(*, side_effect_ownership_lost=False, delivery_attempted=True, delivery_error=None,
+              success=True):
+    d = scheduler._RunDelivery(job={"id": "j1"}, success=success, error=None)
+    d.side_effect_ownership_lost = side_effect_ownership_lost
+    d.delivery_attempted = delivery_attempted
+    d.delivery_error = delivery_error
+    return d
+
+
+class TestDeliveryPhaseInterrupted:
+    def test_completed_delivery_is_not_interrupted(self):
+        # The regression: a run whose delivery completed cleanly must NOT be recorded as an
+        # ownership-lost interruption, no matter what a later sampled heartbeat reads.
+        assert _delivery_phase_interrupted(_delivery()) is False
+
+    def test_loss_during_side_effect_is_interrupted(self):
+        # Delivery raised _FireClaimLostDuringSideEffect before completing → genuine interruption.
+        assert _delivery_phase_interrupted(
+            _delivery(side_effect_ownership_lost=True, delivery_attempted=False)) is True
+
+    def test_completed_delivery_with_a_delivery_error_is_not_an_ownership_interruption(self):
+        # A normal (non-fence) delivery failure is a completed run with a delivery error, handled by
+        # _finish_completed_run — not an ownership-lost interruption.
+        assert _delivery_phase_interrupted(
+            _delivery(delivery_error="discord 500", success=True)) is False
+
+    def test_predicate_does_not_consult_a_sampled_heartbeat(self):
+        # The decision is a pure function of the run-delivery outcome; it must not re-sample
+        # ownership (which is what flipped a delivered success to an error).
+        sig = inspect.signature(_delivery_phase_interrupted)
+        assert list(sig.parameters) == ["d"]
+
+    def test_run_wrapper_uses_the_predicate(self):
+        # Guard the wiring: the post-delivery block must route through _delivery_phase_interrupted
+        # rather than re-adding the sampled `or _fire_claim_ownership_lost()` disjunction.
+        src = inspect.getsource(scheduler._run_one_job_body)
+        assert "_delivery_phase_interrupted(d)" in src
+        assert "d.side_effect_ownership_lost or _fire_claim_ownership_lost()" not in src


### PR DESCRIPTION
## Problem (#105861)

Agent-mode cron jobs hold a durable **fire claim** a heartbeat re-validates every 60s. After the save/compose/deliver phase, `_run_one_job_body` short-circuited to `_record_fire_ownership_lost` whenever:

```python
if d.side_effect_ownership_lost or _fire_claim_ownership_lost():
    _record_fire_ownership_lost(job["id"], fire_owner, execution_id)
    return True
```

`_fire_claim_ownership_lost()` (`fence.lost()`) is a **sampled** flag that flips *permanently* on a single transient missed heartbeat tick (disk latency, a concurrent `jobs.json` rewrite, a brief spawn spike). So a run that had **already delivered its output** got `last_status` overwritten with `Interrupted by shutdown before terminal completion.` — turning a healthy job's history into `error` and firing false watchdog alerts on every subsequent tick, while the message had in fact been sent.

The reporter observed this 3× in one day (~12% of that day's agent runs), all independently verified delivered, zero duplicates.

Confirmed in `_record_fire_ownership_lost` itself: it only writes the error `if ... heartbeat_fire_claim(job_id, expected_owner=fire_owner)` returns **True** — i.e. it wrote the interruption *because the claim was still held*. The `fence.lost()` sample and the atomic heartbeat disagreed; the sample was the stale one.

## Fix

The post-delivery interruption decision is now `_delivery_phase_interrupted(d)`, **True only when the claim was lost *during* the side effect** (`_save_compose_deliver` raised `_FireClaimLostDuringSideEffect`, so delivery did not complete under a held claim). A completed delivery falls through to `_finish_completed_run`, whose owner-fenced `mark_job_run(expected_fire_owner=...)` is the **authoritative** check:

- claim genuinely lost at mark time → `mark_job_run` returns False → records the real ownership loss;
- claim still held → records the real `last_status: ok`.

This removes the redundant, sampled post-delivery check without weakening any guarantee:

- **Duplicate-delivery** is still guarded by the *pre-delivery* fence inside `_save_compose_deliver` (`side_effect_fence()` → raises `_FireClaimLostDuringSideEffect`), which is unchanged.
- **Gateway shutdown** is signaled by `_consume_interrupted_flag` (a separate per-execution flag), not this fence, so the shutdown path is unaffected.
- `_fire_claim_ownership_lost()` is still used for the *pre-run* ownership check earlier in the body.

## Tests

`tests/gateway/test_cron_delivered_success_survives_claim_blip.py`: a completed delivery is not an interruption (the regression), a loss during the side effect still is, a normal delivery error is not an ownership interruption, the predicate takes no sampled-ownership input, and the wrapper routes through `_delivery_phase_interrupted` (guards against re-adding the disjunction).

Fixes #105861
