### PR TITLE
delegate_task: validate parent_session_id before propagating to children

### DIFF
--- a/tests/tools/test_delegation_parent_association.py
+++ b/tests/tools/test_delegation_parent_association.py
@@ -1,0 +1,136 @@
+"""Parent-session association helpers for delegated agent invocations."""
+
+import sys
+from queue import Queue
+from types import ModuleType, SimpleNamespace
+
+import tools.async_delegation as ad
+
+
+class FakeSessionDB:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def get_session(self, session_id):
+        return self.rows.get(session_id)
+
+
+def test_resolve_parent_session_id_accepts_existing_session():
+    db = FakeSessionDB({"parent-1": {"id": "parent-1", "ended_at": None}})
+
+    assert ad.resolve_parent_session_id(" parent-1 ", session_db=db) == "parent-1"
+
+
+def test_resolve_parent_session_id_rejects_missing_or_invalid_session():
+    db = FakeSessionDB({"parent-1": {"id": "parent-1"}})
+
+    assert ad.resolve_parent_session_id("", session_db=db) is None
+    assert ad.resolve_parent_session_id(None, session_db=db) is None
+    assert ad.resolve_parent_session_id("missing", session_db=db) is None
+
+
+def test_build_parent_invocation_context_isolates_concurrent_parents():
+    db = FakeSessionDB({"parent-a": {"id": "parent-a"}, "parent-b": {"id": "parent-b"}})
+    parent_a = SimpleNamespace(session_id="parent-a", _session_db=db)
+    parent_b = SimpleNamespace(session_id="parent-b", _session_db=db)
+
+    ctx_a = ad.build_parent_invocation_context(
+        parent_a,
+        session_key="chat-a",
+        origin_ui_session_id="tab-a",
+    )
+    ctx_b = ad.build_parent_invocation_context(
+        parent_b,
+        session_key="chat-b",
+        origin_ui_session_id="tab-b",
+    )
+
+    assert ctx_a == {
+        "session_key": "chat-a",
+        "origin_ui_session_id": "tab-a",
+        "parent_session_id": "parent-a",
+    }
+    assert ctx_b == {
+        "session_key": "chat-b",
+        "origin_ui_session_id": "tab-b",
+        "parent_session_id": "parent-b",
+    }
+
+
+def test_build_parent_invocation_context_clears_invalid_parent_without_losing_route():
+    db = FakeSessionDB({})
+    parent = SimpleNamespace(session_id="stale-parent", _session_db=db)
+
+    ctx = ad.build_parent_invocation_context(
+        parent,
+        session_key="chat-key",
+        origin_ui_session_id="tab-1",
+    )
+
+    assert ctx == {
+        "session_key": "chat-key",
+        "origin_ui_session_id": "tab-1",
+        "parent_session_id": None,
+    }
+
+
+def _install_fake_process_registry(monkeypatch, q):
+    module = ModuleType("tools.process_registry")
+    module.process_registry = SimpleNamespace(completion_queue=q)
+    monkeypatch.setitem(sys.modules, "tools.process_registry", module)
+
+
+def test_completion_event_reports_success_to_parent_session(monkeypatch):
+    q = Queue()
+    persisted = []
+    monkeypatch.setattr(ad, "_persist_completion", lambda evt, result: persisted.append((evt, result)))
+    _install_fake_process_registry(monkeypatch, q)
+
+    record = {
+        "delegation_id": "deleg-ok",
+        "session_key": "chat-a",
+        "origin_ui_session_id": "tab-a",
+        "parent_session_id": "parent-a",
+        "goal": "finish task",
+        "role": "leaf",
+        "model": "m",
+        "dispatched_at": 10.0,
+        "completed_at": 12.5,
+    }
+    result = {"status": "completed", "summary": "done", "api_calls": 2}
+
+    ad._push_completion_event(record, result, "completed")
+
+    evt = q.get_nowait()
+    assert evt["status"] == "completed"
+    assert evt["summary"] == "done"
+    assert evt["session_key"] == "chat-a"
+    assert evt["origin_ui_session_id"] == "tab-a"
+    assert evt["parent_session_id"] == "parent-a"
+    assert persisted == [(evt, result)]
+
+
+def test_completion_event_reports_failure_to_parent_session(monkeypatch):
+    q = Queue()
+    monkeypatch.setattr(ad, "_persist_completion", lambda evt, result: None)
+    _install_fake_process_registry(monkeypatch, q)
+
+    record = {
+        "delegation_id": "deleg-fail",
+        "session_key": "chat-b",
+        "origin_ui_session_id": "tab-b",
+        "parent_session_id": "parent-b",
+        "goal": "fail task",
+        "dispatched_at": 20.0,
+        "completed_at": 21.0,
+    }
+    result = {"status": "error", "summary": None, "error": "boom"}
+
+    ad._push_completion_event(record, result, "error")
+
+    evt = q.get_nowait()
+    assert evt["status"] == "error"
+    assert evt["error"] == "boom"
+    assert evt["session_key"] == "chat-b"
+    assert evt["origin_ui_session_id"] == "tab-b"
+    assert evt["parent_session_id"] == "parent-b"

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -513,6 +513,63 @@ def _new_delegation_id() -> str:
     return f"deleg_{uuid.uuid4().hex[:8]}"
 
 
