### PR TITLE
fix(gateway): interrupt stale agent before eviction

### DIFF
--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -451,6 +451,8 @@ class GatewayInboundMixin:
                 "(age: %.0fs, idle: %.0fs, timeout: %.0fs)%s",
                 _quick_key, _stale_age, _stale_idle, _raw_stale_timeout, _stale_detail,
             )
+            from gateway.run import _INTERRUPT_REASON_TIMEOUT, request_hard_interrupt
+            request_hard_interrupt(_stale_agent, _INTERRUPT_REASON_TIMEOUT)
             self._hm_evict_running_agent(_quick_key, "stale_running_agent_eviction")
 
     def _hm_evict_reaped_agent(self, _quick_key: str) -> None:

--- a/tests/gateway/test_running_agent_session_toggles.py
+++ b/tests/gateway/test_running_agent_session_toggles.py
@@ -162,7 +162,41 @@ async def test_fresh_ancient_turn_remains_controllable(monkeypatch):
     result = await runner._handle_message(_make_event("/verbose"))
 
     runner._handle_verbose_command.assert_awaited_once()
+    agent.interrupt.assert_not_called()
     assert runner._running_agents[sk] is agent
     assert result == "tool progress: new"
+
+
+def test_stale_turn_is_interrupted_before_its_slot_is_released(monkeypatch):
+    """A replacement turn must not overlap the evicted worker for the same chat."""
+    import time
+    from gateway.run import _INTERRUPT_REASON_TIMEOUT
+
+    runner = _make_runner()
+    sk = build_session_key(_make_source())
+    agent = runner._running_agents[sk]
+    agent.get_activity_summary.return_value = {
+        "seconds_since_activity": 6.0,
+        "last_activity_desc": "waiting on model response",
+        "api_call_count": 1,
+        "max_iterations": 60,
+    }
+    runner._running_agents_ts[sk] = time.time() - 6.0
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "5")
+
+    operations = []
+    agent.interrupt.side_effect = lambda reason: operations.append(("interrupt", reason))
+    runner._invalidate_session_run_generation = (
+        lambda _key, *, reason: operations.append("invalidate")
+    )
+    runner._release_running_agent_state = lambda _key: operations.append("release")
+
+    runner._hm_evict_idle_stale_agent(sk)
+
+    assert operations == [
+        ("interrupt", _INTERRUPT_REASON_TIMEOUT),
+        "invalidate",
+        "release",
+    ]
 
 


### PR DESCRIPTION
## What does this PR do?

Stops a stale gateway worker before its running-session slot is released. This prevents a follow-up message from starting a replacement turn while the evicted worker is still executing.

The stale inbound eviction path previously invalidated the run generation and cleared the slot without interrupting the agent. The old worker could continue model calls or tool side effects even though its final result would later be rejected as stale.

This change uses the existing hard-interrupt compatibility helper and the standard inactivity timeout reason before eviction. It does not change the separate steer-delivery behavior covered by #103342.

## Related Issue

Addresses the stale-eviction overlap in #66704.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run_inbound.py` interrupts the stale agent before invalidating its generation and releasing its slot.
- `tests/gateway/test_running_agent_session_toggles.py` verifies the timeout reason and interrupt, invalidate, release ordering.
- The existing fresh-activity test now confirms that a long-running but active agent is not interrupted.

## How to Test

1. Run the focused regression and related interrupt and timeout suites:

   ```bash
   scripts/run_tests.sh tests/gateway/test_running_agent_session_toggles.py tests/gateway/test_gateway_inactivity_timeout.py tests/gateway/test_abandoned_turn_process_cleanup.py tests/gateway/test_steer_command.py tests/agent/test_interrupt_compat.py -v --tb=short
   ```

2. Confirm all 29 tests pass.
3. Run `ruff check gateway/run_inbound.py tests/gateway/test_running_agent_session_toggles.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

The full suite was not run. The 29 directly related tests passed through the repository test script.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

## Screenshots / Logs

Not applicable.
