### PR TITLE
fix(agent): scope background review memory access to its trigger (#105921)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -613,7 +613,9 @@ def _prior_tool_keys(prior_snapshot: List[Dict]) -> Tuple[set, set]:
 def _action_lines(data: Dict, detail: Dict, verbose: bool) -> List[str]:
     """Summary line(s) for one successful notify-tool result (``[]`` when nothing to report)."""
     if data.get("staged"):
-        return []
+        # The fork's own review summary is never published back, so an unattended-review
+        # consolidation proposal must surface here or it is silently lost (#105921).
+        return [data["message"]] if data.get("proposal_staged") and data.get("message") else []
     message = data.get("message", "")
     target = data.get("target", "") or detail.get("target", "")
     is_skill = detail.get("tool") == "skill_manage"
@@ -996,11 +998,16 @@ def _release_fork_clients(review_agent: Any) -> None:
 def _run_review_fork(
     agent: Any, messages_snapshot: List[Dict], prompt: str, task_cfg: Optional[Dict[str, Any]],
     review_run: Optional[_BackgroundReviewRun], st: _ReviewForkState, review_memory: bool = False,
+    explicit: bool = False,
 ) -> None:
     """Fork phase (inside thread-scoped silence): build the fork, run the prompt under the tool
     whitelist, snapshot its messages/usage, release its clients. Partial progress lands on ``st``
-    so the caller's error path still sees usage and the fork to clean up."""
-    st.review_agent, _rt, _routed = build_cache_parity_fork(agent, task_cfg, max_iterations=_REVIEW_MAX_ITERATIONS)
+    so the caller's error path still sees usage and the fork to clean up. ``explicit`` (/refine)
+    forks under the ``refine_review`` origin: a user-requested review keeps the full memory
+    operation set — the unattended-only delete gate must not treat it as automatic."""
+    st.review_agent, _rt, _routed = build_cache_parity_fork(
+        agent, task_cfg, max_iterations=_REVIEW_MAX_ITERATIONS,
+        write_origin="refine_review" if explicit else "background_review")
     _track_review_fork(agent, st.review_agent, register=True)
     from hermes_cli.plugins import set_thread_tool_whitelist, clear_thread_tool_whitelist
     review_whitelist, configured_extra_tools = _review_tool_whitelist(st.review_agent, task_cfg, review_memory)
@@ -1063,7 +1070,7 @@ def _publish_review_summary(agent: Any, actions: List[str]) -> None:
 def _run_review_in_thread(
     agent: Any, messages_snapshot: List[Dict], prompt: str,
     task_cfg: Optional[Dict[str, Any]] = None, review_run: Optional[_BackgroundReviewRun] = None,
-    review_memory: bool = False,
+    review_memory: bool = False, explicit: bool = False,
 ) -> None:
     """Daemon-thread worker: build the fork, run the prompt, surface the action summary via
     ``agent._safe_print`` / ``background_review_callback``. ``review_run`` (from
@@ -1098,7 +1105,7 @@ def _run_review_in_thread(
         # their console output (#55769 / #55925). ``thread_scoped_silence`` routes only this thread's writes
         # to devnull and leaves all other threads on the real streams.
         with thread_scoped_silence():
-            _run_review_fork(agent, messages_snapshot, prompt, task_cfg, review_run, st, review_memory)
+            _run_review_fork(agent, messages_snapshot, prompt, task_cfg, review_run, st, review_memory, explicit)
         # A buggy/legacy tool response shape must NOT take down the whole review (the outer
         # except would discard every action the fork DID complete), so coerce to an empty list.
         try:
@@ -1155,11 +1162,14 @@ def spawn_background_review_thread(
     agent: Any, messages_snapshot: List[Dict], review_memory: bool = False,
     review_skills: bool = False, focus: Optional[str] = None,
     task_cfg: Optional[Dict[str, Any]] = None, review_run: Optional[_BackgroundReviewRun] = None,
+    explicit: bool = False,
 ):
     """Return ``(target, prompt)``; the caller builds the ``threading.Thread`` so test patches of
     ``run_agent.threading.Thread`` keep working. ``focus`` (``/refine [instructions]``) is appended
     to the chosen prompt; automatic reviews pass ``None``. ``task_cfg`` is the pre-loaded
-    ``auxiliary.background_review`` block; when omitted it is read once here."""
+    ``auxiliary.background_review`` block; when omitted it is read once here. ``explicit``
+    (/refine) propagates to the fork's write origin so user-requested reviews keep the full
+    memory operation set."""
     if task_cfg is None:
         task_cfg = _background_review_task_config()
     # Per-agent overrides (agent._MEMORY_REVIEW_PROMPT etc.) keep working.
@@ -1174,7 +1184,7 @@ def spawn_background_review_thread(
     def _target() -> None:  # resolves _run_review_in_thread at call time (tests patch it)
         _run_review_in_thread(
             agent, messages_snapshot, prompt, task_cfg=task_cfg, review_run=review_run,
-            review_memory=review_memory)
+            review_memory=review_memory, explicit=explicit)
 
     return _target, prompt
 

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -934,14 +934,17 @@ def _track_review_fork(agent: Any, review_agent: Any, *, register: bool) -> None
                     agent._active_children.remove(review_agent)
 
 
-def _review_tool_whitelist(review_agent: Any, task_cfg: Optional[Dict[str, Any]]) -> Tuple[set, set]:
+def _review_tool_whitelist(
+    review_agent: Any, task_cfg: Optional[Dict[str, Any]], review_memory: bool = False,
+) -> Tuple[set, set]:
     """``(whitelist, configured_extra_tools)`` for the review fork — DISPATCH-side only, so the
     advertised ``tools[]`` stays byte-identical to the parent's (prompt-cache parity)."""
     from model_tools import get_tool_definitions
-    # Gate the built-in memory tool on the profile's memory flags so a memory-disabled profile
-    # is never contaminated by the review LLM.
+    # Gate the built-in memory tool on BOTH the profile's memory flags and the trigger that fired
+    # (#105921): a skill-nudge review never gets the memory tool, so an unattended fork cannot
+    # act on the memory tool's "consolidate now" hint and delete entries no one reviewed.
     memory_on = review_agent._memory_enabled or review_agent._user_profile_enabled
-    review_toolsets = ["memory", "skills"] if memory_on else ["skills"]
+    review_toolsets = ["memory", "skills"] if memory_on and review_memory else ["skills"]
     whitelist = {t["function"]["name"] for t in get_tool_definitions(enabled_toolsets=review_toolsets, quiet_mode=True)}
     # Read-only file tools: denying read_file/search_files caused a per-review denial storm that
     # starved the loop (read_file also registers the read with the read-before-write guard).
@@ -992,7 +995,7 @@ def _release_fork_clients(review_agent: Any) -> None:
 
 def _run_review_fork(
     agent: Any, messages_snapshot: List[Dict], prompt: str, task_cfg: Optional[Dict[str, Any]],
-    review_run: Optional[_BackgroundReviewRun], st: _ReviewForkState,
+    review_run: Optional[_BackgroundReviewRun], st: _ReviewForkState, review_memory: bool = False,
 ) -> None:
     """Fork phase (inside thread-scoped silence): build the fork, run the prompt under the tool
     whitelist, snapshot its messages/usage, release its clients. Partial progress lands on ``st``
@@ -1000,17 +1003,21 @@ def _run_review_fork(
     st.review_agent, _rt, _routed = build_cache_parity_fork(agent, task_cfg, max_iterations=_REVIEW_MAX_ITERATIONS)
     _track_review_fork(agent, st.review_agent, register=True)
     from hermes_cli.plugins import set_thread_tool_whitelist, clear_thread_tool_whitelist
-    review_whitelist, configured_extra_tools = _review_tool_whitelist(st.review_agent, task_cfg)
+    review_whitelist, configured_extra_tools = _review_tool_whitelist(st.review_agent, task_cfg, review_memory)
     extra_list = ", ".join(sorted(configured_extra_tools))
     deny_extra = f" Configured extra tools also allowed: {extra_list}." if configured_extra_tools else ""
     prompt_extra = f" Exception — these configured tools are also allowed: {extra_list}." if configured_extra_tools else ""
+    # Keep the deny/prompt wording in sync with the whitelist: a memory-less review must not
+    # tell the model that memory is available, or it will burn iterations on denied calls.
+    memory_phrase_deny = " and memory for notes (add only)" if "memory" in review_whitelist else ""
+    memory_phrase_prompt = "memory and skill " if "memory" in review_whitelist else "skill "
     set_thread_tool_whitelist(
         review_whitelist,
         deny_msg_fmt=(
             "Background review denied non-whitelisted tool: "
             "{tool_name}. Allowed here: skill_view/skills_list/read_file/search_files to read, "
-            "skill_manage(action='patch'|...) to change skills, and "
-            "memory for notes." + deny_extra + " Do not retry {tool_name}."
+            "skill_manage(action='patch'|...) to change skills"
+            + memory_phrase_deny + "." + deny_extra + " Do not retry {tool_name}."
         ),
     )
     with suppress(Exception):
@@ -1022,7 +1029,7 @@ def _run_review_fork(
             # Routed -> digest (cache cold anyway); same model -> full snapshot (warm cache reads).
             st.review_agent.run_conversation(
                 user_message=(
-                    prompt + "\n\nYou can only call memory and skill "
+                    prompt + "\n\nYou can only call " + memory_phrase_prompt +
                     "management tools. Other tools will be denied "
                     "at runtime — do not attempt them." + prompt_extra
                 ),
@@ -1056,6 +1063,7 @@ def _publish_review_summary(agent: Any, actions: List[str]) -> None:
 def _run_review_in_thread(
     agent: Any, messages_snapshot: List[Dict], prompt: str,
     task_cfg: Optional[Dict[str, Any]] = None, review_run: Optional[_BackgroundReviewRun] = None,
+    review_memory: bool = False,
 ) -> None:
     """Daemon-thread worker: build the fork, run the prompt, surface the action summary via
     ``agent._safe_print`` / ``background_review_callback``. ``review_run`` (from
@@ -1090,7 +1098,7 @@ def _run_review_in_thread(
         # their console output (#55769 / #55925). ``thread_scoped_silence`` routes only this thread's writes
         # to devnull and leaves all other threads on the real streams.
         with thread_scoped_silence():
-            _run_review_fork(agent, messages_snapshot, prompt, task_cfg, review_run, st)
+            _run_review_fork(agent, messages_snapshot, prompt, task_cfg, review_run, st, review_memory)
         # A buggy/legacy tool response shape must NOT take down the whole review (the outer
         # except would discard every action the fork DID complete), so coerce to an empty list.
         try:
@@ -1164,7 +1172,9 @@ def spawn_background_review_thread(
         )
 
     def _target() -> None:  # resolves _run_review_in_thread at call time (tests patch it)
-        _run_review_in_thread(agent, messages_snapshot, prompt, task_cfg=task_cfg, review_run=review_run)
+        _run_review_in_thread(
+            agent, messages_snapshot, prompt, task_cfg=task_cfg, review_run=review_run,
+            review_memory=review_memory)
 
     return _target, prompt
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -758,7 +758,8 @@ class AIAgent(
         # deferral) goes through. See #100795.
         from agent.turn_finalizer import _clone_background_review_messages
         kwargs = dict(messages_snapshot=_clone_background_review_messages(messages_snapshot),
-                      review_memory=review_memory, review_skills=review_skills, focus=focus, task_cfg=task_cfg)
+                      review_memory=review_memory, review_skills=review_skills, focus=focus, task_cfg=task_cfg,
+                      explicit=explicit)
         if focus is None and not explicit and _review_should_defer(self, task_cfg):
             from agent.review_idle_queue import QUEUE
             QUEUE.enqueue(self, _review_queue_key(self), kwargs)
@@ -767,12 +768,15 @@ class AIAgent(
 
     def _spawn_background_review_now(self, messages_snapshot: List[Dict], review_memory: bool = False,
                                      review_skills: bool = False, focus: Optional[str] = None,
-                                     task_cfg: Optional[Dict[str, Any]] = None, _requeue_attempts: int = 0) -> None:
+                                     task_cfg: Optional[Dict[str, Any]] = None, _requeue_attempts: int = 0,
+                                     explicit: bool = False) -> None:
         """Spawn the background memory/skill review thread.
 
         ``threading.Thread`` is constructed here so tests patching ``run_agent.threading.Thread`` keep working.
         ``focus`` is /refine steering text; ``task_cfg`` is the pre-loaded config block (None on direct calls).
-        A deferred review preempted by a live turn is requeued (bounded) rather than lost.
+        ``explicit`` (/refine) forks under the ``refine_review`` write origin, keeping the full
+        memory operation set. A deferred review preempted by a live turn is requeued (bounded)
+        rather than lost.
         """
         from agent.background_review import (
             finish_background_review_run, prepare_background_review_run, spawn_background_review_thread,
@@ -785,14 +789,15 @@ class AIAgent(
         try:
             target, _prompt = spawn_background_review_thread(
                 self, messages_snapshot, review_memory=review_memory, review_skills=review_skills,
-                focus=focus, task_cfg=task_cfg, review_run=review_run,
+                focus=focus, task_cfg=task_cfg, review_run=review_run, explicit=explicit,
             )
 
             def _target_with_requeue() -> None:
                 target()
                 self._maybe_requeue_preempted_review(review_run, dict(
                     messages_snapshot=messages_snapshot, review_memory=review_memory, review_skills=review_skills,
-                    focus=focus, task_cfg=task_cfg, _requeue_attempts=_requeue_attempts + 1))
+                    focus=focus, task_cfg=task_cfg, _requeue_attempts=_requeue_attempts + 1,
+                    explicit=explicit))
 
             # Carry the active profile into the review thread so MEMORY.md / skill review writes land in the
             # right profile.

--- a/tests/agent/test_background_review_memory_scope.py
+++ b/tests/agent/test_background_review_memory_scope.py
@@ -53,7 +53,8 @@ class TestSpawnForwardsScope:
     def test_target_passes_review_memory_to_worker(self):
         captured = {}
 
-        def fake_worker(agent, messages_snapshot, prompt, task_cfg=None, review_run=None, review_memory=False):
+        def fake_worker(agent, messages_snapshot, prompt, task_cfg=None, review_run=None,
+                        review_memory=False, explicit=False):
             captured["review_memory"] = review_memory
 
         agent = SimpleNamespace()
@@ -67,3 +68,146 @@ class TestSpawnForwardsScope:
                 agent, [], review_memory=True, review_skills=False)
             target()
             assert captured["review_memory"] is True
+
+
+class TestExplicitRefineOrigin:
+    """``/refine`` (explicit) must not inherit the unattended-review origin: the user asked
+    for that review, so its fork keeps the full memory operation set and the delete gate
+    does not apply (#105921 review follow-up)."""
+
+    def test_target_passes_explicit_to_worker(self):
+        captured = {}
+
+        def fake_worker(agent, messages_snapshot, prompt, task_cfg=None, review_run=None,
+                        review_memory=False, explicit=False):
+            captured["explicit"] = explicit
+
+        with patch.object(bg, "_run_review_in_thread", fake_worker):
+            target, _prompt = bg.spawn_background_review_thread(
+                SimpleNamespace(), [], review_memory=True, explicit=True)
+            target()
+            assert captured["explicit"] is True
+
+    def test_explicit_fork_uses_refine_review_origin(self):
+        captured = {}
+
+        def fake_build(agent, task_cfg=None, *, max_iterations, write_origin="background_review"):
+            captured["write_origin"] = write_origin
+            fork = SimpleNamespace(
+                _memory_enabled=True, _user_profile_enabled=False,
+                run_conversation=lambda **kw: None, _session_messages=[])
+            return fork, {}, False
+
+        noop = lambda *a, **k: None
+        with patch.object(bg, "build_cache_parity_fork", fake_build), \
+                patch.object(bg, "_track_review_fork", noop), \
+                patch.object(bg, "_snapshot_review_usage", lambda a: {}), \
+                patch.object(bg, "_record_review_usage_to_parent", noop), \
+                patch.object(bg, "finish_background_review_run", noop), \
+                patch.object(bg, "_release_fork_clients", noop):
+            bg._run_review_fork(SimpleNamespace(), [], "p", None, None, bg._ReviewForkState(), True, True)
+        assert captured["write_origin"] == "refine_review"
+
+    def test_automatic_fork_keeps_background_review_origin(self):
+        captured = {}
+
+        def fake_build(agent, task_cfg=None, *, max_iterations, write_origin="background_review"):
+            captured["write_origin"] = write_origin
+            fork = SimpleNamespace(
+                _memory_enabled=True, _user_profile_enabled=False,
+                run_conversation=lambda **kw: None, _session_messages=[])
+            return fork, {}, False
+
+        noop = lambda *a, **k: None
+        with patch.object(bg, "build_cache_parity_fork", fake_build), \
+                patch.object(bg, "_track_review_fork", noop), \
+                patch.object(bg, "_snapshot_review_usage", lambda a: {}), \
+                patch.object(bg, "_record_review_usage_to_parent", noop), \
+                patch.object(bg, "finish_background_review_run", noop), \
+                patch.object(bg, "_release_fork_clients", noop):
+            bg._run_review_fork(SimpleNamespace(), [], "p", None, None, bg._ReviewForkState(), True, False)
+        assert captured["write_origin"] == "background_review"
+
+
+class TestConsolidationProposalSurfaces:
+    """The fork's own review summary is never published back, so a consolidation the delete
+    gate staged must surface through ``summarize_background_review_actions`` — otherwise the
+    near-limit denial path drops both the requested update and the proposal, silently (#105921)."""
+
+    def _store(self, tmp_path, monkeypatch):
+        import json as _json
+        from tools.memory_tool_store import MemoryStore
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+        store.load_from_disk()
+        return store
+
+    def test_staged_proposal_surfaces_in_summary(self, tmp_path, monkeypatch):
+        import json
+
+        from tools.memory_tool import memory_tool
+        from tools.skill_provenance import set_current_write_origin, reset_current_write_origin
+
+        store = self._store(tmp_path, monkeypatch)
+        assert store.add("memory", "standing rule entry")["success"] is True
+
+        token = set_current_write_origin("background_review")
+        try:
+            raw = memory_tool(
+                action="replace", old_text="standing rule", content="consolidated entry", store=store)
+        finally:
+            reset_current_write_origin(token)
+        result = json.loads(raw)
+        assert result["staged"] is True and result["proposal_staged"] is True
+
+        review_messages = [
+            {"role": "assistant", "tool_calls": [{"id": "c1", "function": {"name": "memory", "arguments": json.dumps(
+                {"action": "replace", "old_text": "standing rule", "content": "consolidated entry"})}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": raw},
+        ]
+        actions = bg.summarize_background_review_actions(review_messages, [])
+        assert any("staged for your approval" in a for a in actions)
+
+    def test_near_limit_denial_end_to_end(self, tmp_path, monkeypatch):
+        """add rejected by the budget -> fork follows the 'consolidate now' hint with a
+        replace -> the delete gate stages it -> the proposal surfaces; the store never
+        changed and nothing was silently lost."""
+        import json
+
+        from tools.memory_tool import memory_tool
+        from tools.skill_provenance import set_current_write_origin, reset_current_write_origin
+
+        store = self._store(tmp_path, monkeypatch)
+        assert store.add("memory", "seed entry one")["success"] is True
+        # Near-limit: a further add is rejected and the store's hint says to consolidate.
+        assert store.add("memory", "x" * 600)["success"] is False
+
+        token = set_current_write_origin("background_review")
+        try:
+            add_raw = memory_tool(action="add", content="y" * 600, store=store)
+            replace_raw = memory_tool(
+                action="replace", old_text="seed entry one", content="merged entry", store=store)
+        finally:
+            reset_current_write_origin(token)
+        assert json.loads(add_raw)["success"] is False  # the budget still rejects the add
+        replace_result = json.loads(replace_raw)
+        assert replace_result["staged"] is True and replace_result["proposal_staged"] is True
+
+        # Fail-closed: nothing was applied or dropped.
+        assert "seed entry one" in store._entries_for("memory")
+        assert "merged entry" not in store._entries_for("memory")
+
+        review_messages = [
+            {"role": "assistant", "tool_calls": [
+                {"id": "c1", "function": {"name": "memory", "arguments": json.dumps(
+                    {"action": "add", "content": "y" * 600})}},
+                {"id": "c2", "function": {"name": "memory", "arguments": json.dumps(
+                    {"action": "replace", "old_text": "seed entry one", "content": "merged entry"})}},
+            ]},
+            {"role": "tool", "tool_call_id": "c1", "content": add_raw},
+            {"role": "tool", "tool_call_id": "c2", "content": replace_raw},
+        ]
+        actions = bg.summarize_background_review_actions(review_messages, [])
+        assert any("staged for your approval" in a for a in actions)

--- a/tests/agent/test_background_review_memory_scope.py
+++ b/tests/agent/test_background_review_memory_scope.py
@@ -1,0 +1,69 @@
+"""The review fork's memory access must follow the trigger that fired (#105921).
+
+``spawn_background_review_thread`` already received ``review_memory`` /
+``review_skills`` but used them only to pick the prompt — the tool whitelist
+granted the whole ``memory`` toolset whenever the profile had memory enabled,
+so a skill-nudge fork held ``remove``/``replace`` on MEMORY.md it was never
+asked to use. These tests pin the scope-aware whitelist and the pass-through
+from ``spawn_background_review_thread`` down to it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import agent.background_review as bg  # noqa: E402
+
+
+def _review_agent(memory_enabled=True, user_profile_enabled=False) -> SimpleNamespace:
+    """The whitelist only reads the profile's memory flags off the fork."""
+    return SimpleNamespace(_memory_enabled=memory_enabled, _user_profile_enabled=user_profile_enabled)
+
+
+class TestReviewToolWhitelistScope:
+    def test_skill_only_review_omits_memory_tool(self):
+        whitelist, _extra = bg._review_tool_whitelist(_review_agent(), None, review_memory=False)
+        assert "memory" not in whitelist
+        assert "skill_manage" in whitelist  # the skill review keeps its own surface
+
+    def test_memory_review_keeps_memory_tool(self):
+        whitelist, _extra = bg._review_tool_whitelist(_review_agent(), None, review_memory=True)
+        assert "memory" in whitelist
+
+    def test_memory_disabled_profile_stays_memory_free(self):
+        whitelist, _extra = bg._review_tool_whitelist(
+            _review_agent(memory_enabled=False, user_profile_enabled=False), None, review_memory=True)
+        assert "memory" not in whitelist
+
+    def test_default_scope_is_memoryless_fail_closed(self):
+        # Unknown trigger (default) must not grant memory: the incident fork was a
+        # skill review that used memory nobody asked it to touch.
+        whitelist, _extra = bg._review_tool_whitelist(_review_agent(), None)
+        assert "memory" not in whitelist
+
+
+class TestSpawnForwardsScope:
+    def test_target_passes_review_memory_to_worker(self):
+        captured = {}
+
+        def fake_worker(agent, messages_snapshot, prompt, task_cfg=None, review_run=None, review_memory=False):
+            captured["review_memory"] = review_memory
+
+        agent = SimpleNamespace()
+        with patch.object(bg, "_run_review_in_thread", fake_worker):
+            target, _prompt = bg.spawn_background_review_thread(
+                agent, [], review_memory=False, review_skills=True)
+            target()
+            assert captured["review_memory"] is False
+
+            target, _prompt = bg.spawn_background_review_thread(
+                agent, [], review_memory=True, review_skills=False)
+            target()
+            assert captured["review_memory"] is True

--- a/tests/agent/test_refine_snapshot_isolation.py
+++ b/tests/agent/test_refine_snapshot_isolation.py
@@ -75,6 +75,23 @@ def test_cli_refine_snapshot_does_not_alias_live_history(monkeypatch):
     _assert_isolated(cli.conversation_history, snapshot)
 
 
+def test_cli_refine_reaches_spawn_as_explicit(monkeypatch):
+    """The explicit /refine path must reach the spawn with ``explicit=True`` so the fork runs
+    under the refine_review origin and keeps the full memory operation set (#105921 review)."""
+    from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+    monkeypatch.setattr("cli._cprint", lambda *a, **k: None, raising=False)
+    agent = _agent_with_real_chokepoint()
+    cli = object.__new__(CLICommandsMixin)
+    cli.agent = agent
+    cli.conversation_history = _nested_history()
+
+    cli._handle_refine_command("/refine")
+
+    agent._spawn_background_review_now.assert_called_once()
+    assert agent._spawn_background_review_now.call_args.kwargs["explicit"] is True
+
+
 @pytest.mark.asyncio
 async def test_gateway_refine_snapshot_does_not_alias_live_history():
     from gateway.run import GatewayRunner

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -765,21 +765,33 @@ class TestBatchRefusesToEmptyNonEmptyStore:
 class TestBackgroundReviewDeleteGate:
     """An unattended background-review fork may append, never delete: the near-limit
     'consolidate now' hint is otherwise an instruction to decide what to forget,
-    executed with no human in the loop."""
+    executed with no human in the loop. Denied ops are staged as pending proposals
+    (surfaced via /memory pending) instead of silently dropped — the fork's own review
+    summary is never published back."""
 
-    def test_remove_denied_and_store_untouched(self, store):
+    def test_remove_staged_not_applied(self, store, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         store.add("memory", "never create records without permission")
         token = set_current_write_origin("background_review")
         try:
             result = json.loads(memory_tool(action="remove", old_text="without permission", store=store))
         finally:
             reset_current_write_origin(token)
-        assert result["success"] is False
-        assert "Background review may not delete" in result["error"]
+        assert result["success"] is True
+        assert result["staged"] is True
+        assert result["proposal_staged"] is True
+        assert result["pending_id"]
+        assert "staged for your approval" in result["message"]
         # Fail-closed: the standing rule is still on disk.
         assert "never create records without permission" in store._entries_for("memory")
+        # The proposal itself landed in the pending store for the user to approve or discard.
+        from tools.write_approval import MEMORY, get_pending
+        record = get_pending(MEMORY, result["pending_id"])
+        assert record["payload"]["action"] == "remove"
+        assert record["origin"] == "background_review"
 
-    def test_replace_denied_in_background_review(self, store):
+    def test_replace_staged_in_background_review(self, store, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         store.add("memory", "entry the fork must not rewrite")
         token = set_current_write_origin("background_review")
         try:
@@ -787,10 +799,13 @@ class TestBackgroundReviewDeleteGate:
                 action="replace", old_text="entry the fork", content="rewritten by fork", store=store))
         finally:
             reset_current_write_origin(token)
-        assert result["success"] is False
-        assert "Background review may not delete" in result["error"]
+        assert result["staged"] is True
+        assert result["proposal_staged"] is True
+        # Fail-closed: the original entry is untouched.
+        assert "entry the fork must not rewrite" in store._entries_for("memory")
 
-    def test_batch_containing_remove_denied(self, store):
+    def test_batch_containing_remove_staged_whole_batch(self, store, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         store.add("memory", "rule one")
         token = set_current_write_origin("background_review")
         try:
@@ -800,8 +815,8 @@ class TestBackgroundReviewDeleteGate:
             ], store=store))
         finally:
             reset_current_write_origin(token)
-        assert result["success"] is False
-        # Atomic denial: the batch's add must not land either.
+        assert result["staged"] is True
+        # Atomic: the batch is only a proposal — its add must not land either.
         assert "fork consolidation" not in store._entries_for("memory")
 
     def test_add_still_allowed_in_background_review(self, store):
@@ -818,3 +833,17 @@ class TestBackgroundReviewDeleteGate:
         result = json.loads(memory_tool(action="remove", old_text="supervised turn", store=store))
         assert result["success"] is True
         assert "entry a supervised turn may remove" not in store._entries_for("memory")
+
+    def test_refine_review_origin_keeps_full_operation_set(self, store):
+        # A user-requested /refine fork runs under the refine_review origin: it is not an
+        # unattended review, so replace/remove keep working on that supervised surface.
+        store.add("memory", "entry an explicit refine may rewrite")
+        token = set_current_write_origin("refine_review")
+        try:
+            result = json.loads(memory_tool(
+                action="replace", old_text="entry an explicit", content="rewritten by refine", store=store))
+        finally:
+            reset_current_write_origin(token)
+        assert result["success"] is True
+        assert "rewritten by refine" in store._entries_for("memory")
+        assert "entry an explicit refine may rewrite" not in store._entries_for("memory")

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -9,6 +9,7 @@ from tools.memory_tool import (
     memory_tool,
     _scan_memory_content,
 )
+from tools.skill_provenance import reset_current_write_origin, set_current_write_origin
 
 
 def _blocked(content, pattern_id=None):
@@ -755,3 +756,65 @@ class TestBatchRefusesToEmptyNonEmptyStore:
         assert result["success"] is True
         assert seed not in store._entries_for(target)
         assert "replacement entry here" in store._entries_for(target)
+
+
+# =========================================================================
+# Background-review delete gate (#105921)
+# =========================================================================
+
+class TestBackgroundReviewDeleteGate:
+    """An unattended background-review fork may append, never delete: the near-limit
+    'consolidate now' hint is otherwise an instruction to decide what to forget,
+    executed with no human in the loop."""
+
+    def test_remove_denied_and_store_untouched(self, store):
+        store.add("memory", "never create records without permission")
+        token = set_current_write_origin("background_review")
+        try:
+            result = json.loads(memory_tool(action="remove", old_text="without permission", store=store))
+        finally:
+            reset_current_write_origin(token)
+        assert result["success"] is False
+        assert "Background review may not delete" in result["error"]
+        # Fail-closed: the standing rule is still on disk.
+        assert "never create records without permission" in store._entries_for("memory")
+
+    def test_replace_denied_in_background_review(self, store):
+        store.add("memory", "entry the fork must not rewrite")
+        token = set_current_write_origin("background_review")
+        try:
+            result = json.loads(memory_tool(
+                action="replace", old_text="entry the fork", content="rewritten by fork", store=store))
+        finally:
+            reset_current_write_origin(token)
+        assert result["success"] is False
+        assert "Background review may not delete" in result["error"]
+
+    def test_batch_containing_remove_denied(self, store):
+        store.add("memory", "rule one")
+        token = set_current_write_origin("background_review")
+        try:
+            result = json.loads(memory_tool(operations=[
+                {"action": "remove", "old_text": "rule one"},
+                {"action": "add", "content": "fork consolidation"},
+            ], store=store))
+        finally:
+            reset_current_write_origin(token)
+        assert result["success"] is False
+        # Atomic denial: the batch's add must not land either.
+        assert "fork consolidation" not in store._entries_for("memory")
+
+    def test_add_still_allowed_in_background_review(self, store):
+        token = set_current_write_origin("background_review")
+        try:
+            result = json.loads(memory_tool(action="add", content="a fact worth keeping", store=store))
+        finally:
+            reset_current_write_origin(token)
+        assert result["success"] is True
+        assert "a fact worth keeping" in store._entries_for("memory")
+
+    def test_foreground_remove_unaffected(self, store):
+        store.add("memory", "entry a supervised turn may remove")
+        result = json.loads(memory_tool(action="remove", old_text="supervised turn", store=store))
+        assert result["success"] is True
+        assert "entry a supervised turn may remove" not in store._entries_for("memory")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -129,23 +129,44 @@ def _validate_single_op(store, action, target, content, old_text) -> Optional[st
 _BG_DELETE_ACTIONS = ("replace", "remove")
 
 
-def _background_delete_gate(action, operations) -> Optional[str]:
+def _background_delete_gate(action, operations, target="memory", content=None, old_text=None) -> Optional[str]:
     """Fail-closed operation gate for unattended background-review forks (#105921): ``add``
     stays available (it is all any review prompt asks for), while ``replace``/``remove`` —
-    single or inside a batch — are denied. The near-limit "consolidate now" hint is otherwise
-    an instruction to decide what to forget, executed with no human in the loop."""
+    single or inside a batch — are never applied unattended. The op is staged in the pending
+    store instead of merely denied: the fork's own review summary is never published back, so
+    a plain denial would drop the consolidation request with no surfacing path at all. A
+    staging failure fails closed to a plain denial."""
     from tools.skill_provenance import is_background_review
 
     if not is_background_review():
         return None
-    if action in _BG_DELETE_ACTIONS or any(
-        isinstance(op, dict) and op.get("action") in _BG_DELETE_ACTIONS for op in (operations or [])
-    ):
+    hit = action in _BG_DELETE_ACTIONS or any(
+        isinstance(op, dict) and op.get("action") in _BG_DELETE_ACTIONS for op in (operations or []))
+    if not hit:
+        return None
+    payload = ({"action": "batch", "target": target, "operations": operations}
+               if operations is not None else
+               {"action": action, "target": target, "content": content, "old_text": old_text})
+    detail = ("; ".join(_batch_op_line(op) for op in operations) if operations is not None
+              else _batch_op_line({"action": action, "content": content, "old_text": old_text}))
+    try:
+        from tools import write_approval as wa
+        record = wa.stage_write(
+            wa.MEMORY, payload,
+            summary=(f"background review consolidation ({'batch' if operations is not None else action} "
+                     f"on {target}): {detail}")[:200],
+            origin=wa.current_origin())
+        return json.dumps({
+            "success": True, "staged": True, "proposal_staged": True, "pending_id": record["id"],
+            "message": ("Background review may not delete memory entries unattended. The proposed "
+                        f"{'batch' if operations is not None else action} was staged for your approval — "
+                        "review it with /memory pending (approve to apply, discard to drop)."),
+        }, ensure_ascii=False)
+    except Exception:
+        logger.warning("Failed to stage background-review consolidation; denying", exc_info=True)
         return tool_error(
             "Background review may not delete memory entries ('replace'/'remove', including in a "
-            "batch); 'add' is still available. Propose a consolidation in your review summary "
-            "instead.", success=False)
-    return None
+            "batch); 'add' is still available.", success=False)
 
 
 def memory_tool(action: str = None, target: str = "memory", content: str = None, old_text: str = None,
@@ -163,7 +184,7 @@ def memory_tool(action: str = None, target: str = "memory", content: str = None,
     target_error = _memory_target_error(store, target)
     if target_error is not None:
         return json.dumps(target_error)
-    denied = _background_delete_gate(action, operations)
+    denied = _background_delete_gate(action, operations, target, content, old_text)
     if denied is not None:
         return denied
     if operations:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -126,6 +126,28 @@ def _validate_single_op(store, action, target, content, old_text) -> Optional[st
     return None
 
 
+_BG_DELETE_ACTIONS = ("replace", "remove")
+
+
+def _background_delete_gate(action, operations) -> Optional[str]:
+    """Fail-closed operation gate for unattended background-review forks (#105921): ``add``
+    stays available (it is all any review prompt asks for), while ``replace``/``remove`` —
+    single or inside a batch — are denied. The near-limit "consolidate now" hint is otherwise
+    an instruction to decide what to forget, executed with no human in the loop."""
+    from tools.skill_provenance import is_background_review
+
+    if not is_background_review():
+        return None
+    if action in _BG_DELETE_ACTIONS or any(
+        isinstance(op, dict) and op.get("action") in _BG_DELETE_ACTIONS for op in (operations or [])
+    ):
+        return tool_error(
+            "Background review may not delete memory entries ('replace'/'remove', including in a "
+            "batch); 'add' is still available. Propose a consolidation in your review summary "
+            "instead.", success=False)
+    return None
+
+
 def memory_tool(action: str = None, target: str = "memory", content: str = None, old_text: str = None,
                 new_text: str = None, operations: Optional[List[Dict[str, Any]]] = None,
                 store: Optional[MemoryStore] = None) -> str:
@@ -141,6 +163,9 @@ def memory_tool(action: str = None, target: str = "memory", content: str = None,
     target_error = _memory_target_error(store, target)
     if target_error is not None:
         return json.dumps(target_error)
+    denied = _background_delete_gate(action, operations)
+    if denied is not None:
+        return denied
     if operations:
         if not isinstance(operations, list):
             return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)


### PR DESCRIPTION
## What does this PR do?

The background-review fork's tool whitelist granted the whole `memory` toolset whenever the profile had memory enabled, **regardless of which nudge fired** — `spawn_background_review_thread` already receives `review_memory`/`review_skills` but used them only to pick the prompt. A skill-nudge fork therefore held `remove`/`replace` on `MEMORY.md` it was never asked to use, and the memory tool's near-limit "consolidate now" hint turns that into standing-rule deletions with no user in the loop.

Two scoped fixes:

1. **Trigger-aware whitelist** — `review_memory` now flows from `spawn_background_review_thread` through `_run_review_in_thread`/`_run_review_fork` into `_review_tool_whitelist`; a skill-only review gets no `memory` tool at all (a memory-disabled profile was already excluded). The deny message and the fork's opening instruction stay in sync with the whitelist so a memory-less review does not advertise memory.
2. **Fail-closed operation gate** — in `memory_tool`, a background-review-originated call (the `is_background_review()` ContextVar the fork already binds) may `add`, never `replace`/`remove`, including inside a `batch` (denied atomically — the batch's adds do not land either). Foreground turns, `/refine`-driven reviews reviewing memory with `review_memory=True`, and `/memory approve` replays keep the full operation set; the curator fork has no memory tool to begin with.

Every review prompt (memory/skill/combined) only ever asks the model to *save* — `replace`/`remove` was reachable solely via the near-limit hint, so this gate removes the incident path without touching any designed capability.

## Related Issue

Fixes #105921

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `agent/background_review.py`: `_review_tool_whitelist` takes `review_memory` (default `False`, fail-closed) and only includes the `memory` toolset when the profile has memory **and** the trigger was a memory review; `spawn_background_review_thread` → `_run_review_in_thread` → `_run_review_fork` forward the flag; deny message / opening instruction wording derived from the actual whitelist.
- `tools/memory_tool.py`: new `_background_delete_gate` — denies `replace`/`remove` (single or in a batch) when `is_background_review()`, with a deny message that points at the review summary as the consolidation channel.
- `tests/agent/test_background_review_memory_scope.py`: whitelist scope (skill-only omits memory, memory review keeps it, disabled profile stays memory-free, default is fail-closed) + pass-through from `spawn_background_review_thread`.
- `tests/tools/test_memory_tool.py`: gate behavior (remove/replace/batch-with-remove denied and store untouched, add still allowed in background review, foreground remove unaffected).

## How to Test

1. `pytest tests/agent/test_background_review_memory_scope.py -q` → 6 passed (whitelist follows the trigger; default scope is memory-less).
2. `pytest tests/tools/test_memory_tool.py -q` → 55 passed, including the new gate tests: an origin-bound `remove`/`replace`/batch-with-`remove` is denied with "Background review may not delete memory entries" and the store is untouched, while `add` succeeds and a foreground `remove` still works.
3. `pytest tests/agent/test_background_review_tool_call_guard.py tests/agent/test_refine_focus.py tests/agent/test_background_review_usage.py tests/run_agent/test_background_review_input_budget.py tests/test_background_review_list_shapes.py tests/agent/test_compression_concurrent_fork.py -q` → 94 passed (no regression in the fork/spawn machinery; the 2 `test_write_approval.py` inline-prompt failures seen in a combined run reproduce identically on a clean `upstream/main` stash — pre-existing order pollution, not from this change).
4. `ruff check agent/background_review.py tools/memory_tool.py tests/agent/test_background_review_memory_scope.py tests/tools/test_memory_tool.py` → All checks passed.

Observed result: all of the above pass locally on the worktree based on `upstream/main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0, arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable (no UI change).