### PR TITLE
fix(gateway): persist bot-chat reasoning-effort picks to the bot profile config

### DIFF
--- a/tests/test_bot_chat_effort_persistence.py
+++ b/tests/test_bot_chat_effort_persistence.py
@@ -1,0 +1,78 @@
+"""Bot-chat reasoning-effort pick persistence (config.set reasoning for Bot Chats).
+
+Regression coverage for the two-part fix:
+1. `_set_reasoning` writes the pick into the bot profile config when the
+   session is a bot chat (the desktop picker sends no scope, so the pick
+   would otherwise stay session-scoped and snap back on rebuild).
+2. Resume paths re-derive the bot-chat marker from the stored row, because
+   creation stamps it from params but resume never did.
+"""
+
+import contextlib
+import json
+from unittest import mock
+
+import pytest
+
+import tui_gateway.server as server
+
+
+# ── _row_follow_profile_config ─────────────────────────────────────────
+
+_MARKER_CASES = [
+    ({}, False),
+    (None, False),
+    ({"title": "Bot Chat", "hidden": False}, True),
+    ({"title": "Bot Chat", "hidden": False, "model_config": "{}"}, True),
+    ({"title": "Some chat", "hidden": False,
+      "model_config": json.dumps({"follow_profile_config": True})}, True),
+    ({"title": "Some chat", "hidden": False, "model_config": "{}"}, False),
+    ({"title": "Group: something", "hidden": True, "model_config": "{}"}, True),
+    ({"title": "Group: something", "hidden": False, "model_config": "{}"}, False),
+    ({"title": "Some chat", "hidden": False,
+      "model_config": json.dumps({"room_plumbing": True})}, True),
+]
+
+
+@pytest.mark.parametrize("row,expected", _MARKER_CASES)
+def test_row_follow_profile_config(row, expected):
+    assert server._row_follow_profile_config(row) is expected
+
+
+# ── _set_reasoning bot-chat persistence ────────────────────────────────
+
+def _reasoning_params():
+    return {"key": "reasoning", "value": "high", "scope": "", "session_id": ""}
+
+
+def _run_set_reasoning(session):
+    return server._set_reasoning("r1", _reasoning_params(), "reasoning", "high", session)
+
+
+def test_set_reasoning_bot_chat_persists_to_profile_config():
+    session = {"follow_profile_config": True, "agent": None}
+    with mock.patch.object(server, "_session_profile_runtime_scope",
+                           side_effect=lambda s: contextlib.nullcontext()), \
+         mock.patch.object(server, "_write_config_key") as write:
+        _run_set_reasoning(session)
+    write.assert_called_once_with("agent.reasoning_effort", "high")
+    assert session["create_reasoning_override"] is not None
+
+
+def test_set_reasoning_bot_chat_title_detection():
+    session = {"title": "Bot Chat", "agent": None}
+    with mock.patch.object(server, "_session_profile_runtime_scope",
+                           side_effect=lambda s: contextlib.nullcontext()), \
+         mock.patch.object(server, "_write_config_key") as write:
+        _run_set_reasoning(session)
+    write.assert_called_once_with("agent.reasoning_effort", "high")
+
+
+def test_set_reasoning_plain_session_stays_session_scoped():
+    session = {"agent": None}
+    with mock.patch.object(server, "_session_profile_runtime_scope",
+                           side_effect=lambda s: contextlib.nullcontext()), \
+         mock.patch.object(server, "_write_config_key") as write:
+        _run_set_reasoning(session)
+    write.assert_not_called()
+    assert session["create_reasoning_override"] is not None

--- a/tui_gateway/methods_config_set.py
+++ b/tui_gateway/methods_config_set.py
@@ -310,6 +310,13 @@ def _set_reasoning(rid, params, key, value, session):
             session.pop("create_reasoning_override", None)
     else:  # session-scoped like the gateway's `/reasoning <level>`; a menu pick must not rewrite the global
         session["create_reasoning_override"] = parsed
+        # Bot chats rebuild model/effort from their profile config.yaml on every resume, so a
+        # session-scoped pick silently snaps back after an app restart. Persist bot-chat picks
+        # into the bot profile config (scoped write via _session_profile_runtime_scope).
+        # Main-chat picks stay session-scoped.
+        if session.get("follow_profile_config") or str(session.get("title") or "").strip() == "Bot Chat":
+            with _session_profile_runtime_scope(session):
+                _write_config_key("agent.reasoning_effort", arg)
     if session and session.get("agent") is not None:
         session["agent"].reasoning_config = parsed
         _persist_live_session_runtime(session)

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -91,6 +91,23 @@ def _make_agent_in_context(sid: str, key: str, **kwargs):
         _clear_session_context(tokens)
 
 
