### PR TITLE
fix(agent): restore relay telemetry for delegate_task subagents

### DIFF
--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -33,8 +33,13 @@ def delegated_child_context(session_id: str | None = None) -> Iterator[None]:
     token = _DELEGATED_CHILD_CONTEXT.set(True)
     try:
         from gateway.session_context import scoped_current_session_id  # lazy: it calls is_delegated_child_context()
+        # Lazy (relay_runtime is heavy and would risk an import cycle at module load).
+        # The child inherited the parent's mid-callback relay markers via copy_context();
+        # reset them so its own LLM/tool calls are Relay-managed and reach the ATOF log
+        # rather than being treated as nested execution and bypassing Relay.
+        from agent.relay_runtime import new_execution_root
 
-        with scoped_current_session_id(session_id):
+        with new_execution_root(), scoped_current_session_id(session_id):
             yield
     finally:
         _DELEGATED_CHILD_CONTEXT.reset(token)

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -847,6 +847,28 @@ def managed_callback_guard():
         _MANAGED_CALLBACK_DEPTH.reset(token)
 
 
+@contextlib.contextmanager
+def new_execution_root():
+    """Clear the relay-execution markers a copy_context() carried in, for an independent turn root.
+
+    A delegate_task child runs on a worker thread launched with
+    ``copy_context().run(...)``, and that copy is taken while the PARENT is mid
+    tool/LLM callback — so ``_MANAGED_CALLBACK_DEPTH`` (>0) and ``_CURRENT_TURN``
+    (the parent's turn) ride along into the child. The child is not nested
+    execution on the parent's blocked loop; it owns its own conversation and
+    turn, so its own LLM/tool calls must be managed. Reset both for the child's
+    context and restore on exit. Nested suppression *inside* the child still
+    works: its own managed callbacks re-enter ``managed_callback_guard`` and
+    push the depth back up while they run."""
+    depth_token = _MANAGED_CALLBACK_DEPTH.set(0)
+    turn_token = _CURRENT_TURN.set(None)
+    try:
+        yield
+    finally:
+        _CURRENT_TURN.reset(turn_token)
+        _MANAGED_CALLBACK_DEPTH.reset(depth_token)
+
+
 def _warn_on_error(what: str, callback: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     """Run fail-open telemetry work: log ``Hermes Relay <what> failed`` and return None on error."""
     try:

--- a/tests/agent/test_relay_nested_execution.py
+++ b/tests/agent/test_relay_nested_execution.py
@@ -231,3 +231,52 @@ def test_resolve_execution_context_bypasses_inside_guard(relay_turn):
     # Outside the guard the context resolves normally again.
     runtime, session, _parent = relay_runtime.resolve_execution_context("session-1")
     assert runtime is not None and session is not None
+
+
+# --- new_execution_root: the delegate_task child's own root -----------------
+#
+# The bypass above is right for a NESTED call on the parent's blocked loop, but
+# wrong for a delegate_task child: it runs on a worker thread whose context was
+# copy_context()'d from the parent WHILE the parent was mid-callback, so the
+# guard's marker (and the parent's _CURRENT_TURN) ride in and suppress relay for
+# every child LLM call — the child's session/turn scopes open but nothing hangs
+# under them, and nothing reaches ATOF. new_execution_root clears both for the
+# child's own root; the child's own nested callbacks re-raise the guard as before.
+
+
+def test_new_execution_root_clears_and_restores_inherited_markers():
+    depth, turn = relay_runtime._MANAGED_CALLBACK_DEPTH, relay_runtime._CURRENT_TURN
+    depth_token, turn_token = depth.set(2), turn.set("parent-turn")
+    try:
+        with relay_runtime.new_execution_root():
+            assert depth.get() == 0
+            assert turn.get() is None
+        # Both restored on exit — a sibling turn in the same context is unaffected.
+        assert depth.get() == 2
+        assert turn.get() == "parent-turn"
+    finally:
+        turn.reset(turn_token)
+        depth.reset(depth_token)
+
+
+def test_new_execution_root_restores_managed_execution_under_inherited_guard(relay_turn):
+    """With the parent's callback marker inherited (the regression), resolution is
+    suppressed; inside new_execution_root the child resolves and runs managed again."""
+    with relay_runtime.managed_callback_guard():
+        runtime, session, _ = relay_runtime.resolve_execution_context("session-1")
+        assert runtime is None and session is None
+        with relay_runtime.new_execution_root():
+            runtime, session, _ = relay_runtime.resolve_execution_context("session-1")
+            assert runtime is not None and session is not None
+
+
+def test_delegated_child_context_restores_managed_execution_under_inherited_guard(relay_turn):
+    """The seam the real child runs through applies the reset (delegate_tool_child_run
+    wraps child.run_conversation in delegated_child_context)."""
+    from agent.delegation_context import delegated_child_context
+
+    with relay_runtime.managed_callback_guard():
+        assert relay_runtime.resolve_execution_context("session-1")[0] is None
+        with delegated_child_context("session-1"):
+            runtime, session, _ = relay_runtime.resolve_execution_context("session-1")
+            assert runtime is not None and session is not None


### PR DESCRIPTION
## What does this PR do?

`delegate_task` subagents emit session/turn scopes to NeMo Relay but none of their LLM/tool calls, so delegated work is invisible to every Relay exporter (I hit this building [Hobserver](https://github.com/justincc/hobserver), a viewer for the ATOF scope stream — subagent turns rendered as empty shells).

The child runs on a daemon worker launched via `contextvars.copy_context().run(...)` while the parent is mid tool-callback, so it inherits `_MANAGED_CALLBACK_DEPTH > 0` (the marker #77244 made a `ContextVar` precisely so it follows `copy_context()` into worker threads) and every child call takes the `resolve_execution_context` bypass and runs unmanaged. This resets the inherited relay-execution markers at the child's boundary, so a subagent — an independent execution root — is instrumented like any other turn, while genuine nested suppression inside the child is preserved.

## Related Issue

Fixes #105989

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/relay_runtime.py` — add `new_execution_root()` context manager: resets `_MANAGED_CALLBACK_DEPTH` to 0 and `_CURRENT_TURN` to None, restoring both on exit.
- `agent/delegation_context.py` — wrap `delegated_child_context`'s body in `new_execution_root()`, so the seam every child runs through clears the inherited markers.
- `tests/agent/test_relay_nested_execution.py` — cover the reset/restore, and that both `resolve_execution_context` and the `delegated_child_context` seam recover managed execution under an inherited callback guard.

## How to Test

1. With a Relay exporter active, run a `delegate_task` and confirm each subagent `hermes.turn` now has `hermes.logical_llm_call` + provider call scopes beneath it (before: none).
2. `pytest tests/agent/test_relay_nested_execution.py -q` → the 3 new tests pass alongside the existing #77244 regression tests.
3. Confirms the #77244 fix is intact: `test_nested_aux_llm_call_inside_managed_tool_does_not_cross_loops` and `test_resolve_execution_context_bypasses_inside_guard` still pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the relay + delegation slice instead (330 passed / 1 skipped, 0 failures): `tests/agent/test_relay_nested_execution.py`, `test_relay_llm.py`, `test_relay_shared_metrics_runtime.py`, `test_subagent_lifecycle.py`, `test_delegation_session_id_leak.py`, `test_kanban_budget_checkpoint.py`, `test_hermes_subprocess_env.py`, `test_delegate_kanban_isolation.py`, `test_async_delegation.py`, `test_delegate.py`, `test_subagent_process_handoff.py`, `test_subagent_steer.py`, `test_delegate_control_actions.py`. Happy to run the full suite if preferred.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (kernel 6.8.x)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no user-facing docs; the change is documented in the new context manager's docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure `contextvars`, platform-neutral)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
