### PR TITLE
fix(wecom): give media uploads a generous, tunable timeout (#105900)

### DIFF
--- a/plugins/platforms/wecom/media.py
+++ b/plugins/platforms/wecom/media.py
@@ -8,6 +8,7 @@ import base64
 import hashlib
 import logging
 import mimetypes
+import os
 import re
 import uuid
 from pathlib import Path
@@ -30,6 +31,9 @@ FILE_MAX_BYTES = 20 * 1024 * 1024
 ABSOLUTE_MAX_BYTES = FILE_MAX_BYTES
 UPLOAD_CHUNK_SIZE = 512 * 1024
 MAX_UPLOAD_CHUNKS = 100
+# Chunked media uploads (init/chunk/finish) carry hundreds of KB of base64 per request and must not
+# share the short per-request control timeout, or ~1 MB+ files reliably time out (#105900). Env-tunable.
+DEFAULT_MEDIA_UPLOAD_TIMEOUT_SECONDS = 120.0
 VOICE_SUPPORTED_MIMES = {"audio/amr"}
 
 _IMAGE_MAGIC = ((b"\x89PNG\r\n\x1a\n", ".png"), (b"\xff\xd8\xff", ".jpg"), ((b"GIF87a", b"GIF89a"), ".gif"))
@@ -48,6 +52,25 @@ def _dict_at(container: Dict[str, Any], key: str) -> Dict[str, Any]:
 
 def _media_body(media_type: str, media_id: str) -> Dict[str, Any]:
     return {"msgtype": media_type, media_type: {"media_id": media_id}}
+
+
+def _media_upload_timeout_seconds() -> float:
+    """Per-request timeout for the chunked media upload flow (env ``WECOM_MEDIA_UPLOAD_TIMEOUT``).
+
+    Read at call time so ops can tune it without a code change; a missing, malformed, or non-positive
+    value falls back to the default rather than crashing the upload.
+    """
+    raw = os.getenv("WECOM_MEDIA_UPLOAD_TIMEOUT", "").strip()
+    if raw:
+        try:
+            value = float(raw)
+        except ValueError:
+            logger.warning("[wecom] Ignoring invalid WECOM_MEDIA_UPLOAD_TIMEOUT=%r; using %.0fs", raw, DEFAULT_MEDIA_UPLOAD_TIMEOUT_SECONDS)
+        else:
+            if value > 0:
+                return value
+            logger.warning("[wecom] Ignoring non-positive WECOM_MEDIA_UPLOAD_TIMEOUT=%r; using %.0fs", raw, DEFAULT_MEDIA_UPLOAD_TIMEOUT_SECONDS)
+    return DEFAULT_MEDIA_UPLOAD_TIMEOUT_SECONDS
 
 
 class WeComMediaMixin:
@@ -246,8 +269,9 @@ class WeComMediaMixin:
         detected_type = self._detect_wecom_media_type(content_type)
         return {"data": data, "content_type": content_type, "file_name": resolved_name, "detected_type": detected_type, **self._apply_file_size_limits(len(data), detected_type, content_type)}
 
-    async def _checked_request(self, cmd: str, body: Dict[str, Any], operation: str) -> Dict[str, Any]:
-        self._raise_for_wecom_error(response := await self._send_request(cmd, body), operation)
+    async def _checked_request(self, cmd: str, body: Dict[str, Any], operation: str, *, timeout: Optional[float] = None) -> Dict[str, Any]:
+        request_kwargs = {} if timeout is None else {"timeout": timeout}
+        self._raise_for_wecom_error(response := await self._send_request(cmd, body, **request_kwargs), operation)
         return response
 
     async def _upload_media_bytes(self, data: bytes, media_type: str, filename: str) -> Dict[str, Any]:
@@ -256,15 +280,16 @@ class WeComMediaMixin:
         total_size, total_chunks = len(data), (len(data) + UPLOAD_CHUNK_SIZE - 1) // UPLOAD_CHUNK_SIZE
         if total_chunks > MAX_UPLOAD_CHUNKS:
             raise ValueError(f"File too large: {total_chunks} chunks exceeds maximum of {MAX_UPLOAD_CHUNKS} chunks")
+        upload_timeout = _media_upload_timeout_seconds()
         init_payload = {"type": media_type, "filename": filename, "total_size": total_size, "total_chunks": total_chunks, "md5": hashlib.md5(data).hexdigest()}
-        init_response = await self._checked_request(APP_CMD_UPLOAD_MEDIA_INIT, init_payload, "media upload init")
+        init_response = await self._checked_request(APP_CMD_UPLOAD_MEDIA_INIT, init_payload, "media upload init", timeout=upload_timeout)
         upload_id = str(_dict_at(init_response, "body").get("upload_id") or "").strip()
         if not upload_id:
             raise RuntimeError(f"media upload init failed: missing upload_id in response {init_response}")
         for chunk_index, start in enumerate(range(0, total_size, UPLOAD_CHUNK_SIZE)):  # official SDK uses 0-based chunk indexes
             chunk_b64 = base64.b64encode(data[start : start + UPLOAD_CHUNK_SIZE]).decode("ascii")
-            await self._checked_request(APP_CMD_UPLOAD_MEDIA_CHUNK, {"upload_id": upload_id, "chunk_index": chunk_index, "base64_data": chunk_b64}, f"media upload chunk {chunk_index}")
-        finish_response = await self._checked_request(APP_CMD_UPLOAD_MEDIA_FINISH, {"upload_id": upload_id}, "media upload finish")
+            await self._checked_request(APP_CMD_UPLOAD_MEDIA_CHUNK, {"upload_id": upload_id, "chunk_index": chunk_index, "base64_data": chunk_b64}, f"media upload chunk {chunk_index}", timeout=upload_timeout)
+        finish_response = await self._checked_request(APP_CMD_UPLOAD_MEDIA_FINISH, {"upload_id": upload_id}, "media upload finish", timeout=upload_timeout)
         finish_body = _dict_at(finish_response, "body")
         media_id = str(finish_body.get("media_id") or "").strip()
         if not media_id:

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -355,6 +355,65 @@ class TestMediaUpload:
 
         assert connect_attempts == []
 
+    @staticmethod
+    def _upload_send_request_mock():
+        async def _fake_send_request(cmd, body, *, timeout=None):
+            if cmd == "aibot_upload_media_init":
+                return {"body": {"upload_id": "upload-1"}}
+            if cmd == "aibot_upload_media_finish":
+                return {"body": {"media_id": "media-1", "type": "file"}}
+            return {}
+
+        return AsyncMock(side_effect=_fake_send_request)
+
+    @pytest.mark.asyncio
+    async def test_upload_media_bytes_uses_generous_timeout(self, monkeypatch):
+        """init/chunk/finish must not share the short 15s control timeout (#105900)."""
+        from plugins.platforms.wecom.adapter import REQUEST_TIMEOUT_SECONDS, WeComAdapter
+        from plugins.platforms.wecom.media import DEFAULT_MEDIA_UPLOAD_TIMEOUT_SECONDS
+
+        monkeypatch.delenv("WECOM_MEDIA_UPLOAD_TIMEOUT", raising=False)
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_request = self._upload_send_request_mock()
+
+        # >1 chunk so an oversized file exercises multiple chunk requests.
+        data = b"x" * (512 * 1024 + 10)
+        result = await adapter._upload_media_bytes(data, "file", "report.xlsx")
+
+        assert result["media_id"] == "media-1"
+        timeouts = [call.kwargs.get("timeout") for call in adapter._send_request.await_args_list]
+        assert timeouts, "no upload requests were issued"
+        assert all(t == DEFAULT_MEDIA_UPLOAD_TIMEOUT_SECONDS for t in timeouts), timeouts
+        assert DEFAULT_MEDIA_UPLOAD_TIMEOUT_SECONDS != REQUEST_TIMEOUT_SECONDS
+        # init + 2 chunks + finish
+        assert len(timeouts) == 4
+
+    @pytest.mark.asyncio
+    async def test_upload_media_bytes_timeout_env_override(self, monkeypatch):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.setenv("WECOM_MEDIA_UPLOAD_TIMEOUT", "250")
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_request = self._upload_send_request_mock()
+
+        await adapter._upload_media_bytes(b"tiny", "file", "note.txt")
+
+        timeouts = [call.kwargs.get("timeout") for call in adapter._send_request.await_args_list]
+        assert timeouts and all(t == 250.0 for t in timeouts), timeouts
+
+    @pytest.mark.asyncio
+    async def test_upload_media_bytes_invalid_timeout_env_falls_back(self, monkeypatch):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+        from plugins.platforms.wecom.media import DEFAULT_MEDIA_UPLOAD_TIMEOUT_SECONDS
+
+        for bad in ("not-a-number", "0", "-5"):
+            monkeypatch.setenv("WECOM_MEDIA_UPLOAD_TIMEOUT", bad)
+            adapter = WeComAdapter(PlatformConfig(enabled=True))
+            adapter._send_request = self._upload_send_request_mock()
+            await adapter._upload_media_bytes(b"tiny", "file", "note.txt")
+            timeouts = [call.kwargs.get("timeout") for call in adapter._send_request.await_args_list]
+            assert all(t == DEFAULT_MEDIA_UPLOAD_TIMEOUT_SECONDS for t in timeouts), (bad, timeouts)
+
 
 class TestSend:
 


### PR DESCRIPTION
Fixes #105900

## Problem

On WeCom, sending non-image file attachments above ~1 MB (e.g. a ~1.2 MB `.xlsx`) reliably fails with `Timeout sending media to WeCom`, then falls back to the generic "⚠️ Couldn't deliver the file attachment" notice. Small files (tens to ~100 KB) send fine.

**Root cause:** the chunked upload flow (`aibot_upload_media_init` → `aibot_upload_media_chunk` → `aibot_upload_media_finish`) in `plugins/platforms/wecom/media.py` routes every request through `_checked_request` → `_send_request`, which uses the shared `REQUEST_TIMEOUT_SECONDS = 15.0` meant for lightweight control commands. Each chunk carries a 512 KiB slice base64-encoded (~680 KB per request), so files above ~1 MB blow past the 15 s window and every attempt times out — consistent with the reporter's timeline evidence (failures ~15.4 s after "Delivering … MEDIA attachment(s)").

## Fix

- Add a dedicated, env-tunable per-request timeout for the upload flow: `WECOM_MEDIA_UPLOAD_TIMEOUT` (default **120 s**), read at call time so it can be tuned for slow connections without a code change.
- Thread an optional `timeout` through `_checked_request` and apply it to init/chunk/finish. Control commands keep the existing 15 s default.
- A missing, malformed, or non-positive env value falls back to the default (and logs a warning) rather than crashing the upload at parse time.

Only the upload path changes; no wire/protocol change.

## Tests (`tests/gateway/test_wecom.py::TestMediaUpload`)

- `test_upload_media_bytes_uses_generous_timeout` — a >1-chunk file issues init + chunks + finish, all with the generous timeout, asserting it differs from the 15 s control default.
- `test_upload_media_bytes_timeout_env_override` — `WECOM_MEDIA_UPLOAD_TIMEOUT=250` is honored on every upload request.
- `test_upload_media_bytes_invalid_timeout_env_falls_back` — `not-a-number` / `0` / `-5` all fall back to the default.

Full file: `66 passed, 3 skipped` under the project env. (`windows-footguns` and `ruff` preflight gates pass; the affected-test gate false-fails only because that runner's venv lacks `pytest-asyncio`, so all async tests error identically — verified green via `uv run python -m pytest`.)
