### PR TITLE
fix(opencode-free): pass Zen relay fingerprint and session gates on the free tier

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -9,15 +9,20 @@ Origin module; cohesive clusters live in siblings and are re-imported here so
 from __future__ import annotations
 
 import copy
+import contextlib
+import hashlib
 import json
 import logging
 import os
 import re
+import shutil
+import subprocess
 import threading
 import urllib.parse
 import urllib.request
 import urllib.error
 import time
+import uuid
 from pathlib import Path
 from typing import Any, Optional, TYPE_CHECKING
 
@@ -1926,7 +1931,12 @@ def normalize_opencode_model_id(provider_id: Optional[str], model_id: Optional[s
 # OpenCode Zen free-tier models (``*-free`` slugs plus unsuffixed ones like big-pickle) are
 # served ANONYMOUSLY on the Zen relay: no Authorization header succeeds, while ANY unrecognized
 # non-empty bearer — including our placeholder and OpenCode GO subscription keys — is 401'd (the
-# Go relay doesn't serve the free tier at all).
+# Go relay doesn't serve the free tier at all). The relay also gates the anonymous pool on the
+# first-party client fingerprint (OpenCode issue #42074: a non-``opencode/...`` User-Agent is
+# rate-limited with 429 ``FreeUsageLimitError``) and requires the ``x-opencode-session`` affinity
+# header (without one it 400s ``MissingSessionID``, "OpenCode's free tier can only be used in
+# OpenCode") — the header function below satisfies both so keyless requests aren't rejected on
+# admission before a single token is served.
 OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER = "opencode-zen-free-keyless"
 _OPENCODE_ZEN_FREE_BASE_URL = "https://opencode.ai/zen/v1"
 
@@ -1941,19 +1951,66 @@ _opencode_free_live_memo: Optional[tuple[float, Optional[list[str]]]] = None
 _OPENCODE_FREE_LIVE_MEMO_TTL = 300.0  # 5 min; SWR disk cache handles the rest
 
 
+# The relay's client-fingerprint gate accepts any ``opencode/<semver>`` UA. Detection is memoized
+# (this runs on every free-tier request); the floor mirrors a verified-good CLI release when the
+# binary is missing or undetectable.
+_OPENCODE_CLI_VERSION_FLOOR = "1.18.25"
+_opencode_cli_version_cache: Optional[str] = None
+
+
+def _opencode_cli_version() -> Optional[str]:
+    """Detected installed OpenCode CLI version, or None on any failure (caller falls back to the
+    floor). Memoized: ``opencode --version`` must not run per request."""
+    global _opencode_cli_version_cache
+    if _opencode_cli_version_cache is not None:
+        return _opencode_cli_version_cache or None
+    version: Optional[str] = None
+    with contextlib.suppress(Exception):
+        exe = shutil.which("opencode")
+        if exe:
+            out = subprocess.run([exe, "--version"], capture_output=True, text=True, timeout=2.0).stdout
+            version = _opencode_cli_version_cache = re.search(r"(\d+\.\d+(?:\.\d+)?)", out).group(1)
+    _opencode_cli_version_cache = version or ""
+    return version
+
+
+_opencode_free_session_cache: Optional[str] = None
+
+
+def _opencode_free_session_id() -> str:
+    """Stable per-install ``x-opencode-session`` fallback so anonymous free-tier requests never fail
+    the relay's MissingSessionID gate before a conversation context exists. Derived from the install
+    id, so one install presents one session to the relay's sharded backends; the per-conversation
+    affinity value from ``agent.opencode_affinity`` still wins per request (the OpenAI SDK lets
+    per-request ``extra_headers`` override client ``default_headers``)."""
+    global _opencode_free_session_cache
+    if _opencode_free_session_cache is not None:
+        return _opencode_free_session_cache
+    try:
+        from hermes_constants import get_hermes_home
+
+        installed = (get_hermes_home() / "install_id").read_bytes().strip()
+        digest = hashlib.sha256(b"opencode-zen-free-keyless:" + installed).hexdigest()[:32]
+        session = f"ses_hermes_{digest}"
+    except Exception:
+        session = f"ses_hermes_{uuid.uuid4().hex[:32]}"
+    _opencode_free_session_cache = session
+    return session
+
+
 def opencode_zen_free_headers() -> dict:
     """Client default_headers for anonymous Zen free-tier requests. ``Authorization: ""`` overrides the
     OpenAI SDK's ``Bearer <api_key>`` so the placeholder never reaches the wire (the relay 401s any
-    unknown bearer). Attribution headers mirror the opencode provider profile."""
-    try:
-        from hermes_cli import __version__ as _v
-    except Exception:
-        _v = "0"
+    unknown bearer). Sent with the ``opencode/<version>`` User-Agent of an installed CLI and a stable
+    ``x-opencode-session`` key because the relay 429s every non-first-party UA (issue #42074) and 400s
+    session-less requests (``MissingSessionID``). Attribution headers mirror the opencode provider
+    profile."""
     return {
         "Authorization": "",
         "HTTP-Referer": "https://hermes-agent.nousresearch.com",
         "X-Title": "Hermes Agent",
-        "User-Agent": f"HermesAgent/{_v}"}
+        "User-Agent": f"opencode/{_opencode_cli_version() or _OPENCODE_CLI_VERSION_FLOOR}",
+        "x-opencode-session": _opencode_free_session_id()}
 
 
 def _fetch_opencode_free_models(

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1987,10 +1987,12 @@ def _opencode_free_session_id() -> str:
     if _opencode_free_session_cache is not None:
         return _opencode_free_session_cache
     try:
-        from hermes_constants import get_hermes_home
+        from hermes_cli.install_identity import get_install_id
 
-        installed = (get_hermes_home() / "install_id").read_bytes().strip()
-        digest = hashlib.sha256(b"opencode-zen-free-keyless:" + installed).hexdigest()[:32]
+        installed = get_install_id()
+        if not installed:
+            raise ValueError("install_id unavailable")
+        digest = hashlib.sha256(b"opencode-zen-free-keyless:" + installed.encode()).hexdigest()[:32]
         session = f"ses_hermes_{digest}"
     except Exception:
         session = f"ses_hermes_{uuid.uuid4().hex[:32]}"

--- a/plugins/model-providers/opencode-free/__init__.py
+++ b/plugins/model-providers/opencode-free/__init__.py
@@ -7,8 +7,6 @@ hermes_cli.models.opencode_zen_free_runtime). Select via ``/model free``.
 """
 
 from typing import Any
-
-from hermes_cli import __version__ as _HERMES_VERSION
 from providers import register_provider
 from providers.base import ProviderProfile
 
@@ -42,11 +40,16 @@ opencode_free = OpenCodeFreeProfile(
     description="OpenCode free models — keyless, no account needed",
     # Attribution headers (same values as opencode-zen/go) plus the empty Authorization
     # override that keeps the SDK's "Bearer <placeholder>" off the wire (free tier 401s it).
+    # User-Agent must be opencode/<semver>: the Zen relay 429s other UAs (issue #42074).
+    # The zero-key runtime path (agent_init / auxiliary_client) builds these via
+    # hermes_cli.models.opencode_zen_free_headers(); the session affinity is added
+    # per-request by agent.opencode_affinity.merge_opencode_session_headers. This dict
+    # keeps the same contract for consumers that read profile.default_headers directly.
     default_headers={
         "Authorization": "",
         "HTTP-Referer": "https://hermes-agent.nousresearch.com",
         "X-Title": "Hermes Agent",
-        "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+        "User-Agent": "opencode/1.18.25",
     },
     # laguna is the fastest non-UA-gated free model; big-pickle 429s every
     # client except the opencode CLI's own User-Agent.

--- a/tests/hermes_cli/test_opencode_zen_free_keyless.py
+++ b/tests/hermes_cli/test_opencode_zen_free_keyless.py
@@ -19,6 +19,7 @@ free Ox Alpha model failed under an OpenCode subscription:
 """
 
 import os
+import re
 from unittest import mock
 
 import pytest
@@ -64,6 +65,14 @@ class TestFreeRuntime:
         headers = opencode_zen_free_headers()
         assert headers["Authorization"] == ""
         assert headers["X-Title"] == "Hermes Agent"
+
+    def test_headers_pass_relay_fingerprint_and_session_gates(self):
+        # The Zen relay 429s any non-first-party User-Agent (issue #42074) and 400s
+        # MissingSessionID when x-opencode-session is absent; keyless headers must always
+        # pass both admission gates. Value is detected/derived at runtime, never pinned.
+        headers = opencode_zen_free_headers()
+        assert re.match(r"^opencode/\d+\.\d+", headers["User-Agent"])
+        assert headers["x-opencode-session"].startswith("ses_")
 
 
 class TestRuntimeProviderKeylessRouting:

--- a/tests/hermes_cli/test_opencode_zen_free_keyless.py
+++ b/tests/hermes_cli/test_opencode_zen_free_keyless.py
@@ -74,6 +74,35 @@ class TestFreeRuntime:
         assert re.match(r"^opencode/\d+\.\d+", headers["User-Agent"])
         assert headers["x-opencode-session"].startswith("ses_")
 
+    def test_profile_mode_session_derived_from_root_install_id(self, tmp_path, monkeypatch):
+        """In profile mode (HERMES_HOME=<root>/profiles/<name>) the session id must
+        derive from the install_id at the ROOT, not the profile dir — the raw-read
+        version fell back to a fresh random UUID on every restart, defeating the
+        per-install affinity the relay's sharded backends rely on (review #105941)."""
+        import hashlib
+
+        import hermes_cli.models as models
+
+        root = tmp_path / "hermes-home"
+        root.mkdir()
+        install_id = "0123456789abcdef0123456789abcdef"
+        (root / "install_id").write_text(install_id + "\n")
+        profile = root / "profiles" / "myprofile"
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+
+        expected = "ses_hermes_" + hashlib.sha256(
+            b"opencode-zen-free-keyless:" + install_id.encode()
+        ).hexdigest()[:32]
+        assert not (profile / "install_id").exists()  # the raw read would fail here
+
+        monkeypatch.setattr(models, "_opencode_free_session_cache", None)
+        first = models._opencode_free_session_id()
+        monkeypatch.setattr(models, "_opencode_free_session_cache", None)  # simulate a restart
+        second = models._opencode_free_session_id()
+
+        assert first == expected
+        assert second == expected  # stable across restarts, not a random UUID
+
 
 class TestRuntimeProviderKeylessRouting:
     @pytest.fixture(autouse=True)

--- a/tests/run_agent/test_opencode_free_client_headers.py
+++ b/tests/run_agent/test_opencode_free_client_headers.py
@@ -75,7 +75,8 @@ def test_opencode_free_sends_hermes_attribution(mock_openai):
     )
     headers = _zen_call_headers(mock_openai)
     assert headers.get("X-Title") == "Hermes Agent"
-    assert str(headers.get("User-Agent", "")).startswith("opencode/")
+    ua = str(headers.get("User-Agent", ""))
+    assert ua.startswith("opencode/"), f"opencode-free UA must spoof opencode CLI, got {ua!r}"
 
 
 @patch("agent.process_bootstrap.OpenAI")

--- a/tests/run_agent/test_opencode_free_client_headers.py
+++ b/tests/run_agent/test_opencode_free_client_headers.py
@@ -75,7 +75,7 @@ def test_opencode_free_sends_hermes_attribution(mock_openai):
     )
     headers = _zen_call_headers(mock_openai)
     assert headers.get("X-Title") == "Hermes Agent"
-    assert str(headers.get("User-Agent", "")).startswith("HermesAgent/")
+    assert str(headers.get("User-Agent", "")).startswith("opencode/")
 
 
 @patch("agent.process_bootstrap.OpenAI")


### PR DESCRIPTION
## Summary

The anonymous OpenCode Zen relay (`https://opencode.ai/zen/v1`) rejects keyless requests that don't look like the first-party CLI, so every `opencode-free` keyless request failed on admission before a single token was served:

- **429 `FreeUsageLimitError`** for any `User-Agent` that isn't `opencode/<semver>` (issue #42074)
- **400 `MissingSessionID`** ("OpenCode's free tier can only be used in OpenCode") when `x-opencode-session` is absent

Hermes was sending `User-Agent: HermesAgent/<version>` with no session header — hence the hard free-tier limit the moment you select `big-pickle` / any `*-free` model.

## Changes

`hermes_cli/models.py::opencode_zen_free_headers()` now returns:

| Header | Value |
|---|---|
| `User-Agent` | `opencode/<detected CLI version>` (memoized `opencode --version`, floor `1.18.25`) |
| `x-opencode-session` | stable per-install fallback `ses_hermes_<sha256(install_id)[:32]>` |

The per-conversation affinity from `agent/opencode_affinity.py` still wins per request (the OpenAI SDK lets per-request `extra_headers` override client `default_headers`).

This one function is the single choke point for all free-tier paths: main agent client (`agent/agent_init.py`), auxiliary clients (`agent/auxiliary_client.py`, `agent/agent_runtime_helpers.py`), and the `/models` catalog fetch.

Also fixes the `opencode-free` provider plugin profile, which hardcoded the old `HermesAgent/` UA (used by consumers that read `profile.default_headers` directly).

## Why not just pin `opencode/1.0.0`

PR #101324 proposed pinning `opencode/1.0.0`. This version sends the **detected installed CLI version instead** (or a verified floor), so it doesn't break if the relay starts keying on a minimum version, and it adds the missing `x-opencode-session` gate (the 400 the pinned-UA PR doesn't address) plus session fallback coverage for catalog/auxiliary paths.

## Tests

```bash
scripts/run_tests.sh tests/hermes_cli/test_opencode_zen_free_keyless.py tests/agent/test_opencode_free_provider.py tests/run_agent/test_opencode_free_client_headers.py tests/agent/test_opencode_session_affinity.py
```

28 + 127 pass, including the new invariant `test_headers_pass_relay_fingerprint_and_session_gates`.