### PR TITLE
fix(verifier): reconcile file-mutation footer against untracked writers

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -454,6 +454,7 @@ def _reset_per_turn_agent_state(agent: Any) -> None:
         setattr(agent, name, value)
     agent._turn_failed_file_mutations = {}
     agent._turn_file_mutation_paths = set()
+    agent._turn_file_mutation_baselines = {}
     agent._tool_guardrails.reset_for_turn()
     _reset_consol = getattr(agent._memory_store, "reset_consolidation_failures", None)
     if callable(_reset_consol):

--- a/agent/turn_explainers.py
+++ b/agent/turn_explainers.py
@@ -179,8 +179,18 @@ class TurnExplainersMixin:
     ) -> None:
         """Record a ``write_file`` / ``patch`` outcome for the turn-end verifier.
 
-        Failures store ``{path: {error_preview, tool}}``; a later success on the same path removes the entry.
-        No-op when the per-turn state dict is not initialised (tool dispatched outside ``run_conversation``).
+        Failures store ``{path: {error_preview, tool}}``; a later success on the same path
+        removes the entry. When a failure is recorded, the path's on-disk fingerprint
+        (mtime_ns, size, inode) is snapshotted into ``_turn_file_mutation_baselines`` so the
+        footer can tell, at turn end, whether the file was modified by an UNTRACKED writer
+        (terminal, MCP tool, editor, watcher) after the tracked failure. The fingerprint is
+        captured at failure time — the model only falls back to an untracked writer after
+        seeing the failure, so a turn-start baseline would observe unrelated earlier writes —
+        and kept first-write-wins, mirroring the keep-first-error rule above: a later
+        retried failure must not re-anchor the baseline to the post-fallback state.
+        ``None`` is the explicit "path did not exist" sentinel, distinct from "no baseline
+        recorded" (unknown). No-op when the per-turn state dict is not initialised (tool
+        dispatched outside ``run_conversation``).
         """
         if tool_name not in _FILE_MUTATING_TOOLS:
             return
@@ -206,11 +216,62 @@ class TurnExplainersMixin:
         if is_error and not landed:
             # Keep the FIRST error per path unless a later success replaces it.
             preview = _extract_error_preview(result)
+            baselines = getattr(self, "_turn_file_mutation_baselines", None)
             for path in targets:
-                state.setdefault(path, {"tool": tool_name, "error_preview": preview})
+                if path not in state:
+                    state[path] = {"tool": tool_name, "error_preview": preview}
+                    if baselines is not None and path not in baselines:
+                        baselines[path] = self._snapshot_file_fingerprint(path)
         else:
+            baselines = getattr(self, "_turn_file_mutation_baselines", None)
             for path in targets:
                 state.pop(path, None)
