### PR TITLE
fix(cli): mark a fallback hop instead of rendering it as the chosen model

### DIFF
--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -10,6 +10,7 @@ module-level functions taking ``cli`` and siblings are called as ``HermesCLI.<na
 
 from __future__ import annotations
 
+import contextlib
 import copy
 import sys
 import threading
@@ -410,15 +411,39 @@ class CLIModelSwitchMixin:
         else:
             self._console_print(f"[dim]{_escape(msg)}[/dim]")
 
+    def _model_picker_fallback_note(self, current_model: str, current_provider: str) -> str:
+        """One line naming the live model when a fallback has displaced the chosen one.
+
+        ``current_model`` is the CONFIGURED model (``cli.model``), which fallback activation
+        never rewrites, while the status bar shows the LIVE one (``agent.model``). With a
+        primary that fails every turn the two disagree permanently and neither surface said
+        why, so the picker claimed a model that was answering nothing.
+        """
+        agent = getattr(self, "agent", None)
+        # _provider_fallback_active, not _fallback_activated: the latter is also set by
+        # `/model --once` restoration as plumbing, so it would report a deliberate
+        # one-turn switch as a fallback.
+        if agent is None or not getattr(agent, "_provider_fallback_active", False):
+            return ""
+        live_model = str(getattr(agent, "model", "") or "")
+        live_provider = str(getattr(agent, "provider", "") or "")
+        if not live_model or (live_model, live_provider) == (current_model, current_provider):
+            return ""
+        return f"⚠ fallback active — answering on {live_model} via {live_provider}"
+
     def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
         """Open prompt_toolkit-native /model picker modal."""
         self._capture_modal_input_snapshot()
+        fallback_note = ""
+        with contextlib.suppress(Exception):
+            fallback_note = self._model_picker_fallback_note(current_model, current_provider)
         self._model_picker_state = {
             "stage": "provider",
             "providers": providers,
             "selected": next((i for i, p in enumerate(providers) if p.get("is_current")), 0),
             "current_model": current_model,
             "current_provider": current_provider,
+            "fallback_note": fallback_note,
             "user_provs": user_provs,
             "custom_provs": custom_provs,
             "filter": ""}

