### PR TITLE
fix(review): scope background tools to trigger

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -934,14 +934,25 @@ def _track_review_fork(agent: Any, review_agent: Any, *, register: bool) -> None
                     agent._active_children.remove(review_agent)
 
 
-def _review_tool_whitelist(review_agent: Any, task_cfg: Optional[Dict[str, Any]]) -> Tuple[set, set]:
+def _review_tool_whitelist(
+    review_agent: Any,
+    task_cfg: Optional[Dict[str, Any]],
+    *,
+    review_memory: bool = False,
+    review_skills: bool = False,
+) -> Tuple[set, set]:
     """``(whitelist, configured_extra_tools)`` for the review fork — DISPATCH-side only, so the
     advertised ``tools[]`` stays byte-identical to the parent's (prompt-cache parity)."""
     from model_tools import get_tool_definitions
     # Gate the built-in memory tool on the profile's memory flags so a memory-disabled profile
     # is never contaminated by the review LLM.
     memory_on = review_agent._memory_enabled or review_agent._user_profile_enabled
-    review_toolsets = ["memory", "skills"] if memory_on else ["skills"]
+    # A skill-only nudge must not gain access to MEMORY.md merely because the
+    # fork inherited a memory-enabled parent.  The whitelist is per tool, so
+    # the trigger scope is the only safe place to make this distinction.
+    review_toolsets = ["skills"]
+    if memory_on and review_memory:
+        review_toolsets.insert(0, "memory")
     whitelist = {t["function"]["name"] for t in get_tool_definitions(enabled_toolsets=review_toolsets, quiet_mode=True)}
     # Read-only file tools: denying read_file/search_files caused a per-review denial storm that
     # starved the loop (read_file also registers the read with the read-before-write guard).
