### PR TITLE
fix(whatsapp): classify forwarded voice notes as voice instead of audio

### DIFF
--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -411,4 +411,68 @@ import {
   console.log('  ✓ captioned failed download keeps caption and appends note');
 }
 
+// -- inbound voice-note classification (forwarded voice notes lose ptt) ---
+
+{
+  const { isVoiceNoteAudioMessage } = await import('./bridge_helpers.js');
+  // Direct voice note: ptt flag alone decides.
+  assert.equal(isVoiceNoteAudioMessage({ ptt: true, mimetype: 'audio/ogg; codecs=opus', waveform: 'AAA' }), true);
+  assert.equal(isVoiceNoteAudioMessage({ ptt: true, mimetype: 'audio/mpeg', waveform: 'AAA' }), true);
+  // Forwarded voice note: re-encoded without ptt, keeps ogg/opus + waveform.
+  assert.equal(isVoiceNoteAudioMessage({ mimetype: 'audio/ogg; codecs=opus', waveform: 'AAA' }), true);
+  assert.equal(isVoiceNoteAudioMessage({ mimetype: 'audio/ogg', waveform: 'AAA' }), true);
+  assert.equal(isVoiceNoteAudioMessage({ waveform: 'AAA' }), true); // missing mimetype falls back to ogg
+  // Plain audio: no voice-note shape -> stays out of the STT pipeline.
+  assert.equal(isVoiceNoteAudioMessage({ mimetype: 'audio/mpeg', seconds: 3 }), false);
+  assert.equal(isVoiceNoteAudioMessage({ mimetype: 'audio/mp4' }), false);
+  assert.equal(isVoiceNoteAudioMessage({ mimetype: 'audio/ogg; codecs=opus' }), false); // no waveform
+  assert.equal(isVoiceNoteAudioMessage(null), false);
+  assert.equal(isVoiceNoteAudioMessage(undefined), false);
+  console.log('  ✓ isVoiceNoteAudioMessage separates voice-note shape from plain audio');
+}
+
+{
+  // Forwarded voice note: audioMessage without ptt but ogg/opus + waveform.
+  const event = await extractBridgeEvent({
+    msg: {
+      key: { id: 'fwd-voice-1', remoteJid: '15551234567@s.whatsapp.net', fromMe: false },
+      messageTimestamp: 123,
+      message: {
+        audioMessage: { mimetype: 'audio/ogg; codecs=opus', seconds: 4, waveform: 'AAA' },
+      },
+    },
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15551234567@s.whatsapp.net',
+    senderNumber: '15551234567',
+    downloadMedia: async () => Buffer.from(''),
+  });
+  assert.equal(event.hasMedia, true);
+  assert.equal(event.mediaType, 'ptt'); // -> adapter VOICE -> STT pipeline
+  assert.equal(event.nativeType, 'audioMessage');
+  assert.equal(event.mime, 'audio/ogg; codecs=opus');
+  assert.deepEqual(event.nativeMetadata.audio, { ptt: true });
+  console.log('  ✓ forwarded voice note (audioMessage, no ptt) classifies as ptt');
+}
+
+{
+  // Plain audio upload arriving as audioMessage keeps the conservative audio bucket.
+  const event = await extractBridgeEvent({
+    msg: {
+      key: { id: 'plain-audio-1', remoteJid: '15551234567@s.whatsapp.net', fromMe: false },
+      messageTimestamp: 123,
+      message: {
+        audioMessage: { mimetype: 'audio/mpeg', seconds: 30 },
+      },
+    },
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15551234567@s.whatsapp.net',
+    senderNumber: '15551234567',
+    downloadMedia: async () => Buffer.from(''),
+  });
+  assert.equal(event.mediaType, 'audio');
+  assert.equal(event.nativeType, 'audioMessage');
+  assert.deepEqual(event.nativeMetadata.audio, { ptt: false });
+  console.log('  ✓ plain audio without voice-note shape stays audio');
+}
+
 console.log('\n✅ All WhatsApp native bridge helper tests passed.');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -296,6 +296,25 @@ export function appendMediaFailureNote(content, failures) {
   return content ? `${content}\n${note}` : note;
 }
 
