### PR TITLE
fix(desktop): retain background turn leases across reconnect

### DIFF
--- a/apps/desktop/src/store/gateway-background-reconnect.test.ts
+++ b/apps/desktop/src/store/gateway-background-reconnect.test.ts
@@ -1,0 +1,308 @@
+import { type GatewayEvent } from '@hermes/shared'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { HermesGateway } from '@/api/client'
+
+import {
+  activeGateway,
+  activeGatewayConnectionId,
+  activeGatewayProfileKey,
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  disposeSecondariesForConnection,
+  liveSecondaryConnectionIds,
+  openGatewayForAgent,
+  pruneSecondaryGateways,
+  setPrimaryGateway,
+  setPrimaryGatewayConnectionId
+} from './gateway'
+import { requestForSessionProfile } from './session-request-router'
+
+// Real request router, registry and JSON-RPC client; only the browser network
+// boundary and Electron descriptor lookup are simulated. No backend/LLM calls.
+const owner = { connectionId: 'h2-remote', mode: 'remote' as const, profile: 'research' }
+const sessionId = 'h2-running-session'
+const remoteUrl = 'wss://h2-remote.invalid/api/ws?profile=research'
+const sockets: NetworkSocket[] = []
+interface SequencedEvent extends GatewayEvent {
+  seq: number
+}
+
+const history: SequencedEvent[] = []
+const onEvent = vi.fn<(event: GatewayEvent) => void>()
+const onActiveRouteChanged = vi.fn()
+const ambient = vi.fn<() => Promise<never>>()
+let primary: HermesGateway
+
+class NetworkSocket extends EventTarget {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+  readyState = NetworkSocket.CONNECTING
+  readonly requests: Array<{ id: number; method: string; params: Record<string, unknown> }> = []
+
+  constructor(readonly url: string) {
+    super()
+    sockets.push(this)
+    setTimeout(() => {
+      if (this.readyState !== NetworkSocket.CONNECTING) {
+        return
+      }
+
+      this.readyState = NetworkSocket.OPEN
+      this.dispatchEvent(new Event('open'))
+    }, 1)
+  }
+
+  send(data: string): void {
+    if (this.readyState !== NetworkSocket.OPEN) {
+      throw new Error('send on closed mock socket')
+    }
+
+    const request = JSON.parse(data) as (typeof this.requests)[number]
+    this.requests.push(request)
+
+    const result =
+      request.method === 'session.events.since'
+        ? {
+            events: history.filter(
+              event => event.session_id === request.params.session_id && event.seq! > Number(request.params.last_seen)
+            )
+          }
+        : { status: 'streaming' }
+
+    // Server ACK is asynchronous, after request() installed its pending entry.
+    setTimeout(() => this.receive({ jsonrpc: '2.0', id: request.id, result }), 1)
+  }
+
+  receive(frame: unknown): void {
+    if (this.readyState !== NetworkSocket.OPEN) {
+      return
+    }
+
+    this.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(frame) }))
+  }
+
+  close(): void {
+    if (this.readyState >= NetworkSocket.CLOSING) {
+      return
+    }
+
+    this.readyState = NetworkSocket.CLOSING
+    setTimeout(() => this.finishClose(1000), 1)
+  }
+
+  networkDrop(withError = false): void {
+    // A network-originated close is an asynchronous browser event, not a
+    // synchronous call to the registry's close/dispose machinery.
+    setTimeout(() => {
+      if (withError) {
+        this.dispatchEvent(new Event('error'))
+      }
+
+      this.finishClose(1006)
+    }, 1)
+  }
+
+  private finishClose(code: number): void {
+    if (this.readyState === NetworkSocket.CLOSED) {
+      return
+    }
+
+    this.readyState = NetworkSocket.CLOSED
+    this.dispatchEvent(new CloseEvent('close', { code, wasClean: code === 1000 }))
+  }
+}
+
+function publish(type: GatewayEvent['type'], payload: Record<string, unknown>): GatewayEvent {
+  const event: SequencedEvent = { type, session_id: sessionId, seq: history.length + 1, payload }
+  history.push(event)
+
+  for (const socket of sockets.filter(socket => socket.url === remoteUrl)) {
+    socket.receive({ jsonrpc: '2.0', method: 'event', params: event })
+  }
+
+  return event
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers()
+  vi.spyOn(Math, 'random').mockReturnValue(0.5)
+  vi.stubGlobal('WebSocket', NetworkSocket)
+  sockets.length = 0
+  history.length = 0
+  vi.clearAllMocks()
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    getConnectionFor: vi.fn(async () => ({
+      ...owner,
+      authMode: 'token',
+      token: 'test-only',
+      wsUrl: remoteUrl,
+      baseUrl: 'https://h2-remote.invalid'
+    })),
+    getGatewayWsUrlFor: vi.fn(async () => remoteUrl)
+  }
+  configureGatewayRegistry({
+    activeConnectionId: () => 'local',
+    foregroundScopes: () => new Set(),
+    onEvent,
+    onActiveRouteChanged
+  })
+  primary = new HermesGateway()
+  const connected = primary.connect('wss://h2-local.invalid/api/ws')
+  await vi.advanceTimersByTimeAsync(1)
+  await connected
+  setPrimaryGateway(primary, 'default')
+  setPrimaryGatewayConnectionId('local')
+  onActiveRouteChanged.mockClear()
+})
+
+afterEach(() => {
+  closeSecondaryGateways()
+  primary.close()
+  setPrimaryGateway(null)
+  setPrimaryGatewayConnectionId(null)
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('background remote turn reconnect', () => {
+  it.each([
+    { name: 'turn lease only, network close', retained: false, drop: true, error: false },
+    { name: 'turn lease only, network error and close', retained: false, drop: true, error: true },
+    { name: 'retained control, network close', retained: true, drop: true, error: false },
+    { name: 'turn lease only, uninterrupted control', retained: false, drop: false, error: false }
+  ])('$name: delivers completion without selecting the remote', async ({ retained, drop, error }) => {
+    if (retained) {
+      const opened = openGatewayForAgent(owner.connectionId, owner.profile)
+      await vi.advanceTimersByTimeAsync(10)
+      await opened
+    }
+
+    // No open/ensure/relay/foreground pin in the H2 case. The routed submit
+    // itself acquires a whole-turn lease and releases its per-request lease
+    // after ACK, leaving ONLY the whole-turn lease while the model runs.
+    const submitted = requestForSessionProfile(owner, ambient, 'prompt.submit', {
+      session_id: sessionId,
+      text: 'Continue the already-bound background session'
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+    await expect(submitted).resolves.toEqual({ status: 'streaming' })
+    const remote = sockets.filter(socket => socket.url === remoteUrl)
+    expect(remote).toHaveLength(1)
+    expect(remote[0].requests).toEqual([
+      expect.objectContaining({ method: 'prompt.submit', params: expect.objectContaining({ session_id: sessionId }) })
+    ])
+    expect(liveSecondaryConnectionIds()).toEqual(new Set([owner.connectionId]))
+    const started = publish('message.start', {})
+    expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ ...started, connectionId: owner.connectionId }))
+    onEvent.mockClear()
+
+    if (drop) {
+      remote[0].networkDrop(error)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(remote[0].readyState).toBe(NetworkSocket.CLOSED)
+      // Emitted during the outage: only session.events.since can recover it.
+      publish('message.delta', { text: 'during outage' })
+      // First backoff is deterministic; this also crosses the backoff cap.
+      // No explicit reconnect, request, selection or prewarm rescues the entry.
+      await vi.advanceTimersByTimeAsync(16_000)
+      await vi.dynamicImportSettled()
+      await vi.advanceTimersByTimeAsync(10)
+      expect
+        .soft(
+          sockets.filter(socket => socket.url === remoteUrl),
+          'automatic redial'
+        )
+        .toHaveLength(2)
+      expect
+        .soft(liveSecondaryConnectionIds(), 'remote registry route remains live')
+        .toEqual(new Set([owner.connectionId]))
+      expect
+        .soft(onEvent, 'outage notification is replayed')
+        .toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'message.delta', session_id: sessionId, connectionId: owner.connectionId })
+        )
+    }
+
+    const completed = publish('message.complete', { text: 'finished' })
+    expect
+      .soft(onEvent, 'live completion reaches the background event fan-in')
+      .toHaveBeenCalledWith(
+        expect.objectContaining({ ...completed, connectionId: owner.connectionId, profile: owner.profile })
+      )
+    expect(activeGateway()).toBe(primary)
+    expect(activeGatewayProfileKey()).toBe('default')
+    expect(activeGatewayConnectionId()).toBe('local')
+    expect(onActiveRouteChanged).not.toHaveBeenCalled()
+    expect(ambient).not.toHaveBeenCalled()
+
+    // Normal authoritative settlement still releases an unpinned live turn.
+    publish('session.info', { running: false })
+    await vi.advanceTimersByTimeAsync(501)
+
+    if (!retained) {
+      expect(liveSecondaryConnectionIds()).toEqual(new Set())
+      expect(
+        sockets.filter(socket => socket.url === remoteUrl).every(socket => socket.readyState === NetworkSocket.CLOSED)
+      ).toBe(true)
+    }
+  })
+
+  it.each(['close', 'remove', 'prune', 'missing connection'] as const)(
+    '%s stops reconnect and releases the old session lease before reuse',
+    async cleanup => {
+      const submit = () =>
+        requestForSessionProfile(owner, ambient, 'prompt.submit', {
+          session_id: sessionId,
+          text: 'background work'
+        })
+
+      const submitted = submit()
+
+      await vi.advanceTimersByTimeAsync(10)
+      await submitted
+      publish('message.start', {})
+      const original = sockets.find(socket => socket.url === remoteUrl)!
+      original.networkDrop()
+      await vi.advanceTimersByTimeAsync(1)
+
+      if (cleanup === 'close') {
+        closeSecondaryGateways()
+      } else if (cleanup === 'remove') {
+        disposeSecondariesForConnection(owner.connectionId)
+      } else if (cleanup === 'prune') {
+        pruneSecondaryGateways(new Set())
+      } else {
+        vi.mocked(window.hermesDesktop!.getConnectionFor!).mockRejectedValueOnce(
+          new Error(`No connection with id "${owner.connectionId}"`)
+        )
+      }
+
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(liveSecondaryConnectionIds()).toEqual(new Set())
+      expect(sockets.filter(socket => socket.url === remoteUrl)).toEqual([original])
+
+      // Reusing the same scope/session must acquire a new lease, not find a
+      // stale key whose release closure still belongs to the disposed entry.
+      const resubmitted = submit()
+      await vi.advanceTimersByTimeAsync(10)
+      await resubmitted
+      const replacement = sockets.filter(socket => socket.url === remoteUrl)[1]
+      expect(replacement.readyState).toBe(NetworkSocket.OPEN)
+      publish('message.start', {})
+      publish('message.complete', {})
+      publish('session.info', { running: false })
+      await vi.advanceTimersByTimeAsync(501)
+      expect(replacement.readyState).toBe(NetworkSocket.CLOSED)
+      expect(liveSecondaryConnectionIds()).toEqual(new Set())
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(sockets.filter(socket => socket.url === remoteUrl)).toHaveLength(2)
+    }
+  )
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -778,11 +778,9 @@ function createSecondary(profile: string, connectionId: null | string = null): S
       entry.reconnectAttempt = 0
       clearTimer(entry)
     } else if (state === 'closed' || state === 'error') {
-      // A dead socket cannot emit the terminal event that normally releases
-      // its turn lease. Drop the orphaned lease before deciding whether this
-      // route is still retained/active enough to reconnect.
-      releaseTurnLeasesForScope(scope)
-
+      // A transport drop does not settle a running turn. Its lease must keep
+      // the route alive so reconnect can replay missed events and receive the
+      // terminal event. Actual disposal releases orphaned leases below.
       if (entry.wantOpen) {
         scheduleReconnect(entry)
       }
@@ -1678,11 +1676,19 @@ export function touchSecondaryGateways(): void {
 // Tear a secondary down: stop its reconnect loop, detach listeners, close the
 // socket. Caller handles removal from the map.
 function disposeSecondary(entry: Secondary): void {
+  if (!entry.wantOpen) {
+    return
+  }
+
   entry.wantOpen = false
+  entry.pendingConnectionRedial = false
   clearTimer(entry)
   entry.offEvent()
   entry.offState()
   entry.gateway.close()
+  // Release can re-enter disposal at refcount zero. wantOpen is already false,
+  // and listeners are detached, so explicit teardown never rearms reconnect.
+  releaseTurnLeasesForScope(entry.scope)
 }
 
 // Invariant restore for every eviction path: if the active key names a

--- a/apps/desktop/src/store/session-request-router.test.ts
+++ b/apps/desktop/src/store/session-request-router.test.ts
@@ -514,7 +514,7 @@ describe('requestForSessionProfile', () => {
     expect(secondaryGateways).toHaveLength(2)
   })
 
-  it('releases a retained turn when its owning socket closes without a terminal event', async () => {
+  it('retains a disconnected turn until its route is explicitly closed', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')
     installDesktop()
@@ -527,6 +527,9 @@ describe('requestForSessionProfile', () => {
     expect(secondaryGateways[0].close).not.toHaveBeenCalled()
 
     secondaryGateways[0].emitState('closed')
+    expect(secondaryGateways[0].close).not.toHaveBeenCalled()
+
+    closeSecondaryGateways()
     expect(secondaryGateways[0].close).toHaveBeenCalledOnce()
   })
 


### PR DESCRIPTION
## What does this PR do?

Keeps a background secondary gateway alive across a transient WebSocket disconnect when its only remaining owner is an active-turn lease.

After a routed `prompt.submit` ACK, the per-request lease is released but the whole-turn lease must remain. Previously, the secondary's `closed`/`error` callback released that last lease, synchronously disposed the route, and set `wantOpen = false` before reconnect could be scheduled. The background session then received neither replayed outage events nor subsequent completion unless another consumer rescued the route.

Move orphaned-turn cleanup to actual secondary disposal. Transport reconnect retains the existing route and JSON-RPC replay state; explicit disposal disables reconnect and pending material-edit redial before releasing leases. Normal authoritative settlement remains unchanged.

## Related Issue

Fixes #105983

Duplicate searches covered issues and open/closed PRs using desktop reconnect, secondary gateway, turn lease, and narrower mechanism terms. Adjacent changes inspected:
- #93662 bounds primary reconnect IPC waits; it does not preserve a secondary's sole turn lease.
- #88070 handles failed primary remote boot and SSH/HTTP self-healing.
- #95084 reconciles transcript/composer state after reconnect and probes pooled remotes.
- Open #99178 changes reconnect backoff/service proof and backend sibling retirement; its gateway diff still releases turn leases on socket closure.
- Open #104871 reports whole-turn activity to the local backend pool for eviction; it does not change this disconnect teardown.

No exact competing fix found; mechanism searches repeated before publication.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/gateway.ts`: preserve active-turn leases on transport close/error; release them at actual disposal with reentrancy protection and cancelled pending redial.
- `apps/desktop/src/store/gateway-background-reconnect.test.ts`: exercise the real request router, registry, HermesGateway and JSON-RPC client through an asynchronous mock WebSocket. Two parameterized behavior contracts cover automatic reconnect/event replay/foreground isolation, plus explicit close/removal/prune/permanent missing-connection cleanup and same-session reuse.
- `apps/desktop/src/store/session-request-router.test.ts`: replace the old immediate-disconnect-release expectation with retention until explicit route close. Existing terminal ACK, authoritative settlement and pruning tests remain exercised.

No real remote gateway or model calls; no app/backend restart. Existing backoff policy is unchanged: this is ownership-lifetime repair, not a new retry-budget policy. Explicit teardown and permanent missing-connection failures stop retries, and authoritative session settlement releases an unpinned recovered route.

## How to Test

1. Submit on a non-selected registered remote without prewarming, selecting, or relay-pinning its gateway. Let `prompt.submit` ACK while the turn runs.
2. Drop the remote WebSocket, produce an event during the outage, and allow automatic reconnect. The outage event must replay and later completion must reach the background fan-in without changing the foreground gateway.
3. Explicitly close/remove/prune during reconnect (or remove the connection before the next lookup). There must be no later redial. Reusing the same session/route must acquire a fresh lease and settle normally.

Executed from the repository root with independently installed worktree dependencies:

```bash
NODE_ENV=development npm ci --include=dev
NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-h2-final-focused.json' npm --workspace apps/desktop exec -- vitest run --project ui src/store/gateway src/store/session-request-router.test.ts
NODE_ENV=test npm --workspace apps/desktop run typecheck
NODE_ENV=test npm --workspace apps/desktop exec -- eslint src/store/gateway.ts src/store/gateway-background-reconnect.test.ts src/store/session-request-router.test.ts --max-warnings 0
NODE_ENV=production NODE_OPTIONS='--max-old-space-size=8192' npm --workspace apps/desktop run build
NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-h2-final-full-storage.json' npm --workspace apps/desktop run test:ui
git diff --check HEAD^ HEAD
```

## Checklist

### Code

- [x] I've read the Contributing Guide and applicable AGENTS.md files.
- [x] My commit follows Conventional Commits.
- [x] I searched existing issues and open/closed PRs for duplicates.
- [x] This PR contains only related code and tests.
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; renderer-only TypeScript change. Relevant desktop checks were run; full UI has reproduced baseline failures detailed below.
- [x] I've added behavior tests, including a regression proven red on the pinned base.
- [x] Tested on Linux 7.2.2-1-cachyos, Node v22.23.2, npm 12.0.2.

### Documentation & Housekeeping

- [x] Documentation: N/A, no new public behavior/configuration surface.
- [x] `cli-config.yaml.example`: N/A, no configuration changes.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no architecture/workflow changes.
- [x] Cross-platform impact considered: browser WebSocket/registry ownership only, no OS-specific APIs; macOS/Windows execution not performed.
- [x] Tool descriptions/schemas: N/A.

## For New Skills

N/A.

## Screenshots / Logs

Pinned base: `b2aa855b626ff8688eb34b95c60ee8b6a4af3679`.
Local commit: `29859645ab6ce656406282f4289d7bb16aec16f1`.

- Before implementation: original 3-case integration probe had **1 failed / 2 passed**. Sole-turn-lease disconnect failed automatic redial, route retention, outage replay and completion delivery; retained and uninterrupted controls passed.
- Final focused gateway/router suite: **137 passed, 16 files**, including all 8 new integration cases.
- Renderer/Electron/E2E typechecks: PASS.
- Changed-file ESLint with zero warning budget: PASS.
- Production renderer/Electron build and `assert-dist-built`: PASS. Vite reports native-config/dynamic-import/plugin timing warnings; build succeeds.
- Diff whitespace check: PASS; commit worktree clean.
- Final full UI suite: **6 failed / 7361 passed**, 4 failed / 752 passed files.
- Independently installed clean pinned-base worktree: **6 failed / 7353 passed**, 4 failed / 751 passed files. All six failing test titles match exactly:
  - `voice-prefs.test.ts`: desktop toggle across refreshes; legacy preference migration.
  - `billing/index.test.tsx`: auto-refill bounds; polling/settled buy controls.
  - `fallback-model.test.ts`: localized omitted-character count (`5,000` expectation).
  - `use-prompt-actions/utils.test.ts`: locale-specific thousands separators.
- npm install reported 6 dependency advisories (2 moderate, 4 high); no dependency or lockfile changes made.

Local evidence: `/tmp/hermes-h2-red.log`, `/tmp/hermes-h2-final-focused.log`, `/tmp/hermes-h2-final-typecheck.log`, `/tmp/hermes-h2-lint.log`, `/tmp/hermes-h2-build.log`, `/tmp/hermes-h2-final-full-ui.log`, `/tmp/hermes-h2-baseline-full-ui.log`, `/tmp/hermes-h2-duplicates.json`, `/tmp/hermes-h2-adjacent-prs.json`.
