### PR TITLE
fix(desktop): Hide tabs on the sessions sidebar, drop Import session from the nav

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -136,7 +136,6 @@ import {
   ARTIFACTS_ROUTE,
   CRON_ROUTE,
   MESSAGING_ROUTE,
-  SESSION_IMPORT_ROUTE,
   SIDEBAR_NAV_AREA,
   type SidebarNavContribution,
   SKILLS_ROUTE
@@ -230,12 +229,6 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
     icon: props => <Codicon name="watch" {...props} />,
     route: CRON_ROUTE,
     keybindActionId: 'nav.cron'
-  },
-  {
-    id: 'session-import',
-    label: '',
-    icon: props => <Codicon name="cloud-download" {...props} />,
-    route: SESSION_IMPORT_ROUTE
   }
 ]
 
@@ -1469,7 +1462,6 @@ export function ChatSidebar({
                   (item.id === 'messaging' && currentView === 'messaging') ||
                   (item.id === 'artifacts' && currentView === 'artifacts') ||
                   (item.id === 'cron' && currentView === 'cron') ||
-                  (item.id === 'session-import' && currentView === 'session-import') ||
                   // Contributed rows light up at their own route.
                   (currentView === 'extension' && Boolean(item.route) && pathname === item.route)
 

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -163,7 +163,7 @@ export type CommandDispatchResponse =
   | PrefillCommandDispatchResponse
 
 export type SidebarNavId =
-  'artifacts' | 'command-center' | 'cron' | 'messaging' | 'new-session' | 'session-import' | 'settings' | 'skills'
+  'artifacts' | 'command-center' | 'cron' | 'messaging' | 'new-session' | 'settings' | 'skills'
 
 export interface SidebarNavItem {
   /** Built-in view id, or a contributed row's namespaced contribution id. */

--- a/apps/desktop/src/components/pane-shell/tree/hide-only-strip-tabs.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/hide-only-strip-tabs.test.ts
@@ -104,14 +104,14 @@ describe('hide-only strip tabs', () => {
     expect(hideOnlyZoneTabs('g-main')).toEqual([])
   })
 
-  it('refuses to hide the strip that is the only handle for hide-only tabs', () => {
+  it('honors never on the sessions/Bots strip', () => {
     sessionsBotsTree()
     setTreeGroupTabStrip('g-side', 'never')
 
     const side = $layoutTree.get()
     const group = side && side.type === 'split' ? side.children[0] : side
 
-    expect(group && group.type === 'group' ? tabStripVisibleForGroup(group) : false).toBe(true)
+    expect(group && group.type === 'group' ? tabStripVisibleForGroup(group) : true).toBe(false)
   })
 
   it('excludes hide-only tabs from every close verb', () => {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
@@ -135,15 +135,13 @@ describe('Sessions/Bots strip — #91223', () => {
     expect(tabEl('hermes-bots:pane')).toBeTruthy()
   })
 
-  it('an explicit never still paints the strip — hide-only chrome has no other handle', () => {
+  it('an explicit never hides the sessions/Bots strip', () => {
     setTreeGroupTabStrip('g-side', 'never')
-    expect(tabStripVisibleForGroup(zoneAt(0))).toBe(true)
+    expect(tabStripVisibleForGroup(zoneAt(0))).toBe(false)
 
     render(<LiveTreeGroup parentAxis="row" />)
 
-    expect(tablist()).toBeTruthy()
-    expect(tabEl('sessions')).toBeTruthy()
-    expect(tabEl('hermes-bots:pane')).toBeTruthy()
+    expect(tablist()).toBeNull()
   })
 })
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
@@ -9,7 +9,6 @@ const tile = (): StripPane => ({ collapsePane: false, placement: 'main' })
 const workspace = (): StripPane => ({ collapsePane: false, placement: 'main', uncloseable: true })
 const toolPanel = (): StripPane => ({ collapsePane: true, placement: 'bottom' })
 const sideChrome = (): StripPane => ({ collapsePane: false, placement: 'right' })
-const hideOnlyChrome = (): StripPane => ({ collapsePane: false, hideOnly: true, placement: 'left' })
 
 describe('auto (no stored choice)', () => {
   it('gives a lone workspace no strip and a stack of two a strip', () => {
@@ -45,18 +44,14 @@ describe('no dead zone', () => {
     expect(resolveTabStripVisible({ mode: 'never', shown: [toolPanel()] })).toBe(true)
   })
 
-  it('keeps the strip for hide-only chrome even when the zone says never', () => {
-    // Sessions / Bots: the Show/Hide rows and the chips themselves live on
-    // the strip. Hiding it is the #91223 trap — nothing left to click.
-    expect(resolveTabStripVisible({ mode: 'never', shown: [hideOnlyChrome()] })).toBe(true)
-    expect(resolveTabStripVisible({ mode: 'never', shown: [hideOnlyChrome(), hideOnlyChrome()] })).toBe(true)
-  })
-
   it('still hides a zone that cannot strand anything', () => {
-    // The workspace is uncloseable, and a stack is reachable by tab cycling —
-    // the invariant protects handles, it does not veto hiding as such.
+    // The workspace is uncloseable, a stack is reachable by tab cycling, and
+    // hide-only chrome (sessions / Bots) keeps its panes + ⌘⌥T — the invariant
+    // protects handles, it does not veto hiding as such.
     expect(resolveTabStripVisible({ mode: 'never', shown: [workspace()] })).toBe(false)
     expect(resolveTabStripVisible({ mode: 'never', shown: [toolPanel(), toolPanel()] })).toBe(false)
+    expect(resolveTabStripVisible({ mode: 'never', shown: [sideChrome()] })).toBe(false)
+    expect(resolveTabStripVisible({ mode: 'never', shown: [sideChrome(), sideChrome()] })).toBe(false)
   })
 })
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
@@ -19,9 +19,6 @@ import { paneChrome } from './track-model'
 export interface StripPane {
   /** A tool panel (terminal / logs) that collapses rather than closes. */
   collapsePane: boolean
-  /** Standing chrome (sessions / Bots) whose only handle is the strip:
-   *  show/hide replaces Close, and the Show/Hide rows live on the strip. */
-  hideOnly?: boolean
   /** Contribution placement — `'main'` marks a docked tile (session, page,
    *  preview) as opposed to standing side chrome. */
   placement?: string
@@ -42,9 +39,11 @@ export interface StripZone {
 /**
  * A pane is STRANDED without a strip when the strip is the only thing carrying
  * its handle: a lone closeable tile needs its ✕, a lone tool panel needs a chip
- * to grab, hide-only chrome (sessions / Bots) needs the chip that show/hide
- * lives on. The uncloseable workspace is not strandable — it cannot be closed
- * or lost, so a lone chat is free to be chromeless.
+ * to grab. The uncloseable workspace is not strandable — it cannot be closed
+ * or lost, so a lone chat is free to be chromeless. Hide-only chrome (sessions
+ * / Bots) is the same: the panes stay, Show/Hide is a separate verb, and a
+ * hidden strip comes back via ⌘⌥T. Treating it as stranded at any count made
+ * Hide tabs a silent no-op on the sessions sidebar.
  *
  * This outranks an explicit `never` on purpose. "Hide the strip" is a request
  * about chrome, never a request to make a surface unreachable, and a zone that
@@ -59,12 +58,6 @@ export interface StripZone {
  * both the menu row and ⌘⌥T became silent no-ops.
  */
 function stranded(shown: readonly StripPane[]): boolean {
-  // Hide-only chrome is stranded at ANY count: it has no close verb at all, and
-  // both the chips and the Show/Hide rows that replace one live on the strip.
-  if (shown.some(pane => pane.hideOnly)) {
-    return true
-  }
-
   if (shown.length !== 1) {
     return false
   }
@@ -123,7 +116,6 @@ export function tabStripVisibleForZone(zone: {
 
       return {
         collapsePane: zone.isCollapsePane(id),
-        hideOnly: chrome.hideOnly,
         placement: chrome.placement,
         uncloseable: chrome.uncloseable
       }

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1754,8 +1754,7 @@ export const ar = defineLocale({
       chat: 'المحادثة',
       settings: 'الإعدادات',
       cron: 'المهام المجدولة',
-      agents: 'الوكلاء',
-      'session-import': 'استيراد جلسة'
+      agents: 'الوكلاء'
     },
     searchAria: 'البحث في الجلسات',
     searchPlaceholder: 'البحث في الجلسات...',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2388,8 +2388,7 @@ export const en: Translations = {
       skills: 'Capabilities',
       messaging: 'Messaging',
       artifacts: 'Artifacts',
-      cron: 'Scheduled jobs',
-      'session-import': 'Import session'
+      cron: 'Scheduled jobs'
     },
     searchAria: 'Search sessions',
     searchPlaceholder: 'Search sessions…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2061,8 +2061,7 @@ export const ja = defineLocale({
       skills: 'スキルとツール',
       messaging: 'メッセージング',
       artifacts: 'アーティファクト',
-      cron: 'スケジュール済みジョブ',
-      'session-import': 'セッションを取り込む'
+      cron: 'スケジュール済みジョブ'
     },
     searchAria: 'セッションを検索',
     searchPlaceholder: 'セッションを検索…',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2421,8 +2421,7 @@ export const ru = defineLocale({
       skills: 'Возможности',
       messaging: 'Сообщения',
       artifacts: 'Артефакты',
-      cron: 'Запланированные задачи',
-      'session-import': 'Импортировать сессию'
+      cron: 'Запланированные задачи'
     },
     searchAria: 'Поиск сеансов',
     searchPlaceholder: 'Поиск сеансов…',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1986,8 +1986,7 @@ export const zhHant = defineLocale({
       skills: '技能與工具',
       messaging: '訊息平台',
       artifacts: '成品',
-      cron: '排程工作',
-      'session-import': '匯入工作階段'
+      cron: '排程工作'
     },
     searchAria: '搜尋工作階段',
     searchPlaceholder: '搜尋工作階段…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2553,8 +2553,7 @@ export const zh: Translations = {
       skills: '技能与工具',
       messaging: '消息平台',
       artifacts: '产物',
-      cron: '定时任务',
-      'session-import': '导入会话'
+      cron: '定时任务'
     },
     searchAria: '搜索会话',
     searchPlaceholder: '搜索会话…',

--- a/contributors/emails/brooklyn@Brooklyns-MacBook-Air.local
+++ b/contributors/emails/brooklyn@Brooklyns-MacBook-Air.local
@@ -1,0 +1,1 @@
+OutThisLife

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -663,8 +663,8 @@ the id plus a ready-to-paste `hermes --resume <id>` command.
 `--resume @claude` / `--resume @codex` show the same picker and drop you
 straight into the imported conversation.
 
-**Hermes Desktop** has the same importer under **Import session** in the
-sidebar (also in the command palette). It lists the logs on the machine the
+**Hermes Desktop** has the same importer in the command palette (**Import
+session**). It lists the logs on the machine the
 connected backend runs on — not the computer running the app — shows a
 read-only preview, and **Continue in Hermes** copies the conversation into the
 selected profile. Browsing never writes to your session store, importing never


### PR DESCRIPTION
## What does this PR do?

Hide tabs on the Sessions/Bots strip wrote `never` and the resolver overrode it. `hideOnly` chrome was treated as stranded at any tab count, so the command was a silent no-op — same class of bug as #103142, on the sessions sidebar this time. The panes stay; ⌘⌥T brings the strip back.

Also takes **Import session** off the sidebar nav. The importer is still in the command palette.

## Related Issue

<!-- No filed issue; reported directly. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts` — stop treating hide-only chrome as stranded, so `never` can hide the Sessions/Bots strip.
- Matching tests now pin that an explicit `never` hides that strip.
- `SIDEBAR_NAV` — drop the Import session row; i18n + `website/docs/user-guide/sessions.md` follow.

## How to Test

1. Right-click the Sessions/Bots strip → **Hide tabs**. The chips go away (before: nothing happened).
2. Press ⌘⌥T. The strip comes back.
3. Confirm the sidebar nav has no Import session row, and **Import session** still appears in the command palette.

```
cd apps/desktop && npx vitest run src/components/pane-shell/tree/renderer/strip-visibility.test.ts src/components/pane-shell/tree/hide-only-strip-tabs.test.ts src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- renderer-only; vitest files above -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


Made with [Cursor](https://cursor.com)