### PR TITLE
fix(prompt): memory-only sessions no longer request unavailable skill writes

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -158,15 +158,11 @@ HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS = (
 )
 
 
-# Memory guidance (#95681, consolidated): ONE block from ONE builder. The opening frame adapts to which
-# stores config enables; everything else is written exactly once. Leads with the positive posture (save
-# proactively, replace when full) — the routing rules come after, as refinements, not as the headline. WHAT
-# belongs in memory is the memory tool schema's job and is never re-taught here.
-def build_memory_guidance(memory_enabled: bool = True, profile_enabled: bool = True) -> str:
-    """ONE memory-guidance block whose opening frame adapts to the enabled store(s); "" when both are off.
-
-    Positive posture first, routing rules as refinements. WHAT belongs in memory is the tool schema's job.
-    """
+# Keep the every-session memory scope even when task knowledge cannot be saved as a skill.
+def build_memory_guidance(
+    memory_enabled: bool = True, profile_enabled: bool = True, *, skill_manage_available: bool = True,
+) -> str:
+    """Adapt store and skill-write guidance without widening what belongs in memory."""
     if not memory_enabled and not profile_enabled:
         return ""
     if memory_enabled:
@@ -180,11 +176,17 @@ def build_memory_guidance(memory_enabled: bool = True, profile_enabled: bool = T
             "loaded into each new session's context; save durable facts about the user with the "
             "memory tool (target='user') — the built-in notes store is disabled, so never target='memory'. "
         )
-    return frame + (
+    skill_routing = (
         "Skills come first: when you learn something while doing a task — a "
         "procedure, a pitfall, and the user's preferences and corrections "
         "for that kind of work — record it in the skill you used or built "
         "for the task (skill_manage), where it loads only when relevant. "
+        if skill_manage_available else
+        "Task-specific knowledge — procedures, pitfalls, and the user's preferences "
+        "and corrections for that kind of work — belongs in skills, not in memory, "
+        "even when skill writing is unavailable. "
+    )
+    return frame + skill_routing + (
         "Memory is the narrow exception for facts that apply to EVERY "
         "session regardless of task (who the user is, environment facts, "
         "standing conventions with no task home); it has a hard character "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -19,8 +19,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, EXECUTION_GUIDANCE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
-    HERMES_AGENT_HELP_GUIDANCE, HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS, KANBAN_GUIDANCE, MEMORY_GUIDANCE,
-    USER_PROFILE_GUIDANCE, PARALLEL_TOOL_CALL_GUIDANCE, PLATFORM_HINTS, SESSION_SEARCH_GUIDANCE,
+    HERMES_AGENT_HELP_GUIDANCE, HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS, KANBAN_GUIDANCE,
+    PARALLEL_TOOL_CALL_GUIDANCE, PLATFORM_HINTS, SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE, STEER_CHANNEL_NOTE, TASK_COMPLETION_GUIDANCE, TELEGRAM_RICH_MESSAGES_HINT,
     TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, drain_truncation_warnings,
 )
@@ -277,10 +277,11 @@ def _tool_guidance_block(agent: Any) -> Optional[str]:
     # available"; with only USER.md enabled the narrower block is used.
     memory_guidance = None
     if "memory" in names:
-        if getattr(agent, "_memory_enabled", True):
-            memory_guidance = MEMORY_GUIDANCE
-        elif getattr(agent, "_user_profile_enabled", True):
-            memory_guidance = USER_PROFILE_GUIDANCE
+        memory_guidance = _pb.build_memory_guidance(
+            getattr(agent, "_memory_enabled", True),
+            getattr(agent, "_user_profile_enabled", True),
+            skill_manage_available="skill_manage" in names,
+        )
     # Kanban lifecycle: resolved once at __init__ (_kanban_worker_guidance);
     # the kanban_show fallback covers code paths that bypass agent_init.
     _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -6,6 +6,8 @@ from types import SimpleNamespace
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
+import pytest
+
 from agent.system_prompt import build_system_prompt, build_system_prompt_parts
 
 
@@ -53,6 +55,28 @@ def _captured_context_cwd(agent):
     ):
         build_system_prompt_parts(agent)
     return captured["cwd"]