+/**
+ * True when an inbound audioMessage is (or behaves like) a WhatsApp voice
+ * note. Direct voice notes carry `ptt: true`, but WhatsApp re-encodes
+ * *forwarded* voice notes and drops the flag, so they currently fall through
+ * to the plain-audio bucket and skip the automatic STT pipeline. Genuine
+ * audio FILE uploads (mp3/m4a) arrive as documentMessage, never as
+ * audioMessage, so the only audioMessage lacking `ptt` is a forwarded voice
+ * note — which keeps the voice-note shape: an ogg/opus mimetype plus the
+ * encoder's waveform. Recovering on that shape alone would be safe even
+ * without the mimetype guard, but requiring both keeps the conservative
+ * "never transcribe an mp3 upload" behaviour intact for exotic clients.
+ */
+export function isVoiceNoteAudioMessage(item) {
+  if (!item || typeof item !== 'object') return false;
+  if (item.ptt) return true;
+  const mime = String(item.mimetype || 'audio/ogg').toLowerCase();
+  return mime.startsWith('audio/ogg') && Boolean(item.waveform);
+}
+
 export async function extractBridgeEvent({
   msg,
   chatId,
@@ -375,7 +394,7 @@ export async function extractBridgeEvent({
   } else if (messageContent.audioMessage || messageContent.pttMessage) {
     const item = messageContent.pttMessage || messageContent.audioMessage;
     hasMedia = true;
-    mediaType = item.ptt || messageContent.pttMessage ? 'ptt' : 'audio';
+    mediaType = isVoiceNoteAudioMessage(item) || messageContent.pttMessage ? 'ptt' : 'audio';
     nativeType = messageContent.pttMessage ? 'pttMessage' : 'audioMessage';
     mime = item.mimetype || 'audio/ogg';
     nativeMetadata.audio = { ptt: mediaType === 'ptt' };


### PR DESCRIPTION
## Summary

Closes #105809.

Forwarded WhatsApp voice notes are re-encoded by WhatsApp and lose `ptt: true`, so the bridge classified them as plain audio (`mediaType: 'audio'` → `MessageType.AUDIO`) and they skipped the automatic STT pipeline — the agent received an untranscribed audio file instead of a voice note.

## Root cause

`extractBridgeEvent` in `scripts/whatsapp-bridge/bridge_helpers.js` decided voice-note vs. plain-audio purely from the `ptt` flag:

```js
mediaType = item.ptt || messageContent.pttMessage ? 'ptt' : 'audio';
```

## Fix

Classify by voice-note *shape* when the flag is absent. Genuine audio **file** uploads (mp3/m4a) always arrive as `documentMessage` — never as `audioMessage` — so the only `audioMessage` lacking `ptt` is a forwarded voice note, which keeps its ogg/opus mimetype and the encoder's `waveform`. Requiring both keeps the conservative "never auto-transcribe an mp3 upload" behaviour intact.

New exported pure helper in `bridge_helpers.js`:

```js
export function isVoiceNoteAudioMessage(item) {
  if (!item || typeof item !== 'object') return false;
  if (item.ptt) return true;
  const mime = String(item.mimetype || 'audio/ogg').toLowerCase();
  return mime.startsWith('audio/ogg') && Boolean(item.waveform);
}
```

No downstream change needed: the adapter's `_MEDIA_NEEDLES` already maps `ptt` → `MessageType.VOICE` (and deliberately matches `"ptt"` before `"audio"`), and `_event_media_is_stt_input` only excludes `AUDIO`/`DOCUMENT`.

## Tests

Extended `scripts/whatsapp-bridge/bridge.native.test.mjs` with:

- unit cases for `isVoiceNoteAudioMessage` (direct ptt, forwarded shape, mp3-ish upload, missing waveform/mimetype, null/undefined)
- `extractBridgeEvent` integration: forwarded voice note (`audioMessage` without `ptt`, ogg/opus + waveform) → `mediaType: 'ptt'`, `nativeMetadata.audio.ptt: true`
- regression: plain audio without the voice-note shape stays `'audio'`

Full suite passes via `node --test bridge.native.test.mjs` in `scripts/whatsapp-bridge`.
