### PR TITLE
fix(gateway): accept named-profile namespace in session-key parsing and sibling lookup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2902,7 +2902,7 @@ def _parse_session_key(session_key: str) -> "dict | None":
     For group/channel sessions the suffix may be a user_id, not a thread_id, so ``thread_id`` is omitted.
     """
     parts = session_key.split(":")
-    if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+    if len(parts) >= 5 and parts[0] == "agent" and parts[1]:
         result = {"platform": parts[2], "chat_type": parts[3], "chat_id": parts[4]}
         if len(parts) > 5 and parts[3] in {"dm", "thread"}:
             result["thread_id"] = parts[5]

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -19,7 +19,7 @@ from agent.session_activity import format_iteration_progress
 from gateway.config import Platform
 from gateway.platforms.base import EphemeralReply
 from gateway.platforms.event import MessageEvent, MessageType
-from gateway.session import SessionSource
+from gateway.session import SessionSource, _session_key_namespace
 from typing import Any, Dict, Optional, Union
 
 if TYPE_CHECKING:  # string annotations only; never imported at runtime (cycle)
@@ -998,7 +998,7 @@ class GatewayBusySessionMixin:
         chat_type = getattr(source, "chat_type", None) or ""
         # Match the exact key or prefix + ":" so a thread id that merely starts with this one
         # is not matched.
-        prefix = ":".join(["agent:main", platform, chat_type, str(chat_id), str(thread_id)])
+        prefix = ":".join([_session_key_namespace(getattr(source, 'profile', None)), platform, chat_type, str(chat_id), str(thread_id)])
         return [
             key
             for key, agent in self._running_agent_items()

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -520,6 +520,34 @@ def test_parse_session_key_with_extra_parts():
     assert result == {"platform": "discord", "chat_type": "group", "chat_id": "chan123"}
 
 
+def test_parse_session_key_named_profile_namespace():
+    """Named-profile keys (agent:<profile>:...) must parse like agent:main keys.
+
+    Regression: the helper previously asserted parts[1] == "main", so every
+    named-profile key returned None and approval/routing metadata was lost.
+    """
+    result = _parse_session_key("agent:coder:discord:group:chan123")
+    assert result == {"platform": "discord", "chat_type": "group", "chat_id": "chan123"}
+
+
+def test_parse_session_key_named_profile_with_thread_extra():
+    """dm/thread keys under a named profile still recover thread_id."""
+    result = _parse_session_key("agent:coder:telegram:dm:u-1:t-9")
+    assert result == {
+        "platform": "telegram",
+        "chat_type": "dm",
+        "chat_id": "u-1",
+        "thread_id": "t-9",
+    }
+
+
+def test_parse_session_key_rejects_malformed():
+    """Empty/malformed keys must still return None (namespace must be non-empty)."""
+    assert _parse_session_key("") is None
+    assert _parse_session_key("agent::discord:group:chan1") is None
+    assert _parse_session_key("other:main:discord:group:chan1") is None
+
+
 # ---------------------------------------------------------------------------
 # api_server (stateless) wake routing — gateway/wake.py self-post path
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_stop_thread_sibling.py
+++ b/tests/gateway/test_stop_thread_sibling.py
@@ -57,6 +57,44 @@ def test_sibling_returns_empty_for_non_thread_source():
     assert runner._sibling_thread_run_keys(nonthread, "agent:main:discord:group:chan1:userA") == []
 
 
+def test_sibling_matches_named_profile_namespace():
+    """Named-profile keys (agent:<profile>:...) must match siblings too.
+
+    Regression: the prefix was hardcoded to ``agent:main``, so under a named
+    profile the sibling lookup silently returned [] and /stop could not reach
+    the other participant's run.
+    """
+    runner = object.__new__(GatewayRunner)
+    source_a = _thread_source("userA", thread_id="thr1")
+    source_a.profile = "coder"
+    key_a = build_session_key(
+        SessionSource(
+            platform=Platform.DISCORD,
+            chat_type="forum",
+            chat_id="chan1",
+            thread_id="thr1",
+            user_id="userA",
+        ),
+        thread_sessions_per_user=True,
+        profile="coder",
+    )
+    key_b = build_session_key(
+        SessionSource(
+            platform=Platform.DISCORD,
+            chat_type="forum",
+            chat_id="chan1",
+            thread_id="thr1",
+            user_id="userB",
+        ),
+        thread_sessions_per_user=True,
+        profile="coder",
+    )
+    assert key_b.startswith("agent:coder:")
+    runner._running_agents = {key_b: _FakeAgent()}
+    found = runner._sibling_thread_run_keys(source_a, key_a)
+    assert found == [key_b]
+
+
 # ---------------------------------------------------------------------------
 # _handle_stop_command fallback path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Named-profile gateway sessions use namespaced session keys (`agent:<profile>:...`, see `_session_key_namespace()` in `gateway/session.py`). Two core helpers still assume the default-profile literal, so named-profile sessions are misparsed or their sibling lookups silently fail:

| Spot | Symptom under a named profile | Fix |
|---|---|---|
| `_parse_session_key()` | key parses to `None` → routing degrades to the LRU `_session_sources` fallback | accept any non-empty namespace |
| `_sibling_thread_run_keys()` | sibling lookup returns `[]` → `/stop` says "no active task to stop" while the sibling keeps running | derive prefix from `_session_key_namespace(profile)` |

## Why

- `gateway/run.py::_parse_session_key()` required `parts[1] == "main"` — the namespace slot takes no part in any authorization decision, so accepting any non-empty namespace does not weaken any check (same rationale as in #98292).
- `gateway/run_busy.py::_sibling_thread_run_keys()` hardcoded the prefix as `agent:main` instead of using the namespace `build_session_key()` itself produces.

## Changes

- `_parse_session_key()`: accept any **non-empty** namespace slot instead of asserting `parts[1] == "main"`. Malformed keys (`agent::...`, wrong prefix, too few parts) still return `None`.
- `_sibling_thread_run_keys()`: build the prefix via `_session_key_namespace(getattr(source, "profile", None))` — byte-identical `agent:main` for default/unset profiles.

No behavior change for the default `main` case.

## Tests

Reproduce: with a named profile serving any chat platform, trigger a background-process notification or `/stop` a sibling thread run — before: silent fallback / "no active task to stop"; after: correct routing and sibling match.

- 4 new regression tests: named-profile parsing (plain + `dm`/`thread`-with-extra), malformed-key rejection, named-profile sibling matching.
- `pytest tests/gateway/test_background_process_notifications.py tests/gateway/test_stop_thread_sibling.py -q` → **30 passed**.
- Full gateway suite on this host: **7889 passed, 14 failed**. Of those, the same 7 environment-dependent failures reproduce identically on clean `main` (verified in isolation on `main@b2aa855b62`); the other 7 pass in isolation on this branch — order-dependent suite flakiness, not caused by this change.

## Platforms

Tested on macOS (arm64). The changed paths are platform-independent; Linux-gated gateway paths were not exercised live on this host.

## Related

- #98292 (open) — same bug class (qqbot approval buttons); this PR complements #98294, which fixes only the QQBot adapter. The two PRs are orthogonal and can merge independently.
- #105931 — earlier report of these two spots; closed as duplicate of #98292.

## Not in scope

`_build_process_event_source()` in `run_notifications.py` still rewrites named-profile keys to `agent:main` before parsing — redundant and harmless after this fix; candidate for a separate cleanup PR.

## Checklist

- [x] Conventional commit (`fix(gateway): ...`)
- [x] Regression tests for both fixed paths; targeted suites green
- [x] No unrelated changes; default-profile (`agent:main`) behavior byte-identical
