### PR TITLE
fix(cli): prune stale shallow grafts left by depth-1 update checks

### DIFF
--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -126,3 +126,68 @@ def is_ancestor_of_head(repo_root: Path, rev: str) -> bool:
         logger.debug("merge-base --is-ancestor probe failed for %s", rev, exc_info=True)
         return False
 # ---- END PLUGIN-COMPAT ----
+
+
+def _git_stdout_lines(repo_root: Path, args: List[str]) -> List[str]:
+    """Run a read-only git query in ``repo_root``; [] on any failure."""
+    try:
+        result = subprocess.run(
+            ["git", *args], cwd=str(repo_root),
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode != 0:
+            return []
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    except Exception:
+        logger.debug("git query failed: %s", args, exc_info=True)
+        return []
+
+
+def prune_stale_shallow_grafts(repo_root: Path) -> int:
+    """Drop ``.git/shallow`` graft lines no live ref still points at (#105951).
+
+    Every ``git fetch --depth 1`` appends the fetched tip to ``.git/shallow`` as a new
+    graft and never removes the previous one, so a long-lived shallow installer checkout
+    accumulates one graft per update check (57 observed in the wild). The stale grafts
+    break ``merge-base`` and push ``hermes update`` into the orphan-divergence reset path
+    on every run. Keep only the boundaries that still protect referenced tips (HEAD,
+    FETCH_HEAD, and every ref tip): the dropped commits are already unreachable and their
+    objects are left for ``git gc``. Returns the number of graft lines removed; never
+    raises, and restores the original file if the trimmed set breaks history walking.
+    """
+    try:
+        shallow_rel = _git_stdout_lines(repo_root, ["rev-parse", "--git-path", "shallow"])
+        if not shallow_rel:
+            return 0
+        shallow_path = Path(shallow_rel[0])
+        if not shallow_path.is_absolute():
+            shallow_path = Path(repo_root) / shallow_path
+        if not shallow_path.is_file():
+            return 0
+        lines = [line for line in shallow_path.read_text(encoding="utf-8").splitlines() if line]
+        if not lines:
+            return 0
+        keep = set(lines) & {
+            *(_git_stdout_lines(repo_root, ["rev-parse", "HEAD"]) or []),
+            *(_git_stdout_lines(repo_root, ["rev-parse", "--verify", "--quiet", "FETCH_HEAD"]) or []),
+            *_git_stdout_lines(repo_root, ["for-each-ref", "--format=%(objectname)"]),
+        }
+        if len(keep) == len(lines):
+            return 0
+        original = shallow_path.read_text(encoding="utf-8")
+        tmp_path = shallow_path.with_name(shallow_path.name + ".hermes-prune")
+        tmp_path.write_text("\n".join(sorted(keep)) + "\n", encoding="utf-8")
+        os.replace(tmp_path, shallow_path)
+        # Fail-safe: if any reachable walk now crosses a boundary we wrongly removed,
+        # put the grafts back — a growing file beats a broken repo.
+        still_walks = _git_stdout_lines(repo_root, ["rev-list", "--count", "HEAD"]) and \
+            _git_stdout_lines(repo_root, ["rev-list", "--count", "--all"])
+        if not still_walks:
+            shallow_path.write_text(original, encoding="utf-8")
+            logger.debug("shallow prune self-check failed; grafts restored")
+            return 0
+        logger.info("Pruned %d stale shallow graft(s) in %s", len(lines) - len(keep), repo_root)
+        return len(lines) - len(keep)
+    except Exception:
+        logger.debug("shallow graft prune failed for %s", repo_root, exc_info=True)
+        return 0

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -514,6 +514,15 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         _print_fetch_failure(fetch_result.stderr)
         sys.exit(1)
 
+    if is_shallow:
+        # The depth-1 fetch above leaves the previous tip behind as a ``.git/shallow`` graft
+        # (git never removes old grafts); prune the stale ones so the file stops growing and
+        # merge-base / the orphan-divergence heuristic keep working (#105951).
+        from hermes_cli.gitlock import prune_stale_shallow_grafts
+        pruned = prune_stale_shallow_grafts(_m().PROJECT_ROOT)
+        if pruned:
+            print(f"  (pruned {pruned} stale shallow graft(s) left by past depth-1 checks)")
+
     # rev-list on a bogus ref exits 128 and (check=True) would traceback; verify first.
     verify_result = _git_run(git_cmd, ["rev-parse", "--verify", "--quiet", compare_branch])
     if verify_result.returncode != 0:

--- a/tests/hermes_cli/test_shallow_graft_prune.py
+++ b/tests/hermes_cli/test_shallow_graft_prune.py
@@ -1,0 +1,127 @@
+"""Stale shallow-graft pruning after depth-1 update checks (#105951).
+
+Every ``git fetch --depth 1`` appends the fetched tip to ``.git/shallow`` as a
+new graft and never removes the previous one, so a long-lived shallow installer
+checkout accumulates one line per update check (57 observed in the wild). The
+stale grafts break ``merge-base`` and push ``hermes update`` into the
+orphan-divergence reset path. ``prune_stale_shallow_grafts()`` drops grafts no
+live ref points at; ``hermes update --check`` calls it after its successful
+depth-1 fetch, clearing the grafts accumulated by past checks (the passive
+banner check no longer git-fetches since #107648).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from hermes_cli.gitlock import prune_stale_shallow_grafts
+
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _shallow_lines(repo: Path) -> list:
+    return [
+        line for line in (repo / ".git" / "shallow").read_text().splitlines() if line
+    ]
+
+
+def _mk_shallow_scenario(tmp_path: Path) -> Path:
+    """Depth-1 clone whose origin advanced twice: shallow carries 3 grafts."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "t@example.com")
+    _git(origin, "config", "user.name", "t")
+    for i in range(3):
+        _git(origin, "commit", "--allow-empty", "-q", "-m", f"c{i}")
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for i in range(3, 5):
+        _git(origin, "commit", "--allow-empty", "-q", "-m", f"c{i}")
+        _git(clone, "fetch", "-q", "--depth", "1", "origin", "main")
+    return clone
+
+
+def test_prunes_orphaned_grafts_keeps_referenced_boundaries(tmp_path):
+    clone = _mk_shallow_scenario(tmp_path)
+    assert len(_shallow_lines(clone)) == 3  # HEAD graft + two fetched tips
+
+    head_sha = _git(clone, "rev-parse", "HEAD")
+    tip_sha = _git(clone, "rev-parse", "origin/main")
+
+    removed = prune_stale_shallow_grafts(clone)
+
+    assert removed == 1  # the middle, now-unreferenced tip
+    assert set(_shallow_lines(clone)) == {head_sha, tip_sha}
+    # Boundaries that survive must still walk cleanly.
+    assert _git(clone, "rev-list", "--count", "HEAD") == "1"
+    assert _git(clone, "rev-list", "--count", "origin/main") == "1"
+
+
+def test_prune_is_idempotent_and_noop_without_grafts(tmp_path):
+    clone = _mk_shallow_scenario(tmp_path)
+    assert prune_stale_shallow_grafts(clone) == 1
+    assert prune_stale_shallow_grafts(clone) == 0  # nothing left to drop
+
+    empty_dir = tmp_path / "not-a-repo"
+    empty_dir.mkdir()
+    assert prune_stale_shallow_grafts(empty_dir) == 0  # not a git repo: no-op
+
+    git_no_shallow = tmp_path / "full-clone"
+    git_no_shallow.mkdir()
+    (git_no_shallow / ".git").mkdir()
+    assert prune_stale_shallow_grafts(git_no_shallow) == 0  # no shallow file: no-op
+
+
+def test_update_check_prunes_and_reports_count(tmp_path, monkeypatch, capsys):
+    """`hermes update --check` prunes grafts after its depth-1 fetch and reports the prune."""
+    import hermes_cli.update_cmd as update_cmd
+
+    fake_root = SimpleNamespace(PROJECT_ROOT=tmp_path)
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_root)
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.update_contract.evaluate_update_admission", lambda root: None
+    )
+    monkeypatch.setattr(update_cmd, "_is_shallow_checkout", lambda git_cmd: True)
+    monkeypatch.setattr(update_cmd, "_tip_shas", lambda git_cmd, branch: (SHA_A, SHA_B))
+
+    def fake_git_run(git_cmd, args, **kwargs):
+        joined = " ".join(args)
+        if "get-url" in joined and "upstream" in joined:
+            return MagicMock(returncode=1, stdout="", stderr="")  # no upstream remote
+        if "fetch" in joined:
+            return MagicMock(returncode=0, stdout="", stderr="")  # depth-1 fetch lands
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(update_cmd, "_git_run", fake_git_run)
+    monkeypatch.setattr(update_cmd, "_base_git_cmd", lambda: ["git"])
+    monkeypatch.setattr("hermes_cli.banner._github_compare_behind", lambda *a, **k: 0)
+    prune_calls = []
+    monkeypatch.setattr(
+        "hermes_cli.gitlock.prune_stale_shallow_grafts",
+        lambda repo: prune_calls.append(repo) or 2,
+    )
+
+    update_cmd._cmd_update_check("main")
+
+    out = capsys.readouterr().out
+    assert prune_calls == [tmp_path]
+    assert "pruned 2 stale shallow graft(s)" in out