--- a/hermes_cli/cli_status_bar_mixin.py
+++ b/hermes_cli/cli_status_bar_mixin.py
@@ -7,6 +7,7 @@ inside each method (``from cli import ...``) — never at module load time (impo
 
 from __future__ import annotations
 
+import contextlib
 import errno
 import shutil
 import threading
@@ -184,6 +185,21 @@ class CLIStatusBarMixin:
             model_short = model_short[:-5]
         if len(model_short) > 26:
             model_short = f"{model_short[:23]}..."
+        # A fallback hop is not the model the user picked, and the bar renders it
+        # identically — so a demotion reads as the bar lying about the model. Mark it.
+        # `⤵` says "dropped down to this"; /model spells the same state out in words.
+        # Keyed on _provider_fallback_active, NOT _fallback_activated: the latter is
+        # overloaded — `/model --once` restoration sets it as plumbing to force
+        # restore_primary_runtime() to run, which would mark a deliberate one-turn
+        # switch as a fallback. _provider_fallback_active is the provenance flag that
+        # only try_activate_fallback sets (chat_completion_helpers).
+        fallback_active = bool(getattr(agent, "_provider_fallback_active", False))
+        primary_model = ""
+        if fallback_active:
+            with contextlib.suppress(Exception):
+                primary_model = str(
+                    (getattr(agent, "_primary_runtime", None) or {}).get("model") or "")
+            model_short = f"{model_short} ⤵"
 
         prompt_start = getattr(self, "_prompt_start_time", None)
         turn_live = prompt_start is not None
@@ -191,6 +207,8 @@ class CLIStatusBarMixin:
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
+            "fallback_active": fallback_active,
+            "primary_model": primary_model,
             "duration": format_duration_compact(elapsed_seconds),
             "session_title": self._get_status_bar_session_title(),
             "prompt_elapsed": self._format_prompt_elapsed(

--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -584,15 +584,20 @@ class CLITuiMixin:
             panel.blank()
         return panel.close()
 
-    def _render_scroll_list_panel(self, state, title, hint, labels, *, min_width, max_width, indent):
+    def _render_scroll_list_panel(self, state, title, hint, labels, *, min_width, max_width, indent,
+                                  note=None):
         """Titled panel with a hint row and a scrolling selectable list (model picker, palette).
 
         The panel renders into a Window with no max height, so the visible slice is limited to
         the terminal rows or the bottom border and trailing items get clipped on long lists
         (e.g. Ollama Cloud's 36+ models). ``state["_scroll_offset"]`` is updated in place.
+
+        ``note`` is an optional second hint row. Rows do not wrap, so a caller with two things
+        to say passes them separately instead of concatenating into one over-long hint.
         """
         from cli import HermesCLI, _panel_box_width, _wrap_panel_text
-        box_width = _panel_box_width(title, [hint] + labels, min_width=min_width, max_width=max_width)
+        _width_lines = [hint] + ([note] if note else []) + labels
+        box_width = _panel_box_width(title, _width_lines, min_width=min_width, max_width=max_width)
         inner_text_width = max(8, box_width - 6)
         selected = state.get("selected", 0)
         try:
@@ -607,6 +612,8 @@ class CLITuiMixin:
         panel = _Panel('class:clarify-border', box_width, title, 'class:clarify-title')
         panel.blank()
         panel.row('class:clarify-hint', hint)
+        if note:
+            panel.row('class:clarify-hint', note)
         panel.blank()
         for idx in range(scroll_offset, min(scroll_offset + visible, len(labels))):
             style = 'class:clarify-selected' if idx == selected else 'class:clarify-choice'
@@ -654,7 +661,8 @@ class CLITuiMixin:
             else:
                 hint = "No models listed for this provider. Use Back or Cancel."
         return self._render_scroll_list_panel(
-            state, title, hint, choices, min_width=46, max_width=84, indent='  ')
+            state, title, hint, choices, min_width=46, max_width=84, indent='  ',
+            note=state.get("fallback_note") or None)
 
     def _get_command_palette_display_fragments(self):
         state = self._command_palette_state

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -64,6 +64,68 @@ class TestCLIStatusBar:
         assert text.endswith(" weekly-digest ")
         assert cli_obj._status_bar_display_width(text) == 80
 
+    def test_snapshot_marks_a_fallback_hop(self):
+        """A demoted model must not render like the user's own pick.
+
+        The bar reads ``agent.model`` (live, follows fallback) while /model reads
+        ``cli.model`` (configured, never rewritten). Unmarked, a demotion to hop 1
+        looks exactly like the bar reporting the wrong model.
+        """
+        cli_obj = _make_cli(model="gpt-6-astra")
+        cli_obj.agent = SimpleNamespace(
+            model="deepseek-v4-flash",
+            provider="custom:litellm-direct",
+            _provider_fallback_active=True,
+            _primary_runtime={"model": "gpt-6-astra"},
+        )
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["model_short"] == "deepseek-v4-flash ⤵"
+        assert snapshot["fallback_active"] is True
+        assert snapshot["primary_model"] == "gpt-6-astra"
+
+    def test_snapshot_leaves_a_normal_turn_unmarked(self):
+        cli_obj = _make_cli(model="gpt-6-astra")
+        cli_obj.agent = SimpleNamespace(
+            model="gpt-6-astra", provider="openai-codex", _provider_fallback_active=False,
+        )
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["model_short"] == "gpt-6-astra"
+        assert snapshot["fallback_active"] is False
+        assert snapshot["primary_model"] == ""
+
+    def test_snapshot_marks_fallback_without_a_primary_snapshot(self):
+        """``_primary_runtime`` may be absent; the marker must still appear."""
+        cli_obj = _make_cli(model="gpt-6-astra")
+        cli_obj.agent = SimpleNamespace(
+            model="glm-5", provider="opencode-go", _provider_fallback_active=True,
+        )
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["model_short"] == "glm-5 ⤵"
+        assert snapshot["primary_model"] == ""
+
+    def test_one_turn_model_switch_is_not_marked_as_a_fallback(self):
+        """`/model --once` restoration sets ``_fallback_activated`` as plumbing to force
+        ``restore_primary_runtime()`` to run (hermes_cli/cli_model_switch_mixin.py). A
+        deliberate one-turn switch is not a demotion, so the marker must key on the
+        ``_provider_fallback_active`` provenance flag instead."""
+        cli_obj = _make_cli(model="gpt-6-astra")
+        cli_obj.agent = SimpleNamespace(
+            model="glm-5", provider="opencode-go",
+            _fallback_activated=True,          # set by the --once restore path
+            _provider_fallback_active=False,   # no real fallback happened
+        )
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+
+        assert snapshot["model_short"] == "glm-5"
+        assert snapshot["fallback_active"] is False
+
     def test_snapshot_refreshes_persisted_session_title(self):
         cli_obj = _make_cli()
         cli_obj.session_id = "session-1"

--- a/tests/cli/test_model_picker_filter.py
+++ b/tests/cli/test_model_picker_filter.py
@@ -60,3 +60,70 @@ def test_filter_does_not_reorder_or_pick_a_default():
 
 def test_whitespace_query_is_treated_as_empty():
     assert HermesCLI._filter_model_picker_entries(MODELS, "   ") == list(enumerate(MODELS))
+
+
+class TestModelPickerFallbackNote:
+    """The picker's "Current:" row names the CONFIGURED model, which fallback
+    activation never rewrites — so with a primary that fails every turn the
+    picker advertised a model that was answering nothing while the status bar
+    showed the hop. The note is the picker's half of telling the truth.
+    """
+
+    @staticmethod
+    def _cli(agent):
+        cli_obj = HermesCLI.__new__(HermesCLI)
+        cli_obj.agent = agent
+        return cli_obj
+
+    def test_note_names_the_live_model_when_a_fallback_is_active(self):
+        from types import SimpleNamespace
+
+        cli_obj = self._cli(SimpleNamespace(
+            model="deepseek-v4-flash",
+            provider="custom:litellm-direct",
+            _provider_fallback_active=True,
+        ))
+
+        note = cli_obj._model_picker_fallback_note("gpt-6-astra", "openai-codex")
+
+        assert note == (
+            "⚠ fallback active — answering on deepseek-v4-flash via custom:litellm-direct"
+        )
+
+    def test_no_note_on_a_normal_turn(self):
+        from types import SimpleNamespace
+
+        cli_obj = self._cli(SimpleNamespace(
+            model="gpt-6-astra", provider="openai-codex", _provider_fallback_active=False,
+        ))
+
+        assert cli_obj._model_picker_fallback_note("gpt-6-astra", "openai-codex") == ""
+
+    def test_no_note_when_the_hop_matches_the_configured_model(self):
+        """Primary and hop 1 can be the same model on different endpoints; the
+        note would then say nothing the "Current:" row does not already say."""
+        from types import SimpleNamespace
+
+        cli_obj = self._cli(SimpleNamespace(
+            model="deepseek-v4-flash",
+            provider="custom:litellm-control",
+            _provider_fallback_active=True,
+        ))
+
+        assert cli_obj._model_picker_fallback_note(
+            "deepseek-v4-flash", "custom:litellm-control") == ""
+
+    def test_no_agent_yet_is_not_an_error(self):
+        assert self._cli(None)._model_picker_fallback_note("x", "y") == ""
+
+    def test_one_turn_switch_produces_no_note(self):
+        """``_fallback_activated`` alone is the `/model --once` restore plumbing, not a
+        demotion — the note must not claim a fallback for a deliberate switch."""
+        from types import SimpleNamespace
+
+        cli_obj = self._cli(SimpleNamespace(
+            model="glm-5", provider="opencode-go",
+            _fallback_activated=True, _provider_fallback_active=False,
+        ))
+
+        assert cli_obj._model_picker_fallback_note("gpt-6-astra", "openai-codex") == ""


### PR DESCRIPTION
## What

When a provider fallback is active, the CLI status bar renders the hop's model name exactly like a user-chosen model, and `/model` keeps advertising the configured one. Marks the hop (`<model> ⤵`) and gives the `/model` picker a line naming what is actually answering.

## Why

Two surfaces read two different fields, and neither says which:

- `hermes_cli/cli_status_bar_mixin.py` reads `agent.model` — live, follows fallback (its own comment: *"it updates on fallback; self.model never changes"*)
- `hermes_cli/cli_model_switch_mixin.py` passes `cli.model` into the picker — configured, which fallback activation never rewrites

Both are correct in isolation. Together, once a fallback activates they disagree permanently and the bar looks like it is misreporting the model. Reported in the wild by a user whose selected model returned 500 at the vendor: every turn demoted to hop 1, so the bar always showed the hop while `/model` still named the selection. Per-session usage records showed this is not a blip — one session served 51 calls on the selected model and 77 on a fallback hop.

## Flag choice

Both surfaces key on **`_provider_fallback_active`**, not `_fallback_activated`. The latter is overloaded: `/model --once` restoration sets it as plumbing to force `restore_primary_runtime()` to run, and init-time routing sets it as well, so it would report a deliberate one-turn switch as a demotion. `_provider_fallback_active` is the provenance flag `try_activate_fallback` sets — the same one the restore notice already uses to decide whether a recovery happened. Both false-positive cases are pinned by tests.

## Notes

- Marking `model_short` in the snapshot covers all six render sites (three width tiers × text and fragments) without per-tier plumbing; the snapshot also carries `fallback_active` / `primary_model` for other consumers.
- `_render_scroll_list_panel` gains an optional `note=` row. Panel rows do not wrap, so a caller with two things to say needs a second row rather than an over-long hint. The command palette passes nothing and is unchanged.
- The picker note stays silent when the live pair equals the configured pair — a primary and hop 1 can be the same model on different endpoints, where the note would add nothing.

## Tests

`tests/cli/test_cli_status_bar.py` + `tests/cli/test_model_picker_filter.py`: hop marked, normal turn unmarked, missing `_primary_runtime` tolerated, `/model --once` **not** marked, picker note text, no note without a fallback, no note when the hop matches the configured model, no agent yet. 67 passed.

Full `tests/cli`: 1422 passed, 1 failed — `test_resume_quiet_stderr::test_session_not_found_goes_to_stdout_in_full_mode`, which fails the same way on an unmodified tree and passes in isolation (suite-order dependent).