### PR TITLE
fix(desktop): Review pane resolves the changed file's own repo instead of NO DIFFS (#86334, #81722)

### DIFF
--- a/apps/desktop/e2e/review-tool-diff-fallback.spec.ts
+++ b/apps/desktop/e2e/review-tool-diff-fallback.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression E2E for #86334: a tool edit made outside a Git repository must
+ * still open as a read-only diff from the transcript's Changed Files card.
+ *
+ * This drives the real Electron renderer, desktop backend, agent loop, mock
+ * inference transport, and write_file tool. Git intentionally has no authority
+ * over the sandbox project, so the Review pane must use the tool-result diff.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type MockBackendFixture,
+  waitForAppReady,
+  writeEnvFile,
+  writeMockProviderConfig,
+} from './fixtures'
+import { REVIEW_TOOL_DIFF_QUESTION, REVIEW_TOOL_DIFF_TRIGGER, startMockServer } from './mock-server'
+import { expect, test } from './test'
+
+test('tool diff outside Git opens read-only Review instead of NO DIFFS', async () => {
+  test.setTimeout(120_000)
+  const sandbox = createSandbox('review-tool-diff-fallback')
+  const projectRoot = path.join(sandbox.root, 'non-git-project')
+  const changedFile = path.join(projectRoot, 'e2e-review-target.py')
+  fs.mkdirSync(projectRoot)
+  fs.writeFileSync(changedFile, 'def changed_by_e2e():\n    return "before"\n', 'utf8')
+
+  const mock = await startMockServer({ verificationWritePath: changedFile })
+  writeMockProviderConfig(sandbox.hermesHome, mock.url)
+  fs.appendFileSync(path.join(sandbox.hermesHome, 'config.yaml'), `\nterminal:\n  cwd: ${JSON.stringify(projectRoot)}\n`, 'utf8')
+  writeEnvFile(sandbox.hermesHome)
+  const { app, page } = await launchDesktop(buildAppEnv(sandbox))
+  const fixture: MockBackendFixture = {
+    app,
+    page,
+    mock,
+    mockUrl: mock.url,
+    sandbox,
+    cleanup: async () => {
+      await app.close().catch(() => undefined)
+      await mock.close()
+      sandbox.cleanup()
+    },
+  }
+
+  try {
+    await waitForAppReady(fixture, 120_000)
+    const composer = page.locator('[contenteditable="true"]').first()
+    await composer.click()
+    await composer.type(REVIEW_TOOL_DIFF_TRIGGER)
+    await page.keyboard.press('Enter')
+
+    await expect(page.getByText(REVIEW_TOOL_DIFF_QUESTION)).toBeVisible({ timeout: 60_000 })
+    await page.locator('[data-slot="composer-root"] button[aria-label="Stop"]').click()
+
+    await page.waitForFunction(() => {
+      const card = document.querySelector('[data-slot="aui_changed-files"]')
+      const reviewButton = [...(card?.querySelectorAll('button') ?? [])]
+        .find(button => button.textContent?.trim() === 'Review')
+      if (!reviewButton) {
+        return false
+      }
+
+      reviewButton.click()
+      return true
+    }, undefined, { timeout: 30_000 })
+
+    const review = page.getByRole('complementary', { name: 'Review' })
+    await expect(review).toBeVisible()
+    await expect(review).toContainText('e2e-review-target.py')
+    await expect(review).not.toContainText('NO DIFFS')
+
+    const reviewFile = review.locator('[aria-selected]').filter({ hasText: '+1' }).first()
+    await expect(reviewFile).toBeVisible()
+    await reviewFile.click()
+    await expect(review).toContainText('return "before"')
+    await expect(review).toContainText('return "changed"')
+
+    await expect(review.getByRole('button', { name: /Stage|Unstage|Revert|Commit|Push|Create PR/i })).toHaveCount(0)
+    await expect(review.getByText(/Commit changes|Create PR/i)).toHaveCount(0)
+  } finally {
+    await fixture.cleanup()
+  }
+})

--- a/apps/desktop/e2e/review-tool-diff-fallback.spec.ts
+++ b/apps/desktop/e2e/review-tool-diff-fallback.spec.ts
@@ -11,15 +11,20 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 
 import {
+  REVIEW_TOOL_DIFF_QUESTION,
+  REVIEW_TOOL_DIFF_TRIGGER,
+  startMockServer
+} from '../../../tests-js/scripts/mock-server'
+
+import {
   buildAppEnv,
   createSandbox,
   launchDesktop,
   type MockBackendFixture,
   waitForAppReady,
   writeEnvFile,
-  writeMockProviderConfig,
+  writeMockProviderConfig
 } from './fixtures'
-import { REVIEW_TOOL_DIFF_QUESTION, REVIEW_TOOL_DIFF_TRIGGER, startMockServer } from './mock-server'
 import { expect, test } from './test'
 
 test('tool diff outside Git opens read-only Review instead of NO DIFFS', async () => {
@@ -32,9 +37,14 @@ test('tool diff outside Git opens read-only Review instead of NO DIFFS', async (
 
   const mock = await startMockServer({ verificationWritePath: changedFile })
   writeMockProviderConfig(sandbox.hermesHome, mock.url)
-  fs.appendFileSync(path.join(sandbox.hermesHome, 'config.yaml'), `\nterminal:\n  cwd: ${JSON.stringify(projectRoot)}\n`, 'utf8')
+  fs.appendFileSync(
+    path.join(sandbox.hermesHome, 'config.yaml'),
+    `\nterminal:\n  cwd: ${JSON.stringify(projectRoot)}\n`,
+    'utf8'
+  )
   writeEnvFile(sandbox.hermesHome)
   const { app, page } = await launchDesktop(buildAppEnv(sandbox))
+
   const fixture: MockBackendFixture = {
     app,
     page,
@@ -45,7 +55,7 @@ test('tool diff outside Git opens read-only Review instead of NO DIFFS', async (
       await app.close().catch(() => undefined)
       await mock.close()
       sandbox.cleanup()
-    },
+    }
   }
 
   try {
@@ -58,17 +68,25 @@ test('tool diff outside Git opens read-only Review instead of NO DIFFS', async (
     await expect(page.getByText(REVIEW_TOOL_DIFF_QUESTION)).toBeVisible({ timeout: 60_000 })
     await page.locator('[data-slot="composer-root"] button[aria-label="Stop"]').click()
 
-    await page.waitForFunction(() => {
-      const card = document.querySelector('[data-slot="aui_changed-files"]')
-      const reviewButton = [...(card?.querySelectorAll('button') ?? [])]
-        .find(button => button.textContent?.trim() === 'Review')
-      if (!reviewButton) {
-        return false
-      }
+    await page.waitForFunction(
+      () => {
+        const card = document.querySelector('[data-slot="aui_changed-files"]')
 
-      reviewButton.click()
-      return true
-    }, undefined, { timeout: 30_000 })
+        const reviewButton = [...(card?.querySelectorAll('button') ?? [])].find(
+          button => button.textContent?.trim() === 'Review'
+        )
+
+        if (!reviewButton) {
+          return false
+        }
+
+        reviewButton.click()
+
+        return true
+      },
+      undefined,
+      { timeout: 30_000 }
+    )
 
     const review = page.getByRole('complementary', { name: 'Review' })
     await expect(review).toBeVisible()

--- a/apps/desktop/src/app/right-sidebar/review/file-tree.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { HermesReviewFile } from '@/global'
 import { I18nProvider } from '@/i18n'
 import { $sidebarWorkspaceNodeOpen } from '@/store/layout'
-import { $reviewFiles, $reviewOpen } from '@/store/review'
+import { $reviewFiles, $reviewOpen, $reviewReadOnly } from '@/store/review'
 
 import { ReviewFileTree } from './file-tree'
 
@@ -40,6 +40,7 @@ function renderTree() {
 describe('ReviewFileTree', () => {
   beforeEach(() => {
     $reviewOpen.set(true)
+    $reviewReadOnly.set(false)
     $reviewFiles.set([])
     $sidebarWorkspaceNodeOpen.set({})
 
@@ -79,6 +80,7 @@ describe('ReviewFileTree', () => {
     $reviewFiles.set([])
     $sidebarWorkspaceNodeOpen.set({})
     $reviewOpen.set(false)
+    $reviewReadOnly.set(false)
   })
 
   it('virtualizes heavy trees: only the visible window is mounted', () => {
@@ -126,5 +128,29 @@ describe('ReviewFileTree', () => {
     expect(screen.getByText('b.ts')).toBeTruthy()
     expect(screen.getByText('src')).toBeTruthy()
     expect(screen.getByText('c.ts')).toBeTruthy()
+  })
+
+  it('hides git mutation buttons for tool-diff fallback files', () => {
+    $reviewFiles.set([file('note.md')])
+    $reviewReadOnly.set(true)
+
+    renderTree()
+
+    expect(screen.getByText('note.md')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Stage' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Revert' })).toBeNull()
+  })
+
+  it('keeps read-only file actions but removes git mutations from the context menu', async () => {
+    $reviewFiles.set([file('note.md')])
+    $reviewReadOnly.set(true)
+
+    renderTree()
+    fireEvent.contextMenu(screen.getByText('note.md'))
+
+    expect(await screen.findByRole('menuitem', { name: 'Open Changes' })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: 'Open File' })).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: 'Stage' })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: 'Revert' })).toBeNull()
   })
 })

--- a/apps/desktop/src/app/right-sidebar/review/file-tree.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.test.tsx
@@ -148,8 +148,8 @@ describe('ReviewFileTree', () => {
     renderTree()
     fireEvent.contextMenu(screen.getByText('note.md'))
 
-    expect(await screen.findByRole('menuitem', { name: 'Open Changes' })).toBeTruthy()
-    expect(screen.getByRole('menuitem', { name: 'Open File' })).toBeTruthy()
+    expect(await screen.findByRole('menuitem', { name: /open changes/i })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: /open file/i })).toBeTruthy()
     expect(screen.queryByRole('menuitem', { name: 'Stage' })).toBeNull()
     expect(screen.queryByRole('menuitem', { name: 'Revert' })).toBeNull()
   })

--- a/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
@@ -35,6 +35,7 @@ import {
   $reviewFiles,
   $reviewLoading,
   $reviewOpen,
+  $reviewReadOnly,
   $reviewScopeCwd,
   $reviewSelectedPath,
   $reviewTreeMode,
@@ -313,6 +314,7 @@ function ReviewFileRow({ node, depth }: { node: ReviewTreeNode; depth: number })
   const { t } = useI18n()
   const c = t.statusStack.coding
   const selectedPath = useStore($reviewSelectedPath)
+  const readOnly = useStore($reviewReadOnly)
   const file = node.file!
   const selected = file.path === selectedPath
   const glyph = STATUS_GLYPH[file.status] ?? STATUS_GLYPH.M
@@ -385,6 +387,7 @@ function ReviewFileRow({ node, depth }: { node: ReviewTreeNode; depth: number })
       file={file}
       onOpenChanges={() => void selectReviewFile(file)}
       onOpenFile={openInPreview}
+      readOnly={readOnly}
     >
       <div
         aria-selected={selected}
@@ -420,36 +423,38 @@ function ReviewFileRow({ node, depth }: { node: ReviewTreeNode; depth: number })
           )}
         </span>
 
