### PR TITLE
feat(delegation): allow configured child toolsets

### DIFF
--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -407,10 +407,16 @@ class SubagentLifecycleService:
             raise SubagentLifecycleError("metadata exceeds 8192 bytes.")
         if not request.allowed_toolsets:
             return
-        from toolsets import TOOLSETS
-        unknown = set(request.allowed_toolsets) - set(TOOLSETS)
+        from toolsets import validate_toolset
+        unknown = {toolset for toolset in request.allowed_toolsets if not validate_toolset(toolset)}
         if unknown:
             raise SubagentLifecycleError(f"Unknown toolsets: {', '.join(sorted(unknown))}.")
+        from tools.delegate_tool_toolsets import _configured_child_toolsets_allow
+        worker_policy_allows = _configured_child_toolsets_allow(list(request.allowed_toolsets))
+        if worker_policy_allows is False:
+            raise SubagentLifecycleError("Requested toolsets are not permitted by delegation.child_toolsets.")
+        if worker_policy_allows is True:
+            return
         enabled = getattr(parent, "enabled_toolsets", None)
         if enabled is not None and not set(request.allowed_toolsets).issubset(set(enabled)):
             raise SubagentLifecycleError("Requested toolsets would broaden parent permissions.")

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -227,6 +227,8 @@ _REQUEST_REJECTIONS: tuple[tuple[Callable[[Any], bool], str], ...] = (
      "working_directory is not supported because Hermes delegates use isolated task environments."),
     (lambda r: bool(r.blocked_tools),
      "Per-tool blocking is not supported; use allowed_toolsets. Hermes always blocks unsafe child tools."),
+    (lambda r: r.allowed_toolsets is not None and not r.allowed_toolsets,
+     "allowed_toolsets must not be empty; omit it to use the configured worker policy."),
 )
 
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1654,6 +1654,9 @@ delegation:
                                               # The parent TUI owns stdin, so blocking would deadlock; non-interactive resolution is required.
                                               # Both choices emit a logger.warning audit line. Flip to true only for cron/batch pipelines.
   # inherit_mcp_toolsets: true                # When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: true). Set false for strict intersection.
+  # child_toolsets: [file, terminal, web]    # Optional worker-only allowlist. When set, children use exactly these toolsets even if the parent lacks them;
+                                              # parent enabled/disabled toolsets are not inherited. Omit to preserve parent inheritance. [] denies all worker tools.
+                                              # `all`/`*`, unknown, or malformed entries fail closed to no worker tools.
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2606,7 +2606,16 @@ def _build_user_local_paths(home: Path, path_entries: list[str]) -> list[str]:
         str(home / "go" / "bin"),  # Go tools
         str(home / ".npm-global" / "bin"),  # npm global packages
     ]
-    return [p for p in candidates if p not in path_entries and Path(p).exists()]
+    result: list[str] = []
+    for path in candidates:
+        if path in path_entries:
+            continue
+        try:
+            if Path(path).exists():
+                result.append(path)
+        except OSError:
+            continue
+    return result
 
 
 def _build_wsl_interop_paths(path_entries: list[str]) -> list[str]:

--- a/hermes_cli/web_routers/config_env.py
+++ b/hermes_cli/web_routers/config_env.py
@@ -106,6 +106,25 @@ async def get_egress_status():
     return {"text": format_status_text()}
 
 
