### PR TITLE
fix(desktop): Bot Mode shows the focused bot working and settling

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "hermes",
   "productName": "Hermes",
   "private": true,
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Native desktop shell for Hermes Agent.",
   "author": "Nous Research",
   "repository": {

--- a/apps/desktop/src/plugins/hermes-bots/avatar.face-clock.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/avatar.face-clock.test.ts
@@ -220,6 +220,27 @@ describe('the hand-rolled rAF path (older shells)', () => {
 })
 
 describe('the SDK budgeted-loop path', () => {
+  it('paints a thinking gaze and eases back without a discontinuity', async () => {
+    const { captured } = captureLoop()
+    const { startFaceClock } = await loadClock()
+    const face = mountFace()
+    face.innerHTML = '<ellipse data-hb-el="1"/><circle data-hb-dot="1"/>'
+    face.setAttribute('data-hb-mood', 'think')
+    startFaceClock()
+    captured.draw!(1000)
+    observer!.emit([{ isIntersecting: true, target: face }])
+    captured.draw!(2000)
+    const eye = face.querySelector('ellipse')!
+    const gaze = eye.getAttribute('cy')
+    expect(Number(face.querySelector('circle')!.getAttribute('opacity'))).toBeGreaterThan(0)
+    face.setAttribute('data-hb-mood', 'idle')
+    captured.draw!(2067)
+    expect(eye.getAttribute('cy')).toBe(gaze)
+    captured.draw!(2667)
+    expect(Number(eye.getAttribute('cy'))).toBeCloseTo(17.2)
+    expect(Number(face.querySelector('circle')!.getAttribute('opacity'))).toBe(0)
+  })
+
   interface CapturedLoop {
     draw: (now: number) => void
     idleWhen: () => boolean

--- a/apps/desktop/src/plugins/hermes-bots/avatar.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/avatar.tsx
@@ -601,8 +601,22 @@ interface FacePose {
   turn: number
 }
 
-/** Grok-style pose. thinking/working lean and sway. idle is a small sine. */
+/** Working poses lean and sway; idle stays small. */
 function facePose(mood: FaceMood | string, t: number): FacePose {
+  if (mood === 'think') {
+    return {
+      turn: -18 + Math.sin(t * 0.55) * 14,
+      tilt: Math.sin(t * 0.48) * 12 + Math.sin(t * 1.35) * 3,
+      roll: Math.sin(t * 0.95) * 10,
+      gazeX: Math.sin(t * 0.7) * 3.6,
+      gazeY: -2.2 + Math.sin(t * 0.4) * 2.2,
+      blink: t % 1.45 > 1.26,
+      d0: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.4)),
+      d1: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.4 - 0.7)),
+      d2: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.4 - 1.4))
+    }
+  }
+
   if (mood === 'work') {
     return {
       turn: -11 + Math.sin(t * 0.48) * 8,
@@ -637,10 +651,41 @@ interface NumericAttrNode {
   setAttribute(name: string, value: number | string): void
 }
 
+const faceTransitions = new WeakMap<SVGSVGElement, { mood: string; pose: FacePose; from: FacePose; since: number }>()
+
+/** Blend from the last painted pose in elapsed time, even after a paused clock. */
+function settlePose(svg: SVGSVGElement, mood: string, target: FacePose, t: number): FacePose {
+  let state = faceTransitions.get(svg)
+
+  if (!state) {
+    state = { mood, pose: target, from: target, since: t - 0.4 }
+    faceTransitions.set(svg, state)
+  }
+
+  if (state.mood !== mood) {
+    state.mood = mood
+    state.from = state.pose
+    state.since = t
+  }
+
+  const progress = Math.min(1, Math.max(0, (t - state.since) / 0.4))
+  const blend = 1 - (1 - progress) ** 2
+  const pose = { ...target }
+  const keys = ['turn', 'tilt', 'roll', 'gazeX', 'gazeY', 'd0', 'd1', 'd2'] as const
+
+  for (const key of keys) {
+    pose[key] = state.from[key] + (target[key] - state.from[key]) * blend
+  }
+
+  state.pose = pose
+
+  return pose
+}
+
 function paintMathFace(svg: SVGSVGElement, t: number) {
   const mood = svg.getAttribute('data-hb-mood') || 'idle'
   const shape = svg.getAttribute('data-hb-shape') || 'circle'
-  const pose = facePose(mood, t)
+  const pose = settlePose(svg, mood, facePose(mood, t), t)
   const body = svg.querySelector('[data-hb-body]')
   const open = svg.querySelector('[data-hb-open]')
   const shut = svg.querySelector('[data-hb-shut]')
@@ -1016,7 +1061,7 @@ export function BotFace({ shape, color, image, size = 36, name = 'agent', mood =
     )
   }
 
-  const working = mood === 'work'
+  const working = mood === 'work' || mood === 'think'
   const eyeFill = isDarkColor(color) ? 'rgba(232,220,195,0.95)' : 'rgba(0,0,0,0.85)'
   // Catchlight contrast follows the pupil, not the body: dark pupils get the
   // white sparkle, light (cream) pupils on dark bodies get a dark one — a
@@ -1024,7 +1069,7 @@ export function BotFace({ shape, color, image, size = 36, name = 'agent', mood =
   // maroon/ink/oxblood avatars.
   const hlFill = isDarkColor(color) ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.85)'
   const ring = sampleFaceRing(shape)
-  const rest = facePose(working ? 'work' : 'idle', 0)
+  const rest = facePose(mood, 0)
   // Shape-aware initial eye line — the cloud body sits lower, so its eyes
   // (and their catchlights) start at the cloud position instead of jumping
   // there on the first clock paint.
@@ -1036,7 +1081,7 @@ export function BotFace({ shape, color, image, size = 36, name = 'agent', mood =
       className="block overflow-visible"
       data-bot-face={name}
       data-hb-math="1"
-      data-hb-mood={working ? 'work' : 'idle'}
+      data-hb-mood={mood}
       data-hb-shape={shape || 'circle'}
       height={size}
       viewBox="0 0 40 44"
@@ -1066,13 +1111,11 @@ export function BotFace({ shape, color, image, size = 36, name = 'agent', mood =
         strokeLinecap="round"
         strokeWidth={2}
       />
-      {working ? (
-        <g>
-          <circle cx={16.4} cy={41.2} data-hb-dot="1" fill={color} opacity={rest.d0} r={1.15} />
-          <circle cx={20} cy={41.2} data-hb-dot="1" fill={color} opacity={rest.d1} r={1.15} />
-          <circle cx={23.6} cy={41.2} data-hb-dot="1" fill={color} opacity={rest.d2} r={1.15} />
-        </g>
-      ) : null}
+      <g>
+        <circle cx={16.4} cy={41.2} data-hb-dot="1" fill={color} opacity={rest.d0} r={1.15} />
+        <circle cx={20} cy={41.2} data-hb-dot="1" fill={color} opacity={rest.d1} r={1.15} />
+        <circle cx={23.6} cy={41.2} data-hb-dot="1" fill={color} opacity={rest.d2} r={1.15} />
+      </g>
     </svg>
   )
 }

--- a/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
@@ -49,7 +49,6 @@ import {
   botRosterKey,
   botSelectionKey,
   botSourceStatus,
-  isActiveRosterBot,
   isDefaultBot,
   newBotChat,
   ROSTER_KEY,
@@ -63,7 +62,7 @@ import { displayName, stripPreviewMarkdown } from './labels'
 import { duplicateBot } from './profile-ops'
 import { openRosterBot } from './roster-actions'
 import { botRosterMeta, botWorkspaceOwnerKey, setBotsWorkspaceOwner } from './routing'
-import { A2A_PREFIX_RE, botCanonicalSessionId, botRowOwnsWorkspace, previewKind, workerActiveAt } from './row-helpers'
+import { A2A_PREFIX_RE, botCanonicalSessionId, botRowOwnsWorkspace, botWorkingMood, previewKind, useTurnBusy, workerActiveAt } from './row-helpers'
 import type { GroupMember, RosterRow, SidebarRowLabels } from './types'
 import { $botSections, $draggingBot, BOT_DRAG_MIME, botSectionId, moveBotsToSection } from './user-sections'
 
@@ -93,7 +92,6 @@ interface BotRowProps {
 export function BotRow({ bot, onDelete, onEdit, onGroup, onNewSection, showHandle }: BotRowProps) {
   const { t } = useI18n()
   const b = useBots()
-  const activeProfile = useValue(host.state.profile)
   const focusedOwner = focusedRosterOwner(useValue($focusedBotOwner))
   const selectedRosterKey = useValue($selectedRosterKey)
   const botChatFocused = useValue($botChatFocused)
@@ -118,19 +116,10 @@ export function BotRow({ bot, onDelete, onEdit, onGroup, onNewSection, showHandl
   // can highlight a remote row, which has no focusable local chat.
   const isActive = botRowOwnsWorkspace(bot, activeGroup, botChatFocused, focusedOwner, selectedRosterKey)
 
-  // Turn-busy is a SOCKET fact: only the gateway-home profile can be mid-turn.
-  const isGatewayHome =
-    !bot.remoteSource &&
-    bot.name === activeProfile &&
-    isActiveRosterBot(bot, {
-      name: activeProfile,
-      connectionId: activeConnectionId
-    })
-
   const { shape, color, image } = botAppearance(bot.name, meta)
   // Keep user photos/pets. Drop the 160px SVG backfill so the math face can move.
   const photo = Boolean(image && !isBackfilledFacePng(image))
-  const gatewayState = useValue(host.state.gateway)
+  const turnBusy = useTurnBusy()
   // Preview identity must match click identity (#88200): when the backend
   // resolved the pinned canonical chat, preview THAT session — not the
   // profile's most recent (but unrelated) activity. Activity signals
@@ -147,7 +136,7 @@ export function BotRow({ bot, onDelete, onEdit, onGroup, onNewSection, showHandl
     ? Math.max(activitySession?.last_active || 0, bot.worker_session?.last_active || 0)
     : activitySession?.last_active || 0
 
-  const botMood = workerActive || (isGatewayHome && gatewayState === 'busy') ? 'work' : 'idle'
+  const botMood = botWorkingMood(bot, focusedOwner, turnBusy, activeConnectionId)
   // Status keys off the canonical Bot Chat — the very session this row opens,
   // so the dot and the click can never describe different conversations.
   const canonicalSessionId = botCanonicalSessionId(bot)

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -34,11 +34,13 @@ import { BotRow, GroupRow } from './bot-row'
 import {
   $botChatFocused,
   $botsPaneVisible,
+  $focusedBotOwner,
   $openBotChat,
   $rosterHydrated,
   $selectedRosterHydrated,
   $selectedRosterKey,
   clearSelectedRosterKey,
+  focusedRosterOwner,
   parseRosterKey,
   saveSelectedRosterBot
 } from './bot-state'
@@ -77,7 +79,7 @@ import {
 } from './roster-sections'
 import type { ResolvedRosterGatewaySection } from './roster-sections'
 import { botRosterMeta, botWorkspaceOwnerKey, setBotsWorkspaceOwner } from './routing'
-import { ACTIVE_WINDOW_S, activeBots, BOT_ROSTER_SEARCH_THRESHOLD, rosterActivityMatches } from './row-helpers'
+import { ACTIVE_WINDOW_S, activeBots, BOT_ROSTER_SEARCH_THRESHOLD, rosterActivityMatches, useTurnBusy } from './row-helpers'
 import { backfillMessagingProtocol } from './soul'
 import type { BotMeta, GatewaySource, GroupMember, RosterActivityFilter, RosterKindFilter, RosterRow } from './types'
 import {
@@ -256,7 +258,10 @@ export function BotsPane() {
   const { data, error, isLoading, refetch } = useRoster()
   const gatewayState = useValue(host.state.gateway)
   const gatewayUp = gatewayState === 'open'
-  const activeProfile = (useValue(host.state.profile) || 'default').trim() || 'default'
+
+  const turnBusy = useTurnBusy()
+  const workingOwner = focusedRosterOwner(useValue($focusedBotOwner))
+  const activeConnectionId = host.state.connectionId?.get?.() || 'local'
   const [createOpen, setCreateOpen] = useState(false)
   const [groupCreateOpen, setGroupCreateOpen] = useState(false)
   const [editing, setEditing] = useState<null | RosterRow>(null)
@@ -343,7 +348,7 @@ export function BotsPane() {
   // and the persisted connection registry hydrate. Keep that transition in a
   // neutral loading state instead of flashing the first-run "No bots" copy.
   const initialRosterLoading = !data && !error && roster.length === 0
-  const activeRosterKeys = new Set(activeBots(roster, activeProfile, gatewayState).map(botRosterKey))
+  const activeRosterKeys = new Set(activeBots(roster, workingOwner, turnBusy, Date.now(), activeConnectionId).map(botRosterKey))
   const gatewayOptions = rosterGatewayOptions(sourceSnapshot, roster)
   const selectedGateway = gatewayOptions.find(option => option.connectionId === gatewayFilter)
   const gatewayFilterExists = gatewayFilter === 'all' || Boolean(selectedGateway)

--- a/apps/desktop/src/plugins/hermes-bots/row-helpers.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/row-helpers.test.ts
@@ -97,13 +97,19 @@ describe('which bots are working right now', () => {
     row({ name: 'analyst' })
   ]
 
-  it('includes the gateway-busy profile before its first response lands', () => {
-    // analyst has no session at all — a busy turn must still show it.
-    expect(activeBots(roster, 'analyst', 'busy', NOW).map(bot => bot.name)).toContain('analyst')
+  it('counts the focused live turn only for its connection-qualified owner', () => {
+    const local = row({ name: 'analyst', connectionId: 'local' })
+    const remote = row({ name: 'analyst', connectionId: 'remote', remoteSource: true })
+    const owner = { name: 'analyst', connectionId: 'remote', authoritative: true }
+    expect(activeBots([local, remote], owner, true, NOW)).toEqual([remote])
+    expect(activeBots([local, remote], owner, false, NOW)).toEqual([])
+    expect(activeBots([local, remote], null, true, NOW)).toEqual([])
+    expect(activeBots([local, remote], { ...owner, authoritative: false }, true, NOW)).toEqual([])
+    expect(activeBots([row({ name: 'analyst', remoteSource: true })], { ...owner, connectionId: '' }, true, NOW)).toEqual([])
   })
 
   it('includes activity inside the liveness window and excludes activity outside it', () => {
-    const names = activeBots(roster, 'default', 'open', NOW).map(bot => bot.name)
+    const names = activeBots(roster, null, false, NOW).map(bot => bot.name)
 
     expect(names).toContain('researcher')
     expect(names).not.toContain('scribe')
@@ -113,9 +119,9 @@ describe('which bots are working right now', () => {
   })
 
   it('returns an empty list when nothing is active, and tolerates no roster', () => {
-    expect(activeBots(roster.slice(1), 'default', 'open', NOW)).toEqual([])
-    expect(activeBots(null, 'default', 'open', NOW)).toEqual([])
-    expect(activeBots([], 'default', 'open', NOW)).toEqual([])
+    expect(activeBots(roster.slice(1), null, false, NOW)).toEqual([])
+    expect(activeBots(null, null, false, NOW)).toEqual([])
+    expect(activeBots([], null, false, NOW)).toEqual([])
   })
 
   it('counts Bot Chat activity that last_session cannot see', () => {
@@ -127,7 +133,7 @@ describe('which bots are working right now', () => {
       })
     ]
 
-    expect(activeBots(bots, 'other', 'open', NOW).map(bot => bot.name)).toContain('default')
+    expect(activeBots(bots, null, false, NOW).map(bot => bot.name)).toContain('default')
   })
 
   it('counts a live kanban/tool worker heartbeat (#90268)', () => {
@@ -138,7 +144,7 @@ describe('which bots are working right now', () => {
       worker_session: { id: 'w1', last_active: secondsAgo(30), source: 'kanban' }
     })
 
-    expect(activeBots([working], 'other', 'open', NOW).map(bot => bot.name)).toContain('coding')
+    expect(activeBots([working], null, false, NOW).map(bot => bot.name)).toContain('coding')
     expect(workerActiveAt(working, NOW)).toBe(true)
   })
 
@@ -149,7 +155,7 @@ describe('which bots are working right now', () => {
       worker_session: { id: 'w1', last_active: secondsAgo(3600), source: 'kanban' }
     })
 
-    expect(activeBots([finished], 'other', 'open', NOW)).toEqual([])
+    expect(activeBots([finished], null, false, NOW)).toEqual([])
     // Workers get a wider window than chat activity to bridge one missed
     // heartbeat — but not an hour's worth.
     expect(workerActiveAt(finished, NOW)).toBe(false)

--- a/apps/desktop/src/plugins/hermes-bots/row-helpers.ts
+++ b/apps/desktop/src/plugins/hermes-bots/row-helpers.ts
@@ -3,10 +3,11 @@
  * message, whether a bot counts as live, and whether its row owns the
  * highlight.
  *
- * Pure below the surfaces. Every one of these takes a roster row and returns
- * a value, so the bot row, the roster pane and the open path can share one
- * answer instead of each deriving its own.
+ * Shared by the bot row, roster pane and open path rather than deriving
+ * competing answers in each surface.
  */
+
+import { atom, host, useValue } from '@hermes/plugin-sdk'
 
 import { botActivitySession, botHandle, botRosterKey, isActiveRosterBot } from './data'
 import type { RosterActivityFilter, RosterRow } from './types'
@@ -84,23 +85,50 @@ export function workerActiveAt(bot: null | RosterRow | undefined, now = Date.now
   return Boolean(ts && now / 1000 - ts < WORKER_ACTIVE_WINDOW_S)
 }
 
-/** Bots that are working right now: the profile the gateway is running a
- *  turn for (busy), any bot whose last message landed inside the liveness
- *  window, plus any bot with a live kanban/tool worker. Pure — output
- *  follows the input roster's order, so presence never reorders or hides
- *  the normal list. */
+/** Older shells without the live-turn atom remain idle rather than reading socket state. */
+const $idleTurn = atom(false)
+
+export function useTurnBusy(): boolean {
+  return useValue(host.state.busy || $idleTurn)
+}
+
+interface WorkingOwner {
+  authoritative: boolean
+  connectionId: string
+  name: string
+}
+
+/** The busy atom follows tile focus, not the gateway socket or row selection. */
+export function botWorkingMood(
+  bot: RosterRow,
+  owner: WorkingOwner | null,
+  turnBusy: boolean,
+  activeConnectionId = 'local',
+  now = Date.now()
+): 'idle' | 'think' | 'work' {
+  const botConnectionId = bot.connectionId || (bot.remoteSource ? '' : activeConnectionId)
+
+  if (turnBusy && owner?.authoritative && owner.connectionId && owner.name === bot.name && owner.connectionId === botConnectionId) {
+    return 'think'
+  }
+
+  return workerActiveAt(bot, now) ? 'work' : 'idle'
+}
+
+/** Focused turns, recent messages and live workers, preserving roster order. */
 export function activeBots(
   roster: null | RosterRow[] | undefined,
-  activeProfile: string,
-  gatewayState: string,
-  now = Date.now()
+  owner: WorkingOwner | null,
+  turnBusy: boolean,
+  now = Date.now(),
+  activeConnectionId = 'local'
 ): RosterRow[] {
   return (roster || []).filter(bot => {
-    const busyTurn = !bot.remoteSource && bot.name === activeProfile && gatewayState === 'busy'
+    const busyTurn = botWorkingMood(bot, owner, turnBusy, activeConnectionId, now) !== 'idle'
     const last = botActivitySession(bot)?.last_active || 0
     const inWindow = Boolean(last && now / 1000 - last < ACTIVE_WINDOW_S)
 
-    return busyTurn || inWindow || workerActiveAt(bot, now)
+    return busyTurn || inWindow
   })
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -286,7 +286,7 @@ export type AvatarShape = 'circle' | 'cloud' | 'drop' | 'hexagon' | 'pill' | 'sq
 export type BlobKind =
   'boxy' | 'capsule' | 'cloud' | 'droplet' | 'hexagon' | 'nub' | 'organic' | 'round' | 'sun' | 'triangle'
 
-export type FaceMood = 'idle' | 'work'
+export type FaceMood = 'idle' | 'think' | 'work'
 
 export interface AvatarAppearance {
   /** `null` when nothing is picked — the name's deterministic hue stands in.

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
     },
     "apps/desktop": {
       "name": "hermes",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "@assistant-ui/core": "0.2.23",
         "@assistant-ui/react": "0.14.24",

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -18,7 +18,7 @@ There is no new primitive to learn: a Bot **is** a Hermes profile — isolated c
 The roster shows one row per agent profile: avatar, latest-message preview, and timestamp.
 
 - **Click a Bot** to land in its chat — every Bot has a canonical, persistent **Bot Chat** conversation that is created (and pinned) the moment the Bot is born. A row click always opens that Bot Chat (the same conversation the row previews), even when you have other tabs open for the Bot; those tabs stay open beside it. In the tab strip the Bot Chat is captioned with the Bot's name, so two open Bots are told apart at a glance.
-- **Active now** — a presence strip above the roster shows every Bot currently working: the gateway-busy profile plus any Bot that wrote within the last 90 seconds. Each chip opens that Bot's chat. The strip never reorders the roster and disappears when the fleet is idle.
+- **Active now** — the roster's activity filter includes the owner of the focused live turn, Bots that wrote within the last 90 seconds, and Bots with a recent worker heartbeat. A connected gateway alone does not mean a Bot is working.
 - **Search** filters the roster as you type.
 - **Hide a Bot** — right-click a row → **Hide Bot** to take a Bot you don't use out of the roster and the Active-now strip. Hiding is display-only: @mentions still resolve, group-chat memberships are untouched, and routines keep running. Once at least one Bot is hidden, an **eye toggle** appears in the pane header — click it to reveal hidden Bots dimmed in place, then right-click → **Unhide Bot** to bring one back. Hidden Bots never toast, but they accumulate unread activity silently and the eye badges a dot so you know something happened. Hidden state is saved in the Bot's profile metadata, so it follows the Bot to every desktop connected to that backend.
 
@@ -71,7 +71,7 @@ Remote-creation notes:
 Every Bot gets a face:
 
 - **Blob faces** (default) — a deterministic soft-body face drawn from the Bot's name: same name, same face, forever. While you type a name in New Agent the face follows it live; hit **Randomize** to re-roll, **Lock face** to keep the one you like even if the name changes, or pin one of the six silhouettes (round, organic, boxy, nub, cloud, sun) while everything else still comes from the name.
-- **Geometric faces** — the classic 7 shapes × 10 colors, with blinking eyes that scan while the Bot works.
+- **Geometric faces** — the classic 7 shapes × 10 colors. During a focused live turn, the owning Bot leans and looks upward with three animated dots, then eases back to idle when the turn ends. Ownership includes the connection, so same-named Bots on different gateways do not borrow the pose. Background workers keep their existing working animation; photos, blob faces and sigils keep their own rendering.
 - **An uploaded image** — any picture you like.
 - **An AI-generated portrait** — when an image backend is configured, generated in place (this rides the standard `image.generate` RPC and works over both local and remote gateways).
 - **A pixel pet** — a companion from the [petdex gallery](./features/pets.md) that bounces beside the avatar while the Bot is busy. Run `hermes pets` in a terminal to explore the gallery.


### PR DESCRIPTION
Bot Mode's geometric avatar now visibly thinks during its focused live turn and settles back to idle when the turn ends.

## Changes
- Read the SDK's live-turn busy atom rather than comparing socket state with `busy`.
- Match the focused **connection + profile** in both the row avatar and activity filter; an unrelated or same-named bot cannot borrow the pose.
- Add the think pose and elapsed-time easing while preserving worker-heartbeat activity, the existing worker animation, avatar catchlights, static image/blob/sigil rendering, and the shared 15fps visibility-aware clock.
- Update Bot Mode documentation and bump the bundled desktop shell version.

Root cause: `host.state.gateway` reports socket connectivity, while `host.state.busy` follows the focused chat—not necessarily the gateway's home profile.

## Credit and scope
Adapted from @Adolanium's [Hermes-Bot-Mode#101](https://github.com/NousResearch/Hermes-Bot-Mode/pull/101) and its [in-tree port #88134](https://github.com/NousResearch/hermes-agent/pull/88134), preserving newer owner-qualified routing and worker activity. The previous broad avatar-mood direction is not restored. Related to #94726; this does not close that tracker or add the separate unread/attention redesign in #92989.

## Validation
| Check | Result |
| --- | --- |
| Two regression invariants against fresh main | Both fail: live owner is omitted; think dots remain invisible |
| Same focused tests on this change | 28 tests pass |
| Bot Mode Vitest directory | 578 tests pass across 62 files |
| Desktop TypeScript + ESLint | Pass, with existing warnings |
| Desktop production build | Pass |
| Windows-footgun / compatibility-pointer checks | Pass |
| Native Electron with real Hermes backend, temporary profile, loopback scripted inference | Baseline and fixed flows exercised; final fixed flow passes |

**Live repro:** with the same held streaming prompt, both builds report `gateway=open`, `busy=true`, and owner `local/default`. Main's row remains `idle`; this change displays `think`, then returns to `idle` after the real final response. The test opens an actual seeded canonical Bot Chat, requires its history and focused runtime, sends through the visible composer, waits for the model-boundary hold, releases it, and verifies the final answer and settled pose. No busy/owner/presentation predicate was patched. Connection-collision and worker-heartbeat controls are covered by the invariant suite.

The first native probe submitted before row hydration completed and was rejected as evidence; the corrected probe requires the focused runtime before sending. A default-parallel Vitest attempt hit the host's inotify limit; the complete directory passed with polling and two workers.

### Native screenshots
| Before: live turn, idle face | After: live turn, thinking face |
| --- | --- |
| ![Before](https://files.catbox.moe/ewpdb1.png) | ![After](https://files.catbox.moe/ui49nl.png) |

Native frame recordings: [before](https://files.catbox.moe/765bcq.mp4) · [after](https://files.catbox.moe/mxxagi.mp4). Screenshots and videos were downloaded again and verified byte-for-byte against local evidence.

## Infographic
![Bot Mode visibly working](https://v3b.fal.media/files/b/0aa9a050/4tyu1HjZHyVm749qPBseI_euc6G4cL.png)
