### PR TITLE
feat(hermes): add bounded context selection

### DIFF
--- a/plugins/context_engine/bounded/__init__.py
+++ b/plugins/context_engine/bounded/__init__.py
@@ -1,0 +1,709 @@
+"""Bounded context selection plugin: ``plugins/context_engine/bounded``.
+
+Replaces the pre-generation context for every provider request with a deterministic
+subset that (a) preserves the system prompt, the current user request and the newest
+pending tool chain, (b) stays within a *hard budget* derived from the model context
+window (``budget_ratio`` of the window minus an output/tool-schema reserve), and (c)
+never mutates persisted history or the original request message list.
+
+This is "selection", not "compression": ``compress()`` shrinks an over-long transcript
+via the wrapped compressor lifecycle, while ``select_context`` bounds the request that
+goes on the wire each turn. Selection is deterministic, uses no LLM embeddings, and
+fails open (returns ``None``) on any error so the host's normal preflight/compression
+path still governs.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
+
+from agent.context_engine import ContextEngine
+
+if TYPE_CHECKING:
+    from agent.context_compressor import ContextCompressor
+
+logger = logging.getLogger("plugins.context_engine.bounded")
+
+__all__ = ["BoundedContextEngine", "register"]
+
+#: Truncation marker inserted where an oversized retained tool result is clamped.
+_CLAMP_MARKER = "\n...[clamped by hermes bounded context]...\n"
+
+SelectResult = Tuple[List[Dict[str, Any]], int, int, int, int, int, str]
+
+
+class BoundedContextEngine(ContextEngine):
+    """Plugin context engine: bounded, deterministic, replay-safe request selection."""
+
+    #: Attributes the host may write on the plugin that govern the wrapped compressor's
+    #: compaction policy; mirrored to it so the plugin stays the single interface.
+    _MIRRORED_ATTRS = frozenset({
+        "model_thresholds",
+        "_micro_compact_enabled",
+        "_micro_compact_every_n_turns",
+        "_micro_compact_defrag_threshold_tokens",
+    })
+
+    def __init__(
+        self,
+        *,
+        budget_ratio: float = 0.5,
+        reserve_cap_ratio: float = 0.20,
+        output_reserve_tokens: int = 4096,
+        tool_schema_reserve_tokens: int = 8192,
+        recent_window_messages: int = 40,
+        min_recent_tail_messages: int = 8,
+        head_anchor_messages: int = 3,
+        max_relevant_messages: int = 24,
+        relevance_floor_score: int = 2,
+        relevance_min_tokens: int = 1024,
+        relevance_max_tokens: int = 8192,
+        max_tool_result_chars: int = 12000,
+        clamp_head_ratio: float = 0.7,
+        clamp_tail_ratio: float = 0.2,
+        enabled: bool = True,
+    ) -> None:
+        super().__init__()
+        object.__setattr__(self, "_compressor", None)
+        object.__setattr__(self, "model", "")
+        object.__setattr__(self, "_session_id", None)
+        self.enabled = bool(enabled)
+        self.budget_ratio = float(budget_ratio)
+        self.reserve_cap_ratio = float(reserve_cap_ratio)
+        self.output_reserve_tokens = int(output_reserve_tokens)
+        self.tool_schema_reserve_tokens = int(tool_schema_reserve_tokens)
+        self.recent_window_messages = max(1, int(recent_window_messages))
+        self.min_recent_tail_messages = max(1, int(min_recent_tail_messages))
+        self.head_anchor_messages = max(0, int(head_anchor_messages))
+        self.max_relevant_messages = max(0, int(max_relevant_messages))
+        self.relevance_floor_score = max(0, int(relevance_floor_score))
+        self.relevance_min_tokens = max(0, int(relevance_min_tokens))
+        self.relevance_max_tokens = max(0, int(relevance_max_tokens))
+        self.max_tool_result_chars = max(256, int(max_tool_result_chars))
+        self.clamp_head_ratio = float(clamp_head_ratio)
+        self.clamp_tail_ratio = float(clamp_tail_ratio)
+        self._selection_count = 0
+
+    @property
+    def name(self) -> str:
+        return "bounded"
+
+    # -- attribute mirroring to the wrapped compressor ---------------------------------
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in self._MIRRORED_ATTRS:
+            inner = self.__dict__.get("_compressor")
+            if inner is not None:
+                setattr(inner, name, value)
+        object.__setattr__(self, name, value)
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        inner = self.__dict__.get("_compressor")
+        if inner is not None and hasattr(inner, name):
+            return getattr(inner, name)
+        raise AttributeError(name)
+
+    # -- compressor lifecycle (delegated; owns compaction policy) ---------------------
+    def _ensure_compressor(self) -> "ContextCompressor":
+        inner = self.__dict__.get("_compressor")
+        if inner is not None:
+            return inner
+        from agent.context_compressor import ContextCompressor
+
+        inner = ContextCompressor(
+            model=getattr(self, "model", "") or "unknown",
+            threshold_percent=0.50,
+            protect_first_n=3,
+            protect_last_n=6,
+            quiet_mode=True,
+        )
+        object.__setattr__(self, "_compressor", inner)
+        return inner
+
+    def _inner(self) -> Optional["ContextCompressor"]:
+        return self.__dict__.get("_compressor")
+
+    def update_model(
+        self,
+        model: str,
+        context_length: int,
+        base_url: str = "",
+        api_key: str = "",
+        provider: str = "",
+        api_mode: str = "",
+    ) -> None:
+        object.__setattr__(self, "model", model)
+        super().update_model(
+            model,
+            context_length,
+            base_url=base_url,
+            api_key=api_key,
+            provider=provider,
+            api_mode=api_mode,
+        )
+        try:
+            inner = self._ensure_compressor()
+            inner.update_model(
+                model,
+                context_length,
+                base_url=base_url,
+                api_key=api_key,
+                provider=provider,
+                api_mode=api_mode,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("bounded: compressor update_model failed: %s", exc)
+
+    def bind_session_state(self, session_state: Any) -> None:
+        try:
+            inner = self._ensure_compressor()
+            return inner.bind_session_state(session_state)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("bounded: bind_session_state failed: %s", exc)
+            return None
+
+    def on_session_start(self, session_id: str, **kwargs: Any) -> None:
+        object.__setattr__(self, "_session_id", session_id)
+        inner = self._inner()
+        if inner is not None and hasattr(inner, "on_session_start"):
+            try:
+                return inner.on_session_start(session_id, **kwargs)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("bounded: on_session_start failed: %s", exc)
+                return None
+        return None
+
+    def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+        inner = self._inner()
+        if inner is not None and hasattr(inner, "on_session_end"):
+            try:
+                return inner.on_session_end(session_id, messages)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("bounded: on_session_end failed: %s", exc)
+                return None
+        return None
+
+    def on_session_reset(self) -> None:
+        super().on_session_reset()
+        inner = self._inner()
+        if inner is not None and hasattr(inner, "on_session_reset"):
+            try:
+                inner.on_session_reset()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("bounded: on_session_reset failed: %s", exc)
+
+    def update_from_response(self, usage: Dict[str, Any]) -> None:
+        inner = self._inner()
+        if inner is not None:
+            return inner.update_from_response(usage)
+        pt = (usage or {}).get("prompt_tokens") or 0
+        ct = (usage or {}).get("completion_tokens") or 0
+        self.last_prompt_tokens = int(pt)
+        self.last_completion_tokens = int(ct)
+        self.last_total_tokens = int(pt) + int(ct)
+
+    def should_compress(self, prompt_tokens: Optional[int] = None) -> bool:
+        inner = self._inner()
+        if inner is None:
+            return False
+        return inner.should_compress(prompt_tokens)  # type: ignore[invalid-argument-type]
+
+    def should_compress_info(
+        self, prompt_tokens: Optional[int] = None
+    ) -> Tuple[bool, Optional[str]]:
+        inner = self._inner()
+        if inner is None or not hasattr(inner, "should_compress_info"):
+            return self.should_compress(prompt_tokens), None
+        return inner.should_compress_info(prompt_tokens)  # type: ignore[invalid-argument-type]
+
+    def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: Optional[int] = None,
+        focus_topic: Optional[str] = None,
+        force: bool = False,
+        memory_context: str = "",
+    ) -> List[Dict[str, Any]]:
+        inner = self._inner()
+        if inner is None:
+            return messages
+        return inner.compress(
+            messages,
+            current_tokens=current_tokens,
+            focus_topic=focus_topic,
+            force=force,
+            memory_context=memory_context,
+        )
+
+    def prune_tool_results_only(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: Optional[int] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        inner = self._inner()
+        if inner is None:
+            return messages, 0
+        return inner.prune_tool_results_only(messages, current_tokens=current_tokens)
+
+    def has_content_to_compress(self, messages: List[Dict[str, Any]]) -> bool:
+        inner = self._inner()
+        if inner is None:
+            return True
+        return inner.has_content_to_compress(messages)
+
+    def get_status(self) -> Dict[str, Any]:
+        status = super().get_status()
+        status.update({
+            "engine": self.name,
+            "selection_enabled": self.enabled,
+            "selection_count": self._selection_count,
+        })
+        inner = self._inner()
+        if inner is not None and hasattr(inner, "get_status"):
+            try:
+                inner_status = inner.get_status()
+                if isinstance(inner_status, dict):
+                    status.update(inner_status)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("bounded: get_status() failed: %s", exc)
+        return status
+
+    # ---- hard budget ----------------------------------------------------------------
+    def _hard_budget_for(self, context_length: int) -> int:
+        def _capped(value: int) -> int:
+            return min(int(value), int(context_length * 0.10))
+
+        reserve = min(
+            int(context_length * self.reserve_cap_ratio),
+            _capped(self.output_reserve_tokens)
+            + _capped(self.tool_schema_reserve_tokens),
+        )
+        return max(0, int(context_length * self.budget_ratio) - reserve)
+
+    # ---- selection ------------------------------------------------------------------
+    def select_context(
+        self,
+        request_messages: List[Dict[str, Any]],
+        *,
+        conversation_messages: Optional[List[Dict[str, Any]]] = None,
+        incoming_message: Optional[Dict[str, Any]] = None,
+        budget_tokens: int = 0,
+    ) -> Optional[List[Dict[str, Any]]]:  # type: ignore[invalid-method-override]
+        if not self.enabled:
+            return None
+        if not isinstance(request_messages, list) or not request_messages:
+            return None
+        context_length = budget_tokens or self.context_length or 0
+        if context_length <= 0:
+            return None
+        hard_budget = self._hard_budget_for(context_length)
+        if hard_budget <= 0:
+            return None
+        try:
+            result = self._select(request_messages, hard_budget)
+        except Exception as exc:  # fail open: never break the request pipeline
+            logger.warning(
+                "bounded: selection failed, leaving request unchanged: %s", exc
+            )
+            return None
+        self._selection_count += 1
+        if result is None:
+            return None
+        selected, in_tokens, out_tokens, omitted, pruned, clamped, mode = result
+        safe = {
+            "session_id": self._session_id,
+            "mode": mode,
+            "input_messages": len(request_messages),
+            "output_messages": len(selected),
+            "input_tokens_est": in_tokens,
+            "selected_tokens_est": out_tokens,
+            "budget_tokens": context_length,
+            "hard_budget": hard_budget,
+            "omitted_messages": omitted,
+            "pruned_tool_results": pruned,
+            "clamped_tool_results": clamped,
+        }
+        logger.info("bounded selection: %s", safe)
+        return selected
+
+    def _select(
+        self, request_messages: List[Dict[str, Any]], hard_budget: int
+    ) -> Optional[SelectResult]:
+        estimate = _current_request_estimator()
+        in_tokens = estimate(request_messages)
+        if in_tokens <= hard_budget:
+            return request_messages, in_tokens, in_tokens, 0, 0, 0, "short"
+
+        n = len(request_messages)
+        system_idx = {i for i, m in enumerate(request_messages) if _is_system(m)}
+        systems_msgs = [request_messages[i] for i in sorted(system_idx)]
+        first_non_system = next((i for i in range(n) if i not in system_idx), 0)
+        current_idx = _current_request_index(request_messages)
+        if current_idx is None:
+            current_idx = first_non_system
+        pending = _newest_tool_group_indices(request_messages, after_index=current_idx)
+
+        mandatory = set(system_idx) | {current_idx} | pending
+        mandatory_est = sum(estimate([request_messages[i]]) for i in mandatory)
+        if mandatory_est > hard_budget:
+            return None
+        remaining = hard_budget - mandatory_est
+
+        window_ids: List[int] = []
+        est_window = 0
+        limit_front = max(0, current_idx - self.recent_window_messages)
+        j = current_idx - 1
+        while j >= limit_front:
+            m = request_messages[j]
+            if len(window_ids) < self.min_recent_tail_messages:
+                window_ids.append(j)
+                est_window += estimate([m])
+                j -= 1
+                continue
+            if est_window + estimate([m]) > remaining:
+                break
+            window_ids.append(j)
+            est_window += estimate([m])
+            j -= 1
+        window_ids.reverse()
+
+        mandatory_ids = set(mandatory)
+        keep_ids = sorted(set(window_ids) | (mandatory_ids - set(system_idx)))
+        trimmable_identities = {
+            id(request_messages[i]) for i in set(window_ids) if i not in mandatory_ids
+        }
+        original_identities = {id(request_messages[i]) for i in keep_ids}
+        protected_positions = {pos for pos, i in enumerate(keep_ids) if i in pending}
+
+        window_msgs = [request_messages[i] for i in keep_ids]
+        window_msgs = self._clamp_window(
+            window_msgs, protected_positions, hard_budget, estimate
+        )
+        clamped = sum(1 for m in window_msgs if id(m) not in original_identities)
+        window_msgs, pruned = _enforce_pair_validity(window_msgs)
+
+        final = systems_msgs + window_msgs
+        final_est = estimate(final)
+        if final_est > hard_budget:
+            final, final_est = _trim_from_front_until_fit(
+                final, hard_budget, estimate, trimmable_identities=trimmable_identities
+            )
+            final, pruned_extra = _enforce_pair_validity(final)
+            pruned += pruned_extra
+            final_est = estimate(final)
+        if final_est > hard_budget:
+            return None
+
+        room = hard_budget - final_est
+        if room >= self.relevance_min_tokens and (
+            self.head_anchor_messages > 0 or self.max_relevant_messages > 0
+        ):
+            preamble = self._build_preamble(
+                request_messages,
+                current_idx,
+                system_idx,
+                current_idx,
+                room,
+                estimate,
+                exclude_indices=set(keep_ids),
+            )
+            if preamble:
+                candidate = systems_msgs + preamble + window_msgs
+                candidate_est = estimate(candidate)
+                if candidate_est <= hard_budget:
+                    final, final_est = candidate, candidate_est
+
+        omitted = n - len(final)
+        mode = "selected_pruned" if (clamped or pruned) else "selected"
+        return final, in_tokens, final_est, omitted, pruned, clamped, mode
+
+    def _clamp_window(
+        self,
+        window_msgs: List[Dict[str, Any]],
+        protected: Set[int],
+        hard_budget: int,
+        estimate: Callable[[List[Dict[str, Any]]], int],
+    ) -> List[Dict[str, Any]]:
+        if estimate(window_msgs) <= hard_budget:
+            return window_msgs
+        for k, m in enumerate(window_msgs):
+            if k in protected:
+                continue
+            if not _is_tool_result(m):
+                continue
+            text = _message_text(m)
+            if len(text) <= self.max_tool_result_chars:
+                continue
+            head = min(
+                int(len(text) * self.clamp_head_ratio),
+                int(self.max_tool_result_chars * 0.8),
+            )
+            tail = min(
+                int(len(text) * self.clamp_tail_ratio),
+                int(self.max_tool_result_chars * 0.2),
+            )
+            clone = dict(m)
+            clone["content"] = (
+                text[:head] + _CLAMP_MARKER + (text[-tail:] if tail else "")
+            )
+            window_msgs[k] = clone
+            if estimate(window_msgs) <= hard_budget:
+                break
+        return window_msgs
+
+    def _build_preamble(
+        self,
+        request_messages: List[Dict[str, Any]],
+        prefix_end: int,
+        system_idx: Set[int],
+        current_idx: int,
+        room: int,
+        estimate: Callable[[List[Dict[str, Any]]], int],
+        exclude_indices: Set[int],
+    ) -> List[Dict[str, Any]]:
+        if room < self.relevance_min_tokens and self.head_anchor_messages <= 0:
+            return []
+        picked: List[Tuple[int, Dict[str, Any]]] = []
+        picked_idx: Set[int] = set(exclude_indices)
+        picked_tokens = 0
+        current_text = _message_text(request_messages[current_idx])
+        need_anchor = self.head_anchor_messages
+        prefix_end = min(prefix_end, len(request_messages))
+
+        def _consider(i: int, m: Dict[str, Any]) -> None:
+            nonlocal picked_tokens
+            tok = estimate([m])
+            if tok <= 0 or picked_tokens + tok > room:
+                return
+            picked.append((i, m))
+            picked_tokens += tok
+
+        for i in range(prefix_end):
+            if need_anchor <= 0:
+                break
+            if i in picked_idx or i in system_idx:
+                continue
+            if not _is_standalone(request_messages[i]):
+                continue
+            if not _message_text(request_messages[i]):
+                continue
+            _consider(i, request_messages[i])
+            need_anchor -= 1
+
+        available = self.max_relevant_messages + self.head_anchor_messages
+        if (
+            room - picked_tokens >= self.relevance_min_tokens
+            and len(picked) < available
+        ):
+            allowed = min(self.relevance_max_tokens, room - picked_tokens)
+            for i in range(prefix_end):
+                if len(picked) >= available:
+                    break
+                if i in picked_idx or i in system_idx:
+                    continue
+                m = request_messages[i]
+                if not _is_standalone(m):
+                    continue
+                text = _message_text(m)
+                if not text:
+                    continue
+                if _token_overlap(text, current_text) < self.relevance_floor_score:
+                    continue
+                tok = estimate([m])
+                if tok <= 0 or tok > 4096:
+                    continue
+                if picked_tokens + tok > allowed:
+                    continue
+                _consider(i, m)
+
+        picked.sort(key=lambda item: item[0])
+        return [m for _, m in picked]
+
+
+def register(ctx: Any) -> None:
+    """Plugin-loader entry: capture this engine via the discovery collector."""
+    ctx.register_context_engine(BoundedContextEngine())
+
+
+# ---- message classification ---------------------------------------------------------
+def _is_system(m: Any) -> bool:
+    return isinstance(m, dict) and m.get("role") == "system"
+
+
+def _is_assistant(m: Any) -> bool:
+    return isinstance(m, dict) and m.get("role") == "assistant"
+
+
+def _is_tool_call(m: Any) -> bool:
+    return _is_assistant(m) and bool(m.get("tool_calls"))
+
+
+def _is_tool_result(m: Any) -> bool:
+    return (
+        isinstance(m, dict) and m.get("role") == "tool" and bool(m.get("tool_call_id"))
+    )
+
+
+def _is_standalone(m: Any) -> bool:
+    return not (_is_system(m) or _is_tool_call(m) or _is_tool_result(m))
+
+
+def _message_text(m: Any) -> str:
+    content = m.get("content") if isinstance(m, dict) else None
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                for key in ("text", "content"):
+                    value = block.get(key)
+                    if isinstance(value, str):
+                        parts.append(value)
+                        break
+        return "\n".join(parts)
+    return ""
+
+
+def _current_request_index(request_messages: List[Dict[str, Any]]) -> Optional[int]:
+    """Index of the live user request (last user message without a tool_call_id).
+
+    When the trailing user message carries list-content (multimodal attachment/MoA
+    epilogue), the actual text request is the previous user message.
+    """
+    last_user = None
+    for i in range(len(request_messages) - 1, -1, -1):
+        m = request_messages[i]
+        if (
+            isinstance(m, dict)
+            and m.get("role") == "user"
+            and not m.get("tool_call_id")
+        ):
+            last_user = i
+            break
+    if last_user is None:
+        return None
+    content = request_messages[last_user].get("content")
+    if isinstance(content, list):
+        for i in range(last_user - 1, -1, -1):
+            m = request_messages[i]
+            if (
+                isinstance(m, dict)
+                and m.get("role") == "user"
+                and not m.get("tool_call_id")
+            ):
+                return i
+    return last_user
+
+
+def _newest_tool_group_indices(
+    request_messages: List[Dict[str, Any]],
+    after_index: int,
+) -> Set[int]:
+    """Indices of the in-flight tool chain strictly newer than ``after_index``.
+
+    Only an assistant ``tool_calls`` message that appears AFTER the live user request
+    (plus its contiguous results) counts as the pending group; a completed tool group
+    below the current request is ordinary history and is trimmable.
+    """
+    n = len(request_messages)
+    for i in range(n - 1, after_index - 1, -1):
+        if _is_tool_call(request_messages[i]):
+            indices = {i}
+            j = i + 1
+            while j < n and _is_tool_result(request_messages[j]):
+                indices.add(j)
+                j += 1
+            return indices
+    return set()
+
+
+def _enforce_pair_validity(
+    messages: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Drop tool results whose tool_calls pair is not in the selection (pair-validity).
+
+    Runs after any message is trimmed so a retained tool result never dangles without
+    its initiating assistant message.
+    """
+    created_ids = set()
+    for m in messages:
+        for tc in m.get("tool_calls") or []:
+            if isinstance(tc, dict) and tc.get("id"):
+                created_ids.add(tc["id"])
+    kept: List[Dict[str, Any]] = []
+    pruned = 0
+    for m in messages:
+        if _is_tool_result(m) and m.get("tool_call_id") not in created_ids:
+            pruned += 1
+            continue
+        kept.append(m)
+    return kept, pruned
+
+
+def _trim_from_front_until_fit(
+    final: List[Dict[str, Any]],
+    hard_budget: int,
+    estimate: Callable[[List[Dict[str, Any]]], int],
+    trimmable_identities: Set[int],
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Safety net: drop the oldest trimmable message until the selection fits the budget.
+
+    ``trimmable_identities`` covers the verbatim older window messages only — never the
+    system prompt, the current request, the pending tool chain, or messages already
+    replaced by a clamped copy — so the request invariants cannot be violated here.
+    """
+    removable = [
+        i
+        for i, m in enumerate(final)
+        if not _is_system(m) and id(m) in trimmable_identities
+    ]
+    while estimate(final) > hard_budget and removable:
+        i = removable.pop(0)
+        del final[i]
+        removable = [j - 1 if j > i else j for j in removable]
+    return final, estimate(final)
+
+
+# ---- deterministic relevance --------------------------------------------------------
+_WORD_RE = re.compile(r"[A-Za-z0-9_'-]{2,}", re.UNICODE)
+
+_STOPWORDS = frozenset(
+    """
+a about after again all also am an and any are as at be because been before being between
+both but by can could did do does doing down during each few for from further had has have
+having he her here hers herself him himself his how i if in into is it its itself just me
+more most my myself no nor not now of off on once only or other our ours ourselves out over
+own same she should so some such than that the their theirs them themselves then there these
+they this those through to too under until up very was we were what when where which while
+who whom why will with would you your yours yourself yourselves
+""".split()
+)
+
+
+def _word_tokens(text: str) -> List[str]:
+    return [w for w in _WORD_RE.findall(text.lower()) if w not in _STOPWORDS]
+
+
+def _token_overlap(a: str, b: str) -> int:
+    wa = _word_tokens(a)
+    wb = _word_tokens(b)
+    if not wa or not wb:
+        return 0
+    return len(set(wa) & set(wb))
+
+
+# ---- rough token estimator (host-canonical, imported lazily) ------------------------
+_COMMON_ESTIMATOR = None
+
+
+def _current_request_estimator() -> Callable[[List[Dict[str, Any]]], int]:
+    global _COMMON_ESTIMATOR
+    if _COMMON_ESTIMATOR is None:
+        from agent.model_metadata import estimate_messages_tokens_rough
+
+        _COMMON_ESTIMATOR = estimate_messages_tokens_rough
+    return _COMMON_ESTIMATOR

--- a/plugins/context_engine/bounded/__init__.py
+++ b/plugins/context_engine/bounded/__init__.py
@@ -197,13 +197,23 @@ class BoundedContextEngine(ContextEngine):
 
     def update_from_response(self, usage: Dict[str, Any]) -> None:
         inner = self._inner()
-        if inner is not None:
-            return inner.update_from_response(usage)
-        pt = (usage or {}).get("prompt_tokens") or 0
-        ct = (usage or {}).get("completion_tokens") or 0
-        self.last_prompt_tokens = int(pt)
-        self.last_completion_tokens = int(ct)
-        self.last_total_tokens = int(pt) + int(ct)
+        if inner is None:
+            pt = (usage or {}).get("prompt_tokens") or 0
+            ct = (usage or {}).get("completion_tokens") or 0
+            self.last_prompt_tokens = int(pt)
+            self.last_completion_tokens = int(ct)
+            self.last_total_tokens = int(pt) + int(ct)
+            return
+        inner.update_from_response(usage)
+        # Host preflight reads the engine's own counters directly; mirror the inner
+        # compressor's post-response state so wrapper reads are never stale (and the
+        # host-set awaiting-real-usage latch is cleared in sync with the inner one).
+        self.last_prompt_tokens = int(inner.last_prompt_tokens)
+        self.last_completion_tokens = int(inner.last_completion_tokens)
+        self.last_total_tokens = int(inner.last_total_tokens)
+        self.awaiting_real_usage_after_compression = bool(
+            getattr(inner, "awaiting_real_usage_after_compression", False)
+        )
 
     def should_compress(self, prompt_tokens: Optional[int] = None) -> bool:
         inner = self._inner()
@@ -218,6 +228,12 @@ class BoundedContextEngine(ContextEngine):
         if inner is None or not hasattr(inner, "should_compress_info"):
             return self.should_compress(prompt_tokens), None
         return inner.should_compress_info(prompt_tokens)  # type: ignore[invalid-argument-type]
+
+    def should_defer_preflight_to_real_usage(self, rough_tokens: int) -> bool:
+        inner = self._inner()
+        if inner is not None and hasattr(inner, "should_defer_preflight_to_real_usage"):
+            return inner.should_defer_preflight_to_real_usage(rough_tokens)
+        return super().should_defer_preflight_to_real_usage(rough_tokens)
 
     def compress(
         self,
@@ -569,12 +585,14 @@ def _message_text(m: Any) -> str:
 
 
 def _current_request_index(request_messages: List[Dict[str, Any]]) -> Optional[int]:
-    """Index of the live user request (last user message without a tool_call_id).
+    """Index of the live user request: the last user message without a tool_call_id.
 
-    When the trailing user message carries list-content (multimodal attachment/MoA
-    epilogue), the actual text request is the previous user message.
+    The host never emits a separate trailing epilogue user message: MoA context is
+    folded INTO the last user message (turn_request_assembly._append_moa_context) and
+    genuine list-content (multimodal) user messages are passed through unchanged by
+    build_api_messages. So the last user message is ALWAYS the current request and
+    must be preserved, even when its content is a list.
     """
-    last_user = None
     for i in range(len(request_messages) - 1, -1, -1):
         m = request_messages[i]
         if (
@@ -582,21 +600,8 @@ def _current_request_index(request_messages: List[Dict[str, Any]]) -> Optional[i
             and m.get("role") == "user"
             and not m.get("tool_call_id")
         ):
-            last_user = i
-            break
-    if last_user is None:
-        return None
-    content = request_messages[last_user].get("content")
-    if isinstance(content, list):
-        for i in range(last_user - 1, -1, -1):
-            m = request_messages[i]
-            if (
-                isinstance(m, dict)
-                and m.get("role") == "user"
-                and not m.get("tool_call_id")
-            ):
-                return i
-    return last_user
+            return i
+    return None
 
 
 def _newest_tool_group_indices(

--- a/plugins/context_engine/bounded/plugin.yaml
+++ b/plugins/context_engine/bounded/plugin.yaml
@@ -1,0 +1,8 @@
+name: bounded
+description: >-
+  Bounded, deterministic context selection: bounds every provider request to a hard
+  budget derived from the model context window, preserving the system prompt, the
+  current request and the newest pending tool chain while never mutating persisted
+  history. Selection only; compression remains the wrapped compressor's lifecycle.
+version: 0.1.0
+author: Nous Research

--- a/tests/agent/test_context_engine_bounded.py
+++ b/tests/agent/test_context_engine_bounded.py
@@ -1,0 +1,402 @@
+"""Tests for the ``bounded`` plugin context engine (plugins/context_engine/bounded).
+
+Covers the ANCOS Phase-1 validation matrix: hard-budget selection, request
+preservation (system / current request / newest pending tool chain), tool-pair
+validity, replay-safe ordering, no mutation of persisted history or of the original
+request list, deterministic behavior, fail-open semantics, and a 160k-token
+regression where the compressor's own compaction threshold has NOT yet fired.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any, Dict, List
+
+import pytest
+
+from agent.model_metadata import estimate_messages_tokens_rough
+from plugins.context_engine import discover_context_engines, load_context_engine
+from plugins.context_engine.bounded import BoundedContextEngine, _CLAMP_MARKER
+
+
+def _msg(role: str, content: str = "", **extra: Any) -> Dict[str, Any]:
+    m: Dict[str, Any] = {"role": role, "content": content}
+    m.update(extra)
+    return m
+
+
+def _tokenish_text(seed: int, words: int) -> str:
+    return " ".join(f"tok_{seed}_{i}_word" for i in range(words))
+
+
+def _tool_turn(call_id: str, result_text: str) -> List[Dict[str, Any]]:
+    return [
+        _msg(
+            "assistant",
+            content="calling a tool",
+            tool_calls=[
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": "{}"},
+                }
+            ],
+        ),
+        _msg("tool", content=result_text, tool_call_id=call_id, name="web_search"),
+        _msg(
+            "tool",
+            content="second result " + result_text[-2000:],
+            tool_call_id=call_id,
+            name="web_search",
+        ),
+    ]
+
+
+def _build_big_request(
+    rounds: int = 12, words: int = 12000, system: str = "You are a helpful assistant."
+) -> List[Dict[str, Any]]:
+    msgs: List[Dict[str, Any]] = [_msg("system", content=system)]
+    for r in range(rounds):
+        msgs.append(_msg("user", content=_tokenish_text(r, words)))
+        if r % 3 == 0:
+            msgs += _tool_turn(f"call{r}", result_text=_tokenish_text(r + 100, words))
+        msgs.append(_msg("assistant", content=_tokenish_text(r + 200, 120)))
+    msgs.append(
+        _msg("user", content="CURRENT_REQUEST_SENTINEL " + _tokenish_text(999, 400))
+    )
+    return msgs
+
+
+def _build_request_near(target_tokens: int, rounds: int = 12):
+    """Deterministically build a request whose rough estimate lands near ``target_tokens``."""
+    words = max(200, int(target_tokens / max(rounds, 1) / 5.6))
+    req = None
+    est = 0
+    for _ in range(10):
+        req = _build_big_request(rounds=rounds, words=words)
+        est = estimate_messages_tokens_rough(req)
+        if est < target_tokens * 0.90:
+            words = max(words + 1, int(words * target_tokens / max(est, 1) * 1.15))
+        elif est > target_tokens * 1.10:
+            words = max(1, int(words * target_tokens / max(est, 1) * 0.92))
+        else:
+            break
+    return req, est
+
+
+def _engine(context_length: int = 262144, **kwargs: Any) -> BoundedContextEngine:
+    e = BoundedContextEngine(**kwargs)
+    e.context_length = context_length
+    return e
+
+
+def _assert_pair_valid(selected: List[Dict[str, Any]]) -> None:
+    created_ids = set()
+    for m in selected:
+        for tc in m.get("tool_calls") or []:
+            if isinstance(tc, dict) and tc.get("id"):
+                created_ids.add(tc["id"])
+    for m in selected:
+        if m.get("role") == "tool":
+            assert m.get("tool_call_id") in created_ids, "dangling tool result retained"
+
+
+def _assert_replay_order(
+    selected: List[Dict[str, Any]], original: List[Dict[str, Any]]
+) -> None:
+    positions = {id(m): i for i, m in enumerate(original)}
+    last = -1
+    for m in selected:
+        pos = positions.get(id(m), last)
+        assert pos >= last, "selected messages are not in original order"
+        last = pos
+
+
+# ---- identity / discovery ------------------------------------------------------------
+def test_name_and_zero_arg_instantiation():
+    e = BoundedContextEngine()
+    assert e.name == "bounded"
+    assert isinstance(e, BoundedContextEngine)
+
+
+def test_plugin_discovery_includes_bounded():
+    assert "bounded" in {name for name, _, _ in discover_context_engines()}
+
+
+def test_load_context_engine_by_name():
+    e = load_context_engine("bounded")
+    assert e is not None and e.name == "bounded"
+
+
+def test_register_entrypoint_captures_engine():
+    class Collector:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+    from plugins.context_engine.bounded import register
+
+    collector = Collector()
+    register(collector)
+    assert collector.engine is not None and collector.engine.name == "bounded"
+
+
+# ---- fail-open + budget plumbing ----------------------------------------------------
+def test_select_context_none_when_unknown_budget():
+    e = _engine(context_length=0)
+    assert e.select_context([_msg("user", content="hi")]) is None
+
+
+def test_select_context_none_when_disabled():
+    e = _engine(enabled=False)
+    assert e.select_context([_msg("user", content="hi")], budget_tokens=262144) is None
+
+
+@pytest.mark.parametrize("bad", ["nope", [], None, 42])
+def test_select_context_fail_open_on_invalid_input(bad):
+    e = _engine()
+    assert e.select_context(bad, budget_tokens=262144) is None
+
+
+def test_select_context_short_path_returns_unchanged_list():
+    req = [_msg("system", content="S"), _msg("user", content="short")]
+    e = _engine()
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is req
+
+
+def test_hard_budget_formula():
+    e = _engine()
+    assert e._hard_budget_for(262144) == int(262144 * 0.5) - min(
+        int(262144 * 0.2), min(4096, 26214) + min(8192, 26214)
+    )
+
+
+# ---- preservation guarantees --------------------------------------------------------
+def test_system_and_current_request_preserved():
+    e = _engine()
+    req = _build_big_request()
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert out[0]["role"] == "system"
+    assert "CURRENT_REQUEST_SENTINEL" in str(out[-1].get("content"))
+
+
+def test_newest_pending_tool_chain_preserved():
+    e = _engine()
+    req = [_msg("system", content="S")]
+    for r in range(6):
+        req += _tool_turn(f"old{r}", result_text=_tokenish_text(r, 9000))
+    req.append(_msg("user", content="CURRENT_REQUEST_SENTINEL live"))
+    req += _tool_turn("live1", result_text="live result")
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    joined = "\n".join(m.get("content", "") for m in out)
+    assert "live1" in str([tc for m in out for tc in (m.get("tool_calls") or [])])
+    assert "live result" in joined
+
+
+def test_pair_validity_of_selection():
+    req = _build_big_request()
+    out = _engine().select_context(req, budget_tokens=262144)
+    assert out is not None
+    _assert_pair_valid(out)
+
+
+def test_replay_order_is_subsequence_and_system_first():
+    req = _build_big_request()
+    out = _engine().select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert out[0]["role"] == "system"
+    _assert_replay_order(out, req)
+
+
+# ---- boundedness ---------------------------------------------------------------------
+def test_selection_fits_hard_budget_256k():
+    e = _engine(context_length=262144)
+    req = _build_big_request()
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(262144)
+
+
+def test_selection_fits_hard_budget_64k():
+    e = _engine(context_length=65536)
+    req, est_in = _build_request_near(60000, rounds=6)
+    assert est_in > e._hard_budget_for(65536)
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(65536)
+
+
+def test_omits_excess_history():
+    req = _build_big_request()
+    out = _engine().select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert len(out) < len(req)
+
+
+def test_huge_early_message_does_not_fail_open():
+    e = _engine(context_length=65536)
+    req = [
+        _msg("system", content="S"),
+        _msg("user", content=_tokenish_text(1, 100000)),
+        _msg("user", content="CURRENT_REQUEST_SENTINEL small request"),
+    ]
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(65536)
+    joined = "\n".join(str(m.get("content")) for m in out)
+    assert "CURRENT_REQUEST_SENTINEL" in joined
+
+
+def test_never_returns_empty():
+    for ctx in (65536, 262144, 524288):
+        req = _build_big_request()
+        out = _engine(context_length=ctx).select_context(req, budget_tokens=ctx)
+        assert out is None or len(out) > 0
+
+
+# ---- 160k regression: compressor threshold NOT yet triggered -------------------------
+def test_160k_regression_compression_not_yet_triggered_but_selection_bounds():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    req, est_in = _build_request_near(160000)
+    hard_budget = e._hard_budget_for(262144)
+    assert 130000 <= est_in <= 190000, f"build calibration off: {est_in}"
+    assert est_in > hard_budget, "transcript must exceed the selection budget"
+    # Compressor's own threshold (~75% of a <512k window = 196608) has not fired on
+    # this transcript, so nothing would shrink it before the request went out.
+    assert e.should_compress(est_in) is False
+    assert e.should_compress_info(est_in)[0] is False
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) <= hard_budget
+
+
+# ---- determinism / no mutation ------------------------------------------------------
+def test_deterministic_selection():
+    req = _build_big_request()
+    e = _engine()
+    a = e.select_context(req, budget_tokens=262144)
+    b = e.select_context(req, budget_tokens=262144)
+    assert a is not None and b is not None
+    assert a == b
+
+
+def test_request_messages_not_mutated():
+    req = _build_big_request()
+    snapshot = copy.deepcopy(req)
+    _engine().select_context(req, budget_tokens=262144)
+    assert req == snapshot
+
+
+def test_conversation_messages_not_consulted_or_mutated():
+    req = _build_big_request()
+    conv = copy.deepcopy(req)
+    snapshot = copy.deepcopy(conv)
+    out = _engine().select_context(
+        req, conversation_messages=conv, budget_tokens=262144
+    )
+    assert out is not None
+    assert conv == snapshot
+
+
+def test_clamped_tool_result_content_not_altered_in_original():
+    req = [_msg("system", content="S"), _msg("user", content="first")]
+    for r in range(3):
+        req.append(
+            _msg(
+                "assistant",
+                content="calling a tool",
+                tool_calls=[
+                    {
+                        "id": f"c{r}",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    }
+                ],
+            )
+        )
+        req.append(
+            _msg("tool", content="B" * 30000, tool_call_id=f"c{r}", name="web_search")
+        )
+    req.append(_msg("user", content="CURRENT_REQUEST_SENTINEL current"))
+    snapshot = copy.deepcopy(req)
+    e = _engine(context_length=65536)
+    asserted_budget = e._hard_budget_for(65536)
+    assert estimate_messages_tokens_rough(req) > asserted_budget
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    joined = "\n".join(str(m.get("content")) for m in out)
+    assert _CLAMP_MARKER in joined, (
+        "oversized old tool result should be clamped in the selection"
+    )
+    assert estimate_messages_tokens_rough(out) <= asserted_budget
+    assert req == snapshot, "original request list must never be modified"
+
+
+# ---- lifecycle delegation -----------------------------------------------------------
+def test_update_model_sets_context_and_pins_compressor():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    assert e.context_length == 262144
+    assert e.threshold_tokens == int(262144 * e.threshold_percent)
+    assert e._inner() is not None
+
+
+def test_model_thresholds_attr_mirrored_to_inner_compressor():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    e.model_thresholds = {"test/bounded": 0.9}
+    inner = e._inner()
+    assert inner is not None
+    assert inner.model_thresholds == {"test/bounded": 0.9}
+
+
+def test_update_from_response_fallback_without_compressor():
+    e = _engine()
+    e.update_from_response({"prompt_tokens": 5, "completion_tokens": 3})
+    assert e.last_total_tokens == 8
+
+
+def test_delegated_lifecycle_methods():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    e.on_session_start("sess-1")
+    assert e.should_compress(1234) in (True, False)
+    msgs = [_msg("system", content="S"), _msg("user", content="hello")]
+    compressed = e.compress(msgs, force=True)
+    assert isinstance(compressed, list)
+    assert isinstance(e.prune_tool_results_only(msgs)[0], list)
+    status = e.get_status()
+    assert status.get("engine") == "bounded"
+    assert status.get("selection_enabled") is True
+    e.on_session_reset()
+    e.on_session_end("sess-1", msgs)
+
+
+# ---- telemetry (never content) ------------------------------------------------------
+def test_selection_telemetry_fields_no_content(caplog):
+    req = _build_big_request()
+    with caplog.at_level(logging.INFO, logger="plugins.context_engine.bounded"):
+        _engine().select_context(req, budget_tokens=262144)
+    records = [r for r in caplog.records if "bounded selection" in r.getMessage()]
+    assert records
+    for field in (
+        "mode",
+        "input_messages",
+        "output_messages",
+        "input_tokens_est",
+        "selected_tokens_est",
+        "budget_tokens",
+        "hard_budget",
+        "omitted_messages",
+        "pruned_tool_results",
+        "clamped_tool_results",
+    ):
+        assert f"'{field}'" in records[0].getMessage()
+    assert "CURRENT_REQUEST_SENTINEL" not in records[0].getMessage()

--- a/tests/agent/test_context_engine_bounded.py
+++ b/tests/agent/test_context_engine_bounded.py
@@ -17,10 +17,14 @@ import pytest
 
 from agent.model_metadata import estimate_messages_tokens_rough
 from plugins.context_engine import discover_context_engines, load_context_engine
-from plugins.context_engine.bounded import BoundedContextEngine, _CLAMP_MARKER
+from plugins.context_engine.bounded import (
+    BoundedContextEngine,
+    _CLAMP_MARKER,
+    _current_request_index,
+)
 
 
-def _msg(role: str, content: str = "", **extra: Any) -> Dict[str, Any]:
+def _msg(role: str, content: Any = "", **extra: Any) -> Dict[str, Any]:
     m: Dict[str, Any] = {"role": role, "content": content}
     m.update(extra)
     return m
@@ -400,3 +404,294 @@ def test_selection_telemetry_fields_no_content(caplog):
     ):
         assert f"'{field}'" in records[0].getMessage()
     assert "CURRENT_REQUEST_SENTINEL" not in records[0].getMessage()
+
+
+# ---- helper: multimodal user message -----------------------------------------------
+def _multimodal_user(text: str) -> Dict[str, Any]:
+    return _msg(
+        "user",
+        content=[
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,QUJD"}},
+        ],
+    )
+
+
+def _build_turn_history(
+    current: Dict[str, Any], rounds: int = 8, words: int = 12000
+) -> List[Dict[str, Any]]:
+    msgs: List[Dict[str, Any]] = [
+        _msg("system", content="You are a helpful assistant.")
+    ]
+    for r in range(rounds):
+        msgs.append(_msg("user", content=_tokenish_text(r, words)))
+        msgs.append(_msg("assistant", content=_tokenish_text(r + 200, 120)))
+    msgs.append(current)
+    return msgs
+
+
+# ---- F1 regression: the trailing user request must never be dropped ----------------
+def test_f1_current_request_index_prefers_trailing_list_content_user():
+    req = [
+        _msg("system", content="S"),
+        _msg("user", content="A"),
+        _multimodal_user("B multimodal"),
+    ]
+    assert _current_request_index(req) == 2
+
+
+def test_f1_multiturn_text_current_request_remains_current():
+    e = _engine(context_length=262144)
+    current = _msg("user", content="CURRENT_REQUEST_SENTINEL final text request")
+    req = _build_turn_history(current, rounds=8, words=12000)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert len(out) < len(req)
+    assert out[-1] is current
+    assert out[-1]["content"] == "CURRENT_REQUEST_SENTINEL final text request"
+
+
+def test_f1_multiturn_multimodal_tail_remains_current_request():
+    e = _engine(context_length=262144)
+    current = _multimodal_user("CURRENT_REQUEST_SENTINEL analyze this screenshot")
+    req = _build_turn_history(current, rounds=8, words=12000)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert len(out) < len(req)
+    assert out[-1] is current
+    assert "CURRENT_REQUEST_SENTINEL analyze this screenshot" in str(
+        out[-1].get("content")
+    )
+
+
+def test_f1_single_multimodal_request_is_current():
+    e = _engine(context_length=262144)
+    req = [_msg("system", content="S"), _multimodal_user("a single image request")]
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is req
+    assert out[-1]["content"][0]["text"] == "a single image request"
+
+
+def test_f1_text_moa_aggregated_message_remains_current():
+    e = _engine(context_length=262144)
+    current = _msg(
+        "user",
+        content=(
+            "CURRENT_REQUEST_SENTINEL user prompt\n\n"
+            "[MoA aggregated context from reference models]"
+        ),
+    )
+    req = _build_turn_history(current, rounds=8, words=12000)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert out[-1] is current
+    assert "CURRENT_REQUEST_SENTINEL user prompt" in out[-1]["content"]
+
+
+def test_f1_multimodal_tail_not_replaced_by_previous_user():
+    e = _engine(context_length=262144)
+    req = _build_turn_history(
+        _msg("user", content="previous plain request"), rounds=8, words=12000
+    )
+    current = _multimodal_user("CURRENT_REQUEST_SENTINEL actual trailing image request")
+    req.append(current)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert out[-1] is current
+    assert "CURRENT_REQUEST_SENTINEL actual trailing image request" in str(
+        out[-1].get("content")
+    )
+    assert "previous plain request" not in out[-1]["content"]
+
+
+def test_f1_current_request_present_in_final_selection():
+    e = _engine(context_length=262144)
+    current = _msg("user", content="CURRENT_REQUEST_SENTINEL visible final request")
+    req = _build_turn_history(current, rounds=12, words=16000)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert len(out) > 1
+    assert current in out, "current request message identity must survive selection"
+    assert out[-1] is current
+
+
+# ---- R2 regression: wrapper counter / preflight-usage mirroring --------------------
+def test_r2_inner_usage_mirrors_to_wrapper_counters():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    e.update_from_response({
+        "prompt_tokens": 12345,
+        "completion_tokens": 200,
+        "total_tokens": 12545,
+    })
+    inner = e._inner()
+    assert inner is not None
+    assert e.last_prompt_tokens == inner.last_prompt_tokens == 12345
+    assert e.last_completion_tokens == inner.last_completion_tokens == 200
+    assert e.last_total_tokens == inner.last_total_tokens == 12545
+
+
+def test_r2_wrapper_total_derived_when_provider_omits_total():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    e.update_from_response({"prompt_tokens": 500, "completion_tokens": 50})
+    assert e.last_prompt_tokens == 500
+    assert e.last_total_tokens == 550
+
+
+def test_r2_host_facing_preflight_sees_real_usage():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    e.update_from_response({
+        "prompt_tokens": 1000,
+        "completion_tokens": 100,
+        "total_tokens": 1100,
+    })
+    # Host preflight reads the engine's own last_prompt_tokens directly; a fit result
+    # below the threshold must not trigger a compression pass.
+    assert e.last_prompt_tokens == 1000
+    assert 1000 < e.threshold_tokens
+    assert e.should_compress(e.last_prompt_tokens) is False
+
+
+def test_r2_should_defer_preflight_forwards_to_inner():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    inner = e._inner()
+    assert inner is not None
+    rough = e.threshold_tokens * 2
+    assert e.should_defer_preflight_to_real_usage(
+        rough
+    ) == inner.should_defer_preflight_to_real_usage(rough)
+
+
+def test_r2_wrapper_defer_not_shadowed_by_base_false():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    inner = e._inner()
+    assert inner is not None
+    inner.awaiting_real_usage_after_compression = True
+    assert inner.last_real_prompt_tokens == 0
+    assert e.should_defer_preflight_to_real_usage(e.threshold_tokens + 1) is True
+
+
+def test_r2_no_extra_pass_from_zero_wrapper_counter():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    e.update_from_response({"prompt_tokens": 800, "completion_tokens": 50})
+    assert e.last_prompt_tokens == 800
+    assert e.should_compress(e.last_prompt_tokens) is False
+
+
+def test_r2_inner_compressor_semantics_preserved():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    inner = e._inner()
+    assert inner is not None
+    e.update_from_response({
+        "prompt_tokens": 300,
+        "completion_tokens": 20,
+        "total_tokens": 320,
+    })
+    assert inner.last_prompt_tokens == 300
+    assert inner.last_completion_tokens == 20
+    assert inner.awaiting_real_usage_after_compression is False
+    assert e.should_compress_info(300)[0] is False
+
+
+# ---- backfill: multi-tool-call batches ---------------------------------------------
+def test_backfill_multi_tool_call_batch_selection_pair_valid():
+    e = _engine(context_length=65536)
+    req = [_msg("system", content="S")]
+    for r in range(4):
+        req.append(_msg("user", content=_tokenish_text(r, 8000)))
+        req.append(
+            _msg(
+                "assistant",
+                content="calling two tools",
+                tool_calls=[
+                    {
+                        "id": f"c{r}a",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    },
+                    {
+                        "id": f"c{r}b",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": "{}"},
+                    },
+                ],
+            )
+        )
+        req.append(_msg("tool", content="B" * 20000, tool_call_id=f"c{r}a", name="a"))
+        req.append(_msg("tool", content="C" * 20000, tool_call_id=f"c{r}b", name="b"))
+    req.append(_msg("user", content="CURRENT_REQUEST_SENTINEL final"))
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    _assert_pair_valid(out)
+    _assert_replay_order(out, req)
+    assert out[-1]["content"] == "CURRENT_REQUEST_SENTINEL final"
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(65536)
+
+
+# ---- backfill: system-only requests ------------------------------------------------
+def test_backfill_system_only_request_unchanged():
+    e = _engine()
+    system = _msg("system", content="You are a helpful assistant.")
+    out = e.select_context([system], budget_tokens=262144)
+    assert out is not None
+    assert out == [system]
+    assert out[0]["role"] == "system"
+
+
+def test_backfill_oversized_system_only_fails_open():
+    e = _engine(context_length=65536)
+    system = _msg("system", content=_tokenish_text(7, 60000))
+    assert estimate_messages_tokens_rough([system]) > e._hard_budget_for(65536)
+    assert e.select_context([system], budget_tokens=65536) is None
+
+
+# ---- backfill: pending tool chain clamp protection ---------------------------------
+def test_backfill_pending_tool_chain_never_clamped_or_trimmed():
+    e = _engine(context_length=65536)
+    req = [_msg("system", content="S")]
+    for r in range(4):
+        req.append(_msg("user", content=_tokenish_text(r, 8000)))
+        req += _tool_turn(f"old{r}", result_text="B" * 30000)
+    req.append(_msg("user", content="CURRENT_REQUEST_SENTINEL current"))
+    req += _tool_turn("pending1", result_text="P" * 30000)
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    joined = "\n".join(str(m.get("content")) for m in out)
+    assert "P" * 30000 in joined, "pending tool result must never be clamped or trimmed"
+    _assert_pair_valid(out)
+    assert out[-1]["content"] in (
+        "P" * 30000,
+        "second result " + ("P" * 30000)[-2000:],
+    )
+
+
+# ---- backfill: host _apply_context_engine_selection integration --------------------
+def test_backfill_host_pipeline_integration_bounded_engine():
+    from types import SimpleNamespace
+
+    from agent.conversation_loop import _apply_context_engine_selection
+
+    engine = load_context_engine("bounded")
+    assert engine is not None
+    engine.update_model("test/bounded", 262144)
+    agent = SimpleNamespace(context_compressor=engine, session_id="int-test")
+
+    api_messages = _build_turn_history(
+        _multimodal_user("CURRENT_REQUEST_SENTINEL analyze"), rounds=8, words=12000
+    )
+    conversation = copy.deepcopy(api_messages)
+    incoming = api_messages[-1]
+    sel = _apply_context_engine_selection(
+        agent, api_messages, conversation, incoming, logger=logging.getLogger("test")
+    )
+    assert sel is not None
+    assert sel is not api_messages, "real selection must yield a trimmed request"
+    _assert_pair_valid(sel)
+    assert sel[-1]["content"] == api_messages[-1]["content"]
+    assert "CURRENT_REQUEST_SENTINEL analyze" in str(sel[-1].get("content"))


### PR DESCRIPTION
## Summary
- add bounded ContextEngine plugin with tiered context retention
- enforce a deterministic hard context budget
- preserve current request and active execution state
- add selective older-context retrieval and deterministic deduplication
- harden post-selection budget enforcement
- preserve bounded selection while awaiting real post-compression usage

## Validation
- 72 relevant ContextEngine/plugin tests passed
- R1 hard-cap verification passed
- R2 pending-compression verification passed
- current upstream main compatibility audit passed
- all 8 upstream dependency target files are unchanged
- no DB, provider, workflow, business-authority, or production changes

## Scope
This PR is limited to Hermes context management.

It does NOT introduce:
- autonomous business authority
- W-EXECUTE/T3/T4
- provider activation/selection
- database migration
- production deployment
- changes to Organization/BC/PRC/SOP/Knowledge
- 9Router redesign