### PR TITLE
fix(desktop): decouple background queues from foreground connectivity

### DIFF
--- a/apps/desktop/src/app/contrib/wiring-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/contrib/wiring-background-queue-drain.test.tsx
@@ -1,0 +1,223 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $parkedQueueSessions,
+  $queuedPromptsBySession,
+  enqueueQueuedPrompt,
+  getQueuedPrompts
+} from '@/store/composer-queue'
+import { $activeConnectionId } from '@/store/connections'
+import { $activeSessionId, $connection, $gatewayState, $selectedStoredSessionId, setSessions } from '@/store/session'
+import { clearAllSessionStates } from '@/store/session-states'
+import { makeSessionInfo } from '@/test/session-info'
+
+import type { SubmitTextOptions } from '../session/hooks/use-prompt-actions/utils'
+
+import type { AmbientGatewayRequest } from './session-rpc-dispatcher'
+
+// Mount the actual controller: its gateway subscription and enabled policy are
+// NOT copied into a test harness. Keep the real queue hook/stores and session
+// dispatcher. Stub unrelated chrome/boot and the prompt/network boundaries;
+// this proves scheduling/routing, not a WebSocket or an LLM's execution.
+const fixture = vi.hoisted(() => ({
+  ambientRequest: vi.fn(async () => {
+    throw new Error('foreground must not receive background RPCs')
+  }),
+  remoteRequest: vi.fn(async () => ({ accepted: true })),
+  submitText: vi.fn<(text: string, options?: SubmitTextOptions) => Promise<boolean>>(),
+  requestGateway: null as AmbientGatewayRequest | null,
+  runtimeMap: { current: new Map([['stored-remote', 'rt-remote']]) },
+  stateMap: { current: new Map() },
+  selectedRef: { current: 'stored-foreground' },
+  activeRef: { current: 'rt-foreground' }
+}))
+
+vi.mock('@/store/gateway', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  activeGatewayConnectionId: () => 'local',
+  requestGatewayForAgent: fixture.remoteRequest
+}))
+vi.mock('../gateway/hooks/use-gateway-request', () => ({
+  useGatewayRequest: () => ({
+    connectionRef: { current: null },
+    gateway: null,
+    gatewayRef: { current: null },
+    requestGateway: fixture.ambientRequest
+  })
+}))
+vi.mock('../session/hooks/use-session-state-cache', () => ({
+  useSessionStateCache: () => ({
+    activeSessionIdRef: fixture.activeRef,
+    selectedStoredSessionIdRef: fixture.selectedRef,
+    runtimeIdByStoredSessionIdRef: fixture.runtimeMap,
+    sessionStateByRuntimeIdRef: fixture.stateMap
+  })
+}))
+vi.mock('../session/hooks/use-prompt-actions', () => ({
+  usePromptActions: ({ requestGateway }: { requestGateway: AmbientGatewayRequest }) => {
+    fixture.requestGateway = requestGateway
+    fixture.submitText.mockImplementation(async (text, options) => {
+      await requestGateway('prompt.submit', { session_id: options?.sessionId, text })
+
+      return true
+    })
+
+    return { submitText: fixture.submitText }
+  }
+}))
+vi.mock('@/components/boot-failure-overlay', () => ({ BootFailureOverlay: () => null }))
+vi.mock('@/components/confirm-host', () => ({ ConfirmHost: () => null }))
+vi.mock('@/components/desktop-install-overlay', () => ({ DesktopInstallOverlay: () => null }))
+vi.mock('@/components/find-bar', () => ({ FindBar: () => null }))
+vi.mock('@/components/gateway-connecting-overlay', () => ({ GatewayConnectingOverlay: () => null }))
+vi.mock('@/components/notifications', () => ({ NotificationStack: () => null }))
+vi.mock('@/components/onboarding', () => ({ DesktopOnboardingOverlay: () => null }))
+vi.mock('@/components/pet/floating-pet', () => ({ FloatingPet: () => null }))
+vi.mock('@/components/remote-display-banner', () => ({ RemoteDisplayBanner: () => null }))
+vi.mock('@/components/send-diagnostics-dialog', () => ({ SendDiagnosticsHost: () => null }))
+vi.mock('@/components/tips', () => ({ TipHost: () => null }))
+vi.mock('../command-palette', () => ({ CommandPalette: () => null }))
+vi.mock('../model-picker-overlay', () => ({ ModelPickerOverlay: () => null }))
+vi.mock('../model-visibility-overlay', () => ({ ModelVisibilityOverlay: () => null }))
+vi.mock('../pet-generate/pet-generate-overlay', () => ({ PetGenerateOverlay: () => null }))
+vi.mock('../right-sidebar/file-actions', () => ({ FileActionDialogs: () => null }))
+vi.mock('../right-sidebar/files/remote-picker', () => ({ RemoteFolderPicker: () => null }))
+vi.mock('../right-sidebar/terminal/persistent', () => ({ PersistentTerminal: () => null }))
+vi.mock('../session-import', () => ({ SessionImportView: () => null }))
+vi.mock('../session-picker-overlay', () => ({ SessionPickerOverlay: () => null }))
+vi.mock('../session-switcher', () => ({ SessionSwitcher: () => null }))
+vi.mock('../settings/plugin-install-modal', () => ({ PluginInstallModal: () => null }))
+vi.mock('../shell/titlebar-controls', () => ({ TitlebarControls: () => null }))
+vi.mock('../updates-overlay', () => ({ UpdatesOverlay: () => null }))
+vi.mock('./mcp-install-deeplink-dialog', () => ({ McpInstallDeepLinkDialog: () => null }))
+vi.mock('./surfaces', () => ({
+  ChatRoutesSurface: () => null,
+  SidebarSurface: () => null,
+  StatusbarSurface: () => null,
+  TerminalSurface: () => null
+}))
+vi.mock('../gateway/hooks/use-gateway-boot', () => ({ useGatewayBoot: () => ({}) }))
+vi.mock('../session/hooks/use-context-suggestions', () => ({ useContextSuggestions: () => ({}) }))
+vi.mock('../session/hooks/use-cwd-actions', () => ({ useCwdActions: () => ({}) }))
+vi.mock('../session/hooks/use-hermes-config', () => ({ useHermesConfig: () => ({}) }))
+vi.mock('../session/hooks/use-message-stream', () => ({ useMessageStream: () => ({}) }))
+vi.mock('../session/hooks/use-model-controls', () => ({ useModelControls: () => ({}) }))
+vi.mock('../session/hooks/use-preview-routing', () => ({ usePreviewRouting: () => ({}) }))
+vi.mock('../session/hooks/use-route-resume', () => ({ useRouteResume: () => ({}) }))
+vi.mock('../session/hooks/use-session-actions', () => ({ useSessionActions: () => ({}) }))
+vi.mock('../session/hooks/use-session-list-actions', () => ({ useSessionListActions: () => ({}) }))
+vi.mock('../chat/hooks/use-composer-actions', () => ({ useComposerActions: () => ({}) }))
+vi.mock('../hooks/use-keybinds', () => ({ useKeybinds: () => ({}) }))
+vi.mock('../hud/handoff', () => ({ useHudHandoff: () => ({}) }))
+vi.mock('../shell/hooks/use-overlay-routing', () => ({ useOverlayRouting: () => ({}) }))
+vi.mock('./hooks/use-background-sync', () => ({ useBackgroundSync: () => ({}) }))
+vi.mock('./hooks/use-desktop-integrations', () => ({ useDesktopIntegrations: () => ({}) }))
+vi.mock('./hooks/use-pet-bridge', () => ({ usePetBridge: () => ({}) }))
+vi.mock('./hooks/use-quick-entry-bridge', () => ({ useQuickEntryBridge: () => ({}) }))
+vi.mock('./hooks/use-session-tile-delegate', () => ({ useSessionTileDelegate: () => ({}) }))
+vi.mock('@/themes/use-skin-command', () => ({ useSkinCommand: () => ({}) }))
+vi.mock('../hooks/use-config-record', () => ({ useHermesConfigRecord: () => ({}) }))
+vi.mock('./dev/credits-notice-demo', () => ({ installCreditsNoticeDemo: () => undefined }))
+vi.mock('@/store/wake-word', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  armWakeWord: vi.fn()
+}))
+vi.mock('./panes', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $restartPreviewServer: atom(null), useTitlebarToolContributions: () => [] }
+})
+vi.mock('../shell/hooks/use-window-controls-overlay-width', () => ({ useWindowControlsOverlayWidth: () => 0 }))
+
+import { ContribWiring } from './wiring'
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  clearAllSessionStates()
+  $queuedPromptsBySession.set({})
+  $parkedQueueSessions.set({})
+  $connection.set({
+    connectionId: 'local',
+    profile: 'default',
+    mode: 'local',
+    baseUrl: 'http://foreground.invalid',
+    wsUrl: 'ws://foreground.invalid',
+    token: '',
+    logs: [],
+    isFullscreen: false,
+    nativeOverlayWidth: 0,
+    windowButtonPosition: null
+  })
+  $activeSessionId.set('rt-foreground')
+  $selectedStoredSessionId.set('stored-foreground')
+  setSessions([
+    makeSessionInfo({ id: 'stored-foreground', connection_id: 'local', profile: 'default' }),
+    makeSessionInfo({ id: 'stored-remote', connection_id: 'remote-healthy', profile: 'worker' })
+  ])
+})
+
+afterEach(() => {
+  cleanup()
+  queryClient.clear()
+  $queuedPromptsBySession.set({})
+  $parkedQueueSessions.set({})
+  setSessions([])
+  clearAllSessionStates()
+  $activeSessionId.set(null)
+  $selectedStoredSessionId.set(null)
+  $connection.set(null)
+  $gatewayState.set('closed')
+  fixture.requestGateway = null
+  vi.useRealTimers()
+})
+
+describe('ContribWiring background queue: independent remote owner', () => {
+  it.each(['open', 'closed'] as const)('submits healthy remote queue with foreground %s', async foregroundState => {
+    $gatewayState.set(foregroundState)
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <ContribWiring>{null}</ContribWiring>
+        </QueryClientProvider>
+      </MemoryRouter>
+    )
+
+    // Positive reachability probe through the controller's exact dispatcher,
+    // with the foreground state already set. Only scheduling differs below.
+    await expect(fixture.requestGateway!('session.info', { session_id: 'rt-remote' })).resolves.toEqual({
+      accepted: true
+    })
+    expect(fixture.remoteRequest).toHaveBeenCalledWith('remote-healthy', 'worker', 'session.info', {
+      session_id: 'rt-remote'
+    })
+    fixture.remoteRequest.mockClear()
+
+    await act(async () => {
+      enqueueQueuedPrompt('stored-remote', { text: 'continue remotely', attachments: [] })
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    expect(fixture.ambientRequest).not.toHaveBeenCalled()
+    expect($gatewayState.get()).toBe(foregroundState)
+    expect($activeConnectionId.get()).toBe('local')
+    expect.soft(fixture.submitText).toHaveBeenCalledExactlyOnceWith('continue remotely', {
+      attachments: [],
+      fromQueue: true,
+      sessionId: 'rt-remote',
+      storedSessionId: 'stored-remote'
+    })
+    expect.soft(fixture.remoteRequest).toHaveBeenCalledExactlyOnceWith('remote-healthy', 'worker', 'prompt.submit', {
+      session_id: 'rt-remote',
+      text: 'continue remotely'
+    })
+    expect(getQueuedPrompts('stored-remote')).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -675,9 +675,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   })
 
   // Runs outside the selected ChatBar so queues belonging to background
-  // sessions continue once those sessions are idle.
+  // sessions continue once those sessions are idle. The session dispatcher
+  // routes each send to its owner; a disconnected foreground is not a global gate.
   useBackgroundQueueDrain({
-    enabled: gatewayState === 'open',
+    enabled: true,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
     submitText


### PR DESCRIPTION
## What does this PR do?

Allow an idle background session's queued prompt to drain through its own healthy remote gateway even when the selected foreground gateway is disconnected.

`ContribWiring` currently disables the entire background drainer using the foreground `$gatewayState`. The existing session-scoped dispatcher can already reach a different connection/profile, but the disabled hook never attempts that route. Keep the controller's drainer enabled and let the existing owner-routed submission path handle availability and bounded failures.

## Related Issue

Fixes #105982

Related but distinct: #66591 changes retry exhaustion/session-switch behavior; #78456 excludes spectator watch windows. Neither removes the foreground connection gate in `ContribWiring`. #102919 and #102973 add session-list-loading gates, not independent gateway scheduling. This change does not incorporate or replace those fixes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/contrib/wiring.tsx`: remove the foreground-only availability condition from background queue scheduling. Leave other foreground-dependent consumers, the hook's enabled contract, ownership routing, busy/selected/parked guards, and retry policy unchanged.
- `apps/desktop/src/app/contrib/wiring-background-queue-drain.test.tsx`: mount the actual `ContribWiring`, real queue hook/stores, and real session dispatcher. Cover foreground open and closed with a healthy remote queue owner; assert exact connection/profile/runtime routing, queue removal, no ambient RPC, and unchanged foreground connection/state.
- Prompt execution and network transport are stubbed at their boundaries. This is a controller/routing regression test, not a live WebSocket/LLM or native-window end-to-end test.

## How to Test

Manual scenario: queue a follow-up for a remote session, select a different backend, disconnect that foreground backend while the remote owner remains usable, then let the remote session become idle. Its queue should submit to its own backend without switching the foreground.

Executed on Linux 7.2.2-1-cachyos, Node v22.23.2, npm 12.0.2, pinned base `b2aa855b626ff8688eb34b95c60ee8b6a4af3679`, with independent development dependencies in the worktree:

```bash
NODE_ENV=development npm ci --include=dev
NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-h1-adjacent-storage.json' npm --workspace apps/desktop exec -- vitest run --project ui src/app/contrib/wiring-background-queue-drain.test.tsx src/app/session/hooks/use-background-queue-drain.test.tsx src/app/contrib/session-rpc-dispatcher.test.ts src/app/session/hooks/use-prompt-actions/index.test.tsx src/app/session/hooks/use-prompt-actions/resolve-target-session.test.ts src/app/session/hooks/use-prompt-actions/single-flight-resume.test.ts src/app/session/hooks/use-route-resume.test.tsx src/app/chat/composer/hooks/use-composer-queue.test.tsx
NODE_ENV=test npm --workspace apps/desktop run typecheck
NODE_ENV=test npm --workspace apps/desktop run lint
npm --workspace apps/desktop exec -- prettier --check src/app/contrib/wiring.tsx src/app/contrib/wiring-background-queue-drain.test.tsx
NODE_ENV=production NODE_OPTIONS=--max-old-space-size=8192 npm --workspace apps/desktop run build
NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-h1-ui-storage.json' npm --workspace apps/desktop run test:ui
git diff --check
```

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and open/closed PRs with multiple symptom/mechanism terms and inspected adjacent changes.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: renderer-only TypeScript change; Desktop checks run instead. Full Desktop UI suite has reproduced baseline failures documented below.
- [x] I've added regression tests, proven red before the implementation.
- [x] I've tested on Linux with Node v22.23.2; native interactive testing was not performed.

### Documentation & Housekeeping

- [x] Relevant documentation — N/A: no new user-facing API or configuration.
- [x] `cli-config.yaml.example` — N/A: no config changes.
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A: no architecture/workflow changes.
- [x] Cross-platform impact considered: platform-neutral React scheduling and existing gateway routing; macOS/Windows native runs not performed.
- [x] Tool descriptions/schemas — N/A: unchanged.

## Screenshots / Logs

- Red on the pinned base with only the new test: **1 failed / 1 passed**. The closed-foreground case makes zero submit/RPC calls and retains its queued entry despite a successful remote reachability probe through the same dispatcher.
- Green focused/adjacent run: **8 files, 196 tests passed**.
- Typecheck: passed. Full lint: **0 errors, 139 warnings**. Changed files pass Prettier.
- Production build: passed, including renderer assets, Electron bundles, native dependency staging, and `assert-dist-built`. Vite reports config-loader and ineffective-dynamic-import warnings.
- Full UI, change: **752 passed / 4 failed files; 7355 passed / 6 failed tests**.
- Full UI, untouched pinned base in a separate worktree with its own dependency install and fresh localStorage file: **751 passed / 4 failed files; 7353 passed / 6 failed tests**.
- The same six named failures reproduce on both refs: two `voice-prefs.test.ts` cases, two `settings/billing/index.test.tsx` cases (including polling timeout), the omitted-count assertion in `fallback-model.test.ts`, and the thousands-separator assertion in `use-prompt-actions/utils.test.ts`. Rerunning those four files together on the change reproduces all six. These failures were not modified or hidden.
- `git diff --check`: passed.