-        <span className="hidden shrink-0 items-center gap-0.5 group-hover/review-row:flex">
-          <Tip label={file.staged ? c.unstage : c.stage}>
-            <Button
-              aria-label={file.staged ? c.unstage : c.stage}
-              className="size-4 rounded text-muted-foreground/70 hover:text-foreground"
-              onClick={event => {
-                event.stopPropagation()
-                void (file.staged ? unstageReviewFile(file.path) : stageReviewFile(file.path))
-              }}
-              size="icon-xs"
-              variant="ghost"
-            >
-              <Codicon name={file.staged ? 'remove' : 'add'} size="0.7rem" />
-            </Button>
-          </Tip>
-          <Tip label={c.revert}>
-            <Button
-              aria-label={c.revert}
-              className="size-4 rounded text-muted-foreground/70 hover:text-(--ui-red)"
-              onClick={event => {
-                event.stopPropagation()
-                requestRevert(file.path)
-              }}
-              size="icon-xs"
-              variant="ghost"
-            >
-              <Codicon name="discard" size="0.7rem" />
-            </Button>
-          </Tip>
-        </span>
+        {!readOnly && (
+          <span className="hidden shrink-0 items-center gap-0.5 group-hover/review-row:flex">
+            <Tip label={file.staged ? c.unstage : c.stage}>
+              <Button
+                aria-label={file.staged ? c.unstage : c.stage}
+                className="size-4 rounded text-muted-foreground/70 hover:text-foreground"
+                onClick={event => {
+                  event.stopPropagation()
+                  void (file.staged ? unstageReviewFile(file.path) : stageReviewFile(file.path))
+                }}
+                size="icon-xs"
+                variant="ghost"
+              >
+                <Codicon name={file.staged ? 'remove' : 'add'} size="0.7rem" />
+              </Button>
+            </Tip>
+            <Tip label={c.revert}>
+              <Button
+                aria-label={c.revert}
+                className="size-4 rounded text-muted-foreground/70 hover:text-(--ui-red)"
+                onClick={event => {
+                  event.stopPropagation()
+                  requestRevert(file.path)
+                }}
+                size="icon-xs"
+                variant="ghost"
+              >
+                <Codicon name="discard" size="0.7rem" />
+              </Button>
+            </Tip>
+          </span>
+        )}
 
         <DiffCount
           added={node.added}
