### PR TITLE
fix(state): serialize fresh FTS bootstrap

### DIFF
--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -478,6 +478,8 @@ class SessionSchemaMixin:
         foreign_holders = self._foreign_state_db_holders()
         if foreign_holders and self._defer_stale_fts_for_holders(cursor, foreign_holders):
             return False
+        if getattr(self, "_fts_setup_admitted", False):
+            return self._recover_stale_fts_locked(cursor, legacy=legacy)
         with fts_rebuild_admission(self.db_path, timeout_seconds=timeout_seconds) as admitted:
             if not admitted:
                 logger.warning(
@@ -1018,6 +1020,21 @@ class SessionSchemaMixin:
             pass  # Index already exists
 
     def _init_fts(self, cursor: sqlite3.Cursor) -> None:
+        """Serialize complete FTS bootstrap across gateway processes."""
+        with fts_rebuild_admission(self.db_path) as admitted:
+            if not admitted:
+                cursor.execute(_STALE_KEY_UPSERT_SQL, (FTS_STALE_KEY,))
+                self._drop_all_fts_triggers(cursor)
+                self._fts_stale = True
+                self._fts_enabled = self._trigram_available = self._fts_cjk_available = False
+                return
+            self._fts_setup_admitted = True
+            try:
+                self._init_fts_under_admission(cursor)
+            finally:
+                self._fts_setup_admitted = False
+
+    def _init_fts_under_admission(self, cursor: sqlite3.Cursor) -> None:
         """Create/repair the FTS objects on an FTS5-capable runtime. The DDL runs even when the
         vtable exists so CREATE TRIGGER IF NOT EXISTS repairs trigger-only degradation.
         OPT-IN v23 boundary: a legacy v22 inline install keeps its inline schema + triggers
@@ -1066,6 +1083,9 @@ class SessionSchemaMixin:
 
         See #93200.
         """
+        if getattr(self, "_fts_setup_admitted", False):
+            rebuild_fn()
+            return
         with fts_rebuild_admission(self.db_path) as admitted:
             if admitted:
                 rebuild_fn()


### PR DESCRIPTION
## Summary

Fixes the fresh `state.db` corruption reported in #105790 by serializing the complete FTS5 bootstrap across gateway processes.

## Investigation

The current startup path used `fts_rebuild_admission` only for the later FTS rebuild. Fresh database setup still allowed multiple gateway processes to concurrently execute FTS5 DDL that creates and mutates external-content shadow tables, views, and triggers. This matches the reported non-deterministic fresh-DB behavior and corruption in `messages_fts_idx`.

## Root cause

`CREATE ... IF NOT EXISTS` is not sufficient synchronization for FTS5 structural setup. Concurrent setup can interleave shadow-table DDL and leave an FTS b-tree malformed while ordinary SQLite `quick_check` remains green.

## Fix

- Hold the existing per-database FTS admission lock for the complete FTS setup phase.
- Fail closed if setup admission cannot be obtained: persist the stale marker, remove FTS triggers, and keep canonical message writes protected from a partially initialized index.
- Avoid nested admission deadlock when startup setup invokes a rebuild or stale recovery while already holding the authority.
- Preserve external-holder checks and existing stale-index recovery behavior.

## Verification

- `python -m py_compile hermes_state_schema.py`
- `git diff --check`
- `scripts/run_tests.sh tests/gateway/test_session_db_corrupt_fallback.py -q` — passed in 3 consecutive runs.
- Additional malformed-state tests: 28 passed, 4 skipped; one Windows-only failure was an unrelated `os.replace()` permission error while another SQLite connection held the destination file open.

Closes #105790