### PR TITLE
fix(agent): scope corruption-recovery backups dir to the active profile root

### DIFF
--- a/agent/turn_explainers.py
+++ b/agent/turn_explainers.py
@@ -295,11 +295,13 @@ class TurnExplainersMixin:
             )
             if persistence_cause == "corrupt":
                 # Copy-pasteable, so name the real store (profiles / HERMES_HOME do not live under ~/.hermes).
-                from hermes_constants import get_default_hermes_root
+                # get_active_hermes_root() (not get_default_hermes_root()) so a profile scoped in via
+                # set_hermes_home_override (multiplexed gateway) names its own root, not the ambient one.
+                from hermes_constants import get_active_hermes_root
                 from hermes_state import _default_db_path
 
                 body = body.replace("{db_path}", str(_default_db_path()))
                 body = body.replace(
-                    "{backups_dir}", str(get_default_hermes_root() / "backups")
+                    "{backups_dir}", str(get_active_hermes_root() / "backups")
                 )
         return _NO_REPLY + body if body else ""

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -748,12 +748,14 @@ class GatewayNotificationsMixin:
         error = getattr(self, "_session_db_init_error", None)
         if not error:
             return
-        from hermes_constants import get_default_hermes_root
+        from hermes_constants import get_active_hermes_root
         from hermes_state import _default_db_path, classify_persistence_error, format_session_db_unavailable
         if classify_persistence_error(error) == "corrupt":
             # Copy-pasteable, so name the real store (profiles / HERMES_HOME do not live under ~/.hermes).
+            # get_active_hermes_root() (not get_default_hermes_root()) so a profile scoped in via
+            # set_hermes_home_override (multiplexed gateway) names its own root, not the ambient one.
             db_path = _default_db_path()
