### PR TITLE
config: add predefined task_agents schema (research/implementation/review/documentation)

### DIFF
--- a/docs/task-agents-config.md
+++ b/docs/task-agents-config.md
@@ -1,0 +1,140 @@
+# Predefined task-agent configuration
+
+Hermes exposes a small, predefined set of task-specific agent types through the
+`task_agents.definitions` config section. The section is intentionally not an
+open plugin registry: each entry must use one of the approved stable ids below
+so the main-session and orchestrator integration can validate requests before
+spawning a child agent.
+
+Supported ids and purposes:
+
+- `research` — collect and synthesize source-backed information before implementation or decisions.
+- `implementation` — build or modify the requested artifact using repository tools and verification checks.
+- `review` — evaluate completed work for correctness, regressions, security, and readiness before handoff.
+- `documentation` — produce user-facing or integration documentation from implemented behavior and verified examples.
+
+Schema summary:
+
+- `id` (string, required): stable predefined id. Must be one of `research`,
+  `implementation`, `review`, or `documentation`; duplicates are rejected.
+- `enabled` (boolean, required): whether this configured type may be invoked.
+- `purpose` (string, required): human-readable purpose. Purposes must be
+  distinct after whitespace/case normalization.
+- `invocation` (mapping, required): how the integration invokes this type.
+  `entrypoint` must currently be `delegate_task`, `task_category` must match
+  `id`, and `parameters.required` must include `prompt`.
+- `runtime` (mapping, optional): existing model/runtime knobs the invocation
+  integration may pass through or apply when spawning the agent. Supported keys:
+  `model`, `provider`, `base_url`, `api_key`, `api_mode`, `reasoning_effort`,
+  `max_iterations`, `timeout_seconds`, `max_summary_chars`, `enabled_toolsets`,
+  `disabled_toolsets`, and `skills`.
+
+Validated example:
+
+```yaml
+task_agents:
+  definitions:
+    - id: research
+      enabled: true
+      purpose: Collect and synthesize source-backed information before implementation or decisions.
+      invocation:
+        entrypoint: delegate_task
+        task_category: research
+        parameters:
+          required: [prompt]
+          optional: [context, limit, sources, deliverable]
+      runtime:
+        enabled_toolsets: [web, file, terminal, skills]
+        skills: [deep-research]
+        model: ""
+        provider: ""
+        base_url: ""
+        api_key: ""
+        api_mode: ""
+        reasoning_effort: ""
+        max_iterations: 50
+        timeout_seconds: 0
+        max_summary_chars: 24000
+
+    - id: implementation
+      enabled: true
+      purpose: Build or modify the requested artifact using repository tools and verification checks.
+      invocation:
+        entrypoint: delegate_task
+        task_category: implementation
+        parameters:
+          required: [prompt]
+          optional: [context, workdir, tests, constraints]
+      runtime:
+        enabled_toolsets: [file, terminal, search, skills, todo]
+        skills: [test-driven-development]
+        model: ""
+        provider: ""
+        base_url: ""
+        api_key: ""
+        api_mode: ""
+        reasoning_effort: ""
+        max_iterations: 50
+        timeout_seconds: 0
+        max_summary_chars: 24000
+
+    - id: review
+      enabled: true
+      purpose: Evaluate completed work for correctness, regressions, security, and readiness before handoff.
+      invocation:
+        entrypoint: delegate_task
+        task_category: review
+        parameters:
+          required: [prompt]
+          optional: [context, diff, tests, risk_focus]
+      runtime:
+        enabled_toolsets: [file, terminal, search, skills]
+        skills: [github-code-review, requesting-code-review]
+        model: ""
+        provider: ""
+        base_url: ""
+        api_key: ""
+        api_mode: ""
+        reasoning_effort: ""
+        max_iterations: 50
+        timeout_seconds: 0
+        max_summary_chars: 24000
+
+    - id: documentation
+      enabled: true
+      purpose: Produce user-facing or integration documentation from the implemented behavior and verified examples.
+      invocation:
+        entrypoint: delegate_task
+        task_category: documentation
+        parameters:
+          required: [prompt]
+          optional: [context, audience, format, examples]
+      runtime:
+        enabled_toolsets: [file, search, skills]
+        skills: []
+        model: ""
+        provider: ""
+        base_url: ""
+        api_key: ""
+        api_mode: ""
+        reasoning_effort: ""
+        max_iterations: 50
+        timeout_seconds: 0
+        max_summary_chars: 24000
+```
+
+Integration notes:
+
+- Use `hermes_cli.agent_types.load_task_agent_definitions(config)` to obtain
+  validated `TaskAgentDefinition` objects keyed by id. It raises
+  `TaskAgentConfigError` if the section contains errors.
+- Use `hermes_cli.config.validate_config_structure(config)` for user-facing
+  diagnostics; it reports malformed, duplicate, unknown, disabled-shape, and
+  shared-purpose issues as `ConfigIssue` entries.
+- Unknown ids are rejected even if their shape otherwise looks valid. To add a
+  new approved type, update `PREDEFINED_TASK_AGENT_IDS`,
+  `PREDEFINED_TASK_AGENT_DEFINITIONS`, tests, and this document together.
+- Empty string model/provider values mean “inherit the parent session setting,”
+  matching the existing delegation config convention. A `timeout_seconds` or
+  `max_summary_chars` value of `0` preserves the existing unlimited/default
+  runtime behavior where supported.

