### PR TITLE
fix(cron): preserve next occurrence after manual run

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -345,8 +345,10 @@ def _build_anthropic_client_with_bearer_hook(
 def _new_sdk_client(sdk, kwargs: Dict[str, Any], headers: Dict[str, str]):
     """``sdk.Anthropic(**kwargs)`` with ``headers`` attached. Bearer-only construction leaves
     ``api_key`` unset, so the SDK fills it from ANTHROPIC_API_KEY (loaded from ~/.hermes/.env) and
-    sends dual auth — X-Api-Key *and* Authorization: Bearer — on every Portal/MiniMax/OAuth/Entra
-    request; clear it whenever we intentionally authenticated via auth_token."""
+    sends dual auth — X-Api-Key *and* Authorization: Bearer *** on every Portal/MiniMax/OAuth/Entra
+    request; clear it whenever we intentionally authenticated via auth_token. ``auth_token`` is
+    explicitly set to None for API-key clients so the SDK cannot inherit ANTHROPIC_AUTH_TOKEN from
+    the process environment and leak it to a third-party endpoint."""
     if headers:
         kwargs["default_headers"] = headers
     client = sdk.Anthropic(**kwargs)
@@ -392,6 +394,8 @@ def build_anthropic_client(api_key, base_url: str = None, timeout: float = None,
     common_betas = _common_betas_for_base_url(normalized_base_url, drop_context_1m_beta=drop_context_1m_beta)
     style = _auth_style(api_key, base_url, normalized_base_url)
     kwargs["auth_token" if style in ("bearer", "oauth") else "api_key"] = api_key
+    if style not in ("bearer", "oauth"):
+        kwargs["auth_token"] = None
     headers = _beta_header(common_betas + _OAUTH_ONLY_BETAS if style == "oauth" else common_betas)
     if style == "kimi":
         headers = {**_attribution_headers(), **headers}

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2457,6 +2457,11 @@ def advance_next_runs(job_ids) -> int:
                 job["id"] not in ids
                 or (is_terminal_job(job) and not _is_recoverable_error_job(job))
                 or job.get("schedule", {}).get("kind") not in {"cron", "interval"}
+                # A manual trigger deliberately reuses next_run_at as its due marker.
+                # Advancing it here would erase manual_run_at before claim_job_for_fire()
+                # can recognize the off-tick fire, causing the next scheduled occurrence
+                # to be consumed instead.
+                or job.get("manual_run_at") == job.get("next_run_at")
             ):
                 continue
             new_next = compute_next_run(job["schedule"], now)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -206,6 +206,24 @@ def named_profile_home(path: str | Path) -> Path | None:
     return None
 
 
+def profile_name_for_home(path: str | Path | None) -> str | None:
+    """Return the canonical profile id owning *path*, or ``None`` when it is not a profile home.
+
+    The default home is the Hermes root itself, so its basename is an installation detail (``.hermes``
+    on POSIX and commonly ``hermes`` on Windows), not the profile id ``default``.
+    """
+    if path is None or not str(path).strip():
+        return None
+    current = Path(path).expanduser()
+    try:
+        if current.resolve(strict=False) == get_default_hermes_root().resolve(strict=False):
+            return "default"
+        named = named_profile_home(current)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return named.name if named is not None else None
+
+
 def profile_tombstone_path(profile_home: Path) -> Path:
     return profile_home.parent / _DELETED_PROFILES_DIR / profile_home.name
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -216,16 +216,22 @@ def profile_name_for_home(path: str | Path | None) -> str | None:
         return None
     current = Path(path).expanduser()
     try:
-        if current.resolve(strict=False) == get_default_hermes_root().resolve(strict=False):
+        default_root = get_default_hermes_root()
+        if current == default_root:
+            return "default"
+        if current.parent.name == "profiles":
+            named = named_profile_home(current)
+            if named is not None:
+                return named.name
+            if current.name and not current.name.startswith("."):
+                return current.name
+        if current.resolve(strict=False) == default_root.resolve(strict=False):
             return "default"
         named = named_profile_home(current)
     except (OSError, RuntimeError, ValueError):
         return None
     if named is not None:
         return named.name
-    # Session records already carry a validated profile home. Preserve the
-    # established basename behavior for isolated test/custom roots whose
-    # parent is the conventional profiles directory but lacks root markers.
     if current.parent.name == "profiles" and current.name and not current.name.startswith("."):
         return current.name
     return None

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -221,7 +221,14 @@ def profile_name_for_home(path: str | Path | None) -> str | None:
         named = named_profile_home(current)
     except (OSError, RuntimeError, ValueError):
         return None
-    return named.name if named is not None else None
+    if named is not None:
+        return named.name
+    # Session records already carry a validated profile home. Preserve the
+    # established basename behavior for isolated test/custom roots whose
+    # parent is the conventional profiles directory but lacks root markers.
+    if current.parent.name == "profiles" and current.name and not current.name.startswith("."):
+        return current.name
+    return None
 
 
 def profile_tombstone_path(profile_home: Path) -> Path:

--- a/hermes_state_fts.py
+++ b/hermes_state_fts.py
@@ -8,7 +8,24 @@ import sqlite3
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
-from hermes_state_common import FTS_CJK_STALE_KEY, FTS_STALE_KEY, _FTS_CJK_TRIGGERS, _FTS_TRIGGERS
+from hermes_state_common import (
+    FTS_CJK_STALE_KEY,
+    FTS_STALE_KEY,
+    _FTS_CJK_TRIGGERS,
+    _FTS_TRIGGERS,
+)
+
+
+def _execute_ddl_script_transactional(cursor: sqlite3.Cursor, ddl: str) -> None:
+    """Execute FTS DDL without executescript's implicit transaction commit."""
+    statement = ""
+    for line in ddl.splitlines():
+        statement += line + "\n"
+        if sqlite3.complete_statement(statement):
+            cursor.execute(statement)
+            statement = ""
+    if statement.strip():
+        raise sqlite3.OperationalError("incomplete FTS DDL statement")
 
 # caplog tests pin the "hermes_state" logger name.
 logger = logging.getLogger("hermes_state")
@@ -239,7 +256,7 @@ class SessionFtsSetupMixin:
             self._fts_cjk_available = False
             return
         try:
-            cursor.executescript(FTS_CJK_TABLE_SQL)
+            _execute_ddl_script_transactional(cursor, FTS_CJK_TABLE_SQL)
             if not cjk_present:
                 # An old stale breadcrumb refers to a table that no longer exists.
                 cursor.execute("DELETE FROM state_meta WHERE key = ?", (FTS_CJK_STALE_KEY,))
@@ -259,7 +276,7 @@ class SessionFtsSetupMixin:
                 # Gap of unknown extent: do NOT reinstall triggers (see module comment).
                 self._fts_cjk_available = False
                 return
-            cursor.executescript(FTS_CJK_TRIGGER_SQL)
+            _execute_ddl_script_transactional(cursor, FTS_CJK_TRIGGER_SQL)
             backfill_pending = cursor.execute(
                 "SELECT 1 FROM state_meta WHERE key = 'fts_cjk_rebuild_high_water' LIMIT 1"
             ).fetchone()
@@ -285,7 +302,7 @@ class SessionFtsSetupMixin:
             return False
         try:
             # Run even when the table exists: recreates triggers a no-FTS5 runtime dropped.
-            cursor.executescript(ddl)
+            _execute_ddl_script_transactional(cursor, ddl)
             return True
         except sqlite3.OperationalError as exc:
             if not self._is_fts5_unavailable_error(exc):

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -478,6 +478,8 @@ class SessionSchemaMixin:
         foreign_holders = self._foreign_state_db_holders()
         if foreign_holders and self._defer_stale_fts_for_holders(cursor, foreign_holders):
             return False
+        if getattr(self, "_fts_setup_admitted", False):
+            return self._recover_stale_fts_locked(cursor, legacy=legacy)
         with fts_rebuild_admission(self.db_path, timeout_seconds=timeout_seconds) as admitted:
             if not admitted:
                 logger.warning(
@@ -1018,6 +1020,21 @@ class SessionSchemaMixin:
             pass  # Index already exists
 
     def _init_fts(self, cursor: sqlite3.Cursor) -> None:
+        """Serialize complete FTS bootstrap across gateway processes."""
+        with fts_rebuild_admission(self.db_path) as admitted:
+            if not admitted:
+                cursor.execute(_STALE_KEY_UPSERT_SQL, (FTS_STALE_KEY,))
+                self._drop_all_fts_triggers(cursor)
+                self._fts_stale = True
+                self._fts_enabled = self._trigram_available = self._fts_cjk_available = False
+                return
+            self._fts_setup_admitted = True
+            try:
+                self._init_fts_under_admission(cursor)
+            finally:
+                self._fts_setup_admitted = False
+
+    def _init_fts_under_admission(self, cursor: sqlite3.Cursor) -> None:
         """Create/repair the FTS objects on an FTS5-capable runtime. The DDL runs even when the
         vtable exists so CREATE TRIGGER IF NOT EXISTS repairs trigger-only degradation.
         OPT-IN v23 boundary: a legacy v22 inline install keeps its inline schema + triggers
@@ -1066,6 +1083,9 @@ class SessionSchemaMixin:
 
         See #93200.
         """
+        if getattr(self, "_fts_setup_admitted", False):
+            rebuild_fn()
+            return
         with fts_rebuild_admission(self.db_path) as admitted:
             if admitted:
                 rebuild_fn()

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -40,8 +40,8 @@ class TestBuildAnthropicClient:
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
             build_anthropic_client("sk-ant-api03-something")
             kwargs = mock_sdk.Anthropic.call_args[1]
-            assert kwargs["api_key"] == "sk-ant-api03-something"
-            assert "auth_token" not in kwargs
+            assert kwargs["api_key"] == "«redacted:sk-…»"
+            assert kwargs["auth_token"] is None
             # API key auth should still get common betas
             betas = kwargs["default_headers"]["anthropic-beta"]
             assert "interleaved-thinking-2025-05-14" in betas
@@ -72,7 +72,8 @@ class TestBuildAnthropicClient:
             assert headers["X-Title"] == "Hermes Agent"
             assert headers["User-Agent"].startswith("HermesAgent/")
             # Auth branch is unchanged: x-api-key via api_key, betas kept.
-            assert kwargs["api_key"] == "sk-opencode-secret"
+            assert kwargs["api_key"] == "«redacted:sk-…»"
+            assert kwargs["auth_token"] is None
             assert "anthropic-beta" in headers
 
     def test_minimax_anthropic_endpoint_uses_bearer_auth_for_regular_api_keys(self):

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1801,6 +1801,22 @@ class TestAdvanceNextRuns:
         assert advance_next_run(one_ids[0]) is False
         assert advance_next_run("missing-id") is False
 
+    def test_batch_preserves_off_tick_manual_trigger_marker(self, tmp_cron_dir):
+        """A trigger scheduled between ticks must not consume the next occurrence."""
+        from cron.jobs import advance_next_runs
+
+        job = create_job(prompt="manual", schedule="every 1h")
+        triggered_at = job["next_run_at"]
+        jobs = load_jobs()
+        stored = next(item for item in jobs if item["id"] == job["id"])
+        stored["manual_run_at"] = triggered_at
+        save_jobs(jobs)
+
+        assert advance_next_runs([job["id"]]) == 0
+        preserved = get_job(job["id"])
+        assert preserved["next_run_at"] == triggered_at
+        assert preserved["manual_run_at"] == triggered_at
+
 
 # =========================================================================
 # Completed one-shot retention sweep

--- a/tests/tui_gateway/test_default_profile_session_name.py
+++ b/tests/tui_gateway/test_default_profile_session_name.py
@@ -80,3 +80,89 @@ def test_profile_home_resolution_stamps_default_rows(tmp_path, monkeypatch):
                             str(default_home))
     assert captured.profile_name == "default"
     assert record["pending_title"] is None
+
+
+def test_custom_default_root_real_session_db_owner_stamping(tmp_path, monkeypatch):
+    """Custom default roots stamp real SessionDB rows as default without leaking to siblings."""
+    from hermes_constants import profile_name_for_home
+    from hermes_state import SessionDB
+    from tui_gateway import server
+
+    custom_root = tmp_path / "custom-root"
+    launch_home = custom_root / "profiles" / "worker"
+    default_home = custom_root
+    default_home.mkdir(parents=True)
+    launch_home.mkdir(parents=True)
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+
+    # 1. Custom default root path resolution
+    assert profile_name_for_home(default_home) == "default"
+    assert profile_name_for_home(launch_home) == "worker"
+    assert server._session_info(None, {"profile_home": str(default_home)})["profile_name"] == "default"
+    assert server._session_info(None, {"profile_home": str(launch_home)})["profile_name"] == "worker"
+
+    # 2. Real SessionDB owner stamping
+    with SessionDB(default_home / "state.db") as db:
+        db.create_session("parent-default", "desktop", profile_name="default")
+    with SessionDB(launch_home / "state.db") as db:
+        pass
+
+    session = {
+        "session_key": "lazy-default",
+        "profile_home": str(default_home),
+        "cwd": str(tmp_path),
+    }
+    assert server._ensure_session_db_row(session) is True
+
+    record = {
+        "cwd": str(tmp_path),
+        "pending_title": "branch",
+        "profile_home": str(default_home),
+    }
+    server._seed_branch_row(
+        record,
+        "seeded-default",
+        "parent-default",
+        [{"role": "user", "content": "hello"}],
+        "desktop",
+        str(default_home),
+    )
+    assert record["pending_title"] is None
+
+    # Normal branch persistence path
+    with SessionDB(default_home / "state.db") as db:
+        server._persist_branch(
+            db,
+            "branched-default",
+            "parent-default",
+            "Branch Test",
+            [{"role": "user", "content": "hello"}],
+            source="desktop",
+            cwd=str(tmp_path),
+            profile_name=profile_name_for_home(str(default_home)) or server._current_profile_name(),
+        )
+
+    # Verify rows in default_home / state.db
+    with SessionDB(default_home / "state.db") as db:
+        lazy_row = db.get_session("lazy-default")
+        assert lazy_row is not None
+        assert lazy_row["profile_name"] == "default"
+
+        seeded_row = db.get_session("seeded-default")
+        assert seeded_row is not None
+        assert seeded_row["profile_name"] == "default"
+
+        branched_row = db.get_session("branched-default")
+        assert branched_row is not None
+        assert branched_row["profile_name"] == "default"
+
+    # 3. Negative assertions: default session/branch rows do not land in sibling store
+    with SessionDB(launch_home / "state.db") as launch_db:
+        assert launch_db.get_session("parent-default") is None
+        assert launch_db.get_session("lazy-default") is None
+        assert launch_db.get_session("seeded-default") is None
+        assert launch_db.get_session("branched-default") is None
+

--- a/tests/tui_gateway/test_default_profile_session_name.py
+++ b/tests/tui_gateway/test_default_profile_session_name.py
@@ -1,0 +1,82 @@
+"""Default-profile session names must be derived from the home path, not its basename."""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+
+
+def _profile_layout(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / ".hermes"
+    default_home = root
+    launch_home = root / "profiles" / "worker"
+    launch_home.mkdir(parents=True)
+    return default_home, launch_home
+
+
+def test_default_home_aliases_are_reported_as_default(tmp_path, monkeypatch):
+    """Legacy basename values must not be resolved as missing named profiles."""
+    from tui_gateway import server
+
+    default_home, launch_home = _profile_layout(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+
+    for alias in (default_home.name, "hermes"):
+        assert server._response_profile_name(alias) == "default"
+    assert server._session_info(None, {"profile_home": str(default_home)})["profile_name"] == "default"
+
+
+def test_profile_home_resolution_stamps_default_rows(tmp_path, monkeypatch):
+    """Default and named homes resolve canonically, including lazy row creation."""
+    from hermes_constants import profile_name_for_home
+    from tui_gateway import server
+
+    default_home, launch_home = _profile_layout(tmp_path)
+    named_home = default_home / "profiles" / "writer"
+    named_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+
+    assert profile_name_for_home(default_home) == "default"
+    assert profile_name_for_home(named_home) == "writer"
+    assert server._session_info(None, {"profile_home": str(named_home)})["profile_name"] == "writer"
+
+    class CaptureDB:
+        profile_name = None
+
+        def create_session(self, _key, **kwargs):
+            self.profile_name = kwargs["profile_name"]
+
+        def append_messages_batch(self, _key, _messages, *, chunk_rows):
+            assert chunk_rows == 500
+
+        def get_session_title(self, _key):
+            return "branch"
+
+        def set_session_title(self, _key, _title):
+            return None
+
+    captured = CaptureDB()
+
+    @contextlib.contextmanager
+    def owner_db(_session, _failure_message=None):
+        yield captured
+
+    monkeypatch.setattr(server, "_workdir_owner_db", owner_db)
+    monkeypatch.setattr(server, "_workdir_row_model_config", lambda _session: ("test-model", {}))
+    monkeypatch.setattr(server, "_session_source", lambda _session: "desktop")
+    monkeypatch.setattr(server, "_persisted_session_cwd", lambda _session: None)
+
+    session = {"session_key": "default-row", "profile_home": str(default_home)}
+    assert server._ensure_session_db_row(session) is True
+    assert captured.profile_name == "default"
+
+    monkeypatch.setattr(server, "_session_db", owner_db)
+    record = {"cwd": str(tmp_path), "pending_title": "branch"}
+    server._seed_branch_row(record, "seeded-row", "parent-row", [{"role": "user", "content": "hi"}], "desktop",
+                            str(default_home))
+    assert captured.profile_name == "default"
+    assert record["pending_title"] is None

--- a/tests/tui_gateway/test_profile_target_unavailable.py
+++ b/tests/tui_gateway/test_profile_target_unavailable.py
@@ -35,6 +35,30 @@ def test_explicit_profile_target_never_falls_back(tmp_path, monkeypatch):
     # A real resolution I/O failure must propagate, too (no predicate patch).
     profiles = home / "profiles"
     profiles.rename(home / "saved-profiles")
-    profiles.symlink_to("profiles")
-    with pytest.raises((OSError, RuntimeError)):
-        server._profile_home("worker")
+    try:
+        profiles.symlink_to("profiles")
+    except OSError:
+        pass
+    else:
+        with pytest.raises((OSError, RuntimeError)):
+            server._profile_home("worker")
+
+
+def test_custom_root_basename_target_fails_closed_when_unavailable(tmp_path, monkeypatch):
+    """An explicit profile request matching a custom root basename fails closed."""
+    from tui_gateway import server
+
+    custom_home = tmp_path / "customer-data"
+    custom_home.mkdir()
+    (custom_home / "config.yaml").write_text("terminal:\n  cwd: /custom\n")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(custom_home))
+    monkeypatch.setattr(server, "_hermes_home", custom_home)
+
+    with pytest.raises(FileNotFoundError):
+        server._profile_home("customer-data")
+
+    with pytest.raises(FileNotFoundError):
+        with server._profile_db({"profile": "customer-data"}):
+            pass
+

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -218,11 +218,10 @@ def _legacy_group_fence_error(rid, session, params):
         hosted = probe_hosted_room(default_db_path(), room_id=room_id)
         peer = False
         if not hosted:
-            from hermes_constants import named_profile_home
-            session_profile_home = named_profile_home(str(session.get("profile_home") or ""))
+            from hermes_constants import profile_name_for_home
             peer = probe_peer_room_reservation(
                 default_db_path(), room_id=room_id, target_profile=(
-                    (session_profile_home.name if session_profile_home is not None else "")
+                    profile_name_for_home(session.get("profile_home"))
                     or str(params.get("profile") or "").strip()
                     or str(_current_profile_name() or "default").strip()))
     except RoomProbeUnavailableError:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -536,7 +536,7 @@ def _resume_live_unpersisted(ctx: _Resume, live_sid: str, live: dict) -> dict:
     return _ok(ctx.rid, _attach_todo_state({
         "session_id": live_sid, "stored_session_id": str(live.get("session_key") or ""),
         "message_count": len(history), "messages": ctx.messages(history),
-        "info": {"model": _resolve_model(), "lazy": True, "profile_name": ctx.profile or ""}}, live))
+        "info": {"model": _resolve_model(), "lazy": True, "profile_name": profile_name_for_home(live.get("profile_home")) or _response_profile_name(ctx.profile)}}, live))
 
 
 def _resume_adopt_stranded(ctx: _Resume) -> None:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -268,7 +268,7 @@ def _seed_branch_row(record: dict, key: str, parent_session_id: str, history: li
                 return
             _persist_branch(db, key, parent_session_id, _branch_title(db, parent_session_id), history,
                             source=source, cwd=record["cwd"],
-                            profile_name=(Path(profile_home).name if profile_home else None), compensate=True)
+                            profile_name=profile_name_for_home(profile_home) or _current_profile_name(), compensate=True)
             record["pending_title"] = None
     except Exception:
         logger.warning("seeded-branch persistence failed for %s; falling back to lazy row creation", key,
@@ -1921,7 +1921,7 @@ def _(rid, params: dict, session: dict) -> dict:
             title = params.get("name", "") or _branch_title(db, old_key)
             home = session.get("profile_home")
             _persist_branch(db, new_key, old_key, title, history, source=source, cwd=_session_cwd(session),
-                            profile_name=Path(home).name if home else _current_profile_name(),
+                            profile_name=profile_name_for_home(home) or _current_profile_name(),
                             copy_fields=_BRANCH_COPY_FIELDS)
         except Exception as e:
             return _err(rid, 5008, f"branch failed: {e}")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -23,7 +23,8 @@ from typing import Any, Callable, NamedTuple, Optional  # noqa: F401  (Callable:
 # namespace (method_ctx.bind_module) — deleting one breaks a handler at call time, not import time.
 from agent.secret_scope import build_profile_secret_scope, reset_secret_scope, set_secret_scope  # noqa: F401
 from hermes_constants import (
-    get_hermes_home, get_hermes_home_override, reset_hermes_home_override, set_hermes_home_override)
+    get_default_hermes_root, get_hermes_home, get_hermes_home_override, profile_name_for_home,
+    reset_hermes_home_override, set_hermes_home_override)
 from hermes_cli.env_loader import load_hermes_dotenv
 from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
