### PR TITLE
fix(terminal): prevent Windows stdout drain hangs

### DIFF
--- a/tests/tools/test_drain_fd_windows.py
+++ b/tests/tools/test_drain_fd_windows.py
@@ -1,0 +1,81 @@
+"""Regression tests for issue #105865: Windows stdout drain hangs when grandchild inherits write pipe."""
+
+import codecs
+import os
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.environments.base_output import _BoundedOutputCollector, _drain_fd_windows
+
+
+@pytest.mark.windows_only
+def test_drain_fd_windows_returns_promptly_when_writer_remains_open():
+    """Windows drain must stop shortly after process exit even if a grandchild holds the pipe write handle open."""
+    r, w = os.pipe()
+    try:
+        os.write(w, b"hello from child process\n")
+        proc = MagicMock()
+        proc.poll.return_value = 0  # Process has exited, but 'w' is still open
+
+        output = _BoundedOutputCollector(1000)
+        decoder = codecs.getincrementaldecoder("utf-8")("replace")
+
+        t0 = time.monotonic()
+        _drain_fd_windows(proc, r, output, decoder)
+        elapsed = time.monotonic() - t0
+
+        assert "hello from child process" in output.render()
+        assert elapsed < 1.0, f"drain hung for {elapsed:.2f}s instead of bounding after exit"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+@pytest.mark.windows_only
+def test_drain_fd_windows_observes_stop_event():
+    """Windows drain must honor the stop event immediately when handed to another reader."""
+    r, w = os.pipe()
+    try:
+        proc = MagicMock()
+        proc.poll.return_value = None  # Process still running
+
+        stop = threading.Event()
+        stop.set()
+
+        output = _BoundedOutputCollector(1000)
+        decoder = codecs.getincrementaldecoder("utf-8")("replace")
+
+        t0 = time.monotonic()
+        _drain_fd_windows(proc, r, output, decoder, stop=stop)
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 0.2, f"drain took {elapsed:.2f}s despite stop event being set"
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+@pytest.mark.windows_only
+def test_drain_fd_windows_e2e_local_environment_background_child(tmp_path):
+    """LocalEnvironment.execute() on Windows must return promptly when a backgrounded
+    grandchild inherits the pipe writer (reproducer for issue #105865 / #67362)."""
+    from tools.environments.local import LocalEnvironment
+
+    env = LocalEnvironment(cwd=str(tmp_path))
+    try:
+        marker = "windows_drain_e2e_marker"
+        # In Git Bash on Windows, backgrounding with disown leaves the grandchild alive
+        # with an open stdout pipe write handle. The drain must bound to ~300ms.
+        cmd = f'python -c "import time; time.sleep(30)" & disown; echo {marker}'
+        t0 = time.monotonic()
+        result = env.execute(cmd, timeout=15)
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 5.0, f"LocalEnvironment.execute hung for {elapsed:.2f}s on Windows"
+        assert result["returncode"] == 0
+        assert marker in result["output"]
+    finally:
+        env.cleanup()

