### PR TITLE
fix: cached-only pricing lookup misses per-credential catalog keys

### DIFF
--- a/hermes_cli/models_pricing.py
+++ b/hermes_cli/models_pricing.py
@@ -478,7 +478,11 @@ def _cached_only_pricing(normalized: str) -> dict[str, dict[str, str]]:
     cache_key = _pricing_provider_cache_keys.get((_pricing_profile_key(), normalized))
     if cache_key is None and normalized in ("openrouter", "ai-gateway", "fireworks"):
         cache_key = _STATIC_PRICING_SCOPES[normalized]()
-    return (_cached_catalog(cache_key) or {}) if cache_key else {}
+    # The catalog is cached per credential under base_url + "\x00auth:<fingerprint>"
+    # (two credentials never share an entry), so a bare-url lookup misses every
+    # authenticated read. peek_cached_pricing scans the authed-prefixed entries
+    # first and falls back to the bare key — the same precedence fetch uses.
+    return peek_cached_pricing(cache_key) if cache_key else {}
 
 
 def get_pricing_for_provider(


### PR DESCRIPTION
## Summary

`fetch_models_with_pricing` caches every catalog under `base_url + "\x00auth:<blake2b fingerprint>"` — pricing catalogs are keyed **per credential**, so two credentials never share an entry and org-policy-filtered catalogs stay isolated. But `_cached_only_pricing` performed its read with the **bare base URL**, so every authenticated cache-only read missed:

- Cold picker opens (`model.options` without `refresh`) returned `pricing_pending` + `{}` pricing even **after** the background prewarm (`_prewarm_pricing_async`) had already populated the cache.
- Users had to hit **Refresh Models** (which forces a live fetch) before any picker showed prices.
- Affects every picker surface with authenticated pricing — Nous Portal (always authenticated), OpenRouter with a key, etc.

## Repro

1. Fresh process (e.g. desktop relaunch → new `serve` backend). Open any model picker → no prices, `pricing_pending` set.
2. Wait 3s (prewarm thread has fetched and cached the full catalog) and re-query `model.options` with no refresh → **still no prices**.
3. `model.options?refresh=true` → prices appear.

Verified against the live endpoint: after prewarm, `_pricing_cache` holds 391 models under the auth-fingerprinted key, while `get_pricing_for_provider("nous", cached_only=True)` returned `{}` before this fix and the full catalog after.

## Change

In `hermes_cli/models_pricing.py::_cached_only_pricing`, replace the naive `_cached_catalog(cache_key)` lookup with `peek_cached_pricing(cache_key)` — the auth-aware helper already in this module that scans `base_url + "\x00auth:"`-prefixed entries first and falls back to the bare key, matching the precedence the real fetch uses.

One line + comment; no behavior change for unauthenticated providers (bare-key fallback is identical).

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_inventory_pricing.py tests/hermes_cli/test_pricing_cache_auth_key.py tests/hermes_cli/test_sale_pricing.py` — **33 passed, 0 failed**.
- Cold-process live repro (fresh interpreter, real Portal credentials): first `build_model_options_payload` now returns 51 priced Nous models immediately; `pricing_pending` is absent on the first open.

## Note for reviewers

This is the root cause behind the desktop composer-menu pricing PRs currently open (#96448, #93375): their rendering works, but users on cold processes still see no prices until a manual refresh because of this backend bug. This fix is independent of and complementary to both — it makes pricing (and Nous tier locks) appear on the **first** open everywhere, CLI included.