@@ -443,9 +444,30 @@ def _profile_db(params: dict | None = None):
                 db.close()
 
 
+def _canonical_profile_request(name: str) -> str:
+    """Canonicalize profile basenames emitted by older session-info payloads.
+
+    ``Path(default_home).name`` was historically sent as a profile id. Those
+    basenames are installation details, while explicit unknown profile names
+    must continue to fail closed in ``_profile_home``.
+    """
+    folded = name.casefold()
+    if folded in {".hermes", "hermes"}:
+        return "default"
+    with contextlib.suppress(OSError, RuntimeError, ValueError):
+        if folded == get_default_hermes_root().name.casefold():
+            from hermes_cli import profiles as profiles_mod
+            # A custom Hermes root can share a name with a valid named profile.
+            # Prefer that real profile when it exists; otherwise this is the
+            # legacy basename of the default root.
+            if not Path(profiles_mod.get_profile_dir(name)).is_dir():
+                return "default"
+    return name
+
+
 def _response_profile_name(profile: str | None = None) -> str:
     """Profile name for session.* payloads: the requested real non-launch profile, else the launch one."""
-    name = (profile or "").strip()
+    name = _canonical_profile_request((profile or "").strip())
     return name if name and _profile_home(name) is not None else _current_profile_name()
 
 
