### PR TITLE
fix(discord): re-arm voice inactivity timer on user input

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3664,6 +3664,12 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
             if not transcript or is_whisper_hallucination(transcript):
                 return
             logger.info("Voice input from user %d: %s", user_id, transcript[:100])
+            # The user spoke: re-arm the auto-disconnect inactivity timer so an active
+            # two-way voice conversation does not drop after
+            # voice_channel_inactivity_timeout_seconds (refs #105974). The bot's own
+            # TTS playback already re-arms via play_in_voice_channel's finally; the
+            # STT path that hears the user did not.
+            self._reset_voice_timeout(guild_id)
             if self._voice_input_callback:
                 await self._voice_input_callback(
                     guild_id=guild_id, user_id=user_id, transcript=transcript,

--- a/tests/gateway/test_discord_voice_timeout_rearm.py
+++ b/tests/gateway/test_discord_voice_timeout_rearm.py
@@ -1,0 +1,79 @@
+"""Regression tests for the Discord voice inactivity timer re-arm on user input.
+
+Refs #105974: ``_process_voice_input`` (the STT path that hears the user) never
+called ``_reset_voice_timeout()``, so an active two-way voice conversation
+dropped exactly ``voice_channel_inactivity_timeout_seconds`` after the bot
+joined. The bot's own TTS playback already re-armed via
+``play_in_voice_channel``'s ``finally``; the listening path did not.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_adapter():
+    """Build a DiscordAdapter without the heavy __init__ (see existing fixtures)."""
+    adapter = object.__new__(DiscordAdapter)
+    adapter._voice_timeout_tasks = {}
+    adapter._voice_input_callback = None
+    return adapter
+
+
+async def test_process_voice_input_re_arms_inactivity_timeout(monkeypatch):
+    """When the user is heard (valid transcript), the STT path must re-arm the
+    auto-disconnect inactivity timer so an active conversation does not drop
+    (refs #105974)."""
+    adapter = _make_adapter()
+    reset_calls = []
+    adapter._reset_voice_timeout = lambda guild_id: reset_calls.append(guild_id)
+
+    # Stub the STT pipeline so _process_voice_input sees a real, non-hallucinated
+    # transcript without touching ffmpeg / whisper.
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter.VoiceReceiver.pcm_to_wav",
+        lambda pcm, wav_path: None,
+    )
+    monkeypatch.setattr(
+        "tools.transcription_tools.transcribe_audio",
+        lambda wav_path: {"success": True, "transcript": "hello there"},
+    )
+    monkeypatch.setattr(
+        "tools.voice_mode.is_whisper_hallucination", lambda t: False)
+
+    await adapter._process_voice_input(guild_id=42, user_id=7, pcm_data=b"\x00\x00")
+
+    assert reset_calls == [42], (
+        "_process_voice_input must re-arm the voice inactivity timer when the "
+        "user is heard (refs #105974); got calls={}".format(reset_calls)
+    )
+
+
+async def test_process_voice_input_does_not_rearm_on_failed_stt(monkeypatch):
+    """The re-arm must be gated on a valid transcript — a failed/empty STT must
+    NOT reset the timer (that would keep a silent bot connected indefinitely)."""
+    adapter = _make_adapter()
+    reset_calls = []
+    adapter._reset_voice_timeout = lambda guild_id: reset_calls.append(guild_id)
+
+    monkeypatch.setattr(
+        "plugins.platforms.discord.adapter.VoiceReceiver.pcm_to_wav",
+        lambda pcm, wav_path: None,
+    )
+    monkeypatch.setattr(
+        "tools.transcription_tools.transcribe_audio",
+        lambda wav_path: {"success": False, "transcript": ""},
+    )
+    monkeypatch.setattr(
+        "tools.voice_mode.is_whisper_hallucination", lambda t: False)
+
+    await adapter._process_voice_input(guild_id=99, user_id=7, pcm_data=b"\x00\x00")
+
+    assert reset_calls == [], (
+        "failed STT must not re-arm the inactivity timer; got calls={}".format(
+            reset_calls)
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a silent mid-conversation disconnect: when the bot joins a Discord voice channel, the inactivity auto-leave timer is armed once. After that, **user voice input does not reset the timer** — so in an active two-way voice conversation the bot silently disconnects exactly `voice_channel_inactivity_timeout_seconds` (default 300) after joining, even if the user is talking the whole time. This PR re-arms the timer on a successful user transcript.

## Related Issue

Closes #105974.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

`DiscordAdapter._reset_voice_timeout()` was called from the playback paths (`join_voice_channel`, `play_in_voice_channel`'s `finally`, `play_ack_in_voice`) but **not** from `_process_voice_input()` (the STT path that actually hears the user). The only thing that kept an auto-joined bot alive was its own TTS playback.

The fix: call `_reset_voice_timeout(guild_id)` in `_process_voice_input()` once a valid (non-hallucinated) transcript is detected, mirroring the playback-path re-arm pattern. Additive — one line plus a comment.

Why this is safe:
- The re-arm is **gated on a successful transcript** — a silent channel still times out (verified by a negative test).
- Compatible with #43165's `/voice off` fix: `_voice_timeout_handler` returns early when mode == `"off"`, so re-arming there is a no-op (no spam, no disconnect).
- `_reset_voice_timeout` cancels the existing task before re-arming, so calling it on every utterance does not accumulate timers.

## How to Test

New regression tests (`tests/gateway/test_discord_voice_timeout_rearm.py`):

- `test_process_voice_input_re_arms_inactivity_timeout` — valid transcript → `_reset_voice_timeout` called with the guild id. **Fails without the fix** (mutation-verified).
- `test_process_voice_input_does_not_rearm_on_failed_stt` — failed STT → `_reset_voice_timeout` NOT called (the re-arm is correctly gated).

Both pass with the fix; the positive test fails when the fix is reverted.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(discord): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#43165 = `/voice off` spam fix, complementary not overlapping; #101185 = sibling auto-join reply-to-text bug)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the discord voice timeout test suite and all tests pass
- [x] I've added tests for my changes (2 new, mutation-verified)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] N/A — additive one-line re-arm reusing existing `_reset_voice_timeout`; no public API or doc surface changed