### PR TITLE
fix(website): generate llms.txt in build:fast via prebuild:fast hook

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -8,6 +8,7 @@
     "start": "docusaurus start",
     "prebuild": "node scripts/prebuild.mjs",
     "build": "docusaurus build",
+    "prebuild:fast": "node scripts/prebuild.mjs --fast",
     "build:fast": "docusaurus build --locale en",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/website/scripts/prebuild.mjs
+++ b/website/scripts/prebuild.mjs
@@ -21,6 +21,17 @@
 // succeeds — the Skills Hub page just shows an empty state, and llms.txt
 // generation is skipped. CI always has the deps installed, so production
 // deploys get real data.
+//
+// The `--fast` flag (used by the `prebuild:fast` script that gates
+// `build:fast`) skips the slow skill-extraction + unified-index network fetch
+// but still runs generate-llms-txt.py. `build:fast` only builds the default
+// (`en`) locale for quick local iteration, and npm's `prebuild` lifecycle
+// hook only fires before a script named exactly `build` — not `build:fast` —
+// so without `prebuild:fast` the gitignored `static/llms.txt` /
+// `static/llms-full.txt` are never generated, and Docusaurus emits broken-link
+// warnings for the `/docs/llms.txt` + `/docs/llms-full.txt` links in
+// docs/index.mdx (see #105890). `--fast` keeps `build:fast` fast while
+// resolving those links.
 
 import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync, existsSync, statSync } from "node:fs";
@@ -37,6 +48,7 @@ const unifiedIndexFile = join(websiteDir, "static", "api", "skills-index.json");
 const UNIFIED_INDEX_URL =
   "https://hermes-agent.nousresearch.com/docs/api/skills-index.json";
 const UNIFIED_INDEX_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h
+const fast = process.argv.includes("--fast");
 
 function writeEmptyFallback(reason) {
   mkdirSync(dirname(outputFile), { recursive: true });
@@ -119,11 +131,20 @@ async function ensureUnifiedIndex() {
   }
 }
 
-// 0) Pull unified index if we don't have a fresh one.
-await ensureUnifiedIndex();
+// 0) Pull unified index if we don't have a fresh one. Skipped in --fast mode
+//    (network fetch; not needed to generate llms.txt).
+if (!fast) {
+  await ensureUnifiedIndex();
+}
 
-// 1) skills.json — required for the Skills Hub page.
-if (!existsSync(extractScript)) {
+// 1) skills.json — required for the Skills Hub page. Skipped in --fast mode
+//    (extract-skills.py crawls every skill source and takes several minutes);
+//    just ensure the file exists (empty fallback) so the build doesn't 404 it.
+if (fast) {
+  if (!existsSync(outputFile)) {
+    writeEmptyFallback("fast mode (--fast skips skill extraction)");
+  }
+} else if (!existsSync(extractScript)) {
   writeEmptyFallback("extract script missing");
 } else {
   const r = spawnSync("python3", [extractScript], {
@@ -141,5 +162,7 @@ if (!existsSync(extractScript)) {
 runPython(llmsScript, "generate-llms-txt.py");
 
 // 3) automation-blueprints-index.json — Automation Blueprints catalog page. Non-fatal; the page
-//    renders an empty state if the generator can't run.
-runPython(cronBlueprintsScript, "extract-automation-blueprints.py");
+//    renders an empty state if the generator can't run. Skipped in --fast mode.
+if (!fast) {
+  runPython(cronBlueprintsScript, "extract-automation-blueprints.py");
+}


### PR DESCRIPTION
## What does this PR do?

Fixes broken-link warnings in `npm run build:fast`. Docusaurus emits broken-link warnings for `/docs/llms.txt` and `/docs/llms-full.txt` because those gitignored files (generated only by `website/scripts/prebuild.mjs`) are never produced during a fast build — which also fires in CI (runs `build:fast` without `generate-llms-txt.py`). This PR adds a `prebuild:fast` npm script + a `--fast` flag to `prebuild.mjs` that keeps the fast, self-contained `generate-llms-txt.py` step while skipping the slow network/skill-crawl steps.

## Related Issue

Closes #105890.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

Root cause: `build:fast` is defined as `docusaurus build --locale en`. npm's `prebuild` lifecycle hook only fires before a script named **exactly** `build` — not `build:fast` — so the `prebuild` script (`node scripts/prebuild.mjs`) never runs, and `static/llms.txt` / `static/llms-full.txt` are absent when Docusaurus validates the `[/llms.txt]` + `[/llms-full.txt]` links in `docs/index.mdx`.

The fix: add a `prebuild:fast` npm script that runs `prebuild.mjs --fast`, plus a `--fast` flag to `prebuild.mjs` that:
- **Skips** the slow steps: unified-index network fetch (step 0), `extract-skills.py` skill crawl (step 1), and `extract-automation-blueprints.py` (step 3).
- **Keeps** the fast, self-contained, no-network `generate-llms-txt.py` step (step 2) so `static/llms.txt` + `static/llms-full.txt` exist when Docusaurus builds.
- Writes an empty `skills.json` fallback only if the file is missing (so it doesn't clobber an existing populated one from a prior full build).

The full `prebuild` path (run by `npm run build` / `npm run start`) is **unchanged** — `--fast` only gates the slow optional steps; when the flag is absent, every step runs exactly as before.

Files:
- `website/scripts/prebuild.mjs` — add `--fast` flag + gate the slow steps behind `!fast`; keep `generate-llms-txt.py` always-on.
- `website/package.json` — add `prebuild:fast` script so npm's lifecycle hook fires before `build:fast`.

## How to Test

End-to-end, from a clean checkout of `main` with `node v24.15.0` + `npm 12`:

**Before fix (reproduces #105890):** `npm run build:fast` → `[WARNING] Docusaurus found broken links! -> /docs/llms.txt + /docs/llms-full.txt` (exit 0, but warnings present).

**After fix:**
```
$ npm run build:fast
> prebuild:fast → node scripts/prebuild.mjs --fast
  Wrote static/llms.txt (39,584 bytes)
  Wrote static/llms-full.txt (4,173,858 bytes)
> docusaurus build --locale en
[SUCCESS] Generated static files in "build".   # 0 broken-link warnings
```

The `prebuild:fast` step runs in ~0.1s (fast — no skill crawl, no network). `node --check scripts/prebuild.mjs` passes; `package.json` is valid JSON.

The non-fast `prebuild` path is byte-identical in behavior (verified by diff: changes are purely additive `if (fast)` / `if (!fast)` guards around the slow steps; when `--fast` is absent, all original blocks execute).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(website): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `npm run build:fast` and it completes with 0 broken-link warnings
- [x] I've verified the non-fast `prebuild` path is unchanged (additive `if (fast)` guards only)
- [x] I've tested on my platform: macOS 15.2 (node v24.15.0, npm 12)

### Documentation & Housekeeping

- [x] N/A — build-script fix; the slow optional steps remain documented in the full `prebuild` path, no public doc surface changed