### PR TITLE
fix(config): persist context-window resets to auto-detect

### DIFF
--- a/hermes_cli/web_routers/config_env.py
+++ b/hermes_cli/web_routers/config_env.py
@@ -117,8 +117,9 @@ async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
             # full-replace — the frontend can only overwrite what it sends.
             with _CONFIG_MUTATION_LOCK:
                 existing = read_raw_config()
-                incoming = _denormalize_config_from_web(body.config)
-                merged = _deep_merge(existing, incoming)
+                merged = _deep_merge(existing, body.config)
+                # Apply removals after merging so a context reset cannot restore the old value.
+                merged = _denormalize_config_from_web(merged)
                 # Compare normalized approvals.mode across the in-memory
                 # documents, not config blocks and not cache re-reads: the page
                 # PUTs the defaulted GET record while disk holds sparse YAML (a

--- a/hermes_cli/web_server_config.py
+++ b/hermes_cli/web_server_config.py
@@ -792,6 +792,9 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
 
     ctx_sent = "model_context_length" in config
     ctx_override = config.pop("model_context_length", 0)
+    if ctx_sent:
+        # The legacy root alias must not restore the override during save canonicalization.
+        config.pop("context_length", None)
     if not isinstance(ctx_override, int):
         try:
             ctx_override = int(ctx_override)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2512,6 +2512,132 @@ class TestConfigRoundTrip:
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
+    @pytest.mark.parametrize("profile_source", ["current", "query", "body"])
+    @pytest.mark.parametrize(
+        "layout,full_form,context_value",
+        [("nested", False, 0), ("nested", True, 0), ("nested", False, "0"),
+         ("legacy", False, 0), ("legacy", True, 0),
+         ("nested", False, 200000), ("legacy", False, 200000),
+         ("nested", False, None), ("legacy", False, None)],
+        ids=["reset", "full-reset", "string-reset", "legacy-reset", "legacy-full-reset",
+             "positive", "legacy-positive", "omitted", "legacy-omitted"],
+    )
+    def test_context_length_round_trip(self, tmp_path, monkeypatch, profile_source, layout, full_form, context_value):
+        from hermes_cli.profiles import get_profile_dir
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        default_home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+        homes = {"current": default_home, "worker": get_profile_dir("worker"),
+                 "other": get_profile_dir("other")}
+        for home in homes.values():
+            home.mkdir(parents=True, exist_ok=True)
+            context_override = {"context_length": 123456}
+            seed = {
+                "model": {"default": "context-test-model", "x_context_sibling": "keep",
+                          **(context_override if layout == "nested" else {})},
+                "agent": {"x_context_sibling": "keep"},
+                "x_context_sibling": "keep",
+                **(context_override if layout == "legacy" else {}),
+            }
+            (home / "config.yaml").write_text(yaml.safe_dump(seed), encoding="utf-8")
+        target = "current" if profile_source == "current" else "worker"
+        config_path = homes[target] / "config.yaml"
+        untouched = {home / "config.yaml": (home / "config.yaml").read_bytes()
+                     for name, home in homes.items() if name != target}
+        read_params = {} if target == "current" else {"profile": target}
+        payload = {}
+        if full_form:
+            initial = self.client.get("/api/config", params=read_params)
+            assert initial.status_code == 200
+            payload = initial.json()
+            assert isinstance(payload["model"], str)
+            assert payload["model_context_length"] == 123456
+        payload.pop("x_context_sibling", None)
+        if "agent" in payload:
+            payload["agent"].pop("x_context_sibling", None)
+        payload.setdefault("display", {})["skin"] = "mono"
+        if context_value is None:
+            payload.pop("model_context_length", None)
+        else:
+            payload["model_context_length"] = context_value
+        body = {"config": payload}
+        write_params = read_params
+        if profile_source == "body":
+            body["profile"] = target
+            write_params = {"profile": "other"}
+
+        response = self.client.put("/api/config", params=write_params, json=body)
+
+        assert response.status_code == 200, response.text
+        assert response.json()["ok"] is True
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        expected = 123456 if context_value is None else int(context_value)
+        assert "model_context_length" not in raw
+        assert "context_length" not in raw
+        if expected == 0:
+            assert "context_length" not in raw["model"]
+        else:
+            assert raw["model"]["context_length"] == expected
+        assert raw["model"]["default"] == "context-test-model"
+        assert raw["model"]["x_context_sibling"] == "keep"
+        assert raw["agent"]["x_context_sibling"] == "keep"
+        assert raw["x_context_sibling"] == "keep"
+        assert raw["display"]["skin"] == "mono"
+        reloaded = self.client.get("/api/config", params=read_params)
+        assert reloaded.status_code == 200
+        assert reloaded.json()["model_context_length"] == expected
+        for path, original in untouched.items():
+            assert path.read_bytes() == original
+
+    @pytest.mark.parametrize(
+        "payload,expected_model,expected_provider,expected_context",
+        [({"model": "local-model-next"}, "local-model-next", "ollama-local", 123456),
+         ({"model": {"default": "local-model-next"}}, "local-model-next", "ollama-local", 123456),
+         ({"model": "audit-vendor/model-next"}, "audit-vendor/model-next", "openrouter", 0),
+         ({"model": "audit-vendor/model-next", "model_context_length": 0},
+          "audit-vendor/model-next", "openrouter", 0),
+         ({"model": "audit-vendor/model-next", "model_context_length": 200000},
+          "audit-vendor/model-next", "openrouter", 200000)],
+        ids=["same-provider", "nested-model", "provider-switch", "provider-switch-reset", "provider-switch-positive"],
+    )
+    def test_model_update_preserves_config_contracts(self, payload, expected_model, expected_provider, expected_context):
+        from hermes_cli.config import get_config_path
+
+        seed = {"model": {"default": "llama3.2", "provider": "ollama-local",
+                          "base_url": "http://localhost:11434/v1", "api_mode": "chat_completions",
+                          "api_key": "test-placeholder", "api": "legacy-test-placeholder",
+                          "context_length": 123456, "x_context_sibling": "keep"},
+                "agent": {"x_context_sibling": "keep"}}
+        config_path = get_config_path()
+        config_path.write_text(yaml.safe_dump(seed), encoding="utf-8")
+
+        response = self.client.put("/api/config", json={"config": payload})
+
+        assert response.status_code == 200, response.text
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert raw["model"]["default"] == expected_model
+        assert raw["model"]["provider"] == expected_provider
+        if expected_context:
+            assert raw["model"]["context_length"] == expected_context
+        else:
+            assert "context_length" not in raw["model"]
+        assert raw["model"]["x_context_sibling"] == "keep"
+        assert raw["agent"]["x_context_sibling"] == "keep"
+        if expected_provider == "ollama-local":
+            assert raw["model"]["base_url"] == seed["model"]["base_url"]
+            assert raw["model"]["api_mode"] == seed["model"]["api_mode"]
+            assert raw["model"]["api_key"] == seed["model"]["api_key"]
+            assert raw["model"]["api"] == seed["model"]["api"]
+        else:
+            assert raw["model"]["base_url"] == ""
+            assert "api_mode" not in raw["model"]
+            assert "api_key" not in raw["model"]
+            assert "api" not in raw["model"]
+        reloaded = self.client.get("/api/config").json()
+        assert reloaded["model"] == expected_model
+        assert reloaded["model_context_length"] == expected_context
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Context Window setting returning to its old value after selecting `0` (auto-detect). `PUT /api/config` reports success, but the stored `model.context_length` override survives and the next GET returns it again.

