### PR TITLE
feat: GPT Image 2.5 generation and editing via OpenAI and FAL

### DIFF
--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -1,4 +1,4 @@
-"""OpenAI ``gpt-image-2`` at three quality tiers (virtual ids ``gpt-image-2-low/-medium/-high``);
+"""OpenAI GPT Image 2 and 2.5 Flare/Sunburst quality tiers;
 base64 output → image cache. Selection: ``OPENAI_IMAGE_MODEL`` → ``image_gen.openai.model`` →
 ``image_gen.model`` → :data:`DEFAULT_MODEL`."""
 
@@ -18,9 +18,29 @@ from plugins.image_gen._common import (
 
 logger = logging.getLogger(__name__)
 
+# Keep subscription routing independent: Codex does not verify explicit image model selection.
+MODELS = {
+    **{key: {**meta, "api_model": API_MODEL} for key, meta in GPT_IMAGE_2_TIERS.items()},
+    **{
+        model if quality == "auto" else f"{model}-{quality}": {
+            "display": f"GPT Image 2.5 {name} ({quality.title()})",
+            "speed": speed,
+            "strengths": strengths,
+            "api_model": model,
+            "quality": quality,
+        }
+        for model, name, speed, strengths in (
+            ("gpt-image-2.5-flare", "Flare", "Fast", "Everyday image generation and editing"),
+            ("gpt-image-2.5-sunburst", "Sunburst", "Slower", "Precision generation and editing"),
+        )
+        for quality in ("auto", "low", "medium", "high", "xhigh", "max")
+    },
+}
+
+
 def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return resolve_static_model(
-        GPT_IMAGE_2_TIERS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai")
+        MODELS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai")
 
 
 def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
@@ -57,16 +77,16 @@ def _named_bytes_io(ref: str) -> io.BytesIO:
 
 
 class OpenAIImageGenProvider(StaticImageGenProvider):
-    """OpenAI ``images.generate`` / ``images.edit`` backend — gpt-image-2."""
+    """OpenAI ``images.generate`` / ``images.edit`` backend with selectable API models."""
 
     provider_id = "openai"
     label = "OpenAI"
-    models = GPT_IMAGE_2_TIERS
+    models = MODELS
     default_model_id = DEFAULT_MODEL
     price = "varies"
     setup = dict(
         name="OpenAI", badge="paid",
-        tag="gpt-image-2 at low/medium/high quality tiers — text-to-image & image editing",
+        tag="GPT Image 2 / 2.5 Flare / 2.5 Sunburst — text-to-image & image editing",
         key="OPENAI_API_KEY", prompt="OpenAI API key", url="https://platform.openai.com/api-keys")
 
     def is_available(self) -> bool:
@@ -106,7 +126,7 @@ class OpenAIImageGenProvider(StaticImageGenProvider):
         # gpt-image-2 returns b64_json unconditionally and REJECTS
         # ``response_format`` as an unknown parameter. Don't send it.
         request: Dict[str, Any] = dict(
-            model=API_MODEL, prompt=prompt, size=size, n=1, quality=meta["quality"])
+            model=meta["api_model"], prompt=prompt, size=size, n=1, quality=meta["quality"])
         if is_edit:
             try:
                 files = [_named_bytes_io(ref) for ref in sources]

--- a/plugins/image_gen/openai/plugin.yaml
+++ b/plugins/image_gen/openai/plugin.yaml
@@ -1,6 +1,6 @@
 name: openai
 version: 1.0.0
-description: "OpenAI image generation backend (gpt-image-2). Saves generated images to $HERMES_HOME/cache/images/."
+description: "OpenAI image generation backend (GPT Image 2 and GPT Image 2.5 Flare/Sunburst). Saves generated images to $HERMES_HOME/cache/images/."
 author: NousResearch
 kind: backend
 requires_env:

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -57,9 +57,10 @@ class TestMetadata:
     def test_default_model(self, provider):
         assert provider.default_model() == "gpt-image-2-medium"
 
-    def test_list_models_three_tiers(self, provider):
+    def test_picker_matches_resolvable_catalog(self, provider):
         ids = [m["id"] for m in provider.list_models()]
-        assert ids == ["gpt-image-2-low", "gpt-image-2-medium", "gpt-image-2-high"]
+        assert set(ids) == set(provider.models)
+        assert provider.default_model() in ids
 
     def test_catalog_entries_have_display_speed_strengths(self, provider):
         for entry in provider.list_models():
@@ -171,24 +172,40 @@ class TestGenerate:
         # gpt-image-2 rejects response_format — we must NOT send it.
         assert "response_format" not in call_kwargs
 
-    @pytest.mark.parametrize("tier,expected_quality", [
-        ("gpt-image-2-low", "low"),
-        ("gpt-image-2-medium", "medium"),
-        ("gpt-image-2-high", "high"),
+    @pytest.mark.parametrize("api_model,quality", [
+        ("gpt-image-2", quality) for quality in ("low", "medium", "high")
+    ] + [
+        (model, quality)
+        for model in ("gpt-image-2.5-flare", "gpt-image-2.5-sunburst")
+        for quality in ("auto", "low", "medium", "high", "xhigh", "max")
     ])
-    def test_tier_maps_to_quality(self, provider, monkeypatch, tier, expected_quality):
-        monkeypatch.setenv("OPENAI_IMAGE_MODEL", tier)
+    @pytest.mark.parametrize("editing", [False, True])
+    def test_selection_reaches_image_request(
+        self, provider, monkeypatch, tmp_path, api_model, quality, editing
+    ):
+        import yaml
+
+        tier = api_model if quality == "auto" else f"{api_model}-{quality}"
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+            "image_gen": {"openai": {"model": tier}}
+        }))
+        source = tmp_path / "source.png"
+        source.write_bytes(bytes.fromhex(_PNG_HEX))
         fake_client = MagicMock()
-        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        call = fake_client.images.edit if editing else fake_client.images.generate
+        call.return_value = _fake_response(b64=_b64_png())
 
         with _patched_openai(fake_client):
-            result = provider.generate("a cat")
+            result = provider.generate("a cat", image_url=str(source) if editing else None)
 
+        assert result["success"] is True
         assert result["model"] == tier
-        assert result["quality"] == expected_quality
-        assert fake_client.images.generate.call_args.kwargs["quality"] == expected_quality
-        # Always the same underlying API model regardless of tier.
-        assert fake_client.images.generate.call_args.kwargs["model"] == "gpt-image-2"
+        assert result["quality"] == quality
+        assert call.call_args.kwargs["quality"] == quality
+        assert call.call_args.kwargs["model"] == api_model
+        assert "response_format" not in call.call_args.kwargs
+        assert Path(result["image"]).read_bytes() == bytes.fromhex(_PNG_HEX)
 
     @pytest.mark.parametrize("aspect,expected_size", [
         ("landscape", "1536x1024"),

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -30,6 +30,29 @@ def image_tool():
 # Catalog integrity
 # ---------------------------------------------------------------------------
 
+@pytest.mark.parametrize("variant", ["flare", "sunburst"])
+@pytest.mark.parametrize("aspect,size", [
+    ("landscape", "landscape_4_3"), ("square", "square_hd"), ("portrait", "portrait_4_3"),
+])
+def test_image_25_selection_routes_generation_and_edits(image_tool, monkeypatch, variant, aspect, size):
+    model = f"openai/gpt-image-2.5/{variant}/text-to-image"
+    monkeypatch.setenv("FAL_IMAGE_MODEL", model)
+    monkeypatch.setenv("FAL_KEY", "test-key")
+    selected, meta = image_tool._resolve_fal_model()
+    assert selected == model
+    refs = [f"https://example.com/{i}.png" for i in range(17)]
+    for sources, endpoint in (([], model), (refs, f"openai/gpt-image-2.5/{variant}/edit")):
+        actual, payload = image_tool._prepare_fal_request(
+            selected, meta, "a cup", aspect, 42, {"guidance_scale": 9}, sources,
+        )
+        assert actual == endpoint
+        assert payload["quality"] == "medium"
+        assert payload["image_size"] == size
+        assert "seed" not in payload and "guidance_scale" not in payload
+        assert payload.get("image_urls", []) == sources[:16]
+    assert meta["upscale"] is False
+
+
 class TestFalCatalog:
     """Every FAL_MODELS entry must have a consistent shape."""
 

--- a/tools/image_generation_catalog.py
+++ b/tools/image_generation_catalog.py
@@ -153,6 +153,31 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
         },
         max_reference_images=16,
     ),
+    # Same minimum pixel count as GPT Image 2; keep medium quality explicit
+    # rather than inheriting FAL's higher-cost high default.
+    **{
+        f"openai/gpt-image-2.5/{variant}/text-to-image": _model(
+            f"GPT Image 2.5 {variant.title()}", speed, strengths, "Token-based pricing",
+            sizes={
+                "landscape": "landscape_4_3", "square": "square_hd", "portrait": "portrait_4_3",
+            },
+            defaults={"quality": "medium", "num_images": 1, "output_format": "png"},
+            supports={
+                "prompt", "image_size", "quality", "num_images", "output_format", "background",
+                "output_compression", "sync_mode",
+            },
+            edit_endpoint=f"openai/gpt-image-2.5/{variant}/edit",
+            edit_supports={
+                "prompt", "image_urls", "image_size", "quality", "num_images", "output_format",
+                "background", "output_compression", "sync_mode", "mask_url", "input_fidelity",
+            },
+            max_reference_images=16,
+        )
+        for variant, speed, strengths in (
+            ("flare", "Fast", "Everyday creation, natural lighting and textures"),
+            ("sunburst", "Slower", "Precision editing, subject and composition consistency"),
+        )
+    },
     "fal-ai/ideogram/v3": _model(
         "Ideogram V3", "~5s", "Best typography", "$0.03-0.09/image",
         defaults={"rendering_speed": "BALANCED", "expand_prompt": True, "style": "AUTO"},

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -61,7 +61,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `teams_pipeline` | standalone | Microsoft Teams meeting pipeline — Graph-backed, transcript-first meeting summaries |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
-| `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
+| `image_gen/openai` | image backend | OpenAI GPT Image 2 and 2.5 Flare/Sunburst generation and editing (API key) |
 | `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |
 | `image_gen/xai` | image backend | xAI `grok-2-image` backend |
 | `hermes-achievements` | dashboard tab | Steam-style collectible badges generated from your real Hermes session history |

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -126,6 +126,37 @@ Auth reuses the same env vars as the Meta chat provider — `MODEL_API_KEY`
 as aliases. Set `META_BASE_URL` to point at a proxy or alternate host. Text-to-image
 only for now; responses are saved to `$HERMES_HOME/cache/images/`.
 
+## FAL: GPT Image 2.5
+
+Select **GPT Image 2.5 Flare** or **GPT Image 2.5 Sunburst** under
+`hermes tools` → Image Generation → FAL.ai. The model IDs are:
+
+- `openai/gpt-image-2.5/flare/text-to-image`
+- `openai/gpt-image-2.5/sunburst/text-to-image`
+
+For example:
+
+```bash
+hermes config set image_gen.provider fal
+hermes config set image_gen.model openai/gpt-image-2.5/flare/text-to-image
+```
+
+Providing `image_url` or reference images automatically selects the corresponding
+`openai/gpt-image-2.5/flare/edit` or `openai/gpt-image-2.5/sunburst/edit` endpoint.
+Both accept up to 16 source images. Hermes pins quality to `medium`, matching its
+existing FAL GPT Image policy rather than FAL's higher-cost `high` default.
+Landscape and portrait use 4:3 presets to satisfy the minimum pixel count;
+square uses `square_hd`. Upscaling remains off unless requested.
+
+FAL bills by tokens, not a fixed image price: $5/M text input, $1.25/M cached
+text input, $10/M text output, $8/M image input, $2/M cached image input, and
+$30/M image output, rounded up to $0.0001 per request. See the
+[Flare](https://fal.ai/models/openai/gpt-image-2.5/flare/text-to-image) and
+[Sunburst](https://fal.ai/models/openai/gpt-image-2.5/sunburst/text-to-image)
+pages. Direct FAL requires a funded `FAL_KEY`; managed-gateway availability
+depends on that gateway's endpoint allowlist and is not implied by FAL availability.
+Existing provider and model defaults are unchanged.
+
 ## OpenAI API: GPT Image 2.5
 
 The **OpenAI** provider supports GPT Image 2.5 Flare (fast everyday creation)
@@ -154,7 +185,7 @@ does not estimate 2.5 token consumption. See the official
 The **OpenAI (Codex auth)** provider remains separate: its backend can accept
 an image-model value without honoring that selection, so a successful image
 alone does not verify Flare or Sunburst routing. These selections are offered
-only through the direct OpenAI API provider, not Codex auth or FAL.
+through the direct OpenAI API provider and FAL, not as verified Codex-auth selections.
 
 ## Usage
 
@@ -196,7 +227,7 @@ Two inputs drive the edit:
 
 | Backend | Image-to-image | Reference cap | How |
 |---|---|---|---|
-| **FAL.ai** (edit-capable models below) | ✓ | up to 9 | routes to the model's `/edit` endpoint |
+| **FAL.ai** (edit-capable models below) | ✓ | up to 16 (per model) | routes to the model's `/edit` endpoint |
 | **OpenAI** (GPT Image 2 / 2.5 Flare / Sunburst) | ✓ | up to 16 | `images.edit()` |
 | **xAI** (Grok Imagine) | ✓ | 1 | `/v1/images/edits` (`grok-imagine-image-quality`) |
 | **Krea** (`Krea 2`) | ✓ | up to 10 | reference-guided generation (`image_style_references`) |
@@ -205,7 +236,7 @@ Two inputs drive the edit:
 
 FAL models with an editing endpoint: `flux-2/klein/9b`, `flux-2-pro`,
 `nano-banana-pro`, `gpt-image-1.5`, `gpt-image-2`, `ideogram/v3`, and
-`qwen-image`. Pure text-to-image FAL models (`z-image/turbo`, `recraft`,
+`qwen-image`, plus GPT Image 2.5 Flare and Sunburst above. Pure text-to-image FAL models (`z-image/turbo`, `recraft`,
 `krea/*`) reject image inputs with a clear error pointing you at an
 edit-capable model.
 

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -126,6 +126,36 @@ Auth reuses the same env vars as the Meta chat provider — `MODEL_API_KEY`
 as aliases. Set `META_BASE_URL` to point at a proxy or alternate host. Text-to-image
 only for now; responses are saved to `$HERMES_HOME/cache/images/`.
 
+## OpenAI API: GPT Image 2.5
+
+The **OpenAI** provider supports GPT Image 2.5 Flare (fast everyday creation)
+and Sunburst (precision generation and editing), using `OPENAI_API_KEY`.
+Select them through `hermes tools` → Image Generation → OpenAI, or set:
+
+```bash
+hermes config set image_gen.provider openai
+hermes config set image_gen.openai.model gpt-image-2.5-flare
+```
+
+`gpt-image-2.5-flare` and `gpt-image-2.5-sunburst` use automatic quality.
+Append `-low`, `-medium`, `-high`, `-xhigh`, or `-max` to select a fixed quality,
+for example `gpt-image-2.5-sunburst-high`. Both support generation and editing
+with up to 16 reference images. Existing GPT Image 2 selections and the
+`gpt-image-2-medium` default are unchanged.
+
+This is paid API usage, separate from a ChatGPT/Codex subscription. Both models
+cost $5 per million text-input tokens, $8 per million image-input tokens, and
+$30 per million image-output tokens (cached input rates are $1.25 and $2,
+respectively). Per-image cost varies with usage; the GPT Image 2 calculator
+does not estimate 2.5 token consumption. See the official
+[Flare](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare) and
+[Sunburst](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst) docs.
+
+The **OpenAI (Codex auth)** provider remains separate: its backend can accept
+an image-model value without honoring that selection, so a successful image
+alone does not verify Flare or Sunburst routing. These selections are offered
+only through the direct OpenAI API provider, not Codex auth or FAL.
+
 ## Usage
 
 The agent-facing schema is intentionally minimal — the model picks up whatever you've configured:
@@ -167,7 +197,7 @@ Two inputs drive the edit:
 | Backend | Image-to-image | Reference cap | How |
 |---|---|---|---|
 | **FAL.ai** (edit-capable models below) | ✓ | up to 9 | routes to the model's `/edit` endpoint |
-| **OpenAI** (`gpt-image-2`) | ✓ | up to 16 | `images.edit()` |
+| **OpenAI** (GPT Image 2 / 2.5 Flare / Sunburst) | ✓ | up to 16 | `images.edit()` |
 | **xAI** (Grok Imagine) | ✓ | 1 | `/v1/images/edits` (`grok-imagine-image-quality`) |
 | **Krea** (`Krea 2`) | ✓ | up to 10 | reference-guided generation (`image_style_references`) |
 | **OpenAI (Codex auth)** | ✓ | up to 16 | Codex Responses `image_generation` tool with `input_image` content parts |


### PR DESCRIPTION
GPT Image 2.5 Flare and Sunburst can now be selected for generation and editing through Hermes's existing OpenAI API-key and FAL image providers.

## Changes
- Add both model IDs with automatic quality and low/medium/high/xhigh/max selections to the existing picker.
- Route the selected API model and quality through both generation and edit requests.
- Preserve GPT Image 2 selections, existing defaults, credentials, tool schema, Codex provider, and FAL defaults.
- Document selection, token-based pricing, and the distinction from subscription routing.
- Add FAL Flare and Sunburst picker entries, paired generation/edit endpoints, 16-reference caps, supported payload fields, and explicit medium quality.

Root cause: the provider resolved only GPT Image 2 tiers and hardcoded the underlying API model.

## Validation
**Live repro:** On main `b2aa855b626`, requesting `gpt-image-2.5-flare` resolves to `gpt-image-2-medium`. With this change, real plugin discovery and isolated configuration select the new model; the SDK produces and caches actual images from the official API.

| Check | Result |
|---|---|
| Regression before change | 24 new-model generation/edit cases fail; 6 legacy cases pass |
| Image-provider directory after change | 235 passed, 0 failed across 8 files |
| Live Flare generation through Hermes | HTTP 200; `req_2ebaf086dc364feba4f862dc09e9ba16`; final PNG, visual QA passed |
| Live Sunburst edit through Hermes | HTTP 200; `req_1066f21d503042b581662fca2d75408a`; blue cup becomes red; final PNG, visual QA passed |
| Lint / Windows / compat / whitespace | Passed |

Live calls use real plugin discovery, a temporary HERMES_HOME and the real SDK/HTTP transport. The probe observes response usage and disables SDK retries; it clears an inherited empty OPENAI_BASE_URL (the first probe otherwise failed before HTTP). Only low quality was exercised live; the other quality values are documented by OpenAI and covered by request-routing tests. No live user configuration was changed.

Three paid image requests (one preliminary direct request and two Hermes requests) reported usage pricing to **$0.026962** at published token rates; this is not invoice-confirmed billing. The infographic below is the actual low-quality Flare output from the Hermes live probe.

## Provider availability
- Direct OpenAI Images endpoints work despite GET `/models/<id>` returning 404 during rollout. [Flare documentation](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare.md), [Sunburst documentation](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst.md).
- FAL has now published all four endpoints under `openai/gpt-image-2.5/{flare,sunburst}/{text-to-image,edit}`. This follow-up adds the real endpoint IDs, not the guessed initial paths. All 12 production payloads (four endpoints × three aspect presets) validate against the fetched vendor OpenAPI schemas. New routing/payload regression fails on base.
- **FAL live validation blocked:** a real Hermes FAL plugin request reached `openai/gpt-image-2.5/flare/text-to-image`, but returned HTTP 403: "User is locked. Reason: Exhausted balance." No image was generated, no FAL dollar usage was returned, and no remaining paid probes were attempted. Do not treat schema/unit validation as a successful live FAL generation. Full tools + image-provider run completed: 9,155 passed, 1 failed, 91 skipped across 592 files. The failure is the existing sort executable fixture in `test_execution_flag_detection.py` (missing executed marker); that test and approval code are unchanged from main. Image catalog/payload suite: 56 passed; image-provider directory: 235 passed. CI is running on the new head.
- Codex OAuth generated an image with the Flare ID, but also with a deliberately nonexistent image-model ID, without returning an image-model identity. This does not establish honored model selection. Codex routing remains unchanged; two probes used included subscription usage, with no dollar charge returned.

## Infographic
![Hermes image creation: fast creation, precise edits, model and quality selection](https://files.catbox.moe/0zbkwj.png)
