### PR TITLE
fix(delegation): inactive grouping no longer occupies the tool schema

### DIFF
--- a/evals/delegation_group_schema/README.md
+++ b/evals/delegation_group_schema/README.md
@@ -1,0 +1,48 @@
+# Delegation grouping schema receipts
+
+`probe.py TREE OUTPUT [--independent]` assembles real eager CLI tool definitions
+in a fresh, credential-free temporary home with networking forbidden. Run it
+in separate interpreters against base and fix with the same arguments.
+Requires `tiktoken` (`o200k_base`); counts use compact OpenAI function JSON.
+This measures schema footprint, not model quality or billed savings.
+
+Base: `b2aa855b626ff8688eb34b95c60ee8b6a4af3679`.
+
+| Policy | Base delegate tokens | Fixed delegate tokens | Change |
+| --- | ---: | ---: | ---: |
+| Default off | 927 | 826 | -101 |
+| Explicit on | 927 | 913 | -14 |
+
+Only `delegate_task` changed in either same-config comparison. Total eager
+CLI schemas were 7586 → 7485 (off), 7586 → 7572 (on). The field remains
+available when enabled; its parameter schema is unchanged. Repeated assembly
+is byte-stable. The two invariants also check static/previous schema immutability,
+legacy task normalization, and grouped/ungrouped delivery partitioning.
+The default-off exposure assertion failed on base before implementation.
+
+## Real-model N=1 child smoke
+
+Pinned to configured Nous `google/gemini-3.7-flash`; no provider fallback.
+A separate temporary home held only copied Nous authentication and minimal
+explicit configuration (no personal skills/memory). One forced parent tool call
+using the real default-off registry schema produced a one-task array without
+`group`. The actual delegation handler then built and ran one real AIAgent child,
+which completed in one API call with `GROUP_GATE_OK`. Parent tool bytes were
+unchanged across child execution. This is a schema-acceptance/execution smoke,
+not a comparative quality evaluation or proof of asynchronous delivery timing.
+
+Before inference, the live catalog was read and an approximately $0.016 budget
+estimated for two calls (20k input + 1024 output allowance).
+
+| Inference | Input | Output | Reasoning (included in output) | API-reported `usage.cost` |
+| --- | ---: | ---: | ---: | ---: |
+| Parent schema call | 796 | 104 | 75 | $0.000987 |
+| Child | 708 | 42 | 37 | $0.0006885 |
+| Total | 1504 | 146 | 112 | $0.0016755 |
+
+Parent request ID: `gen-1788889571-fBLF8eStu3UAevfGtvgD`.
+The raw provider usage exposes the same values as `upstream_inference_cost`;
+these are API-reported costs, not an independently reconciled Portal invoice.
+The child result's local estimator instead reported `$0.000551` with
+`cost_status: estimated`; do not substitute that estimate for the raw receipt.
+Local full receipt: `/tmp/delegation-group-live-receipt.json`.