--- a/hermes_cli/agent_types.py
+++ b/hermes_cli/agent_types.py
@@ -1,0 +1,364 @@
+"""Predefined task-specific agent configuration.
+
+This module owns the static schema and validation helpers for the configured
+agents that higher-level session/orchestrator code can invoke.  It deliberately
+keeps the allowed set small: users may enable/disable or tune these predefined
+categories, but arbitrary new task-agent identifiers are rejected until the
+product explicitly supports them.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping
+
+
+PREDEFINED_TASK_AGENT_IDS = frozenset({
+    "research",
+    "implementation",
+    "review",
+    "documentation",
+})
+
+SUPPORTED_RUNTIME_KEYS = frozenset({
+    # Model/provider routing mirrors delegation.* and normal runtime provider
+    # resolution for OpenAI-compatible and native providers.
+    "model",
+    "provider",
+    "base_url",
+    "api_key",
+    "api_mode",
+    "reasoning_effort",
+    # Runtime controls already supported by the agent/delegation path.
+    "max_iterations",
+    "timeout_seconds",
+    "max_summary_chars",
+    "enabled_toolsets",
+    "disabled_toolsets",
+    "skills",
+})
+
+PREDEFINED_TASK_AGENT_DEFINITIONS: List[Dict[str, Any]] = [
+    {
+        "id": "research",
+        "enabled": True,
+        "purpose": "Collect and synthesize source-backed information before implementation or decisions.",
+        "invocation": {
+            "entrypoint": "delegate_task",
+            "task_category": "research",
+            "parameters": {
+                "required": ["prompt"],
+                "optional": ["context", "limit", "sources", "deliverable"],
+            },
+        },
+        "runtime": {
+            "enabled_toolsets": ["web", "file", "terminal", "skills"],
+            "skills": ["deep-research"],
+            "model": "",
+            "provider": "",
+            "base_url": "",
+            "api_key": "",
+            "api_mode": "",
+            "reasoning_effort": "",
+            "max_iterations": 50,
+            "timeout_seconds": 0,
+            "max_summary_chars": 24000,
+        },
+    },
+    {
+        "id": "implementation",
+        "enabled": True,
+        "purpose": "Build or modify the requested artifact using repository tools and verification checks.",
+        "invocation": {
+            "entrypoint": "delegate_task",
+            "task_category": "implementation",
+            "parameters": {
+                "required": ["prompt"],
+                "optional": ["context", "workdir", "tests", "constraints"],
+            },
+        },
+        "runtime": {
+            "enabled_toolsets": ["file", "terminal", "search", "skills", "todo"],
+            "skills": ["test-driven-development"],
+            "model": "",
+            "provider": "",
+            "base_url": "",
+            "api_key": "",
+            "api_mode": "",
+            "reasoning_effort": "",
+            "max_iterations": 50,
+            "timeout_seconds": 0,
+            "max_summary_chars": 24000,
+        },
+    },
+    {
+        "id": "review",
+        "enabled": True,
+        "purpose": "Evaluate completed work for correctness, regressions, security, and readiness before handoff.",
+        "invocation": {
+            "entrypoint": "delegate_task",
+            "task_category": "review",
+            "parameters": {
+                "required": ["prompt"],
+                "optional": ["context", "diff", "tests", "risk_focus"],
+            },
+        },
+        "runtime": {
+            "enabled_toolsets": ["file", "terminal", "search", "skills"],
+            "skills": ["github-code-review", "requesting-code-review"],
+            "model": "",
+            "provider": "",
+            "base_url": "",
+            "api_key": "",
+            "api_mode": "",
+            "reasoning_effort": "",
+            "max_iterations": 50,
+            "timeout_seconds": 0,
+            "max_summary_chars": 24000,
+        },
+    },
+    {
+        "id": "documentation",
+        "enabled": True,
+        "purpose": "Produce user-facing or integration documentation from the implemented behavior and verified examples.",
+        "invocation": {
+            "entrypoint": "delegate_task",
+            "task_category": "documentation",
+            "parameters": {
+                "required": ["prompt"],
+                "optional": ["context", "audience", "format", "examples"],
+            },
+        },
+        "runtime": {
+            "enabled_toolsets": ["file", "search", "skills"],
+            "skills": [],
+            "model": "",
+            "provider": "",
+            "base_url": "",
+            "api_key": "",
+            "api_mode": "",
+            "reasoning_effort": "",
+            "max_iterations": 50,
+            "timeout_seconds": 0,
+            "max_summary_chars": 24000,
+        },
+    },
+]
+
+
+@dataclass(frozen=True)
+class TaskAgentDefinition:
+    """Resolved task-agent definition consumed by invocation integrations."""
+
+    id: str
+    purpose: str
+    enabled: bool
+    invocation: Dict[str, Any]
+    runtime: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class TaskAgentConfigIssue:
+    """A schema validation issue for task_agents configuration."""
+
+    severity: str
+    message: str
+    hint: str
+
+
+class TaskAgentConfigError(ValueError):
+    """Raised when task agent definitions cannot be loaded safely."""
+
+    def __init__(self, issues: Iterable[TaskAgentConfigIssue]):
+        self.issues = list(issues)
+        super().__init__("; ".join(issue.message for issue in self.issues))
+
+
+def default_task_agents_config() -> Dict[str, Any]:
+    """Return a fresh default task_agents config section."""
+
+    return {"definitions": copy.deepcopy(PREDEFINED_TASK_AGENT_DEFINITIONS)}
+
+
+def validate_task_agents_config(config: Mapping[str, Any]) -> List[TaskAgentConfigIssue]:
+    """Validate the task_agents section in a loaded config mapping."""
+
+    issues: List[TaskAgentConfigIssue] = []
+    section = config.get("task_agents")
+    if section is None:
+        return issues
+    if not isinstance(section, Mapping):
+        return [TaskAgentConfigIssue(
+            "error",
+            f"task_agents should be a dict, got {type(section).__name__}",
+            "Use task_agents.definitions as a list of predefined agent definitions.",
+        )]
+
+    definitions = section.get("definitions")
+    if definitions is None:
+        issues.append(TaskAgentConfigIssue(
+            "error",
+            "task_agents.definitions is required",
+            "Add a definitions list containing only approved predefined task-agent ids.",
+        ))
+        return issues
+    if not isinstance(definitions, list):
+        issues.append(TaskAgentConfigIssue(
+            "error",
+            f"task_agents.definitions should be a list, got {type(definitions).__name__}",
+            "Change to: task_agents:\n  definitions:\n    - id: research",
+        ))
+        return issues
+
+    seen_ids: Dict[str, int] = {}
+    seen_purposes: Dict[str, str] = {}
+    for index, entry in enumerate(definitions):
+        prefix = f"task_agents.definitions[{index}]"
+        if not isinstance(entry, Mapping):
+            issues.append(TaskAgentConfigIssue(
+                "error",
+                f"{prefix} should be a dict, got {type(entry).__name__}",
+                "Each definition needs id, purpose, enabled, invocation, and optional runtime.",
+            ))
+            continue
+
+        agent_id = entry.get("id")
+        if not isinstance(agent_id, str) or not agent_id.strip():
+            issues.append(TaskAgentConfigIssue("error", f"{prefix}.id must be a non-empty string", "Use one of: " + ", ".join(sorted(PREDEFINED_TASK_AGENT_IDS))))
+            continue
+        if agent_id not in PREDEFINED_TASK_AGENT_IDS:
+            issues.append(TaskAgentConfigIssue(
+                "error",
+                f"Unknown task_agents id '{agent_id}'",
+                "Only predefined task-agent ids are supported: " + ", ".join(sorted(PREDEFINED_TASK_AGENT_IDS)),
+            ))
+        if agent_id in seen_ids:
+            issues.append(TaskAgentConfigIssue(
+                "error",
+                f"Duplicate task_agents id '{agent_id}'",
+                f"Keep exactly one definition for '{agent_id}'. First seen at index {seen_ids[agent_id]}.",
+            ))
+        else:
+            seen_ids[agent_id] = index
+
+        if not isinstance(entry.get("enabled"), bool):
+            issues.append(TaskAgentConfigIssue(
+                "error",
+                f"{prefix}.enabled must be a boolean",
+                "Set enabled to true or false.",
+            ))
+
+        purpose = entry.get("purpose")
+        if not isinstance(purpose, str) or not purpose.strip():
+            issues.append(TaskAgentConfigIssue(
+                "error",
+                f"{prefix}.purpose must be a non-empty string",
+                "Describe the distinct job this predefined agent performs.",
+            ))
+        else:
+            normalized_purpose = " ".join(purpose.lower().split())
+            if normalized_purpose in seen_purposes:
+                issues.append(TaskAgentConfigIssue(
+                    "error",
+                    f"task_agents '{seen_purposes[normalized_purpose]}' and '{agent_id}' share the same purpose",
+                    "Each configured task-agent type must have a distinct purpose.",
+                ))
+            else:
+                seen_purposes[normalized_purpose] = agent_id
+
+        invocation = entry.get("invocation")
+        if not isinstance(invocation, Mapping):
+            issues.append(TaskAgentConfigIssue(
+                "error",
+                f"{prefix}.invocation must be a dict",
+                "Invocation must specify entrypoint, task_category, and parameters.",
+            ))
+        else:
+            if invocation.get("entrypoint") != "delegate_task":
+                issues.append(TaskAgentConfigIssue(
+                    "error",
+                    f"{prefix}.invocation.entrypoint must be 'delegate_task'",
+                    "Configured task agents currently invoke through the existing delegate_task path.",
+                ))
+            if invocation.get("task_category") != agent_id:
+                issues.append(TaskAgentConfigIssue(
+                    "error",
+                    f"{prefix}.invocation.task_category must match id '{agent_id}'",
+                    "Keep task_category equal to the stable task-agent id.",
+                ))
+            parameters = invocation.get("parameters")
+            if not isinstance(parameters, Mapping):
+                issues.append(TaskAgentConfigIssue(
+                    "error",
+                    f"{prefix}.invocation.parameters must be a dict",
+                    "Use parameters.required and parameters.optional lists for integration-time validation.",
+                ))
+            else:
+                required = parameters.get("required", [])
+                optional = parameters.get("optional", [])
+                if not isinstance(required, list) or not all(isinstance(item, str) for item in required):
+                    issues.append(TaskAgentConfigIssue("error", f"{prefix}.invocation.parameters.required must be a list of strings", "List required invocation input names."))
+                elif "prompt" not in required:
+                    issues.append(TaskAgentConfigIssue("error", f"{prefix}.invocation.parameters.required must include 'prompt'", "Task-specific agents need a prompt to execute."))
+                if not isinstance(optional, list) or not all(isinstance(item, str) for item in optional):
+                    issues.append(TaskAgentConfigIssue("error", f"{prefix}.invocation.parameters.optional must be a list of strings", "List optional invocation input names."))
+
+        runtime = entry.get("runtime", {})
+        if runtime is None:
+            runtime = {}
+        if not isinstance(runtime, Mapping):
+            issues.append(TaskAgentConfigIssue(
+                "error",
+                f"{prefix}.runtime must be a dict when provided",
+                "Runtime may contain model/provider overrides, toolsets, skills, and limits.",
+            ))
+        else:
+            unknown_runtime = sorted(set(runtime) - SUPPORTED_RUNTIME_KEYS)
+            if unknown_runtime:
+                issues.append(TaskAgentConfigIssue(
+                    "error",
+                    f"{prefix}.runtime has unsupported keys {unknown_runtime}",
+                    "Supported runtime keys: " + ", ".join(sorted(SUPPORTED_RUNTIME_KEYS)),
+                ))
+            for string_key in ("model", "provider", "base_url", "api_key", "api_mode", "reasoning_effort"):
+                if string_key in runtime and not isinstance(runtime[string_key], str):
+                    issues.append(TaskAgentConfigIssue("error", f"{prefix}.runtime.{string_key} must be a string", "Use an empty string to inherit the session setting."))
+            for int_key in ("max_iterations", "timeout_seconds", "max_summary_chars"):
+                if int_key in runtime:
+                    value = runtime[int_key]
+                    if not isinstance(value, int) or value < 0:
+                        issues.append(TaskAgentConfigIssue("error", f"{prefix}.runtime.{int_key} must be a non-negative integer", "Use 0 for the existing runtime default/unlimited behavior where supported."))
+            for list_key in ("enabled_toolsets", "disabled_toolsets", "skills"):
+                if list_key in runtime and not (isinstance(runtime[list_key], list) and all(isinstance(item, str) for item in runtime[list_key])):
+                    issues.append(TaskAgentConfigIssue("error", f"{prefix}.runtime.{list_key} must be a list of strings", "Use YAML list syntax, e.g. enabled_toolsets: [web, file]."))
+
+    return issues
+
+
+def load_task_agent_definitions(config: Mapping[str, Any]) -> Dict[str, TaskAgentDefinition]:
+    """Return validated task-agent definitions keyed by stable id.
+
+    Raises TaskAgentConfigError when the config contains errors.  Warnings are
+    currently not produced by the validator; if that changes, callers can still
+    load when all issues are non-error.
+    """
+
+    issues = validate_task_agents_config(config)
+    errors = [issue for issue in issues if issue.severity == "error"]
+    if errors:
+        raise TaskAgentConfigError(errors)
+
+    section = config.get("task_agents") or default_task_agents_config()
+    definitions = section.get("definitions", []) if isinstance(section, Mapping) else []
+    loaded: Dict[str, TaskAgentDefinition] = {}
+    for entry in definitions:
+        runtime = dict(entry.get("runtime") or {})
+        loaded[entry["id"]] = TaskAgentDefinition(
+            id=entry["id"],
+            purpose=entry["purpose"],
+            enabled=entry["enabled"],
+            invocation=dict(entry["invocation"]),
+            runtime=runtime,
+        )
+    return loaded

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -26,6 +26,7 @@ import yaml
 from hermes_cli.cli_output import line_input
 from hermes_cli.colors import Colors, color
 from hermes_cli import managed_scope
+from hermes_cli.agent_types import validate_task_agents_config
 from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul
 from hermes_cli.secret_prompt import masked_secret_prompt
 # Re-export from hermes_constants — canonical definition lives there.
@@ -1232,6 +1233,10 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                    f"Move '{key}' under the appropriate section")
 
     _validate_web_backends(config, issues)
+
+    for task_agent_issue in validate_task_agents_config(config):
+        _issue(issues, task_agent_issue.severity, task_agent_issue.message, task_agent_issue.hint)
+
     return issues
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -4,6 +4,8 @@ Pure-data leaf module — must not import from hermes_cli.config. Comments are t
 docs of config.yaml.
 """
 
