### PR TITLE
fix(vision): ZAI vision defaults cover GLM Coding Plan keys

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -793,7 +793,11 @@ def _task_prefers_fast_model(task: Optional[str]) -> bool:
 
 
 # Dedicated vision models for direct providers whose main chat model differs.
-_PROVIDER_VISION_MODELS: Dict[str, str] = {"xiaomi": "mimo-v2.5", "zai": "glm-5v-turbo"}
+# zai: glm-5.3-flash is the GLM Coding Plan's multimodal model (glm-5v-turbo returns 1311
+# "not included in your subscription plan" for Coding Plan keys); on the general pay-as-you-go
+# surface glm-5v-turbo still works, but the coding endpoint order in _ZAI_OPENAI_VISION_URLS
+# makes glm-5.3-flash the default that works on both key types.
+_PROVIDER_VISION_MODELS: Dict[str, str] = {"xiaomi": "mimo-v2.5", "zai": "glm-5.3-flash"}
 
 
 def _resolve_provider_vision_default(provider: str) -> Optional[str]:
@@ -5078,8 +5082,16 @@ def _vision_auto_route(
 
 
 # ZAI vision must use the OpenAI-compatible endpoint: the Anthropic wire rejects max_tokens on
-# multimodal calls (error 1210).
-_ZAI_OPENAI_VISION_URLS = ("https://open.bigmodel.cn/api/paas/v4", "https://api.z.ai/api/paas/v4")
+# multimodal calls (error 1210). Coding Plan keys only have balance on the /coding/ endpoints —
+# the general endpoints return 1113 "Insufficient balance" for them — so try coding surfaces
+# first (mirrors hermes_cli.auth_zai_kimi.ZAI_ENDPOINTS priority, without importing it here to
+# keep the agent/auth layering one-way).
+_ZAI_OPENAI_VISION_URLS = (
+    "https://api.z.ai/api/coding/paas/v4",
+    "https://open.bigmodel.cn/api/coding/paas/v4",
+    "https://open.bigmodel.cn/api/paas/v4",
+    "https://api.z.ai/api/paas/v4",
+)
 
 
 def resolve_vision_provider_client(

--- a/tests/agent/test_zai_vision_coding_plan.py
+++ b/tests/agent/test_zai_vision_coding_plan.py
@@ -1,0 +1,31 @@
+"""ZAI vision endpoint/model defaults cover the GLM Coding Plan (issue: vision 1113/1311).
+
+Coding Plan keys have no balance on the general pay-as-you-go endpoints (error 1113
+"Insufficient balance") and no glm-5v-turbo access (error 1311 "not included in your
+subscription plan"). The vision client must try /coding/ surfaces first and default to
+glm-5.3-flash, the Coding Plan's multimodal model.
+"""
+import pytest
+
+from agent import auxiliary_client
+
+
+def test_zai_vision_urls_try_coding_plan_first():
+    urls = auxiliary_client._ZAI_OPENAI_VISION_URLS
+    assert urls[0] == "https://api.z.ai/api/coding/paas/v4"
+    assert any("/coding/" in u for u in urls), "coding surfaces must be present"
+    # General endpoints remain as last-resort fallbacks (pay-as-you-go keys).
+    assert "https://api.z.ai/api/paas/v4" in urls
+    assert "https://open.bigmodel.cn/api/paas/v4" in urls
+    # Coding surfaces must come BEFORE the general ones.
+    first_general = min(urls.index(u) for u in urls if "/coding/" not in u)
+    first_coding = min(urls.index(u) for u in urls if "/coding/" in u)
+    assert first_coding < first_general
+
+
+def test_zai_vision_default_model_is_coding_plan_multimodal():
+    # glm-5v-turbo is NOT available on the Coding Plan (1311); glm-5.3-flash is.
+    assert auxiliary_client._PROVIDER_VISION_MODELS["zai"] == "glm-5.3-flash"
+    assert (
+        auxiliary_client._resolve_provider_vision_default("zai") == "glm-5.3-flash"
+    )


### PR DESCRIPTION
## Problem
ZAI vision calls fail for GLM Coding Plan subscribers with:
- `1113 Insufficient balance` (general endpoints have no PAYG balance for Coding Plan keys), or
- `1311 Your current subscription plan does not yet include access to GLM-5V-Turbo`, or
- `1210 messages.content.type is invalid, allowed values: ['text']` (after fallback to a text-only model)

Root cause: `_ZAI_OPENAI_VISION_URLS` hardcodes the general pay-as-you-go endpoints and `_PROVIDER_VISION_MODELS['zai']` defaults to `glm-5v-turbo` — which Coding Plan keys cannot use. Notably `hermes_cli.auth_zai_kimi.ZAI_ENDPOINTS` already probes coding endpoints for auth; the vision path just bypassed that surface.

## Fix
- Try `/api/coding/paas/v4` surfaces **first** in `_ZAI_OPENAI_VISION_URLS` (same priority as `ZAI_ENDPOINTS`), keeping general endpoints as fallbacks so pay-as-you-go keys are unaffected.
- Default zai vision model → `glm-5.3-flash`, the Coding Plan's multimodal model (native Image/Video/File input per Z.AI docs).

## Verification (live, Coding Plan key)
| model | general `/api/paas/v4` | coding `/api/coding/paas/v4` |
|---|---|---|
| glm-5.3 | 400 · 1210 text-only | — |
| glm-5v-turbo | 429 · 1113 no balance | 429 · 1311 not in plan |
| **glm-5.3-flash** | 429 · 1113 no balance | **200 · image accepted** |

Tests: `tests/agent/test_zai_vision_coding_plan.py` (endpoint ordering + default model); existing `test_vision_resolved_args.py` still passes (4/4 green).