### PR TITLE
fix(tools): preserve content for programmatic reads

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -752,7 +752,8 @@ def _approval_observability(ids: _CallIds):
 
 
 def _execute_tool(function_name: str, function_args: Dict[str, Any], original_args: Dict[str, Any], ids: _CallIds,
-                  *, user_task: Optional[str], enabled_tools: Optional[List[str]], skip_tool_execution_middleware: bool) -> Any:
+                  *, user_task: Optional[str], enabled_tools: Optional[List[str]],
+                  skip_tool_execution_middleware: bool, programmatic: bool) -> Any:
     """Run the registry handler (through tool-execution middleware unless skipped)
     with the approval observability context bound for the duration."""
     dispatch_kwargs: Dict[str, Any] = {"task_id": ids.task_id, "session_id": ids.session_id}
@@ -762,6 +763,8 @@ def _execute_tool(function_name: str, function_args: Dict[str, Any], original_ar
         dispatch_kwargs["enabled_tools"] = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
     else:
         dispatch_kwargs["user_task"] = user_task
+    if programmatic:
+        dispatch_kwargs["programmatic"] = True
 
     def _dispatch(next_args: Dict[str, Any]) -> Any:
         return registry.dispatch(function_name, next_args, **dispatch_kwargs)
@@ -802,6 +805,7 @@ def handle_function_call(
     function_name: str, function_args: Dict[str, Any], task_id: Optional[str] = None,
     tool_call_id: Optional[str] = None, session_id: Optional[str] = None, turn_id: Optional[str] = None,
     api_request_id: Optional[str] = None, user_task: Optional[str] = None, enabled_tools: Optional[List[str]] = None,
+    programmatic: bool = False,
     skip_pre_tool_call_hook: bool = False, skip_tool_request_middleware: bool = False,
     skip_tool_execution_middleware: bool = False, tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None, disabled_toolsets: Optional[List[str]] = None,
@@ -838,6 +842,7 @@ def handle_function_call(
             return _emit(result, duration_ms=_elapsed_ms(start))
         return handle_function_call(
             *underlying, **asdict(ids), user_task=user_task, enabled_tools=enabled_tools,
+            programmatic=programmatic,
             skip_pre_tool_call_hook=skip_pre_tool_call_hook, skip_tool_request_middleware=skip_tool_request_middleware,
             skip_tool_execution_middleware=skip_tool_execution_middleware, tool_request_middleware_trace=list(trace),
             enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
@@ -867,7 +872,8 @@ def handle_function_call(
         # duration_ms (monotonic) is exposed to post_tool_call / transform_tool_result.
         start = time.monotonic()
         result = _execute_tool(function_name, function_args, original_args, ids, user_task=user_task,
-                               enabled_tools=enabled_tools, skip_tool_execution_middleware=skip_tool_execution_middleware)
+                               enabled_tools=enabled_tools, skip_tool_execution_middleware=skip_tool_execution_middleware,
+                               programmatic=programmatic)
         duration_ms = _elapsed_ms(start)
         _emit(result, duration_ms=duration_ms)
         return _apply_transform_tool_result_hook(function_name, function_args, result, duration_ms, ids)

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -18,6 +18,7 @@ import pytest
 import json
 import os
 import socket
+import tempfile
 import time
 
 os.environ["TERMINAL_ENV"] = "local"
@@ -63,7 +64,9 @@ from tools.code_execution_tool import (
 from tools.registry import registry
 
 
-def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None):
+def _mock_handle_function_call(
+    function_name, function_args, task_id=None, user_task=None, programmatic=False,
+):
     """Mock dispatcher that returns canned responses for each tool."""
     if function_name == "terminal":
         cmd = function_args.get("command", "")
@@ -295,6 +298,37 @@ print(result.get("output", ""))
         self.assertIn("mock output for: echo hello", result["output"])
         self.assertEqual(result["tool_calls_made"], 1)
 
+    def test_programmatic_read_returns_content_after_model_facing_read(self):
+        """execute_code reads need data, not the conversational dedup stub."""
+        from model_tools import handle_function_call
+        from tools.file_tools_read_tracking import _read_tracker
+
+        task_id = "test-programmatic-read-contract"
+        fd, path = tempfile.mkstemp(prefix="hermes-programmatic-read-", suffix=".txt")
+        os.write(fd, b"alpha\nbeta\n")
+        os.close(fd)
+        try:
+            first = json.loads(handle_function_call("read_file", {"path": path}, task_id=task_id))
+            self.assertIn("content", first)
+
+            code = f"""
+from hermes_tools import read_file
+result = read_file({path!r})
+print(result["content"])
+"""
+            result = json.loads(execute_code(
+                code=code,
+                task_id=task_id,
+                enabled_tools=["read_file"],
+                reset=True,
+            ))
+
+            self.assertEqual(result["status"], "success", result)
+            self.assertIn("alpha", result["output"])
+        finally:
+            _read_tracker.clear()
+            os.unlink(path)
+
 
     def test_concurrent_tool_calls_match_responses(self):
         """Regression for the UDS RPC race: multiple threads inside the
@@ -331,7 +365,9 @@ else:
     print(f"OK {N}/{N}")
 '''
 
-        def slow_mock(function_name, function_args, task_id=None, user_task=None):
+        def slow_mock(
+            function_name, function_args, task_id=None, user_task=None, programmatic=False,
+        ):
             import time as _t
             if function_name == "terminal":
                 _t.sleep(0.05)  # ensure requests overlap on the socket
@@ -340,7 +376,8 @@ else:
                 out = cmd[5:] if cmd.startswith("echo ") else f"mock: {cmd}"
                 return json.dumps({"output": out, "exit_code": 0})
             return _mock_handle_function_call(
-                function_name, function_args, task_id=task_id, user_task=user_task
+                function_name, function_args, task_id=task_id, user_task=user_task,
+                programmatic=programmatic,
             )
 
         with patch("model_tools.handle_function_call", side_effect=slow_mock):

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -71,7 +71,9 @@ def _mock_mode(mode):
         yield
 
 
-def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None):
+def _mock_handle_function_call(
+    function_name, function_args, task_id=None, user_task=None, programmatic=False,
+):
     """Minimal mock dispatcher reused across tests."""
     if function_name == "terminal":
         return json.dumps({"output": "mock", "exit_code": 0})

--- a/tests/tools/test_code_kernel.py
+++ b/tests/tools/test_code_kernel.py
@@ -364,7 +364,7 @@ class TestPerCellRpcAuthority(unittest.TestCase):
     """Interpreter state persists across cells; RPC authority must not."""
 
     def _recorder(self, seen):
-        def _handle(tool_name, tool_args, task_id=None):
+        def _handle(tool_name, tool_args, task_id=None, programmatic=False):
             from tools.thread_context import _callback_api
 
             get_approval, _get_sudo, _set_a, _set_s = _callback_api()
@@ -372,6 +372,7 @@ class TestPerCellRpcAuthority(unittest.TestCase):
                 {
                     "tool": tool_name,
                     "task_id": task_id,
+                    "programmatic": programmatic,
                     "approval_cb": get_approval(),
                 }
             )
@@ -406,6 +407,8 @@ class TestPerCellRpcAuthority(unittest.TestCase):
         self.assertIs(seen[0]["approval_cb"], cb_one)
         self.assertIs(seen[1]["approval_cb"], cb_two)
         self.assertEqual(seen[0]["task_id"], "kernel-test")
+        self.assertTrue(seen[0]["programmatic"])
+        self.assertTrue(seen[1]["programmatic"])
 
     def test_cross_cell_alias_dispatches_under_the_current_cell(self):
         # Adversarial cross-cell dataflow: a callable captured in cell 1 and

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -963,7 +963,9 @@ class TestPythonpathSelectiveStrip:
         import tools.code_execution_tool as cet
         from tools.code_execution_tool import execute_code
 
-        def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None):
+        def _mock_handle_function_call(
+            function_name, function_args, task_id=None, user_task=None, programmatic=False,
+        ):
             return '{"output": "mock", "exit_code": 0}'
 
         hermes_root = str(Path(cet.__file__).resolve().parents[1])

--- a/tools/code_execution_rpc.py
+++ b/tools/code_execution_rpc.py
@@ -27,7 +27,8 @@ _TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify", "notify_on_complete",
 
 def _default_dispatch(task_id):
     from model_tools import handle_function_call
-    return lambda tool_name, tool_args: handle_function_call(tool_name, tool_args, task_id=task_id)
+    return lambda tool_name, tool_args: handle_function_call(
+        tool_name, tool_args, task_id=task_id, programmatic=True)
 
 
 def _rpc_token_ok(request: dict, rpc_token: str) -> bool:

--- a/tools/code_kernel.py
+++ b/tools/code_kernel.py
@@ -274,7 +274,8 @@ class CellAuthority:
             except Exception:
                 previous = None
         try:
-            return handle_function_call(tool_name, tool_args, task_id=self.task_id)
+            return handle_function_call(
+                tool_name, tool_args, task_id=self.task_id, programmatic=True)
         finally:
             if previous is not None:
                 try:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -537,7 +537,8 @@ def _record_successful_read(task_data: dict, task_id: str, path: str, resolved_s
     return count
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = DEFAULT_READ_LIMIT, task_id: str = "default") -> str:
+def read_file_tool(path: str, offset: int = 1, limit: int = DEFAULT_READ_LIMIT, task_id: str = "default",
+                   deduplicate: bool = True) -> str:
     """Read a file with pagination and line numbers.
 
     Guard order: device-path blocklist (no I/O) → stat-based special-file
@@ -599,7 +600,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = DEFAULT_READ_LIMIT, 
             # First unchanged read after a compaction boundary serves full content
             # (the summary may have dropped exact bytes); later ones get the stub.
             content_served_in_generation = dedup_key in task_data["dedup_generation_reads"]
-        if cached_mtime is not None:
+        if deduplicate and cached_mtime is not None:
             try:
                 if os.path.getmtime(resolved_str) == cached_mtime and content_served_in_generation:
                     return _dedup_stub_or_block(task_data, dedup_key, path)
@@ -1177,7 +1178,10 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", DEFAULT_READ_LIMIT), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""), offset=args.get("offset", 1),
+        limit=args.get("limit", DEFAULT_READ_LIMIT), task_id=tid,
+        deduplicate=not kw.get("programmatic", False))
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
## Summary

- mark tool calls originating from `execute_code` as programmatic across both local and kernel RPC dispatch paths
- bypass conversational `read_file` deduplication for those programmatic calls so file content is always returned
- preserve deduplication for ordinary model-facing repeated reads
- add regression coverage for the programmatic-read contract and its dispatch propagation

## Verification

- `3 passed in 3.64s` for the new regression, the existing model-facing dedup guard, and kernel RPC authority propagation
- focused five-file matrix: `236 passed, 4 skipped`; its three failures reproduce unchanged on a clean worktree at current `origin/main`
- Ruff check passed on all eight changed files
- `py_compile` passed on all eight changed files
- `git diff --check` passed
- added-line credential scan found no matches
- rebased patch ID matches the independently reviewed Phase 1B patch

## Baseline-only failures

These fail identically on clean `origin/main` and are not introduced by this change:

- two macOS path-alias assertions expect `/tmp/...` while the implementation resolves `/private/tmp/...`
- one kernel lifecycle assertion searches for the truncated process name `hermes_kernel_runner` via `pgrep`
