### PR TITLE
chore: re-land kanban context-leanness guardrails on main

### DIFF
--- a/docs/kanban/context-leanness-runbook.md
+++ b/docs/kanban/context-leanness-runbook.md
@@ -1,0 +1,70 @@
+# Kanban context-leanness runbook
+
+Audit: task `t_4bf79a41` · Guardrail commit: `57904454c` (re-landed on this tree).
+
+## What this guards
+
+Kanban worker handoff must stay **lean and task-scoped**. A worker spawn is a
+fresh `hermes -p <assignee> --cli chat -q "work kanban task <id>"` process;
+it receives **no** full-session context. Working Context is derived at runtime
+by the worker's first `kanban_show()` → `build_worker_context()`, which is
+hard-capped so even a pathological board (retry-storm, comment-storm, giant
+bodies) collapses to a bounded prompt.
+
+## The caps (hermes_cli/kanban_db.py)
+
+| Constant                  | Value | Applies to                               |
+|---------------------------|-------|------------------------------------------|
+| `_CTX_MAX_PRIOR_ATTEMPTS` | 10    | prior runs shown in full                 |
+| `_CTX_MAX_COMMENTS`       | 30    | comments shown in full                   |
+| `_CTX_MAX_FIELD_BYTES`    | 4 KB  | per summary/error/metadata/result        |
+| `_CTX_MAX_BODY_BYTES`     | 8 KB  | per task body (opening post)             |
+| `_CTX_MAX_COMMENT_BYTES`  | 2 KB  | per comment                              |
+
+Plus: assignee role history limited to the 5 most-recent completed runs
+(`LIMIT 5`), first 200 chars of each summary; done-parent handoffs per-field
+capped.
+
+## Instrumentation
+
+`build_worker_context()` logs the rendered size at the return point:
+
+    _log.debug("kanban worker context for %s: %d chars (%d lines)",
+               task_id, len(text), len(lines))
+
+Context is derived at runtime on first `kanban_show`, so this is the
+authoritative observation point for context-size drift.
+
+## Regression test
+
+`tests/plugins/test_kanban_context_leanness.py` enforces:
+
+1. `build_worker_context` output stays bounded (< 512 KB) under pathological
+   inputs (64 KB body, 200-comment storm, 128 KB summary), and per-field caps
+   truncate with visible `… [truncated, N chars omitted]` markers.
+2. No full-session-history section can appear in the render.
+3. The spawned worker env carries no content/session/history blob key, and the
+   spawn argv is exactly the fixed `work kanban task <id>` prompt.
+
+Run locally:
+
+    cd /usr/local/lib/hermes-agent
+    python -m pytest tests/plugins/test_kanban_context_leanness.py -v
+
+## Levers on prompt size (for operators)
+
+Because kanban context is derive-on-demand from the board DB, the real lever
+on prompt size is **board-DB hygiene** — pruning comments, collapsing giant
+summaries — not passing more/fewer session turns at spawn. Watch the
+`kanban worker context for <id>: N chars` debug line for drift.
+
+## Re-land note (this tree)
+
+The original guardrail commit `57904454c` was swept off `main` when a
+`hermes-update` reset the branch to `origin/main`, orphaning the commit
+(preserved at
+`.git/refs/hermes-update-backups/orphan-main-20260906-185016-57904454cec0`).
+The three source changes (instrumentation, doc-comment fix, regression test)
+were re-applied directly to this working tree so the guardrail is live here.
+Any commit landing on a local `main` must be pushed to `origin` or it will be
+orphaned again by the next update reset.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3579,7 +3579,12 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     _ctx_parent_results(lines, conn, task_id, now)
     _ctx_role_history(lines, conn, task, now)
     _ctx_comments(lines, list_comments(conn, task_id), now)
-    return "\n".join(lines).rstrip() + "\n"
+    text = "\n".join(lines).rstrip() + "\n"
+    _log.debug(
+        "kanban worker context for %s: %d chars (%d lines)",
+        task_id, len(text), len(lines),
+    )
+    return text
 
 
 def _ctx_cap(s: Optional[str], limit: int = _CTX_MAX_FIELD_BYTES) -> str:

--- a/tests/plugins/test_kanban_context_leanness.py
+++ b/tests/plugins/test_kanban_context_leanness.py
@@ -1,0 +1,185 @@
+"""Regression: kanban worker handoff stays lean (task-scoped, bounded).
+
+Task t_4bf79a41 — enforces the audit verdict that worker spawn carries no
+full-session context. Guards against future regressions reintroducing context
+bloat in the kanban handoff.
+
+Two invariants are enforced:
+
+  1. ``build_worker_context`` output stays BOUNDED under pathological inputs
+     (huge body, comment storm, oversized metadata) and per-field caps
+     truncate. A future change that removes the caps and lets one giant field
+     dominate the prompt fails here.
+  2. The spawned worker env contains NO content/session blob and the spawn
+     prompt is exactly the fixed, minimal ``work kanban task <id>`` string.
+     A future change that starts passing full-session history on spawn fails
+     here.
+
+Run:  pytest tests/plugins/test_kanban_context_leanness.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror the kanban_db fixtures used by the other plugin tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(kb.Path, "home", lambda: tmp_path)
+    # Force re-init against the isolated home.
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home):
+    _conn = kb.connect()
+    try:
+        yield _conn
+    finally:
+        _conn.close()
+
+
+# A generous but hard ceiling. Worst realistic render with every cap maxed
+# stays far under this; a regression that drops the caps would blow past it.
+_CTX_CEILING = 512 * 1024  # 512 KB
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1: bounded, capped rendering
+# ---------------------------------------------------------------------------
+
+
+def test_worker_context_bounded_under_pathological_inputs(conn):
+    """Huge body + comment storm + oversized metadata must stay bounded."""
+    task_id = kb.create_task(
+        conn,
+        title="pathological",
+        assignee="architect",
+        body="x" * (64 * 1024),           # 64 KB body (> 8 KB cap)
+    )
+    for i in range(200):                  # comment storm (> 30 shown, > 2 KB each)
+        kb.add_comment(conn, task_id, author=f"w{i}", body="y" * (16 * 1024))
+
+    ctx = kb.build_worker_context(conn, task_id)
+
+    assert len(ctx) < _CTX_CEILING, (
+        f"worker context unexpectedly large: {len(ctx)} chars"
+    )
+    # The 64 KB body must be capped (8 KB cap) -> truncation marker present.
+    assert "… [truncated" in ctx
+    # Comment storm must be collapsed: an "earlier comments omitted" marker.
+    assert "earlier comment" in ctx
+
+
+def test_worker_context_caps_per_field(conn):
+    """A single oversized summary/result must be ellipsized, not dominant."""
+    task_id = kb.create_task(conn, title="caps", assignee="architect")
+
+    # Record an oversized summary via a completed run so it flows into context.
+    # claim + complete writes a run; synthesize one directly is simpler but the
+    # public path keeps the test honest with the real lifecycle.
+    kb.claim_task(conn, task_id)
+    # complete_task requires a summary; provide an oversized one.
+    kb.complete_task(
+        conn, task_id,
+        expected_run_id=kb._current_run_id(conn, task_id),
+        summary="z" * (128 * 1024),       # 128 KB summary (> 4 KB cap)
+    )
+
+    ctx = kb.build_worker_context(conn, task_id)
+    assert "… [truncated" in ctx, "oversized summary must be ellipsized"
+    assert len(ctx) < _CTX_CEILING
+
+
+def test_worker_context_no_full_session_history(conn):
+    """Only the task's own + recent assignee handoff summaries appear; the
+    worker context must never contain full prior conversation transcripts."""
+    task_id = kb.create_task(
+        conn, title="lean", assignee="architect", body="A short lean body."
+    )
+    ctx = kb.build_worker_context(conn, task_id)
+    # The context is a bounded composition; assert structural markers.
+    assert ctx.startswith("# Kanban task")
+    assert "## Body" in ctx
+    # No section that would smuggle in arbitrary session history.
+    for forbidden in ("## Session history", "## Conversation", "prior messages"):
+        assert forbidden not in ctx
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2: spawn carries task identity only, never content
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_prompt_and_env_are_lean(conn, monkeypatch, tmp_path):
+    """The spawned worker's argv is the fixed minimal prompt and its env holds
+    only task-scoped identity vars — no context/session blob.
+
+    The spawn path lives in ``hermes_cli.kanban_db_dispatch._default_spawn``
+    (the kanban_db + dispatch split). Patching ``subprocess.Popen`` here mirrors
+    the established `test_kanban_worker_session_source` fixture, which drives
+    the real ``_default_spawn`` so the leak assertions exercise the actual
+    dispatch code.
+    """
+    import subprocess
+
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    task_id = kb.create_task(conn, title="spawn-lean", assignee="architect")
+    kb.claim_task(conn, task_id)
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+
+    captured = {}
+
+    class _Proc:
+        pid = 424242
+        returncode = None
+
+    def _fake_popen(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["env"] = dict(kwargs.get("env", {}))
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "Popen", _fake_popen)
+    # Dispatch-only plumbing; keep the test on the leak + prompt assertions.
+    monkeypatch.setattr(kbd, "_retag_legacy_worker_sessions", lambda _root: None)
+    monkeypatch.setattr(
+        kbd, "_restart_safe_worker_argv", lambda task, command: command
+    )
+    monkeypatch.setattr(kbd, "_resolve_worker_cli_toolsets", lambda _home: None)
+    monkeypatch.setattr(kb, "worker_logs_dir", lambda board=None: tmp_path / "logs")
+
+    ws = str(tmp_path / "ws")
+    import os as _os
+    _os.makedirs(ws, exist_ok=True)
+    kbd._default_spawn(task, ws, board="default")
+
+    assert captured["cmd"], "spawn argv was not captured"
+    # The prompt is exactly the fixed minimal string and the argv lands the
+    # fixed `chat -q "work kanban task <id>"` tail (cmd[-1] is the prompt).
+    assert captured["cmd"][-1] == f"work kanban task {task_id}"
+    assert "chat" in captured["cmd"] and "-q" in captured["cmd"]
+    env = captured["env"]
+    # Task identity must be present.
+    assert env.get("HERMES_KANBAN_TASK") == task_id
+    assert env.get("HERMES_KANBAN_WORKSPACE") == ws
+    # No content/session/history blob key is set on the child env.
+    blob_like = [
+        k for k in env
+        if "CONTEXT" in k.upper() or "SESSION_HISTORY" in k.upper()
+        or "HISTORY" in k.upper() and k != "HERMES_SESSION_SOURCE"
+    ]
+    assert blob_like == [], f"child env carries context/session blob keys: {blob_like}"

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -504,7 +504,9 @@ def _handle_show(args: dict, **kw) -> str:
             # Capped; full log via CLI.
             "events": [_fields(e, _EVENT_FIELDS) for e in kb.list_events(conn, tid)[-50:]],
             "runs": [_fields(r, _RUN_FIELDS) for r in kb.list_runs(conn, tid)],
-            # Same string build_worker_context hands the dispatcher at spawn time.
+            # The same string build_worker_context renders for the worker; the
+            # dispatcher does NOT pass it at spawn — the worker computes it
+            # fresh via its first kanban_show call.
             "worker_context": kb.build_worker_context(conn, tid)})
 
 


### PR DESCRIPTION
Worker handoff must stay lean/task-scoped; a spawn receives no full-session context. Re-applies the guardrail set (originally 57904454c, orphaned off the running tree by a hermes-update reset to origin/main) as a clean change on current main:

- `hermes_cli/kanban_db.py`: log rendered worker-context size at `build_worker_context` return (`_log.debug` instrumentation)
- `tools/kanban_tools.py`: fix stale `_handle_show` comment (dispatcher does NOT pass worker_context at spawn; the worker computes it fresh)
- `tests/plugins/test_kanban_context_leanness.py`: regression test rewritten for the kanban_db/kanban_db_dispatch split (Invariant 2 drives `_default_spawn`)
- `docs/kanban/context-leanness-runbook.md`: runbook + re-land note

The one failing assertion (a body-less task renders no `## Body` section) is fixed by giving the created lean task a real body.

Tests: `python -m pytest tests/plugins/test_kanban_context_leanness.py -q` -> 4 passed; broader kanban group -> 36 passed.