--- a/evals/delegation_group_schema/probe.py
+++ b/evals/delegation_group_schema/probe.py
@@ -1,0 +1,51 @@
+"""Offline same-config schema probe. Run in a fresh interpreter for each tree/policy.
+
+python probe.py /path/to/tree /tmp/receipt.json [--independent]
+Requires tiktoken; no model calls or model-quality claims.
+"""
+
+import json
+import os
+from pathlib import Path
+import socket
+import sys
+import tempfile
+
+root, destination = sys.argv[1:3]
+sys.path.insert(0, root)
+os.chdir(root)
+with tempfile.TemporaryDirectory(prefix="delegate-schema-") as home:
+    os.environ.clear()
+    os.environ.update(HOME=home, HERMES_HOME=home, PATH="/usr/bin:/bin", HERMES_PLATFORM="cli")
+    config = {"tools": {"tool_search": {"defer": []}}}
+    if "--independent" in sys.argv:
+        config["delegation"] = {"independent_completions": True}
+    Path(home, "config.yaml").write_text(json.dumps(config), encoding="utf-8")
+
+    def deny_network(*args, **kwargs):
+        raise RuntimeError("Offline schema probe forbids network access")
+
+    socket.socket.connect = deny_network
+    import tiktoken
+    from model_tools import get_tool_definitions
+
+    encoder = tiktoken.get_encoding("o200k_base")
+    definitions = get_tool_definitions(enabled_toolsets=["hermes-cli"], quiet_mode=True)
+    serialized = json.dumps(definitions, separators=(",", ":"))
+    repeated = get_tool_definitions(enabled_toolsets=["hermes-cli"], quiet_mode=True)
+    assert json.dumps(repeated, separators=(",", ":")) == serialized
+    counts = {
+        definition["function"]["name"]: len(encoder.encode(json.dumps(definition, separators=(",", ":"))))
+        for definition in definitions
+    }
+    delegate = next(d for d in definitions if d["function"]["name"] == "delegate_task")
+    receipt = {
+        "config": config,
+        "tokens": counts,
+        "total_tokens": sum(counts.values()),
+        "delegate": delegate,
+        "repeated_assembly_byte_stable": True,
+        "model_calls": 0,
+    }
+    Path(destination).write_text(json.dumps(receipt, indent=2), encoding="utf-8")
+    print(json.dumps({"destination": destination, "total_tokens": receipt["total_tokens"], "delegate_tokens": counts["delegate_task"]}))

--- a/tests/tools/test_delegate_group_schema.py
+++ b/tests/tools/test_delegate_group_schema.py
@@ -1,0 +1,47 @@
+"""Grouping is advertised only when the delivery policy consumes it."""
+
+import json
+from dataclasses import fields
+
+from tools.delegate_tool import DELEGATE_TASK_SCHEMA, _strip_model_hidden_task_fields
+from tools.delegate_tool_dispatch import _Batch, _units_of
+from tools.delegate_tool_tasks import _normalize_task_list
+from tools.registry import registry
+
+
+def test_group_schema_tracks_delivery_policy_without_mutating_previous_definitions(monkeypatch):
+    from tools import delegate_tool_config
+
+    original = json.dumps(DELEGATE_TASK_SCHEMA)
+    snapshots = []
+    for config in ({}, {"independent_completions": True}, {"independent_completions": False}):
+        monkeypatch.setattr(delegate_tool_config, "_cfg", lambda: config)
+        definition = registry.get_definitions({"delegate_task"})[0]
+        enabled = config.get("independent_completions", False)
+        task = definition["function"]["parameters"]["properties"]["tasks"]["items"]
+        assert ("group" in task["properties"]) == enabled
+        assert ("group" in definition["function"]["description"]) == enabled
+        assert json.dumps(registry.get_definitions({"delegate_task"})[0]) == json.dumps(definition)
+        for previous, serialized in snapshots:
+            assert json.dumps(previous) == serialized
+        snapshots.append((definition, json.dumps(definition)))
+    assert json.dumps(DELEGATE_TASK_SCHEMA) == original
+
+
+def test_legacy_group_replay_remains_accepted_and_delivery_policy_controls_units(monkeypatch):
+    from tools import delegate_tool_config
+
+    tasks = [{"goal": "Review first module", "group": "join"}, {"goal": "Review second module", "group": "join"}, {"goal": "Review third module"}]
+    assert _strip_model_hidden_task_fields(tasks) is tasks
+    normalized, error = _normalize_task_list(None, None, tasks, None, "leaf", 3)
+    assert error is None and normalized == tasks
+    batch = _Batch(**{field.name: None for field in fields(_Batch)})
+    batch.children = [(i, task, None) for i, task in enumerate(tasks)]
+    for enabled in (False, True):
+        monkeypatch.setattr(delegate_tool_config, "_cfg", lambda: {"independent_completions": enabled})
+        units = _units_of(batch)
+        if enabled:
+            assert [[i for i, _, _ in unit.children] for unit in units] == [[0, 1], [2]]
+            assert [unit.group for unit in units] == ["join", None]
+        else:
+            assert units == [batch]

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -498,7 +498,7 @@ def delegate_task(
 
 # ── OpenAI function-calling schema ──────────────────────────────────────────
 
-def _build_top_level_description() -> str:
+def _build_top_level_description(*, independent_completions=None) -> str:
     """delegate_task description: ONLY guidance stated nowhere else in the schema
     (limits live in the 'tasks' parameter description, rebuilt per get_definitions())."""
     try:
@@ -515,15 +515,22 @@ def _build_top_level_description() -> str:
         )
     else:
         restrictions_rule = "- Children cannot call delegate_task, clarify, memory, or cronjob.\n"