+                if baselines is not None:
+                    baselines.pop(path, None)
+
+    @staticmethod
+    def _snapshot_file_fingerprint(path: str):
+        """``(st_mtime_ns, st_size, st_ino)`` for *path*, or ``None`` if it does not exist.
+
+        Read-side only: the raw key (possibly ``~``- or relative) is resolved for the stat
+        call, but the baselines dict is keyed by the same raw string the failure dict uses,
+        so footer-time lookups line up. ``None`` is the "confirmed absent" sentinel —
+        distinct from a missing key, which means "never snapshotted" (unknown).
+        Note: a transient OSError at footer time (permission race, not a deletion) is
+        indistinguishable from "deleted" and reads as changed — the safe direction, since
+        the dangerous claim (a changed file rendered "NOT modified") can never result.
+        """
+        try:
+            st = os.stat(os.path.expanduser(path))
+            return (st.st_mtime_ns, st.st_size, st.st_ino)
+        except OSError:
+            return None
+
+    def _reconcile_file_mutation_failures(self, failed: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+        """Mark failed-mutation entries whose file changed on disk after the tracked failure.
+
+        Compares the footer-time fingerprint against the failure-time baseline in
+        ``_turn_file_mutation_baselines``. Any difference (or absent→present,
+        present→absent) marks the entry with ``external_change: True`` so the footer can
+        reword it — the tracked tool still did not write the file, but the file is no
+        longer "NOT modified", and dropping the entry would also suppress the genuine
+        over-claim case where an unrelated writer happened to touch the same path.
+        Returns a NEW dict; never mutates *failed* or per-turn state. A missing baseline
+        (unknown) leaves the entry unmarked — on ambiguity the warning is preserved.
+        """
+        baselines = getattr(self, "_turn_file_mutation_baselines", None)
+        if not baselines:
+            return failed
+        reconciled: Dict[str, Dict[str, Any]] = {}
+        for path, info in failed.items():
+            entry = dict(info)
+            baseline = baselines.get(path)
+            if baseline is not None or path in baselines:
+                current = self._snapshot_file_fingerprint(path)
+                if current != baseline:
+                    entry["external_change"] = True
+            reconciled[path] = entry
+        return reconciled
 
     def _file_mutation_verifier_enabled(self) -> bool:
         """``display.file_mutation_verifier`` / ``HERMES_FILE_MUTATION_VERIFIER`` (a patchable seam)."""
@@ -252,17 +313,33 @@ class TurnExplainersMixin:
         """
         if not failed:
             return ""
-        lines = [
-            "⚠️ File-mutation verifier: "
-            f"{len(failed)} file(s) were NOT modified this turn despite any "
-            "wording above that may suggest otherwise. Run `git status` or "
-            "`read_file` to confirm."
-        ]
+        changed = [p for p, info in failed.items() if info.get("external_change")]
+        unchanged = [p for p in failed if p not in changed]
+        lines = ["⚠️ File-mutation verifier: "]
+        if unchanged:
+            lines.append(
+                f"{len(unchanged)} file(s) were NOT modified this turn despite any "
+                "wording above that may suggest otherwise"
+            )
+        if changed:
+            if unchanged:
+                lines.append(";")
+            lines.append(
+                f"{len(changed)} file(s) failed but changed on disk through an "
+                "untracked writer after the failure"
+            )
+        lines[-1] += ". Run `git status` or `read_file` to confirm."
         shown = list(failed.items())[:10]
         for path, info in shown:
             preview = (info.get("error_preview") or "").strip()
             tool = info.get("tool") or "patch"
-            lines.append(f"  • `{path}` — [{tool}] {preview or 'failed'}")
+            line = f"  • `{path}` — [{tool}] {preview or 'failed'}"
+            if info.get("external_change"):
+                line += (
+                    " — file changed on disk after this failure via an untracked "
+                    "writer (e.g. a terminal command); the tracked tool still did not write it"
+                )
+            lines.append(line)
         remaining = len(failed) - len(shown)
         if remaining > 0:
             lines.append(f"  • … and {remaining} more")

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -336,7 +336,13 @@ def _log_turn_exit(agent, messages, final_response, api_call_count, _turn_exit_r
 
 def _append_file_mutation_footer(agent, final_response, logger):
     """Append the verifier advisory when ``write_file`` / ``patch`` calls failed and were
-    never superseded by a successful write to the same path (surfaces over-claiming)."""
+    never superseded by a successful write to the same path (surfaces over-claiming).
+
+    Failures whose file changed on disk through an UNTRACKED writer after the tracked
+    failure are reconciled first (``_reconcile_file_mutation_failures``): the entry is
+    reworded rather than dropped, so the absolute "NOT modified" claim is never false while
+    the over-claiming signal is preserved.
+    """
     try:
         # File-mutation verifier footer. This catches the specific case — reported by Ben Eng
         # (#15524-adjacent) — where a model issues a batch of parallel patches, half of them fail with
@@ -347,6 +353,7 @@ def _append_file_mutation_footer(agent, final_response, logger):
         # Empty/interrupted turns already have other surface text that shouldn't be augmented.
         _failed = getattr(agent, "_turn_failed_file_mutations", None) or {}
         if _failed and agent._file_mutation_verifier_enabled():
+            _failed = agent._reconcile_file_mutation_failures(_failed)
             footer = agent._format_file_mutation_failure_footer(_failed)
             if footer:
                 final_response = final_response.rstrip() + "\n\n" + footer

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -109,8 +109,12 @@ def _bare_agent() -> AIAgent:
     the agent pitfalls list.
     """
     agent = object.__new__(AIAgent)
+    # The three per-turn attributes below must mirror _reset_per_turn_agent_state
+    # (agent/turn_context.py); without the baselines dict the reconciler silently
+    # no-ops and new tests turn green for the wrong reason.
     agent._turn_failed_file_mutations = {}
     agent._turn_file_mutation_paths = set()
+    agent._turn_file_mutation_baselines = {}
     return agent
 
 
@@ -227,6 +231,76 @@ class TestRecordFileMutationResult:
         # the initial root cause.
         assert "first error" in agent._turn_failed_file_mutations["/tmp/a.md"]["error_preview"]
 
+    def test_failure_snapshots_baseline_first_write_wins(self, tmp_path):
+        """The failure-time fingerprint anchors the earliest failure, not a retry.
+
+        patch #1 fails at T1; an out-of-band (untracked) write lands at T2; a retried
+        patch #2 fails at T3 against the now-changed file. If the baseline re-anchored to
+        T3, the footer-time comparison would see no change and the false "NOT modified"
+        warning would survive — the original bug. First-write-wins keeps the T1 anchor, so
+        the reconciler marks the entry external_change.
+        """
+        f = tmp_path / "a.md"
+        f.write_text("v1")
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch", {"mode": "replace", "path": str(f), "old_string": "x", "new_string": "y"},
+            json.dumps({"error": "first error"}), is_error=True,
+        )
+        # Untracked writer (terminal fallback) rewrites the file with different-length content.
+        f.write_text("v2 changed by terminal fallback")
+        agent._record_file_mutation_result(
+            "patch", {"mode": "replace", "path": str(f), "old_string": "stale", "new_string": "y"},
+            json.dumps({"error": "second error"}), is_error=True,
+        )
+        reconciled = agent._reconcile_file_mutation_failures(agent._turn_failed_file_mutations)
+        assert reconciled[str(f)]["external_change"] is True
+        # First error still kept; the dict was not mutated in place.
+        assert "first error" in agent._turn_failed_file_mutations[str(f)]["error_preview"]
+        assert "external_change" not in agent._turn_failed_file_mutations[str(f)]
+
+    def test_missing_path_records_absent_sentinel_and_creation_marks_external(self, tmp_path):
+        """Absent at failure time is a sentinel, not an absence: creation later rewords.
+
+        A failed patch targeting a path that does not exist records the explicit "did not
+        exist" sentinel. If an untracked writer creates the file before turn end, the
+        footer must not claim it was NOT modified. A missing baseline (never snapshotted)
+        is a different state — unknown — and keeps the unmarked, full-strength warning.
+        """
+        f = tmp_path / "new.md"
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch", {"mode": "replace", "path": str(f), "old_string": "x", "new_string": "y"},
+            json.dumps({"error": "no such file"}), is_error=True,
+        )
+        assert agent._turn_file_mutation_baselines[str(f)] is None
+        # Untracked writer creates the file.
+        f.write_text("created by terminal")
+        reconciled = agent._reconcile_file_mutation_failures(agent._turn_failed_file_mutations)
+        assert reconciled[str(f)]["external_change"] is True
+
+        # Unknown baseline (no key at all) stays unmarked.
+        agent2 = _bare_agent()
+        failed2 = {str(tmp_path / "ghost.md"): {"tool": "patch", "error_preview": "boom"}}
+        assert "external_change" not in agent2._reconcile_file_mutation_failures(failed2)[str(tmp_path / "ghost.md")]
+
+    def test_success_drops_baseline(self, tmp_path):
+        """A landed write pops the path's baseline alongside the failure entry."""
+        f = tmp_path / "a.md"
+        f.write_text("v1")
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch", {"mode": "replace", "path": str(f), "old_string": "x", "new_string": "y"},
+            json.dumps({"error": "not found"}), is_error=True,
+        )
+        assert str(f) in agent._turn_file_mutation_baselines
+        agent._record_file_mutation_result(
+            "patch", {"mode": "replace", "path": str(f), "old_string": "v1", "new_string": "v2"},
+            json.dumps({"success": True, "files_modified": [str(f)]}), is_error=False,
+        )
+        assert agent._turn_failed_file_mutations == {}
+        assert str(f) not in agent._turn_file_mutation_baselines
+
 
 
 
