### PR TITLE
fix: Bot Mode pet selection no longer clips at gallery edges

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/pet.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/pet.test.tsx
@@ -12,7 +12,7 @@
  * failure must be evicted; a success must not be refetched.
  */
 
-import { render, waitFor } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { hostMock, UnboundedCache, useQueryMock } = vi.hoisted(() => ({
@@ -79,6 +79,55 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
+})
+
+describe('the pet gallery', () => {
+  it('reserves paint space around boundary tiles inside the bounded scroller', async () => {
+    stubFetch(async () => ({ blob: async () => new Blob() }))
+    const PetTab = await loadPetTab()
+    const view = render(<PetTab image={null} onImage={vi.fn()} />)
+    await waitFor(() => expect(view.container.querySelector('img')).toBeTruthy())
+    const tile = view.getByText('Axolotl').closest('button')!
+    const scroller = tile.parentElement!.parentElement!
+
+    // The selection ring paints one pixel outside each tile. The scrollport
+    // must leave room for it even at the first/last row and outer columns.
+    const style = getComputedStyle(scroller)
+
+    for (const side of ['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft'] as const) {
+      expect(parseFloat(style[side]) || 0).toBeGreaterThanOrEqual(1)
+    }
+
+    expect(parseFloat(style.maxHeight)).toBeGreaterThan(0)
+    view.unmount()
+  })
+
+  it('keeps selection while scrolling for more and resets the search window', async () => {
+    useQueryMock.mockReturnValue({ data: { pets: Array.from({ length: 60 }, (_, i) => ({
+      displayName: `Pet ${i}`, slug: `pet-${i}`, spritesheetUrl: SHEET
+    })) } })
+    stubFetch(async () => ({ blob: async () => new Blob() }))
+    const PetTab = await loadPetTab()
+    const onImage = vi.fn()
+    const view = render(<PetTab image={null} onImage={onImage} />)
+    const first = view.getByText('Pet 0').closest('button')!
+    fireEvent.click(first)
+    await waitFor(() => expect(onImage).toHaveBeenCalledWith('data:image/png;base64,ok'))
+    const scroller = first.parentElement!.parentElement!
+    Object.defineProperties(scroller, {
+      clientHeight: { value: 220 }, scrollHeight: { value: 600 }, scrollTop: { value: 400 }
+    })
+    fireEvent.scroll(scroller)
+    expect(view.getByText('Pet 47')).toBeTruthy()
+    expect(view.queryByText('Pet 48')).toBeNull()
+    expect(first.className).toContain('ring-1')
+    fireEvent.change(view.getByRole('textbox'), { target: { value: 'Pet 59' } })
+    expect(view.getByText('Pet 59')).toBeTruthy()
+    fireEvent.change(view.getByRole('textbox'), { target: { value: '' } })
+    expect(view.queryByText('Pet 24')).toBeNull()
+    expect(onImage).toHaveBeenCalledTimes(1)
+    view.unmount()
+  })
 })
 
 describe('the sprite-frame cache', () => {

--- a/apps/desktop/src/plugins/hermes-bots/pet.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/pet.tsx
@@ -230,7 +230,9 @@ export function PetTab({ image, onImage }: PetTabProps) {
           className="overflow-y-auto"
           onScroll={onScroll}
           style={{
-            maxHeight: 220
+            // Leave room for the selection ring outside boundary tiles.
+            maxHeight: 220,
+            padding: 2
           }}
         >
           <div className="grid grid-cols-3 gap-1.5">


### PR DESCRIPTION
Bot Mode's pet picker keeps the selected tile's outline visible at the edges of its scrollable gallery.

- Add a two-pixel inset inside the existing 220px gallery scrollport.
- Keep incremental 24-pet browsing, search reset, ranking, sprite caching, and selection behavior unchanged; no pagination UI or additional state.
- Add two focused invariants for selection-ring paint space and selection/search behavior across incremental browsing.

The one-pixel selection ring paints outside a boundary tile, where the unpadded overflow container clipped it.

**Credit:** @joeythepepe identified and proposed the gallery inset in [NousResearch/Hermes-Bot-Mode#74](https://github.com/NousResearch/Hermes-Bot-Mode/pull/74). This is a minimal in-tree adaptation of that clipping fix, not the proposed pagination redesign. Related pagination work in #88561 was inspected; its pagination half did not land. Related to #94726; this PR does not resolve the entire tracker.

## Validation

**Live repro:** native Electron 40.10.2, production main/preload and the actual `EditProfileDialog` mounted in an isolated renderer, based on `c8aa5608c24e3636e77c267650c0f1f52e44adb0`. Before: first tile flush against scrollport, top/left blue ring clipped. After: 2px inset, full ring visible, same 220px bound.

| Check | Result |
| --- | --- |
| Native 800×600 and 640×480 | Selection retained while scrolling for more; newly loaded tile selectable; search/clear restores the first 24 entries, before and after |
| Native gallery data | Real `pet.gallery` response, 4,824 entries. Public sprite downloads failed in this environment, so selection/paint checks used a controlled local PNG sprite through the real fetch/decode path. No claim of public sprite network verification |
| Regression A/B | Base: paint-space invariant fails (0 < 1), five other tests pass. Fixed: 6/6 pass |
| Bot Mode directory | 62 files, 579 tests pass |
| `npm run check:lint` | All three TypeScript projects and ESLint pass (139 existing warnings, no errors) |
| Static checks | Compatibility pointers and diff whitespace pass |

Reproduction: open Edit Profile → Pet → select the top-left pet → scroll the gallery for additional pets → select a later pet → search and clear; repeat at the smaller viewport. The actual dialog was mounted directly for isolation rather than reached through the roster. Screenshot files: `/tmp/pet-gallery-before-800.png`, `/tmp/pet-gallery-after-800.png`, `/tmp/pet-gallery-before-640.png`, `/tmp/pet-gallery-after-640.png`; machine-readable interaction receipts retained alongside them. Screenshot CDN upload was blocked by storage authorization (403); these local evidence files are available for maintainer inspection.

## Infographic

![Pet gallery selection remains visible](https://v3b.fal.media/files/b/0aa9a03a/Bs6u01-MEfSA8hXJf8FdP_QE1OyCDs.png)


## Additional parent verification

Native Electron at 800×600 and 640×480 now explicitly awaits successful PNG decode and `onImage` propagation into parent dialog state, with a matching 96×104 preview. A distinct later tile selected after scrolling from 24 to 48 entries remains selected across scroll/search/reset; no pet-load failure toast is present at these checkpoints. This uses controlled local PNG sprites against real gallery metadata, not successful public sprite CDN access. Persistence here means unsaved dialog state, not Save/backend or restart persistence. Earlier screenshots containing failed sprite toasts establish geometry only.

Parent reran the complete Bot Mode suite: 579 tests across 62 files passed. Desktop typecheck/lint passed with 0 errors and 139 existing warnings. Local evidence: `/tmp/pet-success-report.md`, `/tmp/pet-success-receipts.json`, `/tmp/pet-success-640.png`, `/tmp/pet-success-800.png`.