The endpoint denormalizes the submitted settings before merging them with the on-disk config. Denormalization removes the override for zero, then the merge restores the old key. Merge first so those removals survive. An explicit context edit also removes the legacy root-level `context_length` alias, which would otherwise be moved back under `model` during saving.

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/web_routers/config_env.py`: merge before denormalizing, within the existing profile scope and mutation lock.
- `hermes_cli/web_server_config.py`: consume the legacy context-length alias when the virtual settings field is explicitly supplied.
- `tests/hermes_cli/test_web_server.py`: add round-trip tests for resets, unrelated updates, profile targeting, and provider switches.

This also lets the existing model-assignment cleanup survive the merge; the cleanup policy itself is unchanged. No model-metadata detection logic changes.

## How to Test

In an isolated test profile, start with `model.context_length: 123456` and send this body to the authenticated settings endpoint:

```json
{"config": {"model_context_length": 0}}
```

After a successful PUT, the stored override should be absent and `GET /api/config` should report `model_context_length: 0`. Positive updates must persist. Unrelated settings updates that omit `model_context_length` must preserve the existing override. Model changes follow the existing assignment-cleanup policy.

```bash
bash scripts/run_tests.sh -j 2 --file-retries 0 \
  tests/hermes_cli/test_web_server.py -q
```

Added 32 parameter cases: 18 fail on unmodified `b3399c1396`; all 32 pass with the fix. Using only the merge reorder still fails six legacy-layout reset cases. The tests check raw disk contents and GET responses for sparse and full-form saves, including the legacy layout. The complete modified test file passes: **219 passed, 1 skipped**.

The full repository suite, native Linux/Windows execution, and live model sessions were not tested.

<details>
<summary>Broader validation and static checks</summary>

Across the same 32 test files, the unmodified baseline (without the new cases) passes **636 tests**. The patched revision passes **668 tests**, including the 32 new parameterized cases. Both runs have **0 failures and 7 skips**. The selection covers the config endpoint, normalization, profile isolation, approvals broadcasts, loaders and neighboring model-assignment paths. The skips are six Windows-only cases and one SQLite WAL-dependent case.

Validated on macOS with Python 3.11, isolated temporary homes, a physical temporary-directory path, and retries disabled.

Full-repository Ruff, Windows-footgun and compatibility-pointer checks pass, as does `git diff --check`. Type-check diagnostic signatures and counts in the three changed files are unchanged from the baseline (20 diagnostics on each revision), ignoring line-number shifts.

Tests ran against `b3399c1396`. An API comparison with `abd83ab560` found the affected implementation and test files unchanged; that newer revision was not tested as a full checkout.

</details>

## Checklist

- [x] Read the contributing guide and checked related PRs.
- [x] Added bug-reproducing tests and preservation controls.
- [x] Verified disk/GET round trips and profile isolation on macOS.
- [x] Ran the relevant suites and static checks; documented limits.
