### PR TITLE
fix(cron): self-heal poisoned croniter cache and blank platform adapter env in tests (#105838)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -44,12 +44,14 @@ HAS_CRONITER: Optional[bool] = None
 def _ensure_croniter() -> bool:
     """Import croniter on first use; honor a pre-set HAS_CRONITER override."""
     global croniter, HAS_CRONITER
-    if HAS_CRONITER is None:
+    if HAS_CRONITER is None or not callable(croniter):
         try:
             from croniter import croniter as _croniter
+
             croniter = _croniter
             HAS_CRONITER = True
         except ImportError:
+            croniter = None
             HAS_CRONITER = False
     return bool(HAS_CRONITER)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -419,6 +419,35 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "PHOTON_HOME_CHANNEL",
     "PHOTON_HOME_CHANNEL_THREAD_ID",
     "PHOTON_HOME_CHANNEL_NAME",
+    # Platform adapter behavior knobs (non-credential). A deployment
+    # machine exports these to steer its live adapters; tests mock config
+    # at import/call time, so the real values win over the mocks and
+    # batch runs diverge from solo runs (#105838). Tests that need them
+    # set them explicitly with monkeypatch.
+    "DISCORD_AUTO_THREAD",
+    "DISCORD_COMMAND_SYNC_POLICY",
+    "DISCORD_HIDE_SLASH_COMMANDS",
+    "DISCORD_HISTORY_BACKFILL",
+    "DISCORD_HISTORY_BACKFILL_LIMIT",
+    "DISCORD_MAX_ATTACHMENT_BYTES",
+    "DISCORD_MISSED_MESSAGE_BACKFILL",
+    "DISCORD_MISSED_MESSAGE_BACKFILL_LIMIT",
+    "DISCORD_REACTIONS",
+    "DISCORD_THREAD_REQUIRE_MENTION",
+    "DISCORD_REPLY_TO_MODE",
+    "TELEGRAM_MENTION_PATTERNS",
+    "TELEGRAM_REACTIONS",
+    "TELEGRAM_WEBHOOK_HOST",
+    "TELEGRAM_WEBHOOK_URL",
+    "TEAMS_CHANNEL_ID",
+    "TEAMS_CHAT_ID",
+    "TEAMS_DELIVERY_MODE",
+    "TEAMS_HOST",
+    "TEAMS_INCOMING_WEBHOOK_URL",
+    "TEAMS_PORT",
+    "TEAMS_SERVICE_URL",
+    "TEAMS_TENANT_ID",
+    "TEAMS_TEAM_ID",
     # API server bind/auth settings are common in local gateway profiles and
     # change adapter defaults plus load_gateway_config() enablement. Tests that
     # need them set opt in explicitly with monkeypatch.

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1937,3 +1937,33 @@ class TestEnsureCronDirWidened:
         with pytest.raises(FileNotFoundError):
             jobs._ensure_cron_dir(scripts_dir)
         assert not deleted_home.exists()
+
+
+class TestCroniterCachePoisoningSelfHeal:
+    """Batch runs must survive a poisoned ``cron.jobs.croniter`` global.
+
+    Earlier test directories that clear/re-import modules can leave the
+    lazy-import global bound to the croniter *module* object with
+    ``HAS_CRONITER`` latched True; solo cron runs never see it. Regression
+    for #105838: every parse_schedule-based test failed with
+    ``'module' object is not callable`` in directory-order runs.
+    """
+
+    def test_poisoned_module_binding_self_heals(self):
+        import croniter as croniter_module
+        import cron.jobs as jobs
+
+        pytest.importorskip("croniter")
+        assert jobs._ensure_croniter(), "precondition: croniter importable"
+
+        saved_croniter, saved_flag = jobs.croniter, jobs.HAS_CRONITER
+        try:
+            # Simulate the poisoned state an earlier directory leaves behind.
+            jobs.croniter = croniter_module
+            jobs.HAS_CRONITER = True
+
+            result = jobs.parse_schedule("every sunday 9am")
+            assert result["kind"] == "cron"
+            assert result["expr"] == "0 9 * * 0"
+        finally:
+            jobs.croniter, jobs.HAS_CRONITER = saved_croniter, saved_flag


### PR DESCRIPTION
### Summary

Two order-dependence mechanisms from #105838, fixed at both ends:

**1. croniter cache poisoning — `cron/jobs.py`**
`_ensure_croniter()` only imported while `HAS_CRONITER is None`. Once an earlier-loaded test directory's import-mocking/reload fixture left the module global `croniter` bound to the *module* object with the flag latched `True`, every later `parse_schedule()` in the same process failed with `ValueError: Invalid schedule 'every ...': 'module' object is not callable`. Now the guard also re-imports when the cached global is not callable, so the lazy import self-heals regardless of who poisoned the cache. Solo runs were green only because nothing had poisoned the process yet.

**2. Platform env leakage — `tests/conftest.py`**
The autouse `_hermetic_environment` fixture blanked credential-*shaped* names only. Non-credential adapter knobs read at call time (`TEAMS_TENANT_ID`, `TEAMS_CHANNEL_ID`, `TEAMS_HOST`, `TEAMS_PORT`, `TEAMS_SERVICE_URL`, `DISCORD_AUTO_THREAD`, `DISCORD_REACTIONS`, `DISCORD_HISTORY_BACKFILL`, `TELEGRAM_REACTIONS`, `TELEGRAM_WEBHOOK_HOST`, …) survived into adapter tests on any deployment machine that exports them, overriding config mocks. Added the non-credential platform families to `_HERMES_BEHAVIORAL_VARS` so they are blanked per-test like the allowlist/home-channel vars already there; tests that need them set them via `monkeypatch` as before.

**Regression test** — `TestCroniterCachePoisoningSelfHeal` in `tests/cron/test_jobs.py` poisons the global exactly as described in the issue and asserts `parse_schedule("every sunday 9am")` still parses.

### Testing

Reproduced first (venv python, current main before the fix):
```
jobs.croniter = croniter_module; jobs.HAS_CRONITER = True
jobs.parse_schedule("every sunday 9am")
-> ValueError: Invalid schedule 'every sunday 9am': 'module' object is not callable   # pristine
-> {'kind': 'cron', 'expr': '0 9 * * 0'}                                            # fixed
```
- `pytest tests/cron -q -m "not slow and not network and not integration"`: 1229 passed (2 pre-existing macOS failures reproduced on pristine main: `test_file_permissions.py::...0700`, `test_script_claim_heartbeat.py::...grace`)
- Mutation check: reverting the guard condition to `HAS_CRONITER is None` makes the new test RED; restored it is GREEN
- All 14 test files touching the newly-blanked env vars re-run green (discord/telegram/teams adapter suites, `test_config.py`, `test_local_env_blocklist.py` per-class)
- `ruff check` clean on all three files; `ruff format` diff count 1051 vs 1052 baseline (no new formatter complaints)

Fixes #105838