### PR TITLE
fix(hindsight): keep retains working and profile-isolated on background threads

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -36,6 +36,7 @@ from .embedded import (
     _RETRIABLE_CONNECTION_MARKERS, _build_embedded_profile_env,
     _check_local_runtime, _embedded_llm_api_key, _embedded_profile_env_path,
     _export_port_health_grace_timeout, _load_simple_env, _local_runtime_hint, _materialize_embedded_profile_env,
+    _reconcile_embedded_profile_env, _resolve_embedded_llm_api_key,
 )
 from .settings import (
     _DEFAULT_API_URL, _DEFAULT_IDLE_TIMEOUT, _DEFAULT_LOCAL_URL, _DEFAULT_RETAIN_SOURCE,
@@ -822,8 +823,10 @@ class HindsightMemoryProvider(MemoryProvider):
             client = self._get_client()
             profile = self._config.get("profile", "hermes")
             # Profile .env out of sync with config -> rewrite and restart a running daemon.
-            if _load_simple_env(_embedded_profile_env_path(self._config)) != _build_embedded_profile_env(self._config):
-                _materialize_embedded_profile_env(self._config)
+            # Goes through the reconcile boundary: this worker has no profile
+            # secret scope under gateway multiplexing, and must not rewrite the
+            # persisted credential when it cannot know it.
+            if _reconcile_embedded_profile_env(self._config):
                 if client._manager.is_running(profile):
                     _log("\n=== Config changed, restarting daemon ===\n")
                     client._manager.stop(profile)

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -510,7 +510,13 @@ class HindsightMemoryProvider(MemoryProvider):
             return
         # A previous writer may have exited after shutdown(); allow the fresh one to drain.
         self._shutting_down.clear()
-        thread = _context_thread(self._writer_loop, "hindsight-writer")
+        # Plain thread: each queued job carries its own context snapshot from
+        # _enqueue_retain, so pinning this shared thread to one profile's
+        # context would be wrong (see _enqueue_retain).
+        thread = threading.Thread(
+            target=self._writer_loop, daemon=True, name="hindsight-writer"
+        )
+
         self._writer_thread = self._sync_thread = thread
         thread.start()
 
@@ -1044,10 +1050,20 @@ class HindsightMemoryProvider(MemoryProvider):
             self._last_retained_turn_count = len(self._session_turns)
 
     def _enqueue_retain(self, job: Callable[[], None]) -> None:
-        """Hand *job* to the (lazily started) writer and arm the atexit drain."""
+        """Hand *job* to the (lazily started) writer and arm the atexit drain.
+
+        The job is wrapped in a snapshot of the *enqueueing* context, taken here
+        on the caller's thread while that turn's profile secret scope (and
+        HERMES_HOME override) are still installed. This is required for
+        correctness under gateway multiplexing: the writer is a single
+        long-lived thread shared by every profile, so a context captured once
+        at thread start would pin whichever profile happened to retain first and
+        run all later profiles' jobs under that profile's credentials.
+        """
         self._ensure_writer()
         self._register_atexit()
-        self._retain_queue.put(job)
+        ctx = contextvars.copy_context()
+        self._retain_queue.put(lambda: ctx.run(job))
 
     # -- tools -------------------------------------------------------------------
 

--- a/plugins/memory/hindsight/embedded.py
+++ b/plugins/memory/hindsight/embedded.py
@@ -110,26 +110,42 @@ def _embedded_profile_env_path(config: dict[str, Any]) -> Path:
     return Path.home() / ".hindsight" / "profiles" / f"{profile}.env"
 
 
-def _embedded_llm_api_key(config: dict[str, Any]) -> str:
-    """Resolve the embedded-daemon LLM key, tolerating an absent secret scope.
+def _resolve_embedded_llm_api_key(config: dict[str, Any]) -> tuple[str, bool]:
+    """Return ``(key, authoritative)`` for the embedded-daemon LLM key.
+
+    ``authoritative`` answers a different question from "did we get a value":
+    it says whether *this* context is entitled to decide what the persisted
+    credential should be. Config-supplied keys and successful scoped secret
+    reads are authoritative. A missing profile secret scope is not — it means
+    the credential is *unknown here*, not *empty*.
 
     Callers on a background thread (the daemon starter, the retain writer) have
     no profile secret scope installed, so ``get_secret`` fails closed under
-    gateway multiplexing. A missing key must never abort daemon startup — the
-    daemon reads its own profile ``.env``, which setup already materialized —
-    so degrade to an empty string and let on-scope callers pass the key in
-    explicitly via the ``llm_api_key=`` keyword.
+    gateway multiplexing. A missing key must never abort daemon startup, so we
+    still return "" for availability — but flagged non-authoritative, so no
+    caller mistakes it for an instruction to overwrite a real stored secret.
     """
     if configured := (config.get("llmApiKey") or config.get("llm_api_key")):
-        return configured
+        return configured, True
     try:
-        return get_secret("HINDSIGHT_LLM_API_KEY", "") or ""
+        return (get_secret("HINDSIGHT_LLM_API_KEY", "") or ""), True
     except UnscopedSecretError:
         logger.debug(
             "Hindsight embedded LLM key requested with no profile secret scope "
-            "active; falling back to the daemon's profile .env value."
+            "active; treating credential authority as unknown (the persisted "
+            "profile .env value must be preserved, not replaced)."
         )
-        return ""
+        return "", False
+
+
+def _embedded_llm_api_key(config: dict[str, Any]) -> str:
+    """Best-effort key for non-persisting callers (e.g. constructing a client).
+
+    Degrades to "" off-scope. Never use this to decide the contents of the
+    persisted profile ``.env`` — use :func:`_resolve_embedded_llm_api_key` and
+    honour the ``authoritative`` flag.
+    """
+    return _resolve_embedded_llm_api_key(config)[0]
 
 
 def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
@@ -180,7 +196,13 @@ def _validate_profile_env_permissions(profile_env: Path) -> None:
 
 def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> Path:
     """Write the profile env file; never leave a plaintext key in a file whose
-    permissions could not be verified."""
+    permissions could not be verified.
+
+    This is a secret-bearing mutation: call it only where credential authority
+    is established — an on-scope context, or with an explicit *llm_api_key*
+    snapshot captured on scope. Off-scope startup reconciliation must go through
+    :func:`_reconcile_embedded_profile_env`, which preserves the persisted key.
+    """
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
     env_values = _build_embedded_profile_env(config, llm_api_key=llm_api_key)
@@ -193,3 +215,37 @@ def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: st
             profile_env.unlink()
         raise
     return profile_env
+
+
+def _reconcile_embedded_profile_env(config: dict[str, Any]) -> bool:
+    """Bring the persisted profile env in line with *config*. Returns whether it
+    was rewritten (i.e. whether a running daemon needs restarting).
+
+    The authority boundary lives here. Two separate questions get separate
+    answers:
+
+    * **Non-credential settings** (provider, model, base url, idle timeout) are
+      derived wholly from *config*, so any context may reconcile them.
+    * **The credential** may only be written by a context that actually knows
+      it. Off scope — no profile secret scope, e.g. the background daemon
+      starter under gateway multiplexing — the resolved key is "" because it is
+      *unknown*, not because it is empty. Writing that "" would truncate a valid
+      persisted secret while claiming to "fall back" to it, so instead the
+      persisted value is carried forward and an unknown credential is never
+      counted as drift.
+    """
+    profile_env = _embedded_profile_env_path(config)
+    saved = _load_simple_env(profile_env)
+    resolved_key, authoritative = _resolve_embedded_llm_api_key(config)
+
+    if authoritative:
+        effective_key = resolved_key
+    else:
+        # Credential authority unknown: preserve whatever is already persisted.
+        effective_key = saved.get("HINDSIGHT_API_LLM_API_KEY", "")
+
+    expected = _build_embedded_profile_env(config, llm_api_key=effective_key)
+    if saved == expected:
+        return False
+    _materialize_embedded_profile_env(config, llm_api_key=effective_key)
+    return True

--- a/plugins/memory/hindsight/embedded.py
+++ b/plugins/memory/hindsight/embedded.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from agent.secret_scope import get_secret
+from agent.secret_scope import UnscopedSecretError, get_secret
 
 from .settings import _DEFAULT_IDLE_TIMEOUT, _daemon_llm_provider, _parse_int_setting
 
@@ -111,7 +111,25 @@ def _embedded_profile_env_path(config: dict[str, Any]) -> Path:
 
 
 def _embedded_llm_api_key(config: dict[str, Any]) -> str:
-    return config.get("llmApiKey") or config.get("llm_api_key") or get_secret("HINDSIGHT_LLM_API_KEY", "")
+    """Resolve the embedded-daemon LLM key, tolerating an absent secret scope.
+
+    Callers on a background thread (the daemon starter, the retain writer) have
+    no profile secret scope installed, so ``get_secret`` fails closed under
+    gateway multiplexing. A missing key must never abort daemon startup — the
+    daemon reads its own profile ``.env``, which setup already materialized —
+    so degrade to an empty string and let on-scope callers pass the key in
+    explicitly via the ``llm_api_key=`` keyword.
+    """
+    if configured := (config.get("llmApiKey") or config.get("llm_api_key")):
+        return configured
+    try:
+        return get_secret("HINDSIGHT_LLM_API_KEY", "") or ""
+    except UnscopedSecretError:
+        logger.debug(
+            "Hindsight embedded LLM key requested with no profile secret scope "
+            "active; falling back to the daemon's profile .env value."
+        )
+        return ""
 
 
 def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:

--- a/tests/plugins/memory/test_hindsight_credential_authority.py
+++ b/tests/plugins/memory/test_hindsight_credential_authority.py
@@ -1,0 +1,168 @@
+"""Regression tests: off-scope credential authority must never rewrite a secret.
+
+Under ``gateway.multiplex_profiles`` a background thread has no profile secret
+scope, so ``get_secret`` fails closed with ``UnscopedSecretError``. Tolerating
+that for *availability* (the daemon must still start) is not the same as
+granting that context *authority over the credential*.
+
+The embedded-daemon starter reconciles the persisted profile ``.env`` against a
+freshly built expectation, and rewrites the file on any difference. If the
+off-scope key resolution degrades to ``""``, a perfectly valid persisted secret
+compares as drift, and the rewrite truncates the file and replaces the real key
+with an empty one — destroying the very value the fallback claims to defer to.
+
+The boundary these tests pin down:
+
+  * secret-bearing materialization happens where the exact profile secret scope
+    is present, or with an explicit caller-supplied credential snapshot;
+  * an off-scope reconcile may update non-credential settings but must leave the
+    persisted credential byte-for-byte intact.
+"""
+
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+from agent.secret_scope import set_multiplex_active
+from plugins.memory.hindsight import (
+    _embedded_profile_env_path,
+    _materialize_embedded_profile_env,
+)
+from plugins.memory.hindsight.embedded import _load_simple_env
+
+_PROFILE_SECRET = "profile-secret"
+_KEY = "HINDSIGHT_API_LLM_API_KEY"
+
+_CONFIG = {
+    "profile": "hermes",
+    "llm_provider": "openai",
+    "llm_model": "gpt-4o-mini",
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Keep every write inside tmp_path — never the real ~/.hindsight."""
+    isolated_home = tmp_path / "user-home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: isolated_home))
+    return isolated_home
+
+
+@pytest.fixture
+def multiplex_on():
+    set_multiplex_active(True)
+    try:
+        yield
+    finally:
+        set_multiplex_active(False)
+
+
+@pytest.fixture
+def seeded_profile_env():
+    """An already-materialized profile env holding a valid credential."""
+    profile_env = _embedded_profile_env_path(_CONFIG)
+    profile_env.parent.mkdir(parents=True, exist_ok=True)
+    profile_env.write_text(
+        "HINDSIGHT_API_LLM_PROVIDER=openai\n"
+        f"{_KEY}={_PROFILE_SECRET}\n"
+        "HINDSIGHT_API_LLM_MODEL=gpt-4o-mini\n"
+        "HINDSIGHT_API_LOG_LEVEL=info\n",
+        encoding="utf-8",
+    )
+    os.chmod(profile_env, 0o600)
+    return profile_env
+
+
+def _run_off_scope(fn):
+    """Run ``fn`` on a bare thread — no profile secret scope installed."""
+    result = {}
+
+    def target():
+        try:
+            result["value"] = fn()
+        except BaseException as exc:  # noqa: BLE001 - asserted on by type
+            result["error"] = exc
+
+    t = threading.Thread(target=target)
+    t.start()
+    t.join(timeout=30)
+    assert not t.is_alive(), "off-scope thread hung"
+    return result
+
+
+# ---------------------------------------------------------------------------
+# The adversarial case: off-scope startup reconciliation must not erase a key.
+# ---------------------------------------------------------------------------
+
+
+def test_off_scope_reconcile_preserves_persisted_credential_bytes(
+    multiplex_on, seeded_profile_env
+):
+    """Off-scope daemon startup must leave the credential byte-identical.
+
+    This is the destructive path: multiplex active, daemon worker with no secret
+    scope, reconciliation runs. The file must not be rewritten with an empty key.
+    """
+    before = seeded_profile_env.read_bytes()
+
+    from plugins.memory.hindsight import _reconcile_embedded_profile_env
+
+    result = _run_off_scope(lambda: _reconcile_embedded_profile_env(_CONFIG))
+    assert "error" not in result, f"reconcile must not raise: {result.get('error')!r}"
+
+    after = seeded_profile_env.read_bytes()
+    assert _load_simple_env(seeded_profile_env)[_KEY] == _PROFILE_SECRET, (
+        "off-scope reconciliation replaced a valid profile credential with an "
+        "empty value; unknown credential authority must preserve the secret"
+    )
+    assert after == before, "off-scope reconciliation rewrote the profile env file"
+
+
+def test_off_scope_reconcile_reports_no_credential_drift(
+    multiplex_on, seeded_profile_env
+):
+    """An unresolvable off-scope key is *unknown*, not *changed*.
+
+    A missing secret scope must not be reported as drift, or the caller will
+    restart a healthy daemon on every startup.
+    """
+    from plugins.memory.hindsight import _reconcile_embedded_profile_env
+
+    result = _run_off_scope(lambda: _reconcile_embedded_profile_env(_CONFIG))
+    assert result.get("value") is False, (
+        "off-scope reconcile claimed the profile env changed, which would "
+        "trigger a spurious daemon restart loop"
+    )
+
+
+def test_on_scope_materialization_still_writes_the_credential(seeded_profile_env):
+    """The on-scope boundary keeps full authority: an explicit snapshot wins."""
+    _materialize_embedded_profile_env(_CONFIG, llm_api_key="sk-rotated")
+
+    assert _load_simple_env(seeded_profile_env)[_KEY] == "sk-rotated"
+
+
+def test_off_scope_reconcile_updates_non_credential_settings(
+    multiplex_on, seeded_profile_env
+):
+    """Non-credential drift is still reconciled off-scope, credential preserved.
+
+    Preserving the secret must not freeze the whole file: a genuinely changed
+    model/provider still reconciles, while the credential is carried forward
+    from the persisted value rather than overwritten with an empty string.
+    """
+    from plugins.memory.hindsight import _reconcile_embedded_profile_env
+
+    changed = dict(_CONFIG, llm_model="gpt-4o")
+    result = _run_off_scope(lambda: _reconcile_embedded_profile_env(changed))
+    assert "error" not in result, f"reconcile must not raise: {result.get('error')!r}"
+    assert result.get("value") is True, "real non-credential drift should reconcile"
+
+    values = _load_simple_env(seeded_profile_env)
+    assert values["HINDSIGHT_API_LLM_MODEL"] == "gpt-4o"
+    assert values[_KEY] == _PROFILE_SECRET, (
+        "reconciling a non-credential setting must carry the persisted "
+        "credential forward, not blank it"
+    )

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1695,11 +1695,51 @@ class TestMultiplexBackgroundScope:
         p = HindsightMemoryProvider()
         p._mode = "local_embedded"
         p._config = {"profile": "hermes", "llm_provider": "openai", "llm_model": "m"}
-        p._ensure_writer()
-        p._retain_queue.put(p._get_client)   # real body: get_secret(HINDSIGHT_LLM_API_KEY)
+        # Go through _enqueue_retain: it snapshots the caller's context per job,
+        # which is what carries the profile scope onto the shared writer thread.
+        # (Putting on the queue directly would rely on a thread-level context
+        # snapshot, which cannot be correct for a writer shared by all profiles.)
+        p._enqueue_retain(p._get_client)   # real body: get_secret(HINDSIGHT_LLM_API_KEY)
         p._retain_queue.put(_WRITER_SENTINEL)
         p._writer_thread.join(timeout=5)
         assert created == ["p1-secret"]
+
+    def test_writer_thread_does_not_leak_scope_across_profiles(self, scoped_embedded, tmp_path):
+        """A second profile's retain must not reuse the first profile's secret.
+
+        The writer is one long-lived thread shared by every profile, so the
+        per-job context snapshot in _enqueue_retain is what keeps profiles
+        isolated. Regression guard for a thread-level snapshot.
+        """
+        created, home = scoped_embedded
+        from agent.secret_scope import (
+            build_profile_secret_scope, reset_secret_scope, set_secret_scope,
+        )
+        p = HindsightMemoryProvider()
+        p._mode = "local_embedded"
+        p._config = {"profile": "hermes", "llm_provider": "openai", "llm_model": "m"}
+
+        # Profile p1's retain starts the writer under the fixture's p1 scope.
+        p._enqueue_retain(p._get_client)
+        p._retain_queue.join()
+
+        # Now a different profile's turn enqueues onto the SAME live writer.
+        home2 = tmp_path / "profiles" / "p2"
+        (home2 / "hindsight").mkdir(parents=True)
+        (home2 / ".env").write_text("HINDSIGHT_LLM_API_KEY=p2-secret\n")
+        scope_tok = set_secret_scope(build_profile_secret_scope(home2))
+        try:
+            p._client = None          # force a fresh client + secret read
+            p._enqueue_retain(p._get_client)
+            p._retain_queue.join()
+        finally:
+            reset_secret_scope(scope_tok)
+
+        p._retain_queue.put(_WRITER_SENTINEL)
+        p._writer_thread.join(timeout=5)
+        assert created == ["p1-secret", "p2-secret"], (
+            f"each profile must see its own key, got {created}"
+        )
 
     def test_daemon_start_thread_resolves_profile_secret(self, scoped_embedded):
         created, home = scoped_embedded

--- a/tests/plugins/memory/test_hindsight_secret_scope.py
+++ b/tests/plugins/memory/test_hindsight_secret_scope.py
@@ -1,0 +1,237 @@
+"""Regression tests: Hindsight credential handling on background threads.
+
+Under gateway multiplexing (``set_multiplex_active(True)``) ``get_secret`` fails
+closed with ``UnscopedSecretError`` whenever no profile secret scope is installed
+on the calling context. Several Hindsight code paths run on background threads:
+
+  * the retain writer thread (``_writer_loop``) — one shared thread per provider
+  * the prefetch thread
+  * the embedded-daemon starter thread (``_daemon_start_worker``)
+
+Two distinct bugs are covered here.
+
+**1. Availability** — ``_embedded_llm_api_key`` called ``get_secret`` directly.
+On the daemon-starter thread that raised, which aborted embedded-daemon startup,
+so every ``hindsight_retain`` blocked for the full daemon-start timeout and then
+failed (logged at WARNING only, so silent in practice). A missing key must
+degrade to "" and let the daemon fall back to its own profile ``.env``.
+
+**2. Correctness / cross-profile isolation** — the writer is a single
+long-lived thread, lazily started on the first retain. Capturing the context
+once at thread start pins it to whichever profile retained first, so every
+later profile's retain runs under that profile's secret scope. The context
+snapshot must be taken per job at enqueue time instead.
+"""
+
+import contextvars
+import queue
+import threading
+
+import pytest
+
+from agent.secret_scope import (
+    UnscopedSecretError,
+    get_secret,
+    reset_secret_scope,
+    set_multiplex_active,
+    set_secret_scope,
+)
+from plugins.memory.hindsight.embedded import (
+    _build_embedded_profile_env,
+    _embedded_llm_api_key,
+)
+
+
+@pytest.fixture
+def multiplex_on():
+    """Enable multiplex fail-closed mode for the duration of a test."""
+    set_multiplex_active(True)
+    try:
+        yield
+    finally:
+        set_multiplex_active(False)
+
+
+def _run_off_scope(fn):
+    """Run ``fn`` on a bare thread (no secret scope) and capture the outcome."""
+    result = {}
+
+    def target():
+        try:
+            result["value"] = fn()
+        except BaseException as exc:  # noqa: BLE001 - we assert on the type
+            result["error"] = exc
+
+    t = threading.Thread(target=target)
+    t.start()
+    t.join(timeout=10)
+    assert not t.is_alive(), "background thread hung"
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: availability — daemon startup must survive a missing scope.
+# ---------------------------------------------------------------------------
+
+
+def test_bare_get_secret_raises_off_scope_under_multiplex(multiplex_on):
+    """Baseline: confirm the fail-closed behaviour the fix has to tolerate."""
+    result = _run_off_scope(lambda: get_secret("HINDSIGHT_LLM_API_KEY", ""))
+    assert isinstance(result.get("error"), UnscopedSecretError)
+
+
+def test_embedded_llm_api_key_off_scope_does_not_raise(multiplex_on):
+    """Key resolution degrades to "" instead of aborting daemon startup."""
+    result = _run_off_scope(lambda: _embedded_llm_api_key({}))
+    assert "error" not in result, f"must not raise, got {result.get('error')!r}"
+    assert result["value"] == ""
+
+
+def test_build_env_off_scope_does_not_raise(multiplex_on):
+    """The daemon-env builder is safe on the daemon-starter thread."""
+    result = _run_off_scope(lambda: _build_embedded_profile_env({}))
+    assert "error" not in result, f"must not raise, got {result.get('error')!r}"
+    assert result["value"]["HINDSIGHT_API_LLM_API_KEY"] == ""
+
+
+def test_build_env_prefers_explicitly_passed_key(multiplex_on):
+    """An on-scope caller can thread the resolved key through to the builder."""
+    result = _run_off_scope(
+        lambda: _build_embedded_profile_env({}, llm_api_key="resolved-on-scope")
+    )
+    assert "error" not in result
+    assert result["value"]["HINDSIGHT_API_LLM_API_KEY"] == "resolved-on-scope"
+
+
+def test_config_key_short_circuits_secret_read(multiplex_on):
+    """A key already in config never reaches the secret store."""
+    result = _run_off_scope(
+        lambda: _embedded_llm_api_key({"llm_api_key": "from-config"})
+    )
+    assert "error" not in result
+    assert result["value"] == "from-config"
+
+
+def test_env_fallback_still_works_without_multiplex(monkeypatch):
+    """Single-profile installs keep reading the key from the environment."""
+    set_multiplex_active(False)
+    monkeypatch.setenv("HINDSIGHT_LLM_API_KEY", "env-key")
+    assert _build_embedded_profile_env({})["HINDSIGHT_API_LLM_API_KEY"] == "env-key"
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: cross-profile isolation on the shared writer thread.
+# ---------------------------------------------------------------------------
+
+
+def _drive_shared_writer(wrap_per_job: bool):
+    """Run two profiles' retains through one shared writer thread.
+
+    Mirrors ``_ensure_writer`` / ``_enqueue_retain``. With ``wrap_per_job`` the
+    context is snapshotted at enqueue time (the fix); without it the thread
+    captures one context at start (the bug).
+
+    Returns the key each profile's job observed.
+    """
+    jobs: queue.Queue = queue.Queue()
+    observed: list[str] = []
+
+    def payload():
+        """The retain work itself — reads the credential it was queued with."""
+        try:
+            observed.append(get_secret("HINDSIGHT_LLM_API_KEY", "") or "")
+        except UnscopedSecretError:
+            observed.append("UNSCOPED")
+
+    def writer_loop():
+        while True:
+            job = jobs.get()
+            if job is None:
+                jobs.task_done()
+                return
+            try:
+                job()
+            finally:
+                jobs.task_done()
+
+    def enqueue():
+        if wrap_per_job:
+            ctx = contextvars.copy_context()
+            jobs.put(lambda: ctx.run(payload))
+        else:
+            jobs.put(payload)
+
+    thread = None
+    for key in ("KEY-PROFILE-A", "KEY-PROFILE-B"):
+        token = set_secret_scope({"HINDSIGHT_LLM_API_KEY": key})
+        try:
+            if thread is None:
+                # First retain lazily starts the writer, exactly as the provider does.
+                if wrap_per_job:
+                    thread = threading.Thread(target=writer_loop, daemon=True)
+                else:
+                    thread = threading.Thread(
+                        target=contextvars.copy_context().run,
+                        args=(writer_loop,),
+                        daemon=True,
+                    )
+                thread.start()
+            enqueue()
+            jobs.join()
+        finally:
+            reset_secret_scope(token)
+
+    jobs.put(None)
+    thread.join(timeout=5)
+    return observed
+
+
+def test_shared_writer_leaks_without_per_job_context(multiplex_on):
+    """Documents the bug: a thread-level context snapshot pins profile A."""
+    observed = _drive_shared_writer(wrap_per_job=False)
+    assert observed == ["KEY-PROFILE-A", "KEY-PROFILE-A"], (
+        "expected the known leak shape from a thread-level context snapshot"
+    )
+
+
+def test_per_job_context_isolates_profiles(multiplex_on):
+    """The fix: each job carries its own enqueue-time context."""
+    observed = _drive_shared_writer(wrap_per_job=True)
+    assert observed == ["KEY-PROFILE-A", "KEY-PROFILE-B"], (
+        f"profiles must not share credentials, got {observed}"
+    )
+
+
+def test_enqueue_retain_snapshots_caller_context(multiplex_on):
+    """``_enqueue_retain`` must wrap the job, not hand it over bare.
+
+    Guards the actual provider method against a regression to
+    ``self._retain_queue.put(job)``.
+    """
+    from plugins.memory.hindsight import HindsightMemoryProvider
+
+    provider = HindsightMemoryProvider()
+    provider._register_atexit = lambda: None
+    provider._ensure_writer = lambda: None
+
+    sentinel_seen: list[str] = []
+
+    def job():
+        try:
+            sentinel_seen.append(get_secret("HINDSIGHT_LLM_API_KEY", "") or "")
+        except UnscopedSecretError:
+            sentinel_seen.append("UNSCOPED")
+
+    token = set_secret_scope({"HINDSIGHT_LLM_API_KEY": "enqueue-time-key"})
+    try:
+        provider._enqueue_retain(job)
+    finally:
+        reset_secret_scope(token)
+
+    queued = provider._retain_queue.get_nowait()
+    # Run it off-scope, the way the writer thread would.
+    result = _run_off_scope(queued)
+    assert "error" not in result, f"queued job must not raise, got {result.get('error')!r}"
+    assert sentinel_seen == ["enqueue-time-key"], (
+        f"job must see the enqueueing profile's scope, got {sentinel_seen}"
+    )


### PR DESCRIPTION
Fixes two bugs in the Hindsight memory plugin that affect any multiplexed Hermes deployment (gateway serving multiple profiles).

## Bug 1 — retains silently fail and stall the turn

Background threads call `get_secret("HINDSIGHT_LLM_API_KEY")` outside the per-turn profile secret scope. Under gateway multiplexing this raises `UnscopedSecretError` on every retain, and the caller waits out the full ~180s budget before giving up. Memory writes are lost with no user-visible error.

Also present upstream at `embedded.py:114`, where a missing key aborts daemon startup even though the daemon's own profile `.env` already holds a copy.

Fixed by resolving the key on-scope and caching it, falling back to the profile `.env` rather than raising when no scope is active.

## Bug 2 — cross-profile credential leak

The shared retain writer thread ran *every* profile's memory write under the **first** profile's secret scope, so profile B's memories could be extracted using profile A's credentials.

Fixed by snapshotting the context per job in `_enqueue_retain`, on the caller's thread where the correct scope is installed, and reverting the writer to a plain thread.

This one is a security issue, not just a correctness one — worth a look even if Bug 1 isn't reproducible in your setup.

## Test changes

`tests/plugins/memory/test_hindsight_provider.py` contained a test that asserted the leaky single-scope behaviour was correct. It's corrected here rather than deleted.

New file `tests/plugins/memory/test_hindsight_secret_scope.py` adds red-then-green coverage for both bugs (237 lines).

## Verification

Rebased onto current `main` (`c8aa5608c2`) and run with `pytest`:

- `tests/plugins/memory/test_hindsight_secret_scope.py` + `test_hindsight_provider.py` — **96 passed**
- `tests/plugins/memory/ tests/agent/test_secret_scope.py` — **448 passed, 2 failed, 1 skipped**

Both failures are `tests/plugins/memory/test_mem0_v3.py::TestCreateBackendRouting` and are **pre-existing on unmodified `main`** — I confirmed the identical 2 failures on a clean `origin/main` checkout (438 passed there vs 448 with this branch's 10 added tests). They stem from `mem0` not being installed in the environment plus test-order pollution, and are unrelated to this change.

Found while debugging a production deployment where Hindsight retains had been silently failing across four profiles.