-            backups_dir = get_default_hermes_root() / "backups"
+            backups_dir = get_active_hermes_root() / "backups"
             message = (
                 "⚠️ Session database corruption detected. Messages may not be "
                 "persisted. Recovery options:\n"

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -162,6 +162,25 @@ def get_default_hermes_root() -> Path:
     return result
 
 
+def get_active_hermes_root() -> Path:
+    """Root Hermes dir for the currently active (possibly profile-scoped) home.
+
+    Like :func:`get_default_hermes_root`, but consults the context-local override first: a
+    multiplexed gateway or CLI operation that scopes into a named profile via
+    ``set_hermes_home_override`` does not mutate ``os.environ``, so ``get_default_hermes_root()``
+    would still resolve the ambient process's root instead of the scoped profile's. Callers that
+    name a path for the operator to act on (e.g. corruption recovery guidance) need the root the
+    active profile actually lives under; callers that want the one shared, process-wide root
+    regardless of profile scope (kanban, auth, plugins, …) should keep using
+    ``get_default_hermes_root()``.
+    """
+    override = get_hermes_home_override()
+    if override is None:
+        return get_default_hermes_root()
+    override_path = Path(override)
+    return override_path.parent.parent if override_path.parent.name == "profiles" else override_path
+
+
 # Tombstone lives beside the profile dir (not inside) so a stale mkdir or rmtree cannot erase it.
 _DELETED_PROFILES_DIR = ".deleted"
 # Files marking a real Hermes home; arbitrary dirs with a ``profiles`` segment lack them.

--- a/tests/run_agent/test_corruption_recovery_guidance.py
+++ b/tests/run_agent/test_corruption_recovery_guidance.py
@@ -63,6 +63,47 @@ def test_gateway_corruption_banner_backups_dir_follows_hermes_home(monkeypatch, 
     assert "~/.hermes/backups" not in sent[0]
 
 
+def test_gateway_corruption_banner_backups_dir_follows_scoped_profile_override(monkeypatch, tmp_path):
+    """The gateway broadcast's step 3 must name the SCOPED profile's root, not the ambient
+    process HERMES_HOME (#105887).
+
+    A multiplexed gateway enters a named profile via ``set_hermes_home_override`` (a contextvar)
+    without mutating ``os.environ`` — see ``gateway.run._profile_runtime_scope``. The corruption
+    banner built while that profile's turn is active must name the backups dir beneath the
+    scoped profile's own root, not whatever root the ambient process HERMES_HOME points at.
+    """
+    import asyncio
+
+    import gateway.run as gateway_run
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    ambient_home = tmp_path / "ambient-default-home"
+    monkeypatch.setenv("HERMES_HOME", str(ambient_home))
+    custom_root = tmp_path / "custom-root"
+    profile_home = custom_root / "profiles" / "work"
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_db_init_error = "database disk image is malformed"
+    sent = []
+    monkeypatch.setattr(
+        runner, "_home_channel_transports", lambda: [("telegram", {}, "home-chat", object())]
+    )
+
+    async def _capture_send(_platform, _home, _transport, message, _log_fmt):
+        sent.append(message)
+
+    monkeypatch.setattr(runner, "_send_home_channel_message", _capture_send)
+    token = set_hermes_home_override(profile_home)
+    try:
+        asyncio.run(runner._send_session_db_warning_notifications())
+    finally:
+        reset_hermes_home_override(token)
+
+    assert sent, "warning must be broadcast to home channels"
+    assert f"{custom_root / 'backups'}" in sent[0]
+    assert str(ambient_home) not in sent[0]
+
+
 def test_format_turn_completion_corrupt_never_names_the_live_db():
     """The 'corrupt' cause must not direct a raw sqlite3 shell at the live DB.
 

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -173,6 +173,31 @@ def test_explanation_persistence_corrupt_backups_dir_follows_hermes_home(monkeyp
     assert "{backups_dir}" not in out
 
 
+def test_explanation_persistence_corrupt_backups_dir_follows_scoped_profile_override(monkeypatch, tmp_path):
+    """Step 3 must name the SCOPED profile's root, not the ambient process HERMES_HOME (#105887).
+
+    A multiplexed gateway or CLI operation enters a named profile via
+    ``set_hermes_home_override`` (a contextvar) without mutating ``os.environ`` — see
+    ``gateway.run._profile_runtime_scope``. Recovery guidance built inside that scope must name
+    the backups dir beneath the scoped profile's own root, not the ambient default's root.
+    """
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    ambient_home = tmp_path / "ambient-default-home"
+    monkeypatch.setenv("HERMES_HOME", str(ambient_home))
+    custom_root = tmp_path / "custom-root"
+    profile_home = custom_root / "profiles" / "work"
+    token = set_hermes_home_override(profile_home)
+    try:
+        out = AIAgent._format_turn_completion_explanation(
+            "session_persistence_failed", "corrupt"
+        )
+    finally:
+        reset_hermes_home_override(token)
+    assert f"{custom_root / 'backups'}" in out
+    assert str(ambient_home) not in out
+
+
 def test_explanation_persistence_replaced_cause_forbids_inplace_repair():
     out = AIAgent._format_turn_completion_explanation(
         "session_persistence_failed", "replaced"


### PR DESCRIPTION
## What does this PR do?

Fixes the corrupt-cause recovery guidance's backups-dir step so it names the **active profile's** root, not the ambient process's root, when the profile was scoped in via the context-local `set_hermes_home_override` override (the mechanism `gateway._profile_runtime_scope` uses for a multiplexed gateway's per-turn profile scoping).

Both places this guidance is built (the end-of-turn "⚠️ No reply" explainer and the gateway startup broadcast) already correctly name the failing profile's `state.db` via `_default_db_path()` (which is override-aware). But the very next line, step 3 ("Restore from a backup in …"), used `get_default_hermes_root()`, which reads `os.environ["HERMES_HOME"]` directly and has no knowledge of the contextvar override — so it silently fell back to whatever profile was ambient at the process level, not the one whose database actually failed. Mid data-loss incident, an operator following that step could be pointed at a different profile's backups directory (or the default profile's, when a secondary/named profile is the one that's corrupt).

## Related Issue

Fixes #105887

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_constants.py`: add `get_active_hermes_root()`, which consults `get_hermes_home_override()` first and falls back to the existing `get_default_hermes_root()` when no override is active. `get_default_hermes_root()` itself is left unchanged — it has ~30 other call sites (kanban, auth, plugins, wake-word lock, …) that intentionally want the one shared process-wide root regardless of any per-turn profile scope, so widening its own behavior would have been a much larger and riskier change than this bug needs.
- `agent/turn_explainers.py`: the turn-completion "corrupt" explanation's `{backups_dir}` interpolation now uses `get_active_hermes_root()`.
- `gateway/run_notifications.py`: `_send_session_db_warning_notifications`'s corrupt-branch broadcast now uses the same helper for its `backups_dir`.
- `tests/run_agent/test_turn_completion_explainer.py`: regression test — under a `set_hermes_home_override`-scoped named profile living beneath a custom root, the explanation names that root's backups dir, never the ambient process `HERMES_HOME`'s.
- `tests/run_agent/test_corruption_recovery_guidance.py`: same regression for the gateway broadcast path.

## How to Test

1. `.venv/bin/python -m pytest tests/run_agent/test_turn_completion_explainer.py tests/run_agent/test_corruption_recovery_guidance.py tests/test_hermes_constants.py tests/test_hermes_home_key_cache.py tests/test_hermes_home_profile_warning.py tests/test_display_hermes_home.py -q`

   Observed result: **120 passed, 5 skipped**.

2. Proved the new tests are RED without the fix: `git checkout HEAD~1 -- hermes_constants.py agent/turn_explainers.py gateway/run_notifications.py`, re-ran the two new tests — both failed with the ambient `HERMES_HOME`'s path (e.g. `.../ambient-default-home/backups/`) instead of the scoped profile's root (`.../custom-root/backups/`); then `git checkout HEAD -- <files>` to restore the fix, re-ran — both passed.

3. `ruff check hermes_constants.py agent/turn_explainers.py gateway/run_notifications.py tests/run_agent/test_corruption_recovery_guidance.py tests/run_agent/test_turn_completion_explainer.py` — all checks passed.

4. Manual repro before the fix, confirming the exact operator-facing symptom:
   ```
   >>> token = set_hermes_home_override("/tmp/custom-root/profiles/work")
   >>> AIAgent._format_turn_completion_explanation("session_persistence_failed", "corrupt")
   ...
   2. Stop the gateway, then recover with:
      hermes sessions recover --source /tmp/custom-root/profiles/work/state.db --inspect-only   # correct profile
      ...
   3. Restore from a backup in /tmp/testhome_default/backups/   # WRONG — names the ambient default's root, not /tmp/custom-root
   ```
   After the fix, step 3 reads `Restore from a backup in /tmp/custom-root/backups/`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — open PRs #91823 and #104319 touch the same two files but only fix the *ambient-env* case (`HERMES_HOME` set directly), which is already correct on current `main` (commit `342967058c`, already landed); neither addresses the contextvar-override case this PR fixes.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused suite above and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Linux (Ubuntu, CI container)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, the new function's docstring documents the distinction from `get_default_hermes_root()`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure `pathlib`/contextvar logic, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Disclosure

This patch was prepared by an AI coding agent (Claude), including the investigation, fix, and regression tests. The behavior was manually verified via direct reproduction (see "How to Test" #4) and by proving the new tests fail without the fix and pass with it.
