### PR TITLE
fix(compression): lean tails stay lean with smaller auxiliary models

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1697,13 +1697,16 @@ def _lower_threshold_to_aux_context(
 ) -> None:
     """Lower the live threshold to the aux model's window and tell the user how to fix config.
     The summariser sends one user prompt (no system/tools), so threshold == aux_context is safe.
-    tail_token_budget and threshold_percent are kept in lockstep (as update_model does) or the 1.5x tail
-    ceiling exceeds the trigger and re-fires."""
+    Retention is recalibrated through its selected policy: lean is window-relative;
+    only legacy follows the lowered threshold."""
     compressor = agent.context_compressor
     old_threshold = compressor.threshold_tokens
     new_threshold = compressor.threshold_tokens = aux_context
     summary_target_ratio = getattr(compressor, "summary_target_ratio", None)
-    if isinstance(summary_target_ratio, (int, float)):
+    if getattr(compressor, "tail_mode", None) == "lean":
+        # Keep the window-relative policy owned by the compressor property.
+        compressor._tail_token_budget = None
+    elif isinstance(summary_target_ratio, (int, float)):
         compressor.tail_token_budget = int(new_threshold * summary_target_ratio)
     main_ctx = compressor.context_length
     if main_ctx:

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -66,6 +66,47 @@ def _make_agent(
     return agent
 
 
+@pytest.mark.parametrize("main_context,aux_context", [(1_000_000, 512_000), (400_000, 80_000)])
+def test_aux_sync_keeps_lean_tail_policy(main_context, aux_context):
+    """Lowering only the trigger must not change window-relative retention."""
+    agent = _make_agent(main_context=main_context)
+    compressor = agent.context_compressor = ContextCompressor(
+        "test-main-model", config_context_length=main_context,
+        threshold_percent=0.85, quiet_mode=True,
+    )
+    before = compressor.tail_token_budget
+    agent._emit_status = lambda message: None
+    client = MagicMock(base_url="http://localhost/v1", api_key="test-key")
+    with patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(client, "aux")), \
+         patch("agent.model_metadata.get_model_context_length", return_value=aux_context):
+        agent._check_compression_model_feasibility()
+        assert compressor.threshold_tokens == aux_context
+        assert compressor.tail_token_budget == before
+        # Repeated feasibility and subsequent model recalibration retain policy.
+        agent._check_compression_model_feasibility()
+        assert compressor.tail_token_budget == before
+        compressor.update_model("test-main-model", context_length=main_context)
+        assert compressor.tail_token_budget == before
+
+
+def test_aux_sync_legacy_tail_follows_lowered_threshold():
+    """Explicit legacy retention follows the current trigger, not its old cache."""
+    agent = _make_agent(main_context=1_000_000)
+    compressor = agent.context_compressor = ContextCompressor(
+        "test-main-model", config_context_length=1_000_000,
+        threshold_percent=0.85, tail_mode="legacy", quiet_mode=True,
+    )
+    before = compressor.tail_token_budget
+    agent._emit_status = lambda message: None
+    client = MagicMock(base_url="http://localhost/v1", api_key="test-key")
+    with patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(client, "aux")), \
+         patch("agent.model_metadata.get_model_context_length", return_value=512_000):
+        agent._check_compression_model_feasibility()
+    assert compressor.threshold_tokens == 512_000
+    assert compressor.tail_token_budget < before
+    assert compressor.tail_token_budget == int(compressor.threshold_tokens * compressor.summary_target_ratio)
+
+
 # ── Core warning logic ──────────────────────────────────────────────
 
 

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -216,6 +216,17 @@ Consumers observe the mode rather than diffing session ids:
 
 Set `in_place: false` to restore the legacy rotating path, where each compaction commits a new session id linked to the previous one via `parent_session_id`.
 
+### Auxiliary feasibility and tail retention
+
+A smaller auxiliary compression model can lower the live compression trigger without
+changing the selected tail policy. In `lean` mode the selection budget remains based
+on the **main model's context window**: 2.5%, clamped to 10K–25K tokens. For example,
+a 1M main model with a 512K auxiliary model retains a 25K selection budget even when
+feasibility lowers its trigger from 850K to 512K. Explicit `legacy` mode instead
+recomputes `threshold_tokens × target_ratio` (102,400 tokens at 512K × 0.20).
+These are tail-selection budgets, not strict limits on the entire compacted context:
+protected messages, boundary alignment, summaries, and anchors can add tokens.
+
 ### Per-model threshold overrides
 
 `compression.model_thresholds` lets you trigger compaction at different points


### PR DESCRIPTION
Lean compaction keeps its window-relative tail budget when auxiliary feasibility lowers the session trigger.

- Invalidate the lean budget cache instead of assigning the legacy formula; explicit legacy and engine fallbacks keep their existing behavior. No new API or configuration.
- Add two invariant tests covering lean retention at both clamp endpoints, repeated feasibility, model recalibration, and explicit legacy recalculation.
- Document selection budgets versus total compacted context.

Root cause: `_lower_threshold_to_aux_context` unconditionally cached `threshold × target_ratio`, bypassing the mode-aware property.

**Live repro:** fresh main `b2aa855b626ff8688eb34b95c60ee8b6a4af3679`, real `AIAgent` + temporary SQLite, public feasibility check followed by admitted in-place compaction:

| Receipt | Before | After |
|---|---:|---:|
| Lean, 1M main / 512K auxiliary: tail after feasibility | 102,400 (from 25,000) | 25,000 |
| Same lean transcript: active messages after compaction | 42 / 100 | 12 / 100 |
| Explicit legacy: tail after feasibility | 102,400 (from 170,000) | 102,400 |
| Explicit legacy: active messages | 42 / 100 | 42 / 100 |
| Original messages archived intact, each mode | 100 | 100 |

Both runs preserve newest ask/answer, role alternation, input role/content, and exact active SQLite role/content. Summary generation and auxiliary metadata/client resolution use offline fixtures; this proves retention and commit plumbing, **not model summary quality or recall**. No user configuration/logs or paid model calls were used.

Validation: canonical runner **171 passed, 0 failed** across feasibility, compressor, and in-place compaction files. RED on main: both lean cases failed at the actual budget comparison; explicit legacy passed. Ruff, Windows-footgun scan, compatibility-pointer scan, and `git diff --check` pass. Full affected-directory validation also passed: **8,713 passed, 0 failed, 30 skipped across 723 files** (`tests/agent/` + `tests/run_agent/`, canonical runner, Linux; native OS skips remain for CI). CI is pending under the canonical notified watcher.

Writer sweep: constructor/lazy-context and `update_model()` already invalidate the cache; TUI configuration synchronization does too. Property writes own the lean/legacy formulas; remaining assignments are explicit test/eval overrides. Only auxiliary feasibility needed correction.

Related #95681. Narrow adaptation of #93576 by @TurgutKural (credited in the commit): retain its diagnosis/invariants without introducing a required recalibration method on context engines. #92738's model-update case is already fixed on main; #100355's reversible auxiliary-route clamp is broader and not claimed here. No issue or source PR is automatically closed by this PR.

## Infographic
![Lean auxiliary feasibility](https://v3b.fal.media/files/b/0aa9a0e9/5BnaCcFWuYbWuLlq6Oy63_Gw5c24Oh.png)
