### PR TITLE
feat(desktop): let users order Group Chat rooms

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "hermes",
   "productName": "Hermes",
   "private": true,
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Native desktop shell for Hermes Agent.",
   "author": "Nous Research",
   "repository": {

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -749,6 +749,8 @@ export function durableGroupChatRooms(all: Record<string, GroupChat> = $groupCha
       // already carries.
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
       image: room.image || null,
+      rosterOrder: room.rosterOrder,
+      pinned: room.pinned,
       syncRevision: Math.max(0, Number(room.syncRevision || 0))
     }
   }
@@ -1348,6 +1350,8 @@ export function updateGroupChat(
         roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
         // Room picture (small data URL, same normalization as bot avatars).
         image: room.image || null,
+        rosterOrder: room.rosterOrder,
+        pinned: room.pinned,
         syncRevision: Math.max(0, Number(room.syncRevision || 0))
       }
     }

--- a/apps/desktop/src/plugins/hermes-bots/group-order.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-order.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { reorderGroupRows, sortGroupRosterRows } from './group-order'
+
+const rows = [
+  { kind: 'group' as const, name: 'Older', activity: 1, pinned: false },
+  { kind: 'bot' as const, name: 'Bot', activity: 2, pinned: false },
+  { kind: 'group' as const, name: 'Newer', activity: 3, pinned: false },
+  { kind: 'group' as const, name: 'Pinned', activity: 0, pinned: true }
+]
+
+describe('room display order', () => {
+  it('keeps legacy recency until explicitly ordered, then only replaces room slots within pin bands', () => {
+    expect(sortGroupRosterRows(rows, {}).map(row => row.name)).toEqual(['Pinned', 'Newer', 'Bot', 'Older'])
+    const rooms = { Older: { rosterOrder: 0 }, Newer: { rosterOrder: 1 } }
+    expect(sortGroupRosterRows(rows, rooms).map(row => row.name)).toEqual(['Pinned', 'Older', 'Bot', 'Newer'])
+    expect(sortGroupRosterRows(rows.map(row => ({ ...row, activity: row.name === 'Newer' ? 999 : row.activity })), rooms).filter(row => row.kind === 'group').map(row => row.name)).toEqual(['Pinned', 'Older', 'Newer'])
+    expect(rows[0].name).toBe('Older')
+  })
+
+  it('moves only visible same-band rooms while retaining hidden slots and ignoring stale targets', () => {
+    const ordered = sortGroupRosterRows(rows.filter(row => row.kind === 'group'), {})
+    expect(reorderGroupRows(ordered, 'Older', -1)).toEqual(['Pinned', 'Older', 'Newer'])
+    expect(reorderGroupRows(ordered, 'Newer', -1)).toBeNull()
+    expect(reorderGroupRows(ordered, 'deleted', 1)).toBeNull()
+    const hidden = { kind: 'group' as const, name: 'Hidden', activity: 2, pinned: false }
+    expect(reorderGroupRows([ordered[0], ordered[1], hidden, ordered[2]], 'Older', -1, ['Newer', 'Older'])).toEqual(['Pinned', 'Older', 'Hidden', 'Newer'])
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-order.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-order.ts
@@ -1,0 +1,34 @@
+interface OrderRow {
+  activity: number
+  kind: 'bot' | 'group'
+  name?: string
+  pinned: boolean
+}
+
+/** Reorder room slots, not bots or folders. Pinning remains the outer band. */
+export function sortGroupRosterRows<T extends OrderRow>(rows: T[], rooms: Record<string, { rosterOrder?: number }>): T[] {
+  const legacy = rows.slice().sort((a, b) => Number(b.pinned) - Number(a.pinned) || b.activity - a.activity)
+
+  const groups = legacy.filter(row => row.kind === 'group').sort((a, b) =>
+    Number(b.pinned) - Number(a.pinned) ||
+    (rooms[a.name!]?.rosterOrder ?? Infinity) - (rooms[b.name!]?.rosterOrder ?? Infinity)
+  )
+
+  let index = 0
+
+  return legacy.map(row => row.kind === 'group' ? groups[index++] : row)
+}
+
+/** Swap visible neighbours without dropping filtered-out rooms from the order. */
+export function reorderGroupRows(rows: OrderRow[], name: string, delta: -1 | 1, visible?: string[]): string[] | null {
+  const row = rows.find(row => row.name === name)
+  const band = rows.filter(candidate => candidate.kind === 'group' && candidate.pinned === row?.pinned && (!visible || visible.includes(candidate.name!)))
+  const index = band.findIndex(candidate => candidate.name === name)
+  const neighbour = index >= 0 ? band[index + delta] : undefined
+
+  if (!neighbour) {
+    return null
+  }
+
+  return rows.filter(row => row.kind === 'group').map(row => row.name === name ? neighbour.name! : row.name === neighbour.name ? name : row.name!)
+}

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -246,6 +246,8 @@ export default {
                   members: Array.isArray(room.members) ? room.members : [],
                   roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
                   image: typeof room.image === 'string' && room.image ? room.image : null,
+                  rosterOrder: Number.isFinite(room.rosterOrder) ? room.rosterOrder : undefined,
+                  pinned: Boolean(room.pinned),
                   syncRevision: Math.max(0, Number(room.syncRevision || 0)),
                   epoch: 0,
                   running: false

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -56,9 +56,10 @@ import {
   useRoster
 } from './data'
 import { EditProfileDialog } from './edit-profile-dialog'
-import { $groupChats, $groupChatWorkspace, $groupNeedsYou } from './group-chat'
+import { $groupChats, $groupChatWorkspace, $groupNeedsYou, updateGroupChat } from './group-chat'
 import { disbandGroupChat, GroupChatWorkspace, openGroupChat } from './group-chat-view'
 import { groupChatMemberBots, groupChatNames, groupLastActivity } from './group-membership'
+import { reorderGroupRows, sortGroupRosterRows } from './group-order'
 import { $groupMainTabsRev, shouldRenderGroupChatInPane } from './group-panes'
 import { $showHiddenBots, isBotHidden, isBotPinned } from './hidden-bots'
 import { useBots } from './i18n'
@@ -414,20 +415,32 @@ export function BotsPane() {
           active: activeRosterKeys.has(botRosterKey(bot))
         }))
 
-  const sortRosterRows = <T extends { activity: number; pinned: boolean }>(rows: T[]): T[] =>
-    rows.slice().sort((a, b) => {
-      const pa = a.pinned ? 1 : 0
-      const pb = b.pinned ? 1 : 0
+  const rosterRows = sortGroupRosterRows([...botRows, ...groupRows], groupRooms)
+  const sortedGroupRows = sortGroupRosterRows(groupRows, groupRooms)
 
-      if (pa !== pb) {
-        return pb - pa
-      }
+  const moveRoom = (name: string, delta: -1 | 1) => {
+    // Read at the gesture, not the last render: a sync or disband may have
+    // replaced this room in the meantime. Ordering never writes bot metadata.
+    const current = $groupChats.get()
 
-      return b.activity - a.activity
+    if (current[name]?.roomId !== groupRooms[name]?.roomId || current[name]?.tombstone) {
+      return
+    }
+
+    const rows = groupChatNames($botMeta.get(), current).map(name => ({
+      kind: 'group' as const,
+      name,
+      pinned: Boolean(current[name]?.pinned),
+      activity: groupLastActivity(current[name])
+    }))
+
+    const order = reorderGroupRows(sortGroupRosterRows(rows, current), name, delta, sortedGroupRows.map(row => row.name))
+
+    order?.forEach((name, rosterOrder) => {
+      updateGroupChat(name, room => ({ ...room, rosterOrder }), { sync: false })
     })
+  }
 
-  const rosterRows = sortRosterRows([...botRows, ...groupRows])
-  const sortedGroupRows = sortRosterRows(groupRows)
   const gatewaySections = rosterGatewaySections(botRows, gatewayOptions, gatewayFilter)
   const showGatewaySections = gatewaySections.sectioned && botRows.length > 0
 
@@ -567,15 +580,31 @@ export function BotsPane() {
   )
 
   const renderGroupRow = (row: { members: GroupMember[]; name: string }) => (
-    <GroupRow
-      active={groupChatName === row.name}
-      group={row.name}
-      key={`group:${row.name}`}
-      members={row.members}
-      needsYou={Boolean(groupNeedsYou[row.name])}
-      onDisband={setDeletingGroup}
-      onOpen={openGroupChat}
-    />
+    <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center" key={`group:${row.name}`}>
+      <GroupRow
+        active={groupChatName === row.name}
+        group={row.name}
+        members={row.members}
+        needsYou={Boolean(groupNeedsYou[row.name])}
+        onDisband={setDeletingGroup}
+        onOpen={openGroupChat}
+      />
+      <div className="flex flex-col">
+        {([-1, 1] as const).map(delta => (
+          <Tip key={delta} label={delta === -1 ? b.sections.moveUp : b.sections.moveDown}>
+            <Button
+              aria-label={`${row.name}: ${delta === -1 ? b.sections.moveUp : b.sections.moveDown}`}
+              disabled={!reorderGroupRows(sortedGroupRows, row.name, delta)}
+              onClick={() => moveRoom(row.name, delta)}
+              size="icon-xs"
+              variant="ghost"
+            >
+              <Codicon name={delta === -1 ? 'chevron-up' : 'chevron-down'} />
+            </Button>
+          </Tip>
+        ))}
+      </div>
+    </div>
   )
 
   const removeSection = (id: string) => {

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -176,6 +176,8 @@ export interface GroupChat {
   syncRevision?: number
   /** Left behind when a room is disbanded, so sync can't resurrect it. */
   tombstone?: boolean
+  /** Local display order, deliberately excluded from the gateway mirror. */
+  rosterOrder?: number
   /** Read when ordering rooms; no write site in the plugin today. */
   pinned?: boolean
   /** How far each `<thread>::<member>` has read into `log`. Required: unlike

--- a/contributors/emails/onur.m.aycicek@gmail.com
+++ b/contributors/emails/onur.m.aycicek@gmail.com
@@ -1,0 +1,2 @@
+onuraycicek
+# Group room ordering, Hermes-Bot-Mode#105

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
     },
     "apps/desktop": {
       "name": "hermes",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "@assistant-ui/core": "0.2.23",
         "@assistant-ui/react": "0.14.24",

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -92,6 +92,8 @@ Right-click a local Bot → **Manage groups** to add or remove it from any numbe
 
 Groups are standalone rows in the same activity-ordered roster as Bot DMs. A Bot keeps one DM row even when it belongs to several groups, while every group gets its own room row with member count, latest-message preview, timestamp, and needs-you state.
 
+Use the **Move up** and **Move down** arrows beside a room to choose its position among rooms. Until the first move, the existing pinned-first, recent-activity order is unchanged. After a move, room order is saved on this Desktop and survives reloads; new rooms follow the explicitly ordered rooms within their pinned or unpinned band. Moves cannot cross the pinned boundary, and filtering does not discard hidden rooms from the saved order. These controls reorder actual Group Chat rooms, not user-created Bot folders, and do not change membership or gateway ownership.
+
 **Open chat** on any group row (2–6 Bots) opens a shared room where the whole group coordinates:
 
 - **One visible conversation.** Public messages and each member's reply stay readable in arrival order, with the speaker's name and timestamp. Starting another topic does not collapse earlier replies. **Reply in thread** continues that topic without reordering the room; **Activity** is a secondary status view, not a replacement for messages. Private Bot Chats remain separate.


### PR DESCRIPTION
Group Chat rooms can now be moved up or down and keep their chosen order after a Desktop reload.

- Adds small, keyboard-focusable Move up/Move down buttons beside actual room rows, using existing translated labels. This does **not** reorder Bot folders or Bot DMs.
- Keeps the legacy pinned-first/activity ordering until the first explicit move. Custom order replaces only room slots; pins remain an outer boundary and filtered-out rooms retain their slots.
- Stores `rosterOrder` in the existing local room metadata and retains it through both persistence paths and hydration. Order is Desktop-local, deliberately absent from the gateway mirror. Member ownership, routing, server revisions, and existing stale-write fences are unchanged.
- Carries the existing room pin field through persistence too; does not add a pin toggle. Includes user documentation and a Desktop patch-version bump.

**Root cause:** the roster only sorted rooms by pin/activity and exposed no room-reordering action.

## Scope and credit

Narrow adaptation of the room-ordering idea from [NousResearch/Hermes-Bot-Mode#105](https://github.com/NousResearch/Hermes-Bot-Mode/pull/105) by **@onuraycicek (Onur Aycicek)**, credited in the commit and contributor mapping. Rename is already implemented and is not reintroduced. [#101870](https://github.com/NousResearch/hermes-agent/pull/101870) concerns ordering **Bots within user sections**, not these Group Chat rooms. Related tracking: #94726; no tracker changes or closure directives.

## Validation

**Live repro:** native Electron on fresh main showed Release → Research → Planning with no reorder controls. On the changed renderer, clicking Planning's Move up produced Release → Planning → Research, and an actual renderer reload retained that order.

| Check | Result |
|---|---|
| Focused TDD | Two invariants failed against the original pin/activity behavior + absent move, then passed. Covers unchanged default, room-only slots, activity stability, pin boundaries, filtered-out slots and missing targets. |
| Bot Mode suite | `CHOKIDAR_USEPOLLING=true npx vitest run --project ui src/plugins/hermes-bots/ --maxWorkers=2`: **63 files, 579 tests passed**. Initial non-polling run hit host inotify ENOSPC; polling resolved it without source or host-limit changes. |
| Full Desktop static gate | `npm run check:lint` passed all three TypeScript projects and eslint; 139 existing warnings, zero errors. |
| Native persistence | Actual room controls wrote the existing plugin storage; reload preserved custom order. |
| Pins and folders | With existing pin metadata seeded, Research moved above Release; neither crossed into the unpinned Planning band. Boundary buttons were disabled. Work folder / Personal folder order and member descriptors were unchanged; another reload retained Research → Release → Planning. |
| Stale mirror | Production merge + durable projection applied an old mirror to the native persisted records and preserved local rank (0 → 0), ignoring mirror-supplied ordering. This is a helper-level stale-mirror probe, separate from native gesture/reload proof. |
| Repository gates | `check-windows-footguns.py --all`, `check_compat_pointers.py`, and `git diff --check` passed. |

The live instance used an isolated, credential-free HOME/HERMES_HOME/userData and real Electron/main/preload/renderer/backend, with explicitly seeded room records and a nonresponding loopback model configuration. No inference or cross-machine turn-delivery claim is made. Existing backend owner/revision paths are untouched. `bot-row.tsx`, `avatar.tsx`, and `row-helpers.ts` are untouched.

## Native screenshots

Before — no reorder controls, Release / Research / Planning:

![Native before](https://files.catbox.moe/tpa522.png)

After actual Move up and reload — Release / Planning / Research:

![Native after reload](https://files.catbox.moe/5sl7ey.png)

Pinned-band move and reload, with separate user folders retained:

![Native pin and folder verification](https://files.catbox.moe/9bmsu7.png)

## Infographic

![Group Chat room ordering](https://v3b.fal.media/files/b/0aa9a04b/D7v8YNuYaODvaz-oWbFDU_5RvHKr0c.png)
