### PR TITLE
fix(cron): extend health diagnostics and harden unattended retries

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -151,6 +151,32 @@ jobs:
         run: |
           ruff check .
 
+  changed-python:
+    name: changed Python correctness (blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          version: "0.9.28"
+      - name: Install pinned project and checkers
+        run: |
+          uv venv --python 3.11
+          uv pip install -e ".[dev]"
+      - name: Check changed lines
+        env:
+          TARGET_BRANCH: ${{ github.base_ref }}
+        run: |
+          if [ -n "$TARGET_BRANCH" ]; then
+            BASE_SHA=$(git merge-base "origin/$TARGET_BRANCH" HEAD)
+          else
+            BASE_SHA=$(git rev-parse HEAD~1)
+          fi
+          .venv/bin/python scripts/check_changed_python.py --base "$BASE_SHA"
+
   windows-footguns:
     # Static guardrails on Windows-unsafe Python primitives — os.kill(pid, 0),
     # os.killpg, os.setsid, signal.SIGKILL without getattr fallback,

--- a/cron/health.py
+++ b/cron/health.py
@@ -1,0 +1,101 @@
+"""Structured cron diagnostics without executing jobs or delivering messages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent.redact import redact_sensitive_text
+
+
+def _diagnostic_text(message: str) -> str:
+    # Diagnostic URLs do not need credentials or query strings. The general
+    # tool redactor deliberately preserves login/share URLs, so tighten this boundary.
+    return redact_sensitive_text(message, force=True, redact_url_credentials=True)
+
+
+def inspect_job(
+    job: dict[str, Any], *, config: dict[str, Any], check_provider: bool = False,
+) -> dict[str, Any]:
+    """Inspect a job in the active profile; credential refresh is opt-in."""
+    from cron.scheduler_delivery import _normalize_deliver_value, _resolve_delivery_targets
+    from hermes_cli.config import resolve_cron_model_drift_defaults
+    from hermes_cli.cron import _cron_doctor_issues_for_job
+
+    issues = [
+        {"code": "job_health", "message": _diagnostic_text(message)}
+        for message in _cron_doctor_issues_for_job(job)
+    ]
+
+    def issue(code: str, message: str) -> None:
+        issues.append({"code": code, "message": _diagnostic_text(message)})
+
+    global_provider, global_model = resolve_cron_model_drift_defaults(config)
+    fleet = config.get("cron") or {}
+    if not isinstance(fleet, dict):
+        fleet = {}
+    provider = job.get("provider") or fleet.get("model_provider") or global_provider or "auto"
+    model = job.get("model") or fleet.get("model") or global_model
+    provider_check = "not_needed" if job.get("no_agent") else "not_checked"
+    if job.get("no_agent"):
+        model = None
+    elif not model:
+        issue("model_unresolved", "No model configured; set a per-job model or run hermes model.")
+
+    if check_provider and not job.get("no_agent"):
+        from hermes_cli.runtime_provider import resolve_runtime_provider, format_runtime_provider_error
+
+        try:
+            kwargs = {"requested": job.get("provider") or fleet.get("model_provider") or None,
+                      "target_model": model}
+            if job.get("base_url"):
+                kwargs["explicit_base_url"] = job["base_url"]
+            runtime = resolve_runtime_provider(**kwargs)
+            provider = runtime["provider"]
+            provider_check = "credentials_resolved"
+        except Exception as exc:
+            provider_check = "failed"
+            issue("provider_unavailable", format_runtime_provider_error(exc))
+
+    targets = []
+    deliveries = _normalize_deliver_value(job.get("deliver", "local"))
+    for delivery in (part.strip() for part in deliveries.split(",") if part.strip()):
+        if delivery == "local":
+            continue
+        try:
+            resolved = _resolve_delivery_targets({**job, "deliver": delivery})
+            if not resolved:
+                issue("missing_delivery_target", f"No destination resolves for {delivery!r}.")
+        except Exception as exc:
+            issue("invalid_delivery_target", str(exc))
+    try:
+        targets = _resolve_delivery_targets(job)
+    except Exception as exc:
+        issue("invalid_delivery_target", str(exc))
+
+    return {
+        "id": job.get("id"), "name": job.get("name"),
+        "provider": provider, "model": model, "provider_check": provider_check,
+        "delivery": targets, "next_run_at": job.get("next_run_at"),
+        "last_run_at": job.get("last_run_at"), "last_status": job.get("last_status"),
+        "last_success_at": job.get("last_success_at") or (
+            job.get("last_run_at") if job.get("last_status") in {"ok", "delivery_failed", "delivery_queued"} else None
+        ),
+        "issues": issues,
+    }
+
+
+def inspect_jobs(*, check_provider: bool = False) -> list[dict[str, Any]]:
+    """Inspect active-profile jobs using its raw config, as the scheduler does."""
+    from cron.jobs import list_jobs
+    from hermes_cli.config import _expand_env_vars, read_user_config_raw
+
+    jobs = list_jobs(include_disabled=False)
+    if not jobs:
+        return []
+    try:
+        config = _expand_env_vars(read_user_config_raw())
+    except Exception as exc:
+        return [{"id": job["id"], "name": job.get("name"), "issues": [
+            {"code": "configuration_error", "message": _diagnostic_text(str(exc))},
+        ]} for job in jobs]
+    return [inspect_job(job, config=config, check_provider=check_provider) for job in jobs]

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2172,6 +2172,7 @@ def _record_run_outcome(
         "error" if not success else ("delivery_failed" if delivery_failed else "ok"))
     job["last_error"] = None if success else error
     if success:
+        job["last_success_at"] = now
         # Healthy run: drop the alert-once dedup markers so a FUTURE break re-alerts, and clear
         # the forward-failure stamp so it only describes CURRENT auto-fire health.
         job.pop("preflight_alerted", None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3165,7 +3165,7 @@ _RECONNECT_ATTENTION_AFTER_SECONDS = _float_env("HERMES_RECONNECT_ATTENTION_AFTE
 
 def _reconnect_backoff(attempt: int) -> int:
     """Exponential reconnect backoff: 30s, 60s, 120s, ... capped at 5 min."""
-    return min(30 * (2 ** (attempt - 1)), _RECONNECT_BACKOFF_CAP)
+    return min(30 * (2 ** min(max(attempt - 1, 0), 4)), _RECONNECT_BACKOFF_CAP)
 
 
 def _reconnect_needs_attention(info: dict, now: float) -> bool:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -518,8 +518,25 @@ def _cron_doctor_issues_for_job(job: Dict[str, Any]) -> List[str]:
     return issues
 
 
-def cron_doctor() -> int:
+def cron_doctor(*, as_json: bool = False, check_provider: bool = False) -> int:
     """Run read-only cron health checks and return a shell-friendly status."""
+    if as_json or check_provider:
+        from cron.health import inspect_jobs
+
+        reports = inspect_jobs(check_provider=check_provider)
+        healthy = not any(report["issues"] for report in reports)
+        if as_json:
+            import json
+
+            print(json.dumps({"healthy": healthy, "jobs": reports}, indent=2))
+        else:
+            for report in reports:
+                print(f"{report['id']}: {report.get('provider', '?')} / {report.get('model', '?')}")
+                for issue in report["issues"]:
+                    print(f"  - {issue['message']}")
+            if healthy:
+                print(color("✓ Cron doctor found no issues", Colors.GREEN))
+        return 0 if healthy else 1
     from cron.jobs import list_jobs
     jobs = list_jobs(include_disabled=False)
     findings = [(job, issues) for job in jobs if (issues := _cron_doctor_issues_for_job(job))]
@@ -755,7 +772,7 @@ def cron_notepad(args) -> int:
 _CRON_SUBCOMMANDS = {
     "list": lambda a: cron_list(getattr(a, "all", False)) or 0,
     "status": lambda a: cron_status() or 0,
-    "doctor": lambda a: cron_doctor(),
+    "doctor": lambda a: cron_doctor(as_json=getattr(a, "json", False), check_provider=getattr(a, "check_provider", False)),
     "tick": lambda a: cron_tick(),
     "runs": lambda a: cron_runs(getattr(a, "job_id", None), getattr(a, "limit", 20)) or 0,
     "incidents": lambda a: cron_incidents(a),

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -181,7 +181,9 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_notepad.add_argument("key", nargs="?", help="Notepad key (get/set/delete)")
     cron_notepad.add_argument("value", nargs="?", help="Value to store (set)")
 
-    cron_subparsers.add_parser("doctor", help="Check scheduled jobs for common health issues")
+    cron_doctor = cron_subparsers.add_parser("doctor", help="Check scheduled jobs for common health issues")
+    _flag(cron_doctor, "--json", help="Print structured job health, effective models, and delivery targets")
+    _flag(cron_doctor, "--check-provider", help="Resolve provider credentials (may refresh OAuth); does not run jobs")
 
     cron_tick = cron_subparsers.add_parser("tick", help="Run due jobs once and exit")
     add_accept_hooks_flag(cron_tick)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -448,6 +448,9 @@ class EmailAdapter(BasePlatformAdapter):
             self._seen_uids_snapshot[self._address] = set(self._seen_uids)
             return True
         except Exception as e:
+            if isinstance(e, imaplib.IMAP4.error) and not isinstance(e, imaplib.IMAP4.abort) and "[AUTHENTICATIONFAILED]" in str(e).upper():
+                return self._fail("[Email] IMAP authentication failed: %s", e, "email_auth_error",
+                                  "IMAP authentication failed. Check EMAIL_ADDRESS and EMAIL_PASSWORD.", retryable=False)
             # Always set an explicit fatal code, else the gateway treats every failure as transient with zero
             # owner signal. retryable=True because imaplib raises the same generic IMAP4.error for bad credentials
             # AND transient NOs (Gmail "too many simultaneous connections"); loops surface via NEEDS_ATTENTION.
@@ -461,14 +464,18 @@ class EmailAdapter(BasePlatformAdapter):
             try:
                 smtp.login(self._address, self._password)
             finally:
-                smtp.quit()
+                try:
+                    smtp.quit()
+                except Exception:
+                    with suppress(Exception):
+                        smtp.close()
             logger.info("[Email] SMTP connection test passed.")
             return True
         except smtplib.SMTPAuthenticationError as e:
-            # Typed auth failure (535 & friends) can never self-heal, so drop out of the reconnect queue — unambiguous, unlike IMAP4.error.
+            # 4xx authentication failures (e.g. 454) are temporary; 5xx requires operator action.
             return self._fail("[Email] SMTP authentication failed: %s", e, "email_auth_error",
                               f"SMTP authentication failed for {self._address}: {e}. Check EMAIL_PASSWORD (for Gmail/Outlook "
-                              "this must be an app password, not the account password).", retryable=False)
+                              "this must be an app password, not the account password).", retryable=e.smtp_code < 500)
         except Exception as e:
             return self._fail("[Email] SMTP connection failed: %s", e, "email_smtp_connect_error",
                               f"SMTP connection to {self._smtp_host} failed: {e}", retryable=True)
@@ -483,6 +490,7 @@ class EmailAdapter(BasePlatformAdapter):
             return self._fail("[Email] %s", message, "email_missing_configuration", message, retryable=False)
         if not self._probe_imap(is_reconnect) or not self._probe_smtp():
             return False
+        self._mark_connected()
         self._running = True
         self._poll_task = asyncio.create_task(self._poll_loop())
         print(f"[Email] Connected as {self._address}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -596,7 +596,7 @@ markers = [
 addopts = "-m 'not integration'"
 
 [tool.ty.environment]
-python-version = "3.13"
+python-version = "3.11"  # Match requires-python and the CI test runtime.
 
 [tool.ty.rules]
 unknown-argument = "warn"

--- a/scripts/check_changed_python.py
+++ b/scripts/check_changed_python.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Block correctness diagnostics on changed Python lines, including new files.
+
+Run with the project's dev environment: python scripts/check_changed_python.py
+--base HEAD. CI supplies the merge base; existing advisory reports retain the
+full-project backlog. A missing/crashed checker or malformed report fails closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+CORRECTNESS_RULES = "E9,F63,F7,F82,B006"
+
+
+def changed_lines(diff: str) -> set[int]:
+    lines = set()
+    for match in re.finditer(
+        r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", diff, re.MULTILINE
+    ):
+        start = int(match[1])
+        count = int(match[2]) if match[2] is not None else 1
+        lines.update(range(start, start + count))
+    return lines
+
+
+def git_output(root: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(root), *args], text=True)
+
+
+def changed_python(root: Path, base: str) -> dict[str, set[int]]:
+    names = git_output(
+        root, "diff", "--name-only", "-z", "--diff-filter=ACMR", base, "--", "*.py"
+    ).split("\0")
+    untracked = git_output(
+        root, "ls-files", "--others", "--exclude-standard", "-z", "--", "*.py"
+    ).split("\0")
+    result = {}
+    for name in sorted(set(names + untracked) - {""}):
+        path = root / name
+        if not path.is_file():
+            continue
+        if name in untracked:
+            lines = set(
+                range(1, len(path.read_text(encoding="utf-8").splitlines()) + 1)
+            )
+        else:
+            lines = changed_lines(
+                git_output(
+                    root,
+                    "diff",
+                    "--no-ext-diff",
+                    "--no-color",
+                    "--unified=0",
+                    base,
+                    "--",
+                    name,
+                )
+            )
+        if lines:
+            result[name] = lines
+    return result
+
+
+def diagnostic_location(entry: dict[str, Any], tool: str) -> tuple[str, int, int, str]:
+    if tool == "ruff":
+        start = (entry.get("location") or {}).get("row", 0)
+        end = (entry.get("end_location") or {}).get("row", start)
+        return entry.get("filename") or "", start, end, entry.get("message", "")
+    location = entry.get("location") or {}
+    positions = location.get("positions") or {}
+    lines = location.get("lines") or {}
+    start = (positions.get("begin") or {}).get("line", lines.get("begin", 0))
+    end = (positions.get("end") or {}).get("line", lines.get("end", start))
+    return location.get("path", ""), start, end, entry.get("description", "")
+
+
+def blocking_diagnostics(
+    entries: list[dict[str, Any]], tool: str, changed: dict[str, set[int]], root: Path
+) -> list[str]:
+    failures = []
+    for entry in entries:
+        if tool == "ty" and entry.get("severity") in {"info", "minor"}:
+            continue
+        filename, start, end, message = diagnostic_location(entry, tool)
+        path = Path(filename)
+        if path.is_absolute():
+            try:
+                filename = path.resolve().relative_to(root.resolve()).as_posix()
+            except ValueError:
+                continue
+        if not filename or not start:
+            # Tool-level diagnostics cannot be assigned to an unchanged line.
+            failures.append(f"{tool}: {message}")
+        elif any(start <= line <= end for line in changed.get(filename, set())):
+            rule = entry.get("code") or entry.get("check_name") or "error"
+            failures.append(f"{filename}:{start}: {tool} {rule}: {message}")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base", default="HEAD", help="Git revision to compare with (CI: merge base)"
+    )
+    args = parser.parse_args()
+    root = Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"], text=True
+        ).strip()
+    )
+    try:
+        changed = changed_python(root, args.base)
+        if not changed:
+            print("No changed Python lines.")
+            return 0
+        files = sorted(changed)
+        commands = {
+            "ruff": [
+                sys.executable,
+                "-m",
+                "ruff",
+                "check",
+                "--extend-select",
+                CORRECTNESS_RULES,
+                "--output-format",
+                "json",
+                "--exit-zero",
+                *files,
+            ],
+            "ty": [
+                sys.executable,
+                "-m",
+                "ty",
+                "check",
+                "--python",
+                sys.executable,
+                "--output-format",
+                "gitlab",
+                "--exit-zero",
+                *files,
+            ],
+        }
+        failures = []
+        for tool, command in commands.items():
+            result = subprocess.run(
+                command, cwd=root, capture_output=True, text=True, check=True
+            )
+            entries = json.loads(result.stdout)
+            if not isinstance(entries, list) or any(
+                not isinstance(entry, dict) for entry in entries
+            ):
+                raise ValueError(f"Invalid {tool} report")
+            failures.extend(blocking_diagnostics(entries, tool, changed, root))
+        for failure in failures:
+            print(failure)
+        print(
+            f"Changed Python check: {len(files)} files, {len(failures)} blocking diagnostics."
+        )
+        return 1 if failures else 0
+    except (OSError, subprocess.CalledProcessError, ValueError) as exc:
+        print(f"Correctness check could not complete: {exc}", file=sys.stderr)
+        if isinstance(exc, subprocess.CalledProcessError) and exc.stderr:
+            print(exc.stderr, file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/cron/test_health.py
+++ b/tests/cron/test_health.py
@@ -1,0 +1,133 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_cron_store(tmp_path, monkeypatch):
+    from cron.jobs import use_cron_store
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    with use_cron_store(tmp_path):
+        yield
+
+
+def future_job(**extra):
+    return {"id": "health-test", "name": "Daily", "deliver": "local",
+            "next_run_at": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(), **extra}
+
+
+def test_success_timestamp_survives_later_failure():
+    from cron.jobs import create_job, get_job, mark_job_run
+
+    job = create_job(prompt="check", schedule="every 1h")
+    mark_job_run(job["id"], True, delivery_error="not_in_channel")
+    successful = get_job(job["id"])
+    mark_job_run(job["id"], False, error="expired")
+    failed = get_job(job["id"])
+    assert failed is not None and successful is not None
+    assert failed["last_success_at"] == successful["last_run_at"]
+
+
+@pytest.mark.parametrize("config, overrides, expected", [
+    ({"model": "global"}, {}, "global"),
+    ({"model": {"model": "alias"}}, {}, "alias"),
+    ({"model": "global", "cron": {"model": "fleet"}}, {}, "fleet"),
+    ({"cron": {"model": "fleet"}}, {"model": "pinned"}, "pinned"),
+])
+def test_health_model_matches_scheduler(monkeypatch, tmp_path, config, overrides, expected):
+    from cron.health import inspect_job
+    from cron.scheduler import _load_cron_job_config
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    job = future_job(**overrides)
+    report = inspect_job(job, config=config)
+    resolved = _load_cron_job_config(job, job["id"], job["name"])
+    assert report["model"] == resolved.model == expected
+
+
+def test_health_reports_destination_and_separate_failures(monkeypatch):
+    from cron.health import inspect_job
+
+    monkeypatch.setenv("SLACK_HOME_CHANNEL", "C-test")
+    report = inspect_job(future_job(deliver="slack", last_status="error", last_error="provider expired",
+                                   last_delivery_error="not_in_channel", last_success_at="yesterday"),
+                         config={"model": {"provider": "openai-codex", "model": "chosen"}})
+    assert report["delivery"][0]["chat_id"] == "C-test"
+    assert report["last_success_at"] == "yesterday"
+    assert report["provider_check"] == "not_checked"
+    messages = [item["message"] for item in report["issues"]]
+    assert any("last run failed" in message for message in messages)
+    assert any("last delivery failed" in message for message in messages)
+
+
+def test_health_is_offline_by_default_and_redacts(monkeypatch):
+    from cron.health import inspect_job
+
+    def forbidden(**kwargs):
+        pytest.fail("Offline health must not resolve credentials")
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", forbidden)
+    report = inspect_job(future_job(last_status="error", last_error="https://user:password@example.test?token=private"), config={})
+    rendered = json.dumps(report)
+    assert "password" not in rendered and "private" not in rendered
+
+
+def test_health_checks_selected_credentials_only_on_request(monkeypatch):
+    from cron.health import inspect_job
+
+    calls = []
+
+    def resolve(**kwargs):
+        calls.append(kwargs)
+        return {"provider": "custom"}
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", resolve)
+    report = inspect_job(future_job(), config={"cron": {"model": "fleet", "model_provider": "custom"}}, check_provider=True)
+    assert calls == [{"requested": "custom", "target_model": "fleet"}]
+    assert report["provider_check"] == "credentials_resolved"
+
+
+def test_health_reports_credential_failure(monkeypatch):
+    from cron.health import inspect_job
+    from hermes_cli.auth import AuthError
+
+    def expired(**kwargs):
+        raise AuthError("Expired login", code="refresh_token_reused", provider="openai-codex", relogin_required=True)
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", expired)
+    report = inspect_job(future_job(), config={}, check_provider=True)
+    assert report["provider_check"] == "failed"
+    assert any(item["code"] == "provider_unavailable" for item in report["issues"])
+
+
+def test_health_preserves_upstream_unverified_delivery_and_grace():
+    from cron.health import inspect_job
+
+    job = future_job(last_status="delivery_queued", last_delivery_unverified=[{"platform": "slack", "chat_id": "C-test"}],
+                     next_run_at=(datetime.now(timezone.utc) - timedelta(minutes=3)).isoformat())
+    report = inspect_job(job, config={})
+    messages = [item["message"] for item in report["issues"]]
+    assert any("unverified" in message for message in messages)
+    assert not any("overdue" in message or "last run failed" in message for message in messages)
+
+
+def test_health_detects_missing_destination(monkeypatch):
+    from cron.health import inspect_job
+
+    monkeypatch.delenv("SLACK_HOME_CHANNEL", raising=False)
+    report = inspect_job(future_job(deliver="slack"), config={})
+    assert any(item["code"] == "missing_delivery_target" for item in report["issues"])
+
+
+def test_health_uses_active_profile_config(tmp_path):
+    from cron.health import inspect_jobs
+    from cron.jobs import create_job
+
+    (tmp_path / "config.yaml").write_text("model:\n  provider: custom\n  default: profile-model\n", encoding="utf-8")
+    create_job(prompt="check", schedule="every 1h", deliver="local")
+    reports = inspect_jobs()
+    assert reports[0]["model"] == "profile-model"
+    assert reports[0]["provider"] == "custom"

--- a/tests/gateway/test_email_auth_failures.py
+++ b/tests/gateway/test_email_auth_failures.py
@@ -1,0 +1,51 @@
+import imaplib
+import smtplib
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.email.adapter import EmailAdapter
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    for key, value in {
+        "EMAIL_ADDRESS": "bot@example.test", "EMAIL_PASSWORD": "test-password",
+        "EMAIL_IMAP_HOST": "imap.example.test", "EMAIL_SMTP_HOST": "smtp.example.test",
+    }.items():
+        monkeypatch.setenv(key, value)
+    return EmailAdapter(PlatformConfig(enabled=True))
+
+
+@pytest.mark.parametrize("error, retryable", [
+    (imaplib.IMAP4.error(b"[AUTHENTICATIONFAILED] Invalid credentials"), False),
+    (imaplib.IMAP4.abort("connection closed"), True),
+    (OSError("network unreachable"), True),
+    (imaplib.IMAP4.error("[UNAVAILABLE] Try again later"), True),
+    (imaplib.IMAP4.error("Too many simultaneous connections"), True),
+])
+def test_imap_failure_classification(monkeypatch, adapter, error, retryable):
+    imap = MagicMock()
+    imap.login.side_effect = error
+    monkeypatch.setattr(adapter, "_connect_imap", lambda: imap)
+    assert adapter._probe_imap(False) is False
+    assert adapter.fatal_error_retryable is retryable
+    imap.logout.assert_called_once()
+    if not retryable:
+        assert adapter.fatal_error_code == "email_auth_error"
+
+
+@pytest.mark.parametrize("code, retryable", [(535, False), (454, True)])
+@pytest.mark.parametrize("quit_fails", [False, True])
+def test_smtp_auth_failure_classification(monkeypatch, adapter, code, retryable, quit_fails):
+    smtp = MagicMock()
+    smtp.login.side_effect = smtplib.SMTPAuthenticationError(code, b"authentication failed")
+    if quit_fails:
+        smtp.quit.side_effect = OSError("connection closed")
+    monkeypatch.setattr(adapter, "_connect_smtp", lambda: smtp)
+    assert adapter._probe_smtp() is False
+    assert adapter.fatal_error_retryable is retryable
+    assert adapter.fatal_error_code == "email_auth_error"
+    if quit_fails:
+        smtp.close.assert_called_once()

--- a/tests/gateway/test_reconnect_delay.py
+++ b/tests/gateway/test_reconnect_delay.py
@@ -1,0 +1,6 @@
+from gateway.run import _reconnect_backoff
+
+
+def test_reconnect_delay_stays_bounded_after_long_outage():
+    assert [_reconnect_backoff(attempt) for attempt in range(1, 7)] == [30, 60, 120, 240, 300, 300]
+    assert _reconnect_backoff(10**6) == _reconnect_backoff(6)

--- a/tests/hermes_cli/test_cron_health_json.py
+++ b/tests/hermes_cli/test_cron_health_json.py
@@ -1,0 +1,29 @@
+import argparse
+import json
+
+from hermes_cli.cron import cron_command
+from hermes_cli.subcommands.cron import build_cron_parser
+
+
+def test_doctor_parser_and_failure_exit(monkeypatch, capsys):
+    parser = argparse.ArgumentParser()
+    build_cron_parser(parser.add_subparsers(), cmd_cron=cron_command)
+    args = parser.parse_args(["cron", "doctor", "--json", "--check-provider"])
+    calls = []
+
+    def inspect(**kwargs):
+        calls.append(kwargs)
+        return [{"id": "test", "issues": [{"code": "provider_unavailable", "message": "expired"}]}]
+
+    monkeypatch.setattr("cron.health.inspect_jobs", inspect)
+    assert args.func(args) == 1
+    assert json.loads(capsys.readouterr().out)["healthy"] is False
+    assert calls == [{"check_provider": True}]
+
+
+def test_doctor_empty_json_is_healthy(monkeypatch, capsys):
+    from hermes_cli.cron import cron_doctor
+
+    monkeypatch.setattr("cron.health.inspect_jobs", lambda **kwargs: [])
+    assert cron_doctor(as_json=True) == 0
+    assert json.loads(capsys.readouterr().out) == {"healthy": True, "jobs": []}

--- a/tests/test_changed_python_check.py
+++ b/tests/test_changed_python_check.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+from scripts.check_changed_python import blocking_diagnostics, changed_lines
+
+
+def test_changed_lines_respect_insertions_and_deletions():
+    assert changed_lines(
+        "@@ -2,0 +3,2 @@\n+x\n+y\n@@ -8,1 +10,0 @@\n-z\n@@ -14 +16 @@\n-a\n+b"
+    ) == {3, 4, 16}
+
+
+def test_old_diagnostics_do_not_block_but_changed_spans_do(tmp_path):
+    entries = [
+        {
+            "filename": str(tmp_path / "file.py"),
+            "location": {"row": 1},
+            "end_location": {"row": 1},
+            "code": "F821",
+            "message": "old",
+        },
+        {
+            "filename": str(tmp_path / "file.py"),
+            "location": {"row": 3},
+            "end_location": {"row": 5},
+            "code": "F821",
+            "message": "new",
+        },
+    ]
+    result = blocking_diagnostics(entries, "ruff", {"file.py": {4}}, tmp_path)
+    assert len(result) == 1 and "new" in result[0]
+
+
+def test_type_errors_block_changed_lines_but_warnings_remain_advisory():
+    entry = {
+        "location": {"path": "file.py", "lines": {"begin": 3}},
+        "description": "bad return",
+        "check_name": "invalid-return-type",
+        "severity": "major",
+    }
+    assert blocking_diagnostics([entry], "ty", {"file.py": {3}}, Path.cwd())
+    assert not blocking_diagnostics(
+        [{**entry, "severity": "minor"}], "ty", {"file.py": {3}}, Path.cwd()
+    )
+
+
+def test_locationless_tool_errors_fail_closed():
+    assert blocking_diagnostics(
+        [{"message": "invalid configuration"}], "ruff", {}, Path.cwd()
+    )
+
+
+def test_gate_checks_new_files_with_real_tools(tmp_path, monkeypatch, capsys):
+    import subprocess
+    from scripts.check_changed_python import main
+
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(tmp_path),
+            "-c",
+            "user.name=Test Fixture",
+            "-c",
+            "user.email=fixture@example.test",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "fixture",
+        ],
+        check=True,
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.argv", ["check_changed_python.py"])
+    file = tmp_path / "example.py"
+    file.write_text("print(undefined_variable)\n", encoding="utf-8")
+    assert main() == 1
+    assert "F821" in capsys.readouterr().out
+    file.write_text("print('valid')\n", encoding="utf-8")
+    assert main() == 0

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -1176,3 +1176,30 @@ Cron jobs run in a completely fresh agent session. The prompt must contain every
 ## Security
 
 Scheduled task prompts are scanned for prompt-injection and credential-exfiltration patterns at creation and update time. Prompts containing invisible Unicode tricks, SSH backdoor attempts, or obvious secret-exfiltration payloads are blocked.
+
+
+## Diagnose an unattended job
+
+`hermes cron doctor` inspects enabled jobs without executing prompts or
+posting messages. Add `--json` for the selected model, delivery destination,
+last execution, last successful execution, and next scheduled run. It flags
+missing working directories or scripts, unresolved destinations, overdue
+schedules, execution failures, and delivery failures separately.
+
+```bash
+hermes cron doctor
+hermes cron doctor --json
+hermes cron doctor --check-provider
+```
+
+The default check stays offline. `--check-provider` also resolves provider
+credentials and may refresh OAuth tokens; it does not make an inference
+request. A resolved credential is not proof that the provider has quota or
+that Slack will accept a message. The command exits with 1 when a job needs
+attention and 0 when the performed checks pass. Paused jobs are excluded.
+Older jobs may have no recorded successful timestamp until they next succeed.
+
+If Codex reports `refresh_token_reused`, create a separate Hermes login with
+`hermes auth add openai-codex --type oauth`. Run a job explicitly with
+`hermes cron run <job-id>` when an end-to-end execution and delivery test is
+needed; that command performs the job's real work and sends its normal output.


### PR DESCRIPTION
## What does this PR do?

Extends the existing cron doctor with structured diagnostics and optional credential resolution, and fixes unattended retry behavior. `hermes cron doctor --json` reports the selected model/provider, resolved delivery targets, run history, and existing health findings. `--check-provider` resolves credentials without executing a job or sending messages; OAuth credentials may refresh.

The patch is ported onto current main. It retains upstream's model resolution and fallback behavior, parser decomposition, platform-plugin layout, overdue grace period, and queued/unverified delivery handling.

## Changes Made

- Extend the existing cron doctor/parser with `--json` and `--check-provider`; preserve the default text command and its exit status.
- Use existing model-precedence and delivery-routing helpers; redact credentials from diagnostic URLs.
- Persist the last successful execution timestamp independently of delivery errors and later failed executions.
- In the current email plugin, stop retries for explicit IMAP `AUTHENTICATIONFAILED`, retain transient IMAP/SMTP retries, preserve authentication errors through connection cleanup, and clear fatal state after reconnecting.
- Bound reconnect exponent calculation for long outages using the existing gateway backoff helper.
- Add changed-line Ruff/ty enforcement alongside existing advisory lint reporting, and use the supported Python 3.11 floor for type checking.

## Validation

- Regression run: 109 files, 1,355 tests passed, 2 failed, 4 skipped. All added regression tests passed.
- Both failures reproduce on untouched upstream: the permission test on the baseline checkout, and the blueprint lifecycle-guard test in the same checkout path. The blueprint test passes from a separate checkout, indicating an environment/path-dependent baseline issue.
- Whole-repository Ruff passed. Changed-line Ruff/ty gate passed with zero blocking diagnostics.
- Plugin compatibility scan passed; no deprecated in-tree imports.
- Whitespace and repository architecture gates passed.
- The complete current-upstream suite and hosted CI have not passed; no claim of full-suite success.

## How to Test

```bash
scripts/run_tests.sh -j 4 tests/cron/ tests/hermes_cli/test_cron.py tests/hermes_cli/test_cron_health_json.py tests/hermes_cli/test_subcommands_cron.py tests/gateway/test_email.py tests/gateway/test_email_auth_failures.py tests/gateway/test_platform_reconnect.py tests/gateway/test_reconnect_delay.py tests/test_changed_python_check.py
hermes cron doctor --json
hermes cron doctor --check-provider
```

Local testing was on macOS. The doctor checks configuration and credentials, not provider quota or successful message delivery.

## Related work

Builds on the existing upstream cron doctor and parser split rather than duplicating them. Earlier related proposals: #43729, #29906, #100457.

## Checklist

- [x] Read the contributing guide; conventional commit message.
- [x] Searched related PRs and retained current upstream implementations where they supersede the original patch.
- [x] Added behavior-focused tests and updated user documentation.
- [x] Considered cross-platform behavior; local execution on macOS only.
- [ ] Complete test suite passes.
- [ ] Required hosted CI checks pass.