-    return _DESCRIPTION_HEAD + restrictions_rule + _DESCRIPTION_TAIL
+    from tools.delegate_tool_config import _get_independent_completions
+
+    if independent_completions is None:
+        independent_completions = _get_independent_completions()
+    delivery = (
+        "each ungrouped task / `group` returns on its own"
+        if independent_completions else "one message per call"
+    )
+    return _DESCRIPTION_HEAD.format(delivery=delivery) + restrictions_rule + _DESCRIPTION_TAIL
 
 _DESCRIPTION_HEAD = (
     "Spawn subagents in isolated contexts; each gets its own conversation, terminal session, and toolset, and only its "
     "final summary returns to you. Pass every task in `tasks` — one entry spawns one subagent, several run in parallel "
     "(limit in the tasks description).\n\n"
     "Runs in the background: dispatch returns immediately with live transcript paths, and the call's results re-enter "
-    "the conversation as a new message when its subagents finish (one message per call by default; with "
-    "delegation.independent_completions each ungrouped task / `group` returns on its own). Results are delivered only "
+    "the conversation as a new message when its subagents finish ({delivery}). Results are delivered only "
     "BETWEEN your turns: finish whatever does not depend on them, then give a one-line status and END YOUR TURN. Never "
     "wait or poll on transcripts, artifact files, or CI for a child. "
     "While children run, `action` (list/steer/stop) controls them live — steer when a transcript shows a "
@@ -564,12 +571,24 @@ def _build_tasks_param_description() -> str:
 def _build_dynamic_schema_overrides() -> dict:
     """Per-call schema overrides (ToolEntry.dynamic_schema_overrides): every
     get_definitions() pass rewrites the descriptions to the user's actual limits."""
+    from tools.delegate_tool_config import _get_independent_completions
+
+    independent_completions = _get_independent_completions()
     overrides_params = {**DELEGATE_TASK_SCHEMA["parameters"]}
     # Copy properties so the static schema dict is never mutated.
     overrides_params["properties"] = {k: dict(v) for k, v in DELEGATE_TASK_SCHEMA["parameters"]["properties"].items()}
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
 
-    return {"description": _build_top_level_description(), "parameters": overrides_params}
+    if not independent_completions:
+        tasks = overrides_params["properties"]["tasks"]
+        tasks["items"] = {**tasks["items"], "properties": {
+            k: v for k, v in tasks["items"]["properties"].items() if k != "group"
+        }}
+
+    return {
+        "description": _build_top_level_description(independent_completions=independent_completions),
+        "parameters": overrides_params,
+    }
 
 def _p(type_: str, description: str, **extra) -> dict:
     return {"type": type_, **extra, "description": description}

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -165,7 +165,9 @@ When a top-level agent provides a `tasks` array, Hermes returns one background h
 
 ### Independent completions (opt-in)
 
-Set `delegation.independent_completions: true` to have results land **per completion unit** as each finishes instead:
+Set `delegation.independent_completions: true` to have results land **per completion unit** as each finishes instead. The model-facing `group` field and grouping guidance are only advertised when this option is enabled. Start a new session after changing it so the tool schema can reflect the setting without changing an existing conversation's cached prefix. Old calls containing `group` remain accepted; with the option off, the whole call still returns together.
+
+When independent completions are enabled:
 
 - Omit `group` when each result is useful to act on separately. Each task reports as soon as it finishes.
 - Use the same `group` string when you want to review outputs together: comparison, synthesis, or one coordinated decision. The group returns **one** consolidated message after all its tasks finish. Even independently executable tasks can belong in one group when their results inform the same decision.


### PR DESCRIPTION
`delegate_task` no longer advertises inactive result-grouping options in the default configuration.

- Gate `tasks[].group` and grouping-only top-level prose on the existing `delegation.independent_completions` resolver.
- Preserve the static schema, previously assembled definitions, legacy call acceptance, default-off behavior, and explicit-on grouped delivery.
- Document when the schema is exposed; include two invariants and a reproducible offline A/B harness under `evals/delegation_group_schema/`.

Root cause: the runtime already ignored task groups when independent completions were disabled, but its model-facing schema advertised the field and taught grouping unconditionally.

**Live repro:** fresh base `b2aa855b626ff8688eb34b95c60ee8b6a4af3679` exposes `group` with an empty delegation config (invariant fails); the fix omits it and all grouping prose, while explicit-on still exposes and consumes it. Repeated assembly and already-held schema bytes remain stable.

## Validation

| Check | Result |
| --- | --- |
| Same-config offline default-off A/B | delegate schema **927 → 826 tokens (-101)**; eager CLI total **7586 → 7485** |
| Same-config explicit-on A/B | delegate schema **927 → 913 tokens (-14)**; eager CLI total **7586 → 7572**; group parameter unchanged |
| Scope control | Only delegate_task token count changes; no behavior or config-default changes |
| New invariants + delegate suite | 83 passed |
| Final invariants + async delegation suite | 34 passed, 1 host-specific skip |
| Full tools directory | 8912 passed, 5 failed, 91 skipped, across 585 files; caveats below |
| Ruff, Windows footguns, compat pointers, diff check | Passed |
| Real-model N=1 child smoke | Nous `google/gemini-3.7-flash`; actual schema generated one child task without group, actual handler/child returned `GROUP_GATE_OK`; parent tool bytes unchanged |

The token counts use `o200k_base` over compact function JSON, not billed token claims or model-quality scores. Both offline arms used clean temporary homes and network denial. Duplicate sweep found #105617 is adjacent description-routing work, not this config gate; this PR does not adopt its routing rewrite.

### Live usage/cost receipt

Nous was explicitly selected with no provider fallback. Preflight read the live catalog and estimated about $0.016 before inference. Parent request `gen-1788889571-fBLF8eStu3UAevfGtvgD`: 796 input / 104 output, API-reported cost **$0.000987**. Child: 708 input / 42 output, API-reported cost **$0.0006885**. Total **$0.0016755** (1504 input / 146 output). Raw usage also labels these upstream inference costs; they are not an independently reconciled Portal invoice. The local child estimator separately said $0.000551, so it is not used as the exact receipt. Full details are in the eval README.

### Caveats

The full tools run is not green: two Modal optional-dependency failures, two Parallel SDK optional-dependency failures, and the real `sort --compress-program` fixture failure all reproduce unchanged on the exact base (133 passed / 5 failed / 1 skipped in the three-file base replay). The full run also needed a retry after `test_local_env_blocklist.py` exceeded its file timeout; its retry passed with thread warnings. No unrelated source or test behavior was changed to conceal these results. The live smoke exercises synchronous actual child execution, not background timing or comparative model quality. CI remains required; no merge is authorized.

## Infographic

![Lean delegation schema gate](https://v3b.fal.media/files/b/0aa9a0ff/sjo2AA6iBwDKT-6eWLQhB_hPRVv4F1.png)
