### PR TITLE
feat(tui): add /cd slash command and scope path completion to session cwd

### DIFF
--- a/ui-tui/src/__tests__/useCompletion.test.ts
+++ b/ui-tui/src/__tests__/useCompletion.test.ts
@@ -32,4 +32,22 @@ describe('completionRequestForInput', () => {
   it('leaves plain text alone', () => {
     expect(completionRequestForInput('hello there')).toBeNull()
   })
+
+  it('passes session_id to path completion when a session is active', () => {
+    expect(completionRequestForInput('./src', 'sess-123')).toMatchObject({
+      method: 'complete.path',
+      params: { word: './src', session_id: 'sess-123' },
+      replaceFrom: 0
+    })
+  })
+
+  it('omits session_id from path completion when no session is active', () => {
+    const req = completionRequestForInput('./src', null)
+    expect(req).toMatchObject({
+      method: 'complete.path',
+      params: { word: './src' },
+      replaceFrom: 0
+    })
+    expect(req?.params).not.toHaveProperty('session_id')
+  })
 })

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -13,7 +13,7 @@ import type {
 } from '../../../gatewayTypes.js'
 import { formatVoiceRecordKey, parseVoiceRecordKey } from '../../../lib/platform.js'
 import { fmtK } from '../../../lib/text.js'
-import type { PanelSection } from '../../../types.js'
+import type { PanelSection, SessionInfo } from '../../../types.js'
 import { applyConfiguredTuiTheme } from '../../createGatewayEventHandler.js'
 import { DEFAULT_INDICATOR_STYLE, INDICATOR_STYLES, type IndicatorStyle } from '../../interfaces.js'
 import { patchOverlayState } from '../../overlayStore.js'
@@ -205,6 +205,35 @@ export const sessionCommands: SlashCommand[] = [
       }
 
       patchOverlayState({ sessions: true })
+    }
+  },
+
+  {
+    aliases: ['cwd'],
+    help: 'change the session working directory',
+    name: 'cd',
+    usage: '/cd <path>',
+    run: (arg, ctx) => {
+      const path = arg.trim()
+
+      if (!path) {
+        return ctx.transcript.sys('usage: /cd <path>')
+      }
+
+      if (!ctx.sid) {
+        return ctx.transcript.sys('error: no active session')
+      }
+
+      ctx.gateway.rpc<SessionInfo>('session.cwd.set', { session_id: ctx.sid, cwd: path }).then(
+        ctx.guarded<SessionInfo>(r => {
+          if (!r?.cwd) {
+            return
+          }
+
+          ctx.transcript.sys(`cwd → ${r.cwd}`)
+          patchUiState(state => (state.info ? { ...state, info: { ...state.info, cwd: r.cwd } } : state))
+        })
+      )
     }
   },
 

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -142,7 +142,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   } = useQueue()
 
   const { historyRef, historyIdx, setHistoryIdx, historyDraftRef, pushHistory } = useInputHistory()
-  const { completions, compIdx, setCompIdx, compReplace } = useCompletion(input, isBlocked, gw)
+  const { completions, compIdx, setCompIdx, compReplace } = useCompletion(input, isBlocked, gw, getUiState().sid)
 
   const clearIn = useCallback(() => {
     setInput('')

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -29,9 +29,10 @@ export function mergeWidgetAppItems(input: string, items: CompletionItem[]): Com
 const TAB_PATH_RE = /((?:["']?(?:[A-Za-z]:[\\/]|\.{1,2}\/|~\/|\/|@|[^"'`\s]+\/))[^\s]*)$/
 
 export function completionRequestForInput(
-  input: string
+  input: string,
+  sessionId?: string | null
 ):
-  | { method: 'complete.path'; params: { word: string }; replaceFrom: number }
+  | { method: 'complete.path'; params: { word: string; session_id?: string }; replaceFrom: number }
   | { method: 'complete.slash'; params: { text: string }; replaceFrom: number; skillsOnly?: boolean }
   | null {
   const isSlashCommand = looksLikeSlashCommand(input)
@@ -71,12 +72,12 @@ export function completionRequestForInput(
 
   return {
     method: 'complete.path',
-    params: { word: pathWord },
+    params: { word: pathWord, ...(sessionId ? { session_id: sessionId } : {}) },
     replaceFrom: input.length - pathWord.length
   }
 }
 
-export function useCompletion(input: string, blocked: boolean, gw: GatewayClient) {
+export function useCompletion(input: string, blocked: boolean, gw: GatewayClient, sessionId?: string | null) {
   const [completions, setCompletions] = useState<CompletionItem[]>([])
   const [compIdx, setCompIdx] = useState(0)
   const [compReplace, setCompReplace] = useState(0)
@@ -102,7 +103,7 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
 
     ref.current = input
 
-    const request = completionRequestForInput(input)
+    const request = completionRequestForInput(input, sessionId)
 
     if (!request) {
       clear()
@@ -163,7 +164,7 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
     }, 60)
 
     return () => clearTimeout(t)
-  }, [blocked, gw, input])
+  }, [blocked, gw, input, sessionId])
 
   return { completions, compIdx, setCompIdx, compReplace }
 }


### PR DESCRIPTION
## Summary

The TUI sent `complete.path` without a `session_id`, so `@file:` and `./` path completion resolved against the **launch directory** (`os.getcwd()`) instead of the session's working directory. This made it impossible to start file listings from the project folder you `cd`'d into.

This PR:

1. **Adds `/cd <path>`** (alias `/cwd`) slash command that calls the existing `session.cwd.set` RPC to change the current session's working directory.
2. **Propagates `session_id` into `complete.path`** so path completion (`./`, `@file:`) resolves relative to the session cwd after a `/cd`.

## Why

There is currently no way to change the working directory once a Hermes session has started (see #50195). The backend `session.cwd.set` RPC already exists (`tui_gateway/methods_session.py`) but nothing in the TUI frontend called it, and `complete.path` never carried the session id — so the backend fell back to `TERMINAL_CWD`/`os.getcwd()`.

## Changes

- `ui-tui/src/hooks/useCompletion.ts` — `completionRequestForInput` and `useCompletion` accept an optional `sessionId`; `complete.path` now includes `session_id` when a session is active.
- `ui-tui/src/app/useComposerState.ts` — passes `getUiState().sid` into `useCompletion`.
- `ui-tui/src/app/slash/commands/session.ts` — new `/cd` command (alias `/cwd`) calling `session.cwd.set`.
- `ui-tui/src/__tests__/useCompletion.test.ts` — tests for `session_id` propagation.

## Test Plan

- `npx tsc --noEmit -p tsconfig.json` — 0 errors
- `npx vitest run src/__tests__/useCompletion.test.ts` — 6 passed
- `npx vitest run src/__tests__/createSlashHandler.test.ts src/__tests__/slashParity.test.ts` — 88 passed
- `npx eslint` on changed files — clean

## Related work

#23535 (`/set-workspace`, alias `/cd`) is a CLI-level approach to switching the session working directory mid-session. It is complementary, not overlapping: it updates `TERMINAL_CWD` and downstream caches, but does **not** fix the root cause this PR addresses — the TUI sending `complete.path` without a `session_id`, which made `./` and `@file:` completion resolve against the launch directory. This PR fixes that bug directly and adds a TUI-native `/cd` that calls the existing `session.cwd.set` RPC.

Closes #50195
