### PR TITLE
fix(cli): monitor prompt handoff no longer races repaint teardown

### DIFF
--- a/hermes_cli/cli_subagent_monitor.py
+++ b/hermes_cli/cli_subagent_monitor.py
@@ -56,6 +56,15 @@ class SubagentMonitor:
             self.selected_id = entries[0]['subagent_id'] if entries else None
         return changed
 
+    def invalidate(self):
+        from hermes_cli.cli_terminal_mixin import _run_on_app_loop
+
+        app = self.app
+        if app is not None:
+            # Teardown clears app.loop; don't let it interleave with a worker's
+            # invalidate call, which reads the loop more than once.
+            _run_on_app_loop(app, app.invalidate)
+
     def tick(self):
         now = time.monotonic()
         if now - self._last_poll < 1:
@@ -63,7 +72,7 @@ class SubagentMonitor:
         self._last_poll = now
         if self.refresh():
             if self.app is not None:
-                self.app.invalidate()
+                self.invalidate()
             else:
                 self.cli._invalidate()
 

--- a/hermes_cli/cli_terminal_mixin.py
+++ b/hermes_cli/cli_terminal_mixin.py
@@ -104,8 +104,8 @@ class CLITerminalMixin:
         if getattr(self, "_terminal_io_broken", False):
             return
         monitor = getattr(self, "_subagent_monitor", None)
-        if monitor is not None and monitor.app is not None:
-            monitor.app.invalidate()
+        if monitor is not None:
+            monitor.invalidate()
         app = getattr(self, "_app", None)
         if app is not None:
             self._app_invalidate(app, "paint_now", swallow=True)

--- a/tests/cli/test_subagent_monitor_prompts.py
+++ b/tests/cli/test_subagent_monitor_prompts.py
@@ -1,9 +1,13 @@
 """Blocking prompts reclaim input from the nested monitor without a keypress."""
 import asyncio
+import threading
 from types import SimpleNamespace
 
+import pytest
 
-def test_prompt_paint_yields_monitor_but_ordinary_paint_does_not():
+
+@pytest.mark.parametrize('paint_source', ['modal', 'tick'])
+def test_prompt_paint_yields_monitor_but_ordinary_paint_does_not(monkeypatch, paint_source):
     from hermes_cli.cli_subagent_monitor import SubagentMonitor, build_monitor_application, install_dock
     from hermes_cli.cli_terminal_mixin import CLITerminalMixin
     from prompt_toolkit.input import create_pipe_input
@@ -29,10 +33,34 @@ def test_prompt_paint_yields_monitor_but_ordinary_paint_does_not():
                 task = asyncio.create_task(app.run_async())
                 await asyncio.wait_for(rendered.wait(), 3)
                 try:
+                    rendered.clear()
                     await asyncio.to_thread(CLITerminalMixin._paint_now, cli)
+                    await asyncio.wait_for(rendered.wait(), 3)
                     assert not task.done(), 'ordinary paints must not dismiss the monitor'
+                    loop = asyncio.get_running_loop()
+                    ui_thread = threading.get_ident()
+                    stopped = threading.Event()
+                    task.add_done_callback(lambda _: stopped.set())
+                    schedule = loop.call_soon_threadsafe
+
+                    def schedule_with_teardown(callback, *args, **kwargs):
+                        handle = schedule(callback, *args, **kwargs)
+                        if (callback == app.on_invalidate.fire
+                                and threading.get_ident() != ui_thread):
+                            # Let an already-queued frame see the modal and finish
+                            # teardown while the worker is still in invalidate().
+                            schedule(app._redraw)
+                            assert stopped.wait(3), 'monitor did not finish teardown'
+                        return handle
+
                     setattr(cli, name, {'pending': True})
-                    await asyncio.to_thread(CLITerminalMixin._paint_now, cli)
+                    with monkeypatch.context() as patch:
+                        patch.setattr(loop, 'call_soon_threadsafe', schedule_with_teardown)
+                        if paint_source == 'tick':
+                            patch.setattr(monitor, 'refresh', lambda: True)
+                            await asyncio.to_thread(monitor.tick)
+                        else:
+                            await asyncio.to_thread(CLITerminalMixin._paint_now, cli)
                     done, _ = await asyncio.wait({task}, timeout=1)
                     assert task in done, f'{name} remained hidden behind the monitor'
                     await task


### PR DESCRIPTION
CLI monitor repaint requests no longer race the nested application's event-loop teardown.

- Route both immediate modal paints and spinner-thread monitor refreshes through one monitor repaint entry point on the existing UI-loop scheduler.
- Capture the application once, so monitor detachment cannot change the target between checks.
- Extend the existing prompt-handoff invariant with event-synchronized teardown for both callers; retain all five prompt types, ordinary-paint behavior, dock suppression, and secret draft restoration. No added sleep or timeout increase.

Root cause: prompt_toolkit's thread-safe `invalidate()` reads `app.loop` multiple times; a queued modal frame can finish the nested application between those reads and leave a worker calling `call_soon_threadsafe(loop=None)`.

This was found in the first-attempt output of CI run 34263993728 for #105960 (retry passed), not a reported user-machine incident. This PR is separate from the UI work and does not modify it.

## Validation

| Check | Result |
| --- | --- |
| Event-synchronized current-main reproduction | Both modal and spinner-tick cases fail with `RuntimeError: no running event loop`; unchanged secret test passes |
| Fixed invariant stress, canonical runner, retries disabled | 10 complete file runs, 3 passing cases each, zero failures |
| **Live repro: native Linux PTY, real HermesCLI layout, nested `in_terminal()` monitor and secret callback** | Controlled before: exact RuntimeError; controlled after and uninstrumented fixed control: no errors, monitor stopped, original draft and cursor restored |
| Canonical `tests/cli/` + `tests/hermes_cli/`, retries disabled | 987 files: 10,619 passed, 1 failed, 137 skipped. Sole failure is the separately addressed root-home fixture in #105920; no duplicate fix here |
| Final modified test after explicit ordinary-frame synchronization | Canonical 10-run stress passed |
| Static checks | Ruff, Windows-footgun scan, compat-pointer check, diff whitespace passed |

Native evidence uses a disposable credential-free profile and the shipped CLI widget/callback implementations; it controls worker scheduling to reproduce the race, not a live model request or historical CI scheduler replay. An earlier interrupted directory run also hit `test_update_success_when_head_moves`; the completed directory run passed that file.

## Infographic

![CLI monitor repaint safety](https://v3b.fal.media/files/b/0aa9a2a7/aua5Y3aMJL-xSdlay_a9r_4nb3wjjY.png)