--- a/tools/environments/base_output.py
+++ b/tools/environments/base_output.py
@@ -381,8 +381,7 @@ def _drain_stdout(proc: ProcessHandle, output: _BoundedOutputCollector, stop: "t
                 if piece is not None:
                     output.append(decoder.decode(piece) if isinstance(piece, bytes) else str(piece))
         elif os.name == "nt":
-            while chunk := os.read(fd, 4096):
-                output.append(decoder.decode(chunk))
+            _drain_fd_windows(proc, fd, output, decoder, stop)
         else:
             _drain_fd_select(proc, fd, output, decoder, stop)
     except Exception:
@@ -423,6 +422,54 @@ def _drain_fd_select(proc, fd: int, output: _BoundedOutputCollector, decoder, st
             idle_after_exit += 1
             if idle_after_exit >= 3:
                 return
+
+
+def _drain_fd_windows(proc, fd: int, output: _BoundedOutputCollector, decoder, stop=None) -> None:
+    """Windows drain: poll ``PeekNamedPipe`` because ``select`` cannot poll pipes.
+
+    ``os.read`` on a Windows pipe blocks until data is available or every writer
+    closes the pipe.  A backgrounded grandchild can retain a writer indefinitely,
+    so use the Win32 pipe API to check availability before reading and apply the
+    same post-exit idle bound as the POSIX drain.
+    """
+    import ctypes
+    import msvcrt
+
+    try:
+        raw_handle = msvcrt.get_osfhandle(fd)
+    except OSError:
+        return
+    if raw_handle in (-1, 0):
+        return
+
+    handle = ctypes.c_void_p(raw_handle)
+    kernel32 = ctypes.windll.kernel32
+    available = ctypes.c_ulong(0)
+    idle_after_exit = 0
+    while True:
+        if stop is not None and stop.is_set():
+            return
+        try:
+            ok = kernel32.PeekNamedPipe(handle, None, 0, None, ctypes.byref(available), None)
+        except OSError:
+            return
+        if not ok:
+            return
+        if available.value:
+            try:
+                chunk = os.read(fd, min(int(available.value), 4096))
+            except (ValueError, OSError):
+                return
+            if not chunk:
+                return
+            output.append(decoder.decode(chunk))
+            idle_after_exit = 0
+            continue
+        if proc.poll() is not None:
+            idle_after_exit += 1
+            if idle_after_exit >= 3:
+                return
+        time.sleep(0.1)
 
 
 def _start_drain_thread(


### PR DESCRIPTION
## Fixes

Fixes #105865.

## Executive summary

On Windows, terminal and file-tool calls using `LocalEnvironment` could block for minutes and reach the outer tool timeout. The immediate cause was the Windows stdout-drain branch calling blocking `os.read()` until true EOF. A backgrounded child process can inherit the pipe write handle, so EOF may not arrive when the shell process exits.

The fix changes only the Windows stdout-drain path. It polls the pipe with Win32 `PeekNamedPipe`, reads only bytes already available, observes the drain stop event, and applies the same bounded post-process-exit idle policy already used by the POSIX implementation.

## Investigation performed

### Premise validation

The issue premise was checked against the current branch before editing:

- `tools/environments/base_output.py` contained the Windows branch:

  ```python
  while chunk := os.read(fd, 4096):
      output.append(decoder.decode(chunk))
  ```

- The same module already documented and implemented a non-blocking `select()` loop for POSIX.
- The shared wait path starts a dedicated stdout-drain thread before polling the process in `BaseEnvironment._wait_for_process`.
- The wait path can join the drain thread during normal completion, interruption, timeout, and yield-to-background handling, so an unbounded Windows read directly affected terminal/file-tool completion.
- Issue #105865 describes the same mechanism: Windows pipes cannot be polled with `select()`, while the blocking `os.read()` waits for true EOF when a descendant retains the write handle.

### Related design context

The existing POSIX implementation already stops after three idle polling intervals once the parent process has exited. Reusing that behavior for Windows preserves the established contract and avoids introducing a second timeout policy or changing output semantics for other backends.

## Root cause

`LocalEnvironment` ultimately uses the shared stdout drain in `BaseEnvironment._wait_for_process`. Before this change:

1. `_drain_stdout` obtained `proc.stdout.fileno()`.
2. On Windows (`os.name == "nt"`), it entered a raw `os.read(fd, 4096)` loop.
3. `os.read` blocked whenever no bytes were immediately available.
4. If a descendant inherited the pipe's write handle, the pipe did not reach true EOF after the shell exited.
5. The drain thread therefore remained blocked even though the parent process had finished.
6. Terminal/file-tool execution could remain stuck until the outer tool timeout or manual cancellation.

`select.select()` cannot solve this on Windows because Windows pipe descriptors are not selectable. The correct Windows primitive is `PeekNamedPipe`, which reports currently available bytes without blocking.

## Implementation

Changed `tools/environments/base_output.py`:

- Added `_drain_fd_windows(...)`.
- Converted the Windows branch of `_drain_stdout` to call the helper.
- Used `msvcrt.get_osfhandle(fd)` to obtain the native Windows handle and wrapped it with `ctypes.c_void_p` for full 64-bit ABI safety, validating against invalid descriptors (-1, 0).
- Used `ctypes.windll.kernel32.PeekNamedPipe` to inspect available bytes.
- Called `os.read` only when `PeekNamedPipe` reported data.
- Preserved the existing 4096-byte chunk size and incremental UTF-8 decoder.
- Honored the optional stop event before every poll.
- Returned on broken/closed pipes and read errors while preserving already captured output.
- Used three 100 ms idle intervals (`time.sleep(0.1)`) after the parent process exits, matching the POSIX drain policy and allowing a short buffered tail without waiting for an unrelated descendant or busy-spinning at 100% CPU.

The change is O(n) in bytes drained, uses bounded polling overhead while idle, adds no persistent worker, and does not alter POSIX, in-memory/mock, or remote backend paths.

## Verification performed

### Static and syntax checks

- `python -m compileall -q tools/environments/base_output.py` — passed.
- `git diff --check` — passed.
- `ruff check tools/environments/base_output.py tests/tools/test_drain_fd_windows.py` — passed.
- `python scripts/check-windows-footguns.py --all` — passed.

### Automated regression tests

Added `tests/tools/test_drain_fd_windows.py`:
- `test_drain_fd_windows_returns_promptly_when_writer_remains_open` — verifies the drain returns promptly (~300ms) after process exit when an open pipe write end is retained by an inherited handle.
- `test_drain_fd_windows_observes_stop_event` — verifies the stop event immediately aborts the drain loop.
- `test_drain_fd_windows_e2e_local_environment_background_child` — end-to-end test verifying `LocalEnvironment.execute()` returns promptly on Windows when a command spawns a backgrounded child process holding the pipe write end.

Ran via pytest on Windows:
`python -m pytest tests/tools/test_drain_fd_windows.py -v` — passed (3 passed in 2.25s).

## Delivery details

- Branch: `fix/issue-105865-windows-pipe-drain`
- Rebased cleanly onto latest `origin/main` as a single atomic commit (`5ea0fc66b7`).
- Diff touches strictly `tools/environments/base_output.py` and `tests/tools/test_drain_fd_windows.py`.
- Fork branch: `JoaoMarcos44/hermes-agent:fix/issue-105865-windows-pipe-drain`
- Pull request: https://github.com/NousResearch/hermes-agent/pull/105981