+from hermes_cli.agent_types import default_task_agents_config
+
 
 def _aux(timeout, *, reasoning_effort=True, **extra):
     """Standard auxiliary-task model block (see DEFAULT_CONFIG["auxiliary"]).
@@ -2340,7 +2342,13 @@ DEFAULT_CONFIG = {
         # Extra ports detection probes for an external llama-server (besides 8080).
         "detect_ports": [],
     },
-    "_config_version": 41,  # Config schema version - bump this when adding new required fields
+
+    # Predefined task-specific agents. The integration layer can invoke these stable ids from a
+    # main or orchestrator session while preserving a narrow, validated product surface. Runtime
+    # fields mirror the delegation and model-provider settings above.
+    "task_agents": default_task_agents_config(),
+
+    "_config_version": 42,  # Config schema version - bump this when adding new required fields
 }
 
 

--- a/tests/hermes_cli/test_task_agents_config.py
+++ b/tests/hermes_cli/test_task_agents_config.py
@@ -1,0 +1,159 @@
+"""Tests for predefined task-agent configuration schema."""
+
+from __future__ import annotations
+
+import importlib
+
+import yaml
+
+
+EXPECTED_AGENT_IDS = {"research", "implementation", "review", "documentation"}
+
+
+def test_default_predefined_task_agents_have_distinct_purposes():
+    from hermes_cli.agent_types import PREDEFINED_TASK_AGENT_DEFINITIONS
+
+    ids = {entry["id"] for entry in PREDEFINED_TASK_AGENT_DEFINITIONS}
+    purposes = [entry["purpose"] for entry in PREDEFINED_TASK_AGENT_DEFINITIONS]
+
+    assert ids == EXPECTED_AGENT_IDS
+    assert len(purposes) == len(set(purposes))
+    for entry in PREDEFINED_TASK_AGENT_DEFINITIONS:
+        assert entry["enabled"] is True
+        assert entry["invocation"]["entrypoint"] == "delegate_task"
+        assert entry["invocation"]["task_category"] == entry["id"]
+        assert "prompt" in entry["invocation"]["parameters"]["required"]
+
+
+def test_valid_task_agent_definitions_load_as_dataclasses():
+    from hermes_cli.agent_types import load_task_agent_definitions
+
+    agents = load_task_agent_definitions({
+        "task_agents": {
+            "definitions": [
+                {
+                    "id": "research",
+                    "purpose": "Collect and synthesize source-backed information before implementation.",
+                    "enabled": True,
+                    "invocation": {
+                        "entrypoint": "delegate_task",
+                        "task_category": "research",
+                        "parameters": {"required": ["prompt"], "optional": ["context"]},
+                    },
+                    "runtime": {
+                        "provider": "openrouter",
+                        "model": "anthropic/claude-sonnet-4",
+                        "reasoning_effort": "high",
+                        "max_iterations": 12,
+                        "enabled_toolsets": ["web", "file"],
+                    },
+                },
+            ]
+        }
+    })
+
+    assert set(agents) == {"research"}
+    assert agents["research"].id == "research"
+    assert agents["research"].runtime["model"] == "anthropic/claude-sonnet-4"
+
+
+def test_load_config_supplies_default_task_agents(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("model: test-model\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import hermes_constants
+    import hermes_cli.config as config_mod
+
+    importlib.reload(hermes_constants)
+    importlib.reload(config_mod)
+
+    cfg = config_mod.load_config()
+    assert {entry["id"] for entry in cfg["task_agents"]["definitions"]} == EXPECTED_AGENT_IDS
+
+
+def test_validate_config_structure_rejects_duplicate_task_agent_ids():
+    from hermes_cli.config import validate_config_structure
+
+    issues = validate_config_structure({
+        "task_agents": {
+            "definitions": [
+                {
+                    "id": "research",
+                    "purpose": "Research sources.",
+                    "enabled": True,
+                    "invocation": {"entrypoint": "delegate_task", "task_category": "research", "parameters": {"required": ["prompt"]}},
+                },
+                {
+                    "id": "research",
+                    "purpose": "Do another research task.",
+                    "enabled": True,
+                    "invocation": {"entrypoint": "delegate_task", "task_category": "research", "parameters": {"required": ["prompt"]}},
+                },
+            ]
+        }
+    })
+
+    assert any(issue.severity == "error" and "Duplicate task_agents id 'research'" in issue.message for issue in issues)
+
+
+def test_validate_config_structure_rejects_unknown_or_malformed_task_agents():
+    from hermes_cli.config import validate_config_structure
+
+    issues = validate_config_structure({
+        "task_agents": {
+            "definitions": [
+                {
+                    "id": "social-media",
+                    "purpose": "Post to social media.",
+                    "enabled": "yes",
+                    "invocation": {"entrypoint": "shell", "task_category": "social-media", "parameters": {}},
+                },
+            ]
+        }
+    })
+    messages = "\n".join(issue.message for issue in issues)
+
+    assert "Unknown task_agents id 'social-media'" in messages
+    assert "enabled must be a boolean" in messages
+    assert "invocation.entrypoint must be 'delegate_task'" in messages
+
+
+def test_validate_config_structure_rejects_shared_purposes():
+    from hermes_cli.config import validate_config_structure
+
+    issues = validate_config_structure({
+        "task_agents": {
+            "definitions": [
+                {
+                    "id": "research",
+                    "purpose": "Analyze the task.",
+                    "enabled": True,
+                    "invocation": {"entrypoint": "delegate_task", "task_category": "research", "parameters": {"required": ["prompt"]}},
+                },
+                {
+                    "id": "review",
+                    "purpose": "Analyze the task.",
+                    "enabled": True,
+                    "invocation": {"entrypoint": "delegate_task", "task_category": "review", "parameters": {"required": ["prompt"]}},
+                },
+            ]
+        }
+    })
+
+    assert any("share the same purpose" in issue.message for issue in issues)
+
+
+def test_documented_schema_example_is_valid_yaml_and_loads():
+    from hermes_cli.agent_types import load_task_agent_definitions
+
+    from pathlib import Path
+    docs_path = Path(__file__).parents[2] / "docs" / "task-agents-config.md"
+    content = docs_path.read_text(encoding="utf-8")
+    start = content.index("```yaml") + len("```yaml")
+    end = content.index("```", start)
+    example = yaml.safe_load(content[start:end])
+
+    agents = load_task_agent_definitions(example)
+    assert set(agents) == EXPECTED_AGENT_IDS


### PR DESCRIPTION
## Summary
- Adds a task_agents.definitions config section for a small, closed set of stable task-specific agent ids (research, implementation, review, documentation) that a main/orchestrator session can invoke through the existing delegate_task path, instead of an open plugin registry.
- Each definition carries a validated invocation contract (entrypoint, task_category, required/optional parameters) and an optional runtime override block reusing the same keys as delegation.* (model, provider, base_url, reasoning_effort, toolsets, skills, iteration/timeout limits).
- hermes_cli/agent_types.py owns the schema, defaults, and validator (validate_task_agents_config / load_task_agent_definitions). Wired into config_defaults.py (new task_agents key, _config_version 41->42) and config.py's validate_config_structure so malformed/unknown/duplicate/shared-purpose definitions surface as ordinary ConfigIssue entries.
- This PR defines the schema only -- nothing yet reads task_agents.definitions to route a delegate_task call by id. Filing separately since it's independently useful (validated config surface) and reviewable on its own; happy to follow up with the invocation wiring in a second PR once this shape is agreed on.

## Test plan
- pytest tests/hermes_cli/test_task_agents_config.py -v -- 7/7 new tests pass
- pytest tests/hermes_cli/test_config*.py tests/hermes_cli/test_set_config_value.py -- 310 passed, 4 skipped, 0 failed