### PR TITLE
fix(cron): propagate persisted job identity

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -45,6 +45,8 @@ from hermes_time import now as _hermes_now
 from agent.interrupt_compat import request_hard_interrupt
 from agent.delegation_context import (
     enter_non_dispatcher_owned_context, exit_non_dispatcher_owned_context)
+from cron.scheduler_identity import (
+    clear_cron_job_identity, cron_job_identity_scope, set_cron_job_identity)
 
 logger = logging.getLogger(__name__)
 
@@ -2032,7 +2034,8 @@ def _prepare_job_prompt(
 
     # no_agent short-circuits BEFORE importing run_agent / opening SessionDB.
     if job.get("no_agent"):
-        return _run_no_agent_job(job, job_id, job_name, cancel_event), None
+        with cron_job_identity_scope(job, job_id):
+            return _run_no_agent_job(job, job_id, job_name, cancel_event), None
 
     # Legacy / hand-edited job with nothing to run: pause it instead of waking the LLM every fire.
     from cron.jobs import EMPTY_PAYLOAD_ERROR, job_payload_is_empty
@@ -2054,7 +2057,9 @@ def _prepare_job_prompt(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path, cancel_event=cancel_event)
+        with cron_job_identity_scope(job, job_id):
+            prerun_script = _run_job_script_with_claim_heartbeat(
+                job, script_path, cancel_event=cancel_event)
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info("Job '%s' (ID: %s): wakeAgent=false, skipping agent run", job_name, job_id)
@@ -2136,6 +2141,7 @@ class _CronRunScope:
         )
         for name in _CRON_DELIVERY_VARS:
             _VAR_MAP[name].set("")
+        set_cron_job_identity(job, job_id)
         # Workdir binds to the per-run task id (tool-layer cwd authority) instead of mutating
         # global TERMINAL_CWD; _SESSION_CWD above remains the prompt/context-file authority.
         self.task_id = f"cron:{job_id}:{execution_id or job.get('execution_id') or uuid.uuid4().hex}"
@@ -2167,6 +2173,7 @@ class _CronRunScope:
             exit_non_dispatcher_owned_context(self._non_dispatcher_token)
         for name in _CRON_DELIVERY_VARS:
             self._var_map[name].set("")
+        clear_cron_job_identity()
 
 
 def _reload_dotenv_and_publish_delivery_target(job: dict) -> None:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -46,7 +46,7 @@ from agent.interrupt_compat import request_hard_interrupt
 from agent.delegation_context import (
     enter_non_dispatcher_owned_context, exit_non_dispatcher_owned_context)
 from cron.scheduler_identity import (
-    clear_cron_job_identity, cron_job_identity_scope, set_cron_job_identity)
+    cron_job_identity_scope, reset_cron_job_identity, set_cron_job_identity)
 
 logger = logging.getLogger(__name__)
 
@@ -2141,7 +2141,7 @@ class _CronRunScope:
         )
         for name in _CRON_DELIVERY_VARS:
             _VAR_MAP[name].set("")
-        set_cron_job_identity(job, job_id)
+        self._cron_identity_tokens = set_cron_job_identity(job, job_id)
         # Workdir binds to the per-run task id (tool-layer cwd authority) instead of mutating
         # global TERMINAL_CWD; _SESSION_CWD above remains the prompt/context-file authority.
         self.task_id = f"cron:{job_id}:{execution_id or job.get('execution_id') or uuid.uuid4().hex}"
@@ -2173,7 +2173,7 @@ class _CronRunScope:
             exit_non_dispatcher_owned_context(self._non_dispatcher_token)
         for name in _CRON_DELIVERY_VARS:
             self._var_map[name].set("")
-        clear_cron_job_identity()
+        reset_cron_job_identity(self._cron_identity_tokens)
 
 
 def _reload_dotenv_and_publish_delivery_target(job: dict) -> None:

--- a/cron/scheduler_identity.py
+++ b/cron/scheduler_identity.py
@@ -6,13 +6,6 @@ from contextlib import contextmanager
 from typing import Iterator
 
 