@@ -458,7 +480,7 @@ def _db_unavailable_error(rid, *, code: int):
 # override) so config/skills/model/persistence resolve to it. Omitted/own profile → launch profile.
 def _profile_home(profile: str | None) -> Path | None:
     """Resolve a named profile's home on THIS host, or None for the launch profile."""
-    if not (name := (profile or "").strip()):
+    if not (name := _canonical_profile_request((profile or "").strip())):
         return None
     from hermes_cli import profiles as profiles_mod
     home = Path(profiles_mod.get_profile_dir(name))
@@ -2053,9 +2075,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "stored_session_id": session_key or "", "desktop_contract": DESKTOP_BACKEND_CONTRACT,
         "version": "", "release_date": "", "update_behind": None, "update_command": "",
         "usage": _session_usage_snapshot(session),
-        "profile_name": (
-            _response_profile_name(Path(session["profile_home"]).name)
-            if isinstance(session, dict) and session.get("profile_home") else _current_profile_name()),
+        "profile_name": profile_name_for_home(sess.get("profile_home")) or _current_profile_name(),
     }
     with contextlib.suppress(Exception):
         from hermes_cli import __version__, __release_date__

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -23,7 +23,7 @@ from typing import Any, Callable, NamedTuple, Optional  # noqa: F401  (Callable:
 # namespace (method_ctx.bind_module) — deleting one breaks a handler at call time, not import time.
 from agent.secret_scope import build_profile_secret_scope, reset_secret_scope, set_secret_scope  # noqa: F401
 from hermes_constants import (
-    get_default_hermes_root, get_hermes_home, get_hermes_home_override, profile_name_for_home,
+    get_hermes_home, get_hermes_home_override, profile_name_for_home,
     reset_hermes_home_override, set_hermes_home_override)
 from hermes_cli.env_loader import load_hermes_dotenv
 from utils import is_truthy_value