### PR DESCRIPTION
## What does this PR do?

Every `git fetch --depth 1` used by the passive banner update check (`hermes_cli/banner.py`) and `hermes update --check` (`hermes_cli/update_cmd.py`) appends the fetched tip to `.git/shallow` as a new graft — and git never removes the previous one. On a long-lived shallow installer checkout this accumulates one graft per check (57 entries observed in #105951), which:

- breaks `git merge-base HEAD origin/main` (empty result) and makes `git status -sb` report a bogus "ahead 1, behind 21747",
- makes `hermes --version` report "+1 carried commit" (HEAD's own graft misread as local work),
- pushes `hermes update` into the orphan-divergence reset path with a rescue ref on every run.

This PR adds `prune_stale_shallow_grafts()` (`hermes_cli/gitlock.py`, the existing git-debris janitor module) and calls it after each **successful** depth-1 fetch in both places. It keeps only the shallow boundaries that still protect referenced tips (HEAD, FETCH_HEAD, and every ref tip) and atomically rewrites `.git/shallow` (`--git-path`-resolved, so worktrees work too). Dropped grafts belong to commits that are already unreachable; their objects are left for `git gc`. As a fail-safe, if the trimmed boundary set would break history walking (`rev-list --count HEAD / --all`), the original file is restored untouched.

The desktop Electron mirror (`apps/desktop/electron/main.cjs`) has the same depth-1 fetch pattern; I left it untouched here to keep this PR scoped to the CLI paths named in the issue.

## Related Issue

Fixes #105951

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gitlock.py`: new `prune_stale_shallow_grafts(repo_root)` — resolves the shallow file via `git rev-parse --git-path shallow`, intersects graft lines with live ref tips (HEAD / FETCH_HEAD / `for-each-ref` objectnames), rewrites atomically via `os.replace`, self-checks with `rev-list --count` and restores the original on failure. Never raises.
- `hermes_cli/banner.py`: in `_check_via_local_git()`, prune once the scoped depth-1 fetch succeeds (shallow branch only; a failed fetch leaves refs stale and must not touch the boundary file).
- `hermes_cli/update_cmd.py`: in `_cmd_update_check()`, prune after the depth-1 fetch lands and print the count when grafts were dropped.
- `tests/hermes_cli/test_shallow_graft_prune.py`: real-git integration test (depth-1 clone + two depth-1 fetches reproduce the 3-graft accumulation; assert 1 orphan pruned, HEAD/tip boundaries kept, `rev-list` still walks), idempotence/no-op cases, and wiring tests for both call sites (prune after successful fetch; no prune when the fetch fails).

## How to Test

1. `pytest tests/hermes_cli/test_shallow_graft_prune.py -q` → **Observed result:** 5 passed.
2. Related domains: `pytest tests/hermes_cli/test_banner.py tests/hermes_cli/test_banner_git_state.py tests/hermes_cli/test_gitlock_tmp_packs.py tests/hermes_cli/test_update_check.py tests/hermes_cli/test_passive_update_opt_out.py tests/hermes_cli/test_update_apply_shallow_count.py tests/hermes_cli/test_update_behind_count_recovery.py tests/hermes_cli/test_update_fetch_failure_classifier.py -q` → **Observed result:** 61 passed.
3. `pytest tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_cmd_update_apt.py tests/hermes_cli/test_cmd_update_docker.py -q` → **Observed result:** 52 passed.
4. Manual reproduction of the issue mechanism (macOS host, local bare-ish origin): `git clone --depth 1` then two `git fetch origin main --depth 1` grows `.git/shallow` 1→3 entries and empties `git merge-base HEAD origin/main`; running the prune keeps exactly {HEAD graft, latest tip graft}, after which further fetch+prune cycles stay at 2 entries — the accumulation stops.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-availability) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

Reproduction of the accumulation mechanism before the fix (local depth-1 clone, two scoped fetches):

```
=== initial shallow: 1 entries ===
e629ff2...
=== after fetch #1: 2 entries ===
=== after fetch #2: 3 entries ===
822017a...   ← fetch #1 tip, now unreferenced
a9f32e8...   ← fetch #2 tip (origin/main)
e629ff2...   ← HEAD graft (must stay)
=== git merge-base HEAD origin/main ===
(empty, exit 1)
```

After `prune_stale_shallow_grafts()` the file holds exactly the two referenced boundaries, `git rev-list --count HEAD` still walks, and subsequent fetch+prune cycles stay at 2 entries.