### PR TITLE
fix(gateway): carry MEDIA: tags forward when a tool call follows the reply

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -495,6 +495,18 @@ def finalize_turn(
     # Response transforms apply only to real, uninterrupted responses.
     if final_response and not interrupted:
         final_response = _append_file_mutation_footer(agent, final_response, logger)
+
+    # -- MEDIA: carry-forward -------------------------------------------
+    # Only the FINAL assistant message reaches the chat platform. When the
+    # model emits MEDIA:/path and THEN calls a tool (mem0_add, memory, ...),
+    # the tag lands in an intermediate turn and the attachment is silently
+    # dropped while the closing message claims the file was sent. Re-attach
+    # any MEDIA: tag emitted earlier in THIS turn that didn't survive.
+    if final_response and not interrupted:
+        try:
+            final_response = _carry_forward_media_tags(final_response, messages)
+        except Exception as _mc_err:
+            logger.debug("MEDIA carry-forward failed: %s", _mc_err)
     if not interrupted:
         final_response = _explain_abnormal_exit(
             agent, final_response, _turn_exit_reason, preserved_verification_fallback, logger,
@@ -638,3 +650,44 @@ def finalize_turn(
     agent._turn_preflight_display_snapshot = None
     agent._turn_received_provider_response = False
     return result
+
+
+def _carry_forward_media_tags(final_response, messages):
+    """Re-append MEDIA: tags emitted earlier in this turn but lost from the final text.
+
+    Scans assistant messages back to the most recent user message (this turn
+    only), collects MEDIA: tags that are absent from ``final_response``, and
+    appends them so the platform's extract_media() can deliver them. Order is
+    preserved and duplicates are dropped.
+    """
+    import re as _re
+    from agent.conversation_loop import logger  # lazy: module-level import is circular
+    _MEDIA_TAG_RE = _re.compile(r"^\s*MEDIA:\S+\s*$", _re.MULTILINE)
+    if not messages:
+        return final_response
+    # This turn = everything after the last user message.
+    start = 0
+    for idx in range(len(messages) - 1, -1, -1):
+        if isinstance(messages[idx], dict) and messages[idx].get("role") == "user":
+            start = idx + 1
+            break
+    already = set(m.group(0).strip() for m in _MEDIA_TAG_RE.finditer(final_response or ""))
+    missing = []
+    for msg in messages[start:]:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, str) or "MEDIA:" not in content:
+            continue
+        for m in _MEDIA_TAG_RE.finditer(content):
+            tag = m.group(0).strip()
+            if tag not in already:
+                already.add(tag)
+                missing.append(tag)
+    if not missing:
+        return final_response
+    logger.info(
+        "MEDIA carry-forward: re-attaching %d tag(s) lost to a trailing tool call: %s",
+        len(missing), missing,
+    )
+    return (final_response or "").rstrip() + "\n" + "\n".join(missing)

--- a/tests/agent/test_turn_finalizer_media_carry_forward.py
+++ b/tests/agent/test_turn_finalizer_media_carry_forward.py
@@ -1,0 +1,61 @@
+"""Regression test: MEDIA: tags must survive a trailing tool call.
+
+Only the FINAL assistant message of a turn is dispatched to the chat platform.
+When the model emits ``MEDIA:/abs/path`` and then calls any tool (storing a
+memory is the common case), the media-bearing message is demoted to an
+intermediate turn and is never sent — while the new final message typically
+claims the files went out.  ``_carry_forward_media_tags`` re-appends any tag
+emitted earlier in the same turn that did not survive into the final text.
+"""
+
+from agent.turn_finalizer import _carry_forward_media_tags
+
+
+def _turn(*assistant_texts, user="send me the report"):
+    msgs = [{"role": "user", "content": user}]
+    msgs += [{"role": "assistant", "content": t} for t in assistant_texts]
+    return msgs
+
+
+def test_tag_lost_to_trailing_tool_call_is_reattached():
+    messages = _turn("Here it is.\nMEDIA:/tmp/report.pdf", "Sent 1 file just now.")
+    out = _carry_forward_media_tags("Sent 1 file just now.", messages)
+    assert "MEDIA:/tmp/report.pdf" in out
+    assert out.startswith("Sent 1 file just now.")
+
+
+def test_multiple_tags_keep_their_order():
+    messages = _turn(
+        "Both attached.\nMEDIA:/tmp/a.pdf\nMEDIA:/tmp/b.xlsx",
+        "Sent 2 files.",
+    )
+    out = _carry_forward_media_tags("Sent 2 files.", messages)
+    assert out.index("MEDIA:/tmp/a.pdf") < out.index("MEDIA:/tmp/b.xlsx")
+
+
+def test_tag_already_final_is_not_duplicated():
+    messages = _turn("Here it is.\nMEDIA:/tmp/report.pdf")
+    final = "Here it is.\nMEDIA:/tmp/report.pdf"
+    out = _carry_forward_media_tags(final, messages)
+    assert out.count("MEDIA:/tmp/report.pdf") == 1
+
+
+def test_tag_from_a_previous_turn_is_not_resent():
+    messages = [
+        {"role": "user", "content": "first ask"},
+        {"role": "assistant", "content": "old one\nMEDIA:/tmp/old.pdf"},
+        {"role": "user", "content": "second ask"},
+        {"role": "assistant", "content": "nothing to attach this time"},
+    ]
+    out = _carry_forward_media_tags("nothing to attach this time", messages)
+    assert "MEDIA:/tmp/old.pdf" not in out
+
+
+def test_no_media_leaves_response_untouched():
+    messages = _turn("just a plain answer")
+    assert _carry_forward_media_tags("just a plain answer", messages) == "just a plain answer"
+
+
+def test_empty_messages_are_safe():
+    assert _carry_forward_media_tags("hello", []) == "hello"
+    assert _carry_forward_media_tags("hello", None) == "hello"


### PR DESCRIPTION
## Problem

Only the **final** assistant message of a turn is dispatched to the chat platform. An agent attaches a file by emitting `MEDIA:/abs/path` in its reply — but if it calls *any* tool after emitting that text, the media-bearing message becomes an intermediate turn and is never sent. The message that *is* dispatched is the one composed afterwards, which typically claims the files were delivered.

The failure is silent and actively misleading: the user is told "Sent 3 files just now" and receives nothing.

**Storing a memory is the usual trigger.** Models habitually record a memory immediately after composing a reply, which is exactly the trailing tool call that strands the tags.

## Evidence

Taken from a production agent's `state.db`, not reproduced synthetically:

- msg `27377` (12:44:01) carried **5 valid `MEDIA:` tags**
- a memory-write tool call ran next
- msg `27379` (425 chars, **no tags**) is what was actually dispatched

On a second agent, every *successful* send has the `MEDIA:` message followed directly by a `user` row — i.e. it happened to be final.

## Why not fix it in the prompt

A system-prompt rule ("do all tool calls first, then emit `MEDIA:` and stop") was tried first. **It did not hold** — the same agent reproduced the bug within 15 minutes (msg `27430` carried 3 tags → memory write → msg `27432` "Sent 3 just now"). The behaviour is an ingrained habit, so the guarantee has to live in code.

## Fix

`_carry_forward_media_tags()` in `agent/turn_finalizer.py`, called from `finalize_turn` right after the file-mutation-verifier footer, where both `final_response` and `messages` are in scope. It scans assistant messages back to the most recent `user` row (this turn only), collects `MEDIA:` tags missing from `final_response`, and appends them so `extract_media()` delivers them.

- Order preserved, duplicates dropped
- Tags from previous turns are never resent
- Skipped when the turn was interrupted
- Wrapped in try/except: a failure here can never break turn finalization
- Logs `MEDIA carry-forward: re-attaching N tag(s) lost to a trailing tool call`

## Verification

Replaying the two real failed turns through the patch: **0 → 5** attachments and **0 → 3** attachments, all files present and delivered.

Added `tests/agent/test_turn_finalizer_media_carry_forward.py` covering: reattachment after a trailing tool call, order preservation, no duplication when the tag is already final, no resend of a previous turn's tag, no-media passthrough, and empty/None `messages`.

## Scope

Platform-agnostic — it fixes the text handed to `extract_media()`, so every platform using that path benefits. Not related to `gateway/media_repair.py`, which rewrites model-mangled `computer_use` screenshot paths in responses that already carry a tag.

Deployed on two production agents since 2026-08-24; no regressions observed.