@@ -474,7 +479,8 @@ function ReviewFileContextMenu({
   dragPath,
   file,
   onOpenChanges,
-  onOpenFile
+  onOpenFile,
+  readOnly
 }: {
   children: ReactNode
   cwd: null | string
@@ -482,6 +488,7 @@ function ReviewFileContextMenu({
   file: HermesReviewFile
   onOpenChanges: () => void
   onOpenFile: () => void
+  readOnly: boolean
 }) {
   const { t } = useI18n()
   const c = t.statusStack.coding
@@ -494,19 +501,23 @@ function ReviewFileContextMenu({
       <ContextMenuContent>
         <ContextMenuItem onSelect={onOpenChanges}>{c.openChanges}</ContextMenuItem>
         <ContextMenuItem onSelect={onOpenFile}>{c.openFile}</ContextMenuItem>
-        <ContextMenuSeparator />
-        <ContextMenuItem
-          onSelect={() =>
-            void (file.staged ? unstageReviewFile(file.path) : stageReviewFile(file.path)).catch(err =>
-              notifyError(err, file.staged ? c.unstage : c.stage)
-            )
-          }
-        >
-          {file.staged ? c.unstage : c.stage}
-        </ContextMenuItem>
-        <ContextMenuItem onSelect={() => requestRevert(file.path)} variant="destructive">
-          {c.revert}
-        </ContextMenuItem>
+        {!readOnly && (
+          <>
+            <ContextMenuSeparator />
+            <ContextMenuItem
+              onSelect={() =>
+                void (file.staged ? unstageReviewFile(file.path) : stageReviewFile(file.path)).catch(err =>
+                  notifyError(err, file.staged ? c.unstage : c.stage)
+                )
+              }
+            >
+              {file.staged ? c.unstage : c.stage}
+            </ContextMenuItem>
+            <ContextMenuItem onSelect={() => requestRevert(file.path)} variant="destructive">
+              {c.revert}
+            </ContextMenuItem>
+          </>
+        )}
         <ContextMenuSeparator />
         <ContextMenuItem onSelect={() => revealFileInTree(dragPath)}>{m.revealInSidebar}</ContextMenuItem>
         {localFs && (

--- a/apps/desktop/src/app/right-sidebar/review/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/index.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesReviewFile } from '@/global'
+import { I18nProvider } from '@/i18n'
+import {
+  $reviewDiff,
+  $reviewFiles,
+  $reviewIsRepo,
+  $reviewLoading,
+  $reviewReadOnly,
+  $reviewSelectedPath
+} from '@/store/review'
+
+vi.mock('@/components/chat/diff-lines', () => ({
+  FileDiffPanel: ({ diff }: { diff: string }) => <div data-testid="diff">{diff}</div>
+}))
+vi.mock('./file-tree', () => ({ ReviewFileTree: () => <div data-testid="review-tree">tree</div> }))
+vi.mock('./ship-bar', () => ({ ReviewShipBar: () => <div data-testid="ship-bar">ship</div> }))
+
+import { ReviewPane } from './index'
+
+const fallbackFile: HermesReviewFile = {
+  added: 1,
+  path: '/workspace/note.md',
+  removed: 0,
+  staged: false,
+  status: 'M'
+}
+
+function renderPane() {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <ReviewPane />
+    </I18nProvider>
+  )
+}
+
+describe('ReviewPane tool-diff fallback', () => {
+  beforeEach(() => {
+    $reviewDiff.set('+hello')
+    $reviewFiles.set([fallbackFile])
+    $reviewIsRepo.set(false)
+    $reviewLoading.set(false)
+    $reviewReadOnly.set(true)
+    $reviewSelectedPath.set(fallbackFile.path)
+  })
+
+  afterEach(() => {
+    cleanup()
+    $reviewDiff.set('')
+    $reviewFiles.set([])
+    $reviewIsRepo.set(true)
+    $reviewReadOnly.set(false)
+    $reviewSelectedPath.set(null)
+  })
+
+  it('renders review content but no git mutation or ship actions', () => {
+    renderPane()
+
+    expect(screen.getByTestId('review-tree')).toBeTruthy()
+    expect(screen.getByTestId('diff').textContent).toBe('+hello')
+    expect(screen.queryByRole('button', { name: 'Stage all' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Revert all' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Stage' })).toBeNull()
+    expect(screen.queryByTestId('ship-bar')).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/review/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/index.tsx
@@ -19,6 +19,7 @@ import {
   $reviewFiles,
   $reviewIsRepo,
   $reviewLoading,
+  $reviewReadOnly,
   $reviewRevertTarget,
   $reviewSelectedPath,
   $reviewTreeMode,
@@ -50,6 +51,7 @@ export function ReviewPane() {
   const files = useStore($reviewFiles)
   const loading = useStore($reviewLoading)
   const isRepo = useStore($reviewIsRepo)
+  const readOnly = useStore($reviewReadOnly)
   const selectedPath = useStore($reviewSelectedPath)
   const diff = useStore($reviewDiff)
   const diffLoading = useStore($reviewDiffLoading)
@@ -75,7 +77,7 @@ export function ReviewPane() {
           : 'border-l shadow-[inset_0.0625rem_0_0_color-mix(in_srgb,white_18%,transparent)]'
       )}
     >
-      {(loading || isRepo) && (
+      {(loading || isRepo || readOnly) && (
         <RightSidebarSectionHeader data-suppress-pane-reveal-side="">
           <div className="flex min-w-0 flex-1">
             {/* Pure self-naming label — redundant under a zone tab that already
@@ -94,30 +96,34 @@ export function ReviewPane() {
               <Codicon name={treeMode === 'tree' ? 'list-flat' : 'list-tree'} size="0.8125rem" />
             </Button>
           </Tip>
-          <Tip label={c.stageAll}>
-            <Button
-              aria-label={c.stageAll}
-              className={ACTION_BTN}
-              disabled={!hasFiles}
-              onClick={() => void stageReviewFile(null).catch(err => notifyError(err, c.stageAll))}
-              size="icon-xs"
-              variant="ghost"
-            >
-              <Codicon name="add" size="0.8125rem" />
-            </Button>
-          </Tip>
-          <Tip label={c.revertAll}>
-            <Button
-              aria-label={c.revertAll}
-              className={ACTION_BTN}
-              disabled={!hasFiles}
-              onClick={() => requestRevert(null)}
-              size="icon-xs"
-              variant="ghost"
-            >
-              <Codicon name="discard" size="0.8125rem" />
-            </Button>
-          </Tip>
+          {!readOnly && (
+            <>
+              <Tip label={c.stageAll}>
+                <Button
+                  aria-label={c.stageAll}
+                  className={ACTION_BTN}
+                  disabled={!hasFiles}
+                  onClick={() => void stageReviewFile(null).catch(err => notifyError(err, c.stageAll))}
+                  size="icon-xs"
+                  variant="ghost"
+                >
+                  <Codicon name="add" size="0.8125rem" />
+                </Button>
+              </Tip>
+              <Tip label={c.revertAll}>
+                <Button
+                  aria-label={c.revertAll}
+                  className={ACTION_BTN}
+                  disabled={!hasFiles}
+                  onClick={() => requestRevert(null)}
+                  size="icon-xs"
+                  variant="ghost"
+                >
+                  <Codicon name="discard" size="0.8125rem" />
+                </Button>
+              </Tip>
+            </>
+          )}
           <Tip label={t.rightSidebar.refreshTree}>
             <Button
               aria-label={t.rightSidebar.refreshTree}
@@ -135,7 +141,7 @@ export function ReviewPane() {
         </RightSidebarSectionHeader>
       )}
 
-      {loading || isRepo ? (
+      {loading || isRepo || readOnly ? (
         hasFiles ? (
           <ReviewFileTree />
         ) : showTreeSkeleton ? (
@@ -161,21 +167,23 @@ export function ReviewPane() {
               {displayPath(selectedFile.path)}
             </span>
             <DiffCount added={selectedFile.added} className="text-[0.64rem] leading-4" removed={selectedFile.removed} />
-            <Tip label={selectedFile.staged ? c.unstage : c.stage}>
-              <Button
-                aria-label={selectedFile.staged ? c.unstage : c.stage}
-                className={ACTION_BTN}
-                onClick={() =>
-                  void (
-                    selectedFile.staged ? unstageReviewFile(selectedFile.path) : stageReviewFile(selectedFile.path)
-                  ).catch(err => notifyError(err, c.stage))
-                }
-                size="icon-xs"
-                variant="ghost"
-              >
-                <Codicon name={selectedFile.staged ? 'remove' : 'add'} size="0.8rem" />
-              </Button>
-            </Tip>
+            {!readOnly && (
+              <Tip label={selectedFile.staged ? c.unstage : c.stage}>
+                <Button
+                  aria-label={selectedFile.staged ? c.unstage : c.stage}
+                  className={ACTION_BTN}
+                  onClick={() =>
+                    void (
+                      selectedFile.staged ? unstageReviewFile(selectedFile.path) : stageReviewFile(selectedFile.path)
+                    ).catch(err => notifyError(err, c.stage))
+                  }
+                  size="icon-xs"
+                  variant="ghost"
+                >
+                  <Codicon name={selectedFile.staged ? 'remove' : 'add'} size="0.8rem" />
+                </Button>
+              </Tip>
+            )}
             <Button
               aria-label={c.close}
               className={ACTION_BTN}
@@ -200,7 +208,7 @@ export function ReviewPane() {
         </div>
       )}
 
-      <ReviewShipBar />
+      {!readOnly && <ReviewShipBar />}
 
       <ConfirmDialog
         confirmLabel={revertingAll ? c.revertAll : c.revert}

--- a/apps/desktop/src/components/assistant-ui/thread/changed-files-card.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/changed-files-card.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const review = vi.hoisted(() => ({
+  openReviewForPath: vi.fn(),
+  revealReview: vi.fn()
+}))
+
+vi.mock('@nanostores/react', () => ({ useStore: (store: { get: () => unknown }) => store.get() }))
+vi.mock('@/app/chat/composer/scope', () => ({ useComposerScope: () => ({ target: 'main' }) }))
+vi.mock('@/app/chat/session-view', () => ({
+  useSessionView: () => ({ $cwd: { get: () => '/session' }, kind: 'primary' })
+}))
+vi.mock('@/store/review', () => review)
+
+import { ChangedFilesCard } from './changed-files-card'
+
+const diff = '--- a/note.md\n+++ b/note.md\n@@ -1 +1 @@\n-old\n+new'
+
+const parts = [
+  {
+    args: { path: '/workspace/note.md' },
+    result: { diff },
+    toolName: 'patch',
+    type: 'tool-call'
+  }
+]
+
+describe('ChangedFilesCard review fallback', () => {
+  it('passes the complete tool-diff snapshot from both review entry points', () => {
+    render(<ChangedFilesCard parts={parts} />)
+
+    const fallback = [
+      { added: 1, diff, name: 'note.md', path: '/workspace/note.md', removed: 1 }
+    ]
+
+    const buttons = screen.getAllByRole('button')
+
+    fireEvent.click(buttons[0]!)
+    expect(review.revealReview).toHaveBeenCalledWith(null, 'main', fallback)
+
+    fireEvent.click(screen.getByText('note.md').closest('button')!)
+    expect(review.openReviewForPath).toHaveBeenCalledWith('/workspace/note.md', null, 'main', fallback)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/changed-files-card.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/changed-files-card.tsx
@@ -49,7 +49,7 @@ export const ChangedFilesCard: FC<{ parts: readonly unknown[] }> = ({ parts }) =
         <span className="min-w-0 flex-1 truncate text-(--ui-text-primary)">{copy.filesChanged(files.length)}</span>
         <button
           className="shrink-0 cursor-pointer text-(--ui-text-tertiary) transition-colors hover:text-(--ui-text-primary)"
-          onClick={() => revealReview(scopeCwd, composerScope.target)}
+          onClick={() => revealReview(scopeCwd, composerScope.target, files)}
           type="button"
         >
           {copy.reviewChanges}
@@ -60,7 +60,7 @@ export const ChangedFilesCard: FC<{ parts: readonly unknown[] }> = ({ parts }) =
           <button
             className="row-hover flex shrink-0 items-center gap-2 rounded-md px-1.5 py-1 text-left"
             key={file.path}
-            onClick={() => void openReviewForPath(file.path, scopeCwd, composerScope.target)}
+            onClick={() => void openReviewForPath(file.path, scopeCwd, composerScope.target, files)}
             title={displayPath(file.path)}
             type="button"
           >

--- a/apps/desktop/src/components/assistant-ui/thread/changed-files.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/changed-files.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveChangedFiles } from './changed-files'
+
+const edit = (path: string, diff: string) => ({
+  args: { path },
+  result: { diff },
+  toolName: 'patch',
+  type: 'tool-call'
+})
+
+describe('deriveChangedFiles', () => {
+  it('retains repeated tool diffs in edit order', () => {
+    const first = '--- a/note.md\n+++ b/note.md\n@@ -1 +1 @@\n-old\n+middle'
+    const second = '--- a/note.md\n+++ b/note.md\n@@ -1 +1 @@\n-middle\n+new'
+
+    expect(deriveChangedFiles([edit('/workspace/note.md', first), edit('/workspace/note.md', second)])).toEqual([
+      {
+        added: 2,
+        diff: `${first}\n@@ -1 +1 @@\n-middle\n+new`,
+        name: 'note.md',
+        path: '/workspace/note.md',
+        removed: 2
+      }
+    ])
+  })
+
+  it('counts header-shaped content lines inside a hunk', () => {
+    const diff = '--- a/options.txt\n+++ b/options.txt\n@@ -1 +1 @@\n--- option\n+++ option'
+
+    expect(deriveChangedFiles([edit('/workspace/options.txt', diff)])).toEqual([
+      {
+        added: 1,
+        diff,
+        name: 'options.txt',
+        path: '/workspace/options.txt',
+        removed: 1
+      }
+    ])
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/changed-files.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/changed-files.ts
@@ -12,6 +12,8 @@ import {
 
 export interface ChangedFile {
   added: number
+  /** Tool-reported unified diffs, retained in edit order for non-Git review. */
+  diff: string
   /** Basename, for the row label. */
   name: string
   /** Path exactly as the tool reported it (absolute or repo-relative). */
@@ -24,6 +26,13 @@ interface ChangedFilePart {
   result?: unknown
   toolName?: unknown
   type?: unknown
+}
+
+function withoutLeadingDiffPreamble(diff: string): string {
+  const lines = diff.split('\n')
+  const firstHunk = lines.findIndex(line => line.startsWith('@@'))
+
+  return firstHunk > 0 ? lines.slice(firstHunk).join('\n') : diff
 }
 
 /**
@@ -59,9 +68,10 @@ export function deriveChangedFiles(parts: readonly unknown[]): ChangedFile[] {
 
     if (existing) {
       existing.added += stats.added
+      existing.diff = `${existing.diff}\n${withoutLeadingDiffPreamble(diff)}`
       existing.removed += stats.removed
     } else {
-      byPath.set(path, { added: stats.added, name: fileEditBasename(path), path, removed: stats.removed })
+      byPath.set(path, { added: stats.added, diff, name: fileEditBasename(path), path, removed: stats.removed })
     }
   }
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -186,6 +186,23 @@ describe('buildToolView file edit diffs', () => {
     expect(inlineDiffFromResult({ diff: patchDiff })).toBe(patchDiff)
   })
 
+  it('does not count concatenated multi-file headers as changed lines', () => {
+    const multiFileDiff = [
+      '--- a/one.txt',
+      '+++ b/one.txt',
+      '@@ -1 +1 @@',
+      '-old one',
+      '+new one',
+      '--- a/two.txt',
+      '+++ b/two.txt',
+      '@@ -1 +1 @@',
+      '-old two',
+      '+new two'
+    ].join('\n')
+
+    expect(countDiffLineStats(multiFileDiff)).toEqual({ added: 2, removed: 2 })
+  })
+
   it('suppresses raw patch args when a diff is available', () => {
     const view = buildToolView(
       part({

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -45,12 +45,43 @@ export interface DiffLineStats {
 
 export function countDiffLineStats(diff: string): DiffLineStats {
   let added = 0
+  let inHunk = false
   let removed = 0
+  const lines = diff.split('\n')
 
-  for (const line of diff.split('\n')) {
-    if (line.startsWith('+') && !line.startsWith('+++')) {
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+
+    if (line.startsWith('diff --git')) {
+      inHunk = false
+
+      continue
+    }
+
+    if (line.startsWith('@@')) {
+      inHunk = true
+
+      continue
+    }
+
+    if (
+      line.startsWith('--- ')
+      && lines[index + 1]?.startsWith('+++ ')
+      && lines[index + 2]?.startsWith('@@')
+    ) {
+      inHunk = false
+      index += 1
+
+      continue
+    }
+
+    if (line.startsWith('\\')) {
+      continue
+    }
+
+    if (line.startsWith('+') && (inHunk || !line.startsWith('+++'))) {
       added += 1
-    } else if (line.startsWith('-') && !line.startsWith('---')) {
+    } else if (line.startsWith('-') && (inHunk || !line.startsWith('---'))) {
       removed += 1
     }
   }

--- a/apps/desktop/src/components/chat/diff-lines.test.tsx
+++ b/apps/desktop/src/components/chat/diff-lines.test.tsx
@@ -22,6 +22,7 @@ vi.mock('./syntax-diff', () => ({
   }
 }))
 
+import { deriveChangedFiles } from '@/components/assistant-ui/thread/changed-files'
 import { ErrorBoundary } from '@/components/error-boundary'
 
 import { FileDiffPanel } from './diff-lines'
@@ -68,5 +69,68 @@ describe('FileDiffPanel survives a failed lazy syntax-diff chunk', () => {
     expect(container.textContent).toContain('const b = 2')
     expect(container.textContent).toContain('const b = 3')
     expect(container.textContent).not.toContain(WORKSPACE_FALLBACK_TEXT)
+  })
+
+  it('renders repeated tool diffs as hunks without exposing later file headers', async () => {
+    const first = '--- a/note.md\n+++ b/note.md\n@@ -1 +1 @@\n-old\n+middle'
+    const second = '--- a/note.md\n+++ b/note.md\n@@ -1 +1 @@\n-middle\n+new'
+
+    const edit = (diff: string) => ({
+      args: { path: '/workspace/note.md' },
+      result: { diff },
+      toolName: 'patch',
+      type: 'tool-call'
+    })
+
+    const [changed] = deriveChangedFiles([edit(first), edit(second)])
+
+    const { container } = renderQuietly(<FileDiffPanel diff={changed!.diff} path="note.md" />)
+
+    await act(() => new Promise(resolve => setTimeout(resolve, 300)))
+
+    expect(container.textContent).toContain('old')
+    expect(container.textContent).toContain('middle')
+    expect(container.textContent).toContain('new')
+    expect(container.textContent).not.toContain('--- a/note.md')
+    expect(container.textContent).not.toContain('+++ b/note.md')
+  })
+
+  it('keeps legitimate changed lines that resemble file headers', async () => {
+    const optionDiff = '--- a/options.txt\n+++ b/options.txt\n@@ -1 +1 @@\n--- option\n+++ option'
+    const { container } = renderQuietly(<FileDiffPanel diff={optionDiff} path="options.txt" />)
+
+    await act(() => new Promise(resolve => setTimeout(resolve, 300)))
+
+    const lines = Array.from(container.querySelectorAll('span'))
+    const removed = lines.find(line => line.textContent === '-- option')
+    const added = lines.find(line => line.textContent === '++ option')
+
+    expect(removed?.className).toContain('ui-diff-remove')
+    expect(added?.className).toContain('ui-diff-add')
+    expect(lines.some(line => line.textContent === '--- option')).toBe(false)
+    expect(lines.some(line => line.textContent === '+++ option')).toBe(false)
+  })
+
+  it('does not render concatenated multi-file headers as changed content', async () => {
+    const multiFileDiff = [
+      '--- a/one.txt',
+      '+++ b/one.txt',
+      '@@ -1 +1 @@',
+      '-old one',
+      '+new one',
+      '--- a/two.txt',
+      '+++ b/two.txt',
+      '@@ -1 +1 @@',
+      '-old two',
+      '+new two'
+    ].join('\n')
+    const { container } = renderQuietly(<FileDiffPanel diff={multiFileDiff} path="combined.patch" />)
+
+    await act(() => new Promise(resolve => setTimeout(resolve, 300)))
+
+    expect(container.textContent).toContain('old one')
+    expect(container.textContent).toContain('new two')
+    expect(container.textContent).not.toContain('a/two.txt')
+    expect(container.textContent).not.toContain('b/two.txt')
   })
 })

--- a/apps/desktop/src/components/chat/diff-lines.test.tsx
+++ b/apps/desktop/src/components/chat/diff-lines.test.tsx
@@ -124,6 +124,7 @@ describe('FileDiffPanel survives a failed lazy syntax-diff chunk', () => {
       '-old two',
       '+new two'
     ].join('\n')
+
     const { container } = renderQuietly(<FileDiffPanel diff={multiFileDiff} path="combined.patch" />)
 
     await act(() => new Promise(resolve => setTimeout(resolve, 300)))

--- a/apps/desktop/src/components/chat/diff-lines.tsx
+++ b/apps/desktop/src/components/chat/diff-lines.tsx
@@ -67,11 +67,11 @@ const DIFF_BOX_CLASS =
   '-mx-1.5 -mb-1.5 max-h-[12rem] max-w-none min-w-0 overflow-auto overscroll-x-contain overscroll-y-auto font-mono text-[0.7rem] leading-relaxed text-(--ui-text-secondary)'
 
 function diffKind(line: string): DiffKind {
-  if (line.startsWith('+') && !line.startsWith('+++')) {
+  if (line.startsWith('+')) {
     return 'add'
   }
 
-  if (line.startsWith('-') && !line.startsWith('---')) {
+  if (line.startsWith('-')) {
     return 'remove'
   }
 
@@ -136,7 +136,11 @@ function parseHunks(diff: string): ParsedHunk[] {
   const hunks: ParsedHunk[] = []
   let active: null | ParsedHunk = null
 
-  for (const line of stripDiffFileHeaders(diff).split('\n')) {
+  const lines = stripDiffFileHeaders(diff).split('\n')
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+
     if (line.startsWith('@@')) {
       const match = /@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line)
 
@@ -148,6 +152,17 @@ function parseHunks(diff: string): ParsedHunk[] {
 
       active = { oldStart: Number(match[1]), newStart: Number(match[2]), lines: [] }
       hunks.push(active)
+
+      continue
+    }
+
+    if (
+      line.startsWith('--- ')
+      && lines[index + 1]?.startsWith('+++ ')
+      && lines[index + 2]?.startsWith('@@')
+    ) {
+      active = null
+      index += 1
 
       continue
     }

--- a/apps/desktop/src/store/review.test.ts
+++ b/apps/desktop/src/store/review.test.ts
@@ -12,6 +12,7 @@ import {
   $reviewLoading,
   $reviewMaxChurn,
   $reviewOpen,
+  $reviewReadOnly,
   $reviewRevertTarget,
   $reviewScopeCwd,
   $reviewScopeTarget,
@@ -27,6 +28,7 @@ import {
   createOrOpenPr,
   generateCommitMessage,
   openReview,
+  openReviewForPath,
   pushChanges,
   refreshReview,
   refreshShipInfo,
@@ -88,6 +90,7 @@ beforeEach(() => {
   requestOneShot.mockResolvedValue('generated message')
   // Reset stores touched across tests.
   $reviewOpen.set(false)
+  $reviewReadOnly.set(false)
   $reviewFiles.set([])
   $reviewLoading.set(false)
   $reviewIsRepo.set(true)
@@ -193,6 +196,252 @@ describe('$reviewMaxChurn', () => {
 })
 
 describe('selectReviewFile / clearReviewSelection', () => {
+  it('uses a tool diff as a read-only fallback when git has no matching file', async () => {
+    const review = stubReview({ list: vi.fn(async () => ({ files: [] })) })
+
+    const fallback = {
+      added: 1,
+      diff: '--- /dev/null\n+++ b/note.md\n@@ -0,0 +1 @@\n+hello',
+      path: '/workspace/note.md',
+      removed: 0
+    }
+
+    await openReviewForPath(fallback.path, null, 'main', [fallback])
+
+    expect(review.list).toHaveBeenCalledWith('/repo', 'uncommitted', null)
+    expect($reviewFiles.get()).toEqual([
+      { added: 1, path: '/workspace/note.md', removed: 0, staged: false, status: 'M' }
+    ])
+    expect($reviewSelectedPath.get()).toBe('/workspace/note.md')
+    expect($reviewDiff.get()).toBe(fallback.diff)
+    expect($reviewReadOnly.get()).toBe(true)
+
+    await stageReviewFile(fallback.path)
+    expect(review.stage).not.toHaveBeenCalled()
+  })
+
+  it('keeps a non-empty git review authoritative over a tool snapshot', async () => {
+    const gitFile = file('src/note.md')
+
+    const review = stubReview({
+      diff: vi.fn(async () => 'git diff'),
+      list: vi.fn(async () => ({ files: [gitFile] }))
+    })
+
+    const fallback = { added: 9, diff: 'tool diff', path: '/workspace/note.md', removed: 4 }
+
+    await openReviewForPath(gitFile.path, null, 'main', [fallback])
+
+    expect($reviewFiles.get()).toEqual([gitFile])
+    expect($reviewReadOnly.get()).toBe(false)
+    expect($reviewDiff.get()).toBe('git diff')
+    expect(review.diff).toHaveBeenCalled()
+  })
+
+  it('keeps git authoritative when every git row is excluded from display', async () => {
+    const review = stubReview({
+      list: vi.fn(async () => ({ files: [file('node_modules/generated.js')] }))
+    })
+
+    const fallback = { added: 1, diff: 'tool diff', path: '/workspace/note.md', removed: 0 }
+
+    await openReviewForPath(fallback.path, null, 'main', [fallback])
+
+    expect($reviewFiles.get()).toEqual([])
+    expect($reviewReadOnly.get()).toBe(false)
+    expect($reviewSelectedPath.get()).toBeNull()
+    expect($reviewDiff.get()).toBeNull()
+    expect(review.diff).not.toHaveBeenCalled()
+  })
+
+  it('replaces a selected absolute fallback diff when relative git becomes authoritative', async () => {
+    const gitPath = 'src/note.md'
+    const fallbackPath = '/repo/src/note.md'
+    const review = stubReview({ list: vi.fn(async () => ({ files: [] })) })
+    const fallback = { added: 1, diff: 'tool diff', path: fallbackPath, removed: 0 }
+    await openReviewForPath(fallbackPath, null, 'main', [fallback])
+    expect($reviewDiff.get()).toBe('tool diff')
+
+    let resolveDiff!: (value: string) => void
+    review.list.mockResolvedValue({ files: [file(gitPath)] })
+    review.diff.mockImplementationOnce(() => new Promise(resolve => {
+      resolveDiff = resolve
+    }))
+
+    const unsafeSnapshots: string[][] = []
+
+    const observeAuthority = () => {
+      const paths = $reviewFiles.get().map(candidate => candidate.path)
+
+      if (!$reviewReadOnly.get() && paths.includes(fallbackPath)) {
+        unsafeSnapshots.push(paths)
+      }
+    }
+
+    const unlistenReadOnly = $reviewReadOnly.listen(observeAuthority)
+    const unlistenFiles = $reviewFiles.listen(observeAuthority)
+
+    await refreshReview()
+
+    unlistenReadOnly()
+    unlistenFiles()
+
+    expect($reviewDiff.get()).toBeNull()
+    expect(unsafeSnapshots).toEqual([])
+    resolveDiff('git diff')
+    await vi.waitFor(() => expect($reviewDiff.get()).toBe('git diff'))
+    expect($reviewReadOnly.get()).toBe(false)
+    expect($reviewSelectedPath.get()).toBe(gitPath)
+    expect(review.diff).toHaveBeenCalledWith('/repo', gitPath, 'uncommitted', null, false)
+  })
+
+  it('replaces a selected fallback diff when a newer card reports the same path', async () => {
+    const review = stubReview({ list: vi.fn(async () => ({ files: [] })) })
+    const path = '/workspace/note.md'
+    await openReviewForPath(path, null, 'main', [{ added: 1, diff: 'old tool diff', path, removed: 0 }])
+
+    review.list.mockImplementationOnce(() => new Promise(() => undefined))
+    revealReview(null, 'main', [{ added: 2, diff: 'new tool diff', path, removed: 1 }])
+
+    expect($reviewDiff.get()).toBe('new tool diff')
+    expect($reviewReadOnly.get()).toBe(true)
+  })
+
+  it('drops fallback rows and selection before a normal reopen can expose git actions', async () => {
+    stubReview({ list: vi.fn(async () => ({ files: [] })) })
+    const fallback = { added: 1, diff: 'tool diff', path: '/workspace/note.md', removed: 0 }
+    await openReviewForPath(fallback.path, null, 'main', [fallback])
+    const unsafeSnapshots: string[][] = []
+
+    const observeAuthority = () => {
+      const paths = $reviewFiles.get().map(candidate => candidate.path)
+
+      if (!$reviewReadOnly.get() && paths.length > 0) {
+        unsafeSnapshots.push(paths)
+      }
+    }
+
+    const unlistenReadOnly = $reviewReadOnly.listen(observeAuthority)
+    const unlistenFiles = $reviewFiles.listen(observeAuthority)
+
+    closeReview()
+
+    unlistenReadOnly()
+    unlistenFiles()
+
+    expect(unsafeSnapshots).toEqual([])
+    expect($reviewFiles.get()).toEqual([])
+    expect($reviewSelectedPath.get()).toBeNull()
+    expect($reviewDiff.get()).toBeNull()
+    expect($reviewReadOnly.get()).toBe(false)
+  })
+
+  it('preserves an already-loaded git diff across periodic list refreshes', async () => {
+    const path = 'src/note.md'
+
+    const review = stubReview({
+      diff: vi.fn(async () => 'git diff'),
+      list: vi.fn(async () => ({ files: [file(path)] }))
+    })
+
+    await openReviewForPath(path)
+    review.diff.mockClear()
+
+    await refreshReview()
+
+    expect($reviewDiff.get()).toBe('git diff')
+    expect(review.diff).not.toHaveBeenCalled()
+  })
+
+  it('uses the tool snapshot when git list fails', async () => {
+    stubReview({
+      list: vi.fn(async () => {
+        throw new Error('not a repository')
+      })
+    })
+    const fallback = { added: 1, diff: 'tool diff', path: '/workspace/note.md', removed: 0 }
+
+    await openReviewForPath(fallback.path, null, 'main', [fallback])
+
+    expect($reviewFiles.get().map(item => item.path)).toEqual([fallback.path])
+    expect($reviewDiff.get()).toBe('tool diff')
+    expect($reviewIsRepo.get()).toBe(false)
+    expect($reviewReadOnly.get()).toBe(true)
+  })
+
+  it('keeps the new tool snapshot when an open pane moves to another scope', async () => {
+    const review = stubReview({ list: vi.fn(async () => ({ files: [] })) })
+    openReview('/old-worktree')
+    await refreshReview()
+    review.list.mockClear()
+    const fallback = { added: 1, diff: 'new scope diff', path: '/new-worktree/note.md', removed: 0 }
+
+    await openReviewForPath(fallback.path, '/new-worktree', 'tile:new', [fallback])
+
+    expect(review.list).toHaveBeenCalledWith('/new-worktree', 'uncommitted', null)
+    expect($reviewFiles.get().map(item => item.path)).toEqual([fallback.path])
+    expect($reviewDiff.get()).toBe(fallback.diff)
+    expect($reviewReadOnly.get()).toBe(true)
+  })
+
+  it('preserves the selected tool diff across periodic refreshes', async () => {
+    stubReview({ list: vi.fn(async () => ({ files: [] })) })
+    const fallback = { added: 1, diff: 'tool diff', path: '/workspace/note.md', removed: 0 }
+    await openReviewForPath(fallback.path, null, 'main', [fallback])
+
+    await refreshReview()
+
+    expect($reviewSelectedPath.get()).toBe(fallback.path)
+    expect($reviewDiff.get()).toBe(fallback.diff)
+    expect($reviewReadOnly.get()).toBe(true)
+  })
+
+  it('stays fail-closed while a new tool snapshot waits for git refresh', async () => {
+    const review = stubReview({ list: vi.fn(async () => ({ files: [] })) })
+    const first = { added: 1, diff: 'first diff', path: '/workspace/first.md', removed: 0 }
+    await openReviewForPath(first.path, null, 'main', [first])
+    expect($reviewReadOnly.get()).toBe(true)
+
+    let resolveList!: (value: { files: HermesReviewFile[] }) => void
+    review.list.mockImplementationOnce(
+      () => new Promise(resolve => {
+        resolveList = resolve
+      })
+    )
+    const second = { added: 1, diff: 'second diff', path: '/workspace/second.md', removed: 0 }
+
+    revealReview(null, 'main', [second])
+
+    expect($reviewReadOnly.get()).toBe(true)
+    resolveList({ files: [] })
+    await vi.waitFor(() => expect($reviewFiles.get().map(item => item.path)).toEqual([second.path]))
+  })
+
+  it('blocks every git mutation and ship action in tool-diff fallback mode', async () => {
+    const review = stubReview({ list: vi.fn(async () => ({ files: [] })) })
+    const fallback = { added: 1, diff: 'tool diff', path: '/workspace/note.md', removed: 0 }
+    await openReviewForPath(fallback.path, null, 'main', [fallback])
+
+    await stageReviewFile(fallback.path)
+    await unstageReviewFile(fallback.path)
+    await revertReviewFile(fallback.path)
+    requestRevert(fallback.path)
+    await confirmRevert()
+    await commitChanges('must not commit', { push: true })
+    expect(await generateCommitMessage()).toBe('')
+    await pushChanges()
+    await createOrOpenPr()
+
+    expect(review.stage).not.toHaveBeenCalled()
+    expect(review.unstage).not.toHaveBeenCalled()
+    expect(review.revert).not.toHaveBeenCalled()
+    expect(review.commit).not.toHaveBeenCalled()
+    expect(review.commitContext).not.toHaveBeenCalled()
+    expect(review.push).not.toHaveBeenCalled()
+    expect(review.createPr).not.toHaveBeenCalled()
+    expect(requestOneShot).not.toHaveBeenCalled()
+  })
+
   it('sets the selected path and fetches its diff', async () => {
     const review = stubReview({ diff: vi.fn(async () => 'the diff') })
 
@@ -274,6 +523,19 @@ describe('view state', () => {
 
     expect($reviewScopeCwd.get()).toBe('/tile-worktree')
     expect($reviewScopeTarget.get()).toBe('tile:project-b')
+  })
+
+  it('ordinary open clears a tool snapshot from an earlier card', async () => {
+    stubReview({ list: vi.fn(async () => ({ files: [] })) })
+    const fallback = { added: 1, diff: 'old tool diff', path: '/workspace/note.md', removed: 0 }
+    await openReviewForPath(fallback.path, null, 'main', [fallback])
+    expect($reviewReadOnly.get()).toBe(true)
+
+    openReview()
+    await refreshReview()
+
+    expect($reviewFiles.get()).toEqual([])
+    expect($reviewReadOnly.get()).toBe(false)
   })
 
   it('revealReview re-homes the origin when the repo stays the same', () => {

--- a/apps/desktop/src/store/review.test.ts
+++ b/apps/desktop/src/store/review.test.ts
@@ -41,7 +41,7 @@ import {
   toggleReviewTreeMode,
   unstageReviewFile
 } from './review'
-import { $currentCwd } from './session'
+import { $connection, $currentCwd } from './session'
 
 // requestOneShot is the only cross-module dependency that must be faked (it
 // reaches the gateway); everything else routes through window.hermesDesktop.git,
@@ -108,6 +108,131 @@ beforeEach(() => {
 
 afterEach(() => {
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+  $connection.set(null)
+})
+
+describe('openReviewForPath repo re-homing (#86334 / #81722)', () => {
+  it('re-homes to the changed file\u2019s own repo when the session cwd is not a repo (umbrella dir)', async () => {
+    // Session cwd is an umbrella directory; git review there is empty, but the
+    // clicked file lives inside a child repository.
+    $currentCwd.set('/umbrella')
+
+    const list = vi.fn(async (cwd: string) =>
+      cwd === '/umbrella/child' ? { files: [file('note.md')] } : { files: [] }
+    )
+
+    const review = stubReview({ diff: vi.fn(async () => 'git diff'), list })
+
+    ;(window as unknown as { hermesDesktop: { gitRoot?: unknown } }).hermesDesktop.gitRoot = vi.fn(
+      async () => '/umbrella/child'
+    )
+
+    const fallback = { added: 1, diff: 'tool diff', path: '/umbrella/child/note.md', removed: 0 }
+
+    await openReviewForPath(fallback.path, null, 'main', [fallback])
+
+    // The pane must land on real, mutable git review of the child repo — not
+    // the read-only tool snapshot fallback.
+    expect($reviewScopeCwd.get()).toBe('/umbrella/child')
+    expect($reviewFiles.get().map(item => item.path)).toEqual(['note.md'])
+    expect($reviewReadOnly.get()).toBe(false)
+    expect($reviewSelectedPath.get()).toBe('note.md')
+    expect($reviewDiff.get()).toBe('git diff')
+    expect(review.list).toHaveBeenCalledWith('/umbrella/child', 'uncommitted', null)
+  })
+
+  it('re-homes over a remote gateway: git-root and review both resolve via the backend REST API', async () => {
+    // Desktop on one machine, gateway on another: desktopGit()/desktopGitRoot
+    // must route through /api/fs/git-root and /api/git/review/* on the REMOTE
+    // backend. The session cwd points at a stale workspace path whose review
+    // list is empty, while the changed file lives in a real repo on the
+    // gateway (#81722).
+    $connection.set({ mode: 'remote' } as never)
+    $currentCwd.set('/gw/workspace')
+
+    const api = vi.fn(async (request: { path: string }) => {
+      const { path } = request
+
+      if (path.startsWith('/api/fs/git-root')) {
+        return { root: '/gw/repo' }
+      }
+
+      if (path.startsWith('/api/git/review/list')) {
+        const cwd = new URL(path, 'http://x').searchParams.get('path')
+
+        return cwd === '/gw/repo' ? { base: null, files: [file('docs/note.md')] } : { base: null, files: [] }
+      }
+
+      if (path.startsWith('/api/git/review/diff')) {
+        return { diff: 'remote git diff' }
+      }
+
+      if (path.startsWith('/api/git/review/ship-info')) {
+        return { ghReady: false, pr: null }
+      }
+
+      throw new Error(`unexpected api call: ${path}`)
+    })
+
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = { api }
+
+    const fallback = { added: 1, diff: 'tool diff', path: '/gw/repo/docs/note.md', removed: 0 }
+
+    await openReviewForPath(fallback.path, null, 'main', [fallback])
+
+    expect($reviewScopeCwd.get()).toBe('/gw/repo')
+    expect($reviewFiles.get().map(item => item.path)).toEqual(['docs/note.md'])
+    expect($reviewReadOnly.get()).toBe(false)
+    expect($reviewSelectedPath.get()).toBe('docs/note.md')
+    expect($reviewDiff.get()).toBe('remote git diff')
+    // The probe went to the backend, not the local Electron bridge.
+    expect(api.mock.calls.some(([request]) => request.path.startsWith('/api/fs/git-root'))).toBe(true)
+  })
+
+  it('keeps the read-only tool snapshot when no repo root exists anywhere', async () => {
+    $currentCwd.set('/no-repo')
+    stubReview({ list: vi.fn(async () => ({ files: [] })) })
+    ;(window as unknown as { hermesDesktop: { gitRoot?: unknown } }).hermesDesktop.gitRoot = vi.fn(async () => null)
+
+    const fallback = { added: 1, diff: 'tool diff', path: '/no-repo/note.md', removed: 0 }
+
+    await openReviewForPath(fallback.path, null, 'main', [fallback])
+
+    expect($reviewScopeCwd.get()).toBeNull()
+    expect($reviewReadOnly.get()).toBe(true)
+    expect($reviewSelectedPath.get()).toBe(fallback.path)
+    expect($reviewDiff.get()).toBe('tool diff')
+  })
+
+  it('never second-guesses an explicit tile scope pin', async () => {
+    const review = stubReview({ list: vi.fn(async () => ({ files: [] })) })
+
+    const gitRoot = vi.fn(async () => '/elsewhere')
+
+    ;(window as unknown as { hermesDesktop: { gitRoot?: unknown } }).hermesDesktop.gitRoot = gitRoot
+
+    const fallback = { added: 1, diff: 'tool diff', path: '/tile/worktree/note.md', removed: 0 }
+
+    await openReviewForPath(fallback.path, '/tile/worktree', 'tile:one', [fallback])
+
+    expect(gitRoot).not.toHaveBeenCalled()
+    expect($reviewScopeCwd.get()).toBe('/tile/worktree')
+    expect(review.list).toHaveBeenCalledWith('/tile/worktree', 'uncommitted', null)
+  })
+
+  it('does not probe git-root for relative tool paths', async () => {
+    stubReview({ list: vi.fn(async () => ({ files: [] })) })
+
+    const gitRoot = vi.fn(async () => '/somewhere')
+
+    ;(window as unknown as { hermesDesktop: { gitRoot?: unknown } }).hermesDesktop.gitRoot = gitRoot
+
+    await openReviewForPath('relative/note.md', null, 'main', [
+      { added: 1, diff: 'tool diff', path: 'relative/note.md', removed: 0 }
+    ])
+
+    expect(gitRoot).not.toHaveBeenCalled()
+  })
 })
 
 describe('refreshReview', () => {
@@ -264,9 +389,12 @@ describe('selectReviewFile / clearReviewSelection', () => {
 
     let resolveDiff!: (value: string) => void
     review.list.mockResolvedValue({ files: [file(gitPath)] })
-    review.diff.mockImplementationOnce(() => new Promise(resolve => {
-      resolveDiff = resolve
-    }))
+    review.diff.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveDiff = resolve
+        })
+    )
 
     const unsafeSnapshots: string[][] = []
 
@@ -404,9 +532,10 @@ describe('selectReviewFile / clearReviewSelection', () => {
 
     let resolveList!: (value: { files: HermesReviewFile[] }) => void
     review.list.mockImplementationOnce(
-      () => new Promise(resolve => {
-        resolveList = resolve
-      })
+      () =>
+        new Promise(resolve => {
+          resolveList = resolve
+        })
     )
     const second = { added: 1, diff: 'second diff', path: '/workspace/second.md', removed: 0 }
 

--- a/apps/desktop/src/store/review.test.ts
+++ b/apps/desktop/src/store/review.test.ts
@@ -794,6 +794,50 @@ describe('revert confirm dialog', () => {
   })
 })
 
+// The PR review asked for read-only to be enforced at the store action layer,
+// not just hidden in the UI: even if a keyboard shortcut, command palette entry,
+// or stray caller reaches a mutation action while the pane shows a read-only
+// tool-diff snapshot, no IPC mutation may fire.
+describe('read-only store-layer guard', () => {
+  it('every mutation action is a no-op while $reviewReadOnly is set', async () => {
+    const review = stubReview()
+    $reviewReadOnly.set(true)
+
+    await stageReviewFile('a.ts')
+    await unstageReviewFile('a.ts')
+    await revertReviewFile('a.ts')
+    requestRevert('a.ts')
+    await commitChanges('msg', { push: true })
+    await pushChanges()
+    await createOrOpenPr()
+    const generated = await generateCommitMessage()
+
+    expect(review.stage).not.toHaveBeenCalled()
+    expect(review.unstage).not.toHaveBeenCalled()
+    expect(review.revert).not.toHaveBeenCalled()
+    expect($reviewRevertTarget.get()).toBeUndefined()
+    expect(review.commit).not.toHaveBeenCalled()
+    expect(review.push).not.toHaveBeenCalled()
+    expect(review.createPr).not.toHaveBeenCalled()
+    expect(review.commitContext).not.toHaveBeenCalled()
+    expect(requestOneShot).not.toHaveBeenCalled()
+    expect(generated).toBe('')
+    expect($reviewShipBusy.get()).toBe(false)
+    expect($reviewCommitMsgBusy.get()).toBe(false)
+  })
+
+  it('confirmRevert refuses a pending revert if read-only flipped on after the request', async () => {
+    const review = stubReview()
+    requestRevert('a.ts')
+    $reviewReadOnly.set(true)
+
+    await confirmRevert()
+
+    expect($reviewRevertTarget.get()).toBeUndefined()
+    expect(review.revert).not.toHaveBeenCalled()
+  })
+})
+
 describe('ship flow', () => {
   it('commitChanges commits the trimmed message and toggles the busy flag', async () => {
     const review = stubReview()

--- a/apps/desktop/src/store/review.ts
+++ b/apps/desktop/src/store/review.ts
@@ -60,6 +60,7 @@ export function toggleReviewTreeMode(): void {
 
 export const $reviewFiles = atom<HermesReviewFile[]>([])
 export const $reviewLoading = atom(false)
+export const $reviewReadOnly = atom(false)
 // False when the active session isn't in a local git repo (detached/fresh chat,
 // remote backend). Lets the pane say "not a repo" instead of stranding on a
 // skeleton or implying a clean repo with "no changes".
@@ -103,9 +104,92 @@ const repoCwd = reviewRepoCwd
 
 type ReviewBridge = NonNullable<NonNullable<NonNullable<Window['hermesDesktop']>['git']>['review']>
 let reviewRefreshSeq = 0
+let reviewDiffSeq = 0
 let reviewRefreshTimer: ReturnType<typeof setTimeout> | null = null
 let shipInfoSeq = 0
 let shipInfoLastCheckedAt = 0
+
+export interface ReviewFallbackFile {
+  added: number
+  diff: string
+  path: string
+  removed: number
+}
+
+const $reviewFallbackFiles = atom<ReviewFallbackFile[]>([])
+
+function setReviewFallback(files: readonly ReviewFallbackFile[] = []): void {
+  const next = files.map(file => ({ ...file }))
+
+  if (next.length === 0) {
+    clearReviewFallback()
+
+    return
+  }
+
+  reviewDiffSeq += 1
+  $reviewFallbackFiles.set(next)
+  $reviewReadOnly.set(true)
+
+  const selected = $reviewSelectedPath.get()
+  const selectedFallback = selected ? next.find(file => file.path === selected) : null
+
+  if (selectedFallback) {
+    $reviewDiff.set(selectedFallback.diff)
+    $reviewDiffLoading.set(false)
+  } else if (selected) {
+    clearReviewSelection()
+  }
+}
+
+function clearReviewFallback(preserveSelection = false, preserveReadOnly = false): void {
+  const hadFallback = $reviewReadOnly.get() || $reviewFallbackFiles.get().length > 0
+
+  $reviewFallbackFiles.set([])
+
+  if (!hadFallback) {
+    if (!preserveReadOnly) {
+      $reviewReadOnly.set(false)
+    }
+
+    return
+  }
+
+  reviewDiffSeq += 1
+  $reviewDiff.set(null)
+  $reviewDiffLoading.set(false)
+
+  if (!preserveSelection) {
+    $reviewFiles.set([])
+    $reviewSelectedPath.set(null)
+  }
+
+  if (!preserveReadOnly) {
+    $reviewReadOnly.set(false)
+  }
+}
+
+function applyReviewFallback(seq: number): boolean {
+  const fallback = $reviewFallbackFiles.get()
+
+  if (seq !== reviewRefreshSeq || fallback.length === 0) {
+    return false
+  }
+
+  $reviewFiles.set(
+    fallback.map(file => ({
+      added: file.added,
+      path: file.path,
+      removed: file.removed,
+      staged: false,
+      status: 'M'
+    }))
+  )
+  $reviewIsRepo.set(false)
+  $reviewReadOnly.set(true)
+
+  return true
+}
 
 // The two things every review op needs: the repo cwd + the IPC bridge. Null when
 // either is missing (no session, remote backend), so callers bail in one line.
@@ -151,24 +235,37 @@ export async function refreshReview(): Promise<void> {
 
     // Hide dep/build/cache dirs and OS noise even when the repo tracks them —
     // .gitignored paths are already dropped upstream by `git status`.
+    const hasGitAuthority = result.files.length > 0
     const files = result.files.filter(file => !isExcludedPath(file.path))
 
-    $reviewFiles.set(files)
+    if (hasGitAuthority) {
+      clearReviewFallback(true, true)
+      $reviewFiles.set(files)
+      $reviewReadOnly.set(false)
+    } else if (!applyReviewFallback(seq)) {
+      $reviewFiles.set([])
+      $reviewReadOnly.set(false)
+    }
 
     // Drop the selection if the file is gone (staged away, reverted) so the diff
     // pane doesn't strand on a ghost; otherwise lazily fetch its diff so a
     // restored (persisted) selection re-renders on boot.
     const selected = $reviewSelectedPath.get()
-    const selectedFile = selected ? files.find(file => file.path === selected) : null
+    const selectedFile = selected ? matchReviewFile($reviewFiles.get(), selected) : undefined
 
     if (selected && !selectedFile) {
       clearReviewSelection()
     } else if (selectedFile && $reviewDiff.get() === null) {
+      // A fallback→Git transition clears the old diff before reaching here, so
+      // authority changes still fetch immediately. Ordinary Git list refreshes
+      // retain an already-valid diff instead of flashing or replacing it on a
+      // transient follow-up fetch failure.
       void selectReviewFile(selectedFile)
     }
   } catch {
-    if (seq === reviewRefreshSeq) {
+    if (seq === reviewRefreshSeq && !applyReviewFallback(seq)) {
       $reviewFiles.set([])
+      $reviewReadOnly.set(false)
     }
   } finally {
     if (seq === reviewRefreshSeq) {
@@ -193,7 +290,19 @@ function scheduleReviewRefresh(): void {
 }
 
 export async function selectReviewFile(file: HermesReviewFile): Promise<void> {
+  const seq = (reviewDiffSeq += 1)
   $reviewSelectedPath.set(file.path)
+
+  if ($reviewReadOnly.get()) {
+    const fallback = $reviewFallbackFiles.get().find(candidate => candidate.path === file.path)
+
+    if (seq === reviewDiffSeq && $reviewSelectedPath.get() === file.path) {
+      $reviewDiff.set(fallback?.diff ?? '')
+      $reviewDiffLoading.set(false)
+    }
+
+    return
+  }
 
   const ctx = reviewCtx()
 
@@ -208,21 +317,22 @@ export async function selectReviewFile(file: HermesReviewFile): Promise<void> {
   try {
     const diff = await ctx.review.diff(ctx.cwd, file.path, 'uncommitted', null, file.staged)
 
-    if ($reviewSelectedPath.get() === file.path) {
+    if (seq === reviewDiffSeq && $reviewSelectedPath.get() === file.path && !$reviewReadOnly.get()) {
       $reviewDiff.set(diff || '')
     }
   } catch {
-    if ($reviewSelectedPath.get() === file.path) {
+    if (seq === reviewDiffSeq && $reviewSelectedPath.get() === file.path && !$reviewReadOnly.get()) {
       $reviewDiff.set('')
     }
   } finally {
-    if ($reviewSelectedPath.get() === file.path) {
+    if (seq === reviewDiffSeq && $reviewSelectedPath.get() === file.path) {
       $reviewDiffLoading.set(false)
     }
   }
 }
 
 export function clearReviewSelection(): void {
+  reviewDiffSeq += 1
   $reviewSelectedPath.set(null)
   $reviewDiff.set(null)
   $reviewDiffLoading.set(false)
@@ -264,7 +374,12 @@ function refreshShipInfoIfStale(): void {
 /** Open the pane scoped to `scopeCwd` (a tile's worktree), or to the active
  *  session's cwd when null — see `$reviewScopeCwd`. Keep the originating
  *  composer target alongside it for agent-ship actions. */
-export function openReview(scopeCwd: null | string = null, scopeTarget = 'main'): void {
+export function openReview(
+  scopeCwd: null | string = null,
+  scopeTarget = 'main',
+  fallbackFiles: readonly ReviewFallbackFile[] = []
+): void {
+  setReviewFallback(fallbackFiles)
   $reviewScopeCwd.set(scopeCwd?.trim() || null)
   $reviewScopeTarget.set(scopeTarget.trim() || 'main')
   $reviewOpen.set(true)
@@ -276,10 +391,13 @@ export function closeReview(): void {
   $reviewOpen.set(false)
   $reviewScopeCwd.set(null)
   $reviewScopeTarget.set('main')
+  clearReviewFallback()
   clearReviewSelection()
 }
 
 export function toggleReview(scopeCwd: null | string = null, scopeTarget = 'main'): void {
+  clearReviewFallback()
+
   // Narrow width: the pane is a collapsed overlay (like the sidebar under ⌘B).
   // Make sure its data is loaded, then slide it in/out via the forced-reveal pin
   // — never the docked open state, which a 0px track would render invisibly.
@@ -315,18 +433,26 @@ export function toggleReview(scopeCwd: null | string = null, scopeTarget = 'main
  * closes an already-open pane — it's the "take me to the diff" entry point used
  * by the transcript's changed-files card.
  */
-export function revealReview(scopeCwd: null | string = null, scopeTarget = 'main'): void {
+export function revealReview(
+  scopeCwd: null | string = null,
+  scopeTarget = 'main',
+  fallbackFiles: readonly ReviewFallbackFile[] = []
+): void {
   const wasOpen = $reviewOpen.get()
   const target = scopeTarget.trim() || 'main'
 
   if (!wasOpen) {
-    openReview(scopeCwd, target)
-  } else if (($reviewScopeCwd.get() ?? null) !== (scopeCwd?.trim() || null) || $reviewScopeTarget.get() !== target) {
-    // Already open but on another worktree's diff — re-home it. The scope
-    // subscription below clears the stale list and re-probes. Keep the
-    // originating composer target alongside the cwd for the agent-ship action.
-    $reviewScopeCwd.set(scopeCwd?.trim() || null)
-    $reviewScopeTarget.set(target)
+    openReview(scopeCwd, target, fallbackFiles)
+  } else {
+    if (($reviewScopeCwd.get() ?? null) !== (scopeCwd?.trim() || null) || $reviewScopeTarget.get() !== target) {
+      // Clear the previous scope through the normal subscription first; install
+      // this card's snapshot afterwards so re-homing cannot erase the new data.
+      $reviewScopeCwd.set(scopeCwd?.trim() || null)
+      $reviewScopeTarget.set(target)
+    }
+
+    setReviewFallback(fallbackFiles)
+    void refreshReview()
   }
 
   if (matchesQuery(SIDEBAR_COLLAPSE_MEDIA_QUERY)) {
@@ -364,9 +490,10 @@ function matchReviewFile(files: readonly HermesReviewFile[], path: string): Herm
 export async function openReviewForPath(
   path: string,
   scopeCwd: null | string = null,
-  scopeTarget = 'main'
+  scopeTarget = 'main',
+  fallbackFiles: readonly ReviewFallbackFile[] = []
 ): Promise<void> {
-  revealReview(scopeCwd, scopeTarget)
+  revealReview(scopeCwd, scopeTarget, fallbackFiles)
   await refreshReview()
 
   const file = matchReviewFile($reviewFiles.get(), path)
@@ -394,16 +521,28 @@ async function afterMutation(): Promise<void> {
 }
 
 export async function stageReviewFile(path: null | string): Promise<void> {
+  if ($reviewReadOnly.get()) {
+    return
+  }
+
   await desktopGit()?.review?.stage(repoCwd() ?? '', path)
   await afterMutation()
 }
 
 export async function unstageReviewFile(path: null | string): Promise<void> {
+  if ($reviewReadOnly.get()) {
+    return
+  }
+
   await desktopGit()?.review?.unstage(repoCwd() ?? '', path)
   await afterMutation()
 }
 
 export async function revertReviewFile(path: null | string): Promise<void> {
+  if ($reviewReadOnly.get()) {
+    return
+  }
+
   await desktopGit()?.review?.revert(repoCwd() ?? '', path)
   await afterMutation()
 }
@@ -416,6 +555,10 @@ export const $reviewRevertTarget = atom<{ path: null | string } | undefined>(und
 
 /** Open the revert confirm for a single file, or `null` for all changes. */
 export function requestRevert(path: null | string): void {
+  if ($reviewReadOnly.get()) {
+    return
+  }
+
   $reviewRevertTarget.set({ path })
 }
 
@@ -429,7 +572,7 @@ export async function confirmRevert(): Promise<void> {
 
   $reviewRevertTarget.set(undefined)
 
-  if (target) {
+  if (target && !$reviewReadOnly.get()) {
     await revertReviewFile(target.path)
   }
 }
@@ -448,6 +591,10 @@ async function runShip<T>(action: () => Promise<T>): Promise<T> {
 }
 
 export async function commitChanges(message: string, opts: { push?: boolean } = {}): Promise<void> {
+  if ($reviewReadOnly.get()) {
+    return
+  }
+
   const ctx = reviewCtx()
 
   if (!ctx || !message.trim()) {
@@ -478,6 +625,10 @@ export function cancelCommitMessage(): void {
 // current box text: handing it back as "don't repeat this" makes a re-press a
 // real regen even on greedy / temperature-pinned models. Throws so the UI toasts.
 export async function generateCommitMessage(previous = ''): Promise<string> {
+  if ($reviewReadOnly.get()) {
+    return ''
+  }
+
   const ctx = reviewCtx()
 
   if (!ctx?.review.commitContext) {
@@ -511,6 +662,10 @@ export async function generateCommitMessage(previous = ''): Promise<string> {
 }
 
 export async function pushChanges(): Promise<void> {
+  if ($reviewReadOnly.get()) {
+    return
+  }
+
   const ctx = reviewCtx()
 
   if (!ctx) {
@@ -526,6 +681,10 @@ export async function pushChanges(): Promise<void> {
 // PR button: open the existing PR in the browser, or create one (pushing first)
 // then open it. Caller gates this on shipInfo.ghReady.
 export async function createOrOpenPr(): Promise<void> {
+  if ($reviewReadOnly.get()) {
+    return
+  }
+
   const ctx = reviewCtx()
 
   if (!ctx) {
@@ -594,6 +753,7 @@ $busy.subscribe(busy => {
 // diff into the new one.
 function onReviewRepoMoved(): void {
   if ($reviewOpen.get()) {
+    clearReviewFallback()
     clearReviewSelection()
     $reviewFiles.set([])
     $reviewLoading.set(true)

--- a/apps/desktop/src/store/review.ts
+++ b/apps/desktop/src/store/review.ts
@@ -5,6 +5,7 @@ import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
 import { isPaneVisible, revealTreePane } from '@/components/pane-shell/tree/store'
 import type { HermesReviewFile, HermesReviewShipInfo } from '@/global'
 import { matchesQuery } from '@/hooks/use-media-query'
+import { desktopGitRoot } from '@/lib/desktop-fs'
 import { desktopGit } from '@/lib/desktop-git'
 import { isExcludedPath } from '@/lib/excluded-paths'
 import { requestOneShot } from '@/lib/oneshot'
@@ -496,11 +497,62 @@ export async function openReviewForPath(
   revealReview(scopeCwd, scopeTarget, fallbackFiles)
   await refreshReview()
 
-  const file = matchReviewFile($reviewFiles.get(), path)
+  let file = matchReviewFile($reviewFiles.get(), path)
+
+  // Git at the pane's current scope has no authority over this file: the
+  // session cwd may not be a repo, may be an umbrella directory ABOVE the
+  // file's own repo, or — on a remote gateway — may be a stale/empty workspace
+  // path while the file lives in a real repo on the backend (#86334, #81722).
+  // Ask the file itself which repo it belongs to (desktopGitRoot is
+  // remote-aware: Electron locally, GET /api/fs/git-root on a gateway) and
+  // re-home the pane there so real git review wins over the read-only tool
+  // snapshot. An explicit scopeCwd is a deliberate pin (a tile's worktree) and
+  // is never second-guessed.
+  if (!scopeCwd && (!file || $reviewReadOnly.get())) {
+    if (await rehomeReviewToChangedFileRepo(path, scopeTarget, fallbackFiles)) {
+      file = matchReviewFile($reviewFiles.get(), path) ?? file
+    }
+  }
 
   if (file) {
     await selectReviewFile(file)
   }
+}
+
+// Monotonic token so an older repo-root probe that resolves late cannot yank
+// the pane away from a scope a newer interaction already established.
+let reviewRehomeSeq = 0
+
+/** Resolve `probePath`'s own git root and re-scope the pane to it. Returns
+ *  true when the pane was re-homed and refreshed against the resolved root. */
+async function rehomeReviewToChangedFileRepo(
+  probePath: string,
+  scopeTarget: string,
+  fallbackFiles: readonly ReviewFallbackFile[]
+): Promise<boolean> {
+  // Only an absolute tool path can name a repo (on either machine); a bare
+  // relative path is meaningless outside the scope we already probed.
+  if (!/^(?:[a-zA-Z]:[\\/]|[\\/])/.test(probePath)) {
+    return false
+  }
+
+  const seq = (reviewRehomeSeq += 1)
+  let root: null | string = null
+
+  try {
+    root = (await desktopGitRoot(probePath))?.trim() || null
+  } catch {
+    root = null
+  }
+
+  if (seq !== reviewRehomeSeq || !root || root === repoCwd()) {
+    return false
+  }
+
+  revealReview(root, scopeTarget, fallbackFiles)
+  await refreshReview()
+
+  return seq === reviewRehomeSeq
 }
 
 // ── Mutations ────────────────────────────────────────────────────────────────

--- a/tests-js/scripts/mock-server.ts
+++ b/tests-js/scripts/mock-server.ts
@@ -301,6 +301,28 @@ function verificationStopScript(writePath: string): ScriptedTurn[] {
 export const VERIFICATION_STOP_TRIGGER = 'E2E_VERIFY_ON_STOP_TRIGGER'
 export const VERIFICATION_STOP_TEXT = 'I cannot provide fresh verification evidence for that edit.'
 
+export const REVIEW_TOOL_DIFF_TRIGGER = 'E2E_REVIEW_TOOL_DIFF_TRIGGER'
+export const REVIEW_TOOL_DIFF_QUESTION = 'Keep the review turn open?'
+
+function reviewToolDiffTurn(writePath: string): ScriptedTurn {
+  return {
+    text: 'I will edit the non-Git project and keep the turn open for review.',
+    toolCalls: [
+      {
+        name: 'write_file',
+        args: {
+          path: writePath,
+          content: 'def changed_by_e2e():\n    return "changed"\n',
+        },
+      },
+      {
+        name: 'clarify',
+        args: { question: REVIEW_TOOL_DIFF_QUESTION, choices: ['Continue', 'Stop'] },
+      },
+    ],
+  }
+}
+
 /**
  * A marker that makes the mock emit a real blocking clarify tool call. Tests
  * use it to hold a turn open while exercising busy-composer interactions.
@@ -505,7 +527,8 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
           const isSidebarCrossTrigger = userText.includes('E2E_SIDEBAR_CROSS')
           const isQueueStopTrigger = userText.includes('E2E_QUEUE_STOP_TRIGGER')
           const isTaskPanelResumeTrigger = userText.includes(TASK_PANEL_RESUME_TRIGGER)
-
+          const isReviewToolDiffTrigger = userText.includes(REVIEW_TOOL_DIFF_TRIGGER)
+            && !messages.some(message => message?.role === 'tool')
           const isVerificationStopTrigger = messages.some(
             message => typeof message?.content === 'string' && message.content.includes(VERIFICATION_STOP_TRIGGER),
           )
@@ -537,6 +560,16 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
               respond()
             }
 
+            return
+          }
+
+          if (isReviewToolDiffTrigger) {
+            const turn = reviewToolDiffTurn(options.verificationWritePath ?? 'e2e-review-target.py')
+            if (stream) {
+              streamScriptedTurn(res, model, turn)
+            } else {
+              nonStreamingScriptedTurn(res, model, turn)
+            }
             return
           }
 


### PR DESCRIPTION
## Summary

The transcript's **"N files changed"** card derives per-file diffs straight from tool results, but clicking **Review** (or a file row) opens a pane that only reads `git status` at `repoCwd() = $reviewScopeCwd ?? $currentCwd`. Whenever that lookup comes back empty, the pane renders **NO DIFFS** even though the diff data is sitting in the transcript. Two distinct legs:

- **#86334 — non-git / umbrella session cwd.** `HERMES_HOME` sessions, or an umbrella Project directory containing child repos: git at the session cwd legitimately has nothing, and the pane ignores the tool diffs the card already holds.
- **#81722 — remote gateway.** Desktop on one machine, gateway on another. `desktopGit()` correctly routes review calls to `GET /api/git/review/list` on the backend, and the backend handler (`hermes_cli/web_git.py::review_list`) is fine for a repo cwd — but the pane still asks about **`$currentCwd`**, which on a remote connection is frequently a stale/remembered workspace path (per-backend `localStorage` memory in `store/session.ts`) or a non-repo like `HERMES_HOME`, not the repo the file was actually edited in. Same silent empty result, same NO DIFFS — even though the file browser's diff tab shows the changes, because *it* resolves the file's own git root first (`desktopGitRoot` → `/api/fs/git-root`, see `preview-file.tsx`).

The common root cause: **the Review pane treats the session cwd as the sole git scope and never uses the changed-file provenance it was invoked with.**

## Changes

This PR builds on **#96866 by @Wenfengcheng** (cherry-picked, authorship preserved), rebased onto current main and extended to cover the remote/umbrella leg.

**From #96866 (fallback leg, #86334):** when git has no reviewable files (or the lookup fails), the Review pane falls back to the tool-result diffs the ChangedFilesCard already derived. Fallback state is strictly read-only — stage/unstage/revert/commit/push/PR are all gated off `$reviewReadOnly` — and git stays authoritative the moment it returns files. Includes hardened diff parsing (multi-hunk concatenation, header-lookalike content lines) and an Electron E2E spec.

Rebase fixes needed to land it on current main:
- the E2E mock-server moved to `tests-js/scripts/mock-server.ts`; the spec's import updated (git rename-detection carried the mock-server changes over cleanly);
- the context-menu test matched stale i18n casing (`Open Changes` vs current `Open changes`).

**New in this PR (remote/umbrella leg, #81722):** `openReviewForPath` now asks the clicked file itself which repo it belongs to. When git at the pane's current scope has no authority over the file (no match, or the read-only fallback engaged) and no explicit tile scope is pinned, it probes `desktopGitRoot(path)` — Electron IPC locally, `GET /api/fs/git-root` on a remote gateway — and re-homes the pane to the resolved root. Review then runs real `git status`/`diff` against the **file's own repo on the right machine**, so:

- umbrella-project sessions land on the child repo with full mutable review (the exact scenario in the #86334 comment thread);
- remote-gateway sessions land on the backend repo via the existing `/api/git/review/*` REST path instead of an empty stale-cwd probe;
- when no repo exists anywhere, the read-only tool-diff fallback still renders the transcript's diffs instead of NO DIFFS.

Guards: an explicit `scopeCwd` (tile worktree pin) is never second-guessed; relative tool paths never probe; a monotonic token drops late-resolving probes so they can't yank a newer scope.

## Tests

- All of #96866's suites adapted and green: `review.test.ts`, `index.test.tsx`, `file-tree.test.tsx`, `changed-files-card.test.tsx`, `changed-files.test.ts`, `fallback-model.test.ts`, `diff-lines.test.tsx` — **107 tests / 7 files passing** (`npx vitest run … --project ui`).
- **5 new regression tests** in `review.test.ts`: umbrella-dir re-home to the child repo; full remote-gateway path (mocked `window.hermesDesktop.api` serving `/api/fs/git-root` + `/api/git/review/*`, asserting the probe goes to the backend REST surface and the pane lands mutable on `/gw/repo`); no-repo-anywhere keeps the read-only tool snapshot; tile-pin never probed; relative paths never probed.
- **Sabotage run:** reverting `review.ts` to the #96866-only state (fallback present, no re-homing) fails exactly the two key new tests (umbrella + remote-gateway) — 2 failed / 56 passed — and restoring the fix returns 58/58.
- `tsc -p .`, `tsc -p tsconfig.electron.json`, `tsc -p tsconfig.e2e.json` — all `--noEmit` clean; `eslint` clean on every touched file; `prettier` applied.
- Backend contract verified empirically against a real temp repo: `hermes_cli.web_git.review_list` returns correct root-relative rows for both root and nested cwds (the handler itself is not the bug).

## Limitations / follow-ups

- The full `test:desktop:all` / E2E matrix was left to CI — the dev box for this PR has 3.7 GB RAM / 2 CPUs and cannot run the Electron suites reliably; every touched vitest suite was run individually instead.
- The remote leg is verified through unit tests that mock the gateway REST transport at `window.hermesDesktop.api` plus code-reading of the Electron routing (`hermes:api` → `resolveProfileApiRequest`) and the FastAPI handlers. A live two-machine desktop→gateway smoke test (Windows client → Linux gateway, per the #86334/#81722 reports) would be a valuable confirmation; reporters on both issues offered to test patches.
- `refreshReview`'s periodic refresh still follows the (possibly re-homed) `$reviewScopeCwd`, so the pane stays on the file's repo until closed or re-homed — consistent with the existing tile-scope behavior.

Fixes #86334
Fixes #81722