@@ -248,6 +322,67 @@ class TestFormatFooter:
         assert "/tmp/a.md" in out
         assert "Could not find old_string" in out
         assert "git status" in out  # user-actionable hint
+
+    def test_external_write_after_failure_rewords_footer(self, tmp_path):
+        """Reproduction of the 2026-09-08 false positive, end to end.
+
+        A tracked patch fails; an untracked writer (terminal fallback) rewrites the file
+        out of band; at turn end the footer must NOT claim the file was "NOT modified".
+        The entry survives (reword, never drop — dropping would also suppress the genuine
+        over-claim case) and the advisory stays actionable. The out-of-band write changes
+        content length so st_size differs regardless of filesystem timestamp granularity.
+        The untouched sibling path in the same dict keeps its full-strength wording, which
+        pins the false-negative guard in the same render.
+        """
+        changed = tmp_path / "changed.md"
+        changed.write_text("v1")
+        untouched = tmp_path / "untouched.md"
+        untouched.write_text("v1")
+        agent = _bare_agent()
+        for f in (changed, untouched):
+            agent._record_file_mutation_result(
+                "patch", {"mode": "replace", "path": str(f), "old_string": "x", "new_string": "y"},
+                json.dumps({"error": "Could not find old_string"}), is_error=True,
+            )
+        # Untracked writer rewrites one of the two paths with different-length content.
+        changed.write_text("v2 rewritten out of band, different length")
+
+        reconciled = agent._reconcile_file_mutation_failures(agent._turn_failed_file_mutations)
+        # 1. The path is still present — reword, not drop.
+        assert str(changed) in reconciled
+        assert reconciled[str(changed)]["external_change"] is True
+        assert "external_change" not in reconciled[str(untouched)]
+
+        out = AIAgent._format_file_mutation_failure_footer(reconciled)
+        # 2. The bare "were NOT modified this turn" claim must not cover the changed path —
+        #    red on base, where the footer renders "2 file(s) were NOT modified".
+        assert "1 file(s) were NOT modified this turn" in out
+        assert "2 file(s) were NOT modified this turn" not in out
+        assert "changed on disk" in out
+        # 3. The path and the user-actionable hint survive the rewording.
+        assert str(changed) in out
+        assert str(untouched) in out
+        assert "git status" in out
+
+    def test_untouched_file_keeps_full_strength_warning(self, tmp_path):
+        """Pin: a failure whose file never changed keeps today's exact warning.
+
+        Guards against a future "simplification" of reconciliation into unconditional
+        suppression, or a fingerprint comparison so loose (float mtime, exists-check)
+        that it fires on every entry.
+        """
+        f = tmp_path / "a.md"
+        f.write_text("v1")
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch", {"mode": "replace", "path": str(f), "old_string": "x", "new_string": "y"},
+            json.dumps({"error": "Could not find old_string"}), is_error=True,
+        )
+        reconciled = agent._reconcile_file_mutation_failures(agent._turn_failed_file_mutations)
+        assert "external_change" not in reconciled[str(f)]
+        out = AIAgent._format_file_mutation_failure_footer(reconciled)
+        assert "1 file(s) were NOT modified this turn" in out
+        assert "git status" in out
 
     def test_truncation_at_10_entries(self):
         failed = {


### PR DESCRIPTION
## What

The turn-end file-mutation footer claims a file was "NOT modified" when a tracked `patch`/`write_file` failed, even if the model then succeeded through an UNTRACKED writer (terminal command, MCP tool, editor, watcher). `terminal` is deliberately absent from `FILE_MUTATING_TOOL_NAMES` (`tool_result_classification.py:9`), so the failure entry is never cleared and the footer fires a false positive.

## Reproduction (on current main)

1. `patch` a file with a refused/failed edit (e.g. path is protected).
2. Same turn, write the file via `terminal` (or any untracked writer).
3. Turn end: footer prints "file(s) were NOT modified this turn" for the file that demonstrably changed on disk.

## Fix

Snapshot a `(st_mtime_ns, st_size, st_ino)` fingerprint of each failed path **at failure time** into per-turn `_turn_file_mutation_baselines` (first-write-wins, mirroring the keep-first-error rule; `None` = explicit "did not exist" sentinel). At footer render, `_reconcile_file_mutation_failures()` compares the current fingerprint to the baseline and marks provably-changed entries `external_change`; the footer rewords those entries and counts them separately in the header instead of the absolute "NOT modified" claim.

**Reword, never drop**: dropping would also suppress the genuine over-claim case where an unrelated writer happened to touch the same path. Unknown baselines and stat failures fail toward keeping the warning.

## Non-changes

- `FILE_MUTATING_TOOL_NAMES` stays `{write_file, patch}` (its shape test is a deliberate guard rail).
- `_turn_file_mutation_paths` gains nothing — it feeds the verify-on-stop nudge and `pre_verify` hook (`turn_stop_gates.py`), which is untouched.
- No new config surface; no `HERMES_*` env vars.

## Tests

Five invariant tests: first-write-wins baseline anchoring; absent-sentinel + creation reword; success drops baseline; end-to-end false-positive reproduction (one out-of-band-modified path reworded, one untouched path keeps full-strength wording in the same render — **red on base**: exactly these 5 fail with the production change reverted); and the untouched-file pin.

```
scripts/run_tests.sh tests/run_agent/test_file_mutation_verifier.py  -> 32/32
sibling suites (turn_finalizer / turn_context / run_budget)            -> 34/34
```

## Review trail

Design: claude-opus-5. Independent implementation review: claude-sonnet-5, APPROVE WITH NITS (both nits addressed in the commit).