+
+
+@pytest.mark.parametrize("stores", [(True, True), (False, True), (True, False), (False, False)])
+@pytest.mark.parametrize("names", [
+    set(), {"memory"}, {"memory", "skill_view", "skills_list"},
+    {"memory", "skill_view", "skills_list", "skill_manage"},
+])
+def test_memory_guidance_respects_available_writes(stores, names, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    agent = _make_agent(valid_tool_names=names, skip_context_files=True,
+                        _memory_enabled=stores[0], _user_profile_enabled=stores[1])
+    prompt = build_system_prompt(agent)
+    enabled = "memory" in names and any(stores)
+    assert ("Memory is the narrow exception" in prompt) == enabled
+    assert ("(skill_manage)" in prompt) == (enabled and "skill_manage" in names)
+    if enabled:
+        assert "EVERY session regardless of task" in prompt
+        assert "procedures and workflows belong in skills" in prompt
+        if "skill_manage" not in names:
+            assert "not in memory" in prompt
+    if enabled and not stores[0]:
+        assert "never target='memory'" in prompt
 
 
 class TestContextFileCwd:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -862,11 +862,10 @@ class TestBuildSystemPrompt:
 
 
     def test_memory_guidance_when_memory_tool_loaded(self, agent_with_memory_tool):
-        from agent.prompt_builder import MEMORY_GUIDANCE
-
         agent_with_memory_tool._memory_enabled = True
         prompt = agent_with_memory_tool._build_system_prompt()
-        assert MEMORY_GUIDANCE in prompt
+        assert "Memory is the narrow exception" in prompt
+        assert "(skill_manage)" not in prompt
 
     def test_no_memory_guidance_when_both_builtin_stores_disabled(
         self, agent_with_memory_tool
@@ -895,13 +894,15 @@ class TestBuildSystemPrompt:
         MEMORY.md store that does not exist in this configuration, so the
         profile-specific block is injected instead.
         """
-        from agent.prompt_builder import MEMORY_GUIDANCE, USER_PROFILE_GUIDANCE
+        from agent.prompt_builder import MEMORY_GUIDANCE
 
         agent_with_memory_tool._memory_enabled = False
         agent_with_memory_tool._user_profile_enabled = True
         prompt = agent_with_memory_tool._build_system_prompt()
         assert MEMORY_GUIDANCE not in prompt
-        assert USER_PROFILE_GUIDANCE in prompt
+        assert "memory tool (target='user')" in prompt
+        assert "never target='memory'" in prompt
+        assert "(skill_manage)" not in prompt
 
 
 

--- a/website/docs/developer-guide/prompt-assembly.md
+++ b/website/docs/developer-guide/prompt-assembly.md
@@ -67,10 +67,10 @@ You value correctness, clarity, and efficiency.
 ...
 
 # Layer 2: Tool-aware behavior guidance
-You have persistent memory across sessions. Save durable facts using
-the memory tool: user preferences, environment details, tool quirks,
-and stable conventions. Memory is injected into every turn, so keep
-it compact and focused on facts that will still matter later.
+Task-learned procedures, pitfalls, and task-specific preferences belong
+in skills. Memory is the narrow exception for facts that apply to EVERY
+session regardless of task. Skill-writing instructions appear here only
+when skill_manage is available; its absence does not widen memory's scope.
 ...
 When the user references something from a past conversation or you
 suspect relevant cross-session context exists, use session_search


### PR DESCRIPTION
Memory-only sessions no longer receive an instruction to call unavailable `skill_manage`, without treating task knowledge as memory.

- Render the memory block using the session's actual skill-write capability and enabled stores.
- Preserve skills-first task routing, the every-session-only memory exception, profile-only target restrictions, and byte-identical fully capable guidance.
- Keep existing prompt/memory snapshots and rebuild boundaries unchanged; update the prompt-assembly example.

Root cause: `_tool_guidance_block` selected unconditional memory constants using only the `memory` tool gate.

## Validation

**Live repro:** On freshly fetched main `b2aa855b626ff8688eb34b95c60ee8b6a4af3679`, real isolated-home AIAgent construction with `valid_tool_names={'memory'}` rendered `(skill_manage)`; after this fix it does not.

| Check | Result |
|---|---|
| Real AIAgent + production prompt builder; writable skills / memory-only / no tools × default / profile-only / notes-only / off | 12 cases per arm; 3 dangling memory instructions before, 0 after; tool populations unchanged |
| Fully capable guidance | Exact bytes unchanged across all store variants |
| Invariant RED → GREEN | 6 failing / 10 passing before → all 16 matrix rows passing after |
| Real loopback HTTP/SSE, two conversation turns with an intervening successful disk memory write | Identical system messages; cached prompt unchanged; no unavailable skill instruction |
| `scripts/run_tests.sh -j 8 tests/agent/ tests/run_agent/` | 8,726 passed, 0 failed, 30 skipped across 723 files |
| Final serial affected-file run | 428 passed, 0 failed across 3 files |
| Ruff, Windows footguns, compatibility pointers, diff whitespace | Passed |

No paid model inference or provider cache/billing claim. The loopback peer supplies explicit test-fixture responses; an initial fixture incorrectly returned JSON to a streaming request, then was corrected to honor SSE before the successful run. Native non-Linux execution was not performed.

## Scope and prior work

Related to #95681. Existing PR #74274 by @santhiprakash identifies the broader skill-write capability class; its complete thread and diff were reviewed. This patch addresses the newer skills-first memory wording introduced by `562ee8ab76a`, preserving that policy rather than restoring the older paragraph. It does not replace that PR's separate skills-index or `/learn` changes and does not close either issue.

## Infographic

![Capability-aware memory guidance](https://v3b.fal.media/files/b/0aa9a0ee/GWPM54XpBq32HvRl105yu_SzO633QK.png)