+def resolve_parent_session_id(
+    parent_session_id: Optional[str],
+    *,
+    session_db: Any = None,
+) -> Optional[str]:
+    """Return a safe durable parent session id for a spawned invocation.
+
+    The association must never turn an otherwise valid child spawn into a
+    broken agent.  When a session DB is available we only keep ids that resolve
+    to an existing row, avoiding session-store foreign-key failures and stale
+    routing pins.  Missing/invalid ids degrade to ``None`` while the caller's
+    ordinary session_key/origin_ui routing remains intact.
+    """
+    sid = str(parent_session_id or "").strip()
+    if not sid:
+        return None
+    if session_db is None:
+        return sid
+    getter = getattr(session_db, "get_session", None)
+    if not callable(getter):
+        return sid
+    try:
+        row = getter(sid)
+    except Exception:
+        logger.debug("Could not validate parent_session_id=%s", sid, exc_info=True)
+        return None
+    return sid if row else None
+
+
+def build_parent_invocation_context(
+    parent_agent: Any,
+    *,
+    session_key: str = "",
+    origin_ui_session_id: str = "",
+) -> Dict[str, Any]:
+    """Public integration API for associating a spawn with its parent session.
+
+    Invocation integrations should call this on the parent thread before they
+    detach work.  The returned dict is intentionally serializable and contains
+    the three routing identifiers consumed by async-delegation dispatch and
+    completion delivery:
+
+    - ``session_key``: platform/durable routing key for the parent conversation.
+    - ``origin_ui_session_id``: live TUI/desktop tab that commissioned the work.
+    - ``parent_session_id``: validated durable state-db id of the spawning
+      main/orchestrator agent, or ``None`` when unavailable/invalid.
+    """
+    return {
+        "session_key": str(session_key or ""),
+        "origin_ui_session_id": str(origin_ui_session_id or ""),
+        "parent_session_id": resolve_parent_session_id(
+            getattr(parent_agent, "session_id", None),
+            session_db=getattr(parent_agent, "_session_db", None),
+        ),
+    }
+
+
 def _prune_completed_locked() -> None:
     """Drop the oldest completed records beyond the cap. Caller holds ``_records_lock``."""
     completed = [(rid, r) for rid, r in _records.items() if r.get("status") != "running"]

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -227,7 +227,10 @@ def _build_child_agent(
         request_overrides = dict(override_request_overrides)
     else:
         request_overrides = {} if override_provider else dict(getattr(parent_agent, "request_overrides", {}) or {})
-    parent_sid = getattr(parent_agent, "session_id", None)
+    from tools.async_delegation import resolve_parent_session_id
+    parent_sid = resolve_parent_session_id(
+        getattr(parent_agent, "session_id", None), session_db=getattr(parent_agent, "_session_db", None),
+    )
     child_session_db = _open_child_session_db(parent_agent)
     with delegated_child_context():
         try:

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -377,9 +377,14 @@ def _dispatch_background(batch: _Batch) -> str:
     # interrupt-propagation list (_build_child_agent attached them, which is correct for sync runs).
     for (_, _, c) in batch.children:
         _detach_child(parent_agent, c)
+    from tools.async_delegation import build_parent_invocation_context
+    _parent_ctx = build_parent_invocation_context(
+        parent_agent, session_key=session_key, origin_ui_session_id=origin_ui_session_id,
+    )
     routing = dict(
-        session_key=session_key, origin_ui_session_id=origin_ui_session_id, origin_session_id=wake_sid,
-        parent_session_id=getattr(parent_agent, "session_id", None), max_async_children=_get_max_async_children(),
+        session_key=_parent_ctx["session_key"], origin_ui_session_id=_parent_ctx["origin_ui_session_id"],
+        origin_session_id=wake_sid, parent_session_id=_parent_ctx["parent_session_id"],
+        max_async_children=_get_max_async_children(),
     )
 
     units = _units_of(batch)


### PR DESCRIPTION
## Summary
- `getattr(parent_agent, "session_id", None)` was passed straight through to every delegated child spawn and completion event with no check that the session still exists — a stale or invalid id then propagates into child creation, the `_delegate_from` sidebar marker, and the `subagent_start` hook, breaking downstream lookups instead of degrading cleanly.
- Adds `resolve_parent_session_id()` in `tools/async_delegation.py`, which validates the id against the session DB and returns `None` on a missing/invalid id so ordinary `session_key`/`origin_ui_session_id` routing still works.
- Adds `build_parent_invocation_context()` as the general integration entrypoint for spawns that need `session_key` + `origin_ui_session_id` + a validated `parent_session_id` bundled together — used by the async batch dispatch path.
- Wires both into `tools/delegate_tool.py`'s synchronous child spawn and `tools/delegate_tool_dispatch.py`'s `_dispatch_background` routing dict, the two places a `parent_agent.session_id` was read raw.

## Test plan
- [x] `pytest tests/tools/test_delegation_parent_association.py -v` — 6/6 new tests pass
- [x] `pytest tests/tools/test_delegate*.py tests/tools/test_async_delegation*.py tests/tools/test_restored_delegation_ownership.py tests/gateway/test_delegation_session_id_leak.py tests/gateway/test_async_delegation_session_binding.py tests/cli/test_cli_async_delegation_delivery.py tests/cli/test_cli_delegate_background_notice.py` — 313 passed, 1 skipped, 0 failed