### PR TITLE
fix(desktop): let subagent header collapse roster and details

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/subagent-section.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/subagent-section.test.tsx
@@ -6,11 +6,14 @@ import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
 
 import { ComposerStatusStack } from './index'
 
+vi.mock('@/lib/use-enter-animation', () => ({ useEnterAnimation: () => undefined }))
+
 vi.stubGlobal(
   'ResizeObserver',
   class {
     disconnect() {}
     observe() {}
+    unobserve() {}
   }
 )
 
@@ -19,7 +22,7 @@ afterEach(() => {
   $subagentsBySession.set({})
 })
 
-it('automatically previews bounded live work only from the composer session, including queued children', () => {
+it('shows live work only from the composer session and keeps it hidden after collapse and progress', () => {
   for (let i = 0; i < 5; i++) {
     upsertSubagent('owner', { subagent_id: `child-${i}`, goal: `Task ${i}`, status: i ? 'queued' : 'running' })
   }
@@ -35,17 +38,47 @@ it('automatically previews bounded live work only from the composer session, inc
 
   expect(screen.getByText('Task 0')).toBeTruthy()
   expect(screen.getByText('Reading actual source')).toBeTruthy()
-  expect(screen.queryByText('Task 4')).toBeNull()
   expect(screen.queryByText('Private foreign task')).toBeNull()
-  expect(screen.getByRole('button', { name: /5 Subagents/ })).toBeTruthy()
-  fireEvent.click(screen.getByRole('button', { name: /5 Subagents/ }))
+  const header = screen.getByRole('button', { name: /5 Subagents/ })
+  fireEvent.click(header)
+  expect(screen.queryByText('Task 0')).toBeNull()
+  expect(screen.queryByText('Task 4')).toBeNull()
+  expect(header.getAttribute('aria-expanded')).toBe('false')
+  act(() => upsertSubagent('owner', { subagent_id: 'child-0', text: 'More progress' }, false, 'subagent.progress'))
+  expect(screen.queryByText('Task 0')).toBeNull()
+  fireEvent.click(header)
+  expect(screen.getByText('Task 0')).toBeTruthy()
   expect(screen.getByText('Task 4')).toBeTruthy()
+  expect(screen.getByText('More progress')).toBeTruthy()
   view.rerender(
     <MemoryRouter>
       <ComposerStatusStack queue={null} sessionId="empty" />
     </MemoryRouter>
   )
   expect(screen.queryByText('Task 0')).toBeNull()
+})
+
+it('collapses a single worker and its selected detail using the caret, preserving the steering draft', () => {
+  upsertSubagent('owner', { subagent_id: 'child', goal: 'Single task' })
+
+  const view = render(
+    <MemoryRouter>
+      <ComposerStatusStack queue={null} sessionId="owner" />
+    </MemoryRouter>
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /Single task/ }))
+  expect(view.container.querySelector('[data-slot="composer-subagent-detail"]')).toBeTruthy()
+  const draft = screen.getByRole('textbox')
+  fireEvent.change(draft, { target: { value: 'Keep this draft' } })
+  const header = screen.getByRole('button', { name: /1 Subagent/ })
+  fireEvent.click(header.firstElementChild!)
+  expect(screen.queryByText('Single task')).toBeNull()
+  expect(view.container.querySelector('[data-slot="composer-subagent-detail"]')).toBeNull()
+  expect(header.getAttribute('aria-expanded')).toBe('false')
+  fireEvent.click(header)
+  expect(view.container.querySelector('[data-slot="composer-subagent-detail"]')).toBeTruthy()
+  expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('Keep this draft')
 })
 
 it('retires the live frame only after every child settles, without depending on the parent busy state', () => {

--- a/apps/desktop/src/app/chat/composer/status-stack/subagent-section.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/subagent-section.tsx
@@ -64,32 +64,35 @@ export function SubagentSection({ sessionId }: SubagentSectionProps) {
   return (
     <div className="composer-no-drag min-w-0" data-slot="composer-subagents">
       <StatusSection
+        collapsedIndicator={
+          <GlyphSpinner
+            ariaLabel={live.some(item => item.status === 'running') ? t.agents.running : t.agents.queued}
+            className="text-(--ui-purple)"
+            spinner="braille"
+          />
+        }
+        defaultCollapsed={false}
         icon={<Codicon className="text-(--ui-purple)" name="agent" size="0.8rem" />}
         label={t.statusStack.subagents(live.length)}
-        preview={
-          <>
-            {live.slice(0, 3).map(row)}
-            {live.length > 3 && (
-              <p className="px-2 text-[0.68rem] text-(--ui-text-tertiary)">{t.agents.moreAgents(live.length - 3)}</p>
-            )}
-          </>
-        }
       >
         <div className="max-h-[25vh] overflow-y-auto overscroll-contain">{live.map(row)}</div>
+        {detail && (
+          <div
+            className="max-h-[25vh] overflow-y-auto overscroll-contain px-3 py-2"
+            data-slot="composer-subagent-detail"
+          >
+            <SubagentControls
+              key={`${sessionId}:${detail.id}`}
+              sessionId={sessionId}
+              setText={text => setDrafts(previous => ({ ...previous, [detail.id]: text }))}
+              subagentId={detail.id}
+              text={drafts[detail.id] ?? ''}
+            />
+            <SubagentRow node={{ ...detail, children: [] }} nowMs={nowMs} />
+            <SubagentTranscript key={`tail:${sessionId}:${detail.id}`} sessionId={sessionId} subagentId={detail.id} />
+          </div>
+        )}
       </StatusSection>
-      {detail && (
-        <div className="max-h-[25vh] overflow-y-auto overscroll-contain px-3 py-2" data-slot="composer-subagent-detail">
-          <SubagentControls
-            key={`${sessionId}:${detail.id}`}
-            sessionId={sessionId}
-            setText={text => setDrafts(previous => ({ ...previous, [detail.id]: text }))}
-            subagentId={detail.id}
-            text={drafts[detail.id] ?? ''}
-          />
-          <SubagentRow node={{ ...detail, children: [] }} nowMs={nowMs} />
-          <SubagentTranscript key={`tail:${sessionId}:${detail.id}`} sessionId={sessionId} subagentId={detail.id} />
-        </div>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## What does this PR do?

Makes the composer subagent header/caret actually minimize the subagent list and any selected worker details.

The live-subagent UI introduced in 092ed67532a renders up to three worker rows as the collapsed `StatusSection` preview. With one worker, expanding and collapsing therefore look the same. Selected-worker details also render outside the section, so they remain visible regardless of its collapse state.

## Reproduction

User-provided recording: https://gyazo.com/fa24e8d35d87288363cb8732a23de094

1. Start a delegated task in Desktop and wait for a live worker above the composer.
2. Click the subagent header or its caret.
3. The worker row stays visible. Open a worker's details and toggle the header again: the details stay visible too.

Expected: collapsing leaves only the header, with the worker count and live status.

## Type of Change

- [x] Bug fix

## Changes Made

- Start the subagent section expanded so live work remains immediately visible, using the existing height-limited scrollable roster rather than a permanently visible three-row preview.
- Keep the count and running/queued indicator in the header when collapsed.
- Move selected-worker details inside the collapsible section; retain selection and steering drafts in the owning component so reopening restores them.
- Add regression coverage for header/caret clicks, a single selected worker, multiple workers, progress while collapsed, draft preservation, and session isolation.

## How to Test

Repeat the reproduction above: header/caret clicks should hide the roster and details, progress should not reopen the section, and reopening should restore the steering draft.

Verified locally on Linux:
- [x] Regression assertions fail on the unfixed implementation.
- [x] `npx vitest run src/app/chat/composer/status-stack` — 11 files, 35 tests passed.
- [x] `npm run typecheck` — Desktop renderer, Electron, and E2E TypeScript checks passed.
- [x] ESLint on both changed files passed.
- [x] `git diff --check` passed.

Verification is through rendered-component tests; the fix has not been installed or manually exercised in the reporting user's running Desktop. Full repository tests were not run for this two-file renderer change.