+def _row_follow_profile_config(row) -> bool:
+    """Bot-chat detection from a stored session row (upstream's own signals in
+    _stored_session_runtime_overrides). The live resume record must carry the
+    marker too, or config.set routes bot-chat picks session-scoped and they
+    snap back to the profile config on the next rebuild."""
+    if not row:
+        return False
+    model_config = _parse_model_config(row.get("model_config"), quiet=True)
+    title = str(row.get("title") or "").strip()
+    return bool(
+        model_config.get("room_plumbing")
+        or model_config.get("follow_profile_config")
+        or (row.get("hidden") and title.startswith("Group:"))
+        or title == "Bot Chat"
+    )
+
+
 def _profile_session_db(profile_home):
     """``(db, owns)``: a DEDICATED handle on ``profile_home``'s state.db, else the shared launch db."""
     if profile_home:
@@ -469,10 +486,14 @@ class _Resume:
         ``overrides`` restores the stored model/provider/reasoning/tier so the deferred build matches eager."""
         if overrides is not None:
             extra.update(model_override=overrides.get("model_override"), resume_runtime_overrides=overrides or None)
-        return _deferred_session_record(
+        record = _deferred_session_record(
             self.target, cols=self.cols, cwd=cwd, history=history, lease=None, source=source,
             close_on_disconnect=_flag(self.params, "close_on_disconnect"),
             profile_home=self.profile_home, explicit_cwd=bool(self.profile_resume_cwd), **extra)
+        # Resume must re-derive the bot-chat marker from the stored row: creation stamps it from
+        # params, resume does not — and without it config.set treats picks as session-scoped.
+        record["follow_profile_config"] = _row_follow_profile_config(self.found)
+        return record
 
     def claim(self, sid: str, record: dict) -> dict | None:
         """Register ``record`` live under the resume lock, or reuse a concurrent winner's session."""
@@ -767,6 +788,7 @@ def _resume_eager(ctx: _Resume) -> dict:
                     _transfer_db_to_agent(agent, ctx.db)
                 ctx.owns_db = False
             if (session := _sessions.get(sid)) is not None:
+                session["follow_profile_config"] = _row_follow_profile_config(ctx.found)
                 if stored_runtime_overrides.get("model_override") is not None:
                     session["model_override"] = stored_runtime_overrides["model_override"]
                 # Each turn re-binds HERMES_HOME (mid-turn memory/skills reads); lease claimed lazily on turn 1.


### PR DESCRIPTION
## What does this PR do?

Bot chats rebuild model and effort from the bot profile's config.yaml on every resume. The desktop effort picker sends `config.set { key: "reasoning" }` with no scope, so `_set_reasoning` takes the session-scoped branch and never writes the profile config. The pick therefore snaps back to the profile's configured effort after the next app restart. This PR persists the pick into the bot profile config when the session is a bot chat, and fixes the resume path so the bot-chat marker survives restarts.

## Related Issue

None. Found while running a multi-bot install; no existing issue or PR covers this path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/methods_config_set.py`: in `_set_reasoning`, when the session is a bot chat, the pick is also written as `agent.reasoning_effort` into the session's profile config via `_session_profile_runtime_scope` (the same mechanism `_set_model` already uses for model picks). Plain sessions stay session-scoped, unchanged.
- `tui_gateway/methods_session.py`: new `_row_follow_profile_config(row)` helper, using the same signals as `_stored_session_runtime_overrides` (room_plumbing / follow_profile_config / hidden "Group:" title / title "Bot Chat"). The marker is stamped onto the live record in `_Resume.record()` (lazy, deferred, cold) and in `_resume_eager` after `_init_session`. Creation stamps the marker from params; resume never did, so resumed bot chats failed the persistence check above.
- `tests/test_bot_chat_effort_persistence.py`: 12 regression tests covering marker detection and the persistence branch.

## How to Test

1. Create a bot profile and open its canonical Bot Chat in the desktop app.
2. Pick a non-default effort in the chat composer (for example Low).
3. `~/.hermes/profiles/<bot>/config.yaml` now contains `agent.reasoning_effort: low` (written immediately).
4. Restart the app, reopen the bot chat. The pick still applies.
5. Repeat in a plain (non-bot) chat: the pick must NOT rewrite the global config.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] `pytest tests/test_bot_chat_effort_persistence.py -q` → 12 passed
- [x] `pytest tests/test_tui_gateway_server.py -q` → 635 passed, 2 failed (both also fail on clean main in this environment; unrelated to this change)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 14.7 (Apple Silicon) — verified live: pick Low in a bot chat writes the profile config immediately and survives app restart and Mac reboot

### Documentation & Housekeeping

- [x] Docstrings updated for the new helper and the changed branch
- [x] No new config keys — N/A
- [x] No architecture or workflow change — N/A
- [x] Cross-platform impact considered: pure Python gateway path, no platform code — N/A
- [x] No tool behavior/schema change — N/A
