### PR TITLE
fix: gateway ordering test runs without root access

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1296,7 +1296,7 @@ class TestSystemUnitHermesHome:
 
     def test_system_unit_orders_after_target_user_manager(self, monkeypatch, tmp_path):
         """#104893: restart-safe workers need user@<uid>.service; the system unit must not race it at boot."""
-        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
         monkeypatch.setattr(
             gateway_cli, "_system_service_identity",


### PR DESCRIPTION
The gateway service ordering test now runs as an ordinary user without probing `/root`.

- Use the existing `tmp_path` fixture for `Path.home()` in the single ordering test.
- Preserve the `After=user@1001.service`, `Wants=user@1001.service`, and user-unit exclusion assertions unchanged.
- No production changes or additional tests.

Root cause: the fixture introduced in `4c4845f0afbb30747570c69766b3b956c737d42a` selected `/root` even for user-unit generation, whose real local-bin discovery raises `PermissionError` on unprivileged Python 3.11.

## Validation

**Live repro:** on main `abd83ab560327c58f17f8e2ecd9be0307d5c9cf9`, running as UID 1000 with Python 3.11.15, the canonical full-file runner fails at `/root/.local/bin`; after the one-line fixture change it passes.

Command: `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 1 tests/hermes_cli/test_gateway_service.py`

| Check | Before | After |
| --- | --- | --- |
| Full gateway service test file | 104 passed, 1 failed, 1 skipped | 105 passed, 0 failed, 1 skipped |
| Retry | Disabled | Disabled |

The skipped case is macOS-only. Ruff, Windows footgun scan (1,491 files), compat-pointer scan, and `git diff --check` pass.

This independently repairs the shared-main failure exposed by [Bot Mode PR #105909](https://github.com/NousResearch/hermes-agent/pull/105909) in [CI run 34256752856](https://github.com/NousResearch/hermes-agent/actions/runs/34256752856); that PR changes no Python files. Related systemd ordering behavior remains unchanged. Remote CI is pending; no merge is requested or authorized here.

## Infographic
![Gateway ordering test home isolation](https://v3b.fal.media/files/b/0aa9a0bf/jAn2uwrAfnORN-NsPKeTH_qDtUZC2e.png)
