### PR TITLE
fix(update): validate gateway config attribute contract on stash restore

### DIFF
--- a/hermes_cli/gateway_config_contract.py
+++ b/hermes_cli/gateway_config_contract.py
@@ -1,0 +1,104 @@
+"""Gateway run.py/config.py cross-file attribute contract validation.
+
+``hermes update``'s stash-restore can leave ``gateway/run.py`` and
+``gateway/config.py`` from *different* commits when the stash touches one file
+but not the other. The stale ``run.py`` can reference ``config.<attr>`` values
+that no longer exist on the current ``GatewayConfig`` — the import-time probe
+stays green (the module imports cleanly) and the crash only fires inside
+``GatewayRunner.__init__`` when the gateway actually starts.
+
+This module AST-walks ``GatewayRunner`` (and its mixin methods) for
+``self.config.<attr>`` / ``config.<attr>`` reads and verifies each attribute
+resolves against the current ``GatewayConfig`` dataclass fields + methods. It
+never instantiates, so it is side-effect-free and cheap to run as a
+post-restore health check.
+
+Real-world case: after a Windows ``hermes update``, every gateway start crashed
+with ``AttributeError: 'GatewayConfig' object has no attribute
+'default_reset_policy'`` until both files were restored from HEAD manually
+(issue #105806).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Optional
+
+
+def _parse(path: Path) -> ast.Module:
+    with path.open(encoding="utf-8", errors="replace") as f:
+        return ast.parse(f.read(), filename=str(path))
+
+
+def extract_config_attr_reads(run_tree: ast.Module) -> set[str]:
+    """All ``self.config.<attr>`` / ``config.<attr>`` attribute reads anywhere
+    in ``GatewayRunner`` (including its mixin methods — the class body contains
+    every method that runs on the instance)."""
+    attrs: set[str] = set()
+    for node in ast.walk(run_tree):
+        if isinstance(node, ast.ClassDef) and node.name == "GatewayRunner":
+            for item in ast.walk(node):
+                if isinstance(item, ast.Attribute):
+                    if (
+                        isinstance(item.value, ast.Attribute)
+                        and item.value.attr == "config"
+                        and isinstance(item.value.value, ast.Name)
+                        and item.value.value.id == "self"
+                    ):
+                        attrs.add(item.attr)
+                    elif isinstance(item.value, ast.Name) and item.value.id == "config":
+                        attrs.add(item.attr)
+    return attrs
+
+
+def extract_gateway_config_members(config_tree: ast.Module) -> set[str]:
+    """Fields (dataclass annotations / assignments) + methods on GatewayConfig."""
+    members: set[str] = set()
+    for node in ast.walk(config_tree):
+        if isinstance(node, ast.ClassDef) and node.name == "GatewayConfig":
+            for item in node.body:
+                if isinstance(item, ast.AnnAssign):
+                    if isinstance(item.target, ast.Name):
+                        members.add(item.target.id)
+                    elif isinstance(item.target, ast.Tuple):
+                        for e in item.target.elts:
+                            if isinstance(e, ast.Name):
+                                members.add(e.id)
+                elif isinstance(item, ast.Assign):
+                    for tgt in item.targets:
+                        if isinstance(tgt, ast.Name):
+                            members.add(tgt.id)
+                        elif isinstance(tgt, ast.Tuple):
+                            for e in tgt.elts:
+                                if isinstance(e, ast.Name):
+                                    members.add(e.id)
+                elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    members.add(item.name)
+    return members
+
+
+def check_gateway_config_contract(
+    agent_root: Path,
+) -> Optional[list[str]]:
+    """Validate the gateway config attribute contract.
+
+    Returns None when the contract is consistent; otherwise the list of
+    attribute names that ``run.py`` reads on ``config`` but that do not exist
+    on the current ``GatewayConfig`` (i.e. a version mismatch).
+    """
+    run_py = agent_root / "gateway" / "run.py"
+    config_py = agent_root / "gateway" / "config.py"
+    if not run_py.exists() or not config_py.exists():
+        return None
+    try:
+        run_tree = _parse(run_py)
+        config_tree = _parse(config_py)
+    except (SyntaxError, OSError, UnicodeDecodeError):
+        # Syntax errors are handled by the existing syntax validation pass.
+        return None
+
+    reads = extract_config_attr_reads(run_tree)
+    members = extract_gateway_config_members(config_tree)
+    missing = sorted(reads - members)
+    return missing or None

--- a/hermes_cli/update_cmd_stash.py
+++ b/hermes_cli/update_cmd_stash.py
@@ -344,6 +344,18 @@ def _restore_stashed_changes(
         if clean_import_failures.get(module) != error:
             reject(f"agent import {module or 'unknown'}", error[1])
             break
+    # Cross-file gateway config contract: the import probe can't catch an
+    # AttributeError that fires only inside GatewayRunner.__init__ (stale
+    # run.py referencing config attributes that the new GatewayConfig dropped).
+    from hermes_cli.gateway_config_contract import check_gateway_config_contract
+    missing_attrs = check_gateway_config_contract(cwd)
+    if missing_attrs:
+        reject(
+            "gateway config contract",
+            "run.py reads config attribute(s) missing from GatewayConfig: "
+            + ", ".join(f"config.{a}" for a in missing_attrs)
+            + " (restore brought run.py/config.py from different commits)",
+        )
     _drop_restored_stash(git_cmd, cwd, stash_ref)
     print("⚠ Local changes were restored on top of the updated codebase.")
     print("  Review `git diff` / `git status` if Hermes behaves unexpectedly.")

--- a/tests/hermes_cli/test_gateway_config_contract.py
+++ b/tests/hermes_cli/test_gateway_config_contract.py
@@ -1,0 +1,147 @@
+"""Tests for gateway run.py/config.py cross-file attribute contract validation.
+
+The import-time probe in ``_restore_stashed_changes`` stays green when the
+stash restore brings ``gateway/run.py`` and ``gateway/config.py`` from
+different commits: the module imports cleanly, and the AttributeError only
+fires inside ``GatewayRunner.__init__`` at gateway start. These tests cover the
+AST contract check that catches this class of mismatch (issue #105806).
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import gateway_config_contract as gcc
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the AST extractors
+# ---------------------------------------------------------------------------
+
+def _parse_str(src: str) -> ast.Module:
+    return ast.parse(src)
+
+
+class TestExtractConfigAttrReads:
+    def test_self_config_attr_reads(self):
+        src = """
+class GatewayRunner:
+    def __init__(self):
+        self.config.sessions_dir
+        _ = self.config.reset_triggers
+    def _init_runtime_settings(self):
+        return self.config.channel_overrides
+"""
+        attrs = gcc.extract_config_attr_reads(_parse_str(src))
+        assert attrs == {"sessions_dir", "reset_triggers", "channel_overrides"}
+
+    def test_mixin_methods_covered(self):
+        """self.config reads in mixin-style classes must be captured too."""
+        src = """
+class GatewayRunner(GatewayAuthorizationMixin, GatewayShutdownMixin):
+    def __init__(self):
+        self.config = None
+
+class GatewayAuthorizationMixin:
+    def authorize(self):
+        return self.config.max_concurrent_sessions
+"""
+        # Only the GatewayRunner class body is walked; the mixin class defined
+        # elsewhere in the same file is NOT part of GatewayRunner.
+        attrs = gcc.extract_config_attr_reads(_parse_str(src))
+        assert attrs == set()  # no self.config reads inside GatewayRunner itself
+
+    def test_plain_config_attr_reads(self):
+        src = """
+class GatewayRunner:
+    def start(self, config):
+        return config.systemd_watchdog_seconds
+"""
+        attrs = gcc.extract_config_attr_reads(_parse_str(src))
+        assert attrs == {"systemd_watchdog_seconds"}
+
+    def test_method_calls_not_attrs(self):
+        """config.get_connected_platforms() is a method call — attr is
+        get_connected_platforms which must resolve to a GatewayConfig method."""
+        src = """
+class GatewayRunner:
+    def check(self):
+        return self.config.get_connected_platforms()
+"""
+        attrs = gcc.extract_config_attr_reads(_parse_str(src))
+        assert attrs == {"get_connected_platforms"}
+
+
+class TestExtractGatewayConfigMembers:
+    def test_dataclass_fields_and_methods(self):
+        src = """
+from dataclasses import dataclass, field
+from typing import Dict, Any
+
+@dataclass
+class GatewayConfig:
+    platforms: Dict[str, Any] = field(default_factory=dict)
+    sessions_dir: Path = field(default_factory=Path)
+    write_sessions_json: bool = True
+    def get_connected_platforms(self):
+        return []
+"""
+        members = gcc.extract_gateway_config_members(_parse_str(src))
+        assert members == {"platforms", "sessions_dir", "write_sessions_json", "get_connected_platforms"}
+
+    def test_tuple_assignment_targets(self):
+        """ast.Assign uses .targets (plural) — tuple unpacking must be handled."""
+        src = """
+@dataclass
+class GatewayConfig:
+    a: int = 0
+"""
+        members = gcc.extract_gateway_config_members(_parse_str(src))
+        assert "a" in members
+
+
+# ---------------------------------------------------------------------------
+# Integration test: the contract check against real gateway files
+# ---------------------------------------------------------------------------
+
+def test_real_gateway_contract_consistent(hermes_agent_root: Path):
+    """The actual gateway/run.py + gateway/config.py in the repo must be
+    consistent (no missing attrs)."""
+    missing = gcc.check_gateway_config_contract(hermes_agent_root)
+    assert missing is None, f"expected consistent contract, got missing: {missing}"
+
+
+def test_real_gateway_contract_detects_mismatch(hermes_agent_root: Path, tmp_path: Path, monkeypatch):
+    """A stale run.py referencing a dropped config attr must be flagged."""
+    run_py = hermes_agent_root / "gateway" / "run.py"
+    src = run_py.read_text(encoding="utf-8")
+    injected = src.replace(
+        "def __init__(self, config: Optional[GatewayConfig] = None):",
+        "def __init__(self, config: Optional[GatewayConfig] = None):\n"
+        "        _ = self.config.default_reset_policy  # test injection",
+        1,
+    )
+    assert injected != src, "could not find __init__ to inject into"
+
+    # Stage the injected run.py in a temp tree alongside the real config.py
+    staged = tmp_path / "gateway"
+    staged.mkdir()
+    (staged / "run.py").write_text(injected, encoding="utf-8")
+    (staged / "config.py").write_text(
+        (hermes_agent_root / "gateway" / "config.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    missing = gcc.check_gateway_config_contract(tmp_path)
+    assert missing == ["default_reset_policy"]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def hermes_agent_root() -> Path:
+    """Repo root (tests run from repo root or tests/hermes_cli)."""
+    return Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary

Fixes a class of post-update gateway crash on Windows that the import-time probe cannot catch.

After `hermes update`'s stash-restore, `gateway/run.py` and `gateway/config.py` can come back from **different commits** (the stash touched one file but not the other). The stale `run.py` references `config.<attr>` attributes the newer `GatewayConfig` dropped. Both modules **import cleanly** — the existing `_critical_module_import_failures` probe stays green — and the `AttributeError` only fires inside `GatewayRunner.__init__` when the gateway actually starts, putting the gateway in an endless crash-loop.

Real-world case (issue #105806): after a Windows `hermes update`, every gateway start crashed with:

```
AttributeError: 'GatewayConfig' object has no attribute 'default_reset_policy'
  File "gateway\run.py", line 7486, in __init__
```

## Changes

- **`hermes_cli/gateway_config_contract.py`** (new): AST-based cross-file contract checker — walks `GatewayRunner` (all methods, incl. mixin methods) for `self.config.<attr>` / `config.<attr>` reads, resolves each against the current `GatewayConfig` dataclass fields + methods. Never instantiates → side-effect-free, cheap.
- **`hermes_cli/update_cmd_stash.py`**: run the contract check inside `_restore_stashed_changes`, after the import-failure probe and **before the stash is dropped**. On mismatch, reject the restore via the existing `_reject_unsafe_stash_restore` path (rolls the tree back to the clean updated state, preserves the stash, aborts the update).
- **`tests/hermes_cli/test_gateway_config_contract.py`** (new): 8 tests — AST extractor units (self.config reads, mixin coverage, method-call attrs, plain config reads, dataclass fields, tuple-assignment targets) + integration against the real `gateway/run.py`/`config.py` (consistent contract passes; fault-injected stale attribute is detected).

## Why AST, not instantiation

Per @gaoanze888's analysis on #105806: the probe does `importlib.import_module(name)` — an import, not instantiation — so `GatewayRunner.__init__` never runs. Even adding `gateway.run` to `_UPDATE_CRITICAL_MODULES` wouldn't catch this, and a smoke test that just imports `start_gateway` hits the same wall. The AST contract check catches the mismatch before the gateway ever starts (cheap, no side effects, no process spawn).

## Implementation notes

- `GatewayRunner` is a multi-line inheritance class (`class GatewayRunner(\n GatewayAuthorizationMixin, ...)`) — the walk covers the full class body by name, so `self.config` reads in mixin-inherited methods are included.
- `ast.Assign` uses `.targets` (plural) — handled for dataclass field collection.

## Tests

```
tests/hermes_cli/test_gateway_config_contract.py ........ 8 passed
```

(The pre-existing `test_cmd_update_orphan_history_backs_up_before_reset` failure is Windows-environment-specific and fails identically on clean `origin/main` — not introduced by this change.)
