### PR TITLE
fix(title): don't title a session after the /model switch note

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -89,6 +89,12 @@ _MACHINE_PREFIXES = (
     # message titled the session "[System: The active model for this chat has…" instead of the user's actual
     # question.
     "[System: The active model for this chat has changed to ",
+    # The CLI/gateway model-switch note (hermes_cli.cli_model_switch_mixin and
+    # gateway.slash_commands_model — keep in sync); also persisted as role="user".
+    # Switching models before the first real message otherwise titles the session
+    # "[Note: model was just switched from deepseek-v4-flash to…" instead of the user's
+    # actual question, and that title is what the status bar's title slot then shows.
+    "[Note: model was just switched from ",
 )
 
 

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -598,3 +598,55 @@ class TestModelSwitchMarkerNotTitleable:
         assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
             "南京市秦淮区 小时级天气预报"
         )
+
+
+class TestCliModelSwitchNoteNotTitleable:
+    """Regression: the CLI/gateway ``/model`` note must never become the title.
+
+    ``cli._pending_model_switch_note`` (hermes_cli/cli_model_switch_mixin.py,
+    mirrored in gateway/slash_commands_model.py) is injected with
+    ``role="user"`` for the same reason as the gateway marker above, so titling
+    has to recognise it too. Seen in the wild: with the LLM titler failing, a
+    session's ``derived`` title became
+    "[Note: model was just switched from muse-spark-1.3-contributor to…", which
+    is also what the status bar renders in its session-title slot.
+    """
+
+    NOTE = (
+        "[Note: model was just switched from muse-spark-1.3-contributor to "
+        "deepseek-v4-flash via OpenCode Go. Adjust your self-identification "
+        "accordingly.]"
+    )
+
+    def test_note_is_not_titleable(self):
+        from agent.title_generator import is_titleable_user_message
+
+        assert is_titleable_user_message(self.NOTE) is False
+
+    def test_guard_covers_the_one_turn_variant(self):
+        """``--once`` adds a sentence mid-note; the prefix must still match."""
+        from agent.title_generator import is_titleable_user_message
+
+        one_turn = (
+            "[Note: model was just switched from gpt-6-astra to glm-5 via "
+            "OpenCode Go. This override applies to the next turn only. "
+            "Adjust your self-identification accordingly.]"
+        )
+        assert is_titleable_user_message(one_turn) is False
+
+    def test_unrelated_note_bracket_text_still_titleable(self):
+        """The guard is narrow: real user text starting "[Note:" still titles."""
+        from agent.title_generator import is_titleable_user_message
+
+        assert is_titleable_user_message("[Note: mine] why does the poller stall?") is True
+
+    def test_instant_title_skips_note_uses_real_message(self):
+        from agent.title_generator import apply_instant_title
+
+        db = MagicMock()
+        db.get_session_title_source.return_value = None
+
+        assert apply_instant_title(db, "sess-1", self.NOTE) is None
+        assert apply_instant_title(db, "sess-1", "how do i queue a tg group?") == (
+            "how do i queue a tg group?"
+        )


### PR DESCRIPTION
## What

`_MACHINE_PREFIXES` in `agent/title_generator.py` already guards the gateway's model-switch marker, but not the CLI/gateway `/model` switch note. Adds that prefix plus a regression class.

## Why it matters

`cli._pending_model_switch_note` is injected with `role="user"` for the same reason as the gateway marker — strict OpenAI-compatible providers reject a system message that is not first (#48338). It is built in two places:

- `hermes_cli/cli_model_switch_mixin.py`
- `gateway/slash_commands_model.py`

So a `/model` switch before the first real question makes that note the session's opening turn, and the derived title becomes `[Note: model was just switched from deepseek-v4-flash to…`.

The part that makes it stick rather than blink: `hermes_state_titles.py` rejects a new non-user title when the existing `title_source` ranks `>=` the new one. The note's title is `derived`, so **the next real message's own derived title cannot replace it** — only the LLM titler (higher rank) can. With the titler erroring, the wrong title is permanent. Observed exactly that in the wild, where it also occupied the CLI status bar's session-title slot, since the bar renders the session title right-aligned.

## Related

Same class as #82559 (personality-pivot markers) and #105227 (async-delegation marker); neither covers this prefix.

## Tests

`tests/agent/test_title_generator.py` — new `TestCliModelSwitchNoteNotTitleable`, mirroring the existing `TestModelSwitchMarkerNotTitleable`:

- the note is not titleable
- the `--once` variant, which inserts a sentence mid-note, is still caught (prefix match, not equality)
- narrowness: real user text starting `[Note:` still titles
- `apply_instant_title` skips the note and takes the real message

40 passed.