### PR TITLE
fix(gateway): treat unreadable user-local bin dirs as absent when building service PATH

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2606,7 +2606,10 @@ def _build_user_local_paths(home: Path, path_entries: list[str]) -> list[str]:
         str(home / "go" / "bin"),  # Go tools
         str(home / ".npm-global" / "bin"),  # npm global packages
     ]
-    return [p for p in candidates if p not in path_entries and Path(p).exists()]
+    # os.path.exists, not Path.exists: pathlib only swallows ENOENT/ENOTDIR-class
+    # errors and propagates EACCES, which fires when an ancestor dir denies +X
+    # (e.g. stat'ing /root/.local/bin as non-root on a 0700 /root).
+    return [p for p in candidates if p not in path_entries and os.path.exists(p)]
 
 
 def _build_wsl_interop_paths(path_entries: list[str]) -> list[str]:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1312,6 +1312,27 @@ class TestSystemUnitHermesHome:
         assert "Wants=user@1001.service" in unit_section
         assert "user@" not in user_unit
 
+    def test_system_unit_tolerates_unreadable_home_bin_dirs(self, monkeypatch, tmp_path):
+        """A home whose bin-dir ancestors deny +X (e.g. /root as non-root) must not crash
+        unit generation: unreadable candidates are treated as absent, not PermissionError."""
+        locked_home = tmp_path / "lockedhome"
+        (locked_home / ".local" / "bin").mkdir(parents=True)
+        locked_home.chmod(0o000)
+        try:
+            monkeypatch.setattr(Path, "home", staticmethod(lambda: locked_home))
+            monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+            monkeypatch.setattr(
+                gateway_cli, "_system_service_identity",
+                lambda run_as_user=None: ("alice", "alice", str(tmp_path), 1001),
+            )
+            monkeypatch.setattr(gateway_cli, "_build_service_path_dirs", lambda: [])
+
+            user_unit = gateway_cli.generate_systemd_unit(system=False)
+        finally:
+            locked_home.chmod(0o700)
+
+        assert str(locked_home / ".local" / "bin") not in user_unit
+
     def test_system_unit_uses_target_user_home_not_calling_user(self, monkeypatch):
         # Simulate sudo: Path.home() returns /root, target user is alice
         monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))


### PR DESCRIPTION
## Summary

`generate_systemd_unit()` crashes with `PermissionError` when the invoking user cannot traverse an ancestor of a user-local bin dir — most visibly, `test_system_unit_orders_after_target_user_manager` (landed in 4c4845f0af) monkeypatches `Path.home` to `/root`, and on runners with a protected `/root` the unit generation dies instead of completing. This currently fails PR CI across the repo.

## Why

`_build_user_local_paths()` checks candidates with `Path(p).exists()`, but `pathlib.Path.exists()` only swallows ENOENT/ENOTDIR-class errors and **propagates** `EACCES`:

- `candidates` include `<home>/.local/bin`, `<home>/.cargo/bin`, `<home>/go/bin`, `<home>/.npm-global/bin`
- on a `/root` mode `0700` box as non-root, `os.stat('/root/.local/bin')` raises `PermissionError: [Errno 13]`
- `pathlib` re-raises anything outside its ignore list, so `exists()` throws and `generate_systemd_unit()` aborts

The same crash class exists for real users: generating a user unit while the target home's ancestors are unreadable to the caller.

## What Changed

- `_build_user_local_paths()` uses `os.path.exists()`, which maps any `OSError` to `False` — an unreadable candidate is treated as absent, which is the correct answer for a `PATH=` entry.
- Added `test_system_unit_tolerates_unreadable_home_bin_dirs`: a mode-`000` home makes the condition deterministic locally, instead of depending on runner images keeping `/root` closed.

## Verification

- `tests/hermes_cli/test_gateway_service.py::TestSystemUnitHermesHome` — 8 passed (was: `test_system_unit_orders_after_target_user_manager` failing with `PermissionError: [Errno 13] Permission denied: '/root/.local/bin'`)
- The new regression test fails without the fix and passes with it
- Full `tests/hermes_cli/test_gateway_service.py` — 106 passed, 1 skipped
- `ruff check` clean


This also unblocks the currently-failing `Run tests` check on other open PRs (e.g. #15851, #105970), which fail on this same test via the shared base.