-CRON_JOB_IDENTITY_VARS = (
-    "HERMES_CRON_JOB_ID",
-    "HERMES_CRON_JOB_ORIGIN_USER_ID",
-    "HERMES_CRON_JOB_ORIGIN_PLATFORM",
-)
-
-
 def cron_job_identity_values(job: dict, job_id: str) -> dict[str, str]:
     """Identity persisted with a cron job, distinct from live sender-session state."""
     raw_origin = job.get("origin")
@@ -26,20 +19,21 @@ def cron_job_identity_values(job: dict, job_id: str) -> dict[str, str]:
     }
 
 
-def set_cron_job_identity(job: dict, job_id: str) -> None:
-    """Bind one job's persisted identity in the current task context."""
+def set_cron_job_identity(job: dict, job_id: str) -> list[tuple]:
+    """Bind one job's persisted identity and return tokens for exact restoration."""
     from gateway.session_context import _VAR_MAP
 
+    tokens = []
     for name, value in cron_job_identity_values(job, job_id).items():
-        _VAR_MAP[name].set(value)
+        var = _VAR_MAP[name]
+        tokens.append((var, var.set(value)))
+    return tokens
 
 
-def clear_cron_job_identity() -> None:
-    """Clear cron identity so later work cannot inherit a completed job."""
-    from gateway.session_context import _VAR_MAP
-
-    for name in CRON_JOB_IDENTITY_VARS:
-        _VAR_MAP[name].set("")
+def reset_cron_job_identity(tokens: list[tuple]) -> None:
+    """Restore the task-local identity that preceded this cron run."""
+    for var, token in reversed(tokens):
+        var.reset(token)
 
 
 @contextmanager

--- a/cron/scheduler_identity.py
+++ b/cron/scheduler_identity.py
@@ -1,0 +1,58 @@
+"""Task-local persisted cron identity for sanitized child-process environments."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+
+CRON_JOB_IDENTITY_VARS = (
+    "HERMES_CRON_JOB_ID",
+    "HERMES_CRON_JOB_ORIGIN_USER_ID",
+    "HERMES_CRON_JOB_ORIGIN_PLATFORM",
+)
+
+
+def cron_job_identity_values(job: dict, job_id: str) -> dict[str, str]:
+    """Identity persisted with a cron job, distinct from live sender-session state."""
+    raw_origin = job.get("origin")
+    origin = raw_origin if isinstance(raw_origin, dict) else {}
+    return {
+        "HERMES_CRON_JOB_ID": str(job_id),
+        "HERMES_CRON_JOB_ORIGIN_USER_ID": str(
+            origin.get("user_id") or origin.get("chat_id") or ""
+        ),
+        "HERMES_CRON_JOB_ORIGIN_PLATFORM": str(origin.get("platform") or ""),
+    }
+
+
+def set_cron_job_identity(job: dict, job_id: str) -> None:
+    """Bind one job's persisted identity in the current task context."""
+    from gateway.session_context import _VAR_MAP
+
+    for name, value in cron_job_identity_values(job, job_id).items():
+        _VAR_MAP[name].set(value)
+
+
+def clear_cron_job_identity() -> None:
+    """Clear cron identity so later work cannot inherit a completed job."""
+    from gateway.session_context import _VAR_MAP
+
+    for name in CRON_JOB_IDENTITY_VARS:
+        _VAR_MAP[name].set("")
+
+
+@contextmanager
+def cron_job_identity_scope(job: dict, job_id: str) -> Iterator[None]:
+    """Bind one job's identity and restore the prior task-local values on exit."""
+    from gateway.session_context import _VAR_MAP
+
+    tokens = []
+    for name, value in cron_job_identity_values(job, job_id).items():
+        var = _VAR_MAP[name]
+        tokens.append((var, var.set(value)))
+    try:
+        yield
+    finally:
+        for var, token in reversed(tokens):
+            var.reset(token)

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -57,11 +57,18 @@ _CRON_AUTO_DELIVER_PLATFORM = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", de
 _CRON_AUTO_DELIVER_CHAT_ID = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
 _CRON_AUTO_DELIVER_THREAD_ID = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
 
