### PR TITLE
test(agent): isolate runtime-main state in auxiliary vision tests (#105888)

### DIFF
--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -15,6 +15,45 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_runtime_main():
+    """Give every test in this file a clean runtime-main baseline (#105888).
+
+    ``resolve_vision_provider_client`` (and the ``auto`` routers) read the live
+    main runtime from a process-global context var plus the legacy compat
+    mirrors.  Earlier auxiliary-client tests that call ``set_runtime_main`` (or
+    patch the mirrors) can leave that state populated; when they run first, the
+    custom-provider tests below inherit it, the context override shadows their
+    monkeypatched mirrors, and endpoint resolution collapses to the wrong
+    provider — so the tests pass or fail depending on collection order.
+
+    Snapshot the context var + every mirror global, reset to an empty baseline
+    before the test, and restore the originals afterwards so results are
+    order-independent regardless of what ran earlier in the process.
+    """
+    import agent.auxiliary_client as aux
+
+    mirror_names = (
+        "_RUNTIME_MAIN_PROVIDER",
+        "_RUNTIME_MAIN_MODEL",
+        "_RUNTIME_MAIN_BASE_URL",
+        "_RUNTIME_MAIN_API_KEY",
+        "_RUNTIME_MAIN_API_MODE",
+        "_RUNTIME_MAIN_AUTH_MODE",
+        "_RUNTIME_MAIN_COMPAT_SNAPSHOT",
+    )
+    saved = {name: getattr(aux, name) for name in mirror_names}
+    token = aux._RUNTIME_MAIN_CONTEXT.set(None)
+    aux._publish_runtime_main_mirrors(("", "", "", "", "", ""))
+    try:
+        yield
+    finally:
+        aux._RUNTIME_MAIN_CONTEXT.reset(token)
+        for name, value in saved.items():
+            setattr(aux, name, value)
 
 
 # ── Text aux tasks — _resolve_auto_route ──────────────────────────────────────────


### PR DESCRIPTION
Fixes #105888

## Problem

`resolve_vision_provider_client` (and the `auto` routers) read the live main runtime from a process-global context var (`_RUNTIME_MAIN_CONTEXT`) plus the legacy compat mirrors in `agent/auxiliary_client.py`. Earlier auxiliary-client tests that call `set_runtime_main` (or patch the mirrors directly) can leave that state populated for the rest of the process.

When such a test runs first, the two custom-provider vision tests inherit the leaked runtime:

- `test_custom_main_forwards_runtime_endpoint`
- `test_custom_prefixed_main_forwards_runtime_endpoint`

The inherited context override shadows the mirrors they monkeypatch, so `_runtime_main_value(...)` returns the leaked endpoint instead of the one under test and provider resolution collapses to the wrong arm (`openai`). The tests therefore pass or fail depending on collection order.

### Reproduction (before this change)

```
pytest tests/agent/test_auxiliary_client.py \
       tests/agent/test_auxiliary_main_first.py::TestResolveVisionCustomProvider
# → both custom-provider tests FAIL (provider == 'openai')

pytest tests/agent/test_auxiliary_main_first.py::TestResolveVisionCustomProvider
# → passes in isolation
```

## Fix

Add a module-level autouse fixture in `tests/agent/test_auxiliary_main_first.py` that:

1. snapshots the context var and every runtime-main mirror global (+ the compat snapshot),
2. resets them to an empty baseline before each test, and
3. restores the originals afterwards.

This is a test-only change — no production code is touched. Each test now establishes and restores the runtime compatibility state it depends on, so results are order-independent, exactly as the issue's *Expected* section asks.

## Verification

```
# was failing, now green:
pytest tests/agent/test_auxiliary_client.py \
       tests/agent/test_auxiliary_main_first.py::TestResolveVisionCustomProvider   # 207 passed
# both leak directions + file alone:
pytest tests/agent/test_auxiliary_main_first.py                                     # 17 passed
pytest tests/agent/test_auxiliary_main_first.py tests/agent/test_auxiliary_client.py # 221 passed
```

Preflight gates (windows-footguns, ruff, affected tests) pass against `upstream/main`.