+def _clear_optional_child_toolsets(existing: Dict[str, Any], incoming: Dict[str, Any]) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Interpret dashboard ``null`` as clearing the virtual optional policy.
+
+    ``/api/config`` deep-merges so schema-invisible data survives form saves.
+    This virtual field needs a distinct reset operation: YAML absence means
+    legacy parent inheritance, while ``[]`` means an explicit deny-all.
+    """
+    delegation = incoming.get("delegation")
+    if not isinstance(delegation, dict) or delegation.get("child_toolsets", object()) is not None:
+        return existing, incoming
+    existing = dict(existing)
+    existing_delegation = existing.get("delegation")
+    if isinstance(existing_delegation, dict):
+        existing["delegation"] = {key: value for key, value in existing_delegation.items() if key != "child_toolsets"}
+    incoming = dict(incoming)
+    incoming["delegation"] = {key: value for key, value in delegation.items() if key != "child_toolsets"}
+    return existing, incoming
+
+
 @router.put("/api/config")
 async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
     def _run():
@@ -118,6 +137,7 @@ async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
             with _CONFIG_MUTATION_LOCK:
                 existing = read_raw_config()
                 incoming = _denormalize_config_from_web(body.config)
+                existing, incoming = _clear_optional_child_toolsets(existing, incoming)
                 merged = _deep_merge(existing, incoming)
                 # Compare normalized approvals.mode across the in-memory
                 # documents, not config blocks and not cache re-reads: the page

--- a/hermes_cli/web_server_config.py
+++ b/hermes_cli/web_server_config.py
@@ -130,6 +130,14 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "Reasoning effort for delegated subagents",
         "", "minimal", "low", "medium", "high", "xhigh", "max", "ultra",
     ),
+    "delegation.child_toolsets": {
+        "type": "optional-list",
+        "description": (
+            "Optional worker capability allowlist. Inherit keeps legacy parent tool inheritance; "
+            "an empty override denies all child tools."
+        ),
+        "category": "delegation",
+    },
     "updates.non_interactive_local_changes": _select(
         "When the chat app / gateway updates Hermes (no terminal prompt), "
         "what to do with uncommitted local source edits. 'stash' keeps them "
@@ -226,13 +234,14 @@ def _build_schema_from_config(config: Dict[str, Any], prefix: str = "") -> Dict[
 
 
 def _config_schema_with_virtual_fields() -> Dict[str, Dict[str, Any]]:
-    """DEFAULT_CONFIG schema plus the virtual ``model_context_length`` field, inserted right
-    after ``model`` so it renders adjacent in the frontend."""
+    """DEFAULT_CONFIG schema plus virtual fields absent from persisted defaults."""
     ordered: Dict[str, Dict[str, Any]] = {}
     for key, entry in _build_schema_from_config(DEFAULT_CONFIG).items():
         ordered[key] = entry
         if key == "model":
             ordered["model_context_length"] = _SCHEMA_OVERRIDES["model_context_length"]
+        if key == "delegation.inherit_mcp_toolsets":
+            ordered["delegation.child_toolsets"] = _SCHEMA_OVERRIDES["delegation.child_toolsets"]
     return ordered
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1205,6 +1205,15 @@ class TestDetectVenvDir:
         assert result is None
 
 
+def test_build_user_local_paths_ignores_permission_errors(monkeypatch, tmp_path):
+    """A generated user unit must not fail when a foreign home is unreadable."""
+    def _denied(_path):
+        raise PermissionError("foreign home")
+
+    monkeypatch.setattr(Path, "exists", _denied)
+    assert gateway_cli._build_user_local_paths(tmp_path, []) == []
+
+
 class TestSystemUnitHermesHome:
     """HERMES_HOME in system units must reference the target user, not root."""
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2582,6 +2582,27 @@ class TestConfigRoundTrip:
                 mismatches.append(f"{key}: expected list, got {type(val).__name__}")
         assert not mismatches, "Type mismatches:\n" + "\n".join(mismatches)
 
+    def test_optional_child_toolsets_schema_preserves_absence_and_explicit_deny(self):
+        """Dashboard config saves preserve inherited, deny-all, and cleared policy states."""
+        from hermes_cli.config import read_raw_config, save_config
+
+        save_config({"delegation": {"max_iterations": 17}})
+        initial = self.client.get("/api/config").json()
+        schema = self.client.get("/api/config/schema").json()["fields"]
+        assert "child_toolsets" not in initial.get("delegation", {})
+        assert schema["delegation.child_toolsets"]["type"] == "optional-list"
+
+        assert self.client.put("/api/config", json={"config": initial}).status_code == 200
+        assert "child_toolsets" not in read_raw_config().get("delegation", {})
+
+        initial["delegation"]["child_toolsets"] = []
+        assert self.client.put("/api/config", json={"config": initial}).status_code == 200
+        assert read_raw_config()["delegation"]["child_toolsets"] == []
+
+        initial["delegation"]["child_toolsets"] = None
+        assert self.client.put("/api/config", json={"config": initial}).status_code == 200
+        assert "child_toolsets" not in read_raw_config().get("delegation", {})
+
     def test_desktop_terminal_font_round_trip_preserves_terminal_config(self):
         """The Appearance picker persists a font without replacing sibling settings."""
         from hermes_cli.config import load_config

--- a/tests/tools/test_delegate_child_toolsets.py
+++ b/tests/tools/test_delegate_child_toolsets.py
@@ -1,0 +1,235 @@
+"""Capability-boundary tests for configured delegated-child toolsets."""
+
+from types import SimpleNamespace
+
+import pytest
+import hermes_cli.config as hc
+
+from tools.delegate_tool_toolsets import _resolve_child_toolsets
+
+
+def _parent(*, enabled, disabled=()):
+    return SimpleNamespace(
+        enabled_toolsets=list(enabled),
+        disabled_toolsets=list(disabled),
+    )
+
+
+def test_child_inherits_parent_toolsets_when_no_worker_policy(monkeypatch):
+    """Existing installs retain inheritance unless an operator configures a policy."""
+    monkeypatch.setattr(
+        "tools.delegate_tool_toolsets._get_configured_child_toolsets", lambda: None
+    )
+
+    child, disabled = _resolve_child_toolsets(
+        _parent(enabled=["delegation", "file", "terminal"]), None, "leaf"
+    )
+
+    assert child == ["file", "terminal"]
+    assert "delegation" in disabled
+
+
+def test_worker_policy_can_grant_explicit_tools_absent_from_parent(monkeypatch):
+    """A planning-only parent cannot execute worker tools, but its child can."""
+    monkeypatch.setattr(
+        "tools.delegate_tool_toolsets._get_configured_child_toolsets",
+        lambda: ["file", "terminal"],
+    )
+    parent = _parent(
+        enabled=["delegation", "todo", "messaging"],
+        disabled=["file", "terminal"],
+    )
+
+    child, disabled = _resolve_child_toolsets(parent, None, "leaf")
+
+    assert child == ["file", "terminal"]
+    assert "file" not in parent.enabled_toolsets
+    assert "terminal" not in parent.enabled_toolsets
+    assert "file" not in disabled
+    assert "terminal" not in disabled
+    assert "delegation" in disabled
+
+
+def test_worker_policy_rejects_unconfigured_requested_toolsets(monkeypatch):
+    """A caller cannot escape an operator policy by naming another toolset."""
+    monkeypatch.setattr(
+        "tools.delegate_tool_toolsets._get_configured_child_toolsets",
+        lambda: ["file"],
+    )
+
+    child, _disabled = _resolve_child_toolsets(
+        _parent(enabled=["delegation"]), ["terminal"], "leaf"
+    )
+
+    assert child == []
+
+
+def test_lifecycle_request_accepts_worker_policy_not_parent_surface(monkeypatch):
+    """The public worker API observes the same configured boundary."""
+    from agent.subagent_lifecycle import SubagentLaunchRequest, SubagentLifecycleService
+
+    monkeypatch.setattr(
+        "tools.delegate_tool_toolsets._get_configured_child_toolsets",
+        lambda: ["terminal"],
+    )
+    parent = _parent(enabled=["delegation"])
+
+    SubagentLifecycleService._validate_request(
+        SubagentLaunchRequest(goal="run a bounded command", allowed_toolsets=("terminal",)),
+        parent,
+    )
+
+
+def test_lifecycle_request_rejects_toolset_outside_worker_policy(monkeypatch):
+    """The public worker API fails closed instead of silently broadening a child."""
+    from agent.subagent_lifecycle import (
+        SubagentLaunchRequest,
+        SubagentLifecycleError,
+        SubagentLifecycleService,
+    )
+
+    monkeypatch.setattr(
+        "tools.delegate_tool_toolsets._get_configured_child_toolsets", lambda: ["file"]
+    )
+    parent = _parent(enabled=["delegation"])
+
+    with pytest.raises(SubagentLifecycleError, match="delegation.child_toolsets"):
+        SubagentLifecycleService._validate_request(
+            SubagentLaunchRequest(goal="run a bounded command", allowed_toolsets=("terminal",)),
+            parent,
+        )
+
+
+@pytest.mark.parametrize("policy", [["file", "*"], ["missing-toolset"], "terminal", None])
+def test_malformed_worker_policy_denies_child_tools(monkeypatch, policy):
+    """A typo or wildcard cannot silently restore the parent's broad surface."""
+    from tools.delegate_tool_config import _get_configured_child_toolsets
+
+    monkeypatch.setattr(
+        "tools.delegate_tool_config._load_child_toolset_policy_config", lambda: {"child_toolsets": policy}
+    )
+
+    assert _get_configured_child_toolsets() == []
+
+
+def test_dynamic_worker_toolset_uses_registry_validation(monkeypatch):
+    """Live MCP/plugin aliases are valid policy names, not static-name failures."""
+    from tools.delegate_tool_config import _get_configured_child_toolsets
+
+    monkeypatch.setattr(
+        "tools.delegate_tool_config._load_child_toolset_policy_config", lambda: {"child_toolsets": ["mcp-worker"]}
+    )
+    monkeypatch.setattr("toolsets.validate_toolset", lambda name: name == "mcp-worker")
+
+    assert _get_configured_child_toolsets() == ["mcp-worker"]
+
+
+def test_profile_read_failure_denies_instead_of_using_cli_snapshot(monkeypatch):
+    """An unreadable active profile cannot fall back to another session's tools."""
+    from tools.delegate_tool_config import _get_configured_child_toolsets
+
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+
+    def fail_load():
+        raise RuntimeError("profile unavailable")
+
+    monkeypatch.setattr("hermes_cli.config.require_readable_config_before_write", fail_load)
+
+    assert _get_configured_child_toolsets() == []
+
+
+def test_invalid_active_profile_does_not_recover_to_parent_tools(tmp_path, monkeypatch):
+    """The config loader's normal defaults recovery is unsafe for authorization."""
+    from tools.delegate_tool_config import _get_configured_child_toolsets
+
+    home = tmp_path / "invalid-profile"
+    home.mkdir()
+    (home / "config.yaml").write_text("delegation: [not-a-mapping\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+    hc._LOAD_CONFIG_CACHE.clear()
+    hc._RAW_CONFIG_CACHE.clear()
+
+    assert _get_configured_child_toolsets() == []
+
+
+def test_unrelated_schema_error_cannot_hide_explicit_deny_policy(tmp_path, monkeypatch):
+    """Raw policy reads never accept the merged loader's defaults recovery."""
+    from tools.delegate_tool_config import _get_configured_child_toolsets
+
+    home = tmp_path / "schema-error-profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "max_turns: 10\nagent: invalid\ndelegation:\n  child_toolsets: []\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+    hc._LOAD_CONFIG_CACHE.clear()
+    hc._RAW_CONFIG_CACHE.clear()
+
+    assert _get_configured_child_toolsets() == []
+
+
+def test_worker_policy_does_not_grant_orchestrator_delegation(monkeypatch):
+    """Depth-derived orchestration cannot escape an empty worker allowlist."""
+    monkeypatch.setattr("tools.delegate_tool_toolsets._get_configured_child_toolsets", lambda: [])
+
+    child, disabled = _resolve_child_toolsets(_parent(enabled=["delegation"]), None, "orchestrator")
+
+    assert child == []
+    assert "delegation" not in child
+    assert "delegation" not in disabled
+
+
+def test_worker_policy_restores_explicit_orchestrator_delegation(monkeypatch):
+    """The role may retain delegation only when the selected policy explicitly allows it."""
+    monkeypatch.setattr(
+        "tools.delegate_tool_toolsets._get_configured_child_toolsets", lambda: ["delegation", "file"]
+    )
+
+    orchestrator, _disabled = _resolve_child_toolsets(
+        _parent(enabled=["delegation"]), None, "orchestrator"
+    )
+    leaf, leaf_disabled = _resolve_child_toolsets(
+        _parent(enabled=["delegation"]), None, "leaf"
+    )
+
+    assert orchestrator == ["file", "delegation"]
+    assert leaf == ["file"]
+    assert "delegation" in leaf_disabled
+
+
+def test_lifecycle_narrowing_does_not_regrant_orchestrator_delegation(monkeypatch):
+    """An API caller that requests file cannot inherit policy delegation transitively."""
+    monkeypatch.setattr(
+        "tools.delegate_tool_toolsets._get_configured_child_toolsets", lambda: ["delegation", "file"]
+    )
+
+    child, _disabled = _resolve_child_toolsets(
+        _parent(enabled=["delegation"]), ["file"], "orchestrator"
+    )
+
+    assert child == ["file"]
+
+
+def test_worker_policy_uses_only_the_active_profile(tmp_path, monkeypatch):
+    """Real config loads never leak an operational allowlist across profiles."""
+    parent = _parent(enabled=["delegation"], disabled=["file", "terminal"])
+    first = tmp_path / "first-profile"
+    second = tmp_path / "second-profile"
+    for profile, policy in ((first, "[terminal]"), (second, "[file]")):
+        profile.mkdir()
+        (profile / "config.yaml").write_text(
+            "model:\n  default: test-model\n"
+            f"delegation:\n  child_toolsets: {policy}\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setenv("HERMES_HOME", str(first))
+    hc._LOAD_CONFIG_CACHE.clear()
+    assert _resolve_child_toolsets(parent, None, "leaf")[0] == ["terminal"]
+
+    monkeypatch.setenv("HERMES_HOME", str(second))
+    hc._LOAD_CONFIG_CACHE.clear()
+    assert _resolve_child_toolsets(parent, None, "leaf")[0] == ["file"]

--- a/tests/tools/test_delegate_child_toolsets.py
+++ b/tests/tools/test_delegate_child_toolsets.py
@@ -64,6 +64,37 @@ def test_worker_policy_rejects_unconfigured_requested_toolsets(monkeypatch):
     assert child == []
 
 
+def test_worker_policy_cannot_exceed_bound_room_execution_policy(monkeypatch):
+    """A target-issued room policy remains the authority ceiling for child tools."""
+    from gateway.hosted_room_execution_policy import (
+        RoomExecutionPolicy,
+        bind_room_execution_policy,
+        reset_room_execution_policy,
+    )
+
+    monkeypatch.setattr(
+        "tools.delegate_tool_toolsets._get_configured_child_toolsets",
+        lambda: ["file", "terminal"],
+    )
+    policy = RoomExecutionPolicy(
+        version=1,
+        target_profile="reviewer",
+        enabled_toolsets=("bot_room", "delegation", "file"),
+        approval_mode="manual",
+        max_iterations=1,
+        policy_digest="test-policy",
+    )
+    token = bind_room_execution_policy(policy)
+    try:
+        child, _disabled = _resolve_child_toolsets(
+            _parent(enabled=["delegation"]), None, "leaf"
+        )
+    finally:
+        reset_room_execution_policy(token)
+
+    assert child == ["file"]
+
+
 def test_lifecycle_request_accepts_worker_policy_not_parent_surface(monkeypatch):
     """The public worker API observes the same configured boundary."""
     from agent.subagent_lifecycle import SubagentLaunchRequest, SubagentLifecycleService
@@ -97,6 +128,25 @@ def test_lifecycle_request_rejects_toolset_outside_worker_policy(monkeypatch):
         SubagentLifecycleService._validate_request(
             SubagentLaunchRequest(goal="run a bounded command", allowed_toolsets=("terminal",)),
             parent,
+        )
+
+
+def test_lifecycle_rejects_empty_toolset_request_under_worker_policy(monkeypatch):
+    """An explicit empty request cannot be reinterpreted as the whole worker policy."""
+    from agent.subagent_lifecycle import (
+        SubagentLaunchRequest,
+        SubagentLifecycleError,
+        SubagentLifecycleService,
+    )
+
+    monkeypatch.setattr(
+        "tools.delegate_tool_toolsets._get_configured_child_toolsets", lambda: ["terminal"]
+    )
+
+    with pytest.raises(SubagentLifecycleError, match="empty"):
+        SubagentLifecycleService._validate_request(
+            SubagentLaunchRequest(goal="run nothing", allowed_toolsets=()),
+            _parent(enabled=["delegation"]),
         )
 
 

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -26,6 +26,13 @@ _LEGACY_MAX_ASYNC_WARNED = False
 # delegation.child_timeout_seconds opts back in.
 DEFAULT_CHILD_TIMEOUT: Optional[float] = None
 
+
+class _ChildToolsetConfigLoadFailed:
+    """Typed sentinel so a policy-read failure cannot be mistaken for absence."""
+
+
+_CHILD_TOOLSET_CONFIG_LOAD_FAILED = _ChildToolsetConfigLoadFailed()
+
 def _cfg() -> dict:
     """The ``delegation`` section, read through the origin so tests can patch it."""
     from tools.delegate_tool import _load_config
@@ -165,6 +172,65 @@ def _get_orchestrator_enabled() -> bool:
 def _get_inherit_mcp_toolsets() -> bool:
     """Whether narrowed child toolsets should keep the parent's MCP toolsets."""
     return is_truthy_value(_cfg().get("inherit_mcp_toolsets"), default=True)
+
+
+def _load_child_toolset_policy_config() -> dict | _ChildToolsetConfigLoadFailed:
+    """Read the active profile's delegation map without the legacy CLI fallback.
+
+    The generic delegation loader preserves historical recovery behavior for
+    non-authorization settings. A worker capability boundary must not recover
+    from a profile-read failure by consulting another session's CLI snapshot.
+    """
+    try:
+        if os.environ.get("HERMES_IGNORE_USER_CONFIG") == "1":
+            from cli import CLI_CONFIG
+            config = CLI_CONFIG
+        else:
+            from hermes_cli.config import require_readable_config_before_write
+            # Capability policy is deliberately read from the raw active profile.
+            # The merged loader recovers unrelated schema failures to defaults or
+            # a last-known-good snapshot; either fallback could hide an explicit
+            # deny policy and restore parent inheritance. This helper only
+            # validates/reads and never writes.
+            config = require_readable_config_before_write()
+    except Exception:
+        logger.warning("Could not read delegation.child_toolsets from the active profile; denying child tools", exc_info=True)
+        return _CHILD_TOOLSET_CONFIG_LOAD_FAILED
+    if not isinstance(config, dict):
+        logger.warning("Active delegation configuration is malformed; denying child tools")
+        return _CHILD_TOOLSET_CONFIG_LOAD_FAILED
+    delegation_cfg = config.get("delegation", {})
+    if not isinstance(delegation_cfg, dict):
+        logger.warning("delegation configuration is malformed; denying child tools")
+        return _CHILD_TOOLSET_CONFIG_LOAD_FAILED
+    return delegation_cfg
+
+
+def _get_configured_child_toolsets() -> Optional[List[str]]:
+    """Operator-owned child capability policy, or ``None`` for legacy inheritance.
+
+    ``delegation.child_toolsets`` deliberately has no wildcard: it is the one
+    configuration boundary allowed to give workers tools their parent cannot
+    use. A malformed policy therefore resolves to an empty list rather than
+    falling back to the parent's surface.
+    """
+    delegation_cfg = _load_child_toolset_policy_config()
+    if isinstance(delegation_cfg, _ChildToolsetConfigLoadFailed):
+        return []
+    if "child_toolsets" not in delegation_cfg:
+        return None
+    raw = delegation_cfg["child_toolsets"]
+    if not isinstance(raw, list) or not all(isinstance(name, str) for name in raw):
+        logger.warning("delegation.child_toolsets must be a list of known toolset names; denying child tools")
+        return []
+
+    from toolsets import validate_toolset
+
+    unknown = [name for name in raw if not name or name in {"all", "*"} or not validate_toolset(name)]
+    if unknown:
+        logger.warning("delegation.child_toolsets contains unknown or wildcard toolsets; denying child tools")
+        return []
+    return list(dict.fromkeys(raw))
 
 def _normalized_runtime_url(value: Any) -> str:
     return str(value or "").strip().rstrip("/")

--- a/tools/delegate_tool_toolsets.py
+++ b/tools/delegate_tool_toolsets.py
@@ -6,7 +6,7 @@ import logging
 from typing import List, Optional
 
 from toolsets import TOOLSETS
-from tools.delegate_tool_config import _get_inherit_mcp_toolsets
+from tools.delegate_tool_config import _get_configured_child_toolsets, _get_inherit_mcp_toolsets
 
 logger = logging.getLogger("tools.delegate_tool")  # log-record parity with the origin module
 
@@ -65,46 +65,89 @@ def _blocked_toolsets_for_role(role: str) -> List[str]:
         name for name, defn in TOOLSETS.items() if defn.get("tools") and set(defn.get("tools", ())).issubset(blocked_names)
     )
 
+
+def _tool_names(toolsets: List[str]) -> set[str]:
+    """Resolve a list of known toolsets to its effective tool names."""
+    from toolsets import resolve_toolset
+
+    return {tool for toolset in toolsets for tool in resolve_toolset(toolset)}
+
+
+def _configured_child_toolsets_allow(toolsets: List[str]) -> Optional[bool]:
+    """Whether a configured worker policy allows a trusted caller's narrowing.
+
+    ``None`` means no configured policy, so the caller must use legacy
+    parent-surface rules. ``False`` is intentionally fail-closed.
+    """
+    configured = _get_configured_child_toolsets()
+    if configured is None:
+        return None
+    from toolsets import validate_toolset
+
+    if not all(isinstance(toolset, str) and validate_toolset(toolset) for toolset in toolsets):
+        return False
+    try:
+        return _tool_names(toolsets).issubset(_tool_names(configured))
+    except Exception:
+        logger.warning("Could not resolve delegation.child_toolsets; denying requested child tools", exc_info=True)
+        return False
+
 def _resolve_child_toolsets(
     parent_agent, toolsets: Optional[List[str]], effective_role: str
 ) -> tuple[List[str], List[str]]:
-    """``(enabled_toolsets, disabled_toolsets)`` for a child. Children never gain tools the parent lacks: explicit
-    ``toolsets`` are intersected with the parent's (composite-expanded) set, else the parent's enabled set is
-    inherited. Blocked tools are stripped twice — whole blocked toolsets here, and exact one-tool deny toolsets via
-    ``disabled_toolsets`` so blocked names inside mixed bundles (hermes-cli) are subtracted AFTER composite
-    expansion and survive registry refreshes. Orchestrators get ``delegation`` re-added unconditionally
-    (role-granted, not inherited)."""
-    # enabled_toolsets=None means "all tools", so derive from loaded tool names.
-    parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
-    if parent_enabled is not None:
-        parent_toolsets = set(parent_enabled)
-    elif parent_agent and hasattr(parent_agent, "valid_tool_names"):
-        import model_tools
-        parent_toolsets = {
-            ts for name in parent_agent.valid_tool_names if (ts := model_tools.get_toolset_for_tool(name)) is not None
-        }
-    else:
-        parent_toolsets = set(DEFAULT_TOOLSETS)
+    """``(enabled_toolsets, disabled_toolsets)`` for a child.
 
-    if toolsets:
-        expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
-        if _get_inherit_mcp_toolsets():
-            # Append any parent MCP toolsets missing from the narrowed child.
-            child_toolsets += [
-                name for name in sorted(parent_toolsets) if _is_mcp_toolset_name(name) and name not in child_toolsets
-            ]
-    elif parent_agent and parent_enabled is not None:
-        child_toolsets = parent_enabled
+    An absent ``delegation.child_toolsets`` preserves legacy inheritance. When
+    configured, it is an exact operator-owned worker surface: parent enables
+    and disables are not inherited, and a trusted caller may only request a
+    semantic subset. Blocked tools remain blocked in both modes.
+    """
+    configured = _get_configured_child_toolsets()
+    using_worker_policy = configured is not None
+    if using_worker_policy:
+        if toolsets and _configured_child_toolsets_allow(toolsets):
+            child_toolsets = list(toolsets)
+        elif toolsets:
+            child_toolsets = []
+        else:
+            child_toolsets = list(configured)
     else:
-        child_toolsets = sorted(parent_toolsets) or DEFAULT_TOOLSETS
+        # enabled_toolsets=None means "all tools", so derive from loaded tool names.
+        parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
+        if parent_enabled is not None:
+            parent_toolsets = set(parent_enabled)
+        elif parent_agent and hasattr(parent_agent, "valid_tool_names"):
+            import model_tools
+            parent_toolsets = {
+                ts for name in parent_agent.valid_tool_names if (ts := model_tools.get_toolset_for_tool(name)) is not None
+            }
+        else:
+            parent_toolsets = set(DEFAULT_TOOLSETS)
+
+        if toolsets:
+            expanded_parent = _expand_parent_toolsets(parent_toolsets)
+            child_toolsets = [t for t in toolsets if t in expanded_parent]
+            if _get_inherit_mcp_toolsets():
+                # Append any parent MCP toolsets missing from the narrowed child.
+                child_toolsets += [
+                    name for name in sorted(parent_toolsets) if _is_mcp_toolset_name(name) and name not in child_toolsets
+                ]
+        elif parent_agent and parent_enabled is not None:
+            child_toolsets = parent_enabled
+        else:
+            child_toolsets = sorted(parent_toolsets) or DEFAULT_TOOLSETS
+    # ``_strip_blocked_tools`` intentionally removes delegation for ordinary
+    # children. Preserve the authorization decision before that role-neutral
+    # stripping so an orchestrator gets it back only when its selected surface
+    # explicitly contains it (or under legacy inheritance).
+    delegation_authorized = not using_worker_policy or "delegation" in child_toolsets
     child_toolsets = _strip_blocked_tools(child_toolsets)
 
-    raw_parent_disabled = getattr(parent_agent, "disabled_toolsets", None)
+    raw_parent_disabled = None if using_worker_policy else getattr(parent_agent, "disabled_toolsets", None)
     inherited_disabled = (
         [str(name) for name in raw_parent_disabled] if isinstance(raw_parent_disabled, (list, tuple, set)) else []
     )
-    if effective_role == "orchestrator":
+    if effective_role == "orchestrator" and delegation_authorized:
         inherited_disabled = [name for name in inherited_disabled if name != "delegation"]
         if "delegation" not in child_toolsets:
             child_toolsets.append("delegation")

--- a/tools/delegate_tool_toolsets.py
+++ b/tools/delegate_tool_toolsets.py
@@ -47,6 +47,29 @@ def _expand_parent_toolsets(parent_toolsets: set) -> set:
         )
     return expanded
 