+# Persisted cron identity for guarded child processes. These stay separate from
+# HERMES_SESSION_*: a job's stored origin authorizes the job, but is not a live sender session.
+_CRON_JOB_ID = ContextVar("HERMES_CRON_JOB_ID", default=_UNSET)
+_CRON_JOB_ORIGIN_USER_ID = ContextVar("HERMES_CRON_JOB_ORIGIN_USER_ID", default=_UNSET)
+_CRON_JOB_ORIGIN_PLATFORM = ContextVar("HERMES_CRON_JOB_ORIGIN_PLATFORM", default=_UNSET)
+
 # Legacy env-var name -> ContextVar for get_session_env (_SESSION_ASYNC_DELIVERY deliberately
 # absent: it is a bool capability, read via async_delivery_supported).
 _VAR_MAP = {var.name: var for var in (
     *_SESSION_VARS, _CRON_AUTO_DELIVER_PLATFORM, _CRON_AUTO_DELIVER_CHAT_ID,
-    _CRON_AUTO_DELIVER_THREAD_ID,
+    _CRON_AUTO_DELIVER_THREAD_ID, _CRON_JOB_ID, _CRON_JOB_ORIGIN_USER_ID,
+    _CRON_JOB_ORIGIN_PLATFORM,
 )}
 
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import subprocess
 from unittest.mock import patch
@@ -105,6 +106,113 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert error is None
     assert "RAM 92% on host" in final_response
     assert "RAM 92% on host" in doc
