### PR TITLE
fix(aux): apply custom-provider extra_headers to auxiliary clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -176,6 +176,15 @@ def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
         if api_key == OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER:
             kwargs["default_headers"] = {**(kwargs.get("default_headers") or {}), **opencode_zen_free_headers()}
     _apply_required_codex_headers(kwargs, access_token=api_key, base_url=base_url)
+    # Custom-provider per-route headers (e.g. zero-data-retention, WAF/gateway auth) must reach
+    # auxiliary clients too. The main agent client merges providers.<name>.extra_headers in
+    # agent_init/client_lifecycle; without the mirror here, auxiliary calls (title generation,
+    # context compression, vision, approvals) to the same endpoint silently drop the route's
+    # configured headers. Provider headers win over the endpoint defaults merged above,
+    # matching the main client's precedence. SECURITY: values may carry credentials; never log.
+    with contextlib.suppress(Exception):
+        from hermes_cli.config import apply_custom_provider_extra_headers_to_client_kwargs
+        apply_custom_provider_extra_headers_to_client_kwargs(kwargs, base_url)
     # Hermes owns aux retry/fallback policy; the SDK default (max_retries=2) would triple
     # wall time on a hung endpoint before Hermes sees one failure.
     # Hermes owns auxiliary retry + provider/model fallback policy (the same-provider transient retry in

--- a/tests/agent/test_auxiliary_custom_provider_extra_headers.py
+++ b/tests/agent/test_auxiliary_custom_provider_extra_headers.py
@@ -1,0 +1,94 @@
+"""Auxiliary clients must apply ``providers.<name>.extra_headers`` on the resolved route.
+
+Companion to ``tests/hermes_cli/test_custom_provider_extra_headers.py`` (pure matching
+helpers) and ``tests/agent/test_auxiliary_user_default_headers.py`` (model-level headers).
+The main agent client merges per-provider ``extra_headers`` in ``agent/agent_init.py`` and
+``agent/client_lifecycle.py``; auxiliary calls (title generation, context compression,
+vision, approvals) build separate OpenAI clients through
+``agent.auxiliary_client._create_openai_client`` and silently dropped those route headers —
+breaking zero-data-retention enforcement, WAF/gateway auth and similar per-route header
+config on every auxiliary request.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Redirect HERMES_HOME so load_config() reads our test config.yaml."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text("model:\n  default: test-model\n")
+
+
+def _write_config(tmp_path, config_dict):
+    import yaml
+    (tmp_path / ".hermes" / "config.yaml").write_text(yaml.dump(config_dict))
+
+
+_PROVIDERS = [
+    {
+        "name": "gw",
+        "base_url": "http://gw.local/v1",
+        "api_key": "k",
+        "extra_headers": {"X-ZDR": "1", "X-Route": "my-route"},
+    },
+]
+
+
+class TestAuxClientAppliesCustomProviderExtraHeaders:
+    def test_client_creation_merges_matching_provider_headers(self, tmp_path):
+        _write_config(tmp_path, {"model": {"default": "m"}, "custom_providers": _PROVIDERS})
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import _create_openai_client
+            _create_openai_client(api_key="k", base_url="http://gw.local/v1")
+
+        assert mock_openai.called
+        headers = mock_openai.call_args.kwargs.get("default_headers", {})
+        assert headers.get("X-ZDR") == "1"
+        assert headers.get("X-Route") == "my-route"
+
+    def test_merge_preserves_existing_default_headers(self, tmp_path):
+        _write_config(tmp_path, {"model": {"default": "m"}, "custom_providers": _PROVIDERS})
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import _create_openai_client
+            _create_openai_client(
+                api_key="k",
+                base_url="http://gw.local/v1",
+                default_headers={"User-Agent": "curl/8.7.1"},
+            )
+
+        assert mock_openai.called
+        headers = mock_openai.call_args.kwargs.get("default_headers", {})
+        assert headers.get("User-Agent") == "curl/8.7.1"  # untouched defaults preserved
+        assert headers.get("X-ZDR") == "1"                 # provider header added
+
+    def test_no_matching_provider_adds_nothing(self, tmp_path):
+        _write_config(tmp_path, {"model": {"default": "m"}, "custom_providers": _PROVIDERS})
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import _create_openai_client
+            _create_openai_client(api_key="k", base_url="http://other.example.com/v1")
+
+        assert mock_openai.called
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert "X-ZDR" not in headers
+
+    def test_named_custom_provider_resolution_applies_headers(self, tmp_path):
+        """End-to-end: resolve_provider_client funnels through the fixed choke point."""
+        _write_config(tmp_path, {"model": {"default": "test-model"}, "custom_providers": _PROVIDERS})
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("gw", "my-model")
+
+        assert client is not None
+        assert model == "my-model"
+        assert mock_openai.called
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("X-ZDR") == "1"


### PR DESCRIPTION
## Summary

Auxiliary LLM calls (title generation, context compression, vision, approvals) build their own OpenAI clients through `agent/auxiliary_client._create_openai_client` and **never applied per-provider `extra_headers`** from config (`providers.<name>.extra_headers` / `custom_providers[].extra_headers`). The main agent client merges those headers in `agent/agent_init.py` and `agent/client_lifecycle.py` — so the same route's headers (zero-data-retention enforcement, WAF/gateway auth, custom bearer schemes) were sent on main-turn requests but silently dropped on every auxiliary request.

## Motivation

Real-world symptom: with a Command Code (OpenAI-compatible) provider configured with `extra_headers: {x-cmd-zdr: 1}` to enforce zero-data-retention, the provider's usage page showed main-loop requests as ZDR but interleaved auxiliary requests (e.g. approval checks, ~3 per turn) as **non-ZDR** — the aux client never carried the header. Any per-route header config has the same split behavior on the aux path.

## What changed

In `agent/auxiliary_client.py`, `_create_openai_client()` — the single choke point every OpenAI-mode auxiliary client flows through (~15 call sites, all receiving the resolved `base_url`) — now mirrors the main client:

```python
with contextlib.suppress(Exception):
    from hermes_cli.config import apply_custom_provider_extra_headers_to_client_kwargs
    apply_custom_provider_extra_headers_to_client_kwargs(kwargs, base_url)
```

Applied last so provider-level headers win over endpoint defaults, matching the main client's precedence. Same helper, same matching by normalized `base_url`, no behavior change for routes without configured headers (no-op). Probe-mode stub returns before this, unchanged.

## Validation

- New `tests/agent/test_auxiliary_custom_provider_extra_headers.py` — 4 tests:
  - `_create_openai_client` merges headers from a matching provider entry
  - existing `default_headers` (e.g. caller/endpoint defaults) are preserved
  - no matching route → nothing added
  - end-to-end: `resolve_provider_client` funnels through the fixed choke point
- `scripts/run_tests.sh`:
  - `tests/agent/test_auxiliary_custom_provider_extra_headers.py` ✓ (4)
  - `tests/agent/test_auxiliary_user_default_headers.py` ✓ (5, regression)
  - `tests/agent/test_auxiliary_named_custom_providers.py` ✓ (regression)

## Checklist

- [x] Fix reproduces the reported symptom and points to the exact line
- [x] Mirrors existing main-client behavior (same helper, same precedence)
- [x] Behavior-contract tests, no change-detectors
- [x] Tested via `scripts/run_tests.sh`
