### PR TITLE
fix(file_operations): strip gRPC after-fork diagnostic from exec stdout and parse a real sha256 digest line

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -920,3 +920,19 @@ class TestEscapeNativeToolArg:
         assert node_cmds, f"no node command captured in: {commands}"
         assert "'C:/Users/alice/app/main.js'" in node_cmds[0]
         assert "/c/Users" not in node_cmds[0]
+
+
+# ── Local patch (ebizmarts): gRPC after-fork diagnostic stripped from stdout ──
+
+
+def test_exec_strips_grpc_fork_poll_diagnostic(mock_env):
+    mock_env.execute.return_value = {
+        "output": (
+            "I0826 11:08:16.577183 7276738 ev_poll_posix.cc:593] "
+            "FD from fork parent still in poll list: fd(46, generation: 1)\n"
+            "actual command output\n"
+        ),
+        "returncode": 0,
+    }
+    result = ShellFileOperations(mock_env)._exec("printf output")
+    assert result.stdout == "actual command output\n"

--- a/tests/tools/test_write_verification.py
+++ b/tests/tools/test_write_verification.py
@@ -71,3 +71,35 @@ class TestWriteVerification:
         assert "error" not in r
         assert f.read_text() == "content lands anyway\n"
         assert "verified" not in r or r.get("verified") is None
+
+
+# ── Local patch (ebizmarts): digest parse tolerates a noisy prefix line ──
+
+
+def test_hash_verification_ignores_non_hash_output_prefix(workdir):
+    # Some native libraries log after fork and their diagnostic is merged
+    # into command stdout before sha256sum output. Verification must find
+    # the digest line rather than assuming the first token is the digest.
+    f = workdir / "noisy-hash.txt"
+    import tools.file_operations as fo
+
+    real_exec = fo.ShellFileOperations._exec
+
+    def noisy_exec(self, cmd, **kw):
+        result = real_exec(self, cmd, **kw)
+        if "sha256sum" in cmd and result.exit_code == 0:
+            return fo.ExecuteResult(
+                stdout=(
+                    "W0826 11:08:16.577183 ev_poll_posix.cc:593] "
+                    "some other diagnostic that is not a digest\n"
+                    + result.stdout
+                ),
+                exit_code=result.exit_code,
+            )
+        return result
+
+    with mock_patch.object(fo.ShellFileOperations, "_exec", noisy_exec):
+        r = json.loads(write_file_tool(str(f), "content survives noisy output\n", task_id="t-wv-noisy"))
+    assert "error" not in r
+    assert r.get("verified") is True
+    assert f.read_text() == "content survives noisy output\n"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -167,6 +167,18 @@ def _split_segments(output: str, sentinel: str) -> list[str]:
     return output.split(sentinel + "\n")
 
 
+# gRPC (google-cloud-pubsub in the Google Chat adapter) logs this after-fork
+# diagnostic into the same stream as command stdout. File operations parse
+# that stream, so leaving the line in place corrupts sizes, hashes and
+# post-write comparisons. Local patch, ebizmarts 2026-09-07 (v0.20.5),
+# re-ported onto v0.21.1 on 2026-09-08.
+_GRPC_FORK_POLL_NOISE_RE = re.compile(
+    r"(?m)^[IWEF]\d{4} \d{2}:\d{2}:\d{2}\.\d+ \d+ "
+    r"ev_poll_posix\.cc:\d+\] FD from fork parent still in poll list: "
+    r"fd\(\d+, generation: \d+\)\r?\n?"
+)
+_SHA256_DIGEST_LINE_RE = re.compile(r"(?m)^([0-9a-fA-F]{64})(?:\s|$)")
+
 class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
     """File operations over any terminal backend exposing ``execute(command, cwd)``
     returning ``{"output": str, "returncode": int}``.
@@ -205,7 +217,8 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
         # child never received the input.
         if result.get("stdin_error") and exit_code == 0:
             exit_code = 1
-        return ExecuteResult(stdout=result.get("output", ""), exit_code=exit_code)
+        stdout = _GRPC_FORK_POLL_NOISE_RE.sub("", result.get("output", "") or "")
+        return ExecuteResult(stdout=stdout, exit_code=exit_code)
 
     def _has_command(self, cmd: str) -> bool:
         """Check if a command exists in the environment (cached); rg goes through
@@ -1193,7 +1206,13 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
         try:
             hash_result = self._exec(f"sha256sum {self._escape_shell_arg(path)} 2>/dev/null")
             if hash_result.exit_code == 0 and hash_result.stdout.strip():
-                disk_sha = hash_result.stdout.strip().split()[0]
+                # Native libraries can emit diagnostics after fork, and some
+                # terminal backends merge that output before sha256sum stdout.
+                # Parse a real digest line instead of trusting the first token.
+                digest_match = _SHA256_DIGEST_LINE_RE.search(hash_result.stdout)
+                if digest_match is None:
+                    return None, None
+                disk_sha = digest_match.group(1).lower()
                 if disk_sha != hashlib.sha256(content_bytes).hexdigest():
                     return False, WriteResult(error=(
                         f"Post-write verification failed for {path}: on-disk "


### PR DESCRIPTION
## What does this PR do?

When the Google Chat platform adapter is connected, `google-cloud-pubsub`'s gRPC runtime logs an after-fork diagnostic to the process's stdout stream:

```
I0826 11:08:16.577183 7276738 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(46, generation: 1)
```

`ShellFileOperations._exec` returns that stream verbatim and file operations parse it, so the extra line corrupts sizes, hashes and post-write comparisons. The visible symptom: every `write_file` fails post-write verification ("on-disk content hash differs from the intended write") on a gateway with Google Chat enabled, because `_verify_written_hash` takes the first whitespace token of the `sha256sum` output, which is now `I0826`.

Two small changes:

- `_exec` strips the known gRPC after-fork diagnostic (anchored regex, nothing else) before building the `ExecuteResult`.
- `_verify_written_hash` finds a real 64-hex digest line instead of trusting the first token; when no digest line exists it returns "could not verify" (`None`) as it already does for a failed hash command.

## Related Issue

No issue filed; happy to open one if you prefer tracking it separately.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py`: `_GRPC_FORK_POLL_NOISE_RE` + `_SHA256_DIGEST_LINE_RE`; strip in `_exec`; digest-line parse in `_verify_written_hash`.
- `tests/tools/test_file_operations.py`: `test_exec_strips_grpc_fork_poll_diagnostic`.
- `tests/tools/test_write_verification.py`: `test_hash_verification_ignores_non_hash_output_prefix`.

## How to Test

1. `pytest tests/tools/test_file_operations.py tests/tools/test_write_verification.py -q` (74 passed, 2 skipped on macOS / Python 3.11).
2. Reproduction without Google Chat: patch `ShellFileOperations._exec` to prepend the diagnostic line to `sha256sum` output (exactly what the new write-verification test does) and call `write_file_tool`; before this change it returns the verification error, after it returns `verified: true`.
3. Field check: a macOS gateway (launchd) with Google Chat connected, running this patch since 2026-09-07, has had no post-write verification failures; the same gateway on unpatched v0.20.5 failed every `write_file`.

## Checklist

- [x] Tests added for the change
- [x] Existing tests pass locally
- [x] No behavior change beyond the stripped diagnostic line and the tolerant digest parse
