### PR TITLE
fix(gateway): prime provider context metadata during startup warm-up

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -953,7 +953,8 @@ def _warm_turn_machinery_sync() -> int:
     """Synchronously initialize first-turn prerequisites (executor thread); returns the schema count.
 
     Covers the lazy init seen in skeleton turns: ``run_agent`` import graph, tool schemas (+ ``check_fn``
-    TTL cache), context files."""
+    TTL cache), context files, and the default route's context-window metadata — a catalog HTTP probe
+    that must not sit between the first inbound turn and its inference request."""
     import run_agent  # noqa: F401  # heavy import graph, cached in sys.modules
     import model_tools
 
@@ -964,6 +965,10 @@ def _warm_turn_machinery_sync() -> int:
         build_context_files_prompt()
     except Exception:
         logger.debug("context-file warm-up failed (non-fatal)", exc_info=True)
+    try:
+        _resolve_gateway_model_context()
+    except Exception:
+        logger.debug("model-context warm-up failed (non-fatal)", exc_info=True)
     return len(tool_defs)
 
 

--- a/tests/gateway/test_startup_model_context_warmup.py
+++ b/tests/gateway/test_startup_model_context_warmup.py
@@ -1,0 +1,72 @@
+"""Model-context warm-up inside the gateway boot warm-up (#105986).
+
+The startup warm-up used to prime only the import graph, tool schemas and
+context files. The first inbound turn then paid a blocking catalog HTTP probe
+(codex OAuth, OpenRouter metadata) inside AIAgent construction — between the
+submit ACK and the actual inference request. The warm-up now resolves the
+default route's context metadata up front with the same route/credential rules
+as normal execution, so the probe's process-local caches are primed before the
+inbound gate opens.
+"""
+
+from unittest.mock import patch
+
+import gateway.run as gateway_run
+
+
+def test_model_context_warmup_primes_default_route(monkeypatch):
+    """Warm-up resolves the default route's model context once, best-effort."""
+    resolved: list = []
+
+    def fake_resolve(model=None):
+        resolved.append(model)
+        return "primed"
+
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model_context", fake_resolve)
+    import model_tools
+
+    monkeypatch.setattr(
+        model_tools, "get_tool_definitions", lambda quiet_mode=False: []
+    )
+
+    count = gateway_run._warm_turn_machinery_sync()
+    assert count == 0
+    assert resolved == [None]
+
+
+def test_model_context_warmup_failure_is_non_fatal(monkeypatch):
+    """A resolver failure degrades to lazy init — warm-up still returns the tool count."""
+
+    def boom(_model=None):
+        raise RuntimeError("catalog unreachable")
+
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model_context", boom)
+    import model_tools
+
+    monkeypatch.setattr(
+        model_tools, "get_tool_definitions", lambda quiet_mode=False: ["t"] * 7
+    )
+
+    count = gateway_run._warm_turn_machinery_sync()
+    assert count == 7
+
+
+def test_model_context_warmup_runs_after_tool_schemas(monkeypatch):
+    """Schema materialization is never skipped because of metadata resolution order."""
+    order: list = []
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_gateway_model_context",
+        lambda model=None: order.append("model-context"),
+    )
+    import model_tools
+
+    monkeypatch.setattr(
+        model_tools,
+        "get_tool_definitions",
+        lambda quiet_mode=False: order.append("tool-schemas") or [],
+    )
+
+    gateway_run._warm_turn_machinery_sync()
+    assert order == ["tool-schemas", "model-context"]


### PR DESCRIPTION
## Problem

The gateway startup warm-up (`_warm_turn_machinery_sync`, gateway/run.py) primes the `run_agent` import graph, tool schemas and context files, but not the configured provider's context-window metadata. The first inbound turn then pays a blocking catalog HTTP probe inside `AIAgent` construction — `ContextCompressor.context_length` → `get_model_context_length()` → e.g. codex OAuth `GET /backend-api/codex/models` (1h process-local cache) or an OpenRouter metadata fetch — sitting between the submit ACK and the actual inference request. Fixes #105986.

## Fix

`_warm_turn_machinery_sync` now additionally calls `_resolve_gateway_model_context()` (best-effort, same non-fatal pattern as the context-file warm-up right above it). That resolver already applies the exact route/credential/profile rules of normal execution, so resolving it inside the existing executor-thread warm-up primes the catalog caches before the inbound gate opens.

- No hardcoded context limits, no config changes, no inference invoked.
- A resolver failure logs at debug and degrades to the historical lazy init — the bounded startup gate and its availability bound are untouched.
- Token/profile cache isolation, context-limit precedence and cache expiry are preserved because the same resolver and caches are used.

## Testing

- `env -u HERMES_YOLO_MODE .venv/bin/python -m pytest tests/gateway/test_startup_model_context_warmup.py -q` → **3 passed** (default-route priming, non-fatal failure, ordering after tool schemas).
- Full #99373 warm-up gate suite `tests/gateway/test_restart_resume_pending.py -q` → **39 passed**.
- Mutation check: removing the resolver call turns the priming/ordering tests red (2 failed), restored → green.
- `ruff check` clean on both files; `ruff format` diff count on `gateway/run.py` unchanged vs pristine main (2471 = 2471, no new drift); the new test file is fully formatted.

```patch
     try:
         from agent.prompt_builder import build_context_files_prompt

         build_context_files_prompt()
     except Exception:
         logger.debug("context-file warm-up failed (non-fatal)", exc_info=True)
+    try:
+        _resolve_gateway_model_context()
+    except Exception:
+        logger.debug("model-context warm-up failed (non-fatal)", exc_info=True)
     return len(tool_defs)
```