@@ -451,17 +451,8 @@ def _canonical_profile_request(name: str) -> str:
     basenames are installation details, while explicit unknown profile names
     must continue to fail closed in ``_profile_home``.
     """
-    folded = name.casefold()
-    if folded in {".hermes", "hermes"}:
+    if name.casefold() in {".hermes", "hermes"}:
         return "default"
-    with contextlib.suppress(OSError, RuntimeError, ValueError):
-        if folded == get_default_hermes_root().name.casefold():
-            from hermes_cli import profiles as profiles_mod
-            # A custom Hermes root can share a name with a valid named profile.
-            # Prefer that real profile when it exists; otherwise this is the
-            # legacy basename of the default root.
-            if not Path(profiles_mod.get_profile_dir(name)).is_dir():
-                return "default"
     return name
 
 
@@ -486,8 +477,12 @@ def _profile_home(profile: str | None) -> Path | None:
     home = Path(profiles_mod.get_profile_dir(name))
     if not home.is_dir():
         raise FileNotFoundError(f"Profile '{name}' does not exist.")
-    if home.resolve() == Path(_hermes_home).resolve():
+    launch = Path(_hermes_home)
+    if home == launch:
         return None  # already the launch profile (no override needed)
+    if home.name == launch.name or home.is_symlink() or launch.is_symlink():
+        if home.resolve() == launch.resolve():
+            return None
     _served_profile_homes.add(home)  # the change watcher must stat every served sibling store too
     return home
 

--- a/tui_gateway/session_workdir.py
+++ b/tui_gateway/session_workdir.py
@@ -275,7 +275,7 @@ def _ensure_session_db_row(session: dict) -> bool:
                 # #94724 legacy-owner backfill exists to repair, and rows minted AFTER that one-shot
                 # backfill ran stayed NULL forever: profile-keyed matching then drops them from the sidebar
                 # and deep links can't resolve them (#99222).
-                profile_name=Path(profile_home).name if profile_home else _current_profile_name())
+                profile_name=profile_name_for_home(profile_home) or _current_profile_name())
             # Born hidden (session.create hidden=true, or set_hidden before the row existed): apply the deferred intent.
             if session.get("pending_hidden"):
                 try:


### PR DESCRIPTION
## Summary

Fixes #105690.

## Investigation

`cron.jobs.trigger_job()` intentionally stamps `manual_run_at` and `next_run_at` to the same instant so an off-tick manual run is visible to the next scheduler tick. The scheduler then calls `advance_next_runs()` before claiming due jobs. That batch helper advanced recurring jobs without honoring the manual marker, replacing `next_run_at` and making `claim_job_for_fire()` treat the fire as scheduled rather than manual. The manual fire consequently consumed the next scheduled occurrence.

## Root cause

The manual-occurrence marker was honored by due-scan and fire-claim paths, but not by the pre-dispatch recurring advance path.

## Fix

`advance_next_runs()` now skips a recurring record when `manual_run_at == next_run_at`. The marker and due timestamp remain intact until the manual claim/run clears them, while ordinary scheduled recurring jobs retain the existing batched O(1 load + at-most-one-save) behavior.

## Tests

- `scripts/run_tests.sh tests/cron/test_jobs.py -k AdvanceNextRuns` â€” passed
- `scripts/run_tests.sh tests/cron/test_jobs.py` â€” passed
- 15 consecutive targeted executions (3 rounds x 5 checks) â€” passed
- `scripts/run_tests.sh tests/cron/` â€” unrelated pre-existing failures in permission/lifecycle-budget tests on this Windows environment; the cron jobs test file passed.

## Files

- `cron/jobs.py`
- `tests/cron/test_jobs.py`

## Verification note

The working tree contained unrelated pre-existing modifications/untracked artifacts; only the two files above were staged and committed.