### PR TITLE
fix(redact): keep Authorization-header redaction line-scoped and value-gated so YAML config survives

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -276,7 +276,7 @@ _JSON_FIELD_RE = re.compile(rf'("{_JSON_KEY_NAMES}")\s*:\s*"([^"]+)"', re.IGNORE
 # name and scheme word preserved. The credential class excludes quotes: pulling
 # a closing quote into the mask turns value corruption into SYNTAX corruption
 # (unterminated quote → shell EOF / SyntaxError).
-_AUTH_HEADER_RE = re.compile(r"((?:Proxy-)?Authorization:\s*)([A-Za-z][\w.+-]*\s+)?([^\s\"']+)", re.IGNORECASE)
+_AUTH_HEADER_RE = re.compile(r"((?:Proxy-)?Authorization:[ \t]*)([A-Za-z][\w.+-]*[ \t]+)?([^\s\"']+)", re.IGNORECASE)
 
 # API-key style headers (single opaque value, no scheme word): non-vendor-prefix
 # values would otherwise leak when a curl command is echoed into tool output.
@@ -601,7 +601,23 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
         text = _redact_assignments(text)
 
     if "uthorization" in text or "UTHORIZATION" in text:  # cheapest gate over every casing
-        text = _AUTH_HEADER_RE.sub(lambda m: m.group(1) + (m.group(2) or "") + _mask_token(m.group(3)), text)
+        # Value-aware gate (issue #96607 pattern): a short non-opaque scalar after
+        # ``authorization:*** — ``true``/``false``/``yes`` in config/YAML — is a
+        # legitimate value, not a credential; the bare-word credential class is
+        # only trusted when the value has credential shape. A scheme word
+        # (Bearer/Basic/...) is a strong "this is a real header" signal, so any
+        # scheme'd value masks unconditionally. Real header tokens
+        # (vendor-prefix, base64, ≥12 mixed-class) still match; prefix-matched
+        # vendor tokens are already handled by the prefix pass above
+        # (ordering matters: the prefix pass runs before this one).
+        def _auth_sub(m):
+            credential = m.group(3)
+            masked = (
+                m.group(2) is not None  # scheme word present → real header
+                or _looks_like_opaque_credential(credential))
+            return m.group(1) + (m.group(2) or "") + (
+                _mask_token(credential) if masked else credential)
+        text = _AUTH_HEADER_RE.sub(_auth_sub, text)
 
     if ":" in text:
         text = _SECRET_HEADER_RE.sub(lambda m: m.group(1) + _mask_token(m.group(2)), text)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -294,6 +294,58 @@ class TestAuthHeaders:
         text = "the authorization model is fully open"
         assert redact_sensitive_text(text) == text
 
+    def test_authorization_yaml_key_not_redacted_across_lines(self):
+        # Regression: the Authorization-header regex's `\s` matched the newline
+        # after a short YAML boolean, so `authorization: true\n  additional_creators_allowed: false`
+        # was redacted as a "credential", destroying two legitimate config lines
+        # (observed corrupting a delivered context bundle). The header pass must
+        # stay line-scoped.
+        text = (
+            "  bootstrap_requires_operator_authorization: true\n"
+            "  additional_creators_allowed: false\n"
+        )
+        assert redact_sensitive_text(text) == text
+
+    def test_authorization_multiline_block_preserved(self):
+        # Same bug class in a larger block: nothing on the following line may be
+        # swallowed, and no newline may be deleted (mask_token strips control chars).
+        text = (
+            "creation:\n"
+            "  bootstrap_requires_operator_authorization: true\n"
+            "  delegation_of_creation_authority_allowed: false\n"
+            "authority:\n"
+            "  architect:\n"
+            "    - prepare target-sphere knowledge directories\n"
+        )
+        assert redact_sensitive_text(text) == text
+
+    def test_auth_header_with_scheme_word_masks_short_values(self):
+        # Gate-interaction contract: a scheme word (Bearer/Basic/...) marks a real
+        # header, so even a short single-class value masks unconditionally — the
+        # value-shape gate applies only to BARE values (YAML booleans etc.).
+        for text in (
+            "Authorization: Basic YWJjOnB3",   # 10-char base64 creds
+            "authorization: Bearer abc123",    # 6-char mixed
+            "Authorization: bearer deadbeef",  # 8-char hex nonce
+        ):
+            result = redact_sensitive_text(text)
+            assert "YWJjOnB3" not in result, text
+            assert "abc123" not in result, text
+            assert "deadbeef" not in result, text
+
+    def test_auth_header_vendor_prefixed_short_token_masked(self):
+        # The value gate's bare-word safety relies on the prefix pass masking
+        # vendor-prefixed tokens (ordering: prefix pass runs before this one).
+        text = "Authorization: token ghp_abc"
+        result = redact_sensitive_text(text)
+        assert "ghp_abc" not in result, result
+
+    def test_authorization_crlf_payload_preserved(self):
+        # [ \t] deliberately excludes \r — a CRLF YAML boolean must pass through
+        # unchanged (no key on the next line swallowed).
+        text = "bootstrap_requires_operator_authorization: true\r\n  additional_creators_allowed: false\r\n"
+        assert redact_sensitive_text(text) == text
+
     def test_token_flush_against_double_quote_preserves_quote(self):
         # Regression for #43083: a token sitting flush against a closing
         # double quote must NOT pull that quote into the mask. Greedy \S+


### PR DESCRIPTION
## Problem

The secret-redaction layer's Authorization-header regex (`_AUTH_HEADER_RE`) uses `\s` (which matches newlines) for whitespace after the header name, and a credential class that captures whatever follows. So a completely benign YAML config file containing:

```yaml
bootstrap_requires_operator_authorization: true
additional_creators_allowed: false
```

is treated as a header: the regex matches `...authorization:` as the header name, ` true\n  ` as the auth scheme, and `additional_creators_allowed` (the NEXT LINE's key) as the credential. The redactor then masks the key and strips the newline, corrupting two legitimate config lines into one broken line: `***  additi***wed: false`.

We hit this in production: a context bundle delivered to a worker agent contained this exact corruption, and the worker correctly blocked on what looked like incomplete startup context.

## Fix (minimal, 2 parts)

1. **`\s` → `[ \t]`** in both whitespace spots of `_AUTH_HEADER_RE`: the match can no longer span a line boundary. (The negated credential class `[^\s"']+` already refused newlines, so only the explicit `\s` needed scoping.)
2. **Value-aware gate** (pattern already used in this codebase, cf. issue #96607): a bare value after `authorization:` only masks when it has credential shape (`_looks_like_opaque_credential`) — config scalars like `true`/`false`/`yes` pass through. A scheme word (`Bearer`, `Basic`, ...) is a strong real-header signal, so scheme'd values mask unconditionally; bare YAML booleans are never scheme'd, so they survive either way.

## Tests

- 2 new regression tests in `TestAuthHeaders` reproduce the exact production payload (policy.yaml boolean pair) and a multiline YAML block variant. Both are **RED on the old code, GREEN after the fix**.
- Scheme-word short-value masking (`Basic YWJj`, `Bearer abc123`), vendor-prefix pass interaction, and CRLF invariants pinned by 3 further tests.
- Full suites green: 121/121 `tests/agent/test_redact.py`; 59/59 across the 9 other redaction-consumer files (registry, terminal error/output hooks, kanban, gateway approval prompts, TUI, monitoring export).
- End-to-end: the real offending bundle now passes `redact_sensitive_text()` **byte-intact** (newline count preserved), while a real JWT bearer token placed in the same text is still masked.

The fix was independently reviewed (diagnosis reproduced from a clean clone pre-fix; a narrow leak in the initial patch — short scheme'd credentials passing the value gate — was caught and closed before submission).

## Notes

- The head/tail-mask non-idempotency on double pass (noted during review) is pre-existing and out of scope for this minimal fix.
- Prior regression in the same "mask corrupts surrounding syntax" class: #43083.