+
+def _bound_room_policy_toolsets() -> Optional[set]:
+    """Current target-issued RoomLink authority ceiling, if this is a hosted turn.
+
+    ``delegation.child_toolsets`` may intentionally exceed ordinary parent
+    visibility, but it cannot exceed an execution policy that was authenticated
+    and bound to this hosted turn.
+    """
+    try:
+        from gateway.hosted_room_execution_policy import current_room_execution_policy
+        policy = current_room_execution_policy()
+    except Exception:
+        logger.warning("Could not read bound room execution policy; denying child tools", exc_info=True)
+        return set()
+    if policy is None:
+        return None
+    enabled = getattr(policy, "enabled_toolsets", ())
+    if not isinstance(enabled, (list, tuple, set, frozenset)):
+        logger.warning("Bound room execution policy has invalid toolsets; denying child tools")
+        return set()
+    return _expand_parent_toolsets(set(enabled))
+
+
 def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     """Remove toolsets whose tools are ALL blocked (derived from DELEGATE_BLOCKED_TOOLS so the two can't drift) plus
     composite toolsets children must never get (``delegation``, ``kanban``)."""
@@ -136,6 +159,11 @@ def _resolve_child_toolsets(
             child_toolsets = parent_enabled
         else:
             child_toolsets = sorted(parent_toolsets) or DEFAULT_TOOLSETS
+    # A route/turn policy is an immutable outer authority boundary. Apply it
+    # after the worker-policy choice so explicit worker configuration cannot
+    # silently bypass a target-issued hosted-room restriction.
+    if (room_ceiling := _bound_room_policy_toolsets()) is not None:
+        child_toolsets = [toolset for toolset in child_toolsets if toolset in room_ceiling]
     # ``_strip_blocked_tools`` intentionally removes delegation for ordinary
     # children. Preserve the authorization decision before that role-neutral
     # stripping so an orchestrator gets it back only when its selected surface

--- a/web/src/components/AutoField.tsx
+++ b/web/src/components/AutoField.tsx
@@ -168,6 +168,38 @@ export function AutoField({
     );
   }
 
+  if (schema.type === "optional-list") {
+    const overridden = Array.isArray(value);
+    return (
+      <div className="grid gap-1.5">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex flex-col gap-0.5">
+            <Label className="text-sm">{label}</Label>
+            <FieldHint schema={schema} schemaKey={schemaKey} />
+          </div>
+          <Switch
+            checked={overridden}
+            onCheckedChange={(enabled) => onChange(enabled ? [] : null)}
+          />
+        </div>
+        {overridden && (
+          <Input
+            value={value.join(", ")}
+            onChange={(e) =>
+              onChange(
+                e.target.value
+                  .split(",")
+                  .map((item) => item.trim())
+                  .filter(Boolean),
+              )
+            }
+            placeholder="comma-separated toolset names"
+          />
+        )}
+      </div>
+    );
+  }
+
   if (schema.type === "list") {
     return (
       <div className="grid gap-1.5">

--- a/website/docs/developer-guide/subagent-lifecycle-api.md
+++ b/website/docs/developer-guide/subagent-lifecycle-api.md
@@ -55,7 +55,9 @@ starts a replacement child. Running Python threads also cannot survive process
 exit; callers must treat those handles as interrupted by process exit.
 
 Requests are fail-closed: goal/context/metadata sizes are capped, unknown or
-parent-broadening toolsets are rejected, and per-tool blocks, working-directory
-overrides, and per-launch timeouts are explicitly rejected until Hermes can
-support them without weakening isolation. Use `allowed_toolsets` to narrow a
-child; Hermes's existing unsafe-tool block remains enforced.
+parent-broadening toolsets are rejected by default, and per-tool blocks,
+working-directory overrides, and per-launch timeouts are explicitly rejected
+until Hermes can support them without weakening isolation. When the active
+profile configures `delegation.child_toolsets`, that explicit worker allowlist
+replaces the parent-surface check: `allowed_toolsets` may narrow it but cannot
+broaden it. Hermes's existing unsafe-tool block remains enforced.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2700,9 +2700,19 @@ delegation:
   worktree_isolation: false                 # Give each child its own git worktree branched from HEAD (local backend + git repos only; inspired by Muse Code). See Subagent Delegation → Worktree Isolation.
   max_spawn_depth: 1                        # Delegation tree depth cap (1-3, clamped). 1 = flat (default): parent spawns leaves that cannot delegate. 2 = orchestrator children can spawn leaf grandchildren. 3 = three levels.
   orchestrator_enabled: true                # Global kill switch. When false, role="orchestrator" is ignored and every child is forced to leaf regardless of max_spawn_depth.
+  # child_toolsets: [file, terminal, web]   # Optional worker-only allowlist; absent = inherit the parent surface.
 ```
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
+
+**Worker tool boundary:** Normally children inherit their parent's non-blocked toolsets. To run a planning/orchestration parent with a smaller surface while granting workers a deliberately separate operational surface, set `delegation.child_toolsets` to an explicit list:
+
+```yaml
+delegation:
+  child_toolsets: [file, terminal, web]
+```
+
+When this key is present, every `delegate_task` child receives exactly that worker allowlist (subject to Hermes's always-blocked child tools); the parent's enabled and disabled toolsets are not inherited. The public subagent lifecycle API may narrow this surface but cannot request a tool outside it. Omit the key to retain legacy parent inheritance. `[]`, `all`/`*`, unknown names, and malformed values fail closed: they give children no configured worker tools. The policy is read from the active profile at child construction, so it never crosses profiles or retroactively changes an existing session.
 
 **Subagent fallback chain:** Set `delegation.fallback_providers` to give workers their own chain (same entry shape as the top-level list). An explicitly pinned child (by provider, endpoint, or model) uses that chain only when it is declared; otherwise it fails loudly instead of borrowing the parent agent's route. For an unpinned child, an absent or `null` setting preserves parent-chain inheritance. Use `fallback_providers: []` under `delegation:` to disable child fallback entirely.
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -304,7 +304,9 @@ Credentials resolve exactly like a `delegation.provider` pin (full runtime-provi
 
 ## Inherited Tool Access
 
-`delegate_task` does not accept a model-facing `toolsets` parameter. Each subagent inherits the parent's enabled toolsets so the model cannot grant a child capabilities that the parent does not have. Configure the parent's tools before starting the conversation if delegated work needs additional capabilities.
+`delegate_task` does not accept a model-facing `toolsets` parameter. By default, each subagent inherits the parent's enabled toolsets so the model cannot grant a child capabilities that the parent does not have. Configure the parent's tools before starting the conversation if delegated work needs additional capabilities.
+
+For an operator-owned parent/worker boundary, set `delegation.child_toolsets` in the active profile. This explicit allowlist replaces parent inheritance for every child, which lets a planning-only parent delegate to workers with a separate operational set. The model cannot alter it; `all`/`*`, unknown, and malformed values deny worker tools rather than expanding access. See [Configuration → Delegation](../configuration.md#delegation).
 
 Certain tools are blocked for subagents even when the parent has them:
 - `delegate_task` — blocked for leaf subagents (the default). Retained for `role="orchestrator"` children, bounded by `max_spawn_depth` — see [Depth Limit and Nested Orchestration](#depth-limit-and-nested-orchestration) below.
@@ -606,6 +608,7 @@ delegation:
   # worktree_isolation: false               # Give each child its own git worktree (see Worktree Isolation above)
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.
+  # child_toolsets: [file, terminal, web]  # Optional worker-only allowlist; omit to inherit the parent surface.
   model: "google/gemini-3-flash-preview"             # Optional provider/model override
   provider: "openrouter"                             # Optional built-in provider
   api_mode: anthropic_messages                       # optional; auto-detected from base_url for anthropic_messages endpoints


### PR DESCRIPTION
## Behavior
- Adds `delegation.child_toolsets`, an operator-owned child-toolset allowlist that may be narrower or intentionally different from the ordinary parent surface.
- Applies the configured policy to both `delegate_task` and `SubagentLifecycleService`; nested delegation remains available only when explicitly allowed.
- In a hosted RoomLink turn, the authenticated bound execution policy is an outer authority ceiling; child tools cannot exceed it.
- Dashboard exposes an optional override: inherit (field absent) retains legacy behavior, while an explicit empty list denies all child tools.

## Compatibility and fail-closed contract
- Existing profiles without `delegation.child_toolsets` keep legacy parent inheritance.
- Malformed, unreadable, `null`, wildcard, or unknown policies deny child tools. An explicit empty lifecycle `allowed_toolsets` request is rejected rather than widened to the worker policy.
- The dashboard preserves absent/inherit versus explicit `[]` deny-all semantics across saves.

## Validation
- `scripts/run_tests.sh tests/tools/test_delegate_child_toolsets.py tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py tests/tools/test_delegate_composite_toolsets.py tests/agent/test_subagent_lifecycle.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_web_server.py tests/gateway/test_hosted_room_execution_policy.py -q` — 303 passed, 5 host-specific skips.
- Targeted TDD regressions for lifecycle empty requests, hosted-policy ceilings, and dashboard round-trips passed.
- `ruff check`, TypeScript typecheck, web ESLint (0 errors; pre-existing warnings), and `git diff --check` passed.

## Production dependency
No production deployment, runtime configuration change, or gateway restart is part of this PR. Existing production behavior changes only after release and deliberate configuration of `delegation.child_toolsets`.