### PR TITLE
test(process-registry): mark systemd probe tests linux_only

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1911,6 +1911,7 @@ class TestSystemdCgroupIsolation:
 
         return fake_popen, captured
 
+    @pytest.mark.linux_only
     def test_wraps_in_systemd_scope_when_supervisor_and_available(
         self, registry, monkeypatch, _gateway_identity
     ):
@@ -2131,6 +2132,7 @@ class TestSystemdCgroupIsolation:
 
         assert session.systemd_unit == ""
 
+    @pytest.mark.linux_only
     def test_systemd_post_spawn_failure_never_kills_gateway_process_group(
         self, registry, monkeypatch, _gateway_identity
     ):
@@ -2165,6 +2167,7 @@ class TestSystemdCgroupIsolation:
         assert stop_unit.call_args.args[0].endswith(".scope")
         killpg.assert_not_called()
 
+    @pytest.mark.linux_only
     def test_pty_spawn_is_wrapped_in_systemd_scope(self, registry, monkeypatch, _gateway_identity):
         """Interactive executors receive the same sibling-cgroup isolation."""
         from ptyprocess import PtyProcess
@@ -2196,6 +2199,7 @@ class TestSystemdCgroupIsolation:
         assert argv[-3:] == ["/bin/bash", "-lic", "set +m; codex"]
         assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
 
+    @pytest.mark.linux_only
     def test_pty_spawn_failure_reaps_scope_before_distinct_pipe_fallback(
         self, registry, monkeypatch, _gateway_identity
     ):
@@ -2251,6 +2255,7 @@ class TestSystemdCgroupIsolation:
             f"hermes-worker-{session.id}-pipe-fallback.scope"
         )
 
+    @pytest.mark.linux_only
     def test_pty_spawn_failure_does_not_fallback_when_scope_reap_fails(
         self, registry, monkeypatch, _gateway_identity
     ):
@@ -2345,6 +2350,7 @@ class TestSystemdCgroupIsolation:
         assert session.id in registry._finished
         assert session.id not in registry._running
 
+    @pytest.mark.linux_only
     def test_systemd_run_user_scope_available_caches_after_probe(
         self, registry, monkeypatch
     ):
@@ -2424,6 +2430,7 @@ class TestSystemdCgroupIsolation:
         assert "XDG_RUNTIME_DIR" not in os.environ
         assert "DBUS_SESSION_BUS_ADDRESS" not in os.environ
 
+    @pytest.mark.linux_only
     def test_systemd_scope_first_probe_is_serialized(self, monkeypatch):
         """Concurrent first-use callers must wait for one definitive probe.
 
@@ -2471,6 +2478,7 @@ class TestSystemdCgroupIsolation:
         assert results == [True, True]
         assert len(probe_calls) == 1
 
+    @pytest.mark.linux_only
     def test_failed_systemd_probe_retries_after_cache_ttl(self, monkeypatch):
         import tools.process_registry as pr
 


### PR DESCRIPTION
## Problem

Eight tests in `TestSystemdCgroupIsolation` fail on macOS/arm64. They mock
`shutil.which` and `subprocess.run` to simulate `systemd-run` being available,
but the mocks never take effect.

## Root cause

`_systemd_run_user_scope_available()` closes the whole probe behind
`if _IS_LINUX:` (`tools/process_registry.py:165`). Off Linux the function
returns the initial `available = False` without ever calling `subprocess.run`,
so no amount of mocking can produce a `True` verdict.

Observable effects on macOS:

- `test_failed_systemd_probe_retries_after_cache_ttl` fails with
  `len(probe_calls) == 0` — the mocked `subprocess.run` is never invoked.
- The argv assertions get `/bin/bash` instead of `/usr/bin/systemd-run`.
- `test_systemd_scope_first_probe_is_serialized` times out waiting on a probe
  that never starts.

## Fix

Add `@pytest.mark.linux_only` to the eight tests that require a live probe
verdict. The marker is already declared in `pyproject.toml:591` and
`tests/conftest.py:1133`, and #105884 uses the same marker for a new systemd
probe test in this very class.

## Scope

Deliberately per-method, not on the class. The class also holds
`test_darwin_never_takes_scope_path_even_with_systemd_run_on_path` and
`test_probe_returns_false_off_linux`, which exist to verify the non-Linux
path — gating the class would silence exactly the tests that protect macOS
behaviour. The class-level `skipif(sys.platform == "win32")` is left intact.

The other `skipif win32` gates in this file (lines 422, 1557) are untouched;
their reasons (`setsid`/`fcntl`) are genuinely POSIX.

## Testing

macOS 15 / arm64 / Python 3.11.16:

- before: 8 failed, 94 passed, 5 skipped
- after (rebased on b2aa855b62): 94 passed, 14 skipped — the extra skip is #105884's new probe test, which already carries the marker
- `ruff check` clean
- `test_darwin_never_takes_scope_path_even_with_systemd_run_on_path`,
  `test_probe_returns_false_off_linux`, `test_falls_back_when_systemd_run_unavailable`
  and `test_falls_back_when_not_under_supervisor` still run and pass