+
+
+def test_run_job_no_agent_injects_stored_cron_origin_without_leaking(hermes_env, monkeypatch):
+    """Script-only jobs receive their own persisted identity, never ambient cron metadata."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    names = (
+        "HERMES_CRON_JOB_ID",
+        "HERMES_CRON_JOB_ORIGIN_USER_ID",
+        "HERMES_CRON_JOB_ORIGIN_PLATFORM",
+    )
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+
+    script_path = hermes_env / "scripts" / "identity.py"
+    script_path.write_text(
+        "import json, os\n"
+        f"print(json.dumps({{k: os.environ.get(k, '') for k in {names!r}}}))\n",
+        encoding="utf-8",
+    )
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="identity.py",
+        no_agent=True,
+        deliver="origin",
+        origin={"platform": "telegram", "chat_id": "123456789"},
+    )
+
+    success, _doc, response, error = run_job(job)
+
+    assert success is True and error is None
+    assert json.loads(response) == {
+        "HERMES_CRON_JOB_ID": job["id"],
+        "HERMES_CRON_JOB_ORIGIN_USER_ID": "123456789",
+        "HERMES_CRON_JOB_ORIGIN_PLATFORM": "telegram",
+    }
+    assert all(os.getenv(name) is None for name in names)
+
+    other = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="identity.py",
+        no_agent=True,
+        deliver="local",
+        origin=None,
+    )
+    success, _doc, response, error = run_job(other)
+    assert success is True and error is None
+    assert json.loads(response) == {
+        "HERMES_CRON_JOB_ID": other["id"],
+        "HERMES_CRON_JOB_ORIGIN_USER_ID": "",
+        "HERMES_CRON_JOB_ORIGIN_PLATFORM": "",
+    }
+
+
+def test_agent_backed_cron_subprocesses_inject_stored_origin_without_leaking(
+    hermes_env, monkeypatch,
+):
+    """Context scripts and later agent tools receive identity without live sender state."""
+    from cron.jobs import create_job
+    from cron.scheduler import _CronRunScope, _prepare_job_prompt
+    from tools.environments.local import build_subprocess_env
+
+    names = (
+        "HERMES_CRON_JOB_ID",
+        "HERMES_CRON_JOB_ORIGIN_USER_ID",
+        "HERMES_CRON_JOB_ORIGIN_PLATFORM",
+    )
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+
+    script_path = hermes_env / "scripts" / "context_identity.py"
+    script_path.write_text(
+        "import json, os\n"
+        f"print(json.dumps({{k: os.environ.get(k, '') for k in {names!r}}}))\n",
+        encoding="utf-8",
+    )
+    job = create_job(
+        prompt="Summarize the script context.",
+        schedule="every 5m",
+        script="context_identity.py",
+        deliver="local",
+        origin={"platform": "telegram", "user_id": "123456789"},
+    )
+    expected = {
+        "HERMES_CRON_JOB_ID": job["id"],
+        "HERMES_CRON_JOB_ORIGIN_USER_ID": "123456789",
+        "HERMES_CRON_JOB_ORIGIN_PLATFORM": "telegram",
+    }
+
+    early, prompt = _prepare_job_prompt(job, job["id"], "context job", None, None)
+    assert early is None
+    assert prompt is not None
+    assert json.dumps(expected) in prompt
+
+    scope = _CronRunScope(job, job["id"], "execution")
+    try:
+        scope.enter()
+        env = build_subprocess_env()
+        assert {name: env.get(name, "") for name in names} == expected
+    finally:
+        scope.exit()
+
+    after = build_subprocess_env()
+    assert all(after.get(name, "") == "" for name in names)
 
 
 def test_run_job_no_agent_reloads_dotenv_before_script(hermes_env, monkeypatch):

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -208,6 +208,25 @@ def test_agent_backed_cron_subprocesses_inject_stored_origin_without_leaking(
         scope.enter()
         env = build_subprocess_env()
         assert {name: env.get(name, "") for name in names} == expected
+
+        inner = _CronRunScope(
+            {"origin": {"platform": "signal", "user_id": "987654321"}},
+            "inner-job",
+            "inner-execution",
+        )
+        try:
+            inner.enter()
+            inner_env = build_subprocess_env()
+            assert {name: inner_env.get(name, "") for name in names} == {
+                "HERMES_CRON_JOB_ID": "inner-job",
+                "HERMES_CRON_JOB_ORIGIN_USER_ID": "987654321",
+                "HERMES_CRON_JOB_ORIGIN_PLATFORM": "signal",
+            }
+        finally:
+            inner.exit()
+
+        restored = build_subprocess_env()
+        assert {name: restored.get(name, "") for name in names} == expected
     finally:
         scope.exit()
 


### PR DESCRIPTION
## What changed

- add task-local cron identity variables for sanitized child-process environments:
  - `HERMES_CRON_JOB_ID`
  - `HERMES_CRON_JOB_ORIGIN_USER_ID`
  - `HERMES_CRON_JOB_ORIGIN_PLATFORM`
- bind the persisted job identity for `no_agent` scripts, agent pre-run/context scripts, and later agent-backed subprocesses
- keep this metadata separate from `HERMES_SESSION_*`, so a stored delivery origin is not treated as a live sender session
- restore every binding via `ContextVar` tokens after the run, including nested job execution, to prevent cross-job leakage

## Why

Guarded local wrappers may need to verify that a subprocess belongs to a specific scheduled job and that the job was originally created from an authorized platform/user. Today the scheduler keeps that information in the job record, but child processes receive empty values:

```text
HERMES_CRON_JOB_ID=
HERMES_CRON_JOB_ORIGIN_USER_ID=
HERMES_CRON_JOB_ORIGIN_PLATFORM=
```

This breaks fail-closed wrappers even though the scheduler has already loaded the correct persisted job. The gap affects both script-only jobs (which short-circuit before `_CronRunScope`) and terminal subprocesses launched by agent-backed jobs.

## Security and concurrency

- does not mutate `os.environ`
- uses `ContextVar` bindings consumed by the existing sanitized `build_subprocess_env()` path
- does not seed `HERMES_SESSION_*` from stored origin metadata
- both `no_agent` and agent-backed bindings are restored by `ContextVar` token in `finally`/scope teardown
- tests cover a second job with no origin and nested agent-backed scopes, proving prior identity is restored rather than leaked or erased

## Reproduction

The new end-to-end `no_agent` test was run against current `origin/main` before the fix and failed with all three values empty. It passes after the fix.

## Verification

```text
scripts/run_tests.sh tests/cron/test_cron_no_agent.py \
  tests/cron/test_scheduler.py \
  tests/cron/test_scheduler_mcp_init.py \
  tests/gateway/test_session_context_inheritance.py

127 passed, 0 failed
```

Also passed:

```text
ruff check cron/scheduler.py gateway/session_context.py tests/cron/test_cron_no_agent.py
scripts/check_compat_pointers.py
git diff --check
```

## Related open work

This is narrower/different from the existing cron execution-metadata PRs:

- #77402 and #94951 expose job/scheduled execution metadata to script jobs but do not propagate stored origin to agent-backed subprocesses.
- #103805 exposes dispatch classification to `no_agent` scripts, not persisted origin authorization metadata.
- #57169 scopes cron job identity for approval classification but does not expose stored origin metadata to sanitized child processes.
