### PR TITLE
gateway: report per-prompt context size in the OpenAI-compat usage block

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -25,7 +25,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 # _resolve_request_profile result for a /p/<profile>/ prefix this gateway does not serve (-> 404);
 # distinct from None (no prefix / multiplexing off -> default profile).
@@ -620,11 +620,26 @@ def _session_chat_user_message(body: Dict[str, Any], *, param: str = "message") 
 
 _USAGE_TOKEN_KEYS = ("input_tokens", "output_tokens", "total_tokens")
 
+# Hermes extras carried alongside the OpenAI-standard trio. A gateway-backed
+# WebUI session builds no in-process agent/ContextCompressor of its own, so
+# these keys on the finish-chunk usage block are its only channel for them.
+# Unknown keys inside `usage` are ignored by OpenAI SDK clients, so this is
+# additive for every non-Hermes consumer.
+_USAGE_EXTRA_KEYS = (
+    "cache_read_tokens", "cache_write_tokens", "estimated_cost",
+    "last_prompt_tokens", "threshold_tokens",
+)
+
 
 def _chat_usage_payload(usage: Dict[str, Any]) -> Dict[str, int]:
-    """OpenAI Chat Completions ``usage`` block (prompt/completion/total) from the agent's usage."""
+    """OpenAI Chat Completions ``usage`` block (prompt/completion/total) from the agent's usage,
+    plus the Hermes extras (cache/cost split, compressor's real prompt size) when present."""
     values = (usage.get(key, 0) for key in _USAGE_TOKEN_KEYS)
-    return dict(zip(("prompt_tokens", "completion_tokens", "total_tokens"), values))
+    payload = dict(zip(("prompt_tokens", "completion_tokens", "total_tokens"), values))
+    for key in _USAGE_EXTRA_KEYS:
+        if key in usage:
+            payload[key] = usage[key]
+    return payload
 
 
 def _responses_usage_payload(usage: Dict[str, Any]) -> Dict[str, int]:
@@ -3590,9 +3605,30 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         self, agent: Any, result: Any, session_id: Optional[str], *, route, requested_runtime, route_source,
         confirmed_runtime_lock: bool) -> tuple:
         """Attach usage, effective session id, ``_compressed`` and runtime metadata to a finished turn."""
+        # Coerce rather than trust-and-`or 0`: a test double's unset attribute is a
+        # MagicMock, which is truthy, so `getattr(...) or 0` passes it straight
+        # through and `max(0, mock)` then blows up with a TypeError.
+        def _usage_num(value: Any) -> Union[int, float]:
+            return value if isinstance(value, (int, float)) and not isinstance(value, bool) else 0
+
         usage = {"input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                  "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
-                 "total_tokens": getattr(agent, "session_total_tokens", 0) or 0}
+                 "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                 # The three above are summed over every API call in the turn - a
+                 # billing total. A gateway-backed WebUI client has no other view
+                 # of context size, and using that total as its ring's numerator
+                 # over-reports on any tool turn (doubles on 2 calls, etc). The
+                 # compressor's last_prompt_tokens is the single most recent real
+                 # prompt, refreshed by conversation_loop's update_from_response();
+                 # threshold_tokens is the window it will actually compact at. -1
+                 # is the compressor's post-compaction sentinel, so clamp to 0.
+                 "cache_read_tokens": _usage_num(getattr(agent, "session_cache_read_tokens", 0)),
+                 "cache_write_tokens": _usage_num(getattr(agent, "session_cache_write_tokens", 0)),
+                 "estimated_cost": _usage_num(getattr(agent, "session_estimated_cost_usd", 0)),
+                 "last_prompt_tokens": max(0, _usage_num(
+                     getattr(getattr(agent, "context_compressor", None), "last_prompt_tokens", 0))),
+                 "threshold_tokens": max(0, _usage_num(
+                     getattr(getattr(agent, "context_compressor", None), "threshold_tokens", 0)))}
         # Effective session id lets callers track compression-triggered rotations.
         # (#16938)
         _eff_sid = getattr(agent, "session_id", session_id)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -631,7 +631,7 @@ _USAGE_EXTRA_KEYS = (
 )
 
 
-def _chat_usage_payload(usage: Dict[str, Any]) -> Dict[str, int]:
+def _chat_usage_payload(usage: Dict[str, Any]) -> Dict[str, Union[int, float]]:
     """OpenAI Chat Completions ``usage`` block (prompt/completion/total) from the agent's usage,
     plus the Hermes extras (cache/cost split, compressor's real prompt size) when present."""
     values = (usage.get(key, 0) for key in _USAGE_TOKEN_KEYS)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -381,7 +381,15 @@ class TestAgentExecution:
         # here doesn't set an explicit session_id string so the guard skips
         # the annotation — header will fall back to the provided session_id.
         assert result["final_response"] == "ok"
