### PR TITLE
fix(desktop): pass InstallRoot to post-update verify instead of cwd

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1606,8 +1606,8 @@ try {
 
     # A zero-exit update is not proof that the runtime survived the update.
     if ($res.Code -eq 0 -and -not $desktopBuildFailed) {
-        $verifyCode = "import hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path.cwd())"
-        $verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode) "verify"
+        $verifyCode = "import sys, hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path(sys.argv[1]))"
+        $verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode, $InstallRoot) "verify"
         if ($verify.Code -ne 0) {
             $finalCode = 8
             $finalMsg = "The updated Hermes runtime or Desktop build failed verification. Repair the installation and review antivirus quarantine before retrying."

--- a/tests/test_desktop_update_windows_python_handoff.py
+++ b/tests/test_desktop_update_windows_python_handoff.py
@@ -124,3 +124,31 @@ def test_desktop_relaunch_waits_for_an_in_place_rebuild() -> None:
     assert "if ((Get-Date) -ge $relaunchDeadline)" in body
     assert "Start-Sleep -Milliseconds 500" in body
     assert "[System.Windows.Forms.Application]::DoEvents()" in body
+
+
+def test_verify_step_passes_install_root_not_cwd() -> None:
+    """The post-update verify must resolve the checkout from ``$InstallRoot``.
+
+    ``verify_windows_desktop_update`` expects the checkout root
+    (``HERMES_HOME\\hermes-agent``) and resolves ``apps/desktop/release`` under
+    it. The hand-off is spawned with ``cwd: HERMES_HOME`` (not the checkout
+    root), so ``Path.cwd()`` points one level too high and the verify reports
+    "The updated Desktop executable is missing" (exit 8) even though the update
+    itself succeeded. The verify must receive ``$InstallRoot`` explicitly.
+    """
+    source = _read()
+
+    assert "verify_windows_desktop_update(Path.cwd())" not in source, (
+        "The verify step must not resolve the checkout from Path.cwd(): the "
+        "hand-off runs with cwd=HERMES_HOME, one level above the checkout root, "
+        "so Path.cwd() makes the verify report a missing executable after a "
+        "successful update. Pass $InstallRoot explicitly instead."
+    )
+    assert "verify_windows_desktop_update(Path(sys.argv[1]))" in source, (
+        "The verify step must resolve the checkout from $InstallRoot via "
+        "sys.argv[1]."
+    )
+    assert '@("-c", $verifyCode, $InstallRoot) "verify"' in source, (
+        "The verify Invoke-HermesStep must forward $InstallRoot as the script "
+        "argument so sys.argv[1] resolves to the checkout root."
+    )


### PR DESCRIPTION
## Summary

The Windows Desktop update hand-off (`scripts/desktop-update/windows.ps1`) runs its post-update verification as:

```powershell
$verifyCode = "import hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path.cwd())"
$verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode) "verify"
```

But the hand-off is spawned with `cwd: HERMES_HOME` (see `apps/desktop/electron/main.ts`), which is **one level above** the checkout root `HERMES_HOME/hermes-agent` that `verify_windows_desktop_update` expects.

`verify_windows_desktop_update` resolves `apps/desktop/release` under the path it is given, so `Path.cwd()` points at `HERMES_HOME/apps/desktop/...` — which does not exist. The verify then raises:

```
RuntimeError: The updated Desktop executable is missing
```

…and the hand-off exits with code 8, even though `hermes update` itself succeeded and the desktop app was rebuilt and packaged correctly.

## Root cause

The verify step relies on the process working directory instead of the explicit `-InstallRoot` argument the script already receives. The hand-off's `cwd` is `HERMES_HOME`, not the checkout root.

## Fix

Pass `$InstallRoot` explicitly as `sys.argv[1]`:

```powershell
$verifyCode = "import sys, hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path(sys.argv[1]))"
$verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode, $InstallRoot) "verify"
```

## Test plan

- Added a source-level regression test (`test_verify_step_passes_install_root_not_cwd`) guarding that the verify step never falls back to `Path.cwd()` and always forwards `$InstallRoot`.
- `pytest tests/test_desktop_update_windows_python_handoff.py` — 5 passed.
- Manually reproduced the failure with `Path.cwd()` (exit 1) and confirmed the fix resolves the checkout root correctly (exit 0).