### PR TITLE
feat(memory): support chat-scoped subagent memory

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -9,6 +9,7 @@ Symbols that tests patch on ``run_agent.*`` (``OpenAI``, ``get_tool_definitions`
 
 from __future__ import annotations
 
+import contextvars
 import logging
 import os
 import re
@@ -17,7 +18,7 @@ import threading
 import time
 import uuid
 from collections import deque
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from datetime import datetime
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional
@@ -49,6 +50,20 @@ logger = logging.getLogger("run_agent")
 
 # Deduped: the gateway builds a fresh AIAgent per message, so it would warn every turn.
 _warned_unavailable_providers: set[str] = set()
+_MEMORY_SCOPE_OVERRIDE: contextvars.ContextVar[Optional[Dict[str, Any]]] = contextvars.ContextVar(
+    "hermes_memory_scope_override", default=None,
+)
+
+
+@contextmanager
+def _bind_memory_scope_parent(parent: Any):
+    """Temporarily source memory-provider scope from a host-owned parent agent."""
+    scope = _memory_scope_kwargs(parent, getattr(parent, "platform", None)) if parent is not None else None
+    token = _MEMORY_SCOPE_OVERRIDE.set(scope)
+    try:
+        yield
+    finally:
+        _MEMORY_SCOPE_OVERRIDE.reset(token)
 
 
 def _warn_memory_provider_unavailable(name: str, reason: str = "") -> None:
@@ -1199,20 +1214,11 @@ def _apply_display_config(agent, _agent_cfg, platform):
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
 
 
-def _memory_provider_init_kwargs(agent, platform) -> Dict[str, Any]:
-    """Scoping kwargs for ``MemoryManager.initialize_all`` (status_callback is CLI-only:
-    gateway status travels a different path and the indicator no-ops without it)."""
-    kwargs = {
-        "session_id": agent.session_id,
-        "platform": platform or "cli",
-        "hermes_home": str(get_hermes_home()),
-        "agent_context": "primary",
-    }
-    if kwargs["platform"] == "cli":
-        kwargs["warning_callback"] = agent._emit_warning
-        kwargs["status_callback"] = agent._emit_status
+def _memory_scope_kwargs(agent, platform) -> Dict[str, Any]:
+    """Stable provider scope copied without retaining the source agent."""
+    kwargs = {"platform": platform or "cli"}
     # Session title (e.g. honcho derives chat-scoped session keys from it).
-    if agent._session_db:
+    if getattr(agent, "_session_db", None):
         with suppress(Exception):
             _st = agent._session_db.get_session_title(agent.session_id)
             if _st:
@@ -1220,9 +1226,24 @@ def _memory_provider_init_kwargs(agent, platform) -> Dict[str, Any]:
     # Gateway user/chat identity for per-user scoping (gateway_session_key: stable per-chat
     # Honcho session isolation).
     for _ident in _GATEWAY_IDENTITY_PARAMS:
-        _val = getattr(agent, f"_{_ident}")
+        _val = getattr(agent, f"_{_ident}", None)
         if _val:
             kwargs[_ident] = _val
+    return kwargs
+
+
+def _memory_provider_init_kwargs(agent, platform) -> Dict[str, Any]:
+    """Scoping kwargs for ``MemoryManager.initialize_all`` (status_callback is CLI-only:
+    gateway status travels a different path and the indicator no-ops without it)."""
+    kwargs = {
+        "session_id": agent.session_id,
+        "hermes_home": str(get_hermes_home()),
+        "agent_context": "primary",
+        **(_MEMORY_SCOPE_OVERRIDE.get() or _memory_scope_kwargs(agent, platform)),
+    }
+    if kwargs["platform"] == "cli":
+        kwargs["warning_callback"] = agent._emit_warning
+        kwargs["status_callback"] = agent._emit_status
     # Profile identity for per-profile provider scoping
     with suppress(Exception):
         from hermes_cli.profiles import get_active_profile_name

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -58,6 +58,7 @@ class SubagentLaunchRequest:
     correlation_id: Optional[str] = None
     metadata: Mapping[str, Any] = dataclasses.field(default_factory=dict)
     timeout_seconds: Optional[float] = None
+    inherit_memory_scope: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -227,6 +228,7 @@ _REQUEST_REJECTIONS: tuple[tuple[Callable[[Any], bool], str], ...] = (
      "working_directory is not supported because Hermes delegates use isolated task environments."),
     (lambda r: bool(r.blocked_tools),
      "Per-tool blocking is not supported; use allowed_toolsets. Hermes always blocks unsafe child tools."),
+    (lambda r: type(r.inherit_memory_scope) is not bool, "inherit_memory_scope must be a boolean."),
 )
 
 
@@ -261,6 +263,7 @@ class SubagentLifecycleService:
             task_index=0, goal=request.goal, context=request.context,
             toolsets=list(request.allowed_toolsets) if request.allowed_toolsets else None,
             model=request.model, max_iterations=DEFAULT_MAX_ITERATIONS, task_count=1, parent_agent=parent, role=request.role,
+            inherit_memory_scope=request.inherit_memory_scope,
         )
         subagent_id = str(getattr(child, "_subagent_id", "") or "")
         if not subagent_id:
@@ -405,6 +408,8 @@ class SubagentLifecycleService:
             raise SubagentLifecycleError("metadata must be JSON-serializable.") from exc
         if metadata_bytes > _MAX_METADATA_BYTES:
             raise SubagentLifecycleError("metadata exceeds 8192 bytes.")
+        if request.inherit_memory_scope and getattr(parent, "_memory_manager", None) is None:
+            raise SubagentLifecycleError("inherit_memory_scope requires an active parent memory provider.")
         if not request.allowed_toolsets:
             return
         from toolsets import TOOLSETS

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -60,7 +60,7 @@ Config file: `~/.hermes/hindsight/config.json`
 | Key | Default | Description |
 |-----|---------|-------------|
 | `bank_id` | `hermes` | Memory bank name (static fallback used when `bank_id_template` is unset or resolves empty) |
-| `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{session}`. Example: `hermes-{profile}` isolates memory per active Hermes profile. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
+| `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{chat}`, `{session}`. Example: `hermes-{platform}-{chat}` isolates memory per gateway conversation. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
 | `bank_mission` | — | Reflect mission (identity/framing for reflect reasoning). Applied via Banks API. |
 | `bank_retain_mission` | — | Retain mission (steers what gets extracted). Applied via Banks API. |
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -408,7 +408,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "llm_api_key", "description": "LLM API key (optional for openai_compatible)", "secret": True, "env_var": "HINDSIGHT_LLM_API_KEY", "when": {"mode": "local_embedded"}},
             {"key": "llm_model", "description": "LLM model", "default": "gpt-4o-mini", "default_from": {"field": "llm_provider", "map": _PROVIDER_DEFAULT_MODELS}, "when": {"mode": "local_embedded"}},
             {"key": "bank_id", "description": "Memory bank name (static fallback when bank_id_template is unset)", "default": "hermes"},
-            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
+            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {chat}, {session}. Example: hermes-{profile}", "default": ""},
             {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
             {"key": "bank_retain_mission", "description": "Custom extraction prompt for memory retention"},
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
@@ -716,7 +716,8 @@ class HindsightMemoryProvider(MemoryProvider):
             self._bank_id_template,
             fallback=cfg.get("bank_id") or banks.get("bankId", "hermes"),
             profile=self._agent_identity, workspace=self._agent_workspace,
-            platform=self._platform, user=self._user_id, session=self._session_id,
+            platform=self._platform, user=self._user_id, chat=self._chat_id,
+            session=self._session_id,
         )
         budget = cfg.get("recall_budget") or cfg.get("budget") or banks.get("budget", "mid")
         self._budget = budget if budget in _VALID_BUDGETS else "mid"

--- a/plugins/memory/hindsight/settings.py
+++ b/plugins/memory/hindsight/settings.py
@@ -114,7 +114,7 @@ def _sanitize_bank_segment(value: str) -> str:
 
 
 def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str) -> str:
-    """Render a bank_id template ({profile}, {workspace}, {platform}, {user}, {session}),
+    """Render a bank_id template ({profile}, {workspace}, {platform}, {user}, {chat}, {session}),
     sanitizing each placeholder; the ``-``/``_`` runs empty placeholders leave are
     collapsed (``hermes-{user}`` -> ``hermes``). Empty/invalid template -> *fallback*."""
     if not template:

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -161,6 +161,34 @@ def test_public_lifecycle_runs_host_aggregation(monkeypatch):
     assert parent.session_cost_status == "estimated"
 
 
+def test_memory_scope_inheritance_is_explicit_and_parent_bounded(monkeypatch):
+    parent = SimpleNamespace(session_id="parent-memory", enabled_toolsets=["file"], _memory_manager=None)
+    builds = []
+
+    def build(**kwargs):
+        builds.append(kwargs)
+        return FakeChild(f"sa-memory-{len(builds)}")
+
+    monkeypatch.setattr("tools.delegate_tool._build_child_agent", build)
+    monkeypatch.setattr(
+        "tools.delegate_tool._run_single_child",
+        lambda *_args, **_kwargs: {"status": "completed", "summary": "ok"},
+    )
+    service = SubagentLifecycleService(lambda: parent)
+
+    handle = service.launch(SubagentLaunchRequest(goal="isolated by default"))
+    service.wait(handle, timeout_seconds=1)
+    assert builds[-1]["inherit_memory_scope"] is False
+
+    with pytest.raises(SubagentLifecycleError, match="active parent memory provider"):
+        service.launch(SubagentLaunchRequest(goal="no provider", inherit_memory_scope=True))
+    with pytest.raises(SubagentLifecycleError, match="must be a boolean"):
+        service.launch(SubagentLaunchRequest(goal="bad flag", inherit_memory_scope="yes"))
+
+    parent._memory_manager = object()
+    handle = service.launch(SubagentLaunchRequest(goal="share the verified scope", inherit_memory_scope=True))
+    service.wait(handle, timeout_seconds=1)
+    assert builds[-1]["inherit_memory_scope"] is True
 
 
 def test_agent_turn_binds_and_clears_lifecycle_parent(monkeypatch):

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1383,6 +1383,27 @@ class TestBankIdTemplate:
         assert p._bank_id == "hermes-coder"
         assert p._bank_id_template == "hermes-{profile}"
 
+    def test_provider_can_scope_bank_to_gateway_chat(self, tmp_path, monkeypatch):
+        config = {
+            "mode": "cloud",
+            "apiKey": "k",
+            "api_url": "http://x",
+            "bank_id_template": "hermes-{platform}-{chat}",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        provider = HindsightMemoryProvider()
+        provider.initialize(
+            session_id="replaceable-session",
+            hermes_home=str(tmp_path),
+            platform="msteams",
+            chat_id="19:room@example",
+        )
+        assert provider._bank_id == "hermes-msteams-19-room-example"
+
 
 # ---------------------------------------------------------------------------
 # Availability tests

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1392,17 +1392,24 @@ class TestBankIdTemplate:
         }
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text(json.dumps(config))
+        config_path.write_text(json.dumps(config), encoding="utf-8")
         monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
 
-        provider = HindsightMemoryProvider()
-        provider.initialize(
-            session_id="replaceable-session",
-            hermes_home=str(tmp_path),
-            platform="msteams",
-            chat_id="19:room@example",
-        )
-        assert provider._bank_id == "hermes-msteams-19-room-example"
+        resolved_banks = []
+        for session_id in ("first-session", "replacement-session"):
+            provider = HindsightMemoryProvider()
+            provider.initialize(
+                session_id=session_id,
+                hermes_home=str(tmp_path),
+                platform="msteams",
+                chat_id="19:room@example",
+            )
+            resolved_banks.append(provider._bank_id)
+
+        assert resolved_banks == [
+            "hermes-msteams-19-room-example",
+            "hermes-msteams-19-room-example",
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -372,6 +372,55 @@ class TestDelegateTask(unittest.TestCase):
             _, kwargs = MockAgent.call_args
             self.assertIsNone(kwargs["session_db"])
 
+    def test_child_memory_scope_is_opt_in_without_reusing_route_identity(self):
+        from agent.agent_init import _GATEWAY_IDENTITY_PARAMS, _memory_provider_init_kwargs
+
+        parent = _make_mock_parent(depth=0)
+        for name in _GATEWAY_IDENTITY_PARAMS:
+            setattr(parent, f"_{name}", None)
+        parent.platform = "msteams"
+        parent._chat_id = "19:meeting-room@example"
+        parent._gateway_session_key = "agent:main:msteams:group:meeting-room"
+        parent._user_id = "employee-42"
+        parent._session_db = None
+        captures = []
+
+        def make_child(**kwargs):
+            child = MagicMock()
+            child.platform = kwargs["platform"]
+            child.session_id = f"child-{len(captures)}"
+            child._session_db = None
+            for name in _GATEWAY_IDENTITY_PARAMS:
+                setattr(child, f"_{name}", None)
+            captures.append((kwargs, _memory_provider_init_kwargs(child, child.platform)))
+            return child
+
+        with patch("run_agent.AIAgent", side_effect=make_child):
+            isolated = _build_child_agent(
+                task_index=0, goal="isolated", context=None, toolsets=None,
+                model=None, max_iterations=10, parent_agent=parent, task_count=1,
+            )
+            inherited = _build_child_agent(
+                task_index=1, goal="inherit", context=None, toolsets=None,
+                model=None, max_iterations=10, parent_agent=parent, task_count=1,
+                inherit_memory_scope=True,
+            )
+
+        isolated_kwargs, isolated_scope = captures[0]
+        inherited_kwargs, inherited_scope = captures[1]
+        self.assertTrue(isolated_kwargs["skip_memory"])
+        self.assertEqual(isolated_scope["platform"], "subagent")
+        self.assertNotIn("chat_id", isolated_scope)
+        self.assertFalse(inherited_kwargs["skip_memory"])
+        self.assertEqual(inherited_scope["platform"], "msteams")
+        self.assertEqual(inherited_scope["chat_id"], parent._chat_id)
+        self.assertEqual(inherited_scope["gateway_session_key"], parent._gateway_session_key)
+        self.assertEqual(inherited_scope["session_id"], inherited.session_id)
+        self.assertEqual(inherited.platform, "subagent")
+        self.assertIsNone(inherited._chat_id)
+        self.assertIsNone(inherited._gateway_session_key)
+        self.assertEqual(isolated.platform, "subagent")
+
     def test_child_dedicated_db_follows_parents_db_path(self):
         """Per-profile parents: the child's dedicated handle must target the
         parent's database FILE, not the launch profile's default state.db.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -174,6 +174,8 @@ def _build_child_agent(
     # callers such as /review pass auxiliary.review here so fallback policy is
     # not accidentally read from the general delegation block.
     routing_cfg: Optional[Dict[str, Any]] = None,
+    # Plugin lifecycle only: opt in to the active parent's memory-provider scope.
+    inherit_memory_scope: bool = False,
     # Legacy; accepted for wire compat but ignored (capability is depth-derived).
     role: str = "leaf",
 ):
@@ -181,6 +183,7 @@ def _build_child_agent(
     inheritance so children can run on a different provider:model pair."""
     import uuid as _uuid
     from run_agent import AIAgent
+    from agent.agent_init import _bind_memory_scope_parent
     from agent.delegation_context import delegated_child_context
     # Role is depth-derived: a child may delegate iff the kill switch is on and
     # depth budget remains below max_spawn_depth. The `role` arg is ignored.
@@ -229,13 +232,13 @@ def _build_child_agent(
         request_overrides = {} if override_provider else dict(getattr(parent_agent, "request_overrides", {}) or {})
     parent_sid = getattr(parent_agent, "session_id", None)
     child_session_db = _open_child_session_db(parent_agent)
-    with delegated_child_context():
+    with delegated_child_context(), _bind_memory_scope_parent(parent_agent if inherit_memory_scope else None):
         try:
             child = AIAgent(
                 **rt, max_iterations=max_iterations, prefill_messages=getattr(parent_agent, "prefill_messages", None),
                 enabled_toolsets=child_toolsets, disabled_toolsets=child_disabled_toolsets, quiet_mode=True,
                 ephemeral_system_prompt=child_prompt, log_prefix=f"[subagent-{task_index}]", platform="subagent",
-                skip_context_files=True, skip_memory=True, clarify_callback=None,
+                skip_context_files=True, skip_memory=not inherit_memory_scope, clarify_callback=None,
                 thinking_callback=(
                     (lambda text: _safe_progress(child_progress_cb, "_thinking", text) if text else None)
                     if child_progress_cb else None

--- a/website/docs/developer-guide/subagent-lifecycle-api.md
+++ b/website/docs/developer-guide/subagent-lifecycle-api.md
@@ -59,3 +59,8 @@ parent-broadening toolsets are rejected, and per-tool blocks, working-directory
 overrides, and per-launch timeouts are explicitly rejected until Hermes can
 support them without weakening isolation. Use `allowed_toolsets` to narrow a
 child; Hermes's existing unsafe-tool block remains enforced.
+
+Children skip memory by default. A plugin may set `inherit_memory_scope=True`
+to let a child participate in the active parent's memory-provider scope. The
+host copies that scope from the verified parent; callers cannot supply a chat
+ID or routing key. The request fails when the parent has no active provider.


### PR DESCRIPTION
## Summary

This proposes a small, opt-in extension to the existing memory-provider and public subagent lifecycle surfaces:

- allow Hindsight bank templates to use the verified gateway chat identity
- let a plugin-launched child explicitly inherit the active parent memory-provider scope
- keep ordinary delegated children memory-isolated by default
- preserve the child session, platform, and route identity while sharing only provider scope
- reject inheritance when the parent has no active memory provider

The use case is a short-lived meeting scribe that should contribute to the same conversation-scoped memory bank as its host without making general subagents share memory. No provider-specific branch, environment variable, HTTP bridge, or model-facing tool schema is added.

## Verification

- scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py -k provider_can_scope_bank_to_gateway_chat
- scripts/run_tests.sh tests/agent/test_subagent_lifecycle.py -k memory_scope
- scripts/run_tests.sh tests/tools/test_delegate.py -k child_memory_scope
- python3 scripts/check_compat_pointers.py
- git diff --check upstream/main

The three focused behavior tests pass on macOS. The compatibility-pointer check also passes. Thank you for considering this contribution.