-        assert usage == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+        # The three billing counters this test sets explicitly, plus the Hermes
+        # extras _finish_turn_result now always attaches. mock_agent has no
+        # explicit cache/cost/context_compressor attrs, so those coerce to 0 -
+        # this is exactly the MagicMock-attribute case _usage_num() guards.
+        assert usage == {
+            "input_tokens": 1, "output_tokens": 2, "total_tokens": 3,
+            "cache_read_tokens": 0, "cache_write_tokens": 0, "estimated_cost": 0,
+            "last_prompt_tokens": 0, "threshold_tokens": 0,
+        }
         create_kwargs = mock_create_agent.call_args.kwargs
         assert create_kwargs["requested_model"] == "MiniMax-M3"
         assert create_kwargs["requested_provider"] == "minimax"

--- a/tests/gateway/test_api_server_usage_extras.py
+++ b/tests/gateway/test_api_server_usage_extras.py
@@ -1,0 +1,83 @@
+"""Hermes usage extras (cache/cost split, real per-turn context size) on the
+OpenAI-compat chat usage block. A gateway-backed WebUI client has no
+in-process agent/ContextCompressor of its own and no other channel for them.
+"""
+
+from types import SimpleNamespace
+
+from gateway.platforms.api_server import _chat_usage_payload
+
+
+class TestChatUsagePayloadExtras:
+    """_chat_usage_payload carries the OpenAI trio always, Hermes extras only
+    when the caller's usage dict actually has them (an older/other caller's
+    usage dict must not gain fabricated zero fields)."""
+
+    def test_openai_trio_present_without_extras(self):
+        usage = {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12}
+        payload = _chat_usage_payload(usage)
+        assert payload == {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}
+
+    def test_extras_pass_through_when_present(self):
+        usage = {
+            "input_tokens": 52451, "output_tokens": 900, "total_tokens": 53351,
+            "cache_read_tokens": 4000, "cache_write_tokens": 100,
+            "estimated_cost": 0.42, "last_prompt_tokens": 26257, "threshold_tokens": 500000,
+        }
+        payload = _chat_usage_payload(usage)
+        assert payload["prompt_tokens"] == 52451, "OpenAI trio still reflects the billing total"
+        assert payload["last_prompt_tokens"] == 26257, (
+            "the real per-turn prompt size must survive alongside the billing total, "
+            "not be overwritten by it - that's the whole point of the extra field"
+        )
+        assert payload["threshold_tokens"] == 500000
+        assert payload["cache_read_tokens"] == 4000
+        assert payload["cache_write_tokens"] == 100
+        assert payload["estimated_cost"] == 0.42
+
+
+class TestFinishTurnResultUsageExtras:
+    """_finish_turn_result must source last_prompt_tokens/threshold_tokens from the
+    agent's own ContextCompressor (the single most recent real prompt), not from
+    the cumulative session counters it also reports."""
+
+    def _make_api_server(self):
+        from gateway.platforms.api_server import APIServerAdapter
+
+        return object.__new__(APIServerAdapter)
+
+    def test_compressor_fields_clamp_the_post_compaction_sentinel(self):
+        api = self._make_api_server()
+        agent = SimpleNamespace(
+            session_prompt_tokens=52451, session_completion_tokens=900, session_total_tokens=53351,
+            session_cache_read_tokens=4000, session_cache_write_tokens=100, session_estimated_cost_usd=0.42,
+            # -1 is ContextCompressor's post-compaction sentinel; a raw pass-through
+            # would render a negative ring on the client.
+            context_compressor=SimpleNamespace(last_prompt_tokens=-1, threshold_tokens=500000),
+            session_id="sess-1", _last_compaction_in_place=False,
+        )
+        _, usage = api._finish_turn_result(
+            agent, {"final_response": "ok"}, "sess-1",
+            route=None, requested_runtime=None, route_source="global", confirmed_runtime_lock=False,
+        )
+        assert usage["input_tokens"] == 52451, "billing total is unaffected by the sentinel clamp"
+        assert usage["last_prompt_tokens"] == 0
+        assert usage["threshold_tokens"] == 500000
+
+    def test_real_prompt_differs_from_the_cumulative_billing_total(self):
+        api = self._make_api_server()
+        agent = SimpleNamespace(
+            session_prompt_tokens=52451, session_completion_tokens=900, session_total_tokens=53351,
+            session_cache_read_tokens=0, session_cache_write_tokens=0, session_estimated_cost_usd=0.0,
+            context_compressor=SimpleNamespace(last_prompt_tokens=26257, threshold_tokens=500000),
+            session_id="sess-1", _last_compaction_in_place=False,
+        )
+        _, usage = api._finish_turn_result(
+            agent, {"final_response": "ok"}, "sess-1",
+            route=None, requested_runtime=None, route_source="global", confirmed_runtime_lock=False,
+        )
+        assert usage["input_tokens"] != usage["last_prompt_tokens"], (
+            "input_tokens is a 2-call billing total (52451); last_prompt_tokens is the "
+            "single most recent real prompt (26257) - a client using the former as a "
+            "context-ring numerator over-reports by 2x on this turn"
+        )

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -201,7 +201,13 @@ async def test_run_agent_registers_active_run_id_for_steering(adapter, monkeypat
     )
 
     assert result["session_id"] == "request-session"