@@ -993,6 +1004,7 @@ def _release_fork_clients(review_agent: Any) -> None:
 def _run_review_fork(
     agent: Any, messages_snapshot: List[Dict], prompt: str, task_cfg: Optional[Dict[str, Any]],
     review_run: Optional[_BackgroundReviewRun], st: _ReviewForkState,
+    *, review_memory: bool = False, review_skills: bool = False,
 ) -> None:
     """Fork phase (inside thread-scoped silence): build the fork, run the prompt under the tool
     whitelist, snapshot its messages/usage, release its clients. Partial progress lands on ``st``
@@ -1000,7 +1012,9 @@ def _run_review_fork(
     st.review_agent, _rt, _routed = build_cache_parity_fork(agent, task_cfg, max_iterations=_REVIEW_MAX_ITERATIONS)
     _track_review_fork(agent, st.review_agent, register=True)
     from hermes_cli.plugins import set_thread_tool_whitelist, clear_thread_tool_whitelist
-    review_whitelist, configured_extra_tools = _review_tool_whitelist(st.review_agent, task_cfg)
+    review_whitelist, configured_extra_tools = _review_tool_whitelist(
+        st.review_agent, task_cfg, review_memory=review_memory, review_skills=review_skills
+    )
     extra_list = ", ".join(sorted(configured_extra_tools))
     deny_extra = f" Configured extra tools also allowed: {extra_list}." if configured_extra_tools else ""
     prompt_extra = f" Exception — these configured tools are also allowed: {extra_list}." if configured_extra_tools else ""
@@ -1056,6 +1070,7 @@ def _publish_review_summary(agent: Any, actions: List[str]) -> None:
 def _run_review_in_thread(
     agent: Any, messages_snapshot: List[Dict], prompt: str,
     task_cfg: Optional[Dict[str, Any]] = None, review_run: Optional[_BackgroundReviewRun] = None,
+    *, review_memory: bool = False, review_skills: bool = False,
 ) -> None:
     """Daemon-thread worker: build the fork, run the prompt, surface the action summary via
     ``agent._safe_print`` / ``background_review_callback``. ``review_run`` (from
@@ -1090,7 +1105,10 @@ def _run_review_in_thread(
         # their console output (#55769 / #55925). ``thread_scoped_silence`` routes only this thread's writes
         # to devnull and leaves all other threads on the real streams.
         with thread_scoped_silence():
-            _run_review_fork(agent, messages_snapshot, prompt, task_cfg, review_run, st)
+            _run_review_fork(
+                agent, messages_snapshot, prompt, task_cfg, review_run, st,
+                review_memory=review_memory, review_skills=review_skills,
+            )
         # A buggy/legacy tool response shape must NOT take down the whole review (the outer
         # except would discard every action the fork DID complete), so coerce to an empty list.
         try:
@@ -1164,7 +1182,10 @@ def spawn_background_review_thread(
         )
 
     def _target() -> None:  # resolves _run_review_in_thread at call time (tests patch it)
-        _run_review_in_thread(agent, messages_snapshot, prompt, task_cfg=task_cfg, review_run=review_run)
+        _run_review_in_thread(
+            agent, messages_snapshot, prompt, task_cfg=task_cfg, review_run=review_run,
+            review_memory=review_memory, review_skills=review_skills,
+        )
 
     return _target, prompt
 

--- a/tests/agent/test_background_review_whitelist.py
+++ b/tests/agent/test_background_review_whitelist.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+import agent.background_review as background_review
+
+
+def test_skill_only_review_does_not_whitelist_memory(monkeypatch):
+    seen = {}
+
+    def definitions(*, enabled_toolsets, quiet_mode):
+        seen["toolsets"] = enabled_toolsets
+        tools = [{"function": {"name": "skill_manage"}}]
+        if "memory" in enabled_toolsets:
+            tools.append({"function": {"name": "memory"}})
+        return tools
+
+    monkeypatch.setattr("model_tools.get_tool_definitions", definitions)
+    fork = SimpleNamespace(_memory_enabled=True, _user_profile_enabled=True)
+
+    allowed, _ = background_review._review_tool_whitelist(
+        fork, {}, review_memory=False, review_skills=True
+    )
+
+    assert seen["toolsets"] == ["skills"]
+    assert "memory" not in allowed
+    assert "skill_manage" in allowed
+
+
+def test_combined_review_keeps_memory_tool_available(monkeypatch):
+    seen = {}
+
+    def definitions(*, enabled_toolsets, quiet_mode):
+        seen["toolsets"] = enabled_toolsets
+        return [{"function": {"name": name}} for name in ("skill_manage", "memory")]
+
+    monkeypatch.setattr("model_tools.get_tool_definitions", definitions)
+    fork = SimpleNamespace(_memory_enabled=True, _user_profile_enabled=False)
+
+    allowed, _ = background_review._review_tool_whitelist(
+        fork, {}, review_memory=True, review_skills=True
+    )
+
+    assert seen["toolsets"] == ["memory", "skills"]
+    assert {"memory", "skill_manage"} <= allowed


### PR DESCRIPTION
## Summary

Fixes #105921 by scoping the background review dispatch whitelist to the trigger that fired.

## Root cause

The review whitelist was per-tool, and every memory-enabled review received the entire `memory` tool. A skill-only review therefore inherited `add`, `replace`, and `remove` despite having no memory-review trigger.

## Change

- Carry `review_memory` and `review_skills` through the review worker.
- Include the `memory` toolset only when the memory review trigger is active.
- Keep combined memory+skill reviews unchanged.
- Add regression tests for skill-only and combined scopes.

This preserves prompt-cache parity because the restriction remains dispatch-side; the advertised tool schema is unchanged.

## Verification

- `scripts/run_tests.sh tests/agent/test_background_review_whitelist.py tests/run_agent/test_background_review.py -q` — 17 tests passed.
- Repeated the targeted suite for 3 consecutive rounds — 3/3 green.
- `git diff --check` — passed.