-    assert usage == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    # Plus the Hermes extras _finish_turn_result always attaches; FakeAgent has
+    # no cache/cost/context_compressor attrs, so they coerce to 0.
+    assert usage == {
+        "input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+        "cache_read_tokens": 0, "cache_write_tokens": 0, "estimated_cost": 0,
+        "last_prompt_tokens": 0, "threshold_tokens": 0,
+    }
     assert observed == {"registered": True, "task_id": "request-session"}
     assert "run_steer_test" not in adapter._active_run_agents
 


### PR DESCRIPTION
## Problem

A gateway-backed WebUI session builds no in-process agent and no `ContextCompressor`. The only usage it ever sees is what the `/v1/chat/completions` finish chunk carries — and that chunk carried three billing counters and nothing else.

The dashboard needs a *context size* to draw its ring. With nothing to use, the client falls back to a default window (128K), so on a 1M-context model the ring is measured against roughly 1/8 of the real window and nags to compress at ~6%. Symptom as reported: *"every new session gets compacted context on the first message."* No compaction was actually running; the gauge was dividing by the wrong number.

## Why the existing counters can't fix it

`session_prompt_tokens` and friends are summed over **every API call in the turn**. A two-call tool turn doubles them. They are a billing total, not a context size.

Measured on a live tool turn:

| field | value |
|---|---|
| `input_tokens` (billing, 2 calls) | 52,451 |
| actual most recent prompt | **26,257** |

Using the billing total as the ring numerator over-reports by 2× on this turn, and more as tool use grows — which is precisely when a false "compress now" is most disruptive.

## Fix

`conversation_loop` already calls `update_from_response()` after each API response, so the compressor holds exactly the right numbers:

- `context_compressor.last_prompt_tokens` — the single most recent real prompt
- `context_compressor.threshold_tokens` — the window it will actually compact at

This forwards both through the OpenAI-compat usage block via `_chat_usage_payload`, the one payload builder shared by the non-streaming response and the SSE finish chunk, along with the cache-read/cache-write/cost split that had no other channel to a gateway-backed client.

Two details worth calling out:

- **`max(0, ...)` is load-bearing.** `-1` is the compressor's post-compaction sentinel; forwarding it raw would render a negative ring. The clamp needs an actual numeric check — `getattr(...) or 0` lets a truthy `MagicMock` straight through in tests, and `max(0, mock)` then raises `TypeError`. `_usage_num()` coerces anything non-numeric to 0.
- **Wire compatibility.** Unknown keys inside a `usage` object are ignored by OpenAI SDK clients, so this is additive for every non-Hermes consumer.

## Consumer

Consumed by [nesquena/hermes-webui#7446](https://github.com/nesquena/hermes-webui/pull/7446), which persists these fields on gateway-backed WebUI sessions and prefers `last_prompt_tokens` over its own tool-free heuristic whenever a gateway sends it.

## Tests

`tests/gateway/test_api_server_usage_extras.py` (new) covers `_chat_usage_payload`'s extras passthrough and `_finish_turn_result`'s sentinel clamp + MagicMock-attribute robustness. Three existing tests across `test_api_server.py` and `test_session_api.py` asserted an exact 3-key usage dict; updated to the new 8-key shape (existing values unchanged).

All 178 tests across the five directly-affected files pass, plus the two other files repo-wide that construct a bare `{"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}` usage dict as mock input (unaffected, confirmed green).

Verified live on this host prior to the rebase: `input_tokens 52,451` (billing, 2 calls), `last_prompt_tokens 26,257` (real prompt), `threshold_tokens 500,000`, context ring `2.63%` instead of a false nag.
